### PR TITLE
Fix wrong "open roles" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can see how we’re thinking about open source here: [https://github.com/war
 
 As a side note, we are open sourcing our extension points as we go. The community has already been [contributing new themes](https://github.com/warpdotdev/themes). And we’ve just opened our [Workflows repository](https://github.com/warpdotdev/workflows) for the community to contribute common useful commands.
 
-Interested in joining the team? See our [open roles](https://www.warp.dev/hiring) and feel free to send us an email: hello at warpdotdev
+Interested in joining the team? See our [open roles](https://www.warp.dev/careers#open-roles) and feel free to send us an email: hello at warpdotdev
 
 ## Support and Questions
 


### PR DESCRIPTION
The original link (https://www.warp.dev/hiring) is pointed to a page with `Page Not Found`, this patch fix it and link it to the right link (https://www.warp.dev/careers#open-roles).