### PR TITLE
Point stable-skill instructions at resources/bundled/skills/

### DIFF
--- a/resources/channel-gated-skills/README.md
+++ b/resources/channel-gated-skills/README.md
@@ -19,7 +19,7 @@ channel-gated-skills/
 ```
 
 > **Stable-ready skills** do not belong here. Place them in the always-bundled
-> `resources/skills/` directory instead. The build script will error if a
+> `resources/bundled/skills/` directory instead. The build script will error if a
 > `stable/` directory exists under `channel-gated-skills/`.
 
 ## Progressive gating
@@ -31,7 +31,7 @@ Gating is **progressive**: earlier gates include all skills from later gates.
 | `local`   | `dogfood` | `dogfood/` + `preview/`       |
 | `dev`     | `dogfood` | `dogfood/` + `preview/`       |
 | `preview` | `preview` | `preview/`                    |
-| `stable`  | —         | *(none — use resources/skills/)* |
+| `stable`  | —         | *(none — use resources/bundled/skills/)* |
 
 A skill placed in `preview/` is bundled on **all** non-stable builds
 (dogfood, preview). A skill placed in `dogfood/` is bundled on dogfood

--- a/script/copy_conditional_skills
+++ b/script/copy_conditional_skills
@@ -13,7 +13,7 @@
 # Gating is progressive: earlier gates include all skills from later gates.
 # For example, a dogfood build includes skills from both dogfood/ and
 # preview/.  The stable channel has no gate — stable-ready skills belong
-# in resources/skills/ (the always-bundled directory).
+# in resources/bundled/skills/ (the always-bundled directory).
 
 set -e
 
@@ -35,10 +35,10 @@ if [ ! -d "$GATED_SKILLS_SRC" ]; then
 fi
 
 # Error out if a stable/ gate directory exists — stable skills should live
-# in the always-bundled resources/skills/ directory instead.
+# in the always-bundled resources/bundled/skills/ directory instead.
 if [ -d "$GATED_SKILLS_SRC/stable" ]; then
   echo "Error: found a 'stable/' directory in $GATED_SKILLS_SRC." >&2
-  echo "The stable channel does not use gated skills. Move stable-ready skills to resources/skills/ (the always-bundled directory) instead." >&2
+  echo "The stable channel does not use gated skills. Move stable-ready skills to resources/bundled/skills/ (the always-bundled directory) instead." >&2
   exit 1
 fi
 


### PR DESCRIPTION
### Description

The channel-gated skills README and the runtime error message in \`script/copy_conditional_skills\` both pointed contributors at \`resources/skills/\` for stable-ready skills, but that directory doesn't exist in the repo — \`script/prepare_bundled_resources\` copies the always-bundled skills from \`resources/bundled/\`, so the right destination is \`resources/bundled/skills/\`.

The result: if anyone bumped into the existing \`stable/\` guard (\`copy_conditional_skills\` line 39), the printed remediation pointed them at a path that doesn't exist.

Three updates:
- \`resources/channel-gated-skills/README.md\` — \"place them in the always-bundled \`resources/skills/\`\" → \`resources/bundled/skills/\` (in the prose blockquote and in the gating table).
- \`script/copy_conditional_skills\` — header comment + the user-facing error \`echo\`.

No behavior change in the script itself; only the comment and the error string contents.

### Testing

Doc/script-comment only — nothing to run. The actual copy logic is unchanged.

### Server API

No server changes.

### Agent Mode

Not applicable.

### Changelog Entries

None.