### PR TITLE
ci: pass OSS_WARP_API_KEY to oz-for-oss reusable workflows

### DIFF
--- a/.github/workflows/create-implementation-from-issue-local.yml
+++ b/.github/workflows/create-implementation-from-issue-local.yml
@@ -31,4 +31,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/create-spec-from-issue-local.yml
+++ b/.github/workflows/create-spec-from-issue-local.yml
@@ -31,4 +31,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/enforce-pr-issue-state.yml
+++ b/.github/workflows/enforce-pr-issue-state.yml
@@ -36,4 +36,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/respond-to-pr-comment-local.yml
+++ b/.github/workflows/respond-to-pr-comment-local.yml
@@ -21,4 +21,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/respond-to-triaged-issue-comment-local.yml
+++ b/.github/workflows/respond-to-triaged-issue-comment-local.yml
@@ -19,4 +19,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -138,4 +138,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/triage-new-issues-local.yml
+++ b/.github/workflows/triage-new-issues-local.yml
@@ -57,4 +57,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/trigger-implementation-on-plan-approved-local.yml
+++ b/.github/workflows/trigger-implementation-on-plan-approved-local.yml
@@ -19,4 +19,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/update-dedupe-local.yml
+++ b/.github/workflows/update-dedupe-local.yml
@@ -20,4 +20,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/update-pr-review-local.yml
+++ b/.github/workflows/update-pr-review-local.yml
@@ -20,4 +20,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/update-triage-local.yml
+++ b/.github/workflows/update-triage-local.yml
@@ -20,4 +20,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}

--- a/.github/workflows/verify-pr-comment-local.yml
+++ b/.github/workflows/verify-pr-comment-local.yml
@@ -15,4 +15,4 @@ jobs:
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
       OZ_MGMT_GHA_PRIVATE_KEY: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
-      WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}
+      OSS_WARP_API_KEY: ${{ secrets.OSS_WARP_API_KEY }}


### PR DESCRIPTION
## Description
The reusable workflows under [`warpdotdev/oz-for-oss`](https://github.com/warpdotdev/oz-for-oss/tree/main/.github/workflows) declare their Warp API key secret as `OSS_WARP_API_KEY`, but the local caller workflows in this repo were forwarding it as `WARP_API_KEY`. Because the name being passed didn't match the name declared by `workflow_call`, the required secret was effectively missing and an undeclared secret was being passed instead, which caused `startup_failure` on every invocation.

Example failure: https://github.com/warpdotdev/warp/actions/runs/25058665906 (Triage New Issues (Local), `startup_failure`).

This PR renames the forwarded secret to `OSS_WARP_API_KEY:` in all local adapter workflows so the names match what the reusable workflows declare. The underlying secret value is still pulled from `secrets.OSS_WARP_API_KEY` in this repo, so no repo secret changes are needed.

Affected workflows:
- `.github/workflows/create-implementation-from-issue-local.yml`
- `.github/workflows/create-spec-from-issue-local.yml`
- `.github/workflows/enforce-pr-issue-state.yml`
- `.github/workflows/respond-to-pr-comment-local.yml`
- `.github/workflows/respond-to-triaged-issue-comment-local.yml`
- `.github/workflows/review-pull-request.yml`
- `.github/workflows/triage-new-issues-local.yml`
- `.github/workflows/trigger-implementation-on-plan-approved-local.yml`
- `.github/workflows/update-dedupe-local.yml`
- `.github/workflows/update-pr-review-local.yml`
- `.github/workflows/update-triage-local.yml`
- `.github/workflows/verify-pr-comment-local.yml`

## Testing
Manual review of the rename. After merge, re-run the failing `Triage New Issues (Local)` workflow to confirm it no longer hits `startup_failure` due to a missing required secret.

## Server API dependencies
N/A — CI workflow change only.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/fbace74a-9da2-445f-8486-e5a5907dce57_
_Run: https://oz.staging.warp.dev/runs/019dd47c-42e0-7072-8206-e6be4df5cde7_

_This PR was generated with [Oz](https://warp.dev/oz)._
