### PR TITLE
Pin conversation list kebab button to the right side of items

### DIFF
--- a/app/src/workspace/view/conversation_list/item.rs
+++ b/app/src/workspace/view/conversation_list/item.rs
@@ -312,16 +312,14 @@ pub fn render_item(props: ItemProps<'_>, app: &AppContext) -> Box<dyn Element> {
                 Some(button_style),
                 appearance,
             );
-            let (parent_anchor, child_anchor, offset_x) = if tooltip_opens_right {
-                (ParentAnchor::TopRight, ChildAnchor::TopRight, -8.)
-            } else {
-                (ParentAnchor::TopLeft, ChildAnchor::TopLeft, 8.)
-            };
+            // The kebab button is pinned to the right edge of the item regardless of which
+            // side of the screen the conversation list panel is on; only the menu's open
+            // direction (handled above) flips with `tooltip_opens_right`.
             let overflow_offset = OffsetPositioning::offset_from_parent(
-                vec2f(offset_x, 6.),
+                vec2f(-8., 6.),
                 ParentOffsetBounds::ParentByPosition,
-                parent_anchor,
-                child_anchor,
+                ParentAnchor::TopRight,
+                ChildAnchor::TopRight,
             );
             // Use add_positioned_child (not overlay) so button stays within item bounds
             stack.add_positioned_child(overflow_button.finish(), overflow_offset);


### PR DESCRIPTION
## Description

Previously we were switching the kebab menu button to the left side of conversation list items when the menu was on the right. This looked bad (and isn't really necessary as long as we open the actual menu on the left side of the button instead of the right), so we're changing it to just stay on the right of the item.

## Testing
demo: https://www.loom.com/share/c6dee7c51c2b49228c4b44a9d590c7b0

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/29ec4431-61fe-4d20-91ec-2e841fc3f389_
_Run: https://oz.staging.warp.dev/runs/019dd4d5-9798-7d71-af0b-8e0b15496f18_

_This PR was generated with [Oz](https://warp.dev/oz)._
