### PR TITLE
[WAR-7381] Move "Discard all" to end of code review overflow menu

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -7022,15 +7022,6 @@ impl CodeReviewView {
 
         let has_changes = matches!(self.state(), CodeReviewViewState::Loaded(loaded) if !loaded.to_diff_stats().has_no_changes());
 
-        if FeatureFlag::DiscardPerFileAndAllChanges.is_enabled() && has_changes {
-            items.push(
-                MenuItemFields::new("Discard all")
-                    .with_icon(Icon::ReverseLeft)
-                    .with_on_select_action(CodeReviewAction::ShowDiscardConfirmDialog(None))
-                    .into_item(),
-            );
-        }
-
         let is_ai_enabled = AISettings::as_ref(ctx).is_any_ai_enabled(ctx);
         if is_ai_enabled && FeatureFlag::DiffSetAsContext.is_enabled() && has_changes {
             items.push(
@@ -7053,6 +7044,15 @@ impl CodeReviewView {
                 MenuItemFields::new(comment_label)
                     .with_icon(comment_icon)
                     .with_on_select_action(CodeReviewAction::OpenCommentComposerFromHeader)
+                    .into_item(),
+            );
+        }
+
+        if FeatureFlag::DiscardPerFileAndAllChanges.is_enabled() && has_changes {
+            items.push(
+                MenuItemFields::new("Discard all")
+                    .with_icon(Icon::ReverseLeft)
+                    .with_on_select_action(CodeReviewAction::ShowDiscardConfirmDialog(None))
                     .into_item(),
             );
         }


### PR DESCRIPTION
## Description

Moves the "Discard all" menu item to the last position in `header_menu_items_new`, so it appears after the AI context and comment items. This matches the intended UX ordering from [WAR-7381](https://linear.app/warpdotdev/issue/WAR-7381/discard-all-should-be-the-last-item-in-the-list).

## Testing

Manually verified the ordering logic. No new tests needed — this is a pure reordering of existing menu items with no behavioral changes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>