### PR TITLE
Surface Reopen Closed Session in the new-session menu on Linux and Windows

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5987,7 +5987,7 @@ impl Workspace {
     /// Builds the unified new-session menu items
     /// tab bar chevron and the vertical tab bar `+` button.
     ///
-    /// Order: Agent → Terminal (sidecar) → Cloud Oz → [tab configs] → separator → New worktree config (sidecar) → New tab config.
+    /// Order: Agent → Terminal (sidecar) → Cloud Oz → [tab configs] → separator → New worktree config (sidecar) → New tab config → separator → Reopen closed session.
     fn unified_new_session_menu_items(
         &self,
         ctx: &mut ViewContext<Self>,
@@ -5999,6 +5999,8 @@ impl Workspace {
         let effective_default = ai_settings.default_session_mode(ctx);
         let default_tab_config_path = ai_settings.default_tab_config_path().to_string();
         let shortcut_label = keybinding_name_to_display_string(NEW_TAB_BINDING_NAME, ctx);
+        let reopen_closed_session_shortcut_label =
+            keybinding_name_to_display_string("app:reopen_closed_session", ctx);
 
         // 1. Agent (if AI enabled)
         if is_any_ai_enabled {
@@ -6158,6 +6160,15 @@ impl Workspace {
                     .into_item(),
             );
         }
+
+        menu_items.push(MenuItem::Separator);
+        menu_items.push(
+            MenuItemFields::new("Reopen closed session")
+                .with_on_select_action(WorkspaceAction::ReopenClosedSession)
+                .with_key_shortcut_label(reopen_closed_session_shortcut_label)
+                .with_disabled(UndoCloseStack::handle(ctx).as_ref(ctx).is_empty())
+                .into_item(),
+        );
 
         menu_items
     }

--- a/app/src/workspace/view_test.rs
+++ b/app/src/workspace/view_test.rs
@@ -686,6 +686,15 @@ fn new_session_menu_label(item: &MenuItem<WorkspaceAction>) -> String {
     }
 }
 
+fn reopen_closed_session_menu_item(
+    menu_items: &[MenuItem<WorkspaceAction>],
+) -> &MenuItemFields<WorkspaceAction> {
+    match menu_items.last() {
+        Some(MenuItem::Item(fields)) if fields.label() == "Reopen closed session" => fields,
+        _ => panic!("expected Reopen closed session to be the last new-session menu item"),
+    }
+}
+
 #[test]
 fn test_reward_modal_no_overlap() {
     App::test((), |mut app| async move {
@@ -2571,6 +2580,37 @@ fn test_unified_new_session_menu_uses_new_worktree_config_label_and_order() {
                 labels.get(separator_index + 2),
                 Some(&"New tab config".to_string())
             );
+        });
+    });
+}
+
+#[test]
+fn test_unified_new_session_menu_includes_reopen_closed_session() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            let menu_items = workspace.unified_new_session_menu_items(ctx);
+            assert!(matches!(
+                menu_items.get(menu_items.len() - 2),
+                Some(MenuItem::Separator)
+            ));
+
+            let reopen_item = reopen_closed_session_menu_item(&menu_items);
+            assert!(reopen_item.is_disabled());
+            assert!(matches!(
+                reopen_item.on_select_action(),
+                Some(action) if matches!(action, WorkspaceAction::ReopenClosedSession)
+            ));
+
+            workspace.add_terminal_tab(false, ctx);
+            workspace.remove_tab(workspace.active_tab_index(), true, true, ctx);
+
+            let menu_items = workspace.unified_new_session_menu_items(ctx);
+            let reopen_item = reopen_closed_session_menu_item(&menu_items);
+            assert!(!reopen_item.is_disabled());
         });
     });
 }


### PR DESCRIPTION
## Description

Issue #9120 reports that on Linux and Windows, the "Restore closed tab" action works via the keyboard shortcut (`Ctrl+Alt+T`) but has no UI affordance, so users can't discover it. macOS already exposes "Reopen closed session" through the application menu bar (`app/src/app_menus.rs:1042-1056`), but Linux and Windows have no such menu.

This adds a "Reopen closed session" entry as the last item in the new-session `+` dropdown (`unified_new_session_menu_items`) on every platform. Behavior matches the existing macOS menu entry: the item is greyed out when `UndoCloseStack` is empty, and the keybinding hint is sourced from the `app:reopen_closed_session` editable binding registered in `app/src/undo_close/mod.rs`. Adding it on macOS too gives parity for users who use the dropdown rather than the menu bar.

## Testing

Added `test_unified_new_session_menu_includes_reopen_closed_session` in `app/src/workspace/view_test.rs`. The test:
- Asserts the second-to-last item is a `MenuItem::Separator`.
- Asserts the last item is "Reopen closed session" and dispatches `WorkspaceAction::ReopenClosedSession`.
- Asserts the item is disabled when the `UndoCloseStack` is empty.
- Adds a terminal tab, removes it, and asserts the item becomes enabled.

Verified locally with `cargo nextest run -p warp test_unified_new_session_menu_includes_reopen_closed_session`, `cargo fmt -- --check`, and `cargo clippy -p warp --all-targets --tests -- -D warnings`.

## Server API dependencies

N/A. Pure UI change wired to an existing action.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Reopen Closed Session is now reachable from the new-session menu on Linux and Windows.

Fixes #9120
