### PR TITLE
fix(context_chips): stop GitDiffStats flicker from shell fallback

### DIFF
--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -1041,15 +1041,31 @@ impl CurrentPrompt {
                 }
                 RefreshConfig::Periodically { .. } => {
                     if self.is_updated_externally(chip_kind) {
-                        let initial_gen = chip_kind.initial_value_generator();
-                        let generator = initial_gen.as_ref().unwrap_or(chip.generator());
-                        self.fetch_chip_value_once(
-                            chip_kind,
-                            generator,
-                            chip.on_click_generator().cloned(),
-                            true,
-                            ctx,
-                        );
+                        // For chips updated externally (e.g. by the per-repo
+                        // git status filesystem watcher), avoid running the
+                        // periodic shell-based generator. Doing so can briefly
+                        // overwrite the structured watcher value with one that
+                        // uses different semantics (for example, the
+                        // `GitDiffStats` shell fallback runs `git diff
+                        // --shortstat HEAD`, which excludes untracked files,
+                        // whereas the watcher counts untracked files as
+                        // changes), causing the chip to flicker between the
+                        // tracked-only count and the all-files count when
+                        // untracked files are present.
+                        //
+                        // If a chip provides an `initial_value_generator` that
+                        // sources from the prompt context (rather than running
+                        // a shell command), use it for a fast initial value
+                        // until the watcher emits a metadata-changed event.
+                        if let Some(initial_gen) = chip_kind.initial_value_generator() {
+                            self.fetch_chip_value_once(
+                                chip_kind,
+                                &initial_gen,
+                                chip.on_click_generator().cloned(),
+                                true,
+                                ctx,
+                            );
+                        }
                     } else {
                         self.fetch_chip_value_at_interval(
                             chip_kind,


### PR DESCRIPTION
## Summary

Fixes #9228.

When a per-repo `GitRepoStatusModel` is attached to `CurrentPrompt`, the `GitDiffStats` chip is updated via filesystem-watcher events whose `DiffStateModel::diff_metadata_against_head()` count includes untracked files (it walks `git status --untracked-files=all`).

However, every time the prompt context is rebuilt (e.g. when a new block's metadata arrives after a command completes), `run_chips` was still firing the chip's periodic shell-based generator once. For `GitDiffStats` that fallback is `shell_git_line_changes()`, which runs `git diff --shortstat HEAD` and counts only tracked changes. Its result was overwriting the watcher's structured `GitLineChanges` value until the next watcher `MetadataChanged` event restored it — causing the chip to visibly flicker between the tracked-only count and the all-files count whenever untracked files were present.

## Fix

In `CurrentPrompt::run_chips`, when a chip is `is_updated_externally`, only run an `initial_value_generator` if one is provided. The shell-based `chip.generator()` is no longer used as a fallback for externally-driven chips:

- `ShellGitBranch` continues to seed its initial value from `current_environment.git_branch()` via `initial_value_generator`, then receives updates from the watcher.
- `GitDiffStats` has no `initial_value_generator`, so the periodic shell command is now skipped entirely. Initial population is handled by the watcher: `GitRepoStatusModel::new()` kicks off `refresh_metadata` immediately and emits `MetadataChanged` once metadata is computed, which `set_git_repo_status` handles by updating `GitDiffStats` with the structured `GitLineChanges`. Existing chip values survive across `clear_chips()` (which only aborts in-flight generators), so there is no transient empty state on subsequent prompt refreshes.

This keeps the diff-count semantics consistent (always all-files) without changing the behavior of remote/non-watched sessions, which still fall back to the shell generator via the periodic timer branch.

## Test plan

- [ ] In a repo with both modified tracked files and untracked files, run a command (e.g. `ls`) and observe the `GitDiffStats` chip — it should stay on the all-files count without flickering down to the tracked-only count.
- [ ] In a repo without the watcher available (e.g. remote session), confirm the chip still updates periodically via the shell fallback (unchanged code path).
- [ ] `ShellGitBranch` continues to update on branch changes via the watcher and shows the correct branch on first paint.


CHANGELOG-BUG-FIX: Fix git diff chip flickering between tracked-only and all-files count when untracked files are present
