### PR TITLE
Fix terminal text selection not auto-scrolling when dragging beyond bounds

### DIFF
--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -4438,7 +4438,10 @@ impl Element for BlockListElement {
         // This matches the pattern used by SelectableArea, Draggable, Resizable,
         // and both Scrollable variants, which all use `raw_event()` for drags.
         let event_at_z_index = if self.is_terminal_selecting
-            && matches!(event.raw_event(), Event::LeftMouseDragged { .. })
+            && matches!(
+                event.raw_event(),
+                Event::LeftMouseDragged { .. } | Event::LeftMouseUp { .. }
+            )
         {
             event.raw_event()
         } else {

--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -4441,8 +4441,7 @@ impl Element for BlockListElement {
             && matches!(
                 event.raw_event(),
                 Event::LeftMouseDragged { .. } | Event::LeftMouseUp { .. }
-            )
-        {
+            ) {
             event.raw_event()
         } else {
             let Some(e) = event.at_z_index(z_index, ctx) else {

--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -4430,9 +4430,23 @@ impl Element for BlockListElement {
         app: &AppContext,
     ) -> bool {
         let z_index = self.child_max_z_index.expect("Z-index should exist.");
-        let Some(event_at_z_index) = event.at_z_index(z_index, ctx) else {
-            // Only proceed if there's a relevant event at this z-index.
-            return false;
+
+        // During an active text selection, bypass the z-index coverage check for
+        // drag events. The input/footer area below the block list is painted at a
+        // higher z-index, so `at_z_index` would filter out drags that cross into
+        // that region — breaking selection auto-scroll when dragging downward.
+        // This matches the pattern used by SelectableArea, Draggable, Resizable,
+        // and both Scrollable variants, which all use `raw_event()` for drags.
+        let event_at_z_index = if self.is_terminal_selecting
+            && matches!(event.raw_event(), Event::LeftMouseDragged { .. })
+        {
+            event.raw_event()
+        } else {
+            let Some(e) = event.at_z_index(z_index, ctx) else {
+                // Only proceed if there's a relevant event at this z-index.
+                return false;
+            };
+            e
         };
 
         let mut handled = false;

--- a/crates/warpui_core/src/event.rs
+++ b/crates/warpui_core/src/event.rs
@@ -2,10 +2,10 @@ use std::ops::Range;
 
 use crate::platform::keyboard::KeyCode;
 use crate::{
+    EventContext,
     elements::{Point, ZIndex},
     keymap::Keystroke,
     zoom::{Scale, ZoomFactor},
-    EventContext,
 };
 use pathfinder_geometry::{rect::RectF, vector::Vector2F};
 
@@ -23,7 +23,6 @@ impl DispatchedEvent {
             Event::ScrollWheel { position, .. }
             | Event::LeftMouseDown { position, .. }
             | Event::LeftMouseUp { position, .. }
-            | Event::LeftMouseDragged { position, .. }
             | Event::MiddleMouseDown { position, .. }
             | Event::RightMouseDown { position, .. }
             | Event::BackMouseDown { position, .. }
@@ -34,6 +33,12 @@ impl DispatchedEvent {
                     None
                 }
             }
+            // Drag events bypass z-index coverage checks so that an active drag
+            // continues to receive events even when the cursor moves over
+            // higher-z-index UI (e.g. the input/footer area). This is critical
+            // for text selection auto-scrolling when the drag exits the scroll
+            // container downward.
+            Event::LeftMouseDragged { .. } => Some(&self.event),
             Event::MouseMoved { .. } => Some(&self.event),
             Event::ModifierStateChanged { .. } => Some(&self.event),
             Event::ModifierKeyChanged { .. } => Some(&self.event),

--- a/crates/warpui_core/src/event.rs
+++ b/crates/warpui_core/src/event.rs
@@ -2,10 +2,10 @@ use std::ops::Range;
 
 use crate::platform::keyboard::KeyCode;
 use crate::{
-    EventContext,
     elements::{Point, ZIndex},
     keymap::Keystroke,
     zoom::{Scale, ZoomFactor},
+    EventContext,
 };
 use pathfinder_geometry::{rect::RectF, vector::Vector2F};
 
@@ -23,6 +23,7 @@ impl DispatchedEvent {
             Event::ScrollWheel { position, .. }
             | Event::LeftMouseDown { position, .. }
             | Event::LeftMouseUp { position, .. }
+            | Event::LeftMouseDragged { position, .. }
             | Event::MiddleMouseDown { position, .. }
             | Event::RightMouseDown { position, .. }
             | Event::BackMouseDown { position, .. }
@@ -33,12 +34,6 @@ impl DispatchedEvent {
                     None
                 }
             }
-            // Drag events bypass z-index coverage checks so that an active drag
-            // continues to receive events even when the cursor moves over
-            // higher-z-index UI (e.g. the input/footer area). This is critical
-            // for text selection auto-scrolling when the drag exits the scroll
-            // container downward.
-            Event::LeftMouseDragged { .. } => Some(&self.event),
             Event::MouseMoved { .. } => Some(&self.event),
             Event::ModifierStateChanged { .. } => Some(&self.event),
             Event::ModifierKeyChanged { .. } => Some(&self.event),


### PR DESCRIPTION
## Description

Fix terminal text selection no longer auto-scrolling downward when drag exits the scroll container (block list).

**Root cause:** `LeftMouseDragged` events were subject to z-index coverage checks in `DispatchedEvent::at_z_index()`. When the user dragged downward past the block list, the cursor entered the area of higher-z-index UI elements (input/footer), causing `is_covered()` to return true and the drag events to be filtered out. This prevented the block list element from receiving drag events, so its auto-scroll logic (`mouse_dragged()`) never executed.

**Fix:** Bypass z-index filtering for `LeftMouseDragged` events in the blocklist element specifically when selecting.

Fixes APP-3952

## Testing

Manual testing: https://www.loom.com/share/0e81bc86229a4e0085b52253ca846346

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed terminal text selection not auto-scrolling when dragging beyond bounds
