### PR TITLE
Fix vertical tabs panel not opening when tab bar set to Always

### DIFF
--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -55,8 +55,8 @@ use crate::window_settings::{
 use crate::workspace::header_toolbar_editor::HeaderToolbarInlineEditor;
 use crate::workspace::tab_settings::{
     DirectoryTabColor, PreserveActiveTabColor, ShowCodeReviewButton, ShowIndicatorsButton,
-    TabCloseButtonPosition, TabSettings, TabSettingsChangedEvent,
-    UseLatestUserPromptAsConversationTitleInTabNames, UseVerticalTabs,
+    ShowVerticalTabPanelInRestoredWindows, TabCloseButtonPosition, TabSettings,
+    TabSettingsChangedEvent, UseLatestUserPromptAsConversationTitleInTabNames, UseVerticalTabs,
     WorkspaceDecorationVisibility,
 };
 use crate::workspace::WorkspaceAction;
@@ -381,6 +381,14 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
             context,
             flags::USE_VERTICAL_TABS_FLAG,
         ));
+        toggle_binding_pairs.push(ToggleSettingActionPair::new(
+            "show vertical tabs panel in restored windows",
+            builder(SettingsAction::AppearancePageToggle(
+                AppearancePageAction::ToggleShowVerticalTabPanelInRestoredWindows,
+            )),
+            context,
+            flags::USE_VERTICAL_TABS_FLAG,
+        ));
     }
 
     if FeatureFlag::Ligatures.is_enabled() {
@@ -452,6 +460,7 @@ pub enum AppearancePageAction {
     ToggleShowCodeReviewButton,
     TogglePreserveActiveTabColor,
     ToggleVerticalTabs,
+    ToggleShowVerticalTabPanelInRestoredWindows,
     ToggleUseLatestUserPromptAsConversationTitleInTabNames,
     ToggleLigatureRendering,
     ToggleBlurTexture,
@@ -590,6 +599,9 @@ impl TypedActionView for AppearanceSettingsPageView {
             ToggleShowCodeReviewButton => self.toggle_show_code_review_button(ctx),
             TogglePreserveActiveTabColor => self.toggle_preserve_active_tab_color(ctx),
             ToggleVerticalTabs => self.toggle_vertical_tabs(ctx),
+            ToggleShowVerticalTabPanelInRestoredWindows => {
+                self.toggle_show_vertical_tab_panel_in_restored_windows(ctx)
+            }
             ToggleUseLatestUserPromptAsConversationTitleInTabNames => {
                 self.toggle_use_latest_user_prompt_as_conversation_title_in_tab_names(ctx)
             }
@@ -1375,6 +1387,9 @@ impl AppearanceSettingsPageView {
 
         if FeatureFlag::VerticalTabs.is_enabled() {
             tab_settings_widgets.push(Box::new(VerticalTabsWidget::default()));
+            tab_settings_widgets.push(Box::new(
+                ShowVerticalTabPanelInRestoredWindowsWidget::default(),
+            ));
             tab_settings_widgets.push(Box::new(
                 UseLatestUserPromptAsConversationTitleInTabNamesWidget::default(),
             ));
@@ -2302,6 +2317,14 @@ impl AppearanceSettingsPageView {
 
         ctx.update_model(&tab_settings, move |tab_settings, ctx| {
             report_if_error!(tab_settings.use_vertical_tabs.set_value(new_value, ctx));
+        });
+    }
+
+    fn toggle_show_vertical_tab_panel_in_restored_windows(&mut self, ctx: &mut ViewContext<Self>) {
+        TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+            report_if_error!(settings
+                .show_vertical_tab_panel_in_restored_windows
+                .toggle_and_save_value(ctx));
         });
     }
 
@@ -4581,6 +4604,56 @@ impl SettingsWidget for VerticalTabsWidget {
                 })
                 .finish(),
             None,
+        )
+    }
+}
+
+#[derive(Default)]
+struct ShowVerticalTabPanelInRestoredWindowsWidget {
+    switch_state: SwitchStateHandle,
+}
+
+impl SettingsWidget for ShowVerticalTabPanelInRestoredWindowsWidget {
+    type View = AppearanceSettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "vertical tabs panel restore window session snapshot"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let tab_settings = TabSettings::as_ref(app);
+
+        render_body_item::<AppearancePageAction>(
+            "Show vertical tabs panel in restored windows".into(),
+            None,
+            LocalOnlyIconState::for_setting(
+                ShowVerticalTabPanelInRestoredWindows::storage_key(),
+                ShowVerticalTabPanelInRestoredWindows::sync_to_cloud(),
+                &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                app,
+            ),
+            ToggleState::Enabled,
+            appearance,
+            appearance
+                .ui_builder()
+                .switch(self.switch_state.clone())
+                .check(*tab_settings.show_vertical_tab_panel_in_restored_windows)
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(
+                        AppearancePageAction::ToggleShowVerticalTabPanelInRestoredWindows,
+                    );
+                })
+                .finish(),
+            Some(
+                "When enabled, reopening or restoring a window opens the vertical tabs panel even if it was closed when the window was last saved."
+                    .to_string(),
+            ),
         )
     }
 }

--- a/app/src/workspace/tab_settings.rs
+++ b/app/src/workspace/tab_settings.rs
@@ -484,6 +484,15 @@ define_settings_group!(TabSettings, settings: [
         toml_path: "appearance.vertical_tabs.enabled",
         description: "Whether to display tabs vertically instead of horizontally.",
     },
+    show_vertical_tab_panel_in_restored_windows: ShowVerticalTabPanelInRestoredWindows {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "appearance.vertical_tabs.show_panel_in_restored_windows",
+        description: "When restoring a window, open the vertical tabs panel even if it was closed when the session was saved.",
+    },
     use_latest_user_prompt_as_conversation_title_in_tab_names: UseLatestUserPromptAsConversationTitleInTabNames {
         type: bool,
         default: false,

--- a/app/src/workspace/tab_settings_tests.rs
+++ b/app/src/workspace/tab_settings_tests.rs
@@ -29,3 +29,30 @@ fn use_latest_user_prompt_as_conversation_title_in_tab_names_uses_vertical_tabs_
         "use_latest_prompt_as_title"
     );
 }
+
+#[test]
+fn show_vertical_tab_panel_in_restored_windows_defaults_to_false() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        TabSettings::handle(&app).read(&app, |settings, _ctx| {
+            assert!(!*settings.show_vertical_tab_panel_in_restored_windows);
+        });
+    });
+}
+
+#[test]
+fn show_vertical_tab_panel_in_restored_windows_uses_vertical_tabs_path() {
+    assert_eq!(
+        ShowVerticalTabPanelInRestoredWindows::toml_path(),
+        Some("appearance.vertical_tabs.show_panel_in_restored_windows")
+    );
+    assert_eq!(
+        ShowVerticalTabPanelInRestoredWindows::hierarchy(),
+        Some("appearance.vertical_tabs")
+    );
+    assert_eq!(
+        ShowVerticalTabPanelInRestoredWindows::toml_key(),
+        "show_panel_in_restored_windows"
+    );
+}

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3390,17 +3390,6 @@ impl Workspace {
     ) {
         match event {
             TabSettingsChangedEvent::WorkspaceDecorationVisibility { .. } => {
-                // Vertical tabs render in the Tabs panel (`vertical_tabs_panel_open`), not the horizontal tab strip
-                // "Always show workspace decorations" must keep that panel open
-                if FeatureFlag::VerticalTabs.is_enabled()
-                    && *TabSettings::as_ref(ctx).use_vertical_tabs
-                    && TabSettings::as_ref(ctx)
-                        .workspace_decoration_visibility
-                        .value()
-                        == &WorkspaceDecorationVisibility::AlwaysShow
-                {
-                    self.vertical_tabs_panel_open = true;
-                }
                 self.sync_window_button_visibility(ctx);
                 ctx.notify();
             }
@@ -3435,6 +3424,15 @@ impl Workspace {
                 }
                 self.sync_panel_positions_from_config(ctx);
                 self.sync_window_button_visibility(ctx);
+                ctx.notify();
+            }
+            TabSettingsChangedEvent::ShowVerticalTabPanelInRestoredWindows { .. } => {
+                if FeatureFlag::VerticalTabs.is_enabled()
+                    && *TabSettings::as_ref(ctx).use_vertical_tabs
+                    && *TabSettings::as_ref(ctx).show_vertical_tab_panel_in_restored_windows
+                {
+                    self.vertical_tabs_panel_open = true;
+                }
                 ctx.notify();
             }
             TabSettingsChangedEvent::ShowCodeReviewButton { .. } => {
@@ -3731,10 +3729,7 @@ impl Workspace {
                 window_snapshot, ..
             } => {
                 if should_default_open
-                    && TabSettings::as_ref(ctx)
-                        .workspace_decoration_visibility
-                        .value()
-                        == &WorkspaceDecorationVisibility::AlwaysShow
+                    && *TabSettings::as_ref(ctx).show_vertical_tab_panel_in_restored_windows
                 {
                     true
                 } else {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3390,6 +3390,17 @@ impl Workspace {
     ) {
         match event {
             TabSettingsChangedEvent::WorkspaceDecorationVisibility { .. } => {
+                // Vertical tabs render in the Tabs panel (`vertical_tabs_panel_open`), not the horizontal tab strip
+                // "Always show workspace decorations" must keep that panel open
+                if FeatureFlag::VerticalTabs.is_enabled()
+                    && *TabSettings::as_ref(ctx).use_vertical_tabs
+                    && TabSettings::as_ref(ctx)
+                        .workspace_decoration_visibility
+                        .value()
+                        == &WorkspaceDecorationVisibility::AlwaysShow
+                {
+                    self.vertical_tabs_panel_open = true;
+                }
                 self.sync_window_button_visibility(ctx);
                 ctx.notify();
             }
@@ -3718,7 +3729,18 @@ impl Workspace {
         match workspace_setting {
             NewWorkspaceSource::Restored {
                 window_snapshot, ..
-            } => window_snapshot.vertical_tabs_panel_open,
+            } => {
+                if should_default_open
+                    && TabSettings::as_ref(ctx)
+                        .workspace_decoration_visibility
+                        .value()
+                        == &WorkspaceDecorationVisibility::AlwaysShow
+                {
+                    true
+                } else {
+                    window_snapshot.vertical_tabs_panel_open
+                }
+            }
             NewWorkspaceSource::TransferredTab {
                 vertical_tabs_panel_open,
                 ..

--- a/app/src/workspace/view_test.rs
+++ b/app/src/workspace/view_test.rs
@@ -2272,6 +2272,35 @@ fn test_vertical_tabs_panel_visibility_restores_from_window_snapshot() {
 }
 
 #[test]
+fn test_vertical_tabs_panel_restored_open_when_show_in_restored_windows_enabled() {
+    let _vertical_tabs_guard = FeatureFlag::VerticalTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        app.update(|ctx| {
+            TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                report_if_error!(settings.use_vertical_tabs.set_value(true, ctx));
+                report_if_error!(settings
+                    .show_vertical_tab_panel_in_restored_windows
+                    .set_value(true, ctx));
+            });
+        });
+
+        let workspace = mock_workspace(&mut app);
+
+        let closed_snapshot = workspace.update(&mut app, |workspace, ctx| {
+            workspace.vertical_tabs_panel_open = false;
+            workspace.snapshot(ctx.window_id(), false, ctx)
+        });
+
+        let restored = restored_workspace(&mut app, closed_snapshot);
+        restored.read(&app, |workspace, _| {
+            assert!(workspace.vertical_tabs_panel_open);
+        });
+    });
+}
+
+#[test]
 fn test_vertical_tabs_panel_defaults_open_for_new_window_when_vertical_tabs_enabled() {
     let _vertical_tabs_guard = FeatureFlag::VerticalTabs.override_enabled(true);
 


### PR DESCRIPTION
## Description
Fixes #9201. When using vertical tabs, **Show the tab bar → Always** now opens the vertical tabs panel and applies on window restore.

## Testing
I did the manual testing myself. After setting it to always I quit the app with tabs toggled off. And after reopening the tabs were visible.

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{Vertical tabs panel now respects “Always” for showing the tab bar and restores correctly after restart.}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
