### PR TITLE
docs(vbrief): ACP harness integration -- project setup and backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Deft project setup for ACP Harness Integration: `vbrief/` lifecycle structure, `PROJECT-DEFINITION.vbrief.json`, and 4 scope vBRIEFs promoted to pending/ backlog (foundation, core harness, client capabilities, UI integration).

--- a/vbrief/PROJECT-DEFINITION.vbrief.json
+++ b/vbrief/PROJECT-DEFINITION.vbrief.json
@@ -1,0 +1,21 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "created": "2026-04-28T19:30:47Z",
+    "updated": "2026-04-28T19:37:00Z"
+  },
+  "plan": {
+    "title": "ACP Harness Integration",
+    "status": "approved",
+    "narratives": {
+      "Overview": "Add Harness::Acp to the Warp terminal, enabling any ACP (Agent Client Protocol) compliant coding agent to be used as a third-party harness. Warp acts as the ACP client, launching the agent as a background subprocess over piped stdin/stdout JSON-RPC, forwarding MCP server configuration, providing file system and terminal capabilities, and mapping ACP permission requests to Warp's existing autonomy gates. Gated behind FeatureFlag::AcpHarness for dogfood rollout.",
+      "Architecture": "New harness module at app/src/ai/agent_sdk/driver/harness/acp.rs implementing ThirdPartyHarness and HarnessRunner traits. Warp uses the agent-client-protocol Rust crate as the ACP client. ACP agent subprocess runs as a background piped process (NOT in terminal PTY). Session lifecycle: initialize -> session/new (with MCP server configs) -> session/prompt (streaming notifications). Agent output events (AgentMessageChunk, AgentThoughtChunk, ToolCall, ToolCallUpdate, Diff) rendered in conversation view. Agent resource requests (fs/read_text_file, fs/write_text_file, terminal/create, request_permission) handled by Warp's existing capability layer. ACP agent binary specified in agent config file as harness: { type: acp, command: my-binary }, loaded via existing -f/WARP_AGENT_CONFIG_FILE mechanism. HarnessConfig gains command: Option<String>. Touch surface mirrors PR #9255 (Hermes): ~21 locations.",
+      "TechStack": "Rust, agent-client-protocol crate (ACP Rust SDK v0.11+), JSON-RPC 2.0 over stdio, tokio. Crates: warp_cli (Harness enum), app/src/ai/agent_sdk (driver, harness), warp_core (FeatureFlag), app/src/ai/ambient_agents (HarnessConfig).",
+      "Goals": "Enable Warp to work with any ACP-compliant coding agent via a standardized protocol analogous to LSP. Reuse existing Warp infrastructure (MCP forwarding, permission gates, conversation view) rather than per-agent integrations. Dogfood gated.",
+      "Requirements": "FR-1: Harness::Acp in warp_cli Harness enum. FR-2: HarnessConfig.command: Option<String>; binary in config file. FR-3: Background piped subprocess (not terminal PTY); JSON-RPC via agent-client-protocol SDK. FR-4: ACP client capabilities: fs.readTextFile=true, fs.writeTextFile=true, terminal=true. FR-5: MCP servers forwarded in session/new. FR-6: RequestPermission -> Warp autonomy gate/BlockedAction. FR-7: AgentMessageChunk/AgentThoughtChunk/ToolCall/ToolCallUpdate/Diff -> conversation view. FR-8: FeatureFlag::AcpHarness gates all new paths. NFR-1: No regression to Oz/Claude/Gemini/Hermes. NFR-2: cargo fmt + clippy pass. NFR-3: Unit tests for session lifecycle, event mapping, command validation.",
+      "AllowDirectCommitsToMaster": "false"
+    },
+    "items": [],
+    "references": []
+  }
+}

--- a/vbrief/pending/2026-04-28-acp-client-capabilities.vbrief.json
+++ b/vbrief/pending/2026-04-28-acp-client-capabilities.vbrief.json
@@ -1,0 +1,52 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "created": "2026-04-28T19:37:00Z",
+    "updated": "2026-04-28T19:37:00Z"
+  },
+  "plan": {
+    "title": "ACP Client Capabilities: fs read/write, terminal, permission gates",
+    "status": "pending",
+    "narratives": {
+      "Overview": "Handle the inbound ACP requests that the agent sends TO Warp as the client: fs/read_text_file, fs/write_text_file, terminal/create, and request_permission. These are the callbacks the agent uses to interact with the user's filesystem and environment. request_permission maps to Warp's existing autonomy gate/BlockedAction flow. Depends on the core harness story.",
+      "AcceptanceCriteria": "1. AcpHarnessRunner handles AgentRequest::ReadTextFile by reading the file from disk (honoring working_dir) and responding with ReadTextFileResponse. 2. AcpHarnessRunner handles AgentRequest::WriteTextFile by writing to disk and responding with WriteTextFileResponse. 3. AcpHarnessRunner handles AgentRequest::CreateTerminal by starting a terminal session in Warp and returning the terminal ID. 4. AcpHarnessRunner handles AgentRequest::RequestPermission by suspending the JSON-RPC loop, emitting a BlockedAction event through the existing Warp autonomy gate, waiting for user response, then sending the PermissionResponse back to the agent. 5. All file operations are path-validated (no directory traversal outside working dir). 6. Unit tests for each request type: happy path + error cases (file not found, permission denied by user).",
+      "Dependencies": [
+        "2026-04-28-acp-core-harness"
+      ]
+    },
+    "items": [
+      {
+        "id": "1",
+        "title": "Handle fs/read_text_file requests from agent",
+        "status": "proposed"
+      },
+      {
+        "id": "2",
+        "title": "Handle fs/write_text_file requests from agent",
+        "status": "proposed"
+      },
+      {
+        "id": "3",
+        "title": "Handle terminal/create requests from agent",
+        "status": "proposed"
+      },
+      {
+        "id": "4",
+        "title": "Handle request_permission -> Warp autonomy gate",
+        "status": "proposed"
+      },
+      {
+        "id": "5",
+        "title": "Path validation for file operations",
+        "status": "proposed"
+      },
+      {
+        "id": "6",
+        "title": "Unit tests for all client capability handlers",
+        "status": "proposed"
+      }
+    ],
+    "references": [],
+    "updated": "2026-04-28T19:45:44Z"
+  }
+}

--- a/vbrief/pending/2026-04-28-acp-core-harness.vbrief.json
+++ b/vbrief/pending/2026-04-28-acp-core-harness.vbrief.json
@@ -1,0 +1,57 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "created": "2026-04-28T19:37:00Z",
+    "updated": "2026-04-28T19:37:00Z"
+  },
+  "plan": {
+    "title": "ACP Core Harness: ThirdPartyHarness + HarnessRunner + JSON-RPC session lifecycle",
+    "status": "pending",
+    "narratives": {
+      "Overview": "Implement AcpHarness (ThirdPartyHarness) and AcpHarnessRunner (HarnessRunner) in app/src/ai/agent_sdk/driver/harness/acp.rs. This is the core story: spawn the ACP agent as a background piped subprocess and drive the full JSON-RPC session lifecycle (initialize, session/new, session/prompt, session/cancel) using the agent-client-protocol Rust SDK. Depends on the foundation story.",
+      "AcceptanceCriteria": "1. agent-client-protocol crate added to app/Cargo.toml (gated by feature or unconditional). 2. app/src/ai/agent_sdk/driver/harness/acp.rs implements AcpHarness (ThirdPartyHarness) with: harness() -> Harness::Acp, cli_agent() -> CLIAgent::Acp (new variant), validate() checks HarnessConfig.command is present and binary is on PATH. 3. AcpHarnessRunner manages subprocess lifecycle: spawn with piped stdin/stdout using agent-client-protocol SDK, send initialize (client caps: fs.read=true, fs.write=true, terminal=true), send session/new with MCP server configs, send session/prompt with prompt text, receive streaming notifications. 4. HarnessRunner::start() returns a CommandHandle-equivalent future that resolves when session/prompt returns (stop_reason: end_turn/cancelled/failed). 5. HarnessRunner::exit() sends session/cancel and closes stdin. 6. HarnessRunner::save_conversation() uploads block snapshot (same pattern as Hermes). 7. mod hermes and mod acp both in harness/mod.rs; harness_kind() returns HarnessKind::ThirdParty(Box::new(AcpHarness)) for Harness::Acp. 8. Unit tests in harness/acp-tests.rs covering: validate with missing command, session lifecycle happy path (mocked SDK), exit/cancel flow.",
+      "Dependencies": [
+        "2026-04-28-acp-foundation"
+      ]
+    },
+    "items": [
+      {
+        "id": "1",
+        "title": "Add agent-client-protocol crate dependency",
+        "status": "proposed"
+      },
+      {
+        "id": "2",
+        "title": "Implement AcpHarness (ThirdPartyHarness trait)",
+        "status": "proposed"
+      },
+      {
+        "id": "3",
+        "title": "Implement AcpHarnessRunner: spawn piped subprocess",
+        "status": "proposed"
+      },
+      {
+        "id": "4",
+        "title": "Implement JSON-RPC session lifecycle (init, session/new, session/prompt)",
+        "status": "proposed"
+      },
+      {
+        "id": "5",
+        "title": "Implement HarnessRunner::exit() via session/cancel",
+        "status": "proposed"
+      },
+      {
+        "id": "6",
+        "title": "Wire into harness_kind() dispatch",
+        "status": "proposed"
+      },
+      {
+        "id": "7",
+        "title": "Unit tests for session lifecycle",
+        "status": "proposed"
+      }
+    ],
+    "references": [],
+    "updated": "2026-04-28T19:45:44Z"
+  }
+}

--- a/vbrief/pending/2026-04-28-acp-foundation.vbrief.json
+++ b/vbrief/pending/2026-04-28-acp-foundation.vbrief.json
@@ -1,0 +1,39 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "created": "2026-04-28T19:37:00Z",
+    "updated": "2026-04-28T19:37:00Z"
+  },
+  "plan": {
+    "title": "ACP Foundation: Enum, Config, Feature Flag",
+    "status": "pending",
+    "narratives": {
+      "Overview": "Add the Harness::Acp variant everywhere the Harness enum is matched, extend HarnessConfig with an optional command field for the agent binary, and add the FeatureFlag::AcpHarness gate. This story has no user-visible behaviour but establishes the compile-time skeleton that all other ACP stories depend on.",
+      "AcceptanceCriteria": "1. Harness::Acp added to crates/warp_cli/src/agent.rs Harness enum with #[value(name = 'acp')]. 2. Harness::display_name, fmt::Display, parse_local_child_harness all handle Acp. 3. HarnessConfig in app/src/ai/ambient_agents/task.rs gains command: Option<String> (skip_serializing_if = None). 4. AgentConfigSnapshotFile in app/src/ai/agent_sdk/config_file.rs gains matching harness_command field. 5. harness_from_name in ambient_agents/task.rs handles 'acp'. 6. FeatureFlag::AcpHarness added to warp_core/src/features.rs (DOGFOOD_FLAGS). 7. Exhaustive match arms added in: agent_sdk/mod.rs (resolve_orchestration_harness_label), ambient_agents/task.rs (harness_from_name), harness_display.rs (display_name, icon_for, brand_color, From<AIAgentHarness>), conversation.rs (AIAgentHarness), pane_group/mod.rs, view_impl.rs, harness_selector.rs, conversation_loader.rs, telemetry/events.rs (CLIAgentType). 8. cargo build passes with no warnings on the new variants."
+    },
+    "items": [
+      {
+        "id": "1",
+        "title": "Add Harness::Acp to warp_cli Harness enum",
+        "status": "proposed"
+      },
+      {
+        "id": "2",
+        "title": "Add HarnessConfig.command: Option<String>",
+        "status": "proposed"
+      },
+      {
+        "id": "3",
+        "title": "Add FeatureFlag::AcpHarness (dogfood)",
+        "status": "proposed"
+      },
+      {
+        "id": "4",
+        "title": "Propagate Acp variant to all exhaustive match sites",
+        "status": "proposed"
+      }
+    ],
+    "references": [],
+    "updated": "2026-04-28T19:45:44Z"
+  }
+}

--- a/vbrief/pending/2026-04-28-acp-ui-integration.vbrief.json
+++ b/vbrief/pending/2026-04-28-acp-ui-integration.vbrief.json
@@ -1,0 +1,53 @@
+{
+  "vBRIEFInfo": {
+    "version": "0.6",
+    "created": "2026-04-28T19:37:00Z",
+    "updated": "2026-04-28T19:37:00Z"
+  },
+  "plan": {
+    "title": "ACP UI Integration: CLIAgent, icons, harness selector, session listener",
+    "status": "pending",
+    "narratives": {
+      "Overview": "Complete the UI-layer wiring that makes Harness::Acp a first-class citizen in the Warp UI: CLIAgent::Acp variant, brand icon/color, harness selector display, session listener registration, plugin manager (no plugin needed), and the use_agent_footer submit strategy. These changes mirror the Hermes PR #9255 pattern exactly for the UI side. Can be done in parallel with or after the core harness story.",
+      "AcceptanceCriteria": "1. CLIAgent::Acp added to terminal/cli_agent.rs with command_prefix='acp-agent' (placeholder, overridden by config), display_name='ACP Agent', icon -> Icon::AcpLogo, color -> ACP_COLOR (neutral grey or configurable). 2. app/assets/bundled/svg/acp.svg created (simple placeholder icon). 3. Icon::AcpLogo added to warp_core/src/ui/icons.rs with svg path mapping. 4. CLIAgentType::Acp added to telemetry/events.rs and From<CLIAgent> impl. 5. is_agent_supported in cli_agent_sessions/listener/mod.rs includes CLIAgent::Acp; create_handler returns DefaultSessionListener. 6. plugin_manager_for_with_shell returns None for CLIAgent::Acp. 7. rich_input_submit_strategy returns DelayedEnter for CLIAgent::Acp. 8. harness_selector.rs build_menu_items includes item_for(Harness::Acp) (gated on FeatureFlag::AcpHarness). 9. view_impl.rs harness/cli_agent match handles Harness::Acp -> CLIAgent::Acp. 10. agent_management/view.rs harness list includes Harness::Acp.",
+      "Dependencies": [
+        "2026-04-28-acp-foundation"
+      ]
+    },
+    "items": [
+      {
+        "id": "1",
+        "title": "Add CLIAgent::Acp with display metadata",
+        "status": "proposed"
+      },
+      {
+        "id": "2",
+        "title": "Create acp.svg icon asset and Icon::AcpLogo",
+        "status": "proposed"
+      },
+      {
+        "id": "3",
+        "title": "Wire CLIAgent::Acp into session listener, plugin manager, footer",
+        "status": "proposed"
+      },
+      {
+        "id": "4",
+        "title": "Add Acp to harness selector UI (feature-flagged)",
+        "status": "proposed"
+      },
+      {
+        "id": "5",
+        "title": "Wire telemetry CLIAgentType::Acp",
+        "status": "proposed"
+      }
+    ],
+    "references": [
+      {
+        "uri": "https://github.com/warpdotdev/warp/pull/9255",
+        "type": "x-vbrief/github-pr",
+        "title": "PR #9255: feat: add Hermes Agent as a third-party harness (reference implementation)"
+      }
+    ],
+    "updated": "2026-04-28T19:45:44Z"
+  }
+}


### PR DESCRIPTION
## Description

Sets up Deft vBRIEF project tracking for the ACP harness integration feature. Documentation/scaffolding only — no code changes.

Adds vbrief/ lifecycle structure, PROJECT-DEFINITION.vbrief.json, and 4 scope vBRIEFs in pending/ backlog (foundation, core harness, client capabilities, UI integration).

## Testing
Documentation-only PR. No code changes.

## Server API dependencies
N/A

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode