### PR TITLE
ci: drop removed focus input from review-pull-request caller

### DIFF
--- a/.github/workflows/review-pull-request.yml
+++ b/.github/workflows/review-pull-request.yml
@@ -17,11 +17,6 @@ on:
         required: false
         default: ""
         type: string
-      focus:
-        description: Optional extra focus guidance for the review
-        required: false
-        default: ""
-        type: string
       comment_id:
         description: Issue comment ID to react to for slash-command reviews
         required: false
@@ -50,7 +45,6 @@ jobs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       trigger_source: ${{ steps.resolve.outputs.trigger_source }}
       requester: ${{ steps.resolve.outputs.requester }}
-      focus: ${{ steps.resolve.outputs.focus }}
       comment_id: ${{ steps.resolve.outputs.comment_id }}
       skip_reason: ${{ steps.resolve.outputs.skip_reason }}
     steps:
@@ -62,7 +56,6 @@ jobs:
           INPUT_PR_NUMBER: ${{ inputs.pr_number || '' }}
           INPUT_TRIGGER_SOURCE: ${{ inputs.trigger_source || '' }}
           INPUT_REQUESTER: ${{ inputs.requester || '' }}
-          INPUT_FOCUS: ${{ inputs.focus || '' }}
           INPUT_COMMENT_ID: ${{ inputs.comment_id || '' }}
           GITHUB_ACTOR_LOGIN: ${{ github.actor }}
         run: |
@@ -81,7 +74,6 @@ jobs:
           has_pr_hooks = Path(".github/workflows/pr-hooks.yml").exists()
           trigger_source = os.environ.get("INPUT_TRIGGER_SOURCE", "").strip() or event_name
           requester = os.environ.get("INPUT_REQUESTER", "").strip() or os.environ.get("GITHUB_ACTOR_LOGIN", "")
-          focus = os.environ.get("INPUT_FOCUS", "")
           comment_id = os.environ.get("INPUT_COMMENT_ID", "")
           pr_number = input_pr_number or str(pr.get("number") or "")
           matches_direct_trigger = (
@@ -103,9 +95,6 @@ jobs:
               fh.write(f"pr_number={pr_number}\n")
               fh.write(f"trigger_source={trigger_source}\n")
               fh.write(f"requester={requester}\n")
-              fh.write("focus<<__EOF__\n")
-              fh.write(focus)
-              fh.write("\n__EOF__\n")
               fh.write(f"comment_id={comment_id}\n")
               if has_pr_hooks and event_name == "pull_request_target" and not input_pr_number:
                   fh.write("skip_reason=pr-hooks-present\n")
@@ -133,7 +122,6 @@ jobs:
       pr_number: ${{ needs.resolve.outputs.pr_number }}
       trigger_source: ${{ needs.resolve.outputs.trigger_source }}
       requester: ${{ needs.resolve.outputs.requester }}
-      focus: ${{ needs.resolve.outputs.focus }}
       comment_id: ${{ needs.resolve.outputs.comment_id }}
     secrets:
       OZ_MGMT_GHA_APP_ID: ${{ secrets.OZ_MGMT_GHA_APP_ID }}


### PR DESCRIPTION
## Description
The local `Review Pull Request` workflow in this repo has been failing on every `pull_request_target` event with `startup_failure` (no jobs created) for newly opened PRs. Recent runs that hit this:
- https://github.com/warpdotdev/warp/actions/runs/25059789050
- https://github.com/warpdotdev/warp/actions/runs/25059784082
- https://github.com/warpdotdev/warp/actions/runs/25059568488

### Root cause
`.github/workflows/review-pull-request.yml` declares a `focus` input on its own `workflow_call` interface and forwards it to the upstream reusable workflow at `warpdotdev/oz-for-oss/.github/workflows/review-pull-request.yml@main`. That upstream workflow's `workflow_call` interface no longer declares `focus` — it was removed in oz-for-oss commit [`757b052`](https://github.com/warpdotdev/oz-for-oss/commit/757b052) (PR #393, "feat(review): allow non-collaborator /oz-review and cap at 3 per PR"). When the local job tries to forward `focus:` in its `with:` block, GitHub fails workflow validation before any job is created, which surfaces as `startup_failure`.

### What this PR changes
Drops every reference to `focus` from the local caller so the contract matches the upstream `workflow_call` again:
- Removes the `focus` input from `workflow_call.inputs`
- Removes `INPUT_FOCUS` from the `resolve` step's `env`
- Removes the `focus = os.environ.get("INPUT_FOCUS", "")` read and the heredoc-style `focus<<__EOF__` write to `GITHUB_OUTPUT`
- Removes `focus` from the `resolve` job's `outputs:`
- Removes `focus: ${{ needs.resolve.outputs.focus }}` from the `review_pr` reusable-workflow `with:`

The forwarded inputs are now `pr_number`, `trigger_source`, `requester`, and `comment_id`, matching the upstream interface.

### Note on `enforce-pr-issue-state.yml`
While debugging, I confirmed `enforce-pr-issue-state.yml` is `workflow_call`-only and is not invoked anywhere in this repo (it has zero historical runs), unlike in `oz-for-oss` where `pr-hooks.yml` orchestrates enforcement before reviews. That gap is independent of this fix — `review-pull-request.yml` here listens directly to `pull_request_target` and does not depend on enforcement output. If we want enforcement to gate PR reviews on this repo too, that's a follow-up (either add a `pr-hooks.yml` orchestrator or wire `enforce-pr-issue-state.yml` to listen to `pull_request_target` directly and have `review-pull-request.yml` `needs:` it).

## Testing
- `python3 -c "import yaml; yaml.safe_load(...)"` on the modified workflow to confirm the YAML still parses.
- Diff-checked that the local `with:` block matches the inputs declared by the upstream `workflow_call` at `warpdotdev/oz-for-oss/.github/workflows/review-pull-request.yml@main`.
- After this merges, the next `pull_request_target` event on a non-draft PR should produce a `Review Pull Request` run that actually creates the `resolve` and `review_pr` jobs instead of failing at startup.

## Server API dependencies
N/A — CI workflow change only.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/dd8c9b9a-256b-4c79-abc2-cb513f7236b5_

## Changelog Entries for Stable
