### PR TITLE
Include .yml and .markdown in Drive import file picker

### DIFF
--- a/crates/warpui_core/src/platform/file_picker.rs
+++ b/crates/warpui_core/src/platform/file_picker.rs
@@ -148,16 +148,5 @@ impl SaveFilePickerConfiguration {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn yaml_file_type_accepts_both_yaml_and_yml() {
-        assert_eq!(FileType::Yaml.extensions(), &["yaml", "yml"]);
-    }
-
-    #[test]
-    fn markdown_file_type_accepts_md_and_markdown() {
-        assert_eq!(FileType::Markdown.extensions(), &["md", "markdown"]);
-    }
-}
+#[path = "file_picker_tests.rs"]
+mod tests;

--- a/crates/warpui_core/src/platform/file_picker.rs
+++ b/crates/warpui_core/src/platform/file_picker.rs
@@ -28,8 +28,8 @@ impl FileType {
     pub fn extensions(&self) -> &[&str] {
         match self {
             FileType::Image => &["png", "jpg", "jpeg"],
-            FileType::Yaml => &["yaml"],
-            FileType::Markdown => &["md"],
+            FileType::Yaml => &["yaml", "yml"],
+            FileType::Markdown => &["md", "markdown"],
         }
     }
 
@@ -144,5 +144,20 @@ impl SaveFilePickerConfiguration {
     pub fn with_default_directory(mut self, directory: PathBuf) -> Self {
         self.default_directory = Some(directory);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yaml_file_type_accepts_both_yaml_and_yml() {
+        assert_eq!(FileType::Yaml.extensions(), &["yaml", "yml"]);
+    }
+
+    #[test]
+    fn markdown_file_type_accepts_md_and_markdown() {
+        assert_eq!(FileType::Markdown.extensions(), &["md", "markdown"]);
     }
 }

--- a/crates/warpui_core/src/platform/file_picker_tests.rs
+++ b/crates/warpui_core/src/platform/file_picker_tests.rs
@@ -1,0 +1,11 @@
+use super::*;
+
+#[test]
+fn yaml_file_type_accepts_both_yaml_and_yml() {
+    assert_eq!(FileType::Yaml.extensions(), &["yaml", "yml"]);
+}
+
+#[test]
+fn markdown_file_type_accepts_md_and_markdown() {
+    assert_eq!(FileType::Markdown.extensions(), &["md", "markdown"]);
+}


### PR DESCRIPTION
### Description

The Warp Drive import flow lets users pick workflow (YAML) and notebook (Markdown) files. The picker uses `FileType::Yaml` and `FileType::Markdown` from `warpui_core::platform::file_picker`, which previously listed only `yaml` and `md`. That doesn't match what the importer is willing to ingest:

- [`app/src/drive/import/nodes.rs`](https://github.com/warpdotdev/warp/blob/main/app/src/drive/import/nodes.rs) (`TryFrom<&Path> for FileType`) accepts both `.yaml` and `.yml` for workflows.
- [`warp_util::file_type::is_markdown_file`](https://github.com/warpdotdev/warp/blob/main/crates/warp_util/src/file_type.rs) recognises both `.md` and `.markdown` (`MARKDOWN_EXTENSIONS`).
- The import modal's helper text in `modal_body.rs` already advertises `"md, yaml, yml"` to users.

The result: a user can drag-and-drop a `.yml` workflow or `.markdown` notebook and it imports cleanly, but the file picker filter hides those same files when they click "Choose files…". This change brings the picker in line with what the rest of the import path already accepts.

I left `FileType::Image` alone — that one has a separate user-facing contract (the theme creator body explicitly says \"(.png, .jpg)\"), so broadening it would need its own design decision.

### Testing

- Added two unit tests covering both extensions for `FileType::Yaml` and `FileType::Markdown`.
- `cargo fmt -p warpui_core -- --check`
- Couldn't run the full `cargo nextest` locally (Metal toolchain not available on this machine), the change is well-scoped to a const-array literal so risk is low.

### Server API

No server changes.

### Agent Mode

Not applicable.

### Changelog Entries

- Warp Drive import file picker now lists `.yml` and `.markdown` files in addition to `.yaml` and `.md`.