### PR TITLE
Fix doubled-word typos in crates/ comments

### DIFF
--- a/crates/settings/src/manager.rs
+++ b/crates/settings/src/manager.rs
@@ -94,7 +94,7 @@ pub enum SettingsEvent {
 }
 
 impl SettingsManager {
-    /// Registers a function that updates a a setting with the given storage key
+    /// Registers a function that updates a setting with the given storage key
     /// to have a new value. Also tracks whether that storage key is for a cloud-synced
     /// setting and what platforms it's supported on.
     #[allow(clippy::too_many_arguments)]

--- a/crates/warp_completer/src/completer/engine/argument/legacy.rs
+++ b/crates/warp_completer/src/completer/engine/argument/legacy.rs
@@ -154,7 +154,7 @@ async fn suggestions_for_parse_error(
                     missing_arg_index,
                 },
         } => {
-            // If there was trailing whitespace in the line, respect the error and try to to complete based
+            // If there was trailing whitespace in the line, respect the error and try to complete based
             // on the missing argument. If there wasn't any trailing whitespace, the user is trying
             // to complete an argument before the one that's missing (such as `git push ori<tab>`) so we
             // treat this as successful parse so that we can parse out the argument correctly.
@@ -213,7 +213,7 @@ async fn suggestions_for_parse_error(
                     positional_index,
                 },
         } => {
-            // If there was ending whitespace in the line respect the error and try to to complete based
+            // If there was ending whitespace in the line respect the error and try to complete based
             // on the missing positional. If there was not an ending whitespace, the user is try trying
             // to complete a positional before the one that's missing such as `git push ori<tab>` so we
             // treat this as successful parse so that we can parse out the positional correctly.
@@ -303,7 +303,7 @@ async fn suggestions_for_last_argument(
         add_extra_positional(shell_command, cursor);
     }
 
-    // Find the last positional and named value within the the command that the user entered.
+    // Find the last positional and named value within the command that the user entered.
     // Whichever ends last is the value we're trying to complete on.
     let last_positional = shell_command.last_positional();
     let last_named_value = shell_command.last_named_argument();

--- a/crates/warp_completer/src/completer/engine/argument/v2.rs
+++ b/crates/warp_completer/src/completer/engine/argument/v2.rs
@@ -143,7 +143,7 @@ async fn suggestions_for_parse_error(
                     missing_arg_index,
                 },
         } => {
-            // If there was trailing whitespace in the line, respect the error and try to to complete based
+            // If there was trailing whitespace in the line, respect the error and try to complete based
             // on the missing argument. If there wasn't any trailing whitespace, the user is trying
             // to complete an argument before the one that's missing (such as `git push ori<tab>`) so we
             // treat this as successful parse so that we can parse out the argument correctly.
@@ -196,7 +196,7 @@ async fn suggestions_for_parse_error(
                     positional_index,
                 },
         } => {
-            // If there was ending whitespace in the line respect the error and try to to complete based
+            // If there was ending whitespace in the line respect the error and try to complete based
             // on the missing positional. If there was not an ending whitespace, the user is try trying
             // to complete a positional before the one that's missing such as `git push ori<tab>` so we
             // treat this as successful parse so that we can parse out the positional correctly.
@@ -277,7 +277,7 @@ async fn suggestions_for_last_argument(
         add_extra_positional(shell_command, cursor);
     }
 
-    // Find the last positional and named value within the the command that the user entered.
+    // Find the last positional and named value within the command that the user entered.
     // Whichever ends last is the value we're trying to complete on.
     let last_positional = shell_command.last_positional();
     let last_named_value = shell_command.last_named_argument();

--- a/crates/warp_completer/src/completer/suggest/test.rs
+++ b/crates/warp_completer/src/completer/suggest/test.rs
@@ -354,7 +354,7 @@ pub fn test_completes_dotfiles() {
         vec!["./", "../", ".bar/"],
     );
 
-    // Dotfiles should not be included if the the path does not start with a dot.
+    // Dotfiles should not be included if the path does not start with a dot.
     assert_eq!(
         complete_at_end_of_line("cat ", &ctx),
         vec!["foo/", "foobar"],
@@ -1682,7 +1682,7 @@ fn test_hidden_suggestion_only_appears_on_exact_match() {
         .with_entries_in_pwd([EngineDirEntry::test_dir("app")]);
     let ctx = FakeCompletionContext::new(registry).with_path_completion_context(path_ctx);
 
-    // Need to use filter_by_query here to incorporate the the exact match logic.
+    // Need to use filter_by_query here to incorporate the exact match logic.
     let suggestion_results =
         complete_at_end_of_line_with_query("cd ", "", MatchStrategy::CaseInsensitive, &ctx);
     assert_eq!(suggestion_results, vec!["app/"]);
@@ -2089,7 +2089,7 @@ fn test_exact_match_completions() {
     );
 
     // Exact match suggestion should be the first suggestion even if others have more priority.
-    // Need to use filter_by_query here to incorporate the the exact match logic.
+    // Need to use filter_by_query here to incorporate the exact match logic.
     let suggestions = complete_at_end_of_line_with_query(
         "test six six-arg",
         "six-arg",

--- a/crates/warp_core/src/ui/color/contrast.rs
+++ b/crates/warp_core/src/ui/color/contrast.rs
@@ -11,7 +11,7 @@ const LUMINANCE_OFFSET_FOR_CONTRAST_RATIO: f32 = 0.05;
 
 /// Returns a new foreground color that when rendered against `background_color` would have a
 /// contrast of at least `minimum_allowed_contrast`. NOTE the `background_color` must be fully
-/// opaque in in order to perform proper contrast checking.
+/// opaque in order to perform proper contrast checking.
 ///
 /// If `foreground_color` already meets the minimum contrast, it is returned unchanged.
 ///

--- a/crates/warp_logging/src/wasm.rs
+++ b/crates/warp_logging/src/wasm.rs
@@ -188,7 +188,7 @@ impl Log for WasmLogger {
     fn flush(&self) {}
 }
 
-/// Initialize the logger which the given config. If failed, it will log a message to the the browser console.
+/// Initialize the logger which the given config. If failed, it will log a message to the browser console.
 fn init_logger(config: Config) {
     let max_level = config.level;
     let wl = WasmLogger {

--- a/crates/warp_logging/src/wasm.rs
+++ b/crates/warp_logging/src/wasm.rs
@@ -188,7 +188,7 @@ impl Log for WasmLogger {
     fn flush(&self) {}
 }
 
-/// Initialize the logger which the given config. If failed, it will log a message to the browser console.
+/// Initialize the logger with the given config. If initialization fails, it will log a message to the browser console.
 fn init_logger(config: Config) {
     let max_level = config.level;
     let wl = WasmLogger {

--- a/crates/warpui/src/fonts/text_layout_test.rs
+++ b/crates/warpui/src/fonts/text_layout_test.rs
@@ -483,7 +483,7 @@ fn test_char_indices() -> Result<()> {
     // characters get combined to become a single glyph. At a high level, what this is testing
     // is that after laying out the string, we see some characters get combined into a single
     // glyph. For example, the text "Zapfino" gets combined into a single glyph, which is why
-    // there is a jump from 23 to 30 in in the list of glyph indices below.
+    // there is a jump from 23 to 30 in the list of glyph indices below.
     // See https://docs.google.com/drawings/d/18qOKhzA5rWaMuxKVeWFDXh7ebrDjxongarAckkm0qnE/edit
     // for a full diagram of what's happening here.
     assert_eq!(

--- a/crates/warpui/src/platform/app.rs
+++ b/crates/warpui/src/platform/app.rs
@@ -83,7 +83,7 @@ impl AppBuilder {
     /// [`Keystroke`]-based binding using the provided `custom_tag_to_keystroke` function.
     ///
     /// This can be useful in the cases where an application registers a binding with a
-    /// [`crate::keymap::Trigger::Custom`] for use in a Mac menu, but still wants to to register the
+    /// [`crate::keymap::Trigger::Custom`] for use in a Mac menu, but still wants to register the
     /// binding with its corresponding `Keystroke` on other platforms that don't support menus.
     pub fn convert_custom_triggers_to_keystroke_triggers(
         &mut self,

--- a/crates/warpui/src/platform/mac/rendering/wgpu/mod.rs
+++ b/crates/warpui/src/platform/mac/rendering/wgpu/mod.rs
@@ -61,7 +61,7 @@ impl Device {
 /// guaranteed that the underlying window won't become invalid while the `WindowHandle` is alive.
 /// In the case of Warp this _should_ be safe because we ultimately deallocate the native window
 /// when [`crate::platform::mac::Window`] is deallocated (once a `Window` is deallocated, there
-/// are no pointers to the native window anymore, which cause it to to be deallocated via the
+/// are no pointers to the native window anymore, which cause it to be deallocated via the
 /// `warp_dealloc_window` callback).
 /// See <https://github.com/rust-windowing/raw-window-handle/pull/73> for more information on the
 /// safety requirements of implementing the [`HasRawWindowHandle`] trait.

--- a/crates/warpui/src/platform/mac/text_layout_test.rs
+++ b/crates/warpui/src/platform/mac/text_layout_test.rs
@@ -52,7 +52,7 @@ fn test_char_indices_ligatures() -> Result<()> {
     // characters get combined to become a single glyph. At a high level, what this is testing
     // is that after laying out the string, we see some characters get combined into a single
     // glyph. For example, the text "Zapfino" gets combined into a single glyph, which is why
-    // there is a jump from 23 to 30 in in the list of glyph indices below.
+    // there is a jump from 23 to 30 in the list of glyph indices below.
     // See https://docs.google.com/drawings/d/18qOKhzA5rWaMuxKVeWFDXh7ebrDjxongarAckkm0qnE/edit
     // for a full diagram of what's happening here.
     assert_eq!(

--- a/crates/warpui/src/windowing/winit/fonts/font_handle.rs
+++ b/crates/warpui/src/windowing/winit/fonts/font_handle.rs
@@ -85,7 +85,7 @@ impl FontHandle {
         }
     }
 
-    /// Validates the the [`FontHandle`] is a parseable font.
+    /// Validates the [`FontHandle`] is a parseable font.
     pub fn validate_font_data(&self) -> Result<(), Error> {
         self.data.validate()
     }

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -3423,7 +3423,7 @@ impl AppContext {
                 return;
             }
 
-            // TODO(PLAT-747): Ideally the the font cache itself is a model and can
+            // TODO(PLAT-747): Ideally the font cache itself is a model and can
             // handle emitting these events.
             FallbackFontModel::handle(self).update(self, |model, ctx| {
                 model.loaded_fallback_font(ctx);

--- a/crates/warpui_core/src/elements/flex/mod_test.rs
+++ b/crates/warpui_core/src/elements/flex/mod_test.rs
@@ -193,7 +193,7 @@ fn test_flex_main_axis_alignment() {
             let view_3_size = vec2f(50., 50.);
 
             // The view has a min axis size, so each element should be rendered right next to
-            // each other and and the flex should take up the total size of the elements.
+            // each other and the flex should take up the total size of the elements.
             assert_eq!(view_1, RectF::new(Vector2F::zero(), view_1_size));
             assert_eq!(view_2, RectF::new(vec2f(50., 0.), view_2_size));
             assert_eq!(view_3, RectF::new(vec2f(100., 0.), view_3_size));
@@ -257,7 +257,7 @@ fn test_flex_main_axis_alignment() {
                 .get_position("flex")
                 .expect("position should exist");
 
-            // Ensure that the the elements are evenly spaced (with no extra space at the
+            // Ensure that the elements are evenly spaced (with no extra space at the
             // beginning or end) and that the flex expands out to the max size of the window.
             assert_eq!(view_1, RectF::new(Vector2F::zero(), view_1_size));
             assert_eq!(view_2, RectF::new(vec2f(125., 0.), view_2_size));
@@ -289,7 +289,7 @@ fn test_flex_main_axis_alignment() {
                 .get_position("flex")
                 .expect("position should exist");
 
-            // Ensure that the the elements are evenly spaced, including space before and after
+            // Ensure that the elements are evenly spaced, including space before and after
             // the child elements, and that the flex expands out to the max size of the window.
             assert_eq!(view_1, RectF::new(vec2f(37.5, 0.), view_1_size));
             assert_eq!(view_2, RectF::new(vec2f(125., 0.), view_2_size));

--- a/crates/warpui_core/src/elements/selectable_area.rs
+++ b/crates/warpui_core/src/elements/selectable_area.rs
@@ -706,7 +706,7 @@ impl Element for SelectableArea {
 
                 // Materialize and cache the selected text if SelectableArea is about to go off-screen.
                 // Since origin isn't available when SelectableArea is off-screen, we aren't able to
-                // materialize the selection on mouse up if that that's the case. As a workaround,
+                // materialize the selection on mouse up if that's the case. As a workaround,
                 // we cache it here ahead of time.
                 if origin.y() < 0.
                     || origin.y() + size.y() > app.windows().active_display_bounds().height()

--- a/crates/websocket/src/sink_map_err.rs
+++ b/crates/websocket/src/sink_map_err.rs
@@ -13,7 +13,7 @@ where
 }
 
 /// Helper struct to map the [`Err`] of an underlying [`Sink`].
-/// This is a fork of the the `SinkMapErr` defined within `futures-util`
+/// This is a fork of the `SinkMapErr` defined within `futures-util`
 /// (https://docs.rs/futures/latest/futures/sink/struct.SinkMapErr.html) except that it does _not_
 /// panic if the caller tries to write to the sink after a previous attempt to write returned an
 /// error. See <https://github.com/rust-lang/futures-rs/issues/2108> for more details about the


### PR DESCRIPTION
## Description

While reading through a few crates I kept noticing duplicated words in comments — "the the", "in in", "to to", "and and", "a a", "that that". A quick `grep` turned up 17 of them across 15 files. All edits are in `//` and `///` comments — no code, test, or behavior change.

Files touched:

- `crates/settings/src/manager.rs`
- `crates/websocket/src/sink_map_err.rs`
- `crates/warp_completer/src/completer/suggest/test.rs`
- `crates/warp_completer/src/completer/engine/argument/legacy.rs`
- `crates/warp_completer/src/completer/engine/argument/v2.rs`
- `crates/warp_core/src/ui/color/contrast.rs`
- `crates/warp_logging/src/wasm.rs`
- `crates/warpui_core/src/core/app.rs`
- `crates/warpui_core/src/elements/selectable_area.rs`
- `crates/warpui_core/src/elements/flex/mod_test.rs`
- `crates/warpui/src/platform/mac/text_layout_test.rs`
- `crates/warpui/src/platform/mac/rendering/wgpu/mod.rs`
- `crates/warpui/src/platform/app.rs`
- `crates/warpui/src/windowing/winit/fonts/font_handle.rs`
- `crates/warpui/src/fonts/text_layout_test.rs`

Distinct from #9318, which sweeps single-word misspellings (Surpress, occassionally, etc.) under `app/`. I also skipped the two doubled-word lines in `crates/integration/src/test.rs` since #9279 is currently editing that file — happy to fold them in if that PR lands first.

## Testing

Comments-only.