### PR TITLE
Rename `delimeter` -> `delimiter` in env_vars and external_secrets

### DIFF
--- a/app/src/env_vars/mod.rs
+++ b/app/src/env_vars/mod.rs
@@ -136,8 +136,8 @@ impl EnvVarCollection {
         self.vars.iter().map(|var| (var.name.as_str(), &var.value))
     }
 
-    pub fn export_variables(&self, delimeter: &str, shell_family: ShellFamily) -> String {
-        serialize_variables_internal(self.key_value_iter(), "", "=", "", delimeter, shell_family)
+    pub fn export_variables(&self, delimiter: &str, shell_family: ShellFamily) -> String {
+        serialize_variables_internal(self.key_value_iter(), "", "=", "", delimiter, shell_family)
     }
 
     pub fn export_variables_for_shell(&self, shell_type: ShellType) -> String {
@@ -264,17 +264,17 @@ pub fn serialize_variables_for_shell<'s, I: IntoIterator<Item = (&'s str, &'s En
 // Prefix — what's prepended to each variable
 // Separator — what separates the variable name from the value
 // Postfix — what's appended to the end of each variable
-// Delimeter — what separates one variable from the next one
+// Delimiter — what separates one variable from the next one
 // set -x var_name var_value;   set -x name2 value2;
 // ------     -             -   -
 //   ^        ^             ^   ^
-// prefix  separator   postfix  delimeter (in this case 4 spaces, usually one space or newline)
+// prefix  separator   postfix  delimiter (in this case 4 spaces, usually one space or newline)
 fn serialize_variables_internal<'s, I: IntoIterator<Item = (&'s str, &'s EnvVarValue)>>(
     pairs: I,
     prefix: &str,
     separator: &str,
     postfix: &str,
-    delimeter: &str,
+    delimiter: &str,
     shell_family: ShellFamily,
 ) -> String {
     pairs
@@ -290,5 +290,5 @@ fn serialize_variables_internal<'s, I: IntoIterator<Item = (&'s str, &'s EnvVarV
             )
         })
         .collect_vec()
-        .join(delimeter)
+        .join(delimiter)
 }

--- a/app/src/external_secrets/mod.rs
+++ b/app/src/external_secrets/mod.rs
@@ -19,12 +19,12 @@ use crate::{terminal::shell::ShellType, ui_components::icons::Icon};
 lazy_static! {
     // Used as a delimeter to separate metadata (such as names and references)
     // in cases the cli tool doesn't display secrets in a common format (i.e. json)
-    static ref WARP_SECRET_DELIMETER: &'static str = "/warp-secret-delimeter/";
+    static ref WARP_SECRET_DELIMITER: &'static str = "/warp-secret-delimeter/";
     static ref LASTPASS_LIST_SECRETS_COMMAND: Vec<String> = {
         vec![
             "lpass".to_owned(),
             "ls".to_owned(),
-            format!("--format=%an{}%ai", *WARP_SECRET_DELIMETER),
+            format!("--format=%an{}%ai", *WARP_SECRET_DELIMITER),
         ]
     };
 }
@@ -320,7 +320,7 @@ fn parse_lastpass_secrets(output: &str) -> anyhow::Result<Vec<ExternalSecret>> {
     let parsed_output: Vec<ExternalSecret> = output
         .lines()
         .filter_map(|line| {
-            let parts = line.split(*WARP_SECRET_DELIMETER).collect_vec();
+            let parts = line.split(*WARP_SECRET_DELIMITER).collect_vec();
             if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
                 Some(ExternalSecret::LastPass(LastPassSecret {
                     name: parts[0].to_owned(),


### PR DESCRIPTION
## Description

Renames a misspelled identifier (`delimeter` -> `delimiter`) across two modules. Pure rename: 2 files, +9/-9 lines, no behavioral change.

**`app/src/env_vars/mod.rs`** - 6 changes:
- `pub fn export_variables(&self, delimeter: &str, ...)` -> `delimiter` (parameter name)
- Internal call site
- Private `serialize_variables_internal(..., delimeter: &str, ...)` parameter
- Three doc comments referencing the parameter

**`app/src/external_secrets/mod.rs`** - 3 changes:
- `static ref WARP_SECRET_DELIMETER` -> `WARP_SECRET_DELIMITER` (the constant *identifier*)
- Two usages of the constant

### What is intentionally preserved

The **string literal value** `"/warp-secret-delimeter/"` on line 22 is **kept as-is**. It is the runtime separator embedded in the `lpass --format=%an{}%ai` command and split back out of lpass's output (`line.split(*WARP_SECRET_DELIMITER)`). Changing the value would mean output emitted with one delimiter is parsed with another, breaking LastPass secret enumeration. Only the Rust identifier name is corrected; the on-the-wire token is unchanged.

### Caller analysis

All three external call sites of `export_variables` (in `drive/index.rs`, `drive/export.rs`, `terminal/input.rs`) use positional arguments. Rust does not have named arguments, so the parameter rename is invisible to callers and breaks nothing.

### Related

The comment `// Used as a delimeter to separate metadata` on line 20 of `external_secrets/mod.rs` is deliberately left for PR #9404 (the round-3 typo bundle), which already includes that fix. Different lines, no conflict.

## Testing

Pure identifier rename; no logic touched. The string-literal preservation note above is the only correctness-relevant detail.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode