### PR TITLE
Make code blocks in thinking text unselectable

### DIFF
--- a/app/src/ai/agent_management/cloud_setup_guide_view.rs
+++ b/app/src/ai/agent_management/cloud_setup_guide_view.rs
@@ -412,6 +412,7 @@ impl CloudSetupGuideView {
                 mouse_handles: Some(handles),
                 file_path: None,
             },
+            true,
             app,
             None,
         )

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -1239,6 +1239,7 @@ pub fn render_text_sections<V: View, A: Action>(
                         working_directory: props.current_working_directory,
                         open_code_block_action_factory: props.open_code_block_action_factory,
                         copy_code_action_factory: props.copy_code_action_factory,
+                        selectable: props.selectable,
                         #[cfg(feature = "local_fs")]
                         resolved_code_block_paths: props.resolved_code_block_paths,
                     },
@@ -2650,6 +2651,8 @@ pub struct CodeSectionProps<'a, A: 'static> {
     pub working_directory: Option<&'a String>,
     pub open_code_block_action_factory: Option<OpenCodeBlockActionFactory<A>>,
     pub copy_code_action_factory: Option<CopyCodeActionFactory<A>>,
+    /// Whether the code block text should be selectable within the parent SelectableArea.
+    pub selectable: bool,
     /// Pre-resolved code block file paths from the background detection task.
     /// Keyed by original path; value is the resolved absolute path (or None if unresolvable).
     #[cfg(feature = "local_fs")]
@@ -2851,6 +2854,7 @@ pub fn render_code_output_section<A: Action>(
                     footer_element: language_text,
                     mouse_handles: props.button_handles.cloned(),
                 },
+                props.selectable,
                 app,
                 source,
             )

--- a/app/src/ai/blocklist/code_block.rs
+++ b/app/src/ai/blocklist/code_block.rs
@@ -118,6 +118,7 @@ pub fn render_code_block_plain(
     code: &str,
     find_highlight_ranges: impl Iterator<Item = HighlightedRange>,
     options: CodeBlockOptions,
+    selectable: bool,
     app: &AppContext,
     source: Option<CodeSource>,
 ) -> Box<dyn Element> {
@@ -131,7 +132,7 @@ pub fn render_code_block_plain(
     )
     .with_color(blended_colors::text_main(theme, theme.surface_1()))
     .with_highlights(find_highlight_ranges)
-    .with_selectable(true)
+    .with_selectable(selectable)
     .finish();
 
     render_code_block_internal(code, code_element, options, app, source, false)
@@ -171,6 +172,7 @@ pub fn render_runnable_code_snippet(
             mouse_handles,
             file_path: None,
         },
+        true,
         app,
         None,
     )

--- a/app/src/terminal/view/plugin_instructions_block.rs
+++ b/app/src/terminal/view/plugin_instructions_block.rs
@@ -160,6 +160,7 @@ impl PluginInstructionsBlock {
                     mouse_handles: Some(handles),
                     file_path: None,
                 },
+                true,
                 app,
                 None,
             );


### PR DESCRIPTION
## Description

Thinking text is not selectable, but code blocks in thinking text would select while dragging but become unselected when you released the mouse, which feels buggy. Make them unselectable to be consistent with other thinking text for now (but consider making thinking text selectable later on).

## Testing

Tested locally, can't select text in code blocks in thinking text

