### PR TITLE
Fix CI to work in the `warpdotdev/warp` repo.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,9 +654,9 @@ jobs:
         shell: bash
         run: |
           if ${{ matrix.os == 'wasm' }}; then
-            ./script/wasm/bundle --bin oss --nouniversal --check-only
+            ./script/wasm/bundle --channel oss --nouniversal --check-only
           else
-            ./script/bundle --bin oss --nouniversal --check-only
+            ./script/bundle --channel oss --nouniversal --check-only
           fi
         env:
           # Attach the GitHub auth token so that requests to the GitHub API

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,7 +510,8 @@ jobs:
           if [ "${{ matrix.os }}" = "windows" ]; then
             cargo clippy --locked --workspace ${{ matrix.clippy_excludes }} --all-targets --tests -- -D warnings
           else
-            cargo clippy --locked --workspace ${{ matrix.clippy_excludes }} --all-targets --all-features --tests -- -D warnings
+            # TODO(vorporeal): Re-enable the `all-features` flag once we've fixed things.
+            cargo clippy --locked --workspace ${{ matrix.clippy_excludes }} --all-targets --tests -- -D warnings
             # Run clippy on warp_completer with default, rather than all features enabled, because there is
             # feature-gated logic for the WIP completions-on-js implementation.
             cargo clippy --locked -p warp_completer --all-targets --tests -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,9 +654,9 @@ jobs:
         shell: bash
         run: |
           if ${{ matrix.os == 'wasm' }}; then
-            ./script/wasm/bundle --bin dev --nouniversal --check-only
+            ./script/wasm/bundle --bin oss --nouniversal --check-only
           else
-            ./script/bundle --bin dev --nouniversal --check-only
+            ./script/bundle --bin oss --nouniversal --check-only
           fi
         env:
           # Attach the GitHub auth token so that requests to the GitHub API

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -164,12 +164,23 @@ elif [[ $RELEASE_CHANNEL = "stable" ]]; then
   WARP_BIN="stable"
   BINARY_NAME="warp"
   APP_NAME="Warp"
+elif [[ $RELEASE_CHANNEL = "oss" ]]; then
+  WARP_BIN="warp-oss"
+  BINARY_NAME="warp-oss"
+  APP_NAME="WarpOss"
+  # The OSS channel does not ship Sentry, so drop the crash_reporting feature
+  # (which would otherwise pull in the Sentry SDK as a dependency).
+  FEATURES="release_bundle"
 fi
 
 # Artifact-specific binary naming
 if [[ "$ARTIFACT" == "cli" ]]; then
-  # For CLI artifacts, use oz instead of warp as the binary name
-  BINARY_NAME="${BINARY_NAME/warp/oz}"
+  # For CLI artifacts, use oz instead of warp as the binary name.  The OSS
+  # channel is an exception: its CLI command name is `warp-oss`, matching
+  # `Channel::cli_command_name` in the Rust source.
+  if [[ $RELEASE_CHANNEL != "oss" ]]; then
+    BINARY_NAME="${BINARY_NAME/warp/oz}"
+  fi
 fi
 
 # Artifact-specific configuration

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -184,7 +184,7 @@ while (( "$#" )); do
       OPEN_AFTER_BUNDLE=true
       shift
       ;;
-    # Specify the release channel (local, dev, preview, stable)
+    # Specify the release channel (local, dev, preview, stable, oss)
     -c|--channel)
       if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
         RELEASE_CHANNEL=$2
@@ -296,6 +296,14 @@ elif [[ $RELEASE_CHANNEL = "stable" ]]; then
     BUNDLE_ID="dev.warp.Warp-Stable"
     WARP_APP_NAME="Warp"
     WARP_SCHEME_NAME="warp"
+elif [[ $RELEASE_CHANNEL = "oss" ]]; then
+    WARP_BIN="warp-oss"
+    BUNDLE_ID="dev.warp.WarpOss"
+    WARP_APP_NAME="WarpOss"
+    WARP_SCHEME_NAME="warposs"
+    # The OSS channel does not ship Sentry, so drop the cocoa_sentry feature
+    # (which would otherwise pull in the Sentry framework dependency).
+    FEATURES="release_bundle,extern_plist"
 fi
 
 OUT_DIR="target/$TARGET_PROFILE_DIR/bundle/osx"
@@ -510,9 +518,12 @@ if [[ "$ARTIFACT" == "app" ]]; then
     "$WORKSPACE_ROOT_DIR/script/prepare_bundled_pprof" "$HELPERS_DIR"
   fi
 
-  # Determine CLI wrapper script path based on release channel
+  # Determine CLI wrapper script path based on release channel.  Each channel's
+  # value here must match `Channel::cli_command_name` in the Rust source.
   if [[ $RELEASE_CHANNEL = "stable" ]]; then
     CLI_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/oz"
+  elif [[ $RELEASE_CHANNEL = "oss" ]]; then
+    CLI_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/warp-oss"
   else
     CLI_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/oz-$RELEASE_CHANNEL"
   fi

--- a/script/presubmit
+++ b/script/presubmit
@@ -20,7 +20,9 @@ echo "Cargo fmt succeeded..."
 
 echo "Running clippy..."
 # Exclude warp_completer because we run clippy on it with default features (rather than all features) below.
-cargo clippy --workspace --exclude warp_completer --all-targets --all-features --tests -- -D warnings
+#
+# TODO(vorporeal): Re-enable the `all-features` flag once we've fixed things.
+cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings
 # Run clippy on warp_completer with default, rather than all features enabled, because there is
 # feature-gated logic for the WIP completions-on-js implementation.
 cargo clippy -p warp_completer --all-targets --tests -- -D warnings

--- a/script/wasm/bundle
+++ b/script/wasm/bundle
@@ -126,6 +126,8 @@ elif [[ $RELEASE_CHANNEL = "preview" ]]; then
   FEATURES="$FEATURES,preview_channel"
 elif [[ $RELEASE_CHANNEL = "stable" ]]; then
   WARP_BIN="stable"
+elif [[ $RELEASE_CHANNEL = "oss" ]]; then
+  WARP_BIN="warp-oss"
 fi
 
 if [ -n "${FEATURES_OVERRIDE+x}" ]; then

--- a/script/windows/bundle.ps1
+++ b/script/windows/bundle.ps1
@@ -9,7 +9,7 @@ Param (
     [Alias('check-only')]
     [Switch]$CHECK_ONLY,
 
-    [ValidateSet('local', 'dev', 'preview', 'stable')]
+    [ValidateSet('local', 'dev', 'preview', 'stable', 'oss')]
     [String]$CHANNEL = 'dev',
 
     [Alias('release-tag')]
@@ -109,6 +109,13 @@ if ("$CHANNEL" -eq 'local') {
     $APP_NAME = 'Warp'
     # TODO(vorporeal): Remove this once we get tests passing with this default enabled.
     $FEATURES = "$FEATURES,nld_improvements"
+} elseif ("$CHANNEL" -eq 'oss') {
+    $WARP_BIN = 'warp-oss'
+    $BINARY_NAME = 'warp-oss.exe'
+    $APP_NAME = 'WarpOss'
+    # The OSS channel does not ship Sentry, so drop the crash_reporting feature
+    # (which would otherwise pull in the Sentry SDK as a dependency).
+    $FEATURES = 'release_bundle,gui,nld_improvements'
 }
 
 $BINARY_PATH = "$CARGO_TARGET_OUTPUT_DIR\$BINARY_NAME"

--- a/script/windows/windows-installer.iss
+++ b/script/windows/windows-installer.iss
@@ -28,7 +28,8 @@
   ((ReleaseChannel == "preview") ? "Preview" : \
   ((ReleaseChannel == "local") ? "Local" : \
   ((ReleaseChannel == "integration") ? "Integration" : \
-  "Unknown"))))
+  ((ReleaseChannel == "oss") ? "Oss" : \
+  "Unknown")))))
 #define AppMutexName "Local\Warp" + ChannelPascalCase + "_SingleInstance"
 
 
@@ -226,9 +227,12 @@ begin
     if not DirExists(BinDir) then
       CreateDir(BinDir);
 
-    { Determine the channel-specific script name. }
+    { Determine the channel-specific script name.  These values must match
+      `Channel::cli_command_name` in the Rust source. }
 #if ReleaseChannel == "stable"
     CmdScriptName := 'oz.cmd'
+#elif ReleaseChannel == "oss"
+    CmdScriptName := 'warp-oss.cmd';
 #else
     CmdScriptName := 'oz-{#ReleaseChannel}.cmd';
 #endif


### PR DESCRIPTION
## Description

A couple issues that needed fixing:
* Using `--all-features` and `--all-targets` causes us to try to build the first-party binaries with embedded configuration, which isn't available from this repository.  To unblock CI, we'll only run clippy on the default feature set for right now.
* Similarly, testing compilation with release configuration was trying to build the `dev` channel; this switches that over to the `oss` channel.