### PR TITLE
Fix Ctrl+G closing CLI agent rich input from editor

### DIFF
--- a/app/src/terminal/view/init.rs
+++ b/app/src/terminal/view/init.rs
@@ -333,11 +333,12 @@ pub fn init(app: &mut AppContext) {
         )
         .with_key_binding("ctrl-g")
         .with_context_predicate(
-            id!("Terminal")
+            (id!("Terminal")
                 & !id!("IMEOpen")
                 & (id!("LongRunningCommand") | id!("AltScreen"))
                 & id!(flags::CLI_AGENT_FOOTER_ENABLED)
-                & id!(flags::CLI_AGENT_RICH_INPUT_CHIP_ENABLED),
+                & id!(flags::CLI_AGENT_RICH_INPUT_CHIP_ENABLED))
+                | (id!("EditorView") & !id!("IMEOpen") & id!(flags::CLI_AGENT_RICH_INPUT_OPEN)),
         ),
         EditableBinding::new(
             "terminal:warpify_subshell",

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -3569,6 +3569,67 @@ fn open_cli_agent_rich_input_for_agent(app: &mut App, agent: CLIAgent) -> ViewHa
 }
 
 #[test]
+fn ctrl_g_closes_cli_agent_rich_input_when_editor_is_focused() {
+    App::test((), |mut app| async move {
+        use crate::settings::import::model::ImportedConfigModel;
+
+        initialize_app_for_terminal_view(&mut app);
+        app.add_singleton_model(ImportedConfigModel::new);
+        app.update(|ctx| {
+            crate::terminal::init(ctx);
+            crate::editor::init(ctx);
+        });
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cli_rich = FeatureFlag::CLIAgentRichInput.override_enabled(true);
+
+        let (window_id, terminal) = add_window_with_id_and_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            CLIAgentSessionsModel::handle(ctx).update(ctx, |sessions, ctx| {
+                sessions.set_session(
+                    view.view_id,
+                    CLIAgentSession {
+                        agent: CLIAgent::OpenCode,
+                        status: CLIAgentSessionStatus::InProgress,
+                        session_context: CLIAgentSessionContext::default(),
+                        input_state: CLIAgentInputState::Closed,
+                        should_auto_toggle_input: false,
+                        listener: None,
+                        remote_host: None,
+                        plugin_version: None,
+                        draft_text: None,
+                        custom_command_prefix: None,
+                    },
+                    ctx,
+                );
+            });
+
+            view.open_cli_agent_rich_input(CLIAgentInputEntrypoint::CtrlG, ctx);
+            assert!(view.has_active_cli_agent_input_session(ctx));
+        });
+
+        let (input_id, editor_id) = terminal.read(&app, |view, ctx| {
+            let input = view.input.clone();
+            let editor = input.as_ref(ctx).editor().clone();
+            (input.id(), editor.id())
+        });
+        let handled = app
+            .dispatch_keystroke(
+                window_id,
+                &[terminal.id(), input_id, editor_id],
+                &warpui::keymap::Keystroke::parse("ctrl-g").expect("valid keystroke"),
+                false,
+            )
+            .expect("dispatch should succeed");
+
+        assert!(handled, "ctrl-g should be handled from the focused editor");
+        terminal.read(&app, |view, ctx| {
+            assert!(!view.has_active_cli_agent_input_session(ctx));
+        });
+    })
+}
+
+#[test]
 fn cli_agent_rich_input_hint_text_mentions_active_cli_agent() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);


### PR DESCRIPTION
## Summary

Fixes #9286.

This updates the `terminal:open_cli_agent_rich_input` Ctrl+G binding so it can match while focus is inside the CLI agent rich input editor. The existing rich input editor context already exposes `CLI_AGENT_RICH_INPUT_OPEN`, so the terminal action can be dispatched from the focused `EditorView` context and handled by the terminal ancestor.

A focused regression test now opens CLI agent rich input, dispatches Ctrl+G through the focused editor responder path, and verifies the rich input closes.

## Root Cause

Ctrl+G could open CLI agent rich input from the terminal context, but after rich input was focused the keybinding lookup happened against `EditorView`. The terminal-only binding predicate no longer matched, so the toggle action did not reach `TerminalView`.

## Validation

Passed:

- `cargo fmt --check`
- `git diff --check`
- `PROTOC=/tmp/warp-protoc-25.1/bin/protoc cargo test -p warp ctrl_g_closes_cli_agent_rich_input_when_editor_is_focused`
- `PROTOC=/tmp/warp-protoc-25.1/bin/protoc cargo test -p warp cli_agent_rich_input`
- `PROTOC=/tmp/warp-protoc-25.1/bin/protoc cargo clippy -p warp --all-targets --tests -- -D warnings`

Broader suite attempted:

- `PROTOC=/tmp/warp-protoc-25.1/bin/protoc cargo test -p warp --lib`
  - parallel run: 3557 passed, 15 failed, 7 ignored
- `PROTOC=/tmp/warp-protoc-25.1/bin/protoc RUST_TEST_THREADS=1 cargo test -p warp --lib`
  - serial run: 3561 passed, 11 failed, 7 ignored

I reran the 11 serial failures individually. 9 passed in isolation. The 2 persistent failures appear host-dependent and unrelated to this diff:

- `terminal::input::decorations::tests::test_decorations_with_multibyte_chars`
- `terminal::input::tests::test_histignorespace_support_in_zsh`

Exact repo presubmit/container parity could not be run in this environment because no container runtime was available, and these tools were missing from PATH: `cargo-nextest`, `wgslfmt`, `clang-format`, and `pwsh`. Host `protoc` was also missing, so tests were run with a temporary protoc 25.1 binary matching the repo Linux setup script version.
