### PR TITLE
[APP-9120] Add "Reopen closed session" to tab context menu

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -23,6 +23,7 @@ use crate::ui_components::icons::{Icon, ICON_DIMENSIONS};
 use crate::util::color::{coloru_with_opacity, Opacity};
 use crate::util::truncation::truncate_from_end;
 
+use crate::undo_close::UndoCloseStack;
 use crate::window_settings::WindowSettings;
 use crate::workspace::sync_inputs::SyncedInputState;
 use crate::workspace::tab_settings::{TabCloseButtonPosition, TabSettings};
@@ -408,6 +409,15 @@ impl TabData {
                 .into_item(),
             );
         }
+
+        let is_empty = UndoCloseStack::as_ref(ctx).is_empty();
+        menu_items.push(
+            MenuItemFields::new("Reopen closed session")
+                .with_on_select_action(WorkspaceAction::ReopenClosedSession)
+                .with_disabled(is_empty)
+                .into_item(),
+        );
+
         menu_items
     }
 

--- a/crates/integration/src/test.rs
+++ b/crates/integration/src/test.rs
@@ -2018,6 +2018,37 @@ pub fn test_removing_tabs_out_of_order() -> Builder {
         )
 }
 
+pub fn test_reopen_closed_session_from_tab_context_menu() -> Builder {
+    new_builder()
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            new_step_with_default_assertions("Open a second tab")
+                .with_keystrokes(&[cmd_or_ctrl_shift("t")])
+                .set_timeout(Duration::from_secs(10))
+                .add_assertion(|app, window_id| {
+                    assert_single_terminal_in_tab_bootstrapped(app, window_id, 1)
+                })
+                .add_assertion(assert_tab_count(2)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Close the second tab")
+                .with_keystrokes(&[cmd_or_ctrl_shift("w")])
+                .add_assertion(assert_tab_count(1)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Right-click first tab to open context menu")
+                .with_right_click_on_saved_position("tab_position_0"),
+        )
+        .with_step(
+            new_step_with_default_assertions(
+                "Click 'Reopen closed session' and verify tab is restored",
+            )
+            .with_click_on_saved_position("Reopen closed session")
+            .set_timeout(Duration::from_secs(10))
+            .add_assertion(assert_tab_count(2)),
+        )
+}
+
 pub fn test_add_and_close_session() -> Builder {
     let pid = Rc::new(std::cell::RefCell::new(0_u32));
     let pid_clone = pid.clone();

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -20,6 +20,7 @@ integration_tests! {
     test_unescaped_prompt_bootstraps,
     test_unnecessary_resizes,
     test_removing_tabs_out_of_order,
+    test_reopen_closed_session_from_tab_context_menu,
     #[ignore = "Affected by agent_view feature flag UI changes"]
     test_suggestions_menu_positioning,
     test_open_and_close_theme_creator_modal,


### PR DESCRIPTION
## Description

Fixes #9120.

The "Reopen closed session" action existed and was reachable via keyboard shortcut (`Cmd/Ctrl+Shift+T`) and the macOS native File menu, but was not surfaced in the tab right-click context menu on any platform.

This PR adds a "Reopen closed session" item to the tab context menu (via `TabData::close_tab_menu_items()`), available on all platforms. The item is disabled (greyed out) when the undo-close stack is empty, consistent with how the same action is presented in the macOS File menu.

<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Testing

Added an integration test `test_reopen_closed_session_from_tab_context_menu` that:
1. Waits for the initial tab to bootstrap
2. Opens a second tab via keyboard shortcut
3. Closes the second tab
4. Right-clicks the first tab to open the context menu
5. Clicks "Reopen closed session" and asserts that the tab count returns to 2

`cargo fmt` and `cargo clippy` pass cleanly.

## Server API dependencies

N/A — this is a purely client-side UI change with no server interaction.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: "Reopen closed session" now appears in the tab right-click context menu on all platforms, disabled when no closed sessions are available to restore.