### PR TITLE
fix(windows): resolve ERROR_UNTRUSTED_MOUNT_POINT (448) for junction and symlink working directories

### DIFF
--- a/app/src/terminal/local_tty/windows/mod.rs
+++ b/app/src/terminal/local_tty/windows/mod.rs
@@ -175,11 +175,14 @@ pub(super) fn spawn(
 
     let start_directory = options
         .start_dir
+        .as_ref()
         .filter(|start_dir| start_dir.is_dir())
+        .and_then(|dir| dunce::canonicalize(dir).ok())
         .or_else(|| {
             std::env::var_os("USERPROFILE")
                 .map(PathBuf::from)
                 .filter(|path| path.is_dir())
+                .and_then(|dir| dunce::canonicalize(&dir).ok())
         })
         .map(|path| HSTRING::from(path.as_os_str()));
 


### PR DESCRIPTION
## Description

Fixes #9044

On Windows, when the configured working directory (or its fallback, `USERPROFILE`) contains or is a junction point or reparse point, `CreateProcessW` fails with **ERROR_UNTRUSTED_MOUNT_POINT (WinError 448)**. This breaks symlink traversal for the shell and all child processes, including `Get-ChildItem`, `pytest`, and any tool that resolves through junctions.

The same commands work correctly in Windows Terminal and standalone PowerShell because they pass canonicalized paths to `CreateProcessW`.

**Root cause:** In `app/src/terminal/local_tty/windows/mod.rs` (line 176), the `start_dir` is validated only with `is_dir()` and then passed directly as `lpCurrentDirectory` to `CreateProcessW` without canonicalization. Junction points pass the `is_dir()` check but fail inside the kernel's path resolution for untrusted mount points.

**Fix:** Call `dunce::canonicalize()` on both the configured `start_dir` and the `USERPROFILE` fallback before passing them to `CreateProcessW`. This resolves symlinks, junctions, and reparse points to their actual paths, eliminating the 448 error.

The `dunce` crate is already a dependency in the `app` crate and is used for the same purpose in `working_directories.rs` (line 745), `available_shells.rs` (lines 818, 850), `standardized_path.rs` (line 99), and `login_item/windows.rs` (line 77).

### What this changes

| Before | After |
|---|---|
| `start_dir` passed raw to `CreateProcessW` | `dunce::canonicalize(start_dir)` resolves junctions first |
| `USERPROFILE` fallback passed raw | `USERPROFILE` also canonicalized |
| Junction directories cause error 448 | Junction directories resolve to their target and work |

## Testing

- [x] `cargo check -p warp` passes clean
- Manual testing on Windows 11:
  1. Create a junction: `New-Item -ItemType Junction -Path "C:\Users\oasrvadmin\AppData\Local\Temp\warp_test" -Target "C:\Users\oasrvadmin\Documents"`
  2. Set Warp startup directory to the junction path
  3. Before fix: `CreateProcessW` fails with error 448
  4. After fix: shell spawns normally, `Get-ChildItem` works through the junction

No new automated tests added because this fix is in the Windows ConPTY spawn path, which requires a running ConPTY session to test. The `dunce::canonicalize` function itself is well tested upstream.

## Server API dependencies
- [x] N/A

## Agent Mode
- [ ] Warp Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed OS Error 448 (ERROR_UNTRUSTED_MOUNT_POINT) on Windows when the working directory contains symlink or junction points.
