### PR TITLE
Fix file path detection across wrapped lines

### DIFF
--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -111,6 +111,28 @@ impl Fragment {
     }
 }
 
+fn append_fragments_across_soft_wrap(
+    fragments: &mut Vec<Fragment>,
+    mut next_fragments: Vec<Fragment>,
+) {
+    match (fragments.last(), next_fragments.first()) {
+        (Some(last_fragment), Some(next_fragment))
+            if !last_fragment.has_separator() && !next_fragment.has_separator() =>
+        {
+            let mut fragment = fragments.pop().expect("Fragment should exist");
+
+            fragment.content.push_str(&next_fragment.content);
+            fragment.total_cell_width += next_fragment.total_cell_width;
+            fragments.push(fragment);
+
+            next_fragments.remove(0);
+        }
+        _ => (),
+    }
+
+    fragments.append(&mut next_fragments);
+}
+
 #[derive(Debug)]
 pub struct FragmentBoundary(pub Range<Point>);
 
@@ -1093,115 +1115,66 @@ impl GridHandler {
     /// Return all possible file paths containing the grid point ordered from longest to shortest.
     pub fn possible_file_paths_at_point(&self, displayed_point: Point) -> Vec<PossiblePath> {
         let point = self.maybe_translate_point_from_displayed_to_original(displayed_point);
-        let last_row_end_with_line_wrap = point.row > 0 && self.row_wraps(point.row - 1);
-        let current_row_end_with_line_wrap =
-            point.row + 1 < self.total_rows() && self.row_wraps(point.row);
 
         // All fragments in the row before the point (not including the point)
-        // + Part of the fragments in the previous row if previous line ends with a line wrap.
-        let mut prefix_chunks = match (point.col > 0, last_row_end_with_line_wrap) {
-            // If the hovered point is not at column 0 and the last row ends with a linewrap,
-            // we should take the fragments from the beginning of the line to current row
-            // and the last couple of cells in the previous row. Note that we need to
-            // concatenate the last fragment in the previous row with the first fragment
-            // in the current row since they technically is one conherent fragment.
-            (true, true) => {
-                let mut prev_line_fragments = self.line_to_fragments(
-                    point.row - 1,
-                    self.columns().saturating_sub(LINK_NUM_CHARACTER_SCAN + 1)..self.columns() - 1,
-                    IncludeFirstWideChar::Yes, /*should_scan_forward*/
-                );
+        // + fragments in earlier soft-wrapped rows.
+        let mut prefix_chunks = Vec::new();
+        let mut first_prefix_row = point.row;
+        let mut scanned_prefix_width = point.col;
+        while first_prefix_row > 0
+            && self.row_wraps(first_prefix_row - 1)
+            && scanned_prefix_width < LINK_NUM_CHARACTER_SCAN
+        {
+            first_prefix_row -= 1;
+            scanned_prefix_width += self.columns();
+        }
 
-                let mut current_line_fragments =
-                    self.line_to_fragments(point.row, 0..point.col - 1, IncludeFirstWideChar::Yes);
+        for row in first_prefix_row..=point.row {
+            let range = if row == point.row {
+                if point.col == 0 {
+                    continue;
+                }
 
-                match (prev_line_fragments.last(), current_line_fragments.first()) {
-                    // Note that if any one of the two fragments has separator, we shouldn't
-                    // concatenate them.
-                    (Some(prev_line_fragment), Some(current_line_fragment))
-                        if prev_line_fragment.has_separator()
-                            || current_line_fragment.has_separator() =>
-                    {
-                        let mut fragment =
-                            prev_line_fragments.pop().expect("Fragment should exist");
+                0..point.col - 1
+            } else if row == first_prefix_row {
+                let extra_width = scanned_prefix_width.saturating_sub(LINK_NUM_CHARACTER_SCAN);
+                extra_width.min(self.columns().saturating_sub(1))..self.columns() - 1
+            } else {
+                0..self.columns() - 1
+            };
 
-                        fragment.content.push_str(&current_line_fragment.content);
-                        prev_line_fragments.push(Fragment {
-                            content: fragment.content,
-                            total_cell_width: fragment.total_cell_width
-                                + current_line_fragment.total_cell_width,
-                        });
-
-                        current_line_fragments.remove(0);
-                    }
-                    _ => (),
-                };
-
-                prev_line_fragments.append(&mut current_line_fragments);
-                prev_line_fragments
-            }
-            // If the previous line does not end with a linewrap, only parse for fragments in the current line.
-            (true, false) => {
-                self.line_to_fragments(point.row, 0..point.col - 1, IncludeFirstWideChar::Yes)
-            }
-            // If the point is at the start of the line and the previous line does end with a linewrap,
-            // parse for fragments in the previous line.
-            (false, true) => self.line_to_fragments(
-                point.row - 1,
-                self.columns().saturating_sub(LINK_NUM_CHARACTER_SCAN + 1)..self.columns() - 1,
-                IncludeFirstWideChar::Yes, /*should_scan_forward*/
-            ),
-            (false, false) => Vec::new(),
-        };
+            let fragments = self.line_to_fragments(row, range, IncludeFirstWideChar::Yes);
+            append_fragments_across_soft_wrap(&mut prefix_chunks, fragments);
+        }
 
         // All fragments in the row after the point (including the point)
-        // + Part of the fragments in the next row if the line ends with a line wrap.
+        // + fragments in later soft-wrapped rows.
         // Note that we set should_scan_forward here to false to prevent overlapping
         // width char characters between prefix and suffix.
-        let suffix_chunks = match current_row_end_with_line_wrap {
-            // If current line ends a line wrap, we parse for fragments in both the current and next line.
-            true => {
-                let mut current_line_fragments = self.line_to_fragments(
-                    point.row,
-                    point.col..self.columns() - 1,
-                    IncludeFirstWideChar::No, /*should_scan_forward*/
-                );
+        let mut suffix_chunks = Vec::new();
+        let mut last_suffix_row = point.row;
+        let mut scanned_suffix_width = self.columns().saturating_sub(point.col);
+        while last_suffix_row + 1 < self.total_rows()
+            && self.row_wraps(last_suffix_row)
+            && scanned_suffix_width < LINK_NUM_CHARACTER_SCAN
+        {
+            last_suffix_row += 1;
+            scanned_suffix_width += self.columns();
+        }
 
-                let mut next_line_fragments = self.line_to_fragments(
-                    point.row + 1,
-                    0..(self.columns() - 1).min(LINK_NUM_CHARACTER_SCAN),
-                    IncludeFirstWideChar::No,
-                );
+        for row in point.row..=last_suffix_row {
+            let range = if row == point.row {
+                point.col..self.columns() - 1
+            } else if row == last_suffix_row {
+                let extra_width = scanned_suffix_width.saturating_sub(LINK_NUM_CHARACTER_SCAN);
+                0..(self.columns() - 1).saturating_sub(extra_width)
+            } else {
+                0..self.columns() - 1
+            };
 
-                match (current_line_fragments.last(), next_line_fragments.first()) {
-                    (Some(current_line_fragment), Some(next_line_fragment))
-                        if current_line_fragment.has_separator()
-                            || next_line_fragment.has_separator() =>
-                    {
-                        let mut fragment =
-                            current_line_fragments.pop().expect("Fragment should exist");
-
-                        fragment.content.push_str(&next_line_fragment.content);
-                        current_line_fragments.push(Fragment {
-                            content: fragment.content,
-                            total_cell_width: fragment.total_cell_width
-                                + next_line_fragment.total_cell_width,
-                        });
-
-                        next_line_fragments.remove(0);
-                    }
-                    _ => (),
-                };
-
-                current_line_fragments.append(&mut next_line_fragments);
-                current_line_fragments
-            }
-            false => self.line_to_fragments(
-                point.row,
-                point.col..self.columns() - 1,
-                IncludeFirstWideChar::No, /*should_scan_forward*/
-            ),
-        };
+            let fragments = self.line_to_fragments(row, range, IncludeFirstWideChar::No);
+            append_fragments_across_soft_wrap(&mut suffix_chunks, fragments);
+        }
 
         // This addresses the case when the file path starts from the point -- in this case
         // the valid path is entirely constructed from suffix chunks. Note that this is only possible

--- a/app/src/terminal/model/grid/grid_handler_test.rs
+++ b/app/src/terminal/model/grid/grid_handler_test.rs
@@ -1069,6 +1069,71 @@ fn test_possible_file_paths() {
 }
 
 #[test]
+fn test_possible_file_paths_across_wrapped_lines() {
+    let first_line = "src/modules/core/internal/utils/wrappers/adapters/";
+    let second_line = "interfaces/implementations/factories/README.md";
+    let full_path = format!("{first_line}{second_line}");
+    let expected_range = Point { row: 0, col: 0 }..=Point {
+        row: 1,
+        col: second_line.len() - 1,
+    };
+    let blockgrid = mock_blockgrid(&format!("{first_line}\n{second_line}"));
+
+    for hover_point in [
+        Point {
+            row: 0,
+            col: first_line.len() - 2,
+        },
+        Point { row: 1, col: 0 },
+    ] {
+        let possible_paths = blockgrid
+            .grid_handler
+            .possible_file_paths_at_point(hover_point);
+
+        assert!(
+            possible_paths.iter().any(|possible_path| {
+                possible_path.path.path.as_str() == full_path.as_str()
+                    && possible_path.path.line_and_column_num.is_none()
+                    && possible_path.range == expected_range
+            }),
+            "expected wrapped file path candidate at {hover_point:?} in {possible_paths:?}"
+        );
+    }
+}
+
+#[test]
+fn test_possible_file_paths_across_multiple_wrapped_lines() {
+    let first_line = "src/core/";
+    let second_line = "wrappers/";
+    let third_line = "adapters/";
+    let fourth_line = "README.md";
+    let full_path = format!("{first_line}{second_line}{third_line}{fourth_line}");
+    let blockgrid = mock_blockgrid(&format!(
+        "{first_line}\n{second_line}\n{third_line}\n{fourth_line}"
+    ));
+
+    for hover_point in [
+        Point { row: 0, col: 5 },
+        Point { row: 1, col: 8 },
+        Point { row: 2, col: 5 },
+        Point { row: 3, col: 5 },
+    ] {
+        let possible_paths = blockgrid
+            .grid_handler
+            .possible_file_paths_at_point(hover_point);
+
+        assert!(
+            possible_paths.iter().any(|possible_path| {
+                possible_path.path.path.as_str() == full_path.as_str()
+                    && possible_path.path.line_and_column_num.is_none()
+                    && possible_path.range.contains(&hover_point)
+            }),
+            "expected multi-line wrapped file path candidate at {hover_point:?} in {possible_paths:?}"
+        );
+    }
+}
+
+#[test]
 fn test_fragment_boundary_at_point() {
     let assert_fragment_boundary =
         |blockgrid: &BlockGrid,


### PR DESCRIPTION
## Description
Fixes #9193.

This updates terminal file path detection so fragments split only by a soft-wrapped terminal line are treated as one continuous path. Fragments are still kept separate when either side contains a file-link separator.

A regression test covers the long wrapped path from the issue and verifies detection from both sides of the wrap boundary.

## Testing
- `cargo fmt --check`
- `cargo test -p warp terminal::model::grid::grid_handler::tests::test_possible_file_paths_across_wrapped_lines --no-default-features`

## Server API dependencies
None.

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed long file paths split across wrapped terminal lines not being detected as file links.
