### PR TITLE
Require Warp version in issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -72,6 +72,13 @@ body:
       description: "For example, `bash 4.0` e.g. Run `bash --version` or `zsh --version`"
     validations:
       required: true
+  - type: input
+    id: "warp-version"
+    attributes:
+      label: "Warp Version"
+      description: "Click the 3-dots menu docked to the right of the tabs in Warp and click the copy button, e.g. `v0.2022.05.30.09.10.stable_01`"
+    validations:
+      required: true
   - type: textarea
     id: "additional-context"
     attributes:

--- a/.github/ISSUE_TEMPLATE/03_ssh.yml
+++ b/.github/ISSUE_TEMPLATE/03_ssh.yml
@@ -30,6 +30,13 @@ body:
       description: "e.g. Debian 11.2"
     validations:
       required: true
+  - type: input
+    id: "warp-version"
+    attributes:
+      label: "Warp Version"
+      description: "Click the 3-dots menu docked to the right of the tabs in Warp and click the copy button, e.g. `v0.2022.05.30.09.10.stable_01`"
+    validations:
+      required: true
   - type: checkboxes
     id: "rcfiles"
     attributes:


### PR DESCRIPTION
Having the Warp version will make it easier to debug and determine if the problem still persists on latest stable.