### PR TITLE
Install libclang-dev and unzip in agent docker container

### DIFF
--- a/docker/agent-dev/Dockerfile
+++ b/docker/agent-dev/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH=/usr/local/cargo/bin:/usr/local/go/bin:$PATH
 RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
-    pkg-config git build-essential libclang-dev curl zsh fish vim locales sudo gnupg2 \
+    pkg-config git build-essential libclang-dev curl unzip zsh fish vim locales sudo gnupg2 \
     protobuf-compiler libprotobuf-dev \
     fontconfig zlib1g libasound2-dev \
     libx11-6 libxcb1 libxi6 libxcursor1 libxkbcommon-x11-0 \

--- a/docker/agent-dev/Dockerfile
+++ b/docker/agent-dev/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH=/usr/local/cargo/bin:/usr/local/go/bin:$PATH
 RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
-    pkg-config git build-essential curl zsh fish vim locales sudo gnupg2 \
+    pkg-config git build-essential libclang-dev curl zsh fish vim locales sudo gnupg2 \
     protobuf-compiler libprotobuf-dev \
     fontconfig zlib1g libasound2-dev \
     libx11-6 libxcb1 libxi6 libxcursor1 libxkbcommon-x11-0 \


### PR DESCRIPTION
## Description

Title. Closes issue #9254

unzip is required by install_build_deps to extract protoc

## Testing

Build the image locally, mounted this repo, and rerun the command `cargo clippy --workspace --all-features --tests -- -D warnings 2>&1`

Note in the original issue `--all-targets` was included, which fails due to missing channel configs (separate issue). 