### PR TITLE
Fix typo: teh -> the in stack positioning test comment

### DIFF
--- a/crates/warpui_core/src/elements/stack/mod_test.rs
+++ b/crates/warpui_core/src/elements/stack/mod_test.rs
@@ -450,7 +450,7 @@ fn test_relative_positioning() {
         );
 
         // Now just bound vertically to the parent. This should not change the positioning since
-        // the element is already bound vertically within teh parent.
+        // the element is already bound vertically within the parent.
         position_child_and_assert_location(
             OffsetPositioning::from_axes(
                 PositioningAxis::relative_to_stack_child(


### PR DESCRIPTION
## Description

Fixes a one-character typo in a comment in `crates/warpui_core/src/elements/stack/mod_test.rs` (line 453): `teh` -> `the`. Comment-only change with no functional or test impact; the previous line of the same comment block uses the correct spelling, so this is an obvious slip.

## Testing

Comment-only change in a test file; no test impact.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode