### PR TITLE
Remove public beta copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ This is an issues-only repo for [Warp](https://www.warp.dev), a [blazingly-fast 
 
 As of April 5th, 2022, Warp is available to all macOS users, without joining a wait-list.
 
-We are calling this new phase of the product our “public beta” – it’s a “beta” because we know there are still some issues to smooth out, but we are confident that even today the experience is meaningfully better than in other terminals.
-
 We have plans to support [Linux](https://github.com/warpdotdev/Warp/issues/120), [Windows,](https://github.com/warpdotdev/Warp/issues/204) and the Web (WASM)!
 
 ## Installation


### PR DESCRIPTION
Removing `beta` from README copy.