### PR TITLE
fix(windows): convert WSL paths to host-native format in /open-file command

### DIFF
--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -487,13 +487,32 @@ impl Input {
                         };
 
                         let parsed_path = CleanPathResult::with_line_and_column_number(args.trim());
-                        // The argument may contain shell-escaped characters (e.g. `\ ` for
-                        // spaces) from auto-suggest. Unescape them so the path matches the
-                        // actual filesystem entry.
                         let unescaped_path = session.shell_family().unescape(&parsed_path.path);
-                        // Expand `~` to the user's home directory.
                         let expanded_path = tilde(&unescaped_path);
-                        let file_path = current_dir.join(&*expanded_path);
+                        let expanded_path_str: &str = expanded_path.as_ref();
+                        let file_path = if let Some(launch_data) = session.launch_data() {
+                            let is_absolute = expanded_path_str.starts_with('/')
+                                || expanded_path_str.starts_with('\\')
+                                || expanded_path_str
+                                    .chars()
+                                    .next()
+                                    .is_some_and(|c: char| c.is_alphabetic())
+                                    && expanded_path_str.contains(':');
+                            if is_absolute {
+                                launch_data
+                                    .maybe_convert_absolute_path(expanded_path_str)
+                                    .unwrap_or_else(|| current_dir.join(expanded_path_str))
+                            } else {
+                                launch_data
+                                    .maybe_convert_relative_path(
+                                        &current_dir.to_string_lossy(),
+                                        expanded_path_str,
+                                    )
+                                    .unwrap_or_else(|| current_dir.join(expanded_path_str))
+                            }
+                        } else {
+                            current_dir.join(expanded_path_str)
+                        };
 
                         match std::fs::metadata(&file_path) {
                             Ok(metadata) if metadata.is_file() => {

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -491,13 +491,17 @@ impl Input {
                         let expanded_path = tilde(&unescaped_path);
                         let expanded_path_str: &str = expanded_path.as_ref();
                         let file_path = if let Some(launch_data) = session.launch_data() {
+                            let has_windows_drive_prefix = expanded_path_str
+                                .as_bytes()
+                                .get(..3)
+                                .is_some_and(|bytes| {
+                                    bytes[0].is_ascii_alphabetic()
+                                        && bytes[1] == b':'
+                                        && matches!(bytes[2], b'/' | b'\\')
+                                });
                             let is_absolute = expanded_path_str.starts_with('/')
                                 || expanded_path_str.starts_with('\\')
-                                || expanded_path_str
-                                    .chars()
-                                    .next()
-                                    .is_some_and(|c: char| c.is_alphabetic())
-                                    && expanded_path_str.contains(':');
+                                || has_windows_drive_prefix;
                             if is_absolute {
                                 launch_data
                                     .maybe_convert_absolute_path(expanded_path_str)


### PR DESCRIPTION
## Description

Fixes #9191

The `/open-file` command fails on Windows when the active session runs inside WSL. Paths like `/home/user/project/file.txt` get mangled during the join with the current working directory because `PathBuf::join` on Windows converts forward slashes to backslashes, producing broken paths.

**Root cause:** In `app/src/terminal/input/slash_commands/mod.rs` (line 496), the path argument is joined with the CWD using `current_dir.join(&*expanded_path)`. For WSL sessions, both the CWD (reported via OSC 7 escape sequences) and the user's path argument are in Unix format. `PathBuf::join` on Windows converts all `/` to `\`, producing mangled results like `\home\user\project\file.txt` instead of the correct `\\WSL$\Ubuntu\home\user\project\file.txt`.

The path conversion infrastructure already exists in `ShellLaunchData` (`maybe_convert_absolute_path`, `maybe_convert_relative_path`) and is used for link detection and drag-and-drop, but was not applied to the `/open-file` command.

**Fix:** Before joining paths, check if the session has a `ShellLaunchData` (WSL, MSYS2, Docker). If so, use `maybe_convert_absolute_path` for absolute paths and `maybe_convert_relative_path` for relative paths to convert them to host-native format. Fall back to the naive join for native sessions (PowerShell, cmd).

### What this changes

| Session type | Before | After |
|---|---|---|
| WSL (absolute path) | `/home/user/file` mangled to `\home\user\file` | Converts to `\\WSL$\Ubuntu\home\user\file` |
| WSL (relative path) | Joins Unix CWD with Unix relative path on Windows | Converts CWD + relative to host-native |
| WSL (`/mnt/c/`) | Path separators mangled | Converts to `C:\Users\...` |
| PowerShell | No change (naive join works) | No change (no `launch_data` conversion) |

## Testing

- [x] `cargo check -p warp` passes clean
- Manual testing on Windows 11 with WSL:
  1. Open a WSL session in Warp
  2. Run `/open-file /home/user/.bashrc` with a valid absolute path
  3. Before fix: `File not found` with mangled path
  4. After fix: file opens in Warp editor with correct `\\WSL$\...` path
- Native PowerShell sessions remain unaffected (no `launch_data` means the naive join path runs)

## Server API dependencies
- [x] N/A

## Agent Mode
- [ ] Warp Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed /open-file path resolution in WSL sessions on Windows, where forward slashes were incorrectly converted to backslashes.
