### PR TITLE
Also recognize .h++ as a C++ header extension

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -152,7 +152,7 @@ pub fn language_by_filename(path: &Path) -> Option<Arc<Language>> {
         "tsx" => language_by_name("tsx"),
         "ts" | "cts" | "mts" => language_by_name("typescript"),
         "java" | "groovy" | "gvy" | "gy" | "gsh" => language_by_name("java"),
-        "cpp" | "cxx" | "cc" | "h" | "hh" | "hpp" | "hxx" | "H" => language_by_name("cpp"),
+        "cpp" | "cxx" | "cc" | "h" | "hh" | "hpp" | "hxx" | "H" | "h++" => language_by_name("cpp"),
         "sh" | "zsh" | "bash" => language_by_name("shell"),
         "cs" => language_by_name("csharp"),
         "html" => language_by_name("html"),

--- a/crates/languages/src/lib_tests.rs
+++ b/crates/languages/src/lib_tests.rs
@@ -25,7 +25,9 @@ fn all_supported_languages_load_successfully() {
 
 #[test]
 fn cpp_header_extensions_resolve_to_cpp_language() {
-    for filename in ["header.hpp", "header.hxx", "header.H"] {
+    // Cover the common modern C++ header extensions (`.hpp`, `.hxx`),
+    // the older uppercase `.H` convention, and the rarer `.h++` form.
+    for filename in ["header.hpp", "header.hxx", "header.H", "header.h++"] {
         let language = language_by_filename(Path::new(filename))
             .unwrap_or_else(|| panic!("expected {filename} to resolve to C++"));
 


### PR DESCRIPTION
Rebased on top of #9388 (which landed \`hpp\`, \`hxx\`, and the uppercase \`H\` form, per @bnavetta's request).

This keeps just the one delta from the original PR: adding \`h++\` to the match arm so the case list covers the full set of C++ header conventions, and extending the existing \`cpp_header_extensions_resolve_to_cpp_language\` test to include \`header.h++\`.

\`h++\` is the rarer of the C++ header conventions but it's part of the canonical set (used in some older codebases and called out in the GNU coding style guidance for C++).

### Testing

- Existing \`cpp_header_extensions_resolve_to_cpp_language\` test extended to include \`header.h++\`.
- \`cargo fmt -p languages -- --check\` passes.
- \`cargo test -p languages\` doesn't run locally for me (Metal toolchain unavailable on this machine — same situation as #9277), but CI should cover it.

### Server API

No server changes.

### Agent Mode

Not applicable.

### Changelog Entries

\`CHANGELOG-IMPROVEMENT\`: Recognize \`.h++\` files as C++ headers (in addition to \`.hpp\`, \`.hxx\`, and \`.H\` from #9388).