### PR TITLE
Show all personal runs in the conversation list

### DIFF
--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -854,10 +854,6 @@ pub struct AgentConversationsModel {
     active_data_consumers_per_window: HashMap<WindowId, HashSet<EntityId>>,
     /// Whether we have finished the initial task load
     has_finished_initial_load: bool,
-    /// Task IDs that have been manually opened from the management page.
-    /// These will appear in the conversation list even if their source is not user-initiated
-    /// (and even after they have been closed).
-    manually_opened_task_ids: HashSet<AmbientAgentTaskId>,
     /// Per-task fetch state for `get_or_async_fetch_task_data`. See [`TaskFetchState`] for
     /// the meaning of each variant. Tasks that have been successfully fetched live in `tasks`
     /// and are absent from this map.
@@ -875,8 +871,6 @@ pub enum AgentConversationsModelEvent {
     ConversationUpdated,
     /// Conversation artifacts were updated (plans, PRs, etc.)
     ConversationArtifactsUpdated { conversation_id: AIConversationId },
-    /// A task was manually opened from the management page.
-    TaskManuallyOpened,
 }
 
 impl Entity for AgentConversationsModel {
@@ -896,7 +890,6 @@ impl AgentConversationsModel {
                 next_poll_abort_handle: None,
                 active_data_consumers_per_window: HashMap::new(),
                 has_finished_initial_load: true,
-                manually_opened_task_ids: HashSet::new(),
                 task_fetch_state: HashMap::new(),
             };
         }
@@ -934,7 +927,6 @@ impl AgentConversationsModel {
             next_poll_abort_handle: None,
             active_data_consumers_per_window: HashMap::new(),
             has_finished_initial_load: false,
-            manually_opened_task_ids: HashSet::new(),
             task_fetch_state: HashMap::new(),
         };
 
@@ -1723,20 +1715,6 @@ impl AgentConversationsModel {
         envs
     }
 
-    pub fn mark_task_as_manually_opened(
-        &mut self,
-        task_id: AmbientAgentTaskId,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        if self.manually_opened_task_ids.insert(task_id) {
-            ctx.emit(AgentConversationsModelEvent::TaskManuallyOpened);
-        }
-    }
-
-    pub fn is_task_manually_opened(&self, task_id: &AmbientAgentTaskId) -> bool {
-        self.manually_opened_task_ids.contains(task_id)
-    }
-
     /// Converts AgentManagementFilters to TaskListFilter for server API calls.
     pub fn build_task_list_filter(
         &self,
@@ -1891,7 +1869,6 @@ impl AgentConversationsModel {
         self.conversations.clear();
         self.abort_existing_poll();
         self.active_data_consumers_per_window.clear();
-        self.manually_opened_task_ids.clear();
         self.task_fetch_state.clear();
         // Reset the initial load flag so that we can retry the initial sync with the new logged in user
         self.has_finished_initial_load = false;

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -402,7 +402,6 @@ fn create_test_model() -> AgentConversationsModel {
         next_poll_abort_handle: None,
         active_data_consumers_per_window: HashMap::new(),
         has_finished_initial_load: false,
-        manually_opened_task_ids: Default::default(),
         task_fetch_state: Default::default(),
     }
 }

--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -1242,8 +1242,6 @@ impl AgentManagementView {
                 self.refresh_details_panel_if_needed(ctx);
                 ctx.notify();
             }
-            // TaskManuallyOpened is handled by the conversation list view, not here.
-            AgentConversationsModelEvent::TaskManuallyOpened => {}
             AgentConversationsModelEvent::ConversationArtifactsUpdated { conversation_id } => {
                 self.update_artifacts_for_conversation(*conversation_id, ctx);
                 self.refresh_details_panel_if_needed(ctx);

--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -185,10 +185,9 @@ impl AgentSource {
             AgentSource::Slack => "Slack",
             AgentSource::Cli => "CLI",
             AgentSource::ScheduledAgent => "Scheduled",
-            AgentSource::Interactive => "Warp (local agent)",
+            AgentSource::Interactive | AgentSource::CloudMode => "Warp App",
             AgentSource::WebApp => "Oz Web",
             AgentSource::GitHubAction => "GitHub Action",
-            AgentSource::CloudMode => "Warp (cloud agent)",
         }
     }
 

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -3244,7 +3244,7 @@ impl PaneGroup {
             match item.get_open_action(None, ctx) {
                 Some(WorkspaceAction::OpenAmbientAgentSession {
                     session_id,
-                    task_id,
+                    task_id: _,
                 }) => {
                     let (view, terminal_manager) = Self::create_shared_session_viewer(
                         session_id,
@@ -3260,24 +3260,15 @@ impl PaneGroup {
                         ctx,
                     );
                     self.replace_pane(pane_id, new_pane, false, ctx);
-
-                    AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
-                        model.mark_task_as_manually_opened(task_id, ctx);
-                    });
                 }
                 Some(WorkspaceAction::OpenConversationTranscriptViewer {
                     conversation_id,
-                    ambient_agent_task_id,
+                    ambient_agent_task_id: _,
                 }) => {
                     let loaded =
                         self.terminal_view_from_pane_id(pane_id, ctx)
                             .is_some_and(|target_view| {
-                                Self::fetch_and_load_transcript(
-                                    target_view,
-                                    conversation_id,
-                                    ambient_agent_task_id,
-                                    ctx,
-                                )
+                                Self::fetch_and_load_transcript(target_view, conversation_id, ctx)
                             });
                     if !loaded {
                         self.pending_ambient_agent_conversation_restorations
@@ -3299,15 +3290,8 @@ impl PaneGroup {
     fn fetch_and_load_transcript(
         target_view: ViewHandle<TerminalView>,
         server_conversation_token: ServerConversationToken,
-        ambient_agent_task_id: Option<AmbientAgentTaskId>,
         ctx: &mut ViewContext<Self>,
     ) -> bool {
-        if let Some(task_id) = ambient_agent_task_id {
-            AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
-                model.mark_task_as_manually_opened(task_id, ctx);
-            });
-        }
-
         let history_model_handle = BlocklistAIHistoryModel::handle(ctx);
         let ai_conversation_id = history_model_handle
             .as_ref(ctx)

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -10,7 +10,6 @@ use warpui::{Entity, EntityId, ModelContext, SingletonEntity};
 
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::conversation::AIConversationId;
-use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::spawn::{spawn_task, AmbientAgentEvent};
 use crate::ai::ambient_agents::task::HarnessConfig;
 use crate::ai::ambient_agents::telemetry::CloudAgentTelemetryEvent;
@@ -608,12 +607,6 @@ impl AmbientAgentViewModel {
                                 },
                             );
                         }
-
-                        // Mark the task as manually opened so it appears in the conversation list
-                        // even though its server-side source may not be user-initiated.
-                        AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
-                            model.mark_task_as_manually_opened(task_id, ctx);
-                        });
 
                         // Mark this task as active immediately so it renders under the Active section
                         // (and doesn't briefly appear under Past before the shared session join completes).

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -21055,12 +21055,6 @@ impl TypedActionView for Workspace {
                 session_id,
                 task_id,
             } => {
-                // Mark task as manually opened so it appears in the conversation list
-                // even if its source is not user-initiated.
-                AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
-                    model.mark_task_as_manually_opened(*task_id, ctx);
-                });
-
                 // Check if there's already a terminal viewing this task.
                 if let Some(tab_index) =
                     self.find_tab_with_ambient_agent_conversation(*task_id, ctx)
@@ -21074,14 +21068,6 @@ impl TypedActionView for Workspace {
                 conversation_id,
                 ambient_agent_task_id,
             } => {
-                // Mark task as manually opened so it appears in the conversation list
-                // even if its source is not user-initiated.
-                if let Some(task_id) = ambient_agent_task_id {
-                    AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
-                        model.mark_task_as_manually_opened(*task_id, ctx);
-                    });
-                }
-
                 // Check if there's already a terminal viewing this conversation's task.
                 if let Some(task_id) = ambient_agent_task_id {
                     if let Some(tab_index) =

--- a/app/src/workspace/view/conversation_list/view_model.rs
+++ b/app/src/workspace/view/conversation_list/view_model.rs
@@ -36,8 +36,7 @@ impl ConversationListViewModel {
                 // to rebuild the cached ID list.
                 AgentConversationsModelEvent::ConversationsLoaded
                 | AgentConversationsModelEvent::NewTasksReceived
-                | AgentConversationsModelEvent::TasksUpdated
-                | AgentConversationsModelEvent::TaskManuallyOpened => {
+                | AgentConversationsModelEvent::TasksUpdated => {
                     me.refresh_cached_items(ctx);
                 }
                 // Status changes don't affect the set of IDs (status is read
@@ -88,16 +87,6 @@ impl ConversationListViewModel {
             .filter(|item| {
                 item.get_session_status()
                     .is_none_or(|status| status == SessionStatus::Available)
-            })
-            // Only show user-initiated sources (Slack, Linear, Interactive) or tasks that have
-            // been manually opened from the management page.
-            .filter(|item| {
-                let is_user_initiated = item.source().is_some_and(|s| s.is_user_initiated());
-                let is_manually_opened = match item {
-                    ConversationOrTask::Task(task) => model.is_task_manually_opened(&task.task_id),
-                    ConversationOrTask::Conversation(_) => false,
-                };
-                is_user_initiated || is_manually_opened
             })
             .map(|item| match item {
                 ConversationOrTask::Task(task) => ConversationOrTaskId::TaskId(task.task_id),


### PR DESCRIPTION
## Description

In the tools panel conversation list, we were filtering out some personal cloud conversations (i.e. CLI, scheduled agents, agent webhooks, or github action agents). Now we show all personal cloud conversations (we just had to remove the filter)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode