### PR TITLE
Fix typo in cloud_object doc comment

### DIFF
--- a/crates/warp_server_client/src/cloud_object/mod.rs
+++ b/crates/warp_server_client/src/cloud_object/mod.rs
@@ -544,7 +544,7 @@ pub struct CloudObjectMetadata {
     pub pending_changes_statuses: CloudObjectStatuses,
     pub trashed_ts: Option<ServerTimestamp>,
     pub folder_id: Option<SyncId>,
-    /// Welcome objects are created on the server when a user first recieves
+    /// Welcome objects are created on the server when a user first receives
     /// access to Warp Drive as part of onboarding.
     pub is_welcome_object: bool,
     pub last_editor_uid: Option<String>,


### PR DESCRIPTION
## Description

Corrects a misspelling in the doc comment on `is_welcome_object` in `crates/warp_server_client/src/cloud_object/mod.rs`: `recieves` → `receives`.

## Testing

Doc-comment-only change.