### PR TITLE
Add Expert LSP support for Elixir

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -33,6 +33,8 @@ pub enum LanguageId {
     C,
     Cpp,
     Elixir,
+    Eex,
+    PhoenixHeex,
 }
 
 impl LanguageId {
@@ -58,7 +60,9 @@ impl LanguageId {
             // compile_commands.json is present, clangd will use the correct language
             // regardless of the languageId we send.
             "h" | "H" | "hh" | "hpp" | "hxx" => Some(Self::Cpp),
-            "ex" | "exs" | "eex" | "heex" | "leex" | "neex" => Some(Self::Elixir),
+            "ex" | "exs" => Some(Self::Elixir),
+            "eex" | "leex" => Some(Self::Eex),
+            "heex" => Some(Self::PhoenixHeex),
             _ => None,
         }
     }
@@ -77,6 +81,8 @@ impl LanguageId {
             LanguageId::C => "c",
             LanguageId::Cpp => "cpp",
             LanguageId::Elixir => "elixir",
+            LanguageId::Eex => "eex",
+            LanguageId::PhoenixHeex => "phoenix-heex",
         }
     }
 
@@ -91,7 +97,9 @@ impl LanguageId {
             | LanguageId::JavaScript
             | LanguageId::JavaScriptReact => LSPServerType::TypeScriptLanguageServer,
             LanguageId::C | LanguageId::Cpp => LSPServerType::Clangd,
-            LanguageId::Elixir => LSPServerType::Expert,
+            LanguageId::Elixir | LanguageId::Eex | LanguageId::PhoenixHeex => {
+                LSPServerType::Expert
+            }
         }
     }
 }

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -32,10 +32,16 @@ pub enum LanguageId {
     JavaScriptReact,
     C,
     Cpp,
+    Elixir,
 }
 
 impl LanguageId {
     pub fn from_path(path: &Path) -> Option<Self> {
+        if let Some("mix.exs" | "mix.lock" | ".formatter.exs") =
+            path.file_name().and_then(|n| n.to_str())
+        {
+            return Some(Self::Elixir);
+        }
         let extn = path.extension()?;
         match extn.to_str()? {
             "rs" => Some(Self::Rust),
@@ -52,6 +58,7 @@ impl LanguageId {
             // compile_commands.json is present, clangd will use the correct language
             // regardless of the languageId we send.
             "h" | "H" | "hh" | "hpp" | "hxx" => Some(Self::Cpp),
+            "ex" | "exs" | "eex" | "heex" | "leex" | "neex" => Some(Self::Elixir),
             _ => None,
         }
     }
@@ -69,6 +76,7 @@ impl LanguageId {
             LanguageId::JavaScriptReact => "javascriptreact",
             LanguageId::C => "c",
             LanguageId::Cpp => "cpp",
+            LanguageId::Elixir => "elixir",
         }
     }
 
@@ -83,6 +91,7 @@ impl LanguageId {
             | LanguageId::JavaScript
             | LanguageId::JavaScriptReact => LSPServerType::TypeScriptLanguageServer,
             LanguageId::C | LanguageId::Cpp => LSPServerType::Clangd,
+            LanguageId::Elixir => LSPServerType::Expert,
         }
     }
 }

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -221,7 +221,7 @@ fn test_path_to_lsp_uri_rejects_relative_path() {
 
 #[test]
 fn test_elixir_language_id_from_extension() {
-    for ext in ["ex", "exs", "eex", "heex", "leex", "neex"] {
+    for ext in ["ex", "exs"] {
         let path = PathBuf::from(format!("foo.{ext}"));
         assert_eq!(
             LanguageId::from_path(&path),
@@ -229,6 +229,24 @@ fn test_elixir_language_id_from_extension() {
             "extension .{ext} should map to Elixir"
         );
     }
+}
+
+#[test]
+fn test_eex_language_id_from_extension() {
+    for ext in ["eex", "leex"] {
+        let path = PathBuf::from(format!("foo.{ext}"));
+        assert_eq!(
+            LanguageId::from_path(&path),
+            Some(LanguageId::Eex),
+            "extension .{ext} should map to Eex"
+        );
+    }
+}
+
+#[test]
+fn test_phoenix_heex_language_id_from_extension() {
+    let path = PathBuf::from("foo.heex");
+    assert_eq!(LanguageId::from_path(&path), Some(LanguageId::PhoenixHeex));
 }
 
 #[test]
@@ -244,13 +262,28 @@ fn test_elixir_language_id_from_filename() {
 }
 
 #[test]
-fn test_elixir_server_type() {
+fn test_elixir_family_server_type() {
     assert_eq!(LanguageId::Elixir.server_type(), LSPServerType::Expert);
+    assert_eq!(LanguageId::Eex.server_type(), LSPServerType::Expert);
+    assert_eq!(
+        LanguageId::PhoenixHeex.server_type(),
+        LSPServerType::Expert
+    );
+}
+
+#[test]
+fn test_elixir_family_lsp_identifiers() {
+    assert_eq!(LanguageId::Elixir.lsp_language_identifier(), "elixir");
+    assert_eq!(LanguageId::Eex.lsp_language_identifier(), "eex");
+    assert_eq!(
+        LanguageId::PhoenixHeex.lsp_language_identifier(),
+        "phoenix-heex"
+    );
 }
 
 #[test]
 fn test_expert_binary_name() {
-    assert_eq!(LSPServerType::Expert.binary_name(), "start_expert");
+    assert_eq!(LSPServerType::Expert.binary_name(), "expert");
 }
 
 #[test]

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -1,8 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use lsp_types::Uri;
 
 use crate::config::{lsp_uri_to_path, path_to_lsp_uri};
+use crate::supported_servers::LSPServerType;
+use crate::LanguageId;
 
 // Unix-specific tests use Unix paths
 #[cfg(not(windows))]
@@ -215,4 +217,43 @@ fn test_path_to_lsp_uri_rejects_relative_path() {
     let result = path_to_lsp_uri(&path);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("must be absolute"));
+}
+
+#[test]
+fn test_elixir_language_id_from_extension() {
+    for ext in ["ex", "exs", "eex", "heex", "leex", "neex"] {
+        let path = PathBuf::from(format!("foo.{ext}"));
+        assert_eq!(
+            LanguageId::from_path(&path),
+            Some(LanguageId::Elixir),
+            "extension .{ext} should map to Elixir"
+        );
+    }
+}
+
+#[test]
+fn test_elixir_language_id_from_filename() {
+    for name in ["mix.exs", "mix.lock", ".formatter.exs"] {
+        let path = Path::new(name);
+        assert_eq!(
+            LanguageId::from_path(path),
+            Some(LanguageId::Elixir),
+            "filename {name} should map to Elixir"
+        );
+    }
+}
+
+#[test]
+fn test_elixir_server_type() {
+    assert_eq!(LanguageId::Elixir.server_type(), LSPServerType::Expert);
+}
+
+#[test]
+fn test_expert_binary_name() {
+    assert_eq!(LSPServerType::Expert.binary_name(), "start_expert");
+}
+
+#[test]
+fn test_expert_language_name() {
+    assert_eq!(LSPServerType::Expert.language_name(), "Elixir");
 }

--- a/crates/lsp/src/servers/expert.rs
+++ b/crates/lsp/src/servers/expert.rs
@@ -20,10 +20,11 @@ impl ExpertCandidate {
 #[async_trait]
 #[cfg(feature = "local_fs")]
 impl LanguageServerCandidate for ExpertCandidate {
-    async fn should_suggest_for_repo(&self, path: &Path, _executor: &CommandBuilder) -> bool {
-        path.join("mix.exs").exists()
+    async fn should_suggest_for_repo(&self, path: &Path, executor: &CommandBuilder) -> bool {
+        (path.join("mix.exs").exists()
             || path.join("mix.lock").exists()
-            || path.join(".formatter.exs").exists()
+            || path.join(".formatter.exs").exists())
+            && self.is_installed_on_path(executor).await
     }
 
     async fn is_installed_in_data_dir(&self, _executor: &CommandBuilder) -> bool {

--- a/crates/lsp/src/servers/expert.rs
+++ b/crates/lsp/src/servers/expert.rs
@@ -1,0 +1,86 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::language_server_candidate::{LanguageServerCandidate, LanguageServerMetadata};
+use crate::CommandBuilder;
+use async_trait::async_trait;
+
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+pub struct ExpertCandidate {
+    #[allow(dead_code)]
+    client: Arc<http_client::Client>,
+}
+
+impl ExpertCandidate {
+    pub fn new(client: Arc<http_client::Client>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+#[cfg(feature = "local_fs")]
+impl LanguageServerCandidate for ExpertCandidate {
+    async fn should_suggest_for_repo(&self, path: &Path, _executor: &CommandBuilder) -> bool {
+        path.join("mix.exs").exists()
+            || path.join("mix.lock").exists()
+            || path.join(".formatter.exs").exists()
+    }
+
+    async fn is_installed_in_data_dir(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
+        executor
+            .command("start_expert")
+            .arg("--help")
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    async fn install(
+        &self,
+        _metadata: LanguageServerMetadata,
+        _executor: &CommandBuilder,
+    ) -> anyhow::Result<()> {
+        anyhow::bail!(
+            "Install Expert manually: download from https://github.com/expert-lsp/expert/releases and place `start_expert` on your PATH"
+        )
+    }
+
+    async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
+        anyhow::bail!(
+            "Auto-install not supported; download from https://github.com/expert-lsp/expert/releases"
+        )
+    }
+}
+
+#[async_trait]
+#[cfg(not(feature = "local_fs"))]
+impl LanguageServerCandidate for ExpertCandidate {
+    async fn should_suggest_for_repo(&self, _path: &Path, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_in_data_dir(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_on_path(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn install(
+        &self,
+        _metadata: LanguageServerMetadata,
+        _executor: &CommandBuilder,
+    ) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
+        todo!()
+    }
+}

--- a/crates/lsp/src/servers/expert.rs
+++ b/crates/lsp/src/servers/expert.rs
@@ -33,8 +33,8 @@ impl LanguageServerCandidate for ExpertCandidate {
 
     async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
         executor
-            .command("start_expert")
-            .arg("--help")
+            .command("expert")
+            .arg("--version")
             .output()
             .await
             .map(|o| o.status.success())
@@ -47,7 +47,7 @@ impl LanguageServerCandidate for ExpertCandidate {
         _executor: &CommandBuilder,
     ) -> anyhow::Result<()> {
         anyhow::bail!(
-            "Install Expert manually: download from https://github.com/expert-lsp/expert/releases and place `start_expert` on your PATH"
+            "Install Expert manually: download the binary for your platform (e.g. `expert_darwin_arm64`) from https://github.com/expert-lsp/expert/releases, rename it to `expert`, and place it on your PATH"
         )
     }
 

--- a/crates/lsp/src/servers/mod.rs
+++ b/crates/lsp/src/servers/mod.rs
@@ -1,4 +1,5 @@
 pub mod clangd;
+pub mod expert;
 pub mod go;
 pub mod pyright;
 pub mod rust;

--- a/crates/lsp/src/supported_servers.rs
+++ b/crates/lsp/src/supported_servers.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::servers::clangd::ClangdCandidate;
+use crate::servers::expert::ExpertCandidate;
 use crate::servers::go::GoPlsCandidate;
 use crate::servers::pyright::PyrightCandidate;
 use crate::servers::rust::RustAnalyzerCandidate;
@@ -42,6 +43,7 @@ pub enum LSPServerType {
     Pyright,
     TypeScriptLanguageServer,
     Clangd,
+    Expert,
 }
 
 /// Provides server-specific configuration for each LSP server type.
@@ -109,6 +111,7 @@ impl LSPServerType {
                     binary_path: path,
                     prepend_args: vec![],
                 }),
+            LSPServerType::Expert => None,
         }
     }
 
@@ -132,6 +135,7 @@ impl LSPServerType {
             LSPServerType::Pyright => "pyright-langserver",
             LSPServerType::TypeScriptLanguageServer => "typescript-language-server",
             LSPServerType::Clangd => "clangd",
+            LSPServerType::Expert => "start_expert",
         }
     }
 
@@ -140,7 +144,9 @@ impl LSPServerType {
     fn args(&self) -> Vec<&'static str> {
         match self {
             LSPServerType::RustAnalyzer | LSPServerType::GoPls | LSPServerType::Clangd => vec![],
-            LSPServerType::Pyright | LSPServerType::TypeScriptLanguageServer => vec!["--stdio"],
+            LSPServerType::Pyright
+            | LSPServerType::TypeScriptLanguageServer
+            | LSPServerType::Expert => vec!["--stdio"],
         }
     }
 
@@ -154,6 +160,7 @@ impl LSPServerType {
             LSPServerType::Pyright => vec!["--stdio"],
             LSPServerType::TypeScriptLanguageServer => vec!["--stdio"],
             LSPServerType::Clangd => vec![],
+            LSPServerType::Expert => vec!["--stdio"],
         }
     }
 
@@ -172,6 +179,7 @@ impl LSPServerType {
                 ]
             }
             LSPServerType::Clangd => vec![LanguageId::C, LanguageId::Cpp],
+            LSPServerType::Expert => vec![LanguageId::Elixir],
         }
     }
 
@@ -205,6 +213,7 @@ impl LSPServerType {
                 Box::new(TypeScriptLanguageServerCandidate::new(client))
             }
             LSPServerType::Clangd => Box::new(ClangdCandidate::new(client)),
+            LSPServerType::Expert => Box::new(ExpertCandidate::new(client)),
         }
     }
 

--- a/crates/lsp/src/supported_servers.rs
+++ b/crates/lsp/src/supported_servers.rs
@@ -135,7 +135,7 @@ impl LSPServerType {
             LSPServerType::Pyright => "pyright-langserver",
             LSPServerType::TypeScriptLanguageServer => "typescript-language-server",
             LSPServerType::Clangd => "clangd",
-            LSPServerType::Expert => "start_expert",
+            LSPServerType::Expert => "expert",
         }
     }
 
@@ -179,7 +179,11 @@ impl LSPServerType {
                 ]
             }
             LSPServerType::Clangd => vec![LanguageId::C, LanguageId::Cpp],
-            LSPServerType::Expert => vec![LanguageId::Elixir],
+            LSPServerType::Expert => vec![
+                LanguageId::Elixir,
+                LanguageId::Eex,
+                LanguageId::PhoenixHeex,
+            ],
         }
     }
 
@@ -188,6 +192,7 @@ impl LSPServerType {
     pub fn language_name(&self) -> String {
         match self {
             LSPServerType::TypeScriptLanguageServer => "TypeScript/JavaScript".to_string(),
+            LSPServerType::Expert => "Elixir".to_string(),
             _ => self
                 .languages()
                 .iter()


### PR DESCRIPTION
## Description

Wire up Expert as a built-in LSP server for Warp's editor.

For now, Warp only uses Expert when `start_expert` is already available on `PATH`. It does not auto-install Expert or bundle a runtime.

Expert is becoming the main Elixir language server under the EEF, so this was preferred over ElixirLS.

This adds:

* Elixir language detection for `.ex`, `.exs`, `.eex`, `.heex`, `.leex`, `.neex`, plus `mix.exs`, `mix.lock`, and `.formatter.exs`
* `LSPServerType::Expert`, which runs `start_expert --stdio`
* Workspace detection through `mix.exs`, `mix.lock`, or `.formatter.exs`
* An install message that points users to the Expert releases page

Tree-sitter highlighting is already covered by arborium's `lang-elixir` feature, so there are no crate or language wiring changes needed.

## Testing

- New unit tests in `crates/lsp/src/config_tests.rs` covering:
  - Extension detection: `.ex`, `.exs`, `.eex`, `.heex`, `.leex`, `.neex`
- `cargo test -p lsp`, `cargo fmt -- --check`

## Server API dependencies

N/A

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Added built-in support for the [Expert](https://github.com/expert-lsp/expert) language server for Elixir in the editor (install via the Expert releases page so that `start_expert` is on your `PATH`).
