### PR TITLE
Fix file tree loading flicker

### DIFF
--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -2892,6 +2892,13 @@ impl View for FileTreeView {
             return self.render_error_state(DISABLED_TEXT.to_string(), app);
         }
 
+        if matches!(
+            self.enablement,
+            CodingPanelEnablementState::PendingRemoteSession
+        ) {
+            return self.render_loading_state(app);
+        }
+
         if self.displayed_directories.is_empty() {
             if let CodingPanelEnablementState::RemoteSession { has_remote_server } = self.enablement
             {

--- a/app/src/coding_panel_enablement_state.rs
+++ b/app/src/coding_panel_enablement_state.rs
@@ -1,6 +1,11 @@
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CodingPanelEnablementState {
     Enabled,
+    /// An SSH command has been detected at preexec time but the remote
+    /// session has not finished bootstrapping yet. The file tree should
+    /// show a loading state immediately to avoid flickering the stale
+    /// local tree.
+    PendingRemoteSession,
     /// The active session is on a remote host.
     ///
     /// `has_remote_server` is `true` when the session is registered with

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7307,6 +7307,14 @@ impl TerminalView {
             && !model.is_read_only()
     }
 
+    /// Returns `true` when an interactive SSH command has been detected at
+    /// preexec and the SSH block is still running (long-running). Used by
+    /// the workspace to derive `PendingRemoteSession` without storing
+    /// mutable state on the workspace itself.
+    pub fn has_pending_ssh_command(&self) -> bool {
+        self.warpify_state.get_pending_ssh_host().is_some() && self.is_long_running()
+    }
+
     /// Like `is_long_running`, but also requires the user to be in control of the command
     /// (i.e. the user ran it, or took it over from the agent). Returns `false` for commands
     /// that are currently being driven by the agent.
@@ -10341,6 +10349,7 @@ impl TerminalView {
                                 self.warpify_state
                                     .set_pending_ssh_host(warpify_command.to_string(), ssh_host);
                                 self.model.lock().start_notify_on_end_of_ssh_login();
+                                ctx.emit(Event::TerminalViewStateChanged);
                             }
                         } else {
                             self.warpify_state.clear_pending_ssh_host();

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13017,7 +13017,10 @@ impl Workspace {
             pane_group::Event::SyncInput(input_type) => {
                 self.process_sync_event_for_all_synced_pane_groups(input_type, ctx);
             }
-            pane_group::Event::TerminalViewStateChanged => ctx.notify(),
+            pane_group::Event::TerminalViewStateChanged => {
+                self.update_active_session(ctx);
+                ctx.notify();
+            }
             pane_group::Event::OnboardingTutorialCompleted => {
                 self.pending_session_config_tab_config_chip = false;
                 self.show_session_config_tab_config_chip = false;
@@ -14283,24 +14286,33 @@ impl Workspace {
 
         if let Some(terminal_handle) = pane_group_handle.as_ref(ctx).active_session_view(ctx) {
             #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
-            let (session, path_if_local, is_local, is_wsl_session, session_id, pwd) =
-                terminal_handle.read(ctx, |terminal, ctx| {
-                    let active_session_id = terminal.active_block_session_id();
-                    let session = active_session_id
-                        .and_then(|id| terminal.sessions_model().as_ref(ctx).get(id));
-                    let path_if_local = terminal.active_session_path_if_local(ctx);
-                    let is_local = terminal.active_session_is_local(ctx);
-                    let is_wsl_session = session.as_ref().map(|s| s.is_wsl()).unwrap_or(false);
-                    let pwd = terminal.pwd();
-                    (
-                        session,
-                        path_if_local,
-                        is_local,
-                        is_wsl_session,
-                        active_session_id,
-                        pwd,
-                    )
-                });
+            let (
+                session,
+                path_if_local,
+                is_local,
+                is_wsl_session,
+                session_id,
+                pwd,
+                has_pending_ssh,
+            ) = terminal_handle.read(ctx, |terminal, ctx| {
+                let active_session_id = terminal.active_block_session_id();
+                let session =
+                    active_session_id.and_then(|id| terminal.sessions_model().as_ref(ctx).get(id));
+                let path_if_local = terminal.active_session_path_if_local(ctx);
+                let is_local = terminal.active_session_is_local(ctx);
+                let is_wsl_session = session.as_ref().map(|s| s.is_wsl()).unwrap_or(false);
+                let pwd = terminal.pwd();
+                let has_pending_ssh = terminal.has_pending_ssh_command();
+                (
+                    session,
+                    path_if_local,
+                    is_local,
+                    is_wsl_session,
+                    active_session_id,
+                    pwd,
+                    has_pending_ssh,
+                )
+            });
 
             let window_id = ctx.window_id();
             let working_directory_clone = path_if_local.clone();
@@ -14350,6 +14362,18 @@ impl Workspace {
                 is_unsupported_session,
                 has_remote_server,
             );
+
+            // When an SSH command is running (pending host set + block
+            // still long-running), the old local session is still active
+            // so the enablement computes as `Enabled`. Override to
+            // `PendingRemoteSession` so the file tree shows loading
+            // instead of the stale local tree.
+            let enablement =
+                if has_pending_ssh && matches!(enablement, CodingPanelEnablementState::Enabled) {
+                    CodingPanelEnablementState::PendingRemoteSession
+                } else {
+                    enablement
+                };
 
             self.left_panel_view.update(ctx, |left_panel, ctx| {
                 left_panel.update_coding_panel_enablement(enablement, ctx);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -2815,10 +2815,16 @@ impl Workspace {
         if FeatureFlag::SshRemoteServer.is_enabled() {
             ctx.subscribe_to_model(
                 &RemoteServerManager::handle(ctx),
-                |me, _handle, event, ctx| {
-                    if matches!(event, RemoteServerManagerEvent::SessionConnected { .. }) {
+                |me, _handle, event, ctx| match event {
+                    RemoteServerManagerEvent::SessionConnected { .. } => {
                         me.update_active_session(ctx);
                     }
+                    RemoteServerManagerEvent::SetupStateChanged { state, .. }
+                        if state.is_failed() =>
+                    {
+                        me.update_active_session(ctx);
+                    }
+                    _ => {}
                 },
             );
         }
@@ -14342,8 +14348,9 @@ impl Workspace {
             // `connect_session` was called at `InitShell` time.
             let has_remote_server = is_remote
                 && FeatureFlag::SshRemoteServer.is_enabled()
-                && session_id
-                    .is_some_and(|sid| RemoteServerManager::as_ref(ctx).session(sid).is_some());
+                && session_id.is_some_and(|sid| {
+                    RemoteServerManager::as_ref(ctx).is_session_potentially_active(sid)
+                });
 
             // When the session has a remote server, tell it about the current
             // directory so it can start indexing and push repo metadata back.

--- a/app/src/workspace/view/global_search/view.rs
+++ b/app/src/workspace/view/global_search/view.rs
@@ -1995,7 +1995,8 @@ impl View for GlobalSearchView {
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         match self.enablement {
-            CodingPanelEnablementState::RemoteSession { .. } => {
+            CodingPanelEnablementState::PendingRemoteSession
+            | CodingPanelEnablementState::RemoteSession { .. } => {
                 return self.render_remote_state(app);
             }
             CodingPanelEnablementState::UnsupportedSession => {

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -802,6 +802,23 @@ impl RemoteServerManager {
         self.sessions.get(&session_id)
     }
 
+    /// Returns `true` when the session exists and is in a state where the
+    /// remote server might still deliver data (`Connecting`, `Initializing`,
+    /// `Connected`, or `Reconnecting`). Returns `false` for `Disconnected`
+    /// sessions and sessions not tracked by the manager.
+    pub fn is_session_potentially_active(&self, session_id: SessionId) -> bool {
+        match self.sessions.get(&session_id) {
+            Some(RemoteSessionState::Disconnected) | None => false,
+            Some(
+                RemoteSessionState::Connecting
+                | RemoteSessionState::Initializing { .. }
+                | RemoteSessionState::Connected { .. },
+            ) => true,
+            #[cfg(not(target_family = "wasm"))]
+            Some(RemoteSessionState::Reconnecting { .. }) => true,
+        }
+    }
+
     /// Returns the detected remote platform for this session, if available.
     pub fn platform_for_session(&self, session_id: SessionId) -> Option<&RemotePlatform> {
         self.session_platforms.get(&session_id)


### PR DESCRIPTION
## Description

Fix file tree flickering during SSH session transitions. Previously, when SSHing into a remote host, the file tree would stay stuck showing the stale local file tree until the remote session finished bootstrapping, then abruptly switch—causing a visible flicker.

Now the file tree shows a loading state as soon as the SSH command is detected at preexec, giving a smooth transition: **local tree → loading → remote tree** (on success) or **local tree → loading → local tree** (on failure).

### Changes

- **`CodingPanelEnablementState`**: Add `PendingRemoteSession` variant to represent the transitional state between local and remote sessions.
- **`TerminalView`**: Add `has_pending_ssh_command()` method that derives the pending SSH state from `warpify_state.get_pending_ssh_host()` combined with `is_long_running()`. Emit `TerminalViewStateChanged` when SSH is detected at preexec so the workspace can react.
- **`Workspace`**: In `update_active_session()`, override enablement to `PendingRemoteSession` when `has_pending_ssh && enablement == Enabled`. Also call `update_active_session()` on `TerminalViewStateChanged` events so the file tree refreshes immediately when SSH starts.
- **File tree / global search views**: Handle `PendingRemoteSession` by rendering a loading state.

Co-Authored-By: Oz <oz-agent@warp.dev>

## Testing
Manual testing: ran `ssh` commands and verified the file tree transitions smoothly from local → loading → remote (or back to local on failure) with no flickering.

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed file tree flickering when transitioning to an SSH remote session