### PR TITLE
Sync blocklist image extensions with is_binary_file

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -2310,7 +2310,7 @@ fn is_supported_blocklist_image_source(source: &str) -> bool {
         .map(|ext| {
             matches!(
                 ext.to_ascii_lowercase().as_str(),
-                "jpg" | "jpeg" | "png" | "gif" | "webp" | "svg"
+                "jpg" | "jpeg" | "png" | "gif" | "bmp" | "tiff" | "tif" | "webp" | "ico" | "svg"
             )
         })
         .unwrap_or(false)

--- a/app/src/ai/blocklist/block/view_impl/common_tests.rs
+++ b/app/src/ai/blocklist/block/view_impl/common_tests.rs
@@ -10,9 +10,9 @@ use warpui::App;
 use super::{blocklist_image_asset_source, ResolvedBlocklistImageSources};
 use super::{
     collect_visual_markdown_lightbox_collection, compute_visual_section_width,
-    inline_image_source_label, lightbox_trigger_for_section, query_prefix_highlight_len,
-    render_scrollable_collapsible_content, text_sections_with_indices, CollapsibleElementState,
-    CollapsibleExpansionState, VisualMarkdownLightboxCollection,
+    inline_image_source_label, is_supported_blocklist_image_source, lightbox_trigger_for_section,
+    query_prefix_highlight_len, render_scrollable_collapsible_content, text_sections_with_indices,
+    CollapsibleElementState, CollapsibleExpansionState, VisualMarkdownLightboxCollection,
 };
 use crate::{
     ai::agent::{
@@ -291,4 +291,44 @@ fn blocklist_image_asset_source_uses_cached_resolution_when_available() {
         Some(AssetSource::LocalFile { path }) => assert_eq!(path, cached_path),
         other => panic!("expected cached local file asset source, got {other:?}"),
     }
+}
+
+/// `is_supported_blocklist_image_source` should accept the same image extensions
+/// that `warp_util::file_type::is_binary_file` recognises (plus `svg`, which is
+/// text/XML and not in `is_binary_file`). Until #9395 / this fix landed the
+/// blocklist list was only `jpg | jpeg | png | gif | webp | svg`, so inline
+/// references to local `.bmp` / `.tiff` / `.tif` / `.ico` images failed the
+/// support check and silently rendered as plain text.
+#[test]
+fn is_supported_blocklist_image_source_covers_common_local_formats() {
+    for source in [
+        "diagram.jpg",
+        "diagram.jpeg",
+        "diagram.png",
+        "diagram.gif",
+        "diagram.bmp",
+        "diagram.tiff",
+        "diagram.tif",
+        "diagram.webp",
+        "diagram.ico",
+        "diagram.svg",
+    ] {
+        assert!(
+            is_supported_blocklist_image_source(source),
+            "{source} should be a supported local image source"
+        );
+    }
+    // Case-insensitive on the extension.
+    assert!(is_supported_blocklist_image_source("PHOTO.PNG"));
+    assert!(is_supported_blocklist_image_source("scan.TIFF"));
+    // HTTP / HTTPS sources are intentionally rejected regardless of extension.
+    assert!(!is_supported_blocklist_image_source(
+        "http://example.com/x.png"
+    ));
+    assert!(!is_supported_blocklist_image_source(
+        "https://example.com/x.png"
+    ));
+    // Non-image extensions stay rejected.
+    assert!(!is_supported_blocklist_image_source("doc.pdf"));
+    assert!(!is_supported_blocklist_image_source("notes.md"));
 }


### PR DESCRIPTION
## Description

Follow-up to #9395 in a different file. While auditing image-extension lists across the repo I found a third copy in `is_supported_blocklist_image_source` (`app/src/ai/blocklist/block/view_impl/common.rs`) that suffers from the exact same drift: it only matches `jpg | jpeg | png | gif | webp | svg`, missing `.bmp`, `.tiff` / `.tif`, and `.ico`. So inline references to local `.bmp` / `.tiff` / `.ico` images in agent block output fail the support check and don't render as the inline image — they silently fall back to plain text — even though the same files do route to the system viewer once #9395 lands.

```diff
-                "jpg" | "jpeg" | "png" | "gif" | "webp" | "svg"
+                "jpg" | "jpeg" | "png" | "gif" | "bmp" | "tiff" | "tif" | "webp" | "ico" | "svg"
```

The full picture, for context:

| Location | What it does | Pre-fix |
|---|---|---|
| `crates/warp_util/src/file_type.rs` (`is_binary_file`) | Canonical binary-file extension list | 9 image formats |
| `app/src/util/openable_file_type.rs` (`is_supported_image_file`) | Routes click-to-open to `FileTarget::SystemGeneric` | 6 formats — fixed in #9395 |
| **This PR** — `app/src/ai/blocklist/block/view_impl/common.rs` (`is_supported_blocklist_image_source`) | Gates inline rendering of agent block image references | 6 formats |
| `crates/warpui_core/src/platform/file_picker.rs` (`FileType::Image`) | Theme-creator file-picker filter | 3 formats — left for a separate PR; the right "what should be selectable as a theme background" set is more subjective |

## Testing

- Added `is_supported_blocklist_image_source_covers_common_local_formats` in `common_tests.rs`. Asserts every supported extension passes (10 cases), case-insensitivity (`PHOTO.PNG`, `scan.TIFF`), and that HTTP / HTTPS sources and non-image extensions still return false. Fails on master for the four new extensions, passes after the change.
- `cargo fmt -p warp -- --check` passes locally.
- Couldn't run `cargo nextest` locally because the Metal toolchain isn't installed (same caveat as #9277, #9345, #9346, #9395) — relying on CI for the full clippy / nextest pass.

## Related

- #9395 — same fix for `is_supported_image_file` (file-open routing path).

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Inline `.bmp`, `.tiff` / `.tif`, and `.ico` images in agent block output now render correctly instead of falling back to plain text.