### PR TITLE
Handle errors during patch in close-needs-info workflow

### DIFF
--- a/.github/workflows/close-needs-info-issues.yml
+++ b/.github/workflows/close-needs-info-issues.yml
@@ -109,26 +109,34 @@ jobs:
               }
 
               // Close the issue with a comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body:
-                  "This issue has been automatically closed because it was labeled " +
-                  "`needs-info` and received no response for 3 business days. " +
-                  "If you have the requested information, please reply and we will reopen.",
-              });
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body:
+                    "This issue has been automatically closed because it was labeled " +
+                    "`needs-info` and received no response for 3 business days. " +
+                    "If you have the requested information, please reply and we will reopen.",
+                });
+              } catch (commentErr) {
+                core.warning(`Could not comment on issue #${issue.number}: ${commentErr.message}`);
+              }
 
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: "closed",
-                state_reason: "not_planned",
-              });
+              try {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: "closed",
+                  state_reason: "not_planned",
+                });
 
-              closedCount++;
-              core.info(`Closed issue #${issue.number}: ${issue.title}`);
+                closedCount++;
+                core.info(`Closed issue #${issue.number}: ${issue.title}`);
+              } catch (updateErr) {
+                core.warning(`Could not close issue #${issue.number}: ${updateErr.message}`);
+              }
             }
 
             core.info(`Done. Closed ${closedCount} stale needs-info issue(s).`);


### PR DESCRIPTION
## Summary

- Wraps the `createComment` call in a `try/catch` so that locked issues (which return a 403) log a warning instead of crashing the entire run
- Wraps the `issues.update` (PATCH) call in its own `try/catch` for the same reason — each issue is processed independently
- The root cause was [run 24697788177](https://github.com/warpdotdev/Warp/actions/runs/24697788177/job/72234256858#step:2:286) where issue #222 is locked, causing `Unable to create comment because issue is locked` to throw an unhandled exception and abort all remaining issues

## Test

- [X] Verified on ad-hock run triggered via workflow dispatch

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._