### PR TITLE
Fix remote server banner issues

### DIFF
--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -439,6 +439,14 @@ impl Sessions {
         !self.pending_session_start_times.is_empty() || !self.sessions.is_empty()
     }
 
+    /// Returns whether the given `session_id` is tracked by this [`Sessions`]
+    /// model, either as a pending session (registered via [`Self::register_pending_session`])
+    /// or a fully bootstrapped one.
+    pub fn tracks_session(&self, session_id: SessionId) -> bool {
+        self.sessions.contains_key(&session_id)
+            || self.pending_session_start_times.contains_key(&session_id)
+    }
+
     /// Returns a map of the spawning commands for all subshell sessions, keyed the session's `SessionId`.
     pub fn spawning_command_for_subshell_sessions(&self) -> HashMap<SessionId, SubshellSource> {
         self.sessions

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -158,7 +158,7 @@ use crate::terminal::view::ssh_remote_server_choice_view::{
     SshRemoteServerChoiceView, SshRemoteServerChoiceViewEvent,
 };
 use crate::terminal::view::ssh_remote_server_failed_banner::{
-    SshRemoteServerFailedBanner, SshRemoteServerFailedBannerEvent,
+    SshRemoteServerFailedBanner, SshRemoteServerFailedBannerEvent, SshRemoteServerFailureKind,
 };
 use crate::terminal::view::telemetry::PromptSuggestionFallbackReason;
 use crate::workspace::view::cloud_agent_capacity_modal::CloudAgentCapacityModalVariant;
@@ -4173,215 +4173,241 @@ impl TerminalView {
         // so the ModelEventDispatcher can gate session initialization on them.
         if FeatureFlag::SshRemoteServer.is_enabled() {
             let mgr_handle = RemoteServerManager::handle(ctx);
-            ctx.subscribe_to_model(&mgr_handle, |me, _, event, ctx| match event {
-                RemoteServerManagerEvent::SetupStateChanged { .. } => {
-                    // Sessions handles the state update directly via its own
-                    // subscription to the manager. Notify the view so the
-                    // loading footer re-renders with the updated message.
-                    ctx.notify();
-                }
-                RemoteServerManagerEvent::SessionConnected { session_id, .. } => {
-                    me.model.lock().event_proxy.send_terminal_event(
-                        crate::terminal::event::Event::RemoteServerReady {
-                            session_id: *session_id,
-                        },
-                    );
-                    let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
-                        .as_ref(ctx)
-                        .platform_for_session(*session_id)
-                        .map(|p| {
-                            (
-                                Some(p.os.as_str().to_owned()),
-                                Some(p.arch.as_str().to_owned()),
-                            )
-                        })
-                        .unwrap_or((None, None));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::RemoteServerInitialization {
-                            phase: RemoteServerInitPhase::Initialize,
-                            error: None,
-                            remote_os,
-                            remote_arch,
-                        },
-                        ctx
-                    );
-                }
-                RemoteServerManagerEvent::SessionConnectionFailed {
-                    session_id,
-                    phase,
-                    error,
-                } => {
-                    me.model.lock().event_proxy.send_terminal_event(
-                        crate::terminal::event::Event::RemoteServerFailed {
-                            session_id: *session_id,
-                            error: error.clone(),
-                        },
-                    );
-                    let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
-                        .as_ref(ctx)
-                        .platform_for_session(*session_id)
-                        .map(|p| {
-                            (
-                                Some(p.os.as_str().to_owned()),
-                                Some(p.arch.as_str().to_owned()),
-                            )
-                        })
-                        .unwrap_or((None, None));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::RemoteServerInitialization {
-                            phase: *phase,
-                            error: Some(error.clone()),
-                            remote_os,
-                            remote_arch,
-                        },
-                        ctx
-                    );
-                }
-                RemoteServerManagerEvent::SessionDisconnected { session_id, .. } => {
-                    let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
-                        .as_ref(ctx)
-                        .platform_for_session(*session_id)
-                        .map(|p| {
-                            (
-                                Some(p.os.as_str().to_owned()),
-                                Some(p.arch.as_str().to_owned()),
-                            )
-                        })
-                        .unwrap_or((None, None));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::RemoteServerDisconnection {
-                            remote_os,
-                            remote_arch,
-                        },
-                        ctx
-                    );
-                }
-                RemoteServerManagerEvent::SessionDeregistered { session_id } => {
-                    // Clean up any stale SSH remote-server choice block if the
-                    // session disappears (e.g. network drop, Ctrl-C, `exit`)
-                    // before the user picks an option.
-                    me.remove_ssh_remote_server_choice_block(*session_id, ctx);
-                    me.remove_ssh_remote_server_failed_banner(*session_id, ctx);
-                }
-                RemoteServerManagerEvent::BinaryInstallComplete { session_id, result } => {
-                    let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
-                        .as_ref(ctx)
-                        .platform_for_session(*session_id)
-                        .map(|p| {
-                            (
-                                Some(p.os.as_str().to_owned()),
-                                Some(p.arch.as_str().to_owned()),
-                            )
-                        })
-                        .unwrap_or((None, None));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::RemoteServerInstallation {
-                            error: result.as_ref().err().cloned(),
-                            remote_os,
-                            remote_arch,
-                        },
-                        ctx
-                    );
-                    if result.is_err() {
-                        me.show_ssh_remote_server_failed_banner(*session_id, ctx);
+            ctx.subscribe_to_model(&mgr_handle, |me, _, event, ctx| {
+                // `RemoteServerManager` is a singleton, so every `TerminalView` receives every event.
+                // Filter for session-scoped events that are specifically tracked by this view.
+                // Host-scoped variants return `None` and pass through unfiltered.
+                if let Some(sid) = event.session_id() {
+                    if !me.sessions.as_ref(ctx).tracks_session(sid) {
+                        return;
                     }
                 }
-                RemoteServerManagerEvent::BinaryCheckComplete {
-                    session_id,
-                    result,
-                    remote_platform,
-                } => {
-                    let (remote_os, remote_arch) = remote_platform
-                        .as_ref()
-                        .map(|p| {
-                            (
-                                Some(p.os.as_str().to_owned()),
-                                Some(p.arch.as_str().to_owned()),
-                            )
-                        })
-                        .unwrap_or((None, None));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::RemoteServerBinaryCheck {
-                            found: matches!(result, Ok(true)),
-                            error: result.as_ref().err().cloned(),
-                            remote_os,
-                            remote_arch,
-                        },
-                        ctx
-                    );
-                    if result.is_err() {
-                        me.show_ssh_remote_server_failed_banner(*session_id, ctx);
+                match event {
+                    RemoteServerManagerEvent::SetupStateChanged { .. } => {
+                        // Sessions handles the state update directly via its own
+                        // subscription to the manager. Notify the view so the
+                        // loading footer re-renders with the updated message.
+                        ctx.notify();
                     }
-                }
-                RemoteServerManagerEvent::ClientRequestFailed {
-                    session_id,
-                    operation,
-                    error_kind,
-                } => {
-                    let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
-                        .as_ref(ctx)
-                        .platform_for_session(*session_id)
-                        .map(|p| {
-                            (
-                                Some(p.os.as_str().to_owned()),
-                                Some(p.arch.as_str().to_owned()),
-                            )
-                        })
-                        .unwrap_or((None, None));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::RemoteServerClientRequestError {
-                            operation: *operation,
-                            error_type: *error_kind,
-                            remote_os,
-                            remote_arch,
-                        },
-                        ctx
-                    );
-                }
-                RemoteServerManagerEvent::ServerMessageDecodingError { session_id } => {
-                    let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
-                        .as_ref(ctx)
-                        .platform_for_session(*session_id)
-                        .map(|p| {
-                            (
-                                Some(p.os.as_str().to_owned()),
-                                Some(p.arch.as_str().to_owned()),
-                            )
-                        })
-                        .unwrap_or((None, None));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::RemoteServerMessageDecodingError {
-                            remote_os,
-                            remote_arch,
-                        },
-                        ctx
-                    );
-                }
-                RemoteServerManagerEvent::NavigatedToDirectory {
-                    session_id: nav_session_id,
-                    host_id,
-                    indexed_path,
-                    ..
-                } => {
-                    // Check if this navigation belongs to our active session
-                    // using exact session_id match (no CWD heuristics).
-                    let is_relevant = me
-                        .active_block_session_id()
-                        .is_some_and(|sid| sid == *nav_session_id);
-                    if is_relevant {
-                        ctx.emit(Event::Pane(PaneEvent::RemoteRepoNavigated {
-                            host_id: host_id.clone(),
-                            indexed_path: indexed_path.clone(),
-                        }));
+                    RemoteServerManagerEvent::SessionConnected { session_id, .. } => {
+                        me.model.lock().event_proxy.send_terminal_event(
+                            crate::terminal::event::Event::RemoteServerReady {
+                                session_id: *session_id,
+                            },
+                        );
+                        let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
+                            .as_ref(ctx)
+                            .platform_for_session(*session_id)
+                            .map(|p| {
+                                (
+                                    Some(p.os.as_str().to_owned()),
+                                    Some(p.arch.as_str().to_owned()),
+                                )
+                            })
+                            .unwrap_or((None, None));
+                        send_telemetry_from_ctx!(
+                            TelemetryEvent::RemoteServerInitialization {
+                                phase: RemoteServerInitPhase::Initialize,
+                                error: None,
+                                remote_os,
+                                remote_arch,
+                            },
+                            ctx
+                        );
                     }
+                    RemoteServerManagerEvent::SessionConnectionFailed {
+                        session_id,
+                        phase,
+                        error,
+                    } => {
+                        me.model.lock().event_proxy.send_terminal_event(
+                            crate::terminal::event::Event::RemoteServerFailed {
+                                session_id: *session_id,
+                                error: error.clone(),
+                            },
+                        );
+                        let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
+                            .as_ref(ctx)
+                            .platform_for_session(*session_id)
+                            .map(|p| {
+                                (
+                                    Some(p.os.as_str().to_owned()),
+                                    Some(p.arch.as_str().to_owned()),
+                                )
+                            })
+                            .unwrap_or((None, None));
+                        send_telemetry_from_ctx!(
+                            TelemetryEvent::RemoteServerInitialization {
+                                phase: *phase,
+                                error: Some(error.clone()),
+                                remote_os,
+                                remote_arch,
+                            },
+                            ctx
+                        );
+                        me.show_ssh_remote_server_failed_banner(
+                            *session_id,
+                            SshRemoteServerFailureKind::Launch,
+                            error,
+                            ctx,
+                        );
+                    }
+                    RemoteServerManagerEvent::SessionDisconnected { session_id, .. } => {
+                        let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
+                            .as_ref(ctx)
+                            .platform_for_session(*session_id)
+                            .map(|p| {
+                                (
+                                    Some(p.os.as_str().to_owned()),
+                                    Some(p.arch.as_str().to_owned()),
+                                )
+                            })
+                            .unwrap_or((None, None));
+                        send_telemetry_from_ctx!(
+                            TelemetryEvent::RemoteServerDisconnection {
+                                remote_os,
+                                remote_arch,
+                            },
+                            ctx
+                        );
+                    }
+                    RemoteServerManagerEvent::SessionDeregistered { session_id } => {
+                        // Clean up any stale SSH remote-server choice block if the
+                        // session disappears (e.g. network drop, Ctrl-C, `exit`)
+                        // before the user picks an option.
+                        me.remove_ssh_remote_server_choice_block(*session_id, ctx);
+                        me.remove_ssh_remote_server_failed_banner(*session_id, ctx);
+                    }
+                    RemoteServerManagerEvent::BinaryInstallComplete { session_id, result } => {
+                        let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
+                            .as_ref(ctx)
+                            .platform_for_session(*session_id)
+                            .map(|p| {
+                                (
+                                    Some(p.os.as_str().to_owned()),
+                                    Some(p.arch.as_str().to_owned()),
+                                )
+                            })
+                            .unwrap_or((None, None));
+                        send_telemetry_from_ctx!(
+                            TelemetryEvent::RemoteServerInstallation {
+                                error: result.as_ref().err().cloned(),
+                                remote_os,
+                                remote_arch,
+                            },
+                            ctx
+                        );
+                        if let Err(error) = result {
+                            me.show_ssh_remote_server_failed_banner(
+                                *session_id,
+                                SshRemoteServerFailureKind::BinaryInstall,
+                                error,
+                                ctx,
+                            );
+                        }
+                    }
+                    RemoteServerManagerEvent::BinaryCheckComplete {
+                        session_id,
+                        result,
+                        remote_platform,
+                    } => {
+                        let (remote_os, remote_arch) = remote_platform
+                            .as_ref()
+                            .map(|p| {
+                                (
+                                    Some(p.os.as_str().to_owned()),
+                                    Some(p.arch.as_str().to_owned()),
+                                )
+                            })
+                            .unwrap_or((None, None));
+                        send_telemetry_from_ctx!(
+                            TelemetryEvent::RemoteServerBinaryCheck {
+                                found: matches!(result, Ok(true)),
+                                error: result.as_ref().err().cloned(),
+                                remote_os,
+                                remote_arch,
+                            },
+                            ctx
+                        );
+                        if let Err(error) = result {
+                            me.show_ssh_remote_server_failed_banner(
+                                *session_id,
+                                SshRemoteServerFailureKind::BinaryCheck,
+                                error,
+                                ctx,
+                            );
+                        }
+                    }
+                    RemoteServerManagerEvent::ClientRequestFailed {
+                        session_id,
+                        operation,
+                        error_kind,
+                    } => {
+                        let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
+                            .as_ref(ctx)
+                            .platform_for_session(*session_id)
+                            .map(|p| {
+                                (
+                                    Some(p.os.as_str().to_owned()),
+                                    Some(p.arch.as_str().to_owned()),
+                                )
+                            })
+                            .unwrap_or((None, None));
+                        send_telemetry_from_ctx!(
+                            TelemetryEvent::RemoteServerClientRequestError {
+                                operation: *operation,
+                                error_type: *error_kind,
+                                remote_os,
+                                remote_arch,
+                            },
+                            ctx
+                        );
+                    }
+                    RemoteServerManagerEvent::ServerMessageDecodingError { session_id } => {
+                        let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
+                            .as_ref(ctx)
+                            .platform_for_session(*session_id)
+                            .map(|p| {
+                                (
+                                    Some(p.os.as_str().to_owned()),
+                                    Some(p.arch.as_str().to_owned()),
+                                )
+                            })
+                            .unwrap_or((None, None));
+                        send_telemetry_from_ctx!(
+                            TelemetryEvent::RemoteServerMessageDecodingError {
+                                remote_os,
+                                remote_arch,
+                            },
+                            ctx
+                        );
+                    }
+                    RemoteServerManagerEvent::NavigatedToDirectory {
+                        session_id: nav_session_id,
+                        host_id,
+                        indexed_path,
+                        ..
+                    } => {
+                        // Check if this navigation belongs to our active session
+                        // using exact session_id match (no CWD heuristics).
+                        let is_relevant = me
+                            .active_block_session_id()
+                            .is_some_and(|sid| sid == *nav_session_id);
+                        if is_relevant {
+                            ctx.emit(Event::Pane(PaneEvent::RemoteRepoNavigated {
+                                host_id: host_id.clone(),
+                                indexed_path: indexed_path.clone(),
+                            }));
+                        }
+                    }
+                    RemoteServerManagerEvent::SessionConnecting { .. }
+                    | RemoteServerManagerEvent::SessionReconnected { .. }
+                    | RemoteServerManagerEvent::HostConnected { .. }
+                    | RemoteServerManagerEvent::HostDisconnected { .. }
+                    | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
+                    | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+                    | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. } => {}
                 }
-                RemoteServerManagerEvent::SessionConnecting { .. }
-                | RemoteServerManagerEvent::SessionReconnected { .. }
-                | RemoteServerManagerEvent::HostConnected { .. }
-                | RemoteServerManagerEvent::HostDisconnected { .. }
-                | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
-                | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
-                | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. } => {}
             });
         }
         terminal_view.any_session_contains_restored_remote_blocks =
@@ -11424,6 +11450,8 @@ impl TerminalView {
     fn show_ssh_remote_server_failed_banner(
         &mut self,
         session_id: SessionId,
+        kind: SshRemoteServerFailureKind,
+        error: &str,
         ctx: &mut ViewContext<Self>,
     ) {
         let already_present = self.rich_content_views.iter().any(|view| {
@@ -11437,7 +11465,9 @@ impl TerminalView {
             return;
         }
 
-        let banner = ctx.add_typed_action_view(|_| SshRemoteServerFailedBanner::new(session_id));
+        let error = error.to_owned();
+        let banner = ctx
+            .add_typed_action_view(|_| SshRemoteServerFailedBanner::new(session_id, kind, error));
 
         ctx.subscribe_to_view(&banner, move |me, _, event, ctx| match event {
             SshRemoteServerFailedBannerEvent::Dismissed => {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -11385,8 +11385,8 @@ impl TerminalView {
         })
     }
 
-    /// Returns `true` when the loading footer should be shown in place of the
-    /// input editor during the SSH remote-server setup flow.
+    /// Returns `true` when the pending session has a connecting remote-server setup state
+    /// and no failure banner is already shown for that session.
     fn show_remote_server_loading_footer(&self, model: &TerminalModel, app: &AppContext) -> bool {
         if !FeatureFlag::SshRemoteServer.is_enabled() {
             return false;
@@ -11399,6 +11399,16 @@ impl TerminalView {
         let Some(pending_sid) = model.pending_session_id() else {
             return false;
         };
+        let has_failed_banner = self.rich_content_views.iter().any(|view| {
+            matches!(
+                view.metadata(),
+                Some(RichContentMetadata::SshRemoteServerFailedBanner { handle })
+                if handle.as_ref(app).session_id() == pending_sid
+            )
+        });
+        if has_failed_banner {
+            return false;
+        }
         self.sessions
             .as_ref(app)
             .remote_server_setup_state(pending_sid)

--- a/app/src/terminal/view/ssh_remote_server_failed_banner.rs
+++ b/app/src/terminal/view/ssh_remote_server_failed_banner.rs
@@ -13,6 +13,10 @@ use warpui::{
 
 use crate::{terminal::model::session::SessionId, ui_components::icons::Icon, Appearance};
 
+const BANNER_BODY: &str =
+    "While advanced features like file browsing and code review are currently \
+    disabled, the rest of your Warpified experience is fully available.";
+
 #[derive(Clone, Debug)]
 pub enum SshRemoteServerFailedBannerAction {
     Dismiss,
@@ -23,15 +27,36 @@ pub enum SshRemoteServerFailedBannerEvent {
     Dismissed,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum SshRemoteServerFailureKind {
+    BinaryCheck,
+    BinaryInstall,
+    Launch,
+}
+
+impl SshRemoteServerFailureKind {
+    fn title(self) -> &'static str {
+        match self {
+            Self::BinaryCheck => "SSH extension couldn't be found",
+            Self::BinaryInstall => "SSH extension couldn't be installed",
+            Self::Launch => "SSH extension couldn't be started",
+        }
+    }
+}
+
 pub struct SshRemoteServerFailedBanner {
     session_id: SessionId,
+    kind: SshRemoteServerFailureKind,
+    error: String,
     close_mouse_state: MouseStateHandle,
 }
 
 impl SshRemoteServerFailedBanner {
-    pub fn new(session_id: SessionId) -> Self {
+    pub fn new(session_id: SessionId, kind: SshRemoteServerFailureKind, error: String) -> Self {
         Self {
             session_id,
+            kind,
+            error,
             close_mouse_state: MouseStateHandle::default(),
         }
     }
@@ -68,27 +93,20 @@ impl View for SshRemoteServerFailedBanner {
         .with_margin_right(8.)
         .finish();
 
-        // Title
-        let title = Text::new(
-            "SSH extension couldn't be installed",
-            appearance.ui_font_family(),
-            font_size,
-        )
-        .with_color(fg_color)
-        .finish();
+        let title = Text::new(self.kind.title(), appearance.ui_font_family(), font_size)
+            .with_color(fg_color)
+            .finish();
 
-        // Description
-        let body = Text::new(
-            "The binary could not be written or executed on the remote host. \
-             This may be due to permission restrictions or missing dependencies. \
-             While advanced features like file browsing and code review are currently \
-             disabled, the rest of your Warpified experience is fully available.",
-            appearance.ui_font_family(),
-            small_font_size,
-        )
-        .soft_wrap(true)
-        .with_color(muted_color)
-        .finish();
+        let trimmed_error = self.error.trim();
+        let body_text = if trimmed_error.is_empty() {
+            format!("Failed to start the remote server. {BANNER_BODY}")
+        } else {
+            format!("Failed to start the remote server due to the following error: {trimmed_error}. {BANNER_BODY}")
+        };
+        let body = Text::new(body_text, appearance.ui_font_family(), small_font_size)
+            .soft_wrap(true)
+            .with_color(muted_color)
+            .finish();
 
         // Close (X) button
         let close_icon_color = muted_color;

--- a/app/src/terminal/view/ssh_remote_server_failed_banner.rs
+++ b/app/src/terminal/view/ssh_remote_server_failed_banner.rs
@@ -2,10 +2,11 @@
 //! We fall back to the existing Warpification behavior and display this banner so the user knows why advanced features are unavailable.
 
 use warp_core::ui::theme::color::internal_colors;
+use warp_core::ui::theme::AnsiColorIdentifier;
 use warpui::{
     elements::{
-        ConstrainedBox, Container, CrossAxisAlignment, Flex, Hoverable, MainAxisAlignment,
-        MainAxisSize, MouseStateHandle, ParentElement, Shrinkable, Text,
+        ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Flex, Hoverable,
+        MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement, Radius, Shrinkable, Text,
     },
     platform::Cursor,
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext,
@@ -40,6 +41,16 @@ impl SshRemoteServerFailureKind {
             Self::BinaryCheck => "SSH extension couldn't be found",
             Self::BinaryInstall => "SSH extension couldn't be installed",
             Self::Launch => "SSH extension couldn't be started",
+        }
+    }
+
+    fn description(self) -> &'static str {
+        match self {
+            Self::BinaryCheck => "The SSH extension binary could not be found on the remote host.",
+            Self::BinaryInstall => {
+                "The binary could not be written or executed on the remote host."
+            }
+            Self::Launch => "The SSH extension could not be started on the remote host.",
         }
     }
 }
@@ -97,16 +108,43 @@ impl View for SshRemoteServerFailedBanner {
             .with_color(fg_color)
             .finish();
 
-        let trimmed_error = self.error.trim();
-        let body_text = if trimmed_error.is_empty() {
-            format!("Failed to start the remote server. {BANNER_BODY}")
-        } else {
-            format!("Failed to start the remote server due to the following error: {trimmed_error}. {BANNER_BODY}")
-        };
+        let body_text = format!("{} {BANNER_BODY}", self.kind.description());
         let body = Text::new(body_text, appearance.ui_font_family(), small_font_size)
             .soft_wrap(true)
             .with_color(muted_color)
             .finish();
+
+        // Error detail line wrapped in a red-tinted background container.
+        let trimmed_error = self.error.trim();
+        let error_element = if trimmed_error.is_empty() {
+            None
+        } else {
+            let ansi_red = AnsiColorIdentifier::Red.to_ansi_color(&theme.terminal_colors().normal);
+            let error_bg = theme.ansi_overlay_1(ansi_red);
+            let error_text_color = theme.ansi_fg_red();
+
+            let error_text = Text::new(
+                format!("ERROR: {trimmed_error}"),
+                appearance.ui_font_family(),
+                small_font_size,
+            )
+            .soft_wrap(true)
+            .with_color(error_text_color)
+            .finish();
+
+            let error_container = Container::new(error_text)
+                .with_background(error_bg)
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+                .with_uniform_padding(12.)
+                .finish();
+
+            Some(
+                Container::new(error_container)
+                    .with_margin_top(8.)
+                    .with_margin_left(24.)
+                    .finish(),
+            )
+        };
 
         // Close (X) button
         let close_icon_color = muted_color;
@@ -149,11 +187,17 @@ impl View for SshRemoteServerFailedBanner {
             .with_margin_left(24.)
             .finish();
 
-        let content = Flex::column()
+        let mut content = Flex::column()
             .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_child(header_row)
-            .with_child(body_container)
-            .finish();
+            .with_child(body_container);
+
+        if let Some(error) = error_element {
+            content = content.with_child(error);
+        }
+
+        let content = content.finish();
 
         Container::new(content)
             .with_background(internal_colors::fg_overlay_1(theme))

--- a/app/src/terminal/view/ssh_remote_server_failed_banner.rs
+++ b/app/src/terminal/view/ssh_remote_server_failed_banner.rs
@@ -38,7 +38,7 @@ pub enum SshRemoteServerFailureKind {
 impl SshRemoteServerFailureKind {
     fn title(self) -> &'static str {
         match self {
-            Self::BinaryCheck => "SSH extension couldn't be found",
+            Self::BinaryCheck => "SSH extension couldn't be verified",
             Self::BinaryInstall => "SSH extension couldn't be installed",
             Self::Launch => "SSH extension couldn't be started",
         }
@@ -46,7 +46,9 @@ impl SshRemoteServerFailureKind {
 
     fn description(self) -> &'static str {
         match self {
-            Self::BinaryCheck => "The SSH extension binary could not be found on the remote host.",
+            Self::BinaryCheck => {
+                "The SSH extension binary could not be verified on the remote host."
+            }
             Self::BinaryInstall => {
                 "The binary could not be written or executed on the remote host."
             }

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -309,6 +309,34 @@ pub enum RemoteServerManagerEvent {
     ServerMessageDecodingError { session_id: SessionId },
 }
 
+impl RemoteServerManagerEvent {
+    /// Returns the [`SessionId`] this event pertains to, or `None` for
+    /// host-scoped variants.
+    pub fn session_id(&self) -> Option<SessionId> {
+        match self {
+            RemoteServerManagerEvent::SessionConnecting { session_id }
+            | RemoteServerManagerEvent::SessionConnected { session_id, .. }
+            | RemoteServerManagerEvent::SessionConnectionFailed { session_id, .. }
+            | RemoteServerManagerEvent::SessionDisconnected { session_id, .. }
+            | RemoteServerManagerEvent::SessionReconnected { session_id, .. }
+            | RemoteServerManagerEvent::SessionDeregistered { session_id }
+            | RemoteServerManagerEvent::NavigatedToDirectory { session_id, .. }
+            | RemoteServerManagerEvent::SetupStateChanged { session_id, .. }
+            | RemoteServerManagerEvent::BinaryCheckComplete { session_id, .. }
+            | RemoteServerManagerEvent::BinaryInstallComplete { session_id, .. }
+            | RemoteServerManagerEvent::ClientRequestFailed { session_id, .. }
+            | RemoteServerManagerEvent::ServerMessageDecodingError { session_id } => {
+                Some(*session_id)
+            }
+            RemoteServerManagerEvent::HostConnected { .. }
+            | RemoteServerManagerEvent::HostDisconnected { .. }
+            | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
+            | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+            | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. } => None,
+        }
+    }
+}
+
 /// Shell info recorded by [`RemoteServerManager::notify_session_bootstrapped`].
 ///
 /// Persists for the lifetime of the session (removed only in

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -498,6 +498,14 @@ impl RemoteServerManager {
                     let result = transport.install_binary().await;
                     let _ = spawner
                         .spawn(move |_me, ctx| {
+                            if let Err(ref error) = result {
+                                ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
+                                    session_id,
+                                    state: RemoteServerSetupState::Failed {
+                                        error: error.clone(),
+                                    },
+                                });
+                            }
                             ctx.emit(RemoteServerManagerEvent::BinaryInstallComplete {
                                 session_id,
                                 result,

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -450,8 +450,16 @@ impl RemoteServerManager {
                     };
                     let _ = spawner
                         .spawn(move |me, ctx| {
-                            if let Some(ref p) = platform {
+                            if let Some(p) = &platform {
                                 me.session_platforms.insert(session_id, p.clone());
+                            }
+                            if let Err(error) = &check_result {
+                                ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
+                                    session_id,
+                                    state: RemoteServerSetupState::Failed {
+                                        error: error.clone(),
+                                    },
+                                });
                             }
                             ctx.emit(RemoteServerManagerEvent::BinaryCheckComplete {
                                 session_id,
@@ -498,7 +506,7 @@ impl RemoteServerManager {
                     let result = transport.install_binary().await;
                     let _ = spawner
                         .spawn(move |_me, ctx| {
-                            if let Err(ref error) = result {
+                            if let Err(error) = &result {
                                 ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
                                     session_id,
                                     state: RemoteServerSetupState::Failed {


### PR DESCRIPTION
## Description
* Fixes [APP-4305](https://linear.app/warpdotdev/issue/APP-4305/fix-initialization-error-ux-showing-in-all-sessions) and [APP-4306 ](https://linear.app/warpdotdev/issue/APP-4306/improved-error-ux-displaying-the-actual-error-message)
* More detailed error strings: https://warpdev.slack.com/archives/C0AMRA82ZKL/p1777081270892889
* Failed banner rendering in multiple terminals: https://warpdev.slack.com/archives/C0AMRA82ZKL/p1777080951130509
* Renders banner when init and connect fails (via `Event::SessionConnectionFailed`) 
* Ensures the loading footer isn't shown when the failed banner is rendered: 
  *  Via explicit check when rendering loading footer + via sending `SetupStateChanged` along with the on complete events  
## Testing
Verified banner is not shown in multiple terminal sessions locally 
https://www.loom.com/share/a59958ae580f4b3ba9a6e2c2a66abeb3

Updated banner ui
<img width="730" height="145" alt="Screenshot 2026-04-28 at 6 56 18 PM" src="https://github.com/user-attachments/assets/576871c1-5e5c-4a78-87b8-3bd53c3f5ca3" />

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode