### PR TITLE
Add i18n support with Simplified Chinese strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14385,6 +14385,7 @@ dependencies = [
  "warp_editor",
  "warp_files",
  "warp_graphql",
+ "warp_i18n",
  "warp_isolation_platform",
  "warp_js",
  "warp_logging",
@@ -14688,6 +14689,10 @@ dependencies = [
  "cynic",
  "cynic-codegen",
 ]
+
+[[package]]
+name = "warp_i18n"
+version = "0.1.0"
 
 [[package]]
 name = "warp_isolation_platform"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ remote_server = { path = "crates/remote_server" }
 warp_files = { path = "crates/warp_files" }
 warp_graphql = { path = "crates/graphql" }
 warp_graphql_schema = { path = "crates/warp_graphql_schema" }
+warp_i18n = { path = "crates/warp_i18n" }
 warp_isolation_platform = { path = "crates/isolation_platform" }
 warp_js = { path = "crates/warp_js" }
 warp_logging = { path = "crates/warp_logging" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -219,6 +219,7 @@ warp_completer.workspace = true
 warp_core.workspace = true
 warp_editor.workspace = true
 warp_graphql.workspace = true
+warp_i18n.workspace = true
 warp_js = { workspace = true, optional = true }
 warp_server_client.workspace = true
 warp_util.workspace = true

--- a/app/src/ai/agent_management/agent_type_selector.rs
+++ b/app/src/ai/agent_management/agent_type_selector.rs
@@ -9,6 +9,7 @@ use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::color::internal_colors;
+use warp_i18n::{t, Key as I18nKey};
 use warpui::elements::{
     Align, Border, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Dismiss,
     DropShadow, Element, Flex, Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle,
@@ -126,7 +127,7 @@ impl AgentTypeSelector {
         let theme = appearance.theme();
 
         let title = Text::new(
-            "Choose your agent".to_string(),
+            t(I18nKey::ChooseYourAgent),
             appearance.ui_font_family(),
             TITLE_FONT_SIZE,
         )
@@ -185,8 +186,8 @@ impl AgentTypeSelector {
         &self,
         index: usize,
         icon: Icon,
-        title: &'static str,
-        description: &'static str,
+        title_key: I18nKey,
+        description_key: I18nKey,
         is_suggested: bool,
         mouse_state: MouseStateHandle,
         action: AgentTypeSelectorAction,
@@ -246,7 +247,7 @@ impl AgentTypeSelector {
                 .with_border(Border::all(1.).with_border_color(avatar_border))
                 .finish();
 
-            let title_text = Text::new(title.to_string(), font_family, OPTION_TITLE_FONT_SIZE)
+            let title_text = Text::new(t(title_key), font_family, OPTION_TITLE_FONT_SIZE)
                 .with_style(Properties::default().weight(Weight::Semibold))
                 .with_color(active_text.into())
                 .finish();
@@ -257,11 +258,14 @@ impl AgentTypeSelector {
                 .with_child(title_text);
 
             if is_suggested {
-                let suggested_text =
-                    Text::new("Suggested".to_string(), font_family, OPTION_DESC_FONT_SIZE)
-                        .with_style(Properties::default().weight(Weight::Medium))
-                        .with_color(badge_text_color)
-                        .finish();
+                let suggested_text = Text::new(
+                    t(I18nKey::AgentManagementSuggested),
+                    font_family,
+                    OPTION_DESC_FONT_SIZE,
+                )
+                .with_style(Properties::default().weight(Weight::Medium))
+                .with_color(badge_text_color)
+                .finish();
 
                 let suggested = Container::new(suggested_text)
                     .with_horizontal_padding(8.)
@@ -275,7 +279,7 @@ impl AgentTypeSelector {
             }
 
             let description_text =
-                Text::new(description.to_string(), font_family, OPTION_DESC_FONT_SIZE)
+                Text::new(t(description_key), font_family, OPTION_DESC_FONT_SIZE)
                     .with_style(Properties::default().weight(Weight::Normal))
                     .with_color(nonactive_text.into())
                     .soft_wrap(true)
@@ -333,8 +337,8 @@ impl AgentTypeSelector {
         let cloud_agent_option = self.render_option(
             0,
             Icon::OzCloud,
-            "Cloud agent",
-            "Runs autonomously in a cloud environment you choose. Best for parallel or long-running work.",
+            I18nKey::AgentManagementCloudAgent,
+            I18nKey::AgentManagementCloudAgentDescription,
             true,
             self.cloud_agent_mouse_state.clone(),
             AgentTypeSelectorAction::SelectCloudAgent,
@@ -344,8 +348,8 @@ impl AgentTypeSelector {
         let local_agent_option = self.render_option(
             1,
             Icon::Oz,
-            "Local agent",
-            "Runs on your machine and requires supervision. Best for quick, interactive tasks.",
+            I18nKey::AgentManagementLocalAgent,
+            I18nKey::AgentManagementLocalAgentDescription,
             false,
             self.local_agent_mouse_state.clone(),
             AgentTypeSelectorAction::SelectLocalAgent,

--- a/app/src/ai/agent_management/details_action_buttons.rs
+++ b/app/src/ai/agent_management/details_action_buttons.rs
@@ -1,6 +1,7 @@
 //! Action buttons row for conversation details panel.
 
 use warp_core::ui::theme::AnsiColorIdentifier;
+use warp_i18n::{t, Key as I18nKey};
 use warpui::elements::{ChildView, CrossAxisAlignment, Empty, Flex, ParentElement};
 use warpui::{AppContext, Element, Entity, TypedActionView, View, ViewContext, ViewHandle};
 
@@ -116,7 +117,7 @@ impl ConversationActionButtonsRow {
         let open_button = ctx.add_typed_action_view(|_| {
             Self::make_action_button(
                 Icon::LinkExternal,
-                "Open conversation",
+                t(I18nKey::ConversationActionOpenConversation).into_owned(),
                 None,
                 AgentDetailsAction::Open,
             )
@@ -125,7 +126,7 @@ impl ConversationActionButtonsRow {
         let cancel_task_button = ctx.add_typed_action_view(|_| {
             Self::make_action_button(
                 Icon::StopFilled,
-                "Cancel task",
+                t(I18nKey::ConversationActionCancelTask).into_owned(),
                 Some(AnsiColorIdentifier::Red),
                 AgentDetailsAction::CancelTask,
             )
@@ -134,7 +135,7 @@ impl ConversationActionButtonsRow {
         let fork_conversation_button = ctx.add_typed_action_view(|_| {
             Self::make_action_button(
                 Icon::ArrowSplit,
-                "Fork conversation",
+                t(I18nKey::ConversationActionForkConversation).into_owned(),
                 None,
                 AgentDetailsAction::ForkConversation,
             )
@@ -143,7 +144,7 @@ impl ConversationActionButtonsRow {
         let view_details_button = ctx.add_typed_action_view(|_| {
             Self::make_action_button(
                 Icon::Info,
-                "View details",
+                t(I18nKey::ConversationActionViewDetails).into_owned(),
                 None,
                 AgentDetailsAction::ViewDetails,
             )
@@ -152,7 +153,7 @@ impl ConversationActionButtonsRow {
         let copy_link_button = ctx.add_typed_action_view(|_| {
             Self::make_action_button(
                 Icon::Link,
-                "Copy link to run",
+                t(I18nKey::ConversationActionCopyLinkToRun).into_owned(),
                 None,
                 AgentDetailsAction::CopyLink,
             )
@@ -181,7 +182,7 @@ impl ConversationActionButtonsRow {
 
     fn make_action_button(
         icon: Icon,
-        tooltip: &str,
+        tooltip: String,
         icon_color: Option<AnsiColorIdentifier>,
         action: AgentDetailsAction,
     ) -> ActionButton {

--- a/app/src/ai/agent_management/notifications/item.rs
+++ b/app/src/ai/agent_management/notifications/item.rs
@@ -1,6 +1,7 @@
 use enum_iterator::Sequence;
 use instant::Instant;
 use uuid::Uuid;
+use warp_i18n::{t, Key as I18nKey};
 use warpui::EntityId;
 
 use crate::ai::agent::conversation::AIConversationId;
@@ -33,12 +34,13 @@ pub enum NotificationFilter {
 }
 
 impl NotificationFilter {
-    pub(crate) fn label(&self) -> &'static str {
+    pub(crate) fn label(&self) -> String {
         match self {
-            NotificationFilter::All => "All tabs",
-            NotificationFilter::Unread => "Unread",
-            NotificationFilter::Errors => "Errors",
+            NotificationFilter::All => t(I18nKey::NotificationsAllTabs),
+            NotificationFilter::Unread => t(I18nKey::NotificationsUnread),
+            NotificationFilter::Errors => t(I18nKey::NotificationsErrors),
         }
+        .into_owned()
     }
 }
 

--- a/app/src/ai/agent_management/notifications/toast_stack.rs
+++ b/app/src/ai/agent_management/notifications/toast_stack.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use pathfinder_geometry::vector::vec2f;
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::color::internal_colors;
+use warp_i18n::{t, Key as I18nKey};
 use warpui::elements::{
     Border, ChildAnchor, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment,
     DispatchEventResult, Element, EventHandler, Flex, Hoverable, MouseStateHandle,
@@ -459,7 +460,7 @@ fn render_keybinding_hint(keystroke: Keystroke, appearance: &Appearance) -> Box<
 
     let hint_text = appearance
         .ui_builder()
-        .wrappable_text("Open conversation".to_string(), false)
+        .wrappable_text(t(I18nKey::ConversationActionOpenConversation), false)
         .with_style(UiComponentStyles {
             font_size: Some(12.),
             font_color: Some(theme.disabled_text_color(theme.surface_2()).into()),

--- a/app/src/ai/agent_management/notifications/view.rs
+++ b/app/src/ai/agent_management/notifications/view.rs
@@ -1,4 +1,5 @@
 use warp_core::ui::theme::color::internal_colors;
+use warp_i18n::{t, Key as I18nKey};
 use warpui::elements::new_scrollable::{ScrollableAppearance, SingleAxisConfig};
 use warpui::elements::{
     Border, ChildView, ClippedScrollStateHandle, ConstrainedBox, Container, CornerRadius,
@@ -120,7 +121,7 @@ impl NotificationMailboxView {
             ActionButton::new("", NakedTheme)
                 .with_icon(Icon::X)
                 .with_size(ButtonSize::XSmall)
-                .with_tooltip("Close")
+                .with_tooltip(t(I18nKey::CommonClose).into_owned())
                 .with_tooltip_sublabel("Esc")
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(NotificationMailboxViewAction::Dismiss);
@@ -128,7 +129,7 @@ impl NotificationMailboxView {
         });
 
         let mark_all_read_button = ctx.add_typed_action_view(|_| {
-            ActionButton::new("Mark all as read", NakedTheme)
+            ActionButton::new(t(I18nKey::NotificationsMarkAllAsRead), NakedTheme)
                 .with_size(ButtonSize::Small)
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(NotificationMailboxViewAction::MarkAllRead);
@@ -409,7 +410,7 @@ impl NotificationMailboxView {
 
         let label = appearance
             .ui_builder()
-            .wrappable_text("Notifications".to_string(), false)
+            .wrappable_text(t(I18nKey::Notifications), false)
             .with_style(UiComponentStyles {
                 font_size: Some(14.),
                 font_color: Some(theme.main_text_color(theme.surface_2()).into()),
@@ -459,10 +460,11 @@ impl NotificationMailboxView {
 
             let is_active = self.active_filter == filter;
             let count = notifications.filtered_count(filter);
+            let filter_label = filter.label();
             let label = if count == 0 {
-                filter.label().to_string()
+                filter_label
             } else {
-                format!("{} ({count})", filter.label())
+                format!("{filter_label} ({count})")
             };
             let text_color = if is_active {
                 theme.main_text_color(theme.surface_2())
@@ -546,7 +548,7 @@ impl NotificationMailboxView {
         Container::new(
             appearance
                 .ui_builder()
-                .wrappable_text("No notifications".to_string(), false)
+                .wrappable_text(t(I18nKey::NotificationsNoNotifications), false)
                 .with_style(UiComponentStyles {
                     font_size: Some(14.),
                     font_color: Some(theme.sub_text_color(theme.surface_2()).into()),

--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -69,6 +69,7 @@ use warp_cli::agent::Harness;
 use warp_core::ui::icons::Icon;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::Fill;
+use warp_i18n::{t, Key as I18nKey};
 use warpui::clipboard::ClipboardContent;
 use warpui::elements::new_scrollable::{
     NewScrollableElement, ScrollableAppearance, SingleAxisConfig,
@@ -225,9 +226,9 @@ impl AgentManagementView {
         let list_state = Self::construct_fresh_list_state(ctx.handle());
 
         let all_filter_button = ctx.add_typed_action_view(|_ctx| {
-            ActionButton::new("All", NakedTheme)
+            ActionButton::new(t(I18nKey::AgentManagementAllFilter), NakedTheme)
                 .with_size(ButtonSize::Small)
-                .with_tooltip("View your agent tasks plus all shared team tasks")
+                .with_tooltip(t(I18nKey::AgentManagementAllFilterTooltip).into_owned())
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(AgentManagementViewAction::SetOwnerFilter(
                         OwnerFilter::All,
@@ -236,9 +237,9 @@ impl AgentManagementView {
         });
 
         let personal_filter_button = ctx.add_typed_action_view(|_ctx| {
-            ActionButton::new("Personal", NakedTheme)
+            ActionButton::new(t(I18nKey::AgentManagementPersonalFilter), NakedTheme)
                 .with_size(ButtonSize::Small)
-                .with_tooltip("View agent tasks you created")
+                .with_tooltip(t(I18nKey::AgentManagementPersonalFilterTooltip).into_owned())
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(AgentManagementViewAction::SetOwnerFilter(
                         OwnerFilter::PersonalOnly,
@@ -247,7 +248,7 @@ impl AgentManagementView {
         });
 
         let setup_guide_button = CompactibleActionButton::new(
-            "Get started".to_string(),
+            t(I18nKey::AgentManagementGetStarted).into_owned(),
             None,
             ButtonSize::Small,
             AgentManagementViewAction::ToggleSetupGuide,
@@ -257,7 +258,7 @@ impl AgentManagementView {
         );
 
         let view_agents_button = ctx.add_typed_action_view(|_ctx| {
-            ActionButton::new("View Agents", NakedTheme)
+            ActionButton::new(t(I18nKey::AgentManagementViewAgents), NakedTheme)
                 .with_size(ButtonSize::Small)
                 .with_icon(Icon::ArrowLeft)
                 .on_click(|ctx| {
@@ -275,7 +276,7 @@ impl AgentManagementView {
         let creator_dropdown = ctx.add_typed_action_view(Self::create_creator_dropdown);
 
         let no_filter_results_button = ctx.add_typed_action_view(move |_ctx| {
-            ActionButton::new("Clear filters", SecondaryTheme)
+            ActionButton::new(t(I18nKey::AgentManagementClearFilters), SecondaryTheme)
                 .with_size(ButtonSize::Small)
                 .on_click(move |ctx| {
                     ctx.dispatch_typed_action(AgentManagementViewAction::ClearFilters)
@@ -283,7 +284,7 @@ impl AgentManagementView {
         });
 
         let clear_all_filters_button = ctx.add_typed_action_view(move |_ctx| {
-            ActionButton::new("Clear all", NakedTheme)
+            ActionButton::new(t(I18nKey::AgentManagementClearAll), NakedTheme)
                 .with_icon(Icon::X)
                 .with_size(ButtonSize::Small)
                 .on_click(move |ctx| {
@@ -314,7 +315,7 @@ impl AgentManagementView {
                 },
                 ctx,
             );
-            editor.set_placeholder_text("Search", ctx);
+            editor.set_placeholder_text(t(I18nKey::AgentManagementSearch).into_owned(), ctx);
             editor
         });
         ctx.subscribe_to_view(&search_editor, |me, _handle, event, ctx| {
@@ -322,7 +323,7 @@ impl AgentManagementView {
         });
 
         let new_agent_button = CompactibleActionButton::new(
-            "New agent".to_string(),
+            t(I18nKey::AgentManagementNewAgent).into_owned(),
             None,
             ButtonSize::Small,
             AgentManagementViewAction::ShowAgentTypeSelector,
@@ -490,11 +491,11 @@ impl AgentManagementView {
         };
 
         let mut dropdown = Dropdown::new(ctx);
-        Self::setup_filter_menu(&mut dropdown, "Status", ctx);
+        Self::setup_filter_menu(&mut dropdown, I18nKey::AgentManagementStatus, ctx);
 
         // Use this helper to make dropdown items with status icons
         let make_status_option =
-            |label: &str, action: AgentManagementViewAction, icon_data: Option<(Icon, Fill)>| {
+            |label: String, action: AgentManagementViewAction, icon_data: Option<(Icon, Fill)>| {
                 let mut fields = MenuItemFields::new(label)
                     .with_on_select_action(DropdownAction::SelectActionAndClose(action));
                 if let Some((icon, color)) = icon_data {
@@ -505,22 +506,22 @@ impl AgentManagementView {
 
         let items = vec![
             make_status_option(
-                "All",
+                t(I18nKey::CommonAll).into_owned(),
                 AgentManagementViewAction::SetStatusFilter(StatusFilter::All),
                 None,
             ),
             make_status_option(
-                "Working",
+                t(I18nKey::AgentManagementWorking).into_owned(),
                 AgentManagementViewAction::SetStatusFilter(StatusFilter::Working),
                 Some((Icon::ClockLoader, Fill::from(magenta))),
             ),
             make_status_option(
-                "Done",
+                t(I18nKey::AgentManagementDone).into_owned(),
                 AgentManagementViewAction::SetStatusFilter(StatusFilter::Done),
                 Some((Icon::Check, Fill::from(green))),
             ),
             make_status_option(
-                "Failed",
+                t(I18nKey::AgentManagementFailed).into_owned(),
                 AgentManagementViewAction::SetStatusFilter(StatusFilter::Failed),
                 Some((Icon::X, Fill::from(red))),
             ),
@@ -535,7 +536,7 @@ impl AgentManagementView {
         ctx: &mut ViewContext<Dropdown<AgentManagementViewAction>>,
     ) -> Dropdown<AgentManagementViewAction> {
         let mut dropdown = Dropdown::new(ctx);
-        Self::setup_filter_menu(&mut dropdown, "Source", ctx);
+        Self::setup_filter_menu(&mut dropdown, I18nKey::AgentManagementSource, ctx);
         // Set a max height so we can fit all of the source options without scrolling
         dropdown.set_menu_max_height(200., ctx);
 
@@ -564,9 +565,11 @@ impl AgentManagementView {
         }
 
         let mut items = vec![MenuItem::Item(
-            MenuItemFields::new("All").with_on_select_action(DropdownAction::SelectActionAndClose(
-                AgentManagementViewAction::SetSourceFilter(SourceFilter::All),
-            )),
+            MenuItemFields::new(t(I18nKey::CommonAll).into_owned()).with_on_select_action(
+                DropdownAction::SelectActionAndClose(
+                    AgentManagementViewAction::SetSourceFilter(SourceFilter::All),
+                ),
+            ),
         )];
         for source in sources {
             items.push(MenuItem::Item(
@@ -597,29 +600,46 @@ impl AgentManagementView {
         ctx: &mut ViewContext<Dropdown<AgentManagementViewAction>>,
     ) -> Dropdown<AgentManagementViewAction> {
         let mut dropdown = Dropdown::new(ctx);
-        Self::setup_filter_menu(&mut dropdown, "Created on", ctx);
+        Self::setup_filter_menu(&mut dropdown, I18nKey::AgentManagementCreatedOn, ctx);
 
         let items = vec![
-            MenuItem::Item(MenuItemFields::new("All").with_on_select_action(
-                DropdownAction::SelectActionAndClose(
-                    AgentManagementViewAction::SetCreatedOnFilter(CreatedOnFilter::All),
+            MenuItem::Item(
+                MenuItemFields::new(t(I18nKey::CommonAll).into_owned()).with_on_select_action(
+                    DropdownAction::SelectActionAndClose(
+                        AgentManagementViewAction::SetCreatedOnFilter(CreatedOnFilter::All),
+                    ),
                 ),
-            )),
-            MenuItem::Item(MenuItemFields::new("Last 24 hours").with_on_select_action(
-                DropdownAction::SelectActionAndClose(
-                    AgentManagementViewAction::SetCreatedOnFilter(CreatedOnFilter::Last24Hours),
-                ),
-            )),
-            MenuItem::Item(MenuItemFields::new("Past 3 days").with_on_select_action(
-                DropdownAction::SelectActionAndClose(
-                    AgentManagementViewAction::SetCreatedOnFilter(CreatedOnFilter::Past3Days),
-                ),
-            )),
-            MenuItem::Item(MenuItemFields::new("Last week").with_on_select_action(
-                DropdownAction::SelectActionAndClose(
-                    AgentManagementViewAction::SetCreatedOnFilter(CreatedOnFilter::LastWeek),
-                ),
-            )),
+            ),
+            MenuItem::Item(
+                MenuItemFields::new(t(I18nKey::AgentManagementLast24Hours).into_owned())
+                    .with_on_select_action(
+                        DropdownAction::SelectActionAndClose(
+                            AgentManagementViewAction::SetCreatedOnFilter(
+                                CreatedOnFilter::Last24Hours,
+                            ),
+                        ),
+                    ),
+            ),
+            MenuItem::Item(
+                MenuItemFields::new(t(I18nKey::AgentManagementPast3Days).into_owned())
+                    .with_on_select_action(
+                        DropdownAction::SelectActionAndClose(
+                            AgentManagementViewAction::SetCreatedOnFilter(
+                                CreatedOnFilter::Past3Days,
+                            ),
+                        ),
+                    ),
+            ),
+            MenuItem::Item(
+                MenuItemFields::new(t(I18nKey::AgentManagementLastWeek).into_owned())
+                    .with_on_select_action(
+                        DropdownAction::SelectActionAndClose(
+                            AgentManagementViewAction::SetCreatedOnFilter(
+                                CreatedOnFilter::LastWeek,
+                            ),
+                        ),
+                    ),
+            ),
         ];
 
         dropdown.set_rich_items(items, ctx);
@@ -631,34 +651,40 @@ impl AgentManagementView {
         ctx: &mut ViewContext<Dropdown<AgentManagementViewAction>>,
     ) -> Dropdown<AgentManagementViewAction> {
         let mut dropdown = Dropdown::new(ctx);
-        Self::setup_filter_menu(&mut dropdown, "Has artifact", ctx);
+        Self::setup_filter_menu(&mut dropdown, I18nKey::AgentManagementHasArtifact, ctx);
 
         let items = vec![
-            MenuItem::Item(MenuItemFields::new("All").with_on_select_action(
-                DropdownAction::SelectActionAndClose(AgentManagementViewAction::SetArtifactFilter(
-                    ArtifactFilter::All,
-                )),
-            )),
-            MenuItem::Item(MenuItemFields::new("Pull Request").with_on_select_action(
-                DropdownAction::SelectActionAndClose(AgentManagementViewAction::SetArtifactFilter(
-                    ArtifactFilter::PullRequest,
-                )),
-            )),
-            MenuItem::Item(MenuItemFields::new("Plan").with_on_select_action(
-                DropdownAction::SelectActionAndClose(AgentManagementViewAction::SetArtifactFilter(
-                    ArtifactFilter::Plan,
-                )),
-            )),
-            MenuItem::Item(MenuItemFields::new("Screenshot").with_on_select_action(
-                DropdownAction::SelectActionAndClose(AgentManagementViewAction::SetArtifactFilter(
-                    ArtifactFilter::Screenshot,
-                )),
-            )),
-            MenuItem::Item(MenuItemFields::new("File").with_on_select_action(
-                DropdownAction::SelectActionAndClose(AgentManagementViewAction::SetArtifactFilter(
-                    ArtifactFilter::File,
-                )),
-            )),
+            MenuItem::Item(
+                MenuItemFields::new(t(I18nKey::CommonAll).into_owned()).with_on_select_action(
+                    DropdownAction::SelectActionAndClose(
+                        AgentManagementViewAction::SetArtifactFilter(ArtifactFilter::All),
+                    ),
+                ),
+            ),
+            MenuItem::Item(
+                MenuItemFields::new(t(I18nKey::AgentManagementArtifactPullRequest).into_owned())
+                    .with_on_select_action(DropdownAction::SelectActionAndClose(
+                        AgentManagementViewAction::SetArtifactFilter(ArtifactFilter::PullRequest),
+                    )),
+            ),
+            MenuItem::Item(
+                MenuItemFields::new(t(I18nKey::AgentManagementArtifactPlan).into_owned())
+                    .with_on_select_action(DropdownAction::SelectActionAndClose(
+                        AgentManagementViewAction::SetArtifactFilter(ArtifactFilter::Plan),
+                    )),
+            ),
+            MenuItem::Item(
+                MenuItemFields::new(t(I18nKey::AgentManagementArtifactScreenshot).into_owned())
+                    .with_on_select_action(DropdownAction::SelectActionAndClose(
+                        AgentManagementViewAction::SetArtifactFilter(ArtifactFilter::Screenshot),
+                    )),
+            ),
+            MenuItem::Item(
+                MenuItemFields::new(t(I18nKey::AgentManagementArtifactFile).into_owned())
+                    .with_on_select_action(DropdownAction::SelectActionAndClose(
+                        AgentManagementViewAction::SetArtifactFilter(ArtifactFilter::File),
+                    )),
+            ),
         ];
 
         dropdown.set_rich_items(items, ctx);
@@ -670,13 +696,15 @@ impl AgentManagementView {
         ctx: &mut ViewContext<Dropdown<AgentManagementViewAction>>,
     ) -> Dropdown<AgentManagementViewAction> {
         let mut dropdown = Dropdown::new(ctx);
-        Self::setup_filter_menu(&mut dropdown, "Harness", ctx);
+        Self::setup_filter_menu(&mut dropdown, I18nKey::AgentManagementHarness, ctx);
 
         // "All" has no leading icon, matching the Status dropdown's "All" row.
         let mut items = vec![MenuItem::Item(
-            MenuItemFields::new("All").with_on_select_action(DropdownAction::SelectActionAndClose(
-                AgentManagementViewAction::SetHarnessFilter(HarnessFilter::All),
-            )),
+            MenuItemFields::new(t(I18nKey::CommonAll).into_owned()).with_on_select_action(
+                DropdownAction::SelectActionAndClose(
+                    AgentManagementViewAction::SetHarnessFilter(HarnessFilter::All),
+                ),
+            ),
         )];
 
         for harness in [Harness::Oz, Harness::Claude, Harness::Gemini] {
@@ -700,20 +728,23 @@ impl AgentManagementView {
         ctx: &mut ViewContext<FilterableDropdown<AgentManagementViewAction>>,
     ) -> FilterableDropdown<AgentManagementViewAction> {
         let mut dropdown = FilterableDropdown::new(ctx);
-        Self::setup_searchable_filter_menu(&mut dropdown, "Environment", ctx);
+        Self::setup_searchable_filter_menu(&mut dropdown, I18nKey::AgentManagementEnvironment, ctx);
 
         // Keep the button compact when a specific environment ID is selected by abbreviating the
         // displayed ID. (The dropdown menu still shows the full ID.)
-        dropdown.set_menu_header_text_override(|text| {
-            if matches!(text, "All" | "None") {
-                return format!("Environment: {text}");
+        let all_label = t(I18nKey::CommonAll).into_owned();
+        let none_label = t(I18nKey::CommonNone).into_owned();
+        dropdown.set_menu_header_text_override(move |text| {
+            let prefix = t(I18nKey::AgentManagementEnvironment);
+            if text == all_label || text == none_label {
+                return format!("{prefix}: {text}");
             }
 
             let abbreviated = text.chars().take(6).collect::<String>();
             if abbreviated == text {
-                format!("Environment: {text}")
+                format!("{prefix}: {text}")
             } else {
-                format!("Environment: {abbreviated}…")
+                format!("{prefix}: {abbreviated}…")
             }
         });
 
@@ -727,31 +758,31 @@ impl AgentManagementView {
         ctx: &mut ViewContext<FilterableDropdown<AgentManagementViewAction>>,
     ) -> FilterableDropdown<AgentManagementViewAction> {
         let mut dropdown = FilterableDropdown::new(ctx);
-        Self::setup_searchable_filter_menu(&mut dropdown, "Created by", ctx);
+        Self::setup_searchable_filter_menu(&mut dropdown, I18nKey::AgentManagementCreatedBy, ctx);
         dropdown
     }
 
     // Initialize the dropdown menu for the filter dropdowns (status, source)
     fn setup_filter_menu<A: Action + Clone>(
         dropdown: &mut Dropdown<A>,
-        label_prefix: &'static str,
+        label_key: I18nKey,
         ctx: &mut ViewContext<Dropdown<A>>,
     ) {
         dropdown.set_menu_width(160., ctx);
         dropdown.set_main_axis_size(MainAxisSize::Min, ctx);
-        dropdown.set_menu_header_text_override(move |text| format!("{}: {}", label_prefix, text));
+        dropdown.set_menu_header_text_override(move |text| format!("{}: {}", t(label_key), text));
         dropdown.set_style(DropdownStyle::ActionButtonSecondary, ctx);
     }
 
     // Initialize the dropdown menu for the searchable filter dropdowns (creator)
     fn setup_searchable_filter_menu<A: Action + Clone>(
         dropdown: &mut FilterableDropdown<A>,
-        label_prefix: &'static str,
+        label_key: I18nKey,
         ctx: &mut ViewContext<FilterableDropdown<A>>,
     ) {
         dropdown.set_menu_width(320., ctx);
         dropdown.set_main_axis_size(MainAxisSize::Min, ctx);
-        dropdown.set_menu_header_text_override(move |text| format!("{}: {}", label_prefix, text));
+        dropdown.set_menu_header_text_override(move |text| format!("{}: {}", t(label_key), text));
         dropdown.set_button_variant(ButtonVariant::Secondary);
     }
 
@@ -763,14 +794,14 @@ impl AgentManagementView {
         let envs = model.get_all_environment_ids_and_names(ctx);
 
         let selected_name = match &self.filters.environment {
-            EnvironmentFilter::All => Some("All".to_string()),
-            EnvironmentFilter::NoEnvironment => Some("None".to_string()),
+            EnvironmentFilter::All => Some(t(I18nKey::CommonAll).into_owned()),
+            EnvironmentFilter::NoEnvironment => Some(t(I18nKey::CommonNone).into_owned()),
             EnvironmentFilter::Specific(id) => envs.get(id).cloned(),
         };
 
         self.environment_dropdown.update(ctx, |dropdown, ctx| {
             let mut items = vec![MenuItem::Item(
-                MenuItemFields::new("All").with_on_select_action(
+                MenuItemFields::new(t(I18nKey::CommonAll).into_owned()).with_on_select_action(
                     DropdownAction::SelectActionAndClose(
                         AgentManagementViewAction::SetEnvironmentFilter(EnvironmentFilter::All),
                     ),
@@ -778,7 +809,7 @@ impl AgentManagementView {
             )];
 
             items.push(MenuItem::Item(
-                MenuItemFields::new("None").with_on_select_action(
+                MenuItemFields::new(t(I18nKey::CommonNone).into_owned()).with_on_select_action(
                     DropdownAction::SelectActionAndClose(
                         AgentManagementViewAction::SetEnvironmentFilter(
                             EnvironmentFilter::NoEnvironment,
@@ -812,12 +843,12 @@ impl AgentManagementView {
     fn update_creator_dropdown(&mut self, ctx: &mut ViewContext<Self>) {
         let creators = AgentConversationsModel::as_ref(ctx).get_all_creators(ctx);
         let creator_filter_name = match &self.filters.creator {
-            CreatorFilter::All => "All",
-            CreatorFilter::Specific { name, .. } => name,
+            CreatorFilter::All => t(I18nKey::CommonAll).into_owned(),
+            CreatorFilter::Specific { name, .. } => name.clone(),
         };
         self.creator_dropdown.update(ctx, |dropdown, ctx| {
             let mut items = vec![MenuItem::Item(
-                MenuItemFields::new("All").with_on_select_action(
+                MenuItemFields::new(t(I18nKey::CommonAll).into_owned()).with_on_select_action(
                     DropdownAction::SelectActionAndClose(
                         AgentManagementViewAction::SetCreatorFilter(CreatorFilter::All),
                     ),
@@ -836,7 +867,7 @@ impl AgentManagementView {
                 ));
             }
             dropdown.set_rich_items(items, ctx);
-            dropdown.set_selected_by_name(creator_filter_name, ctx);
+            dropdown.set_selected_by_name(&creator_filter_name, ctx);
         });
     }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -501,6 +501,7 @@ fn apply_scroll_multiplier(event: &mut Event, app: &AppContext) {
 pub fn run() -> Result<()> {
     // Perform any necessary platform-specific initialization.
     platform::init();
+    warp_i18n::init_from_env();
 
     // Ensure feature flags are initialized before parsing command-line arguments.
     init_feature_flags();

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -55,6 +55,7 @@ use warp_core::{
     channel::ChannelState, context_flag::ContextFlag, features::FeatureFlag,
     settings::ToggleableSetting as _, ui::theme::color::internal_colors,
 };
+use warp_i18n::{t, Key as I18nKey};
 use warp_editor::editor::NavigationKey;
 use warpify_page::{WarpifyPageAction, WarpifyPageView};
 use warpui::Element;
@@ -229,23 +230,34 @@ use std::fmt::{self, Display};
 
 impl Display for SettingsSection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SettingsSection::BillingAndUsage => write!(f, "Billing and usage"),
-            SettingsSection::Keybindings => write!(f, "Keyboard shortcuts"),
-            SettingsSection::SharedBlocks => write!(f, "Shared blocks"),
-            SettingsSection::MCPServers => write!(f, "MCP Servers"),
-            SettingsSection::WarpDrive => write!(f, "Warp Drive"),
-            SettingsSection::WarpAgent => write!(f, "Warp Agent"),
-            SettingsSection::AgentProfiles => write!(f, "Profiles"),
-            SettingsSection::AgentMCPServers => write!(f, "MCP servers"),
-            SettingsSection::Knowledge => write!(f, "Knowledge"),
-            SettingsSection::ThirdPartyCLIAgents => write!(f, "Third party CLI agents"),
-            SettingsSection::CodeIndexing => write!(f, "Indexing and projects"),
-            SettingsSection::EditorAndCodeReview => write!(f, "Editor and Code Review"),
-            SettingsSection::CloudEnvironments => write!(f, "Environments"),
-            SettingsSection::OzCloudAPIKeys => write!(f, "Oz Cloud API Keys"),
-            _ => write!(f, "{self:?}"),
-        }
+        let label = match self {
+            SettingsSection::About => t(I18nKey::SettingsAbout),
+            SettingsSection::Account => t(I18nKey::SettingsAccount),
+            SettingsSection::MCPServers | SettingsSection::AgentMCPServers => {
+                t(I18nKey::SettingsMcpServers)
+            }
+            SettingsSection::BillingAndUsage => t(I18nKey::SettingsBillingAndUsage),
+            SettingsSection::Appearance => t(I18nKey::SettingsAppearance),
+            SettingsSection::Features => t(I18nKey::SettingsFeatures),
+            SettingsSection::Keybindings => t(I18nKey::SettingsKeybindings),
+            SettingsSection::Privacy => t(I18nKey::SettingsPrivacy),
+            SettingsSection::Referrals => t(I18nKey::SettingsReferrals),
+            SettingsSection::SharedBlocks => t(I18nKey::SettingsSharedBlocks),
+            SettingsSection::Teams => t(I18nKey::SettingsTeams),
+            SettingsSection::WarpDrive => t(I18nKey::SettingsWarpDrive),
+            SettingsSection::Warpify => t(I18nKey::SettingsWarpify),
+            SettingsSection::AI => t(I18nKey::SettingsAgents),
+            SettingsSection::WarpAgent => t(I18nKey::SettingsWarpAgent),
+            SettingsSection::AgentProfiles => t(I18nKey::SettingsProfiles),
+            SettingsSection::Knowledge => t(I18nKey::SettingsKnowledge),
+            SettingsSection::ThirdPartyCLIAgents => t(I18nKey::SettingsThirdPartyCliAgents),
+            SettingsSection::Code => t(I18nKey::SettingsCode),
+            SettingsSection::CodeIndexing => t(I18nKey::SettingsCodeIndexing),
+            SettingsSection::EditorAndCodeReview => t(I18nKey::SettingsEditorAndCodeReview),
+            SettingsSection::CloudEnvironments => t(I18nKey::SettingsCloudEnvironments),
+            SettingsSection::OzCloudAPIKeys => t(I18nKey::SettingsOzCloudApiKeys),
+        };
+        write!(f, "{label}")
     }
 }
 
@@ -1185,19 +1197,19 @@ impl SettingsView {
         let mut nav_items = vec![
             SettingsNavItem::Page(SettingsSection::Account),
             SettingsNavItem::Umbrella(SettingsUmbrella::new(
-                "Agents",
+                t(I18nKey::SettingsAgents).into_owned(),
                 SettingsSection::ai_subpages().to_vec(),
             )),
             SettingsNavItem::Page(SettingsSection::BillingAndUsage),
             SettingsNavItem::Umbrella(SettingsUmbrella::new(
-                "Code",
+                t(I18nKey::SettingsCode).into_owned(),
                 vec![
                     SettingsSection::CodeIndexing,
                     SettingsSection::EditorAndCodeReview,
                 ],
             )),
             SettingsNavItem::Umbrella(SettingsUmbrella::new(
-                "Cloud platform",
+                t(I18nKey::SettingsCloudPlatform).into_owned(),
                 vec![
                     SettingsSection::CloudEnvironments,
                     SettingsSection::OzCloudAPIKeys,

--- a/app/src/settings_view/nav.rs
+++ b/app/src/settings_view/nav.rs
@@ -22,7 +22,7 @@ const SUBPAGE_LEFT_MARGIN: f32 = NAV_ITEM_LEFT_MARGIN + 12.;
 
 /// A collapsible group of settings subpages in the sidebar.
 pub struct SettingsUmbrella {
-    pub label: &'static str,
+    pub label: String,
     pub subpages: Vec<SettingsSection>,
     pub expanded: bool,
     /// Saved expanded state from before search began, restored when search is cleared.
@@ -32,10 +32,10 @@ pub struct SettingsUmbrella {
 }
 
 impl SettingsUmbrella {
-    pub fn new(label: &'static str, subpages: Vec<SettingsSection>) -> Self {
+    pub fn new(label: impl Into<String>, subpages: Vec<SettingsSection>) -> Self {
         let subpage_count = subpages.len();
         Self {
-            label,
+            label: label.into(),
             subpages,
             expanded: false,
             pre_search_expanded: None,

--- a/crates/warp_i18n/Cargo.toml
+++ b/crates/warp_i18n/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "warp_i18n"
+version = "0.1.0"
+edition = "2021"
+publish.workspace = true
+license.workspace = true
+
+[dependencies]

--- a/crates/warp_i18n/src/lib.rs
+++ b/crates/warp_i18n/src/lib.rs
@@ -1,0 +1,354 @@
+//! Lightweight application text localization for Warp.
+//!
+//! The crate deliberately keeps catalog lookup dependency-free so UI code can
+//! adopt localized strings incrementally without adding runtime setup beyond
+//! [`init_from_env`].
+
+use std::borrow::Cow;
+use std::env;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Locale {
+    EnUs = 1,
+    ZhCn = 2,
+}
+
+impl Locale {
+    pub fn from_locale_identifier(identifier: &str) -> Option<Self> {
+        let normalized = identifier
+            .split(['.', '@'])
+            .next()
+            .unwrap_or(identifier)
+            .replace('_', "-")
+            .to_ascii_lowercase();
+
+        match normalized.as_str() {
+            "" | "c" | "posix" => None,
+            "en" | "en-us" => Some(Self::EnUs),
+            "zh" | "zh-cn" | "zh-hans" | "zh-hans-cn" | "zh-sg" | "zh-hans-sg" => {
+                Some(Self::ZhCn)
+            }
+            _ => None,
+        }
+    }
+
+    pub fn from_env() -> Option<Self> {
+        for var in ["WARP_LOCALE", "LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG"] {
+            let Ok(value) = env::var(var) else {
+                continue;
+            };
+
+            for candidate in value.split(':') {
+                if let Some(locale) = Self::from_locale_identifier(candidate) {
+                    return Some(locale);
+                }
+            }
+        }
+
+        None
+    }
+
+    fn from_u8(value: u8) -> Self {
+        match value {
+            value if value == Self::ZhCn as u8 => Self::ZhCn,
+            _ => Self::EnUs,
+        }
+    }
+}
+
+static ACTIVE_LOCALE: AtomicU8 = AtomicU8::new(Locale::EnUs as u8);
+
+/// Initializes the active UI locale from environment variables.
+///
+/// `WARP_LOCALE` takes precedence, followed by common POSIX locale variables.
+pub fn init_from_env() {
+    if let Some(locale) = Locale::from_env() {
+        set_locale(locale);
+    }
+}
+
+pub fn set_locale(locale: Locale) {
+    ACTIVE_LOCALE.store(locale as u8, Ordering::Relaxed);
+}
+
+pub fn current_locale() -> Locale {
+    Locale::from_u8(ACTIVE_LOCALE.load(Ordering::Relaxed))
+}
+
+pub fn t(key: Key) -> Cow<'static, str> {
+    match current_locale() {
+        Locale::EnUs => Cow::Borrowed(english(key)),
+        Locale::ZhCn => zh_cn(key)
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Borrowed(english(key))),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Key {
+    AgentManagementAllFilter,
+    AgentManagementAllFilterTooltip,
+    AgentManagementArtifactFile,
+    AgentManagementArtifactPlan,
+    AgentManagementArtifactPullRequest,
+    AgentManagementArtifactScreenshot,
+    AgentManagementClearAll,
+    AgentManagementClearFilters,
+    AgentManagementCloudAgent,
+    AgentManagementCloudAgentDescription,
+    AgentManagementCreatedBy,
+    AgentManagementCreatedOn,
+    AgentManagementDone,
+    AgentManagementEnvironment,
+    AgentManagementFailed,
+    AgentManagementGetStarted,
+    AgentManagementHasArtifact,
+    AgentManagementHarness,
+    AgentManagementLast24Hours,
+    AgentManagementLastWeek,
+    AgentManagementLocalAgent,
+    AgentManagementLocalAgentDescription,
+    AgentManagementNewAgent,
+    AgentManagementPast3Days,
+    AgentManagementPersonalFilter,
+    AgentManagementPersonalFilterTooltip,
+    AgentManagementSearch,
+    AgentManagementSource,
+    AgentManagementStatus,
+    AgentManagementSuggested,
+    AgentManagementViewAgents,
+    AgentManagementWorking,
+    ChooseYourAgent,
+    CommonAll,
+    CommonClose,
+    CommonNone,
+    ConversationActionCancelTask,
+    ConversationActionCopyLinkToRun,
+    ConversationActionForkConversation,
+    ConversationActionOpenConversation,
+    ConversationActionViewDetails,
+    Notifications,
+    NotificationsAllTabs,
+    NotificationsErrors,
+    NotificationsMarkAllAsRead,
+    NotificationsNoNotifications,
+    NotificationsUnread,
+    SettingsAbout,
+    SettingsAccount,
+    SettingsAgents,
+    SettingsAppearance,
+    SettingsBillingAndUsage,
+    SettingsCloudEnvironments,
+    SettingsCloudPlatform,
+    SettingsCode,
+    SettingsCodeIndexing,
+    SettingsEditorAndCodeReview,
+    SettingsFeatures,
+    SettingsKeybindings,
+    SettingsKnowledge,
+    SettingsMcpServers,
+    SettingsOzCloudApiKeys,
+    SettingsPrivacy,
+    SettingsProfiles,
+    SettingsReferrals,
+    SettingsSharedBlocks,
+    SettingsTeams,
+    SettingsThirdPartyCliAgents,
+    SettingsWarpAgent,
+    SettingsWarpDrive,
+    SettingsWarpify,
+}
+
+fn english(key: Key) -> &'static str {
+    match key {
+        Key::AgentManagementAllFilter => "All",
+        Key::AgentManagementAllFilterTooltip => "View your agent tasks plus all shared team tasks",
+        Key::AgentManagementArtifactFile => "File",
+        Key::AgentManagementArtifactPlan => "Plan",
+        Key::AgentManagementArtifactPullRequest => "Pull Request",
+        Key::AgentManagementArtifactScreenshot => "Screenshot",
+        Key::AgentManagementClearAll => "Clear all",
+        Key::AgentManagementClearFilters => "Clear filters",
+        Key::AgentManagementCloudAgent => "Cloud agent",
+        Key::AgentManagementCloudAgentDescription => {
+            "Runs autonomously in a cloud environment you choose. Best for parallel or long-running work."
+        }
+        Key::AgentManagementCreatedBy => "Created by",
+        Key::AgentManagementCreatedOn => "Created on",
+        Key::AgentManagementDone => "Done",
+        Key::AgentManagementEnvironment => "Environment",
+        Key::AgentManagementFailed => "Failed",
+        Key::AgentManagementGetStarted => "Get started",
+        Key::AgentManagementHasArtifact => "Has artifact",
+        Key::AgentManagementHarness => "Harness",
+        Key::AgentManagementLast24Hours => "Last 24 hours",
+        Key::AgentManagementLastWeek => "Last week",
+        Key::AgentManagementLocalAgent => "Local agent",
+        Key::AgentManagementLocalAgentDescription => {
+            "Runs on your machine and requires supervision. Best for quick, interactive tasks."
+        }
+        Key::AgentManagementNewAgent => "New agent",
+        Key::AgentManagementPast3Days => "Past 3 days",
+        Key::AgentManagementPersonalFilter => "Personal",
+        Key::AgentManagementPersonalFilterTooltip => "View agent tasks you created",
+        Key::AgentManagementSearch => "Search",
+        Key::AgentManagementSource => "Source",
+        Key::AgentManagementStatus => "Status",
+        Key::AgentManagementSuggested => "Suggested",
+        Key::AgentManagementViewAgents => "View Agents",
+        Key::AgentManagementWorking => "Working",
+        Key::ChooseYourAgent => "Choose your agent",
+        Key::CommonAll => "All",
+        Key::CommonClose => "Close",
+        Key::CommonNone => "None",
+        Key::ConversationActionCancelTask => "Cancel task",
+        Key::ConversationActionCopyLinkToRun => "Copy link to run",
+        Key::ConversationActionForkConversation => "Fork conversation",
+        Key::ConversationActionOpenConversation => "Open conversation",
+        Key::ConversationActionViewDetails => "View details",
+        Key::Notifications => "Notifications",
+        Key::NotificationsAllTabs => "All tabs",
+        Key::NotificationsErrors => "Errors",
+        Key::NotificationsMarkAllAsRead => "Mark all as read",
+        Key::NotificationsNoNotifications => "No notifications",
+        Key::NotificationsUnread => "Unread",
+        Key::SettingsAbout => "About",
+        Key::SettingsAccount => "Account",
+        Key::SettingsAgents => "Agents",
+        Key::SettingsAppearance => "Appearance",
+        Key::SettingsBillingAndUsage => "Billing and usage",
+        Key::SettingsCloudEnvironments => "Environments",
+        Key::SettingsCloudPlatform => "Cloud platform",
+        Key::SettingsCode => "Code",
+        Key::SettingsCodeIndexing => "Indexing and projects",
+        Key::SettingsEditorAndCodeReview => "Editor and Code Review",
+        Key::SettingsFeatures => "Features",
+        Key::SettingsKeybindings => "Keyboard shortcuts",
+        Key::SettingsKnowledge => "Knowledge",
+        Key::SettingsMcpServers => "MCP Servers",
+        Key::SettingsOzCloudApiKeys => "Oz Cloud API Keys",
+        Key::SettingsPrivacy => "Privacy",
+        Key::SettingsProfiles => "Profiles",
+        Key::SettingsReferrals => "Referrals",
+        Key::SettingsSharedBlocks => "Shared blocks",
+        Key::SettingsTeams => "Teams",
+        Key::SettingsThirdPartyCliAgents => "Third party CLI agents",
+        Key::SettingsWarpAgent => "Warp Agent",
+        Key::SettingsWarpDrive => "Warp Drive",
+        Key::SettingsWarpify => "Warpify",
+    }
+}
+
+fn zh_cn(key: Key) -> Option<&'static str> {
+    Some(match key {
+        Key::AgentManagementAllFilter => "全部",
+        Key::AgentManagementAllFilterTooltip => "查看你的智能体任务以及团队共享的所有任务",
+        Key::AgentManagementArtifactFile => "文件",
+        Key::AgentManagementArtifactPlan => "计划",
+        Key::AgentManagementArtifactPullRequest => "拉取请求",
+        Key::AgentManagementArtifactScreenshot => "截图",
+        Key::AgentManagementClearAll => "全部清除",
+        Key::AgentManagementClearFilters => "清除筛选",
+        Key::AgentManagementCloudAgent => "云端智能体",
+        Key::AgentManagementCloudAgentDescription => {
+            "在你选择的云环境中自主运行。适合并行任务或耗时较长的工作。"
+        }
+        Key::AgentManagementCreatedBy => "创建者",
+        Key::AgentManagementCreatedOn => "创建时间",
+        Key::AgentManagementDone => "已完成",
+        Key::AgentManagementEnvironment => "环境",
+        Key::AgentManagementFailed => "失败",
+        Key::AgentManagementGetStarted => "开始使用",
+        Key::AgentManagementHasArtifact => "包含产物",
+        Key::AgentManagementHarness => "执行框架",
+        Key::AgentManagementLast24Hours => "过去 24 小时",
+        Key::AgentManagementLastWeek => "上周",
+        Key::AgentManagementLocalAgent => "本地智能体",
+        Key::AgentManagementLocalAgentDescription => {
+            "在你的机器上运行，需要人工监督。适合快速、交互式任务。"
+        }
+        Key::AgentManagementNewAgent => "新建智能体",
+        Key::AgentManagementPast3Days => "过去 3 天",
+        Key::AgentManagementPersonalFilter => "个人",
+        Key::AgentManagementPersonalFilterTooltip => "查看你创建的智能体任务",
+        Key::AgentManagementSearch => "搜索",
+        Key::AgentManagementSource => "来源",
+        Key::AgentManagementStatus => "状态",
+        Key::AgentManagementSuggested => "推荐",
+        Key::AgentManagementViewAgents => "查看智能体",
+        Key::AgentManagementWorking => "运行中",
+        Key::ChooseYourAgent => "选择智能体",
+        Key::CommonAll => "全部",
+        Key::CommonClose => "关闭",
+        Key::CommonNone => "无",
+        Key::ConversationActionCancelTask => "取消任务",
+        Key::ConversationActionCopyLinkToRun => "复制运行链接",
+        Key::ConversationActionForkConversation => "派生会话",
+        Key::ConversationActionOpenConversation => "打开会话",
+        Key::ConversationActionViewDetails => "查看详情",
+        Key::Notifications => "通知",
+        Key::NotificationsAllTabs => "所有标签页",
+        Key::NotificationsErrors => "错误",
+        Key::NotificationsMarkAllAsRead => "全部标为已读",
+        Key::NotificationsNoNotifications => "没有通知",
+        Key::NotificationsUnread => "未读",
+        Key::SettingsAbout => "关于",
+        Key::SettingsAccount => "账户",
+        Key::SettingsAgents => "智能体",
+        Key::SettingsAppearance => "外观",
+        Key::SettingsBillingAndUsage => "账单和用量",
+        Key::SettingsCloudEnvironments => "环境",
+        Key::SettingsCloudPlatform => "云平台",
+        Key::SettingsCode => "代码",
+        Key::SettingsCodeIndexing => "索引和项目",
+        Key::SettingsEditorAndCodeReview => "编辑器和代码审查",
+        Key::SettingsFeatures => "功能",
+        Key::SettingsKeybindings => "键盘快捷键",
+        Key::SettingsKnowledge => "知识",
+        Key::SettingsMcpServers => "MCP 服务器",
+        Key::SettingsOzCloudApiKeys => "Oz Cloud API 密钥",
+        Key::SettingsPrivacy => "隐私",
+        Key::SettingsProfiles => "配置",
+        Key::SettingsReferrals => "推荐",
+        Key::SettingsSharedBlocks => "共享块",
+        Key::SettingsTeams => "团队",
+        Key::SettingsThirdPartyCliAgents => "第三方 CLI 智能体",
+        Key::SettingsWarpAgent => "Warp 智能体",
+        Key::SettingsWarpDrive => "Warp Drive",
+        Key::SettingsWarpify => "Warpify",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static TEST_LOCALE_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn parses_supported_locale_identifiers() {
+        assert_eq!(Locale::from_locale_identifier("zh_CN.UTF-8"), Some(Locale::ZhCn));
+        assert_eq!(Locale::from_locale_identifier("zh-Hans-CN"), Some(Locale::ZhCn));
+        assert_eq!(Locale::from_locale_identifier("en_US.UTF-8"), Some(Locale::EnUs));
+        assert_eq!(Locale::from_locale_identifier("C"), None);
+    }
+
+    #[test]
+    fn translates_simplified_chinese() {
+        let _guard = TEST_LOCALE_LOCK.lock().unwrap();
+        set_locale(Locale::ZhCn);
+        assert_eq!(t(Key::Notifications), "通知");
+        assert_eq!(t(Key::SettingsKeybindings), "键盘快捷键");
+        set_locale(Locale::EnUs);
+    }
+
+    #[test]
+    fn defaults_to_english() {
+        let _guard = TEST_LOCALE_LOCK.lock().unwrap();
+        set_locale(Locale::EnUs);
+        assert_eq!(t(Key::Notifications), "Notifications");
+    }
+}


### PR DESCRIPTION
## Description

Adds an initial dependency-free i18n layer for Warp UI text and wires it into a first set of high-traffic surfaces:

- New `warp_i18n` crate with locale detection from `WARP_LOCALE`, `LANGUAGE`, `LC_ALL`, `LC_MESSAGES`, and `LANG`, plus English fallback behavior.
- Simplified Chinese (`zh-CN`) catalog entries for settings navigation, agent management filters/dropdowns, the agent type selector, notifications, and conversation action buttons.
- Startup locale initialization from the app entrypoint.

## Testing

- `git diff --check`
- Not run: `cargo fmt`, `cargo test`, or `./script/presubmit` because this Windows environment does not have `cargo`/`rustc` installed.

## Server API dependencies

- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Added initial Simplified Chinese localization support for settings, agent management, and notifications.

Co-Authored-By: Warp <agent@warp.dev>