### PR TITLE
added pre-submit checks and os options to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -4,9 +4,11 @@ labels: ["Bugs"]
 body:
   - type: checkboxes
     attributes:
-      label: "Dupe Check"
+      label: "Pre-submit Checks"
       options:
         - label: "I have [searched Warp bugs](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+label%3ABugs) and there are no duplicates"
+          required: true
+        - label: "I have [searched Warp known issues page](https://docs.warp.dev/help/known-issues) and my issue is not there"
           required: true
   - type: textarea
     id: "describe-the-bug"
@@ -47,7 +49,7 @@ body:
       options:
         - MacOS
         - Linux
-        # - Windows
+        - Windows
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -4,9 +4,11 @@ labels: ["Feature requests"]
 body:
   - type: checkboxes
     attributes:
-      label: "Dupe Check"
+      label: "Pre-submit Checks"
       options:
         - label: "I have [searched Warp feature requests](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+label%3A%22Feature+requests%22) and there are no duplicates"
+          required: true
+        - label: "I have [searched Warp docs](https://docs.warp.dev) and my feature is not there"
           required: true
   - type: textarea
     id: "describe-solution"
@@ -31,6 +33,17 @@ body:
     validations:
       required: false
   - type: dropdown
+    id: "os"
+    attributes:
+      label: "Operating system (Optional, if relevant)"
+      multiple: false
+      options:
+        - MacOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+  - type: dropdown
     id: "importance"
     attributes:
       label: "How important is this feature to you?"
@@ -50,7 +63,5 @@ body:
       multiple: false
       options:
         - Ignore
-        # - Windows
-        # - Linux
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/03_ssh_tmux.yml
+++ b/.github/ISSUE_TEMPLATE/03_ssh_tmux.yml
@@ -2,12 +2,38 @@ name: SSH Warpify Issues? Use this template
 description: "Issue template specialized for the circumstances where SSH Warpification with tmux fails"
 labels: ["Bugs","SSH-tmux"]
 body:
+  - type: checkboxes
+    attributes:
+      label: "Pre-submit Checks"
+      options:
+        - label: "I have [searched Warp SSH issues](https://github.com/warpdotdev/Warp/issues?q=is%3Aissue+is%3Aopen+label%3ASSH%2CSSH-tmux) and there are no duplicates"
+          required: true
+        - label: "I have [searched Warp known issues page](https://docs.warp.dev/help/known-issues) and my issue is not there"
+          required: true
   - type: textarea
     id: "shell-output"
     attributes:
       label: "Include shell output"
       description: "Click on the top right icon of your terminal block, select `Copy`, and paste the contents here. Please redact any personal details."
       render: shell
+    validations:
+      required: true
+  - type: dropdown
+    id: "os"
+    attributes:
+      label: "Operating system"
+      multiple: false
+      options:
+        - MacOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+  - type: input
+    id: "os-version"
+    attributes:
+      label: "Operating system and version"
+      description: "For example: Debian 11.2"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/04_ssh_legacy.yml
+++ b/.github/ISSUE_TEMPLATE/04_ssh_legacy.yml
@@ -4,9 +4,11 @@ labels: ["Bugs","SSH"]
 body:
   - type: checkboxes
     attributes:
-      label: "Dupe Check"
+      label: "Pre-submit Checks"
       options:
         - label: "I have [searched Warp SSH issues](https://github.com/warpdotdev/Warp/issues?q=is%3Aissue+is%3Aopen+label%3ASSH%2CSSH-tmux) and there are no duplicates"
+          required: true
+        - label: "I have [searched Warp known issues page](https://docs.warp.dev/help/known-issues) and my issue is not there"
           required: true
   - type: dropdown
     id: "os"
@@ -16,7 +18,7 @@ body:
       options:
         - MacOS
         - Linux
-        # - Windows
+        - Windows
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Based on comments in slack thread: https://warpdev.slack.com/archives/C06MJ1612N4/p1739237604295219

Changes: 
- Added Windows OS option to templates
- Added KI / Warp Docs links as well so users can confirm they are not submitting a KI / existing feature