### PR TITLE
Fix stale path references in WARP.md

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -65,11 +65,11 @@ This is a Rust-based terminal emulator with a custom UI framework called **WarpU
 - Workspace and session management (`workspace/`)
 
 **Core Libraries**:
-- `warp_core/` - Core utilities and platform abstractions
-- `editor/` - Text editing functionality
-- `ui/` - Custom UI framework
-- `ipc/` - Inter-process communication
-- `graphql/` - GraphQL client and schema
+- `crates/warp_core/` - Core utilities and platform abstractions
+- `crates/editor/` - Text editing functionality
+- `crates/warpui/` and `crates/warpui_core/` - Custom UI framework
+- `crates/ipc/` - Inter-process communication
+- `crates/graphql/` - GraphQL client and schema
 
 ### Key Architectural Patterns
 
@@ -82,10 +82,10 @@ This is a Rust-based terminal emulator with a custom UI framework called **WarpU
 ### Development Guidelines
 
 **Workspace Structure**:
-- This is a Cargo workspace with 34+ member crates
-- Main binary is in `app/`, UI framework in `ui/`
+- This is a Cargo workspace with 60+ member crates
+- Main binary is in `app/`, UI framework in `crates/warpui/`
 - Platform-specific code is conditionally compiled
-- Integration tests are in `integration/`
+- Integration tests are in `crates/integration/`
 
 **Coding Style Preferences**:
 - Avoid unnecessary type annotations, especially in closure params.
@@ -134,11 +134,11 @@ This is a Rust-based terminal emulator with a custom UI framework called **WarpU
 
 **Database**:
 - Uses Diesel ORM with SQLite
-- Migrations in `migrations/` directory
-- Schema defined in `app/src/persistence/schema.rs`
+- Migrations in `crates/persistence/migrations/`
+- Schema defined in `crates/persistence/src/schema.rs`
 
 **GraphQL**:
-- Schema and client code generation from `graphql/api/schema.graphql`
+- Schema and client code generation from `crates/warp_graphql_schema/api/schema.graphql`
 - TypeScript types generated for frontend integration
 
 ### Feature Flags


### PR DESCRIPTION
## Description

A few path references in WARP.md don't match the current workspace layout. The "Core Libraries" bullets list `warp_core/`, `editor/`, `ui/`, `ipc/`, and `graphql/` as if they live at the repo root, but each one is under `crates/`. The "Workspace Structure" line still says "34+ member crates" — `find crates -maxdepth 1 -mindepth 1 -type d` returns 63 today. And the Database / GraphQL sections point at paths that don't resolve:

- `migrations/` → `crates/persistence/migrations/`
- `app/src/persistence/schema.rs` → `crates/persistence/src/schema.rs`
- `graphql/api/schema.graphql` → `crates/warp_graphql_schema/api/schema.graphql`

Updated each reference to match what's on disk.

## Testing

Docs-only change.