### PR TITLE
Fix/opencode tui exit stuck terminal

### DIFF
--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -1921,7 +1921,9 @@ impl TerminalModel {
     /// paths where Warp has evidence that terminal presentation is corrupted, but not enough
     /// evidence to mark the foreground command as finished.
     fn recover_terminal_modes_without_completing_command(&mut self) {
-        self.unset_mode(Mode::BracketedPaste);
+        if self.is_term_mode_set(TermMode::BRACKETED_PASTE) {
+            self.unset_mode(Mode::BracketedPaste);
+        }
         self.exit_alt_screen(true);
     }
 
@@ -3101,7 +3103,9 @@ impl ansi::Handler for TerminalModel {
             }
             IsReceivingInBandCommandOutput::No => {
                 log::warn!("Received 'end_in_band_command_output' while not expecting to read in-band command output.");
-                self.recover_terminal_modes_without_completing_command();
+                if from_osc_sequence {
+                    self.recover_terminal_modes_without_completing_command();
+                }
             }
         }
 

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -1915,6 +1915,16 @@ impl TerminalModel {
         self.set_title(None);
     }
 
+    /// Restores terminal modes that can otherwise leave the UI visually stuck after a TUI exits.
+    ///
+    /// This intentionally does not complete the active command. It is safe to call from recovery
+    /// paths where Warp has evidence that terminal presentation is corrupted, but not enough
+    /// evidence to mark the foreground command as finished.
+    fn recover_terminal_modes_without_completing_command(&mut self) {
+        self.unset_mode(Mode::BracketedPaste);
+        self.exit_alt_screen(true);
+    }
+
     pub fn get_pending_session_info(&self) -> &Option<SessionInfo> {
         &self.pending_session_info
     }
@@ -2778,13 +2788,12 @@ impl ansi::Handler for TerminalModel {
         // of bracketed paste being enabled, but the local shell doesn't know
         // how to turn it off (and will never do so).  We forcibly unset the
         // mode to avoid getting stuck in this state.
-        self.unset_mode(Mode::BracketedPaste);
-
-        // Similar to bracketed paste, above, make sure we quit out of the
-        // alt screen if we're currently in it.  This prevents issues where we
-        // remain in the alt screen after disconnect when we should return to
-        // the blocklist (for the local shell).
-        self.exit_alt_screen(true);
+        //
+        // Similar to bracketed paste, make sure we quit out of the alt screen
+        // if we're currently in it. This prevents issues where we remain in
+        // the alt screen after disconnect when we should return to the
+        // blocklist (for the local shell).
+        self.recover_terminal_modes_without_completing_command();
 
         let block_id = data.next_block_id.to_string();
         let is_for_in_band_command = self.block_list().active_block().is_in_band_command_block();
@@ -3092,6 +3101,7 @@ impl ansi::Handler for TerminalModel {
             }
             IsReceivingInBandCommandOutput::No => {
                 log::warn!("Received 'end_in_band_command_output' while not expecting to read in-band command output.");
+                self.recover_terminal_modes_without_completing_command();
             }
         }
 

--- a/app/src/terminal/model/terminal_model_test.rs
+++ b/app/src/terminal/model/terminal_model_test.rs
@@ -737,6 +737,42 @@ fn test_unexpected_in_band_command_output_end_unsets_bracketed_paste_without_fin
 }
 
 #[test]
+fn test_unexpected_internal_in_band_command_output_end_does_not_recover_modes() {
+    let mut terminal = TerminalModel::mock(None, None);
+
+    terminal.simulate_long_running_block("opencode", "");
+    terminal.enter_alt_screen(true);
+    terminal.set_mode(Mode::BracketedPaste);
+
+    terminal.end_in_band_command_output(false);
+
+    assert!(terminal.is_alt_screen_active());
+    assert!(terminal.is_term_mode_set(TermMode::BRACKETED_PASTE));
+    assert!(terminal.block_list().active_block().is_executing());
+}
+
+#[test]
+fn test_unexpected_in_band_command_output_end_does_not_emit_redundant_unset_bracketed_paste() {
+    let (event_tx, event_rx) = async_channel::unbounded();
+    let event_proxy = ChannelEventListener::builder_for_test()
+        .with_terminal_events_tx(event_tx)
+        .build();
+    let mut terminal = TerminalModel::mock(None, Some(event_proxy));
+
+    terminal.simulate_long_running_block("opencode", "");
+
+    terminal.end_in_band_command_output(true);
+
+    let events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+    assert!(!events.iter().any(|event| matches!(
+        event,
+        Event::Handler(HandlerEvent::UnsetMode {
+            mode: Mode::BracketedPaste
+        })
+    )));
+}
+
+#[test]
 fn test_alt_screen_selection_tracks_scroll() {
     let mut terminal: TerminalModel = TerminalModel::mock(None, None);
     terminal.enter_alt_screen(true);

--- a/app/src/terminal/model/terminal_model_test.rs
+++ b/app/src/terminal/model/terminal_model_test.rs
@@ -702,6 +702,7 @@ fn test_unexpected_in_band_command_output_end_exits_alt_screen_without_finishing
 
     terminal.simulate_long_running_block("opencode", "");
     terminal.enter_alt_screen(true);
+    while event_rx.try_recv().is_ok() {}
 
     terminal.end_in_band_command_output(true);
 
@@ -724,6 +725,7 @@ fn test_unexpected_in_band_command_output_end_unsets_bracketed_paste_without_fin
 
     terminal.simulate_long_running_block("opencode", "");
     terminal.set_mode(Mode::BracketedPaste);
+    while event_rx.try_recv().is_ok() {}
 
     terminal.end_in_band_command_output(true);
 
@@ -760,6 +762,7 @@ fn test_unexpected_in_band_command_output_end_does_not_emit_redundant_unset_brac
     let mut terminal = TerminalModel::mock(None, Some(event_proxy));
 
     terminal.simulate_long_running_block("opencode", "");
+    while event_rx.try_recv().is_ok() {}
 
     terminal.end_in_band_command_output(true);
 

--- a/app/src/terminal/model/terminal_model_test.rs
+++ b/app/src/terminal/model/terminal_model_test.rs
@@ -693,6 +693,50 @@ fn test_unset_bracketed_paste_mode_on_command_finished() {
 }
 
 #[test]
+fn test_unexpected_in_band_command_output_end_exits_alt_screen_without_finishing_block() {
+    let (event_tx, event_rx) = async_channel::unbounded();
+    let event_proxy = ChannelEventListener::builder_for_test()
+        .with_terminal_events_tx(event_tx)
+        .build();
+    let mut terminal = TerminalModel::mock(None, Some(event_proxy));
+
+    terminal.simulate_long_running_block("opencode", "");
+    terminal.enter_alt_screen(true);
+
+    terminal.end_in_band_command_output(true);
+
+    assert!(!terminal.is_alt_screen_active());
+    assert!(terminal.block_list().active_block().is_executing());
+
+    let events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, Event::BlockCompleted(_))));
+}
+
+#[test]
+fn test_unexpected_in_band_command_output_end_unsets_bracketed_paste_without_finishing_block() {
+    let (event_tx, event_rx) = async_channel::unbounded();
+    let event_proxy = ChannelEventListener::builder_for_test()
+        .with_terminal_events_tx(event_tx)
+        .build();
+    let mut terminal = TerminalModel::mock(None, Some(event_proxy));
+
+    terminal.simulate_long_running_block("opencode", "");
+    terminal.set_mode(Mode::BracketedPaste);
+
+    terminal.end_in_band_command_output(true);
+
+    assert!(!terminal.is_term_mode_set(TermMode::BRACKETED_PASTE));
+    assert!(terminal.block_list().active_block().is_executing());
+
+    let events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, Event::BlockCompleted(_))));
+}
+
+#[test]
 fn test_alt_screen_selection_tracks_scroll() {
     let mut terminal: TerminalModel = TerminalModel::mock(None, None);
     terminal.enter_alt_screen(true);


### PR DESCRIPTION
## Description
Fixes #9426.

Recover terminal presentation modes when Warp receives an unexpected in-band command output end marker from the Warp OSC sequence. This prevents Warp from remaining stuck on a blank alternate-screen-style view after `opencode` exits or tears down without the normal `CommandFinished`/`Precmd` shell lifecycle.
This intentionally only restores presentation state:
- exits alternate screen
- unsets bracketed paste only if Warp believes it is enabled
- does not synthesize `CommandFinished`
- does not mark the command/block complete
- does not assume the shell prompt is ready
The recovery is limited to the real OSC marker path and does not run for internal cleanup calls.

## Testing
Added focused terminal model tests covering:
- unexpected OSC in-band output end exits alt screen without finishing the active block
- unexpected OSC in-band output end unsets bracketed paste without finishing the active block
- internal non-OSC cleanup does not recover terminal modes
- redundant bracketed-paste unset events are not emitted
Ran:
- `cargo fmt --check`
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" cargo test -p warp in_band_command_output_end`
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" cargo test -p warp terminal::model::terminal_model::tests`
Also ran:
- `DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" cargo test -p warp`
The full `warp` crate test suite completed with unrelated existing failures: `3604 passed`, `9 failed`, `6 ignored`. The failures were outside the touched terminal model recovery path.
Also fix your later headers/checklist formatting:
## Server API dependencies
No server API dependencies.
## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed an issue where Warp could remain stuck on a blank alternate-screen view after `opencode` exits.