### PR TITLE
fix: point OSS desktop entry at package launcher

### DIFF
--- a/app/channels/oss/dev.warp.WarpOss.desktop
+++ b/app/channels/oss/dev.warp.WarpOss.desktop
@@ -7,7 +7,7 @@ Type=Application
 Name=WarpOss
 GenericName=TerminalEmulator
 
-Exec=warp-oss %U
+Exec=warp-terminal-oss %U
 StartupWMClass=dev.warp.WarpOss
 
 Keywords=shell;prompt;command;commandline;cmd;


### PR DESCRIPTION
## Description

Fixes #9381.

The OSS Linux app package installs a `warp-terminal-oss` launcher in `/usr/bin`, matching the package name generated by the Linux bundle scripts. The OSS desktop entry still pointed at the internal binary name, `warp-oss`, so launching WarpOss from the app menu can fail on packaged installs.

This updates the OSS `.desktop` file to use the packaged launcher name.

## Testing

- `grep -qx 'Exec=warp-terminal-oss %U' app/channels/oss/dev.warp.WarpOss.desktop`
- `git diff --check`

## Server API dependencies

No server API dependencies.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed the OSS Linux desktop entry so WarpOss launches through the packaged `warp-terminal-oss` command.
