### PR TITLE
fix: add yaml language support

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -32,6 +32,7 @@ pub enum LanguageId {
     JavaScriptReact,
     C,
     Cpp,
+    Yaml,
 }
 
 impl LanguageId {
@@ -52,6 +53,7 @@ impl LanguageId {
             // compile_commands.json is present, clangd will use the correct language
             // regardless of the languageId we send.
             "h" | "H" | "hh" | "hpp" | "hxx" => Some(Self::Cpp),
+            "yaml" | "yml" => Some(Self::Yaml),
             _ => None,
         }
     }
@@ -69,6 +71,7 @@ impl LanguageId {
             LanguageId::JavaScriptReact => "javascriptreact",
             LanguageId::C => "c",
             LanguageId::Cpp => "cpp",
+            LanguageId::Yaml => "yaml",
         }
     }
 
@@ -83,6 +86,7 @@ impl LanguageId {
             | LanguageId::JavaScript
             | LanguageId::JavaScriptReact => LSPServerType::TypeScriptLanguageServer,
             LanguageId::C | LanguageId::Cpp => LSPServerType::Clangd,
+            LanguageId::Yaml => LSPServerType::Yaml,
         }
     }
 }

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use lsp_types::Uri;
 
-use crate::config::{lsp_uri_to_path, path_to_lsp_uri};
+use crate::config::{lsp_uri_to_path, path_to_lsp_uri, LanguageId};
 
 // Unix-specific tests use Unix paths
 #[cfg(not(windows))]
@@ -215,4 +215,39 @@ fn test_path_to_lsp_uri_rejects_relative_path() {
     let result = path_to_lsp_uri(&path);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("must be absolute"));
+}
+
+// LanguageId tests
+#[test]
+fn test_language_id_from_yaml_file() {
+    let path = PathBuf::from("/path/to/config.yaml");
+    let lang = LanguageId::from_path(&path);
+    assert_eq!(lang, Some(LanguageId::Yaml));
+}
+
+#[test]
+fn test_language_id_from_yml_file() {
+    let path = PathBuf::from("/path/to/config.yml");
+    let lang = LanguageId::from_path(&path);
+    assert_eq!(lang, Some(LanguageId::Yaml));
+}
+
+#[test]
+fn test_language_id_yaml_lsp_identifier() {
+    let lang = LanguageId::Yaml;
+    assert_eq!(lang.lsp_language_identifier(), "yaml");
+}
+
+#[test]
+fn test_language_id_from_rust_file() {
+    let path = PathBuf::from("/path/to/main.rs");
+    let lang = LanguageId::from_path(&path);
+    assert_eq!(lang, Some(LanguageId::Rust));
+}
+
+#[test]
+fn test_language_id_from_unsupported_file() {
+    let path = PathBuf::from("/path/to/file.txt");
+    let lang = LanguageId::from_path(&path);
+    assert_eq!(lang, None);
 }

--- a/crates/lsp/src/servers/mod.rs
+++ b/crates/lsp/src/servers/mod.rs
@@ -3,3 +3,4 @@ pub mod go;
 pub mod pyright;
 pub mod rust;
 pub mod typescript_language_server;
+pub mod yaml;

--- a/crates/lsp/src/servers/yaml.rs
+++ b/crates/lsp/src/servers/yaml.rs
@@ -1,36 +1,35 @@
 use std::path::Path;
-use std::sync::Arc;
 
 use crate::language_server_candidate::{LanguageServerCandidate, LanguageServerMetadata};
 use crate::CommandBuilder;
 use async_trait::async_trait;
 
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
-pub struct YamlLanguageServerCandidate {
-    client: Arc<http_client::Client>,
-}
+pub struct YamlLanguageServerCandidate;
 
 impl YamlLanguageServerCandidate {
-    pub fn new(client: Arc<http_client::Client>) -> Self {
-        Self { client }
+    pub fn new() -> Self {
+        Self
     }
-}
 
 #[async_trait]
 #[cfg(feature = "local_fs")]
 impl LanguageServerCandidate for YamlLanguageServerCandidate {
-    async fn should_suggest_for_repo(&self, path: &Path, _executor: &CommandBuilder) -> bool {
-        // Suggest YAML server if any YAML files are present
-        if let Ok(entries) = std::fs::read_dir(path) {
-            for entry in entries.flatten() {
-                if let Some(name) = entry.file_name().to_str() {
-                    if name.ends_with(".yaml") || name.ends_with(".yml") {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+    async fn should_suggest_for_repo(&self, path: &Path, executor: &CommandBuilder) -> bool {
+        // Only suggest YAML server if yaml-language-server is available on PATH
+        // and there are YAML files present
+        let has_yaml_files = if let Ok(entries) = std::fs::read_dir(path) {
+            entries.flatten().any(|entry| {
+                entry.file_name()
+                    .to_str()
+                    .map(|name| name.ends_with(".yaml") || name.ends_with(".yml"))
+                    .unwrap_or(false)
+            })
+        } else {
+            false
+        };
+
+        has_yaml_files && self.is_installed_on_path(executor).await
     }
 
     async fn is_installed_in_data_dir(&self, _executor: &CommandBuilder) -> bool {
@@ -57,7 +56,8 @@ impl LanguageServerCandidate for YamlLanguageServerCandidate {
     }
 
     async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
-        // Return a placeholder metadata since we don't support custom installation yet
+        // yaml-language-server is an npm package, not a GitHub release
+        // Return placeholder metadata since we don't support automatic installation
         Ok(LanguageServerMetadata {
             version: "unknown".to_string(),
             url: None,

--- a/crates/lsp/src/servers/yaml.rs
+++ b/crates/lsp/src/servers/yaml.rs
@@ -1,0 +1,95 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::language_server_candidate::{LanguageServerCandidate, LanguageServerMetadata};
+use crate::CommandBuilder;
+use async_trait::async_trait;
+
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+pub struct YamlLanguageServerCandidate {
+    client: Arc<http_client::Client>,
+}
+
+impl YamlLanguageServerCandidate {
+    pub fn new(client: Arc<http_client::Client>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+#[cfg(feature = "local_fs")]
+impl LanguageServerCandidate for YamlLanguageServerCandidate {
+    async fn should_suggest_for_repo(&self, path: &Path, _executor: &CommandBuilder) -> bool {
+        // Suggest YAML server if any YAML files are present
+        if let Ok(entries) = std::fs::read_dir(path) {
+            for entry in entries.flatten() {
+                if let Some(name) = entry.file_name().to_str() {
+                    if name.ends_with(".yaml") || name.ends_with(".yml") {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    async fn is_installed_in_data_dir(&self, _executor: &CommandBuilder) -> bool {
+        // yaml-language-server doesn't support custom installation yet
+        false
+    }
+
+    async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
+        executor
+            .command("yaml-language-server")
+            .arg("--version")
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    async fn install(
+        &self,
+        _metadata: LanguageServerMetadata,
+        _executor: &CommandBuilder,
+    ) -> anyhow::Result<()> {
+        anyhow::bail!("YAML language server installation is not yet supported. Please install yaml-language-server via npm: npm install -g yaml-language-server");
+    }
+
+    async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
+        // Return a placeholder metadata since we don't support custom installation yet
+        Ok(LanguageServerMetadata {
+            version: "unknown".to_string(),
+            url: None,
+            digest: None,
+        })
+    }
+}
+
+#[async_trait]
+#[cfg(not(feature = "local_fs"))]
+impl LanguageServerCandidate for YamlLanguageServerCandidate {
+    async fn should_suggest_for_repo(&self, _path: &Path, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_in_data_dir(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_on_path(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn install(
+        &self,
+        _metadata: LanguageServerMetadata,
+        _executor: &CommandBuilder,
+    ) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
+        todo!()
+    }
+}

--- a/crates/lsp/src/supported_servers.rs
+++ b/crates/lsp/src/supported_servers.rs
@@ -5,6 +5,7 @@ use crate::servers::go::GoPlsCandidate;
 use crate::servers::pyright::PyrightCandidate;
 use crate::servers::rust::RustAnalyzerCandidate;
 use crate::servers::typescript_language_server::TypeScriptLanguageServerCandidate;
+use crate::servers::yaml::YamlLanguageServerCandidate;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::CommandBuilder;
 use crate::{LanguageId, LanguageServerCandidate};
@@ -42,6 +43,7 @@ pub enum LSPServerType {
     Pyright,
     TypeScriptLanguageServer,
     Clangd,
+    Yaml,
 }
 
 /// Provides server-specific configuration for each LSP server type.
@@ -109,6 +111,10 @@ impl LSPServerType {
                     binary_path: path,
                     prepend_args: vec![],
                 }),
+            LSPServerType::Yaml => {
+                // yaml-language-server doesn't support custom installation yet
+                None
+            }
         }
     }
 
@@ -132,6 +138,7 @@ impl LSPServerType {
             LSPServerType::Pyright => "pyright-langserver",
             LSPServerType::TypeScriptLanguageServer => "typescript-language-server",
             LSPServerType::Clangd => "clangd",
+            LSPServerType::Yaml => "yaml-language-server",
         }
     }
 
@@ -141,6 +148,7 @@ impl LSPServerType {
         match self {
             LSPServerType::RustAnalyzer | LSPServerType::GoPls | LSPServerType::Clangd => vec![],
             LSPServerType::Pyright | LSPServerType::TypeScriptLanguageServer => vec!["--stdio"],
+            LSPServerType::Yaml => vec!["--stdio"],
         }
     }
 
@@ -154,6 +162,7 @@ impl LSPServerType {
             LSPServerType::Pyright => vec!["--stdio"],
             LSPServerType::TypeScriptLanguageServer => vec!["--stdio"],
             LSPServerType::Clangd => vec![],
+            LSPServerType::Yaml => vec!["--stdio"],
         }
     }
 
@@ -172,6 +181,7 @@ impl LSPServerType {
                 ]
             }
             LSPServerType::Clangd => vec![LanguageId::C, LanguageId::Cpp],
+            LSPServerType::Yaml => vec![LanguageId::Yaml],
         }
     }
 
@@ -205,6 +215,7 @@ impl LSPServerType {
                 Box::new(TypeScriptLanguageServerCandidate::new(client))
             }
             LSPServerType::Clangd => Box::new(ClangdCandidate::new(client)),
+            LSPServerType::Yaml => Box::new(YamlLanguageServerCandidate::new(client)),
         }
     }
 

--- a/crates/lsp/src/supported_servers.rs
+++ b/crates/lsp/src/supported_servers.rs
@@ -215,7 +215,7 @@ impl LSPServerType {
                 Box::new(TypeScriptLanguageServerCandidate::new(client))
             }
             LSPServerType::Clangd => Box::new(ClangdCandidate::new(client)),
-            LSPServerType::Yaml => Box::new(YamlLanguageServerCandidate::new(client)),
+            LSPServerType::Yaml => Box::new(YamlLanguageServerCandidate::new()),
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
