### PR TITLE
Make Cmd-W hide macOS windows

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2034,7 +2034,15 @@ fn app_callbacks(is_integration_test: bool) -> warpui::platform::AppCallbacks {
             // e.g. clicking on the Dock icon. It is NOT called from the New Window
             // menu item.
             App::record_last_active_timestamp();
-            ctx.dispatch_global_action("root_view:open_new", &());
+            if let Some(window_id) = ctx
+                .windows()
+                .frontmost_window_id()
+                .or_else(|| ctx.window_ids().next())
+            {
+                ctx.windows().show_window_and_focus_app(window_id);
+            } else {
+                ctx.dispatch_global_action("root_view:open_new", &());
+            }
             ctx.dispatch_global_action("workspace:save_app", &());
         })),
         on_open_urls: Some(Box::new(move |urls, ctx| {

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -1962,6 +1962,9 @@ impl RootView {
 
     fn close_window(&mut self, _: &(), ctx: &mut ViewContext<Self>) -> bool {
         if ContextFlag::CloseWindow.is_enabled() {
+            #[cfg(target_os = "macos")]
+            ctx.windows().hide_window(ctx.window_id());
+            #[cfg(not(target_os = "macos"))]
             ctx.close_window();
         }
         true

--- a/app/src/util/bindings.rs
+++ b/app/src/util/bindings.rs
@@ -245,7 +245,7 @@ pub fn trigger_to_keystroke(trigger: &Trigger) -> Option<Keystroke> {
         Trigger::Custom(custom) => custom_tag_to_keystroke(*custom),
         // Similarly, Standard Actions have their keyboard shortcuts set when creating the menu
         Trigger::Standard(standard) => match standard {
-            StandardAction::Close => mac_only_keystroke("cmd-shift-W"),
+            StandardAction::Close => mac_only_keystroke("cmd-w"),
             // "cmd-q" to quit and "cmd-h" to hide are the standard bindings for these actions on
             // Mac.
             StandardAction::Quit => mac_only_keystroke("cmd-q"),
@@ -397,8 +397,14 @@ pub fn custom_tag_to_keystroke(custom: CustomTag) -> Option<Keystroke> {
                 Keystroke::parse("ctrl-shift-|").ok()
             }
         }
-        CustomAction::CloseWindow => mac_only_keystroke("cmd-shift-W"),
-        CustomAction::CloseCurrentSession => Keystroke::parse(cmd_or_ctrl_shift("w")).ok(),
+        CustomAction::CloseWindow => mac_only_keystroke("cmd-w"),
+        CustomAction::CloseCurrentSession => {
+            if OperatingSystem::get().is_mac() {
+                None
+            } else {
+                Keystroke::parse(cmd_or_ctrl_shift("w")).ok()
+            }
+        }
         CustomAction::ViewChangelog => Keystroke::parse(cmd_or_ctrl_shift("alt-o")).ok(),
         CustomAction::NewAgentModePane => Keystroke::parse("ctrl-space").ok(),
         CustomAction::AttachSelectionAsAgentModeContext => {

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -4,7 +4,13 @@ use warpui::{
     App,
 };
 
-use crate::{util::bindings::keybinding_name_to_display_string, workspace::WorkspaceAction};
+use crate::{
+    util::bindings::{
+        custom_tag_to_keystroke, keybinding_name_to_display_string, trigger_to_keystroke,
+        CustomAction,
+    },
+    workspace::WorkspaceAction,
+};
 
 #[test]
 fn test_keybinding_name_to_display_string() {
@@ -71,4 +77,29 @@ fn test_keybinding_name_to_display_string() {
             );
         });
     });
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_cmd_w_defaults_to_close_window_on_macos() {
+    use warpui::actions::StandardAction;
+
+    assert_eq!(
+        Some("cmd-w"),
+        custom_tag_to_keystroke(CustomAction::CloseWindow.into())
+            .as_ref()
+            .map(|keystroke| keystroke.normalized())
+            .as_deref()
+    );
+    assert_eq!(
+        None,
+        custom_tag_to_keystroke(CustomAction::CloseCurrentSession.into())
+    );
+    assert_eq!(
+        Some("cmd-w"),
+        trigger_to_keystroke(&Trigger::Standard(StandardAction::Close))
+            .as_ref()
+            .map(|keystroke| keystroke.normalized())
+            .as_deref()
+    );
 }

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -927,7 +927,7 @@ pub fn init(app: &mut AppContext) {
                 .with_custom_description(bindings::MAC_MENUS_CONTEXT, "Close Window"),
             WorkspaceAction::CloseWindow,
         )
-        .with_mac_key_binding("cmd-shift-W")
+        .with_mac_key_binding("cmd-w")
         .with_context_predicate(id!("Workspace"))
         .with_group(bindings::BindingGroup::Close.as_str())
         .with_custom_action(CustomAction::CloseWindow)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -20779,6 +20779,9 @@ impl TypedActionView for Workspace {
             }
             CloseWindow => {
                 if ContextFlag::CloseWindow.is_enabled() {
+                    #[cfg(target_os = "macos")]
+                    ctx.windows().hide_window(ctx.window_id());
+                    #[cfg(not(target_os = "macos"))]
                     ctx.close_window();
                 }
             }


### PR DESCRIPTION
## Description
Make macOS Cmd-W close the Warp window without tearing down the current session. The close-window action now hides the macOS window, and Dock/Finder reopen restores an existing hidden window before creating a new one.

## Testing
- cargo fmt
- cargo test -p warp cmd_w --lib
- cargo clippy -p warp --lib --tests -- -D warnings

## Server API dependencies
None.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

Co-Authored-By: Warp <agent@warp.dev>