### PR TITLE
Fix git diff chip flicker by not running shell fallback under GitRepoStatusModel

### DIFF
--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -1041,15 +1041,24 @@ impl CurrentPrompt {
                 }
                 RefreshConfig::Periodically { .. } => {
                     if self.is_updated_externally(chip_kind) {
-                        let initial_gen = chip_kind.initial_value_generator();
-                        let generator = initial_gen.as_ref().unwrap_or(chip.generator());
-                        self.fetch_chip_value_once(
-                            chip_kind,
-                            generator,
-                            chip.on_click_generator().cloned(),
-                            true,
-                            ctx,
-                        );
+                        // The chip is being kept up to date by an external source (e.g. the
+                        // filesystem-watching `GitRepoStatusModel`). Only run an initial fetch
+                        // here when the chip provides a contextual `initial_value_generator`
+                        // — those compute their value from `PromptContext` and can't disagree
+                        // with the external source. Falling back to `chip.generator()` would
+                        // run the chip's shell command (e.g. `git diff --shortstat HEAD` for
+                        // `GitDiffStats`), which can produce a different value than the
+                        // external source and cause a brief flicker before the next external
+                        // update overwrites it (see issue #9228).
+                        if let Some(initial_gen) = chip_kind.initial_value_generator() {
+                            self.fetch_chip_value_once(
+                                chip_kind,
+                                &initial_gen,
+                                chip.on_click_generator().cloned(),
+                                true,
+                                ctx,
+                            );
+                        }
                     } else {
                         self.fetch_chip_value_at_interval(
                             chip_kind,

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -1436,51 +1436,60 @@ impl CurrentPrompt {
                 self.git_repo_status = Some(weak);
                 ctx.subscribe_to_model(&strong, |me, event, ctx| match event {
                     GitRepoStatusEvent::MetadataChanged => {
-                        let metadata = me
-                            .git_repo_status
-                            .as_ref()
-                            .and_then(|w| w.upgrade(ctx))
-                            .and_then(|h| h.as_ref(ctx).metadata().cloned());
-
-                        let Some(metadata) = metadata else {
-                            return;
-                        };
-
-                        // Update ShellGitBranch.
-                        let new_branch = ChipValue::Text(metadata.current_branch_name.clone());
-                        let current_branch = me
-                            .latest_chip_value(&ContextChipKind::ShellGitBranch)
-                            .cloned();
-                        if current_branch.as_ref() != Some(&new_branch) {
-                            me.update_chip_value(
-                                &ContextChipKind::ShellGitBranch,
-                                Some(new_branch),
-                            );
-                            // Refresh the branch dropdown so it stays in sync.
-                            let chip_kind = ContextChipKind::ShellGitBranch;
-                            if let Some(chip) = chip_kind.to_chip() {
-                                if let Some(on_click_gen) = chip.on_click_generator().cloned() {
-                                    me.refresh_on_click_values(&chip_kind, on_click_gen, ctx);
-                                }
-                            }
-                        }
-
-                        // Update GitDiffStats with structured data directly.
-                        let new_diff_stats = ChipValue::GitDiffStats(
-                            GitLineChanges::from_diff_stats(&metadata.stats_against_head),
-                        );
-                        let current_diff_stats = me
-                            .latest_chip_value(&ContextChipKind::GitDiffStats)
-                            .cloned();
-                        if current_diff_stats.as_ref() != Some(&new_diff_stats) {
-                            me.update_chip_value(
-                                &ContextChipKind::GitDiffStats,
-                                Some(new_diff_stats),
-                            );
-                        }
+                        me.apply_git_repo_status_metadata(ctx);
                     }
                 });
+
+                // The model may already have metadata when we attach (e.g. when
+                // a session re-binds to a long-lived `GitRepoStatusModel`). No
+                // `MetadataChanged` event fires from subscribing alone, so apply
+                // any existing metadata once up front; otherwise the chips would
+                // stay empty until the next file event.
+                self.apply_git_repo_status_metadata(ctx);
             }
+        }
+    }
+
+    /// Pulls the current metadata from `git_repo_status` (if any) and pushes it
+    /// into the `ShellGitBranch` and `GitDiffStats` chip values. Used both as
+    /// the body of the `MetadataChanged` subscription callback and as the
+    /// initial-state hydration call from `set_git_repo_status`.
+    #[cfg(feature = "local_fs")]
+    fn apply_git_repo_status_metadata(&mut self, ctx: &mut ModelContext<Self>) {
+        let Some(metadata) = self
+            .git_repo_status
+            .as_ref()
+            .and_then(|w| w.upgrade(ctx))
+            .and_then(|h| h.as_ref(ctx).metadata().cloned())
+        else {
+            return;
+        };
+
+        // Update ShellGitBranch.
+        let new_branch = ChipValue::Text(metadata.current_branch_name.clone());
+        let current_branch = self
+            .latest_chip_value(&ContextChipKind::ShellGitBranch)
+            .cloned();
+        if current_branch.as_ref() != Some(&new_branch) {
+            self.update_chip_value(&ContextChipKind::ShellGitBranch, Some(new_branch));
+            // Refresh the branch dropdown so it stays in sync.
+            let chip_kind = ContextChipKind::ShellGitBranch;
+            if let Some(chip) = chip_kind.to_chip() {
+                if let Some(on_click_gen) = chip.on_click_generator().cloned() {
+                    self.refresh_on_click_values(&chip_kind, on_click_gen, ctx);
+                }
+            }
+        }
+
+        // Update GitDiffStats with structured data directly.
+        let new_diff_stats = ChipValue::GitDiffStats(GitLineChanges::from_diff_stats(
+            &metadata.stats_against_head,
+        ));
+        let current_diff_stats = self
+            .latest_chip_value(&ContextChipKind::GitDiffStats)
+            .cloned();
+        if current_diff_stats.as_ref() != Some(&new_diff_stats) {
+            self.update_chip_value(&ContextChipKind::GitDiffStats, Some(new_diff_stats));
         }
     }
 

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -1041,15 +1041,6 @@ impl CurrentPrompt {
                 }
                 RefreshConfig::Periodically { .. } => {
                     if self.is_updated_externally(chip_kind) {
-                        // The chip is being kept up to date by an external source (e.g. the
-                        // filesystem-watching `GitRepoStatusModel`). Only run an initial fetch
-                        // here when the chip provides a contextual `initial_value_generator`
-                        // — those compute their value from `PromptContext` and can't disagree
-                        // with the external source. Falling back to `chip.generator()` would
-                        // run the chip's shell command (e.g. `git diff --shortstat HEAD` for
-                        // `GitDiffStats`), which can produce a different value than the
-                        // external source and cause a brief flicker before the next external
-                        // update overwrites it (see issue #9228).
                         if let Some(initial_gen) = chip_kind.initial_value_generator() {
                             self.fetch_chip_value_once(
                                 chip_kind,
@@ -1440,20 +1431,11 @@ impl CurrentPrompt {
                     }
                 });
 
-                // The model may already have metadata when we attach (e.g. when
-                // a session re-binds to a long-lived `GitRepoStatusModel`). No
-                // `MetadataChanged` event fires from subscribing alone, so apply
-                // any existing metadata once up front; otherwise the chips would
-                // stay empty until the next file event.
                 self.apply_git_repo_status_metadata(ctx);
             }
         }
     }
 
-    /// Pulls the current metadata from `git_repo_status` (if any) and pushes it
-    /// into the `ShellGitBranch` and `GitDiffStats` chip values. Used both as
-    /// the body of the `MetadataChanged` subscription callback and as the
-    /// initial-state hydration call from `set_git_repo_status`.
     #[cfg(feature = "local_fs")]
     fn apply_git_repo_status_metadata(&mut self, ctx: &mut ModelContext<Self>) {
         let Some(metadata) = self
@@ -1462,17 +1444,17 @@ impl CurrentPrompt {
             .and_then(|w| w.upgrade(ctx))
             .and_then(|h| h.as_ref(ctx).metadata().cloned())
         else {
+            self.update_chip_value(&ContextChipKind::ShellGitBranch, None);
+            self.update_chip_value(&ContextChipKind::GitDiffStats, None);
             return;
         };
 
-        // Update ShellGitBranch.
         let new_branch = ChipValue::Text(metadata.current_branch_name.clone());
         let current_branch = self
             .latest_chip_value(&ContextChipKind::ShellGitBranch)
             .cloned();
         if current_branch.as_ref() != Some(&new_branch) {
             self.update_chip_value(&ContextChipKind::ShellGitBranch, Some(new_branch));
-            // Refresh the branch dropdown so it stays in sync.
             let chip_kind = ContextChipKind::ShellGitBranch;
             if let Some(chip) = chip_kind.to_chip() {
                 if let Some(on_click_gen) = chip.on_click_generator().cloned() {
@@ -1481,7 +1463,6 @@ impl CurrentPrompt {
             }
         }
 
-        // Update GitDiffStats with structured data directly.
         let new_diff_stats = ChipValue::GitDiffStats(GitLineChanges::from_diff_stats(
             &metadata.stats_against_head,
         ));

--- a/app/src/context_chips/current_prompt_test.rs
+++ b/app/src/context_chips/current_prompt_test.rs
@@ -1205,6 +1205,84 @@ fn test_externally_driven_chip_skips_periodic_timer() {
 
 #[cfg(feature = "local_fs")]
 #[test]
+fn test_externally_driven_git_diff_stats_does_not_run_shell_command() {
+    // Regression test for #9228. When `GitRepoStatusModel` is providing
+    // `GitDiffStats` values, the chip should not also run its shell-command
+    // generator (`git diff --shortstat HEAD`) — the shell command excludes
+    // untracked files and produces a value that races with the watcher's
+    // value, causing a visible flicker on every block completion.
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [ContextChipKind::GitDiffStats],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        let repo_handle = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        temp_dir.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+        let git_status =
+            app.add_model(move |_| GitRepoStatusModel::new_for_test(repo_handle, None));
+
+        let executor = Arc::new(RecordingCommandExecutor::default());
+        let sessions =
+            app.add_model(|_| Sessions::new_for_test().with_command_executor(executor.clone()));
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
+            cp.update_states_with_new_context(ctx);
+        });
+
+        app.read(|ctx| {
+            let cp = current_prompt.as_ref(ctx);
+            let state = cp
+                .states
+                .get(&ContextChipKind::GitDiffStats)
+                .expect("GitDiffStats state should exist after set_git_repo_status");
+            assert!(
+                state.refresh_handle.is_none(),
+                "Externally-driven chip should not have a periodic refresh handle"
+            );
+            assert!(
+                state.generator_handle.is_none(),
+                "Externally-driven GitDiffStats should not also run its shell-command generator"
+            );
+        });
+
+        assert!(
+            executor.commands.lock().is_empty(),
+            "Externally-driven GitDiffStats should not invoke any shell command, got: {:?}",
+            executor.commands.lock()
+        );
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
 fn test_git_status_change_updates_chip_value() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| {

--- a/app/src/context_chips/current_prompt_test.rs
+++ b/app/src/context_chips/current_prompt_test.rs
@@ -1211,10 +1211,144 @@ fn test_externally_driven_git_diff_stats_does_not_run_shell_command() {
     // generator (`git diff --shortstat HEAD`) — the shell command excludes
     // untracked files and produces a value that races with the watcher's
     // value, causing a visible flicker on every block completion.
+    //
+    // The session is bootstrapped with `git` in its external command list so
+    // the chip is `Enabled` (otherwise `fetch_chip_value_once` would short-
+    // circuit on availability and the test wouldn't actually exercise the
+    // shell-fallback path). `latest_context` is also populated for the same
+    // reason — without it `fetch_chip_value_once` would still proceed past
+    // availability checks but the test wouldn't model how the chip is
+    // refreshed in production.
     App::test((), |mut app| async move {
+        let session_id = SessionId::from(7228);
         app.add_singleton_model(|_| {
             Prompt::mock_with(
                 [ContextChipKind::GitDiffStats],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_| History::new(vec![]));
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| crate::settings::manager::SettingsManager::default());
+        crate::settings::InputSettings::register(&mut app);
+        app.update(crate::settings::AISettings::register_and_subscribe_to_events);
+        app.add_singleton_model(crate::workspaces::user_workspaces::UserWorkspaces::default_mock);
+        #[cfg(windows)]
+        app.add_singleton_model(SystemInfo::new);
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        let repo_handle = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        temp_dir.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+        let git_status =
+            app.add_model(move |_| GitRepoStatusModel::new_for_test(repo_handle, None));
+
+        // The first executor response satisfies `load_external_commands` (so
+        // `git` becomes a known executable on the session); the second is
+        // what the pre-fix code would have consumed when running the
+        // `git diff --shortstat HEAD` shell fallback.
+        let executor = Arc::new(RecordingCommandExecutor::with_success_responses([
+            "git\n", "",
+        ]));
+        let sessions = app.add_model(|ctx| {
+            let mut sessions = Sessions::new_for_test().with_command_executor(executor.clone());
+            sessions.initialize_bootstrapped_session(
+                SessionInfo::new_for_test().with_id(session_id),
+                "test command".to_string(),
+                vec![],
+                None,
+                ctx,
+            );
+            sessions
+        });
+        let sessions_for_prompt = sessions.clone();
+        let current_prompt =
+            app.add_model(move |ctx| CurrentPrompt::new(sessions_for_prompt.clone(), ctx));
+
+        let session = app
+            .read(|ctx| sessions.as_ref(ctx).get(session_id))
+            .expect("session should exist");
+        session.load_external_commands().await;
+        executor.clear();
+
+        current_prompt
+            .update(&mut app, |cp, ctx| {
+                cp.latest_context = Some(PromptContext {
+                    active_block_metadata: BlockMetadata::new(
+                        Some(session_id),
+                        Some("/tmp/project".to_string()),
+                    ),
+                    environment: Environment::default(),
+                });
+                cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
+                cp.update_states_with_new_context(ctx);
+                cp.await_generators(ctx)
+            })
+            .await;
+
+        app.read(|ctx| {
+            let cp = current_prompt.as_ref(ctx);
+            let state = cp
+                .states
+                .get(&ContextChipKind::GitDiffStats)
+                .expect("GitDiffStats state should exist after set_git_repo_status");
+            assert!(
+                state.refresh_handle.is_none(),
+                "externally-driven chip should not have a periodic refresh handle"
+            );
+            assert!(
+                state.generator_handle.is_none(),
+                "externally-driven GitDiffStats should not also run its shell-command generator"
+            );
+        });
+
+        assert!(
+            executor.commands.lock().is_empty(),
+            "externally-driven GitDiffStats should not invoke any shell command, got: {:?}",
+            executor.commands.lock()
+        );
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_set_git_repo_status_applies_existing_metadata() {
+    // When `set_git_repo_status` attaches a model that already has metadata
+    // computed (e.g. a re-bind to a long-lived `GitRepoStatusModel`), no
+    // `MetadataChanged` event fires from the subscription itself — so the
+    // chip values must be hydrated from `metadata()` immediately, otherwise
+    // they stay empty until the next file event.
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [
+                    ContextChipKind::ShellGitBranch,
+                    ContextChipKind::GitDiffStats,
+                ],
                 false,
                 WarpPromptSeparator::None,
             )
@@ -1244,40 +1378,43 @@ fn test_externally_driven_git_diff_stats_does_not_run_shell_command() {
                 )
                 .unwrap()
         });
-        let git_status =
-            app.add_model(move |_| GitRepoStatusModel::new_for_test(repo_handle, None));
+        let initial_metadata = GitStatusMetadata {
+            current_branch_name: "feature-x".to_string(),
+            main_branch_name: "main".to_string(),
+            stats_against_head: DiffStats::default(),
+        };
+        let git_status = app.add_model(move |_| {
+            GitRepoStatusModel::new_for_test(repo_handle, Some(initial_metadata))
+        });
 
-        let executor = Arc::new(RecordingCommandExecutor::default());
-        let sessions =
-            app.add_model(|_| Sessions::new_for_test().with_command_executor(executor.clone()));
+        let sessions = app.add_model(|_| Sessions::new_for_test());
         let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
 
+        // Create chip states first so `update_chip_value` has somewhere to write.
+        // In production this matches the order: chips are running before the
+        // view re-binds the prompt to a `GitRepoStatusModel`.
         current_prompt.update(&mut app, |cp, ctx| {
-            cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
             cp.update_states_with_new_context(ctx);
+            cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
         });
 
         app.read(|ctx| {
             let cp = current_prompt.as_ref(ctx);
-            let state = cp
-                .states
-                .get(&ContextChipKind::GitDiffStats)
-                .expect("GitDiffStats state should exist after set_git_repo_status");
-            assert!(
-                state.refresh_handle.is_none(),
-                "Externally-driven chip should not have a periodic refresh handle"
+            assert_eq!(
+                cp.latest_chip_value(&ContextChipKind::ShellGitBranch),
+                Some(&crate::context_chips::ChipValue::Text(
+                    "feature-x".to_string()
+                )),
+                "ShellGitBranch should be hydrated from existing metadata on subscribe"
             );
             assert!(
-                state.generator_handle.is_none(),
-                "Externally-driven GitDiffStats should not also run its shell-command generator"
+                matches!(
+                    cp.latest_chip_value(&ContextChipKind::GitDiffStats),
+                    Some(crate::context_chips::ChipValue::GitDiffStats(_))
+                ),
+                "GitDiffStats should be hydrated from existing metadata on subscribe"
             );
         });
-
-        assert!(
-            executor.commands.lock().is_empty(),
-            "Externally-driven GitDiffStats should not invoke any shell command, got: {:?}",
-            executor.commands.lock()
-        );
     });
 }
 

--- a/app/src/context_chips/current_prompt_test.rs
+++ b/app/src/context_chips/current_prompt_test.rs
@@ -1206,19 +1206,6 @@ fn test_externally_driven_chip_skips_periodic_timer() {
 #[cfg(feature = "local_fs")]
 #[test]
 fn test_externally_driven_git_diff_stats_does_not_run_shell_command() {
-    // Regression test for #9228. When `GitRepoStatusModel` is providing
-    // `GitDiffStats` values, the chip should not also run its shell-command
-    // generator (`git diff --shortstat HEAD`) — the shell command excludes
-    // untracked files and produces a value that races with the watcher's
-    // value, causing a visible flicker on every block completion.
-    //
-    // The session is bootstrapped with `git` in its external command list so
-    // the chip is `Enabled` (otherwise `fetch_chip_value_once` would short-
-    // circuit on availability and the test wouldn't actually exercise the
-    // shell-fallback path). `latest_context` is also populated for the same
-    // reason — without it `fetch_chip_value_once` would still proceed past
-    // availability checks but the test wouldn't model how the chip is
-    // refreshed in production.
     App::test((), |mut app| async move {
         let session_id = SessionId::from(7228);
         app.add_singleton_model(|_| {
@@ -1267,10 +1254,6 @@ fn test_externally_driven_git_diff_stats_does_not_run_shell_command() {
         let git_status =
             app.add_model(move |_| GitRepoStatusModel::new_for_test(repo_handle, None));
 
-        // The first executor response satisfies `load_external_commands` (so
-        // `git` becomes a known executable on the session); the second is
-        // what the pre-fix code would have consumed when running the
-        // `git diff --shortstat HEAD` shell fallback.
         let executor = Arc::new(RecordingCommandExecutor::with_success_responses([
             "git\n", "",
         ]));
@@ -1337,11 +1320,6 @@ fn test_externally_driven_git_diff_stats_does_not_run_shell_command() {
 #[cfg(feature = "local_fs")]
 #[test]
 fn test_set_git_repo_status_applies_existing_metadata() {
-    // When `set_git_repo_status` attaches a model that already has metadata
-    // computed (e.g. a re-bind to a long-lived `GitRepoStatusModel`), no
-    // `MetadataChanged` event fires from the subscription itself — so the
-    // chip values must be hydrated from `metadata()` immediately, otherwise
-    // they stay empty until the next file event.
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| {
             Prompt::mock_with(
@@ -1390,9 +1368,6 @@ fn test_set_git_repo_status_applies_existing_metadata() {
         let sessions = app.add_model(|_| Sessions::new_for_test());
         let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
 
-        // Create chip states first so `update_chip_value` has somewhere to write.
-        // In production this matches the order: chips are running before the
-        // view re-binds the prompt to a `GitRepoStatusModel`.
         current_prompt.update(&mut app, |cp, ctx| {
             cp.update_states_with_new_context(ctx);
             cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
@@ -1405,15 +1380,104 @@ fn test_set_git_repo_status_applies_existing_metadata() {
                 Some(&crate::context_chips::ChipValue::Text(
                     "feature-x".to_string()
                 )),
-                "ShellGitBranch should be hydrated from existing metadata on subscribe"
             );
-            assert!(
-                matches!(
-                    cp.latest_chip_value(&ContextChipKind::GitDiffStats),
-                    Some(crate::context_chips::ChipValue::GitDiffStats(_))
-                ),
-                "GitDiffStats should be hydrated from existing metadata on subscribe"
+            assert!(matches!(
+                cp.latest_chip_value(&ContextChipKind::GitDiffStats),
+                Some(crate::context_chips::ChipValue::GitDiffStats(_))
+            ));
+        });
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_set_git_repo_status_clears_stale_chip_values_when_new_model_has_no_metadata() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [
+                    ContextChipKind::ShellGitBranch,
+                    ContextChipKind::GitDiffStats,
+                ],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        let repo_handle = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        temp_dir.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+
+        let prev_metadata = GitStatusMetadata {
+            current_branch_name: "feature-x".to_string(),
+            main_branch_name: "main".to_string(),
+            stats_against_head: DiffStats::default(),
+        };
+        let prev_git_status = app
+            .add_model(move |_| GitRepoStatusModel::new_for_test(repo_handle, Some(prev_metadata)));
+
+        let temp_dir_b = tempfile::TempDir::new().unwrap();
+        let repo_handle_b = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        temp_dir_b.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+        let new_git_status =
+            app.add_model(move |_| GitRepoStatusModel::new_for_test(repo_handle_b, None));
+
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.update_states_with_new_context(ctx);
+            cp.set_git_repo_status(Some(prev_git_status.downgrade()), ctx);
+        });
+
+        app.read(|ctx| {
+            let cp = current_prompt.as_ref(ctx);
+            assert_eq!(
+                cp.latest_chip_value(&ContextChipKind::ShellGitBranch),
+                Some(&crate::context_chips::ChipValue::Text(
+                    "feature-x".to_string()
+                )),
             );
+        });
+
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.set_git_repo_status(Some(new_git_status.downgrade()), ctx);
+        });
+
+        app.read(|ctx| {
+            let cp = current_prompt.as_ref(ctx);
+            assert_eq!(cp.latest_chip_value(&ContextChipKind::ShellGitBranch), None);
+            assert_eq!(cp.latest_chip_value(&ContextChipKind::GitDiffStats), None);
         });
     });
 }


### PR DESCRIPTION
Closes #9228.

### Description

\`GitDiffStats\` flickers between the right value and a tracked-only-count value on every block completion when both modified-tracked and untracked files exist in the repo. The cause is exactly what the issue calls out: the chip has two update paths and they disagree.

The watcher path (\`GitRepoStatusModel\` -> \`DiffStateModel::diff_metadata_against_head\`) uses \`git status --untracked-files=all\` and includes untracked files. The shell-fallback path (\`shell_git_line_changes\`) uses \`git diff --shortstat HEAD\` and excludes untracked files.

\`is_updated_externally\` already disables the *periodic* timer for chips that have a watcher attached, but \`run_chips\` was still doing one shell-driven fetch each time the prompt context updated whenever the chip didn't have a contextual \`initial_value_generator\`:

\`\`\`rust
if self.is_updated_externally(chip_kind) {
    let initial_gen = chip_kind.initial_value_generator();
    let generator = initial_gen.as_ref().unwrap_or(chip.generator()); // <-- shell fallback
    self.fetch_chip_value_once(...);
}
\`\`\`

For \`ShellGitBranch\` that's fine — its \`initial_value_generator\` is contextual, reads from \`PromptContext\`, and can't disagree with the watcher. For \`GitDiffStats\` it's \`None\`, so the call falls through to the chip's shell command and races with the watcher.

This change keeps the contextual initial fetch for \`ShellGitBranch\` but skips the fetch entirely for chips like \`GitDiffStats\` that don't have a contextual initial generator. The watcher's \`MetadataChanged\` event already populates the value (and \`refresh_metadata\` is called explicitly after block-completion events), so we don't need a parallel shell fetch.

### Testing

- Added \`test_externally_driven_git_diff_stats_does_not_run_shell_command\` in \`current_prompt_test.rs\`. It mirrors the existing \`test_externally_driven_chip_skips_periodic_timer\` setup but asserts both \`state.generator_handle.is_none()\` and that the recording \`CommandExecutor\` saw no commands.
- \`cargo fmt -p warp -- --check\` passes.
- Couldn't run the full \`cargo nextest\` locally (Metal toolchain isn't available on this machine — same situation as #9277).

### Server API

No server changes.

### Agent Mode

Not applicable.

### Changelog Entries

\`CHANGELOG-BUG-FIX\`: Stop the git diff context chip from briefly flickering to a tracked-only count when a command completes in a repo that also has untracked files.