### PR TITLE
Don't let `./script/run` fail for external contributors.

### DIFF
--- a/script/run
+++ b/script/run
@@ -20,7 +20,7 @@ OS_TYPE="$(uname -s)"
 
 FEATURES="gui"
 
-./script/install_channel_config
+./script/install_channel_config || echo "Skipping internal channel config installation (no repo access)."
 
 # If warp_channel_config is on PATH, build the Local channel binary; otherwise build the OSS channel.
 if command -v warp-channel-config &>/dev/null; then


### PR DESCRIPTION
## Description

Fixes https://github.com/warpdotdev/warp/issues/9266.

We don't want `./script/run` to error out b/c of `./script/install_channel_config` failing.