### PR TITLE
fix: highlight C++ header extensions

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -152,7 +152,7 @@ pub fn language_by_filename(path: &Path) -> Option<Arc<Language>> {
         "tsx" => language_by_name("tsx"),
         "ts" | "cts" | "mts" => language_by_name("typescript"),
         "java" | "groovy" | "gvy" | "gy" | "gsh" => language_by_name("java"),
-        "cpp" | "cxx" | "cc" | "h" | "hh" => language_by_name("cpp"),
+        "cpp" | "cxx" | "cc" | "h" | "hh" | "hpp" | "hxx" | "H" => language_by_name("cpp"),
         "sh" | "zsh" | "bash" => language_by_name("shell"),
         "cs" => language_by_name("csharp"),
         "html" => language_by_name("html"),

--- a/crates/languages/src/lib_tests.rs
+++ b/crates/languages/src/lib_tests.rs
@@ -1,4 +1,6 @@
-use crate::{load_language, SUPPORTED_LANGUAGES};
+use std::path::Path;
+
+use crate::{language_by_filename, load_language, SUPPORTED_LANGUAGES};
 
 /// Validate that every supported language can be loaded successfully.
 /// This catches invalid node types, syntax errors, and other issues in .scm query files
@@ -19,4 +21,14 @@ fn all_supported_languages_load_successfully() {
             .collect::<Vec<_>>()
             .join("\n")
     );
+}
+
+#[test]
+fn cpp_header_extensions_resolve_to_cpp_language() {
+    for filename in ["header.hpp", "header.hxx", "header.H"] {
+        let language = language_by_filename(Path::new(filename))
+            .unwrap_or_else(|| panic!("expected {filename} to resolve to C++"));
+
+        assert_eq!(language.display_name(), "C++");
+    }
 }


### PR DESCRIPTION
## Description

Fixes #9387.

Warp already maps `.hpp` and `.hxx` files to C++ in the LSP and file icon paths, but the syntax-highlighting language resolver only handled `.cpp`, `.cxx`, `.cc`, `.h`, and `.hh`. This adds the missing C++ header extensions to `language_by_filename` so `.hpp`, `.hxx`, and uppercase `.H` files resolve to the C++ grammar for highlighting.

## Testing

- Added a regression test for `.hpp`, `.hxx`, and `.H` filename resolution.
- `git diff --check`
- Not run: `cargo test -p languages` because this OpenClaw host does not currently have `cargo` installed.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed missing syntax highlighting for C++ header files using `.hpp`, `.hxx`, or `.H` extensions.
