### PR TITLE
Apply grace window after needs-info label event

### DIFF
--- a/.github/workflows/close-needs-info-issues.yml
+++ b/.github/workflows/close-needs-info-issues.yml
@@ -21,6 +21,10 @@ jobs:
           script: |
             const LABEL = "needs-info";
             const BUSINESS_DAYS = 3;
+            // Grace window after the label event to avoid treating the
+            // maintainer's own follow-up comment (typically posted seconds
+            // after applying the label) as a user response.
+            const LABEL_GRACE_WINDOW_MS = 60 * 1000;
 
             function addBusinessDays(date, days) {
               const result = new Date(date);
@@ -80,18 +84,24 @@ jobs:
                 continue;
               }
 
-              // Check for any comments after the label was applied
+              // Check for any comments after the label was applied, ignoring
+              // comments within a short grace window so the maintainer's
+              // request-for-info comment posted right after labeling isn't
+              // counted as a user response.
+              const commentCutoff = new Date(
+                lastLabeledAt.getTime() + LABEL_GRACE_WINDOW_MS
+              );
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                since: lastLabeledAt.toISOString(),
+                since: commentCutoff.toISOString(),
                 per_page: 100,
               });
 
-              // Filter to comments strictly after the label event
+              // Filter to comments strictly after the grace window
               const hasNewComments = comments.some(
-                (c) => new Date(c.created_at) > lastLabeledAt
+                (c) => new Date(c.created_at) > commentCutoff
               );
 
               if (hasNewComments) {


### PR DESCRIPTION
## Problem

The `Close Stale Needs-Info Issues` workflow has been running nightly
but closing 0 issues (see [this run](https://github.com/warpdotdev/Warp/actions/runs/24592642512/job/71916451356),
final log line: `Done. Closed 0 stale needs-info issue(s).`).

## Root cause

When the `needs-info` label is applied during triage, the maintainer
also posts a comment asking for more info 1–2 seconds later. The
existing `hasNewComments` check treats any comment with
`created_at > lastLabeledAt` as a user response, so every issue is
skipped because its own "please provide info" comment looks like a
response.

Examples from the last run's target issues:

- #8509: label at `2026-04-14T00:50:15Z`, maintainer comment at `2026-04-14T00:50:16Z`
- #8439: label at `2026-04-14T05:16:07Z`, maintainer comment at `2026-04-14T05:16:09Z`
- #8559: label at `2026-04-14T05:14:01Z`, maintainer comment at `2026-04-14T05:14:02Z`

## Fix

Apply a 60-second grace window after the `needs-info` label event
before counting comments. Only comments posted strictly after
`lastLabeledAt + 60s` are treated as a user response. This keeps the
check simple and does not depend on comment author metadata or
association.

_Conversation: https://staging.warp.dev/conversation/e5f9ba58-e3eb-4aa3-8d02-fe15781a22a0_
_Run: https://oz.staging.warp.dev/runs/019da068-5803-72a4-9c57-985672f4e60a_

_This PR was generated with [Oz](https://warp.dev/oz)._
