### PR TITLE
Update agent attribution setting

### DIFF
--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1457,8 +1457,8 @@ define_settings_group!(AISettings, settings: [
         supported_platforms: SupportedPlatforms::ALL,
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::No),
         private: false,
-        toml_path: "agents.oz.other.agent_attribution_enabled",
-        description: "Whether Oz adds an attribution co-author line to commit messages and pull requests it creates.",
+        toml_path: "agents.warp_agent.other.agent_attribution_enabled",
+        description: "Whether the Warp Agent adds an attribution co-author line to commit messages and pull requests it creates.",
     }
 ]);
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

We're updating references of Oz to Warp Agent in-app. This change applies it to the agent attribution setting, which missed the rename.
