### PR TITLE
feat(tabs): add CycleMostRecentTab as third Ctrl+Tab behavior option

### DIFF
--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -360,6 +360,10 @@ pub fn init(app: &mut AppContext) {
         "root_view:handle_pane_navigation_event",
         RootView::focus_pane,
     );
+    app.add_action(
+        "root_view:activate_tab_by_pane_group_id",
+        RootView::activate_tab_by_pane_group_id,
+    );
     app.add_action("root_view:close_window", RootView::close_window);
     app.add_action("root_view:minimize_window", RootView::minimize_window);
     app.add_action(
@@ -2522,6 +2526,20 @@ impl RootView {
         if let AuthOnboardingState::Terminal(workspace) = &self.auth_onboarding_state {
             workspace.update(ctx, |view, ctx| {
                 view.focus_pane(*pane_view_locator, ctx);
+            });
+        }
+        true
+    }
+
+    fn activate_tab_by_pane_group_id(
+        &mut self,
+        pane_group_id: &EntityId,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        ctx.windows().show_window_and_focus_app(ctx.window_id());
+        if let AuthOnboardingState::Terminal(workspace) = &self.auth_onboarding_state {
+            workspace.update(ctx, |view, ctx| {
+                view.activate_tab_by_pane_group_id(*pane_group_id, ctx);
             });
         }
         true

--- a/app/src/search/command_palette/data_sources.rs
+++ b/app/src/search/command_palette/data_sources.rs
@@ -9,17 +9,20 @@ use crate::search::command_palette::launch_config;
 use crate::search::command_palette::mixer::{CommandPaletteItemAction, ItemSummary};
 use crate::search::command_palette::new_session::NewSessionDataSource;
 use crate::search::command_palette::repos::RepoDataSource;
-use crate::search::command_palette::{navigation, CommandPaletteMixer};
+use crate::search::command_palette::{navigation, tabs, CommandPaletteMixer};
 use crate::search::data_source::QueryResult;
 use crate::search::files::model::FileSearchModel;
 use crate::search::mixer::AddAsyncSourceOptions;
 use crate::search::QueryFilter;
 use crate::session_management::SessionSource;
 use crate::settings::AISettings;
+use crate::workspace::Workspace;
 use warp_core::context_flag::ContextFlag;
 use warp_core::features::FeatureFlag;
 use warpui::keymap::BindingId;
-use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
+use warpui::{
+    AppContext, Entity, ModelContext, ModelHandle, SingletonEntity, WeakViewHandle, WindowId,
+};
 
 use super::conversations;
 use super::warp_drive;
@@ -34,6 +37,7 @@ pub struct DataSourceStore {
     historical_conversation_data_source: ModelHandle<conversations::DataSource>,
     all_conversation_data_source: ModelHandle<conversations::DataSource>,
     repo_data_source: ModelHandle<RepoDataSource>,
+    tabs_data_source: Option<ModelHandle<tabs::DataSource>>,
 }
 
 impl DataSourceStore {
@@ -73,6 +77,7 @@ impl DataSourceStore {
             historical_conversation_data_source,
             all_conversation_data_source,
             repo_data_source,
+            tabs_data_source: None,
         }
     }
 
@@ -168,6 +173,32 @@ impl DataSourceStore {
 
             ctx.notify();
         });
+    }
+
+    /// Resets the [`CommandPaletteMixer`] to the set of data sources relevant for the Ctrl+Tab
+    /// palette, which shows tabs sorted by MRU order.
+    pub fn reset_ctrl_tab_mixer(
+        &mut self,
+        mixer: ModelHandle<CommandPaletteMixer>,
+        workspace: WeakViewHandle<Workspace>,
+        window_id: WindowId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.tabs_data_source.is_none() {
+            self.tabs_data_source =
+                Some(ctx.add_model(|_| tabs::DataSource::new(workspace, window_id)));
+        }
+
+        if let Some(tabs_data_source) = &self.tabs_data_source {
+            mixer.update(ctx, |mixer, ctx| {
+                mixer.reset(ctx);
+                mixer.add_sync_source(
+                    tabs_data_source.clone(),
+                    HashSet::from([QueryFilter::Tabs]),
+                );
+                ctx.notify();
+            });
+        }
     }
 
     /// Returns a [`QueryResult`] from the data sources identified by the `summary`. `None` if none
@@ -270,6 +301,11 @@ impl DataSourceStore {
 
             ItemSummary::NoOp => {
                 // No-op action (used for non-interactable separator items that don't do anything on click).
+                None
+            }
+
+            ItemSummary::Tab { .. } => {
+                // Tabs are only shown in the ctrl_tab palette, not in recent commands.
                 None
             }
         }

--- a/app/src/search/command_palette/filter_chip_renderer.rs
+++ b/app/src/search/command_palette/filter_chip_renderer.rs
@@ -100,6 +100,7 @@ impl FilterChipRenderer for QueryFilter {
             | QueryFilter::NaturalLanguage
             | QueryFilter::Actions
             | QueryFilter::Sessions
+            | QueryFilter::Tabs
             | QueryFilter::Drive
             | QueryFilter::LaunchConfigurations
             | QueryFilter::PromptHistory

--- a/app/src/search/command_palette/mixer.rs
+++ b/app/src/search/command_palette/mixer.rs
@@ -37,6 +37,11 @@ pub enum CommandPaletteItemAction {
         pane_view_locator: PaneViewLocator,
         window_id: WindowId,
     },
+    /// Navigate to a specific tab identified by its pane_group EntityId.
+    NavigateToTab {
+        pane_group_id: EntityId,
+        window_id: WindowId,
+    },
     /// Navigate to a specific conversation.
     NavigateToConversation {
         pane_view_locator: Option<PaneViewLocator>,
@@ -93,6 +98,11 @@ impl CommandPaletteItemAction {
                 pane_view_locator, ..
             } => ItemSummary::Session {
                 pane_view_locator: *pane_view_locator,
+            },
+            CommandPaletteItemAction::NavigateToTab {
+                pane_group_id, ..
+            } => ItemSummary::Tab {
+                pane_group_id: *pane_group_id,
             },
             CommandPaletteItemAction::NavigateToConversation {
                 conversation_id, ..
@@ -168,6 +178,9 @@ pub enum ItemSummary {
     },
     Session {
         pane_view_locator: PaneViewLocator,
+    },
+    Tab {
+        pane_group_id: EntityId,
     },
     NewSession {
         id: NewSessionOptionId,

--- a/app/src/search/command_palette/mod.rs
+++ b/app/src/search/command_palette/mod.rs
@@ -5,6 +5,7 @@ mod filter_chip_renderer;
 pub mod launch_config;
 pub mod mixer;
 pub mod navigation;
+pub mod tabs;
 #[cfg_attr(not(feature = "local_tty"), allow(dead_code))]
 pub mod new_session;
 pub mod render_util;

--- a/app/src/search/command_palette/tabs/data_source.rs
+++ b/app/src/search/command_palette/tabs/data_source.rs
@@ -37,10 +37,11 @@ impl SyncDataSource for DataSource {
 
         let results = tabs
             .into_iter()
-            .filter(|tab| {
+            .enumerate()
+            .filter(|(_, tab)| {
                 query_text.is_empty() || tab.title.to_lowercase().contains(&query_text)
             })
-            .map(|tab| QueryResult::from(SearchItem::new(tab)))
+            .map(|(i, tab)| QueryResult::from(SearchItem::new(tab, i)))
             .collect();
 
         Ok(results)

--- a/app/src/search/command_palette/tabs/data_source.rs
+++ b/app/src/search/command_palette/tabs/data_source.rs
@@ -1,0 +1,52 @@
+use crate::search::command_palette::mixer::CommandPaletteItemAction;
+use crate::search::command_palette::tabs::SearchItem;
+use crate::search::data_source::{Query, QueryResult};
+use crate::search::mixer::{DataSourceRunErrorWrapper, SyncDataSource};
+use crate::workspace::Workspace;
+use warpui::{AppContext, Entity, WeakViewHandle, WindowId};
+
+/// Data source that produces tabs sorted by MRU order for the Ctrl+Tab palette.
+pub struct DataSource {
+    workspace: WeakViewHandle<Workspace>,
+    window_id: WindowId,
+}
+
+impl DataSource {
+    pub fn new(workspace: WeakViewHandle<Workspace>, window_id: WindowId) -> Self {
+        Self {
+            workspace,
+            window_id,
+        }
+    }
+}
+
+impl SyncDataSource for DataSource {
+    type Action = CommandPaletteItemAction;
+
+    fn run_query(
+        &self,
+        query: &Query,
+        ctx: &AppContext,
+    ) -> Result<Vec<QueryResult<Self::Action>>, DataSourceRunErrorWrapper> {
+        let Some(workspace) = self.workspace.upgrade(ctx) else {
+            return Ok(vec![]);
+        };
+        let tabs = workspace.as_ref(ctx).tab_navigation_data(self.window_id, ctx);
+
+        let query_text = query.text.trim().to_lowercase();
+
+        let results = tabs
+            .into_iter()
+            .filter(|tab| {
+                query_text.is_empty() || tab.title.to_lowercase().contains(&query_text)
+            })
+            .map(|tab| QueryResult::from(SearchItem::new(tab)))
+            .collect();
+
+        Ok(results)
+    }
+}
+
+impl Entity for DataSource {
+    type Event = ();
+}

--- a/app/src/search/command_palette/tabs/mod.rs
+++ b/app/src/search/command_palette/tabs/mod.rs
@@ -1,0 +1,5 @@
+pub mod data_source;
+pub mod search_item;
+
+pub use data_source::DataSource;
+pub use search_item::SearchItem;

--- a/app/src/search/command_palette/tabs/search_item.rs
+++ b/app/src/search/command_palette/tabs/search_item.rs
@@ -12,11 +12,12 @@ use warpui::{AppContext, Element, SingletonEntity};
 
 pub struct SearchItem {
     tab: TabNavigationData,
+    mru_rank: usize,
 }
 
 impl SearchItem {
-    pub fn new(tab: TabNavigationData) -> Self {
-        Self { tab }
+    pub fn new(tab: TabNavigationData, mru_rank: usize) -> Self {
+        Self { tab, mru_rank }
     }
 }
 
@@ -84,7 +85,7 @@ impl crate::search::item::SearchItem for SearchItem {
     }
 
     fn score(&self) -> OrderedFloat<f64> {
-        OrderedFloat::from(0.0)
+        OrderedFloat::from(1000.0 - self.mru_rank as f64)
     }
 
     fn accept_result(&self) -> Self::Action {

--- a/app/src/search/command_palette/tabs/search_item.rs
+++ b/app/src/search/command_palette/tabs/search_item.rs
@@ -1,0 +1,108 @@
+use crate::appearance::Appearance;
+use crate::search::command_palette::mixer::CommandPaletteItemAction;
+use crate::search::command_palette::render_util::render_search_item_icon;
+use crate::search::item::IconLocation;
+use crate::search::result_renderer::ItemHighlightState;
+use crate::session_management::TabNavigationData;
+use crate::ui_components::icons::Icon;
+use ordered_float::OrderedFloat;
+use warpui::elements::{ConstrainedBox, Container, Flex, ParentElement, Text};
+use warpui::fonts::{Properties, Weight};
+use warpui::{AppContext, Element, SingletonEntity};
+
+pub struct SearchItem {
+    tab: TabNavigationData,
+}
+
+impl SearchItem {
+    pub fn new(tab: TabNavigationData) -> Self {
+        Self { tab }
+    }
+}
+
+impl crate::search::item::SearchItem for SearchItem {
+    type Action = CommandPaletteItemAction;
+
+    fn is_multiline(&self) -> bool {
+        true
+    }
+
+    fn render_icon(
+        &self,
+        highlight_state: ItemHighlightState,
+        appearance: &Appearance,
+    ) -> Box<dyn Element> {
+        let color = appearance.theme().foreground().into_solid();
+        render_search_item_icon(appearance, Icon::Navigation, color, highlight_state)
+    }
+
+    fn icon_location(&self, appearance: &Appearance) -> IconLocation {
+        let margin_top = (appearance.line_height_ratio() * appearance.monospace_font_size())
+            - appearance.monospace_font_size();
+        IconLocation::Top { margin_top }
+    }
+
+    fn render_item(
+        &self,
+        highlight_state: ItemHighlightState,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+
+        let title_text = Text::new_inline(
+            self.tab.title.clone(),
+            appearance.ui_font_family(),
+            appearance.monospace_font_size(),
+        )
+        .with_color(highlight_state.main_text_fill(appearance).into_solid())
+        .with_style(Properties::default().weight(Weight::Bold))
+        .finish();
+
+        if let Some(subtitle) = &self.tab.subtitle {
+            let subtitle_text = Text::new_inline(
+                subtitle.clone(),
+                appearance.ui_font_family(),
+                appearance.monospace_font_size() - 2.,
+            )
+            .with_color(highlight_state.sub_text_fill(appearance).into_solid())
+            .finish();
+
+            let contents = Flex::column()
+                .with_child(title_text)
+                .with_child(
+                    Container::new(subtitle_text)
+                        .with_padding_top(4.)
+                        .finish(),
+                )
+                .finish();
+            ConstrainedBox::new(contents).with_height(50.).finish()
+        } else {
+            ConstrainedBox::new(Flex::column().with_child(title_text).finish())
+                .with_height(50.)
+                .finish()
+        }
+    }
+
+    fn score(&self) -> OrderedFloat<f64> {
+        OrderedFloat::from(0.0)
+    }
+
+    fn accept_result(&self) -> Self::Action {
+        CommandPaletteItemAction::NavigateToTab {
+            pane_group_id: self.tab.pane_group_id,
+            window_id: self.tab.window_id,
+        }
+    }
+
+    fn execute_result(&self) -> Self::Action {
+        self.accept_result()
+    }
+
+    fn accessibility_label(&self) -> String {
+        format!("Selected tab: {}.", self.tab.title)
+    }
+
+    fn accessibility_help_message(&self) -> Option<String> {
+        Some("Press enter to navigate to this tab.".into())
+    }
+}

--- a/app/src/search/command_palette/view.rs
+++ b/app/src/search/command_palette/view.rs
@@ -812,6 +812,20 @@ impl View {
 
                 send_telemetry_from_ctx!(TelemetryEvent::SelectNavigationPaletteItem, ctx);
             }
+            CommandPaletteItemAction::NavigateToTab {
+                pane_group_id,
+                window_id,
+            } => {
+                if let Some(root_view_id) = ctx.root_view_id(window_id) {
+                    ctx.dispatch_action_for_view(
+                        window_id,
+                        root_view_id,
+                        "root_view:activate_tab_by_pane_group_id",
+                        &pane_group_id,
+                    );
+                }
+                send_telemetry_from_ctx!(TelemetryEvent::SelectNavigationPaletteItem, ctx);
+            }
             CommandPaletteItemAction::NavigateToConversation {
                 pane_view_locator,
                 window_id,

--- a/app/src/search/data_source.rs
+++ b/app/src/search/data_source.rs
@@ -53,6 +53,10 @@ lazy_static! {
         primary_text: "sessions:",
         aliases: vec![]
     };
+    static ref TABS_FILTER_ATOM: FilterAtom = FilterAtom {
+        primary_text: "tabs:",
+        aliases: vec![]
+    };
     static ref CONVERSATIONS_FILTER_ATOM: FilterAtom = FilterAtom {
         primary_text: "conversations:",
         aliases: vec![]
@@ -167,6 +171,9 @@ pub enum QueryFilter {
     /// Filter results for open sessions.
     Sessions,
 
+    /// Filter results for open tabs.
+    Tabs,
+
     /// Filter results for all conversations.
     Conversations,
 
@@ -239,6 +246,7 @@ impl QueryFilter {
             QueryFilter::NaturalLanguage => "e.g. replace string in file",
             QueryFilter::Actions => "Search actions",
             QueryFilter::Sessions => "Search sessions",
+            QueryFilter::Tabs => "Search tabs",
             QueryFilter::Conversations => "Search conversations",
             QueryFilter::HistoricalConversations => "Search historical conversations",
             QueryFilter::LaunchConfigurations => "Search launch configurations",
@@ -273,6 +281,7 @@ impl QueryFilter {
             QueryFilter::NaturalLanguage => &NATURAL_LANGUAGE_FILTER_ATOM,
             QueryFilter::Actions => &ACTIONS_FILTER_ATOM,
             QueryFilter::Sessions => &SESSIONS_FILTER_ATOM,
+            QueryFilter::Tabs => &TABS_FILTER_ATOM,
             QueryFilter::Conversations => &CONVERSATIONS_FILTER_ATOM,
             QueryFilter::LaunchConfigurations => &LAUNCH_CONFIG_FILTER_ATOM,
             QueryFilter::Drive => &DRIVE_FILTER_ATOM,
@@ -305,6 +314,7 @@ impl QueryFilter {
             QueryFilter::NaturalLanguage => "AI command suggestions",
             QueryFilter::Actions => "actions",
             QueryFilter::Sessions => "sessions",
+            QueryFilter::Tabs => "tabs",
             QueryFilter::Conversations => "conversations",
             QueryFilter::LaunchConfigurations => "launch configurations",
             QueryFilter::Drive => "Warp Drive",
@@ -342,6 +352,7 @@ impl QueryFilter {
             }
             QueryFilter::Actions => None,
             QueryFilter::Sessions => Some("bundled/svg/terminal-input.svg"),
+            QueryFilter::Tabs => Some("bundled/svg/terminal-input.svg"),
             QueryFilter::Conversations | QueryFilter::HistoricalConversations => {
                 Some("bundled/svg/conversation.svg")
             }

--- a/app/src/search/filter_chip_renderer.rs
+++ b/app/src/search/filter_chip_renderer.rs
@@ -36,6 +36,7 @@ impl FilterChipRenderer for QueryFilter {
     fn icon_margin_top(&self) -> f32 {
         match self {
             QueryFilter::Sessions => 2.,
+            QueryFilter::Tabs => 2.,
             QueryFilter::NaturalLanguage => 2.,
             _ => 0.,
         }

--- a/app/src/session_management.rs
+++ b/app/src/session_management.rs
@@ -234,3 +234,12 @@ pub fn num_shared_sessions(ctx: &AppContext) -> usize {
     }
     num_shared_sessions
 }
+
+/// Metadata for a single tab, used by the Ctrl+Tab MRU switcher.
+#[derive(Clone)]
+pub struct TabNavigationData {
+    pub pane_group_id: EntityId,
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub window_id: WindowId,
+}

--- a/app/src/settings/mod.rs
+++ b/app/src/settings/mod.rs
@@ -214,6 +214,7 @@ pub enum CtrlTabBehavior {
     #[default]
     ActivatePrevNextTab,
     CycleMostRecentSession,
+    CycleMostRecentTab,
 }
 
 impl CtrlTabBehavior {
@@ -221,6 +222,7 @@ impl CtrlTabBehavior {
         match self {
             Self::ActivatePrevNextTab => "Activate previous/next tab",
             Self::CycleMostRecentSession => "Cycle most recent session",
+            Self::CycleMostRecentTab => "Cycle most recent tab",
         }
     }
 }

--- a/app/src/settings_view/features_page.rs
+++ b/app/src/settings_view/features_page.rs
@@ -2773,6 +2773,7 @@ impl FeaturesPageView {
             let values = vec![
                 CtrlTabBehavior::ActivatePrevNextTab,
                 CtrlTabBehavior::CycleMostRecentSession,
+                CtrlTabBehavior::CycleMostRecentTab,
             ];
 
             let current_value = *KeysSettings::as_ref(ctx).ctrl_tab_behavior;

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -282,7 +282,7 @@ use crate::server::telemetry::{
     MCPServerCollectionPaneEntrypoint, OpenedWarpAISource, SharingDialogSource, TierLimitHitEvent,
     WarpDriveSource,
 };
-use crate::session_management::{SessionNavigationData, SessionSource};
+use crate::session_management::{SessionNavigationData, SessionSource, TabNavigationData};
 use crate::settings::{
     active_theme_kind, respect_system_theme, AccessibilitySettings, AliasExpansionSettings,
     AppEditorSettings, BlockVisibilitySettings, ChangelogSettings, CursorBlink, DebugSettings,
@@ -890,6 +890,9 @@ pub struct Workspace {
     window_id: WindowId,
     tabs: Vec<TabData>,
     active_tab_index: usize,
+    /// Tracks tab activation order (most-recently-used first).
+    /// Each entry is the `pane_group.id()` of the corresponding tab.
+    tab_mru_order: Vec<EntityId>,
     hovered_tab_index: Option<TabBarHoverIndex>,
     tab_bar_hover_state: MouseStateHandle,
     tab_fixed_width: Option<f32>,
@@ -3029,6 +3032,7 @@ impl Workspace {
         let mut ws = Self {
             tabs: Vec::new(),
             active_tab_index: 0,
+            tab_mru_order: Vec::new(),
             hovered_tab_index: None,
             tab_bar_hover_state: Default::default(),
             traffic_light_mouse_states: Default::default(),
@@ -4010,6 +4014,8 @@ impl Workspace {
 
         self.tabs.push(TabData::new(new_pane_group.clone()));
         let new_tab_index = self.tab_count() - 1;
+        self.tab_mru_order
+            .push(self.tabs[new_tab_index].pane_group.id());
         self.activate_tab_internal(new_tab_index, ctx);
 
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
@@ -4736,6 +4742,43 @@ impl Workspace {
         self.tabs.len()
     }
 
+    pub fn tab_mru_order(&self) -> &[EntityId] {
+        &self.tab_mru_order
+    }
+
+    pub fn activate_tab_by_pane_group_id(&mut self, pane_group_id: EntityId, ctx: &mut ViewContext<Self>) {
+        if let Some(index) = self.tabs.iter().position(|t| t.pane_group.id() == pane_group_id) {
+            self.activate_tab(index, ctx);
+        }
+    }
+
+    pub fn tab_navigation_data(&self, window_id: WindowId, ctx: &AppContext) -> Vec<TabNavigationData> {
+        self.tab_mru_order
+            .iter()
+            .filter_map(|&pane_group_id| {
+                let tab = self
+                    .tabs
+                    .iter()
+                    .find(|t| t.pane_group.id() == pane_group_id)?;
+                let title = tab.pane_group.as_ref(ctx).display_title(ctx);
+                let subtitle = tab.pane_group.as_ref(ctx).active_session_path(ctx).map(|p| {
+                    if let Some(home) = dirs::home_dir() {
+                        if let Ok(stripped) = p.strip_prefix(&home) {
+                            return format!("~/{}", stripped.display());
+                        }
+                    }
+                    p.display().to_string()
+                });
+                Some(TabNavigationData {
+                    pane_group_id,
+                    title,
+                    subtitle,
+                    window_id,
+                })
+            })
+            .collect()
+    }
+
     pub fn tab_views(&self) -> impl Iterator<Item = &ViewHandle<PaneGroup>> {
         self.tabs.iter().map(|s| &s.pane_group)
     }
@@ -4928,6 +4971,11 @@ impl Workspace {
 
         self.active_tab_index = index;
 
+        if let Some(tab) = self.tabs.get(index) {
+            let pane_group_id = tab.pane_group.id();
+            self.tab_mru_order.retain(|id| *id != pane_group_id);
+            self.tab_mru_order.insert(0, pane_group_id);
+        }
         if self.vertical_tabs_panel_open
             && FeatureFlag::VerticalTabs.is_enabled()
             && *TabSettings::as_ref(ctx).use_vertical_tabs
@@ -9993,6 +10041,32 @@ impl Workspace {
                     });
                 ctx.notify();
             }
+            CtrlTabBehavior::CycleMostRecentTab => {
+                self.current_workspace_state.is_palette_open = false;
+                if !self.current_workspace_state.is_ctrl_tab_palette_open {
+                    self.open_palette_action(
+                        PaletteMode::Navigation,
+                        PaletteSource::CtrlTab {
+                            shift_pressed_initially: matches!(
+                                direction,
+                                SessionCycleDirection::Previous
+                            ),
+                        },
+                        None,
+                        ctx,
+                    );
+                }
+                self.ctrl_tab_palette
+                    .update(ctx, |palette, ctx| match direction {
+                        SessionCycleDirection::Next => {
+                            palette.select_next_item(ctx);
+                        }
+                        SessionCycleDirection::Previous => {
+                            palette.select_prev_item(ctx);
+                        }
+                    });
+                ctx.notify();
+            }
         }
     }
 
@@ -10101,6 +10175,9 @@ impl Workspace {
         }
 
         let tab_data = self.tabs.remove(index);
+
+        let removed_pane_group_id = tab_data.pane_group.id();
+        self.tab_mru_order.retain(|id| *id != removed_pane_group_id);
 
         if add_to_undo_stack {
             let handle = ctx.handle();
@@ -10458,6 +10535,8 @@ impl Workspace {
         });
 
         self.tabs.insert(tab_index, tab_data);
+        self.tab_mru_order
+            .push(self.tabs[tab_index].pane_group.id());
         self.activate_tab(tab_index, ctx);
 
         ctx.notify();
@@ -10767,17 +10846,24 @@ impl Workspace {
         match new_tab_placement_setting {
             NewTabPlacement::AfterAllTabs => {
                 self.tabs.push(TabData::new(new_pane_group));
+                self.tab_mru_order
+                    .push(self.tabs.last().unwrap().pane_group.id());
                 self.activate_tab_internal(self.tab_count() - 1, ctx);
             }
             // Add tab after current tab
             _ => {
                 if self.tab_count() == 0 {
                     self.tabs.push(TabData::new(new_pane_group));
+                    self.tab_mru_order
+                        .push(self.tabs.last().unwrap().pane_group.id());
                     self.activate_tab_internal(self.tab_count() - 1, ctx);
                 } else {
+                    let insert_idx = self.active_tab_index + 1;
                     self.tabs
-                        .insert(self.active_tab_index + 1, TabData::new(new_pane_group));
-                    self.activate_tab_internal(self.active_tab_index + 1, ctx);
+                        .insert(insert_idx, TabData::new(new_pane_group));
+                    self.tab_mru_order
+                        .push(self.tabs[insert_idx].pane_group.id());
+                    self.activate_tab_internal(insert_idx, ctx);
                 }
             }
         }
@@ -10841,9 +10927,12 @@ impl Workspace {
 
         if self.tab_count() == 0 {
             self.tabs.push(TabData::new(new_pane_group));
+            self.tab_mru_order
+                .push(self.tabs.last().unwrap().pane_group.id());
             self.activate_tab_internal(self.tab_count() - 1, ctx);
         } else {
             self.tabs.insert(new_idx, TabData::new(new_pane_group));
+            self.tab_mru_order.push(self.tabs[new_idx].pane_group.id());
             self.activate_tab_internal(new_idx, ctx);
         }
     }
@@ -11380,6 +11469,8 @@ impl Workspace {
 
         self.tabs.push(TabData::new(new_pane_group.clone()));
         let new_tab_index = self.tab_count() - 1;
+        self.tab_mru_order
+            .push(self.tabs[new_tab_index].pane_group.id());
         self.activate_tab_internal(new_tab_index, ctx);
 
         // Get both IDs from the NEW tab's pane group
@@ -12183,15 +12274,49 @@ impl Workspace {
 
     fn open_ctrl_tab_palette(
         &mut self,
+        query_filter: QueryFilter,
         shift_pressed_initially: bool,
         ctx: &mut ViewContext<Self>,
     ) {
         let offset = if shift_pressed_initially { -1 } else { 1 };
+
         self.ctrl_tab_palette.update(ctx, |view, ctx| {
             view.reset(ctx);
-            view.set_active_query_filter(QueryFilter::Sessions, ctx);
-            view.set_initial_selection_offset(offset, ctx);
         });
+
+        // Tabs data source setup must happen OUTSIDE ctrl_tab_palette.update() to avoid
+        // workspace borrow conflict: inside update_view the workspace view is temporarily
+        // removed from the app context, so WeakViewHandle::upgrade() returns None. Here
+        // we pass the WeakViewHandle directly — DataSource::run_query upgrades it later
+        // (after this action handler returns) when the workspace IS back in the context.
+        if query_filter == QueryFilter::Tabs {
+            let workspace_weak = ctx.handle();
+            let window_id = ctx.window_id();
+            let mixer = self
+                .ctrl_tab_palette
+                .as_ref(ctx)
+                .search_bar
+                .as_ref(ctx)
+                .mixer()
+                .clone();
+            let data_source_store = self
+                .ctrl_tab_palette
+                .as_ref(ctx)
+                .data_source_store
+                .clone();
+            data_source_store.update(ctx, |store, ctx| {
+                store.reset_ctrl_tab_mixer(mixer, workspace_weak, window_id, ctx);
+            });
+        }
+
+        self.ctrl_tab_palette.update(ctx, |view, ctx| {
+            // Set offset BEFORE filter: the tabs query is synchronous, so results
+            // arrive during set_active_query_filter. The offset must already be
+            // stored so on_mixer_results_changed picks it up.
+            view.set_initial_selection_offset(offset, ctx);
+            view.set_active_query_filter(query_filter, ctx);
+        });
+
         ctx.notify();
     }
 
@@ -12360,7 +12485,13 @@ impl Workspace {
             PaletteMode::Navigation => match source {
                 PaletteSource::CtrlTab {
                     shift_pressed_initially,
-                } => self.open_ctrl_tab_palette(shift_pressed_initially, ctx),
+                } => {
+                    let filter = match *KeysSettings::as_ref(ctx).ctrl_tab_behavior {
+                        CtrlTabBehavior::CycleMostRecentTab => QueryFilter::Tabs,
+                        _ => QueryFilter::Sessions,
+                    };
+                    self.open_ctrl_tab_palette(filter, shift_pressed_initially, ctx);
+                }
                 _ => self.open_navigation_palette(ctx),
             },
             PaletteMode::LaunchConfig => self.open_launch_config_palette(ctx),

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -10055,16 +10055,20 @@ impl Workspace {
                         None,
                         ctx,
                     );
+                } else {
+                    // Only advance selection when palette is already open.
+                    // On first open, set_initial_selection_offset(1) already
+                    // pre-selects the second item (most recent previous tab).
+                    self.ctrl_tab_palette
+                        .update(ctx, |palette, ctx| match direction {
+                            SessionCycleDirection::Next => {
+                                palette.select_next_item(ctx);
+                            }
+                            SessionCycleDirection::Previous => {
+                                palette.select_prev_item(ctx);
+                            }
+                        });
                 }
-                self.ctrl_tab_palette
-                    .update(ctx, |palette, ctx| match direction {
-                        SessionCycleDirection::Next => {
-                            palette.select_next_item(ctx);
-                        }
-                        SessionCycleDirection::Previous => {
-                            palette.select_prev_item(ctx);
-                        }
-                    });
                 ctx.notify();
             }
         }
@@ -10237,6 +10241,11 @@ impl Workspace {
 
         let placeholder_pane_group =
             std::mem::replace(&mut placeholder_tab.pane_group, new_pane_group);
+        let old_id = placeholder_pane_group.id();
+        let new_id = placeholder_tab.pane_group.id();
+        if let Some(pos) = self.tab_mru_order.iter().position(|&id| id == old_id) {
+            self.tab_mru_order[pos] = new_id;
+        }
         let working_directories_model = self.working_directories_model.clone();
         placeholder_pane_group.update(ctx, |pg, ctx| {
             pg.detach_panes_for_close(&working_directories_model, ctx);

--- a/app/src/workspace/view_test.rs
+++ b/app/src/workspace/view_test.rs
@@ -2861,3 +2861,28 @@ fn test_open_cloud_agent_setup_guide_action_opens_management_view_and_is_idempot
         });
     });
 }
+
+#[test]
+fn test_tab_mru_order() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+
+            let id_a = workspace.tabs[0].pane_group.id();
+            let id_b = workspace.tabs[1].pane_group.id();
+            let id_c = workspace.tabs[2].pane_group.id();
+
+            workspace.handle_action(&WorkspaceAction::ActivateTab(0), ctx);
+            workspace.handle_action(&WorkspaceAction::ActivateTab(1), ctx);
+            workspace.handle_action(&WorkspaceAction::ActivateTab(2), ctx);
+            workspace.handle_action(&WorkspaceAction::ActivateTab(0), ctx);
+
+            assert_eq!(workspace.tab_mru_order(), &[id_a, id_c, id_b]);
+        });
+    });
+}


### PR DESCRIPTION
## Summary

Adds a new `CycleMostRecentTab` option to the Ctrl+Tab behavior settings, allowing users to cycle through tabs by most-recently-used order using the existing ctrl_tab palette UI.

### What changed

- **New `CtrlTabBehavior` variant**: `CycleMostRecentTab` added as a third option alongside `ActivatePrevNextTab` and `CycleMostRecentSession`
- **MRU tracking**: `Workspace` tracks tab activation order via `tab_mru_order: Vec<EntityId>`, updated in `set_active_tab_index()`
- **Tabs data source**: New `search/command_palette/tabs/` module with `DataSource` (provides MRU-ordered tabs) and `SearchItem` (renders two-row layout: bold title + gray CWD subtitle)
- **Palette wiring**: `QueryFilter::Tabs`, `NavigateToTab` action, `reset_ctrl_tab_mixer()` for tabs-only palette mode
- **Activation**: `root_view` handles `activate_tab_by_pane_group_id` action to switch to the selected tab
- **Settings UI**: Third dropdown option in Features settings page
- **Offset fix**: `set_initial_selection_offset` now called before `set_active_query_filter` to fix pre-selection for synchronous data sources

### Files changed (16 files, +435/-7)

| File | Change |
|------|--------|
| `settings/mod.rs` | `CycleMostRecentTab` enum variant |
| `settings_view/features_page.rs` | Third dropdown option |
| `session_management.rs` | `TabNavigationData` struct with subtitle |
| `workspace/view.rs` | MRU tracking, `tab_navigation_data()`, palette opening logic |
| `workspace/view_test.rs` | `test_tab_mru_order` unit test |
| `search/data_source.rs` | `QueryFilter::Tabs` variant |
| `search/filter_chip_renderer.rs` | Tabs filter chip |
| `search/command_palette/tabs/` | New module: `mod.rs`, `data_source.rs`, `search_item.rs` |
| `search/command_palette/data_sources.rs` | `reset_ctrl_tab_mixer()`, `ItemSummary::Tab` |
| `search/command_palette/mixer.rs` | `NavigateToTab` action |
| `search/command_palette/view.rs` | `NavigateToTab` handler |
| `search/command_palette/filter_chip_renderer.rs` | Tabs filter support |
| `root_view.rs` | `activate_tab_by_pane_group_id` action handler |

### How to test

1. Open Warp → Settings → Features → "Ctrl-Tab behavior" → select **"Cycle Most Recent Tab"**
2. Open 3+ tabs, switch between them
3. Press Ctrl+Tab → palette opens with tabs in MRU order, 2nd item pre-selected
4. Release Ctrl → switches to selected tab
5. Each item shows tab title (bold) + working directory (gray)