### PR TITLE
Add OpenRouter BYOK model support

### DIFF
--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use parking_lot::FairMutex;
 use serde::{de, Deserialize, Serialize};
 use std::{
@@ -36,6 +37,7 @@ pub fn is_using_api_key_for_provider(provider: &LLMProvider, app: &AppContext) -
         LLMProvider::OpenAI => api_keys.is_some_and(|keys| keys.openai.is_some()),
         LLMProvider::Anthropic => api_keys.is_some_and(|keys| keys.anthropic.is_some()),
         LLMProvider::Google => api_keys.is_some_and(|keys| keys.google.is_some()),
+        LLMProvider::OpenRouter => api_keys.is_some_and(|keys| keys.open_router.is_some()),
         _ => false,
     }
 }
@@ -89,6 +91,7 @@ pub enum LLMProvider {
     Anthropic,
     Google,
     Xai,
+    OpenRouter,
     Unknown,
 }
 
@@ -100,6 +103,7 @@ impl LLMProvider {
             LLMProvider::Anthropic => Some(Icon::ClaudeLogo),
             LLMProvider::Google => Some(Icon::GeminiLogo),
             LLMProvider::Xai => None,
+            LLMProvider::OpenRouter => None,
             LLMProvider::Unknown => None,
         }
     }
@@ -136,6 +140,25 @@ pub struct LLMInfo {
     pub provider: LLMProvider,
     pub host_configs: HashMap<LLMModelHost, RoutingHostConfig>,
     pub discount_percentage: Option<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterModelsResponse {
+    data: Vec<OpenRouterModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterModel {
+    id: String,
+    name: Option<String>,
+    description: Option<String>,
+    architecture: Option<OpenRouterArchitecture>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenRouterArchitecture {
+    #[serde(default)]
+    input_modalities: Vec<String>,
 }
 
 impl<'de> Deserialize<'de> for LLMInfo {
@@ -853,9 +876,33 @@ impl LLMPreferences {
             return;
         }
 
+        let open_router_api_key = UserWorkspaces::as_ref(ctx)
+            .is_byo_api_key_enabled()
+            .then(|| {
+                ai::api_keys::ApiKeyManager::as_ref(ctx)
+                    .keys()
+                    .open_router
+                    .clone()
+            })
+            .flatten();
         let ai_api_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         ctx.spawn(
-            async move { ai_api_client.get_feature_model_choices().await },
+            async move {
+                let mut update = ai_api_client.get_feature_model_choices().await?;
+                if let Some(open_router_api_key) = open_router_api_key {
+                    match fetch_open_router_models(open_router_api_key).await {
+                        Ok(open_router_models) => {
+                            merge_open_router_models(&mut update, open_router_models);
+                        }
+                        Err(e) => {
+                            report_error!(e.context(
+                                "Failed to fetch OpenRouter models; using Warp model list"
+                            ));
+                        }
+                    }
+                }
+                Ok::<ModelsByFeature, anyhow::Error>(update)
+            },
             |me, result, ctx| match result {
                 Ok(update) => {
                     if update != me.models_by_feature {
@@ -1047,6 +1094,85 @@ fn get_new_agent_mode_choices(
         .filter(|info| !old_ids.contains(&info.id))
         .cloned()
         .collect()
+}
+
+async fn fetch_open_router_models(api_key: String) -> anyhow::Result<Vec<LLMInfo>> {
+    let response = reqwest::Client::new()
+        .get("https://openrouter.ai/api/v1/models")
+        .bearer_auth(api_key)
+        .header("HTTP-Referer", "https://warp.dev")
+        .header("X-Title", "Warp")
+        .send()
+        .await
+        .context("Failed to call OpenRouter models endpoint")?
+        .error_for_status()
+        .context("OpenRouter models endpoint returned an error")?
+        .json::<OpenRouterModelsResponse>()
+        .await
+        .context("Failed to parse OpenRouter models response")?;
+
+    Ok(response
+        .data
+        .into_iter()
+        .map(OpenRouterModel::into_llm_info)
+        .collect())
+}
+
+impl OpenRouterModel {
+    fn into_llm_info(self) -> LLMInfo {
+        let display_name = self.name.unwrap_or_else(|| self.id.clone());
+        let vision_supported = self.architecture.is_some_and(|architecture| {
+            architecture
+                .input_modalities
+                .iter()
+                .any(|modality| modality.eq_ignore_ascii_case("image"))
+        });
+
+        LLMInfo {
+            display_name: display_name.clone(),
+            base_model_name: display_name,
+            id: self.id.into(),
+            reasoning_level: None,
+            usage_metadata: LLMUsageMetadata {
+                request_multiplier: 1,
+                credit_multiplier: None,
+            },
+            description: self.description,
+            disable_reason: None,
+            vision_supported,
+            spec: None,
+            provider: LLMProvider::OpenRouter,
+            host_configs: HashMap::from([(
+                LLMModelHost::DirectApi,
+                RoutingHostConfig {
+                    enabled: true,
+                    model_routing_host: LLMModelHost::DirectApi,
+                },
+            )]),
+            discount_percentage: None,
+        }
+    }
+}
+
+fn merge_open_router_models(
+    models_by_feature: &mut ModelsByFeature,
+    open_router_models: Vec<LLMInfo>,
+) {
+    merge_open_router_models_into_available(&mut models_by_feature.agent_mode, &open_router_models);
+    merge_open_router_models_into_available(&mut models_by_feature.coding, &open_router_models);
+    if let Some(cli_agent) = &mut models_by_feature.cli_agent {
+        merge_open_router_models_into_available(cli_agent, &open_router_models);
+    }
+}
+
+fn merge_open_router_models_into_available(
+    available: &mut AvailableLLMs,
+    open_router_models: &[LLMInfo],
+) {
+    available
+        .choices
+        .retain(|choice| choice.provider != LLMProvider::OpenRouter);
+    available.choices.extend(open_router_models.iter().cloned());
 }
 
 /// Gets the last cached LLM metadata.

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use parking_lot::FairMutex;
 use serde::{de, Deserialize, Serialize};
 use std::{
@@ -140,25 +139,6 @@ pub struct LLMInfo {
     pub provider: LLMProvider,
     pub host_configs: HashMap<LLMModelHost, RoutingHostConfig>,
     pub discount_percentage: Option<f32>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OpenRouterModelsResponse {
-    data: Vec<OpenRouterModel>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OpenRouterModel {
-    id: String,
-    name: Option<String>,
-    description: Option<String>,
-    architecture: Option<OpenRouterArchitecture>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OpenRouterArchitecture {
-    #[serde(default)]
-    input_modalities: Vec<String>,
 }
 
 impl<'de> Deserialize<'de> for LLMInfo {
@@ -876,33 +856,9 @@ impl LLMPreferences {
             return;
         }
 
-        let open_router_api_key = UserWorkspaces::as_ref(ctx)
-            .is_byo_api_key_enabled()
-            .then(|| {
-                ai::api_keys::ApiKeyManager::as_ref(ctx)
-                    .keys()
-                    .open_router
-                    .clone()
-            })
-            .flatten();
         let ai_api_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         ctx.spawn(
-            async move {
-                let mut update = ai_api_client.get_feature_model_choices().await?;
-                if let Some(open_router_api_key) = open_router_api_key {
-                    match fetch_open_router_models(open_router_api_key).await {
-                        Ok(open_router_models) => {
-                            merge_open_router_models(&mut update, open_router_models);
-                        }
-                        Err(e) => {
-                            report_error!(e.context(
-                                "Failed to fetch OpenRouter models; using Warp model list"
-                            ));
-                        }
-                    }
-                }
-                Ok::<ModelsByFeature, anyhow::Error>(update)
-            },
+            async move { ai_api_client.get_feature_model_choices().await },
             |me, result, ctx| match result {
                 Ok(update) => {
                     if update != me.models_by_feature {
@@ -1094,85 +1050,6 @@ fn get_new_agent_mode_choices(
         .filter(|info| !old_ids.contains(&info.id))
         .cloned()
         .collect()
-}
-
-async fn fetch_open_router_models(api_key: String) -> anyhow::Result<Vec<LLMInfo>> {
-    let response = reqwest::Client::new()
-        .get("https://openrouter.ai/api/v1/models")
-        .bearer_auth(api_key)
-        .header("HTTP-Referer", "https://warp.dev")
-        .header("X-Title", "Warp")
-        .send()
-        .await
-        .context("Failed to call OpenRouter models endpoint")?
-        .error_for_status()
-        .context("OpenRouter models endpoint returned an error")?
-        .json::<OpenRouterModelsResponse>()
-        .await
-        .context("Failed to parse OpenRouter models response")?;
-
-    Ok(response
-        .data
-        .into_iter()
-        .map(OpenRouterModel::into_llm_info)
-        .collect())
-}
-
-impl OpenRouterModel {
-    fn into_llm_info(self) -> LLMInfo {
-        let display_name = self.name.unwrap_or_else(|| self.id.clone());
-        let vision_supported = self.architecture.is_some_and(|architecture| {
-            architecture
-                .input_modalities
-                .iter()
-                .any(|modality| modality.eq_ignore_ascii_case("image"))
-        });
-
-        LLMInfo {
-            display_name: display_name.clone(),
-            base_model_name: display_name,
-            id: self.id.into(),
-            reasoning_level: None,
-            usage_metadata: LLMUsageMetadata {
-                request_multiplier: 1,
-                credit_multiplier: None,
-            },
-            description: self.description,
-            disable_reason: None,
-            vision_supported,
-            spec: None,
-            provider: LLMProvider::OpenRouter,
-            host_configs: HashMap::from([(
-                LLMModelHost::DirectApi,
-                RoutingHostConfig {
-                    enabled: true,
-                    model_routing_host: LLMModelHost::DirectApi,
-                },
-            )]),
-            discount_percentage: None,
-        }
-    }
-}
-
-fn merge_open_router_models(
-    models_by_feature: &mut ModelsByFeature,
-    open_router_models: Vec<LLMInfo>,
-) {
-    merge_open_router_models_into_available(&mut models_by_feature.agent_mode, &open_router_models);
-    merge_open_router_models_into_available(&mut models_by_feature.coding, &open_router_models);
-    if let Some(cli_agent) = &mut models_by_feature.cli_agent {
-        merge_open_router_models_into_available(cli_agent, &open_router_models);
-    }
-}
-
-fn merge_open_router_models_into_available(
-    available: &mut AvailableLLMs,
-    open_router_models: &[LLMInfo],
-) {
-    available
-        .choices
-        .retain(|choice| choice.provider != LLMProvider::OpenRouter);
-    available.choices.extend(open_router_models.iter().cloned());
 }
 
 /// Gets the last cached LLM metadata.

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::HashMap;
 
 #[test]
 fn llm_info_deserializes_without_base_model_name() {
@@ -80,4 +81,69 @@ fn llm_info_round_trip_serializes_and_deserializes() {
         serde_json::from_str(&serialized).expect("should deserialize after round trip");
 
     assert_eq!(info, round_tripped);
+}
+
+#[test]
+fn open_router_model_maps_to_llm_info() {
+    let info = OpenRouterModel {
+        id: "anthropic/claude-sonnet-4.5".to_string(),
+        name: Some("Claude Sonnet 4.5".to_string()),
+        description: Some("OpenRouter hosted model".to_string()),
+        architecture: Some(OpenRouterArchitecture {
+            input_modalities: vec!["text".to_string(), "image".to_string()],
+        }),
+    }
+    .into_llm_info();
+
+    assert_eq!(info.id.to_string(), "anthropic/claude-sonnet-4.5");
+    assert_eq!(info.display_name, "Claude Sonnet 4.5");
+    assert_eq!(info.provider, LLMProvider::OpenRouter);
+    assert!(info.vision_supported);
+    assert!(info
+        .host_configs
+        .get(&LLMModelHost::DirectApi)
+        .is_some_and(|config| config.enabled));
+}
+
+#[test]
+fn merge_open_router_models_replaces_existing_open_router_choices() {
+    let mut models_by_feature = ModelsByFeature::default();
+    models_by_feature.agent_mode.choices.push(LLMInfo {
+        display_name: "Old OpenRouter Model".to_string(),
+        base_model_name: "Old OpenRouter Model".to_string(),
+        id: "old/openrouter".to_string().into(),
+        reasoning_level: None,
+        usage_metadata: LLMUsageMetadata {
+            request_multiplier: 1,
+            credit_multiplier: None,
+        },
+        description: None,
+        disable_reason: None,
+        vision_supported: false,
+        spec: None,
+        provider: LLMProvider::OpenRouter,
+        host_configs: HashMap::new(),
+        discount_percentage: None,
+    });
+
+    let replacement = OpenRouterModel {
+        id: "openai/gpt-4o".to_string(),
+        name: Some("GPT-4o".to_string()),
+        description: None,
+        architecture: None,
+    }
+    .into_llm_info();
+
+    merge_open_router_models(&mut models_by_feature, vec![replacement]);
+
+    assert!(models_by_feature
+        .agent_mode
+        .choices
+        .iter()
+        .any(|info| info.id.to_string() == "openai/gpt-4o"));
+    assert!(models_by_feature
+        .agent_mode
+        .choices
+        .iter()
+        .all(|info| info.id.to_string() != "old/openrouter"));
 }

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::collections::HashMap;
 
 #[test]
 fn llm_info_deserializes_without_base_model_name() {
@@ -81,69 +80,4 @@ fn llm_info_round_trip_serializes_and_deserializes() {
         serde_json::from_str(&serialized).expect("should deserialize after round trip");
 
     assert_eq!(info, round_tripped);
-}
-
-#[test]
-fn open_router_model_maps_to_llm_info() {
-    let info = OpenRouterModel {
-        id: "anthropic/claude-sonnet-4.5".to_string(),
-        name: Some("Claude Sonnet 4.5".to_string()),
-        description: Some("OpenRouter hosted model".to_string()),
-        architecture: Some(OpenRouterArchitecture {
-            input_modalities: vec!["text".to_string(), "image".to_string()],
-        }),
-    }
-    .into_llm_info();
-
-    assert_eq!(info.id.to_string(), "anthropic/claude-sonnet-4.5");
-    assert_eq!(info.display_name, "Claude Sonnet 4.5");
-    assert_eq!(info.provider, LLMProvider::OpenRouter);
-    assert!(info.vision_supported);
-    assert!(info
-        .host_configs
-        .get(&LLMModelHost::DirectApi)
-        .is_some_and(|config| config.enabled));
-}
-
-#[test]
-fn merge_open_router_models_replaces_existing_open_router_choices() {
-    let mut models_by_feature = ModelsByFeature::default();
-    models_by_feature.agent_mode.choices.push(LLMInfo {
-        display_name: "Old OpenRouter Model".to_string(),
-        base_model_name: "Old OpenRouter Model".to_string(),
-        id: "old/openrouter".to_string().into(),
-        reasoning_level: None,
-        usage_metadata: LLMUsageMetadata {
-            request_multiplier: 1,
-            credit_multiplier: None,
-        },
-        description: None,
-        disable_reason: None,
-        vision_supported: false,
-        spec: None,
-        provider: LLMProvider::OpenRouter,
-        host_configs: HashMap::new(),
-        discount_percentage: None,
-    });
-
-    let replacement = OpenRouterModel {
-        id: "openai/gpt-4o".to_string(),
-        name: Some("GPT-4o".to_string()),
-        description: None,
-        architecture: None,
-    }
-    .into_llm_info();
-
-    merge_open_router_models(&mut models_by_feature, vec![replacement]);
-
-    assert!(models_by_feature
-        .agent_mode
-        .choices
-        .iter()
-        .any(|info| info.id.to_string() == "openai/gpt-4o"));
-    assert!(models_by_feature
-        .agent_mode
-        .choices
-        .iter()
-        .all(|info| info.id.to_string() != "old/openrouter"));
 }

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -2129,6 +2129,9 @@ impl From<warp_graphql::queries::get_feature_model_choices::LlmProvider> for LLM
                 LLMProvider::Google
             }
             warp_graphql::queries::get_feature_model_choices::LlmProvider::Xai => LLMProvider::Xai,
+            warp_graphql::queries::get_feature_model_choices::LlmProvider::Openrouter => {
+                LLMProvider::OpenRouter
+            }
             warp_graphql::queries::get_feature_model_choices::LlmProvider::Unknown => {
                 LLMProvider::Unknown
             }
@@ -2149,6 +2152,7 @@ impl From<warp_graphql::workspace::LlmProvider> for LLMProvider {
             warp_graphql::workspace::LlmProvider::Anthropic => LLMProvider::Anthropic,
             warp_graphql::workspace::LlmProvider::Google => LLMProvider::Google,
             warp_graphql::workspace::LlmProvider::Xai => LLMProvider::Xai,
+            warp_graphql::workspace::LlmProvider::Openrouter => LLMProvider::OpenRouter,
             warp_graphql::workspace::LlmProvider::Unknown => LLMProvider::Unknown,
             warp_graphql::workspace::LlmProvider::Other(value) => {
                 report_error!(anyhow!(

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -3052,7 +3052,7 @@ impl SettingsWidget for GlobalAIWidget {
 
     fn search_terms(&self) -> &str {
         "oz warp agent global ai a.i. active next command prompt code diffs suggestion suggested suggestions \
-                agent mode natural language detection input hint api keys bring your own byo google anthropic openai"
+                agent mode natural language detection input hint api keys bring your own byo google anthropic openai openrouter"
     }
 
     fn render(
@@ -5802,6 +5802,7 @@ struct ApiKeysWidget {
     openai_api_key_editor: ViewHandle<EditorView>,
     anthropic_api_key_editor: ViewHandle<EditorView>,
     google_api_key_editor: ViewHandle<EditorView>,
+    open_router_api_key_editor: ViewHandle<EditorView>,
 
     can_use_warp_credits_with_byok: SwitchStateHandle,
     upgrade_highlight_index: HighlightedHyperlink,
@@ -5818,6 +5819,7 @@ impl ApiKeysWidget {
             openai: openai_key,
             anthropic: anthropic_key,
             google: google_key,
+            open_router: open_router_key,
             ..
         } = ApiKeyManager::as_ref(ctx).keys().clone();
 
@@ -5859,6 +5861,9 @@ impl ApiKeysWidget {
                         let key = buffer_text.is_empty().not().then_some(buffer_text);
                         ApiKeyManager::handle(ctx).update(ctx, |model, ctx| {
                             model.$set_func(key, ctx);
+                        });
+                        LLMPreferences::handle(ctx).update(ctx, |preferences, ctx| {
+                            preferences.refresh_available_models(ctx);
                         });
                     }
                 });
@@ -5905,11 +5910,18 @@ impl ApiKeysWidget {
             set_google_key,
             "AIzaSy..."
         );
+        create_api_key_editor!(
+            open_router_api_key_editor,
+            open_router_key,
+            set_open_router_key,
+            "sk-or-v1-..."
+        );
 
         Self {
             openai_api_key_editor,
             anthropic_api_key_editor,
             google_api_key_editor,
+            open_router_api_key_editor,
 
             can_use_warp_credits_with_byok: Default::default(),
             upgrade_highlight_index: Default::default(),
@@ -5996,6 +6008,13 @@ impl ApiKeysWidget {
             appearance,
             "Google API Key",
             self.google_api_key_editor.clone(),
+            is_enabled,
+            app,
+        ));
+        column.add_child(render_api_key_input(
+            appearance,
+            "OpenRouter API Key",
+            self.open_router_api_key_editor.clone(),
             is_enabled,
             app,
         ));
@@ -6097,7 +6116,7 @@ impl SettingsWidget for ApiKeysWidget {
     type View = AISettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "api keys bring your own byo openai anthropic google claude gemini gpt"
+        "api keys bring your own byo openai anthropic google openrouter claude gemini gpt"
     }
 
     fn render(

--- a/app/src/terminal/input/models/data_source.rs
+++ b/app/src/terminal/input/models/data_source.rs
@@ -496,7 +496,10 @@ impl SearchItem for ModelSearchItem {
             let byok_available = UserWorkspaces::as_ref(app).is_byo_api_key_enabled()
                 && matches!(
                     self.provider,
-                    LLMProvider::OpenAI | LLMProvider::Anthropic | LLMProvider::Google
+                    LLMProvider::OpenAI
+                        | LLMProvider::Anthropic
+                        | LLMProvider::Google
+                        | LLMProvider::OpenRouter
                 );
 
             let mut text_fragments = vec![

--- a/crates/graphql/src/api/queries/get_feature_model_choices.rs
+++ b/crates/graphql/src/api/queries/get_feature_model_choices.rs
@@ -107,6 +107,7 @@ pub enum LlmProvider {
     Anthropic,
     Google,
     Xai,
+    Openrouter,
     Unknown,
     #[cynic(fallback)]
     Other(String),

--- a/crates/graphql/src/api/workspace.rs
+++ b/crates/graphql/src/api/workspace.rs
@@ -70,6 +70,7 @@ pub enum LlmProvider {
     Anthropic,
     Google,
     Xai,
+    Openrouter,
     Unknown,
     #[cynic(fallback)]
     Other(String),

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -1882,6 +1882,7 @@ enum LlmProvider {
   ANTHROPIC
   GOOGLE
   OPENAI
+  OPENROUTER
   UNKNOWN
   XAI
 }


### PR DESCRIPTION
## Summary
- Add OpenRouter as a recognized LLM provider for BYOK model selection.
- Add an OpenRouter API key field to AI settings and refresh model choices after the key is saved.
- Treat server-approved OpenRouter models as BYOK-capable in the model picker.

## Note
This intentionally does not fetch arbitrary OpenRouter catalog models client-side. Warp's agent backend currently validates selected model IDs against the account's server-approved model list, so showing unsupported OpenRouter model IDs causes requests like `/agent` to fail with `the requested base model ... is not allowed for your account`.

## Testing
- `cargo fmt --check`
- `cargo check -p warp_graphql -p ai -p warp --lib`
- `cargo clippy -p warp_graphql -p ai -p warp --lib -- -D warnings`
- Built and launched `target/debug/warp-oss` for manual validation.

## Server API dependencies
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Warp <agent@warp.dev>