### PR TITLE
Fix git diff chip refresh flicker with untracked files

### DIFF
--- a/app/src/code_review/git_status_update.rs
+++ b/app/src/code_review/git_status_update.rs
@@ -302,10 +302,11 @@ impl GitRepoStatusModel {
 impl GitRepoStatusModel {
     pub(crate) fn new_for_test(
         repository: ModelHandle<Repository>,
+        repo_path: PathBuf,
         metadata: Option<GitStatusMetadata>,
     ) -> Self {
         Self {
-            repo_path: PathBuf::from("/test"),
+            repo_path,
             repository,
             subscriber_id: None,
             metadata,

--- a/app/src/code_review/git_status_update.rs
+++ b/app/src/code_review/git_status_update.rs
@@ -11,16 +11,16 @@ use {
     crate::util::git::{detect_current_branch_display, detect_main_branch},
     async_channel::Sender,
     repo_metadata::{
+        Repository, RepositoryUpdate,
         repositories::DetectedRepositories,
         repository::{RepositorySubscriber, SubscriberId},
-        Repository, RepositoryUpdate,
     },
     std::{collections::HashMap, time::Duration},
-    warpui::{r#async::SpawnedFutureHandle, ModelHandle, WeakModelHandle},
+    warpui::{ModelHandle, WeakModelHandle, r#async::SpawnedFutureHandle},
 };
 
 #[cfg(feature = "local_fs")]
-use super::diff_state::{diff_metadata_against_head, DiffStats};
+use super::diff_state::{DiffStats, diff_metadata_against_head};
 
 /// Public metadata exposed to consumers — the subset of diff metadata
 /// that the git chip (prompt display, agent view footer) needs.

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -39,7 +39,9 @@ use super::{
     ChipValue, ContextChipKind,
 };
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::{GitRepoStatusEvent, GitRepoStatusModel};
+use crate::code_review::git_status_update::{
+    GitRepoStatusEvent, GitRepoStatusModel, GitStatusMetadata,
+};
 #[cfg(feature = "local_fs")]
 use crate::context_chips::display_chip::GitLineChanges;
 use std::collections::{HashMap, HashSet};
@@ -945,6 +947,28 @@ impl CurrentPrompt {
         state.on_click_generator_handle = Some(handle);
     }
 
+    #[cfg(feature = "local_fs")]
+    fn latest_git_status_metadata(&self, ctx: &AppContext) -> Option<GitStatusMetadata> {
+        let active_working_directory = self
+            .latest_context
+            .as_ref()?
+            .active_block_metadata
+            .current_working_directory()?;
+
+        self.git_repo_status
+            .as_ref()
+            .and_then(|w| w.upgrade(ctx))
+            .and_then(|h| {
+                let status_model = h.as_ref(ctx);
+                let active_working_directory = std::path::Path::new(active_working_directory);
+
+                if !active_working_directory.starts_with(status_model.repo_path()) {
+                    return None;
+                }
+
+                status_model.metadata().cloned()
+            })
+    }
     fn fetch_chip_value_at_interval(
         &mut self,
         chip_kind: &ContextChipKind,
@@ -1444,13 +1468,9 @@ impl CurrentPrompt {
     /// `ShellGitBranch` and `GitDiffStats` chip states.
     #[cfg(feature = "local_fs")]
     fn apply_git_repo_metadata(&mut self, ctx: &mut ModelContext<Self>) {
-        let metadata = self
-            .git_repo_status
-            .as_ref()
-            .and_then(|w| w.upgrade(ctx))
-            .and_then(|h| h.as_ref(ctx).metadata().cloned());
-
-        let Some(metadata) = metadata else {
+        let Some(metadata) = self.latest_git_status_metadata(ctx) else {
+            self.update_chip_value(&ContextChipKind::ShellGitBranch, None);
+            self.update_chip_value(&ContextChipKind::GitDiffStats, None);
             return;
         };
 

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -20,7 +20,7 @@ use crate::{
         view::{ContextMenuAction, PromptPart, PromptPosition, TerminalAction},
     },
 };
-use futures::{pin_mut, FutureExt as _};
+use futures::{FutureExt as _, pin_mut};
 use itertools::Itertools;
 use settings::Setting as _;
 use warp_completer::completer::{CommandExitStatus, CommandOutput};
@@ -28,7 +28,7 @@ use warp_core::user_preferences::GetUserPreferences;
 
 use super::ChipResult;
 use super::{
-    chips_to_string,
+    ChipValue, ContextChipKind, chips_to_string,
     context_chip::{
         ChipAvailability, ChipDisabledReason, ChipFingerprintInput, ChipRuntimeCapabilities,
         ContextChip, Environment, ExternalCommandsAvailability, GeneratorContext, PromptGenerator,
@@ -36,7 +36,6 @@ use super::{
     },
     logging::{ChipCommandLogEntry, PromptChipExecutionPhase, PromptChipLogger},
     prompt::Prompt,
-    ChipValue, ContextChipKind,
 };
 #[cfg(feature = "local_fs")]
 use crate::code_review::git_status_update::{
@@ -51,8 +50,8 @@ use std::time::Duration;
 #[cfg(feature = "local_fs")]
 use warpui::WeakModelHandle;
 use warpui::{
-    r#async::{SpawnedFutureHandle, Timer},
     AppContext, ViewHandle,
+    r#async::{SpawnedFutureHandle, Timer},
 };
 use warpui::{Entity, ModelAsRef, ModelContext, ModelHandle, SingletonEntity};
 
@@ -949,26 +948,130 @@ impl CurrentPrompt {
 
     #[cfg(feature = "local_fs")]
     fn latest_git_status_metadata(&self, ctx: &AppContext) -> Option<GitStatusMetadata> {
-        let active_working_directory = self
-            .latest_context
-            .as_ref()?
+        let latest_context = self.latest_context.as_ref()?;
+        let active_working_directory = latest_context
             .active_block_metadata
             .current_working_directory()?;
+
+        // The shell-reported cwd can be in a different path encoding than the
+        // OS-native repo path that `DetectedRepositories` produced. The most
+        // common case is MSYS2 / Git Bash on Windows reporting paths like
+        // `/c/Users/foo/proj` while `repo_path` is `C:\Users\foo\proj`. WSL
+        // does the same with `/mnt/c/...`. Run the cwd through the session's
+        // `ShellLaunchData` so the ancestor check sees the same encoding the
+        // repo path is stored in. When no conversion is available (or it
+        // fails) we fall back to comparing the raw string, which matches the
+        // pre-existing behavior for native shells.
+        let active_session = latest_context
+            .active_block_metadata
+            .session_id()
+            .and_then(|session_id| self.sessions.as_ref(ctx).get(session_id));
+        let native_working_directory = active_session
+            .as_ref()
+            .and_then(|session| session.launch_data())
+            .and_then(|launch_data| {
+                launch_data.maybe_convert_absolute_path(active_working_directory)
+            });
 
         self.git_repo_status
             .as_ref()
             .and_then(|w| w.upgrade(ctx))
             .and_then(|h| {
                 let status_model = h.as_ref(ctx);
-                let active_working_directory = std::path::Path::new(active_working_directory);
-
-                if !active_working_directory.starts_with(status_model.repo_path()) {
+                if !Self::working_directory_belongs_to_repo(
+                    active_working_directory,
+                    native_working_directory.as_deref(),
+                    status_model.repo_path(),
+                ) {
                     return None;
                 }
 
                 status_model.metadata().cloned()
             })
     }
+    /// Whether the cwd is inside `repo_path`. Prefers the
+    /// `ShellLaunchData`-converted form when available so MSYS2 / WSL paths
+    /// like `/c/Users/foo/proj` correctly match the native `C:\Users\foo\proj`
+    /// repo root. Falls back to the raw shell-reported string when no
+    /// conversion is available, preserving the pre-existing behavior on
+    /// native shells.
+    #[cfg(feature = "local_fs")]
+    fn working_directory_belongs_to_repo(
+        raw_working_directory: &str,
+        native_working_directory: Option<&std::path::Path>,
+        repo_path: &std::path::Path,
+    ) -> bool {
+        let cwd: &std::path::Path =
+            native_working_directory.unwrap_or_else(|| std::path::Path::new(raw_working_directory));
+        cwd.starts_with(repo_path)
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn update_chip_value_from_git_status_metadata(
+        &mut self,
+        chip_kind: &ContextChipKind,
+        metadata: &GitStatusMetadata,
+    ) {
+        match chip_kind {
+            ContextChipKind::ShellGitBranch => {
+                self.update_chip_value(
+                    chip_kind,
+                    Some(ChipValue::Text(metadata.current_branch_name.clone())),
+                );
+            }
+            ContextChipKind::GitDiffStats => {
+                self.update_chip_value(
+                    chip_kind,
+                    Some(ChipValue::GitDiffStats(GitLineChanges::from_diff_stats(
+                        &metadata.stats_against_head,
+                    ))),
+                );
+            }
+            ContextChipKind::WorkingDirectory
+            | ContextChipKind::Username
+            | ContextChipKind::Hostname
+            | ContextChipKind::Date
+            | ContextChipKind::Time12
+            | ContextChipKind::Time24
+            | ContextChipKind::VirtualEnvironment
+            | ContextChipKind::CondaEnvironment
+            | ContextChipKind::NodeVersion
+            | ContextChipKind::Custom { .. }
+            | ContextChipKind::GithubPullRequest
+            | ContextChipKind::KubernetesContext
+            | ContextChipKind::SvnBranch
+            | ContextChipKind::SvnDirtyItems
+            | ContextChipKind::Ssh
+            | ContextChipKind::Subshell
+            | ContextChipKind::AgentPlanAndTodoList => {}
+        }
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn update_git_chip_value_from_repo_status(
+        &mut self,
+        chip_kind: &ContextChipKind,
+        ctx: &AppContext,
+    ) {
+        if let Some(metadata) = self.latest_git_status_metadata(ctx) {
+            self.update_chip_value_from_git_status_metadata(chip_kind, &metadata);
+        } else {
+            self.update_chip_value(chip_kind, None);
+        }
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn clear_git_chip_generators(&mut self) {
+        for chip_kind in [
+            ContextChipKind::ShellGitBranch,
+            ContextChipKind::GitDiffStats,
+        ] {
+            if let Some(state) = self.states.get_mut(&chip_kind) {
+                state.clear_abort_handlers();
+            }
+        }
+    }
+
     fn fetch_chip_value_at_interval(
         &mut self,
         chip_kind: &ContextChipKind,
@@ -1070,6 +1173,9 @@ impl CurrentPrompt {
                                 true,
                                 ctx,
                             );
+                        } else {
+                            #[cfg(feature = "local_fs")]
+                            self.update_git_chip_value_from_repo_status(chip_kind, ctx);
                         }
                     } else {
                         self.fetch_chip_value_at_interval(
@@ -1446,6 +1552,7 @@ impl CurrentPrompt {
         if let Some(weak) = handle {
             if let Some(strong) = weak.upgrade(ctx) {
                 self.git_repo_status = Some(weak);
+                self.clear_git_chip_generators();
                 ctx.subscribe_to_model(&strong, |me, event, ctx| match event {
                     GitRepoStatusEvent::MetadataChanged => {
                         me.apply_git_repo_metadata(ctx);
@@ -1569,9 +1676,11 @@ impl CurrentPrompt {
         let current = *SessionSettings::as_ref(ctx).github_pr_chip_default_validation;
         if current != GithubPrPromptChipDefaultValidation::Suppressed {
             SessionSettings::handle(ctx).update(ctx, |settings, ctx| {
-                report_if_error!(settings
-                    .github_pr_chip_default_validation
-                    .set_value(GithubPrPromptChipDefaultValidation::Suppressed, ctx));
+                report_if_error!(
+                    settings
+                        .github_pr_chip_default_validation
+                        .set_value(GithubPrPromptChipDefaultValidation::Suppressed, ctx)
+                );
             });
         }
     }
@@ -1597,9 +1706,11 @@ impl CurrentPrompt {
             .unwrap_or(false);
         if gh_on_path {
             SessionSettings::handle(ctx).update(ctx, |settings, ctx| {
-                report_if_error!(settings
-                    .github_pr_chip_default_validation
-                    .set_value(GithubPrPromptChipDefaultValidation::Unvalidated, ctx));
+                report_if_error!(
+                    settings
+                        .github_pr_chip_default_validation
+                        .set_value(GithubPrPromptChipDefaultValidation::Unvalidated, ctx)
+                );
             });
         }
     }
@@ -1608,9 +1719,11 @@ impl CurrentPrompt {
         let current = *SessionSettings::as_ref(ctx).github_pr_chip_default_validation;
         if current == GithubPrPromptChipDefaultValidation::Unvalidated {
             SessionSettings::handle(ctx).update(ctx, |settings, ctx| {
-                report_if_error!(settings
-                    .github_pr_chip_default_validation
-                    .set_value(GithubPrPromptChipDefaultValidation::Validated, ctx));
+                report_if_error!(
+                    settings
+                        .github_pr_chip_default_validation
+                        .set_value(GithubPrPromptChipDefaultValidation::Validated, ctx)
+                );
             });
         }
     }

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -20,11 +20,11 @@ use crate::code_review::git_status_update::{GitRepoStatusModel, GitStatusMetadat
 #[cfg(windows)]
 use crate::system::SystemInfo;
 use crate::{
-    auth::{auth_manager::AuthManager, AuthStateProvider},
+    auth::{AuthStateProvider, auth_manager::AuthManager},
     context_chips::{
+        ChipAvailability, ChipDisabledReason, ChipRuntimeCapabilities, ContextChipKind,
         context_chip::{ChipFingerprintInput, Environment},
         prompt::Prompt,
-        ChipAvailability, ChipDisabledReason, ChipRuntimeCapabilities, ContextChipKind,
     },
     features::FeatureFlag,
     menu::MenuItem,
@@ -33,6 +33,7 @@ use crate::{
     },
     settings::WarpPromptSeparator,
     terminal::{
+        History,
         model::{
             block::BlockMetadata,
             session::{CommandExecutor, ExecuteCommandOptions, SessionId, SessionInfo, Sessions},
@@ -40,7 +41,6 @@ use crate::{
         session_settings::{GithubPrPromptChipDefaultValidation, SessionSettings},
         shell::Shell,
         view::PromptPosition,
-        History,
     },
 };
 #[cfg(feature = "local_fs")]
@@ -324,18 +324,26 @@ fn test_github_pr_chip_runtime_policy_configuration() {
     );
     assert_eq!(policy.shell_command_timeout(), Some(Duration::from_secs(5)));
     assert!(policy.suppress_on_failure());
-    assert!(policy
-        .fingerprint_inputs()
-        .contains(&ChipFingerprintInput::SessionId));
-    assert!(policy
-        .fingerprint_inputs()
-        .contains(&ChipFingerprintInput::WorkingDirectory));
-    assert!(policy
-        .fingerprint_inputs()
-        .contains(&ChipFingerprintInput::GitBranch));
-    assert!(policy
-        .fingerprint_inputs()
-        .contains(&ChipFingerprintInput::RequiredExecutablesPresence));
+    assert!(
+        policy
+            .fingerprint_inputs()
+            .contains(&ChipFingerprintInput::SessionId)
+    );
+    assert!(
+        policy
+            .fingerprint_inputs()
+            .contains(&ChipFingerprintInput::WorkingDirectory)
+    );
+    assert!(
+        policy
+            .fingerprint_inputs()
+            .contains(&ChipFingerprintInput::GitBranch)
+    );
+    assert!(
+        policy
+            .fingerprint_inputs()
+            .contains(&ChipFingerprintInput::RequiredExecutablesPresence)
+    );
     assert_eq!(
         chip.availability(&ChipRuntimeCapabilities {
             session_is_local: Some(false),
@@ -347,9 +355,11 @@ fn test_github_pr_chip_runtime_policy_configuration() {
         policy.invalidate_on_commands(),
         &["git".to_string(), "gh".to_string(), "gt".to_string()]
     );
-    assert!(policy
-        .fingerprint_inputs()
-        .contains(&ChipFingerprintInput::InvalidatingCommandCount));
+    assert!(
+        policy
+            .fingerprint_inputs()
+            .contains(&ChipFingerprintInput::InvalidatingCommandCount)
+    );
 }
 
 #[test]
@@ -1598,6 +1608,63 @@ fn test_git_diff_stats_clears_when_repo_status_is_stale_for_working_directory() 
             );
         });
     });
+}
+
+/// Regression coverage for the `working_directory_belongs_to_repo` helper.
+///
+/// On MSYS2 / WSL the shell-reported cwd (e.g. `/c/Users/foo/proj` or
+/// `/mnt/c/Users/foo/proj`) does not lexically `starts_with` the OS-native
+/// `repo_path` (`C:\Users\foo\proj`) detected by `DetectedRepositories`.
+/// `latest_git_status_metadata` runs the cwd through
+/// `ShellLaunchData::maybe_convert_absolute_path` first; this helper then
+/// prefers the converted form when available and falls back to the raw string
+/// only when no conversion is provided.
+#[cfg(feature = "local_fs")]
+mod working_directory_belongs_to_repo_tests {
+    use std::path::Path;
+
+    use super::CurrentPrompt;
+
+    #[test]
+    fn falls_back_to_raw_cwd_when_no_conversion_is_provided() {
+        assert!(CurrentPrompt::working_directory_belongs_to_repo(
+            "/tmp/repo/src",
+            None,
+            Path::new("/tmp/repo"),
+        ));
+        assert!(!CurrentPrompt::working_directory_belongs_to_repo(
+            "/tmp/different",
+            None,
+            Path::new("/tmp/repo"),
+        ));
+    }
+
+    #[test]
+    fn prefers_converted_cwd_over_raw_string_for_msys2_style_paths() {
+        // Round 2 regression: shell reports `/c/Users/foo/proj/sub`, the
+        // launch-data conversion produces the OS-native `C:\Users\foo\proj\sub`,
+        // and the detected repo path is `C:\Users\foo\proj`. The lexical
+        // `starts_with` against the raw string would fail, so the helper must
+        // consult the converted path.
+        let converted = Path::new("/canonical/repo/sub");
+        assert!(CurrentPrompt::working_directory_belongs_to_repo(
+            "/c/canonical/repo/sub",
+            Some(converted),
+            Path::new("/canonical/repo"),
+        ));
+    }
+
+    #[test]
+    fn rejects_when_converted_cwd_is_outside_repo_even_if_raw_matches() {
+        // The converted form is the source of truth: if the launch-data path
+        // resolves outside the repo, raw-string accidents must not let the
+        // metadata leak through.
+        assert!(!CurrentPrompt::working_directory_belongs_to_repo(
+            "/canonical/repo/sub",
+            Some(Path::new("/elsewhere/sub")),
+            Path::new("/canonical/repo"),
+        ));
+    }
 }
 
 #[cfg(feature = "local_fs")]

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -1178,8 +1178,9 @@ fn test_externally_driven_chip_skips_periodic_timer() {
                 )
                 .unwrap()
         });
+        let repo_path = temp_dir.path().to_path_buf();
         let git_status =
-            app.add_model(move |_| GitRepoStatusModel::new_for_test(repo_handle, None));
+            app.add_model(move |_| GitRepoStatusModel::new_for_test(repo_handle, repo_path, None));
 
         let sessions = app.add_model(|_| Sessions::new_for_test());
         let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
@@ -1198,6 +1199,402 @@ fn test_externally_driven_chip_skips_periodic_timer() {
             assert!(
                 state.refresh_handle.is_none(),
                 "Externally-driven chip should not have a periodic refresh handle"
+            );
+        });
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_externally_driven_git_diff_stats_uses_repo_status_without_shell_fallback() {
+    App::test((), |mut app| async move {
+        let session_id = SessionId::from(902);
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [ContextChipKind::GitDiffStats],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_| History::new(vec![]));
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| crate::settings::manager::SettingsManager::default());
+        crate::settings::InputSettings::register(&mut app);
+        app.update(crate::settings::AISettings::register_and_subscribe_to_events);
+        app.add_singleton_model(crate::workspaces::user_workspaces::UserWorkspaces::default_mock);
+        #[cfg(windows)]
+        app.add_singleton_model(SystemInfo::new);
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        let repo_handle = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        temp_dir.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+
+        let initial_metadata = GitStatusMetadata {
+            current_branch_name: "main".to_string(),
+            main_branch_name: "main".to_string(),
+            stats_against_head: DiffStats {
+                files_changed: 2,
+                total_additions: 8,
+                total_deletions: 0,
+            },
+        };
+        let repo_path = temp_dir.path().to_path_buf();
+        let git_status = app.add_model(move |_| {
+            GitRepoStatusModel::new_for_test(repo_handle, repo_path, Some(initial_metadata))
+        });
+
+        let executor = Arc::new(RecordingCommandExecutor::default());
+        let sessions = app.add_model(|ctx| {
+            let mut sessions = Sessions::new_for_test().with_command_executor(executor.clone());
+            sessions.initialize_bootstrapped_session(
+                SessionInfo::new_for_test().with_id(session_id),
+                "test command".to_string(),
+                vec![],
+                None,
+                ctx,
+            );
+            sessions
+        });
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.latest_context = Some(PromptContext {
+                active_block_metadata: BlockMetadata::new(
+                    Some(session_id),
+                    Some(temp_dir.path().display().to_string()),
+                ),
+                environment: Environment::default(),
+            });
+            cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
+            cp.update_states_with_new_context(ctx);
+        });
+
+        assert!(
+            executor.commands.lock().is_empty(),
+            "GitDiffStats should use GitRepoStatusModel instead of running git diff"
+        );
+
+        app.read(|ctx| {
+            let value = current_prompt
+                .as_ref(ctx)
+                .latest_chip_value(&ContextChipKind::GitDiffStats)
+                .and_then(|value| value.as_git_diff_stats())
+                .cloned();
+            assert_eq!(
+                value,
+                Some(crate::context_chips::display_chip::GitLineChanges {
+                    files_changed: 2,
+                    lines_added: 8,
+                    lines_removed: 0,
+                })
+            );
+        });
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_git_diff_stats_clears_shell_timer_when_repo_status_attaches_late() {
+    App::test((), |mut app| async move {
+        let session_id = SessionId::from(903);
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [ContextChipKind::GitDiffStats],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_| History::new(vec![]));
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| crate::settings::manager::SettingsManager::default());
+        crate::settings::InputSettings::register(&mut app);
+        app.update(crate::settings::AISettings::register_and_subscribe_to_events);
+        app.add_singleton_model(crate::workspaces::user_workspaces::UserWorkspaces::default_mock);
+        #[cfg(windows)]
+        app.add_singleton_model(SystemInfo::new);
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        let repo_handle = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        temp_dir.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+
+        let initial_metadata = GitStatusMetadata {
+            current_branch_name: "main".to_string(),
+            main_branch_name: "main".to_string(),
+            stats_against_head: DiffStats {
+                files_changed: 3,
+                total_additions: 13,
+                total_deletions: 2,
+            },
+        };
+        let repo_path = temp_dir.path().to_path_buf();
+        let git_status = app.add_model(move |_| {
+            GitRepoStatusModel::new_for_test(repo_handle, repo_path, Some(initial_metadata))
+        });
+
+        let executor = Arc::new(RecordingCommandExecutor::default());
+        let sessions = app.add_model(|ctx| {
+            let mut sessions = Sessions::new_for_test().with_command_executor(executor.clone());
+            sessions.initialize_bootstrapped_session(
+                SessionInfo::new_for_test().with_id(session_id),
+                "test command".to_string(),
+                vec![],
+                None,
+                ctx,
+            );
+            sessions
+        });
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.latest_context = Some(PromptContext {
+                active_block_metadata: BlockMetadata::new(
+                    Some(session_id),
+                    Some(temp_dir.path().display().to_string()),
+                ),
+                environment: Environment::default(),
+            });
+            cp.update_states_with_new_context(ctx);
+        });
+
+        app.read(|ctx| {
+            let cp = current_prompt.as_ref(ctx);
+            let state = cp
+                .states
+                .get(&ContextChipKind::GitDiffStats)
+                .expect("GitDiffStats state should exist after running chips");
+            assert!(
+                state.refresh_handle.is_some(),
+                "GitDiffStats should start with a periodic shell refresh before repo status attaches"
+            );
+        });
+
+        current_prompt
+            .update(&mut app, |cp, ctx| cp.await_generators(ctx))
+            .await;
+        executor.clear();
+
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
+        });
+
+        assert!(
+            executor.commands.lock().is_empty(),
+            "Attaching GitRepoStatusModel should not run the shell fallback"
+        );
+
+        app.read(|ctx| {
+            let cp = current_prompt.as_ref(ctx);
+            let state = cp
+                .states
+                .get(&ContextChipKind::GitDiffStats)
+                .expect("GitDiffStats state should exist after set_git_repo_status");
+            assert!(
+                state.refresh_handle.is_none(),
+                "Repo status should clear the stale periodic shell refresh"
+            );
+
+            let value = cp
+                .latest_chip_value(&ContextChipKind::GitDiffStats)
+                .and_then(|value| value.as_git_diff_stats())
+                .cloned();
+            assert_eq!(
+                value,
+                Some(crate::context_chips::display_chip::GitLineChanges {
+                    files_changed: 3,
+                    lines_added: 13,
+                    lines_removed: 2,
+                })
+            );
+        });
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_git_diff_stats_clears_when_repo_status_is_stale_for_working_directory() {
+    App::test((), |mut app| async move {
+        let session_id = SessionId::from(904);
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [ContextChipKind::GitDiffStats],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_| History::new(vec![]));
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| crate::settings::manager::SettingsManager::default());
+        crate::settings::InputSettings::register(&mut app);
+        app.update(crate::settings::AISettings::register_and_subscribe_to_events);
+        app.add_singleton_model(crate::workspaces::user_workspaces::UserWorkspaces::default_mock);
+        #[cfg(windows)]
+        app.add_singleton_model(SystemInfo::new);
+
+        let repo_dir = tempfile::TempDir::new().unwrap();
+        let other_dir = tempfile::TempDir::new().unwrap();
+        let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        let repo_handle = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        repo_dir.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+
+        let initial_metadata = GitStatusMetadata {
+            current_branch_name: "main".to_string(),
+            main_branch_name: "main".to_string(),
+            stats_against_head: DiffStats {
+                files_changed: 2,
+                total_additions: 8,
+                total_deletions: 0,
+            },
+        };
+        let repo_path = repo_dir.path().to_path_buf();
+        let git_status = app.add_model(move |_| {
+            GitRepoStatusModel::new_for_test(repo_handle, repo_path, Some(initial_metadata))
+        });
+
+        let executor = Arc::new(RecordingCommandExecutor::default());
+        let sessions = app.add_model(|ctx| {
+            let mut sessions = Sessions::new_for_test().with_command_executor(executor.clone());
+            sessions.initialize_bootstrapped_session(
+                SessionInfo::new_for_test().with_id(session_id),
+                "test command".to_string(),
+                vec![],
+                None,
+                ctx,
+            );
+            sessions
+        });
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.latest_context = Some(PromptContext {
+                active_block_metadata: BlockMetadata::new(
+                    Some(session_id),
+                    Some(repo_dir.path().display().to_string()),
+                ),
+                environment: Environment::default(),
+            });
+            cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
+            cp.update_states_with_new_context(ctx);
+        });
+
+        app.read(|ctx| {
+            let value = current_prompt
+                .as_ref(ctx)
+                .latest_chip_value(&ContextChipKind::GitDiffStats)
+                .and_then(|value| value.as_git_diff_stats())
+                .cloned();
+            assert_eq!(
+                value,
+                Some(crate::context_chips::display_chip::GitLineChanges {
+                    files_changed: 2,
+                    lines_added: 8,
+                    lines_removed: 0,
+                })
+            );
+        });
+
+        current_prompt.update(&mut app, |cp, _ctx| {
+            cp.latest_context = Some(PromptContext {
+                active_block_metadata: BlockMetadata::new(
+                    Some(session_id),
+                    Some(other_dir.path().display().to_string()),
+                ),
+                environment: Environment::default(),
+            });
+        });
+
+        git_status.update(&mut app, |model, ctx| {
+            model.set_metadata_for_test(
+                Some(GitStatusMetadata {
+                    current_branch_name: "stale-branch".to_string(),
+                    main_branch_name: "main".to_string(),
+                    stats_against_head: DiffStats {
+                        files_changed: 9,
+                        total_additions: 99,
+                        total_deletions: 9,
+                    },
+                }),
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            let value = current_prompt
+                .as_ref(ctx)
+                .latest_chip_value(&ContextChipKind::GitDiffStats);
+            assert_eq!(
+                value, None,
+                "Stale repo-status metadata should be cleared instead of applied"
             );
         });
     });
@@ -1245,8 +1642,9 @@ fn test_git_status_change_updates_chip_value() {
             main_branch_name: "main".to_string(),
             stats_against_head: DiffStats::default(),
         };
+        let repo_path = temp_dir.path().to_path_buf();
         let git_status = app.add_model(move |_| {
-            GitRepoStatusModel::new_for_test(repo_handle, Some(initial_metadata))
+            GitRepoStatusModel::new_for_test(repo_handle, repo_path, Some(initial_metadata))
         });
 
         let sessions = app.add_model(|_| Sessions::new_for_test());
@@ -1254,6 +1652,13 @@ fn test_git_status_change_updates_chip_value() {
 
         // Subscribe to the git status model and run chips.
         current_prompt.update(&mut app, |cp, ctx| {
+            cp.latest_context = Some(PromptContext {
+                active_block_metadata: BlockMetadata::new(
+                    None,
+                    Some(temp_dir.path().display().to_string()),
+                ),
+                environment: Environment::default(),
+            });
             cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
             cp.update_states_with_new_context(ctx);
         });


### PR DESCRIPTION
## Description

Fixes #9228.

The git diff context chip can be updated from `GitRepoStatusModel`, which includes untracked files, but prompt refreshes could still fall back to the shell generator. That shell fallback runs `git diff --shortstat HEAD`, which only reports tracked-file changes. When a repo had untracked files, the chip could briefly flip between the structured repo-status count and the tracked-only shell count.

This change keeps externally driven git chips on repo-status metadata when available, clears stale git chip timers when repo status attaches, and still allows initial-value generators for externally driven chips that need them.

## Testing

- `cargo fmt --check`
- `git diff --check`
- `./script/run-clang-format.py -r --extensions 'c,h,cpp,m' ./crates/warpui/src/ ./app/src/`
- `find . -name '*.wgsl' -exec wgslfmt --check {} +`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo test -p warp context_chips::current_prompt::tests::test_externally_driven_git_diff_stats_uses_repo_status_without_shell_fallback --features local_fs`
- `cargo test -p warp context_chips::current_prompt::tests::test_git_diff_stats_clears_shell_timer_when_repo_status_attaches_late --features local_fs`
- `cargo test -p warp context_chips::current_prompt::tests::test_git_status_change_updates_chip_value --features local_fs`
- `cargo test -p warp context_chips::current_prompt::tests::test_externally_driven_chip_skips_periodic_timer --features local_fs`
- `cargo nextest run -p warp_completer --features v2`
- `cargo test --doc`

Attempted full workspace nextest in a clean headless LXC with `CARGO_BUILD_JOBS=1 cargo nextest run --no-fail-fast --workspace --exclude command-signatures-v2`; it compiled and ran but failed environment-dependent UI/font tests unrelated to this change.

## Server API dependencies

None.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed the git diff prompt chip flickering between tracked-only and all-file counts when untracked files are present.
