### PR TITLE
Retry local child task creation without parent run id on 422

### DIFF
--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use cynic::{MutationBuilder, QueryBuilder};
+use http::StatusCode;
 use itertools::Itertools;
 #[cfg(test)]
 use mockall::automock;
@@ -61,7 +62,7 @@ use ai::index::full_source_code_embedding::{
     store_client::{IntermediateNode, StoreClient},
     CodebaseContextConfig, ContentHash, EmbeddingConfig, NodeHash, RepoMetadata,
 };
-use warp_graphql::client::Operation;
+use warp_graphql::client::{GraphQLError, Operation};
 #[cfg(not(feature = "agent_mode_evals"))]
 use warp_graphql::queries::get_request_limit_info::{
     GetRequestLimitInfo, GetRequestLimitInfoVariables,
@@ -979,6 +980,23 @@ fn into_file_artifact_record(
     }
 }
 
+fn graphql_http_status(err: &anyhow::Error) -> Option<StatusCode> {
+    err.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<GraphQLError>()
+            .and_then(|graphql_err| match graphql_err {
+                GraphQLError::HttpError { status, .. } => Some(*status),
+                GraphQLError::RequestError(_)
+                | GraphQLError::StagingAccessBlocked
+                | GraphQLError::ResponseError(_) => None,
+            })
+    })
+}
+
+fn should_retry_create_agent_task_without_parent_run_id(err: &anyhow::Error) -> bool {
+    graphql_http_status(err) == Some(StatusCode::UNPROCESSABLE_ENTITY)
+}
+
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl AIClient for ServerApi {
@@ -1352,19 +1370,49 @@ impl AIClient for ServerApi {
             .map(|c| serde_json::to_string(&c))
             .transpose()
             .map_err(|e| anyhow!("Failed to serialize agent config: {e}"))?;
-
-        let variables = CreateAgentTaskVariables {
-            input: CreateAgentTaskInput {
-                prompt,
-                environment_uid: environment_uid.map(|uid| uid.into()),
-                parent_run_id: parent_run_id.map(|run_id| run_id.into()),
-                agent_config_snapshot,
-            },
-            request_context: get_request_context(),
+        let response = match self
+            .send_graphql_request(
+                CreateAgentTask::build(CreateAgentTaskVariables {
+                    input: CreateAgentTaskInput {
+                        prompt: prompt.clone(),
+                        environment_uid: environment_uid.clone().map(Into::into),
+                        parent_run_id: parent_run_id.clone().map(Into::into),
+                        agent_config_snapshot: agent_config_snapshot.clone(),
+                    },
+                    request_context: get_request_context(),
+                }),
+                None,
+            )
+            .await
+        {
+            Ok(response) => response,
+            // Older warp-server builds reject the newer `parentRunId` field at GraphQL
+            // variable-coercion time with HTTP 422. Retry without the parent linkage so local
+            // child harnesses can still start; the child process still receives the parent run id
+            // via env vars for orchestration/messaging.
+            Err(err)
+                if parent_run_id.is_some()
+                    && should_retry_create_agent_task_without_parent_run_id(&err) =>
+            {
+                log::warn!(
+                    "CreateAgentTask rejected parent_run_id with HTTP 422; retrying without parent linkage for compatibility"
+                );
+                self.send_graphql_request(
+                    CreateAgentTask::build(CreateAgentTaskVariables {
+                        input: CreateAgentTaskInput {
+                            prompt,
+                            environment_uid: environment_uid.map(Into::into),
+                            parent_run_id: None,
+                            agent_config_snapshot,
+                        },
+                        request_context: get_request_context(),
+                    }),
+                    None,
+                )
+                .await?
+            }
+            Err(err) => return Err(err),
         };
-
-        let operation = CreateAgentTask::build(variables);
-        let response = self.send_graphql_request(operation, None).await?;
 
         match response.create_agent_task {
             CreateAgentTaskResult::CreateAgentTaskOutput(output) => output

--- a/app/src/server/server_api/ai_test.rs
+++ b/app/src/server/server_api/ai_test.rs
@@ -1,5 +1,7 @@
 use chrono::TimeZone;
 use chrono::Utc;
+use http::StatusCode;
+use warp_graphql::client::GraphQLError;
 
 use super::{
     build_list_agent_runs_url, AgentMessageHeader, AgentRunEvent, AgentSource,
@@ -7,6 +9,29 @@ use super::{
     ListRunsResponse, ReadAgentMessageResponse, RunSortBy, RunSortOrder, TaskListFilter,
 };
 use crate::notebooks::NotebookId;
+
+#[test]
+fn create_agent_task_retry_detects_422_graphql_errors_through_context() {
+    let err = anyhow::anyhow!(GraphQLError::HttpError {
+        status: StatusCode::UNPROCESSABLE_ENTITY,
+        body: "unknown field".to_string(),
+    })
+    .context("wrapped for higher-level handling");
+
+    assert!(super::should_retry_create_agent_task_without_parent_run_id(
+        &err
+    ));
+}
+
+#[test]
+fn create_agent_task_retry_ignores_non_422_graphql_errors() {
+    let err = anyhow::anyhow!(GraphQLError::HttpError {
+        status: StatusCode::BAD_REQUEST,
+        body: "bad request".to_string(),
+    });
+
+    assert!(!super::should_retry_create_agent_task_without_parent_run_id(&err));
+}
 
 #[test]
 fn test_deserialize_file_artifact_download_response() {


### PR DESCRIPTION
## Description
Retry local child `createAgentTask` requests without `parentRunId` when older server builds reject the GraphQL field with HTTP 422. This keeps local Claude child agents working against lagging server schema versions while still preserving parent linkage via env vars.

Conversation: https://app.warp.dev/conversation/76203bc5-6631-4d48-bbe1-8e604abb9a9b

## Testing
- `cargo fmt --manifest-path /Users/katarina/Developer/warp-worktrees/local-child-agent-parent-run-id-compat-warp/Cargo.toml --all --check`
- `cargo clippy --manifest-path /Users/katarina/Developer/warp-worktrees/local-child-agent-parent-run-id-compat-warp/Cargo.toml --workspace --all-targets --all-features --tests -- -D warnings`
- `cargo test --manifest-path /Users/katarina/Developer/warp-worktrees/local-child-agent-parent-run-id-compat-warp/app/Cargo.toml -p warp server::server_api::ai::tests::`

## Server API dependencies
- [ ] Is this change necessary to make the client compatible with a desired server API breaking change?
- [ ] Does this change rely on a new server API?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle?

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fix local Claude child agents failing to start when older servers reject the parent run id field.

Co-Authored-By: Oz <oz-agent@warp.dev>
