### PR TITLE
Open Profiles settings from Manage Profiles button

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3833,7 +3833,7 @@ impl Input {
                 });
             }
             InlineProfileSelectorEvent::ManageProfiles => {
-                ctx.emit(Event::OpenSettings(SettingsSection::WarpAgent));
+                ctx.emit(Event::OpenSettings(SettingsSection::AgentProfiles));
             }
             InlineProfileSelectorEvent::Dismissed => {
                 if self

--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -1825,7 +1825,7 @@ impl TypedActionView for ProfileModelSelector {
             ProfileModelSelectorAction::ManageProfiles => {
                 self.set_profile_menu_visibility(false, ctx);
                 ctx.emit(ProfileModelSelectorEvent::OpenSettings(
-                    SettingsSection::WarpAgent,
+                    SettingsSection::AgentProfiles,
                 ));
             }
             ProfileModelSelectorAction::ToggleProfileMenu => {


### PR DESCRIPTION
## Description
The "Manage profiles" option in the profile picker (in the agent view footer, and in the inline `/profile` selector) was opening the Warp Agent settings page instead of the Profiles subpage. This PR updates both call sites to navigate directly to `SettingsSection::AgentProfiles`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/d74cb06b-5442-4202-a7bd-990add2521e2_
_Run: https://oz.staging.warp.dev/runs/019dd5e1-2922-74f6-995b-87a027a9eb06_

_This PR was generated with [Oz](https://warp.dev/oz)._
