### PR TITLE
Drop warp-internal references from docker/linux-dev README

### DIFF
--- a/docker/linux-dev/README.md
+++ b/docker/linux-dev/README.md
@@ -14,7 +14,7 @@ You'll need to install:
 
 ## Setup
 
-You'll run all of these commands from the `warp-internal` repository's root directory.
+You'll run all of these commands from the repository's root directory.
 
 First, build the docker container image:
 
@@ -27,7 +27,7 @@ Next, run the container:
 
 ```
 # The path to the source code directory that you want to mount in the
-# container. This can be the `warp-internal` repository or some parent
+# container. This can be the `warp` repository or some parent
 # directory of your choice.
 LOCAL_PATH="/Users/$USER/src"
 


### PR DESCRIPTION
### Description

\`docker/linux-dev/README.md\` still referenced the private \`warp-internal\` repository in two places (a sentence about the repo root, and a comment in the docker-run snippet). External contributors following this doc would be looking for a repo they can't access.

Updated:

- \"You'll run all of these commands from the \`warp-internal\` repository's root directory.\" → drop the repo name (\"the repository's root directory\").
- \"This can be the \`warp-internal\` repository or some parent directory of your choice.\" → \"the \`warp\` repository or some parent directory of your choice.\"

Doc-only.

### Testing

Markdown only.

### Server API

No server changes.

### Agent Mode

Not applicable.

### Changelog Entries

None.