### PR TITLE
Warp local API like server so we can use openai-compatible endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ desired_behavior.md
 
 # Don't include the python cache for bundled skills.
 __pycache__/
+# CocoIndex Code (ccc)
+/.cocoindex_code/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14823,6 +14823,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "warp_shim_server"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "clap",
+ "cynic",
+ "dirs 6.0.0",
+ "futures",
+ "futures-util",
+ "prost 0.14.3",
+ "prost-types",
+ "reqwest",
+ "reqwest-eventsource",
+ "rustls 0.23.39",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml 0.9.6",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+ "warp_graphql",
+ "warp_multi_agent_api",
+]
+
+[[package]]
 name = "warp_terminal"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ warp_logging = { path = "crates/warp_logging" }
 warp_managed_secrets = { path = "crates/managed_secrets" }
 warp_ripgrep = { path = "crates/warp_ripgrep" }
 warp_server_client = { path = "crates/warp_server_client" }
+warp_shim_server = { path = "crates/warp_shim_server" }
 warp_terminal = { path = "crates/warp_terminal" }
 warp_util = { path = "crates/warp_util" }
 warp_web_event_bus = { path = "crates/warp_web_event_bus" }
@@ -260,10 +261,12 @@ tempfile = "3.8.0"
 thiserror = "2.0.17"
 tokio = "1.47.1"
 tokio-util = { version = "0.7", features = ["io"] }
+toml = "0.9.6"
 toml_edit = "0.25.5"
 tower = "0.5.2"
 tower-http = "0.6.6"
 tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 arborium = { version = "2", default-features = false, features = [
   "lang-rust",
   "lang-go",

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1004,7 +1004,9 @@ fn initialize_app(
     // Extract API key from command line options, if applicable.
     let api_key = match launch_mode {
         LaunchMode::CommandLine { global_options, .. } => global_options.api_key.clone(),
-        LaunchMode::App { api_key, .. } if ChannelState::channel().is_dogfood() => api_key.clone(),
+        LaunchMode::App { api_key, .. }
+            if ChannelState::channel().is_dogfood()
+                || ChannelState::channel() == warp_core::channel::Channel::Oss => api_key.clone(),
         _ => None,
     };
     let api_key = if FeatureFlag::APIKeyAuthentication.is_enabled() {

--- a/crates/warp_core/src/channel/mod.rs
+++ b/crates/warp_core/src/channel/mod.rs
@@ -37,13 +37,13 @@ impl Channel {
     /// Whether this channel honors the `--server-root-url` / `--ws-server-url` /
     /// `--session-sharing-server-url` flags (and their `WARP_*` env-var equivalents).
     ///
-    /// Release channels (`Stable`, `Preview`, `Oss`) ignore these overrides so shipped
-    /// builds can't be redirected away from their baked-in server URLs. Internal-only channels
-    /// (`Dev`, `Local`, `Integration`) continue to honor them for local development and testing.
+    /// First-party release channels (`Stable`, `Preview`) ignore these overrides so shipped
+    /// builds can't be redirected away from their baked-in server URLs. OSS and internal-only
+    /// channels (`Oss`, `Dev`, `Local`, `Integration`) honor them for local routing and testing.
     pub fn allows_server_url_overrides(&self) -> bool {
         match self {
-            Channel::Dev | Channel::Local | Channel::Integration => true,
-            Channel::Stable | Channel::Preview | Channel::Oss => false,
+            Channel::Dev | Channel::Local | Channel::Oss | Channel::Integration => true,
+            Channel::Stable | Channel::Preview => false,
         }
     }
 
@@ -59,6 +59,10 @@ impl Channel {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;
 
 impl fmt::Display for Channel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/warp_core/src/channel/mod_tests.rs
+++ b/crates/warp_core/src/channel/mod_tests.rs
@@ -1,0 +1,21 @@
+use super::Channel;
+
+#[test]
+fn server_url_override_policy_matches_channel_matrix() {
+    let cases = [
+        (Channel::Stable, false),
+        (Channel::Preview, false),
+        (Channel::Dev, true),
+        (Channel::Local, true),
+        (Channel::Oss, true),
+        (Channel::Integration, true),
+    ];
+
+    for (channel, expected) in cases {
+        assert_eq!(
+            channel.allows_server_url_overrides(),
+            expected,
+            "unexpected override policy for {channel:?}"
+        );
+    }
+}

--- a/crates/warp_shim_server/Cargo.toml
+++ b/crates/warp_shim_server/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "warp_shim_server"
+edition = "2024"
+authors.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "warp-shim-server"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+async-stream.workspace = true
+axum.workspace = true
+base64.workspace = true
+bytes.workspace = true
+clap.workspace = true
+dirs.workspace = true
+futures.workspace = true
+futures-util.workspace = true
+prost.workspace = true
+prost-types.workspace = true
+reqwest.workspace = true
+reqwest-eventsource.workspace = true
+rustls.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
+toml.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+url.workspace = true
+uuid.workspace = true
+warp_multi_agent_api.workspace = true
+
+[dev-dependencies]
+cynic.workspace = true
+tower = { workspace = true, features = ["util"] }
+warp_graphql.workspace = true

--- a/crates/warp_shim_server/README.md
+++ b/crates/warp_shim_server/README.md
@@ -1,0 +1,142 @@
+# Warp Shim Server
+
+`warp-shim-server` is a local control-plane shim for the OSS Warp build. It accepts the Warp AI protobuf/SSE protocol, forwards Agent Mode turns to a user-controlled OpenAI-compatible `/chat/completions` upstream, and returns harmless local stubs for non-AI Warp control-plane surfaces.
+
+## Smoke-test launch
+
+Start the shim:
+
+```bash
+cargo run -p warp_shim_server --bin warp-shim-server -- --port 4444 --upstream-url http://127.0.0.1:11434/v1
+```
+
+Start OSS Warp pointed at the shim. The launch command must include `WARP_API_KEY=local-shim` (or any value):
+
+```bash
+WARP_API_KEY=local-shim \
+WARP_SERVER_ROOT_URL=http://127.0.0.1:4444 \
+WARP_WS_SERVER_URL=ws://127.0.0.1:4444/graphql/v2 \
+cargo run -p warp --bin warp-oss
+```
+
+After this patch, OSS builds honor `WARP_API_KEY` and skip the login modal.
+
+`WARP_WS_SERVER_URL` is required because Warp derives RTC HTTP endpoints from the WebSocket URL.
+
+## Manual GUI smoke test
+
+1. Build/run an OpenAI-compatible local model server, for example Ollama or vLLM.
+2. Run the shim with the command above.
+3. Run `warp-oss` with the environment command above.
+4. Open Agent Mode and send `hello`; verify a streaming assistant reply appears.
+5. Send `list files in /` or another safe read-only prompt; verify the model requests a client-executed tool and then continues after the tool result.
+
+## Configuration
+
+CLI values override environment variables, which override TOML, which override defaults.
+
+Supported environment fallbacks:
+
+- `WARP_SHIM_CONFIG`
+- `WARP_SHIM_HOST`
+- `WARP_SHIM_PORT`
+- `WARP_SHIM_UPSTREAM_URL`
+- `WARP_SHIM_API_KEY`
+- `WARP_SHIM_API_KEY_ENV`
+- `WARP_SHIM_MODEL_MAP` (comma-separated, for example `auto=llama3.1,cli-agent-auto=llama3.1`)
+
+Config lookup order:
+
+1. `--config <path>`
+2. `WARP_SHIM_CONFIG`
+3. `./warp-shim.toml`
+4. `~/.warp-shim/config.toml`
+
+Example TOML:
+
+```toml
+[server]
+host = "127.0.0.1"
+port = 4444
+public_base_url = "http://127.0.0.1:4444"
+
+[upstreams.default]
+base_url = "http://127.0.0.1:11434/v1"
+api_key_env = "OPENAI_API_KEY"
+timeout_secs = 180
+streaming = true
+
+[models]
+auto = { upstream = "default", model = "llama3.1" }
+"cli-agent-auto" = { upstream = "default", model = "llama3.1" }
+"computer-use-agent-auto" = { upstream = "default", model = "llama3.1" }
+"coding-auto" = { upstream = "default", model = "llama3.1" }
+
+[features]
+tools_enabled = true
+mcp_tools_enabled = true
+passive_suggestions_enabled = true
+```
+
+You can also pass model mappings directly:
+
+```bash
+cargo run -p warp_shim_server --bin warp-shim-server -- \
+  --upstream-url http://127.0.0.1:11434/v1 \
+  --model auto=llama3.1 \
+  --model cli-agent-auto=llama3.1
+```
+
+Secrets are never printed by the shim; startup logs only report whether an upstream API key is configured.
+
+## Implemented local surfaces
+
+- `POST /ai/multi-agent` OpenAI-compatible bridge with client-executed tool loops
+- `POST /ai/passive-suggestions` successful no-op stream
+- `POST /graphql/v2?op=GetFeatureModelChoices`
+- `POST /graphql/v2?op=FreeAvailableModels`
+- `POST /graphql/v2?op=GetUser`
+- `POST /graphql/v2?op=GetUserSettings`
+- `POST /graphql/v2?op=GetWorkspacesMetadataForUser`
+- `POST /client/login`
+- `POST /proxy/token` and `POST /proxy/customToken`
+- `GET /api/v1/agent/events/stream`
+- `POST /api/v1/agent/run`, `GET /api/v1/agent/runs`, and `GET /api/v1/agent/runs/:id`
+- `POST /api/v1/harness-support/*` minimal no-op responses
+- Browser auth pages such as `/login/*`, `/signup/*`, `/upgrade`, `/login_options/*`, and `/link_sso`
+
+Unknown GraphQL operations return `{"data":null}` and are logged with the operation name, request field names, and whether auth was present. Unknown non-telemetry paths return `404 {"error":"warp-shim: unsupported endpoint"}` and are logged with method/path.
+
+## Tool support
+
+The shim declares only tools that it can convert safely and only when the client lists them in `request.settings.supported_tools` (an empty list follows the protobuf contract and is treated as no override). Supported Warp tools are `RunShellCommand`, `WriteToLongRunningShellCommand`, `ReadShellCommandOutput`, `ReadFiles`, `ApplyFileDiffs`, `SearchCodebase`, `Grep`, `FileGlob`, `FileGlobV2`, and `ReadMcpResource`.
+
+MCP tools are generated from `request.mcp_context.servers[].tools` when `CallMcpTool` is client-supported. The upstream OpenAI tool name is `mcp__<sanitized_server_id>__<sanitized_tool_name>`, while the emitted Warp tool call preserves the original MCP `server_id` and tool `name`. MCP schemas are normalized to OpenAI-compatible object schemas before they are sent upstream.
+
+Explicitly unsupported tools such as `StartAgent`, `Subagent`, and `UseComputer` are not declared upstream.
+
+## Troubleshooting
+
+- **Metal toolchain build errors:** some Warp crates require Apple’s Metal toolchain. Install it with Xcode’s Metal Toolchain component if unrelated Warp crates fail while building `warp-oss`.
+- **Paste your auth token modal:** if you see a "Paste your auth token" modal at startup, you're missing `WARP_API_KEY=local-shim`.
+- **Port conflicts:** if `4444` is busy, start the shim with another `--port` and update both `WARP_SERVER_ROOT_URL` and `WARP_WS_SERVER_URL` to match.
+- **Model mapping mismatches:** if the upstream rejects `model: "auto"`, pass `--model auto=<upstream-model>` (and optionally mappings for `cli-agent-auto`, `coding-auto`, and `computer-use-agent-auto`).
+- **BYOK confusion:** Warp BYOK settings do not route traffic for this shim. The shim’s `--upstream-url`, `--api-key`, `--api-key-env`, and model mappings control upstream routing.
+- **No streaming reply:** confirm the upstream implements OpenAI-compatible streaming SSE at `/v1/chat/completions`. If it only supports non-streaming responses, set `streaming = false` in TOML.
+
+## Limitations
+
+- No Warp cloud agents; cloud-agent endpoints are local unsupported/no-op stubs.
+- No Warp Drive, sharing, team collaboration, cloud conversation storage, billing, or telemetry.
+- Conversation and pending tool-call state are in memory and are lost when the shim restarts.
+- Passive suggestions intentionally return a successful no-op stream. This avoids client errors but does not surface suggestion UI content.
+- Tool coverage is conservative; unsupported Warp tools are omitted rather than translated incorrectly.
+- OpenAI-compatible servers vary in tool-call support and JSON schema strictness.
+
+## Privacy warning
+
+Terminal context, prompts, command output, file snippets, and tool results may be sent to the configured upstream model. Be deliberate about which model/server you point the shim at, especially when working in sensitive repositories or terminals.
+
+## Security warning
+
+The shim binds to `127.0.0.1` by default. Do **not** expose it to a network interface or the public internet. It accepts local Warp traffic and is not hardened as a public service.

--- a/crates/warp_shim_server/src/config.rs
+++ b/crates/warp_shim_server/src/config.rs
@@ -1,0 +1,486 @@
+use std::{
+    collections::BTreeMap,
+    env, fmt, fs,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::Parser;
+use serde::Deserialize;
+use url::Url;
+
+const DEFAULT_PORT: u16 = 4444;
+const DEFAULT_UPSTREAM_NAME: &str = "default";
+const DEFAULT_UPSTREAM_TIMEOUT_SECS: u64 = 180;
+const DEFAULT_MODEL_IDS: [&str; 4] = [
+    "auto",
+    "cli-agent-auto",
+    "computer-use-agent-auto",
+    "coding-auto",
+];
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "warp-shim-server",
+    about = "Local Warp control-plane shim scaffold for OSS Warp AI flows"
+)]
+struct CliArgs {
+    /// Path to a warp-shim TOML config file.
+    #[arg(long, value_name = "PATH")]
+    config: Option<PathBuf>,
+
+    /// Host/IP address to bind. Defaults to 127.0.0.1.
+    #[arg(long, value_name = "HOST")]
+    host: Option<IpAddr>,
+
+    /// Port to bind. Defaults to 4444.
+    #[arg(long, value_name = "PORT")]
+    port: Option<u16>,
+
+    /// OpenAI-compatible upstream base URL, for example http://127.0.0.1:11434/v1.
+    #[arg(long, value_name = "URL")]
+    upstream_url: Option<String>,
+
+    /// API key to send to the upstream. Optional for local upstreams such as Ollama.
+    #[arg(long, value_name = "KEY")]
+    api_key: Option<String>,
+
+    /// Environment variable containing the upstream API key.
+    #[arg(long, value_name = "ENV")]
+    api_key_env: Option<String>,
+
+    /// Model mapping in the form warp_model=upstream_model. May be repeated.
+    #[arg(long = "model", value_name = "WARP=UPSTREAM")]
+    model: Vec<ModelMappingArg>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelMappingArg {
+    warp_model: String,
+    upstream_model: String,
+}
+
+impl FromStr for ModelMappingArg {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        let (warp_model, upstream_model) = value
+            .split_once('=')
+            .ok_or_else(|| "model mappings must use warp_model=upstream_model".to_string())?;
+        let warp_model = warp_model.trim();
+        let upstream_model = upstream_model.trim();
+
+        if warp_model.is_empty() || upstream_model.is_empty() {
+            return Err("model mapping names must not be empty".to_string());
+        }
+
+        Ok(Self {
+            warp_model: warp_model.to_string(),
+            upstream_model: upstream_model.to_string(),
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ShimConfig {
+    pub config_path: Option<PathBuf>,
+    pub server: ServerConfig,
+    pub upstreams: BTreeMap<String, UpstreamConfig>,
+    pub models: BTreeMap<String, ModelMapping>,
+    pub features: FeatureConfig,
+}
+
+impl ShimConfig {
+    pub fn from_sources() -> Result<Self> {
+        let cli = CliArgs::parse();
+        let (toml, config_path) = read_toml_config(cli.config.as_deref())?;
+
+        let host = cli
+            .host
+            .or(parse_env("WARP_SHIM_HOST")?)
+            .or(toml.server.host)
+            .unwrap_or_else(default_host);
+        let port = cli
+            .port
+            .or(parse_env("WARP_SHIM_PORT")?)
+            .or(toml.server.port)
+            .unwrap_or(DEFAULT_PORT);
+        let public_base_url = toml
+            .server
+            .public_base_url
+            .clone()
+            .unwrap_or_else(|| format!("http://{}", SocketAddr::new(host, port)));
+
+        let upstreams = merge_upstreams(&cli, &toml)?;
+        let models = merge_models(&cli, &toml, &upstreams)?;
+        let features = merge_features(&toml.features);
+
+        Ok(Self {
+            config_path,
+            server: ServerConfig {
+                host,
+                port,
+                public_base_url,
+            },
+            upstreams,
+            models,
+            features,
+        })
+    }
+
+    pub fn bind_addr(&self) -> SocketAddr {
+        SocketAddr::new(self.server.host, self.server.port)
+    }
+
+    pub fn default_upstream(&self) -> Result<&UpstreamConfig> {
+        self.upstreams
+            .get(DEFAULT_UPSTREAM_NAME)
+            .ok_or_else(|| anyhow!("validated config is missing the default upstream"))
+    }
+
+    pub fn model_mappings_for_log(&self) -> String {
+        self.models
+            .iter()
+            .map(|(warp_model, mapping)| {
+                format!("{warp_model}={}:{}", mapping.upstream, mapping.model)
+            })
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ServerConfig {
+    pub host: IpAddr,
+    pub port: u16,
+    pub public_base_url: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct UpstreamConfig {
+    pub base_url: Url,
+    pub api_key: Option<String>,
+    pub api_key_env: Option<String>,
+    pub timeout_secs: u64,
+    pub streaming: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct ModelMapping {
+    pub upstream: String,
+    pub model: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct FeatureConfig {
+    pub tools_enabled: bool,
+    pub mcp_tools_enabled: bool,
+    pub passive_suggestions_enabled: bool,
+}
+
+impl Default for FeatureConfig {
+    fn default() -> Self {
+        Self {
+            tools_enabled: true,
+            mcp_tools_enabled: true,
+            passive_suggestions_enabled: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct TomlConfig {
+    server: TomlServer,
+    upstreams: BTreeMap<String, TomlUpstream>,
+    models: BTreeMap<String, TomlModelMapping>,
+    features: TomlFeatures,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct TomlServer {
+    host: Option<IpAddr>,
+    port: Option<u16>,
+    public_base_url: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct TomlUpstream {
+    base_url: Option<String>,
+    api_key: Option<String>,
+    api_key_env: Option<String>,
+    timeout_secs: Option<u64>,
+    streaming: Option<bool>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct TomlModelMapping {
+    #[serde(default)]
+    upstream: Option<String>,
+    model: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+struct TomlFeatures {
+    tools_enabled: Option<bool>,
+    mcp_tools_enabled: Option<bool>,
+    passive_suggestions_enabled: Option<bool>,
+}
+
+fn default_host() -> IpAddr {
+    IpAddr::V4(Ipv4Addr::LOCALHOST)
+}
+
+fn read_toml_config(cli_config_path: Option<&Path>) -> Result<(TomlConfig, Option<PathBuf>)> {
+    if let Some(path) = cli_config_path {
+        return parse_toml_file(path).map(|config| (config, Some(path.to_path_buf())));
+    }
+
+    if let Some(path) = non_empty_env("WARP_SHIM_CONFIG").map(PathBuf::from) {
+        return parse_toml_file(&path).map(|config| (config, Some(path)));
+    }
+
+    for path in implicit_config_paths() {
+        if path.exists() {
+            return parse_toml_file(&path).map(|config| (config, Some(path)));
+        }
+    }
+
+    Ok((TomlConfig::default(), None))
+}
+
+fn implicit_config_paths() -> Vec<PathBuf> {
+    let mut paths = vec![PathBuf::from("warp-shim.toml")];
+    if let Some(home_dir) = dirs::home_dir() {
+        paths.push(home_dir.join(".warp-shim").join("config.toml"));
+    }
+    paths
+}
+
+fn parse_toml_file(path: &Path) -> Result<TomlConfig> {
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("failed to read shim config {}", path.display()))?;
+    toml::from_str(&contents)
+        .with_context(|| format!("failed to parse shim config {}", path.display()))
+}
+
+fn merge_upstreams(cli: &CliArgs, toml: &TomlConfig) -> Result<BTreeMap<String, UpstreamConfig>> {
+    let mut upstreams = BTreeMap::new();
+
+    for (name, upstream) in &toml.upstreams {
+        if name == DEFAULT_UPSTREAM_NAME {
+            continue;
+        }
+
+        let base_url = upstream
+            .base_url
+            .clone()
+            .ok_or_else(|| anyhow!("[upstreams.{name}].base_url is required"))?;
+        upstreams.insert(
+            name.clone(),
+            build_upstream_config(name, base_url, upstream, None, None)?,
+        );
+    }
+
+    let default_toml = toml
+        .upstreams
+        .get(DEFAULT_UPSTREAM_NAME)
+        .cloned()
+        .unwrap_or_default();
+    let default_base_url = cli
+        .upstream_url
+        .clone()
+        .or_else(|| non_empty_env("WARP_SHIM_UPSTREAM_URL"))
+        .or_else(|| default_toml.base_url.clone())
+        .ok_or_else(|| {
+            anyhow!(
+                "--upstream-url is required unless WARP_SHIM_UPSTREAM_URL or \
+                 [upstreams.default].base_url is configured"
+            )
+        })?;
+    let default_api_key_env = cli
+        .api_key_env
+        .clone()
+        .or_else(|| non_empty_env("WARP_SHIM_API_KEY_ENV"))
+        .or_else(|| default_toml.api_key_env.clone());
+    let default_api_key = cli
+        .api_key
+        .clone()
+        .or_else(|| non_empty_env("WARP_SHIM_API_KEY"))
+        .or_else(|| default_toml.api_key.clone())
+        .or_else(|| default_api_key_env.as_deref().and_then(non_empty_env));
+
+    upstreams.insert(
+        DEFAULT_UPSTREAM_NAME.to_string(),
+        build_upstream_config(
+            DEFAULT_UPSTREAM_NAME,
+            default_base_url,
+            &default_toml,
+            Some(default_api_key),
+            default_api_key_env,
+        )?,
+    );
+
+    Ok(upstreams)
+}
+
+fn build_upstream_config(
+    name: &str,
+    base_url: String,
+    upstream: &TomlUpstream,
+    api_key_override: Option<Option<String>>,
+    api_key_env_override: Option<String>,
+) -> Result<UpstreamConfig> {
+    let base_url = Url::parse(base_url.trim())
+        .with_context(|| format!("invalid base URL for upstream `{name}`"))?;
+    match base_url.scheme() {
+        "http" | "https" => {}
+        scheme => bail!("upstream `{name}` must use http or https, not `{scheme}`"),
+    }
+
+    let api_key_env = api_key_env_override.or_else(|| upstream.api_key_env.clone());
+    let api_key = api_key_override.unwrap_or_else(|| {
+        upstream
+            .api_key
+            .clone()
+            .or_else(|| api_key_env.as_deref().and_then(non_empty_env))
+    });
+
+    Ok(UpstreamConfig {
+        base_url,
+        api_key,
+        api_key_env,
+        timeout_secs: upstream
+            .timeout_secs
+            .unwrap_or(DEFAULT_UPSTREAM_TIMEOUT_SECS),
+        streaming: upstream.streaming.unwrap_or(true),
+    })
+}
+
+fn merge_models(
+    cli: &CliArgs,
+    toml: &TomlConfig,
+    upstreams: &BTreeMap<String, UpstreamConfig>,
+) -> Result<BTreeMap<String, ModelMapping>> {
+    let models = if !cli.model.is_empty() {
+        model_args_to_map(&cli.model)
+    } else if let Some(env_models) = parse_env_model_map()? {
+        model_args_to_map(&env_models)
+    } else if !toml.models.is_empty() {
+        toml.models
+            .iter()
+            .map(|(warp_model, mapping)| {
+                (
+                    warp_model.clone(),
+                    ModelMapping {
+                        upstream: mapping
+                            .upstream
+                            .clone()
+                            .unwrap_or_else(|| DEFAULT_UPSTREAM_NAME.to_string()),
+                        model: mapping.model.clone(),
+                    },
+                )
+            })
+            .collect()
+    } else {
+        DEFAULT_MODEL_IDS
+            .into_iter()
+            .map(|warp_model| {
+                (
+                    warp_model.to_string(),
+                    ModelMapping {
+                        upstream: DEFAULT_UPSTREAM_NAME.to_string(),
+                        model: "auto".to_string(),
+                    },
+                )
+            })
+            .collect()
+    };
+
+    for (warp_model, mapping) in &models {
+        if !upstreams.contains_key(&mapping.upstream) {
+            bail!(
+                "model mapping `{warp_model}` references unknown upstream `{}`",
+                mapping.upstream
+            );
+        }
+    }
+
+    Ok(models)
+}
+
+fn model_args_to_map(args: &[ModelMappingArg]) -> BTreeMap<String, ModelMapping> {
+    args.iter()
+        .map(|arg| {
+            (
+                arg.warp_model.clone(),
+                ModelMapping {
+                    upstream: DEFAULT_UPSTREAM_NAME.to_string(),
+                    model: arg.upstream_model.clone(),
+                },
+            )
+        })
+        .collect()
+}
+
+fn parse_env_model_map() -> Result<Option<Vec<ModelMappingArg>>> {
+    let Some(value) = non_empty_env("WARP_SHIM_MODEL_MAP") else {
+        return Ok(None);
+    };
+
+    let mut mappings = Vec::new();
+    for entry in value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+    {
+        let mapping = entry
+            .parse::<ModelMappingArg>()
+            .map_err(|err| anyhow!("invalid WARP_SHIM_MODEL_MAP entry `{entry}`: {err}"))?;
+        mappings.push(mapping);
+    }
+
+    if mappings.is_empty() {
+        bail!("WARP_SHIM_MODEL_MAP did not contain any model mappings");
+    }
+
+    Ok(Some(mappings))
+}
+
+fn merge_features(toml: &TomlFeatures) -> FeatureConfig {
+    let defaults = FeatureConfig::default();
+    FeatureConfig {
+        tools_enabled: toml.tools_enabled.unwrap_or(defaults.tools_enabled),
+        mcp_tools_enabled: toml.mcp_tools_enabled.unwrap_or(defaults.mcp_tools_enabled),
+        passive_suggestions_enabled: toml
+            .passive_suggestions_enabled
+            .unwrap_or(defaults.passive_suggestions_enabled),
+    }
+}
+
+fn parse_env<T>(name: &str) -> Result<Option<T>>
+where
+    T: FromStr,
+    T::Err: fmt::Display,
+{
+    let Some(value) = non_empty_env(name) else {
+        return Ok(None);
+    };
+
+    value
+        .parse::<T>()
+        .map(Some)
+        .map_err(|err| anyhow!("invalid {name}: {err}"))
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}

--- a/crates/warp_shim_server/src/conversation/mod.rs
+++ b/crates/warp_shim_server/src/conversation/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod store;
+pub(crate) mod transcript;

--- a/crates/warp_shim_server/src/conversation/store.rs
+++ b/crates/warp_shim_server/src/conversation/store.rs
@@ -1,0 +1,80 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
+
+use super::transcript::{PendingToolCall, TranscriptMessage};
+
+#[derive(Clone, Default)]
+pub(crate) struct ConversationStore {
+    inner: Arc<RwLock<HashMap<String, ConversationState>>>,
+    turn_locks: Arc<RwLock<HashMap<String, Arc<Mutex<()>>>>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ConversationState {
+    pub(crate) conversation_id: String,
+    pub(crate) task_id: String,
+    pub(crate) messages: Vec<TranscriptMessage>,
+    pub(crate) pending_tool_calls: HashMap<String, PendingToolCall>,
+    pub(crate) completed_tool_call_ids: HashSet<String>,
+}
+
+impl ConversationStore {
+    pub(crate) async fn lock_turn(&self, conversation_id: &str) -> OwnedMutexGuard<()> {
+        if let Some(lock) = self.turn_locks.read().await.get(conversation_id).cloned() {
+            return lock.lock_owned().await;
+        }
+
+        let mut guard = self.turn_locks.write().await;
+        guard
+            .entry(conversation_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+            .lock_owned()
+            .await
+    }
+
+    pub(crate) async fn load_or_create(
+        &self,
+        conversation_id: String,
+        task_id: String,
+        seed_messages: Vec<TranscriptMessage>,
+    ) -> (ConversationState, bool) {
+        if let Some(existing) = self.inner.read().await.get(&conversation_id).cloned() {
+            return (existing, false);
+        }
+
+        let mut guard = self.inner.write().await;
+        if let Some(existing) = guard.get_mut(&conversation_id) {
+            if existing.messages.is_empty() {
+                existing.messages = seed_messages;
+            }
+            if existing.task_id.is_empty() {
+                existing.task_id = task_id;
+            }
+            return (existing.clone(), false);
+        }
+
+        let state = ConversationState {
+            conversation_id,
+            task_id,
+            messages: seed_messages,
+            pending_tool_calls: HashMap::new(),
+            completed_tool_call_ids: HashSet::new(),
+        };
+        let state_for_return = state.clone();
+        guard.insert(state.conversation_id.clone(), state);
+
+        (state_for_return, true)
+    }
+
+    pub(crate) async fn save(&self, state: ConversationState) {
+        self.inner
+            .write()
+            .await
+            .insert(state.conversation_id.clone(), state);
+    }
+}

--- a/crates/warp_shim_server/src/conversation/transcript.rs
+++ b/crates/warp_shim_server/src/conversation/transcript.rs
@@ -1,0 +1,150 @@
+use warp_multi_agent_api as api;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TranscriptRole {
+    User,
+    Assistant,
+    Tool,
+}
+
+impl TranscriptRole {
+    pub(crate) fn as_openai_role(&self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+            Self::Tool => "tool",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TranscriptToolCall {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) arguments: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TranscriptMessage {
+    pub(crate) role: TranscriptRole,
+    pub(crate) content: String,
+    pub(crate) tool_call_id: Option<String>,
+    pub(crate) tool_calls: Vec<TranscriptToolCall>,
+}
+
+impl TranscriptMessage {
+    pub(crate) fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: TranscriptRole::User,
+            content: content.into(),
+            tool_call_id: None,
+            tool_calls: vec![],
+        }
+    }
+
+    pub(crate) fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: TranscriptRole::Assistant,
+            content: content.into(),
+            tool_call_id: None,
+            tool_calls: vec![],
+        }
+    }
+
+    pub(crate) fn assistant_tool_calls(
+        content: impl Into<String>,
+        tool_calls: Vec<TranscriptToolCall>,
+    ) -> Self {
+        Self {
+            role: TranscriptRole::Assistant,
+            content: content.into(),
+            tool_call_id: None,
+            tool_calls,
+        }
+    }
+
+    pub(crate) fn tool_result(tool_call_id: impl Into<String>, content: impl Into<String>) -> Self {
+        Self {
+            role: TranscriptRole::Tool,
+            content: content.into(),
+            tool_call_id: Some(tool_call_id.into()),
+            tool_calls: vec![],
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum WarpToolKind {
+    Builtin(api::ToolType),
+    Mcp {
+        server_id: String,
+        server_name: String,
+        tool_name: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PendingToolCall {
+    pub(crate) warp_tool_call_id: String,
+    pub(crate) openai_tool_call_id: String,
+    pub(crate) openai_tool_name: String,
+    pub(crate) kind: WarpToolKind,
+}
+
+pub(crate) fn history_from_request(request: &api::Request) -> Vec<TranscriptMessage> {
+    request
+        .task_context
+        .as_ref()
+        .into_iter()
+        .flat_map(|context| &context.tasks)
+        .flat_map(|task| &task.messages)
+        .filter_map(transcript_message_from_api_message)
+        .collect()
+}
+
+fn transcript_message_from_api_message(message: &api::Message) -> Option<TranscriptMessage> {
+    match message.message.as_ref()? {
+        api::message::Message::UserQuery(user_query) => non_empty(&user_query.query).map(|query| {
+            TranscriptMessage::user(format_with_context(query, user_query.context.as_ref()))
+        }),
+        api::message::Message::AgentOutput(output) => {
+            non_empty(&output.text).map(TranscriptMessage::assistant)
+        }
+        api::message::Message::SystemQuery(system_query) => system_query_to_text(system_query)
+            .map(|query| format_with_context(query, system_query.context.as_ref()))
+            .map(TranscriptMessage::user),
+        _ => None,
+    }
+}
+
+fn system_query_to_text(system_query: &api::message::SystemQuery) -> Option<&str> {
+    match system_query.r#type.as_ref()? {
+        api::message::system_query::Type::AutoCodeDiff(query) => non_empty(&query.query),
+        api::message::system_query::Type::CreateNewProject(query) => non_empty(&query.query),
+        api::message::system_query::Type::CloneRepository(query) => non_empty(&query.url),
+        api::message::system_query::Type::SummarizeConversation(query) => non_empty(&query.prompt),
+        api::message::system_query::Type::FetchReviewComments(query) => non_empty(&query.repo_path),
+        api::message::system_query::Type::ResumeConversation(_) => {
+            Some("Continue the conversation.")
+        }
+        api::message::system_query::Type::GeneratePassiveSuggestions(_) => None,
+    }
+}
+
+fn format_with_context(query: &str, context: Option<&api::InputContext>) -> String {
+    let Some(context) = context else {
+        return query.to_string();
+    };
+
+    let context = super::super::upstream::prompt::context_prefix(context);
+    if context.is_empty() {
+        query.to_string()
+    } else {
+        format!("{context}\n\nUser request:\n{query}")
+    }
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}

--- a/crates/warp_shim_server/src/lib.rs
+++ b/crates/warp_shim_server/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod config;
+pub mod server;
+
+pub(crate) mod conversation;
+pub(crate) mod protocol;
+pub(crate) mod routes;
+pub(crate) mod stubs;
+pub(crate) mod upstream;

--- a/crates/warp_shim_server/src/main.rs
+++ b/crates/warp_shim_server/src/main.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use tracing_subscriber::EnvFilter;
+use warp_shim_server::{config::ShimConfig, server};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    init_tracing();
+
+    let config = ShimConfig::from_sources()?;
+    server::serve(config).await
+}
+
+fn init_tracing() {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("warp_shim_server=info"));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_target(false)
+        .init();
+}

--- a/crates/warp_shim_server/src/protocol/mod.rs
+++ b/crates/warp_shim_server/src/protocol/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod protobuf;
+pub(crate) mod response_builder;
+pub(crate) mod sse;

--- a/crates/warp_shim_server/src/protocol/protobuf.rs
+++ b/crates/warp_shim_server/src/protocol/protobuf.rs
@@ -1,0 +1,6 @@
+use prost::Message as _;
+use warp_multi_agent_api as api;
+
+pub(crate) fn decode_request(bytes: &[u8]) -> Result<api::Request, prost::DecodeError> {
+    api::Request::decode(bytes)
+}

--- a/crates/warp_shim_server/src/protocol/response_builder.rs
+++ b/crates/warp_shim_server/src/protocol/response_builder.rs
@@ -1,0 +1,205 @@
+use warp_multi_agent_api as api;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct UsageTotals {
+    pub(crate) total_input: u32,
+    pub(crate) output: u32,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResponseBuilder {
+    conversation_id: String,
+    request_id: String,
+    run_id: String,
+}
+
+impl ResponseBuilder {
+    pub(crate) fn new(conversation_id: String, request_id: String, run_id: String) -> Self {
+        Self {
+            conversation_id,
+            request_id,
+            run_id,
+        }
+    }
+
+    pub(crate) fn init(&self) -> api::ResponseEvent {
+        api::ResponseEvent {
+            r#type: Some(api::response_event::Type::Init(
+                api::response_event::StreamInit {
+                    conversation_id: self.conversation_id.clone(),
+                    request_id: self.request_id.clone(),
+                    run_id: self.run_id.clone(),
+                },
+            )),
+        }
+    }
+
+    pub(crate) fn create_task(&self, task_id: &str) -> api::ResponseEvent {
+        self.client_actions(vec![api::ClientAction {
+            action: Some(api::client_action::Action::CreateTask(
+                api::client_action::CreateTask {
+                    task: Some(api::Task {
+                        id: task_id.to_string(),
+                        description: "Local Warp Agent Mode".to_string(),
+                        ..Default::default()
+                    }),
+                },
+            )),
+        }])
+    }
+
+    pub(crate) fn add_agent_output(
+        &self,
+        task_id: &str,
+        message_id: &str,
+        text: impl Into<String>,
+    ) -> api::ResponseEvent {
+        self.client_actions(vec![api::ClientAction {
+            action: Some(api::client_action::Action::AddMessagesToTask(
+                api::client_action::AddMessagesToTask {
+                    task_id: task_id.to_string(),
+                    messages: vec![self.agent_output_message(task_id, message_id, text)],
+                },
+            )),
+        }])
+    }
+
+    pub(crate) fn append_agent_output(
+        &self,
+        task_id: &str,
+        message_id: &str,
+        text_delta: impl Into<String>,
+    ) -> api::ResponseEvent {
+        self.client_actions(vec![api::ClientAction {
+            action: Some(api::client_action::Action::AppendToMessageContent(
+                api::client_action::AppendToMessageContent {
+                    task_id: task_id.to_string(),
+                    message: Some(self.agent_output_message(task_id, message_id, text_delta)),
+                    mask: Some(prost_types::FieldMask {
+                        paths: vec!["agent_output.text".to_string()],
+                    }),
+                },
+            )),
+        }])
+    }
+
+    pub(crate) fn add_tool_call(
+        &self,
+        task_id: &str,
+        message_id: &str,
+        tool_call: api::message::ToolCall,
+    ) -> api::ResponseEvent {
+        self.client_actions(vec![api::ClientAction {
+            action: Some(api::client_action::Action::AddMessagesToTask(
+                api::client_action::AddMessagesToTask {
+                    task_id: task_id.to_string(),
+                    messages: vec![api::Message {
+                        id: message_id.to_string(),
+                        task_id: task_id.to_string(),
+                        request_id: self.request_id.clone(),
+                        message: Some(api::message::Message::ToolCall(tool_call)),
+                        ..Default::default()
+                    }],
+                },
+            )),
+        }])
+    }
+
+    pub(crate) fn model_used(
+        &self,
+        task_id: &str,
+        message_id: &str,
+        model_id: &str,
+        display_name: &str,
+    ) -> api::ResponseEvent {
+        self.client_actions(vec![api::ClientAction {
+            action: Some(api::client_action::Action::AddMessagesToTask(
+                api::client_action::AddMessagesToTask {
+                    task_id: task_id.to_string(),
+                    messages: vec![api::Message {
+                        id: message_id.to_string(),
+                        task_id: task_id.to_string(),
+                        request_id: self.request_id.clone(),
+                        message: Some(api::message::Message::ModelUsed(api::message::ModelUsed {
+                            model_id: model_id.to_string(),
+                            model_display_name: display_name.to_string(),
+                            is_fallback: false,
+                        })),
+                        ..Default::default()
+                    }],
+                },
+            )),
+        }])
+    }
+
+    pub(crate) fn finished_success(
+        &self,
+        usage: Option<(String, UsageTotals)>,
+    ) -> api::ResponseEvent {
+        api::ResponseEvent {
+            r#type: Some(api::response_event::Type::Finished(
+                api::response_event::StreamFinished {
+                    reason: Some(api::response_event::stream_finished::Reason::Done(
+                        api::response_event::stream_finished::Done {},
+                    )),
+                    token_usage: usage
+                        .map(|(model_id, usage)| {
+                            vec![api::response_event::stream_finished::TokenUsage {
+                                model_id,
+                                total_input: usage.total_input,
+                                output: usage.output,
+                                ..Default::default()
+                            }]
+                        })
+                        .unwrap_or_default(),
+                    should_refresh_model_config: false,
+                    request_cost: None,
+                    conversation_usage_metadata: None,
+                },
+            )),
+        }
+    }
+
+    pub(crate) fn finished_internal_error(&self, message: impl Into<String>) -> api::ResponseEvent {
+        api::ResponseEvent {
+            r#type: Some(api::response_event::Type::Finished(
+                api::response_event::StreamFinished {
+                    reason: Some(api::response_event::stream_finished::Reason::InternalError(
+                        api::response_event::stream_finished::InternalError {
+                            message: message.into(),
+                        },
+                    )),
+                    token_usage: vec![],
+                    should_refresh_model_config: false,
+                    request_cost: None,
+                    conversation_usage_metadata: None,
+                },
+            )),
+        }
+    }
+
+    fn agent_output_message(
+        &self,
+        task_id: &str,
+        message_id: &str,
+        text: impl Into<String>,
+    ) -> api::Message {
+        api::Message {
+            id: message_id.to_string(),
+            task_id: task_id.to_string(),
+            request_id: self.request_id.clone(),
+            message: Some(api::message::Message::AgentOutput(
+                api::message::AgentOutput { text: text.into() },
+            )),
+            ..Default::default()
+        }
+    }
+
+    fn client_actions(&self, actions: Vec<api::ClientAction>) -> api::ResponseEvent {
+        api::ResponseEvent {
+            r#type: Some(api::response_event::Type::ClientActions(
+                api::response_event::ClientActions { actions },
+            )),
+        }
+    }
+}

--- a/crates/warp_shim_server/src/protocol/sse.rs
+++ b/crates/warp_shim_server/src/protocol/sse.rs
@@ -1,0 +1,41 @@
+use axum::response::sse::Event;
+use base64::{Engine as _, prelude::BASE64_URL_SAFE};
+use prost::Message as _;
+use warp_multi_agent_api as api;
+
+pub(crate) fn encode_response_event_data(event: &api::ResponseEvent) -> String {
+    BASE64_URL_SAFE.encode(event.encode_to_vec())
+}
+
+pub(crate) fn encode_response_event_for_sse(event: &api::ResponseEvent) -> Event {
+    Event::default().data(encode_response_event_data(event))
+}
+
+#[cfg(test)]
+pub(crate) fn decode_response_event_data_like_client(
+    data: &str,
+) -> anyhow::Result<api::ResponseEvent> {
+    let decoded = BASE64_URL_SAFE.decode(data.trim_matches('"'))?;
+    Ok(api::ResponseEvent::decode(decoded.as_slice())?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::response_builder::ResponseBuilder;
+
+    #[test]
+    fn response_event_data_round_trips_through_client_decode_logic() {
+        let event = ResponseBuilder::new(
+            "conversation-1".to_string(),
+            "request-1".to_string(),
+            "run-1".to_string(),
+        )
+        .finished_success(None);
+
+        let encoded = encode_response_event_data(&event);
+        let decoded = decode_response_event_data_like_client(&encoded).unwrap();
+
+        assert_eq!(decoded, event);
+    }
+}

--- a/crates/warp_shim_server/src/routes/ai.rs
+++ b/crates/warp_shim_server/src/routes/ai.rs
@@ -1,0 +1,1771 @@
+use std::convert::Infallible;
+
+use anyhow::{Context, Result, anyhow};
+use async_stream::stream;
+use axum::{
+    Json, Router,
+    body::Bytes,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response, sse::Sse},
+    routing::post,
+};
+use futures_util::{Stream, StreamExt};
+use serde_json::json;
+use uuid::Uuid;
+use warp_multi_agent_api as api;
+
+use crate::{
+    config::{ShimConfig, UpstreamConfig},
+    conversation::transcript::{self, TranscriptMessage, WarpToolKind},
+    protocol::{protobuf, response_builder::ResponseBuilder, sse},
+    server::ShimState,
+    upstream::{openai, prompt, tool_registry::ToolRegistry},
+};
+
+pub(crate) fn router() -> Router<ShimState> {
+    Router::new()
+        .route("/ai/multi-agent", post(post_multi_agent))
+        .route("/ai/passive-suggestions", post(post_passive_suggestions))
+}
+
+async fn post_multi_agent(State(state): State<ShimState>, body: Bytes) -> Response {
+    let request = match protobuf::decode_request(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            tracing::warn!(%error, "failed to decode multi-agent protobuf request");
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": format!("invalid warp_multi_agent_api::Request protobuf: {error}")
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    Sse::new(multi_agent_stream(state, request)).into_response()
+}
+
+async fn post_passive_suggestions(State(state): State<ShimState>, body: Bytes) -> Response {
+    let request = match protobuf::decode_request(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            tracing::warn!(%error, "failed to decode passive-suggestions protobuf request");
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": format!("invalid warp_multi_agent_api::Request protobuf: {error}")
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    Sse::new(passive_suggestions_stream(state, request)).into_response()
+}
+
+fn passive_suggestions_stream(
+    state: ShimState,
+    request: api::Request,
+) -> impl Stream<Item = Result<axum::response::sse::Event, Infallible>> {
+    stream! {
+        let response_context = ResponseContext::from_request(&request);
+        let builder = ResponseBuilder::new(
+            response_context.conversation_id,
+            response_context.request_id,
+            response_context.run_id,
+        );
+        yield Ok(sse::encode_response_event_for_sse(&builder.init()));
+        tracing::debug!(
+            passive_suggestions_enabled = state.config.features.passive_suggestions_enabled,
+            "returning no-op successful passive suggestions stream"
+        );
+        yield Ok(sse::encode_response_event_for_sse(&builder.finished_success(None)));
+    }
+}
+
+fn multi_agent_stream(
+    state: ShimState,
+    request: api::Request,
+) -> impl Stream<Item = Result<axum::response::sse::Event, Infallible>> {
+    stream! {
+        let response_context = ResponseContext::from_request(&request);
+        let builder = ResponseBuilder::new(
+            response_context.conversation_id.clone(),
+            response_context.request_id.clone(),
+            response_context.run_id.clone(),
+        );
+        yield Ok(sse::encode_response_event_for_sse(&builder.init()));
+
+        let _turn_guard = state
+            .conversations
+            .lock_turn(&response_context.conversation_id)
+            .await;
+
+        let seed_messages = transcript::history_from_request(&request);
+        let (mut conversation, is_new_conversation) = state
+            .conversations
+            .load_or_create(
+                response_context.conversation_id.clone(),
+                response_context.task_id.clone(),
+                seed_messages,
+            )
+            .await;
+
+        if should_create_task(&response_context, is_new_conversation) {
+            yield Ok(sse::encode_response_event_for_sse(
+                &builder.create_task(&conversation.task_id),
+            ));
+        }
+
+        let tool_registry = ToolRegistry::for_request(&request, &state.config.features);
+        append_tool_call_results(&mut conversation, &request, &tool_registry);
+
+        let input_messages = prompt::input_messages(&request);
+        conversation.messages.extend(input_messages);
+
+        let resolved_model = match resolve_model(&state.config, &request) {
+            Ok(model) => model,
+            Err(error) => {
+                tracing::warn!(%error, "failed to resolve upstream model for multi-agent request");
+                state.conversations.save(conversation).await;
+                yield Ok(sse::encode_response_event_for_sse(
+                    &builder.finished_internal_error(error.to_string()),
+                ));
+                return;
+            }
+        };
+
+        let chat_request = openai::OpenAiChatRequest::new(
+            resolved_model.upstream_model.clone(),
+            &conversation.messages,
+            prompt::system_message(),
+            resolved_model.upstream.streaming,
+            tool_registry.openai_tools(),
+        );
+
+        let message_id = format!("local-message-{}", Uuid::new_v4());
+        let model_message_id = format!("local-model-{}", Uuid::new_v4());
+
+        if resolved_model.upstream.streaming {
+            let result = stream_upstream_response(
+                state.http_client.clone(),
+                builder.clone(),
+                conversation.task_id.clone(),
+                message_id.clone(),
+                resolved_model.upstream.clone(),
+                chat_request,
+            );
+            futures_util::pin_mut!(result);
+
+            let mut final_text = String::new();
+            let mut usage = None;
+            let mut tool_call_accumulator = openai::OpenAiToolCallAccumulator::default();
+            while let Some(item) = result.next().await {
+                match item {
+                    StreamRouteItem::Event(event) => yield Ok(event),
+                    StreamRouteItem::TextDelta(delta) => final_text.push_str(&delta),
+                    StreamRouteItem::ToolCallDeltas(deltas) => {
+                        tool_call_accumulator.push_deltas(deltas);
+                    }
+                    StreamRouteItem::Usage(new_usage) => usage = Some(new_usage),
+                    StreamRouteItem::Error(error) => {
+                        tracing::warn!(%error, "upstream streaming failed");
+                        state.conversations.save(conversation).await;
+                        yield Ok(sse::encode_response_event_for_sse(
+                            &builder.finished_internal_error(error),
+                        ));
+                        return;
+                    }
+                }
+            }
+
+            let tool_calls = match tool_call_accumulator.finish() {
+                Ok(tool_calls) => tool_calls,
+                Err(error) => {
+                    tracing::warn!(%error, "failed to assemble upstream tool calls");
+                    state.conversations.save(conversation).await;
+                    yield Ok(sse::encode_response_event_for_sse(
+                        &builder.finished_internal_error(error.to_string()),
+                    ));
+                    return;
+                }
+            };
+
+            let tool_call_events = match append_upstream_response(
+                &mut conversation,
+                &tool_registry,
+                &builder,
+                final_text,
+                tool_calls,
+            ) {
+                Ok(events) => events,
+                Err(error) => {
+                    tracing::warn!(%error, "failed to convert upstream tool call");
+                    state.conversations.save(conversation).await;
+                    yield Ok(sse::encode_response_event_for_sse(
+                        &builder.finished_internal_error(error.to_string()),
+                    ));
+                    return;
+                }
+            };
+            for event in tool_call_events {
+                yield Ok(sse::encode_response_event_for_sse(&event));
+            }
+            yield Ok(sse::encode_response_event_for_sse(&builder.model_used(
+                &conversation.task_id,
+                &model_message_id,
+                &resolved_model.warp_model_id,
+                &resolved_model.upstream_model,
+            )));
+            yield Ok(sse::encode_response_event_for_sse(&builder.finished_success(
+                usage.map(|usage| (resolved_model.upstream_model.clone(), usage)),
+            )));
+            state.conversations.save(conversation).await;
+        } else {
+            match openai::complete_chat_completion(
+                &state.http_client,
+                &resolved_model.upstream,
+                chat_request,
+            ).await {
+                Ok(output) => {
+                    if !output.content.is_empty() {
+                        yield Ok(sse::encode_response_event_for_sse(&builder.add_agent_output(
+                            &conversation.task_id,
+                            &message_id,
+                            output.content.clone(),
+                        )));
+                    }
+                    let tool_call_events = match append_upstream_response(
+                        &mut conversation,
+                        &tool_registry,
+                        &builder,
+                        output.content,
+                        output.tool_calls,
+                    ) {
+                        Ok(events) => events,
+                        Err(error) => {
+                            tracing::warn!(%error, "failed to convert upstream tool call");
+                            state.conversations.save(conversation).await;
+                            yield Ok(sse::encode_response_event_for_sse(
+                                &builder.finished_internal_error(error.to_string()),
+                            ));
+                            return;
+                        }
+                    };
+                    for event in tool_call_events {
+                        yield Ok(sse::encode_response_event_for_sse(&event));
+                    }
+                    yield Ok(sse::encode_response_event_for_sse(&builder.model_used(
+                        &conversation.task_id,
+                        &model_message_id,
+                        &resolved_model.warp_model_id,
+                        &resolved_model.upstream_model,
+                    )));
+                    yield Ok(sse::encode_response_event_for_sse(&builder.finished_success(
+                        output.usage.map(|usage| (resolved_model.upstream_model.clone(), usage)),
+                    )));
+                    state.conversations.save(conversation).await;
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "upstream non-streaming completion failed");
+                    state.conversations.save(conversation).await;
+                    yield Ok(sse::encode_response_event_for_sse(
+                        &builder.finished_internal_error(error.to_string()),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+fn stream_upstream_response(
+    http_client: reqwest::Client,
+    builder: ResponseBuilder,
+    task_id: String,
+    message_id: String,
+    upstream: UpstreamConfig,
+    chat_request: openai::OpenAiChatRequest,
+) -> impl Stream<Item = StreamRouteItem> {
+    stream! {
+        let mut upstream_stream = match openai::stream_chat_completion(
+            &http_client,
+            &upstream,
+            chat_request,
+        ) {
+            Ok(stream) => stream,
+            Err(error) => {
+                yield StreamRouteItem::Error(error.to_string());
+                return;
+            }
+        };
+
+        let mut has_message = false;
+        while let Some(event) = upstream_stream.next().await {
+            match event {
+                Ok(reqwest_eventsource::Event::Open) => {}
+                Ok(reqwest_eventsource::Event::Message(message)) => {
+                    match openai::parse_stream_item(&message.data) {
+                        Ok(openai::StreamItem::Chunk(chunk)) => {
+                            let content = chunk.content;
+                            let tool_call_deltas = chunk.tool_call_deltas;
+                            if !content.is_empty() {
+                                let response_event = if has_message {
+                                    builder.append_agent_output(&task_id, &message_id, content.clone())
+                                } else {
+                                    has_message = true;
+                                    builder.add_agent_output(&task_id, &message_id, content.clone())
+                                };
+                                yield StreamRouteItem::TextDelta(content);
+                                yield StreamRouteItem::Event(sse::encode_response_event_for_sse(&response_event));
+                            }
+                            if !tool_call_deltas.is_empty() {
+                                yield StreamRouteItem::ToolCallDeltas(tool_call_deltas);
+                            }
+                        }
+                        Ok(openai::StreamItem::Usage(usage)) => {
+                            yield StreamRouteItem::Usage(usage);
+                        }
+                        Ok(openai::StreamItem::Done) => break,
+                        Ok(openai::StreamItem::Empty) => {}
+                        Err(error) => {
+                            upstream_stream.close();
+                            yield StreamRouteItem::Error(error.to_string());
+                            return;
+                        }
+                    }
+                }
+                Err(error) => {
+                    upstream_stream.close();
+                    yield StreamRouteItem::Error(error.to_string());
+                    return;
+                }
+            }
+        }
+    }
+}
+
+enum StreamRouteItem {
+    Event(axum::response::sse::Event),
+    TextDelta(String),
+    ToolCallDeltas(Vec<openai::OpenAiToolCallDelta>),
+    Usage(crate::protocol::response_builder::UsageTotals),
+    Error(String),
+}
+
+fn append_upstream_response(
+    conversation: &mut crate::conversation::store::ConversationState,
+    tool_registry: &ToolRegistry,
+    builder: &ResponseBuilder,
+    final_text: String,
+    openai_tool_calls: Vec<openai::OpenAiToolCall>,
+) -> Result<Vec<api::ResponseEvent>> {
+    if openai_tool_calls.is_empty() {
+        if !final_text.is_empty() {
+            conversation
+                .messages
+                .push(TranscriptMessage::assistant(final_text));
+        }
+        return Ok(vec![]);
+    }
+
+    let mut converted_tool_calls = Vec::new();
+    for openai_tool_call in &openai_tool_calls {
+        converted_tool_calls.push(tool_registry.convert_openai_tool_call(
+            openai_tool_call,
+            format!("local-tool-call-{}", Uuid::new_v4()),
+        )?);
+    }
+
+    let transcript_calls = converted_tool_calls
+        .iter()
+        .map(|conversion| conversion.openai_tool_call.clone())
+        .collect();
+    conversation
+        .messages
+        .push(TranscriptMessage::assistant_tool_calls(
+            final_text,
+            transcript_calls,
+        ));
+
+    let mut events = Vec::new();
+    for conversion in converted_tool_calls {
+        let message_id = format!("local-tool-message-{}", Uuid::new_v4());
+        conversation.pending_tool_calls.insert(
+            conversion.pending.warp_tool_call_id.clone(),
+            conversion.pending,
+        );
+        events.push(builder.add_tool_call(
+            &conversation.task_id,
+            &message_id,
+            conversion.tool_call,
+        ));
+    }
+    Ok(events)
+}
+
+fn append_tool_call_results(
+    conversation: &mut crate::conversation::store::ConversationState,
+    request: &api::Request,
+    tool_registry: &ToolRegistry,
+) {
+    for result in tool_call_results_from_request(request) {
+        if conversation
+            .completed_tool_call_ids
+            .contains(&result.tool_call_id)
+        {
+            tracing::warn!(
+                tool_call_id = %result.tool_call_id,
+                "ignoring duplicate tool-call result"
+            );
+            continue;
+        }
+
+        if let Some(pending) = conversation.pending_tool_calls.remove(&result.tool_call_id) {
+            if !tool_result_matches_pending(result, &pending.kind) {
+                tracing::warn!(
+                    tool_call_id = %result.tool_call_id,
+                    openai_tool_name = %pending.openai_tool_name,
+                    expected_kind = ?pending.kind,
+                    "ignoring mismatched tool-call result"
+                );
+                conversation
+                    .pending_tool_calls
+                    .insert(result.tool_call_id.clone(), pending);
+                continue;
+            }
+
+            let content = tool_registry.result_to_openai_content(result);
+            conversation.messages.push(TranscriptMessage::tool_result(
+                pending.openai_tool_call_id,
+                content,
+            ));
+            conversation
+                .completed_tool_call_ids
+                .insert(result.tool_call_id.clone());
+        } else {
+            let content = tool_registry.result_to_openai_content(result);
+            tracing::warn!(
+                tool_call_id = %result.tool_call_id,
+                "received result for unknown tool call; appending as user-visible text context"
+            );
+            conversation.messages.push(TranscriptMessage::user(format!(
+                "Tool result for unknown tool_call_id `{}`:\n{}",
+                result.tool_call_id, content
+            )));
+            conversation
+                .completed_tool_call_ids
+                .insert(result.tool_call_id.clone());
+        }
+    }
+}
+
+#[allow(deprecated)]
+fn tool_call_results_from_request(
+    request: &api::Request,
+) -> Vec<&api::request::input::ToolCallResult> {
+    let Some(input) = request.input.as_ref() else {
+        return vec![];
+    };
+    match input.r#type.as_ref() {
+        Some(api::request::input::Type::ToolCallResult(result)) => vec![result],
+        Some(api::request::input::Type::UserInputs(user_inputs)) => user_inputs
+            .inputs
+            .iter()
+            .filter_map(|input| match input.input.as_ref() {
+                Some(api::request::input::user_inputs::user_input::Input::ToolCallResult(
+                    result,
+                )) => Some(result),
+                _ => None,
+            })
+            .collect(),
+        _ => vec![],
+    }
+}
+
+fn tool_result_matches_pending(
+    result: &api::request::input::ToolCallResult,
+    pending_kind: &WarpToolKind,
+) -> bool {
+    match pending_kind {
+        WarpToolKind::Builtin(expected) => tool_result_type(result) == Some(*expected),
+        WarpToolKind::Mcp { .. } => matches!(
+            result.result.as_ref(),
+            Some(api::request::input::tool_call_result::Result::CallMcpTool(
+                _
+            ))
+        ),
+    }
+}
+
+#[allow(deprecated)]
+fn tool_result_type(result: &api::request::input::ToolCallResult) -> Option<api::ToolType> {
+    use api::request::input::tool_call_result::Result as ResultType;
+
+    match result.result.as_ref()? {
+        ResultType::RunShellCommand(_) => Some(api::ToolType::RunShellCommand),
+        ResultType::WriteToLongRunningShellCommand(_) => {
+            Some(api::ToolType::WriteToLongRunningShellCommand)
+        }
+        ResultType::ReadShellCommandOutput(_) => Some(api::ToolType::ReadShellCommandOutput),
+        ResultType::ReadFiles(_) => Some(api::ToolType::ReadFiles),
+        ResultType::ApplyFileDiffs(_) => Some(api::ToolType::ApplyFileDiffs),
+        ResultType::SearchCodebase(_) => Some(api::ToolType::SearchCodebase),
+        ResultType::Grep(_) => Some(api::ToolType::Grep),
+        ResultType::FileGlob(_) => Some(api::ToolType::FileGlob),
+        ResultType::FileGlobV2(_) => Some(api::ToolType::FileGlobV2),
+        ResultType::ReadMcpResource(_) => Some(api::ToolType::ReadMcpResource),
+        ResultType::CallMcpTool(_) => Some(api::ToolType::CallMcpTool),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ResponseContext {
+    conversation_id: String,
+    request_id: String,
+    run_id: String,
+    task_id: String,
+    had_request_conversation_id: bool,
+    had_request_task_id: bool,
+}
+
+impl ResponseContext {
+    fn from_request(request: &api::Request) -> Self {
+        let request_conversation_id = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| non_empty(&metadata.conversation_id));
+        let task_id_from_request = first_task_id(request);
+        let generated_task_id = format!("local-task-{}", Uuid::new_v4());
+        let task_id = if request_conversation_id.is_some() {
+            task_id_from_request
+                .clone()
+                .unwrap_or_else(|| generated_task_id.clone())
+        } else {
+            generated_task_id.clone()
+        };
+        let run_id = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| non_empty(&metadata.ambient_agent_task_id))
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("local-run-{task_id}"));
+
+        Self {
+            conversation_id: request_conversation_id
+                .map(str::to_string)
+                .unwrap_or_else(|| Uuid::new_v4().to_string()),
+            request_id: Uuid::new_v4().to_string(),
+            run_id,
+            task_id,
+            had_request_conversation_id: request_conversation_id.is_some(),
+            had_request_task_id: task_id_from_request.is_some(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ResolvedModel {
+    warp_model_id: String,
+    upstream_model: String,
+    upstream: UpstreamConfig,
+}
+
+fn resolve_model(config: &ShimConfig, request: &api::Request) -> Result<ResolvedModel> {
+    let warp_model_id = request
+        .settings
+        .as_ref()
+        .and_then(|settings| settings.model_config.as_ref())
+        .and_then(|model_config| non_empty(&model_config.base))
+        .unwrap_or("auto");
+
+    let mapping = config
+        .models
+        .get(warp_model_id)
+        .or_else(|| config.models.get("auto"))
+        .or_else(|| config.models.values().next())
+        .ok_or_else(|| anyhow!("no model mappings configured in warp shim"))?;
+    let upstream = config.upstreams.get(&mapping.upstream).with_context(|| {
+        format!(
+            "model mapping references unknown upstream `{}`",
+            mapping.upstream
+        )
+    })?;
+
+    Ok(ResolvedModel {
+        warp_model_id: warp_model_id.to_string(),
+        upstream_model: mapping.model.clone(),
+        upstream: upstream.clone(),
+    })
+}
+
+fn should_create_task(context: &ResponseContext, is_new_conversation: bool) -> bool {
+    is_new_conversation && (!context.had_request_conversation_id || !context.had_request_task_id)
+}
+
+fn first_task_id(request: &api::Request) -> Option<String> {
+    request
+        .task_context
+        .as_ref()?
+        .tasks
+        .iter()
+        .find_map(|task| non_empty(&task.id).map(str::to_string))
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{BTreeMap, HashMap, HashSet},
+        net::Ipv4Addr,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    use axum::{
+        Json, Router,
+        body::{Body, to_bytes},
+        extract::State as AxumState,
+        http::{Request, StatusCode},
+        response::sse::{Event, Sse},
+        routing::post,
+    };
+    use futures_util::stream;
+    use prost::Message as _;
+    use serde_json::{Value, json};
+    use tokio::{
+        net::TcpListener,
+        sync::{Notify, oneshot},
+        time::{Duration, sleep},
+    };
+    use tower::ServiceExt;
+    use url::Url;
+
+    use super::*;
+    use crate::{
+        config::{FeatureConfig, ModelMapping, ServerConfig},
+        protocol::sse::decode_response_event_data_like_client,
+    };
+
+    #[tokio::test]
+    async fn multi_agent_streams_fake_openai_reply_as_warp_response_events() {
+        let upstream_url = spawn_fake_openai_upstream().await;
+        let config = test_config(upstream_url, true);
+        let request = test_multi_agent_request();
+
+        let response = crate::server::router(Arc::new(config))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ai/multi-agent")
+                    .header("content-type", "application/x-protobuf")
+                    .body(Body::from(request.encode_to_vec()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let events = decode_sse_response_events(&body);
+
+        assert!(matches!(
+            events.first().and_then(|event| event.r#type.as_ref()),
+            Some(api::response_event::Type::Init(_))
+        ));
+        assert!(events.iter().any(|event| matches!(
+            event.r#type.as_ref(),
+            Some(api::response_event::Type::Finished(finished))
+                if matches!(
+                    finished.reason,
+                    Some(api::response_event::stream_finished::Reason::Done(_))
+                )
+        )));
+
+        let (assistant_text, agent_output_ids) = collect_agent_output_text(&events);
+        assert_eq!(assistant_text, "Hello from fake upstream.");
+        assert_eq!(
+            agent_output_ids.len(),
+            1,
+            "agent output message id must be stable"
+        );
+        assert!(events.iter().any(contains_model_used_event));
+    }
+
+    #[tokio::test]
+    async fn tool_call_result_loop_resumes_upstream_and_emits_final_text() {
+        let seen_requests = Arc::new(Mutex::new(Vec::new()));
+        let upstream_url = spawn_tool_loop_openai_upstream(seen_requests.clone()).await;
+        let config = test_config(upstream_url, true);
+        let app = crate::server::router(Arc::new(config));
+
+        let first_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ai/multi-agent")
+                    .header("content-type", "application/x-protobuf")
+                    .body(Body::from(
+                        test_multi_agent_request_with_supported_tools(
+                            "tool-loop-conversation",
+                            &[api::ToolType::RunShellCommand],
+                        )
+                        .encode_to_vec(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first_response.status(), StatusCode::OK);
+        let first_body = to_bytes(first_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let first_events = decode_sse_response_events(&first_body);
+        let tool_calls = collect_tool_calls(&first_events);
+        assert_eq!(tool_calls.len(), 1);
+        let warp_tool_call_id = tool_calls[0].tool_call_id.clone();
+        let Some(api::message::tool_call::Tool::RunShellCommand(run)) = &tool_calls[0].tool else {
+            panic!("expected run shell command tool call");
+        };
+        assert_eq!(run.command, "pwd");
+
+        let second_response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ai/multi-agent")
+                    .header("content-type", "application/x-protobuf")
+                    .body(Body::from(
+                        test_tool_result_request("tool-loop-conversation", &warp_tool_call_id)
+                            .encode_to_vec(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second_response.status(), StatusCode::OK);
+        let second_body = to_bytes(second_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let second_events = decode_sse_response_events(&second_body);
+        let (assistant_text, _) = collect_agent_output_text(&second_events);
+        assert_eq!(assistant_text, "Tool result received.");
+
+        let requests = seen_requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(
+            requests[0]["tools"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|tool| tool["function"]["name"] == "run_shell_command")
+        );
+        let second_messages = requests[1]["messages"].as_array().unwrap();
+        assert!(second_messages.iter().any(|message| {
+            message["role"] == "assistant"
+                && message["tool_calls"][0]["id"] == "call_run_1"
+                && message["tool_calls"][0]["function"]["name"] == "run_shell_command"
+        }));
+        assert!(second_messages.iter().any(|message| {
+            message["role"] == "tool" && message["tool_call_id"] == "call_run_1"
+        }));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn mismatched_tool_result_keeps_pending_call_and_does_not_append_context() {
+        let registry =
+            ToolRegistry::for_request(&api::Request::default(), &FeatureConfig::default());
+        let mut conversation = crate::conversation::store::ConversationState {
+            conversation_id: "conversation".to_string(),
+            task_id: "task".to_string(),
+            messages: vec![],
+            pending_tool_calls: HashMap::from([(
+                "warp-call".to_string(),
+                crate::conversation::transcript::PendingToolCall {
+                    warp_tool_call_id: "warp-call".to_string(),
+                    openai_tool_call_id: "openai-call".to_string(),
+                    openai_tool_name: "run_shell_command".to_string(),
+                    kind: WarpToolKind::Builtin(api::ToolType::RunShellCommand),
+                },
+            )]),
+            completed_tool_call_ids: HashSet::new(),
+        };
+        let request = api::Request {
+            input: Some(api::request::Input {
+                r#type: Some(api::request::input::Type::ToolCallResult(
+                    api::request::input::ToolCallResult {
+                        tool_call_id: "warp-call".to_string(),
+                        result: Some(api::request::input::tool_call_result::Result::ReadFiles(
+                            api::ReadFilesResult::default(),
+                        )),
+                    },
+                )),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        append_tool_call_results(&mut conversation, &request, &registry);
+
+        assert!(conversation.pending_tool_calls.contains_key("warp-call"));
+        assert!(conversation.completed_tool_call_ids.is_empty());
+        assert!(conversation.messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mcp_tools_are_declared_with_sanitized_names_and_routed_back_to_call_mcp_tool() {
+        let seen_requests = Arc::new(Mutex::new(Vec::new()));
+        let upstream_url = spawn_mcp_tool_openai_upstream(seen_requests.clone()).await;
+        let config = test_config(upstream_url, true);
+        let request = test_mcp_request();
+
+        let response = crate::server::router(Arc::new(config))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ai/multi-agent")
+                    .header("content-type", "application/x-protobuf")
+                    .body(Body::from(request.encode_to_vec()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let events = decode_sse_response_events(&body);
+        let tool_calls = collect_tool_calls(&events);
+        assert_eq!(tool_calls.len(), 1);
+        let Some(api::message::tool_call::Tool::CallMcpTool(call)) = &tool_calls[0].tool else {
+            panic!("expected CallMcpTool tool call");
+        };
+        assert_eq!(call.server_id, "linear-prod");
+        assert_eq!(call.name, "create.issue");
+        let args = struct_to_json_for_test(call.args.as_ref().unwrap());
+        assert_eq!(args["title"], "Bug");
+
+        let requests = seen_requests.lock().unwrap();
+        let tools = requests[0]["tools"].as_array().unwrap();
+        let mcp_tool = tools
+            .iter()
+            .find(|tool| tool["function"]["name"] == "mcp__linear_prod__create_issue")
+            .expect("MCP tool declaration");
+        assert_eq!(
+            mcp_tool["function"]["parameters"]["properties"]["title"]["type"],
+            "string"
+        );
+    }
+
+    #[tokio::test]
+    async fn passive_suggestions_returns_successful_noop_stream() {
+        let config = test_config(Url::parse("http://127.0.0.1:1/v1").unwrap(), true);
+        let mut request = test_multi_agent_request();
+        request.input = Some(api::request::Input {
+            r#type: Some(api::request::input::Type::GeneratePassiveSuggestions(
+                api::request::input::GeneratePassiveSuggestions::default(),
+            )),
+            ..Default::default()
+        });
+
+        let response = crate::server::router(Arc::new(config))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ai/passive-suggestions")
+                    .header("content-type", "application/x-protobuf")
+                    .body(Body::from(request.encode_to_vec()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let events = decode_sse_response_events(&body);
+        assert!(events.iter().any(|event| matches!(
+            event.r#type.as_ref(),
+            Some(api::response_event::Type::Finished(finished))
+                if matches!(finished.reason, Some(api::response_event::stream_finished::Reason::Done(_)))
+        )));
+    }
+
+    #[tokio::test]
+    async fn invalid_protobuf_returns_json_400_before_sse_starts() {
+        let config = test_config(Url::parse("http://127.0.0.1:1/v1").unwrap(), true);
+        let response = crate::server::router(Arc::new(config))
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/ai/multi-agent")
+                    .header("content-type", "application/x-protobuf")
+                    .body(Body::from("not protobuf"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/json"
+        );
+    }
+
+    #[tokio::test]
+    async fn http_e2e_streams_fake_openai_reply_over_reqwest_protobuf() {
+        let upstream_url = spawn_fake_openai_upstream().await;
+        let (shim_url, shutdown, server) = spawn_shim_server(test_config(upstream_url, true)).await;
+
+        let response = reqwest::Client::new()
+            .post(shim_url.join("/ai/multi-agent").unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/x-protobuf")
+            .body(test_multi_agent_request().encode_to_vec())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            content_type.starts_with("text/event-stream"),
+            "unexpected content-type: {content_type}"
+        );
+
+        let body = response.bytes().await.unwrap();
+        let events = decode_sse_response_events(&body);
+        let (assistant_text, _) = collect_agent_output_text(&events);
+        assert_eq!(assistant_text, "Hello from fake upstream.");
+        assert!(has_finished_done(&events));
+
+        shutdown_shim_server(shutdown, server).await;
+    }
+
+    #[tokio::test]
+    async fn tool_loop_http_e2e_sends_tool_result_context_upstream() {
+        let seen_requests = Arc::new(Mutex::new(Vec::<Vec<u8>>::new()));
+        let upstream_url = spawn_tool_loop_openai_upstream_raw(seen_requests.clone()).await;
+        let (shim_url, shutdown, server) = spawn_shim_server(test_config(upstream_url, true)).await;
+        let client = reqwest::Client::new();
+
+        let first_response = client
+            .post(shim_url.join("/ai/multi-agent").unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/x-protobuf")
+            .body(
+                test_multi_agent_request_with_supported_tools(
+                    "tool-loop-http-conversation",
+                    &[api::ToolType::RunShellCommand],
+                )
+                .encode_to_vec(),
+            )
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(first_response.status(), StatusCode::OK);
+        let first_events = decode_sse_response_events(&first_response.bytes().await.unwrap());
+        let tool_calls = collect_tool_calls(&first_events);
+        assert_eq!(tool_calls.len(), 1);
+        let warp_tool_call_id = tool_calls[0].tool_call_id.clone();
+        let Some(api::message::tool_call::Tool::RunShellCommand(run)) = &tool_calls[0].tool else {
+            panic!("expected run shell command tool call");
+        };
+        assert_eq!(run.command, "pwd");
+        assert!(has_finished_done(&first_events));
+
+        let second_response = client
+            .post(shim_url.join("/ai/multi-agent").unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/x-protobuf")
+            .body(
+                test_tool_result_request("tool-loop-http-conversation", &warp_tool_call_id)
+                    .encode_to_vec(),
+            )
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(second_response.status(), StatusCode::OK);
+        let second_events = decode_sse_response_events(&second_response.bytes().await.unwrap());
+        let (assistant_text, _) = collect_agent_output_text(&second_events);
+        assert_eq!(assistant_text, "Tool result received.");
+        assert!(has_finished_done(&second_events));
+
+        {
+            let requests = seen_requests.lock().unwrap();
+            assert_eq!(requests.len(), 2);
+            let first_upstream_request: Value = serde_json::from_slice(&requests[0]).unwrap();
+            assert!(
+                first_upstream_request["tools"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|tool| tool["function"]["name"] == "run_shell_command")
+            );
+
+            let second_upstream_request: Value = serde_json::from_slice(&requests[1]).unwrap();
+            let second_messages = second_upstream_request["messages"].as_array().unwrap();
+            assert!(second_messages.iter().any(|message| {
+                message["role"] == "assistant"
+                    && message["tool_calls"][0]["id"] == "call_run_1"
+                    && message["tool_calls"][0]["function"]["name"] == "run_shell_command"
+            }));
+            assert!(second_messages.iter().any(|message| {
+                message["role"] == "tool" && message["tool_call_id"] == "call_run_1"
+            }));
+        }
+
+        shutdown_shim_server(shutdown, server).await;
+    }
+
+    #[tokio::test]
+    async fn same_conversation_requests_are_serialized_before_upstream() {
+        let upstream_state = Arc::new(BlockingUpstreamState::new());
+        let upstream_url = spawn_blocking_counter_openai_upstream(upstream_state.clone()).await;
+        let (shim_url, shutdown, server) = spawn_shim_server(test_config(upstream_url, true)).await;
+        let client = reqwest::Client::new();
+
+        let first_request =
+            test_multi_agent_request_with_supported_tools("shared-conversation", &[]);
+        let first_url = shim_url.join("/ai/multi-agent").unwrap();
+        let first_client = client.clone();
+        let first = tokio::spawn(async move {
+            let response = first_client
+                .post(first_url)
+                .header(reqwest::header::CONTENT_TYPE, "application/x-protobuf")
+                .body(first_request.encode_to_vec())
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            decode_sse_response_events(&response.bytes().await.unwrap())
+        });
+
+        upstream_state.first_started.notified().await;
+
+        let second_request =
+            test_multi_agent_request_with_supported_tools("shared-conversation", &[]);
+        let second_url = shim_url.join("/ai/multi-agent").unwrap();
+        let second_client = client.clone();
+        let second = tokio::spawn(async move {
+            let response = second_client
+                .post(second_url)
+                .header(reqwest::header::CONTENT_TYPE, "application/x-protobuf")
+                .body(second_request.encode_to_vec())
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            decode_sse_response_events(&response.bytes().await.unwrap())
+        });
+
+        sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            upstream_state.hits.load(Ordering::SeqCst),
+            1,
+            "second request reached upstream before first turn finished"
+        );
+
+        upstream_state.release_first.notify_waiters();
+        let first_events = first.await.unwrap();
+        let second_events = second.await.unwrap();
+
+        assert!(has_finished_done(&first_events));
+        assert!(has_finished_done(&second_events));
+        assert_eq!(upstream_state.hits.load(Ordering::SeqCst), 2);
+        assert_eq!(upstream_state.max_active.load(Ordering::SeqCst), 1);
+
+        shutdown_shim_server(shutdown, server).await;
+    }
+
+    #[tokio::test]
+    async fn upstream_http_error_after_sse_starts_finishes_with_internal_error() {
+        let upstream_url = spawn_http_error_openai_upstream().await;
+        let (shim_url, shutdown, server) = spawn_shim_server(test_config(upstream_url, true)).await;
+
+        let response = reqwest::Client::new()
+            .post(shim_url.join("/ai/multi-agent").unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/x-protobuf")
+            .body(test_multi_agent_request().encode_to_vec())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let events = decode_sse_response_events(&response.bytes().await.unwrap());
+        assert!(matches!(
+            events.first().and_then(|event| event.r#type.as_ref()),
+            Some(api::response_event::Type::Init(_))
+        ));
+        assert!(has_finished_internal_error(&events));
+        assert!(!has_finished_done(&events));
+
+        shutdown_shim_server(shutdown, server).await;
+    }
+
+    async fn spawn_tool_loop_openai_upstream(seen_requests: Arc<Mutex<Vec<Value>>>) -> Url {
+        async fn chat_completions(
+            AxumState(seen_requests): AxumState<Arc<Mutex<Vec<Value>>>>,
+            Json(body): Json<Value>,
+        ) -> Sse<impl futures_util::Stream<Item = std::result::Result<Event, Infallible>>> {
+            seen_requests.lock().unwrap().push(body.clone());
+            let has_tool_result = body["messages"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|message| message["role"] == "tool");
+
+            let chunks = if has_tool_result {
+                vec![
+                    Ok(Event::default().data(
+                        json!({ "choices": [{ "delta": { "content": "Tool result received." } }] })
+                            .to_string(),
+                    )),
+                    Ok(Event::default().data("[DONE]")),
+                ]
+            } else {
+                assert_eq!(body["tool_choice"], "auto");
+                vec![
+                    Ok(Event::default().data(
+                        json!({
+                            "choices": [{
+                                "delta": {
+                                    "tool_calls": [{
+                                        "index": 0,
+                                        "id": "call_run_1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "run_shell_command",
+                                            "arguments": "{\"command\":\"pwd\",\"risk_category\":\"read_only\"}"
+                                        }
+                                    }]
+                                }
+                            }]
+                        })
+                        .to_string(),
+                    )),
+                    Ok(Event::default().data("[DONE]")),
+                ]
+            };
+            Sse::new(stream::iter(chunks))
+        }
+
+        let app = Router::new()
+            .route("/v1/chat/completions", post(chat_completions))
+            .with_state(seen_requests);
+        spawn_openai_router(app).await
+    }
+
+    async fn spawn_tool_loop_openai_upstream_raw(seen_requests: Arc<Mutex<Vec<Vec<u8>>>>) -> Url {
+        async fn chat_completions(
+            AxumState(seen_requests): AxumState<Arc<Mutex<Vec<Vec<u8>>>>>,
+            body: Bytes,
+        ) -> Sse<impl futures_util::Stream<Item = std::result::Result<Event, Infallible>>> {
+            seen_requests.lock().unwrap().push(body.to_vec());
+            let body: Value = serde_json::from_slice(&body).unwrap();
+            let has_tool_result = body["messages"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|message| message["role"] == "tool");
+
+            let chunks = if has_tool_result {
+                vec![
+                    Ok(Event::default().data(
+                        json!({ "choices": [{ "delta": { "content": "Tool result received." } }] })
+                            .to_string(),
+                    )),
+                    Ok(Event::default().data("[DONE]")),
+                ]
+            } else {
+                vec![
+                    Ok(Event::default().data(
+                        json!({
+                            "choices": [{
+                                "delta": {
+                                    "tool_calls": [{
+                                        "index": 0,
+                                        "id": "call_run_1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "run_shell_command",
+                                            "arguments": "{\"command\":\"pwd\",\"risk_category\":\"read_only\"}"
+                                        }
+                                    }]
+                                }
+                            }]
+                        })
+                        .to_string(),
+                    )),
+                    Ok(Event::default().data("[DONE]")),
+                ]
+            };
+            Sse::new(stream::iter(chunks))
+        }
+
+        let app = Router::new()
+            .route("/v1/chat/completions", post(chat_completions))
+            .with_state(seen_requests);
+        spawn_openai_router(app).await
+    }
+
+    struct BlockingUpstreamState {
+        active: AtomicUsize,
+        hits: AtomicUsize,
+        max_active: AtomicUsize,
+        first_started: Notify,
+        release_first: Notify,
+    }
+
+    impl BlockingUpstreamState {
+        fn new() -> Self {
+            Self {
+                active: AtomicUsize::new(0),
+                hits: AtomicUsize::new(0),
+                max_active: AtomicUsize::new(0),
+                first_started: Notify::new(),
+                release_first: Notify::new(),
+            }
+        }
+
+        fn enter(&self) {
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            let mut observed = self.max_active.load(Ordering::SeqCst);
+            while active > observed {
+                match self.max_active.compare_exchange(
+                    observed,
+                    active,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                ) {
+                    Ok(_) => break,
+                    Err(next) => observed = next,
+                }
+            }
+        }
+
+        fn exit(&self) {
+            self.active.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    async fn spawn_blocking_counter_openai_upstream(state: Arc<BlockingUpstreamState>) -> Url {
+        async fn chat_completions(
+            AxumState(state): AxumState<Arc<BlockingUpstreamState>>,
+            _body: Bytes,
+        ) -> Sse<impl futures_util::Stream<Item = std::result::Result<Event, Infallible>>> {
+            state.enter();
+            let hit = state.hits.fetch_add(1, Ordering::SeqCst) + 1;
+            if hit == 1 {
+                state.first_started.notify_waiters();
+                state.release_first.notified().await;
+            }
+            let chunks = vec![
+                Ok(Event::default().data(
+                    json!({ "choices": [{ "delta": { "content": format!("reply {hit}") } }] })
+                        .to_string(),
+                )),
+                Ok(Event::default().data("[DONE]")),
+            ];
+            state.exit();
+            Sse::new(stream::iter(chunks))
+        }
+
+        let app = Router::new()
+            .route("/v1/chat/completions", post(chat_completions))
+            .with_state(state);
+        spawn_openai_router(app).await
+    }
+
+    async fn spawn_http_error_openai_upstream() -> Url {
+        async fn chat_completions() -> impl IntoResponse {
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": "fake upstream exploded" })),
+            )
+        }
+
+        let app = Router::new().route("/v1/chat/completions", post(chat_completions));
+        spawn_openai_router(app).await
+    }
+
+    async fn spawn_shim_server(
+        config: ShimConfig,
+    ) -> (
+        Url,
+        oneshot::Sender<()>,
+        tokio::task::JoinHandle<anyhow::Result<()>>,
+    ) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (shutdown, shutdown_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            crate::server::serve_listener(listener, config, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+        });
+        (
+            Url::parse(&format!("http://{addr}")).unwrap(),
+            shutdown,
+            server,
+        )
+    }
+
+    async fn shutdown_shim_server(
+        shutdown: oneshot::Sender<()>,
+        server: tokio::task::JoinHandle<anyhow::Result<()>>,
+    ) {
+        let _ = shutdown.send(());
+        let result = server.await.unwrap();
+        assert!(result.is_ok(), "shim server failed: {result:?}");
+    }
+
+    async fn spawn_mcp_tool_openai_upstream(seen_requests: Arc<Mutex<Vec<Value>>>) -> Url {
+        async fn chat_completions(
+            AxumState(seen_requests): AxumState<Arc<Mutex<Vec<Value>>>>,
+            Json(body): Json<Value>,
+        ) -> Sse<impl futures_util::Stream<Item = std::result::Result<Event, Infallible>>> {
+            seen_requests.lock().unwrap().push(body.clone());
+            let chunks = vec![
+                Ok(Event::default().data(
+                    json!({
+                        "choices": [{
+                            "delta": {
+                                "tool_calls": [{
+                                    "index": 0,
+                                    "id": "call_mcp_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "mcp__linear_prod__create_issue",
+                                        "arguments": "{\"title\":\"Bug\"}"
+                                    }
+                                }]
+                            }
+                        }]
+                    })
+                    .to_string(),
+                )),
+                Ok(Event::default().data("[DONE]")),
+            ];
+            Sse::new(stream::iter(chunks))
+        }
+
+        let app = Router::new()
+            .route("/v1/chat/completions", post(chat_completions))
+            .with_state(seen_requests);
+        spawn_openai_router(app).await
+    }
+
+    async fn spawn_openai_router(app: Router) -> Url {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        Url::parse(&format!("http://{addr}/v1")).unwrap()
+    }
+
+    async fn spawn_fake_openai_upstream() -> Url {
+        async fn chat_completions(
+            Json(body): Json<Value>,
+        ) -> Sse<impl futures_util::Stream<Item = std::result::Result<Event, Infallible>>> {
+            assert_eq!(body["model"], "local-test-model");
+            assert_eq!(body["stream"], true);
+
+            let chunks = vec![
+                Ok(Event::default().data(
+                    json!({
+                        "choices": [{ "delta": { "content": "Hello " } }]
+                    })
+                    .to_string(),
+                )),
+                Ok(Event::default().data(
+                    json!({
+                        "choices": [{ "delta": { "content": "from fake upstream." } }]
+                    })
+                    .to_string(),
+                )),
+                Ok(Event::default().data("[DONE]")),
+            ];
+            Sse::new(stream::iter(chunks))
+        }
+
+        let app = Router::new().route("/v1/chat/completions", post(chat_completions));
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        Url::parse(&format!("http://{addr}/v1")).unwrap()
+    }
+
+    fn test_config(upstream_url: Url, streaming: bool) -> ShimConfig {
+        let mut upstreams = BTreeMap::new();
+        upstreams.insert(
+            "default".to_string(),
+            UpstreamConfig {
+                base_url: upstream_url,
+                api_key: None,
+                api_key_env: None,
+                timeout_secs: 180,
+                streaming,
+            },
+        );
+
+        let mut models = BTreeMap::new();
+        models.insert(
+            "auto".to_string(),
+            ModelMapping {
+                upstream: "default".to_string(),
+                model: "local-test-model".to_string(),
+            },
+        );
+
+        ShimConfig {
+            config_path: None,
+            server: ServerConfig {
+                host: Ipv4Addr::LOCALHOST.into(),
+                port: 4444,
+                public_base_url: "http://127.0.0.1:4444".to_string(),
+            },
+            upstreams,
+            models,
+            features: FeatureConfig::default(),
+        }
+    }
+
+    fn test_multi_agent_request() -> api::Request {
+        api::Request {
+            task_context: Some(api::request::TaskContext {
+                tasks: vec![api::Task {
+                    id: "client-task".to_string(),
+                    ..Default::default()
+                }],
+            }),
+            input: Some(api::request::Input {
+                context: Some(api::InputContext {
+                    directory: Some(api::input_context::Directory {
+                        pwd: "/tmp/warp-shim-test".to_string(),
+                        ..Default::default()
+                    }),
+                    shell: Some(api::input_context::Shell {
+                        name: "zsh".to_string(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                r#type: Some(api::request::input::Type::UserInputs(
+                    api::request::input::UserInputs {
+                        inputs: vec![api::request::input::user_inputs::UserInput {
+                            input: Some(
+                                api::request::input::user_inputs::user_input::Input::UserQuery(
+                                    api::request::input::UserQuery {
+                                        query: "Say hello".to_string(),
+                                        ..Default::default()
+                                    },
+                                ),
+                            ),
+                        }],
+                    },
+                )),
+            }),
+            settings: Some(api::request::Settings {
+                model_config: Some(api::request::settings::ModelConfig {
+                    base: "auto".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            metadata: Some(api::request::Metadata::default()),
+            ..Default::default()
+        }
+    }
+
+    fn test_multi_agent_request_with_supported_tools(
+        conversation_id: &str,
+        supported_tools: &[api::ToolType],
+    ) -> api::Request {
+        let mut request = test_multi_agent_request();
+        request.metadata = Some(api::request::Metadata {
+            conversation_id: conversation_id.to_string(),
+            ..Default::default()
+        });
+        request.settings = Some(api::request::Settings {
+            model_config: Some(api::request::settings::ModelConfig {
+                base: "auto".to_string(),
+                ..Default::default()
+            }),
+            supported_tools: supported_tools.iter().map(|tool| *tool as i32).collect(),
+            ..Default::default()
+        });
+        request
+    }
+
+    fn test_tool_result_request(conversation_id: &str, tool_call_id: &str) -> api::Request {
+        api::Request {
+            task_context: Some(api::request::TaskContext {
+                tasks: vec![api::Task {
+                    id: "client-task".to_string(),
+                    ..Default::default()
+                }],
+            }),
+            input: Some(api::request::Input {
+                r#type: Some(api::request::input::Type::UserInputs(
+                    api::request::input::UserInputs {
+                        inputs: vec![api::request::input::user_inputs::UserInput {
+                            input: Some(
+                                api::request::input::user_inputs::user_input::Input::ToolCallResult(
+                                    api::request::input::ToolCallResult {
+                                        tool_call_id: tool_call_id.to_string(),
+                                        result: Some(
+                                            api::request::input::tool_call_result::Result::RunShellCommand(
+                                                api::RunShellCommandResult {
+                                                    command: "pwd".to_string(),
+                                                    result: Some(
+                                                        api::run_shell_command_result::Result::CommandFinished(
+                                                            api::ShellCommandFinished {
+                                                                command_id: "cmd-1".to_string(),
+                                                                output: "/tmp\n".to_string(),
+                                                                exit_code: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    ..Default::default()
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ),
+                        }],
+                    },
+                )),
+                ..Default::default()
+            }),
+            settings: Some(api::request::Settings {
+                model_config: Some(api::request::settings::ModelConfig {
+                    base: "auto".to_string(),
+                    ..Default::default()
+                }),
+                supported_tools: vec![api::ToolType::RunShellCommand as i32],
+                ..Default::default()
+            }),
+            metadata: Some(api::request::Metadata {
+                conversation_id: conversation_id.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn test_mcp_request() -> api::Request {
+        let mut request = test_multi_agent_request_with_supported_tools(
+            "mcp-conversation",
+            &[api::ToolType::CallMcpTool],
+        );
+        request.mcp_context = Some(api::request::McpContext {
+            servers: vec![api::request::mcp_context::McpServer {
+                id: "linear-prod".to_string(),
+                name: "Linear Prod".to_string(),
+                tools: vec![api::request::mcp_context::McpTool {
+                    name: "create.issue".to_string(),
+                    description: "Create a Linear issue".to_string(),
+                    input_schema: Some(json_to_struct_for_test(&json!({
+                        "type": "object",
+                        "properties": {
+                            "title": { "type": "string" }
+                        },
+                        "required": ["title"]
+                    }))),
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        request
+    }
+
+    fn decode_sse_response_events(body: &[u8]) -> Vec<api::ResponseEvent> {
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        body.split("\n\n")
+            .filter_map(|frame| {
+                let data = frame
+                    .lines()
+                    .filter_map(|line| line.strip_prefix("data:"))
+                    .map(str::trim)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                (!data.is_empty()).then(|| decode_response_event_data_like_client(&data).unwrap())
+            })
+            .collect()
+    }
+
+    fn collect_tool_calls(events: &[api::ResponseEvent]) -> Vec<api::message::ToolCall> {
+        let mut tool_calls = Vec::new();
+        for event in events {
+            let Some(api::response_event::Type::ClientActions(actions)) = event.r#type.as_ref()
+            else {
+                continue;
+            };
+            for action in &actions.actions {
+                if let Some(api::client_action::Action::AddMessagesToTask(add)) = &action.action {
+                    for message in &add.messages {
+                        if let Some(api::message::Message::ToolCall(tool_call)) = &message.message {
+                            tool_calls.push(tool_call.clone());
+                        }
+                    }
+                }
+            }
+        }
+        tool_calls
+    }
+
+    fn json_to_struct_for_test(value: &Value) -> prost_types::Struct {
+        let fields = value
+            .as_object()
+            .unwrap()
+            .iter()
+            .map(|(key, value)| (key.clone(), json_to_prost_value_for_test(value)))
+            .collect();
+        prost_types::Struct { fields }
+    }
+
+    fn json_to_prost_value_for_test(value: &Value) -> prost_types::Value {
+        use prost_types::value::Kind;
+        prost_types::Value {
+            kind: Some(match value {
+                Value::Null => Kind::NullValue(0),
+                Value::Bool(value) => Kind::BoolValue(*value),
+                Value::Number(value) => Kind::NumberValue(value.as_f64().unwrap()),
+                Value::String(value) => Kind::StringValue(value.clone()),
+                Value::Array(values) => Kind::ListValue(prost_types::ListValue {
+                    values: values.iter().map(json_to_prost_value_for_test).collect(),
+                }),
+                Value::Object(_) => Kind::StructValue(json_to_struct_for_test(value)),
+            }),
+        }
+    }
+
+    fn struct_to_json_for_test(value: &prost_types::Struct) -> Value {
+        Value::Object(
+            value
+                .fields
+                .iter()
+                .map(|(key, value)| (key.clone(), prost_value_to_json_for_test(value)))
+                .collect(),
+        )
+    }
+
+    fn prost_value_to_json_for_test(value: &prost_types::Value) -> Value {
+        use prost_types::value::Kind;
+        match value.kind.as_ref() {
+            Some(Kind::NullValue(_)) | None => Value::Null,
+            Some(Kind::NumberValue(value)) => serde_json::Number::from_f64(*value)
+                .map(Value::Number)
+                .unwrap_or(Value::Null),
+            Some(Kind::StringValue(value)) => Value::String(value.clone()),
+            Some(Kind::BoolValue(value)) => Value::Bool(*value),
+            Some(Kind::StructValue(value)) => struct_to_json_for_test(value),
+            Some(Kind::ListValue(value)) => Value::Array(
+                value
+                    .values
+                    .iter()
+                    .map(prost_value_to_json_for_test)
+                    .collect(),
+            ),
+        }
+    }
+
+    fn collect_agent_output_text(events: &[api::ResponseEvent]) -> (String, Vec<String>) {
+        let mut text = String::new();
+        let mut ids = Vec::<String>::new();
+        for event in events {
+            let Some(api::response_event::Type::ClientActions(actions)) = event.r#type.as_ref()
+            else {
+                continue;
+            };
+            for action in &actions.actions {
+                match action.action.as_ref() {
+                    Some(api::client_action::Action::AddMessagesToTask(add)) => {
+                        for message in &add.messages {
+                            if let Some(api::message::Message::AgentOutput(output)) =
+                                &message.message
+                            {
+                                if !ids.contains(&message.id) {
+                                    ids.push(message.id.clone());
+                                }
+                                text.push_str(&output.text);
+                            }
+                        }
+                    }
+                    Some(api::client_action::Action::AppendToMessageContent(append)) => {
+                        if let Some(message) = append.message.as_ref()
+                            && let Some(api::message::Message::AgentOutput(output)) =
+                                &message.message
+                        {
+                            if !ids.contains(&message.id) {
+                                ids.push(message.id.clone());
+                            }
+                            text.push_str(&output.text);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        (text, ids)
+    }
+
+    fn contains_model_used_event(event: &api::ResponseEvent) -> bool {
+        let Some(api::response_event::Type::ClientActions(actions)) = event.r#type.as_ref() else {
+            return false;
+        };
+        actions
+            .actions
+            .iter()
+            .any(|action| match action.action.as_ref() {
+                Some(api::client_action::Action::AddMessagesToTask(add)) => {
+                    add.messages.iter().any(|message| {
+                        matches!(message.message, Some(api::message::Message::ModelUsed(_)))
+                    })
+                }
+                _ => false,
+            })
+    }
+
+    fn has_finished_done(events: &[api::ResponseEvent]) -> bool {
+        events.iter().any(|event| {
+            matches!(
+                event.r#type.as_ref(),
+                Some(api::response_event::Type::Finished(finished))
+                    if matches!(
+                        finished.reason,
+                        Some(api::response_event::stream_finished::Reason::Done(_))
+                    )
+            )
+        })
+    }
+
+    fn has_finished_internal_error(events: &[api::ResponseEvent]) -> bool {
+        events.iter().any(|event| {
+            matches!(
+                event.r#type.as_ref(),
+                Some(api::response_event::Type::Finished(finished))
+                    if matches!(
+                        finished.reason,
+                        Some(api::response_event::stream_finished::Reason::InternalError(_))
+                    )
+            )
+        })
+    }
+}

--- a/crates/warp_shim_server/src/routes/auth.rs
+++ b/crates/warp_shim_server/src/routes/auth.rs
@@ -1,0 +1,35 @@
+use axum::{
+    Json, Router,
+    http::StatusCode,
+    response::{Html, IntoResponse},
+    routing::{get, post},
+};
+
+use crate::{server::ShimState, stubs::rest_payloads};
+
+pub(crate) fn router() -> Router<ShimState> {
+    Router::new()
+        .route("/client/login", post(client_login))
+        .route("/proxy/token", post(firebase_token))
+        .route("/proxy/customToken", post(firebase_token))
+        .route("/login", get(local_shim_auth_page))
+        .route("/login/{*path}", get(local_shim_auth_page))
+        .route("/signup", get(local_shim_auth_page))
+        .route("/signup/{*path}", get(local_shim_auth_page))
+        .route("/upgrade", get(local_shim_auth_page))
+        .route("/login_options", get(local_shim_auth_page))
+        .route("/login_options/{*path}", get(local_shim_auth_page))
+        .route("/link_sso", get(local_shim_auth_page))
+}
+
+async fn client_login() -> StatusCode {
+    StatusCode::NO_CONTENT
+}
+
+async fn firebase_token() -> impl IntoResponse {
+    (StatusCode::OK, Json(rest_payloads::firebase_token()))
+}
+
+async fn local_shim_auth_page() -> Html<String> {
+    Html(rest_payloads::local_shim_auth_page())
+}

--- a/crates/warp_shim_server/src/routes/graphql.rs
+++ b/crates/warp_shim_server/src/routes/graphql.rs
@@ -1,0 +1,95 @@
+use axum::{
+    Json, Router,
+    body::Bytes,
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::post,
+};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{config::ShimConfig, server::ShimState, stubs::graphql_payloads};
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GraphqlParams {
+    op: Option<String>,
+}
+
+pub(crate) fn router() -> Router<ShimState> {
+    Router::new().route("/graphql/v2", post(post_graphql).get(get_graphql))
+}
+
+async fn post_graphql(
+    State(state): State<ShimState>,
+    Query(params): Query<GraphqlParams>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let op = params
+        .op
+        .as_deref()
+        .and_then(non_empty)
+        .map(str::to_string)
+        .or_else(|| operation_name_from_body(&body))
+        .unwrap_or_default();
+    let auth_present = headers.contains_key(axum::http::header::AUTHORIZATION);
+    let payload = dispatch(&state.config, &op, &body, auth_present);
+    (StatusCode::OK, Json(payload))
+}
+
+async fn get_graphql(Query(params): Query<GraphqlParams>) -> impl IntoResponse {
+    let op = params.op.as_deref().unwrap_or("<missing>");
+    tracing::info!(%op, "received GET for GraphQL endpoint in local shim mode");
+    (StatusCode::OK, "warp-shim GraphQL endpoint")
+}
+
+fn dispatch(config: &ShimConfig, op: &str, body: &[u8], auth_present: bool) -> Value {
+    match op {
+        "GetFeatureModelChoices" => graphql_payloads::get_feature_model_choices(config),
+        "FreeAvailableModels" => graphql_payloads::free_available_models(config),
+        "GetUser" => graphql_payloads::get_user(config),
+        "GetUserSettings" => graphql_payloads::get_user_settings(),
+        "GetWorkspacesMetadataForUser" => {
+            graphql_payloads::get_workspaces_metadata_for_user(config)
+        }
+        _ => {
+            let request_fields = request_field_names(body);
+            let logged_op = if op.is_empty() { "<missing>" } else { op };
+            tracing::info!(
+                op = %logged_op,
+                auth_present,
+                request_fields = ?request_fields,
+                "unsupported GraphQL operation in local shim mode"
+            );
+            graphql_payloads::unknown_operation()
+        }
+    }
+}
+
+fn operation_name_from_body(body: &[u8]) -> Option<String> {
+    serde_json::from_slice::<Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("operationName")?
+                .as_str()
+                .and_then(non_empty)
+                .map(str::to_string)
+        })
+}
+
+fn request_field_names(body: &[u8]) -> Option<Vec<String>> {
+    serde_json::from_slice::<Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .as_object()
+                .map(|object| object.keys().cloned().collect())
+        })
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}

--- a/crates/warp_shim_server/src/routes/mod.rs
+++ b/crates/warp_shim_server/src/routes/mod.rs
@@ -1,0 +1,18 @@
+use axum::Router;
+
+use crate::server::ShimState;
+
+pub(crate) mod ai;
+pub(crate) mod auth;
+pub(crate) mod graphql;
+pub(crate) mod public_api;
+pub(crate) mod rtc;
+
+pub(crate) fn router() -> Router<ShimState> {
+    Router::new()
+        .merge(ai::router())
+        .merge(graphql::router())
+        .merge(auth::router())
+        .merge(public_api::router())
+        .merge(rtc::router())
+}

--- a/crates/warp_shim_server/src/routes/public_api.rs
+++ b/crates/warp_shim_server/src/routes/public_api.rs
@@ -1,0 +1,158 @@
+use axum::{
+    Json, Router,
+    body::Bytes,
+    extract::{Path, State},
+    http::{StatusCode, Uri},
+    response::IntoResponse,
+    routing::{get, post, put},
+};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{server::ShimState, stubs::rest_payloads};
+
+pub(crate) fn router() -> Router<ShimState> {
+    Router::new()
+        .route("/api/v1/agent/run", post(spawn_agent_unsupported))
+        .route("/api/v1/agent/runs", get(list_agent_runs))
+        .route("/api/v1/agent/runs/{id}", get(agent_run_not_found))
+        .route(
+            "/api/v1/agent/runs/{id}/conversation",
+            get(agent_run_conversation_not_found),
+        )
+        .route("/api/v1/agent/events", get(list_agent_events))
+        .route("/api/v1/agent/events/{run_id}", post(report_agent_event))
+        .route(
+            "/api/v1/harness-support/external-conversation",
+            post(create_external_conversation),
+        )
+        .route(
+            "/api/v1/harness-support/transcript",
+            post(upload_target).get(fetch_transcript_not_found),
+        )
+        .route(
+            "/api/v1/harness-support/block-snapshot",
+            post(upload_target),
+        )
+        .route(
+            "/api/v1/harness-support/upload-snapshot",
+            post(upload_snapshot_targets),
+        )
+        .route(
+            "/api/v1/harness-support/upload/{id}",
+            put(discard_upload).post(discard_upload),
+        )
+        .route(
+            "/api/v1/harness-support/resolve-prompt",
+            post(resolve_prompt),
+        )
+        .route(
+            "/api/v1/harness-support/report-artifact",
+            post(report_artifact),
+        )
+        .route("/api/v1/harness-support/notify-user", post(no_content))
+        .route("/api/v1/harness-support/finish-task", post(no_content))
+        .route("/api/v1/harness-support/{*path}", post(harness_fallback))
+}
+
+async fn spawn_agent_unsupported() -> impl IntoResponse {
+    tracing::info!("unsupported local shim endpoint: cloud-agent spawn");
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(rest_payloads::error(
+            "unsupported in local shim: cloud agents are not available",
+        )),
+    )
+}
+
+async fn list_agent_runs() -> impl IntoResponse {
+    (StatusCode::OK, Json(rest_payloads::list_runs()))
+}
+
+async fn agent_run_not_found(Path(id): Path<String>) -> impl IntoResponse {
+    tracing::info!(%id, "local shim cloud-agent run not found");
+    (
+        StatusCode::NOT_FOUND,
+        Json(rest_payloads::error("run not found in local shim")),
+    )
+}
+
+async fn agent_run_conversation_not_found(Path(id): Path<String>) -> impl IntoResponse {
+    tracing::info!(%id, "local shim cloud-agent run conversation not found");
+    (
+        StatusCode::NOT_FOUND,
+        Json(rest_payloads::error(
+            "run conversation not found in local shim",
+        )),
+    )
+}
+
+async fn list_agent_events() -> impl IntoResponse {
+    (StatusCode::OK, Json(rest_payloads::list_agent_events()))
+}
+
+async fn report_agent_event(Path(run_id): Path<String>) -> impl IntoResponse {
+    tracing::info!(%run_id, "accepted local shim cloud-agent event report");
+    (StatusCode::OK, Json(rest_payloads::report_agent_event()))
+}
+
+async fn create_external_conversation() -> impl IntoResponse {
+    (StatusCode::OK, Json(rest_payloads::external_conversation()))
+}
+
+async fn upload_target(State(state): State<ShimState>) -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(rest_payloads::upload_target(
+            &state.config.server.public_base_url,
+        )),
+    )
+}
+
+async fn upload_snapshot_targets(State(state): State<ShimState>, body: Bytes) -> impl IntoResponse {
+    let file_count = serde_json::from_slice::<SnapshotUploadRequest>(&body)
+        .map(|request| request.files.len())
+        .unwrap_or_default();
+    (
+        StatusCode::OK,
+        Json(rest_payloads::snapshot_uploads(
+            &state.config.server.public_base_url,
+            file_count,
+        )),
+    )
+}
+
+async fn discard_upload(Path(id): Path<String>, body: Bytes) -> impl IntoResponse {
+    tracing::info!(%id, bytes = body.len(), "discarded local shim harness upload");
+    StatusCode::NO_CONTENT
+}
+
+async fn resolve_prompt() -> impl IntoResponse {
+    (StatusCode::OK, Json(rest_payloads::resolved_prompt()))
+}
+
+async fn report_artifact() -> impl IntoResponse {
+    (StatusCode::OK, Json(rest_payloads::report_artifact()))
+}
+
+async fn no_content() -> StatusCode {
+    StatusCode::NO_CONTENT
+}
+
+async fn fetch_transcript_not_found() -> impl IntoResponse {
+    (
+        StatusCode::NOT_FOUND,
+        Json(rest_payloads::error("no transcript in local shim")),
+    )
+}
+
+async fn harness_fallback(uri: Uri) -> impl IntoResponse {
+    tracing::info!(path = %uri.path(), "accepted unknown local shim harness-support POST");
+    (StatusCode::OK, Json(Value::Object(Default::default())))
+}
+
+#[derive(Deserialize)]
+struct SnapshotUploadRequest {
+    #[serde(default)]
+    files: Vec<Value>,
+}

--- a/crates/warp_shim_server/src/routes/rtc.rs
+++ b/crates/warp_shim_server/src/routes/rtc.rs
@@ -1,0 +1,19 @@
+use std::convert::Infallible;
+
+use axum::{
+    Router,
+    response::sse::{Event, KeepAlive, Sse},
+    routing::get,
+};
+use futures_util::{Stream, stream};
+
+use crate::server::ShimState;
+
+pub(crate) fn router() -> Router<ShimState> {
+    Router::new().route("/api/v1/agent/events/stream", get(idle_agent_events_stream))
+}
+
+async fn idle_agent_events_stream() -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    tracing::info!("opened idle local shim agent events stream");
+    Sse::new(stream::pending::<Result<Event, Infallible>>()).keep_alive(KeepAlive::default())
+}

--- a/crates/warp_shim_server/src/server.rs
+++ b/crates/warp_shim_server/src/server.rs
@@ -1,0 +1,158 @@
+use std::{
+    future::Future,
+    sync::{Arc, Once},
+};
+
+use anyhow::{Context, Result};
+use axum::{
+    Json, Router,
+    extract::State,
+    http::{Method, StatusCode, Uri},
+    response::IntoResponse,
+    routing::get,
+};
+use tokio::net::TcpListener;
+use url::Url;
+
+use crate::{
+    config::ShimConfig, conversation::store::ConversationStore, routes, stubs::rest_payloads,
+};
+
+#[derive(Clone)]
+pub(crate) struct ShimState {
+    pub(crate) config: Arc<ShimConfig>,
+    pub(crate) http_client: reqwest::Client,
+    pub(crate) conversations: ConversationStore,
+}
+
+pub async fn serve(config: ShimConfig) -> Result<()> {
+    let bind_addr = config.bind_addr();
+    let listener = TcpListener::bind(bind_addr)
+        .await
+        .with_context(|| format!("failed to bind warp shim server to {bind_addr}"))?;
+
+    serve_listener(listener, config, shutdown_signal()).await
+}
+
+pub async fn serve_listener<F>(listener: TcpListener, config: ShimConfig, shutdown: F) -> Result<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let local_addr = listener
+        .local_addr()
+        .context("failed to read warp shim listener address")?;
+    let config = Arc::new(config);
+    let default_upstream = config.default_upstream()?;
+
+    tracing::info!(
+        bind_addr = %config.bind_addr(),
+        %local_addr,
+        public_base_url = %config.server.public_base_url,
+        config_path = ?config.config_path,
+        upstream_url = %upstream_url_for_log(&default_upstream.base_url),
+        upstream_timeout_secs = default_upstream.timeout_secs,
+        upstream_streaming = default_upstream.streaming,
+        upstream_has_api_key = default_upstream.api_key.is_some(),
+        upstream_api_key_env_configured = default_upstream.api_key_env.is_some(),
+        model_mappings = %config.model_mappings_for_log(),
+        tools_enabled = config.features.tools_enabled,
+        mcp_tools_enabled = config.features.mcp_tools_enabled,
+        passive_suggestions_enabled = config.features.passive_suggestions_enabled,
+        "starting warp shim server"
+    );
+
+    tracing::info!(%local_addr, "warp shim server listening");
+
+    axum::serve(listener, router(config))
+        .with_graceful_shutdown(shutdown)
+        .await
+        .context("warp shim server failed")
+}
+
+pub(crate) fn router(config: Arc<ShimConfig>) -> Router {
+    init_tls_provider();
+
+    let state = ShimState {
+        config,
+        http_client: reqwest::Client::new(),
+        conversations: ConversationStore::default(),
+    };
+
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(healthz))
+        .merge(routes::router())
+        .fallback(fallback)
+        .with_state(state)
+}
+
+async fn healthz(State(state): State<ShimState>) -> impl IntoResponse {
+    tracing::trace!(bind_addr = %state.config.bind_addr(), "health check");
+    (StatusCode::OK, "OK")
+}
+
+async fn fallback(method: Method, uri: Uri) -> impl IntoResponse {
+    let path = uri.path();
+    if method == Method::POST && is_telemetry_like_path(path) {
+        tracing::info!(%path, "accepted telemetry-like POST in local shim mode");
+        return StatusCode::NO_CONTENT.into_response();
+    }
+
+    tracing::info!(%method, %path, "unsupported local shim endpoint");
+    (
+        StatusCode::NOT_FOUND,
+        Json(rest_payloads::unsupported_endpoint()),
+    )
+        .into_response()
+}
+
+pub(crate) fn upstream_url_for_log(url: &Url) -> String {
+    let mut sanitized = url.clone();
+    let _ = sanitized.set_username("");
+    let _ = sanitized.set_password(None);
+    sanitized.set_query(None);
+    sanitized.set_fragment(None);
+    sanitized.to_string()
+}
+
+fn init_tls_provider() {
+    static TLS_PROVIDER: Once = Once::new();
+    TLS_PROVIDER.call_once(|| {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
+fn is_telemetry_like_path(path: &str) -> bool {
+    let path = path.to_ascii_lowercase();
+    path.contains("telemetry")
+        || path.contains("metrics")
+        || path.contains("analytics")
+        || path.contains("event")
+        || path.contains("log")
+}
+
+async fn shutdown_signal() {
+    if let Err(error) = tokio::signal::ctrl_c().await {
+        tracing::warn!(%error, "failed to listen for shutdown signal");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upstream_url_for_log_strips_userinfo_query_and_fragment() {
+        let url = Url::parse(
+            "https://user:super-secret@example.com:8443/v1?api_key=secret&token=secret#frag",
+        )
+        .unwrap();
+
+        let logged = upstream_url_for_log(&url);
+
+        assert_eq!(logged, "https://example.com:8443/v1");
+        assert!(!logged.contains("super-secret"));
+        assert!(!logged.contains("api_key"));
+        assert!(!logged.contains("token"));
+    }
+}

--- a/crates/warp_shim_server/src/stubs/graphql_payloads.rs
+++ b/crates/warp_shim_server/src/stubs/graphql_payloads.rs
@@ -1,0 +1,375 @@
+use serde_json::{Value, json};
+
+use crate::config::ShimConfig;
+
+const LOCAL_USER_UID: &str = "local-shim-user";
+const LOCAL_USER_EMAIL: &str = "local@warp-shim";
+const LOCAL_WORKSPACE_UID: &str = "local-shim-workspace";
+
+pub(crate) fn get_feature_model_choices(config: &ShimConfig) -> Value {
+    json!({
+        "data": {
+            "user": {
+                "__typename": "UserOutput",
+                "user": {
+                    "workspaces": [
+                        {
+                            "featureModelChoice": feature_model_choice(config),
+                        }
+                    ]
+                }
+            }
+        }
+    })
+}
+
+pub(crate) fn free_available_models(config: &ShimConfig) -> Value {
+    json!({
+        "data": {
+            "freeAvailableModels": {
+                "__typename": "FreeAvailableModelsOutput",
+                "featureModelChoice": feature_model_choice(config),
+                "responseContext": {
+                    "serverVersion": "warp-shim-local",
+                }
+            }
+        }
+    })
+}
+
+pub(crate) fn get_user(config: &ShimConfig) -> Value {
+    json!({
+        "data": {
+            "user": {
+                "__typename": "UserOutput",
+                "apiKeyOwnerType": null,
+                "principalType": "USER",
+                "user": {
+                    "anonymousUserInfo": null,
+                    "experiments": [],
+                    "isOnWorkDomain": false,
+                    "isOnboarded": true,
+                    "profile": {
+                        "displayName": "Warp Shim User",
+                        "email": LOCAL_USER_EMAIL,
+                        "needsSsoLink": false,
+                        "photoUrl": null,
+                        "uid": LOCAL_USER_UID,
+                    },
+                    "llms": feature_model_choice(config),
+                }
+            }
+        }
+    })
+}
+
+pub(crate) fn get_user_settings() -> Value {
+    json!({
+        "data": {
+            "user": {
+                "__typename": "UserOutput",
+                "user": {
+                    "settings": {
+                        "isCloudConversationStorageEnabled": false,
+                        "isCrashReportingEnabled": false,
+                        "isTelemetryEnabled": false,
+                    }
+                }
+            }
+        }
+    })
+}
+
+pub(crate) fn get_workspaces_metadata_for_user(config: &ShimConfig) -> Value {
+    json!({
+        "data": {
+            "user": {
+                "__typename": "UserOutput",
+                "user": {
+                    "workspaces": [workspace(config)],
+                    "experiments": [],
+                    "discoverableTeams": [],
+                }
+            },
+            "pricingInfo": {
+                "__typename": "PricingInfoOutput",
+                "pricingInfo": {
+                    "plans": [],
+                    "overages": {
+                        "pricePerRequestUsdCents": 0,
+                    },
+                    "addonCreditsOptions": [],
+                }
+            }
+        }
+    })
+}
+
+pub(crate) fn unknown_operation() -> Value {
+    json!({ "data": null })
+}
+
+fn feature_model_choice(config: &ShimConfig) -> Value {
+    let choices = model_catalog(config);
+    json!({
+        "agentMode": available_llms(default_model_id(config, "auto"), choices.clone(), None),
+        "planning": available_llms(default_model_id(config, "auto"), choices.clone(), None),
+        "coding": available_llms(
+            default_model_id(config, "coding-auto"),
+            choices.clone(),
+            preferred_model_id(config, "coding-auto"),
+        ),
+        "cliAgent": available_llms(
+            default_model_id(config, "cli-agent-auto"),
+            choices.clone(),
+            preferred_model_id(config, "cli-agent-auto"),
+        ),
+        "computerUseAgent": available_llms(
+            default_model_id(config, "computer-use-agent-auto"),
+            choices,
+            preferred_model_id(config, "computer-use-agent-auto"),
+        ),
+    })
+}
+
+fn available_llms(
+    default_id: String,
+    choices: Vec<Value>,
+    preferred_codex_model_id: Option<String>,
+) -> Value {
+    json!({
+        "defaultId": default_id,
+        "choices": choices,
+        "preferredCodexModelId": preferred_codex_model_id,
+    })
+}
+
+fn model_catalog(config: &ShimConfig) -> Vec<Value> {
+    let mut models = config
+        .models
+        .keys()
+        .map(|model_id| model_info(model_id))
+        .collect::<Vec<_>>();
+    if models.is_empty() {
+        tracing::warn!("shim config has no model mappings; returning fallback `auto` model");
+        models.push(model_info("auto"));
+    }
+    models
+}
+
+fn model_info(model_id: &str) -> Value {
+    let display_name = format!("Local {model_id}");
+    json!({
+        "id": model_id,
+        "displayName": display_name,
+        "baseModelName": display_name,
+        "reasoningLevel": null,
+        "usageMetadata": {
+            "creditMultiplier": null,
+            "requestMultiplier": 1,
+        },
+        "description": "OpenAI-compatible via warp-shim",
+        "disableReason": null,
+        "visionSupported": false,
+        "spec": {
+            "cost": 0,
+            "quality": 0,
+            "speed": 0,
+        },
+        "provider": "UNKNOWN",
+        "hostConfigs": [
+            {
+                "enabled": true,
+                "modelRoutingHost": "DIRECT_API",
+            }
+        ],
+        "pricing": {
+            "discountPercentage": null,
+        },
+    })
+}
+
+fn default_model_id(config: &ShimConfig, preferred: &str) -> String {
+    preferred_model_id(config, preferred)
+        .or_else(|| preferred_model_id(config, "auto"))
+        .unwrap_or_else(|| {
+            config
+                .models
+                .keys()
+                .next()
+                .cloned()
+                .unwrap_or_else(|| "auto".to_string())
+        })
+}
+
+fn preferred_model_id(config: &ShimConfig, preferred: &str) -> Option<String> {
+    config
+        .models
+        .contains_key(preferred)
+        .then(|| preferred.to_string())
+}
+
+fn workspace(config: &ShimConfig) -> Value {
+    json!({
+        "uid": LOCAL_WORKSPACE_UID,
+        "name": "Warp Shim Local Workspace",
+        "stripeCustomerId": null,
+        "members": [],
+        "teams": [],
+        "billingMetadata": billing_metadata(),
+        "bonusGrantsInfo": {
+            "grants": [],
+            "spendingInfo": null,
+        },
+        "settings": workspace_settings(),
+        "hasBillingHistory": false,
+        "inviteCode": null,
+        "pendingEmailInvites": [],
+        "inviteLinkDomainRestrictions": [],
+        "isEligibleForDiscovery": false,
+        "featureModelChoice": feature_model_choice(config),
+        "totalRequestsUsedSinceLastRefresh": 0,
+    })
+}
+
+fn billing_metadata() -> Value {
+    json!({
+        "customerType": "FREE",
+        "delinquencyStatus": "NO_DELINQUENCY",
+        "tier": {
+            "name": "Local Shim",
+            "description": "Local shim workspace",
+            "warpAiPolicy": {
+                "limit": 0,
+                "isCodeSuggestionsToggleable": false,
+                "isPromptSuggestionsToggleable": false,
+                "isNextCommandEnabled": false,
+                "isVoiceEnabled": false,
+            },
+            "teamSizePolicy": {
+                "isUnlimited": true,
+                "limit": 1,
+            },
+            "sharedNotebooksPolicy": {
+                "isUnlimited": true,
+                "limit": 0,
+            },
+            "sharedWorkflowsPolicy": {
+                "isUnlimited": true,
+                "limit": 0,
+            },
+            "sessionSharingPolicy": {
+                "enabled": false,
+                "maxSessionBytesSize": 0,
+            },
+            "aiAutonomyPolicy": null,
+            "telemetryDataCollectionPolicy": {
+                "default": false,
+                "toggleable": true,
+            },
+            "ugcDataCollectionPolicy": {
+                "defaultSetting": "DISABLE",
+                "toggleable": true,
+            },
+            "usageBasedPricingPolicy": {
+                "toggleable": false,
+            },
+            "codebaseContextPolicy": {
+                "toggleable": false,
+                "isUnlimitedIndices": true,
+                "maxIndices": 0,
+                "maxFilesPerRepo": 0,
+                "embeddingGenerationBatchSize": 0,
+            },
+            "byoApiKeyPolicy": {
+                "enabled": true,
+            },
+            "purchaseAddOnCreditsPolicy": {
+                "enabled": false,
+            },
+            "enterprisePayAsYouGoPolicy": null,
+            "enterpriseCreditsAutoReloadPolicy": null,
+            "multiAdminPolicy": {
+                "enabled": false,
+            },
+            "ambientAgentsPolicy": {
+                "enabled": false,
+                "toggleable": false,
+                "maxConcurrentAgents": 0,
+                "instanceShape": null,
+            },
+        },
+        "serviceAgreements": [],
+        "aiOverages": null,
+    })
+}
+
+fn workspace_settings() -> Value {
+    json!({
+        "isDiscoverable": false,
+        "isInviteLinkEnabled": false,
+        "llmSettings": {
+            "enabled": true,
+            "hostConfigs": [
+                {
+                    "host": "DIRECT_API",
+                    "settings": {
+                        "enabled": true,
+                        "optOutOfNewModels": false,
+                        "enablementSetting": "RESPECT_USER_SETTING",
+                    }
+                }
+            ],
+        },
+        "telemetrySettings": {
+            "forceEnabled": false,
+        },
+        "ugcCollectionSettings": {
+            "setting": "DISABLE",
+        },
+        "cloudConversationStorageSettings": {
+            "setting": "DISABLE",
+        },
+        "aiPermissionsSettings": {
+            "allowAiInRemoteSessions": false,
+            "remoteSessionRegexList": [],
+        },
+        "linkSharingSettings": {
+            "anyoneWithLinkSharingEnabled": false,
+            "directLinkSharingEnabled": false,
+        },
+        "secretRedactionSettings": {
+            "enabled": false,
+            "regexes": [],
+        },
+        "aiAutonomySettings": {
+            "applyCodeDiffsSetting": null,
+            "readFilesSetting": null,
+            "readFilesAllowlist": null,
+            "createPlansSetting": null,
+            "executeCommandsSetting": null,
+            "executeCommandsAllowlist": null,
+            "executeCommandsDenylist": null,
+            "writeToPtySetting": null,
+            "computerUseSetting": null,
+        },
+        "usageBasedPricingSettings": {
+            "enabled": false,
+            "maxMonthlySpendCents": null,
+        },
+        "addonCreditsSettings": {
+            "autoReloadEnabled": false,
+            "maxMonthlySpendCents": null,
+            "selectedAutoReloadCreditDenomination": null,
+        },
+        "codebaseContextSettings": {
+            "enabled": false,
+            "setting": "DISABLE",
+        },
+        "sandboxedAgentSettings": null,
+    })
+}
+
+#[cfg(test)]
+#[path = "graphql_payloads_tests.rs"]
+mod tests;

--- a/crates/warp_shim_server/src/stubs/graphql_payloads_tests.rs
+++ b/crates/warp_shim_server/src/stubs/graphql_payloads_tests.rs
@@ -1,0 +1,253 @@
+use std::{collections::BTreeMap, net::Ipv4Addr, sync::Arc};
+
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use cynic::GraphQlResponse;
+use serde::de::DeserializeOwned;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use url::Url;
+
+use crate::{
+    config::{FeatureConfig, ModelMapping, ServerConfig, ShimConfig, UpstreamConfig},
+    stubs::graphql_payloads,
+};
+
+fn test_config() -> ShimConfig {
+    let mut upstreams = BTreeMap::new();
+    upstreams.insert(
+        "default".to_string(),
+        UpstreamConfig {
+            base_url: Url::parse("http://127.0.0.1:11434/v1").unwrap(),
+            api_key: None,
+            api_key_env: None,
+            timeout_secs: 180,
+            streaming: true,
+        },
+    );
+
+    let mut models = BTreeMap::new();
+    models.insert(
+        "auto".to_string(),
+        ModelMapping {
+            upstream: "default".to_string(),
+            model: "llama3.1".to_string(),
+        },
+    );
+    models.insert(
+        "cli-agent-auto".to_string(),
+        ModelMapping {
+            upstream: "default".to_string(),
+            model: "llama3.1".to_string(),
+        },
+    );
+    models.insert(
+        "coding-auto".to_string(),
+        ModelMapping {
+            upstream: "default".to_string(),
+            model: "qwen2.5-coder".to_string(),
+        },
+    );
+    models.insert(
+        "computer-use-agent-auto".to_string(),
+        ModelMapping {
+            upstream: "default".to_string(),
+            model: "llama3.1".to_string(),
+        },
+    );
+
+    ShimConfig {
+        config_path: None,
+        server: ServerConfig {
+            host: Ipv4Addr::LOCALHOST.into(),
+            port: 4444,
+            public_base_url: "http://127.0.0.1:4444".to_string(),
+        },
+        upstreams,
+        models,
+        features: FeatureConfig::default(),
+    }
+}
+
+fn decode<T>(value: Value) -> GraphQlResponse<T>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_value(value).unwrap()
+}
+
+#[test]
+fn get_feature_model_choices_round_trips_through_graphql_response_type() {
+    let response: GraphQlResponse<
+        warp_graphql::queries::get_feature_model_choices::GetFeatureModelChoices,
+    > = decode(graphql_payloads::get_feature_model_choices(&test_config()));
+    let data = response.data.unwrap();
+
+    let warp_graphql::queries::get_feature_model_choices::UserResult::UserOutput(output) =
+        data.user
+    else {
+        panic!("expected UserOutput");
+    };
+    let workspace = output.user.workspaces.into_iter().next().unwrap();
+    let choices = workspace.feature_model_choice.agent_mode.choices;
+
+    assert_eq!(workspace.feature_model_choice.agent_mode.default_id, "auto");
+    assert_eq!(choices.len(), 4);
+    assert!(choices.iter().any(|choice| choice.id == "coding-auto"));
+    assert!(matches!(
+        choices[0].host_configs[0].model_routing_host,
+        warp_graphql::queries::get_feature_model_choices::LlmModelHost::DirectApi
+    ));
+}
+
+#[test]
+fn free_available_models_round_trips_through_graphql_response_type() {
+    let response: GraphQlResponse<
+        warp_graphql::queries::free_available_models::FreeAvailableModels,
+    > = decode(graphql_payloads::free_available_models(&test_config()));
+    let data = response.data.unwrap();
+
+    let warp_graphql::queries::free_available_models::FreeAvailableModelsResult::FreeAvailableModelsOutput(output) =
+        data.free_available_models
+    else {
+        panic!("expected FreeAvailableModelsOutput");
+    };
+
+    assert_eq!(
+        output.feature_model_choice.cli_agent.default_id,
+        "cli-agent-auto"
+    );
+    assert_eq!(output.feature_model_choice.cli_agent.choices.len(), 4);
+}
+
+#[test]
+fn get_user_round_trips_through_graphql_response_type() {
+    let response: GraphQlResponse<warp_graphql::queries::get_user::GetUser> =
+        decode(graphql_payloads::get_user(&test_config()));
+    let data = response.data.unwrap();
+
+    let warp_graphql::queries::get_user::UserResult::UserOutput(output) = data.user else {
+        panic!("expected UserOutput");
+    };
+
+    assert_eq!(
+        output.principal_type,
+        Some(warp_graphql::queries::get_user::PrincipalType::User)
+    );
+    assert_eq!(output.user.profile.uid, "local-shim-user");
+    assert_eq!(
+        output.user.profile.email.as_deref(),
+        Some("local@warp-shim")
+    );
+    assert_eq!(output.user.llms.agent_mode.default_id, "auto");
+}
+
+#[test]
+fn get_user_settings_round_trips_through_graphql_response_type() {
+    let response: GraphQlResponse<warp_graphql::queries::get_user_settings::GetUserSettings> =
+        decode(graphql_payloads::get_user_settings());
+    let data = response.data.unwrap();
+
+    let warp_graphql::queries::get_user_settings::UserResult::UserOutput(output) = data.user else {
+        panic!("expected UserOutput");
+    };
+    let settings = output.user.settings.unwrap();
+
+    assert!(!settings.is_cloud_conversation_storage_enabled);
+    assert!(!settings.is_crash_reporting_enabled);
+    assert!(!settings.is_telemetry_enabled);
+}
+
+#[test]
+fn get_workspaces_metadata_for_user_round_trips_through_graphql_response_type() {
+    let response: GraphQlResponse<
+        warp_graphql::queries::get_workspaces_metadata_for_user::GetWorkspacesMetadataForUser,
+    > = decode(graphql_payloads::get_workspaces_metadata_for_user(
+        &test_config(),
+    ));
+    let data = response.data.unwrap();
+
+    let warp_graphql::queries::get_workspaces_metadata_for_user::UserResult::UserOutput(output) =
+        data.user
+    else {
+        panic!("expected UserOutput");
+    };
+    let workspace = output.user.workspaces.into_iter().next().unwrap();
+
+    assert_eq!(workspace.uid.into_inner(), "local-shim-workspace");
+    assert!(workspace.settings.llm_settings.enabled);
+    assert_eq!(workspace.settings.llm_settings.host_configs.len(), 1);
+    assert!(matches!(
+        workspace.settings.llm_settings.host_configs[0].host,
+        warp_graphql::workspace::LlmModelHost::DirectApi
+    ));
+    assert!(
+        workspace.settings.llm_settings.host_configs[0]
+            .settings
+            .enabled
+    );
+
+    let warp_graphql::queries::get_workspaces_metadata_for_user::PricingInfoResult::PricingInfoOutput(pricing_output) =
+        data.pricing_info
+    else {
+        panic!("expected PricingInfoOutput");
+    };
+    assert!(pricing_output.pricing_info.plans.is_empty());
+    assert!(pricing_output.pricing_info.addon_credits_options.is_empty());
+}
+
+#[tokio::test]
+async fn graphql_post_uses_operation_name_from_json_body_when_query_param_is_missing() {
+    let response = crate::server::router(Arc::new(test_config()))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/graphql/v2")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "operationName": "GetUserSettings",
+                        "query": "query GetUserSettings { user { __typename } }"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let decoded: GraphQlResponse<warp_graphql::queries::get_user_settings::GetUserSettings> =
+        serde_json::from_slice(&body).unwrap();
+    let data = decoded.data.unwrap();
+    let warp_graphql::queries::get_user_settings::UserResult::UserOutput(output) = data.user else {
+        panic!("expected UserOutput");
+    };
+    let settings = output.user.settings.unwrap();
+
+    assert!(!settings.is_telemetry_enabled);
+}
+
+#[tokio::test]
+async fn unknown_graphql_operation_returns_ok_with_null_data() {
+    let response = crate::server::router(Arc::new(test_config()))
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/graphql/v2?op=TotallyUnknown")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"query":"query TotallyUnknown { ping }"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(value, json!({ "data": null }));
+}

--- a/crates/warp_shim_server/src/stubs/mod.rs
+++ b/crates/warp_shim_server/src/stubs/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod graphql_payloads;
+pub(crate) mod rest_payloads;

--- a/crates/warp_shim_server/src/stubs/rest_payloads.rs
+++ b/crates/warp_shim_server/src/stubs/rest_payloads.rs
@@ -1,0 +1,83 @@
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+pub(crate) fn firebase_token() -> Value {
+    json!({
+        "idToken": "local-shim-id-token",
+        "refreshToken": "local-shim-refresh-token",
+        "expiresIn": "3600",
+    })
+}
+
+pub(crate) fn unsupported_endpoint() -> Value {
+    error("warp-shim: unsupported endpoint")
+}
+
+pub(crate) fn error(message: &'static str) -> Value {
+    json!({ "error": message })
+}
+
+pub(crate) fn list_runs() -> Value {
+    json!({ "runs": [] })
+}
+
+pub(crate) fn list_agent_events() -> Value {
+    json!([])
+}
+
+pub(crate) fn report_agent_event() -> Value {
+    json!({ "sequence": 0 })
+}
+
+pub(crate) fn external_conversation() -> Value {
+    json!({ "conversation_id": Uuid::new_v4().to_string() })
+}
+
+pub(crate) fn upload_target(public_base_url: &str) -> Value {
+    let upload_id = Uuid::new_v4();
+    let public_base_url = public_base_url.trim_end_matches('/');
+    json!({
+        "url": format!("{public_base_url}/api/v1/harness-support/upload/{upload_id}"),
+        "method": "PUT",
+        "headers": {},
+    })
+}
+
+pub(crate) fn snapshot_uploads(public_base_url: &str, count: usize) -> Value {
+    let uploads = (0..count)
+        .map(|_| upload_target(public_base_url))
+        .collect::<Vec<_>>();
+    json!({ "uploads": uploads })
+}
+
+pub(crate) fn resolved_prompt() -> Value {
+    json!({
+        "prompt": "Local shim mode: no remote task prompt is available.",
+        "system_prompt": null,
+        "resumption_prompt": null,
+    })
+}
+
+pub(crate) fn report_artifact() -> Value {
+    json!({ "artifact_uid": Uuid::new_v4().to_string() })
+}
+
+pub(crate) fn local_shim_auth_page() -> String {
+    r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Warp Shim Local Mode</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 720px; margin: 4rem auto; line-height: 1.5; }
+    code { background: #f4f4f4; padding: 0.15rem 0.3rem; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Warp Shim Local Mode</h1>
+  <p>This browser auth page is a local shim stub. The shim accepts local Warp traffic and does not contact Warp cloud authentication.</p>
+  <p>Launch OSS Warp with <code>WARP_API_KEY=local-shim</code> while using this server.</p>
+</body>
+</html>"#
+        .to_string()
+}

--- a/crates/warp_shim_server/src/upstream/mod.rs
+++ b/crates/warp_shim_server/src/upstream/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod openai;
+pub(crate) mod prompt;
+pub(crate) mod tool_registry;

--- a/crates/warp_shim_server/src/upstream/openai.rs
+++ b/crates/warp_shim_server/src/upstream/openai.rs
@@ -1,0 +1,607 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use anyhow::{Context, Result, anyhow};
+use reqwest_eventsource::{EventSource, RequestBuilderExt};
+use serde::{Deserialize, Deserializer, Serialize};
+use url::Url;
+
+use crate::{
+    config::UpstreamConfig,
+    conversation::transcript::{TranscriptMessage, TranscriptRole, TranscriptToolCall},
+    protocol::response_builder::UsageTotals,
+};
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct OpenAiChatRequest {
+    model: String,
+    messages: Vec<OpenAiMessage>,
+    stream: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tools: Vec<OpenAiToolDeclaration>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<&'static str>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct OpenAiMessage {
+    role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tool_calls: Vec<OpenAiToolCall>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub(crate) struct OpenAiToolCall {
+    pub(crate) id: String,
+    #[serde(rename = "type")]
+    pub(crate) kind: String,
+    pub(crate) function: OpenAiToolCallFunction,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub(crate) struct OpenAiToolCallFunction {
+    pub(crate) name: String,
+    pub(crate) arguments: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct OpenAiToolDeclaration {
+    #[serde(rename = "type")]
+    pub(crate) kind: String,
+    pub(crate) function: OpenAiFunction,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct OpenAiFunction {
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) parameters: serde_json::Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum StreamItem {
+    Chunk(ParsedStreamChunk),
+    Usage(UsageTotals),
+    Done,
+    Empty,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ParsedStreamChunk {
+    pub(crate) content: String,
+    pub(crate) tool_call_deltas: Vec<OpenAiToolCallDelta>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OpenAiToolCallDelta {
+    pub(crate) index: usize,
+    pub(crate) id: Option<String>,
+    pub(crate) name: Option<String>,
+    pub(crate) arguments: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CompletionOutput {
+    pub(crate) content: String,
+    pub(crate) tool_calls: Vec<OpenAiToolCall>,
+    pub(crate) usage: Option<UsageTotals>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct OpenAiToolCallAccumulator {
+    calls: BTreeMap<usize, PartialToolCall>,
+}
+
+#[derive(Debug, Default)]
+struct PartialToolCall {
+    id: Option<String>,
+    name: Option<String>,
+    arguments: String,
+}
+
+impl OpenAiChatRequest {
+    pub(crate) fn new(
+        model: String,
+        messages: &[TranscriptMessage],
+        system_message: String,
+        stream: bool,
+        tools: Vec<OpenAiToolDeclaration>,
+    ) -> Self {
+        let mut openai_messages = vec![OpenAiMessage {
+            role: "system".to_string(),
+            content: Some(system_message),
+            tool_call_id: None,
+            tool_calls: vec![],
+        }];
+        openai_messages.extend(messages.iter().map(OpenAiMessage::from_transcript));
+        let tool_choice = (!tools.is_empty()).then_some("auto");
+
+        Self {
+            model,
+            messages: openai_messages,
+            stream,
+            tools,
+            tool_choice,
+        }
+    }
+}
+
+impl OpenAiMessage {
+    fn from_transcript(message: &TranscriptMessage) -> Self {
+        let tool_calls = message
+            .tool_calls
+            .iter()
+            .map(OpenAiToolCall::from_transcript)
+            .collect::<Vec<_>>();
+        let content = match message.role {
+            TranscriptRole::Assistant if !tool_calls.is_empty() && message.content.is_empty() => {
+                None
+            }
+            _ => Some(message.content.clone()),
+        };
+
+        Self {
+            role: message.role.as_openai_role().to_string(),
+            content,
+            tool_call_id: message.tool_call_id.clone(),
+            tool_calls,
+        }
+    }
+}
+
+impl OpenAiToolCall {
+    fn from_transcript(tool_call: &TranscriptToolCall) -> Self {
+        Self {
+            id: tool_call.id.clone(),
+            kind: "function".to_string(),
+            function: OpenAiToolCallFunction {
+                name: tool_call.name.clone(),
+                arguments: tool_call.arguments.clone(),
+            },
+        }
+    }
+}
+
+impl OpenAiToolCallAccumulator {
+    pub(crate) fn push_deltas(&mut self, deltas: Vec<OpenAiToolCallDelta>) {
+        for delta in deltas {
+            let entry = self.calls.entry(delta.index).or_default();
+            if let Some(id) = delta.id {
+                entry.id = Some(id);
+            }
+            if let Some(name) = delta.name {
+                entry.name = Some(name);
+            }
+            entry.arguments.push_str(&delta.arguments);
+        }
+    }
+
+    pub(crate) fn finish(self) -> Result<Vec<OpenAiToolCall>> {
+        self.calls
+            .into_iter()
+            .map(|(index, call)| {
+                let name = call
+                    .name
+                    .ok_or_else(|| anyhow!("streamed tool call at index {index} had no name"))?;
+                Ok(OpenAiToolCall {
+                    id: call.id.unwrap_or_else(|| format!("call_{index}")),
+                    kind: "function".to_string(),
+                    function: OpenAiToolCallFunction {
+                        name,
+                        arguments: call.arguments,
+                    },
+                })
+            })
+            .collect()
+    }
+}
+
+pub(crate) fn stream_chat_completion(
+    client: &reqwest::Client,
+    upstream: &UpstreamConfig,
+    request: OpenAiChatRequest,
+) -> Result<EventSource> {
+    let request = request_builder(client, upstream, request)?;
+    request
+        .eventsource()
+        .map_err(|err| anyhow!("failed to open upstream eventsource: {err}"))
+}
+
+pub(crate) async fn complete_chat_completion(
+    client: &reqwest::Client,
+    upstream: &UpstreamConfig,
+    request: OpenAiChatRequest,
+) -> Result<CompletionOutput> {
+    let response = request_builder(client, upstream, request)?
+        .send()
+        .await
+        .context("failed to send upstream chat completion request")?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .context("failed to read upstream chat completion response")?;
+    if !status.is_success() {
+        return Err(anyhow!(
+            "upstream returned {status}: {}",
+            sanitized_upstream_body_for_error(&body)
+        ));
+    }
+
+    let response: ChatCompletionResponse = serde_json::from_str(&body).with_context(|| {
+        format!(
+            "failed to decode upstream chat completion response: {}",
+            sanitized_upstream_body_for_error(&body)
+        )
+    })?;
+    let mut content = String::new();
+    let mut tool_calls = Vec::new();
+    for choice in response.choices {
+        if let Some(choice_content) = choice.message.content {
+            content.push_str(&choice_content);
+        }
+        tool_calls.extend(choice.message.tool_calls);
+    }
+
+    Ok(CompletionOutput {
+        content,
+        tool_calls,
+        usage: response.usage.map(Into::into),
+    })
+}
+
+pub(crate) fn parse_stream_item(data: &str) -> Result<StreamItem> {
+    let data = data.trim();
+    if data.is_empty() {
+        return Ok(StreamItem::Empty);
+    }
+    if data == "[DONE]" {
+        return Ok(StreamItem::Done);
+    }
+
+    let chunk: ChatCompletionStreamChunk = serde_json::from_str(data).with_context(|| {
+        format!(
+            "failed to decode upstream streaming chunk: {}",
+            truncate_for_error(data)
+        )
+    })?;
+    if let Some(usage) = chunk.usage {
+        return Ok(StreamItem::Usage(usage.into()));
+    }
+
+    let mut parsed = ParsedStreamChunk::default();
+    for choice in chunk.choices {
+        let Some(delta) = choice.delta else {
+            continue;
+        };
+        if let Some(content) = delta.content {
+            parsed.content.push_str(&content);
+        }
+        for (position, tool_call) in delta.tool_calls.into_iter().enumerate() {
+            parsed.tool_call_deltas.push(OpenAiToolCallDelta {
+                index: tool_call.index.unwrap_or(position),
+                id: tool_call.id,
+                name: tool_call
+                    .function
+                    .as_ref()
+                    .and_then(|function| function.name.clone()),
+                arguments: tool_call
+                    .function
+                    .and_then(|function| function.arguments)
+                    .unwrap_or_default(),
+            });
+        }
+    }
+
+    if parsed.content.is_empty() && parsed.tool_call_deltas.is_empty() {
+        Ok(StreamItem::Empty)
+    } else {
+        Ok(StreamItem::Chunk(parsed))
+    }
+}
+
+const MAX_UPSTREAM_ERROR_BODY_CHARS: usize = 512;
+
+fn sanitized_upstream_body_for_error(body: &str) -> String {
+    let redacted = match serde_json::from_str::<serde_json::Value>(body) {
+        Ok(mut value) => {
+            redact_json_secrets(&mut value);
+            value.to_string()
+        }
+        Err(_) => body.to_string(),
+    };
+    truncate_for_error(&redacted)
+}
+
+fn truncate_for_error(value: &str) -> String {
+    let mut chars = value.chars();
+    let truncated = chars
+        .by_ref()
+        .take(MAX_UPSTREAM_ERROR_BODY_CHARS)
+        .collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}…<truncated>")
+    } else {
+        truncated
+    }
+}
+
+fn redact_json_secrets(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for (key, child) in object.iter_mut() {
+                if is_secret_json_key(key) {
+                    *child = serde_json::Value::String("[redacted]".to_string());
+                } else {
+                    redact_json_secrets(child);
+                }
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                redact_json_secrets(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_secret_json_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("api_key")
+        || key.contains("apikey")
+        || key.contains("token")
+        || key.contains("secret")
+        || key.contains("password")
+        || key.contains("authorization")
+}
+
+fn request_builder(
+    client: &reqwest::Client,
+    upstream: &UpstreamConfig,
+    request: OpenAiChatRequest,
+) -> Result<reqwest::RequestBuilder> {
+    let mut builder = client
+        .post(chat_completions_url(&upstream.base_url))
+        .timeout(Duration::from_secs(upstream.timeout_secs))
+        .json(&request);
+
+    if let Some(api_key) = &upstream.api_key {
+        builder = builder.bearer_auth(api_key);
+    }
+
+    Ok(builder)
+}
+
+fn chat_completions_url(base_url: &Url) -> Url {
+    let mut url = base_url.clone();
+    let path = format!("{}/chat/completions", url.path().trim_end_matches('/'));
+    url.set_path(&path);
+    url.set_query(None);
+    url
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionResponse {
+    choices: Vec<ChatCompletionChoice>,
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionChoice {
+    message: ChatCompletionMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionMessage {
+    content: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    tool_calls: Vec<OpenAiToolCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionStreamChunk {
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    choices: Vec<ChatCompletionStreamChoice>,
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionStreamChoice {
+    delta: Option<ChatCompletionDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionDelta {
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    content: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_null_default")]
+    tool_calls: Vec<RawToolCallDelta>,
+}
+
+/// Deserializer that treats explicit JSON `null` as the type's default.
+///
+/// Some OpenAI-compatible servers (notably sglang/SGL) emit `null` for fields
+/// that the OpenAI spec describes as optional or missing. The default serde
+/// behavior with `#[serde(default)]` only fills in the default when the field
+/// is absent — explicit `null` still triggers a type-mismatch error. This
+/// helper bridges that gap so we accept `null`, missing, and present values
+/// uniformly.
+fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let opt = Option::<T>::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
+}
+
+#[derive(Debug, Deserialize)]
+struct RawToolCallDelta {
+    index: Option<usize>,
+    id: Option<String>,
+    function: Option<RawToolCallDeltaFunction>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawToolCallDeltaFunction {
+    name: Option<String>,
+    arguments: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+struct OpenAiUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+}
+
+impl From<OpenAiUsage> for UsageTotals {
+    fn from(value: OpenAiUsage) -> Self {
+        Self {
+            total_input: value.prompt_tokens,
+            output: value.completion_tokens,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_streaming_delta() {
+        let data = r#"{"choices":[{"delta":{"content":"hello"}}]}"#;
+        assert_eq!(
+            parse_stream_item(data).unwrap(),
+            StreamItem::Chunk(ParsedStreamChunk {
+                content: "hello".to_string(),
+                tool_call_deltas: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn tolerates_null_tool_calls_in_streaming_delta() {
+        // sglang/SGL servers emit explicit `null` for `tool_calls` in
+        // streaming chunks. Plain `#[serde(default)]` rejects this; the
+        // `deserialize_null_default` shim accepts it. Regression for a real
+        // chunk observed against an sglang upstream.
+        let data = r#"{"id":"adce1542e8364a12a4686b61e1b00ca4","object":"chat.completion.chunk","created":1777464380,"model":"zai-org/GLM-5.1-FP8","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}],"usage":null}"#;
+
+        // Empty content + empty tool_calls collapses to `Empty` per the
+        // existing `parse_stream_item` semantics, which is the right
+        // behavior — this chunk simply opens the stream.
+        assert_eq!(parse_stream_item(data).unwrap(), StreamItem::Empty);
+    }
+
+    #[test]
+    fn tolerates_null_content_with_real_text_in_later_chunk() {
+        // Same upstream typically follows the role-only opener with chunks
+        // that carry actual content. Make sure we still surface the text.
+        let data = r#"{"choices":[{"delta":{"role":"assistant","content":"hi","reasoning_content":null,"tool_calls":null}}]}"#;
+        assert_eq!(
+            parse_stream_item(data).unwrap(),
+            StreamItem::Chunk(ParsedStreamChunk {
+                content: "hi".to_string(),
+                tool_call_deltas: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn parses_streaming_tool_call_delta() {
+        let data = serde_json::json!({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "read_files",
+                            "arguments": "{\"files\":[]}",
+                        }
+                    }]
+                }
+            }]
+        })
+        .to_string();
+        assert_eq!(
+            parse_stream_item(&data).unwrap(),
+            StreamItem::Chunk(ParsedStreamChunk {
+                content: String::new(),
+                tool_call_deltas: vec![OpenAiToolCallDelta {
+                    index: 0,
+                    id: Some("call_1".to_string()),
+                    name: Some("read_files".to_string()),
+                    arguments: "{\"files\":[]}".to_string(),
+                }],
+            })
+        );
+    }
+
+    #[test]
+    fn accumulates_streaming_tool_call_arguments() {
+        let mut accumulator = OpenAiToolCallAccumulator::default();
+        accumulator.push_deltas(vec![OpenAiToolCallDelta {
+            index: 0,
+            id: Some("call_1".to_string()),
+            name: Some("read_files".to_string()),
+            arguments: "{\"files\":".to_string(),
+        }]);
+        accumulator.push_deltas(vec![OpenAiToolCallDelta {
+            index: 0,
+            id: None,
+            name: None,
+            arguments: "[]}".to_string(),
+        }]);
+
+        assert_eq!(
+            accumulator.finish().unwrap(),
+            vec![OpenAiToolCall {
+                id: "call_1".to_string(),
+                kind: "function".to_string(),
+                function: OpenAiToolCallFunction {
+                    name: "read_files".to_string(),
+                    arguments: "{\"files\":[]}".to_string(),
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn appends_chat_completions_to_v1_base_url() {
+        let url = Url::parse("http://127.0.0.1:11434/v1").unwrap();
+        assert_eq!(
+            chat_completions_url(&url).as_str(),
+            "http://127.0.0.1:11434/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn redacts_and_truncates_upstream_error_bodies() {
+        let body = serde_json::json!({
+            "error": {
+                "message": "bad request",
+                "api_key": "sk-secret",
+                "nested": { "password": "pw-secret", "token": "tok-secret" }
+            },
+            "long": "x".repeat(700)
+        })
+        .to_string();
+
+        let sanitized = sanitized_upstream_body_for_error(&body);
+
+        assert!(sanitized.contains("[redacted]"));
+        assert!(sanitized.contains("<truncated>"));
+        assert!(!sanitized.contains("sk-secret"));
+        assert!(!sanitized.contains("pw-secret"));
+        assert!(!sanitized.contains("tok-secret"));
+    }
+}

--- a/crates/warp_shim_server/src/upstream/prompt.rs
+++ b/crates/warp_shim_server/src/upstream/prompt.rs
@@ -1,0 +1,344 @@
+use warp_multi_agent_api as api;
+
+use crate::conversation::transcript::TranscriptMessage;
+
+pub(crate) fn system_message() -> String {
+    [
+        "You are a local Warp Agent Mode shim assistant.",
+        "You answer through a local OpenAI-compatible model endpoint configured by the user.",
+        "When tools are declared, use them for file reads, shell commands, code search, file edits, glob/grep, and MCP operations instead of pretending you already performed those actions.",
+        "After a tool result is returned, continue from that result and either call another declared tool or provide the final answer.",
+        "Do not claim Warp cloud capabilities; this shim only routes local Agent Mode requests and client-executed tools.",
+    ]
+    .join("\n")
+}
+
+#[allow(deprecated)]
+pub(crate) fn input_messages(request: &api::Request) -> Vec<TranscriptMessage> {
+    let Some(input) = request.input.as_ref() else {
+        return vec![TranscriptMessage::user("Continue the conversation.")];
+    };
+
+    let mut messages = match input.r#type.as_ref() {
+        Some(api::request::input::Type::UserInputs(user_inputs)) => user_inputs
+            .inputs
+            .iter()
+            .filter_map(|input| user_input_to_message(input, input_context(input, request)))
+            .collect(),
+        Some(api::request::input::Type::UserQuery(query)) => {
+            vec![user_query_to_message(query, input.context.as_ref(), None)]
+        }
+        Some(api::request::input::Type::QueryWithCannedResponse(query)) => vec![text_to_message(
+            &query.query,
+            input.context.as_ref(),
+            Some("Warp canned-response query"),
+        )],
+        Some(api::request::input::Type::AutoCodeDiffQuery(query)) => vec![text_to_message(
+            &query.query,
+            input.context.as_ref(),
+            Some("Automatic code-diff query"),
+        )],
+        Some(api::request::input::Type::ResumeConversation(_)) => {
+            vec![text_to_message(
+                "Continue the conversation.",
+                input.context.as_ref(),
+                None,
+            )]
+        }
+        Some(api::request::input::Type::InitProjectRules(_)) => vec![text_to_message(
+            "Create or update project rules for this workspace.",
+            input.context.as_ref(),
+            None,
+        )],
+        Some(api::request::input::Type::CreateNewProject(query)) => vec![text_to_message(
+            &format!("Create a new project from this request: {}", query.query),
+            input.context.as_ref(),
+            None,
+        )],
+        Some(api::request::input::Type::CloneRepository(query)) => vec![text_to_message(
+            &format!("Help clone and set up this repository: {}", query.url),
+            input.context.as_ref(),
+            None,
+        )],
+        Some(api::request::input::Type::CodeReview(_)) => vec![text_to_message(
+            "Review the provided code changes.",
+            input.context.as_ref(),
+            None,
+        )],
+        Some(api::request::input::Type::SummarizeConversation(query)) => vec![text_to_message(
+            &format!("Summarize the active conversation. {}", query.prompt),
+            input.context.as_ref(),
+            None,
+        )],
+        Some(api::request::input::Type::CreateEnvironment(query)) => vec![text_to_message(
+            &format!(
+                "Create a development environment for repositories: {}",
+                query.repo_paths.join(", ")
+            ),
+            input.context.as_ref(),
+            None,
+        )],
+        Some(api::request::input::Type::FetchReviewComments(query)) => vec![text_to_message(
+            &format!(
+                "Fetch review comments for repository path: {}",
+                query.repo_path
+            ),
+            input.context.as_ref(),
+            None,
+        )],
+        Some(api::request::input::Type::StartFromAmbientRunPrompt(query)) => vec![text_to_message(
+            non_empty(&query.runtime_base_prompt)
+                .unwrap_or("Start from the latest ambient run prompt."),
+            input.context.as_ref(),
+            None,
+        )],
+        Some(api::request::input::Type::InvokeSkill(query)) => {
+            let text = query
+                .user_query
+                .as_ref()
+                .and_then(|query| non_empty(&query.query))
+                .unwrap_or("Invoke the requested Warp skill.");
+            vec![text_to_message(
+                text,
+                input.context.as_ref(),
+                Some("Skill invocation"),
+            )]
+        }
+        Some(api::request::input::Type::GeneratePassiveSuggestions(_))
+        | Some(api::request::input::Type::ToolCallResult(_))
+        | None => Vec::new(),
+    };
+
+    if messages.is_empty() && should_default_to_continue(input) {
+        messages.push(TranscriptMessage::user("Continue the conversation."));
+    }
+    messages
+}
+
+#[allow(deprecated)]
+fn should_default_to_continue(input: &api::request::Input) -> bool {
+    match input.r#type.as_ref() {
+        Some(api::request::input::Type::ToolCallResult(_))
+        | Some(api::request::input::Type::GeneratePassiveSuggestions(_)) => false,
+        Some(api::request::input::Type::UserInputs(user_inputs)) => !user_inputs.inputs.iter().any(
+            |input| matches!(
+                input.input.as_ref(),
+                Some(api::request::input::user_inputs::user_input::Input::ToolCallResult(_))
+                    | Some(
+                        api::request::input::user_inputs::user_input::Input::PassiveSuggestionResult(_),
+                    )
+            ),
+        ),
+        _ => true,
+    }
+}
+
+#[allow(deprecated)]
+pub(crate) fn context_prefix(context: &api::InputContext) -> String {
+    let mut lines = Vec::new();
+
+    if let Some(directory) = context.directory.as_ref()
+        && let Some(pwd) = non_empty(&directory.pwd)
+    {
+        lines.push(format!("- Current directory: {pwd}"));
+    }
+    if let Some(os) = context.operating_system.as_ref() {
+        let platform = non_empty(&os.platform).unwrap_or("unknown");
+        if let Some(distribution) = non_empty(&os.distribution) {
+            lines.push(format!("- OS: {platform} ({distribution})"));
+        } else if platform != "unknown" {
+            lines.push(format!("- OS: {platform}"));
+        }
+    }
+    if let Some(shell) = context.shell.as_ref() {
+        match (non_empty(&shell.name), non_empty(&shell.version)) {
+            (Some(name), Some(version)) => lines.push(format!("- Shell: {name} {version}")),
+            (Some(name), None) => lines.push(format!("- Shell: {name}")),
+            _ => {}
+        }
+    }
+    if let Some(git) = context.git.as_ref() {
+        if let Some(branch) = non_empty(&git.branch) {
+            lines.push(format!("- Git branch: {branch}"));
+        } else if let Some(head) = non_empty(&git.head) {
+            lines.push(format!("- Git head: {head}"));
+        }
+    }
+
+    for selected in &context.selected_text {
+        if let Some(text) = non_empty(&selected.text) {
+            lines.push(format!("- Selected text:\n{text}"));
+        }
+    }
+    for command in &context.executed_shell_commands {
+        let command_text = non_empty(&command.command).unwrap_or("<unknown command>");
+        let output = non_empty(&command.output).unwrap_or("<no output>");
+        lines.push(format!(
+            "- Executed command (exit {}): {command_text}\n{output}",
+            command.exit_code
+        ));
+    }
+    for image in &context.images {
+        lines.push(format!(
+            "- [image omitted: mime_type={}, bytes={}]",
+            empty_as_unknown(&image.mime_type),
+            image.data.len()
+        ));
+    }
+    for file in &context.files {
+        if let Some(content) = file.content.as_ref()
+            && let Some(text) = non_empty(&content.content)
+        {
+            lines.push(format!("- File {}:\n{text}", content.file_path));
+        }
+    }
+    for codebase in &context.codebases {
+        lines.push(format!(
+            "- Codebase: {} at {}",
+            empty_as_unknown(&codebase.name),
+            empty_as_unknown(&codebase.path)
+        ));
+    }
+    for rules in &context.project_rules {
+        if let Some(root) = non_empty(&rules.root_path) {
+            lines.push(format!("- Project rules root: {root}"));
+        }
+        for rule_file in &rules.active_rule_files {
+            if let Some(content) = non_empty(&rule_file.content) {
+                lines.push(format!("- Active rule {}:\n{content}", rule_file.file_path));
+            }
+        }
+        if !rules.additional_rule_file_paths.is_empty() {
+            lines.push(format!(
+                "- Additional rule files: {}",
+                rules.additional_rule_file_paths.join(", ")
+            ));
+        }
+    }
+
+    if lines.is_empty() {
+        String::new()
+    } else {
+        format!("Context from Warp:\n{}", lines.join("\n"))
+    }
+}
+
+fn user_input_to_message(
+    input: &api::request::input::user_inputs::UserInput,
+    context: Option<&api::InputContext>,
+) -> Option<TranscriptMessage> {
+    match input.input.as_ref()? {
+        api::request::input::user_inputs::user_input::Input::UserQuery(query) => {
+            Some(user_query_to_message(query, context, None))
+        }
+        api::request::input::user_inputs::user_input::Input::CliAgentUserQuery(query) => {
+            let user_query = query.user_query.as_ref()?;
+            let mut message = user_query_to_message(user_query, context, Some("CLI agent query"));
+            if let Some(running_command) = query.running_command.as_ref() {
+                let mut extra = format!("\n\nRunning command: {}", running_command.command);
+                if let Some(snapshot) = running_command.snapshot.as_ref()
+                    && let Some(output) = non_empty(&snapshot.output)
+                {
+                    extra.push_str("\nCurrent command output:\n");
+                    extra.push_str(output);
+                }
+                message.content.push_str(&extra);
+            }
+            Some(message)
+        }
+        api::request::input::user_inputs::user_input::Input::MessagesReceivedFromAgents(messages) => {
+            let content = messages
+                .messages
+                .iter()
+                .map(|message| {
+                    format!(
+                        "Message from {} about {}:\n{}",
+                        empty_as_unknown(&message.sender_agent_id),
+                        empty_as_unknown(&message.subject),
+                        message.message_body
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            non_empty(&content).map(TranscriptMessage::user)
+        }
+        api::request::input::user_inputs::user_input::Input::EventsFromAgents(events) => {
+            (!events.agent_events.is_empty()).then(|| {
+                TranscriptMessage::user(format!(
+                    "Received {} agent event(s). Tool/event handling is not implemented in this shim item.",
+                    events.agent_events.len()
+                ))
+            })
+        }
+        api::request::input::user_inputs::user_input::Input::PassiveSuggestionResult(_)
+        | api::request::input::user_inputs::user_input::Input::ToolCallResult(_) => None,
+    }
+}
+
+fn input_context<'a>(
+    input: &'a api::request::input::user_inputs::UserInput,
+    request: &'a api::Request,
+) -> Option<&'a api::InputContext> {
+    match input.input.as_ref()? {
+        api::request::input::user_inputs::user_input::Input::UserQuery(_)
+        | api::request::input::user_inputs::user_input::Input::CliAgentUserQuery(_) => {
+            request.input.as_ref()?.context.as_ref()
+        }
+        _ => None,
+    }
+}
+
+fn user_query_to_message(
+    query: &api::request::input::UserQuery,
+    context: Option<&api::InputContext>,
+    label: Option<&str>,
+) -> TranscriptMessage {
+    let mut content = format_user_content(&query.query, context, label);
+    if !query.referenced_attachments.is_empty() {
+        let attachments = query
+            .referenced_attachments
+            .keys()
+            .map(|key| format!("[attachment omitted: {key}]"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        content.push_str("\n\nReferenced attachments:\n");
+        content.push_str(&attachments);
+    }
+    TranscriptMessage::user(content)
+}
+
+fn text_to_message(
+    text: &str,
+    context: Option<&api::InputContext>,
+    label: Option<&str>,
+) -> TranscriptMessage {
+    TranscriptMessage::user(format_user_content(text, context, label))
+}
+
+fn format_user_content(
+    text: &str,
+    context: Option<&api::InputContext>,
+    label: Option<&str>,
+) -> String {
+    let mut parts = Vec::new();
+    if let Some(context) = context
+        .map(context_prefix)
+        .filter(|context| !context.is_empty())
+    {
+        parts.push(context);
+    }
+    if let Some(label) = label {
+        parts.push(format!("Request kind: {label}"));
+    }
+    parts.push(format!("User request:\n{}", text.trim()));
+    parts.join("\n\n")
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}
+
+fn empty_as_unknown(value: &str) -> &str {
+    non_empty(value).unwrap_or("unknown")
+}

--- a/crates/warp_shim_server/src/upstream/tool_registry.rs
+++ b/crates/warp_shim_server/src/upstream/tool_registry.rs
@@ -1,0 +1,1324 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Result, anyhow, bail};
+use serde_json::{Value, json};
+use warp_multi_agent_api as api;
+
+use crate::{
+    config::FeatureConfig,
+    conversation::transcript::{PendingToolCall, TranscriptToolCall, WarpToolKind},
+    upstream::openai::{OpenAiFunction, OpenAiToolCall, OpenAiToolDeclaration},
+};
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ToolRegistry {
+    adapters: BTreeMap<String, ToolAdapter>,
+}
+
+#[derive(Clone, Debug)]
+struct ToolAdapter {
+    openai_name: String,
+    description: String,
+    schema: Value,
+    kind: AdapterKind,
+}
+
+#[derive(Clone, Debug)]
+enum AdapterKind {
+    Builtin(BuiltinTool),
+    Mcp(McpToolRoute),
+}
+
+#[derive(Clone, Debug)]
+struct McpToolRoute {
+    server_id: String,
+    server_name: String,
+    tool_name: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BuiltinTool {
+    RunShellCommand,
+    WriteToLongRunningShellCommand,
+    ReadShellCommandOutput,
+    ReadFiles,
+    ApplyFileDiffs,
+    SearchCodebase,
+    Grep,
+    FileGlob,
+    FileGlobV2,
+    ReadMcpResource,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct WarpToolCall {
+    pub(crate) openai_tool_call: TranscriptToolCall,
+    pub(crate) pending: PendingToolCall,
+    pub(crate) tool_call: api::message::ToolCall,
+}
+
+impl ToolRegistry {
+    pub(crate) fn for_request(request: &api::Request, features: &FeatureConfig) -> Self {
+        if !features.tools_enabled {
+            return Self::default();
+        }
+
+        let mut registry = Self::default();
+        for builtin in BuiltinTool::all() {
+            if request_supports_tool(request, builtin.tool_type()) {
+                registry.insert(ToolAdapter::builtin(builtin));
+            }
+        }
+
+        if features.mcp_tools_enabled && request_supports_tool(request, api::ToolType::CallMcpTool)
+        {
+            registry.insert_mcp_tools(request);
+        }
+
+        registry
+    }
+
+    pub(crate) fn openai_tools(&self) -> Vec<OpenAiToolDeclaration> {
+        self.adapters
+            .values()
+            .map(|adapter| OpenAiToolDeclaration {
+                kind: "function".to_string(),
+                function: OpenAiFunction {
+                    name: adapter.openai_name.clone(),
+                    description: adapter.description.clone(),
+                    parameters: openai_compatible_object_schema(adapter.schema.clone()),
+                },
+            })
+            .collect()
+    }
+
+    pub(crate) fn convert_openai_tool_call(
+        &self,
+        openai_tool_call: &OpenAiToolCall,
+        warp_tool_call_id: String,
+    ) -> Result<WarpToolCall> {
+        let adapter = self
+            .adapters
+            .get(&openai_tool_call.function.name)
+            .ok_or_else(|| {
+                anyhow!(
+                    "upstream requested unsupported tool `{}`",
+                    openai_tool_call.function.name
+                )
+            })?;
+        let args = parse_arguments(&openai_tool_call.function.arguments)?;
+        let tool = adapter.openai_args_to_tool(&args)?;
+        let kind = adapter.warp_tool_kind();
+        let pending = PendingToolCall {
+            warp_tool_call_id: warp_tool_call_id.clone(),
+            openai_tool_call_id: openai_tool_call.id.clone(),
+            openai_tool_name: adapter.openai_name.clone(),
+            kind,
+        };
+
+        Ok(WarpToolCall {
+            openai_tool_call: TranscriptToolCall {
+                id: openai_tool_call.id.clone(),
+                name: openai_tool_call.function.name.clone(),
+                arguments: openai_tool_call.function.arguments.clone(),
+            },
+            pending,
+            tool_call: api::message::ToolCall {
+                tool_call_id: warp_tool_call_id,
+                tool: Some(tool),
+            },
+        })
+    }
+
+    pub(crate) fn result_to_openai_content(
+        &self,
+        result: &api::request::input::ToolCallResult,
+    ) -> String {
+        result_to_openai_content(result)
+    }
+
+    fn insert(&mut self, adapter: ToolAdapter) {
+        self.adapters.insert(adapter.openai_name.clone(), adapter);
+    }
+
+    fn insert_mcp_tools(&mut self, request: &api::Request) {
+        let mut used_names = self.adapters.keys().cloned().collect::<BTreeSet<_>>();
+        let Some(mcp_context) = request.mcp_context.as_ref() else {
+            return;
+        };
+
+        for server in &mcp_context.servers {
+            let server_key = non_empty(&server.id)
+                .or_else(|| non_empty(&server.name))
+                .unwrap_or("server");
+            let short_server_id = sanitize_openai_name_part(server_key, 24);
+            for tool in &server.tools {
+                let Some(tool_name) = non_empty(&tool.name) else {
+                    continue;
+                };
+                let sanitized_tool_name = sanitize_openai_name_part(tool_name, 40);
+                let base_name = format!("mcp__{short_server_id}__{sanitized_tool_name}");
+                let openai_name = unique_tool_name(base_name, &mut used_names);
+                let schema = tool
+                    .input_schema
+                    .as_ref()
+                    .map(struct_to_json_value)
+                    .unwrap_or_else(empty_object_schema);
+
+                self.insert(ToolAdapter {
+                    openai_name,
+                    description: if tool.description.trim().is_empty() {
+                        format!("Call MCP tool `{tool_name}` on server `{}`.", server.name)
+                    } else {
+                        tool.description.clone()
+                    },
+                    schema,
+                    kind: AdapterKind::Mcp(McpToolRoute {
+                        server_id: server.id.clone(),
+                        server_name: server.name.clone(),
+                        tool_name: tool.name.clone(),
+                    }),
+                });
+            }
+        }
+    }
+}
+
+impl ToolAdapter {
+    fn builtin(tool: BuiltinTool) -> Self {
+        Self {
+            openai_name: tool.openai_name().to_string(),
+            description: tool.description().to_string(),
+            schema: tool.schema(),
+            kind: AdapterKind::Builtin(tool),
+        }
+    }
+
+    fn openai_args_to_tool(&self, args: &Value) -> Result<api::message::tool_call::Tool> {
+        match &self.kind {
+            AdapterKind::Builtin(tool) => tool.openai_args_to_tool(args),
+            AdapterKind::Mcp(route) => {
+                let args = json_to_struct(args)?;
+                Ok(api::message::tool_call::Tool::CallMcpTool(
+                    api::message::tool_call::CallMcpTool {
+                        name: route.tool_name.clone(),
+                        args: Some(args),
+                        server_id: route.server_id.clone(),
+                    },
+                ))
+            }
+        }
+    }
+
+    fn warp_tool_kind(&self) -> WarpToolKind {
+        match &self.kind {
+            AdapterKind::Builtin(tool) => WarpToolKind::Builtin(tool.tool_type()),
+            AdapterKind::Mcp(route) => WarpToolKind::Mcp {
+                server_id: route.server_id.clone(),
+                server_name: route.server_name.clone(),
+                tool_name: route.tool_name.clone(),
+            },
+        }
+    }
+}
+
+impl BuiltinTool {
+    fn all() -> [Self; 10] {
+        [
+            Self::RunShellCommand,
+            Self::WriteToLongRunningShellCommand,
+            Self::ReadShellCommandOutput,
+            Self::ReadFiles,
+            Self::ApplyFileDiffs,
+            Self::SearchCodebase,
+            Self::Grep,
+            Self::FileGlob,
+            Self::FileGlobV2,
+            Self::ReadMcpResource,
+        ]
+    }
+
+    fn tool_type(self) -> api::ToolType {
+        match self {
+            Self::RunShellCommand => api::ToolType::RunShellCommand,
+            Self::WriteToLongRunningShellCommand => api::ToolType::WriteToLongRunningShellCommand,
+            Self::ReadShellCommandOutput => api::ToolType::ReadShellCommandOutput,
+            Self::ReadFiles => api::ToolType::ReadFiles,
+            Self::ApplyFileDiffs => api::ToolType::ApplyFileDiffs,
+            Self::SearchCodebase => api::ToolType::SearchCodebase,
+            Self::Grep => api::ToolType::Grep,
+            Self::FileGlob => api::ToolType::FileGlob,
+            Self::FileGlobV2 => api::ToolType::FileGlobV2,
+            Self::ReadMcpResource => api::ToolType::ReadMcpResource,
+        }
+    }
+
+    fn openai_name(self) -> &'static str {
+        match self {
+            Self::RunShellCommand => "run_shell_command",
+            Self::WriteToLongRunningShellCommand => "write_to_long_running_shell_command",
+            Self::ReadShellCommandOutput => "read_shell_command_output",
+            Self::ReadFiles => "read_files",
+            Self::ApplyFileDiffs => "apply_file_diffs",
+            Self::SearchCodebase => "search_codebase",
+            Self::Grep => "grep",
+            Self::FileGlob => "file_glob",
+            Self::FileGlobV2 => "file_glob_v2",
+            Self::ReadMcpResource => "read_mcp_resource",
+        }
+    }
+
+    fn description(self) -> &'static str {
+        match self {
+            Self::RunShellCommand => "Run a shell command in the user's Warp session.",
+            Self::WriteToLongRunningShellCommand => {
+                "Write input to a long-running shell command that is still active."
+            }
+            Self::ReadShellCommandOutput => {
+                "Read updated output from a long-running shell command."
+            }
+            Self::ReadFiles => "Read one or more files from the user's machine.",
+            Self::ApplyFileDiffs => {
+                "Apply file edits, create files, delete files, or rename files."
+            }
+            Self::SearchCodebase => "Search the user's codebase semantically for relevant files.",
+            Self::Grep => "Search file contents for exact text or patterns.",
+            Self::FileGlob => "Find files by glob pattern under a directory.",
+            Self::FileGlobV2 => "Find files by filename pattern with depth and result limits.",
+            Self::ReadMcpResource => "Read a resource exposed by one of the user's MCP servers.",
+        }
+    }
+
+    fn schema(self) -> Value {
+        match self {
+            Self::RunShellCommand => json!({
+                "type": "object",
+                "properties": {
+                    "command": { "type": "string", "description": "Command line to run." },
+                    "risk_category": {
+                        "type": "string",
+                        "enum": ["read_only", "trivial_local_change", "nontrivial_local_change", "external_change", "risky", "unspecified"],
+                        "description": "Risk assessment for the command. Use read_only for inspection commands."
+                    },
+                    "wait_until_complete": { "type": "boolean", "description": "If false, Warp may return an early snapshot for long-running commands." },
+                    "uses_pager": { "type": "boolean", "description": "Whether the command is expected to use a pager/TUI." },
+                    "is_read_only": { "type": "boolean", "description": "Deprecated compatibility flag; prefer risk_category." },
+                    "is_risky": { "type": "boolean", "description": "Deprecated compatibility flag; prefer risk_category." }
+                },
+                "required": ["command"]
+            }),
+            Self::WriteToLongRunningShellCommand => json!({
+                "type": "object",
+                "properties": {
+                    "command_id": { "type": "string", "description": "ID from a prior long-running command snapshot." },
+                    "input": { "type": "string", "description": "Text or bytes to send to the PTY." },
+                    "mode": { "type": "string", "enum": ["raw", "line", "block"], "description": "raw writes bytes as-is; line submits one command/input line; block bracket-pastes multiline text." }
+                },
+                "required": ["command_id", "input"]
+            }),
+            Self::ReadShellCommandOutput => json!({
+                "type": "object",
+                "properties": {
+                    "command_id": { "type": "string", "description": "ID from a prior long-running command snapshot." },
+                    "delay_ms": { "type": "integer", "minimum": 0, "description": "Optional delay before reading output." },
+                    "on_completion": { "type": "boolean", "description": "If true, wait until the command completes or the client cap is reached." }
+                },
+                "required": ["command_id"]
+            }),
+            Self::ReadFiles => json!({
+                "type": "object",
+                "properties": {
+                    "files": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": { "type": "string", "description": "File path to read." },
+                                "path": { "type": "string", "description": "Alias for name." },
+                                "line_ranges": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "start": { "type": "integer", "minimum": 1 },
+                                            "end": { "type": "integer", "minimum": 1 }
+                                        },
+                                        "required": ["start", "end"]
+                                    }
+                                }
+                            },
+                            "required": ["name"]
+                        }
+                    }
+                },
+                "required": ["files"]
+            }),
+            Self::ApplyFileDiffs => json!({
+                "type": "object",
+                "properties": {
+                    "summary": { "type": "string", "description": "Brief summary of the requested edits." },
+                    "diffs": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "file_path": { "type": "string" },
+                                "search": { "type": "string", "description": "Exact content to replace; empty can mean insertion for compatible clients." },
+                                "replace": { "type": "string" }
+                            },
+                            "required": ["file_path", "search", "replace"]
+                        }
+                    },
+                    "new_files": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "file_path": { "type": "string" },
+                                "content": { "type": "string" }
+                            },
+                            "required": ["file_path", "content"]
+                        }
+                    },
+                    "deleted_files": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": { "file_path": { "type": "string" } },
+                            "required": ["file_path"]
+                        }
+                    },
+                    "v4a_updates": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "file_path": { "type": "string" },
+                                "move_to": { "type": "string" },
+                                "hunks": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "change_context": { "type": "array", "items": { "type": "string" } },
+                                            "pre_context": { "type": "string" },
+                                            "old": { "type": "string" },
+                                            "new": { "type": "string" },
+                                            "post_context": { "type": "string" }
+                                        }
+                                    }
+                                }
+                            },
+                            "required": ["file_path", "hunks"]
+                        }
+                    }
+                }
+            }),
+            Self::SearchCodebase => json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string" },
+                    "path_filters": { "type": "array", "items": { "type": "string" } },
+                    "codebase_path": { "type": "string" }
+                },
+                "required": ["query"]
+            }),
+            Self::Grep => json!({
+                "type": "object",
+                "properties": {
+                    "queries": { "type": "array", "items": { "type": "string" } },
+                    "query": { "type": "string", "description": "Alias for a single queries entry." },
+                    "path": { "type": "string", "description": "Relative file or directory path to search." }
+                },
+                "required": ["queries", "path"]
+            }),
+            Self::FileGlob => json!({
+                "type": "object",
+                "properties": {
+                    "patterns": { "type": "array", "items": { "type": "string" } },
+                    "pattern": { "type": "string", "description": "Alias for a single patterns entry." },
+                    "path": { "type": "string" }
+                },
+                "required": ["patterns", "path"]
+            }),
+            Self::FileGlobV2 => json!({
+                "type": "object",
+                "properties": {
+                    "patterns": { "type": "array", "items": { "type": "string" } },
+                    "pattern": { "type": "string", "description": "Alias for a single patterns entry." },
+                    "search_dir": { "type": "string" },
+                    "max_matches": { "type": "integer", "minimum": 0 },
+                    "max_depth": { "type": "integer", "minimum": 0 },
+                    "min_depth": { "type": "integer", "minimum": 0 }
+                },
+                "required": ["patterns", "search_dir"]
+            }),
+            Self::ReadMcpResource => json!({
+                "type": "object",
+                "properties": {
+                    "uri": { "type": "string" },
+                    "server_id": { "type": "string", "description": "ID of the MCP server that owns the resource." }
+                },
+                "required": ["uri"]
+            }),
+        }
+    }
+
+    fn openai_args_to_tool(self, args: &Value) -> Result<api::message::tool_call::Tool> {
+        match self {
+            Self::RunShellCommand => run_shell_command_from_args(args),
+            Self::WriteToLongRunningShellCommand => {
+                write_to_long_running_shell_command_from_args(args)
+            }
+            Self::ReadShellCommandOutput => read_shell_command_output_from_args(args),
+            Self::ReadFiles => read_files_from_args(args),
+            Self::ApplyFileDiffs => apply_file_diffs_from_args(args),
+            Self::SearchCodebase => search_codebase_from_args(args),
+            Self::Grep => grep_from_args(args),
+            Self::FileGlob => file_glob_from_args(args),
+            Self::FileGlobV2 => file_glob_v2_from_args(args),
+            Self::ReadMcpResource => read_mcp_resource_from_args(args),
+        }
+    }
+}
+
+fn request_supports_tool(request: &api::Request, tool: api::ToolType) -> bool {
+    let Some(settings) = request.settings.as_ref() else {
+        return true;
+    };
+    settings.supported_tools.is_empty()
+        || settings
+            .supported_tools
+            .iter()
+            .any(|value| api::ToolType::try_from(*value).ok() == Some(tool))
+}
+
+fn run_shell_command_from_args(args: &Value) -> Result<api::message::tool_call::Tool> {
+    let command = required_string(args, "command")?;
+    let risk_category = optional_string(args, "risk_category")
+        .as_deref()
+        .map(risk_category_from_str)
+        .transpose()?
+        .unwrap_or_else(|| {
+            if optional_bool(args, "is_risky").unwrap_or(false) {
+                api::RiskCategory::Risky
+            } else if optional_bool(args, "is_read_only").unwrap_or(false) {
+                api::RiskCategory::ReadOnly
+            } else {
+                api::RiskCategory::Unspecified
+            }
+        });
+    let wait_until_complete_value = optional_bool(args, "wait_until_complete").map(|value| {
+        api::message::tool_call::run_shell_command::WaitUntilCompleteValue::WaitUntilComplete(value)
+    });
+
+    Ok(api::message::tool_call::Tool::RunShellCommand(
+        api::message::tool_call::RunShellCommand {
+            command,
+            is_read_only: risk_category == api::RiskCategory::ReadOnly,
+            uses_pager: optional_bool(args, "uses_pager").unwrap_or(false),
+            citations: vec![],
+            is_risky: risk_category == api::RiskCategory::Risky,
+            risk_category: risk_category as i32,
+            wait_until_complete_value,
+        },
+    ))
+}
+
+fn write_to_long_running_shell_command_from_args(
+    args: &Value,
+) -> Result<api::message::tool_call::Tool> {
+    let mode = match optional_string(args, "mode")
+        .unwrap_or_else(|| "raw".to_string())
+        .as_str()
+    {
+        "raw" => api::message::tool_call::write_to_long_running_shell_command::mode::Mode::Raw(()),
+        "line" => {
+            api::message::tool_call::write_to_long_running_shell_command::mode::Mode::Line(())
+        }
+        "block" => {
+            api::message::tool_call::write_to_long_running_shell_command::mode::Mode::Block(())
+        }
+        mode => bail!("unknown write mode `{mode}`"),
+    };
+
+    Ok(
+        api::message::tool_call::Tool::WriteToLongRunningShellCommand(
+            api::message::tool_call::WriteToLongRunningShellCommand {
+                input: required_string(args, "input")?.into_bytes(),
+                mode: Some(
+                    api::message::tool_call::write_to_long_running_shell_command::Mode {
+                        mode: Some(mode),
+                    },
+                ),
+                command_id: required_string(args, "command_id")?,
+            },
+        ),
+    )
+}
+
+fn read_shell_command_output_from_args(args: &Value) -> Result<api::message::tool_call::Tool> {
+    let delay = if optional_bool(args, "on_completion").unwrap_or(false) {
+        Some(api::message::tool_call::read_shell_command_output::Delay::OnCompletion(()))
+    } else {
+        optional_i64_checked(args, "delay_ms")?
+            .map(|millis| {
+                if millis < 0 {
+                    bail!("`delay_ms` must be non-negative");
+                }
+                let nanos = i32::try_from((millis % 1000) * 1_000_000)
+                    .map_err(|_| anyhow!("`delay_ms` nanos overflowed i32"))?;
+                Ok(
+                    api::message::tool_call::read_shell_command_output::Delay::Duration(
+                        prost_types::Duration {
+                            seconds: millis / 1000,
+                            nanos,
+                        },
+                    ),
+                )
+            })
+            .transpose()?
+    };
+
+    Ok(api::message::tool_call::Tool::ReadShellCommandOutput(
+        api::message::tool_call::ReadShellCommandOutput {
+            command_id: required_string(args, "command_id")?,
+            delay,
+        },
+    ))
+}
+
+fn read_files_from_args(args: &Value) -> Result<api::message::tool_call::Tool> {
+    let files = required_array(args, "files")?
+        .iter()
+        .map(|file| {
+            let name = optional_string(file, "name")
+                .or_else(|| optional_string(file, "path"))
+                .ok_or_else(|| anyhow!("read_files entries require `name`"))?;
+            let line_ranges = optional_array(file, "line_ranges")
+                .into_iter()
+                .flatten()
+                .map(line_range_from_value)
+                .collect::<Result<Vec<_>>>()?;
+            Ok(api::message::tool_call::read_files::File { name, line_ranges })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(api::message::tool_call::Tool::ReadFiles(
+        api::message::tool_call::ReadFiles { files },
+    ))
+}
+
+fn apply_file_diffs_from_args(args: &Value) -> Result<api::message::tool_call::Tool> {
+    let diffs = optional_array(args, "diffs")
+        .into_iter()
+        .flatten()
+        .map(|diff| {
+            Ok(api::message::tool_call::apply_file_diffs::FileDiff {
+                file_path: required_string(diff, "file_path")?,
+                search: required_string(diff, "search")?,
+                replace: required_string(diff, "replace")?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let new_files = optional_array(args, "new_files")
+        .into_iter()
+        .flatten()
+        .map(|file| {
+            Ok(api::message::tool_call::apply_file_diffs::NewFile {
+                file_path: required_string(file, "file_path")?,
+                content: required_string(file, "content")?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let deleted_files = optional_array(args, "deleted_files")
+        .into_iter()
+        .flatten()
+        .map(|file| {
+            Ok(api::message::tool_call::apply_file_diffs::DeleteFile {
+                file_path: required_string(file, "file_path")?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let v4a_updates = optional_array(args, "v4a_updates")
+        .into_iter()
+        .flatten()
+        .map(v4a_update_from_value)
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(api::message::tool_call::Tool::ApplyFileDiffs(
+        api::message::tool_call::ApplyFileDiffs {
+            summary: optional_string(args, "summary").unwrap_or_default(),
+            diffs,
+            new_files,
+            deleted_files,
+            v4a_updates,
+        },
+    ))
+}
+
+fn search_codebase_from_args(args: &Value) -> Result<api::message::tool_call::Tool> {
+    Ok(api::message::tool_call::Tool::SearchCodebase(
+        api::message::tool_call::SearchCodebase {
+            query: required_string(args, "query")?,
+            path_filters: optional_string_array(args, "path_filters")?,
+            codebase_path: optional_string(args, "codebase_path").unwrap_or_default(),
+        },
+    ))
+}
+
+fn grep_from_args(args: &Value) -> Result<api::message::tool_call::Tool> {
+    Ok(api::message::tool_call::Tool::Grep(
+        api::message::tool_call::Grep {
+            queries: string_array_or_single(args, "queries", "query")?,
+            path: required_string(args, "path")?,
+        },
+    ))
+}
+
+#[allow(deprecated)]
+fn file_glob_from_args(args: &Value) -> Result<api::message::tool_call::Tool> {
+    Ok(api::message::tool_call::Tool::FileGlob(
+        api::message::tool_call::FileGlob {
+            patterns: string_array_or_single(args, "patterns", "pattern")?,
+            path: required_string(args, "path")?,
+        },
+    ))
+}
+
+fn file_glob_v2_from_args(args: &Value) -> Result<api::message::tool_call::Tool> {
+    Ok(api::message::tool_call::Tool::FileGlobV2(
+        api::message::tool_call::FileGlobV2 {
+            patterns: string_array_or_single(args, "patterns", "pattern")?,
+            search_dir: required_string(args, "search_dir")?,
+            max_matches: optional_non_negative_i32(args, "max_matches")?.unwrap_or_default(),
+            max_depth: optional_non_negative_i32(args, "max_depth")?.unwrap_or_default(),
+            min_depth: optional_non_negative_i32(args, "min_depth")?.unwrap_or_default(),
+        },
+    ))
+}
+
+fn read_mcp_resource_from_args(args: &Value) -> Result<api::message::tool_call::Tool> {
+    Ok(api::message::tool_call::Tool::ReadMcpResource(
+        api::message::tool_call::ReadMcpResource {
+            uri: required_string(args, "uri")?,
+            server_id: optional_string(args, "server_id").unwrap_or_default(),
+        },
+    ))
+}
+
+fn v4a_update_from_value(
+    value: &Value,
+) -> Result<api::message::tool_call::apply_file_diffs::V4aFileUpdate> {
+    let hunks = optional_array(value, "hunks")
+        .into_iter()
+        .flatten()
+        .map(|hunk| {
+            Ok(
+                api::message::tool_call::apply_file_diffs::v4a_file_update::Hunk {
+                    change_context: optional_string_array(hunk, "change_context")?,
+                    pre_context: optional_string(hunk, "pre_context").unwrap_or_default(),
+                    old: optional_string(hunk, "old").unwrap_or_default(),
+                    new: optional_string(hunk, "new").unwrap_or_default(),
+                    post_context: optional_string(hunk, "post_context").unwrap_or_default(),
+                },
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(api::message::tool_call::apply_file_diffs::V4aFileUpdate {
+        file_path: required_string(value, "file_path")?,
+        move_to: optional_string(value, "move_to").unwrap_or_default(),
+        hunks,
+    })
+}
+
+fn line_range_from_value(value: &Value) -> Result<api::FileContentLineRange> {
+    let start = required_positive_u32(value, "start")?;
+    let end = required_positive_u32(value, "end")?;
+    if end < start {
+        bail!("`end` must be greater than or equal to `start`");
+    }
+
+    Ok(api::FileContentLineRange { start, end })
+}
+
+fn result_to_openai_content(result: &api::request::input::ToolCallResult) -> String {
+    use api::request::input::tool_call_result::Result as ResultType;
+
+    let value = match result.result.as_ref() {
+        Some(ResultType::RunShellCommand(result)) => run_shell_command_result_to_json(result),
+        Some(ResultType::WriteToLongRunningShellCommand(result)) => {
+            write_to_long_running_shell_command_result_to_json(result)
+        }
+        Some(ResultType::ReadShellCommandOutput(result)) => {
+            read_shell_command_output_result_to_json(result)
+        }
+        Some(ResultType::ReadFiles(result)) => read_files_result_to_json(result),
+        Some(ResultType::ApplyFileDiffs(result)) => apply_file_diffs_result_to_json(result),
+        Some(ResultType::SearchCodebase(result)) => search_codebase_result_to_json(result),
+        Some(ResultType::Grep(result)) => grep_result_to_json(result),
+        #[allow(deprecated)]
+        Some(ResultType::FileGlob(result)) => file_glob_result_to_json(result),
+        Some(ResultType::FileGlobV2(result)) => file_glob_v2_result_to_json(result),
+        Some(ResultType::ReadMcpResource(result)) => read_mcp_resource_result_to_json(result),
+        Some(ResultType::CallMcpTool(result)) => call_mcp_tool_result_to_json(result),
+        Some(other) => json!({
+            "status": "unsupported_result_type",
+            "debug": format!("{other:?}"),
+        }),
+        None => json!({ "status": "cancelled_or_empty" }),
+    };
+
+    serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+}
+
+fn run_shell_command_result_to_json(result: &api::RunShellCommandResult) -> Value {
+    use api::run_shell_command_result::Result as ShellResult;
+    match &result.result {
+        Some(ShellResult::CommandFinished(finished)) => json!({
+            "status": "finished",
+            "command": result.command,
+            "command_id": finished.command_id,
+            "output": finished.output,
+            "exit_code": finished.exit_code,
+        }),
+        Some(ShellResult::LongRunningCommandSnapshot(snapshot)) => {
+            long_running_snapshot_to_json("long_running_snapshot", Some(&result.command), snapshot)
+        }
+        Some(ShellResult::PermissionDenied(_)) => json!({
+            "status": "permission_denied",
+            "command": result.command,
+        }),
+        None => json!({ "status": "cancelled", "command": result.command }),
+    }
+}
+
+fn write_to_long_running_shell_command_result_to_json(
+    result: &api::WriteToLongRunningShellCommandResult,
+) -> Value {
+    use api::write_to_long_running_shell_command_result::Result as WriteResult;
+    match &result.result {
+        Some(WriteResult::CommandFinished(finished)) => {
+            shell_finished_to_json("finished", finished)
+        }
+        Some(WriteResult::LongRunningCommandSnapshot(snapshot)) => {
+            long_running_snapshot_to_json("long_running_snapshot", None, snapshot)
+        }
+        Some(WriteResult::Error(_)) => json!({ "status": "error", "message": "command not found" }),
+        None => json!({ "status": "cancelled" }),
+    }
+}
+
+fn read_shell_command_output_result_to_json(result: &api::ReadShellCommandOutputResult) -> Value {
+    use api::read_shell_command_output_result::Result as ReadResult;
+    match &result.result {
+        Some(ReadResult::CommandFinished(finished)) => {
+            let mut value = shell_finished_to_json("finished", finished);
+            value["command"] = json!(result.command);
+            value
+        }
+        Some(ReadResult::LongRunningCommandSnapshot(snapshot)) => {
+            long_running_snapshot_to_json("long_running_snapshot", Some(&result.command), snapshot)
+        }
+        Some(ReadResult::Error(_)) => json!({
+            "status": "error",
+            "command": result.command,
+            "message": "command not found",
+        }),
+        None => json!({ "status": "cancelled", "command": result.command }),
+    }
+}
+
+fn read_files_result_to_json(result: &api::ReadFilesResult) -> Value {
+    use api::read_files_result::Result as ReadResult;
+    match &result.result {
+        Some(ReadResult::TextFilesSuccess(success)) => json!({
+            "status": "success",
+            "files": success.files.iter().map(file_content_to_json).collect::<Vec<_>>(),
+        }),
+        Some(ReadResult::AnyFilesSuccess(success)) => json!({
+            "status": "success",
+            "files": success.files.iter().map(any_file_content_to_json).collect::<Vec<_>>(),
+        }),
+        Some(ReadResult::Error(error)) => json!({ "status": "error", "message": error.message }),
+        None => json!({ "status": "cancelled" }),
+    }
+}
+
+fn apply_file_diffs_result_to_json(result: &api::ApplyFileDiffsResult) -> Value {
+    use api::apply_file_diffs_result::Result as ApplyResult;
+    match &result.result {
+        Some(ApplyResult::Success(success)) => json!({
+            "status": "success",
+            "updated_files": success.updated_files_v2.iter().filter_map(|file| file.file.as_ref()).map(file_content_to_json).collect::<Vec<_>>(),
+            "deleted_files": success.deleted_files.iter().map(|file| file.file_path.clone()).collect::<Vec<_>>(),
+        }),
+        Some(ApplyResult::Error(error)) => json!({ "status": "error", "message": error.message }),
+        None => json!({ "status": "cancelled" }),
+    }
+}
+
+fn search_codebase_result_to_json(result: &api::SearchCodebaseResult) -> Value {
+    use api::search_codebase_result::Result as SearchResult;
+    match &result.result {
+        Some(SearchResult::Success(success)) => json!({
+            "status": "success",
+            "files": success.files.iter().map(file_content_to_json).collect::<Vec<_>>(),
+        }),
+        Some(SearchResult::Error(error)) => json!({ "status": "error", "message": error.message }),
+        None => json!({ "status": "cancelled" }),
+    }
+}
+
+fn grep_result_to_json(result: &api::GrepResult) -> Value {
+    use api::grep_result::Result as GrepResult;
+    match &result.result {
+        Some(GrepResult::Success(success)) => json!({
+            "status": "success",
+            "matched_files": success.matched_files.iter().map(|file| json!({
+                "file_path": file.file_path,
+                "matched_lines": file.matched_lines.iter().map(|line| line.line_number).collect::<Vec<_>>(),
+            })).collect::<Vec<_>>(),
+        }),
+        Some(GrepResult::Error(error)) => json!({ "status": "error", "message": error.message }),
+        None => json!({ "status": "cancelled" }),
+    }
+}
+
+#[allow(deprecated)]
+fn file_glob_result_to_json(result: &api::FileGlobResult) -> Value {
+    use api::file_glob_result::Result as GlobResult;
+    match &result.result {
+        Some(GlobResult::Success(success)) => json!({
+            "status": "success",
+            "matched_files": success.matched_files,
+        }),
+        Some(GlobResult::Error(error)) => json!({ "status": "error", "message": error.message }),
+        None => json!({ "status": "cancelled" }),
+    }
+}
+
+fn file_glob_v2_result_to_json(result: &api::FileGlobV2Result) -> Value {
+    use api::file_glob_v2_result::Result as GlobResult;
+    match &result.result {
+        Some(GlobResult::Success(success)) => json!({
+            "status": "success",
+            "matched_files": success.matched_files.iter().map(|file| file.file_path.clone()).collect::<Vec<_>>(),
+            "warnings": success.warnings,
+        }),
+        Some(GlobResult::Error(error)) => json!({ "status": "error", "message": error.message }),
+        None => json!({ "status": "cancelled" }),
+    }
+}
+
+fn read_mcp_resource_result_to_json(result: &api::ReadMcpResourceResult) -> Value {
+    use api::read_mcp_resource_result::Result as ReadResult;
+    match &result.result {
+        Some(ReadResult::Success(success)) => json!({
+            "status": "success",
+            "contents": success.contents.iter().map(mcp_resource_content_to_json).collect::<Vec<_>>(),
+        }),
+        Some(ReadResult::Error(error)) => json!({ "status": "error", "message": error.message }),
+        None => json!({ "status": "cancelled" }),
+    }
+}
+
+fn call_mcp_tool_result_to_json(result: &api::CallMcpToolResult) -> Value {
+    use api::call_mcp_tool_result::Result as CallResult;
+    match &result.result {
+        Some(CallResult::Success(success)) => json!({
+            "status": "success",
+            "results": success.results.iter().map(mcp_tool_result_to_json).collect::<Vec<_>>(),
+        }),
+        Some(CallResult::Error(error)) => json!({ "status": "error", "message": error.message }),
+        None => json!({ "status": "cancelled" }),
+    }
+}
+
+fn shell_finished_to_json(status: &str, finished: &api::ShellCommandFinished) -> Value {
+    json!({
+        "status": status,
+        "command_id": finished.command_id,
+        "output": finished.output,
+        "exit_code": finished.exit_code,
+    })
+}
+
+fn long_running_snapshot_to_json(
+    status: &str,
+    command: Option<&str>,
+    snapshot: &api::LongRunningShellCommandSnapshot,
+) -> Value {
+    json!({
+        "status": status,
+        "command": command.unwrap_or_default(),
+        "command_id": snapshot.command_id,
+        "output": snapshot.output,
+        "cursor": snapshot.cursor,
+        "is_alt_screen_active": snapshot.is_alt_screen_active,
+        "is_preempted": snapshot.is_preempted,
+    })
+}
+
+fn file_content_to_json(file: &api::FileContent) -> Value {
+    json!({
+        "file_path": file.file_path,
+        "content": file.content,
+        "line_range": file.line_range.as_ref().map(|range| json!({ "start": range.start, "end": range.end })),
+    })
+}
+
+fn any_file_content_to_json(file: &api::AnyFileContent) -> Value {
+    match &file.content {
+        Some(api::any_file_content::Content::TextContent(text)) => file_content_to_json(text),
+        Some(api::any_file_content::Content::BinaryContent(binary)) => json!({
+            "file_path": binary.file_path,
+            "binary_bytes": binary.data.len(),
+            "content": "[binary file omitted]",
+        }),
+        None => json!({ "content": "[empty file result]" }),
+    }
+}
+
+fn mcp_resource_content_to_json(content: &api::McpResourceContent) -> Value {
+    match &content.content_type {
+        Some(api::mcp_resource_content::ContentType::Text(text)) => json!({
+            "uri": content.uri,
+            "mime_type": text.mime_type,
+            "text": text.content,
+        }),
+        Some(api::mcp_resource_content::ContentType::Binary(binary)) => json!({
+            "uri": content.uri,
+            "mime_type": binary.mime_type,
+            "binary_bytes": binary.data.len(),
+            "content": "[binary MCP resource omitted]",
+        }),
+        None => json!({ "uri": content.uri, "text": "" }),
+    }
+}
+
+fn mcp_tool_result_to_json(result: &api::call_mcp_tool_result::success::Result) -> Value {
+    use api::call_mcp_tool_result::success::result::Result as ToolResult;
+    match &result.result {
+        Some(ToolResult::Text(text)) => json!({ "type": "text", "text": text.text }),
+        Some(ToolResult::Image(image)) => json!({
+            "type": "image",
+            "mime_type": image.mime_type,
+            "bytes": image.data.len(),
+            "content": "[image omitted]",
+        }),
+        Some(ToolResult::Resource(resource)) => {
+            let mut value = mcp_resource_content_to_json(resource);
+            value["type"] = json!("resource");
+            value
+        }
+        None => json!({ "type": "empty", "text": "" }),
+    }
+}
+
+fn parse_arguments(arguments: &str) -> Result<Value> {
+    if arguments.trim().is_empty() {
+        return Ok(json!({}));
+    }
+    let value: Value = serde_json::from_str(arguments)
+        .map_err(|error| anyhow!("failed to parse tool arguments as JSON: {error}"))?;
+    if !value.is_object() {
+        bail!("tool arguments must be a JSON object");
+    }
+    Ok(value)
+}
+
+fn required_string(value: &Value, key: &str) -> Result<String> {
+    optional_string(value, key)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow!("missing required string `{key}`"))
+}
+
+fn optional_string(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(|value| match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    })
+}
+
+fn required_i64(value: &Value, key: &str) -> Result<i64> {
+    optional_i64(value, key).ok_or_else(|| anyhow!("missing required integer `{key}`"))
+}
+
+fn optional_i64(value: &Value, key: &str) -> Option<i64> {
+    value.get(key).and_then(|value| match value {
+        Value::Number(value) => value
+            .as_i64()
+            .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok())),
+        Value::String(value) => value.parse::<i64>().ok(),
+        _ => None,
+    })
+}
+
+fn required_positive_u32(value: &Value, key: &str) -> Result<u32> {
+    let raw = required_i64(value, key)?;
+    if raw < 1 {
+        bail!("`{key}` must be greater than or equal to 1");
+    }
+    u32::try_from(raw).map_err(|_| anyhow!("`{key}` must be less than or equal to u32::MAX"))
+}
+
+fn optional_non_negative_i32(value: &Value, key: &str) -> Result<Option<i32>> {
+    let Some(raw) = optional_i64_checked(value, key)? else {
+        return Ok(None);
+    };
+    if raw < 0 {
+        bail!("`{key}` must be non-negative");
+    }
+    Ok(Some(i32::try_from(raw).map_err(|_| {
+        anyhow!("`{key}` must be less than or equal to i32::MAX")
+    })?))
+}
+
+fn optional_i64_checked(value: &Value, key: &str) -> Result<Option<i64>> {
+    let Some(value) = value.get(key) else {
+        return Ok(None);
+    };
+    match value {
+        Value::Number(number) => {
+            if let Some(value) = number.as_i64() {
+                Ok(Some(value))
+            } else if let Some(value) = number.as_u64() {
+                Ok(Some(i64::try_from(value).map_err(|_| {
+                    anyhow!("`{key}` must be less than or equal to i64::MAX")
+                })?))
+            } else {
+                bail!("`{key}` must be an integer");
+            }
+        }
+        Value::String(value) => value
+            .parse::<i64>()
+            .map(Some)
+            .map_err(|_| anyhow!("`{key}` must be an integer")),
+        _ => bail!("`{key}` must be an integer"),
+    }
+}
+
+fn optional_bool(value: &Value, key: &str) -> Option<bool> {
+    value.get(key).and_then(|value| match value {
+        Value::Bool(value) => Some(*value),
+        Value::String(value) => value.parse::<bool>().ok(),
+        _ => None,
+    })
+}
+
+fn required_array<'a>(value: &'a Value, key: &str) -> Result<&'a Vec<Value>> {
+    optional_array(value, key).ok_or_else(|| anyhow!("missing required array `{key}`"))
+}
+
+fn optional_array<'a>(value: &'a Value, key: &str) -> Option<&'a Vec<Value>> {
+    value.get(key).and_then(Value::as_array)
+}
+
+fn optional_string_array(value: &Value, key: &str) -> Result<Vec<String>> {
+    optional_array(value, key)
+        .into_iter()
+        .flatten()
+        .map(|value| match value {
+            Value::String(value) => Ok(value.clone()),
+            _ => bail!("`{key}` entries must be strings"),
+        })
+        .collect()
+}
+
+fn string_array_or_single(value: &Value, array_key: &str, single_key: &str) -> Result<Vec<String>> {
+    let mut values = optional_string_array(value, array_key)?;
+    if values.is_empty()
+        && let Some(single) = optional_string(value, single_key)
+    {
+        values.push(single);
+    }
+    if values.is_empty() {
+        bail!("missing required string array `{array_key}`");
+    }
+    Ok(values)
+}
+
+fn risk_category_from_str(value: &str) -> Result<api::RiskCategory> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "read_only" | "readonly" => Ok(api::RiskCategory::ReadOnly),
+        "trivial_local_change" | "trivial" => Ok(api::RiskCategory::TrivialLocalChange),
+        "nontrivial_local_change" | "nontrivial" => Ok(api::RiskCategory::NontrivialLocalChange),
+        "external_change" | "external" => Ok(api::RiskCategory::ExternalChange),
+        "risky" => Ok(api::RiskCategory::Risky),
+        "unspecified" | "unknown" => Ok(api::RiskCategory::Unspecified),
+        other => bail!("unknown risk_category `{other}`"),
+    }
+}
+
+fn json_to_struct(value: &Value) -> Result<prost_types::Struct> {
+    let Some(map) = value.as_object() else {
+        bail!("expected JSON object for struct conversion");
+    };
+    Ok(prost_types::Struct {
+        fields: map
+            .iter()
+            .map(|(key, value)| (key.clone(), json_to_prost_value(value)))
+            .collect(),
+    })
+}
+
+fn json_to_prost_value(value: &Value) -> prost_types::Value {
+    use prost_types::value::Kind;
+    prost_types::Value {
+        kind: Some(match value {
+            Value::Null => Kind::NullValue(0),
+            Value::Bool(value) => Kind::BoolValue(*value),
+            Value::Number(value) => Kind::NumberValue(value.as_f64().unwrap_or_default()),
+            Value::String(value) => Kind::StringValue(value.clone()),
+            Value::Array(values) => Kind::ListValue(prost_types::ListValue {
+                values: values.iter().map(json_to_prost_value).collect(),
+            }),
+            Value::Object(map) => Kind::StructValue(prost_types::Struct {
+                fields: map
+                    .iter()
+                    .map(|(key, value)| (key.clone(), json_to_prost_value(value)))
+                    .collect(),
+            }),
+        }),
+    }
+}
+
+fn struct_to_json_value(value: &prost_types::Struct) -> Value {
+    Value::Object(
+        value
+            .fields
+            .iter()
+            .map(|(key, value)| (key.clone(), prost_value_to_json(value)))
+            .collect(),
+    )
+}
+
+fn prost_value_to_json(value: &prost_types::Value) -> Value {
+    use prost_types::value::Kind;
+    match value.kind.as_ref() {
+        Some(Kind::NullValue(_)) | None => Value::Null,
+        Some(Kind::NumberValue(value)) => serde_json::Number::from_f64(*value)
+            .map(Value::Number)
+            .unwrap_or(Value::Null),
+        Some(Kind::StringValue(value)) => Value::String(value.clone()),
+        Some(Kind::BoolValue(value)) => Value::Bool(*value),
+        Some(Kind::StructValue(value)) => struct_to_json_value(value),
+        Some(Kind::ListValue(value)) => {
+            Value::Array(value.values.iter().map(prost_value_to_json).collect())
+        }
+    }
+}
+
+fn empty_object_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {}
+    })
+}
+
+fn openai_compatible_object_schema(schema: Value) -> Value {
+    let Value::Object(mut object) = schema else {
+        tracing::warn!("dropping non-object tool schema before sending it upstream");
+        return empty_object_schema();
+    };
+
+    match object.get("type").and_then(Value::as_str) {
+        Some("object") => {}
+        None => {
+            object.insert("type".to_string(), json!("object"));
+        }
+        Some(schema_type) => {
+            tracing::warn!(
+                schema_type,
+                "dropping non-object tool schema before sending it upstream"
+            );
+            return empty_object_schema();
+        }
+    }
+
+    if !matches!(object.get("properties"), Some(Value::Object(_))) {
+        object.insert("properties".to_string(), json!({}));
+    }
+
+    let property_names = object
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|properties| properties.keys().cloned().collect::<BTreeSet<_>>())
+        .unwrap_or_default();
+    let required_is_valid = object
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|required| {
+            required.iter().all(|value| {
+                value
+                    .as_str()
+                    .is_some_and(|name| property_names.contains(name))
+            })
+        })
+        .unwrap_or(true);
+    if !required_is_valid {
+        tracing::warn!("dropping invalid tool schema `required` list before sending it upstream");
+        object.remove("required");
+    }
+
+    Value::Object(object)
+}
+
+fn sanitize_openai_name_part(value: &str, max_len: usize) -> String {
+    let mut sanitized = String::new();
+    let mut previous_was_separator = false;
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            sanitized.push(ch);
+            previous_was_separator = false;
+        } else if !previous_was_separator {
+            sanitized.push('_');
+            previous_was_separator = true;
+        }
+    }
+    let sanitized = sanitized.trim_matches('_');
+    let sanitized = if sanitized.is_empty() {
+        "tool".to_string()
+    } else {
+        sanitized.to_string()
+    };
+    sanitized.chars().take(max_len).collect()
+}
+
+fn unique_tool_name(base_name: String, used_names: &mut BTreeSet<String>) -> String {
+    let mut candidate: String = base_name.chars().take(64).collect();
+    if used_names.insert(candidate.clone()) {
+        return candidate;
+    }
+
+    let mut suffix_number = 2usize;
+    loop {
+        let suffix = format!("_{suffix_number}");
+        let prefix_len = 64usize.saturating_sub(suffix.len());
+        candidate = format!(
+            "{}{}",
+            base_name.chars().take(prefix_len).collect::<String>(),
+            suffix
+        );
+        if used_names.insert(candidate.clone()) {
+            return candidate;
+        }
+        suffix_number += 1;
+    }
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}
+
+#[cfg(test)]
+#[path = "tool_registry_tests.rs"]
+mod tests;

--- a/crates/warp_shim_server/src/upstream/tool_registry_tests.rs
+++ b/crates/warp_shim_server/src/upstream/tool_registry_tests.rs
@@ -1,0 +1,649 @@
+use serde_json::json;
+use warp_multi_agent_api as api;
+
+use super::*;
+use crate::{
+    config::FeatureConfig,
+    upstream::openai::{OpenAiToolCall, OpenAiToolCallFunction},
+};
+
+#[test]
+fn run_shell_command_adapter_roundtrips_representative_payload() {
+    let registry = registry_for_tools(&[api::ToolType::RunShellCommand]);
+    let converted = convert(
+        &registry,
+        "run_shell_command",
+        json!({
+            "command": "pwd",
+            "risk_category": "read_only",
+            "wait_until_complete": true
+        }),
+    );
+
+    let Some(api::message::tool_call::Tool::RunShellCommand(call)) = converted.tool_call.tool
+    else {
+        panic!("expected RunShellCommand tool call");
+    };
+    assert_eq!(call.command, "pwd");
+    assert_eq!(call.risk_category, api::RiskCategory::ReadOnly as i32);
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(
+            api::request::input::tool_call_result::Result::RunShellCommand(
+                api::RunShellCommandResult {
+                    command: "pwd".to_string(),
+                    result: Some(api::run_shell_command_result::Result::CommandFinished(
+                        api::ShellCommandFinished {
+                            command_id: "cmd-1".to_string(),
+                            output: "/tmp\n".to_string(),
+                            exit_code: 0,
+                        },
+                    )),
+                    ..Default::default()
+                },
+            ),
+        ),
+    });
+    assert!(content.contains("/tmp"));
+}
+
+#[test]
+fn write_to_long_running_shell_command_adapter_roundtrips_representative_payload() {
+    let registry = registry_for_tools(&[api::ToolType::WriteToLongRunningShellCommand]);
+    let converted = convert(
+        &registry,
+        "write_to_long_running_shell_command",
+        json!({ "command_id": "cmd-1", "input": "q", "mode": "line" }),
+    );
+
+    let Some(api::message::tool_call::Tool::WriteToLongRunningShellCommand(call)) =
+        converted.tool_call.tool
+    else {
+        panic!("expected WriteToLongRunningShellCommand tool call");
+    };
+    assert_eq!(call.command_id, "cmd-1");
+    assert_eq!(call.input, b"q".to_vec());
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(
+            api::request::input::tool_call_result::Result::WriteToLongRunningShellCommand(
+                api::WriteToLongRunningShellCommandResult {
+                    result: Some(
+                        api::write_to_long_running_shell_command_result::Result::CommandFinished(
+                            api::ShellCommandFinished {
+                                command_id: "cmd-1".to_string(),
+                                output: "done".to_string(),
+                                exit_code: 0,
+                            },
+                        ),
+                    ),
+                },
+            ),
+        ),
+    });
+    assert!(content.contains("done"));
+}
+
+#[test]
+fn read_shell_command_output_adapter_roundtrips_representative_payload() {
+    let registry = registry_for_tools(&[api::ToolType::ReadShellCommandOutput]);
+    let converted = convert(
+        &registry,
+        "read_shell_command_output",
+        json!({ "command_id": "cmd-1", "delay_ms": 250 }),
+    );
+
+    let Some(api::message::tool_call::Tool::ReadShellCommandOutput(call)) =
+        converted.tool_call.tool
+    else {
+        panic!("expected ReadShellCommandOutput tool call");
+    };
+    assert_eq!(call.command_id, "cmd-1");
+    assert!(matches!(
+        call.delay,
+        Some(api::message::tool_call::read_shell_command_output::Delay::Duration(_))
+    ));
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(
+            api::request::input::tool_call_result::Result::ReadShellCommandOutput(
+                api::ReadShellCommandOutputResult {
+                    command: "npm test".to_string(),
+                    result: Some(
+                        api::read_shell_command_output_result::Result::LongRunningCommandSnapshot(
+                            api::LongRunningShellCommandSnapshot {
+                                command_id: "cmd-1".to_string(),
+                                output: "still running".to_string(),
+                                is_preempted: true,
+                                ..Default::default()
+                            },
+                        ),
+                    ),
+                },
+            ),
+        ),
+    });
+    assert!(content.contains("still running"));
+}
+
+#[test]
+fn read_files_adapter_roundtrips_representative_payload() {
+    let registry = registry_for_tools(&[api::ToolType::ReadFiles]);
+    let converted = convert(
+        &registry,
+        "read_files",
+        json!({ "files": [{ "name": "src/main.rs", "line_ranges": [{ "start": 1, "end": 3 }] }] }),
+    );
+
+    let Some(api::message::tool_call::Tool::ReadFiles(call)) = converted.tool_call.tool else {
+        panic!("expected ReadFiles tool call");
+    };
+    assert_eq!(call.files[0].name, "src/main.rs");
+    assert_eq!(call.files[0].line_ranges[0].start, 1);
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(api::request::input::tool_call_result::Result::ReadFiles(
+            api::ReadFilesResult {
+                result: Some(api::read_files_result::Result::TextFilesSuccess(
+                    api::read_files_result::TextFilesSuccess {
+                        files: vec![file_content("src/main.rs", "fn main() {}")],
+                    },
+                )),
+            },
+        )),
+    });
+    assert!(content.contains("fn main"));
+}
+
+#[test]
+fn apply_file_diffs_adapter_roundtrips_representative_payload() {
+    let registry = registry_for_tools(&[api::ToolType::ApplyFileDiffs]);
+    let converted = convert(
+        &registry,
+        "apply_file_diffs",
+        json!({
+            "summary": "edit greeting",
+            "diffs": [{ "file_path": "src/lib.rs", "search": "hello", "replace": "hi" }],
+            "new_files": [{ "file_path": "README.md", "content": "docs" }],
+            "deleted_files": [{ "file_path": "old.txt" }]
+        }),
+    );
+
+    let Some(api::message::tool_call::Tool::ApplyFileDiffs(call)) = converted.tool_call.tool else {
+        panic!("expected ApplyFileDiffs tool call");
+    };
+    assert_eq!(call.summary, "edit greeting");
+    assert_eq!(call.diffs[0].replace, "hi");
+    assert_eq!(call.new_files[0].file_path, "README.md");
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(
+            api::request::input::tool_call_result::Result::ApplyFileDiffs(
+                api::ApplyFileDiffsResult {
+                    result: Some(api::apply_file_diffs_result::Result::Success(
+                        api::apply_file_diffs_result::Success {
+                            updated_files_v2: vec![
+                                api::apply_file_diffs_result::success::UpdatedFileContent {
+                                    file: Some(file_content("src/lib.rs", "hi")),
+                                    was_edited_by_user: false,
+                                },
+                            ],
+                            deleted_files: vec![
+                                api::apply_file_diffs_result::success::DeletedFile {
+                                    file_path: "old.txt".to_string(),
+                                },
+                            ],
+                            ..Default::default()
+                        },
+                    )),
+                },
+            ),
+        ),
+    });
+    assert!(content.contains("old.txt"));
+}
+
+#[test]
+fn search_codebase_adapter_roundtrips_representative_payload() {
+    let registry = registry_for_tools(&[api::ToolType::SearchCodebase]);
+    let converted = convert(
+        &registry,
+        "search_codebase",
+        json!({ "query": "routing state", "path_filters": ["crates/**"], "codebase_path": "/repo" }),
+    );
+
+    let Some(api::message::tool_call::Tool::SearchCodebase(call)) = converted.tool_call.tool else {
+        panic!("expected SearchCodebase tool call");
+    };
+    assert_eq!(call.query, "routing state");
+    assert_eq!(call.path_filters, vec!["crates/**".to_string()]);
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(
+            api::request::input::tool_call_result::Result::SearchCodebase(
+                api::SearchCodebaseResult {
+                    result: Some(api::search_codebase_result::Result::Success(
+                        api::search_codebase_result::Success {
+                            files: vec![file_content("crates/x.rs", "match route")],
+                        },
+                    )),
+                },
+            ),
+        ),
+    });
+    assert!(content.contains("match route"));
+}
+
+#[test]
+fn grep_adapter_roundtrips_representative_payload() {
+    let registry = registry_for_tools(&[api::ToolType::Grep]);
+    let converted = convert(
+        &registry,
+        "grep",
+        json!({ "queries": ["TODO"], "path": "src" }),
+    );
+
+    let Some(api::message::tool_call::Tool::Grep(call)) = converted.tool_call.tool else {
+        panic!("expected Grep tool call");
+    };
+    assert_eq!(call.queries, vec!["TODO".to_string()]);
+    assert_eq!(call.path, "src");
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(api::request::input::tool_call_result::Result::Grep(
+            api::GrepResult {
+                result: Some(api::grep_result::Result::Success(
+                    api::grep_result::Success {
+                        matched_files: vec![api::grep_result::success::GrepFileMatch {
+                            file_path: "src/lib.rs".to_string(),
+                            matched_lines: vec![
+                                api::grep_result::success::grep_file_match::GrepLineMatch {
+                                    line_number: 7,
+                                },
+                            ],
+                        }],
+                    },
+                )),
+            },
+        )),
+    });
+    assert!(content.contains("src/lib.rs"));
+}
+
+#[test]
+#[allow(deprecated)]
+fn file_glob_adapter_roundtrips_representative_payload() {
+    let registry = registry_for_tools(&[api::ToolType::FileGlob]);
+    let converted = convert(
+        &registry,
+        "file_glob",
+        json!({ "patterns": ["*.rs"], "path": "src" }),
+    );
+
+    let Some(api::message::tool_call::Tool::FileGlob(call)) = converted.tool_call.tool else {
+        panic!("expected FileGlob tool call");
+    };
+    assert_eq!(call.patterns, vec!["*.rs".to_string()]);
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(api::request::input::tool_call_result::Result::FileGlob(
+            api::FileGlobResult {
+                result: Some(api::file_glob_result::Result::Success(
+                    api::file_glob_result::Success {
+                        matched_files: "src/lib.rs\nsrc/main.rs".to_string(),
+                    },
+                )),
+            },
+        )),
+    });
+    assert!(content.contains("src/main.rs"));
+}
+
+#[test]
+fn file_glob_v2_adapter_roundtrips_representative_payload() {
+    let registry = registry_for_tools(&[api::ToolType::FileGlobV2]);
+    let converted = convert(
+        &registry,
+        "file_glob_v2",
+        json!({ "patterns": ["*.rs"], "search_dir": "src", "max_matches": 10, "max_depth": 2 }),
+    );
+
+    let Some(api::message::tool_call::Tool::FileGlobV2(call)) = converted.tool_call.tool else {
+        panic!("expected FileGlobV2 tool call");
+    };
+    assert_eq!(call.search_dir, "src");
+    assert_eq!(call.max_matches, 10);
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(api::request::input::tool_call_result::Result::FileGlobV2(
+            api::FileGlobV2Result {
+                result: Some(api::file_glob_v2_result::Result::Success(
+                    api::file_glob_v2_result::Success {
+                        matched_files: vec![api::file_glob_v2_result::success::FileGlobMatch {
+                            file_path: "src/lib.rs".to_string(),
+                        }],
+                        warnings: String::new(),
+                    },
+                )),
+            },
+        )),
+    });
+    assert!(content.contains("src/lib.rs"));
+}
+
+#[test]
+fn read_shell_command_output_rejects_negative_delay() {
+    let registry = registry_for_tools(&[api::ToolType::ReadShellCommandOutput]);
+    let error = convert_error(
+        &registry,
+        "read_shell_command_output",
+        json!({ "command_id": "cmd-1", "delay_ms": -1 }),
+    );
+
+    assert!(error.contains("delay_ms"));
+    assert!(error.contains("non-negative"));
+}
+
+#[test]
+fn read_files_rejects_invalid_line_ranges() {
+    let registry = registry_for_tools(&[api::ToolType::ReadFiles]);
+    for args in [
+        json!({ "files": [{ "name": "src/main.rs", "line_ranges": [{ "start": 0, "end": 3 }] }] }),
+        json!({ "files": [{ "name": "src/main.rs", "line_ranges": [{ "start": 4, "end": 3 }] }] }),
+        json!({ "files": [{ "name": "src/main.rs", "line_ranges": [{ "start": 1, "end": u64::from(u32::MAX) + 1 }] }] }),
+    ] {
+        let error = convert_error(&registry, "read_files", args);
+        assert!(
+            error.contains("start") || error.contains("end"),
+            "unexpected error: {error}"
+        );
+    }
+}
+
+#[test]
+fn file_glob_v2_rejects_negative_and_overflowing_limits() {
+    let registry = registry_for_tools(&[api::ToolType::FileGlobV2]);
+    for (field, value, expected) in [
+        ("max_matches", json!(-1), "non-negative"),
+        ("max_depth", json!(i64::from(i32::MAX) + 1), "i32::MAX"),
+        ("min_depth", json!(u64::MAX), "i64::MAX"),
+    ] {
+        let mut args = json!({ "patterns": ["*.rs"], "search_dir": "src" });
+        args[field] = value;
+        let error = convert_error(&registry, "file_glob_v2", args);
+        assert!(error.contains(field), "unexpected error: {error}");
+        assert!(error.contains(expected), "unexpected error: {error}");
+    }
+}
+
+#[test]
+fn read_mcp_resource_adapter_roundtrips_representative_payload() {
+    let registry = registry_for_tools(&[api::ToolType::ReadMcpResource]);
+    let converted = convert(
+        &registry,
+        "read_mcp_resource",
+        json!({ "uri": "file://resource", "server_id": "server-1" }),
+    );
+
+    let Some(api::message::tool_call::Tool::ReadMcpResource(call)) = converted.tool_call.tool
+    else {
+        panic!("expected ReadMcpResource tool call");
+    };
+    assert_eq!(call.uri, "file://resource");
+    assert_eq!(call.server_id, "server-1");
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(
+            api::request::input::tool_call_result::Result::ReadMcpResource(
+                api::ReadMcpResourceResult {
+                    result: Some(api::read_mcp_resource_result::Result::Success(
+                        api::read_mcp_resource_result::Success {
+                            contents: vec![api::McpResourceContent {
+                                uri: "file://resource".to_string(),
+                                content_type: Some(api::mcp_resource_content::ContentType::Text(
+                                    api::mcp_resource_content::Text {
+                                        content: "resource body".to_string(),
+                                        mime_type: "text/plain".to_string(),
+                                    },
+                                )),
+                            }],
+                        },
+                    )),
+                },
+            ),
+        ),
+    });
+    assert!(content.contains("resource body"));
+}
+
+#[test]
+fn mcp_tool_adapter_roundtrips_representative_payload_and_routes_to_original_server_tool() {
+    let registry = registry_with_mcp_tool();
+    let openai_tool = registry
+        .openai_tools()
+        .into_iter()
+        .find(|tool| {
+            tool.function
+                .name
+                .starts_with("mcp__linear_prod__create_issue")
+        })
+        .expect("MCP tool declaration exists");
+    assert_eq!(
+        openai_tool.function.parameters["properties"]["title"]["type"],
+        "string"
+    );
+
+    let converted = convert(
+        &registry,
+        &openai_tool.function.name,
+        json!({ "title": "Bug", "priority": 1 }),
+    );
+
+    let Some(api::message::tool_call::Tool::CallMcpTool(call)) = converted.tool_call.tool else {
+        panic!("expected CallMcpTool tool call");
+    };
+    assert_eq!(call.server_id, "linear-prod");
+    assert_eq!(call.name, "create.issue");
+    let args = super::struct_to_json_value(call.args.as_ref().unwrap());
+    assert_eq!(args["title"], "Bug");
+
+    let content = registry.result_to_openai_content(&api::request::input::ToolCallResult {
+        tool_call_id: "warp-call".to_string(),
+        result: Some(api::request::input::tool_call_result::Result::CallMcpTool(
+            api::CallMcpToolResult {
+                result: Some(api::call_mcp_tool_result::Result::Success(
+                    api::call_mcp_tool_result::Success {
+                        results: vec![api::call_mcp_tool_result::success::Result {
+                            result: Some(api::call_mcp_tool_result::success::result::Result::Text(
+                                api::call_mcp_tool_result::success::result::Text {
+                                    text: "created LIN-1".to_string(),
+                                },
+                            )),
+                        }],
+                    },
+                )),
+            },
+        )),
+    });
+    assert!(content.contains("LIN-1"));
+}
+
+#[test]
+fn registry_omits_explicitly_unsupported_tools() {
+    let registry = registry_for_tools(&[api::ToolType::StartAgent, api::ToolType::UseComputer]);
+    assert!(registry.openai_tools().is_empty());
+}
+
+#[test]
+fn declared_tool_schemas_are_openai_compatible_json_schema_objects() {
+    #[derive(serde::Deserialize)]
+    struct FunctionSchema {
+        #[serde(rename = "type")]
+        schema_type: String,
+        properties: serde_json::Map<String, serde_json::Value>,
+        #[serde(default)]
+        required: Vec<String>,
+    }
+
+    let registry = registry_for_tools(&[
+        api::ToolType::RunShellCommand,
+        api::ToolType::WriteToLongRunningShellCommand,
+        api::ToolType::ReadShellCommandOutput,
+        api::ToolType::ReadFiles,
+        api::ToolType::ApplyFileDiffs,
+        api::ToolType::SearchCodebase,
+        api::ToolType::Grep,
+        api::ToolType::FileGlob,
+        api::ToolType::FileGlobV2,
+        api::ToolType::ReadMcpResource,
+    ]);
+
+    for tool in registry.openai_tools() {
+        let schema: FunctionSchema =
+            serde_json::from_value(tool.function.parameters.clone()).unwrap();
+        assert_eq!(schema.schema_type, "object", "{}", tool.function.name);
+        for required in &schema.required {
+            assert!(
+                schema.properties.contains_key(required),
+                "{} required unknown property `{}`",
+                tool.function.name,
+                required
+            );
+        }
+    }
+}
+
+#[test]
+fn mcp_tool_schema_is_normalized_before_declaration() {
+    let registry = ToolRegistry::for_request(
+        &api::Request {
+            settings: Some(api::request::Settings {
+                supported_tools: vec![api::ToolType::CallMcpTool as i32],
+                ..Default::default()
+            }),
+            mcp_context: Some(api::request::McpContext {
+                servers: vec![api::request::mcp_context::McpServer {
+                    id: "server".to_string(),
+                    name: "Server".to_string(),
+                    tools: vec![api::request::mcp_context::McpTool {
+                        name: "broken".to_string(),
+                        input_schema: Some(
+                            super::json_to_struct(&json!({
+                                "properties": { "query": { "type": "string" } },
+                                "required": ["query"]
+                            }))
+                            .unwrap(),
+                        ),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        &FeatureConfig::default(),
+    );
+
+    let tool = registry.openai_tools().remove(0);
+    assert_eq!(tool.function.parameters["type"], "object");
+    assert_eq!(
+        tool.function.parameters["properties"]["query"]["type"],
+        "string"
+    );
+}
+
+fn registry_for_tools(tools: &[api::ToolType]) -> ToolRegistry {
+    ToolRegistry::for_request(
+        &api::Request {
+            settings: Some(api::request::Settings {
+                supported_tools: tools.iter().map(|tool| *tool as i32).collect(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        &FeatureConfig::default(),
+    )
+}
+
+fn registry_with_mcp_tool() -> ToolRegistry {
+    ToolRegistry::for_request(
+        &api::Request {
+            settings: Some(api::request::Settings {
+                supported_tools: vec![api::ToolType::CallMcpTool as i32],
+                ..Default::default()
+            }),
+            mcp_context: Some(api::request::McpContext {
+                servers: vec![api::request::mcp_context::McpServer {
+                    id: "linear-prod".to_string(),
+                    name: "Linear Prod".to_string(),
+                    tools: vec![api::request::mcp_context::McpTool {
+                        name: "create.issue".to_string(),
+                        description: "Create a Linear issue".to_string(),
+                        input_schema: Some(
+                            super::json_to_struct(&json!({
+                                "type": "object",
+                                "properties": {
+                                    "title": { "type": "string" },
+                                    "priority": { "type": "integer" }
+                                },
+                                "required": ["title"]
+                            }))
+                            .unwrap(),
+                        ),
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        &FeatureConfig::default(),
+    )
+}
+
+fn convert(registry: &ToolRegistry, name: &str, args: serde_json::Value) -> WarpToolCall {
+    convert_result(registry, name, args).unwrap()
+}
+
+fn convert_error(registry: &ToolRegistry, name: &str, args: serde_json::Value) -> String {
+    convert_result(registry, name, args)
+        .unwrap_err()
+        .to_string()
+}
+
+fn convert_result(
+    registry: &ToolRegistry,
+    name: &str,
+    args: serde_json::Value,
+) -> anyhow::Result<WarpToolCall> {
+    registry.convert_openai_tool_call(
+        &OpenAiToolCall {
+            id: "openai-call".to_string(),
+            kind: "function".to_string(),
+            function: OpenAiToolCallFunction {
+                name: name.to_string(),
+                arguments: args.to_string(),
+            },
+        },
+        "warp-call".to_string(),
+    )
+}
+
+fn file_content(path: &str, content: &str) -> api::FileContent {
+    api::FileContent {
+        file_path: path.to_string(),
+        content: content.to_string(),
+        line_range: None,
+    }
+}


### PR DESCRIPTION
### **code not reviewed, use at your own risk**

It works, but it is not necessarily safe... think twice before running this.

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
