### PR TITLE
Remove `NotAmbientAgent` state from AmbientAgentViewModel.

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -194,9 +194,9 @@ pub struct AgentInputFooter {
     context_window_button: ViewHandle<ActionButton>,
     model_selector: ViewHandle<ProfileModelSelector>,
     ftu_callout_close_button: ViewHandle<ActionButton>,
-    environment_selector: ViewHandle<EnvironmentSelector>,
+    environment_selector: Option<ViewHandle<EnvironmentSelector>>,
     prompt_alert: ViewHandle<PromptAlertView>,
-    ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+    ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
     left_display_chips: Vec<ViewHandle<DisplayChip>>,
     right_display_chips: Vec<ViewHandle<DisplayChip>>,
     // Separate set of display chips for the CLI agent footer.
@@ -241,7 +241,7 @@ impl AgentInputFooter {
         terminal_view_id: EntityId,
         ai_input_model: ModelHandle<BlocklistAIInputModel>,
         terminal_model: Arc<FairMutex<TerminalModel>>,
-        ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+        ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
         prompt: ModelHandle<PromptType>,
         display_chip_config: DisplayChipConfig,
         ctx: &mut ViewContext<Self>,
@@ -596,27 +596,35 @@ impl AgentInputFooter {
             me.handle_profile_model_selector_event(event, ctx);
         });
 
-        let environment_selector = ctx.add_typed_action_view(|ctx| {
-            EnvironmentSelector::new(
-                menu_positioning_provider.clone(),
-                ambient_agent_view_model.clone(),
-                ctx,
-            )
-        });
+        let environment_selector =
+            ambient_agent_view_model
+                .as_ref()
+                .map(|ambient_agent_view_model| {
+                    ctx.add_typed_action_view(|ctx| {
+                        EnvironmentSelector::new(
+                            menu_positioning_provider.clone(),
+                            ambient_agent_view_model.clone(),
+                            ctx,
+                        )
+                    })
+                });
 
-        ctx.subscribe_to_view(&environment_selector, |_, _, event, ctx| match event {
-            EnvironmentSelectorEvent::MenuVisibilityChanged { open } => {
-                ctx.emit(AgentInputFooterEvent::ToggledChipMenu { open: *open });
-            }
-            EnvironmentSelectorEvent::OpenEnvironmentManagementPane => {
-                ctx.emit(AgentInputFooterEvent::OpenEnvironmentManagementPane);
-            }
-        });
+        if let Some(environment_selector) = environment_selector.as_ref() {
+            ctx.subscribe_to_view(environment_selector, |_, _, event, ctx| match event {
+                EnvironmentSelectorEvent::MenuVisibilityChanged { open } => {
+                    ctx.emit(AgentInputFooterEvent::ToggledChipMenu { open: *open });
+                }
+                EnvironmentSelectorEvent::OpenEnvironmentManagementPane => {
+                    ctx.emit(AgentInputFooterEvent::OpenEnvironmentManagementPane);
+                }
+            });
+        }
 
-        // Show/hide the environment footer when the ambient agent state changes.
-        ctx.subscribe_to_model(&ambient_agent_view_model, |_, _, _, ctx| {
-            ctx.notify();
-        });
+        if let Some(ambient_agent_view_model) = ambient_agent_view_model.as_ref() {
+            ctx.subscribe_to_model(ambient_agent_view_model, |_, _, _, ctx| {
+                ctx.notify();
+            });
+        }
 
         let prompt_alert = ctx.add_typed_action_view(PromptAlertView::new);
         ctx.subscribe_to_view(&prompt_alert, |_, _, event, ctx| {
@@ -791,17 +799,22 @@ impl AgentInputFooter {
             && FeatureFlag::CloudMode.is_enabled()
             && self
                 .ambient_agent_view_model
-                .as_ref(app)
-                .is_configuring_ambient_agent()
+                .as_ref()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model
+                        .as_ref(app)
+                        .is_configuring_ambient_agent()
+                })
     }
 
     fn render_cloud_mode_v2_footer(&self, app: &AppContext) -> Box<dyn Element> {
-        let left = Flex::row()
+        let mut left = Flex::row()
             .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_spacing(CLOUD_MODE_V2_FOOTER_GAP)
-            .with_child(ChildView::new(&self.environment_selector).finish())
-            .finish();
+            .with_spacing(CLOUD_MODE_V2_FOOTER_GAP);
+        if let Some(environment_selector) = self.environment_selector.as_ref() {
+            left = left.with_child(ChildView::new(environment_selector).finish());
+        }
 
         let mut right = Flex::row()
             .with_main_axis_size(MainAxisSize::Min)
@@ -819,8 +832,13 @@ impl AgentInputFooter {
 
         // The V2 model selector is Oz-specific; hide it for other harnesses
         // until they support model selection.
-        let selected_harness = self.ambient_agent_view_model.as_ref(app).selected_harness();
-        if selected_harness == Harness::Oz {
+        let is_oz_harness =
+            self.ambient_agent_view_model
+                .as_ref()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model.as_ref(app).selected_harness() == Harness::Oz
+                });
+        if is_oz_harness {
             if let Some(model_selector) = self.v2_model_selector.as_ref() {
                 right = right.with_child(ChildView::new(model_selector).finish());
             }
@@ -830,7 +848,7 @@ impl AgentInputFooter {
             .with_main_axis_size(MainAxisSize::Max)
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(left)
+            .with_child(left.finish())
             .with_child(right.finish())
             .finish()
     }
@@ -1439,7 +1457,10 @@ impl AgentInputFooter {
             .all_display_chips()
             .any(|chip| chip.as_ref(app).display_chip_kind().has_open_menu());
 
-        let has_open_env_selector = self.environment_selector.as_ref(app).is_menu_open();
+        let has_open_env_selector = self
+            .environment_selector
+            .as_ref()
+            .is_some_and(|selector| selector.as_ref(app).is_menu_open());
 
         has_open_display_chip || has_open_env_selector
     }
@@ -1828,7 +1849,12 @@ impl AgentInputFooter {
         app: &AppContext,
     ) -> Option<Box<dyn Element>> {
         let is_cloud_mode = FeatureFlag::CloudModeImageContext.is_enabled()
-            && self.ambient_agent_view_model.as_ref(app).is_ambient_agent();
+            && self
+                .ambient_agent_view_model
+                .as_ref()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model.as_ref(app).is_ambient_agent()
+                });
         if !item.available_in().is_available_for_agent_view()
             || !item.available_to_session_viewer(shared_status, is_cloud_mode)
         {
@@ -1957,10 +1983,17 @@ impl View for AgentInputFooter {
             .with_spacing(4.);
 
         let is_ambient_agent = FeatureFlag::CloudMode.is_enabled()
-            && self.ambient_agent_view_model.as_ref(app).is_ambient_agent();
+            && self
+                .ambient_agent_view_model
+                .as_ref()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model.as_ref(app).is_ambient_agent()
+                });
         if is_ambient_agent {
-            left_buttons =
-                left_buttons.with_child(ChildView::new(&self.environment_selector).finish());
+            if let Some(environment_selector) = self.environment_selector.as_ref() {
+                left_buttons =
+                    left_buttons.with_child(ChildView::new(environment_selector).finish());
+            }
         }
 
         let terminal_model = self.terminal_model.lock();

--- a/app/src/ai/blocklist/agent_view/controller.rs
+++ b/app/src/ai/blocklist/agent_view/controller.rs
@@ -14,9 +14,7 @@ use crate::terminal::input::message_bar::{Message, MessageItem};
 use crate::terminal::input::slash_commands::SlashCommandTrigger;
 use crate::util::bindings::keybinding_name_to_keystroke;
 use crate::{
-    ai::agent::conversation::AIConversationId,
-    terminal::{view::ambient_agent::AmbientAgentViewModel, TerminalModel},
-    BlocklistAIHistoryModel,
+    ai::agent::conversation::AIConversationId, terminal::TerminalModel, BlocklistAIHistoryModel,
 };
 
 use super::{DismissalStrategy, EphemeralMessage, EphemeralMessageModel};
@@ -343,7 +341,6 @@ pub struct AgentViewController {
     /// Set during terminal pane attach; used for pane-group-scoped visibility checks.
     pane_group_id: Option<EntityId>,
     agent_view_state: AgentViewState,
-    ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
     ephemeral_message_model: ModelHandle<EphemeralMessageModel>,
     pending_confirmation: Option<PendingConfirmation>,
     pending_confirmation_abort_handle: Option<SpawnedFutureHandle>,
@@ -368,16 +365,13 @@ impl AgentViewController {
     pub fn new(
         terminal_model: Arc<FairMutex<TerminalModel>>,
         terminal_view_id: EntityId,
-        ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
         ephemeral_message_model: ModelHandle<EphemeralMessageModel>,
-        _ctx: &mut ModelContext<Self>,
     ) -> Self {
         Self {
             terminal_model,
             terminal_view_id,
             pane_group_id: None,
             agent_view_state: AgentViewState::Inactive,
-            ambient_agent_view_model,
             ephemeral_message_model,
             pending_confirmation: None,
             pending_confirmation_abort_handle: None,
@@ -411,29 +405,14 @@ impl AgentViewController {
     /// Returns whether the user is allowed to exit agent view.
     /// This is used to determine both whether the escape key should work
     /// and whether the escape keybinding should be displayed.
-    pub fn can_exit_agent_view(
-        &self,
-        ctx: &impl warpui::ModelAsRef,
-    ) -> Result<(), ExitAgentViewError> {
+    pub fn can_exit_agent_view(&self) -> Result<(), ExitAgentViewError> {
         let model = self.terminal_model.lock();
 
-        let ambient_agent_model = self.ambient_agent_view_model.as_ref(ctx);
         let is_fullscreen_with_long_running = self.agent_view_state.is_fullscreen()
             && model
                 .block_list()
                 .active_block()
                 .is_active_and_long_running();
-
-        // Ambient agent sessions should not allow exiting agent view if it's not backed by a terminal session because there's nothing to escape to.
-        if ambient_agent_model.is_ambient_agent() {
-            if !ambient_agent_model.has_parent_terminal() {
-                return Err(ExitAgentViewError::AmbientAgent);
-            }
-            // But if there is a terminal backing and we're in a LRC, we should be able to escape
-            else if is_fullscreen_with_long_running {
-                return Ok(());
-            }
-        }
 
         // In a non-ambient agent case, users cannot exit the fullscreen agent view with an active long running command.
         if is_fullscreen_with_long_running {
@@ -802,21 +781,6 @@ impl AgentViewController {
             .block_list_mut()
             .set_agent_view_state(self.agent_view_state.clone());
 
-        if origin == AgentViewEntryOrigin::CloudAgent {
-            // Only enter setup state if there are no existing environments.
-            // If environments exist, the user should go directly to composing.
-            let has_environments =
-                !crate::ai::cloud_environments::CloudAmbientAgentEnvironment::get_all(ctx)
-                    .is_empty();
-            self.ambient_agent_view_model.update(ctx, |model, ctx| {
-                if has_environments {
-                    model.enter_composing_from_setup(ctx);
-                } else {
-                    model.enter_setup(ctx);
-                }
-            });
-        }
-
         ctx.emit(AgentViewControllerEvent::EnteredAgentView {
             conversation_id,
             is_new: exchange_count == 0,
@@ -882,7 +846,7 @@ impl AgentViewController {
     ) {
         self.clear_new_conversation_keybinding_confirmation(ctx);
         // Check if exiting agent view is allowed.
-        if self.can_exit_agent_view(ctx).is_err() {
+        if self.can_exit_agent_view().is_err() {
             return;
         }
 
@@ -942,16 +906,6 @@ impl AgentViewController {
             .block_list_mut()
             .set_agent_view_state(self.agent_view_state.clone());
 
-        // Capture ambient agent status before resetting it
-        let was_ambient_agent = self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent();
-
-        // Reset ambient agent status when exiting agent view
-        if was_ambient_agent {
-            self.ambient_agent_view_model.update(ctx, |model, ctx| {
-                model.reset_status(ctx);
-            });
-        }
-
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         let final_exchange_count = history_model
             .as_ref(ctx)
@@ -965,7 +919,7 @@ impl AgentViewController {
             display_mode,
             original_exchange_count: original_conversation_length,
             final_exchange_count,
-            was_ambient_agent,
+            was_ambient_agent: origin == AgentViewEntryOrigin::CloudAgent,
             is_exit_before_new_entrance,
         });
     }

--- a/app/src/ai/blocklist/agent_view/zero_state_block.rs
+++ b/app/src/ai/blocklist/agent_view/zero_state_block.rs
@@ -97,13 +97,14 @@ impl AgentViewZeroStateBlock {
         origin: AgentViewEntryOrigin,
         agent_view_controller: ModelHandle<AgentViewController>,
         sessions: &ModelHandle<Sessions>,
-        cloud_agent_view_model: &ModelHandle<AmbientAgentViewModel>,
+        cloud_agent_view_model: Option<&ModelHandle<AmbientAgentViewModel>>,
         terminal_model: Arc<FairMutex<TerminalModel>>,
         model_events_dispatcher: &ModelHandle<ModelEventDispatcher>,
         should_show_init_callout: bool,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        let cloud_agent_view_model_clone = cloud_agent_view_model.clone();
+        let cloud_agent_view_model_clone = cloud_agent_view_model.cloned();
+
         let model_events_clone = model_events_dispatcher.clone();
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
@@ -116,7 +117,10 @@ impl AgentViewZeroStateBlock {
                         me.should_hide = true;
                         ctx.unsubscribe_to_model(&model_events_clone);
                         ctx.unsubscribe_to_model(&history_model);
-                        ctx.unsubscribe_to_model(&cloud_agent_view_model_clone);
+                        if let Some(cloud_agent_view_model) = cloud_agent_view_model_clone.as_ref()
+                        {
+                            ctx.unsubscribe_to_model(cloud_agent_view_model);
+                        }
                         ctx.notify();
                         return;
                     }
@@ -140,7 +144,7 @@ impl AgentViewZeroStateBlock {
             ctx.notify();
         });
 
-        let cloud_agent_view_model_clone = cloud_agent_view_model.clone();
+        let cloud_agent_view_model_clone = cloud_agent_view_model.cloned();
         ctx.subscribe_to_model(
             model_events_dispatcher,
             move |me, model_events_dispatcher, event, ctx| {
@@ -152,7 +156,11 @@ impl AgentViewZeroStateBlock {
                             me.should_hide = true;
                             ctx.unsubscribe_to_model(&model_events_dispatcher);
                             ctx.unsubscribe_to_model(&BlocklistAIHistoryModel::handle(ctx));
-                            ctx.unsubscribe_to_model(&cloud_agent_view_model_clone);
+                            if let Some(cloud_agent_view_model) =
+                                cloud_agent_view_model_clone.as_ref()
+                            {
+                                ctx.unsubscribe_to_model(cloud_agent_view_model);
+                            }
                             ctx.notify();
                         }
                     }
@@ -166,34 +174,35 @@ impl AgentViewZeroStateBlock {
             },
         );
 
-        let model_events_clone = model_events_dispatcher.clone();
-        ctx.subscribe_to_model(cloud_agent_view_model, move |me, model, event, ctx| {
-            if FeatureFlag::CloudModeSetupV2.is_enabled() {
-                match event {
-                    AmbientAgentViewModelEvent::DispatchedAgent
-                    | AmbientAgentViewModelEvent::Cancelled
-                        if !me.should_hide =>
-                    {
-                        me.should_hide = true;
-                        ctx.unsubscribe_to_model(&model);
-                        ctx.unsubscribe_to_model(&model_events_clone);
-                        ctx.unsubscribe_to_model(&BlocklistAIHistoryModel::handle(ctx));
-                        ctx.notify();
+        if let Some(cloud_agent_view_model) = cloud_agent_view_model {
+            let model_events_clone = model_events_dispatcher.clone();
+            ctx.subscribe_to_model(cloud_agent_view_model, move |me, model, event, ctx| {
+                if FeatureFlag::CloudModeSetupV2.is_enabled() {
+                    match event {
+                        AmbientAgentViewModelEvent::DispatchedAgent
+                        | AmbientAgentViewModelEvent::Cancelled
+                            if !me.should_hide =>
+                        {
+                            me.should_hide = true;
+                            ctx.unsubscribe_to_model(&model);
+                            ctx.unsubscribe_to_model(&model_events_clone);
+                            ctx.unsubscribe_to_model(&BlocklistAIHistoryModel::handle(ctx));
+                            ctx.notify();
+                        }
+                        _ => (),
                     }
-                    _ => (),
+                } else if model.as_ref(ctx).should_show_status_footer() {
+                    me.should_hide = true;
+                    ctx.unsubscribe_to_model(&model);
+                    ctx.unsubscribe_to_model(&model_events_clone);
+                    ctx.unsubscribe_to_model(&BlocklistAIHistoryModel::handle(ctx));
+                    ctx.notify();
                 }
-            } else if model.as_ref(ctx).should_show_status_footer() {
-                me.should_hide = true;
-                ctx.unsubscribe_to_model(&model);
-                ctx.unsubscribe_to_model(&model_events_clone);
-                ctx.unsubscribe_to_model(&BlocklistAIHistoryModel::handle(ctx));
-                ctx.notify();
-            }
-        });
+            });
+        }
 
-        let cloud_agent_view = cloud_agent_view_model.as_ref(ctx);
         let has_parent_terminal =
-            !cloud_agent_view.is_ambient_agent() || cloud_agent_view.has_parent_terminal();
+            cloud_agent_view_model.is_none_or(|model| !model.as_ref(ctx).is_ambient_agent());
         let changelog_model = ChangelogModel::handle(ctx);
         ctx.subscribe_to_model(&changelog_model, |me, changelog_model, event, ctx| {
             if let changelog_model::Event::ChangelogRequestComplete { .. } = event {

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -792,7 +792,7 @@ pub struct AIBlock {
     state_handles: AIBlockStateHandles,
     controller: ModelHandle<BlocklistAIController>,
     active_session: ModelHandle<ActiveSession>,
-    ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+    ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
     terminal_view_id: EntityId,
     window_id: warpui::WindowId,
 
@@ -972,7 +972,7 @@ impl AIBlock {
         context_model: ModelHandle<BlocklistAIContextModel>,
         find_model: ModelHandle<TerminalFindModel>,
         active_session: ModelHandle<ActiveSession>,
-        ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+        ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
         cli_subagent_controller: &ModelHandle<CLISubagentController>,
         model_event_dispatcher: &ModelHandle<ModelEventDispatcher>,
         agent_view_controller: ModelHandle<AgentViewController>,

--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -113,7 +113,7 @@ pub struct BlocklistAIStatusBar {
     terminal_model: Arc<FairMutex<TerminalModel>>,
     shimmering_text_handle: ShimmeringTextStateHandle,
     state_handles: StateHandles,
-    ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+    ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
 
     autoexecute_keystroke: Option<Keystroke>,
     queue_next_prompt_keystroke: Option<Keystroke>,
@@ -155,7 +155,7 @@ impl BlocklistAIStatusBar {
         model_event_dispatcher: &ModelHandle<ModelEventDispatcher>,
         terminal_model: Arc<FairMutex<TerminalModel>>,
         shortcut_view_model: ModelHandle<AgentShortcutViewModel>,
-        ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+        ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
         input_suggestions_model: ModelHandle<InputSuggestionsModeModel>,
         slash_command_model: ModelHandle<SlashCommandModel>,
         ephemeral_message_model: ModelHandle<EphemeralMessageModel>,
@@ -356,20 +356,22 @@ impl BlocklistAIStatusBar {
         let child_agent_status_card = ctx.add_typed_action_view(|ctx| {
             ChildAgentStatusCard::new(agent_view_controller.clone(), ctx)
         });
-        ctx.subscribe_to_model(&ambient_agent_view_model, |me, _, event, ctx| match event {
-            AmbientAgentViewModelEvent::DispatchedAgent
-            | AmbientAgentViewModelEvent::ProgressUpdated => {
-                me.update_agent_tip(ctx);
-                ctx.notify();
-            }
-            AmbientAgentViewModelEvent::SessionReady { .. }
-            | AmbientAgentViewModelEvent::Failed { .. }
-            | AmbientAgentViewModelEvent::NeedsGithubAuth
-            | AmbientAgentViewModelEvent::Cancelled => {
-                ctx.notify();
-            }
-            _ => (),
-        });
+        if let Some(ambient_agent_view_model) = ambient_agent_view_model.as_ref() {
+            ctx.subscribe_to_model(ambient_agent_view_model, |me, _, event, ctx| match event {
+                AmbientAgentViewModelEvent::DispatchedAgent
+                | AmbientAgentViewModelEvent::ProgressUpdated => {
+                    me.update_agent_tip(ctx);
+                    ctx.notify();
+                }
+                AmbientAgentViewModelEvent::SessionReady { .. }
+                | AmbientAgentViewModelEvent::Failed { .. }
+                | AmbientAgentViewModelEvent::NeedsGithubAuth
+                | AmbientAgentViewModelEvent::Cancelled => {
+                    ctx.notify();
+                }
+                _ => (),
+            });
+        }
 
         Self {
             active_exchange_model: None,
@@ -879,7 +881,10 @@ impl BlocklistAIStatusBar {
             return None;
         }
 
-        let ambient_agent_model = self.ambient_agent_view_model.as_ref(app);
+        let ambient_agent_model = self
+            .ambient_agent_view_model
+            .as_ref()
+            .map(|ambient_agent_view_model| ambient_agent_view_model.as_ref(app))?;
 
         let progress = ambient_agent_model.agent_progress()?;
         let progress_text = if progress.harness_started_at.is_some() {
@@ -911,7 +916,10 @@ impl BlocklistAIStatusBar {
             return None;
         }
 
-        let ambient_agent_model = self.ambient_agent_view_model.as_ref(app);
+        let ambient_agent_model = self
+            .ambient_agent_view_model
+            .as_ref()
+            .map(|ambient_agent_view_model| ambient_agent_view_model.as_ref(app))?;
         let theme = Appearance::as_ref(app).theme();
         let error_color = theme.ansi_fg_red();
 
@@ -1142,11 +1150,16 @@ impl View for BlocklistAIStatusBar {
             if let Some(cloud_mode_setup_status) = self.render_cloud_mode_setup_status(app) {
                 cloud_mode_setup_status
             } else if FeatureFlag::CloudModeSetupV2.is_enabled()
-                && is_cloud_agent_pre_first_exchange(
-                    &self.ambient_agent_view_model,
-                    &self.agent_view_controller,
-                    app,
-                )
+                && self
+                    .ambient_agent_view_model
+                    .as_ref()
+                    .is_some_and(|ambient_agent_view_model| {
+                        is_cloud_agent_pre_first_exchange(
+                            Some(ambient_agent_view_model),
+                            &self.agent_view_controller,
+                            app,
+                        )
+                    })
             {
                 render_warping_indicator_base(
                     WarpingIndicatorProps {
@@ -1206,11 +1219,13 @@ impl View for BlocklistAIStatusBar {
                     .is_none(),
             ) {
                 warping_indicator
-            } else if self
-                .ambient_agent_view_model
-                .as_ref(app)
-                .is_waiting_for_session()
-            {
+            } else if self.ambient_agent_view_model.as_ref().is_some_and(
+                |ambient_agent_view_model| {
+                    ambient_agent_view_model
+                        .as_ref(app)
+                        .is_waiting_for_session()
+                },
+            ) {
                 // Don't render warping indicator - the loading screen is shown in the main view
                 return Empty::new().finish();
             } else if agent_view_controller.is_active() {

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -857,8 +857,8 @@ impl View for AIBlock {
             .is_some_and(|exchange| exchange.id == self.client_ids.client_exchange_id);
         let has_inserted_cloud_mode_user_query_block = self
             .ambient_agent_view_model
-            .as_ref(app)
-            .has_inserted_cloud_mode_user_query_block();
+            .as_ref()
+            .is_some_and(|model| model.as_ref(app).has_inserted_cloud_mode_user_query_block());
         let should_hide_first_block_query_and_header = should_hide_first_ai_block_query_and_header(
             has_inserted_cloud_mode_user_query_block,
             is_shared_ambient_agent_session,

--- a/app/src/ai/blocklist/passive_suggestions/maa.rs
+++ b/app/src/ai/blocklist/passive_suggestions/maa.rs
@@ -94,7 +94,7 @@ pub struct PassiveSuggestionsModel {
     latest_request: Option<Request>,
     pending_file_read_handle: Option<SpawnedFutureHandle>,
     terminal_model: Arc<FairMutex<TerminalModel>>,
-    ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+    ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
 
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
     terminal_view_id: EntityId,
@@ -108,7 +108,7 @@ impl PassiveSuggestionsModel {
         terminal_model: Arc<FairMutex<TerminalModel>>,
         ai_controller: ModelHandle<BlocklistAIController>,
         model_event_dispatcher: &ModelHandle<ModelEventDispatcher>,
-        ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+        ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
         terminal_view_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
@@ -136,6 +136,12 @@ impl PassiveSuggestionsModel {
         }
         // Dropping the [`Request`] aborts the spawned stream handle.
         self.latest_request.take();
+    }
+
+    fn is_ambient_agent_session(&self, ctx: &ModelContext<Self>) -> bool {
+        self.ambient_agent_view_model
+            .as_ref()
+            .is_some_and(|model| model.as_ref(ctx).is_ambient_agent())
     }
 
     /// Sends a MAA request to generate passive suggestions.
@@ -394,7 +400,7 @@ impl PassiveSuggestionsModel {
         }
 
         // Suppress passive suggestions in cloud mode sessions.
-        if self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent() {
+        if self.is_ambient_agent_session(ctx) {
             return;
         }
 
@@ -443,7 +449,7 @@ impl PassiveSuggestionsModel {
     ) {
         self.abort_pending_requests(ctx);
         // Suppress passive suggestions in cloud mode sessions.
-        if self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent() {
+        if self.is_ambient_agent_session(ctx) {
             return;
         }
 

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -3791,11 +3791,13 @@ impl PaneGroup {
                     );
                     // Keep the viewer's AmbientAgentViewModel harness in sync with the loaded run.
                     if let Some(harness) = harness {
-                        view.ambient_agent_view_model()
-                            .clone()
-                            .update(ctx, |model, ctx| {
+                        if let Some(ambient_agent_view_model) =
+                            view.ambient_agent_view_model().cloned()
+                        {
+                            ambient_agent_view_model.update(ctx, |model, ctx| {
                                 model.set_harness(harness, ctx);
                             });
+                        }
                     }
                     // 3p runs have no materialized AIConversation, so enter agent view with a
                     // fresh vehicle conversation and retag the restored snapshot block onto it so

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -414,8 +414,8 @@ impl PaneContent for TerminalPane {
         if view.model.lock().shared_session_status().is_viewer() {
             // We save and restore ambient agent sessions
             // (restoring the shared session if it's still open and the conversation transcript otherwise).
-            let ambient_model = view.ambient_agent_view_model().as_ref(app);
-            if ambient_model.is_ambient_agent() {
+            if let Some(ambient_model) = view.ambient_agent_view_model() {
+                let ambient_model = ambient_model.as_ref(app);
                 let task_id = ambient_model.task_id();
 
                 return LeafContents::AmbientAgent(AmbientAgentPaneSnapshot {
@@ -1396,13 +1396,18 @@ fn handle_terminal_view_event(
                                     AgentViewEntryOrigin::CloudAgent,
                                     ctx,
                                 );
-                                terminal_view.ambient_agent_view_model().update(
-                                    ctx,
-                                    |model, ctx| {
+                                if let Some(ambient_agent_view_model) =
+                                    terminal_view.ambient_agent_view_model()
+                                {
+                                    ambient_agent_view_model.update(ctx, |model, ctx| {
                                         model.set_conversation_id(Some(conversation_id));
                                         model.spawn_agent_with_request(spawn_request, ctx);
-                                    },
-                                );
+                                    });
+                                } else {
+                                    log::error!(
+                                        "Remote StartAgent child pane missing ambient agent view model"
+                                    );
+                                }
                             });
 
                             group

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -1604,11 +1604,6 @@ pub struct Input {
     terminal_input_message_bar: ViewHandle<TerminalInputMessageBar>,
 
     agent_input_footer: ViewHandle<AgentInputFooter>,
-
-    harness_selector: ViewHandle<HarnessSelector>,
-
-    host_selector: Option<ViewHandle<HostSelector>>,
-
     prompt_suggestions_view: ViewHandle<PromptSuggestionsView>,
 
     inline_slash_commands_view: ViewHandle<InlineSlashCommandView>,
@@ -1667,13 +1662,26 @@ pub struct Input {
     agent_status_view: ViewHandle<BlocklistAIStatusBar>,
     agent_view_controller: ModelHandle<AgentViewController>,
     agent_shortcut_view_model: ModelHandle<AgentShortcutViewModel>,
-    ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+    ambient_agent_view_state: Option<AmbientAgentViewState>,
     ephemeral_message_model: ModelHandle<EphemeralMessageModel>,
 
     /// When a command is executed from a prompt chip (e.g. `cd` from the directory dropdown),
     /// we snapshot the current input contents here so we can restore them after the command
     /// completes and the buffer would normally be cleared.
     input_contents_before_prompt_chip_command: Option<String>,
+}
+
+struct AmbientAgentViewState {
+    view_model: ModelHandle<AmbientAgentViewModel>,
+    #[allow(dead_code)]
+    harness_selector: ViewHandle<HarnessSelector>,
+    host_selector: Option<ViewHandle<HostSelector>>,
+}
+
+impl AmbientAgentViewState {
+    fn view_model(&self) -> &ModelHandle<AmbientAgentViewModel> {
+        &self.view_model
+    }
 }
 
 #[derive(Clone)]
@@ -2030,7 +2038,7 @@ impl Input {
         current_repo_path: Option<PathBuf>,
         model_events: ModelHandle<crate::terminal::model_events::ModelEventDispatcher>,
         agent_view_controller: ModelHandle<AgentViewController>,
-        ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+        ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
         active_session: ModelHandle<ActiveSession>,
         ephemeral_message_model: ModelHandle<EphemeralMessageModel>,
         ctx: &mut ViewContext<Self>,
@@ -2057,7 +2065,7 @@ impl Input {
             model_events: model_events.clone(),
             is_shared_session_viewer,
             agent_view_controller: agent_view_controller.clone(),
-            ambient_agent_view_model: Some(ambient_agent_view_model.clone()),
+            ambient_agent_view_model: ambient_agent_view_model.clone(),
         };
 
         let prompt_view = ctx.add_typed_action_view(|ctx| {
@@ -2118,19 +2126,21 @@ impl Input {
             ctx.notify();
         });
 
-        ctx.subscribe_to_model(&ambient_agent_view_model, |me, handle, _, ctx| {
-            let is_ambient = handle.as_ref(ctx).is_ambient_agent();
-            me.editor.update(ctx, |editor, ctx| {
-                if let Some(ai_context_menu) = editor.ai_context_menu() {
-                    ai_context_menu.update(ctx, |menu, ctx| {
-                        menu.set_is_in_ambient_agent(is_ambient, ctx);
-                    });
+        if let Some(ambient_agent_view_model) = ambient_agent_view_model.as_ref() {
+            ctx.subscribe_to_model(ambient_agent_view_model, |me, handle, _, ctx| {
+                let is_ambient = handle.as_ref(ctx).is_ambient_agent();
+                me.editor.update(ctx, |editor, ctx| {
+                    if let Some(ai_context_menu) = editor.ai_context_menu() {
+                        ai_context_menu.update(ctx, |menu, ctx| {
+                            menu.set_is_in_ambient_agent(is_ambient, ctx);
+                        });
+                    }
+                });
+                if handle.as_ref(ctx).should_show_status_footer() {
+                    ctx.notify();
                 }
             });
-            if handle.as_ref(ctx).should_show_status_footer() {
-                ctx.notify();
-            }
-        });
+        }
 
         let prompt_selection_state_handle = SelectionHandle::default();
 
@@ -2169,26 +2179,34 @@ impl Input {
             )
         });
 
-        let harness_selector = ctx.add_typed_action_view(|ctx| {
-            HarnessSelector::new(
-                menu_positioning_provider.clone(),
-                ambient_agent_view_model.clone(),
-                ctx,
-            )
-        });
-
-        let host_selector = if FeatureFlag::CloudModeInputV2.is_enabled() {
-            let view = ctx.add_typed_action_view(|ctx| {
-                HostSelector::new(menu_positioning_provider.clone(), ctx)
-            });
-            harness_selector.update(ctx, |selector, ctx| {
-                selector.set_button_theme(NakedHeaderButtonTheme, ctx);
-            });
-            Some(view)
-        } else {
-            None
-        };
-
+        let ambient_agent_view_state =
+            ambient_agent_view_model
+                .as_ref()
+                .map(|view_model| AmbientAgentViewState {
+                    view_model: view_model.clone(),
+                    harness_selector: {
+                        let harness_selector = ctx.add_typed_action_view(|ctx| {
+                            HarnessSelector::new(
+                                menu_positioning_provider.clone(),
+                                view_model.clone(),
+                                ctx,
+                            )
+                        });
+                        if FeatureFlag::CloudModeInputV2.is_enabled() {
+                            harness_selector.update(ctx, |selector, ctx| {
+                                selector.set_button_theme(NakedHeaderButtonTheme, ctx);
+                            });
+                        }
+                        harness_selector
+                    },
+                    host_selector: if FeatureFlag::CloudModeInputV2.is_enabled() {
+                        Some(ctx.add_typed_action_view(|ctx| {
+                            HostSelector::new(menu_positioning_provider.clone(), ctx)
+                        }))
+                    } else {
+                        None
+                    },
+                });
         ctx.subscribe_to_view(&agent_input_footer, |me, _, event, ctx| {
             match event {
                 #[cfg(feature = "voice_input")]
@@ -3267,10 +3285,8 @@ impl Input {
             agent_status_view,
             agent_view_controller,
             agent_input_footer,
-            harness_selector,
-            host_selector,
             agent_shortcut_view_model,
-            ambient_agent_view_model,
+            ambient_agent_view_state,
             slash_command_data_source,
             ephemeral_message_model,
             input_contents_before_prompt_chip_command: None,
@@ -3340,6 +3356,24 @@ impl Input {
 
     pub fn agent_input_footer(&self) -> &ViewHandle<AgentInputFooter> {
         &self.agent_input_footer
+    }
+
+    fn ambient_agent_view_model(&self) -> Option<&ModelHandle<AmbientAgentViewModel>> {
+        self.ambient_agent_view_state
+            .as_ref()
+            .map(AmbientAgentViewState::view_model)
+    }
+
+    fn harness_selector(&self) -> Option<&ViewHandle<HarnessSelector>> {
+        self.ambient_agent_view_state
+            .as_ref()
+            .map(|state| &state.harness_selector)
+    }
+
+    fn host_selector(&self) -> Option<&ViewHandle<HostSelector>> {
+        self.ambient_agent_view_state
+            .as_ref()
+            .and_then(|state| state.host_selector.as_ref())
     }
 
     /// Update the at button's disabled state based on whether AI context menu should render
@@ -5851,10 +5885,13 @@ impl Input {
             return false;
         }
 
-        let ambient_agent_model = self.ambient_agent_view_model.as_ref(app);
-        ambient_agent_model.is_ambient_agent()
-            && !ambient_agent_model.is_configuring_ambient_agent()
-            && !ambient_agent_model.is_agent_running()
+        self.ambient_agent_view_model()
+            .is_some_and(|ambient_agent_model| {
+                let ambient_agent_model = ambient_agent_model.as_ref(app);
+                ambient_agent_model.is_ambient_agent()
+                    && !ambient_agent_model.is_configuring_ambient_agent()
+                    && !ambient_agent_model.is_agent_running()
+            })
     }
 
     /// Try to execute a command in the local session that was
@@ -9718,7 +9755,11 @@ impl Input {
         // Shared session viewers cannot attach images unless in cloud mode
         let is_viewer = self.model.lock().shared_session_status().is_viewer();
         let is_cloud_mode_with_images = FeatureFlag::CloudModeImageContext.is_enabled()
-            && self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent();
+            && self
+                .ambient_agent_view_model()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model.as_ref(ctx).is_ambient_agent()
+                });
         if is_viewer && !is_cloud_mode_with_images {
             self.insert_clipboard_text_content(ctx, content);
             return;
@@ -9778,7 +9819,11 @@ impl Input {
         // with the CloudModeImageContext feature enabled.
         let is_viewer = self.model.lock().shared_session_status().is_viewer();
         let is_cloud_mode_with_images = FeatureFlag::CloudModeImageContext.is_enabled()
-            && self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent();
+            && self
+                .ambient_agent_view_model()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model.as_ref(ctx).is_ambient_agent()
+                });
         if is_viewer && !is_cloud_mode_with_images {
             return false;
         }
@@ -11778,9 +11823,12 @@ impl Input {
 
             // Check if we're configuring an ambient agent and spawn it instead of submitting a regular AI query.
             if self
-                .ambient_agent_view_model
-                .as_ref(ctx)
-                .is_configuring_ambient_agent()
+                .ambient_agent_view_model()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model
+                        .as_ref(ctx)
+                        .is_configuring_ambient_agent()
+                })
             {
                 let prompt = command.trim().to_owned();
                 if prompt.is_empty() {
@@ -11862,9 +11910,11 @@ impl Input {
                     context_model.clear_pending_attachments(ctx);
                 });
 
-                self.ambient_agent_view_model.update(ctx, |state, ctx| {
-                    state.spawn_agent(prompt, attachments, ctx);
-                });
+                if let Some(ambient_agent_view_model) = self.ambient_agent_view_model() {
+                    ambient_agent_view_model.update(ctx, |state, ctx| {
+                        state.spawn_agent(prompt, attachments, ctx);
+                    });
+                }
                 return;
             }
 
@@ -12028,7 +12078,12 @@ impl Input {
                 // In cloud mode (ambient agent), Cmd+Enter should exit cloud mode entirely and start a
                 // new *local* agent conversation in the root terminal. This should work whether the
                 // buffer is empty (blank convo) or non-empty (prefill draft, but don't auto-send).
-                if self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent() {
+                if self
+                    .ambient_agent_view_model()
+                    .is_some_and(|ambient_agent_model| {
+                        ambient_agent_model.as_ref(ctx).is_ambient_agent()
+                    })
+                {
                     let mut draft = self.editor.as_ref(ctx).buffer_text(ctx);
                     // Normalize draft for empty-checks and for prefill.
                     draft.truncate(draft.trim_end().len());
@@ -12543,7 +12598,9 @@ impl Input {
                     .map(ServerConversationToken::from_uuid)
             });
 
-        let ambient_agent_task_id = self.ambient_agent_view_model.as_ref(ctx).task_id();
+        let ambient_agent_task_id = self
+            .ambient_agent_view_model()
+            .and_then(|ambient_agent_model| ambient_agent_model.as_ref(ctx).task_id());
 
         // Collect attachments from ai_context_model
         let attachments: Vec<AgentAttachment> = self
@@ -14283,9 +14340,13 @@ impl View for Input {
             return self.render_cli_agent_input(app);
         }
         let is_universal_input = self.should_show_universal_developer_input(app);
-        let ambient_agent_model = self.ambient_agent_view_model.as_ref(app);
+        let should_show_status_footer =
+            self.ambient_agent_view_model()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model.as_ref(app).should_show_status_footer()
+                });
 
-        if FeatureFlag::CloudMode.is_enabled() && ambient_agent_model.should_show_status_footer() {
+        if FeatureFlag::CloudMode.is_enabled() && should_show_status_footer {
             self.render_ambient_agent_status_footer(app)
         } else if FeatureFlag::AgentView.is_enabled()
             && self.agent_view_controller.as_ref(app).is_active()

--- a/app/src/terminal/input/agent.rs
+++ b/app/src/terminal/input/agent.rs
@@ -28,8 +28,8 @@ use warpui::elements::Expanded;
 use warpui::{
     elements::{
         Align, AnchorPair, Border, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment,
-        DispatchEventResult, DropTarget, Element, EventHandler, Flex, Hoverable, MainAxisSize,
-        OffsetPositioning, OffsetType, ParentElement, PositionedElementOffsetBounds,
+        DispatchEventResult, DropTarget, Element, Empty, EventHandler, Flex, Hoverable,
+        MainAxisSize, OffsetPositioning, OffsetType, ParentElement, PositionedElementOffsetBounds,
         PositioningAxis, Radius, SavePosition, Stack, XAxisAnchor, YAxisAnchor,
     },
     presenter::ChildView,
@@ -67,9 +67,8 @@ impl Input {
         FeatureFlag::CloudModeInputV2.is_enabled()
             && FeatureFlag::CloudMode.is_enabled()
             && self
-                .ambient_agent_view_model
-                .as_ref(app)
-                .is_configuring_ambient_agent()
+                .ambient_agent_view_model()
+                .is_some_and(|model| model.as_ref(app).is_configuring_ambient_agent())
     }
 
     /// Renders the input when there is an active `AgentView`.
@@ -120,22 +119,27 @@ impl Input {
         let show_harness_row = FeatureFlag::CloudMode.is_enabled()
             && FeatureFlag::AgentHarness.is_enabled()
             && self
-                .ambient_agent_view_model
-                .as_ref(app)
-                .is_configuring_ambient_agent();
+                .ambient_agent_view_model()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model
+                        .as_ref(app)
+                        .is_configuring_ambient_agent()
+                });
         if show_harness_row {
-            // Temporarily render the harness selector in the cloud mode UDI until we fully
-            // implement the new designs.
-            let harness_row = Flex::row()
-                .with_main_axis_size(MainAxisSize::Min)
-                .with_child(ChildView::new(&self.harness_selector).finish())
-                .finish();
-            column.add_child(
-                Container::new(harness_row)
-                    .with_padding_top(spacing::UDI_CHIP_MARGIN)
-                    .with_padding_bottom(4.)
-                    .finish(),
-            );
+            if let Some(harness_selector) = self.harness_selector() {
+                // Temporarily render the harness selector in the cloud mode UDI until we fully
+                // implement the new designs.
+                let harness_row = Flex::row()
+                    .with_main_axis_size(MainAxisSize::Min)
+                    .with_child(ChildView::new(harness_selector).finish())
+                    .finish();
+                column.add_child(
+                    Container::new(harness_row)
+                        .with_padding_top(spacing::UDI_CHIP_MARGIN)
+                        .with_padding_bottom(4.)
+                        .finish(),
+                );
+            }
         }
 
         let terminal_spacing = TerminalSettings::as_ref(app)
@@ -484,10 +488,12 @@ impl Input {
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_spacing(CLOUD_MODE_V2_TOP_ROW_INNER_GAP);
 
-        if let Some(host) = self.host_selector.as_ref() {
+        if let Some(host) = self.host_selector() {
             row.add_child(ChildView::new(host).finish());
         }
-        row.add_child(ChildView::new(&self.harness_selector).finish());
+        if let Some(harness_selector) = self.harness_selector() {
+            row.add_child(ChildView::new(harness_selector).finish());
+        }
 
         row.finish()
     }
@@ -559,7 +565,10 @@ impl Input {
     }
 
     pub(super) fn render_ambient_agent_status_footer(&self, app: &AppContext) -> Box<dyn Element> {
-        let ambient_agent_model = self.ambient_agent_view_model.as_ref(app);
+        let Some(ambient_agent_model) = self.ambient_agent_view_model() else {
+            return Empty::new().finish();
+        };
+        let ambient_agent_model = ambient_agent_model.as_ref(app);
         let mut stack = Stack::new().with_constrain_absolute_children();
 
         // Don't render status bar when agent has failed or is waiting for session

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -387,6 +387,7 @@ impl TerminalManager {
                 initial_input_config,
                 conversation_restoration,
                 Some(inactive_pty_reads_rx.clone()),
+                false,
                 ctx,
             )
         });

--- a/app/src/terminal/mock_terminal_manager.rs
+++ b/app/src/terminal/mock_terminal_manager.rs
@@ -76,6 +76,7 @@ impl MockTerminalManager {
                 // into the web view.
                 conversation_restoration,
                 None, // inactive_pty_reads_rx
+                false,
                 ctx,
             )
         });

--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -171,7 +171,7 @@ pub struct ProfileModelSelector {
     is_blurred: bool,
     new_model_popup: ViewHandle<FeaturePopup>,
     input_model: ModelHandle<BlocklistAIInputModel>,
-    ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+    ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
     render_compact: bool,
     hovered_llm_info: Option<LLMInfo>,
     manage_api_key_button: ViewHandle<ActionButton>,
@@ -230,7 +230,7 @@ impl ProfileModelSelector {
         menu_positioning_provider: Arc<dyn crate::terminal::input::MenuPositioningProvider>,
         terminal_view_id: EntityId,
         input_model: ModelHandle<BlocklistAIInputModel>,
-        ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+        ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
         terminal_model: Arc<FairMutex<TerminalModel>>,
         controller: Option<ModelHandle<BlocklistAIController>>,
         ctx: &mut ViewContext<Self>,
@@ -1366,10 +1366,14 @@ impl ProfileModelSelector {
 
         // Allow editing if composing an ambient agent query, or if the user has edit access
         // in a shared session (i.e., not a viewer, or is an executor).
-        let is_composing_ambient_agent = self
-            .ambient_agent_view_model
-            .as_ref(app)
-            .is_configuring_ambient_agent();
+        let is_composing_ambient_agent =
+            self.ambient_agent_view_model
+                .as_ref()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model
+                        .as_ref(app)
+                        .is_configuring_ambient_agent()
+                });
         let terminal_model = self.terminal_model.lock();
         let has_edit_access = is_composing_ambient_agent
             || !terminal_model.shared_session_status().is_viewer()

--- a/app/src/terminal/remote_tty/terminal_manager.rs
+++ b/app/src/terminal/remote_tty/terminal_manager.rs
@@ -122,6 +122,7 @@ impl TerminalManager {
                 initial_input_config,
                 None, // conversation_restoration - not used for remote
                 None, // inactive_pty_reads_rx
+                false,
                 ctx,
             )
         });

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -137,7 +137,7 @@ impl TerminalManager {
         resources: TerminalViewResources,
         initial_size: Vector2F,
         window_id: WindowId,
-        is_deferring_terminal_session_connection: bool,
+        is_cloud_mode: bool,
         ctx: &mut AppContext,
     ) -> Self {
         // Create all the necessary channels we need for communication.
@@ -165,7 +165,7 @@ impl TerminalManager {
         // TODO: use the sharer's size.
         let sizes = compute_block_size(initial_size, ctx);
 
-        let model = if is_deferring_terminal_session_connection {
+        let model = if is_cloud_mode {
             TerminalModel::new_for_cloud_mode_shared_session_viewer(
                 sizes,
                 terminal_colors_list(ctx),
@@ -222,6 +222,7 @@ impl TerminalManager {
                 None, // initial_input_config - not used for viewer
                 None, // no conversation restoration for shared session viewer
                 Some(inactive_pty_reads_rx.clone()),
+                is_cloud_mode,
                 ctx,
             )
         });
@@ -650,11 +651,13 @@ impl TerminalManager {
 
                 view.update(ctx, |terminal_view, ctx| {
                     if let Some(task_id) = ambient_task_id {
-                        terminal_view
-                            .ambient_agent_view_model()
-                            .update(ctx, |model, ctx| {
+                        if let Some(ambient_agent_view_model) =
+                            terminal_view.ambient_agent_view_model()
+                        {
+                            ambient_agent_view_model.update(ctx, |model, ctx| {
                                 model.enter_viewing_existing_session(task_id, ctx);
                             });
+                        }
                     }
 
                     terminal_view.on_session_share_joined(

--- a/app/src/terminal/universal_developer_input.rs
+++ b/app/src/terminal/universal_developer_input.rs
@@ -329,7 +329,7 @@ impl UniversalDeveloperInputButtonBar {
         terminal_view_id: EntityId,
         input_model: ModelHandle<BlocklistAIInputModel>,
         cli_subagent_controller: ModelHandle<CLISubagentController>,
-        ambient_agent_view_model: ModelHandle<AmbientAgentViewModel>,
+        ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
         terminal_model: std::sync::Arc<parking_lot::FairMutex<crate::terminal::TerminalModel>>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2733,7 +2733,7 @@ pub struct TerminalView {
     agent_view_back_button: ViewHandle<ActionButton>,
     is_using_conversation_for_pane_header_title: bool,
 
-    ambient_agent_view_model: ModelHandle<ambient_agent::AmbientAgentViewModel>,
+    ambient_agent_view_model: Option<ModelHandle<ambient_agent::AmbientAgentViewModel>>,
 
     /// Cloud mode conversation details panel (side panel showing task metadata).
     cloud_mode_details_panel:
@@ -2846,6 +2846,27 @@ impl TerminalView {
     /// the state of this terminal. If this terminal view has an active input
     /// editor, other terminals should match those contents.
     /// Otherwise, they should just start syncing.
+    fn is_nested_cloud_mode(&self, app: &AppContext) -> bool {
+        if !self.is_ambient_agent_session(app) {
+            return false;
+        }
+
+        let Some(pane_stack) = self
+            .pane_stack
+            .as_ref()
+            .and_then(|handle| handle.upgrade(app))
+        else {
+            return false;
+        };
+
+        pane_stack
+            .as_ref(app)
+            .entries()
+            .iter()
+            .position(|(_, view)| view.id() == self.view_id)
+            .is_some_and(|index| index > 0)
+    }
+
     pub fn create_sync_event_based_on_terminal_state(&self, app_ctx: &AppContext) -> SyncEvent {
         if !matches!(
             self.model.lock().terminal_input_state(),
@@ -2946,35 +2967,25 @@ impl TerminalView {
         initial_input_config: Option<InputConfig>,
         conversation_restoration: Option<ConversationRestorationInNewPaneType>,
         inactive_pty_reads_rx: Option<async_broadcast::InactiveReceiver<Arc<Vec<u8>>>>,
+        is_cloud_mode: bool,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         let terminal_view_id = ctx.view_id();
         let active_session = ctx.add_model(|ctx| {
             ActiveSession::new(sessions.clone(), model_events_handle.clone(), ctx)
         });
-
-        let ambient_agent_view_model = ctx.add_model(|ctx| {
-            ambient_agent::AmbientAgentViewModel::new(
-                terminal_view_id,
-                false, // New terminal views don't have parent by default
-                ctx,
-            )
+        let ambient_agent_view_model = is_cloud_mode.then(|| {
+            ctx.add_model(|ctx| ambient_agent::AmbientAgentViewModel::new(terminal_view_id, ctx))
         });
 
         let ephemeral_message_model = ctx.add_model(|_| EphemeralMessageModel::new());
 
-        let agent_view_controller = ctx.add_model(|ctx| {
+        let agent_view_controller = ctx.add_model(|_| {
             AgentViewController::new(
                 model.clone(),
                 terminal_view_id,
-                ambient_agent_view_model.clone(),
                 ephemeral_message_model.clone(),
-                ctx,
             )
-        });
-
-        ctx.subscribe_to_model(&ambient_agent_view_model, |me, _, event, ctx| {
-            me.handle_ambient_agent_event(event, ctx);
         });
 
         ctx.subscribe_to_model(&agent_view_controller, |me, _, event, ctx| {
@@ -3041,7 +3052,7 @@ impl TerminalView {
                                         *origin,
                                         me.agent_view_controller.clone(),
                                         &me.sessions,
-                                        &me.ambient_agent_view_model,
+                                        me.ambient_agent_view_model.as_ref(),
                                         me.model.clone(),
                                         &me.model_events_handle,
                                         should_show_init_callout,
@@ -3473,7 +3484,10 @@ impl TerminalView {
                 event,
                 BlocklistAIControllerEvent::FinishedReceivingOutput { .. }
             ) && me.is_cloud_mode_details_panel_open
-                && me.ambient_agent_view_model.as_ref(ctx).is_ambient_agent()
+                && me
+                    .ambient_agent_view_model
+                    .as_ref()
+                    .is_some_and(|model| model.as_ref(ctx).is_ambient_agent())
             {
                 me.fetch_and_update_cloud_mode_details_panel(ctx);
             }
@@ -3501,7 +3515,10 @@ impl TerminalView {
                 // Only refresh panel if it's currently open (avoids unnecessary work)
                 if should_refresh_details_panel
                     && me.is_cloud_mode_details_panel_open
-                    && me.ambient_agent_view_model.as_ref(ctx).is_ambient_agent()
+                    && me
+                        .ambient_agent_view_model
+                        .as_ref()
+                        .is_some_and(|model| model.as_ref(ctx).is_ambient_agent())
                 {
                     me.fetch_and_update_cloud_mode_details_panel(ctx);
                     ctx.notify();
@@ -3598,6 +3615,11 @@ impl TerminalView {
             }
             BlocklistAIStatusBarEvent::Stop => me.ctrl_c(ctx),
         });
+        if let Some(ambient_agent_view_model) = ambient_agent_view_model.as_ref() {
+            ctx.subscribe_to_model(ambient_agent_view_model, |me, _, event, ctx| {
+                me.handle_ambient_agent_event(event, ctx);
+            });
+        }
 
         let ai_render_context = Rc::new(RefCell::new(BlocklistAIRenderContext {
             block_ids: HashMap::from_iter([
@@ -4451,7 +4473,7 @@ impl TerminalView {
         // For ambient agent sessions (cloud mode), always pop from pane stack.
         // These sessions are pushed onto a nav stack and have no underlying terminal
         // to return to via the normal agent view exit path.
-        if self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent() {
+        if self.is_ambient_agent_session(ctx) {
             if let Some(pane_stack) = self.pane_stack.as_ref().and_then(|h| h.upgrade(ctx)) {
                 pane_stack.update(ctx, |stack, ctx| {
                     stack.pop(ctx);
@@ -5041,7 +5063,7 @@ impl TerminalView {
                     }
                 }
 
-                if self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent()
+                if self.is_ambient_agent_session(ctx)
                     && self
                         .model
                         .lock()
@@ -5273,7 +5295,7 @@ impl TerminalView {
 
                 // Show AI credits modal for cloud-mode out-of-credits failures.
                 if FeatureFlag::CloudMode.is_enabled()
-                    && self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent()
+                    && self.is_ambient_agent_session(ctx)
                     && !self.model.lock().is_shared_ambient_agent_session()
                 {
                     if let Some(conversation) =
@@ -6572,8 +6594,10 @@ impl TerminalView {
             .active_conversation_id()
     }
 
-    pub fn ambient_agent_view_model(&self) -> &ModelHandle<ambient_agent::AmbientAgentViewModel> {
-        &self.ambient_agent_view_model
+    pub fn ambient_agent_view_model(
+        &self,
+    ) -> Option<&ModelHandle<ambient_agent::AmbientAgentViewModel>> {
+        self.ambient_agent_view_model.as_ref()
     }
 
     fn ambient_agent_task_id_for_details_panel_from_model(
@@ -6582,8 +6606,8 @@ impl TerminalView {
         app: &AppContext,
     ) -> Option<AmbientAgentTaskId> {
         self.ambient_agent_view_model
-            .as_ref(app)
-            .task_id()
+            .as_ref()
+            .and_then(|model| model.as_ref(app).task_id())
             .or_else(|| model.ambient_agent_task_id())
     }
     pub fn ambient_agent_task_id_for_details_panel(
@@ -6775,9 +6799,7 @@ impl TerminalView {
             return false;
         }
 
-        if model.shared_session_status().is_view_pending()
-            && !self.ambient_agent_view_model.as_ref(app).is_ambient_agent()
-        {
+        if model.shared_session_status().is_view_pending() && !self.is_ambient_agent_session(app) {
             return false;
         }
 
@@ -6786,7 +6808,7 @@ impl TerminalView {
         // rendered instead (see `TerminalView::render`).
         if !FeatureFlag::CloudModeSetupV2.is_enabled()
             && is_cloud_agent_pre_first_exchange(
-                &self.ambient_agent_view_model,
+                self.ambient_agent_view_model.as_ref(),
                 &self.agent_view_controller,
                 app,
             )
@@ -7173,7 +7195,7 @@ impl TerminalView {
         if self
             .agent_view_controller
             .as_ref(app)
-            .can_exit_agent_view(app)
+            .can_exit_agent_view()
             .is_err()
         {
             return false;
@@ -10021,7 +10043,7 @@ impl TerminalView {
         let disabled_reason = self
             .agent_view_controller
             .as_ref(ctx)
-            .can_exit_agent_view(ctx)
+            .can_exit_agent_view()
             .err()
             .map(|e| e.to_string());
 
@@ -12621,7 +12643,7 @@ impl TerminalView {
         // directly to the environment management pane
         if FeatureFlag::AgentView.is_enabled()
             && self.agent_view_controller.as_ref(ctx).is_active()
-            && self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent()
+            && self.is_ambient_agent_session(ctx)
         {
             self.open_environment_management_pane(ctx);
             return;
@@ -14839,13 +14861,13 @@ impl TerminalView {
         // Then check if there's selected text in the cloud mode error screen
         let error_selected_text = self
             .ambient_agent_view_model
-            .as_ref(ctx)
-            .ui_state
-            .error_selected_text
-            .clone();
-        if let Some(text) = error_selected_text.read().clone().filter(|t| !t.is_empty()) {
-            ctx.clipboard().write(ClipboardContent::plain_text(text));
-            return;
+            .as_ref()
+            .map(|model| model.as_ref(ctx).ui_state.error_selected_text.clone());
+        if let Some(error_selected_text) = error_selected_text {
+            if let Some(text) = error_selected_text.read().clone().filter(|t| !t.is_empty()) {
+                ctx.clipboard().write(ClipboardContent::plain_text(text));
+                return;
+            }
         }
 
         let semantic_selection = SemanticSelection::as_ref(ctx);
@@ -17417,7 +17439,7 @@ impl TerminalView {
     fn clear_buffer(&mut self, ctx: &mut ViewContext<Self>) {
         let agent_view_state = self.agent_view_controller.as_ref(ctx).agent_view_state();
         let is_fullscreen_agent_view = agent_view_state.is_fullscreen();
-        let is_ambient_agent = self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent();
+        let is_ambient_agent = self.is_ambient_agent_session(ctx);
 
         // When in the modal agent view, "clear buffer" has special semantics.
         // Try to clear it specially, but if it wasn't successful, then clear normally.
@@ -19823,7 +19845,7 @@ impl TerminalView {
                     if self
                         .agent_view_controller
                         .as_ref(ctx)
-                        .can_exit_agent_view(ctx)
+                        .can_exit_agent_view()
                         .is_err()
                     {
                         return;
@@ -19838,9 +19860,10 @@ impl TerminalView {
                     {
                         // During first-time setup, always exit directly without confirmation
                         // since the setup overlay would obscure any confirmation dialog.
-                        let ambient_agent_view = self.ambient_agent_view_model.as_ref(ctx);
-                        let is_in_setup = ambient_agent_view.is_ambient_agent()
-                            && ambient_agent_view.is_in_setup();
+                        let is_in_setup = self
+                            .ambient_agent_view_model
+                            .as_ref()
+                            .is_some_and(|model| model.as_ref(ctx).is_in_setup());
                         if !is_in_setup && !self.input.as_ref(ctx).buffer_text(ctx).is_empty() {
                             self.agent_view_controller.update(ctx, |session, ctx| {
                                 session.exit_agent_view_with_required_confirmation(
@@ -25392,9 +25415,11 @@ impl TypedActionView for TerminalView {
                 ctx.notify();
             }
             CancelAmbientAgentTask => {
-                self.ambient_agent_view_model.update(ctx, |model, ctx| {
-                    model.cancel_task(ctx);
-                });
+                if let Some(ambient_agent_view_model) = self.ambient_agent_view_model.as_ref() {
+                    ambient_agent_view_model.update(ctx, |model, ctx| {
+                        model.cancel_task(ctx);
+                    });
+                }
                 ctx.notify();
             }
             ToggleUsageFooter => {
@@ -25490,7 +25515,7 @@ impl View for TerminalView {
                         .with_child(column.finish())
                 } else {
                     let output_area = if (model.shared_session_status().is_view_pending()
-                        && !self.ambient_agent_view_model.as_ref(app).is_ambient_agent())
+                        && !self.is_ambient_agent_session(app))
                         || model.is_loading_conversation_transcript()
                     {
                         self.render_viewer_loading(app)
@@ -25520,7 +25545,7 @@ impl View for TerminalView {
                         column.add_child(self.render_input());
                     } else if !model.is_read_only()
                         && is_cloud_agent_pre_first_exchange(
-                            &self.ambient_agent_view_model,
+                            self.ambient_agent_view_model.as_ref(),
                             &self.agent_view_controller,
                             app,
                         )
@@ -25552,9 +25577,8 @@ impl View for TerminalView {
             // Show progress steps while waiting for an ambient agent to start.
             if self
                 .ambient_agent_view_model
-                .as_ref(app)
-                .agent_progress()
-                .is_some()
+                .as_ref()
+                .is_some_and(|model| model.as_ref(app).agent_progress().is_some())
             {
                 stack.add_child(self.render_ambient_agent_progress(appearance, app));
             }
@@ -25878,7 +25902,11 @@ impl View for TerminalView {
         }
 
         // Render first-time cloud agent setup view when in Setup status
-        if self.ambient_agent_view_model.as_ref(app).is_in_setup() {
+        if self
+            .ambient_agent_view_model
+            .as_ref()
+            .is_some_and(|model| model.as_ref(app).is_in_setup())
+        {
             stack.add_child(ChildView::new(&self.first_time_cloud_agent_setup_view).finish());
         }
 
@@ -26052,10 +26080,7 @@ impl View for TerminalView {
             }
         }
 
-        let ambient_agent_view_model = self.ambient_agent_view_model.as_ref(app);
-        if ambient_agent_view_model.is_ambient_agent()
-            && !ambient_agent_view_model.has_parent_terminal()
-        {
+        if self.is_ambient_agent_session(app) && !self.is_nested_cloud_mode(app) {
             context.set.insert(init::ROOT_CLOUD_MODE_PANE_KEY);
         }
 

--- a/app/src/terminal/view/ambient_agent/block/entry.rs
+++ b/app/src/terminal/view/ambient_agent/block/entry.rs
@@ -50,8 +50,15 @@ impl AmbientAgentEntryBlock {
         pane_stack: WeakModelHandle<PaneStack<TerminalView>>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        let view_model = terminal_view.as_ref(ctx).ambient_agent_view_model().clone();
-        ctx.subscribe_to_model(&view_model, Self::handle_ambient_agent_view_model_event);
+        if let Some(view_model) = terminal_view
+            .as_ref(ctx)
+            .ambient_agent_view_model()
+            .cloned()
+        {
+            ctx.subscribe_to_model(&view_model, Self::handle_ambient_agent_view_model_event);
+        } else {
+            log::warn!("AmbientAgentEntryBlock created without an ambient agent view model");
+        }
 
         let pane_configuration = terminal_view.as_ref(ctx).pane_configuration().clone();
         ctx.subscribe_to_model(&pane_configuration, Self::handle_pane_configuration_event);
@@ -108,17 +115,20 @@ impl AmbientAgentEntryBlock {
             .unwrap_or_else(|| "New cloud agent".to_owned())
     }
 
-    fn ambient_agent_view_model<'a>(&self, app: &'a AppContext) -> &'a AmbientAgentViewModel {
+    fn ambient_agent_view_model<'a>(
+        &self,
+        app: &'a AppContext,
+    ) -> Option<&'a AmbientAgentViewModel> {
         self.terminal_view
             .as_ref(app)
             .ambient_agent_view_model()
-            .as_ref(app)
+            .map(|model| model.as_ref(app))
     }
 
     /// Gets the detail text to display based on the ambient agent status.
     fn detail_text(&self, app: &AppContext) -> Option<&'static str> {
-        match self.ambient_agent_view_model(app).status() {
-            Status::NotAmbientAgent | Status::Setup | Status::Composing => None,
+        match self.ambient_agent_view_model(app)?.status() {
+            Status::Setup | Status::Composing => None,
             Status::WaitingForSession { .. } => Some("Starting environment..."),
             Status::AgentRunning => Some("Agent is working on task"),
             Status::Failed { .. } => Some("Agent failed"),
@@ -135,7 +145,9 @@ impl AmbientAgentEntryBlock {
     ) -> Box<dyn warpui::Element> {
         let theme = appearance.theme();
 
-        let view_model = self.ambient_agent_view_model(app);
+        let Some(view_model) = self.ambient_agent_view_model(app) else {
+            return Empty::new().finish();
+        };
         let (icon, color) = if view_model.is_failed() {
             (Icon::AlertTriangle, theme.ui_error_color())
         } else if view_model.is_needs_github_auth() {

--- a/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
+++ b/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
@@ -146,7 +146,7 @@ impl View for CloudModeSetupTextBlock {
                 .with_child(
                     Text::new(
                         if is_cloud_agent_pre_first_exchange(
-                            &self.ambient_agent_view_model,
+                            Some(&self.ambient_agent_view_model),
                             &self.agent_view_controller,
                             app,
                         ) {

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -64,7 +64,14 @@ pub fn create_cloud_mode_view(
 
     // Subscribe to the ambient agent view model to join the session once it's ready.
     // This ensures that we use the manager corresponding to this specific view.
-    let view_model = terminal_view.as_ref(ctx).ambient_agent_view_model().clone();
+    let Some(view_model) = terminal_view
+        .as_ref(ctx)
+        .ambient_agent_view_model()
+        .cloned()
+    else {
+        log::warn!("Cloud mode view was created without an ambient agent view model");
+        return (terminal_view, terminal_manager);
+    };
     terminal_manager.update(ctx, |_, ctx| {
         ctx.subscribe_to_model(&view_model, move |manager, event, ctx| {
             if let AmbientAgentViewModelEvent::SessionReady { session_id } = event {
@@ -85,13 +92,17 @@ pub fn create_cloud_mode_view(
 /// received yet. In this state, we hide the interactive input and render a loading footer
 /// instead.
 pub fn is_cloud_agent_pre_first_exchange(
-    ambient_agent_view_model: &ModelHandle<AmbientAgentViewModel>,
+    ambient_agent_view_model: Option<&ModelHandle<AmbientAgentViewModel>>,
     agent_view_controller: &ModelHandle<AgentViewController>,
     app: &AppContext,
 ) -> bool {
     if !(FeatureFlag::CloudMode.is_enabled() && FeatureFlag::AgentView.is_enabled()) {
         return false;
     }
+
+    let Some(ambient_agent_view_model) = ambient_agent_view_model else {
+        return false;
+    };
 
     if !matches!(
         ambient_agent_view_model.as_ref(app).status(),

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -49,8 +49,6 @@ pub struct AgentProgress {
 /// Status of the ambient agent run.
 #[derive(Debug, Clone)]
 pub enum Status {
-    /// Not in an ambient agent session.
-    NotAmbientAgent,
     /// First-time environment setup for cloud agents.
     Setup,
     /// The user is composing their ambient agent prompt.
@@ -84,11 +82,6 @@ pub struct AmbientAgentViewModel {
     /// The terminal view this model is part of.
     terminal_view_id: EntityId,
 
-    /// Whether this ambient agent view has a parent terminal view to return to.
-    /// `false` for standalone views (e.g., from "New Cloud Conversation").
-    /// `true` for nested views (pushed onto an existing terminal's pane stack).
-    has_parent_terminal: bool,
-
     /// Selected cloud environment to launch the ambient agent with.
     environment_id: Option<SyncId>,
 
@@ -120,11 +113,7 @@ pub struct AmbientAgentViewModel {
 }
 
 impl AmbientAgentViewModel {
-    pub fn new(
-        terminal_view_id: EntityId,
-        has_parent_terminal: bool,
-        ctx: &mut ModelContext<Self>,
-    ) -> Self {
+    pub fn new(terminal_view_id: EntityId, ctx: &mut ModelContext<Self>) -> Self {
         ctx.subscribe_to_model(&CloudModel::handle(ctx), |me, event, ctx| {
             me.handle_cloud_model_event(event, ctx);
         });
@@ -140,10 +129,9 @@ impl AmbientAgentViewModel {
         let ui_state = AmbientAgentProgressUIState::new(ctx);
 
         Self {
-            status: Status::NotAmbientAgent,
+            status: Status::Composing,
             request: None,
             terminal_view_id,
-            has_parent_terminal,
             environment_id: None,
             progress_timer_handle: None,
             ui_state,
@@ -297,7 +285,7 @@ impl AmbientAgentViewModel {
 
     /// Whether or not this terminal session is for an ambient agent.
     pub fn is_ambient_agent(&self) -> bool {
-        !matches!(self.status, Status::NotAmbientAgent)
+        true
     }
 
     /// Returns the task ID for the current cloud agent task, if one has been spawned.
@@ -311,17 +299,6 @@ impl AmbientAgentViewModel {
 
     pub fn set_has_inserted_cloud_mode_user_query_block(&mut self, has_inserted: bool) {
         self.has_inserted_cloud_mode_user_query_block = has_inserted;
-    }
-
-    /// Returns whether this ambient agent view has a parent terminal to return to.
-    pub fn has_parent_terminal(&self) -> bool {
-        self.has_parent_terminal
-    }
-
-    /// Sets whether this ambient agent view has a parent terminal to return to.
-    /// This should be called when pushing the view onto an existing pane stack.
-    pub fn set_has_parent_terminal(&mut self, has_parent: bool) {
-        self.has_parent_terminal = has_parent;
     }
 
     /// Whether or not this terminal session is in the setup state (first-time environment creation).
@@ -420,9 +397,7 @@ impl AmbientAgentViewModel {
         // Store the task ID for later use
         self.task_id = Some(task_id);
 
-        if matches!(self.status, Status::NotAmbientAgent) {
-            self.status = Status::AgentRunning;
-        }
+        self.status = Status::AgentRunning;
 
         // Fetch the task so we can set the correct environment (instead of defaulting to the most
         // recently-used one) and the correct harness (so non-oz viewers know to use the
@@ -456,9 +431,9 @@ impl AmbientAgentViewModel {
         &self.status
     }
 
-    /// Reset the status back to NotAmbientAgent.
-    pub fn reset_status(&mut self, ctx: &mut ModelContext<Self>) {
-        self.status = Status::NotAmbientAgent;
+    /// Reset cloud-specific prompt state so a retained cloud view can compose a new task.
+    pub fn reset_for_new_cloud_prompt(&mut self, ctx: &mut ModelContext<Self>) {
+        self.status = Status::Composing;
         self.environment_id = None;
         self.task_id = None;
         self.conversation_id = None;
@@ -801,7 +776,7 @@ impl AmbientAgentViewModel {
 
         // Extract or create progress tracking.
         let progress = if let Status::WaitingForSession { mut progress } =
-            std::mem::replace(&mut self.status, Status::NotAmbientAgent)
+            std::mem::replace(&mut self.status, Status::Composing)
         {
             progress.stopped_at = Some(now);
             progress
@@ -835,7 +810,7 @@ impl AmbientAgentViewModel {
 
         // Extract or create progress tracking.
         let progress = if let Status::WaitingForSession { mut progress } =
-            std::mem::replace(&mut self.status, Status::NotAmbientAgent)
+            std::mem::replace(&mut self.status, Status::Composing)
         {
             progress.stopped_at = Some(now);
             progress
@@ -866,7 +841,7 @@ impl AmbientAgentViewModel {
 
         // Extract or create progress tracking.
         let progress = if let Status::WaitingForSession { mut progress } =
-            std::mem::replace(&mut self.status, Status::NotAmbientAgent)
+            std::mem::replace(&mut self.status, Status::Composing)
         {
             progress.stopped_at = Some(now);
             progress

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -97,6 +97,10 @@ impl TerminalView {
         event: &AmbientAgentViewModelEvent,
         ctx: &mut ViewContext<Self>,
     ) {
+        let Some(ambient_agent_view_model) = self.ambient_agent_view_model.clone() else {
+            return;
+        };
+
         // Tear down the non-oz cloud-mode queued-prompt block on terminal / transition
         // events that replace it. `Failed`, `NeedsGithubAuth`, and `Cancelled` hand off
         // to the existing error / auth / cancelled UI; `HarnessCommandStarted` hands
@@ -135,16 +139,14 @@ impl TerminalView {
                     return;
                 }
                 if FeatureFlag::CloudModeSetupV2.is_enabled() {
-                    if self
-                        .ambient_agent_view_model
+                    if ambient_agent_view_model
                         .as_ref(ctx)
                         .is_third_party_harness()
                     {
                         // Non-oz runs: render the submitted prompt via the queued-prompt UI.
                         // The block is removed later by `HarnessCommandStarted` / failure /
                         // cancel / auth handlers.
-                        let prompt = self
-                            .ambient_agent_view_model
+                        let prompt = ambient_agent_view_model
                             .as_ref(ctx)
                             .request()
                             .map(|request| request.prompt.clone())
@@ -154,10 +156,7 @@ impl TerminalView {
                         }
                     } else {
                         let initial_user_query = ctx.add_view(|ctx| {
-                            CloudModeInitialUserQuery::new(
-                                self.ambient_agent_view_model.clone(),
-                                ctx,
-                            )
+                            CloudModeInitialUserQuery::new(ambient_agent_view_model.clone(), ctx)
                         });
                         self.insert_rich_content(
                             None,
@@ -168,14 +167,13 @@ impl TerminalView {
                             },
                             ctx,
                         );
-                        self.ambient_agent_view_model.update(ctx, |model, _| {
+                        ambient_agent_view_model.update(ctx, |model, _| {
                             model.set_has_inserted_cloud_mode_user_query_block(true);
                         });
                     }
                 } else {
                     // Reset tip cooldown so the first tip shows for 60 seconds
-                    let tip_model = self
-                        .ambient_agent_view_model
+                    let tip_model = ambient_agent_view_model
                         .as_ref(ctx)
                         .ui_state
                         .tip_model
@@ -196,8 +194,7 @@ impl TerminalView {
             AmbientAgentViewModelEvent::EnvironmentSelected => {}
             AmbientAgentViewModelEvent::ProgressUpdated => {
                 // Refresh the tip (respects 60s cooldown internally)
-                let tip_model = self
-                    .ambient_agent_view_model
+                let tip_model = ambient_agent_view_model
                     .as_ref(ctx)
                     .ui_state
                     .tip_model
@@ -224,7 +221,7 @@ impl TerminalView {
             }
             AmbientAgentViewModelEvent::ShowCloudAgentCapacityModal => {
                 if FeatureFlag::CloudMode.is_enabled()
-                    && self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent()
+                    && ambient_agent_view_model.as_ref(ctx).is_ambient_agent()
                     && !self.model.lock().is_shared_ambient_agent_session()
                 {
                     ctx.emit(crate::terminal::view::Event::ShowCloudAgentCapacityModal {
@@ -236,7 +233,7 @@ impl TerminalView {
             }
             AmbientAgentViewModelEvent::ShowAICreditModal => {
                 if FeatureFlag::CloudMode.is_enabled()
-                    && self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent()
+                    && ambient_agent_view_model.as_ref(ctx).is_ambient_agent()
                     && !self.model.lock().is_shared_ambient_agent_session()
                 {
                     self.show_out_of_credits_modal(ctx);
@@ -292,7 +289,7 @@ impl TerminalView {
                     }
                 }
                 // Collapse the setup-commands summary, matching the oz first-exchange behavior.
-                self.ambient_agent_view_model.update(ctx, |model, ctx| {
+                ambient_agent_view_model.update(ctx, |model, ctx| {
                     model.set_setup_command_visibility(false, ctx);
                 });
                 // Force a fresh viewer size report to the sharer so the harness CLI (e.g.
@@ -314,8 +311,12 @@ impl TerminalView {
             return;
         }
 
+        let Some(ambient_agent_view_model) = self.ambient_agent_view_model.clone() else {
+            return;
+        };
+
         if !is_cloud_agent_pre_first_exchange(
-            &self.ambient_agent_view_model,
+            self.ambient_agent_view_model.as_ref(),
             &self.agent_view_controller,
             ctx,
         ) {
@@ -327,13 +328,12 @@ impl TerminalView {
         // and should NOT be classified as a setup command; the `HarnessCommandStarted`
         // handler flips the block-list flag so the block renders like a normal CLI-agent
         // session.
-        if self
-            .ambient_agent_view_model
+        if ambient_agent_view_model
             .as_ref(ctx)
             .is_third_party_harness()
             && self.active_block_matches_run_harness(ctx)
         {
-            self.ambient_agent_view_model.update(ctx, |model, ctx| {
+            ambient_agent_view_model.update(ctx, |model, ctx| {
                 model.mark_harness_command_started(ctx);
             });
             return;
@@ -343,13 +343,12 @@ impl TerminalView {
             return;
         };
 
-        if !self
-            .ambient_agent_view_model
+        if !ambient_agent_view_model
             .as_ref(ctx)
             .setup_command_state()
             .did_execute_a_setup_command()
         {
-            self.ambient_agent_view_model.update(ctx, |model, _| {
+            ambient_agent_view_model.update(ctx, |model, _| {
                 model
                     .setup_command_state_mut()
                     .set_did_execute_a_setup_command(true);
@@ -357,7 +356,7 @@ impl TerminalView {
 
             let setup_command_text = ctx.add_typed_action_view(|ctx| {
                 super::CloudModeSetupTextBlock::new(
-                    self.ambient_agent_view_model.clone(),
+                    ambient_agent_view_model.clone(),
                     self.agent_view_controller.clone(),
                     ctx,
                 )
@@ -374,7 +373,7 @@ impl TerminalView {
         let setup_command_block = ctx.add_typed_action_view(|ctx| {
             super::CloudModeSetupCommandBlock::new(
                 block_id.clone(),
-                self.ambient_agent_view_model.clone(),
+                ambient_agent_view_model.clone(),
                 &self.model_events_handle,
                 self.model.clone(),
                 ctx,
@@ -420,8 +419,10 @@ impl TerminalView {
         {
             return;
         }
-        if !self
-            .ambient_agent_view_model
+        let Some(ambient_agent_view_model) = self.ambient_agent_view_model.as_ref() else {
+            return;
+        };
+        if !ambient_agent_view_model
             .as_ref(ctx)
             .is_third_party_harness()
         {
@@ -483,7 +484,10 @@ impl TerminalView {
         let Some(cli_agent) = CLIAgent::detect(&command, None, None, ctx) else {
             return false;
         };
-        match self.ambient_agent_view_model.as_ref(ctx).selected_harness() {
+        let Some(ambient_agent_view_model) = self.ambient_agent_view_model.as_ref() else {
+            return false;
+        };
+        match ambient_agent_view_model.as_ref(ctx).selected_harness() {
             Harness::Oz => false,
             Harness::Claude => matches!(cli_agent, CLIAgent::Claude),
             Harness::OpenCode => matches!(cli_agent, CLIAgent::OpenCode),
@@ -503,15 +507,15 @@ impl TerminalView {
         initial_prompt: Option<String>,
         ctx: &mut ViewContext<Self>,
     ) {
-        let ambient_agent_view = self.ambient_agent_view_model.as_ref(ctx);
-        let is_nested_cloud_mode =
-            ambient_agent_view.is_ambient_agent() && ambient_agent_view.has_parent_terminal();
+        let is_nested_cloud_mode = self.is_nested_cloud_mode(ctx);
 
         // (1) If we're currently in an empty cloud mode session (setup/composing; no
         // dispatched query yet), do not allow creating a new cloud mode session.
         if is_nested_cloud_mode
-            && (ambient_agent_view.is_in_setup()
-                || ambient_agent_view.is_configuring_ambient_agent())
+            && self.ambient_agent_view_model.as_ref().is_some_and(|model| {
+                let model = model.as_ref(ctx);
+                model.is_in_setup() || model.is_configuring_ambient_agent()
+            })
         {
             return;
         }
@@ -616,7 +620,14 @@ impl TerminalView {
         // Only insert an ambient agent entry block once the agent is actually dispatched.
         // This avoids persisting an empty "New cloud agent" entry when the user enters cloud mode
         // but exits without sending anything.
-        let ambient_agent_view_model = terminal_view.as_ref(ctx).ambient_agent_view_model().clone();
+        let Some(ambient_agent_view_model) = terminal_view
+            .as_ref(ctx)
+            .ambient_agent_view_model()
+            .cloned()
+        else {
+            log::warn!("Cloud mode view was created without an ambient agent view model");
+            return;
+        };
         let terminal_view_weak = terminal_view.downgrade();
         let terminal_manager_weak = terminal_manager.downgrade();
         let pane_stack = self.pane_stack.clone();
@@ -669,13 +680,9 @@ impl TerminalView {
         });
 
         let pane_config = self.pane_configuration.clone();
+        let ambient_agent_view_model_for_update = ambient_agent_view_model.clone();
         terminal_view.update(ctx, |view, ctx| {
             view.set_pane_configuration(pane_config);
-
-            // Mark as having a parent since it's pushed onto an existing pane stack
-            view.ambient_agent_view_model.update(ctx, |model, _ctx| {
-                model.set_has_parent_terminal(true);
-            });
 
             if let Some(request) = spawn_request {
                 // Spawn the agent immediately with the provided request.
@@ -684,7 +691,7 @@ impl TerminalView {
                     AgentViewEntryOrigin::CloudAgent,
                     ctx,
                 );
-                view.ambient_agent_view_model.update(ctx, |model, ctx| {
+                ambient_agent_view_model_for_update.update(ctx, |model, ctx| {
                     model.spawn_agent_with_request(request, ctx);
                 });
             } else {
@@ -719,7 +726,10 @@ impl TerminalView {
         appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
-        let ambient_agent_model = self.ambient_agent_view_model.as_ref(app);
+        let Some(ambient_agent_view_model) = self.ambient_agent_view_model.as_ref() else {
+            return Empty::new().finish();
+        };
+        let ambient_agent_model = ambient_agent_view_model.as_ref(app);
         let Some(progress) = ambient_agent_model.agent_progress() else {
             return Empty::new().finish();
         };
@@ -782,10 +792,12 @@ impl TerminalView {
             }
             super::FirstTimeCloudAgentSetupViewEvent::EnvironmentCreated => {
                 // Set the environment on the ambient agent view model
-                self.ambient_agent_view_model.update(ctx, |model, ctx| {
-                    // Transition from Setup to Composing
-                    model.enter_composing_from_setup(ctx);
-                });
+                if let Some(ambient_agent_view_model) = self.ambient_agent_view_model.as_ref() {
+                    ambient_agent_view_model.update(ctx, |model, ctx| {
+                        // Transition from Setup to Composing
+                        model.enter_composing_from_setup(ctx);
+                    });
+                }
 
                 // Focus the input box so user can start typing
                 self.focus_input_box(ctx);

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -193,7 +193,7 @@ impl TerminalView {
         // In cloud mode, we want to preserve the shared session sharing dialog even after the shared session has ended.
         // We need this to be able to view and change permissions on a cloud mode shared session that failed before
         // any conversation started, to view cloud mode sessions that failed during setup.
-        let is_ambient_agent = self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent();
+        let is_ambient_agent = self.is_ambient_agent_session(ctx);
         if !is_ambient_agent {
             let shareable_object = self.agent_view_shareable_object(ctx);
             self.pane_configuration.update(ctx, |pane_config, ctx| {
@@ -238,11 +238,10 @@ impl TerminalView {
             .and_then(|h| h.upgrade(app))
             .is_some_and(|stack| stack.as_ref(app).depth() > 1);
 
-        let ambient_agent_view = self.ambient_agent_view_model.as_ref(app);
         let is_transcript_viewer = self.model.lock().is_conversation_transcript_viewer();
-        let has_parent_terminal = (ambient_agent_view.is_ambient_agent()
-            && ambient_agent_view.has_parent_terminal())
-            || (!ambient_agent_view.is_ambient_agent() && !is_transcript_viewer);
+        let is_ambient_agent = self.is_ambient_agent_session(app);
+        let has_parent_terminal = (is_ambient_agent && self.is_nested_cloud_mode(app))
+            || (!is_ambient_agent && !is_transcript_viewer);
         let is_fullscreen_agent_view = self.agent_view_controller.as_ref(app).is_fullscreen();
 
         if in_nav_stack || (is_fullscreen_agent_view && has_parent_terminal) {
@@ -393,10 +392,11 @@ impl TerminalView {
         let mut icon_button_count: u32 = 0;
 
         if FeatureFlag::CloudMode.is_enabled() {
-            let ambient_agent_model = self.ambient_agent_view_model.as_ref(app);
-            let button_element = if ambient_agent_model.is_ambient_agent()
-                && ambient_agent_model.is_waiting_for_session()
-            {
+            let is_waiting_for_session = self
+                .ambient_agent_view_model
+                .as_ref()
+                .is_some_and(|model| model.as_ref(app).is_waiting_for_session());
+            let button_element = if is_waiting_for_session {
                 Some(self.render_ambient_agent_cancel_button(app))
             } else if self.can_show_cloud_mode_details_ui(app) {
                 #[cfg(not(target_arch = "wasm32"))]
@@ -586,8 +586,7 @@ impl BackingView for TerminalView {
 
         // Shared-session related items.
         let shared_session_status = model.shared_session_status();
-        let is_ambient_agent = FeatureFlag::CloudMode.is_enabled()
-            && self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent();
+        let is_ambient_agent = self.is_ambient_agent_session(ctx);
         if shared_session_status.is_sharer_or_viewer() {
             if !is_ambient_agent {
                 items.push(
@@ -779,8 +778,7 @@ impl TerminalView {
         let theme = appearance.theme();
 
         // Check if we're configuring or waiting on an ambient agent
-        let is_ambient_agent = FeatureFlag::CloudMode.is_enabled()
-            && self.ambient_agent_view_model.as_ref(app).is_ambient_agent();
+        let is_ambient_agent = self.is_ambient_agent_session(app);
 
         // When a long-running command is active, show InProgress
         // instead of the conversation's actual status.
@@ -940,7 +938,10 @@ impl TerminalView {
 
     pub fn is_ambient_agent_session(&self, ctx: &AppContext) -> bool {
         FeatureFlag::CloudMode.is_enabled()
-            && self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent()
+            && self
+                .ambient_agent_view_model
+                .as_ref()
+                .is_some_and(|model| model.as_ref(ctx).is_ambient_agent())
     }
 
     fn selected_conversation_for_user_facing_chrome<'a>(

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -606,7 +606,7 @@ impl TerminalView {
         });
 
         // Mark this terminal as a viewer for chips and AI context menu once on join
-        let is_ambient = self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent();
+        let is_ambient = self.is_ambient_agent_session(ctx);
         self.input().update(ctx, |input, ctx| {
             input
                 .prompt_render_helper
@@ -704,7 +704,7 @@ impl TerminalView {
         }
 
         // For ambient agent tasks, preserve the shareable object so the share dialog remains visible
-        let is_ambient_agent = self.ambient_agent_view_model.as_ref(ctx).is_ambient_agent();
+        let is_ambient_agent = self.is_ambient_agent_session(ctx);
         let shareable_object_to_keep = if is_ambient_agent {
             self.shared_session
                 .as_ref()

--- a/app/src/terminal/view/testing.rs
+++ b/app/src/terminal/view/testing.rs
@@ -32,6 +32,16 @@ impl TerminalView {
         restored_blocks: Option<&[SerializedBlockListItem]>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
+        Self::new_for_test_with_cloud_mode(tips_model, restored_blocks, false, ctx)
+    }
+
+    #[cfg(test)]
+    pub fn new_for_test_with_cloud_mode(
+        tips_model: ModelHandle<TipsCompleted>,
+        restored_blocks: Option<&[SerializedBlockListItem]>,
+        is_cloud_mode: bool,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
         use pathfinder_geometry::vector::vec2f;
         use warpui::units::{IntoPixels as _, Pixels};
 
@@ -110,6 +120,7 @@ impl TerminalView {
             None,
             None, // conversation_restoration - not used for test
             None, // inactive_pty_reads_rx - not used for test
+            is_cloud_mode,
             ctx,
         )
     }

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -4,7 +4,9 @@ use std::rc::Rc;
 
 use crate::ai::agent::conversation::ConversationStatus;
 use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
-use warpui::{notification::UserNotification, Presenter, WindowInvalidation};
+use warpui::{
+    notification::UserNotification, platform::WindowStyle, Presenter, WindowInvalidation,
+};
 
 use crate::ai::agent::task::TaskId;
 use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
@@ -53,6 +55,14 @@ use crate::test_util::terminal::initialize_app_for_terminal_view;
 use crate::test_util::{add_window_with_terminal, assert_eventually};
 
 use super::*;
+
+fn add_window_with_cloud_mode_terminal(app: &mut App) -> ViewHandle<TerminalView> {
+    let tips_model = app.add_model(|_| Default::default());
+    let (_, terminal) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+        TerminalView::new_for_test_with_cloud_mode(tips_model, None, true, ctx)
+    });
+    terminal
+}
 
 /// Test to verify that blocks created through normal execution
 /// have the correct local status set
@@ -329,26 +339,77 @@ fn command_first_word_and_suffix_handles_alias_without_args() {
 
 #[test]
 fn root_cloud_mode_pane_sets_root_cloud_mode_context_key() {
+    use std::any::Any;
+    use std::sync::Arc;
+
+    use parking_lot::FairMutex;
+
+    use crate::pane_group::pane::PaneStack;
     use crate::settings::import::model::ImportedConfigModel;
+    use crate::terminal::{TerminalManager, TerminalModel};
+
+    struct TestTerminalManager {
+        model: Arc<FairMutex<TerminalModel>>,
+        view: ViewHandle<TerminalView>,
+    }
+
+    impl TerminalManager for TestTerminalManager {
+        fn model(&self) -> Arc<FairMutex<TerminalModel>> {
+            self.model.clone()
+        }
+
+        fn view(&self) -> ViewHandle<TerminalView> {
+            self.view.clone()
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         app.add_singleton_model(ImportedConfigModel::new);
         FeatureFlag::AgentView.set_enabled(true);
         FeatureFlag::CloudMode.set_enabled(true);
 
-        let terminal = add_window_with_terminal(&mut app, None);
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        let nested_terminal = add_window_with_cloud_mode_terminal(&mut app);
 
         terminal.read(&app, |view, ctx| {
-            assert!(!view
+            assert!(view
                 .keymap_context(ctx)
                 .set
                 .contains(init::ROOT_CLOUD_MODE_PANE_KEY));
         });
 
-        terminal.update(&mut app, |view, ctx| {
-            view.ambient_agent_view_model().update(ctx, |model, ctx| {
-                model.enter_setup(ctx);
+        let root_view = terminal.clone();
+        let nested_view = nested_terminal.clone();
+        let root_model = terminal.read(&app, |view, _| view.model.clone());
+        let nested_model = nested_terminal.read(&app, |view, _| view.model.clone());
+        let _pane_stack = app.update(move |ctx| {
+            let root_manager = ctx.add_model(|_| {
+                let manager: Box<dyn TerminalManager> = Box::new(TestTerminalManager {
+                    model: root_model,
+                    view: root_view.clone(),
+                });
+                manager
             });
+            let nested_manager = ctx.add_model(|_| {
+                let manager: Box<dyn TerminalManager> = Box::new(TestTerminalManager {
+                    model: nested_model,
+                    view: nested_view.clone(),
+                });
+                manager
+            });
+            let pane_stack = ctx.add_model(|ctx| PaneStack::new(root_manager, root_view, ctx));
+            pane_stack.update(ctx, |stack, ctx| {
+                stack.push(nested_manager, nested_view, ctx);
+            });
+            pane_stack
         });
 
         terminal.read(&app, |view, ctx| {
@@ -358,13 +419,7 @@ fn root_cloud_mode_pane_sets_root_cloud_mode_context_key() {
                 .contains(init::ROOT_CLOUD_MODE_PANE_KEY));
         });
 
-        terminal.update(&mut app, |view, ctx| {
-            view.ambient_agent_view_model().update(ctx, |model, _| {
-                model.set_has_parent_terminal(true);
-            });
-        });
-
-        terminal.read(&app, |view, ctx| {
+        nested_terminal.read(&app, |view, ctx| {
             assert!(!view
                 .keymap_context(ctx)
                 .set
@@ -382,12 +437,14 @@ fn set_input_mode_agent_does_not_enter_local_agent_from_root_cloud_mode_pane() {
         FeatureFlag::AgentView.set_enabled(true);
         FeatureFlag::CloudMode.set_enabled(true);
 
-        let terminal = add_window_with_terminal(&mut app, None);
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
 
         terminal.update(&mut app, |view, ctx| {
-            view.ambient_agent_view_model().update(ctx, |model, ctx| {
-                model.enter_setup(ctx);
-            });
+            view.ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .update(ctx, |model, ctx| {
+                    model.enter_setup(ctx);
+                });
             view.model
                 .lock()
                 .set_shared_session_status(SharedSessionStatus::FinishedViewer);

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -1225,8 +1225,7 @@ fn find_cloud_mode_terminal_in_workspace(
                     terminal_view
                         .as_ref(ctx)
                         .ambient_agent_view_model()
-                        .as_ref(ctx)
-                        .is_ambient_agent()
+                        .is_some()
                         .then_some(terminal_view.id())
                 });
 

--- a/specs/APP-4274/TECH.md
+++ b/specs/APP-4274/TECH.md
@@ -1,0 +1,118 @@
+# Refactor AmbientAgentViewModel to be cloud-agent scoped
+Linear: APP-4274
+## Context
+This refactor simplifies the relationship between `AmbientAgentViewModel`, `AgentViewController`, and cloud-mode terminal views.
+Before the change, `AmbientAgentViewModel` existed more broadly than its actual responsibility. It represented cloud-agent-specific state, but it could also be present in local/non-cloud agent flows, which made `TerminalView`, `Input`, and `AgentViewController` look like they all owned parallel pieces of agent state. This made it unclear which abstraction was the source of truth for local Agent View state, cloud-agent lifecycle state, root vs nested cloud-mode navigation state, and cloud-only UI like harness selection and ambient progress.
+The final model is:
+- `AgentViewController` owns local/fullscreen/inline Agent View conversation state.
+- `AmbientAgentViewModel` owns cloud-agent conversation/session state only.
+- `TerminalView` optionally has an `AmbientAgentViewModel` only when the terminal represents cloud mode.
+- Root vs nested cloud mode is derived from `PaneStack`, not stored as parallel navigation state.
+Relevant files:
+- `app/src/terminal/view.rs:2849` — `TerminalView::is_nested_cloud_mode`
+- `app/src/terminal/view.rs:2970` — `TerminalView::new(..., is_cloud_mode: bool, ...)`
+- `app/src/terminal/input.rs:1660` — `Input.ambient_agent_view_state`
+- `app/src/terminal/input.rs:1669` — private `AmbientAgentViewState`
+- `app/src/terminal/input.rs:2176` — construction of `AmbientAgentViewState`
+- `app/src/terminal/view/pane_impl.rs:939` — `TerminalView::is_ambient_agent_session`
+- `app/src/terminal/view/ambient_agent/model.rs:77` — `AmbientAgentViewModel`
+- `app/src/terminal/view_test.rs:338` — root/nested cloud-mode keymap regression test
+## Goals
+Make `AmbientAgentViewModel` cloud-scoped, avoid constructing dummy ambient models for local/non-cloud Agent View flows, keep cloud-agent state attached to the terminal/view entry for the cloud conversation, remove denormalized cloud navigation state from `TerminalView`, make the schema encode invariants around cloud-only UI state, and preserve cloud setup, composing, spawning, shared-session viewer, progress, and cancellation flows.
+## Non-goals
+This does not redesign `AgentViewController`, change local Agent View behavior except by removing ambient-model coupling, change cloud-agent server APIs or task spawning semantics, or change `PaneStack` ownership semantics.
+## Proposed changes
+### `AmbientAgentViewModel` is optional on `TerminalView`
+`TerminalView::new` takes `is_cloud_mode: bool` and constructs an ambient model only when that flag is true. Cloud-mode terminals get `Some(ModelHandle<AmbientAgentViewModel>)`; normal/local terminals get `None`.
+This makes the presence of `AmbientAgentViewModel` meaningful: if it exists, the terminal is capable of cloud-agent UI and lifecycle behavior.
+### `AgentViewController` no longer carries ambient model state
+`AgentViewController` remains responsible for Agent View entry/exit/conversation display state. Cloud-agent-specific progress, setup, harness, task, environment, and cancellation state lives in `AmbientAgentViewModel`.
+This removes the previous parallel-state ambiguity where local Agent View and ambient-agent state appeared coupled even when local flows did not need ambient state.
+### `AmbientAgentViewModel` represents only cloud-agent lifecycle state
+`AmbientAgentViewModel` starts in a cloud-relevant state (`Composing`) and tracks cloud-only concepts:
+- setup/composing/waiting/running/failure/cancelled status
+- selected cloud environment
+- selected harness
+- spawned task ID
+- cloud-agent request
+- progress timing
+- setup command state
+Because non-cloud terminals do not construct this model, the model no longer needs a “not ambient agent” status variant or parent-terminal bookkeeping.
+### `Input` groups ambient-only UI state
+`Input` now stores `ambient_agent_view_state: Option<AmbientAgentViewState>` instead of independent optional ambient-model and harness-selector fields.
+`AmbientAgentViewState` contains:
+- `view_model: ModelHandle<AmbientAgentViewModel>`
+- `harness_selector: ViewHandle<HarnessSelector>`
+The grouped state is constructed only when `ambient_agent_view_model` exists. This encodes the invariant directly: no ambient model means no harness selector, and if a harness selector exists then an ambient model exists.
+Accessors on `Input` preserve existing call-site ergonomics:
+- `ambient_agent_view_model()`
+- `harness_selector()`
+### Cloud navigation is derived from `PaneStack`
+The refactor removes `CloudAgentNavigation` and `TerminalView.cloud_agent_navigation`.
+`TerminalView::is_nested_cloud_mode` now checks:
+1. The terminal is an ambient/cloud session.
+2. The terminal has an owning `PaneStack`.
+3. The terminal’s view appears in the stack.
+4. The terminal is not the first entry.
+This makes `PaneStack` the source of truth:
+- first stack entry = root cloud-mode pane
+- later stack entries = nested cloud-mode panes
+- no stack = not nested
+This avoids stale cached navigation state and handles root/nested state consistently after push/pop. The important subtlety is that stack depth alone is insufficient: a root pane in a stack with depth greater than one is still root. The implementation checks the terminal’s actual position in the stack instead.
+### Root cloud-mode keymap context uses derived state
+The root cloud-mode key is set only when the terminal is an ambient/cloud session and is not nested according to `PaneStack`.
+This preserves the intended behavior for bindings like setting input mode to Agent Mode: root cloud-mode panes should not accidentally enter local Agent View.
+### Pane chrome and cloud-mode entry use derived nested state
+The pane header and cloud-agent entry paths now consult `is_nested_cloud_mode` instead of cached navigation state.
+Important behavior:
+- nested cloud-mode panes show parent/back navigation where appropriate
+- starting cloud mode from a nested cloud-mode pane can pop back to the parent and start a sibling run
+- root cloud-mode panes remain distinguishable from nested panes even when the stack depth is greater than one
+## End-to-end flow
+### Local/non-cloud Agent View
+1. `TerminalView::new(..., is_cloud_mode: false, ...)`
+2. `ambient_agent_view_model = None`
+3. `Input.ambient_agent_view_state = None`
+4. `AgentViewController` handles Agent View state
+5. Cloud-only UI/state is absent
+### Cloud-mode terminal
+1. `TerminalView::new(..., is_cloud_mode: true, ...)`
+2. `AmbientAgentViewModel` is constructed for that terminal view
+3. `Input` creates `AmbientAgentViewState`
+4. Cloud setup/composing/progress/cancellation use the ambient model
+5. Root vs nested navigation is derived from `PaneStack`
+### Nested cloud-mode pane
+1. A cloud-mode terminal is pushed onto a `PaneStack`
+2. `PaneStack::push` calls `TerminalView::set_pane_stack`
+3. `is_nested_cloud_mode` finds the terminal’s index in `PaneStack::entries`
+4. Index `> 0` means nested
+5. Keymap/chrome/cloud-entry behavior follows from that derived state
+## Review comment resolutions
+### Group `AmbientAgentViewModel` and `HarnessSelector`
+Resolved by introducing private `AmbientAgentViewState` in `Input`.
+This prevents impossible/ambiguous optional-state combinations and makes the schema match the real invariant.
+### Remove denormalized cloud navigation
+Resolved by removing `CloudAgentNavigation` and `TerminalView.cloud_agent_navigation`.
+Root/nested state now comes from the owning `PaneStack`.
+## Testing and validation
+Focused validation passed:
+- `cargo test -p warp root_cloud_mode_pane_sets_root_cloud_mode_context_key --features local_tty,local_fs`
+- `cargo test -p warp set_input_mode_agent_does_not_enter_local_agent_from_root_cloud_mode_pane --features local_tty,local_fs`
+- `cargo check -p warp --features local_tty,local_fs`
+The key regression test is `root_cloud_mode_pane_sets_root_cloud_mode_context_key` in `app/src/terminal/view_test.rs:338`.
+It verifies:
+1. A standalone cloud-mode terminal gets `ROOT_CLOUD_MODE_PANE_KEY`.
+2. After creating a `PaneStack`, the root terminal still gets the key.
+3. A pushed nested cloud-mode terminal does not get the key.
+The test keeps the `PaneStack` handle alive through assertions so `TerminalView`’s weak stack handle can upgrade during keymap evaluation.
+## Risks and mitigations
+### Optional ambient model requires many call sites to handle `None`
+Call sites use optional accessors or only pass the model into cloud-capable components when present. This makes non-cloud behavior explicit rather than hidden behind dummy state.
+### Deriving nested state from `PaneStack` could misclassify panes
+The helper checks stack membership and entry index, not only stack depth. This keeps root panes root even when they have nested children.
+### Cloud shared-session viewers still need ambient state
+Shared-session viewer construction passes `is_cloud_mode` through to `TerminalView::new`, so cloud-mode shared session viewers still construct `AmbientAgentViewModel`.
+## Follow-ups
+- Cloud UI verification requires pushing the branch so a cloud agent can build/test the changed client state.
+- If more cloud-only UI state is added to `Input`, it should live under `AmbientAgentViewState` rather than as independent optional fields.
+- If more root/nested cloud behavior appears, it should continue to derive from `PaneStack` rather than reintroducing cached navigation state.


### PR DESCRIPTION
## Description
Refactor AmbientAgentViewModel to remove NotAmbientAgent state and simplify semantics - presence of the model indicates that the parent view is rendering an ambient agent task.
