### PR TITLE
Refactor app initialization path to make sure remote server is initialized with the right setup

### DIFF
--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -181,10 +181,11 @@ impl AIExecutionProfilesModel {
                             id: ClientProfileId::new()
                         }
                     }
-                    // Proxy and Daemon don't use AI execution profiles.
-                    // They never reach this code path since they don't go
-                    // through initialize_app, but handle exhaustively.
-                    LaunchMode::Proxy | LaunchMode::Daemon => DefaultProfileState::Unsynced {
+                    // RemoteServerProxy and RemoteServerDaemon don't use AI
+                    // execution profiles. They never reach this code path
+                    // since they don't go through initialize_app, but handle
+                    // exhaustively.
+                    LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon => DefaultProfileState::Unsynced {
                         id: ClientProfileId::new(),
                         profile: AIExecutionProfile::create_default_from_legacy_settings(ctx),
                     },

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -181,6 +181,13 @@ impl AIExecutionProfilesModel {
                             id: ClientProfileId::new()
                         }
                     }
+                    // Proxy and Daemon don't use AI execution profiles.
+                    // They never reach this code path since they don't go
+                    // through initialize_app, but handle exhaustively.
+                    LaunchMode::Proxy | LaunchMode::Daemon => DefaultProfileState::Unsynced {
+                        id: ClientProfileId::new(),
+                        profile: AIExecutionProfile::create_default_from_legacy_settings(ctx),
+                    },
                 };
             }
         }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -478,6 +478,7 @@ impl LaunchMode {
     }
 
     /// Whether Sentry / crash reporting should be initialized in `init_common`.
+    #[cfg_attr(not(feature = "crash_reporting"), allow(dead_code))]
     fn needs_crash_reporting(&self) -> bool {
         match self {
             LaunchMode::App { .. } => true,

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -336,9 +336,9 @@ fn determine_agent_source(
         LaunchMode::App { .. } | LaunchMode::Test { .. } => {
             Some(crate::ai::ambient_agents::AgentSource::CloudMode)
         }
-        // Proxy and Daemon are headless server processes that don't use the
-        // agent subsystem.
-        LaunchMode::Proxy | LaunchMode::Daemon => None,
+        // RemoteServerProxy and RemoteServerDaemon are headless server
+        // processes that don't use the agent subsystem.
+        LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon => None,
     }
 }
 
@@ -371,11 +371,11 @@ pub enum LaunchMode {
 
     /// Remote server proxy — bridges SSH stdio to the daemon's Unix socket.
     /// This is a short-lived process that runs for the lifetime of an SSH session.
-    Proxy,
+    RemoteServerProxy,
 
     /// Remote server daemon — long-lived headless process serving remote
     /// connections via a Unix domain socket.
-    Daemon,
+    RemoteServerDaemon,
 }
 
 impl LaunchMode {
@@ -384,8 +384,8 @@ impl LaunchMode {
             LaunchMode::App { args, .. } => Cow::Borrowed(args),
             LaunchMode::CommandLine { .. }
             | LaunchMode::Test { .. }
-            | LaunchMode::Proxy
-            | LaunchMode::Daemon => Cow::Owned(warp_cli::AppArgs::default()),
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::RemoteServerDaemon => Cow::Owned(warp_cli::AppArgs::default()),
         }
     }
 
@@ -398,8 +398,8 @@ impl LaunchMode {
             } => *is_integration_test,
             LaunchMode::App { .. }
             | LaunchMode::CommandLine { .. }
-            | LaunchMode::Proxy
-            | LaunchMode::Daemon => false,
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::RemoteServerDaemon => false,
         }
     }
 
@@ -408,8 +408,8 @@ impl LaunchMode {
             LaunchMode::Test { driver, .. } => driver.take(),
             LaunchMode::App { .. }
             | LaunchMode::CommandLine { .. }
-            | LaunchMode::Proxy
-            | LaunchMode::Daemon => None,
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::RemoteServerDaemon => None,
         }
     }
 
@@ -426,9 +426,9 @@ impl LaunchMode {
             LaunchMode::App { .. } => ExecutionMode::App,
             LaunchMode::CommandLine { .. } => ExecutionMode::Sdk,
             LaunchMode::Test { .. } => ExecutionMode::App,
-            // Proxy and Daemon don't use execution mode, but Sdk is the
-            // closest match (headless, no GUI).
-            LaunchMode::Proxy | LaunchMode::Daemon => ExecutionMode::Sdk,
+            // RemoteServerProxy and RemoteServerDaemon don't use execution
+            // mode, but Sdk is the closest match (headless, no GUI).
+            LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon => ExecutionMode::Sdk,
         }
     }
 
@@ -437,8 +437,8 @@ impl LaunchMode {
             LaunchMode::CommandLine { is_sandboxed, .. } => *is_sandboxed,
             LaunchMode::App { .. }
             | LaunchMode::Test { .. }
-            | LaunchMode::Proxy
-            | LaunchMode::Daemon => false,
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::RemoteServerDaemon => false,
         }
     }
 
@@ -449,7 +449,7 @@ impl LaunchMode {
                 CliCommand::Agent(AgentCommand::Run(args)) => !args.gui,
                 _ => true,
             },
-            LaunchMode::Proxy | LaunchMode::Daemon => true,
+            LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon => true,
             LaunchMode::App { .. } | LaunchMode::Test { .. } => false,
         }
     }
@@ -461,7 +461,7 @@ impl LaunchMode {
                 matches!(command, CliCommand::Agent(AgentCommand::Run { .. }))
             }
             LaunchMode::App { .. } | LaunchMode::Test { .. } => true,
-            LaunchMode::Proxy | LaunchMode::Daemon => false,
+            LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon => false,
         }
     }
 
@@ -472,8 +472,8 @@ impl LaunchMode {
             LaunchMode::App { .. } => true,
             LaunchMode::CommandLine { .. }
             | LaunchMode::Test { .. }
-            | LaunchMode::Proxy
-            | LaunchMode::Daemon => false,
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::RemoteServerDaemon => false,
         }
     }
 
@@ -481,30 +481,22 @@ impl LaunchMode {
     #[cfg_attr(not(feature = "crash_reporting"), allow(dead_code))]
     fn needs_crash_reporting(&self) -> bool {
         match self {
-            LaunchMode::App { .. } => true,
-            LaunchMode::CommandLine { .. } => true,
-            LaunchMode::Test { .. } => true,
-            LaunchMode::Daemon => true,
-            LaunchMode::Proxy => false,
+            LaunchMode::App { .. }
+            | LaunchMode::CommandLine { .. }
+            | LaunchMode::Test { .. }
+            | LaunchMode::RemoteServerDaemon
+            | LaunchMode::RemoteServerProxy => true,
         }
     }
 
     /// Whether profiling and tracing should be initialized in `init_common`.
     fn needs_profiling(&self) -> bool {
         match self {
-            LaunchMode::App { .. } => true,
-            LaunchMode::CommandLine { .. } => true,
-            LaunchMode::Test { .. } => true,
-            LaunchMode::Daemon => true,
-            LaunchMode::Proxy => false,
-        }
-    }
-
-    /// Whether this is a CLI-like mode (logs to file/stderr, not stdout).
-    fn is_cli_like(&self) -> bool {
-        match self {
-            LaunchMode::App { .. } | LaunchMode::Test { .. } => false,
-            LaunchMode::CommandLine { .. } | LaunchMode::Proxy | LaunchMode::Daemon => true,
+            LaunchMode::App { .. }
+            | LaunchMode::CommandLine { .. }
+            | LaunchMode::Test { .. }
+            | LaunchMode::RemoteServerDaemon
+            | LaunchMode::RemoteServerProxy => true,
         }
     }
 
@@ -519,8 +511,8 @@ impl LaunchMode {
                 }
             }
             // Proxy must log to stderr because stdout is the protocol channel.
-            LaunchMode::Proxy => Some(LogDestination::Stderr),
-            LaunchMode::Daemon => Some(LogDestination::File),
+            LaunchMode::RemoteServerProxy => Some(LogDestination::Stderr),
+            LaunchMode::RemoteServerDaemon => Some(LogDestination::File),
             LaunchMode::App { .. } | LaunchMode::Test { .. } => None,
         }
     }
@@ -643,6 +635,7 @@ pub fn run() -> Result<()> {
                 }
             }
             #[cfg(not(target_family = "wasm"))]
+<<<<<<< HEAD
             warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerProxy(args)) => {
                 init_common(&LaunchMode::Proxy, None)?;
                 return crate::remote_server::run_proxy(args.identity_key.clone());
@@ -651,6 +644,16 @@ pub fn run() -> Result<()> {
             warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerDaemon(args)) => {
                 init_common(&LaunchMode::Daemon, None)?;
                 return crate::remote_server::run_daemon(args.identity_key.clone());
+=======
+            warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerProxy) => {
+                init_common(&LaunchMode::RemoteServerProxy, None)?;
+                return crate::remote_server::run_proxy();
+            }
+            #[cfg(not(target_family = "wasm"))]
+            warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerDaemon) => {
+                init_common(&LaunchMode::RemoteServerDaemon, None)?;
+                return crate::remote_server::run_daemon();
+>>>>>>> f8ebef6 (comments)
             }
             #[cfg(not(target_family = "wasm"))]
             warp_cli::Command::Worker(warp_cli::WorkerCommand::RipgrepSearch {
@@ -773,8 +776,8 @@ fn init_common(launch_mode: &LaunchMode, timer: Option<&mut IntervalTimer>) -> R
         tracing::init()?;
     }
 
-    let is_cli = launch_mode.is_cli_like();
     let log_destination = launch_mode.log_destination();
+    let is_cli = log_destination.is_some();
 
     cfg_if::cfg_if! {
         if #[cfg(enable_crash_recovery)] {
@@ -809,6 +812,10 @@ fn init_common(launch_mode: &LaunchMode, timer: Option<&mut IntervalTimer>) -> R
 }
 
 /// Runs the app.
+///
+/// Note that every initialization step in this function is specific to the GUI app and Oz. If you want
+/// to add setup steps that should be generic to all launch modes (e.g. remote server). It should be added
+/// in init_common instead.
 fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
     let mut timer = IntervalTimer::new();
 
@@ -2374,9 +2381,10 @@ fn launch(ctx: &mut warpui::AppContext, app_state: Option<AppState>, launch_mode
                 }
             }
         }
-        // Proxy and Daemon never go through run_internal / launch; they call
-        // init_common directly and then their own entry points.
-        LaunchMode::Proxy | LaunchMode::Daemon => {
+        // RemoteServerProxy and RemoteServerDaemon never go through
+        // run_internal / launch; they call init_common directly and then
+        // their own entry points.
+        LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon => {
             log::error!("Proxy/Daemon modes should not use the launch() path");
             std::process::exit(1);
         }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -336,6 +336,9 @@ fn determine_agent_source(
         LaunchMode::App { .. } | LaunchMode::Test { .. } => {
             Some(crate::ai::ambient_agents::AgentSource::CloudMode)
         }
+        // Proxy and Daemon are headless server processes that don't use the
+        // agent subsystem.
+        LaunchMode::Proxy | LaunchMode::Daemon => None,
     }
 }
 
@@ -365,13 +368,24 @@ pub enum LaunchMode {
         driver: Box<Option<TestDriver>>,
         is_integration_test: bool,
     },
+
+    /// Remote server proxy — bridges SSH stdio to the daemon's Unix socket.
+    /// This is a short-lived process that runs for the lifetime of an SSH session.
+    Proxy,
+
+    /// Remote server daemon — long-lived headless process serving remote
+    /// connections via a Unix domain socket.
+    Daemon,
 }
 
 impl LaunchMode {
     fn args(&self) -> Cow<'_, warp_cli::AppArgs> {
         match self {
             LaunchMode::App { args, .. } => Cow::Borrowed(args),
-            _ => Cow::Owned(warp_cli::AppArgs::default()),
+            LaunchMode::CommandLine { .. }
+            | LaunchMode::Test { .. }
+            | LaunchMode::Proxy
+            | LaunchMode::Daemon => Cow::Owned(warp_cli::AppArgs::default()),
         }
     }
 
@@ -382,14 +396,20 @@ impl LaunchMode {
                 is_integration_test,
                 ..
             } => *is_integration_test,
-            _ => false,
+            LaunchMode::App { .. }
+            | LaunchMode::CommandLine { .. }
+            | LaunchMode::Proxy
+            | LaunchMode::Daemon => false,
         }
     }
 
     fn take_test_driver(&mut self) -> Option<TestDriver> {
         match self {
             LaunchMode::Test { driver, .. } => driver.take(),
-            _ => None,
+            LaunchMode::App { .. }
+            | LaunchMode::CommandLine { .. }
+            | LaunchMode::Proxy
+            | LaunchMode::Daemon => None,
         }
     }
 
@@ -406,13 +426,19 @@ impl LaunchMode {
             LaunchMode::App { .. } => ExecutionMode::App,
             LaunchMode::CommandLine { .. } => ExecutionMode::Sdk,
             LaunchMode::Test { .. } => ExecutionMode::App,
+            // Proxy and Daemon don't use execution mode, but Sdk is the
+            // closest match (headless, no GUI).
+            LaunchMode::Proxy | LaunchMode::Daemon => ExecutionMode::Sdk,
         }
     }
 
     fn is_sandboxed(&self) -> bool {
         match self {
             LaunchMode::CommandLine { is_sandboxed, .. } => *is_sandboxed,
-            _ => false,
+            LaunchMode::App { .. }
+            | LaunchMode::Test { .. }
+            | LaunchMode::Proxy
+            | LaunchMode::Daemon => false,
         }
     }
 
@@ -423,7 +449,8 @@ impl LaunchMode {
                 CliCommand::Agent(AgentCommand::Run(args)) => !args.gui,
                 _ => true,
             },
-            _ => false,
+            LaunchMode::Proxy | LaunchMode::Daemon => true,
+            LaunchMode::App { .. } | LaunchMode::Test { .. } => false,
         }
     }
 
@@ -433,7 +460,8 @@ impl LaunchMode {
             LaunchMode::CommandLine { command, .. } => {
                 matches!(command, CliCommand::Agent(AgentCommand::Run { .. }))
             }
-            _ => true,
+            LaunchMode::App { .. } | LaunchMode::Test { .. } => true,
+            LaunchMode::Proxy | LaunchMode::Daemon => false,
         }
     }
 
@@ -442,8 +470,59 @@ impl LaunchMode {
     pub(crate) fn crash_recovery_enabled(&self) -> bool {
         match self {
             LaunchMode::App { .. } => true,
-            LaunchMode::CommandLine { .. } => false,
-            LaunchMode::Test { .. } => false,
+            LaunchMode::CommandLine { .. }
+            | LaunchMode::Test { .. }
+            | LaunchMode::Proxy
+            | LaunchMode::Daemon => false,
+        }
+    }
+
+    /// Whether Sentry / crash reporting should be initialized in `init_common`.
+    fn needs_crash_reporting(&self) -> bool {
+        match self {
+            LaunchMode::App { .. } => true,
+            LaunchMode::CommandLine { .. } => true,
+            LaunchMode::Test { .. } => true,
+            LaunchMode::Daemon => true,
+            LaunchMode::Proxy => false,
+        }
+    }
+
+    /// Whether profiling and tracing should be initialized in `init_common`.
+    fn needs_profiling(&self) -> bool {
+        match self {
+            LaunchMode::App { .. } => true,
+            LaunchMode::CommandLine { .. } => true,
+            LaunchMode::Test { .. } => true,
+            LaunchMode::Daemon => true,
+            LaunchMode::Proxy => false,
+        }
+    }
+
+    /// Whether this is a CLI-like mode (logs to file/stderr, not stdout).
+    fn is_cli_like(&self) -> bool {
+        match self {
+            LaunchMode::App { .. } | LaunchMode::Test { .. } => false,
+            LaunchMode::CommandLine { .. }
+            | LaunchMode::Proxy
+            | LaunchMode::Daemon => true,
+        }
+    }
+
+    /// Log destination for this mode.
+    fn log_destination(&self) -> Option<LogDestination> {
+        match self {
+            LaunchMode::CommandLine { debug, .. } => {
+                if *debug {
+                    Some(LogDestination::Stderr)
+                } else {
+                    Some(LogDestination::File)
+                }
+            }
+            // Proxy must log to stderr because stdout is the protocol channel.
+            LaunchMode::Proxy => Some(LogDestination::Stderr),
+            LaunchMode::Daemon => Some(LogDestination::File),
+            LaunchMode::App { .. } | LaunchMode::Test { .. } => None,
         }
     }
 
@@ -566,10 +645,12 @@ pub fn run() -> Result<()> {
             }
             #[cfg(not(target_family = "wasm"))]
             warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerProxy(args)) => {
+                init_common(&LaunchMode::Proxy, None)?;
                 return crate::remote_server::run_proxy(args.identity_key.clone());
             }
             #[cfg(not(target_family = "wasm"))]
             warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerDaemon(args)) => {
+                init_common(&LaunchMode::Daemon, None)?;
                 return crate::remote_server::run_daemon(args.identity_key.clone());
             }
             #[cfg(not(target_family = "wasm"))]
@@ -663,21 +744,28 @@ pub fn run_integration_test(driver: TestDriver) -> Result<()> {
     run_internal(launch)
 }
 
-/// Runs the app.
-fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
+/// Shared early initialization for **every** process type (app, CLI, proxy,
+/// daemon).  Every step in this function runs for all modes, including
+/// lightweight ones like Proxy.  Think carefully before adding here — if
+/// the step is only needed by the full app, add it to `run_internal`
+/// instead.
+fn init_common(
+    launch_mode: &LaunchMode,
+    timer: Option<&mut IntervalTimer>,
+) -> Result<()> {
     #[cfg(windows)]
     dynamic_libraries::configure_library_loading();
 
-    profiling::init();
+    if launch_mode.needs_profiling() {
+        profiling::init();
+    }
 
     // The `run` function already initializes feature flags, but ensure they're initialized here
     // for other entrypoints.
     init_feature_flags();
 
-    let mut timer = IntervalTimer::new();
-
     #[cfg(feature = "crash_reporting")]
-    {
+    if launch_mode.needs_crash_reporting() {
         // Ensure that the main/root Sentry hub is initialized on the main
         // thread.  PtySpawner creates a background thread to receive logs from
         // the terminal server process, and we don't want it to be the host of
@@ -685,21 +773,12 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
         sentry::Hub::main();
     }
 
-    tracing::init()?;
+    if launch_mode.needs_profiling() {
+        tracing::init()?;
+    }
 
-    let is_cli = matches!(launch_mode, LaunchMode::CommandLine { .. });
-
-    // Log to a file for CLI commands to not obscure the command output.
-    let log_destination = match &launch_mode {
-        LaunchMode::CommandLine { debug, .. } => {
-            if *debug {
-                Some(LogDestination::Stderr)
-            } else {
-                Some(LogDestination::File)
-            }
-        }
-        _ => None,
-    };
+    let is_cli = launch_mode.is_cli_like();
+    let log_destination = launch_mode.log_destination();
 
     cfg_if::cfg_if! {
         if #[cfg(enable_crash_recovery)] {
@@ -713,12 +792,31 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
         }
     }
 
-    timer.mark_interval_end("LOG_FILE_SETUP_COMPLETE");
+    if let Some(timer) = timer {
+        timer.mark_interval_end("LOG_FILE_SETUP_COMPLETE");
+    }
 
     // Adjust resource limits early, before doing other work, to ensure that
     // any children we spawn (like the terminal server) inherit our adjusted
     // rlimits.
     resource_limits::adjust_resource_limits();
+
+    // Configure rustls to use its default crypto provider.  This MUST be called
+    // before making any network requests that use TLS, otherwise rustls will
+    // panic.
+    #[cfg(not(target_family = "wasm"))]
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("must be able to initialize crypto provider for TLS support");
+
+    Ok(())
+}
+
+/// Runs the app.
+fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
+    let mut timer = IntervalTimer::new();
+
+    init_common(&launch_mode, Some(&mut timer))?;
 
     // For wasm builds we have this special case to parse out the intent
     // from the url that is used to visite the app on web.
@@ -790,14 +888,6 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
     // start spawning any child processes.
     #[cfg(windows)]
     command::windows::init();
-
-    // Configure rustls to use its default crypto provider.  This MUST be called
-    // before making any network requests that use TLS, otherwise rustls will
-    // panic.
-    #[cfg(not(target_family = "wasm"))]
-    rustls::crypto::aws_lc_rs::default_provider()
-        .install_default()
-        .expect("must be able to initialize crypto provider for TLS support");
 
     let private_preferences = settings::init_private_user_preferences();
     let (public_preferences, startup_toml_parse_error) = settings::init_public_user_preferences();
@@ -2287,6 +2377,12 @@ fn launch(ctx: &mut warpui::AppContext, app_state: Option<AppState>, launch_mode
                     }
                 }
             }
+        }
+        // Proxy and Daemon never go through run_internal / launch; they call
+        // init_common directly and then their own entry points.
+        LaunchMode::Proxy | LaunchMode::Daemon => {
+            log::error!("Proxy/Daemon modes should not use the launch() path");
+            std::process::exit(1);
         }
     }
 }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -503,9 +503,7 @@ impl LaunchMode {
     fn is_cli_like(&self) -> bool {
         match self {
             LaunchMode::App { .. } | LaunchMode::Test { .. } => false,
-            LaunchMode::CommandLine { .. }
-            | LaunchMode::Proxy
-            | LaunchMode::Daemon => true,
+            LaunchMode::CommandLine { .. } | LaunchMode::Proxy | LaunchMode::Daemon => true,
         }
     }
 
@@ -749,10 +747,7 @@ pub fn run_integration_test(driver: TestDriver) -> Result<()> {
 /// lightweight ones like Proxy.  Think carefully before adding here — if
 /// the step is only needed by the full app, add it to `run_internal`
 /// instead.
-fn init_common(
-    launch_mode: &LaunchMode,
-    timer: Option<&mut IntervalTimer>,
-) -> Result<()> {
+fn init_common(launch_mode: &LaunchMode, timer: Option<&mut IntervalTimer>) -> Result<()> {
     #[cfg(windows)]
     dynamic_libraries::configure_library_loading();
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -635,25 +635,14 @@ pub fn run() -> Result<()> {
                 }
             }
             #[cfg(not(target_family = "wasm"))]
-<<<<<<< HEAD
             warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerProxy(args)) => {
-                init_common(&LaunchMode::Proxy, None)?;
+                init_common(&LaunchMode::RemoteServerProxy, None)?;
                 return crate::remote_server::run_proxy(args.identity_key.clone());
             }
             #[cfg(not(target_family = "wasm"))]
             warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerDaemon(args)) => {
-                init_common(&LaunchMode::Daemon, None)?;
-                return crate::remote_server::run_daemon(args.identity_key.clone());
-=======
-            warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerProxy) => {
-                init_common(&LaunchMode::RemoteServerProxy, None)?;
-                return crate::remote_server::run_proxy();
-            }
-            #[cfg(not(target_family = "wasm"))]
-            warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerDaemon) => {
                 init_common(&LaunchMode::RemoteServerDaemon, None)?;
-                return crate::remote_server::run_daemon();
->>>>>>> f8ebef6 (comments)
+                return crate::remote_server::run_daemon(args.identity_key.clone());
             }
             #[cfg(not(target_family = "wasm"))]
             warp_cli::Command::Worker(warp_cli::WorkerCommand::RipgrepSearch {

--- a/app/src/remote_server/mod.rs
+++ b/app/src/remote_server/mod.rs
@@ -20,7 +20,7 @@ pub mod unix;
 /// Run the `remote-server-proxy` subcommand.
 #[cfg(unix)]
 pub fn run_proxy(identity_key: String) -> anyhow::Result<()> {
-    unix::run_proxy(identity_key)
+    unix::proxy::run(&identity_key)
 }
 
 #[cfg(not(unix))]

--- a/app/src/remote_server/unix/mod.rs
+++ b/app/src/remote_server/unix/mod.rs
@@ -11,24 +11,12 @@
 //! All platform-specific code is contained here so that the parent `mod.rs`
 //! is a thin dispatcher with no Unix assumptions.
 
-mod proxy;
+pub(super) mod proxy;
 
 use super::server_model::{ConnectionId, ServerModel};
 use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
 use warpui::r#async::executor;
-
-/// Run the `remote-server-proxy` subcommand.
-///
-/// Ensures the daemon is running (starting it if necessary), then bridges
-/// this process's stdin/stdout to the daemon's Unix socket for the lifetime
-/// of the SSH session.
-pub fn run_proxy(identity_key: String) -> anyhow::Result<()> {
-    env_logger::Builder::from_default_env()
-        .target(env_logger::Target::Stderr)
-        .init();
-    proxy::run(&identity_key)
-}
 
 /// Run the `remote-server-daemon` subcommand.
 ///
@@ -36,15 +24,6 @@ pub fn run_proxy(identity_key: String) -> anyhow::Result<()> {
 /// WarpUI app startup to [`super::run_daemon_app`] with the Unix-specific
 /// `ServerModel` constructor.
 pub fn run_daemon(identity_key: String) -> anyhow::Result<()> {
-    // Log to a rotating file so daemon output is preserved across invocations.
-    // The file is written to the same directory as client logs (~/Library/Logs
-    // on macOS, ~/.local/share/warp-terminal on Linux). Since the daemon runs
-    // on the remote host, there is no conflict with client-side log files.
-    warp_logging::init(warp_logging::LogConfig {
-        is_cli: true,
-        log_destination: Some(warp_logging::LogDestination::File),
-    })?;
-
     // socket_path: ~/.warp[-channel]/remote-server/{identity_key}/server.sock
     //   The Unix domain socket the daemon binds on.  Proxy processes connect
     //   to it and bridge their SSH stdio channel through it.


### PR DESCRIPTION
## Description
Right now our app initialization logic in `run_internal` contains a mix of different components:
1. Shared initialization of resources like sentry crash reporting and logger that should be shared with most launch modes
2. App specific initialization of singleton models, plugins, etc

This means when we introduce new launch modes (e.g. proxy / daemon) with remote server, we could easily miss initialization of some resources

This PR refactors it so we pull out a shared `init_common` method for (1) that specifically sets up:
1. Feature flags
2. Logging
3. Resource limits
4. TLS crypto provider 

Each LaunchModel also now provides implementation to opt-out of each of the steps above

## Testing
Tested locally
