### PR TITLE
Don't require login to open file from URI

### DIFF
--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -7,7 +7,6 @@ pub mod browser_url_handler;
 
 use crate::ai::active_agent_views_model::{ActiveAgentViewsModel, ConversationOrTaskId};
 use crate::ai::agent::api::ServerConversationToken;
-use crate::auth::AuthStateProvider;
 use crate::drive::OpenWarpDriveObjectSettings;
 use crate::launch_configs::launch_config::LaunchConfig;
 use crate::linear::{LinearAction, LinearIssueWork};

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -1008,11 +1008,6 @@ fn get_primary_window(
 /// * For other files, open a new session at the parent directory path, then possibly execute the
 ///   file.
 fn open_file(window_id: Option<WindowId>, path: PathBuf, ctx: &mut AppContext) {
-    let auth_state = AuthStateProvider::as_ref(ctx).get();
-    // Don't open files if we're not logged in.
-    if !auth_state.is_logged_in() {
-        return;
-    }
     let primary_window_and_view = window_id.and_then(|window_id| {
         ctx.root_view_id(window_id)
             .map(|view_id| (window_id, view_id))


### PR DESCRIPTION
## Description

This gate was added ~2 years ago to prevent some panic, but I confirmed the panic doesn't happen anymore. Warp no longer requires login, so we should support opening files in warp even when not logged in.

I noticed this while testing #9277 

## Testing

Tested locally. While logged out, `open "warplocal://action/new_tab?path=/Users/rolandhuang/warp"` opens the tab in that directory correctly. 

Also tested with right click on file > open in WarpLocal while logged out works

While on the login screen, it just focuses the window. 