### PR TITLE
Fix common spelling errors in app/src comments

### DIFF
--- a/app/src/ai/blocklist/inline_action/code_diff_view.rs
+++ b/app/src/ai/blocklist/inline_action/code_diff_view.rs
@@ -3042,7 +3042,7 @@ pub fn convert_file_edits_to_file_diffs(
 
                 for (index, (_, search_content)) in search_blocks_with_ranges.iter().enumerate() {
                     if index > 0 {
-                        // add "..." between each edit to indicate the seperation
+                        // add "..." between each edit to indicate the separation
                         dummy_content.push_str("...\n");
                     }
                     for search_line in search_content.lines() {

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -1150,7 +1150,7 @@ impl AIExecutionProfilesModel {
     /// `edit_profile_internal` edits an AIExecutionProfile and upserts the changed profile to the cloud
     /// Parameters:
     /// * `profile_id`: The id of the profile to edit
-    /// * `edit_fn`: a closure that safely modifies the AIExecutionProfile. It should return `true` if the profile was changed, `false` otherwise. When `true`, it syncs the changes to the cloud, and otherwise exits early to prevent excessive cloud operations if no changes occured.
+    /// * `edit_fn`: a closure that safely modifies the AIExecutionProfile. It should return `true` if the profile was changed, `false` otherwise. When `true`, it syncs the changes to the cloud, and otherwise exits early to prevent excessive cloud operations if no changes occurred.
     /// * `ctx`: The model context
     fn edit_profile_internal(
         &mut self,

--- a/app/src/notebooks/active_notebook_data.rs
+++ b/app/src/notebooks/active_notebook_data.rs
@@ -311,7 +311,7 @@ impl ActiveNotebookData {
 
     /// Checks whether or not this notebook has edit conflicts that would
     /// results in the conflict resolution banner being shown. We check both
-    /// if a conflicting object has been recieved from the server, and that there
+    /// if a conflicting object has been received from the server, and that there
     /// are no pending content changes on the notebook.
     ///
     /// We need to check the pending content changes because of a race condition where

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -1389,7 +1389,7 @@ fn test_focused_pane_is_synchronized_with_application_focus() {
             // Second, emit an event on the pane group to trigger assertion
             // logic in the FocusDetectionView.  This event effect is enqueued after
             // the focus effect but before the focus effect is processed, meaning
-            // it will observe any changes that occured synchronously as part
+            // it will observe any changes that occurred synchronously as part
             // of the focus effect but will _not_ observe any changes that result
             // from events dispatched during focus handling.
             //

--- a/app/src/server/cloud_objects/update_manager_test.rs
+++ b/app/src/server/cloud_objects/update_manager_test.rs
@@ -3673,7 +3673,7 @@ fn test_pending_conflict_correctly_clears_after_edits() {
             ModelEvent::UpsertNotebook { .. }
         ));
 
-        // While we still have edits in flight, recieve an RTC message, that has a TS before the object update
+        // While we still have edits in flight, receive an RTC message, that has a TS before the object update
         // response. This should put the notebook conflict status as pending
         let mocked_metadata = ServerMetadata {
             uid: server_id,
@@ -3805,7 +3805,7 @@ fn test_pending_conflict_correctly_stays_after_edits() {
             ModelEvent::UpsertNotebook { .. }
         ));
 
-        // While we still have edits in flight, recieve an RTC message, that has a TS after the object update
+        // While we still have edits in flight, receive an RTC message, that has a TS after the object update
         // response. This should put the notebook conflict status as pending
         let mocked_metadata = ServerMetadata {
             uid: server_id,

--- a/app/src/settings/cloud_preferences_syncer_tests.rs
+++ b/app/src/settings/cloud_preferences_syncer_tests.rs
@@ -339,7 +339,7 @@ fn test_sync_local_pref_to_cloud_after_initial_sync() {
             &mut server_api,
         ));
 
-        // Expect the creation of one or two cloud settings in seperate requests depending on the platform
+        // Expect the creation of one or two cloud settings in separate requests depending on the platform
         all_client_ids.append(&mut expect_bulk_create_generic_string_objects(
             &mut server_api,
             1,

--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -3404,7 +3404,7 @@ impl Element for BlockListElement {
                     });
                     visible_height_px += height_px;
 
-                    // we want to show different text in the seperator if this is an indvidual conversation
+                    // we want to show different text in the separator if this is an individual conversation
                     // restored from the command palette
                     let banner_intro_text = if is_historical_conversation_restoration {
                         "Conversation restored".to_string()

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -335,7 +335,7 @@ pub struct Block {
     /// determine if commands in a restored session should be included in
     /// History::session_commands. This is optional b/c just like session_id, pwd, git_branch, etc.
     /// which are determined at precmd time, it is unset at block creation. It is also to
-    /// accomodate the case where determining the ShellHost fails during session restoration, e.g.
+    /// accommodate the case where determining the ShellHost fails during session restoration, e.g.
     /// if the values in sqlite are NULL or invalid.
     shell_host: Option<ShellHost>,
 

--- a/app/src/terminal/model/iterm_image.rs
+++ b/app/src/terminal/model/iterm_image.rs
@@ -68,7 +68,7 @@ pub fn parse_iterm_image_metadata(params: &[&[u8]]) -> ITermImageMetadata {
 
         // Because the format of arguments is (MultipartFile | File) = [optional arguments],
         // The first optional argument will have "MultipartFile=" or "File=" prefixed to it.
-        // For example, params[1] will be "File=inline=0". So the key-value seperation done before
+        // For example, params[1] will be "File=inline=0". So the key-value separation done before
         // will yield a value of "inline=0", which we need to further split.
         if key == b"File" || key == b"MultipartFile" {
             (key, value) = match value.iter().position(|&byte| byte == b'=') {

--- a/app/src/terminal/shared_session/viewer/event_loop.rs
+++ b/app/src/terminal/shared_session/viewer/event_loop.rs
@@ -307,7 +307,7 @@ impl EventLoop {
                     {
                         // Role is set to the presence manager's role to stay as up-to-date as possible.
                         // This avoids a race condition if a viewer gets a new role before catching up,
-                        // by ensuring we're not overwritting the new role.
+                        // by ensuring we're not overwriting the new role.
                         if let Some(role) = presence_manager.as_ref(ctx).role() {
                             self.terminal_model.lock().set_shared_session_status(
                                 SharedSessionStatus::ActiveViewer { role },

--- a/crates/warpui_core/src/elements/stack/mod_test.rs
+++ b/crates/warpui_core/src/elements/stack/mod_test.rs
@@ -668,7 +668,7 @@ fn test_relative_positioning_bound_to_window_by_position() {
             .scene()
             .expect("Presenter should have rendered a scene after the view was updated.");
 
-        // The expected bounds should have a modified position to accomodate the size of the
+        // The expected bounds should have a modified position to accommodate the size of the
         // positioned child (it should be moved back to (0,0) from it's 'default' (75, 75).
         //
         // Note the usage of `RectF::from_points`, which specifies top-left


### PR DESCRIPTION
### Description

Follow-up to #9338 (which fixed doubled-word typos under `crates/`). While running a similar pass over `app/src/`, I picked up a handful of common single-word misspellings, all in comments and doc comments — no identifiers, behavior, or test names touched.

| Misspelling | Correction | Occurrences |
|---|---|---|
| `accomodate` | `accommodate` | 2 |
| `indvidual` | `individual` | 1 |
| `occured` | `occurred` | 2 |
| `overwritting` | `overwriting` | 1 |
| `recieve` / `recieved` | `receive` / `received` | 3 |
| `seperate` / `seperation` / `seperator` | `separate` / `separation` / `separator` | 3 |

### Testing

Comments only — nothing to run. `cargo fmt -p app -- --check` and `cargo fmt -p warpui_core -- --check` both pass.

### Server API

No server changes.

### Agent Mode

Not applicable.

### Changelog Entries

None.