### PR TITLE
Add no-op telemetry context provider for remote server

### DIFF
--- a/app/src/remote_server/mod.rs
+++ b/app/src/remote_server/mod.rs
@@ -58,9 +58,16 @@ pub(super) fn run_daemon_app(
             .spawn(warp_logging::rotate_log_files())
             .detach();
 
+        use crate::server::telemetry::context_provider::NoopTelemetryContextProvider;
         use repo_metadata::repositories::DetectedRepositories;
         use repo_metadata::watcher::DirectoryWatcher;
         use repo_metadata::RepoMetadataModel;
+
+        // Register a no-op telemetry context so that `send_telemetry_from_ctx!`
+        // calls (e.g. from RepoMetadataModel on ExceededMaxFileLimit) don't
+        // panic due to a missing TelemetryContextModel singleton.
+        ctx.add_singleton_model(NoopTelemetryContextProvider::new_context_provider);
+
         // Order matters: DetectedRepositories must be registered before
         // RepoMetadataModel because LocalRepoMetadataModel::new()
         // subscribes to DetectedRepositories::handle(ctx).

--- a/app/src/server/telemetry/context_provider.rs
+++ b/app/src/server/telemetry/context_provider.rs
@@ -24,3 +24,27 @@ impl TelemetryContextProvider for AppTelemetryContextProvider {
         auth_state.anonymous_id()
     }
 }
+
+/// A no-op telemetry context provider for headless contexts (e.g. the remote
+/// server daemon) that run without authentication. Telemetry events that
+/// require a user/anonymous ID will silently produce empty identifiers,
+/// preventing panics from an unregistered `TelemetryContextModel` singleton.
+pub struct NoopTelemetryContextProvider;
+
+impl NoopTelemetryContextProvider {
+    pub fn new_context_provider(
+        _ctx: &mut ModelContext<TelemetryContextModel>,
+    ) -> TelemetryContextModel {
+        Box::new(Self)
+    }
+}
+
+impl TelemetryContextProvider for NoopTelemetryContextProvider {
+    fn user_id(&self, _ctx: &AppContext) -> Option<String> {
+        None
+    }
+
+    fn anonymous_id(&self, _ctx: &AppContext) -> String {
+        String::new()
+    }
+}

--- a/app/src/server/telemetry/context_provider.rs
+++ b/app/src/server/telemetry/context_provider.rs
@@ -29,9 +29,11 @@ impl TelemetryContextProvider for AppTelemetryContextProvider {
 /// server daemon) that run without authentication. Telemetry events that
 /// require a user/anonymous ID will silently produce empty identifiers,
 /// preventing panics from an unregistered `TelemetryContextModel` singleton.
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
 pub struct NoopTelemetryContextProvider;
 
 impl NoopTelemetryContextProvider {
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub fn new_context_provider(
         _ctx: &mut ModelContext<TelemetryContextModel>,
     ) -> TelemetryContextModel {


### PR DESCRIPTION
## Description
Currently our preview remote server implementation could crash if we tried to send a telemetry event because we never initialized our telemetry context provider

We will migrate this soon to an actual telemetry provider once we have auth syncing. But for now, we are going to use a noop telemetry provider

## Testing
Tested locally to confirm this is no longer panicking