### PR TITLE
Add /set-tab-color slash command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14566,6 +14566,7 @@ dependencies = [
  "shellexpand",
  "string-offset",
  "strum",
+ "strum_macros",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.17",

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -135,15 +135,23 @@ pub static RENAME_TAB: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand 
     argument: Some(Argument::required().with_hint_text("<tab name>")),
 });
 
-pub static SET_TAB_COLOR: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
-    name: "/set-tab-color",
-    description: "Set the color of the current tab",
-    icon_path: "bundled/svg/ellipse.svg",
-    availability: Availability::ALWAYS,
-    auto_enter_ai_mode: false,
-    argument: Some(
-        Argument::required().with_hint_text("<red|green|yellow|blue|magenta|cyan|none|default>"),
-    ),
+pub static SET_TAB_COLOR: LazyLock<StaticCommand> = LazyLock::new(|| {
+    let mut hint = String::from("<");
+    for color in crate::ui_components::color_dot::TAB_COLOR_OPTIONS {
+        hint.push_str(&color.to_string().to_ascii_lowercase());
+        hint.push('|');
+    }
+    hint.push_str("none>");
+    let hint_text: &'static str = Box::leak(hint.into_boxed_str());
+
+    StaticCommand {
+        name: "/set-tab-color",
+        description: "Set the color of the current tab",
+        icon_path: "bundled/svg/ellipse.svg",
+        availability: Availability::ALWAYS,
+        auto_enter_ai_mode: false,
+        argument: Some(Argument::required().with_hint_text(hint_text)),
+    }
 });
 
 pub static FORK: LazyLock<StaticCommand> = LazyLock::new(|| {
@@ -674,10 +682,15 @@ mod tests {
 
         assert!(!argument.is_optional);
         assert!(!argument.should_execute_on_selection);
-        assert_eq!(
-            argument.hint_text,
-            Some("<red|green|yellow|blue|magenta|cyan|none|default>")
-        );
+
+        let hint = argument
+            .hint_text
+            .expect("/set-tab-color hint text is set dynamically");
+        for color in crate::ui_components::color_dot::TAB_COLOR_OPTIONS {
+            let lower = color.to_string().to_ascii_lowercase();
+            assert!(hint.contains(&lower), "hint should mention `{lower}`");
+        }
+        assert!(hint.contains("none"), "hint should mention `none`");
     }
 
     #[test]

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -142,8 +142,7 @@ pub static SET_TAB_COLOR: LazyLock<StaticCommand> = LazyLock::new(|| StaticComma
     availability: Availability::ALWAYS,
     auto_enter_ai_mode: false,
     argument: Some(
-        Argument::required()
-            .with_hint_text("<red|green|yellow|blue|magenta|cyan|none>"),
+        Argument::required().with_hint_text("<red|green|yellow|blue|magenta|cyan|none|default>"),
     ),
 });
 
@@ -677,7 +676,7 @@ mod tests {
         assert!(!argument.should_execute_on_selection);
         assert_eq!(
             argument.hint_text,
-            Some("<red|green|yellow|blue|magenta|cyan|none>")
+            Some("<red|green|yellow|blue|magenta|cyan|none|default>")
         );
     }
 

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 use warp_core::features::FeatureFlag;
 
 use crate::search::slash_command_menu::{static_commands::Argument, StaticCommand};
+use crate::ui_components::color_dot;
 
 use super::Availability;
 
@@ -135,23 +136,23 @@ pub static RENAME_TAB: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand 
     argument: Some(Argument::required().with_hint_text("<tab name>")),
 });
 
-pub static SET_TAB_COLOR: LazyLock<StaticCommand> = LazyLock::new(|| {
+static SET_TAB_COLOR_HINT: LazyLock<String> = LazyLock::new(|| {
     let mut hint = String::from("<");
-    for color in crate::ui_components::color_dot::TAB_COLOR_OPTIONS {
+    for color in color_dot::TAB_COLOR_OPTIONS {
         hint.push_str(&color.to_string().to_ascii_lowercase());
         hint.push('|');
     }
     hint.push_str("none>");
-    let hint_text: &'static str = Box::leak(hint.into_boxed_str());
+    hint
+});
 
-    StaticCommand {
-        name: "/set-tab-color",
-        description: "Set the color of the current tab",
-        icon_path: "bundled/svg/ellipse.svg",
-        availability: Availability::ALWAYS,
-        auto_enter_ai_mode: false,
-        argument: Some(Argument::required().with_hint_text(hint_text)),
-    }
+pub static SET_TAB_COLOR: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
+    name: "/set-tab-color",
+    description: "Set the color of the current tab",
+    icon_path: "bundled/svg/ellipse.svg",
+    availability: Availability::ALWAYS,
+    auto_enter_ai_mode: false,
+    argument: Some(Argument::required().with_hint_text(SET_TAB_COLOR_HINT.as_str())),
 });
 
 pub static FORK: LazyLock<StaticCommand> = LazyLock::new(|| {
@@ -686,7 +687,7 @@ mod tests {
         let hint = argument
             .hint_text
             .expect("/set-tab-color hint text is set dynamically");
-        for color in crate::ui_components::color_dot::TAB_COLOR_OPTIONS {
+        for color in color_dot::TAB_COLOR_OPTIONS {
             let lower = color.to_string().to_ascii_lowercase();
             assert!(hint.contains(&lower), "hint should mention `{lower}`");
         }

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -135,6 +135,18 @@ pub static RENAME_TAB: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand 
     argument: Some(Argument::required().with_hint_text("<tab name>")),
 });
 
+pub static SET_TAB_COLOR: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
+    name: "/set-tab-color",
+    description: "Set the color of the current tab",
+    icon_path: "bundled/svg/ellipse.svg",
+    availability: Availability::ALWAYS,
+    auto_enter_ai_mode: false,
+    argument: Some(
+        Argument::required()
+            .with_hint_text("<red|green|yellow|blue|magenta|cyan|none>"),
+    ),
+});
+
 pub static FORK: LazyLock<StaticCommand> = LazyLock::new(|| {
     let hint_text = "<optional prompt to send in forked conversation>";
     StaticCommand {
@@ -526,6 +538,7 @@ fn all_commands() -> Vec<StaticCommand> {
         NEW.clone(),
         PLAN.clone(),
         RENAME_TAB.clone(),
+        SET_TAB_COLOR.clone(),
         USAGE,
         CONVERSATIONS,
         EXPORT_TO_CLIPBOARD,
@@ -648,6 +661,24 @@ mod tests {
         assert!(!argument.is_optional);
         assert!(!argument.should_execute_on_selection);
         assert_eq!(argument.hint_text, Some("<tab name>"));
+    }
+
+    #[test]
+    fn set_tab_color_command_requires_argument() {
+        let command = COMMAND_REGISTRY
+            .get_command_with_name(SET_TAB_COLOR.name)
+            .expect("expected /set-tab-color to be registered");
+        let argument = command
+            .argument
+            .as_ref()
+            .expect("expected /set-tab-color to require an argument");
+
+        assert!(!argument.is_optional);
+        assert!(!argument.should_execute_on_selection);
+        assert_eq!(
+            argument.hint_text,
+            Some("<red|green|yellow|blue|magenta|cyan|none>")
+        );
     }
 
     #[test]

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -9,6 +9,7 @@ use ai::skills::SkillReference;
 use warp_core::features::FeatureFlag;
 use warp_core::send_telemetry_from_ctx;
 use warp_core::ui::appearance::Appearance;
+use warp_core::ui::theme::AnsiColorIdentifier;
 use warpui::clipboard::ClipboardContent;
 use warpui::{SingletonEntity, ViewContext};
 
@@ -419,6 +420,40 @@ impl Input {
                 };
 
                 ctx.dispatch_typed_action(&WorkspaceAction::SetActiveTabName(name.to_owned()));
+            }
+            set_tab_color if command.name == commands::SET_TAB_COLOR.name => {
+                let Some(arg) = argument
+                    .map(|name| name.trim())
+                    .filter(|name| !name.is_empty())
+                else {
+                    show_error_toast(
+                        "Please provide a color after /set-tab-color (red, green, yellow, blue, magenta, cyan, or none)"
+                            .to_owned(),
+                        ctx,
+                    );
+                    return true;
+                };
+
+                let color = match arg.to_ascii_lowercase().as_str() {
+                    "red" => Some(AnsiColorIdentifier::Red),
+                    "green" => Some(AnsiColorIdentifier::Green),
+                    "yellow" => Some(AnsiColorIdentifier::Yellow),
+                    "blue" => Some(AnsiColorIdentifier::Blue),
+                    "magenta" => Some(AnsiColorIdentifier::Magenta),
+                    "cyan" => Some(AnsiColorIdentifier::Cyan),
+                    "none" | "default" | "clear" | "reset" => None,
+                    other => {
+                        show_error_toast(
+                            format!(
+                                "Unknown tab color '{other}'. Use one of: red, green, yellow, blue, magenta, cyan, or none."
+                            ),
+                            ctx,
+                        );
+                        return true;
+                    }
+                };
+
+                ctx.dispatch_typed_action(&WorkspaceAction::SetActiveTabColor(color));
             }
             create_env if command.name == commands::CREATE_ENVIRONMENT.name => {
                 // If the user included args after the slash command, treat them as repo paths/URLs.

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -423,39 +423,48 @@ impl Input {
                 ctx.dispatch_typed_action(&WorkspaceAction::SetActiveTabName(name.to_owned()));
             }
             set_tab_color if command.name == commands::SET_TAB_COLOR.name => {
+                let supported_options = || {
+                    crate::ui_components::color_dot::TAB_COLOR_OPTIONS
+                        .iter()
+                        .map(|c| c.to_string().to_ascii_lowercase())
+                        .chain(std::iter::once("none".to_owned()))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+
                 let Some(arg) = argument
                     .map(|name| name.trim())
                     .filter(|name| !name.is_empty())
                 else {
                     show_error_toast(
-                        "Please provide a color after /set-tab-color (red, green, yellow, blue, magenta, cyan, none, or default)"
-                            .to_owned(),
+                        format!(
+                            "Please provide a color after /set-tab-color ({})",
+                            supported_options()
+                        ),
                         ctx,
                     );
                     return true;
                 };
 
-                // `none`/`clear` explicitly clear the color (suppressing any
-                // directory default); `default`/`reset` remove the manual override
-                // so the directory default can apply when `DirectoryTabColors`
-                // is enabled.
-                let color = match arg.to_ascii_lowercase().as_str() {
-                    "red" => SelectedTabColor::Color(AnsiColorIdentifier::Red),
-                    "green" => SelectedTabColor::Color(AnsiColorIdentifier::Green),
-                    "yellow" => SelectedTabColor::Color(AnsiColorIdentifier::Yellow),
-                    "blue" => SelectedTabColor::Color(AnsiColorIdentifier::Blue),
-                    "magenta" => SelectedTabColor::Color(AnsiColorIdentifier::Magenta),
-                    "cyan" => SelectedTabColor::Color(AnsiColorIdentifier::Cyan),
-                    "none" | "clear" => SelectedTabColor::Cleared,
-                    "default" | "reset" => SelectedTabColor::Unset,
-                    other => {
-                        show_error_toast(
-                            format!(
-                                "Unknown tab color '{other}'. Use one of: red, green, yellow, blue, magenta, cyan, none, or default."
-                            ),
-                            ctx,
-                        );
-                        return true;
+                let color = if arg.eq_ignore_ascii_case("none") {
+                    SelectedTabColor::Cleared
+                } else {
+                    let parsed = arg
+                        .parse::<AnsiColorIdentifier>()
+                        .ok()
+                        .filter(|c| crate::ui_components::color_dot::TAB_COLOR_OPTIONS.contains(c));
+                    match parsed {
+                        Some(c) => SelectedTabColor::Color(c),
+                        None => {
+                            show_error_toast(
+                                format!(
+                                    "Unknown tab color '{arg}'. Use one of: {}.",
+                                    supported_options()
+                                ),
+                                ctx,
+                            );
+                            return true;
+                        }
                     }
                 };
 

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -25,6 +25,7 @@ use crate::search::slash_command_menu::{SlashCommandId, StaticCommand};
 use crate::server::ids::SyncId;
 use crate::server::telemetry::SlashCommandAcceptedDetails;
 use crate::settings::AISettings;
+use crate::tab::SelectedTabColor;
 use crate::terminal::input::decorations::InputBackgroundJobOptions;
 use crate::terminal::input::inline_menu::{InlineMenuAction, InlineMenuType};
 use crate::terminal::input::message_bar::Message;
@@ -427,25 +428,30 @@ impl Input {
                     .filter(|name| !name.is_empty())
                 else {
                     show_error_toast(
-                        "Please provide a color after /set-tab-color (red, green, yellow, blue, magenta, cyan, or none)"
+                        "Please provide a color after /set-tab-color (red, green, yellow, blue, magenta, cyan, none, or default)"
                             .to_owned(),
                         ctx,
                     );
                     return true;
                 };
 
+                // `none`/`clear` explicitly clear the color (suppressing any
+                // directory default); `default`/`reset` remove the manual override
+                // so the directory default can apply when `DirectoryTabColors`
+                // is enabled.
                 let color = match arg.to_ascii_lowercase().as_str() {
-                    "red" => Some(AnsiColorIdentifier::Red),
-                    "green" => Some(AnsiColorIdentifier::Green),
-                    "yellow" => Some(AnsiColorIdentifier::Yellow),
-                    "blue" => Some(AnsiColorIdentifier::Blue),
-                    "magenta" => Some(AnsiColorIdentifier::Magenta),
-                    "cyan" => Some(AnsiColorIdentifier::Cyan),
-                    "none" | "default" | "clear" | "reset" => None,
+                    "red" => SelectedTabColor::Color(AnsiColorIdentifier::Red),
+                    "green" => SelectedTabColor::Color(AnsiColorIdentifier::Green),
+                    "yellow" => SelectedTabColor::Color(AnsiColorIdentifier::Yellow),
+                    "blue" => SelectedTabColor::Color(AnsiColorIdentifier::Blue),
+                    "magenta" => SelectedTabColor::Color(AnsiColorIdentifier::Magenta),
+                    "cyan" => SelectedTabColor::Color(AnsiColorIdentifier::Cyan),
+                    "none" | "clear" => SelectedTabColor::Cleared,
+                    "default" | "reset" => SelectedTabColor::Unset,
                     other => {
                         show_error_toast(
                             format!(
-                                "Unknown tab color '{other}'. Use one of: red, green, yellow, blue, magenta, cyan, or none."
+                                "Unknown tab color '{other}'. Use one of: red, green, yellow, blue, magenta, cyan, none, or default."
                             ),
                             ctx,
                         );

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -36,6 +36,7 @@ use crate::terminal::input::{
     CompletionsTrigger, Event, Input, InputSuggestionsMode, UserQueryMenuAction,
 };
 use crate::terminal::view::TerminalAction;
+use crate::ui_components::color_dot;
 use crate::view_components::DismissibleToast;
 use crate::workflows::{WorkflowSelectionSource, WorkflowSource, WorkflowType};
 use crate::workspace::{ForkedConversationDestination, ToastStack, WorkspaceAction};
@@ -424,7 +425,7 @@ impl Input {
             }
             set_tab_color if command.name == commands::SET_TAB_COLOR.name => {
                 let supported_options = || {
-                    crate::ui_components::color_dot::TAB_COLOR_OPTIONS
+                    color_dot::TAB_COLOR_OPTIONS
                         .iter()
                         .map(|c| c.to_string().to_ascii_lowercase())
                         .chain(std::iter::once("none".to_owned()))
@@ -452,7 +453,7 @@ impl Input {
                     let parsed = arg
                         .parse::<AnsiColorIdentifier>()
                         .ok()
-                        .filter(|c| crate::ui_components::color_dot::TAB_COLOR_OPTIONS.contains(c));
+                        .filter(|c| color_dot::TAB_COLOR_OPTIONS.contains(c));
                     match parsed {
                         Some(c) => SelectedTabColor::Color(c),
                         None => {

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -113,6 +113,9 @@ pub enum WorkspaceAction {
     ResetPaneName(PaneViewLocator),
     RenameActiveTab,
     SetActiveTabName(String),
+    /// Sets the color of the active tab. `None` clears any selected color
+    /// (falling back to the default directory color, if any).
+    SetActiveTabColor(Option<AnsiColorIdentifier>),
     ToggleTabRightClickMenu {
         tab_index: usize,
         anchor: TabContextMenuAnchor,
@@ -721,6 +724,7 @@ impl WorkspaceAction {
             | ResetPaneName(_)
             | RenameActiveTab
             | SetActiveTabName(_)
+            | SetActiveTabColor(_)
             | CloseTab(_)
             | CloseActiveTab
             | CloseOtherTabs(_)

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -21,7 +21,7 @@ use crate::server::telemetry::{
     AddTabWithShellSource, AgentModeEntrypoint, PaletteSource, SharingDialogSource,
 };
 use crate::settings_view::{SettingsAction as SettingsTabAction, SettingsSection};
-use crate::tab::NewSessionMenuItem;
+use crate::tab::{NewSessionMenuItem, SelectedTabColor};
 use crate::tab_configs::TabConfig;
 use crate::terminal::available_shells::AvailableShell;
 use crate::terminal::view::inline_banner::ZeroStatePromptSuggestionType;
@@ -113,9 +113,12 @@ pub enum WorkspaceAction {
     ResetPaneName(PaneViewLocator),
     RenameActiveTab,
     SetActiveTabName(String),
-    /// Sets the color of the active tab. `None` clears any selected color
-    /// (falling back to the default directory color, if any).
-    SetActiveTabColor(Option<AnsiColorIdentifier>),
+    /// Sets the manual color override for the active tab.
+    ///
+    /// - `Color(_)` — apply that color.
+    /// - `Cleared` — explicitly clear (suppresses any directory default).
+    /// - `Unset` — remove the manual override (lets the directory default apply, if any).
+    SetActiveTabColor(SelectedTabColor),
     ToggleTabRightClickMenu {
         tab_index: usize,
         anchor: TabContextMenuAnchor,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5113,29 +5113,16 @@ impl Workspace {
             );
             return;
         }
-        let is_same = self.tabs[index].color() == Some(color);
-        self.tabs[index].selected_color = if is_same {
-            send_telemetry_from_ctx!(
-                TelemetryEvent::TabOperations {
-                    action: TabTelemetryAction::ResetColor,
-                },
-                ctx
-            );
+        let next = if self.tabs[index].color() == Some(color) {
             if FeatureFlag::DirectoryTabColors.is_enabled() {
                 SelectedTabColor::Cleared
             } else {
                 SelectedTabColor::Unset
             }
         } else {
-            send_telemetry_from_ctx!(
-                TelemetryEvent::TabOperations {
-                    action: TabTelemetryAction::SetColor,
-                },
-                ctx
-            );
             SelectedTabColor::Color(color)
         };
-        ctx.notify();
+        self.set_tab_color(index, next, ctx);
     }
 
     /// Syncs the tab color for the given tab based on the active terminal's CWD.

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5065,6 +5065,49 @@ impl Workspace {
         ctx.notify();
     }
 
+    /// Programmatically sets the manual color override for a tab.
+    /// `Some(color)` selects that color; `None` clears any manual selection,
+    /// falling back to the default directory color when present.
+    pub fn set_tab_color(
+        &mut self,
+        index: usize,
+        color: Option<AnsiColorIdentifier>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.tabs.get(index).is_none() {
+            log::warn!(
+                "Not setting tab color: index was {index} but len is {}",
+                self.tabs.len()
+            );
+            return;
+        }
+        let new_selected_color = match color {
+            Some(c) => SelectedTabColor::Color(c),
+            None => {
+                if FeatureFlag::DirectoryTabColors.is_enabled() {
+                    SelectedTabColor::Cleared
+                } else {
+                    SelectedTabColor::Unset
+                }
+            }
+        };
+        if self.tabs[index].selected_color == new_selected_color {
+            return;
+        }
+        self.tabs[index].selected_color = new_selected_color;
+        send_telemetry_from_ctx!(
+            TelemetryEvent::TabOperations {
+                action: if color.is_some() {
+                    TabTelemetryAction::SetColor
+                } else {
+                    TabTelemetryAction::ResetColor
+                },
+            },
+            ctx
+        );
+        ctx.notify();
+    }
+
     pub fn toggle_tab_color(
         &mut self,
         index: usize,
@@ -19677,6 +19720,9 @@ impl TypedActionView for Workspace {
             ResetPaneName(locator) => self.clear_pane_name(*locator, ctx),
             RenameActiveTab => self.rename_tab(self.active_tab_index, ctx),
             SetActiveTabName(name) => self.set_active_tab_name(name, ctx),
+            SetActiveTabColor(color) => {
+                self.set_tab_color(self.active_tab_index, *color, ctx)
+            }
             ToggleTabRightClickMenu { tab_index, anchor } => {
                 self.toggle_tab_right_click_menu(*tab_index, *anchor, ctx)
             }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5066,12 +5066,14 @@ impl Workspace {
     }
 
     /// Programmatically sets the manual color override for a tab.
-    /// `Some(color)` selects that color; `None` clears any manual selection,
-    /// falling back to the default directory color when present.
+    ///
+    /// - `Color(_)` applies that color.
+    /// - `Cleared` explicitly clears the color (also suppresses any directory default).
+    /// - `Unset` removes the manual override, letting the directory default apply.
     pub fn set_tab_color(
         &mut self,
         index: usize,
-        color: Option<AnsiColorIdentifier>,
+        color: SelectedTabColor,
         ctx: &mut ViewContext<Self>,
     ) {
         if self.tabs.get(index).is_none() {
@@ -5081,23 +5083,13 @@ impl Workspace {
             );
             return;
         }
-        let new_selected_color = match color {
-            Some(c) => SelectedTabColor::Color(c),
-            None => {
-                if FeatureFlag::DirectoryTabColors.is_enabled() {
-                    SelectedTabColor::Cleared
-                } else {
-                    SelectedTabColor::Unset
-                }
-            }
-        };
-        if self.tabs[index].selected_color == new_selected_color {
+        if self.tabs[index].selected_color == color {
             return;
         }
-        self.tabs[index].selected_color = new_selected_color;
+        self.tabs[index].selected_color = color;
         send_telemetry_from_ctx!(
             TelemetryEvent::TabOperations {
-                action: if color.is_some() {
+                action: if matches!(color, SelectedTabColor::Color(_)) {
                     TabTelemetryAction::SetColor
                 } else {
                     TabTelemetryAction::ResetColor
@@ -19720,9 +19712,7 @@ impl TypedActionView for Workspace {
             ResetPaneName(locator) => self.clear_pane_name(*locator, ctx),
             RenameActiveTab => self.rename_tab(self.active_tab_index, ctx),
             SetActiveTabName(name) => self.set_active_tab_name(name, ctx),
-            SetActiveTabColor(color) => {
-                self.set_tab_color(self.active_tab_index, *color, ctx)
-            }
+            SetActiveTabColor(color) => self.set_tab_color(self.active_tab_index, *color, ctx),
             ToggleTabRightClickMenu { tab_index, anchor } => {
                 self.toggle_tab_right_click_menu(*tab_index, *anchor, ctx)
             }

--- a/app/src/workspace/view_test.rs
+++ b/app/src/workspace/view_test.rs
@@ -879,7 +879,9 @@ fn test_set_active_tab_color() {
 
             // Setting a color stores it as the manual selection and resolves to it.
             workspace.handle_action(
-                &WorkspaceAction::SetActiveTabColor(Some(AnsiColorIdentifier::Magenta)),
+                &WorkspaceAction::SetActiveTabColor(SelectedTabColor::Color(
+                    AnsiColorIdentifier::Magenta,
+                )),
                 ctx,
             );
             assert_eq!(
@@ -893,7 +895,9 @@ fn test_set_active_tab_color() {
 
             // Replacing with a different color overwrites the previous selection.
             workspace.handle_action(
-                &WorkspaceAction::SetActiveTabColor(Some(AnsiColorIdentifier::Green)),
+                &WorkspaceAction::SetActiveTabColor(SelectedTabColor::Color(
+                    AnsiColorIdentifier::Green,
+                )),
                 ctx,
             );
             assert_eq!(
@@ -901,28 +905,46 @@ fn test_set_active_tab_color() {
                 SelectedTabColor::Color(AnsiColorIdentifier::Green),
             );
 
-            // Clearing with `None` removes the manual selection.
-            workspace.handle_action(&WorkspaceAction::SetActiveTabColor(None), ctx);
-            assert!(matches!(
+            // `Cleared` explicitly suppresses any color (including a directory default).
+            workspace.handle_action(
+                &WorkspaceAction::SetActiveTabColor(SelectedTabColor::Cleared),
+                ctx,
+            );
+            assert_eq!(
                 workspace.tabs[active].selected_color,
-                SelectedTabColor::Cleared | SelectedTabColor::Unset,
-            ));
+                SelectedTabColor::Cleared,
+            );
             assert_eq!(workspace.tabs[active].color(), None);
 
-            // Action targets the active tab — switching to tab 0 leaves it unaffected.
+            // `Unset` removes the manual override so a directory default could apply.
+            // With no directory default configured, the resolved color is still `None`.
+            workspace.handle_action(
+                &WorkspaceAction::SetActiveTabColor(SelectedTabColor::Unset),
+                ctx,
+            );
+            assert_eq!(
+                workspace.tabs[active].selected_color,
+                SelectedTabColor::Unset,
+            );
+            assert_eq!(workspace.tabs[active].color(), None);
+
+            // Action targets the active tab — switching to tab 0 leaves the second tab
+            // unaffected.
             workspace.handle_action(&WorkspaceAction::ActivateTab(0), ctx);
             workspace.handle_action(
-                &WorkspaceAction::SetActiveTabColor(Some(AnsiColorIdentifier::Blue)),
+                &WorkspaceAction::SetActiveTabColor(SelectedTabColor::Color(
+                    AnsiColorIdentifier::Blue,
+                )),
                 ctx,
             );
             assert_eq!(
                 workspace.tabs[0].selected_color,
                 SelectedTabColor::Color(AnsiColorIdentifier::Blue),
             );
-            assert!(matches!(
+            assert_eq!(
                 workspace.tabs[active].selected_color,
-                SelectedTabColor::Cleared | SelectedTabColor::Unset,
-            ));
+                SelectedTabColor::Unset,
+            );
         });
     });
 }

--- a/app/src/workspace/view_test.rs
+++ b/app/src/workspace/view_test.rs
@@ -867,6 +867,67 @@ fn test_set_active_tab_name_clears_active_rename_editor_state() {
 }
 
 #[test]
+fn test_set_active_tab_color() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.add_terminal_tab(false, ctx);
+            let active = workspace.active_tab_index;
+
+            // Setting a color stores it as the manual selection and resolves to it.
+            workspace.handle_action(
+                &WorkspaceAction::SetActiveTabColor(Some(AnsiColorIdentifier::Magenta)),
+                ctx,
+            );
+            assert_eq!(
+                workspace.tabs[active].selected_color,
+                SelectedTabColor::Color(AnsiColorIdentifier::Magenta),
+            );
+            assert_eq!(
+                workspace.tabs[active].color(),
+                Some(AnsiColorIdentifier::Magenta),
+            );
+
+            // Replacing with a different color overwrites the previous selection.
+            workspace.handle_action(
+                &WorkspaceAction::SetActiveTabColor(Some(AnsiColorIdentifier::Green)),
+                ctx,
+            );
+            assert_eq!(
+                workspace.tabs[active].selected_color,
+                SelectedTabColor::Color(AnsiColorIdentifier::Green),
+            );
+
+            // Clearing with `None` removes the manual selection.
+            workspace.handle_action(&WorkspaceAction::SetActiveTabColor(None), ctx);
+            assert!(matches!(
+                workspace.tabs[active].selected_color,
+                SelectedTabColor::Cleared | SelectedTabColor::Unset,
+            ));
+            assert_eq!(workspace.tabs[active].color(), None);
+
+            // Action targets the active tab — switching to tab 0 leaves it unaffected.
+            workspace.handle_action(&WorkspaceAction::ActivateTab(0), ctx);
+            workspace.handle_action(
+                &WorkspaceAction::SetActiveTabColor(Some(AnsiColorIdentifier::Blue)),
+                ctx,
+            );
+            assert_eq!(
+                workspace.tabs[0].selected_color,
+                SelectedTabColor::Color(AnsiColorIdentifier::Blue),
+            );
+            assert!(matches!(
+                workspace.tabs[active].selected_color,
+                SelectedTabColor::Cleared | SelectedTabColor::Unset,
+            ));
+        });
+    });
+}
+
+#[test]
 fn test_workspace_sessions_retrieves_tabs() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);

--- a/crates/warp_core/Cargo.toml
+++ b/crates/warp_core/Cargo.toml
@@ -36,6 +36,7 @@ serde_with.workspace = true
 sentry = { workspace = true, optional = true }
 sentry-log = { workspace = true, optional = true }
 strum.workspace = true
+strum_macros.workspace = true
 sysinfo.workspace = true
 thiserror.workspace = true
 concat-idents.workspace = true

--- a/crates/warp_core/src/ui/theme/mod.rs
+++ b/crates/warp_core/src/ui/theme/mod.rs
@@ -530,12 +530,15 @@ impl AnsiColors {
     Eq,
     schemars::JsonSchema,
     settings_value::SettingsValue,
+    strum_macros::Display,
+    strum_macros::EnumString,
 )]
 #[schemars(
     description = "One of the eight standard ANSI terminal colors.",
     rename_all = "snake_case"
 )]
 #[serde(rename_all = "lowercase")]
+#[strum(ascii_case_insensitive)]
 pub enum AnsiColorIdentifier {
     Black,
     Red,
@@ -545,22 +548,6 @@ pub enum AnsiColorIdentifier {
     Magenta,
     Cyan,
     White,
-}
-
-impl std::fmt::Display for AnsiColorIdentifier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let color_name = match self {
-            Self::Black => "Black",
-            Self::Red => "Red",
-            Self::Green => "Green",
-            Self::Yellow => "Yellow",
-            Self::Blue => "Blue",
-            Self::Magenta => "Magenta",
-            Self::Cyan => "Cyan",
-            Self::White => "White",
-        };
-        write!(f, "{color_name}")
-    }
 }
 
 impl AnsiColorIdentifier {


### PR DESCRIPTION
## Description

Adds a programmatic way to set or clear the active tab's color, mirroring the manual color selection in the right-click context menu. Closes the gap between the existing `/rename-tab` (programmatic tab rename) and the previously click-only color picker.

The new `/set-tab-color <color>` slash command accepts:

- `red`, `green`, `yellow`, `blue`, `magenta`, `cyan` — the same six options the right-click picker exposes (`TAB_COLOR_OPTIONS`).
- `none`, `default`, `clear`, or `reset` — clears any manual override (the tab falls back to its default directory color when `DirectoryTabColors` is on).

Implementation summary:

- New `WorkspaceAction::SetActiveTabColor(Option<AnsiColorIdentifier>)` action variant; reuses the existing `TabTelemetryAction::SetColor` / `ResetColor` events.
- New `WorkspaceView::set_tab_color(index, Option<AnsiColorIdentifier>, ctx)` method that maps `Some/None` to `SelectedTabColor::Color` / `Cleared` (or `Unset` when `DirectoryTabColors` is off) — same toggle/clear semantics the right-click flow uses.
- `SET_TAB_COLOR` registered alongside `RENAME_TAB` and dispatched from `Input::execute_slash_command`. Empty or unrecognized colors surface a toast.

## Testing

- `cargo fmt -- --check` — passes.
- `cargo clippy -p warp --all-targets --tests -- -D warnings` — passes.
- `cargo test -p warp --lib -- set_tab_color test_set_active_tab_color` — both new tests pass:
  - `commands::tests::set_tab_color_command_requires_argument` verifies the slash command is registered with the expected required argument and hint text.
  - `workspace::view::tests::test_set_active_tab_color` drives the action end-to-end: set, replace, clear, and confirms it only affects the active tab.

## Server API dependencies

No server API changes.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-NEW-FEATURE: Added a `/set-tab-color` slash command for setting or clearing the current tab's color from the input bar.