### PR TITLE
No syntax highlighting in text code blocks

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -7,7 +7,7 @@ body:
       label: "Describe the bug"
       description: "A clear and concise description of what the bug is."
       placeholder: Tell us what you see.
-      render: shell
+      render: text
     validations:
       required: true
   - type: textarea
@@ -28,7 +28,7 @@ body:
       label: "Expected behaviour"
       description: "A clear and concise description of what you expected to happen."
       placeholder: Tell us what you expect to see.
-      render: shell
+      render: text
     validations:
       required: false
   - type: textarea
@@ -61,6 +61,6 @@ body:
     attributes:
       label: "Additional context"
       description: "Add any other context about the problem here."
-      render: shell
+      render: text
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       label: "Describe the solution you'd like?"
       description: "A clear and concise description of what you want to happen."
-      render: shell
+      render: text
     validations:
       required: true
   - type: textarea
@@ -15,7 +15,7 @@ body:
       label: "Is your feature request related to a problem? Please describe."
       description: "A clear and concise description of what the problem is."
       placeholder: "I'm always frustrated when [...]"
-      render: shell
+      render: text
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
Since you are using the code blocks for text input and not code, setting the language to shell actually leads to undesired syntax highlighting. using "text" as rendering language fixes this.