### PR TITLE
[codex] Spec local Ollama model support

### DIFF
--- a/specs/GH4339/product.md
+++ b/specs/GH4339/product.md
@@ -1,0 +1,103 @@
+# Local Ollama Model Support - Product Spec
+GitHub issue: https://github.com/warpdotdev/warp/issues/4339
+Figma: none provided
+
+## Summary
+Add first-class local model support for Warp's built-in agent experience, starting with Ollama-compatible local endpoints. Users can configure an Ollama server, choose locally served models in the existing model picker, and run normal local Warp agent conversations without sending prompt text, terminal context, command output, file contents, or tool results to Warp's model servers.
+
+This spec prioritizes the maintainer feedback requested in issue #4339: fully local execution, offline access, and preserving Warp's native agent UX. Ollama is the initial provider because it is widely used for local inference and exposes an OpenAI-compatible API surface, but the configuration should not hard-code assumptions that prevent future support for LM Studio, MLX server, llama.cpp server, or any other OpenAI-compatible local endpoint.
+
+## Problem
+Warp's current native agent mode depends on Warp-hosted model and harness infrastructure. That makes the feature unavailable or unacceptable for users who cannot send terminal history, code, credentials-adjacent output, or internal project context to external services. The current BYO API key flow still routes through Warp's hosted agent path and does not satisfy the strongest user requirement in #4339: data should remain on the local machine.
+
+Users already run local models through Ollama and similar tools, but Warp cannot target them from the native agent UX. The workaround is to run a separate CLI agent or editor, losing Warp's terminal-integrated conversation UI, permissions, code review surfaces, and model picker.
+
+## Goals
+- Let users add one local Ollama-compatible endpoint from Settings.
+- Let users discover or manually enter local model IDs exposed by that endpoint.
+- Show configured local models in Warp's existing agent model picker.
+- Route local agent-mode requests to the configured endpoint from the client process, without sending prompt contents or agent tool payloads to Warp-hosted model servers.
+- Preserve the native local agent UX: streaming messages, tool calls, file reads, command execution, diffs, permissions, cancellation, and conversation history.
+- Work offline after configuration when the Ollama server and selected model are available locally.
+- Keep cloud models and BYO API key behavior unchanged for users who do not configure local models.
+- Make data-boundary behavior explicit in the UI so users can tell whether a selected model is local or cloud-backed.
+
+## Non-goals
+- Shipping a bundled model runtime or downloading models from Warp.
+- Supporting cloud ambient agent runs on local endpoints. Local models run only on the user's machine.
+- Supporting remote/shared-session participants by relaying local model prompts through Warp servers.
+- Guaranteeing that every Ollama model has enough context length or tool-calling quality for every Warp agent workflow.
+- Adding arbitrary provider-specific APIs beyond the OpenAI-compatible chat-completions surface in the first iteration.
+- Replacing Warp's cloud model list, subscription, usage, or credit accounting for cloud-backed models.
+- Changing third-party CLI agent harnesses such as Claude Code, Gemini CLI, Codex, or OpenCode.
+
+## Behavior
+1. Settings exposes a **Local models** section under AI settings.
+
+2. The section has an enable switch. When disabled, local models do not appear in model pickers and no local endpoint checks run.
+
+3. When enabled, the user can configure:
+   - endpoint URL, defaulting to `http://localhost:11434/v1`
+   - optional API key, default empty
+   - a list of model IDs
+
+4. The endpoint URL accepts only `http://` or `https://` URLs. Empty, malformed, or non-HTTP URLs are rejected before save.
+
+5. The optional API key is stored using the same local secret-storage expectations as existing BYO API keys. If no API key is set, local requests omit authorization headers.
+
+6. The user can click **Refresh models** to fetch the endpoint's model list. For Ollama's OpenAI-compatible API this uses `GET /models` relative to the configured base URL.
+
+7. If refresh succeeds, the returned model IDs replace the local model list after user confirmation when the replacement would remove currently selected local models.
+
+8. If refresh fails, Settings shows a concise error that includes the failed endpoint and the high-level reason: unreachable, unauthorized, invalid response, timeout, or TLS error.
+
+9. Users can also add model IDs manually. Manually added IDs are preserved across refreshes unless the user removes them.
+
+10. Configured local models appear in every model picker that controls local agent-mode requests. Each local model row uses a local/provider indicator and does not show Warp credit pricing.
+
+11. Local models are excluded from cloud-only surfaces, including cloud ambient agent launch and schedule flows. If a cloud-only surface currently reads the same active model preference, it must either filter local models or show a blocking message explaining that local models only run on this machine.
+
+12. Selecting a local model updates the same per-terminal/default profile preference that cloud model selection uses today, so the selected model remains stable across tabs and app restarts.
+
+13. Starting a normal local agent conversation with a local model keeps the same conversation UI as cloud-backed local agent mode: streaming assistant output, tool cards, permission prompts, command execution, diffs, cancellation, and retry surfaces.
+
+14. For local-model conversations, Warp sends no prompt text, terminal context, command output, file contents, tool inputs, tool results, screenshots, or local conversation transcript to Warp's model-generation service.
+
+15. Non-content service calls that are unrelated to generation, such as auth state, feature flags, update checks, or cloud Drive sync, are unchanged. The product copy must not imply that the entire app becomes air-gapped unless offline mode is separately implemented for those systems.
+
+16. If the app is offline and the selected local endpoint is reachable, starting and continuing local-model agent conversations still works.
+
+17. If the local endpoint is unreachable when the user submits a prompt, the conversation shows a recoverable error with actions to retry and open Local model settings.
+
+18. If the endpoint returns a model-not-found error, Warp shows a recoverable error naming the selected model and offering to refresh the model list.
+
+19. If the endpoint does not support a capability Warp requested, such as tool calling or streaming, Warp fails before running tools and explains which local-model capability is missing.
+
+20. The first release requires streaming chat completions and tool-call compatible responses. Models/endpoints that do not support those capabilities are allowed to be listed but disabled for native agent mode with a tooltip explaining why.
+
+21. The local agent path respects the user's existing execution profile permissions. A local model cannot bypass file-read, command-execution, MCP, or code-diff approval gates.
+
+22. The local agent path applies the same secret redaction setting currently used before agent requests. Redaction remains defense in depth; local routing does not disable it.
+
+23. Conversation history for local-model conversations is stored locally in the same local conversation/history surfaces as comparable Warp agent conversations. It is not uploaded solely for model generation.
+
+24. If the user shares a session while a local-model conversation is running, remote participants can see the terminal/session state that session sharing already exposes, but the local model request payload itself is not sent to Warp's generation service.
+
+25. Usage and billing UI distinguishes local model usage from Warp-credit model usage. Local model turns show no Warp credit charge.
+
+26. Telemetry for local-model usage may record non-content events such as provider type, success/failure category, latency buckets, and capability checks. It must not include prompt text, terminal context, file contents, command output, tool payloads, or model responses.
+
+27. Existing users with no local models configured see no behavior change.
+
+28. Existing users with cloud models selected continue to use the current server-backed path.
+
+29. Removing the selected local model from Settings falls back to the default cloud model if cloud AI is enabled. If cloud AI is disabled, the model picker prompts the user to choose another available local model.
+
+30. Importing/exporting settings includes non-secret local model configuration, but not the local endpoint API key.
+
+## Open Questions
+- Should the first version support only OpenAI-compatible endpoints, or expose an Ollama-native adapter for better model discovery and error reporting?
+- Should local model configuration be global per user, per workspace, or both?
+- Should local model conversations be eligible for Warp Drive sync when the user explicitly opts in, or should they remain local-only regardless of Drive settings?
+- Which minimum tool-calling contract should Warp require from local endpoints before enabling native agent mode?
+- Should local endpoints be allowed for remote SSH sessions, and if so, should requests run on the local machine, the remote host, or a user-selected host?

--- a/specs/GH4339/product.md
+++ b/specs/GH4339/product.md
@@ -41,63 +41,67 @@ Users already run local models through Ollama and similar tools, but Warp cannot
    - optional API key, default empty
    - a list of model IDs
 
-4. The endpoint URL accepts only `http://` or `https://` URLs. Empty, malformed, or non-HTTP URLs are rejected before save.
+4. The endpoint URL accepts only `http://` or `https://` URLs. Empty, malformed, or non-HTTP URLs are rejected before save. Warp classifies the endpoint before saving:
+   - loopback endpoints (`localhost`, `127.0.0.0/8`, `::1`) are treated as **local machine** endpoints and may use `http://`
+   - private-network endpoints (RFC1918 IPv4, link-local addresses, and unique-local IPv6) are treated as **network-local** endpoints and must show a warning that prompts and optional API keys will leave this device for another host on the user's network
+   - public endpoints are treated as **remote** endpoints, must use `https://`, and require an explicit warning/confirmation before Warp sends prompts or API keys to them
 
-5. The optional API key is stored using the same local secret-storage expectations as existing BYO API keys. If no API key is set, local requests omit authorization headers.
+5. Cleartext `http://` is allowed by default only for loopback endpoints. `http://` private-network endpoints require explicit user confirmation that the endpoint is not encrypted. `http://` public endpoints are rejected.
 
-6. The user can click **Refresh models** to fetch the endpoint's model list. For Ollama's OpenAI-compatible API this uses `GET /models` relative to the configured base URL.
+6. The optional API key is stored using the same local secret-storage expectations as existing BYO API keys. If no API key is set, local requests omit authorization headers. Warp must show the endpoint locality label before saving an API key so users can see where that key will be sent.
 
-7. If refresh succeeds, the returned model IDs replace the local model list after user confirmation when the replacement would remove currently selected local models.
+7. The user can click **Refresh models** to fetch the endpoint's model list. For Ollama's OpenAI-compatible API this uses `GET /models` relative to the configured base URL.
 
-8. If refresh fails, Settings shows a concise error that includes the failed endpoint and the high-level reason: unreachable, unauthorized, invalid response, timeout, or TLS error.
+8. If refresh succeeds, the returned model IDs replace the local model list after user confirmation when the replacement would remove currently selected local models.
 
-9. Users can also add model IDs manually. Manually added IDs are preserved across refreshes unless the user removes them.
+9. If refresh fails, Settings shows a concise error that includes the failed endpoint and the high-level reason: unreachable, unauthorized, invalid response, timeout, or TLS error.
 
-10. Configured local models appear in every model picker that controls local agent-mode requests. Each local model row uses a local/provider indicator and does not show Warp credit pricing.
+10. Users can also add model IDs manually. Manually added IDs are preserved across refreshes unless the user removes them.
 
-11. Local models are excluded from cloud-only surfaces, including cloud ambient agent launch and schedule flows. If a cloud-only surface currently reads the same active model preference, it must either filter local models or show a blocking message explaining that local models only run on this machine.
+11. Configured local models appear in every model picker that controls local agent-mode requests. Each local model row uses a local/provider indicator and does not show Warp credit pricing.
 
-12. Selecting a local model updates the same per-terminal/default profile preference that cloud model selection uses today, so the selected model remains stable across tabs and app restarts.
+12. Local models are excluded from cloud-only surfaces, including cloud ambient agent launch and schedule flows. If a cloud-only surface currently reads the same active model preference, it must either filter local models or show a blocking message explaining that local models only run on this machine.
 
-13. Starting a normal local agent conversation with a local model keeps the same conversation UI as cloud-backed local agent mode: streaming assistant output, tool cards, permission prompts, command execution, diffs, cancellation, and retry surfaces.
+13. Selecting a local model updates the same per-terminal/default profile preference that cloud model selection uses today, so the selected model remains stable across tabs and app restarts.
 
-14. For local-model conversations, Warp sends no prompt text, terminal context, command output, file contents, tool inputs, tool results, screenshots, or local conversation transcript to Warp's model-generation service.
+14. Starting a normal local agent conversation with a local model keeps the same conversation UI as cloud-backed local agent mode: streaming assistant output, tool cards, permission prompts, command execution, diffs, cancellation, and retry surfaces.
 
-15. Non-content service calls that are unrelated to generation, such as auth state, feature flags, update checks, or cloud Drive sync, are unchanged. The product copy must not imply that the entire app becomes air-gapped unless offline mode is separately implemented for those systems.
+15. For local-model conversations, Warp sends no prompt text, terminal context, command output, file contents, tool inputs, tool results, screenshots, or local conversation transcript to Warp's model-generation service.
 
-16. If the app is offline and the selected local endpoint is reachable, starting and continuing local-model agent conversations still works.
+16. Non-content service calls that are unrelated to generation, such as auth state, feature flags, update checks, or cloud Drive metadata sync, are unchanged. The product copy must not imply that the entire app becomes air-gapped unless offline mode is separately implemented for those systems.
 
-17. If the local endpoint is unreachable when the user submits a prompt, the conversation shows a recoverable error with actions to retry and open Local model settings.
+17. If the app is offline and the selected local endpoint is reachable, starting and continuing local-model agent conversations still works.
 
-18. If the endpoint returns a model-not-found error, Warp shows a recoverable error naming the selected model and offering to refresh the model list.
+18. If the local endpoint is unreachable when the user submits a prompt, the conversation shows a recoverable error with actions to retry and open Local model settings.
 
-19. If the endpoint does not support a capability Warp requested, such as tool calling or streaming, Warp fails before running tools and explains which local-model capability is missing.
+19. If the endpoint returns a model-not-found error, Warp shows a recoverable error naming the selected model and offering to refresh the model list.
 
-20. The first release requires streaming chat completions and tool-call compatible responses. Models/endpoints that do not support those capabilities are allowed to be listed but disabled for native agent mode with a tooltip explaining why.
+20. If the endpoint does not support a capability Warp requested, such as tool calling or streaming, Warp fails before running tools and explains which local-model capability is missing.
 
-21. The local agent path respects the user's existing execution profile permissions. A local model cannot bypass file-read, command-execution, MCP, or code-diff approval gates.
+21. The first release requires streaming chat completions and tool-call compatible responses. Models/endpoints that do not support those capabilities are allowed to be listed but disabled for native agent mode with a tooltip explaining why.
 
-22. The local agent path applies the same secret redaction setting currently used before agent requests. Redaction remains defense in depth; local routing does not disable it.
+22. The local agent path respects the user's existing execution profile permissions. A local model cannot bypass file-read, command-execution, MCP, or code-diff approval gates.
 
-23. Conversation history for local-model conversations is stored locally in the same local conversation/history surfaces as comparable Warp agent conversations. It is not uploaded solely for model generation.
+23. The local agent path applies the same secret redaction setting currently used before agent requests. Redaction remains defense in depth; local routing does not disable it.
 
-24. If the user shares a session while a local-model conversation is running, remote participants can see the terminal/session state that session sharing already exposes, but the local model request payload itself is not sent to Warp's generation service.
+24. Conversation history for local-model conversations is stored locally in the same local conversation/history surfaces as comparable Warp agent conversations. In the first release, local-model conversation transcripts are not uploaded to Warp Drive and are not eligible for cross-device transcript sync. If a future version adds opt-in sync, it must require explicit user consent before uploading local-model transcript content.
 
-25. Usage and billing UI distinguishes local model usage from Warp-credit model usage. Local model turns show no Warp credit charge.
+25. If the user shares a session while a local-model conversation is running, remote participants can see the terminal/session state that session sharing already exposes, but the local model request payload itself is not sent to Warp's generation service.
 
-26. Telemetry for local-model usage may record non-content events such as provider type, success/failure category, latency buckets, and capability checks. It must not include prompt text, terminal context, file contents, command output, tool payloads, or model responses.
+26. Usage and billing UI distinguishes local model usage from Warp-credit model usage. Local model turns show no Warp credit charge.
 
-27. Existing users with no local models configured see no behavior change.
+27. Telemetry for local-model usage may record non-content events such as provider type, endpoint locality class, success/failure category, latency buckets, and capability checks. It must not include prompt text, terminal context, file contents, command output, tool payloads, API keys, endpoint paths/query strings, or model responses.
 
-28. Existing users with cloud models selected continue to use the current server-backed path.
+28. Existing users with no local models configured see no behavior change.
 
-29. Removing the selected local model from Settings falls back to the default cloud model if cloud AI is enabled. If cloud AI is disabled, the model picker prompts the user to choose another available local model.
+29. Existing users with cloud models selected continue to use the current server-backed path.
 
-30. Importing/exporting settings includes non-secret local model configuration, but not the local endpoint API key.
+30. Removing the selected local model from Settings does not automatically route future prompts to cloud generation. The next prompt is blocked until the user explicitly selects another local model or confirms switching that terminal/profile back to a cloud model.
+
+31. Importing/exporting settings includes non-secret local model configuration, but not the local endpoint API key.
 
 ## Open Questions
 - Should the first version support only OpenAI-compatible endpoints, or expose an Ollama-native adapter for better model discovery and error reporting?
 - Should local model configuration be global per user, per workspace, or both?
-- Should local model conversations be eligible for Warp Drive sync when the user explicitly opts in, or should they remain local-only regardless of Drive settings?
 - Which minimum tool-calling contract should Warp require from local endpoints before enabling native agent mode?
 - Should local endpoints be allowed for remote SSH sessions, and if so, should requests run on the local machine, the remote host, or a user-selected host?

--- a/specs/GH4339/tech.md
+++ b/specs/GH4339/tech.md
@@ -36,6 +36,13 @@ Validation should happen before committing settings:
 - require `http` or `https`
 - trim trailing slash for stable joining
 - reject empty model IDs
+- classify the endpoint as loopback, private-network, or public before saving
+- allow cleartext `http://` by default only for loopback endpoints
+- require an explicit cleartext warning for `http://` private-network endpoints
+- reject `http://` public endpoints
+- require an explicit remote-endpoint confirmation before saving a public `https://` endpoint or API key
+
+Persist the endpoint locality class with the setting or recompute it whenever the URL changes. The UI should use that class for model-picker labeling, telemetry bucketing, and warnings before any prompt or API key is sent to a non-loopback endpoint.
 
 ### 2. Extend model metadata for local providers
 Update `app/src/ai/llms.rs`:
@@ -124,6 +131,13 @@ Responsibilities:
 
 The first implementation can support a bounded single-agent loop and explicitly disable orchestration/subagent features for local models until a local multi-agent planner exists.
 
+The local runner must preserve the same prompt-injection and trust-boundary protections that the server harness applies today. In particular:
+- terminal output, command output, file contents, MCP resource contents, and tool results are untrusted data, not developer/system instructions
+- tool results must be wrapped or tagged so the model cannot reinterpret them as higher-priority instructions
+- any existing server-side system/developer prompt rules that distinguish user intent from observed terminal/tool data must be ported or replaced with equivalent client-side rules before enabling local tool use
+- local model tool calls must still flow through the existing permission, denylist, and approval logic before any file, shell, MCP, or diff action runs
+- tests must cover an injected instruction inside terminal output or a tool result and assert it remains untrusted context
+
 ### 8. Capability gating
 Before enabling a local model for native agent mode, check endpoint/model capabilities:
 - streaming chat completions
@@ -147,6 +161,8 @@ Audit local routing to ensure content-bearing data does not reach Warp generatio
 - no prompt/tool payload in telemetry
 - no transcript upload as a side effect of local generation
 - no cloud ambient task creation for local-model runs
+- no automatic local-to-cloud fallback after endpoint failure or model removal
+- no Warp Drive transcript upload in the first release
 
 Non-content existing app calls can remain unchanged, but the local model path should be testable by injecting a mock `ServerApi` that fails if generation is called.
 
@@ -173,16 +189,20 @@ For local conversations:
 - Persist enough local history for restore/retry in the same surfaces used by local Warp agent conversations.
 - Mark usage as provider-local and credit-free.
 - Do not depend on server conversation tokens for local-only turns.
+- Store local-model transcripts locally only in the first release. Do not sync transcript content to Warp Drive, even when general Drive sync is enabled.
+- If a selected local model is removed, store a blocked selection state and require explicit user selection before the next prompt can run. Do not silently select a cloud fallback.
 
 If existing history models require a server conversation token, introduce a local conversation token/ID variant rather than fabricating a server token.
 
 ## Testing and Validation
 ### Unit tests
-- `app/src/ai/llms` tests: local provider metadata serializes/deserializes, overlaid models appear only when enabled, fallback selection works when a local model is removed.
+- `app/src/ai/llms` tests: local provider metadata serializes/deserializes, overlaid models appear only when enabled, and removing the selected local model leaves local generation blocked until the user explicitly selects a replacement.
 - local settings tests: endpoint URL validation, model ID validation, secret omission from exported settings.
+- local endpoint policy tests: loopback `http://` is accepted, private-network `http://` requires warning state, public `http://` is rejected, and public `https://` is saved only after explicit confirmation.
 - local provider client tests: parses `GET /models`, handles unreachable/401/invalid JSON/timeouts.
 - `app/src/ai/agent/api/impl_tests.rs`: cloud model routes to `ServerApi`; local model does not call `ServerApi::generate_multi_agent_output`; supported tool set is reduced for local provider.
-- local runner tests: converts a simple user query into OpenAI-compatible messages; converts assistant text deltas into `ResponseEvent`; converts one tool call into the expected client action; converts tool results back into chat messages.
+- local runner tests: converts a simple user query into OpenAI-compatible messages; converts assistant text deltas into `ResponseEvent`; converts one tool call into the expected client action; converts tool results back into chat messages; preserves trust boundaries when terminal output or tool results contain injected instructions.
+- local history tests: local-model transcripts are not uploaded to Warp Drive and removed local models leave the selection blocked instead of falling back to cloud.
 
 ### Integration tests
 - Configure a fake OpenAI-compatible local server, select a local model, submit a simple prompt, and assert the conversation renders streamed text.

--- a/specs/GH4339/tech.md
+++ b/specs/GH4339/tech.md
@@ -1,0 +1,221 @@
+# Local Ollama Model Support - Tech Spec
+Product spec: `specs/GH4339/product.md`
+GitHub issue: https://github.com/warpdotdev/warp/issues/4339
+
+## Context
+Warp's native local agent path currently builds a `warp_multi_agent_api::Request` in the client and streams the response from `ServerApi::generate_multi_agent_output`. The important boundary is `app/src/ai/agent/api/impl.rs`: `generate_multi_agent_output` converts client inputs into the multi-agent protobuf request, then unconditionally calls the Warp server API.
+
+Relevant code:
+- `app/src/ai/agent/api.rs` defines `RequestParams`, including the selected base model, coding model, CLI-agent model, computer-use model, API keys, tool support, autonomy, and session context.
+- `app/src/ai/agent/api/impl.rs` builds the `warp_multi_agent_api::Request`, computes supported tools, applies secret redaction, and calls `ServerApi::generate_multi_agent_output`.
+- `app/src/server/server_api.rs` implements `generate_multi_agent_output` by sending the protobuf request to Warp's AI endpoint and decoding streamed `ResponseEvent` values.
+- `app/src/ai/blocklist/controller/response_stream.rs` owns the in-flight response stream model and already consumes an abstract `api::ResponseStream`, so a local provider can reuse downstream rendering if it emits the same event stream shape.
+- `app/src/ai/agent/api/convert_to.rs` and `convert_from.rs` are the conversion boundary between app-side conversation structures and `warp_multi_agent_api`.
+- `app/src/ai/llms.rs` stores `LLMInfo`, `LLMProvider`, `ModelsByFeature`, `AvailableLLMs`, and `LLMPreferences`. The model list is currently server-derived through `get_feature_model_choices` and cached in private user preferences.
+- `app/src/server/server_api/ai.rs` converts GraphQL `LlmProvider` and model-choice data into client `LLMInfo`.
+- `app/src/terminal/view/ambient_agent/model_selector.rs` and `app/src/terminal/input/models/data_source.rs` render model choices from `LLMPreferences`.
+- `app/src/ai/execution_profiles/profiles.rs` owns active/default execution profiles and per-session model preferences.
+- `app/src/settings_view/ai_page.rs` and related settings modules are the natural home for local model configuration UI.
+- `app/src/ai/agent_sdk/driver/harness/*` is for third-party CLI harnesses and should not be used for this feature; Ollama support is model routing for Warp's native agent, not a Claude/Gemini-style CLI harness.
+
+The first implementation should add a client-side generation provider abstraction without rewriting downstream conversation rendering. The local provider should translate between Warp's existing request/response stream shape and OpenAI-compatible streaming chat completions.
+
+## Proposed Changes
+### 1. Add persisted local model settings
+Add an AI settings group for local model configuration. The stored data should include:
+- `enabled: bool`
+- `endpoint_url: String`, default `http://localhost:11434/v1`
+- `model_ids: Vec<String>`
+- `manually_added_model_ids: Vec<String>` or equivalent metadata to preserve user-entered IDs across refreshes
+- an API-key reference stored through the existing local secret mechanism rather than plain preferences
+
+Use the existing settings pattern in `app/src/settings` and Settings UI in `app/src/settings_view/ai_page.rs`. Emit a specific `AISettingsChangedEvent` or a sibling local-model settings event so model lists refresh without restarting.
+
+Validation should happen before committing settings:
+- parse as URL
+- require `http` or `https`
+- trim trailing slash for stable joining
+- reject empty model IDs
+
+### 2. Extend model metadata for local providers
+Update `app/src/ai/llms.rs`:
+- Add `LLMProvider::Ollama` or `LLMProvider::Local`.
+- Add icon/display metadata that clearly marks the provider as local. A generic local icon is acceptable if no Ollama asset is available.
+- Add enough metadata to distinguish local models from server-backed models. This can be a new field on `LLMInfo`, a provider predicate, or a model ID namespace such as `local:ollama:<model>`.
+
+Recommended model ID strategy:
+- Store user-facing model IDs as Ollama returns them, such as `qwen2.5-coder:7b`.
+- Convert them to a stable internal ID before inserting into `LLMPreferences`, for example `local/ollama/qwen2.5-coder:7b`.
+- Keep the raw provider model ID in provider metadata so request routing does not have to parse display strings.
+
+### 3. Merge local models into `LLMPreferences`
+`LLMPreferences` currently updates from `ServerApi::get_feature_model_choices` and cached `ModelsByFeature`. Extend it so local models are overlaid on the server model list when local model settings are enabled.
+
+Implementation shape:
+- Build `AvailableLLMs` entries for local models with zero credit multiplier, no upgrade disable reason, provider `Local/Ollama`, and conservative/default `LLMSpec` values.
+- Add local models to `agent_mode` and any other local-only model lists that should support native agent mode.
+- Do not add local models to cloud-only model choices.
+- When settings change, recompute the overlaid `ModelsByFeature` and emit `LLMPreferencesEvent::UpdatedAvailableLLMs`.
+- Ensure `get_active_base_model` falls back to a valid model if the selected local model disappears.
+
+This keeps `ModelSelector` and slash-command model picker changes small because they already read `LLMPreferences`.
+
+### 4. Add endpoint model discovery
+Add a local provider client, for example `app/src/ai/local_models/ollama.rs`.
+
+Initial API:
+- `list_models(endpoint: Url, api_key: Option<Secret>) -> Result<Vec<LocalModelInfo>, LocalModelError>`
+- call `GET {endpoint}/models`
+- parse OpenAI-compatible model-list responses
+- return high-level error categories for Settings UI
+- use a short timeout, for example 5 seconds
+
+Keep this client independent from UI so it can be unit-tested with a local HTTP test server.
+
+### 5. Introduce an agent generation router
+Replace the unconditional server call in `app/src/ai/agent/api/impl.rs` with a provider router:
+
+```rust
+pub async fn generate_multi_agent_output(
+    server_api: Arc<ServerApi>,
+    mut params: RequestParams,
+    cancellation_rx: futures::channel::oneshot::Receiver<()>,
+) -> Result<ResponseStream, ConvertToAPITypeError> {
+    let request = build_multi_agent_request(&mut params)?;
+    match AgentGenerationProvider::for_model(&params.model, app_or_settings) {
+        AgentGenerationProvider::WarpCloud => server_generate(server_api, request, cancellation_rx).await,
+        AgentGenerationProvider::LocalOllama(config) => {
+            local_ollama_generate(config, request, cancellation_rx).await
+        }
+    }
+}
+```
+
+`generate_multi_agent_output` currently does not receive `AppContext`, so the real design needs one of:
+- add provider-routing data to `RequestParams` at construction time
+- pass an immutable provider registry/config into `generate_multi_agent_output`
+- split request construction from dispatch so `ResponseStream::new` can choose the provider before spawning
+
+The lowest-risk option is to add a routing enum to `RequestParams` when `RequestParams::new` already has `AppContext` and selected model information.
+
+### 6. Split request construction from server dispatch
+Move the request-building logic in `app/src/ai/agent/api/impl.rs` into a helper that returns `warp_multi_agent_api::Request`. Keep existing tests around tool support and settings, then add routing tests.
+
+Suggested helpers:
+- `build_multi_agent_request(params: &mut RequestParams) -> Result<api::Request, ConvertToAPITypeError>`
+- `generate_via_warp_cloud(server_api, request, cancellation_rx) -> Result<ResponseStream, ConvertToAPITypeError>`
+- `generate_via_local_provider(local_config, request, cancellation_rx) -> Result<ResponseStream, ConvertToAPITypeError>`
+
+This isolates the existing cloud behavior and makes the local path explicit.
+
+### 7. Implement a local harness adapter
+The hard part is not the HTTP call to Ollama; it is preserving Warp's agent loop. Warp's server currently acts as the model/harness that emits `ResponseEvent` values containing assistant messages and tool calls. The client must own that loop for local models.
+
+Add a local agent runner module, for example `app/src/ai/local_agent_runner/`.
+
+Responsibilities:
+- Convert `warp_multi_agent_api::Request` conversation input into OpenAI-compatible chat messages.
+- Add the system/developer instructions required for Warp tools.
+- Advertise supported tools as OpenAI-compatible tool definitions.
+- Stream assistant deltas back as `warp_multi_agent_api::ResponseEvent` message chunks.
+- Detect tool calls, emit the same client actions the cloud harness emits, and pause until existing tool execution returns results through the conversation controller.
+- Continue the loop by sending tool results back to the local model.
+- Emit a final `StreamFinished` with local usage metadata when available.
+
+The first implementation can support a bounded single-agent loop and explicitly disable orchestration/subagent features for local models until a local multi-agent planner exists.
+
+### 8. Capability gating
+Before enabling a local model for native agent mode, check endpoint/model capabilities:
+- streaming chat completions
+- tool calls/function calls
+- enough context length for the selected request, if the endpoint exposes it
+
+If capabilities are unknown, allow the model to be configured but run a preflight on first use. Disable or fail gracefully if required features are missing.
+
+For the first PR, local models should set `supported_tools_override` to a conservative subset:
+- read files
+- grep/glob
+- run shell command
+- read shell command output
+- apply file diffs, if the model passes tool-call preflight
+
+Keep computer use, orchestration v2, research agent, web search, and cloud child agents disabled for local provider routing until separately designed.
+
+### 9. Preserve data-boundary guarantees
+Audit local routing to ensure content-bearing data does not reach Warp generation APIs:
+- no call to `ServerApi::generate_multi_agent_output`
+- no prompt/tool payload in telemetry
+- no transcript upload as a side effect of local generation
+- no cloud ambient task creation for local-model runs
+
+Non-content existing app calls can remain unchanged, but the local model path should be testable by injecting a mock `ServerApi` that fails if generation is called.
+
+### 10. UI and UX updates
+Settings:
+- Add local model controls to AI settings.
+- Add refresh, manual add/remove, status/error, and selected endpoint display.
+- Store API key through the existing secret entry component if possible.
+
+Model pickers:
+- Show local models with a local/Ollama indicator.
+- Hide credit pricing and BYOK key prompts for local models.
+- Disable local models in cloud-only contexts with clear tooltip copy.
+
+Error states:
+- endpoint unreachable
+- model not found
+- invalid endpoint response
+- missing streaming/tool support
+- local generation cancelled
+
+### 11. Conversation history and usage
+For local conversations:
+- Persist enough local history for restore/retry in the same surfaces used by local Warp agent conversations.
+- Mark usage as provider-local and credit-free.
+- Do not depend on server conversation tokens for local-only turns.
+
+If existing history models require a server conversation token, introduce a local conversation token/ID variant rather than fabricating a server token.
+
+## Testing and Validation
+### Unit tests
+- `app/src/ai/llms` tests: local provider metadata serializes/deserializes, overlaid models appear only when enabled, fallback selection works when a local model is removed.
+- local settings tests: endpoint URL validation, model ID validation, secret omission from exported settings.
+- local provider client tests: parses `GET /models`, handles unreachable/401/invalid JSON/timeouts.
+- `app/src/ai/agent/api/impl_tests.rs`: cloud model routes to `ServerApi`; local model does not call `ServerApi::generate_multi_agent_output`; supported tool set is reduced for local provider.
+- local runner tests: converts a simple user query into OpenAI-compatible messages; converts assistant text deltas into `ResponseEvent`; converts one tool call into the expected client action; converts tool results back into chat messages.
+
+### Integration tests
+- Configure a fake OpenAI-compatible local server, select a local model, submit a simple prompt, and assert the conversation renders streamed text.
+- Configure a fake local server that requests a read-file tool, assert Warp shows the existing permission flow and returns the tool result to the local runner.
+- Start with the network offline or with Warp server generation mocked unavailable, keep the fake local endpoint reachable, and assert a local-model conversation still completes.
+- Select a local model, attempt to start a cloud ambient agent run, and assert the cloud-only surface blocks local selection.
+
+### Manual validation
+- Run Ollama locally with a tool-capable model. Configure `http://localhost:11434/v1`, refresh models, select one, and complete a basic local agent prompt.
+- Disconnect from the internet while leaving Ollama running and verify a local agent prompt still works.
+- Shut down Ollama and verify the recoverable endpoint error appears.
+- Choose a model that does not support tool calls and verify Warp disables it or fails before running tools.
+- Confirm cloud model behavior, BYOK behavior, and usage/credits UI are unchanged for cloud-backed models.
+
+## Risks and Mitigations
+### Risk: OpenAI-compatible endpoints differ in tool-call behavior
+Mitigation: gate native agent mode on a preflight and keep the first release conservative. Document unsupported endpoints/models in the error state.
+
+### Risk: local model quality creates unsafe tool calls
+Mitigation: keep execution profiles and permission gates unchanged. Local models must pass through the same approval and denylist paths as cloud models.
+
+### Risk: accidental data leakage through fallback
+Mitigation: do not fall back from local to cloud automatically. If local generation fails, the user must explicitly choose a cloud model before Warp sends content to Warp's generation service.
+
+### Risk: conversation history assumes server conversation tokens
+Mitigation: introduce a local conversation identifier rather than overloading `ServerConversationToken`. Add tests that local conversations do not call server transcript APIs.
+
+### Risk: implementation becomes a full duplicate of the server harness
+Mitigation: split the first implementation into a minimal local single-agent runner and explicitly disable orchestration/research/computer-use features until they are separately ported.
+
+## Follow-ups
+- Support additional OpenAI-compatible local providers such as LM Studio, MLX server, llama.cpp server, and vLLM.
+- Add workspace-scoped local model profiles.
+- Add optional explicit sync/export for local-model conversation metadata.
+- Support local routing for remote SSH sessions with a user-selected endpoint location.
+- Consider ACP as an alternate local harness path if Warp chooses to delegate the agent loop to local agent runtimes instead of embedding it in the client.


### PR DESCRIPTION
## Summary
- Adds product and tech specs for issue #4339 local/Ollama model support.
- Defines the data-boundary requirement: local agent prompts, terminal context, tool payloads, and transcripts do not go through Warp's model-generation service.
- Proposes a client-side generation router, local model settings, Ollama/OpenAI-compatible model discovery, and a minimal local agent runner.

## Validation
- Docs-only spec change; no code tests run.

## Notes
- Opening as draft because #4339 is triaged and under maintainer feedback, but does not currently have a ready-to-spec label.