### PR TITLE
Fix hoverable state when there are multiple 'Open Skill' buttons.

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -426,13 +426,11 @@ pub(super) struct AIBlockStateHandles {
     /// Mouse state handle for AI document created block
     ai_document_handle: MouseStateHandle,
 
-    /// Mouse state handle for 'open skill' button
-    /// from an OpenSkill action banner
-    open_skill_button_handle: MouseStateHandle,
+    /// Mouse state handles for 'open skill' buttons from ReadSkill action banners.
+    open_skill_button_handles: HashMap<AIAgentActionId, MouseStateHandle>,
 
-    /// Mouse state handle for 'open skill' button
-    /// from a ReadFiles action banner
-    read_from_skill_button_handle: MouseStateHandle,
+    /// Mouse state handles for 'open skill' buttons from ReadFiles-style action banners.
+    read_from_skill_button_handles: HashMap<AIAgentActionId, MouseStateHandle>,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -1844,6 +1842,23 @@ impl AIBlock {
             if matches!(&action.action, AIAgentActionType::StartAgent { .. }) {
                 self.state_handles
                     .orchestration_navigation_card_handles
+                    .entry(action.id.clone())
+                    .or_default();
+            }
+
+            if matches!(&action.action, AIAgentActionType::ReadSkill(_)) {
+                self.state_handles
+                    .open_skill_button_handles
+                    .entry(action.id.clone())
+                    .or_default();
+            }
+
+            if matches!(
+                &action.action,
+                AIAgentActionType::ReadFiles(_) | AIAgentActionType::SearchCodebase(..)
+            ) {
+                self.state_handles
+                    .read_from_skill_button_handles
                     .entry(action.id.clone())
                     .or_default();
             }
@@ -6189,10 +6204,12 @@ impl TypedActionView for AIBlock {
             } => {
                 // Resets the interaction states of ReadSkill and ReadFiles tool call banners before opening a new code pane
                 // Avoids an immediate re-hover (and stuck tooltip) while the new code pane is being created
-                for handle in [
-                    &self.state_handles.open_skill_button_handle,
-                    &self.state_handles.read_from_skill_button_handle,
-                ] {
+                for handle in self
+                    .state_handles
+                    .open_skill_button_handles
+                    .values()
+                    .chain(self.state_handles.read_from_skill_button_handles.values())
+                {
                     if let Ok(mut state) = handle.lock() {
                         state.reset_interaction_state();
                     }

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -1675,7 +1675,12 @@ fn render_read_skill(
             let skill_icon_override = icon_override_for_skill_name(&skill.name);
             let open_button = render_skill_button(
                 "Open skill",
-                props.state_handles.open_skill_button_handle.clone(),
+                props
+                    .state_handles
+                    .open_skill_button_handles
+                    .get(id)
+                    .expect("Button state must exist for each ReadSkill action.")
+                    .clone(),
                 appearance,
                 skill.provider,
                 skill_icon_override,
@@ -1779,7 +1784,12 @@ fn render_read_files(
         let skill_icon_override = icon_override_for_skill_name(&skill.name);
         let open_button = render_skill_button(
             &format!("/{}", skill.name),
-            props.state_handles.read_from_skill_button_handle.clone(),
+            props
+                .state_handles
+                .read_from_skill_button_handles
+                .get(id)
+                .expect("Button state must exist for each ReadFiles-style action.")
+                .clone(),
             appearance,
             skill.provider,
             skill_icon_override,


### PR DESCRIPTION
## Description
When there are multiple 'Open Skill' buttons per AI block (e.g. parallel tool call for the read-skill tool), they share the same mouse state handle and thus have weird hover and click interactions.

This PR fixes that by using one mouse state handle per button.

## Testing
loom.com/share/9274bf288a8345a3836ee66019b7e225?from_recorder=1&focus_title=1

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: Fixed a bug where multiple 'open skill' buttons shared hover state.
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
