### PR TITLE
feat(notifications): notify when AI CLI is blocked in inactive tab

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -336,6 +336,7 @@ use crate::workflows::WorkflowSelectionSource;
 use crate::workspace::sync_inputs::SyncedInputState;
 use crate::workspace::{CommandSearchOptions, OneTimeModalModel, ToastStack, WorkspaceAction};
 use crate::workspace::{ForkAIConversationParams, ForkFromExchange, ForkedConversationDestination};
+use crate::workspace::Workspace;
 use crate::workspaces::{user_workspaces::UserWorkspaces, workspace::CustomerType};
 use crate::AIRequestUsageModel;
 use crate::ActiveSession as WindowActiveSession;
@@ -11759,8 +11760,8 @@ impl TerminalView {
             }
         }
 
-        // Desktop notifications — only when navigated away and not in-progress.
-        if !self.is_navigated_away_from_window(ctx)
+        // Desktop notifications — only when not visible and not in-progress.
+        if !self.is_cli_agent_terminal_not_visible(ctx)
             || matches!(status, CLIAgentSessionStatus::InProgress)
         {
             return;
@@ -19568,6 +19569,38 @@ impl TerminalView {
     fn is_navigated_away_from_window(&self, ctx: &mut ViewContext<Self>) -> bool {
         let active_window = ctx.windows().active_window();
         Some(ctx.window_id()) != active_window
+    }
+
+    /// Returns `true` when this terminal view is NOT currently visible to the user, meaning
+    /// a desktop notification should be sent for important status changes. Returns `false`
+    /// when the user can see this terminal (same OS window, same active tab).
+    ///
+    /// Notification should fire when:
+    /// - Warp is not the active OS window (user is in another app), OR
+    /// - Warp is active but the user is on a different tab within the same window.
+    fn is_cli_agent_terminal_not_visible(&self, ctx: &ViewContext<Self>) -> bool {
+        let active_window = ctx.windows().active_window();
+        // Case 1: this Warp window is not the active OS window.
+        if Some(ctx.window_id()) != active_window {
+            return true;
+        }
+        // Case 2: Warp IS the active OS window — check whether this terminal is in the active tab.
+        let Some(active_window_id) = active_window else {
+            // No active window reported (e.g. in tests) — treat as navigated away so notifications fire.
+            return true;
+        };
+        let Some(workspace) = ctx
+            .views_of_type::<Workspace>(active_window_id)
+            .and_then(|views| views.first().cloned())
+        else {
+            // Cannot resolve workspace — default to notifying rather than silently dropping it.
+            return true;
+        };
+        !workspace
+            .as_ref(ctx)
+            .active_tab_pane_group()
+            .as_ref(ctx)
+            .contains_terminal_view(self.view_id, ctx)
     }
 
     fn is_block_active_and_running(&self, model: &TerminalModel, block_index: BlockIndex) -> bool {

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -4605,3 +4605,159 @@ fn linear_deeplink_via_default_entrypoint_does_not_auto_submit_in_fullscreen() {
         });
     })
 }
+
+/// When a CLI agent session transitions to `Blocked` and the terminal is not in the
+/// active tab (simulated here by the test platform returning `None` for the active
+/// OS window), a `SendNotification` event should be emitted.
+#[test]
+fn cli_agent_blocked_sends_desktop_notification() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        // Enable desktop notifications with "needs attention" type.
+        SessionSettings::handle(&app).update(&mut app, |settings, ctx| {
+            let _ = settings.notifications.set_value(
+                NotificationsSettings {
+                    mode: NotificationsMode::Enabled,
+                    is_needs_attention_enabled: true,
+                    ..Default::default()
+                },
+                ctx,
+            );
+        });
+
+        let (tx, rx) = async_channel::bounded::<BlockNotification>(1);
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let Event::SendNotification(notification) = event {
+                    tx.try_send(notification.clone()).ok();
+                }
+            });
+        });
+
+        // Register a Blocked session via a PermissionRequest event.
+        terminal.update(&mut app, |view, ctx| {
+            CLIAgentSessionsModel::handle(ctx).update(ctx, |sessions, ctx| {
+                sessions.set_session(
+                    view.view_id,
+                    CLIAgentSession {
+                        agent: CLIAgent::Claude,
+                        status: CLIAgentSessionStatus::InProgress,
+                        session_context: CLIAgentSessionContext::default(),
+                        input_state: CLIAgentInputState::Closed,
+                        should_auto_toggle_input: false,
+                        listener: None,
+                        remote_host: None,
+                        plugin_version: None,
+                        draft_text: None,
+                        custom_command_prefix: None,
+                    },
+                    ctx,
+                );
+                sessions.update_from_event(
+                    view.view_id,
+                    &CLIAgentEvent {
+                        v: 1,
+                        agent: CLIAgent::Claude,
+                        event: CLIAgentEventType::PermissionRequest,
+                        session_id: None,
+                        cwd: None,
+                        project: None,
+                        payload: CLIAgentEventPayload {
+                            summary: Some("Needs your approval".to_owned()),
+                            ..Default::default()
+                        },
+                    },
+                    ctx,
+                );
+            });
+        });
+
+        use futures_lite::StreamExt;
+        let notification = pin!(rx).next().await;
+        assert!(
+            notification.is_some(),
+            "Expected a SendNotification event when CLI agent is Blocked and terminal is not visible"
+        );
+    })
+}
+
+/// When a CLI agent session transitions to `InProgress` (e.g. user replied to a
+/// permission request), no desktop notification should be emitted.
+#[test]
+fn cli_agent_in_progress_does_not_send_desktop_notification() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        SessionSettings::handle(&app).update(&mut app, |settings, ctx| {
+            let _ = settings.notifications.set_value(
+                NotificationsSettings {
+                    mode: NotificationsMode::Enabled,
+                    is_needs_attention_enabled: true,
+                    ..Default::default()
+                },
+                ctx,
+            );
+        });
+
+        let notification_count = Rc::new(RefCell::new(0usize));
+        let count = notification_count.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if matches!(event, Event::SendNotification(_)) {
+                    *count.borrow_mut() += 1;
+                }
+            });
+        });
+
+        // Pre-set session as Blocked, then transition to InProgress via ToolComplete.
+        terminal.update(&mut app, |view, ctx| {
+            CLIAgentSessionsModel::handle(ctx).update(ctx, |sessions, ctx| {
+                sessions.set_session(
+                    view.view_id,
+                    CLIAgentSession {
+                        agent: CLIAgent::Claude,
+                        status: CLIAgentSessionStatus::Blocked {
+                            message: Some("Waiting".to_owned()),
+                        },
+                        session_context: CLIAgentSessionContext::default(),
+                        input_state: CLIAgentInputState::Closed,
+                        should_auto_toggle_input: false,
+                        listener: None,
+                        remote_host: None,
+                        plugin_version: None,
+                        draft_text: None,
+                        custom_command_prefix: None,
+                    },
+                    ctx,
+                );
+                // Transition to InProgress — should NOT send a notification.
+                sessions.update_from_event(
+                    view.view_id,
+                    &CLIAgentEvent {
+                        v: 1,
+                        agent: CLIAgent::Claude,
+                        event: CLIAgentEventType::ToolComplete,
+                        session_id: None,
+                        cwd: None,
+                        project: None,
+                        payload: CLIAgentEventPayload::default(),
+                    },
+                    ctx,
+                );
+            });
+        });
+
+        assert_eq!(
+            *notification_count.borrow(),
+            0,
+            "No notification should fire for InProgress status"
+        );
+    })
+}

--- a/crates/warpui/build.rs
+++ b/crates/warpui/build.rs
@@ -71,6 +71,16 @@ fn compile_metal_shaders() {
     let metal_path = "src/platform/mac/rendering/metal/shaders/shaders.metal";
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
+    // When WARP_SKIP_METAL=1, create a dummy metallib so cargo check/test work
+    // in environments without the Metal Toolchain (e.g. CI, Command Line Tools only).
+    // The resulting binary will not render correctly — for development use only.
+    if env::var("WARP_SKIP_METAL").is_ok() {
+        println!("cargo:rerun-if-changed={header_path}");
+        println!("cargo:rerun-if-changed={metal_path}");
+        std::fs::write(out_path.join("shaders.metallib"), []).unwrap();
+        return;
+    }
+
     let air_path = out_path.join("shaders.air");
     let air_path = air_path.to_str().unwrap();
 


### PR DESCRIPTION
## Summary

Extends the desktop notification trigger for CLI agents (Claude, Gemini, Codex, etc.) to also fire when the user is on a **different tab** within the same Warp window — not just when Warp is minimized or in the background.

## Problem

Previously, `handle_cli_agent_sessions_event` only sent a desktop notification when Warp was not the active OS window (`is_navigated_away_from_window`). If you had two tabs open — one running a CLI agent, one for your own work — and the agent blocked waiting for input, **no notification was sent** because Warp was technically the active window.

## Solution

Adds a new helper `is_cli_agent_terminal_not_visible` that returns `true` in two cases:
1. Warp is not the active OS window (existing behaviour, preserved)
2. Warp IS active but the blocking terminal is **not in the active tab's pane group** (new)

The guard in `handle_cli_agent_sessions_event` is updated to call this instead of `is_navigated_away_from_window`.

## Also included

- `WARP_SKIP_METAL=1` env var in `warpui/build.rs` — creates a dummy metallib so `cargo check`/`cargo test` work in environments without the Metal Toolchain. Development aid only.

## Tests

Two unit tests in `terminal/view_test.rs`:
- `cli_agent_blocked_sends_desktop_notification`
- `cli_agent_in_progress_does_not_send_desktop_notification`

Both passing: `test result: ok. 2 passed; 0 failed`