### PR TITLE
Initialize privacy settings from `WarpDrivePrivacySettings`

### DIFF
--- a/app/src/settings/privacy.rs
+++ b/app/src/settings/privacy.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use regex::Regex;
 use warp_core::features::FeatureFlag;
 use warp_core::report_if_error;
-use warp_core::user_preferences::GetUserPreferences as _;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity, UpdateModel};
 
 use crate::ai::blocklist::telemetry_banner::should_collect_ai_ugc_telemetry;
@@ -248,44 +247,14 @@ impl PrivacySettings {
         let auth_state = AuthStateProvider::as_ref(ctx).get().clone();
         let auth_client = ServerApiProvider::as_ref(ctx).get_auth_client();
 
-        let is_telemetry_enabled: bool = ctx
-            .private_user_preferences()
-            .read_value(TELEMETRY_ENABLED_DEFAULTS_KEY)
-            .unwrap_or_default()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or(true);
-
-        let is_crash_reporting_enabled: bool = ctx
-            .private_user_preferences()
-            .read_value(CRASH_REPORTING_ENABLED_DEFAULTS_KEY)
-            .unwrap_or_default()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or(true);
-
-        let is_cloud_conversation_storage_enabled: bool = ctx
-            .private_user_preferences()
-            .read_value(CLOUD_CONVERSATION_STORAGE_ENABLED_DEFAULTS_KEY)
-            .unwrap_or_default()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or(true);
-
-        // Make sure the user-preferences stores match what's in memory.
-        // Needed for warp drive preferences to work and no harm in doing in general.
-        let _ = ctx.private_user_preferences().write_value(
-            TELEMETRY_ENABLED_DEFAULTS_KEY,
-            serde_json::to_string(&is_telemetry_enabled)
-                .expect("is_telemetry_enabled is a boolean."),
-        );
-        let _ = ctx.private_user_preferences().write_value(
-            CRASH_REPORTING_ENABLED_DEFAULTS_KEY,
-            serde_json::to_string(&is_crash_reporting_enabled)
-                .expect("is_crash_reporting_enabled is a boolean."),
-        );
-        let _ = ctx.private_user_preferences().write_value(
-            CLOUD_CONVERSATION_STORAGE_ENABLED_DEFAULTS_KEY,
-            serde_json::to_string(&is_cloud_conversation_storage_enabled)
-                .expect("is_cloud_conversation_storage_enabled is a boolean."),
-        );
+        // Initialize from `WarpDrivePrivacySettings`, which is the source of truth for these
+        // booleans.
+        let warp_drive_privacy = WarpDrivePrivacySettings::as_ref(ctx);
+        let is_telemetry_enabled = *warp_drive_privacy.is_telemetry_enabled.value();
+        let is_crash_reporting_enabled = *warp_drive_privacy.is_crash_reporting_enabled.value();
+        let is_cloud_conversation_storage_enabled = *warp_drive_privacy
+            .is_cloud_conversation_storage_enabled
+            .value();
 
         // Listen for changes to the cloud model and update ourselves when they happen.
         ctx.subscribe_to_model(&WarpDrivePrivacySettings::handle(ctx), |me, event, ctx| {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

These settings weren't properly migrated over when we switched to using a settings file. They're still reading from `private_user_preferences`, when they should be reading from the settings file.

Updated the initialization to read directly from the `WarpDrivePrivacySettings` settings struct, which handles routing to the correct backend when doing reads.

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->
Tested locally.
