### PR TITLE
Add FAQ entry for model subscription access

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -60,6 +60,14 @@ Contributors with several merged PRs may be invited to become collaborators. The
 
 Yes. Use whatever you like — Warp's built-in agent, Claude Code, Codex, Gemini CLI, Cursor, others, or no agent at all. The repo ships agent-readable context (skills under [`.agents/skills/`](.agents/skills/), specs under [`specs/`](specs/), and [`WARP.md`](WARP.md)) that any harness supporting these formats can pick up.
 
+### Can I use Codex or Claude models with my existing subscriptions in Warp, or submit a PR to add that?
+
+Not today. Warp's built-in agent harness runs server-side and isn't open in this repo today.
+
+That said, we plan to support [ACP (agent client protocol)](https://agentclientprotocol.com/) in Warp, so you could connect other models or subscriptions directly and get a native Warp experience for your coding agent of choice.
+
+We will update the community as we explore this.
+
 ### How can I get Oz to implement an issue for me?
 
 Mention **@oss-maintainers** on any issue with a readiness label and ask. Approved requests run on **complimentary Oz credits** — you don't need to set up your own Oz account or pay for compute.

--- a/FAQ.md
+++ b/FAQ.md
@@ -66,7 +66,7 @@ Not today. Warp's built-in agent harness runs server-side and isn't open in this
 
 That said, we plan to support [ACP (agent client protocol)](https://agentclientprotocol.com/) in Warp, so you could connect other models or subscriptions directly and get a native Warp experience for your coding agent of choice.
 
-We will update the community as we explore this.
+[This is tracked on our roadmap](https://github.com/warpdotdev/warp/issues/9233), and we will update the community as we explore this.
 
 ### How can I get Oz to implement an issue for me?
 


### PR DESCRIPTION
## Description

Adds a FAQ entry for a common question about whether users can access other models or subscriptions in Warp's agent.

The answer clarifies that Warp's built-in agent harness runs server-side and is not open in this repo, so a personal subscription cannot be used for Codex model access there. It also points users toward planned ACP support for connecting Codex directly while using their own subscription.

## Testing

Documentation-only change; not run.

## Server API dependencies

None.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

Co-Authored-By: Oz <oz-agent@warp.dev>
