### PR TITLE
Fix typos in code comments

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -422,7 +422,7 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                                 // checks if the read file action result is completed and successful.
                                 // if successful, we have FileContext with pre-computed line counts that we use to clamp displayed file ranges to the length of the file
                                 let file_names = match agent_action_results {
-                                    // if completed and succesful, generate a user message with file info + line count
+                                    // if completed and successful, generate a user message with file info + line count
                                     Some(AIAgentActionResult {
                                         result:
                                             AIAgentActionResultType::ReadFiles(

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1952,7 +1952,7 @@ impl BlocklistAIHistoryModel {
             return;
         }
 
-        // There's a slight concern here that the conversations we're preserving might not have persisted succesfully
+        // There's a slight concern here that the conversations we're preserving might not have persisted successfully
         // because of some unexpected error. Attempting to then restore these conversations would lead to unexpected behavior.
         // In the future it might be worthwhile to check that these conversations exist in the database before marking them as historical,
         // but for now this is an edge case that we don't need to worry about too much.

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -1150,7 +1150,7 @@ impl AIExecutionProfilesModel {
     /// `edit_profile_internal` edits an AIExecutionProfile and upserts the changed profile to the cloud
     /// Parameters:
     /// * `profile_id`: The id of the profile to edit
-    /// * `edit_fn`: a closure that safely modifies the AIExecutionProfile. It should return `true` if the profile was changed, `false` otherwise. When `true`, it syncs the changes to the cloud, and otherwise exits early to prevent excessive cloud operations if no changes occured.
+    /// * `edit_fn`: a closure that safely modifies the AIExecutionProfile. It should return `true` if the profile was changed, `false` otherwise. When `true`, it syncs the changes to the cloud, and otherwise exits early to prevent excessive cloud operations if no changes occurred.
     /// * `ctx`: The model context
     fn edit_profile_internal(
         &mut self,

--- a/app/src/notebooks/active_notebook_data.rs
+++ b/app/src/notebooks/active_notebook_data.rs
@@ -311,7 +311,7 @@ impl ActiveNotebookData {
 
     /// Checks whether or not this notebook has edit conflicts that would
     /// results in the conflict resolution banner being shown. We check both
-    /// if a conflicting object has been recieved from the server, and that there
+    /// if a conflicting object has been received from the server, and that there
     /// are no pending content changes on the notebook.
     ///
     /// We need to check the pending content changes because of a race condition where

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -1389,7 +1389,7 @@ fn test_focused_pane_is_synchronized_with_application_focus() {
             // Second, emit an event on the pane group to trigger assertion
             // logic in the FocusDetectionView.  This event effect is enqueued after
             // the focus effect but before the focus effect is processed, meaning
-            // it will observe any changes that occured synchronously as part
+            // it will observe any changes that occurred synchronously as part
             // of the focus effect but will _not_ observe any changes that result
             // from events dispatched during focus handling.
             //

--- a/app/src/pane_group/pane/view/header/mod.rs
+++ b/app/src/pane_group/pane/view/header/mod.rs
@@ -821,9 +821,9 @@ impl<P: BackingView> View for PaneHeader<P> {
     }
 }
 
-/// Based on the drag position and target pane, calcuates which direction the pane should move.
+/// Based on the drag position and target pane, calculates which direction the pane should move.
 ///
-/// We determine the split by dividing the pane into four quadrants, each refering to a split direction:
+/// We determine the split by dividing the pane into four quadrants, each referring to a split direction:
 /// +--------+
 /// |\ up   /|
 /// | \    / |

--- a/app/src/server/cloud_objects/update_manager_test.rs
+++ b/app/src/server/cloud_objects/update_manager_test.rs
@@ -3673,7 +3673,7 @@ fn test_pending_conflict_correctly_clears_after_edits() {
             ModelEvent::UpsertNotebook { .. }
         ));
 
-        // While we still have edits in flight, recieve an RTC message, that has a TS before the object update
+        // While we still have edits in flight, receive an RTC message, that has a TS before the object update
         // response. This should put the notebook conflict status as pending
         let mocked_metadata = ServerMetadata {
             uid: server_id,
@@ -3805,7 +3805,7 @@ fn test_pending_conflict_correctly_stays_after_edits() {
             ModelEvent::UpsertNotebook { .. }
         ));
 
-        // While we still have edits in flight, recieve an RTC message, that has a TS after the object update
+        // While we still have edits in flight, receive an RTC message, that has a TS after the object update
         // response. This should put the notebook conflict status as pending
         let mocked_metadata = ServerMetadata {
             uid: server_id,

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -1890,7 +1890,7 @@ pub enum TelemetryEvent {
 
         /// The server-generated output ID for the output in this block.
         ///
-        /// This is only populated if the some part of the response was succesfully received.
+        /// This is only populated if the some part of the response was successfully received.
         server_output_id: Option<ServerOutputId>,
 
         was_autodetected_ai_query: bool,

--- a/app/src/settings/cloud_preferences_syncer_tests.rs
+++ b/app/src/settings/cloud_preferences_syncer_tests.rs
@@ -339,7 +339,7 @@ fn test_sync_local_pref_to_cloud_after_initial_sync() {
             &mut server_api,
         ));
 
-        // Expect the creation of one or two cloud settings in seperate requests depending on the platform
+        // Expect the creation of one or two cloud settings in separate requests depending on the platform
         all_client_ids.append(&mut expect_bulk_create_generic_string_objects(
             &mut server_api,
             1,

--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -3404,7 +3404,7 @@ impl Element for BlockListElement {
                     });
                     visible_height_px += height_px;
 
-                    // we want to show different text in the seperator if this is an indvidual conversation
+                    // we want to show different text in the separator if this is an individual conversation
                     // restored from the command palette
                     let banner_intro_text = if is_historical_conversation_restoration {
                         "Conversation restored".to_string()

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -105,7 +105,7 @@ const MINS_PER_HOUR: i64 = 60;
 /// larger numbers. Our row-coordinates in the BlockList are stored as floating-points, and the function
 /// block.find() makes comparisons between floating-point sums to find, given a BlockList row coordinate,
 /// the location within a specific BlockSection (e.g., OutputGrid, Prompt, BottomPadding, etc). Because of
-/// precision issues, row coordinates exactly on the row boundary may on occassion be arbitrarily and incorrectly
+/// precision issues, row coordinates exactly on the row boundary may on occasion be arbitrarily and incorrectly
 /// lumped into the lesser row (the one above).
 ///
 /// By adding a small decimal to the row coordinate, we offset possible downwards precision errors. The value

--- a/app/src/terminal/view/block_banner/mod.rs
+++ b/app/src/terminal/view/block_banner/mod.rs
@@ -48,7 +48,7 @@ impl WithinBlockBanner {
     }
 }
 
-/// These Elements should be common accross all block banners. The specific content for each banner
+/// These Elements should be common across all block banners. The specific content for each banner
 /// should be passed in here. This function also enforces the height invariant.
 fn render_block_banner(
     build_child: impl FnOnce(&MouseState) -> Box<dyn Element>,

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -696,7 +696,7 @@ impl WorkspaceAction {
     }
 
     /// Matches what actions require the app state to be saved, and which don't. We match all
-    /// actions directly, rather than using _, so we're forced to make a concious decision for each
+    /// actions directly, rather than using _, so we're forced to make a conscious decision for each
     /// of them, rather than following some default.
     pub fn should_save_app_state_on_action(&self) -> bool {
         use WorkspaceAction::*;

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -438,7 +438,7 @@ pub struct RenderState {
     /// The render-related content version the model is managing.
     buffer_version: RefCell<RenderBufferVersion>,
 
-    /// Wether we are performing a lazy layout.
+    /// Whether we are performing a lazy layout.
     lazy_layout: bool,
 
     pending_edits: Mutex<Vec<PendingLayout>>,

--- a/crates/warp_server_client/src/cloud_object/mod.rs
+++ b/crates/warp_server_client/src/cloud_object/mod.rs
@@ -544,7 +544,7 @@ pub struct CloudObjectMetadata {
     pub pending_changes_statuses: CloudObjectStatuses,
     pub trashed_ts: Option<ServerTimestamp>,
     pub folder_id: Option<SyncId>,
-    /// Welcome objects are created on the server when a user first recieves
+    /// Welcome objects are created on the server when a user first receives
     /// access to Warp Drive as part of onboarding.
     pub is_welcome_object: bool,
     pub last_editor_uid: Option<String>,

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -519,7 +519,7 @@ impl ShellType {
 
             ShellType::Fish => {
                 let history_file_contents = String::from_utf8_lossy(history_file_bytes);
-                // fish has psuedo-yaml.
+                // fish has pseudo-yaml.
                 // The commands start with "- cmd: ".
                 history_lines = history_file_contents
                     .lines()


### PR DESCRIPTION
## Description

Fixes 18 spelling typos across 16 code-comment locations. All changes are inside `//` or `///` comments; no functional code is touched. Categories:

- `concious` -> `conscious`, `Wether` -> `Whether`, `psuedo` -> `pseudo`, `occassion` -> `occasion`, `calcuates` -> `calculates` (single-word slips)
- `succesful` / `succesfully` -> `successful` / `successfully` (x3)
- `recieve` / `recieved` / `recieves` -> `receive` / `received` / `receives` (x4)
- `occured` -> `occurred` (x2)
- `seperate`, `seperator`, `indvidual`, `accross`, `refering` -> standard spellings

Skipped intentionally:
- `crates/ai/src/diff_validation/mod_test.rs:13` - the typo there is inside a verbatim GNU/Linux copypasta string used as test input.
- `resources/bundled/mcp_skills/figma/...` - vendor documentation.

## Testing

Comment-only changes; no test impact.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode