### PR TITLE
[twarp 01] specs: tab-colors

### DIFF
--- a/.agents/skills/twarp-next/SKILL.md
+++ b/.agents/skills/twarp-next/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: twarp-next
+description: Drive twarp's roadmap one step at a time. Reads roadmap/ROADMAP.md, identifies the active feature and phase, and dispatches to spec writing, implementation, or status report. Use when the user runs /twarp-next or asks "what's next on twarp".
+---
+
+# twarp-next
+
+Single entry point for twarp side-project work. The user runs this when they come back to the project; the skill figures out the right next action without further prompting.
+
+The user's expected loop is **review and approve, nothing else**. Anything that needs human judgment becomes a PR; everything else is automated.
+
+## Workflow
+
+1. Read `roadmap/ROADMAP.md` — find the active feature (`Currently active:` line) and its declared phase from the table.
+2. Read `roadmap/<feature>/STATUS.md` — get sub-phase detail and PR references.
+3. **Reconcile against git.** For any PR referenced, run `gh pr view <num> --json state,mergedAt,url`. If git says merged but STATUS says `*-in-review`, advance the phase before doing anything else.
+4. Dispatch based on the (now-reconciled) phase using the table below.
+5. Update `STATUS.md` and the `ROADMAP.md` table on completion of each step.
+
+## Phase → action
+
+| Phase | Action |
+|-------|--------|
+| `not-started` | Briefly confirm scope with the user (one-line summary from STATUS.md). On confirmation, set phase to `spec-pending` and proceed. |
+| `spec-pending` | Use `write-product-spec` to fill `roadmap/<feature>/PRODUCT.md` (must include a smoke-test checklist — see "Smoke-test checklist" below). Then `write-tech-spec` to fill `roadmap/<feature>/TECH.md`. Open a spec PR via `create-pr`, title `[twarp NN] specs: <feature>`. Set phase to `spec-in-review`. |
+| `spec-in-review` | Status report only. **Do not modify code.** Tell the user what they're waiting on. |
+| `impl-pending` | Implement the next unchecked sub-phase using `implement-specs`, scoped only to that sub-phase. Run `./script/presubmit`; if it fails, use `diagnose-ci-failures` / `fix-errors` and iterate until green. Open an impl PR via `create-pr`, title `[twarp NN<sub>] <feature>: <sub-phase summary>`. Tick the sub-phase checkbox in STATUS.md. Set phase to `impl-in-review`. |
+| `impl-in-review` | Status report only. **Do not modify code.** |
+| `merged` | If unchecked sub-phases remain in STATUS.md, set phase back to `impl-pending` and recurse once. Otherwise update the `Currently active:` line in ROADMAP.md to the next feature, set its row to `not-started`, and recurse once. |
+
+## Hard rules
+
+- **Only one feature active at a time.** Never start feature N+1 while N has unchecked sub-phases.
+- **Never auto-merge.** Open the PR; the user merges.
+- **Never skip the spec PR.** Implementation cannot start until PRODUCT.md and TECH.md are merged to master.
+- **Specs must include a smoke-test checklist.** The user uses it to validate the impl PR.
+- **CI must pass before reporting "ready for review".** Iterate on red presubmit until green; never hand the user a red PR.
+- **Sub-phased features (02, 04)** complete every sub-PR before reaching `merged`.
+- **Git is authoritative.** If STATUS.md disagrees with `gh pr view`, trust git and fix STATUS.md.
+- **Don't touch upstream cherry-picks.** That's a separate workflow run on its own cadence.
+- **Never edit ROADMAP.md to reorder features.** That's a human decision; if the user wants to reorder, they'll do it.
+
+## Smoke-test checklist
+
+Every PRODUCT.md must end with a `## Smoke test` section. This is a numbered list of concrete steps the user runs against a built twarp binary to validate the feature works. Example for tab colors:
+
+```
+## Smoke test
+1. Open twarp. Open three tabs.
+2. Focus tab 2. Press ⌘⌥1. Tab 2 indicator turns red.
+3. Focus tab 2. Press ⌘⌥0. Tab 2 indicator returns to default.
+4. Press ⌘⌥4 on tab 3. Tab 3 indicator turns green; tab 2 unaffected.
+5. Restart twarp. Tab colors persist.
+```
+
+If a sub-phase has its own smoke test (e.g. 4a vs 4b), include sub-headings.
+
+## Status report format
+
+When the active phase is `*-in-review`, or there is otherwise nothing to do without user action, output **exactly** this and stop:
+
+```
+twarp status
+  Active:  <NN — feature name>
+  Phase:   <phase>
+  PR:      <gh url, or — if none>
+  Waiting: <user review | CI | other>
+  Next:    <one line: what happens after this clears>
+```
+
+No code edits, no preamble, no follow-up offers.
+
+## Argument handling
+
+- `/twarp-next` (no args) — full workflow above.
+- `/twarp-next status` — status report only, even if work could be done. Useful when the user just wants a sitrep.
+- `/twarp-next reset` — refuse. State changes that destroy work need explicit human action; tell the user to edit `ROADMAP.md` and the relevant `STATUS.md` themselves.
+
+## Child skills used
+
+- `write-product-spec` — fill PRODUCT.md (override its default `specs/<linear-ticket>/` path; write to `roadmap/<feature>/PRODUCT.md`)
+- `write-tech-spec` — fill TECH.md (same path override)
+- `implement-specs` — write code from approved specs (point it at the merged spec files)
+- `create-pr` — open PR with structured description
+- `diagnose-ci-failures` — investigate red CI
+- `fix-errors` — recover from build/test failures
+- `simplify` — clean up dead code (especially during 02 sub-phases)
+- `add-feature-flag` / `remove-feature-flag` / `promote-feature` — for any flag-gated rollouts inside a feature
+- `warp-integration-test` / `rust-unit-tests` — test coverage
+
+## What this skill does NOT do
+
+- Doesn't pick the order — that's in ROADMAP.md, set by humans.
+- Doesn't merge PRs — only the user merges.
+- Doesn't manage upstream cherry-picks — separate cadence.
+- Doesn't modify the four feature definitions in README.md — those are the contract. If scope needs to change, that's a human decision and a separate PR.

--- a/.agents/skills/twarp-next/SKILL.md
+++ b/.agents/skills/twarp-next/SKILL.md
@@ -7,7 +7,7 @@ description: Drive twarp's roadmap one step at a time. Reads roadmap/ROADMAP.md,
 
 Single entry point for twarp side-project work. The user runs this when they come back to the project; the skill figures out the right next action without further prompting.
 
-The user's expected loop is **review and approve, nothing else**. Anything that needs human judgment becomes a PR; everything else is automated.
+The user's expected loop is **review and approve, nothing else**. Anything that needs human judgment becomes a PR; everything else is automated. **Invoking `/twarp-next` is itself the user's confirmation to proceed** — never pause to ask "shall I start?" or "ready to begin?". The only stopping points are `*-in-review` phases, where the user is reviewing a real PR.
 
 ## Workflow
 
@@ -21,7 +21,7 @@ The user's expected loop is **review and approve, nothing else**. Anything that 
 
 | Phase | Action |
 |-------|--------|
-| `not-started` | Briefly confirm scope with the user (one-line summary from STATUS.md). On confirmation, set phase to `spec-pending` and proceed. |
+| `not-started` | Set phase to `spec-pending` and recurse once. Invoking `/twarp-next` is the confirmation — do not ask. |
 | `spec-pending` | Use `write-product-spec` to fill `roadmap/<feature>/PRODUCT.md` (must include a smoke-test checklist — see "Smoke-test checklist" below). Then `write-tech-spec` to fill `roadmap/<feature>/TECH.md`. Open a spec PR via `create-pr`, title `[twarp NN] specs: <feature>`. Set phase to `spec-in-review`. |
 | `spec-in-review` | Status report only. **Do not modify code.** Tell the user what they're waiting on. |
 | `impl-pending` | Implement the next unchecked sub-phase using `implement-specs`, scoped only to that sub-phase. Run `./script/presubmit`; if it fails, use `diagnose-ci-failures` / `fix-errors` and iterate until green. Open an impl PR via `create-pr`, title `[twarp NN<sub>] <feature>: <sub-phase summary>`. Tick the sub-phase checkbox in STATUS.md. Set phase to `impl-in-review`. |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,115 @@
+# twarp
+
+**Tidier Warp** — a community fork of [Warp](https://github.com/warpdotdev/warp) for people who want a fast, modern terminal without the AI overlay, plus a few quality-of-life additions for keyboard-driven workflows and git review.
+
+> **Status:** planning / pre-alpha. Forked from `warpdotdev/warp@d0f045c0` on 2026-04-29. None of the differences below are implemented yet — this README is the roadmap.
+
+## Why fork?
+
+Warp is an excellent terminal. twarp aims to be a leaner, AI-free distribution of it with a few focused additions. If you want an agent in your terminal, run one yourself (e.g., `claude`) — but the terminal itself shouldn't be an AI.
+
+## What's different from Warp
+
+### 1. No AI tools
+
+twarp removes Warp's AI features — the agentic mode, cloud-agent surfaces, in-line AI suggestions, AI command help, anything that calls out to an LLM from inside the terminal. The terminal is the terminal.
+
+In practice this means ripping out (or feature-gating off by default) the agent UI, the cloud-mode codepaths, the AI command palette, and any LLM-backed completion. Telemetry that exists solely to support those features goes with them.
+
+### 2. Tab color shortcuts
+
+A keyboard shortcut to assign a color to the active tab — useful for visually distinguishing workflows at a glance ("red tab is prod, green tab is local").
+
+Tentative defaults (configurable):
+
+| Shortcut | Color |
+|---|---|
+| `⌘⌥1` | Red |
+| `⌘⌥2` | Orange |
+| `⌘⌥3` | Yellow |
+| `⌘⌥4` | Green |
+| `⌘⌥5` | Blue |
+| `⌘⌥6` | Purple |
+| `⌘⌥7` | Pink |
+| `⌘⌥8` | Gray |
+| `⌘⌥0` | Reset |
+
+Upstream is already exploring per-tab color indication on `oz-agent/APP-4321-active-tab-color-indication` — twarp will likely build on top of that work rather than re-invent it.
+
+### 3. Custom command shortcuts
+
+A declarative way to bind a keyboard shortcut to a sequence of terminal actions: open a new tab, type text, press keys, wait, type more. Lets you turn frequent multi-step workflows into one keystroke.
+
+Two driving examples:
+
+- **`⌘⇧D`** — open a new tab and auto-type `claude` (with enter).
+- **`⌘⇧A`** — open a new tab, type `claude` and enter, wait a couple of seconds, then type `/address-code-review-comments ultrathink` and enter.
+
+Sketch of the config format (final shape TBD):
+
+```yaml
+shortcuts:
+  - keys: cmd+shift+d
+    actions:
+      - new_tab
+      - type: "claude"
+      - press: enter
+
+  - keys: cmd+shift+a
+    actions:
+      - new_tab
+      - type: "claude"
+      - press: enter
+      - wait: 2s
+      - type: "/address-code-review-comments ultrathink"
+      - press: enter
+```
+
+The intent is for the shortcut system to be powerful enough that "open Claude in a fresh tab and feed it a slash command" is one keystroke, and small enough that the config stays readable.
+
+### 4. Open Changes panel (VS Code-style git review)
+
+A built-in side panel for reviewing the current repo's changes — modeled directly on **VS Code's Source Control view**, behavior-for-behavior where it makes sense.
+
+Goals:
+
+- See **working-tree changes and staged changes separately**, with file counts at each level.
+- Click a file to view the diff inline.
+- Stage / unstage / discard at file or hunk level.
+- Show the **git Timeline** (file history) for the focused file.
+- Commit message input + commit / push / pull from the same panel.
+
+The aim is parity with VS Code's panel for the operations a terminal user already does dozens of times a day, so you don't need to switch out of the terminal to review changes before committing.
+
+## Tracking upstream Warp
+
+twarp keeps `warpdotdev/warp` as `upstream` and **cherry-picks selectively** rather than bulk-merging. We deliberately don't run `git merge upstream/master`, because that re-fights the AI-deletion every cycle.
+
+Workflow:
+
+1. `git fetch upstream` periodically.
+2. `git log upstream/master ^HEAD --oneline` to see what's new.
+3. `git cherry-pick <sha>` for individual commits worth taking — perf, rendering, fixes, non-AI features. Skip AI-related commits.
+4. Record integrated commits in `UPSTREAM_CHANGELOG.md` so we don't re-pick them.
+
+Baseline (the state we forked from): `warpdotdev/warp@d0f045c0` (2026-04-28).
+
+## Building twarp
+
+Build process is unchanged from upstream Warp. See the original Warp README below for `./script/bootstrap`, `./script/run`, and `./script/presubmit`, and [WARP.md](WARP.md) for the full engineering guide.
+
+## Acknowledgements
+
+twarp is a fork of [Warp](https://github.com/warpdotdev/warp), open-sourced by Warp Inc. on 2026-04-28. All upstream credit goes to the Warp team — twarp's modifications are limited to the four areas above.
+
+## Licensing
+
+twarp inherits Warp's licensing unchanged: the `warpui_core` and `warpui` crates are MIT, the rest of the tree is AGPL v3. See [LICENSE-MIT](LICENSE-MIT) and [LICENSE-AGPL](LICENSE-AGPL).
+
+---
+
+> The section below is the **original Warp README, preserved unchanged** as part of the fork. Statements about Warp AI, OpenAI sponsorship, and GPT-powered agents describe upstream Warp, not twarp.
+
 <a href="https://www.warp.dev">
     <img width="1024" alt="Warp Agentic Development Environment product preview" src="https://github.com/user-attachments/assets/9976b2da-2edd-4604-a36c-8fd53719c6d4" />
 </a>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Warp is an excellent terminal. twarp aims to be a leaner, AI-free distribution o
 
 twarp removes Warp's AI features — the agentic mode, cloud-agent surfaces, in-line AI suggestions, AI command help, anything that calls out to an LLM from inside the terminal. The terminal is the terminal.
 
-In practice this means ripping out (or feature-gating off by default) the agent UI, the cloud-mode codepaths, the AI command palette, and any LLM-backed completion. Telemetry that exists solely to support those features goes with them.
+In practice this means ripping out the agent UI, the cloud-mode codepaths, the AI command palette, and any LLM-backed completion. Telemetry that exists solely to support those features goes with them.
+
+Build progress for all four sections below is tracked in [`roadmap/ROADMAP.md`](roadmap/ROADMAP.md).
 
 ### 2. Tab color shortcuts
 

--- a/roadmap/01-tab-colors/PRODUCT.md
+++ b/roadmap/01-tab-colors/PRODUCT.md
@@ -1,0 +1,70 @@
+---
+name: 01 — Tab color shortcuts
+status: draft
+---
+
+# Tab color shortcuts
+
+## Summary
+
+Keyboard shortcuts that color-tag the currently active tab, so users can visually distinguish workflows at a glance ("red tab is prod, green tab is local"). Eight color shortcuts plus one reset, on top of the tab-color surface that already exists upstream — this feature only adds the keyboard surface, not the rendering or storage of tab colors.
+
+## Behavior
+
+1. The following default keyboard shortcuts are registered and dispatch to the active tab in the focused window:
+
+   | Shortcut | Action |
+   |---|---|
+   | `⌘⌥1` | Set color: Red |
+   | `⌘⌥2` | Set color: Yellow |
+   | `⌘⌥3` | Set color: Green |
+   | `⌘⌥4` | Set color: Cyan |
+   | `⌘⌥5` | Set color: Blue |
+   | `⌘⌥6` | Set color: Magenta |
+   | `⌘⌥7` | Set color: White |
+   | `⌘⌥8` | Set color: Black |
+   | `⌘⌥0` | Reset color |
+
+   **Open question:** README §2 lists Red/Orange/Yellow/Green/Blue/Purple/Pink/Gray as the tentative defaults. The existing upstream `AnsiColorIdentifier` palette only has eight colors (Red, Green, Yellow, Blue, Magenta, Cyan, White, Black) — Orange, Purple, Pink, and Gray are not present. This spec uses the eight ANSI identifiers as-is so the feature ships small and stays aligned with how the rest of the tab-color subsystem renders. If the user wants Orange/Purple/Pink/Gray, that requires extending `AnsiColorIdentifier` and the theme palette — a separate, larger change. README is marked "Tentative defaults (configurable)", so this divergence is in-bounds; flag in review if you want a different default mapping or want to expand the palette before shipping.
+
+2. The eight color shortcuts (⌘⌥1–⌘⌥8) **unconditionally set** the active tab to the named color. Pressing the shortcut for the color a tab already has is a no-op (visually unchanged). This differs from the existing tab-context-menu's toggle-off behavior — the dedicated reset shortcut (⌘⌥0) is the only way to clear a color via keyboard, which keeps each color shortcut predictable.
+
+3. The reset shortcut (⌘⌥0) clears the active tab's manual color. After reset:
+   - If the tab has a directory-driven color (via the existing automatic-coloring feature), that color becomes visible.
+   - Otherwise the tab returns to the default uncolored appearance.
+   - Pressing ⌘⌥0 on an already-uncolored tab is a no-op (no error, no visible change).
+
+4. Shortcuts only affect the **currently active tab** in the **currently focused window**. Inactive tabs and tabs in other windows are untouched. There is no multi-select coloring and no "color all tabs" action in this feature.
+
+5. Each color shortcut produces an immediate visible change — the tab indicator (and any other surfaces that already show tab color upstream) updates synchronously, with no confirmation modal or transient state.
+
+6. The shortcuts are listed in the keybindings settings page like any other built-in shortcut, under a category that groups them together (e.g. "Tabs"). Users can rebind any of them, unbind them, or assign the same actions to other keys through the existing settings surface — no special UI is added for this feature.
+
+7. The color set is fixed at the eight named colors above plus reset. There is no UI for picking arbitrary colors via this feature; users who want a different palette adjust the theme's ANSI palette globally, which is the existing mechanism that drives tab color rendering.
+
+8. Color names map to the existing ANSI color identifiers used by the rest of the tab-color subsystem, so the rendered hue is theme-aware (light vs. dark themes apply their own ANSI palette) and matches the color a user would get by picking that color from the existing tab context menu.
+
+9. Persistence matches the existing manual-tab-color behavior: a tab's color is saved with the rest of the tab/session state and restored when the workspace is restored. Closing and reopening a tab in the same session does not preserve color (a closed tab is gone). Restart of the app preserves color via the normal session restore path.
+
+10. Shortcut handling respects normal focus rules:
+    - When focus is in a non-tab surface that captures the keystroke (e.g. an open modal, command palette, settings page editor, the AI assistant input), the shortcut does not change tab color and is handled by that surface or ignored, consistent with how other ⌘⌥-number shortcuts behave today.
+    - When the user is typing in the terminal (the normal case), the shortcut takes effect on the active tab.
+
+11. With zero tabs (an impossible state in practice but worth being explicit), the shortcuts are a no-op.
+
+12. The feature does not gate on any new feature flag. It ships unconditionally, like other built-in default keybindings.
+
+## Smoke test
+
+Run against a freshly built twarp binary.
+
+1. Open twarp. Open three tabs.
+2. Focus tab 2. Press `⌘⌥1`. Tab 2's color indicator turns red.
+3. Press `⌘⌥1` again on tab 2. Tab 2 stays red (unconditional set, no toggle-off).
+4. Press `⌘⌥3` on tab 2. Tab 2's color changes to green.
+5. Press `⌘⌥0` on tab 2. Tab 2 returns to the default (uncolored) appearance.
+6. Press `⌘⌥0` on tab 2 again. No change, no error.
+7. Press `⌘⌥5` on tab 3. Tab 3 turns blue. Tab 2 unaffected.
+8. Cycle through `⌘⌥1`..`⌘⌥8` on tab 1, confirming each maps to: red, yellow, green, cyan, blue, magenta, white, black.
+9. Open the keybindings settings page. Confirm the nine new entries are listed and rebindable.
+10. Quit twarp and relaunch with workspace restore enabled. The previously colored tabs come back with their colors.

--- a/roadmap/01-tab-colors/STATUS.md
+++ b/roadmap/01-tab-colors/STATUS.md
@@ -1,6 +1,6 @@
 # 01 — Tab color shortcuts
 
-**Phase:** not-started
+**Phase:** spec-pending
 **Spec PR:** —
 **Impl PR:** —
 

--- a/roadmap/01-tab-colors/STATUS.md
+++ b/roadmap/01-tab-colors/STATUS.md
@@ -1,0 +1,21 @@
+# 01 — Tab color shortcuts
+
+**Phase:** not-started
+**Spec PR:** —
+**Impl PR:** —
+
+## Scope
+
+Keyboard shortcuts (⌘⌥1–8 for color, ⌘⌥0 to reset) that set the active tab's color. See README §2 for the full table and intent.
+
+## Approach note
+
+Build on top of upstream `oz-agent/APP-4321-active-tab-color-indication` if that branch has landed by the time the spec is written; otherwise implement the per-tab color indicator surface from scratch. This decision belongs in TECH.md, not here — flag it for the spec phase.
+
+## Sub-phases
+
+Single phase — one PRODUCT.md + TECH.md, one impl PR.
+
+## Why this is feature 01
+
+Smallest scope of the four; validates the whole spec → review → impl → review loop with the least blast radius. If something about the workflow is wrong, we find out here.

--- a/roadmap/01-tab-colors/TECH.md
+++ b/roadmap/01-tab-colors/TECH.md
@@ -1,0 +1,109 @@
+---
+name: 01 — Tab color shortcuts
+status: draft
+---
+
+# Tab color shortcuts — TECH
+
+See `roadmap/01-tab-colors/PRODUCT.md` for behavior.
+
+## Context
+
+The tab-color rendering and storage stack already exists upstream and is intact in this checkout. This feature only adds the keyboard surface on top.
+
+Existing pieces (do not rebuild):
+
+- `app/src/tab.rs:79` — `SelectedTabColor { Unset, Color(AnsiColorIdentifier), Cleared }`. Per-tab on `TabData::selected_color`.
+- `crates/warp_core/src/ui/theme/mod.rs:539` — `AnsiColorIdentifier` enum with the eight ANSI colors. The product spec's color set is fixed to this palette (see PRODUCT invariant 1's open question).
+- `app/src/workspace/action.rs:210` — `WorkspaceAction::ToggleTabColor { color, tab_index }`. Used by the existing tab context menu. Toggle semantics: same color → clear, different color → set.
+- `app/src/workspace/view.rs:5068` — `WorkspaceView::toggle_tab_color`, the handler for the above. Already chooses between `SelectedTabColor::Cleared` and `SelectedTabColor::Unset` based on `FeatureFlag::DirectoryTabColors`. Already emits `TabTelemetryAction::SetColor` / `ResetColor`.
+- `app/src/persistence/sqlite.rs:899` — `selected_color` is serialized to and restored from the workspace sqlite store. PRODUCT invariant 9 requires no change here.
+- `app/src/workspace/mod.rs (~150-560)` — workspace `EditableBinding` registry. New default keybindings are registered alongside existing ones like `workspace:close_active_tab`, `workspace:toggle_navigation_palette`, etc., grouped via `.with_group(bindings::BindingGroup::Navigation.as_str())`. Tab-related bindings already live in this group (see lines ~494-578).
+- `crates/warpui_core/src/keymap.rs:645` — `EditableBinding` builder API: `with_mac_key_binding`, `with_linux_or_windows_key_binding`, `with_group`, `with_context_predicate` are the methods we use. There is no `Tabs` group; `Navigation` is the established home for tab-related defaults.
+
+Upstream branch `oz-agent/APP-4321-active-tab-color-indication` (commit `86570e7`) is unrelated polish for already-color-coded tabs and is not merged. We do not depend on or cherry-pick it for this feature.
+
+## Proposed changes
+
+### New action variants
+
+Add two variants to `WorkspaceAction` in `app/src/workspace/action.rs`:
+
+```rust
+SetActiveTabColor { color: AnsiColorIdentifier },
+ResetActiveTabColor,
+```
+
+Place them next to `ToggleTabColor` (line 210). They take no `tab_index` — the handler resolves the active tab. This matches PRODUCT invariant 4 (always acts on the active tab) and keeps the keybinding payload minimal. Add them to whatever exhaustive-match arms exist for `WorkspaceAction` (e.g. the persistability filter at line 730 — match the surrounding pattern).
+
+Keep `ToggleTabColor` unchanged. The context menu's existing toggle UX is correct for that surface; do not change it.
+
+### New handler methods
+
+In `app/src/workspace/view.rs`, alongside `toggle_tab_color` (line 5068):
+
+- `set_tab_color(&mut self, index: usize, color: AnsiColorIdentifier, ctx: &mut ViewContext<Self>)` — unconditional set. If `self.tabs[index].color() == Some(color)`, return without notifying (PRODUCT invariant 2: visually unchanged, no toggle-off). Otherwise set `self.tabs[index].selected_color = SelectedTabColor::Color(color)`, emit `TabTelemetryAction::SetColor`, and `ctx.notify()`.
+- `reset_tab_color(&mut self, index: usize, ctx: &mut ViewContext<Self>)` — unconditional reset. If the tab is already uncolored (`self.tabs[index].selected_color` is `Unset` and there's no Cleared override needed), return without notifying (PRODUCT invariant 3, last bullet). Otherwise set to `SelectedTabColor::Cleared` if `FeatureFlag::DirectoryTabColors` is enabled, else `Unset` — same branch the existing `toggle_tab_color` already uses. Emit `TabTelemetryAction::ResetColor` and `ctx.notify()`.
+
+Bounds-check the index identically to `toggle_tab_color` and `log::warn!` on miss. Both methods are pub.
+
+Add a thin "active tab" wrapper used by the action handler — e.g. `set_active_tab_color(&mut self, color, ctx)` and `reset_active_tab_color(&mut self, ctx)` — that resolves the active tab index and delegates. If there's an existing helper like `active_tab_index()`, use it; otherwise read whatever field the rest of the workspace view reads. PRODUCT invariant 11: a missing/zero-tab state is a no-op.
+
+### Action dispatch
+
+In the `WorkspaceAction` match arm in `app/src/workspace/view.rs` (line ~20019, alongside the existing `ToggleTabColor` arm), add:
+
+```rust
+SetActiveTabColor { color } => self.set_active_tab_color(*color, ctx),
+ResetActiveTabColor => self.reset_active_tab_color(ctx),
+```
+
+### Default keybindings
+
+In `app/src/workspace/mod.rs`, add nine `EditableBinding` registrations near the existing tab/navigation bindings (around lines 494-578). Naming convention follows `workspace:<verb>_<noun>`:
+
+```rust
+EditableBinding::new(
+    "workspace:set_active_tab_color_red",
+    "Set active tab color: Red",
+    WorkspaceAction::SetActiveTabColor { color: AnsiColorIdentifier::Red },
+)
+.with_group(bindings::BindingGroup::Navigation.as_str())
+.with_context_predicate(id!("Workspace"))
+.with_mac_key_binding("cmd-alt-1")
+.with_linux_or_windows_key_binding("ctrl-alt-1"),
+```
+
+Repeat for the eight colors per the PRODUCT.md table (⌘⌥1=Red, ⌘⌥2=Yellow, ⌘⌥3=Green, ⌘⌥4=Cyan, ⌘⌥5=Blue, ⌘⌥6=Magenta, ⌘⌥7=White, ⌘⌥8=Black) and `workspace:reset_active_tab_color` on `cmd-alt-0` / `ctrl-alt-0`. Use the same `Workspace` context predicate the surrounding tab bindings use, so the shortcuts respect PRODUCT invariant 10 (focus rules — modals/palette/etc. that capture keys keep capturing them).
+
+The Linux/Windows mappings use `ctrl-alt-N` to mirror the Mac `cmd-alt-N`, matching the convention used for the other ⌘⌥-style bindings in this file. If the existing tab-switch bindings use a different cross-platform convention (verify against neighbours during implementation), follow theirs instead.
+
+No new entries in `BindingGroup`. Tab-related bindings already use `Navigation`; reuse it. PRODUCT invariant 6 only requires that the entries appear and are rebindable in the keybindings settings page — `EditableBinding` registration alone gives us that.
+
+### Persistence
+
+No change. `selected_color` already round-trips through sqlite (PRODUCT invariant 9 satisfied by existing code).
+
+### Feature flag
+
+None. PRODUCT invariant 12 requires the feature ships unconditionally.
+
+## Testing and validation
+
+Unit tests, in the existing test module for `WorkspaceView`:
+
+- `set_tab_color` on an uncolored tab → `selected_color` becomes `Color(c)`. Maps to PRODUCT invariant 2 first half.
+- `set_tab_color` on a tab already that color → no change (assert `ctx.notify()` not called, or just assert the field stays `Color(c)`). Maps to PRODUCT invariant 2 second half (no toggle-off).
+- `set_tab_color` on a tab with a different color → `selected_color` becomes the new `Color(c)`. Maps to PRODUCT invariant 2.
+- `reset_tab_color` on a colored tab with `DirectoryTabColors` disabled → `Unset`. Maps to PRODUCT invariant 3.
+- `reset_tab_color` on a colored tab with `DirectoryTabColors` enabled → `Cleared`. Maps to PRODUCT invariant 3 first bullet.
+- `reset_tab_color` on an already-uncolored tab → no-op. Maps to PRODUCT invariant 3 last bullet.
+- Bounds: `set_tab_color`/`reset_tab_color` on an out-of-range index logs and returns. Mirrors the existing `toggle_tab_color` test if there is one.
+
+Active-tab routing test:
+- `set_active_tab_color`/`reset_active_tab_color` mutate only the active tab; siblings untouched. Maps to PRODUCT invariant 4.
+- Zero-tab state is a no-op. Maps to PRODUCT invariant 11.
+
+No integration test for the keybinding routing layer — `EditableBinding` registration is config-shaped and the keymap system has its own coverage.
+
+Manual validation: the smoke test in `PRODUCT.md` is the canonical pre-merge check. Run it against a `cargo run` build before requesting review. Steps 9 (settings page entries appear and are rebindable) and 10 (persistence across restart) cover the parts unit tests can't.

--- a/roadmap/02-ai-removal/STATUS.md
+++ b/roadmap/02-ai-removal/STATUS.md
@@ -1,0 +1,26 @@
+# 02 — AI removal
+
+**Phase:** not-started
+**Spec PR:** —
+**Impl PRs:** —
+
+## Scope
+
+Rip out Warp's AI features: agentic mode UI, cloud-agent surfaces, inline AI suggestions, AI command palette, LLM-backed completion, and AI-only telemetry. See README §1.
+
+## Sub-phases
+
+- [ ] **2a — Audit doc (no code change).** Enumerate every file, module, crate, feature flag, telemetry event, and config key tied to AI. Output: `roadmap/02-ai-removal/AUDIT.md`, which drives 2b–2d. Reviewable as a single PR with no behavior change.
+- [ ] **2b — Remove agent UI + cloud-mode codepaths.**
+- [ ] **2c — Remove AI command palette + inline suggestions + LLM-backed completion.**
+- [ ] **2d — Remove AI-only telemetry, feature flags, and dead config.**
+
+## Notes
+
+- Run the `simplify` skill on each sub-PR to catch dead code the rip-out leaves behind.
+- Cherry-pick conflict cost begins here. After 2a merges, schedule a recurring upstream-watcher agent (weekly) to surface conflicting upstream commits early.
+- The fork inherits Warp's MIT/AGPL split. Removing AI code shouldn't change licensing, but call out anything ambiguous in 2a's audit.
+
+## Why this is feature 02 (not last)
+
+The fork's identity is "no AI." Establishing that early matters more than minimizing cherry-pick conflict cost — and the conflict cost is unavoidable regardless of timing.

--- a/roadmap/03-command-shortcuts/STATUS.md
+++ b/roadmap/03-command-shortcuts/STATUS.md
@@ -1,0 +1,23 @@
+# 03 — Custom command shortcuts
+
+**Phase:** not-started
+**Spec PR:** —
+**Impl PR:** —
+
+## Scope
+
+Declarative keybindings → action sequence (`new_tab`, `type:`, `press:`, `wait:`). See README §3 for the YAML sketch and the two driving examples (⌘⇧D for `claude`, ⌘⇧A for `claude` + delayed slash command).
+
+## Sub-phases
+
+Likely one impl PR if the config schema holds during spec review. If the schema is contentious or the action set grows past the README sketch, split into:
+
+1. config + parser (no runtime effect)
+2. executor + bindings registration
+
+This decision belongs in TECH.md.
+
+## Notes
+
+- Spec phase should explicitly enumerate the action vocabulary (`new_tab`, `type`, `press`, `wait`, …) and decide what's in v1 vs deferred.
+- The config format is user-facing — error messages for malformed config are part of the product spec, not just an implementation detail.

--- a/roadmap/04-open-changes/STATUS.md
+++ b/roadmap/04-open-changes/STATUS.md
@@ -1,0 +1,27 @@
+# 04 — Open Changes panel
+
+**Phase:** not-started
+**Spec PR:** —
+**Impl PRs:** —
+
+## Scope
+
+VS Code Source Control–style side panel: working/staged file separation, inline diffs, file & hunk staging, commit message + commit/push/pull, and file Timeline (history). See README §4. Match VS Code behavior-for-behavior where it makes sense.
+
+## Sub-phases
+
+- [ ] **4a — Panel scaffold + working/staged file lists** (read-only, no diff yet).
+- [ ] **4b — Inline diff view** for the focused file.
+- [ ] **4c — Stage / unstage / discard** at file and hunk granularity.
+- [ ] **4d — Commit message input + commit / push / pull** controls.
+- [ ] **4e — File Timeline (history view)** for the focused file.
+
+## Notes
+
+- 4e is the most likely scope-cut candidate if the surface area gets unmanageable; treat as a stretch goal — the feature can ship as `merged` without it if 4a–4d are solid.
+- Spec phase produces one PRODUCT.md / TECH.md covering all of 4a–4e, then each sub-phase ships its own impl PR.
+- Backed by the same git plumbing the terminal already uses (no new daemons, no LSP-style sidecar).
+
+## Why this is feature 04 (last)
+
+Largest surface area; most UI; benefits the most from a stable foundation (post-AI-removal). Saving it for last means we ship it onto a tree that already reflects the fork's identity.

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -8,7 +8,7 @@ Single source of truth for what's being built next. `/twarp-next` reads this fil
 
 | # | Feature | Phase | Spec PR | Impl PR(s) |
 |---|---------|-------|---------|-----------|
-| 01 | [Tab color shortcuts](01-tab-colors/STATUS.md) | not-started | — | — |
+| 01 | [Tab color shortcuts](01-tab-colors/STATUS.md) | spec-pending | — | — |
 | 02 | [AI removal](02-ai-removal/STATUS.md) | not-started | — | — |
 | 03 | [Custom command shortcuts](03-command-shortcuts/STATUS.md) | not-started | — | — |
 | 04 | [Open Changes panel](04-open-changes/STATUS.md) | not-started | — | — |

--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -1,0 +1,54 @@
+# twarp roadmap
+
+Single source of truth for what's being built next. `/twarp-next` reads this file every invocation; the user reads it to see status at a glance.
+
+**Currently active:** `01-tab-colors`
+
+## Features
+
+| # | Feature | Phase | Spec PR | Impl PR(s) |
+|---|---------|-------|---------|-----------|
+| 01 | [Tab color shortcuts](01-tab-colors/STATUS.md) | not-started | — | — |
+| 02 | [AI removal](02-ai-removal/STATUS.md) | not-started | — | — |
+| 03 | [Custom command shortcuts](03-command-shortcuts/STATUS.md) | not-started | — | — |
+| 04 | [Open Changes panel](04-open-changes/STATUS.md) | not-started | — | — |
+
+## Phases
+
+- `not-started` — no work begun
+- `spec-pending` — `/twarp-next` is writing PRODUCT.md / TECH.md
+- `spec-in-review` — spec PR open, awaiting user review + merge
+- `impl-pending` — specs merged, `/twarp-next` is implementing the next sub-phase
+- `impl-in-review` — impl PR open, awaiting user review + merge
+- `merged` — feature shipped
+
+## Rules
+
+- Only one feature is active at a time.
+- A feature advances from `spec-in-review` → `impl-pending` only after the spec PR is **merged to master**.
+- Features 02 and 04 are sub-phased; their STATUS.md tracks individual sub-PRs and the feature only reaches `merged` after every sub-PR ships.
+- The next feature only starts after the current one reaches `merged`.
+- Git is the source of truth. If STATUS.md and `gh pr view` disagree, trust git and update STATUS.md.
+
+## Order rationale
+
+1. **Tab colors first** — smallest scope, validates the workflow at low risk; upstream has groundwork on `oz-agent/APP-4321-active-tab-color-indication`.
+2. **AI removal second** — establishes the fork's identity. Cherry-pick conflicts from upstream become unavoidable from here, so eat the cost after the workflow is proven.
+3. **Command shortcuts third** — independent subsystem, no dependency on 01 or 02.
+4. **Open Changes panel last** — largest scope, sub-phased into panel scaffold → diffs → staging → commit/push → file timeline.
+
+## Out of scope for `/twarp-next`
+
+- **Upstream cherry-picks.** Run on a separate cadence — schedule a recurring agent (`/schedule`) to fetch, list new commits, and propose cherry-picks. Not driven by this skill.
+- **CI / repo hygiene unrelated to the active feature.**
+
+## Spec storage convention
+
+For twarp roadmap features, specs live alongside `STATUS.md`:
+
+```
+roadmap/<NN-feature>/PRODUCT.md
+roadmap/<NN-feature>/TECH.md
+```
+
+This intentionally overrides the repo's default `specs/<linear-ticket>/...` convention, because twarp roadmap features are not tracked in Linear.


### PR DESCRIPTION
## Summary

- Adds `roadmap/01-tab-colors/PRODUCT.md` and `roadmap/01-tab-colors/TECH.md` — the spec pair for feature 01 (tab color shortcuts).
- Tweaks `.agents/skills/twarp-next/SKILL.md` so invoking `/twarp-next` itself counts as confirmation to advance from `not-started` → `spec-pending`, removing a needless prompt-and-wait gate. (Per session feedback this turn — your only confirmation gates are PR review/merge, not mid-workflow prompts.)
- Bumps `roadmap/01-tab-colors/STATUS.md` to `spec-pending` and `ROADMAP.md`'s row to match.

## What's in the specs

**PRODUCT** — nine default keybindings (⌘⌥1–⌘⌥8 set color, ⌘⌥0 reset), unconditional-set semantics so each color shortcut is predictable (toggle-off lives only on the dedicated reset shortcut), active-tab only, persistence and theme behaviour inherited from upstream.

**TECH** — adds two new variants `WorkspaceAction::SetActiveTabColor { color }` and `ResetActiveTabColor`, with thin handlers in `WorkspaceView` that delegate to `set_tab_color` / `reset_tab_color` (parallel to the existing `toggle_tab_color`). Registers nine `EditableBinding`s in `app/src/workspace/mod.rs` under the `Navigation` group, mirroring the convention used by other tab actions. No feature flag, no persistence change, no dependency on the unmerged `oz-agent/APP-4321-active-tab-color-indication` polish branch (which is unrelated visual tweaks, not the coloring mechanism).

## Open question for your review

`AnsiColorIdentifier` upstream has only eight colors (Red/Green/Yellow/Blue/Magenta/Cyan/White/Black). README §2's tentative list (Red/**Orange**/Yellow/Green/Blue/**Purple**/**Pink**/**Gray**) doesn't map cleanly. PRODUCT.md uses the eight ANSI colors as-is, and flags this inline in invariant 1. Three options:
1. **Ship as spec'd** (eight ANSI colors, no palette extension). Smallest scope, most aligned with feature 01's "validate the workflow at low risk" intent.
2. **Remap names** (e.g. ⌘⌥6 = Magenta, displayed as "Purple"). Cosmetic only; no code surface change.
3. **Extend the palette** (add Orange/Purple/Pink/Gray to `AnsiColorIdentifier` and the theme). Larger change; touches theming and tab rendering.

Default to (1) unless you say otherwise during review.

## Test plan

This is a specs-only PR — no compiled code changes. Review checklist:

- [ ] `PRODUCT.md` behavior matches your expectations for ⌘⌥1–8 / ⌘⌥0
- [ ] Smoke-test checklist at the end of `PRODUCT.md` is the validation you want to run after the impl PR ships
- [ ] `TECH.md` plan is acceptable (new `SetActiveTabColor`/`ResetActiveTabColor` variants vs reusing `ToggleTabColor`; `Navigation` binding group; no feature flag)
- [ ] Decide the open question above before merging this PR — the impl PR will follow the merged spec literally
- [ ] The skill tweak in `.agents/skills/twarp-next/SKILL.md` matches the workflow you want

After this merges, `/twarp-next` advances to `impl-pending` and produces the impl PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)