### PR TITLE
Fix typo in markdown_parser doc comment

### DIFF
--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1315,7 +1315,7 @@ fn parse_underline<'a>(state: &mut InlineState, remaining: &'a str) -> &'a str {
 ///
 /// This is approximately equivalent to the CommonMark [process emphasis](https://spec.commonmark.org/0.30/#phase-2-inline-structure)
 /// algorithm. However:
-/// * It omits `openers_bottom`, which is purely a performace optimization.
+/// * It omits `openers_bottom`, which is purely a performance optimization.
 /// * It uses a `Vec` rather than a linked list, which changes the structure a bit to work with lifetimes.
 /// * It also parses [GFM strikethrough](https://github.github.com/gfm/#strikethrough-extension-).
 fn process_emphasis(state: &mut InlineState, stack_bottom: Option<usize>) {


### PR DESCRIPTION
## Description

Fixes a typo in the `process_emphasis` doc comment in `crates/markdown_parser/src/markdown_parser.rs`: `performace` → `performance`.

## Testing

Doc-comment-only change.