### PR TITLE
Scope orchestration SSE subscriptions to active parent/child roles

### DIFF
--- a/app/src/ai/active_agent_views_model.rs
+++ b/app/src/ai/active_agent_views_model.rs
@@ -5,6 +5,9 @@ use chrono::{DateTime, Utc};
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
+use crate::ai::blocklist::orchestration_event_streamer::{
+    register_agent_event_consumer, unregister_agent_event_consumer,
+};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::terminal::model::session::active_session::ActiveSession;
 use warpui::{
@@ -122,6 +125,18 @@ impl ActiveAgentViewsModel {
             },
         );
 
+        // On pane re-attach the controller's `agent_view_state` is still
+        // `Active` while the unregister path has already torn down the
+        // streamer consumer. Re-register here; the `EnteredAgentView`
+        // subscription only fires on subsequent state transitions.
+        if let Some(conversation_id) = controller
+            .as_ref(ctx)
+            .agent_view_state()
+            .active_conversation_id()
+        {
+            register_agent_event_consumer(conversation_id, terminal_view_id, ctx);
+        }
+
         ctx.subscribe_to_model(controller, move |model, event, ctx| match event {
             AgentViewControllerEvent::EnteredAgentView {
                 conversation_id, ..
@@ -142,6 +157,9 @@ impl ActiveAgentViewsModel {
                         focused_terminal_state.active_conversation_id = Some(conv_id);
                     }
                 }
+                // Bridge the controller's lifecycle into the streamer's
+                // per-conversation consumer registry.
+                register_agent_event_consumer(*conversation_id, terminal_view_id, ctx);
                 // Emit so subscribers can move this conversation to the Active section.
                 ctx.emit(ActiveAgentViewsEvent::TerminalViewFocused);
             }
@@ -163,6 +181,7 @@ impl ActiveAgentViewsModel {
                         state.active_conversation_id = None;
                     }
                 }
+                unregister_agent_event_consumer(*conversation_id, terminal_view_id, ctx);
                 // Emit so subscribers can move this conversation to the Past section.
                 ctx.emit(ActiveAgentViewsEvent::ConversationClosed {
                     conversation_id: *conversation_id,
@@ -198,6 +217,9 @@ impl ActiveAgentViewsModel {
             }
 
             if let Some(conversation_id) = closed_conversation_id {
+                // The pane-close path bypasses exit_agent_view_internal, so
+                // unregister the streamer consumer here.
+                unregister_agent_event_consumer(conversation_id, terminal_pane_id, ctx);
                 ctx.emit(ActiveAgentViewsEvent::ConversationClosed { conversation_id });
             }
         }

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -812,6 +812,14 @@ impl AIConversation {
         self.parent_conversation_id.is_some()
     }
 
+    /// True iff this conversation knows about a parent agent — either via a
+    /// local parent placeholder (`parent_conversation_id`, set in the GUI
+    /// parent) or via the parent's server-side run identifier
+    /// (`parent_agent_id`, stamped in driver-hosted processes).
+    pub fn has_parent_agent(&self) -> bool {
+        self.parent_conversation_id.is_some() || self.parent_agent_id.is_some()
+    }
+
     /// Returns true if this is a placeholder for a child agent executing on a
     /// remote worker. The parent's client should not report task status for
     /// these — the remote worker handles it.

--- a/app/src/ai/agent_events/driver.rs
+++ b/app/src/ai/agent_events/driver.rs
@@ -188,13 +188,13 @@ where
     let mut has_connected_once = false;
 
     loop {
+        // `open_stream` is lazy for the SSE-backed source: the TCP
+        // connect happens when the stream is first polled, not when
+        // this returns Ok. Wait for the `AgentEventSourceItem::Open`
+        // event below before declaring connectivity, so a server
+        // outage doesn't reset `failures` between every retry.
         let mut stream = match source.open_stream(&config.run_ids, since_sequence).await {
-            Ok(stream) => {
-                failures = 0;
-                has_connected_once = true;
-                notify_driver_state(consumer, AgentEventDriverState::Connected).await;
-                stream
-            }
+            Ok(stream) => stream,
             Err(err) => {
                 failures += 1;
                 let backoff = agent_event_backoff(failures, config.reconnect_backoff_steps);
@@ -249,6 +249,8 @@ where
                 }
                 NextDriverItem::StreamItem(Some(Ok(AgentEventSourceItem::Open))) => {
                     failures = 0;
+                    has_connected_once = true;
+                    notify_driver_state(consumer, AgentEventDriverState::Connected).await;
                     log::info!("Agent event stream opened for {:?}", config.run_ids);
                 }
                 NextDriverItem::StreamItem(Some(Ok(AgentEventSourceItem::Event(event)))) => {

--- a/app/src/ai/agent_management/agent_management_model_tests.rs
+++ b/app/src/ai/agent_management/agent_management_model_tests.rs
@@ -164,6 +164,7 @@ fn deletion_cleans_up_pending_artifacts() {
                 terminal_view_id,
                 conversation_id,
                 conversation_title: None,
+                run_id: None,
             });
         });
 

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -41,8 +41,11 @@ use crate::{
             AmbientConversationStatus,
         },
         blocklist::{
-            agent_view::AgentViewEntryOrigin, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
-            BlocklistAIPermissions,
+            agent_view::AgentViewEntryOrigin,
+            orchestration_event_streamer::{
+                register_agent_event_consumer, unregister_agent_event_consumer,
+            },
+            BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIPermissions,
         },
         cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEnvironment},
         execution_profiles::profiles::AIExecutionProfilesModel,
@@ -283,6 +286,17 @@ pub struct AgentDriver {
     /// when building the runner and taken back to `None` after use so subsequent runs start
     /// fresh.
     resume_payload: Option<ResumePayload>,
+
+    /// Conversation ID this driver is running. Set at construction for
+    /// resumed runs and on `ConversationServerTokenAssigned` for fresh
+    /// runs; consumed by `unregister_streamer_consumer` at end of run.
+    run_conversation_id: Option<AIConversationId>,
+
+    /// Parent agent run's `run_id` from the server task metadata, when
+    /// this driver run was spawned by another agent. Stamped onto the
+    /// conversation's `parent_agent_id` field at register time so the
+    /// streamer recognizes the child role in driver-hosted processes.
+    parent_run_id: Option<String>,
 }
 
 pub(crate) enum SDKConversationOutputStatus {
@@ -588,6 +602,9 @@ impl AgentDriver {
 
         // Inject cloud provider env vars.
         cloud_provider::collect_env_vars(&cloud_providers, &mut env_vars)?;
+        // Clone before consuming for env vars; the field on `Self` is
+        // also needed at register time.
+        let parent_run_id_for_self = parent_run_id.clone();
         env_vars.extend(task_env_vars(
             task_id.as_ref(),
             parent_run_id.as_deref(),
@@ -616,6 +633,17 @@ impl AgentDriver {
             me.handle_terminal_driver_event(event, ctx);
         });
 
+        let mut run_conversation_id: Option<AIConversationId> = None;
+
+        // For a resumed conversation the ID is known up front; register
+        // immediately so the streamer can satisfy the parent gate as soon
+        // as the first child is registered.
+        if let Some(conv_id) = restored_conversation_id {
+            stamp_parent_agent_id_if_some(conv_id, parent_run_id_for_self.as_deref(), ctx);
+            register_agent_event_consumer(conv_id, ctx.model_id(), ctx);
+            run_conversation_id = Some(conv_id);
+        }
+
         Ok(Self {
             terminal_driver,
             working_dir,
@@ -633,7 +661,18 @@ impl AgentDriver {
             snapshot_script_timeout: snapshot_script_timeout
                 .unwrap_or(snapshot::DEFAULT_DECLARATIONS_SCRIPT_TIMEOUT),
             resume_payload,
+            run_conversation_id,
+            parent_run_id: parent_run_id_for_self,
         })
+    }
+
+    /// Pair to the registration in `new` / `execute_run`. No-op when
+    /// nothing was registered.
+    fn unregister_streamer_consumer(&self, ctx: &mut ModelContext<Self>) {
+        let Some(conversation_id) = self.run_conversation_id else {
+            return;
+        };
+        unregister_agent_event_consumer(conversation_id, ctx.model_id(), ctx);
     }
 
     pub fn set_output_format(&mut self, output_format: OutputFormat) {
@@ -681,6 +720,13 @@ impl AgentDriver {
                     }
                 }
                 let result = Self::run_internal(task, foreground.clone()).await;
+
+                // Unregister the driver consumer now that the run is done.
+                // The streamer will tear down the SSE if no other consumer
+                // remains and the conversation isn't a child.
+                let _ = foreground
+                    .spawn(|me, ctx| me.unregister_streamer_consumer(ctx))
+                    .await;
 
                 // Run the snapshot upload before signaling the caller. The caller resumes and
                 // triggers process termination as soon as it receives `result`; the snapshot
@@ -1679,6 +1725,25 @@ impl AgentDriver {
                 return;
             }
 
+            // Fresh runs learn their conversation_id via
+            // `ConversationServerTokenAssigned`; resumed runs already
+            // registered in `new` (and so skip this branch).
+            if me.run_conversation_id.is_none() {
+                if let BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
+                    conversation_id,
+                    ..
+                } = event
+                {
+                    me.run_conversation_id = Some(*conversation_id);
+                    stamp_parent_agent_id_if_some(
+                        *conversation_id,
+                        me.parent_run_id.as_deref(),
+                        ctx,
+                    );
+                    register_agent_event_consumer(*conversation_id, ctx.model_id(), ctx);
+                }
+            }
+
             match event {
                 BlocklistAIHistoryEvent::UpdatedTodoList { .. } => {
                     // TODO: Log TODO list updates.
@@ -2283,6 +2348,25 @@ pub(super) async fn report_driver_error(
             anyhow!(e).context(format!("Failed to report driver error for task {task_id}"))
         );
     }
+}
+
+/// Stamps `parent_agent_id` (= parent's `run_id` under v2) onto the
+/// driver-hosted conversation so the streamer's child-role check
+/// succeeds. No-op when `parent_run_id` is `None` (a top-level run).
+fn stamp_parent_agent_id_if_some(
+    conv_id: AIConversationId,
+    parent_run_id: Option<&str>,
+    ctx: &mut ModelContext<AgentDriver>,
+) {
+    let Some(parent_run_id) = parent_run_id else {
+        return;
+    };
+    let parent_run_id = parent_run_id.to_owned();
+    BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _| {
+        if let Some(conv) = history.conversation_mut(&conv_id) {
+            conv.set_parent_agent_id(parent_run_id);
+        }
+    });
 }
 
 /// Write the session URL to stdout using the appropriate output format

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1518,6 +1518,12 @@ impl BlocklistAIHistoryModel {
             .conversations_by_id
             .get(&conversation_id)
             .and_then(|c| c.title().map(|t| t.to_string()));
+        // Capture the run_id BEFORE the in-memory record is dropped so it
+        // can be forwarded on the DeletedConversation event.
+        let run_id = self
+            .conversations_by_id
+            .get(&conversation_id)
+            .and_then(|c| c.run_id());
 
         self.remove_conversation_from_memory(conversation_id, terminal_view_id, ctx);
 
@@ -1552,6 +1558,7 @@ impl BlocklistAIHistoryModel {
                 terminal_view_id,
                 conversation_id,
                 conversation_title,
+                run_id,
             });
         }
     }
@@ -1563,6 +1570,14 @@ impl BlocklistAIHistoryModel {
         terminal_view_id: Option<EntityId>,
         ctx: &mut ModelContext<Self>,
     ) {
+        // Capture the run_id BEFORE the in-memory record is dropped so the
+        // RemoveConversation event can carry it (event subscribers can no
+        // longer look it up via `conversation()` after this function returns).
+        let run_id = self
+            .conversations_by_id
+            .get(&conversation_id)
+            .and_then(|c| c.run_id());
+
         // Clean up reverse indices before removing the conversation. Guard
         // token-index removals with an equality check: the live conversation's
         // token and the metadata's token can diverge after a rebind, and we
@@ -1614,6 +1629,7 @@ impl BlocklistAIHistoryModel {
             ctx.emit(BlocklistAIHistoryEvent::RemoveConversation {
                 terminal_view_id,
                 conversation_id,
+                run_id,
             });
         }
     }
@@ -2129,16 +2145,23 @@ pub enum BlocklistAIHistoryEvent {
 
     /// This is emitted when an ephemeral/abandoned conversation is cleaned up
     /// (e.g. empty conversations the user never used, rejected passive code suggestions).
+    /// `run_id` carries the conversation's last known server run identifier
+    /// (captured before the in-memory record was dropped) so subscribers can
+    /// still act on it without a history-model lookup.
     RemoveConversation {
         terminal_view_id: EntityId,
         conversation_id: AIConversationId,
+        run_id: Option<String>,
     },
 
     /// This is emitted when a user explicitly deletes an existing conversation.
+    /// `run_id` is captured before the in-memory record was dropped — see
+    /// the note on [`Self::RemoveConversation`].
     DeletedConversation {
         terminal_view_id: EntityId,
         conversation_id: AIConversationId,
         conversation_title: Option<String>,
+        run_id: Option<String>,
     },
 
     /// Emitted when conversations are restored in a terminal view.

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -1,7 +1,10 @@
 use super::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
-use super::orchestration_events::{OrchestrationEventService, PendingEvent, PendingEventDetail};
+use super::orchestration_events::{
+    build_lifecycle_event, LifecycleEventDetailPayload, LifecycleEventDetailStage,
+    OrchestrationEventService, PendingEvent, PendingEventDetail,
+};
 use crate::ai::agent::{
-    conversation::{AIConversationId, ConversationStatus},
+    conversation::AIConversationId, AIAgentExchangeId, AIAgentOutputMessageType,
     ReceivedMessageInput,
 };
 use crate::ai::agent_events::{
@@ -20,18 +23,15 @@ use uuid::Uuid;
 use warp_core::features::FeatureFlag;
 use warp_multi_agent_api as api;
 use warpui::r#async::Timer;
-use warpui::{Entity, ModelContext, SingletonEntity};
+use warpui::{
+    Entity, EntityId, GetSingletonModelHandle, ModelContext, SingletonEntity, UpdateModel,
+};
 
-/// Backoff schedule (seconds) reused for the post-restore
+/// Backoff schedule (seconds) for the post-restore
 /// `get_ambient_agent_task` retry: 1s, 2s, 5s, then 10s max.
 const RESTORE_FETCH_BACKOFF_STEPS: &[u64] = &[1, 2, 5, 10];
 /// How often (milliseconds) the drain timer checks for SSE events.
 const SSE_DRAIN_INTERVAL_MS: u64 = 500;
-
-/// Tracks messages awaiting server-side delivery confirmation.
-struct PendingDeliveryConfirmation {
-    message_ids: Vec<String>,
-}
 
 /// Per-event item delivered from the SSE background task to the entity.
 struct SseStreamItem {
@@ -76,26 +76,53 @@ impl AgentEventConsumer for SseForwardingConsumer {
     }
 }
 
+/// All per-conversation streaming state. Created lazily on first access
+/// (via `entry().or_default()`) and dropped when the conversation is
+/// removed from the history model.
+#[derive(Default)]
+struct ConversationStreamState {
+    /// Run IDs the SSE filter watches for this conversation. When the
+    /// conversation has any orchestration role, this contains its own
+    /// `self_run_id` (its inbox — used both for parent→child traffic on
+    /// children and child→parent traffic on parents); when it acts as a
+    /// parent it additionally contains each registered child run_id.
+    watched_run_ids: HashSet<String>,
+    /// Last fully handled event sequence number. 0 means "no events
+    /// processed yet".
+    event_cursor: i64,
+    /// Message IDs awaiting server-side `mark_delivered` confirmation,
+    /// triggered when the recipient streams a `MessagesReceivedFromAgents`
+    /// chunk through `BlocklistAIHistoryEvent::UpdatedStreamingExchange`.
+    pending_message_ids: Vec<String>,
+    /// Local consumers (terminal pane id for an open agent view, driver
+    /// model id for `agent_sdk`) that need events delivered to this
+    /// conversation.
+    consumers: HashSet<EntityId>,
+    /// Active SSE connection, if one is open.
+    sse_connection: Option<SseConnectionState>,
+    /// Consecutive `get_ambient_agent_task` failure count for the
+    /// post-restore retry loop; resets on success.
+    restore_fetch_failures: usize,
+}
+
 /// Async network coordinator for v2 orchestration event delivery via SSE.
-/// Opens persistent SSE connections to the server and forwards events into
-/// the OrchestrationEventService. Owns watched run_ids, event cursors used
-/// for deduplication, lifecycle reporting, and delivery confirmation.
-/// SSE retries with exponential backoff on failure.
+///
+/// Holds at most one long-lived SSE connection per conversation. The
+/// streamer opens a connection only when a conversation has both an
+/// active local consumer (an open agent view, or an `agent_sdk` driver
+/// in CLI / cloud worker processes) and at least one orchestration role
+/// in this process — being a child, or having registered child run_ids.
+/// Without a local consumer the events would have nowhere to go, so the
+/// connection stays closed and the cursor is used to backfill once a
+/// consumer registers.
 pub struct OrchestrationEventStreamer {
     ai_client: Arc<dyn AIClient>,
     server_api: Arc<ServerApi>,
-    watched_run_ids: HashMap<AIConversationId, HashSet<String>>,
-    event_cursor: HashMap<AIConversationId, i64>,
-    pending_delivery: HashMap<AIConversationId, PendingDeliveryConfirmation>,
-    conversation_statuses: HashMap<AIConversationId, ConversationStatus>,
-    /// Active SSE connections keyed by conversation.
-    sse_connections: HashMap<AIConversationId, SseConnectionState>,
+    /// Per-conversation streaming state.
+    streams: HashMap<AIConversationId, ConversationStreamState>,
     /// Monotonic counter for SSE connection generations. Ensures stale
     /// callbacks from replaced connections are discarded.
     next_sse_generation: u64,
-    /// Consecutive failure count for the post-restore `get_ambient_agent_task`
-    /// fetch (resets on success). Drives exponential backoff for retries.
-    restore_fetch_failures: HashMap<AIConversationId, usize>,
 }
 
 pub enum OrchestrationEventStreamerEvent {
@@ -114,13 +141,8 @@ impl OrchestrationEventStreamer {
         Self {
             ai_client,
             server_api,
-            watched_run_ids: HashMap::new(),
-            event_cursor: HashMap::new(),
-            pending_delivery: HashMap::new(),
-            conversation_statuses: HashMap::new(),
-            sse_connections: HashMap::new(),
+            streams: HashMap::new(),
             next_sse_generation: 0,
-            restore_fetch_failures: HashMap::new(),
         }
     }
 
@@ -140,38 +162,93 @@ impl OrchestrationEventStreamer {
         Self {
             ai_client,
             server_api,
-            watched_run_ids: HashMap::new(),
-            event_cursor: HashMap::new(),
-            pending_delivery: HashMap::new(),
-            conversation_statuses: HashMap::new(),
-            sse_connections: HashMap::new(),
+            streams: HashMap::new(),
             next_sse_generation: 0,
-            restore_fetch_failures: HashMap::new(),
         }
     }
 
-    /// Registers a run_id to watch for events on a conversation.
-    /// Called by the start_agent executor for child run_ids and by
-    /// self-registration for the conversation's own token.
-    ///
-    /// If SSE mode is active for this conversation, the current connection is
-    /// torn down and a new one is opened with the updated run_id set.
+    // ---- Public consumer registry API ---------------------------------
+
+    /// Register a consumer for a conversation. Re-evaluates eligibility
+    /// and opens the SSE connection if the conversation is newly
+    /// eligible. Idempotent: re-registering an existing consumer is a
+    /// no-op for the registry, but still triggers eligibility
+    /// re-evaluation (which is itself idempotent).
+    pub fn register_consumer(
+        &mut self,
+        conversation_id: AIConversationId,
+        consumer_id: EntityId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let stream = self.streams.entry(conversation_id).or_default();
+        let inserted = stream.consumers.insert(consumer_id);
+        if inserted {
+            log::info!(
+                "register_consumer for {conversation_id:?}: {consumer_id:?} \
+                 (total={})",
+                stream.consumers.len()
+            );
+        }
+        // If the server-token event fired before this registration, pick
+        // up the now-available child role here.
+        self.ensure_self_run_id_watched(conversation_id, ctx);
+        self.reevaluate_eligibility(conversation_id, ctx);
+    }
+
+    /// Unregister a consumer for a conversation. Re-evaluates eligibility
+    /// and tears down the SSE connection if the conversation is no longer
+    /// eligible (and the conversation is not also in the child role).
+    pub fn unregister_consumer(
+        &mut self,
+        conversation_id: AIConversationId,
+        consumer_id: EntityId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let removed = self
+            .streams
+            .get_mut(&conversation_id)
+            .map(|s| s.consumers.remove(&consumer_id))
+            .unwrap_or(false);
+        if removed {
+            let remaining = self
+                .streams
+                .get(&conversation_id)
+                .map(|s| s.consumers.len())
+                .unwrap_or(0);
+            log::info!(
+                "unregister_consumer for {conversation_id:?}: {consumer_id:?} \
+                 (remaining={remaining})"
+            );
+        }
+        self.reevaluate_eligibility(conversation_id, ctx);
+    }
+
+    /// Registers a run_id to watch for events on a conversation. Called
+    /// by the start_agent executor for child run_ids and by the
+    /// streamer's own helpers for self_run_id (child / parent inbox).
     pub fn register_watched_run_id(
         &mut self,
         conversation_id: AIConversationId,
         run_id: String,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.watched_run_ids
+        let inserted = self
+            .streams
             .entry(conversation_id)
             .or_default()
+            .watched_run_ids
             .insert(run_id);
-
-        // Reconnect SSE with the updated run_ids when a new child is spawned.
-        if self.sse_connections.contains_key(&conversation_id) {
-            self.reconnect_sse(conversation_id, ctx);
+        // Adding the first child flips the conversation into the parent
+        // role; ensure self_run_id is also watched so child→parent
+        // messages match the SSE filter (without it the parent only sees
+        // child lifecycle events).
+        let self_inserted = self.ensure_self_run_id_watched(conversation_id, ctx);
+        if inserted || self_inserted {
+            self.reevaluate_eligibility(conversation_id, ctx);
         }
     }
+
+    // ---- Event subscriptions from BlocklistAIHistoryModel -------------
 
     fn handle_history_event(
         &mut self,
@@ -179,15 +256,6 @@ impl OrchestrationEventStreamer {
         ctx: &mut ModelContext<Self>,
     ) {
         match event {
-            BlocklistAIHistoryEvent::UpdatedConversationStatus {
-                conversation_id,
-                is_restored,
-                ..
-            } => {
-                if !*is_restored {
-                    self.on_conversation_status_updated(*conversation_id, ctx);
-                }
-            }
             BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
                 conversation_id, ..
             } => self.on_server_token_assigned(*conversation_id, ctx),
@@ -197,19 +265,21 @@ impl OrchestrationEventStreamer {
                 ..
             } => self.on_streaming_exchange_updated(*conversation_id, *exchange_id, ctx),
             BlocklistAIHistoryEvent::RemoveConversation {
-                conversation_id, ..
+                conversation_id,
+                run_id,
+                ..
             }
             | BlocklistAIHistoryEvent::DeletedConversation {
-                conversation_id, ..
+                conversation_id,
+                run_id,
+                ..
             } => {
-                self.watched_run_ids.remove(conversation_id);
-                self.event_cursor.remove(conversation_id);
-                self.pending_delivery.remove(conversation_id);
-                self.conversation_statuses.remove(conversation_id);
-                self.restore_fetch_failures.remove(conversation_id);
-                // Dropping the SSE connection state closes the channel,
-                // causing the task's next send to fail and terminate.
-                self.sse_connections.remove(conversation_id);
+                self.on_conversation_removed(*conversation_id, run_id.clone(), ctx);
+            }
+            BlocklistAIHistoryEvent::RestoredConversations {
+                conversation_ids, ..
+            } => {
+                self.on_restored_conversations(conversation_ids.clone(), ctx);
             }
             BlocklistAIHistoryEvent::StartedNewConversation { .. }
             | BlocklistAIHistoryEvent::CreatedSubtask { .. }
@@ -222,265 +292,9 @@ impl OrchestrationEventStreamer {
             | BlocklistAIHistoryEvent::UpdatedTodoList { .. }
             | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. }
             | BlocklistAIHistoryEvent::SplitConversation { .. }
+            | BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
             | BlocklistAIHistoryEvent::UpdatedConversationMetadata { .. }
             | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. } => {}
-            BlocklistAIHistoryEvent::RestoredConversations {
-                conversation_ids, ..
-            } => {
-                self.on_restored_conversations(conversation_ids.clone(), ctx);
-            }
-        }
-    }
-
-    /// Handles restoration of conversations on startup (or driver re-attach).
-    ///
-    /// Re-establishes orchestration event delivery state that is not persisted
-    /// directly in memory: watched run_ids, the per-conversation event cursor,
-    /// and — for `Success` parents with watched children — the SSE event loop.
-    fn on_restored_conversations(
-        &mut self,
-        conversation_ids: Vec<AIConversationId>,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        // Orchestration v2 owns the events endpoints and the cursor model.
-        // V1 conversations may carry a run_id but the v2-only event APIs
-        // would return spurious 4xx responses, so skip restore entirely
-        // when V2 is disabled.
-        if !FeatureFlag::OrchestrationV2.is_enabled() {
-            return;
-        }
-
-        for conv_id in conversation_ids {
-            let (run_id, cursor, status, is_viewer) = {
-                let history_model = BlocklistAIHistoryModel::as_ref(ctx);
-                let Some(conversation) = history_model.conversation(&conv_id) else {
-                    continue;
-                };
-                let is_viewer = conversation.is_viewing_shared_session();
-                let run_id = conversation.run_id();
-                let cursor = conversation.last_event_sequence().unwrap_or(0);
-                let status = conversation.status().clone();
-                (run_id, cursor, status, is_viewer)
-            };
-
-            // Shared-session viewers receive updates through session sharing;
-            // subscribing here would re-inject events the session has already
-            // processed.
-            if is_viewer {
-                continue;
-            }
-
-            // Initialize the in-memory cursor from the persisted SQLite value.
-            // A later server `GET /agent/runs/{run_id}` response may advance
-            // it to `max(SQLite, server)` before delivery starts.
-            //
-            // Note: a status transition arriving in the window before
-            // finish_restore_fetch completes may trigger
-            // start_event_delivery with only the SQLite cursor. This is
-            // acceptable — worst case is one extra batch of duplicate
-            // events.
-            self.event_cursor.insert(conv_id, cursor);
-            self.conversation_statuses.insert(conv_id, status.clone());
-
-            // Register the conversation's own run_id so lifecycle events for
-            // self are correctly filtered and the SSE loop has a set
-            // of run_ids to open against.
-            if let Some(ref own) = run_id {
-                self.watched_run_ids
-                    .entry(conv_id)
-                    .or_default()
-                    .insert(own.clone());
-            }
-
-            // No run_id means we can't query the server for children or for
-            // the canonical cursor. There's nothing more to do here; if a
-            // run_id gets assigned later the standard self-registration path
-            // will pick it up.
-            let Some(run_id) = run_id else {
-                self.maybe_start_delivery_after_restore(conv_id, &status, ctx);
-                continue;
-            };
-
-            let Ok(task_id) = run_id.parse::<crate::ai::ambient_agents::AmbientAgentTaskId>()
-            else {
-                log::warn!("could not parse run_id {run_id:?} for {conv_id:?}");
-                self.maybe_start_delivery_after_restore(conv_id, &status, ctx);
-                continue;
-            };
-
-            self.spawn_restore_fetch(conv_id, task_id, cursor, ctx);
-        }
-    }
-
-    /// Issues `GET /agent/runs/{task_id}` and routes the result through
-    /// `finish_restore_fetch`. Used both for the initial post-restore fetch
-    /// and for backoff-driven retries.
-    fn spawn_restore_fetch(
-        &mut self,
-        conv_id: AIConversationId,
-        task_id: crate::ai::ambient_agents::AmbientAgentTaskId,
-        sqlite_cursor: i64,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let ai_client = self.ai_client.clone();
-        ctx.spawn(
-            async move { ai_client.get_ambient_agent_task(&task_id).await },
-            move |me, run_result, ctx| {
-                me.finish_restore_fetch(conv_id, task_id, sqlite_cursor, run_result, ctx);
-            },
-        );
-    }
-
-    /// Completes the post-restore async fetch by merging the server cursor,
-    /// installing the server-reported child run_ids, and — if the parent is
-    /// `Success` — starting event delivery. On a server-fetch failure,
-    /// schedules a retry with exponential backoff: V2 children always have a
-    /// server-side `ai_tasks` row, so the server is the authoritative source
-    /// for the watched run_id set, and any local fallback would be incomplete
-    /// anyway. Without network connectivity event delivery wouldn't function,
-    /// so retrying is the right behavior.
-    fn finish_restore_fetch(
-        &mut self,
-        conv_id: AIConversationId,
-        task_id: crate::ai::ambient_agents::AmbientAgentTaskId,
-        sqlite_cursor: i64,
-        run_result: anyhow::Result<crate::ai::ambient_agents::task::AmbientAgentTask>,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        match run_result {
-            Ok(task) => {
-                // If the conversation was removed while the fetch was in-flight,
-                // the removal handler already cleaned up all streamer state. Return
-                // early to avoid recreating watched_run_ids for a deleted conversation.
-                if !self.event_cursor.contains_key(&conv_id) {
-                    self.restore_fetch_failures.remove(&conv_id);
-                    return;
-                }
-
-                // Reset the retry counter on success.
-                self.restore_fetch_failures.remove(&conv_id);
-
-                // Merge the server cursor: use the max of SQLite and server
-                // values so we don't re-deliver events the client already
-                // acknowledged locally.
-                let server_seq = task.last_event_sequence.unwrap_or(0);
-                let merged = sqlite_cursor.max(server_seq);
-                self.event_cursor.insert(conv_id, merged);
-
-                // The server response includes `children` inline on
-                // `AmbientAgentTask`; this is the authoritative set of
-                // direct child run_ids for the parent.
-                //
-                // Insert children and reconnect SSE once if any new run_ids
-                // were added and a connection is already open (e.g. because a
-                // status transition raced with this fetch and opened SSE with
-                // only the parent's own run_id).
-                let had_sse = self.sse_connections.contains_key(&conv_id);
-                let watched = self.watched_run_ids.entry(conv_id).or_default();
-                let mut any_new_children = false;
-                for child in task.children {
-                    if watched.insert(child) {
-                        any_new_children = true;
-                    }
-                }
-                if any_new_children && had_sse {
-                    self.reconnect_sse(conv_id, ctx);
-                }
-
-                let status = BlocklistAIHistoryModel::as_ref(ctx)
-                    .conversation(&conv_id)
-                    .map(|c| c.status().clone())
-                    .unwrap_or(ConversationStatus::Success);
-                self.maybe_start_delivery_after_restore(conv_id, &status, ctx);
-            }
-            Err(err) => {
-                log::warn!("Restore: get_agent_run failed for {conv_id:?}: {err:#}; will retry");
-                self.start_restore_fetch_retry_timer(conv_id, task_id, sqlite_cursor, ctx);
-            }
-        }
-    }
-
-    /// Schedules a retry of the post-restore `get_ambient_agent_task` fetch
-    /// after an exponential backoff. The backoff schedule reuses
-    /// `RESTORE_FETCH_BACKOFF_STEPS` (1s, 2s, 5s, 10s capped) keyed on a
-    /// per-conversation failure counter. The counter resets on success.
-    fn start_restore_fetch_retry_timer(
-        &mut self,
-        conv_id: AIConversationId,
-        task_id: crate::ai::ambient_agents::AmbientAgentTaskId,
-        sqlite_cursor: i64,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let failures = self
-            .restore_fetch_failures
-            .entry(conv_id)
-            .and_modify(|c| *c += 1)
-            .or_insert(1);
-        let step_index = failures
-            .saturating_sub(1)
-            .min(RESTORE_FETCH_BACKOFF_STEPS.len() - 1);
-        let backoff = Duration::from_secs(RESTORE_FETCH_BACKOFF_STEPS[step_index]);
-        ctx.spawn(
-            async move { Timer::after(backoff).await },
-            move |me, _, ctx| {
-                // The conversation may have been removed in the meantime;
-                // if so, drop the retry. Otherwise re-issue the fetch.
-                if !me.event_cursor.contains_key(&conv_id) {
-                    me.restore_fetch_failures.remove(&conv_id);
-                    return;
-                }
-                me.spawn_restore_fetch(conv_id, task_id, sqlite_cursor, ctx);
-            },
-        );
-    }
-
-    /// Starts event delivery for a restored conversation if the parent is
-    /// currently `Success` and has at least one watched run_id. `InProgress`
-    /// parents are deferred to `on_conversation_status_updated` once they
-    /// next transition to `Success`.
-    fn maybe_start_delivery_after_restore(
-        &mut self,
-        conv_id: AIConversationId,
-        status: &ConversationStatus,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let has_watched = self
-            .watched_run_ids
-            .get(&conv_id)
-            .is_some_and(|w| !w.is_empty());
-        if !has_watched {
-            return;
-        }
-        if matches!(status, ConversationStatus::Success) {
-            self.start_event_delivery(conv_id, ctx);
-        }
-    }
-
-    fn on_conversation_status_updated(
-        &mut self,
-        conversation_id: AIConversationId,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let (current_status, previous_status) = {
-            let Some(conversation) =
-                BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
-            else {
-                self.conversation_statuses.remove(&conversation_id);
-                return;
-            };
-            let prev = self
-                .conversation_statuses
-                .insert(conversation_id, conversation.status().clone());
-            (conversation.status().clone(), prev)
-        };
-
-        let became_success = matches!(&current_status, ConversationStatus::Success)
-            && !matches!(previous_status.as_ref(), Some(ConversationStatus::Success));
-
-        // Open an SSE stream when a conversation with watched run_ids
-        // becomes idle.
-        if became_success && self.watched_run_ids.contains_key(&conversation_id) {
-            self.start_event_delivery(conversation_id, ctx);
         }
     }
 
@@ -489,34 +303,68 @@ impl OrchestrationEventStreamer {
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
     ) {
-        let run_id = {
-            let Some(conversation) =
-                BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
-            else {
-                return;
+        if self.ensure_self_run_id_watched(conversation_id, ctx) {
+            self.reevaluate_eligibility(conversation_id, ctx);
+        }
+    }
+
+    /// Inserts `self_run_id` into the conversation's watched set if the
+    /// conversation has any orchestration role (child or parent) and is
+    /// not a passive remote-run view. Returns whether anything was
+    /// inserted; callers reevaluate eligibility on `true`. Idempotent.
+    fn ensure_self_run_id_watched(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &warpui::AppContext,
+    ) -> bool {
+        let (run_id, is_child) = {
+            let history = BlocklistAIHistoryModel::as_ref(ctx);
+            let Some(conversation) = history.conversation(&conversation_id) else {
+                return false;
             };
-            // Shared session viewers must not subscribe to events — the
-            // actual agent handles event delivery. Subscribing here would
-            // re-inject events the session has already processed.
-            if conversation.is_viewing_shared_session() {
-                return;
+            // Passive views of agent runs hosted elsewhere (shared-session
+            // viewers and remote-child placeholders) must not subscribe —
+            // the actual agent (in another process) is the inbox.
+            if conversation.is_viewing_shared_session() || conversation.is_remote_child() {
+                return false;
             }
             let Some(run_id) = conversation.run_id() else {
-                return;
+                return false;
             };
-            run_id
+            (run_id, conversation.has_parent_agent())
         };
-        self.register_watched_run_id(conversation_id, run_id, ctx);
+
+        // Parent role: any watched run_id that isn't this conversation's
+        // own self_run_id (i.e. a registered child).
+        let is_parent = self
+            .streams
+            .get(&conversation_id)
+            .is_some_and(|s| s.watched_run_ids.iter().any(|id| id != &run_id));
+
+        if !is_child && !is_parent {
+            return false;
+        }
+
+        self.streams
+            .entry(conversation_id)
+            .or_default()
+            .watched_run_ids
+            .insert(run_id)
     }
 
     fn on_streaming_exchange_updated(
         &mut self,
         conversation_id: AIConversationId,
-        exchange_id: crate::ai::agent::AIAgentExchangeId,
+        exchange_id: AIAgentExchangeId,
         ctx: &mut ModelContext<Self>,
     ) {
-        let Some(pending) = self.pending_delivery.get(&conversation_id) else {
-            return;
+        // Snapshot pending IDs so the immutable borrow on `self.streams`
+        // doesn't collide with the history model lookup below.
+        let pending_ids: HashSet<String> = match self.streams.get(&conversation_id) {
+            Some(s) if !s.pending_message_ids.is_empty() => {
+                s.pending_message_ids.iter().cloned().collect()
+            }
+            _ => return,
         };
 
         let Some(conversation) =
@@ -530,13 +378,11 @@ impl OrchestrationEventStreamer {
 
         // Check if the exchange output contains any of the messages we're
         // waiting to confirm.
-        let pending_ids: HashSet<&str> = pending.message_ids.iter().map(String::as_str).collect();
         let mut confirmed_ids = Vec::new();
         if let Some(output) = exchange.output_status.output() {
             for msg in &output.get().messages {
-                if let crate::ai::agent::AIAgentOutputMessageType::MessagesReceivedFromAgents {
-                    messages,
-                } = &msg.message
+                if let AIAgentOutputMessageType::MessagesReceivedFromAgents { messages } =
+                    &msg.message
                 {
                     for received in messages {
                         if pending_ids.contains(received.message_id.as_str()) {
@@ -552,11 +398,10 @@ impl OrchestrationEventStreamer {
         }
 
         // Remove confirmed messages from pending.
-        if let Some(pending) = self.pending_delivery.get_mut(&conversation_id) {
-            pending.message_ids.retain(|id| !confirmed_ids.contains(id));
-            if pending.message_ids.is_empty() {
-                self.pending_delivery.remove(&conversation_id);
-            }
+        if let Some(stream) = self.streams.get_mut(&conversation_id) {
+            stream
+                .pending_message_ids
+                .retain(|id| !confirmed_ids.contains(id));
         }
 
         let hydrator = MessageHydrator::new(self.ai_client.clone());
@@ -574,15 +419,502 @@ impl OrchestrationEventStreamer {
         );
     }
 
+    /// Cleans up local state for a removed/deleted conversation, then
+    /// prunes the removed conversation's run_id from any *other*
+    /// tracked conversation's watched set (in case it was a child of
+    /// another parent we're still tracking) and re-evaluates eligibility
+    /// for those parents.
+    ///
+    /// `removed_run_id` is the run_id of the conversation as captured by
+    /// the history model just before it dropped its in-memory record.
+    /// Looking it up here would return `None` because the history model
+    /// emits the removal event after removing the record.
+    fn on_conversation_removed(
+        &mut self,
+        conversation_id: AIConversationId,
+        removed_run_id: Option<String>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        // Drop all per-conversation streamer state in one go (cursor,
+        // pending IDs, consumers, watched run_ids, SSE connection).
+        // Dropping the SSE receiver causes the driver task's next send
+        // to fail and exit; the drain timer's `is_current` check then
+        // no-ops on its next tick.
+        self.streams.remove(&conversation_id);
+
+        // Prune the removed conversation's run_id from every other
+        // tracked conversation's watched set, then re-evaluate eligibility
+        // for the affected parents.
+        if let Some(run_id) = removed_run_id.as_deref() {
+            let mut affected = Vec::new();
+            for (other_id, stream) in self.streams.iter_mut() {
+                if stream.watched_run_ids.remove(run_id) {
+                    affected.push(*other_id);
+                }
+            }
+            for other_id in affected {
+                self.reevaluate_eligibility(other_id, ctx);
+            }
+        }
+    }
+
+    // ---- Restore-on-startup ------------------------------------------
+
+    /// Re-establishes orchestration event delivery state for conversations
+    /// loaded from disk on startup. Initializes the in-memory cursor from
+    /// the SQLite-persisted `last_event_sequence`, registers each
+    /// conversation's own run_id as watched, and (when a run_id is
+    /// available) issues `GET /agent/runs/{run_id}` to repopulate child
+    /// run_ids and merge the server-side cursor. SSE eligibility is then
+    /// re-evaluated through the standard predicate — it opens an SSE iff
+    /// a consumer registers and the conversation has a role in the tree.
+    fn on_restored_conversations(
+        &mut self,
+        conversation_ids: Vec<AIConversationId>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        // Orchestration v2 owns the events endpoints and the cursor model.
+        // V1 conversations may carry a run_id but the v2-only event APIs
+        // would return spurious 4xx responses, so skip restore entirely
+        // when V2 is disabled.
+        if !FeatureFlag::OrchestrationV2.is_enabled() {
+            return;
+        }
+
+        for conv_id in conversation_ids {
+            let (run_id, cursor, is_remote_view) = {
+                let history = BlocklistAIHistoryModel::as_ref(ctx);
+                let Some(conversation) = history.conversation(&conv_id) else {
+                    continue;
+                };
+                let is_remote_view =
+                    conversation.is_viewing_shared_session() || conversation.is_remote_child();
+                let run_id = conversation.run_id();
+                let cursor = conversation.last_event_sequence().unwrap_or(0);
+                (run_id, cursor, is_remote_view)
+            };
+
+            // Passive views of remote runs (shared-session viewers,
+            // remote-child placeholders) must not subscribe — the actual
+            // agent in another process owns the inbox.
+            if is_remote_view {
+                continue;
+            }
+
+            // Initialize the in-memory cursor from the persisted SQLite
+            // value, and register the conversation's own run_id so
+            // lifecycle events for self are correctly filtered. A later
+            // server `GET /agent/runs/{run_id}` response may advance the
+            // cursor to `max(SQLite, server)` before delivery starts.
+            let stream = self.streams.entry(conv_id).or_default();
+            stream.event_cursor = cursor;
+            if let Some(ref own) = run_id {
+                stream.watched_run_ids.insert(own.clone());
+            }
+
+            // No run_id means we can't query the server for children or
+            // for the canonical cursor. Re-evaluate eligibility based on
+            // current state; a run_id assigned later flows through
+            // `on_server_token_assigned`.
+            let Some(run_id) = run_id else {
+                self.reevaluate_eligibility(conv_id, ctx);
+                continue;
+            };
+
+            let Ok(task_id) = run_id.parse::<crate::ai::ambient_agents::AmbientAgentTaskId>()
+            else {
+                log::warn!("could not parse run_id {run_id:?} for {conv_id:?}");
+                self.reevaluate_eligibility(conv_id, ctx);
+                continue;
+            };
+
+            self.spawn_restore_fetch(conv_id, task_id, cursor, ctx);
+        }
+    }
+
+    /// Issues `GET /agent/runs/{task_id}` and routes the result through
+    /// `finish_restore_fetch`. Used both for the initial post-restore
+    /// fetch and for backoff-driven retries.
+    fn spawn_restore_fetch(
+        &mut self,
+        conv_id: AIConversationId,
+        task_id: crate::ai::ambient_agents::AmbientAgentTaskId,
+        sqlite_cursor: i64,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let ai_client = self.ai_client.clone();
+        ctx.spawn(
+            async move { ai_client.get_ambient_agent_task(&task_id).await },
+            move |me, run_result, ctx| {
+                me.finish_restore_fetch(conv_id, task_id, sqlite_cursor, run_result, ctx);
+            },
+        );
+    }
+
+    /// Completes the post-restore async fetch by merging the server cursor
+    /// and installing the server-reported child run_ids. On a server-fetch
+    /// failure, schedules a retry with exponential backoff: V2 children
+    /// always have a server-side `ai_tasks` row, so the server is the
+    /// authoritative source for the watched run_id set, and any local
+    /// fallback would be incomplete. Without network connectivity event
+    /// delivery wouldn't function anyway, so retrying is the right
+    /// behavior.
+    fn finish_restore_fetch(
+        &mut self,
+        conv_id: AIConversationId,
+        task_id: crate::ai::ambient_agents::AmbientAgentTaskId,
+        sqlite_cursor: i64,
+        run_result: anyhow::Result<crate::ai::ambient_agents::task::AmbientAgentTask>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match run_result {
+            Ok(task) => {
+                // If the conversation was removed while the fetch was
+                // in-flight, the removal handler already cleaned up all
+                // streamer state. Return early to avoid recreating
+                // state for a deleted conversation.
+                let had_sse;
+                let any_new_children;
+                {
+                    let Some(stream) = self.streams.get_mut(&conv_id) else {
+                        return;
+                    };
+
+                    // Reset the retry counter on success.
+                    stream.restore_fetch_failures = 0;
+
+                    // Merge the server cursor: use the max of SQLite and
+                    // server values so we don't re-deliver events the
+                    // client already acknowledged locally.
+                    let server_seq = task.last_event_sequence.unwrap_or(0);
+                    stream.event_cursor = sqlite_cursor.max(server_seq);
+
+                    // Insert any new children. If new run_ids were added
+                    // and an SSE connection is already open (e.g. a
+                    // status race opened SSE with only the parent's own
+                    // run_id), reconnect so the new run_ids are included
+                    // in the filter; otherwise re-evaluate eligibility.
+                    had_sse = stream.sse_connection.is_some();
+                    let mut added = false;
+                    for child in task.children {
+                        if stream.watched_run_ids.insert(child) {
+                            added = true;
+                        }
+                    }
+                    any_new_children = added;
+                }
+                if any_new_children && had_sse {
+                    self.reconnect_sse(conv_id, ctx);
+                } else {
+                    self.reevaluate_eligibility(conv_id, ctx);
+                }
+            }
+            Err(err) => {
+                // If the conversation was removed mid-flight, drop the
+                // retry on the floor. Without this guard the retry timer
+                // would resurrect a stream entry via `entry().or_default()`
+                // and re-issue `get_ambient_agent_task` indefinitely for a
+                // deleted conversation.
+                if !self.streams.contains_key(&conv_id) {
+                    return;
+                }
+                log::warn!("Restore: get_agent_run failed for {conv_id:?}: {err:#}; will retry");
+                self.start_restore_fetch_retry_timer(conv_id, task_id, sqlite_cursor, ctx);
+            }
+        }
+    }
+
+    /// Schedules a retry of the post-restore `get_ambient_agent_task`
+    /// fetch after an exponential backoff (1s, 2s, 5s, 10s capped) keyed
+    /// on a per-conversation failure counter. The counter resets on
+    /// success.
+    fn start_restore_fetch_retry_timer(
+        &mut self,
+        conv_id: AIConversationId,
+        task_id: crate::ai::ambient_agents::AmbientAgentTaskId,
+        sqlite_cursor: i64,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let stream = self.streams.entry(conv_id).or_default();
+        stream.restore_fetch_failures += 1;
+        let failures = stream.restore_fetch_failures;
+        let step_index = failures
+            .saturating_sub(1)
+            .min(RESTORE_FETCH_BACKOFF_STEPS.len() - 1);
+        let backoff = Duration::from_secs(RESTORE_FETCH_BACKOFF_STEPS[step_index]);
+        ctx.spawn(
+            async move { Timer::after(backoff).await },
+            move |me, _, ctx| {
+                // The conversation may have been removed in the meantime;
+                // if so, drop the retry. Otherwise re-issue the fetch.
+                if !me.streams.contains_key(&conv_id) {
+                    return;
+                }
+                me.spawn_restore_fetch(conv_id, task_id, sqlite_cursor, ctx);
+            },
+        );
+    }
+
+    // ---- Eligibility predicate ---------------------------------------
+
+    fn self_run_id(
+        &self,
+        conversation_id: AIConversationId,
+        ctx: &warpui::AppContext,
+    ) -> Option<String> {
+        BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .and_then(|c| c.run_id())
+    }
+
+    /// Parent role: the conversation has at least one watched child
+    /// run_id (i.e. a watched run_id that is not its own self_run_id).
+    fn is_parent_agent_conversation(
+        &self,
+        conversation_id: AIConversationId,
+        ctx: &warpui::AppContext,
+    ) -> bool {
+        let Some(stream) = self.streams.get(&conversation_id) else {
+            return false;
+        };
+        let self_run_id = self.self_run_id(conversation_id, ctx);
+        stream
+            .watched_run_ids
+            .iter()
+            .any(|id| Some(id.as_str()) != self_run_id.as_deref())
+    }
+
+    fn has_active_consumer(&self, conversation_id: AIConversationId) -> bool {
+        self.streams
+            .get(&conversation_id)
+            .is_some_and(|s| !s.consumers.is_empty())
+    }
+
+    /// True iff this conversation is a passive view of an agent run that
+    /// is actually executing in another process — either a shared-session
+    /// viewer or a placeholder for a remote child run spawned via
+    /// `start_agent` with cloud `execution_mode`. Either way the actual
+    /// run lives elsewhere (and that process owns the inbox), so this
+    /// process should not open its own SSE for the conversation.
+    fn is_remote_run_view(
+        &self,
+        conversation_id: AIConversationId,
+        ctx: &warpui::AppContext,
+    ) -> bool {
+        BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .is_some_and(|c| c.is_viewing_shared_session() || c.is_remote_child())
+    }
+
+    /// True iff this conversation should currently hold an SSE connection.
+    /// A subscription is needed only when there is an active consumer in
+    /// this process (an open agent view or an agent_sdk driver) AND the
+    /// conversation has a real role to consume events for. Passive views
+    /// of agent runs hosted elsewhere are excluded regardless of state.
+    fn is_eligible(&self, conversation_id: AIConversationId, ctx: &warpui::AppContext) -> bool {
+        if !self.has_active_consumer(conversation_id) {
+            return false;
+        }
+        if self.is_remote_run_view(conversation_id, ctx) {
+            return false;
+        }
+        let has_parent = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .is_some_and(|c| c.has_parent_agent());
+        has_parent || self.is_parent_agent_conversation(conversation_id, ctx)
+    }
+
+    /// Returns the list of run_ids to subscribe to for `conversation_id`.
+    /// Includes both the conversation's own `self_run_id` (when it is a
+    /// child) and any registered child run_ids (when the conversation
+    /// is a parent). Both contributions live in `watched_run_ids`
+    /// already, so this is a straight clone.
+    fn run_ids_for_sse(&self, conversation_id: AIConversationId) -> Vec<String> {
+        self.streams
+            .get(&conversation_id)
+            .map(|s| s.watched_run_ids.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Re-evaluates eligibility and either opens / reconnects or tears
+    /// down the SSE connection for the given conversation.
+    fn reevaluate_eligibility(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let eligible = self.is_eligible(conversation_id, ctx);
+        let connected = self
+            .streams
+            .get(&conversation_id)
+            .is_some_and(|s| s.sse_connection.is_some());
+
+        match (eligible, connected) {
+            (true, false) => self.start_sse_connection(conversation_id, ctx),
+            (true, true) => {
+                // Already connected; reconnect with the current run_ids
+                // list (in case the parent role's contribution
+                // changed).
+                self.reconnect_sse(conversation_id, ctx);
+            }
+            (false, true) => self.teardown_sse(conversation_id, ctx),
+            (false, false) => {}
+        }
+    }
+
+    /// Opens a long-lived SSE connection for `conversation_id`. Events
+    /// are sent through an mpsc channel and drained by a periodic timer.
+    fn start_sse_connection(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let run_ids = self.run_ids_for_sse(conversation_id);
+        if run_ids.is_empty() {
+            return;
+        }
+
+        let cursor = self
+            .streams
+            .get(&conversation_id)
+            .map(|s| s.event_cursor)
+            .unwrap_or(0);
+
+        let server_api = self.server_api.clone();
+        let ai_client = self.ai_client.clone();
+
+        let self_run_id = self.self_run_id(conversation_id, ctx).unwrap_or_default();
+
+        let (tx, rx) = mpsc::unbounded();
+        let generation = self.next_sse_generation;
+        self.next_sse_generation += 1;
+
+        self.streams
+            .entry(conversation_id)
+            .or_default()
+            .sse_connection = Some(SseConnectionState {
+            event_receiver: rx,
+            generation,
+        });
+
+        log::info!(
+            "Opening SSE stream for {conversation_id:?} (gen={generation}, \
+             run_ids={run_ids:?}, since={cursor})"
+        );
+
+        let config = AgentEventDriverConfig::retry_forever(run_ids.clone(), cursor);
+        let source = ServerApiAgentEventSource::new(server_api);
+        let hydrator = MessageHydrator::new(ai_client);
+
+        ctx.spawn(
+            async move {
+                let mut consumer = SseForwardingConsumer {
+                    tx,
+                    self_run_id,
+                    hydrator,
+                };
+                run_agent_event_driver(source, config, &mut consumer).await
+            },
+            move |me, result, ctx| {
+                let is_current = me
+                    .streams
+                    .get(&conversation_id)
+                    .and_then(|s| s.sse_connection.as_ref())
+                    .is_some_and(|c| c.generation == generation);
+                if !is_current {
+                    return;
+                }
+
+                me.drain_sse_events(conversation_id, ctx);
+
+                if let Err(err) = result {
+                    log::warn!(
+                        "SSE driver exited for {conversation_id:?} (gen={generation}): {err:#}"
+                    );
+                    me.reconnect_sse(conversation_id, ctx);
+                }
+            },
+        );
+
+        // Start periodic event drain.
+        self.start_sse_drain_timer(conversation_id, generation, ctx);
+    }
+
+    /// Periodically fires to drain buffered SSE events into the event
+    /// service.
+    fn start_sse_drain_timer(
+        &self,
+        conversation_id: AIConversationId,
+        generation: u64,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        ctx.spawn(
+            async move {
+                Timer::after(Duration::from_millis(SSE_DRAIN_INTERVAL_MS)).await;
+            },
+            move |me, _, ctx| {
+                let is_current = me
+                    .streams
+                    .get(&conversation_id)
+                    .and_then(|s| s.sse_connection.as_ref())
+                    .is_some_and(|c| c.generation == generation);
+                if !is_current {
+                    return;
+                }
+                me.drain_sse_events(conversation_id, ctx);
+                me.start_sse_drain_timer(conversation_id, generation, ctx);
+            },
+        );
+    }
+
+    /// Drains all buffered SSE events and feeds them through the
+    /// `handle_event_batch` sink.
+    fn drain_sse_events(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let cursor;
+        let mut events = Vec::new();
+        let mut messages = Vec::new();
+        {
+            let Some(stream) = self.streams.get_mut(&conversation_id) else {
+                return;
+            };
+            cursor = stream.event_cursor;
+            let Some(sse) = stream.sse_connection.as_mut() else {
+                return;
+            };
+
+            while let Ok(Some(item)) = sse.event_receiver.try_next() {
+                // Deduplicate: discard events at or below the cursor.
+                if item.event.sequence > cursor {
+                    if let Some(msg) = item.fetched_message {
+                        messages.push(msg);
+                    }
+                    events.push(item.event);
+                }
+            }
+        }
+
+        if events.is_empty() {
+            return;
+        }
+
+        let self_run_id = self.self_run_id(conversation_id, ctx).unwrap_or_default();
+
+        self.handle_event_batch(conversation_id, &self_run_id, cursor, events, messages, ctx);
+    }
+
     /// Feeds a batch of fetched events through the OrchestrationEventService,
-    /// updating the in-memory and persisted cursors and tracking message IDs
-    /// awaiting delivery confirmation.
+    /// updating the in-memory and persisted cursors and tracking message
+    /// IDs awaiting delivery confirmation.
     fn handle_event_batch(
         &mut self,
         conversation_id: AIConversationId,
         self_run_id: &str,
         previous_cursor: i64,
-        events: Vec<crate::server::server_api::ai::AgentRunEvent>,
+        events: Vec<AgentRunEvent>,
         messages: Vec<ReceivedMessageInput>,
         ctx: &mut ModelContext<Self>,
     ) {
@@ -591,19 +923,22 @@ impl OrchestrationEventStreamer {
             .map(|e| e.sequence)
             .max()
             .unwrap_or(previous_cursor);
-        self.event_cursor.insert(conversation_id, max_seq);
+        self.streams
+            .entry(conversation_id)
+            .or_default()
+            .event_cursor = max_seq;
 
-        // Persist the cursor to SQLite so that after a restart we can resume
-        // event delivery from this sequence number without re-delivering
-        // events the parent has already acted on.
+        // Persist the cursor to SQLite so that after a restart we can
+        // resume event delivery from this sequence number without
+        // re-delivering events the parent has already acted on.
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |model, ctx| {
             model.update_event_sequence(conversation_id, max_seq, ctx);
         });
 
-        // Also persist the cursor to the server so driver / cloud restarts
-        // can resume without local SQLite state. Fire-and-forget: log on
-        // failure, don't block event delivery. The server persists the
-        // cursor on `ai_tasks.last_event_sequence`.
+        // Also persist the cursor to the server so driver / cloud
+        // restarts can resume without local SQLite state. Fire-and-forget:
+        // log on failure, don't block event delivery. The server persists
+        // the cursor on `ai_tasks.last_event_sequence`.
         let own_run_id = BlocklistAIHistoryModel::as_ref(ctx)
             .conversation(&conversation_id)
             .and_then(|c| c.run_id());
@@ -634,12 +969,10 @@ impl OrchestrationEventStreamer {
             .filter_map(|e| e.ref_id.clone())
             .collect();
         if !message_ids.is_empty() {
-            self.pending_delivery
+            self.streams
                 .entry(conversation_id)
-                .or_insert_with(|| PendingDeliveryConfirmation {
-                    message_ids: Vec::new(),
-                })
-                .message_ids
+                .or_default()
+                .pending_message_ids
                 .extend(message_ids);
         }
 
@@ -654,179 +987,31 @@ impl OrchestrationEventStreamer {
         });
     }
 
-    /// Opens an SSE connection for the given conversation if one isn't already active.
-    fn start_event_delivery(
-        &mut self,
-        conversation_id: AIConversationId,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        if !self.sse_connections.contains_key(&conversation_id) {
-            self.start_sse_connection(conversation_id, ctx);
-        }
-    }
-
-    /// Opens a long-lived SSE connection for `conversation_id`. Events are
-    /// sent through an mpsc channel and drained by a periodic timer.
-    fn start_sse_connection(
-        &mut self,
-        conversation_id: AIConversationId,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let Some(watched) = self.watched_run_ids.get(&conversation_id) else {
-            return;
-        };
-        if watched.is_empty() {
-            return;
-        }
-
-        let watched: Vec<String> = watched.iter().cloned().collect();
-        let cursor = self
-            .event_cursor
-            .get(&conversation_id)
-            .copied()
-            .unwrap_or(0);
-
-        let server_api = self.server_api.clone();
-        let ai_client = self.ai_client.clone();
-
-        let self_run_id = BlocklistAIHistoryModel::as_ref(ctx)
-            .conversation(&conversation_id)
-            .and_then(|c| c.run_id())
-            .map(|s| s.to_string())
-            .unwrap_or_default();
-
-        let (tx, rx) = mpsc::unbounded();
-        let generation = self.next_sse_generation;
-        self.next_sse_generation += 1;
-
-        self.sse_connections.insert(
-            conversation_id,
-            SseConnectionState {
-                event_receiver: rx,
-                generation,
-            },
-        );
-
-        log::info!(
-            "Opening SSE stream for {conversation_id:?} (gen={generation}, \
-             run_ids={watched:?}, since={cursor})"
-        );
-
-        let config = AgentEventDriverConfig::retry_forever(watched.clone(), cursor);
-        let source = ServerApiAgentEventSource::new(server_api);
-        let hydrator = MessageHydrator::new(ai_client);
-
-        ctx.spawn(
-            async move {
-                let mut consumer = SseForwardingConsumer {
-                    tx,
-                    self_run_id,
-                    hydrator,
-                };
-                run_agent_event_driver(source, config, &mut consumer).await
-            },
-            move |me, result, ctx| {
-                let is_current = me
-                    .sse_connections
-                    .get(&conversation_id)
-                    .is_some_and(|s| s.generation == generation);
-                if !is_current {
-                    return;
-                }
-
-                me.drain_sse_events(conversation_id, ctx);
-
-                if let Err(err) = result {
-                    log::warn!(
-                        "SSE driver exited for {conversation_id:?} (gen={generation}): {err:#}"
-                    );
-                    me.reconnect_sse(conversation_id, ctx);
-                }
-            },
-        );
-
-        // Start periodic event drain.
-        self.start_sse_drain_timer(conversation_id, generation, ctx);
-    }
-
-    /// Periodically fires to drain buffered SSE events into the event service.
-    fn start_sse_drain_timer(
-        &self,
-        conversation_id: AIConversationId,
-        generation: u64,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        ctx.spawn(
-            async move {
-                Timer::after(Duration::from_millis(SSE_DRAIN_INTERVAL_MS)).await;
-            },
-            move |me, _, ctx| {
-                let is_current = me
-                    .sse_connections
-                    .get(&conversation_id)
-                    .is_some_and(|s| s.generation == generation);
-                if !is_current {
-                    return;
-                }
-                me.drain_sse_events(conversation_id, ctx);
-                me.start_sse_drain_timer(conversation_id, generation, ctx);
-            },
-        );
-    }
-
-    /// Drains all buffered SSE events and feeds them through the
-    /// `handle_event_batch` sink.
-    fn drain_sse_events(
-        &mut self,
-        conversation_id: AIConversationId,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let Some(sse) = self.sse_connections.get_mut(&conversation_id) else {
-            return;
-        };
-
-        let cursor = self
-            .event_cursor
-            .get(&conversation_id)
-            .copied()
-            .unwrap_or(0);
-
-        let mut events = Vec::new();
-        let mut messages = Vec::new();
-
-        while let Ok(Some(item)) = sse.event_receiver.try_next() {
-            // Deduplicate: discard events at or below the cursor.
-            if item.event.sequence > cursor {
-                if let Some(msg) = item.fetched_message {
-                    messages.push(msg);
-                }
-                events.push(item.event);
-            }
-        }
-
-        if events.is_empty() {
-            return;
-        }
-
-        let self_run_id = BlocklistAIHistoryModel::as_ref(ctx)
-            .conversation(&conversation_id)
-            .and_then(|c| c.run_id())
-            .map(|s| s.to_string())
-            .unwrap_or_default();
-
-        self.handle_event_batch(conversation_id, &self_run_id, cursor, events, messages, ctx);
-    }
-
-    /// Tears down the current SSE connection and opens a new one with the
-    /// latest watched run_ids and cursor.
+    /// Tears down the current SSE connection and (if still eligible)
+    /// opens a new one with the latest run_ids list and cursor.
     fn reconnect_sse(&mut self, conversation_id: AIConversationId, ctx: &mut ModelContext<Self>) {
         // Drain buffered events before dropping the channel so we don't
         // discard already-fetched message bodies.
         self.drain_sse_events(conversation_id, ctx);
-        self.sse_connections.remove(&conversation_id);
+        if let Some(stream) = self.streams.get_mut(&conversation_id) {
+            stream.sse_connection = None;
+        }
 
-        if self.watched_run_ids.contains_key(&conversation_id) {
+        if self.is_eligible(conversation_id, ctx) {
             self.start_sse_connection(conversation_id, ctx);
+        }
+    }
+
+    /// Drops the SSE connection for a no-longer-eligible conversation.
+    /// Leaves `watched_run_ids` and `consumers` alone — those reflect
+    /// external state and are pruned through their own paths.
+    fn teardown_sse(&mut self, conversation_id: AIConversationId, ctx: &mut ModelContext<Self>) {
+        // Drain anything buffered so we don't lose hydrated messages.
+        self.drain_sse_events(conversation_id, ctx);
+        if let Some(stream) = self.streams.get_mut(&conversation_id) {
+            if stream.sse_connection.take().is_some() {
+                log::info!("Tearing down SSE for {conversation_id:?} (no longer eligible)");
+            }
         }
     }
 }
@@ -852,10 +1037,7 @@ fn parse_occurred_at(s: &str) -> prost_types::Timestamp {
         })
 }
 
-fn convert_lifecycle_events(
-    events: &[crate::server::server_api::ai::AgentRunEvent],
-    self_run_id: &str,
-) -> Vec<api::AgentEvent> {
+fn convert_lifecycle_events(events: &[AgentRunEvent], self_run_id: &str) -> Vec<api::AgentEvent> {
     events
         .iter()
         .filter(|e| e.event_type != "new_message" && e.run_id != self_run_id)
@@ -881,19 +1063,15 @@ fn convert_lifecycle_events(
             // TODO: Parse richer detail payloads (reason, error_message) from
             // the server event log once the schema supports them.
             let detail = match lifecycle_type {
-                api::LifecycleEventType::Errored => {
-                    super::orchestration_events::LifecycleEventDetailPayload {
-                        stage: Some(
-                            super::orchestration_events::LifecycleEventDetailStage::Runtime,
-                        ),
-                        reason: event.ref_id.clone(),
-                        ..Default::default()
-                    }
-                }
-                _ => super::orchestration_events::LifecycleEventDetailPayload::default(),
+                api::LifecycleEventType::Errored => LifecycleEventDetailPayload {
+                    stage: Some(LifecycleEventDetailStage::Runtime),
+                    reason: event.ref_id.clone(),
+                    ..Default::default()
+                },
+                _ => LifecycleEventDetailPayload::default(),
             };
             let event_id = Uuid::new_v4().to_string();
-            Some(super::orchestration_events::build_lifecycle_event(
+            Some(build_lifecycle_event(
                 event_id,
                 event.run_id.clone(),
                 lifecycle_type,
@@ -931,6 +1109,51 @@ fn build_pending_events(
         });
     }
     pending
+}
+
+// ---- Free-function consumer registration helpers ---------------------
+//
+// Wrap the feature-flag check + singleton handle update so call sites
+// in `ActiveAgentViewsModel` and the agent_sdk driver don't have to
+// repeat the boilerplate. The generic bound covers both
+// `&mut AppContext` and `&mut ModelContext<T>` / `&mut ViewContext<T>`.
+//
+// Consumers are identified by an `EntityId` — the terminal pane's id
+// for an agent view, the driver model's id for `agent_sdk`. The
+// streamer never branches on consumer kind, so a single pair of helpers
+// covers both call sites.
+
+/// Registers a consumer of orchestration agent events for
+/// `conversation_id`. No-op when `OrchestrationV2` is disabled.
+pub fn register_agent_event_consumer<C>(
+    conversation_id: AIConversationId,
+    consumer_id: EntityId,
+    ctx: &mut C,
+) where
+    C: GetSingletonModelHandle + UpdateModel,
+{
+    if !FeatureFlag::OrchestrationV2.is_enabled() {
+        return;
+    }
+    OrchestrationEventStreamer::handle(ctx).update(ctx, |streamer, ctx| {
+        streamer.register_consumer(conversation_id, consumer_id, ctx);
+    });
+}
+
+/// Pair to [`register_agent_event_consumer`].
+pub fn unregister_agent_event_consumer<C>(
+    conversation_id: AIConversationId,
+    consumer_id: EntityId,
+    ctx: &mut C,
+) where
+    C: GetSingletonModelHandle + UpdateModel,
+{
+    if !FeatureFlag::OrchestrationV2.is_enabled() {
+        return;
+    }
+    OrchestrationEventStreamer::handle(ctx).update(ctx, |streamer, ctx| {
+        streamer.unregister_consumer(conversation_id, consumer_id, ctx);
+    });
 }
 
 #[cfg(test)]

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -221,11 +221,11 @@ fn finish_restore_fetch_uses_server_cursor_when_sqlite_is_absent() {
             OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
         });
 
-        // Seed event_cursor as on_restored_conversations would before spawning
-        // the async fetch. Without this the guard that detects mid-flight
-        // conversation deletion would fire and return early.
+        // Seed a stream entry as on_restored_conversations would before
+        // spawning the async fetch. Without this the guard that detects
+        // mid-flight conversation deletion would fire and return early.
         poller.update(&mut app, |me, _| {
-            me.event_cursor.insert(conversation_id, 0);
+            me.streams.entry(conversation_id).or_default();
         });
 
         let task_id: crate::ai::ambient_agents::AmbientAgentTaskId =
@@ -241,91 +241,9 @@ fn finish_restore_fetch_uses_server_cursor_when_sqlite_is_absent() {
         });
 
         poller.read(&app, |me, _| {
-            assert_eq!(me.event_cursor.get(&conversation_id).copied(), Some(42));
-        });
-    });
-}
-
-#[test]
-fn restored_inprogress_parent_defers_delivery_until_success() {
-    use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
-    use crate::server::server_api::ai::MockAIClient;
-    use crate::server::server_api::ServerApiProvider;
-    use std::sync::Arc;
-    use warpui::App;
-
-    App::test((), |mut app| async move {
-        let _v2_guard = FeatureFlag::OrchestrationV2.override_enabled(true);
-
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
-
-        let mut conversation = AIConversation::new(false);
-        // Use a parsable UUID-shaped run_id so the poller can construct
-        // an `AmbientAgentTaskId` for the (mocked) server fetch.
-        conversation.set_run_id("550e8400-e29b-41d4-a716-446655440100".to_string());
-        let conversation_id: AIConversationId = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            // The default status after restore is `InProgress` for live
-            // conversations, but assert it explicitly to make the test
-            // self-documenting.
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let mut mock = MockAIClient::new();
-        // The async restore fetch may or may not complete during the test;
-        // a permissive expectation prevents spurious panics either way.
-        mock.expect_get_ambient_agent_task()
-            .returning(|_| Ok(make_ambient_task_with_event_seq(None)));
-        mock.expect_update_event_sequence_on_server()
-            .returning(|_, _| Ok(()));
-        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
-        let server_api = ServerApiProvider::new_for_test().get();
-
-        let streamer = app.add_singleton_model(|ctx| {
-            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
-        });
-
-        // Synchronous part of `on_restored_conversations`: cursor seeded,
-        // own run_id watched. No event delivery yet because parent is
-        // InProgress.
-        streamer.update(&mut app, |me, ctx| {
-            me.on_restored_conversations(vec![conversation_id], ctx);
-        });
-        streamer.read(&app, |me, _| {
-            assert_eq!(me.event_cursor.get(&conversation_id).copied(), Some(0));
-            assert!(
-                me.watched_run_ids
-                    .get(&conversation_id)
-                    .is_some_and(|w| !w.is_empty()),
-                "own run_id should have been registered as watched"
-            );
-            assert!(
-                me.sse_connections.is_empty(),
-                "InProgress parent must not open SSE"
-            );
-        });
-
-        // Transitioning the conversation to Success should open an SSE
-        // connection for event delivery.
-        history_model.update(&mut app, |model, ctx| {
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::Success,
-                ctx,
-            );
-        });
-        streamer.read(&app, |me, _| {
-            assert!(
-                me.sse_connections.contains_key(&conversation_id),
-                "Success transition with watched run_ids should open an SSE connection"
+            assert_eq!(
+                me.streams.get(&conversation_id).map(|s| s.event_cursor),
+                Some(42)
             );
         });
     });
@@ -430,9 +348,9 @@ fn handle_event_batch_persists_max_seq_to_history_model() {
 #[test]
 fn finish_restore_fetch_no_ops_when_conversation_deleted_mid_flight() {
     // If the conversation is removed while the async fetch is in-flight, the
-    // RemoveConversation handler clears event_cursor. finish_restore_fetch
-    // uses the missing cursor as a sentinel and must not re-populate
-    // watched_run_ids or event_cursor for the deleted conversation.
+    // RemoveConversation handler removes the streams entry. finish_restore_fetch
+    // uses the missing entry as a sentinel and must not re-populate
+    // streamer state for the deleted conversation.
     use crate::ai::agent::conversation::AIConversation;
     use crate::server::server_api::ai::MockAIClient;
     use crate::server::server_api::ServerApiProvider;
@@ -460,16 +378,15 @@ fn finish_restore_fetch_no_ops_when_conversation_deleted_mid_flight() {
             OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
         });
 
-        // Seed cursor as on_restored_conversations would.
+        // Seed a stream entry as on_restored_conversations would.
         poller.update(&mut app, |me, _| {
-            me.event_cursor.insert(conversation_id, 0);
+            me.streams.entry(conversation_id).or_default();
         });
 
         // Simulate the RemoveConversation handler firing while the fetch is
-        // in-flight: it clears event_cursor (and all other state).
+        // in-flight: it drops the conversation's streamer state.
         poller.update(&mut app, |me, _| {
-            me.watched_run_ids.remove(&conversation_id);
-            me.event_cursor.remove(&conversation_id);
+            me.streams.remove(&conversation_id);
         });
 
         // The in-flight fetch now completes — with children.
@@ -489,12 +406,137 @@ fn finish_restore_fetch_no_ops_when_conversation_deleted_mid_flight() {
 
         poller.read(&app, |me, _| {
             assert!(
-                !me.watched_run_ids.contains_key(&conversation_id),
-                "watched_run_ids must not be repopulated for a deleted conversation"
+                !me.streams.contains_key(&conversation_id),
+                "streamer state must not be repopulated for a deleted conversation"
             );
+        });
+    });
+}
+
+#[test]
+fn finish_restore_fetch_err_does_not_resurrect_deleted_conversation() {
+    // Mirror image of `finish_restore_fetch_no_ops_when_conversation_deleted_mid_flight`
+    // but for the Err arm: a transient fetch failure on a conversation that
+    // was just removed must not resurrect a streams entry (which would then
+    // defeat the deletion sentinel inside the retry timer and cause an
+    // indefinite retry loop).
+    use crate::ai::agent::conversation::AIConversation;
+    use crate::server::server_api::ai::MockAIClient;
+    use crate::server::server_api::ServerApiProvider;
+    use std::sync::Arc;
+    use warpui::App;
+
+    App::test((), |mut app| async move {
+        let _v2_guard = FeatureFlag::OrchestrationV2.override_enabled(true);
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+
+        let mut conversation = AIConversation::new(false);
+        conversation.set_run_id("550e8400-e29b-41d4-a716-446655440500".to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let mock = MockAIClient::new();
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+
+        let poller = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        // Seed the entry as on_restored_conversations would, then drop it
+        // (simulates the RemoveConversation handler firing while the fetch
+        // is in-flight).
+        poller.update(&mut app, |me, _| {
+            me.streams.entry(conversation_id).or_default();
+            me.streams.remove(&conversation_id);
+        });
+
+        // The in-flight fetch now completes with an error.
+        let task_id: crate::ai::ambient_agents::AmbientAgentTaskId =
+            "550e8400-e29b-41d4-a716-446655440000".parse().unwrap();
+        poller.update(&mut app, |me, ctx| {
+            me.finish_restore_fetch(
+                conversation_id,
+                task_id,
+                /* sqlite_cursor */ 0,
+                Err(anyhow::anyhow!("transient network failure")),
+                ctx,
+            );
+        });
+
+        poller.read(&app, |me, _| {
             assert!(
-                !me.event_cursor.contains_key(&conversation_id),
-                "event_cursor must not be repopulated for a deleted conversation"
+                !me.streams.contains_key(&conversation_id),
+                "Err retry must not resurrect a streams entry for a deleted conversation"
+            );
+        });
+    });
+}
+
+#[test]
+fn on_conversation_removed_prunes_stale_child_run_id_from_parent() {
+    // Regression for the case where a child conversation is deleted: the
+    // parent's `watched_run_ids` set must be pruned of that child's run_id
+    // so subsequent SSE reconnects do not include the dead run_id in the
+    // filter. Previously the streamer looked up the run_id from the history
+    // model after the removal, which always returned `None` because the
+    // history model emits `RemoveConversation` after dropping the record.
+    use crate::ai::agent::conversation::AIConversation;
+    use crate::server::server_api::ai::MockAIClient;
+    use crate::server::server_api::ServerApiProvider;
+    use std::sync::Arc;
+    use warpui::App;
+
+    App::test((), |mut app| async move {
+        let _v2_guard = FeatureFlag::OrchestrationV2.override_enabled(true);
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+
+        let parent_id = AIConversation::new(false).id();
+        let mut child_conversation = AIConversation::new(false);
+        let child_run_id = "550e8400-e29b-41d4-a716-446655440600".to_string();
+        child_conversation.set_run_id(child_run_id.clone());
+        let child_id = child_conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![child_conversation], ctx);
+        });
+
+        let mock = MockAIClient::new();
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+
+        let poller = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        // Seed the parent's watched set with the child's run_id, as
+        // `register_watched_run_id` would have done after the child got
+        // its server token.
+        poller.update(&mut app, |me, _| {
+            me.streams
+                .entry(parent_id)
+                .or_default()
+                .watched_run_ids
+                .insert(child_run_id.clone());
+        });
+
+        // Now invoke the removal handler with the run_id (mirroring the
+        // event payload that history_model emits with the captured run_id).
+        poller.update(&mut app, |me, ctx| {
+            me.on_conversation_removed(child_id, Some(child_run_id.clone()), ctx);
+        });
+
+        poller.read(&app, |me, _| {
+            assert!(
+                me.streams
+                    .get(&parent_id)
+                    .is_some_and(|s| !s.watched_run_ids.contains(&child_run_id)),
+                "parent's watched_run_ids must be pruned of the removed child's run_id"
             );
         });
     });
@@ -541,21 +583,22 @@ fn finish_restore_fetch_reconnects_sse_when_children_added_to_open_connection() 
 
         // Seed the state on_restored_conversations would have set up, then
         // inject a fake open SSE connection (generation 0) simulating the
-        // race: a status transition fired before the restore fetch completed.
+        // race: a consumer registered before the restore fetch completed.
+        // The dummy `EntityId` stands in for any local consumer (e.g. an
+        // open agent view); without it the eligibility predicate would
+        // bail and reconnect_sse would tear the connection down instead
+        // of opening a new one.
         let (_, rx) = futures::channel::mpsc::unbounded::<SseStreamItem>();
+        let consumer_id = warpui::EntityId::new();
         poller.update(&mut app, |me, _| {
-            me.event_cursor.insert(conversation_id, 0);
-            me.watched_run_ids
-                .entry(conversation_id)
-                .or_default()
-                .insert(own_run_id.to_string());
-            me.sse_connections.insert(
-                conversation_id,
-                SseConnectionState {
-                    event_receiver: rx,
-                    generation: 0,
-                },
-            );
+            let stream = me.streams.entry(conversation_id).or_default();
+            stream.event_cursor = 0;
+            stream.watched_run_ids.insert(own_run_id.to_string());
+            stream.consumers.insert(consumer_id);
+            stream.sse_connection = Some(SseConnectionState {
+                event_receiver: rx,
+                generation: 0,
+            });
             me.next_sse_generation = 1;
         });
 
@@ -576,17 +619,18 @@ fn finish_restore_fetch_reconnects_sse_when_children_added_to_open_connection() 
 
         poller.read(&app, |me, _| {
             assert!(
-                me.watched_run_ids
+                me.streams
                     .get(&conversation_id)
-                    .is_some_and(|w| w.contains("child-run-1")),
+                    .is_some_and(|s| s.watched_run_ids.contains("child-run-1")),
                 "child run_id must be in watched set"
             );
             // The old generation-0 connection must have been replaced by a
             // new one with a higher generation, proving SSE was reconnected.
             let gen = me
-                .sse_connections
+                .streams
                 .get(&conversation_id)
-                .map(|s| s.generation);
+                .and_then(|s| s.sse_connection.as_ref())
+                .map(|c| c.generation);
             assert!(
                 gen.is_some_and(|g| g > 0),
                 "SSE must be reconnected (new generation) after children are discovered; got gen={gen:?}"

--- a/specs/review-sse-connection-strategy/TECH.md
+++ b/specs/review-sse-connection-strategy/TECH.md
@@ -1,0 +1,278 @@
+# Tech spec: scope SSE event subscriptions to open parent/child conversations
+
+## Context
+
+`OrchestrationEventStreamer` (`app/src/ai/blocklist/orchestration_event_streamer.rs`) delivers v2 orchestration events (cross-agent messages and lifecycle events) into a conversation by holding a long-lived SSE connection per conversation. The streamer is SSE-only and gated solely on `OrchestrationV2`; the previous polling fallback path was removed before this change so all state and code paths described below are SSE-only.
+
+A key semantic to keep in mind throughout: **an agent run subscribes to its own `run_id` because that subscription is its inbox.** Server-side, `AgentEventDriverConfig::run_ids` filters events whose run_id matches the set; for a given agent run, events with `run_id == self_run_id` are messages and lifecycle signals destined for that run. Both parent agent runs and child agent runs (including headless CLI children of any harness) must keep this subscription up while their run is active in order to receive messages.
+
+> **Note.** The "Today the lifecycle is wrong" subsection and the "Relevant code" listing below describe the *pre-rewrite* state of the streamer (then often called "the poller") that motivated this change. Specific identifiers, line numbers, and field names in those subsections are historical and no longer correspond to the current code. The "Proposed changes" section onwards reflects the implementation as it now exists.
+
+Today the lifecycle is wrong in three ways:
+
+1. **Wrong start trigger.** SSE only opens on the `ConversationStatus::Success` transition (`orchestration_event_streamer.rs:229-237`, `start_event_delivery` at line 494). A conversation that is open in the UI but still in-progress will not subscribe; conversely once it has subscribed, status no longer matters.
+2. **Wrong stop trigger for parents.** Cleanup only runs on `RemoveConversation`/`DeletedConversation` (lines 178-193). Closing the agent view of a parent conversation does not tear down its SSE, so a parent the user has abandoned in the UI keeps a live connection.
+3. **Wrong scope.** `on_server_token_assigned` (line 240) registers the conversation's own run_id for *every* cloud-backed conversation that gets a server token (except shared-session viewers, line 254). Solo conversations — neither parents (have spawned children) nor children (`parent_conversation_id` set) — are not part of an orchestration tree and cannot meaningfully receive or send orchestration events. They should not subscribe. The shared-session-viewer exclusion is also incomplete: the GUI auto-opens a viewer pane for cloud children spawned via `start_agent` (`Conversation::is_remote_child()` is true), and those placeholders look like child conversations to the predicate — they have `parent_conversation_id` set — even though the actual run is on a cloud worker. Without a guard they open a redundant SSE in the parent's process for events the parent's own SSE will already deliver.
+
+There is also a related state-leak: `register_watched_run_id` (line 138) only inserts into `watched_run_ids`; nothing removes a child's run_id when the child finishes or is deleted. A long-lived parent accumulates dead run_ids and reconnects with an ever-growing filter.
+
+### Relevant code
+
+- `app/src/ai/blocklist/orchestration_event_streamer.rs` — owner of `watched_run_ids`, `sse_connections`, polling/SSE timers, and all cleanup paths.
+- `app/src/ai/blocklist/action_model/execute/start_agent.rs:112-119` — the only external caller of `register_watched_run_id`, registering a *child's* run_id under the *parent's* `AIConversationId` when the child receives a server token.
+- `app/src/ai/active_agent_views_model.rs` — already tracks "is this conversation expanded in any pane?" via `agent_view_handles`. Emits `ActiveAgentViewsEvent::ConversationClosed { conversation_id }` on `ExitedAgentView` (line 167-169) and on `unregister_agent_view_controller` from the pane-close path (line 200-202; see `pane_group/pane/terminal_pane.rs:383-385`). Helper `is_conversation_open(conversation_id, ctx)` (line 354) gives the cross-pane "open anywhere?" check.
+- `app/src/ai/agent/conversation.rs:781-792` — `parent_conversation_id()` and `is_child_agent_conversation()` classify a conversation as child or non-child; combined with the poller's own `watched_run_ids` set these classify a conversation as parent/child/solo.
+- `app/src/ai/agent_events/driver.rs (38-50, 177-199)` — `AgentEventDriverConfig::run_ids` is forwarded to `ServerApi::stream_agent_events` and is the server-side filter for which events come back. A run watching its own run_id is using that subscription as its inbox.
+- `app/src/ai/agent_sdk/driver.rs` — drives Oz conversations headlessly via the Warp CLI (locally for `start_agent` with `execution_mode: local` + Oz harness, and on cloud workers for cloud Oz runs). The same `OrchestrationEventStreamer` singleton is registered here (`lib.rs:1564-1566` is unconditional aside from the `OrchestrationV2` feature flag), so the streamer must serve a CLI/cloud process where there are no `AgentViewController` registrations at all.
+
+## Proposed changes
+
+### Consumer abstraction
+
+The streamer's job is to deliver events to a consumer. Today there is one implicit consumer (the agent view), but in CLI and cloud worker processes the consumer is the `agent_sdk::driver` itself, which has no agent view. Generalize this: the streamer owns a set of registered *consumers* per conversation, where a consumer is anything that needs orchestration events delivered for that conversation.
+
+The registry lives **inside `OrchestrationEventStreamer`** as part of the per-conversation `ConversationStreamState` (a single `streams: HashMap<AIConversationId, ConversationStreamState>` map collects every per-conversation field — watched run_ids, cursor, pending message IDs, consumers, SSE connection, restore-retry counter — under one entry). Consumers are identified by `EntityId` (the terminal pane id for an agent view; the driver model id for `agent_sdk`). Two public methods drive the registry:
+
+- `register_consumer(conversation_id, consumer_id, ctx)` — inserts and re-evaluates eligibility through `reevaluate_eligibility`, which calls `start_sse_connection` if the conversation is newly eligible.
+- `unregister_consumer(conversation_id, consumer_id, ctx)` — removes and re-evaluates eligibility, tearing down the SSE if the conversation is no longer eligible.
+
+This avoids introducing a separate singleton and the event-subscribe plumbing that would come with it. The streamer is the only consumer of these signals, so co-locating the state keeps the lifecycle decisions in one place.
+
+Two callers wire up registrations through the free helpers `register_agent_event_consumer` / `unregister_agent_event_consumer`:
+
+- The agent view path: `ActiveAgentViewsModel` reacts to `EnteredAgentView` / `ExitedAgentView` and calls the helpers on behalf of the open view.
+- The driver path: `agent_sdk::driver` calls the same helpers around its run lifetime.
+
+The streamer's eligibility check observes a single signal — `has_active_consumer(conversation_id)` reads the conversation's stream entry — and does not care which type registered. In the GUI client this collapses to "agent view is open somewhere"; in CLI/cloud workers it collapses to "the driver is running."
+
+A single `EntityId` per consumer is enough: the streamer treats every consumer as opaque, the entity id is unique per pane / driver model, and unregister keys back to that same id.
+
+### Eligibility predicate
+
+The streamer treats parent and child agent runs differently because the trigger conditions are different, but both check the same consumer signal.
+
+**Child role** — the conversation has a parent agent run from this process's perspective. Two signals satisfy this: `parent_conversation_id.is_some()` (the parent has a local placeholder, set by `start_new_child_conversation` when the GUI parent spawned the child) OR `parent_agent_id.is_some()` (the conversation knows its parent's server-side agent identifier, which under v2 is the parent's `run_id`). The two signals address two different processes:
+
+- The parent's GUI process gets `parent_conversation_id` set when it creates the child placeholder via `start_new_child_conversation`.
+- The driver-hosted process (CLI subprocess for `execution_mode: local`, cloud worker for cloud children) never sees the parent's local `AIConversationId`. It does fetch the parent's `run_id` from the server task metadata (`get_ambient_agent_task` returns `parent_run_id`), so the agent_sdk driver stamps that run_id onto the conversation's `parent_agent_id` field at register time. That stamp is what the streamer's child-role check picks up.
+
+The subscription is the child's inbox. It is gated on having an active consumer in *this process* the same way the parent role is. In the process where the child run actually lives, the agent_sdk driver registers a consumer for the run's lifetime, so the child's inbox stays live for the whole run. In any other process (e.g. the user's GUI tracking a cloud child), the child's own SSE only opens while a consumer is registered — i.e. the child's agent view is open. Without a local consumer the events would have nowhere to land, and the user's GUI already sees child→parent traffic via the parent's SSE. This applies to every harness — Oz, ClaudeCode, Gemini, headless CLI children spawned via `start_agent` with `execution_mode: local`, and cloud children. Children today cannot themselves spawn children; if that constraint is lifted later, this role keeps applying unchanged.
+
+**Parent role** — the conversation has at least one child run_id registered in `watched_run_ids` (from `register_watched_run_id` in `start_agent.rs`). The subscription delivers child lifecycle and child→parent messages into the parent's consumer. The parent role is gated on having an active consumer. In the GUI that means the agent view is open; in CLI/cloud it means the agent driver is running. When the last consumer for a parent disappears, child events for that parent are stored on the server and backfilled via the cursor when a consumer comes back.
+
+Today, child agent runs cannot themselves spawn children, so no live conversation simultaneously holds both roles. The design must still admit the case so that allowing children-of-children later is a code change to the spawn path, not to the subscription model. Both roles' run_id contributions are unioned into the SSE filter whenever both apply.
+
+The stronger present-day motivator for the consumer abstraction is a different shape: a top-level cloud Oz agent run — not itself a child — that spawns children. It has the parent role only, runs on a cloud worker with no agent view, and is driven by the agent_sdk driver. Without the consumer abstraction the parent gate would never be satisfied (no agent view ever exists in that process) and the cloud Oz agent could not receive its children's events. With the abstraction the driver registers as the consumer and the parent role is eligible.
+
+**Solo conversations** — neither parent nor child — are excluded. They have no role in the orchestration tree and no inbox traffic to receive.
+
+Formally, a conversation should be subscribed iff:
+
+```
+has_active_consumer()
+  AND (is_child_agent_conversation() OR has_at_least_one_watched_child_run_id())
+```
+
+Where `has_active_consumer()` returns true when at least one `AgentViewController` or `agent_sdk::driver` is registered for this conversation. This predicate is the single invariant the streamer maintains. Every code path either makes a conversation eligible (and ensures a connection exists) or makes it ineligible (and tears the connection down).
+
+### Subscription drivers
+
+**Children.** The trigger is server-token assignment, not status. `on_server_token_assigned` calls `ensure_self_run_id_watched` to register the self run_id and re-runs `reevaluate_eligibility` immediately. Children must be listening as soon as they have a run_id, regardless of status. Teardown for children happens only on `RemoveConversation` / `DeletedConversation`.
+
+**Parents.** Subscribe to a single "consumer changed" signal from the registry described above:
+
+- On consumer-removed for a conversation: `reevaluate_eligibility` runs the predicate and tears the SSE down if the conversation is no longer eligible. If it is also a child, the child role keeps it alive.
+- On consumer-added for a conversation: `reevaluate_eligibility` opens the SSE if newly eligible. This handles both the GUI reopen case (agent view opened after being closed) and the CLI startup case (driver registered before any agent view exists).
+- `register_watched_run_id` (called from `start_agent.rs`) re-evaluates eligibility after the insert. If a consumer exists, this opens or reconnects the SSE; if none exists, it is a no-op until a consumer registers.
+
+`reevaluate_eligibility` is the single dispatch point: it computes the eligibility predicate and either calls `start_sse_connection`, reconnects, or tears down. Status is not part of the lifecycle decision for either role.
+
+The agent_sdk driver registers itself as a consumer at the start of its run (a natural place is `AgentDriver::execute_run` for Oz, or where the third-party harness path picks up the `task_id` for ThirdParty harnesses) and unregisters when the run terminates. Registration is by `AIConversationId` so it composes with the existing per-conversation streamer state.
+
+Because both roles share a single SSE connection per conversation, the SSE's `run_ids` filter must be the union of `{self_run_id}` (child role) and the registered child run_ids (parent role), where each role's contribution is included only when that role's eligibility is met. The simplest implementation is to compute the run_id list at SSE-open time from current state.
+
+### Trigger ordering and re-evaluation
+
+Eligibility depends on three pieces of state, each of which lands at a different time and is set by a different code path:
+
+- `Conversation::has_parent_agent()` — true when the conversation has either `parent_conversation_id` (set on a child created with a local placeholder) or `parent_agent_id` (the parent's run_id, stamped by the agent_sdk driver in driver-hosted processes). Available before any run_id is assigned for the local-placeholder case; depends on the parent's run_id for the driver case.
+- `self_run_id` — set on `ConversationServerTokenAssigned` for this conversation.
+- Watched child run_ids on a parent — added by `register_watched_run_id` only after the *child* receives its server token (`start_agent.rs` waits for `ConversationServerTokenAssigned` on the child, then registers under the parent).
+
+A consumer that registers earlier than any of these will not yet make the conversation eligible. That is fine: re-evaluation happens at every state change, so the SSE opens at the moment eligibility flips, regardless of which event arrived first. Concretely, the streamer re-runs the predicate at exactly four sites:
+
+1. `register_consumer` and `unregister_consumer` — consumer set changed.
+2. `register_watched_run_id` — a child run_id was added to a parent's set.
+3. `on_server_token_assigned` — this conversation received its run_id (and may now be a child).
+4. `on_conversation_removed` for any other conversation — if it was a child of this one, its run_id was just pruned from this parent's watched set; the parent may have no remaining children.
+
+A consumer never needs to re-register on its own to chase the run_id. It registers once at the start of its lifetime and unregisters once at the end; the streamer is responsible for catching up state changes in between.
+
+A practical consequence for the GUI: opening an agent view for a brand-new conversation calls `register_consumer` immediately, but no SSE opens until either the conversation receives `ConversationServerTokenAssigned` (and is found to be a child) or `register_watched_run_id` runs against it (when its first child is spawned). For the CLI/cloud driver path the same applies: the driver registers immediately at run start, but the SSE waits until the run_id is assigned.
+
+### Solo exclusion at registration time
+
+`on_server_token_assigned` calls `ensure_self_run_id_watched`, which inserts the conversation's own run_id only when the conversation already has a role: it has a parent (`Conversation::has_parent_agent()`) or it is already a parent (some other watched run_id is registered). Conversations that are not yet children at server-token time may later become parents via `register_watched_run_id`; that path runs `ensure_self_run_id_watched` again to add the self run_id once the parent role kicks in, so solo conversations stay out of the watched set entirely until and unless they enter the orchestration tree.
+
+This avoids opening inbox subscriptions for conversations that have no orchestration role.
+
+### Removal of stale child run_ids in a still-eligible parent
+
+In the existing `RemoveConversation` / `DeletedConversation` arm, also walk every other entry in `watched_run_ids` and remove the closed conversation's run_id from each set. Capture the run_id from `BlocklistAIHistoryModel::conversation(conversation_id).and_then(|c| c.run_id())` before the conversation is removed (the event handler runs before history-model state is fully gone for `RemoveConversation`; for `DeletedConversation` we need the same guarantee — verify during implementation, fall back to passing the run_id on the event if necessary).
+
+After the prune, re-evaluate the parent's eligibility:
+- If the parent has remaining children and its view is still open, reconnect the SSE with the smaller run_id set.
+- If the parent has no remaining children and is not itself a child, tear down its SSE.
+- If the parent has no remaining children but is itself a child, keep the SSE alive for the child-role inbox.
+
+### Reconnect behavior
+
+`reconnect_sse` runs the full `is_eligible` predicate before re-opening: if the conversation is no longer eligible, the connection is dropped without re-opening. The proactive reconnect (`AgentEventDriverConfig::proactive_reconnect_after`, ~14 minutes) and error-driven reconnect both pass through this gate, so an ineligible conversation stops reconnecting automatically.
+
+### State machine
+
+Replace "agent view open" with "has active consumer" in the parent gate; otherwise the same shape:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Solo: conversation created
+    Solo --> ChildOnly: server token assigned and parent_conversation_id set
+    Solo --> ParentOnly: child run_id registered while consumer active
+    Solo --> ParentLatent: child run_id registered while no consumer
+    ChildOnly --> ChildAndParent: registers a grandchild
+    ParentOnly --> ParentLatent: last consumer unregisters
+    ParentLatent --> ParentOnly: consumer registers
+    ChildOnly --> Subscribed: SSE active (always-on inbox)
+    ParentOnly --> Subscribed: SSE active (consumer present)
+    ChildAndParent --> Subscribed: SSE active (both roles)
+    Subscribed --> ChildOnly: parent role ends (no children + no consumer)
+    Subscribed --> ParentOnly: child role ends (rare; only via removal)
+    Subscribed --> [*]: conversation removed
+    ChildOnly --> [*]: conversation removed
+    ParentOnly --> [*]: conversation removed
+    ParentLatent --> [*]: conversation removed
+    Solo --> [*]: conversation removed
+```
+
+A conversation is in `Subscribed` iff its entry in `streams` has `sse_connection.is_some()`. Exiting `Subscribed` always tears down the SSE.
+
+## Testing and validation
+
+Add unit tests in `orchestration_event_streamer_tests.rs` covering the new invariants:
+
+1. **Solo conversation does not subscribe.** Server token assigned for a conversation that is not a child and never spawns one; consumers come and go; status reaches Success → no entry in `sse_connections` at any point.
+2. **Child subscribes immediately on server-token assignment regardless of consumer state.** A child conversation (parent_conversation_id set) gets server token while no consumer is registered → SSE is active. Adding/removing consumers does not affect the connection.
+3. **Headless CLI child of any harness subscribes.** Cover Oz, ClaudeCode, and Gemini harness children spawned with `execution_mode: local` — each must have a live SSE once their run_id is assigned, with no agent view ever opened. The Oz CLI case must also have the agent_sdk driver registered as a consumer.
+4. **Parent subscribes when first child is registered while a consumer is active.** Register a consumer first, then `register_watched_run_id` → connection opens.
+5. **Parent latent until a consumer registers.** Children registered while no consumer exists → no connection. Consumer registers → connection opens with the right run_id list.
+6. **Last consumer leaving tears down (parent-only conversation).** A subscribed parent that is not itself a child has its only consumer unregister; `sse_connections`/cursor/timer state are all gone. `watched_run_ids` is preserved so the parent can re-subscribe when a new consumer appears.
+7. **Last consumer leaving does not tear down a parent-and-child conversation.** Forward-looking, since children cannot spawn children today; exercise the predicate by constructing a `Conversation` test fixture with both `parent_conversation_id` set and at least one watched child run_id. Verify it stays subscribed when its consumers leave (child role keeps it alive), and that the parent contribution is only present in the run_id filter while a consumer exists.
+8. **Reconnect on consumer return.** Parent-only: last consumer leaves → consumer rejoins → new SSE connection opened with the latest cursor and the current set of child run_ids.
+9. **Stale child run_id is pruned.** Parent with two children registered, one child conversation deleted → parent's `watched_run_ids` shrinks, SSE reconnects with the smaller set.
+10. **Last child removed leaves a non-child parent with no role → teardown.** Parent that was never a child has its only child removed → connection torn down even if a consumer is still registered.
+11. **Multiple consumers do not double-tear-down.** Two consumers (e.g. agent view + driver, or two agent views) for the same parent; one unregisters → SSE persists; second unregisters → SSE torn down.
+12. **Cloud Oz parent (driver-only consumer) receives child events.** A top-level cloud Oz conversation (not itself a child) that spawns one or more children, with only the agent_sdk driver registered as a consumer (no agent view), must have all the child run_ids in the SSE filter — verifies that the consumer abstraction admits the driver to satisfy the parent gate. This is the present-day motivator for the abstraction.
+
+Manual validation:
+
+Observation setup. Each test below names the process where SSE state should appear: either the user's GUI Warp app (a desktop binary) or a driver process (a local CLI subagent subprocess, or a cloud Oz worker). The relevant log lines are the same in either process; the difference is which log file you tail.
+
+Log lines to watch for, all at info level unless noted:
+
+- `register_consumer for {conv:?}: {consumer_id:?} (total=N)` — a consumer registered.
+- `unregister_consumer for {conv:?}: {consumer_id:?} (remaining=N)` — a consumer unregistered.
+- `Opening SSE stream for {conv:?} (gen=, run_ids=, since=)` — SSE connection opened.
+- `SSE driver exited for {conv:?} (gen=)` — SSE driver task exited (warn level).
+- `Tearing down SSE for {conv:?} (no longer eligible)` — explicit teardown after eligibility flipped to false.
+
+Where to tail:
+
+- GUI process: the Warp app log for the active build flavor (e.g. `~/Library/Logs/dev.warp.Warp-Stable/warp.log` on macOS).
+- Local CLI driver subprocess: the subprocess's stderr or its dedicated log file. `start_agent` with `execution_mode: local` runs `warp_cli` as a subprocess; tail wherever that subprocess writes logs.
+- Cloud Oz worker: the worker logs surfaced by the Oz UI / cloud logging tool for the run.
+- Server-side: `stream_agent_events` requests in the dev `warp-server` access log — one request per active SSE; new requests on reconnect; disconnects when the client closes the stream.
+
+### A. Solo conversation
+
+Start a regular cloud conversation. Don't call `start_agent`. Open and close its pane.
+
+- GUI: `register_consumer` and `unregister_consumer` for the conversation, but **no** `Opening SSE stream` line at any point.
+- Server: no `stream_agent_events` request.
+
+### B. Local parent + Local child (both in user's GUI; child runs as a local CLI subagent subprocess)
+
+In the user's GUI, spawn a child via `start_agent` with `execution_mode: local` + a CLI harness (e.g. `claude-code`). The parent's conversation lives in the GUI; the child's run is hosted in a separate driver subprocess.
+
+GUI process expectations:
+
+- With parent's pane open and a child registered: `register_consumer` (AgentView) for parent, then `Opening SSE stream` for parent with `run_ids = [child_run_id, parent_self_run_id]` — the child run_id for child lifecycle events and the parent's self_run_id for child→parent messages.
+- Child's `Opening SSE stream` does **not** appear in the GUI unless the user explicitly opens the child's view.
+- Closing parent's pane: `unregister_consumer` for parent, then `SSE driver exited` for parent.
+
+Local CLI driver subprocess expectations:
+
+- At driver startup (after the run_id is assigned via streaming events): `register_consumer` (Driver) for child, then `Opening SSE stream` for child with `run_ids` containing the child's `self_run_id`.
+- When the driver run completes: `unregister_consumer` (Driver) for child, then `Tearing down SSE`.
+
+Server: one `stream_agent_events` request per active SSE.
+
+### C. Local parent + Cloud child (parent in GUI, child in cloud worker)
+
+In the user's GUI, spawn a child via `start_agent` with cloud Oz harness. Parent runs in GUI; child runs on a cloud worker.
+
+GUI process expectations:
+
+- Parent: same as B — SSE only while parent's pane is open and the child run_id is registered. `run_ids = [child_run_id, parent_self_run_id]`.
+- Child: **no** `Opening SSE stream` for the child in the GUI unless the user opens the child's view (e.g. via the cloud agent transcript). The intentional behavior is that child→parent traffic flows through the parent's SSE; the child's own SSE in the GUI would be redundant.
+
+Cloud worker expectations:
+
+- `register_consumer` (Driver) for child on run start, then `Opening SSE stream` for child once `run_id` is assigned.
+- When the run completes: `unregister_consumer` + `Tearing down SSE`.
+
+### D. Cloud parent + Local child (both in same cloud worker process)
+
+A top-level cloud Oz parent driver spawns a CLI subagent locally (in the same worker process). Both runs are headless on the cloud worker — driver runs do not have a GUI; any user-side viewer pane on the parent or child is a passive remote-run view and is covered by section F. Two `AgentDriver` instances register two `Driver` consumers with the worker's single streamer.
+
+Cloud worker expectations:
+
+- Parent: `register_consumer` (Driver) for parent on run start. Once the parent registers a child run_id (from `start_agent`), `Opening SSE stream` for parent with `run_ids = [child_run_id, parent_self_run_id]` — the child run_id for child lifecycle and the parent's self_run_id for child→parent messages.
+- Child: `register_consumer` (Driver) for child, then `Opening SSE stream` for child with `run_ids = [child_self_run_id]`.
+- Parent and child each unregister and tear down their own SSE when their respective drivers complete.
+
+### E. Cloud parent + Cloud child (separate cloud workers)
+
+Like D but split across two worker processes. The parent worker holds the parent's SSE (with `run_ids = [child_run_id, parent_self_run_id]`); the child worker holds the child's SSE (`run_ids = [child_self_run_id]`). Each driver consumer is in its own process. Both runs are headless; any user-side viewer pane is covered by section F.
+
+### F. Passive view of a remote run
+
+A conversation in the local process that is a passive view of an agent run hosted in another process. Two flavors share the same predicate path:
+
+- **Shared-session viewer.** Open a pane that views someone else's shared session. The local conversation has `is_viewing_shared_session() == true`.
+- **Remote-child placeholder.** Spawn a child via `start_agent` with `execution_mode: cloud` (e.g. cloud Oz). The user's GUI auto-opens a viewer pane for the child; the local placeholder conversation has `is_remote_child() == true` and `parent_conversation_id` set, but the actual run lives on the cloud worker.
+
+In both cases the local process has no run to host — the inbox lives elsewhere — so opening an SSE here would re-inject events the real consumer has already processed.
+
+- GUI: `register_consumer` (AgentView) when the pane opens, but **no** `Opening SSE stream` for the viewer's conversation_id at any point. The `is_remote_run_view` guard in `is_eligible` covers both flavors and prevents subscription even when the conversation has `parent_conversation_id` set or appears to have a watched run_id (the auto-opened cloud-child viewer satisfies both).
+- Server: no `stream_agent_events` request from this client for the viewer's conversation_id. The parent's SSE in the same process is unaffected and continues to deliver child events for the cloud child via the parent's `watched_run_ids`.
+
+### Specific behaviors to spot-check after running B or C
+
+1. **Stale child run_id pruned.** Spawn two children, then delete the second child's conversation. Expected in the parent's process (GUI for B/C, worker for D/E): a new `Opening SSE stream` for the parent with `run_ids` shrunk by one (and a generation bump). Server: previous parent `stream_agent_events` request disconnects, new one opens with the smaller run_id list.
+2. **Last child removed leaves a non-child parent with no role.** Continuing from (1), delete the remaining child too. Expected: `Tearing down SSE` for the parent; no new `Opening SSE stream` follows.
+3. **Reopen parent — SSE re-establishes with cursor.** Close the parent's pane in the GUI, then reopen. Expected: `register_consumer` followed by `Opening SSE stream` with `since=<cursor>` matching the last persisted cursor.
+4. **Solo with consumer registered.** Open an agent view for a conversation that has no children registered and is not itself a child. Expected: `register_consumer`, but **no** `Opening SSE stream` for that conversation.
+
+Run `./script/presubmit` before opening the PR. Add a `CHANGELOG-IMPROVEMENT:` line for "Tighten orchestration event subscription scope: solo conversations no longer subscribe; parent subscriptions are tied to agent view openness; child subscriptions remain active for the lifetime of the run."
+
+## Risks and mitigations
+
+- **Race between server token assignment and consumer registration.** Re-deriving eligibility from current state on every consumer-add and on every `register_watched_run_id` call covers the ordering. Verify with unit tests.
+- **Headless child without UI must still subscribe.** A regression here breaks message delivery to CLI subagents. Tests (3) and the manual CLI-child step are the primary safeguards. The implementation must not gate the child path on consumer presence — only the parent path is consumer-gated.
+- **Driver lifecycle in the agent_sdk.** The driver must register and unregister at the right boundaries: register before any child can be spawned and unregister only after the run has terminated and any teardown work is complete. Registering too late means the driver misses early grandchild events; unregistering too early causes the same. Pin the registration to the run's outer scope in `AgentDriver::execute_run`.
+- **Single SSE serves dual roles.** A conversation that is both child and parent uses one connection with a unioned run_id set. Reconnects must include both contributions; the run_id list should be recomputed each time the connection is opened or reconnected. Add an assertion to surface a divergence in tests.
+- **Event ordering.** Consumer-removed and `RemoveConversation` may arrive in either order. Both paths run idempotent teardown — verify by making the teardown helper safe to call when the conversation is already gone.
+
+## Follow-ups
+
+- Expose a debug snapshot from the streamer (count of streams with an open `sse_connection`, count of streams with non-empty `watched_run_ids`, total run_ids across all sets, count of registered consumers per conversation, role classification per conversation) so we can monitor connection scope in production via a dev panel or telemetry.


### PR DESCRIPTION
## Description

Refactors `OrchestrationEventStreamer` so v2 orchestration SSE connections are opened only for conversations that actually need them in the current process.

## What

A conversation now subscribes to its SSE feed iff it has both:
- a real role in an orchestration tree — child (the conversation has a parent agent) or parent (it has at least one registered child run_id), and
- an active local consumer — an open agent view, or an `agent_sdk` driver in CLI / cloud worker processes.

Solo conversations and passive views of remote runs (shared-session viewers, remote-child placeholders) no longer subscribe. The streamer is the single owner of the consumer registry and the eligibility decision; consumers register/unregister around their lifetime and the streamer re-evaluates eligibility at every state change.

Other lifecycle improvements:
- The `Success`-transition start trigger and the conversation-status tracking it relied on are gone. Status is no longer part of the subscription decision.
- A child's run_id is pruned from any tracked parent's filter when the child conversation is removed; the parent's SSE is reconnected with the smaller filter or torn down if it has no remaining role.
- The SSE `run_ids` filter is recomputed from current state on each open / reconnect.

Tech spec: `specs/review-sse-connection-strategy/TECH.md`.

## Why

The pre-rewrite lifecycle had three problems: wrong start trigger (only fired on `ConversationStatus::Success`), wrong stop trigger (only on conversation removal — abandoned parents kept live SSEs), and wrong scope (every cloud-backed conversation self-registered, including passive viewers of remote runs).

## Testing

- Unit tests in `orchestration_event_streamer_tests.rs` cover the consumer/role gate, restore-on-startup cursor merging, mid-flight deletion (both Ok and Err paths), and SSE reconnection when children are discovered after the connection is open.
- `cargo fmt`, `cargo clippy -p warp --lib --tests -- -D warnings`, and the streamer test module all pass locally.
- Manual validation runbook (sections A–F + spot-checks) is documented in TECH.md.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Tighten orchestration event subscription scope so SSE runs only for active parent and child agent runs.

Co-Authored-By: Oz <oz-agent@warp.dev>
