### PR TITLE
Fix scroll-to-selected-block keybinding when editor input is focused

### DIFF
--- a/app/src/terminal/view/init.rs
+++ b/app/src/terminal/view/init.rs
@@ -655,9 +655,7 @@ pub fn init(app: &mut AppContext) {
     )
     .with_custom_action(CustomAction::ScrollToTopOfSelectedBlocks)
     .with_context_predicate(
-        id!("Terminal")
-            & !id!("EditorFocused")
-            & ne!("TerminalView_BlockSelectionCardinality", "None"),
+        id!("Terminal") & ne!("TerminalView_BlockSelectionCardinality", "None"),
     )]);
     app.register_editable_bindings([EditableBinding::new(
         "terminal:scroll_to_bottom_of_selected_block",
@@ -666,9 +664,7 @@ pub fn init(app: &mut AppContext) {
     )
     .with_custom_action(CustomAction::ScrollToBottomOfSelectedBlocks)
     .with_context_predicate(
-        id!("Terminal")
-            & !id!("EditorFocused")
-            & ne!("TerminalView_BlockSelectionCardinality", "None"),
+        id!("Terminal") & ne!("TerminalView_BlockSelectionCardinality", "None"),
     )]);
 
     // Register a mac only keybinding for selecting all blocks that uses the "Select All" mac menu


### PR DESCRIPTION
## Description

Removes the `!id!("EditorFocused")` guard from the context predicates for both `ScrollToTopOfSelectedBlocks` and `ScrollToBottomOfSelectedBlocks` keybindings in `app/src/terminal/view/init.rs`.

**Root cause:** In shell mode, focus intentionally stays in the editor input when blocks are selected (by design). The `!id!("EditorFocused")` condition in the keybinding context predicates meant `cmdorctrl-shift-up` / `cmdorctrl-shift-down` never fired while the input was focused — which is always the case when blocks are selected in shell mode.

**Fix:** Drop the `!id!("EditorFocused")` guard. The `TerminalView_BlockSelectionCardinality != None` condition already ensures the bindings only activate when at least one block is selected, consistent with other block-action keybindings (copy, find, copy-output, etc.) that work regardless of editor focus.

## Testing

- Manually verified that selecting a block and pressing `cmd-shift-up` / `cmd-shift-down` (Mac) now scrolls to the top/bottom of the selected block even when the input box is focused, in both terminal and agent view https://www.loom.com/share/b19d484533aa41d6b66a6ada685ce949
- No new automated tests added; this is a pure keybinding context predicate fix with no algorithmic logic.
- `cargo fmt --check` passes, `cargo clippy` clean.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed scroll-to-start/end of selected block keybinding (Cmd/Ctrl+Shift+Up/Down) not working when the input is focused.

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._