### PR TITLE
Add DEMO_LAUNCH_BANNER experiment

### DIFF
--- a/app/src/server/experiments/convert.rs
+++ b/app/src/server/experiments/convert.rs
@@ -36,6 +36,8 @@ impl Display for ServerExperiment {
             Self::FreeUserNoAiExperiment => "FREE_USER_NO_AI_EXPERIMENT",
             Self::OzMultiHarnessControl => "OZ_MULTI_HARNESS_CONTROL",
             Self::OzMultiHarnessExperiment => "OZ_MULTI_HARNESS_EXPERIMENT",
+            Self::DemoLaunchBannerControl => "DEMO_LAUNCH_BANNER_CONTROL",
+            Self::DemoLaunchBannerExperiment => "DEMO_LAUNCH_BANNER_EXPERIMENT",
             #[cfg(test)]
             Self::TestExperiment => "TEST_EXPERIMENT",
         };
@@ -69,6 +71,8 @@ impl ServerExperiment {
             "FREE_USER_NO_AI_EXPERIMENT" => Ok(Self::FreeUserNoAiExperiment),
             "OZ_MULTI_HARNESS_CONTROL" => Ok(Self::OzMultiHarnessControl),
             "OZ_MULTI_HARNESS_EXPERIMENT" => Ok(Self::OzMultiHarnessExperiment),
+            "DEMO_LAUNCH_BANNER_CONTROL" => Ok(Self::DemoLaunchBannerControl),
+            "DEMO_LAUNCH_BANNER_EXPERIMENT" => Ok(Self::DemoLaunchBannerExperiment),
             s => Err(anyhow::anyhow!(
                 "String doesn't match any server experiment variant {s}"
             )),
@@ -108,6 +112,8 @@ impl TryFrom<Experiment> for ServerExperiment {
             Experiment::FreeUserNoAiExperiment => Ok(Self::FreeUserNoAiExperiment),
             Experiment::OzMultiHarnessControl => Ok(Self::OzMultiHarnessControl),
             Experiment::OzMultiHarnessExperiment => Ok(Self::OzMultiHarnessExperiment),
+            Experiment::DemoLaunchBannerControl => Ok(Self::DemoLaunchBannerControl),
+            Experiment::DemoLaunchBannerExperiment => Ok(Self::DemoLaunchBannerExperiment),
             // Experiments that we no longer support on the client.
             e => Err(anyhow::anyhow!(
                 "Server-side enabled experiment '{e:?}' is no longer supported by the client."

--- a/app/src/server/experiments/mod.rs
+++ b/app/src/server/experiments/mod.rs
@@ -50,6 +50,8 @@ pub enum ServerExperiment {
     FreeUserNoAiExperiment,
     OzMultiHarnessControl,
     OzMultiHarnessExperiment,
+    DemoLaunchBannerControl,
+    DemoLaunchBannerExperiment,
     /// A test-only experiment.
     /// Does not correspond to a real server-side experiment.
     #[cfg(test)]
@@ -148,6 +150,12 @@ impl ServerExperiment {
             }
             Self::OzMultiHarnessExperiment => {
                 FeatureFlag::AgentHarness.set_enabled(true);
+            }
+            Self::DemoLaunchBannerControl => {
+                FeatureFlag::DemoLaunchBanner.set_enabled(false);
+            }
+            Self::DemoLaunchBannerExperiment => {
+                FeatureFlag::DemoLaunchBanner.set_enabled(true);
             }
             #[cfg(test)]
             Self::TestExperiment => {

--- a/crates/graphql/src/api/experiment.rs
+++ b/crates/graphql/src/api/experiment.rs
@@ -67,6 +67,8 @@ pub enum Experiment {
     FreeUserInitialCreditsThreeHundred,
     OzMultiHarnessControl,
     OzMultiHarnessExperiment,
+    DemoLaunchBannerControl,
+    DemoLaunchBannerExperiment,
     #[cynic(fallback)]
     Other(String),
 }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -835,6 +835,9 @@ pub enum FeatureFlag {
     VerticalTabsSummaryMode,
 
     CloudModeInputV2,
+
+    /// Controls the demo launch banner shown to users in the experiment arm.
+    DemoLaunchBanner,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =


### PR DESCRIPTION
## Summary

- Adds `DemoLaunchBannerControl` and `DemoLaunchBannerExperiment` variants to the `Experiment` GraphQL enum in `crates/graphql/src/api/experiment.rs`
- Registers the variants in the `ServerExperiment` enum in `app/src/server/experiments/mod.rs`
- Adds `Display`, `from_string`, and `TryFrom<Experiment>` conversions in `convert.rs`
- Adds `DemoLaunchBanner` `FeatureFlag` in `crates/warp_features/src/lib.rs`; the control arm disables it and the experiment arm enables it

Follows the exact same pattern as `OzMultiHarness`.

## Test plan

- [ ] Ensure the client correctly parses `DEMO_LAUNCH_BANNER_CONTROL` and `DEMO_LAUNCH_BANNER_EXPERIMENT` experiment strings from the server
- [ ] Verify `FeatureFlag::DemoLaunchBanner.is_enabled()` reflects the assigned arm after login
- [ ] Check that users not enrolled in the experiment default to the flag being disabled

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._