### PR TITLE
Add Build Status section linking to build.warp.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@
 
 You can [download Warp](https://www.warp.dev/download) and [read our docs](https://docs.warp.dev/) for platform-specific instructions.
 
+## Build Status
+
+You can track the latest CI results and build health at [build.warp.dev](https://build.warp.dev).
+
 ## Licensing
 
 Warp's UI framework (the `warpui_core` and `warpui` crates) are licensed under the [MIT license](LICENSE-MIT).

--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@
 
 You can [download Warp](https://www.warp.dev/download) and [read our docs](https://docs.warp.dev/) for platform-specific instructions.
 
-## Build Status
+## Warp Contributions Overview Dashboard
 
-You can track the latest CI results and build health at [build.warp.dev](https://build.warp.dev).
+Explore [build.warp.dev](https://build.warp.dev) to:
+- Watch thousands of Oz agents triage issues, write specs, implement changes, and review PRs
+- View top contributors and in-flight features
+- Track your own issues with GitHub sign-in
+- Click into active agent sessions in a web-compiled Warp terminal
 
 ## Licensing
 


### PR DESCRIPTION
## Description
Adds a **Build Status** section to the README right after Installation and before Licensing, prominently linking to [build.warp.dev](https://build.warp.dev).

## Testing
README-only change, no code tests needed.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/24b02952-f7b1-45c4-9122-dd116c4522ec_
_Run: https://oz.staging.warp.dev/runs/019dd668-0e7c-7cf8-bcbd-0deee3485a1b_

_This PR was generated with [Oz](https://warp.dev/oz)._
