### PR TITLE
Remove stale feature flag: LessHorizontalTerminalPadding

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -464,7 +464,6 @@ default = [
     "shared_with_me",
     "block_toolbelt_save_as_workflow",
     "remove_alt_screen_padding",
-    "less_horizontal_terminal_padding",
     "session_sharing_acls",
     "external_agent_mode_context",
     "shell_selector",
@@ -777,7 +776,6 @@ alacritty_settings_import = []
 shared_with_me = []
 ai_rules = []
 am_workflows = []
-less_horizontal_terminal_padding = []
 shell_selector = []
 shared_session_long_running_commands = []
 block_toolbelt_save_as_workflow = []

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2376,8 +2376,6 @@ pub fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::AIRules,
         #[cfg(feature = "ssh_tmux_wrapper")]
         FeatureFlag::SSHTmuxWrapper,
-        #[cfg(feature = "less_horizontal_terminal_padding")]
-        FeatureFlag::LessHorizontalTerminalPadding,
         #[cfg(feature = "shell_selector")]
         FeatureFlag::ShellSelector,
         #[cfg(feature = "block_toolbelt_save_as_workflow")]

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -745,11 +745,7 @@ lazy_static! {
 
     /// The padding between the left of the element and where the grid contents (either via the
     /// `BlockList` or the `AltScreen`) should be rendered.
-    pub static ref PADDING_LEFT: f32 = if FeatureFlag::LessHorizontalTerminalPadding.is_enabled() {
-        16.
-    } else {
-        20.
-    };
+    pub static ref PADDING_LEFT: f32 = 16.;
 }
 
 #[derive(Default)]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -142,10 +142,6 @@ pub enum FeatureFlag {
     /// Routes SSH sessions through the tmux-backed SSH wrapper.
     SSHTmuxWrapper,
 
-    /// Reduces the amount of horizontal padding in the blocklist
-    /// from 20px to 16px.
-    LessHorizontalTerminalPadding,
-
     /// Enables the shell selector, allowing us to open a new tab in
     /// a shell other than the default shell.
     ShellSelector,


### PR DESCRIPTION
## Description
Removes the stale `LessHorizontalTerminalPadding` feature flag.

This flag was already enabled in the `default` features list in `app/Cargo.toml`, so it has been live for all builds. This change:
- Removes `less_horizontal_terminal_padding` from `app/Cargo.toml` (both the `[features]` definition and the `default` array).
- Removes the `LessHorizontalTerminalPadding` variant from the `FeatureFlag` enum in `crates/warp_features/src/lib.rs`.
- Removes the `#[cfg(feature = "less_horizontal_terminal_padding")] FeatureFlag::LessHorizontalTerminalPadding` entry in `app/src/lib.rs::enabled_features`.
- Inlines the runtime check in `app/src/terminal/view.rs` so `PADDING_LEFT` is unconditionally `16.` (the previously gated value).

Resolves [SAL-54](https://linear.app/warp/issue/SAL-54).

## Testing
- `cargo fmt --check` passes.
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` passes.
- `cargo check -p warp` passes.
No behavior change is expected — the flag was already enabled by default, so the new constant value matches existing production behavior.

## Server API dependencies
N/A — flag removal only.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

_Conversation: https://staging.warp.dev/conversation/5d49d93b-29b2-43b7-8332-8c7b7bc0138a_
_Run: https://oz.staging.warp.dev/runs/019dd56d-eaba-7c76-84ec-d32808ce8e9a_

_This PR was generated with [Oz](https://warp.dev/oz)._
