### PR TITLE
Migrate SSH install setting to standard macros

### DIFF
--- a/app/src/settings_view/warpify_page.rs
+++ b/app/src/settings_view/warpify_page.rs
@@ -21,7 +21,8 @@ use warpui::{
 };
 
 use crate::terminal::warpify::settings::{
-    EnableSshWarpification, SshExtensionInstallMode, UseSshTmuxWrapper, WarpifySettingsChangedEvent,
+    EnableSshWarpification, SshExtensionInstallMode, SshExtensionInstallModeSetting,
+    UseSshTmuxWrapper, WarpifySettingsChangedEvent,
 };
 use crate::ui_components::blended_colors;
 use crate::{
@@ -109,7 +110,7 @@ impl WarpifyPageView {
             me.update_button_states(model, ctx);
             if matches!(
                 event,
-                WarpifySettingsChangedEvent::SshExtensionInstallMode { .. }
+                WarpifySettingsChangedEvent::SshExtensionInstallModeSetting { .. }
             ) {
                 me.update_dropdown(ctx);
             }
@@ -721,8 +722,8 @@ impl SettingsWidget for SSHWidget {
                         Some(SSH_EXTENSION_INSTALL_MODE_DESCRIPTION),
                         None,
                         LocalOnlyIconState::for_setting(
-                            SshExtensionInstallMode::storage_key(),
-                            SshExtensionInstallMode::sync_to_cloud(),
+                            SshExtensionInstallModeSetting::storage_key(),
+                            SshExtensionInstallModeSetting::sync_to_cloud(),
                             &mut self.local_only_icon_tooltip_states.borrow_mut(),
                             app,
                         ),

--- a/app/src/terminal/warpify/settings.rs
+++ b/app/src/terminal/warpify/settings.rs
@@ -92,15 +92,15 @@ pub enum SshExtensionInstallMode {
     NeverInstall,
 }
 
-settings::macros::implement_setting_for_enum!(
-    SshExtensionInstallMode,
-    WarpifySettings,
-    SupportedPlatforms::ALL,
-    SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+maybe_define_setting!(SshExtensionInstallModeSetting, group: WarpifySettings, {
+    type: SshExtensionInstallMode,
+    default: SshExtensionInstallMode::default(),
+    supported_platforms: SupportedPlatforms::ALL,
+    sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
     private: false,
     toml_path: "warpify.ssh.ssh_extension_install_mode",
     description: "Controls SSH extension installation behavior.",
-);
+});
 
 impl SshExtensionInstallMode {
     pub fn display_name(&self) -> &'static str {
@@ -158,7 +158,7 @@ pub struct WarpifySettings {
 
     /// Controls the installation behavior for the SSH extension (remote server) when the binary
     /// is not installed on the remote host.
-    pub ssh_extension_install_mode: SshExtensionInstallMode,
+    pub ssh_extension_install_mode: SshExtensionInstallModeSetting,
 }
 
 #[cfg(windows)]
@@ -224,7 +224,7 @@ impl WarpifySettings {
             ssh_hosts_denylist,
             enable_ssh_warpification: EnableSshWarpification::new_from_storage(ctx),
             use_ssh_tmux_wrapper: UseSshTmuxWrapper::new_from_storage(ctx),
-            ssh_extension_install_mode: SshExtensionInstallMode::new_from_storage(ctx),
+            ssh_extension_install_mode: SshExtensionInstallModeSetting::new_from_storage(ctx),
         }
     }
 
@@ -247,7 +247,7 @@ impl WarpifySettings {
             ssh_hosts_denylist,
             enable_ssh_warpification: EnableSshWarpification::new(None),
             use_ssh_tmux_wrapper: UseSshTmuxWrapper::new(None),
-            ssh_extension_install_mode: SshExtensionInstallMode::new(None),
+            ssh_extension_install_mode: SshExtensionInstallModeSetting::new(None),
         }
     }
 
@@ -272,7 +272,7 @@ impl WarpifySettings {
                 }
                 WarpifySettingsChangedEvent::EnableSshWarpification { .. } => {}
                 WarpifySettingsChangedEvent::UseSshTmuxWrapper { .. } => {}
-                WarpifySettingsChangedEvent::SshExtensionInstallMode { .. } => {}
+                WarpifySettingsChangedEvent::SshExtensionInstallModeSetting { .. } => {}
             })
         });
 
@@ -311,7 +311,7 @@ impl WarpifySettings {
         register_settings_events!(
             WarpifySettings,
             ssh_extension_install_mode,
-            SshExtensionInstallMode,
+            SshExtensionInstallModeSetting,
             handle.clone(),
             ctx
         );
@@ -345,7 +345,7 @@ pub enum WarpifySettingsChangedEvent {
     UseSshTmuxWrapper {
         change_event_reason: ChangeEventReason,
     },
-    SshExtensionInstallMode {
+    SshExtensionInstallModeSetting {
         change_event_reason: ChangeEventReason,
     },
 }


### PR DESCRIPTION
## Description
We want to migrate SSH install setting to use `maybe_define_setting` instead of `implement_setting_for_enum`

The former allows us to have properly setup wrapper that exposes methods like `is_value_explicitly_set` which we will use in the followup server experiment setup

## Testing
Tested locally and confirmed changing setting still works