### PR TITLE
Forward Opt+Enter as ESC+CR to alt-screen programs on macOS

### DIFF
--- a/crates/warp_terminal/src/model/escape_sequences.rs
+++ b/crates/warp_terminal/src/model/escape_sequences.rs
@@ -570,9 +570,13 @@ fn meta_keystroke_to_escape_sequence(
     _mode_provider: &impl ModeProvider,
 ) -> Option<Vec<u8>> {
     // On mac, we have a setting that allows users to map the Option keys to
-    // meta.
+    // meta. When that setting is off, Option+letter produces special glyphs
+    // (Option+E = é, etc.), so we don't treat alt as meta by default. The
+    // exception is Enter, which never has an Option-modified glyph — TUIs like
+    // claude/vim/fish expect Option+Enter to arrive as ESC+CR (xterm
+    // convention), so we let alt-enter through here too.
     if OperatingSystem::get().is_mac() {
-        if !keystroke.meta {
+        if !keystroke.meta && !(keystroke.alt && keystroke.key == "enter") {
             return None;
         }
     } else {

--- a/crates/warp_terminal/src/model/escape_sequences_test.rs
+++ b/crates/warp_terminal/src/model/escape_sequences_test.rs
@@ -469,6 +469,24 @@ fn test_meta_keystroke_to_escape_sequence() {
     validate_keystroke_test_cases(test_cases, &terminal_model_mock);
 }
 
+/// On macOS, Option+Enter must encode as ESC+CR even when the user has not
+/// enabled Option-as-Meta. Without this, the bare `\r` falls through to the
+/// PTY and TUIs like claude/vim/fish treat it as plain Enter (submit) rather
+/// than the Alt+Enter sequence they expect for inserting a newline.
+#[test]
+fn test_alt_enter_on_mac_yields_esc_cr_without_option_as_meta() {
+    if !OperatingSystem::get().is_mac() {
+        return;
+    }
+    let test_cases: &[(Keystroke, Vec<u8>)] = &[(
+        Keystroke::parse("alt-enter").unwrap(),
+        vec![C0::ESC, b'\r'],
+    )];
+
+    let terminal_model_mock = TerminalModelMock::new();
+    validate_keystroke_test_cases(test_cases, &terminal_model_mock);
+}
+
 #[test]
 fn test_unmatched_keystroke_does_not_yield_escape_sequence() {
     let test_cases: &[Keystroke] = &[


### PR DESCRIPTION
## Summary

When a TUI like Claude, vim, or fish runs in alt-screen mode, pressing **Option+Enter** on macOS (without the "Option as Meta" setting enabled) was sending a bare `\r` to the PTY instead of the xterm-style `\x1b\r`. The TUI then treated it as a plain Enter and submitted, instead of inserting a newline.

## Relationship to #9514

#9514 (`fb3cb0e`) fixed the case where `meta_keystroke_to_escape_sequence` was reaching the literal-key-name fallback for `enter`/`tab`/`escape` and emitting `ESC` + the literal bytes of the string `"enter"`. After that fix, users who have **Option-as-Meta enabled** correctly get `ESC+CR` for Opt+Enter.

This PR handles the remaining case: users on macOS with **Option-as-Meta disabled** (the default) — for whom `meta_keystroke_to_escape_sequence` early-returns before it ever reaches the special-key map. I rebased onto current `master` and trimmed my original change to just this carve-out, since the special-key map entry is no longer needed.

## Root cause

When alt-screen is active, focus is on `TerminalView` (via `focus_terminal()` → `ctx.focus_self()`), so the editor's `alt-enter` keybinding never fires. The keystroke reaches `alt_screen_element.rs`'s `KeyDown` handler and calls `KeystrokeWithDetails::to_escape_sequence()`. In the legacy fallback chain inside `meta_keystroke_to_escape_sequence` (`crates/warp_terminal/src/model/escape_sequences.rs`):

```rust
if OperatingSystem::get().is_mac() {
    if !keystroke.meta {
        return None;            // ← exits here for Opt+Enter on Mac
    }
}
```

For default Mac config, Opt+Enter has `keystroke.alt = true, keystroke.meta = false`. The function returns `None`, the rest of the chain returns `None` too, and `alt_screen_element` falls through to `key_down(chars)` which dispatches the raw `\r` to the PTY. The Mac `meta`-only gate is correct for letter keys (Option+E = é, etc., shouldn't become `ESC+e`) but Enter has no Option-modified glyph, so it's safe — and expected by xterm-style TUIs — to encode Opt+Enter as a meta keystroke.

## Changes

- `crates/warp_terminal/src/model/escape_sequences.rs`
  - Allow `alt-enter` through `meta_keystroke_to_escape_sequence` on Mac even when `meta` is unset.
- `crates/warp_terminal/src/model/escape_sequences_test.rs`
  - Add a Mac-only test asserting `alt-enter` produces `ESC+CR` when Option-as-Meta is off.

## Test plan

- [x] `cargo test -p warp_terminal escape_sequences` passes (18 tests, including the new one)
- [x] Built locally and verified Opt+Enter inserts a newline in Claude inside the alt-screen instead of submitting
- [ ] Verify behavior is unchanged with `extra_meta_keys.left_alt = true` (Option-as-Meta enabled) — should hit upstream's #9514 path
- [ ] Verify behavior is unchanged when Kitty keyboard protocol is enabled (CSI u path takes precedence)
- [ ] Sanity-check that Opt+letter still produces special glyphs (é, ø, etc.) and isn't being intercepted as `ESC+letter`

## Notes

Filed as a draft. Per CONTRIBUTING.md, bug fixes need a triaged issue first — happy to file one and link it back here once a maintainer confirms scope.
