### PR TITLE
APP-4263 Fix git ops flicker bug 

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -6722,7 +6722,7 @@ impl CodeReviewView {
                 // intent (Commit and push vs Commit and publish).
                 let diff_state = self.diff_state_model.as_ref(ctx);
                 let allow_create_pr = diff_state.pr_info().is_none()
-                    && !diff_state.pr_info_stale()
+                    && !diff_state.is_pr_info_refreshing()
                     && !diff_state.is_on_main_branch();
                 let has_upstream = diff_state.upstream_ref().is_some();
                 ctx.add_typed_action_view(|ctx| {
@@ -6772,7 +6772,7 @@ impl CodeReviewView {
         let has_uncommitted_changes = self.has_uncommitted_changes(app);
         let has_upstream = diff_state.upstream_ref().is_some();
         let has_local_commits = !diff_state.unpushed_commits().is_empty();
-        let pr_info_stale = diff_state.pr_info_stale();
+        let is_pr_info_refreshing = diff_state.is_pr_info_refreshing();
         // False when upstream == main (e.g. after `git checkout -b feature origin/master`),
         // which means the branch hasn't been pushed to its own remote ref yet.
         let upstream_differs_from_main = diff_state.upstream_differs_from_main();
@@ -6785,7 +6785,7 @@ impl CodeReviewView {
             PrimaryGitActionMode::Push
         } else if diff_state.pr_info().is_some() {
             PrimaryGitActionMode::ViewPr
-        } else if !pr_info_stale
+        } else if !is_pr_info_refreshing
             && has_upstream
             && !diff_state.is_on_main_branch()
             && upstream_differs_from_main
@@ -6826,6 +6826,7 @@ impl CodeReviewView {
                     button.set_label("Push", ctx);
                     button.set_icon(Some(Icon::ArrowUp), ctx);
                     button.set_disabled(false, ctx);
+                    button.set_tooltip(None::<String>, ctx);
                     button.set_on_click(
                         |ctx| ctx.dispatch_typed_action(CodeReviewAction::OpenPushDialog),
                         ctx,
@@ -6841,6 +6842,7 @@ impl CodeReviewView {
                     button.set_label("Create PR", ctx);
                     button.set_icon(Some(Icon::Github), ctx);
                     button.set_disabled(false, ctx);
+                    button.set_tooltip(None::<String>, ctx);
                     button.set_on_click(
                         |ctx| ctx.dispatch_typed_action(CodeReviewAction::OpenCreatePrDialog),
                         ctx,
@@ -6849,7 +6851,9 @@ impl CodeReviewView {
                 });
             }
             PrimaryGitActionMode::ViewPr => {
-                let pr_info = self.diff_state_model.as_ref(ctx).pr_info().cloned();
+                let diff_state = self.diff_state_model.as_ref(ctx);
+                let pr_info = diff_state.pr_info().cloned();
+                let is_pr_info_refreshing = diff_state.is_pr_info_refreshing();
                 if let Some(pr_info) = pr_info {
                     let url = pr_info.url.clone();
                     let number = pr_info.number;
@@ -6857,7 +6861,11 @@ impl CodeReviewView {
                     self.git_primary_action_button.update(ctx, |button, ctx| {
                         button.set_label(label, ctx);
                         button.set_icon(Some(Icon::Github), ctx);
-                        button.set_disabled(false, ctx);
+                        button.set_disabled(is_pr_info_refreshing, ctx);
+                        button.set_tooltip(
+                            is_pr_info_refreshing.then_some("Refreshing PR info"),
+                            ctx,
+                        );
                         button.set_on_click(
                             move |ctx| {
                                 ctx.dispatch_typed_action(CodeReviewAction::ViewPr(url.clone()))
@@ -6873,6 +6881,7 @@ impl CodeReviewView {
                     button.set_label("Publish", ctx);
                     button.set_icon(Some(Icon::UploadCloud), ctx);
                     button.set_disabled(false, ctx);
+                    button.set_tooltip(None::<String>, ctx);
                     button.set_on_click(
                         |ctx| ctx.dispatch_typed_action(CodeReviewAction::PublishBranch),
                         ctx,
@@ -6925,17 +6934,21 @@ impl CodeReviewView {
             MenuItemFields::new(format!("PR #{}", pr_info.number))
                 .with_icon(Icon::Github)
                 .with_on_select_action(CodeReviewAction::ViewPr(pr_info.url))
+                .with_disabled(diff_state.is_pr_info_refreshing())
                 .into_item()
         } else {
             let is_on_main = diff_state.is_on_main_branch();
             let has_upstream = diff_state.upstream_ref().is_some();
-            let pr_info_stale = diff_state.pr_info_stale();
+            let is_pr_info_refreshing = diff_state.is_pr_info_refreshing();
             let upstream_differs_from_main = diff_state.upstream_differs_from_main();
             MenuItemFields::new("Create PR")
                 .with_icon(Icon::Github)
                 .with_on_select_action(CodeReviewAction::OpenCreatePrDialog)
                 .with_disabled(
-                    pr_info_stale || is_on_main || !has_upstream || !upstream_differs_from_main,
+                    is_pr_info_refreshing
+                        || is_on_main
+                        || !has_upstream
+                        || !upstream_differs_from_main,
                 )
                 .into_item()
         }

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -6721,8 +6721,9 @@ impl CodeReviewView {
                 // `has_upstream` controls the label/icon on the push-chained
                 // intent (Commit and push vs Commit and publish).
                 let diff_state = self.diff_state_model.as_ref(ctx);
-                let allow_create_pr =
-                    diff_state.pr_info().is_none() && !diff_state.is_on_main_branch();
+                let allow_create_pr = diff_state.pr_info().is_none()
+                    && !diff_state.pr_info_stale()
+                    && !diff_state.is_on_main_branch();
                 let has_upstream = diff_state.upstream_ref().is_some();
                 ctx.add_typed_action_view(|ctx| {
                     GitDialog::new_for_commit(
@@ -6771,6 +6772,7 @@ impl CodeReviewView {
         let has_uncommitted_changes = self.has_uncommitted_changes(app);
         let has_upstream = diff_state.upstream_ref().is_some();
         let has_local_commits = !diff_state.unpushed_commits().is_empty();
+        let pr_info_stale = diff_state.pr_info_stale();
         // False when upstream == main (e.g. after `git checkout -b feature origin/master`),
         // which means the branch hasn't been pushed to its own remote ref yet.
         let upstream_differs_from_main = diff_state.upstream_differs_from_main();
@@ -6783,7 +6785,11 @@ impl CodeReviewView {
             PrimaryGitActionMode::Push
         } else if diff_state.pr_info().is_some() {
             PrimaryGitActionMode::ViewPr
-        } else if has_upstream && !diff_state.is_on_main_branch() && upstream_differs_from_main {
+        } else if !pr_info_stale
+            && has_upstream
+            && !diff_state.is_on_main_branch()
+            && upstream_differs_from_main
+        {
             PrimaryGitActionMode::CreatePr
         } else {
             // Nothing actionable — show Commit disabled.
@@ -6923,11 +6929,14 @@ impl CodeReviewView {
         } else {
             let is_on_main = diff_state.is_on_main_branch();
             let has_upstream = diff_state.upstream_ref().is_some();
+            let pr_info_stale = diff_state.pr_info_stale();
             let upstream_differs_from_main = diff_state.upstream_differs_from_main();
             MenuItemFields::new("Create PR")
                 .with_icon(Icon::Github)
                 .with_on_select_action(CodeReviewAction::OpenCreatePrDialog)
-                .with_disabled(is_on_main || !has_upstream || !upstream_differs_from_main)
+                .with_disabled(
+                    pr_info_stale || is_on_main || !has_upstream || !upstream_differs_from_main,
+                )
                 .into_item()
         }
     }

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -6826,7 +6826,7 @@ impl CodeReviewView {
                     button.set_label("Push", ctx);
                     button.set_icon(Some(Icon::ArrowUp), ctx);
                     button.set_disabled(false, ctx);
-                    button.set_tooltip(None::<String>, ctx);
+                    button.clear_tooltip(ctx);
                     button.set_on_click(
                         |ctx| ctx.dispatch_typed_action(CodeReviewAction::OpenPushDialog),
                         ctx,
@@ -6842,7 +6842,7 @@ impl CodeReviewView {
                     button.set_label("Create PR", ctx);
                     button.set_icon(Some(Icon::Github), ctx);
                     button.set_disabled(false, ctx);
-                    button.set_tooltip(None::<String>, ctx);
+                    button.clear_tooltip(ctx);
                     button.set_on_click(
                         |ctx| ctx.dispatch_typed_action(CodeReviewAction::OpenCreatePrDialog),
                         ctx,
@@ -6881,7 +6881,7 @@ impl CodeReviewView {
                     button.set_label("Publish", ctx);
                     button.set_icon(Some(Icon::UploadCloud), ctx);
                     button.set_disabled(false, ctx);
-                    button.set_tooltip(None::<String>, ctx);
+                    button.clear_tooltip(ctx);
                     button.set_on_click(
                         |ctx| ctx.dispatch_typed_action(CodeReviewAction::PublishBranch),
                         ctx,
@@ -6930,16 +6930,16 @@ impl CodeReviewView {
     /// (e.g. a worktree branch whose tracking was auto-set to origin/master).
     fn pr_menu_item(&self, app: &AppContext) -> MenuItem<CodeReviewAction> {
         let diff_state = self.diff_state_model.as_ref(app);
+        let is_pr_info_refreshing = diff_state.is_pr_info_refreshing();
         if let Some(pr_info) = diff_state.pr_info().cloned() {
             MenuItemFields::new(format!("PR #{}", pr_info.number))
                 .with_icon(Icon::Github)
                 .with_on_select_action(CodeReviewAction::ViewPr(pr_info.url))
-                .with_disabled(diff_state.is_pr_info_refreshing())
+                .with_disabled(is_pr_info_refreshing)
                 .into_item()
         } else {
             let is_on_main = diff_state.is_on_main_branch();
             let has_upstream = diff_state.upstream_ref().is_some();
-            let is_pr_info_refreshing = diff_state.is_pr_info_refreshing();
             let upstream_differs_from_main = diff_state.upstream_differs_from_main();
             MenuItemFields::new("Create PR")
                 .with_icon(Icon::Github)

--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -1536,6 +1536,11 @@ impl DiffStateModel {
             if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
                 self.refresh_pr_info(ctx);
             }
+        } else if FeatureFlag::GitOperationsInCodeReview.is_enabled()
+            && self.pr_info().is_none()
+            && !self.is_pr_info_refreshing()
+        {
+            self.refresh_pr_info(ctx);
         }
 
         ctx.emit(DiffStateModelEvent::DiffMetadataChanged(

--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -348,6 +348,7 @@ struct DiffMetadata {
     unpushed_commits: Vec<Commit>,
     upstream_ref: Option<String>,
     pr_info: Option<PrInfo>,
+    pr_info_stale: bool,
 }
 
 #[derive(Default, Debug)]
@@ -1420,6 +1421,7 @@ impl DiffStateModel {
             unpushed_commits,
             upstream_ref,
             pr_info: None,
+            pr_info_stale: true,
         })
     }
 
@@ -1497,10 +1499,22 @@ impl DiffStateModel {
             .metadata
             .as_ref()
             .and_then(|metadata| metadata.pr_info.clone());
+        let previous_pr_info_stale = self
+            .metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.pr_info_stale);
 
         match metadata {
             Ok(mut metadata) => {
+                // Carry forward cached PR info so the button doesn't flash
+                // "Create PR" between branch switch and `refresh_pr_info`.
                 metadata.pr_info = previous_pr_info;
+                // Inherit staleness only on same-branch refreshes; branch
+                // change leaves it at the default (stale) so the retry can
+                // re-fire.
+                if previous_branch.as_deref() == Some(metadata.current_branch_name.as_str()) {
+                    metadata.pr_info_stale = previous_pr_info_stale;
+                }
                 self.metadata = Some(metadata);
             }
             Err(e) => {
@@ -1526,9 +1540,12 @@ impl DiffStateModel {
             if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
                 self.refresh_pr_info(ctx);
             }
-        } else if FeatureFlag::GitOperationsInCodeReview.is_enabled() && self.pr_info().is_none() {
-            // No cached PR info yet — check once so the button updates
-            // after an external push or PR creation.
+        } else if FeatureFlag::GitOperationsInCodeReview.is_enabled()
+            && self
+                .metadata
+                .as_ref()
+                .is_some_and(|metadata| metadata.pr_info_stale)
+        {
             self.refresh_pr_info(ctx);
         }
 
@@ -2914,6 +2931,7 @@ impl DiffStateModel {
             |me, pr_info, ctx| {
                 if let Some(metadata) = &mut me.metadata {
                     metadata.pr_info = pr_info;
+                    metadata.pr_info_stale = false;
                     ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
                         InvalidationBehavior::PromptRefresh,
                     ));

--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -587,6 +587,14 @@ impl DiffStateModel {
             .and_then(|metadata| metadata.pr_info.as_ref())
     }
 
+    /// Whether PR info for the current branch is still being refreshed.
+    pub fn pr_info_stale(&self) -> bool {
+        self.metadata
+            .as_ref()
+            .map(|metadata| metadata.pr_info_stale)
+            .unwrap_or(true)
+    }
+
     /// Checks if git operations like stash or reset would be blocked due to repository state.
     /// This performs quick file existence checks to detect if git is in the middle of an operation.
     #[cfg(feature = "local_fs")]

--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -1500,12 +1500,7 @@ impl DiffStateModel {
 
         match metadata {
             Ok(mut metadata) => {
-                // Preserve cached PR info across same-branch metadata refreshes.
-                // `load_metadata_for_repo` always initialises pr_info: None, but
-                // re-fetching it on every file-system tick would be too expensive.
-                if previous_branch.as_deref() == Some(metadata.current_branch_name.as_str()) {
-                    metadata.pr_info = previous_pr_info;
-                }
+                metadata.pr_info = previous_pr_info;
                 self.metadata = Some(metadata);
             }
             Err(e) => {

--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -348,7 +348,6 @@ struct DiffMetadata {
     unpushed_commits: Vec<Commit>,
     upstream_ref: Option<String>,
     pr_info: Option<PrInfo>,
-    pr_info_stale: bool,
 }
 
 #[derive(Default, Debug)]
@@ -373,6 +372,7 @@ pub struct DiffStateModel {
     metadata: Option<DiffMetadata>,
     computing_diffs_abort_handle: Option<SpawnedFutureHandle>,
     computing_metadata_abort_handle: Option<SpawnedFutureHandle>,
+    refreshing_pr_info_handle: Option<SpawnedFutureHandle>,
     /// Controls whether periodic throttled metadata refresh is active.
     /// Refresh is suppressed when the code review pane is not open.
     metadata_refresh_enabled: bool,
@@ -419,6 +419,7 @@ impl DiffStateModel {
             metadata: None,
             computing_diffs_abort_handle: None,
             computing_metadata_abort_handle: None,
+            refreshing_pr_info_handle: None,
             metadata_refresh_enabled: false,
         };
 
@@ -587,12 +588,9 @@ impl DiffStateModel {
             .and_then(|metadata| metadata.pr_info.as_ref())
     }
 
-    /// Whether PR info for the current branch is still being refreshed.
-    pub fn pr_info_stale(&self) -> bool {
-        self.metadata
-            .as_ref()
-            .map(|metadata| metadata.pr_info_stale)
-            .unwrap_or(true)
+    /// Whether PR info for the current branch is currently being refreshed.
+    pub fn is_pr_info_refreshing(&self) -> bool {
+        self.refreshing_pr_info_handle.is_some()
     }
 
     /// Checks if git operations like stash or reset would be blocked due to repository state.
@@ -1429,7 +1427,6 @@ impl DiffStateModel {
             unpushed_commits,
             upstream_ref,
             pr_info: None,
-            pr_info_stale: true,
         })
     }
 
@@ -1507,22 +1504,13 @@ impl DiffStateModel {
             .metadata
             .as_ref()
             .and_then(|metadata| metadata.pr_info.clone());
-        let previous_pr_info_stale = self
-            .metadata
-            .as_ref()
-            .is_some_and(|metadata| metadata.pr_info_stale);
 
         match metadata {
             Ok(mut metadata) => {
-                // Carry forward cached PR info so the button doesn't flash
-                // "Create PR" between branch switch and `refresh_pr_info`.
+                // Carry forward cached PR info while refresh_pr_info is pending
+                // so the header doesn't flash to Commit/Create PR between
+                // branch switch and PR lookup completion.
                 metadata.pr_info = previous_pr_info;
-                // Inherit staleness only on same-branch refreshes; branch
-                // change leaves it at the default (stale) so the retry can
-                // re-fire.
-                if previous_branch.as_deref() == Some(metadata.current_branch_name.as_str()) {
-                    metadata.pr_info_stale = previous_pr_info_stale;
-                }
                 self.metadata = Some(metadata);
             }
             Err(e) => {
@@ -1548,13 +1536,6 @@ impl DiffStateModel {
             if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
                 self.refresh_pr_info(ctx);
             }
-        } else if FeatureFlag::GitOperationsInCodeReview.is_enabled()
-            && self
-                .metadata
-                .as_ref()
-                .is_some_and(|metadata| metadata.pr_info_stale)
-        {
-            self.refresh_pr_info(ctx);
         }
 
         ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
@@ -2917,6 +2898,9 @@ impl DiffStateModel {
     /// Call this on branch change or after push — not on every metadata refresh.
     #[cfg(feature = "local_fs")]
     pub fn refresh_pr_info(&mut self, ctx: &mut ModelContext<Self>) {
+        if let Some(handle) = self.refreshing_pr_info_handle.take() {
+            handle.abort();
+        }
         let Some(repo_path) = self.active_repository_path(ctx) else {
             return;
         };
@@ -2929,7 +2913,7 @@ impl DiffStateModel {
             use futures::FutureExt;
             futures::future::ready(None).boxed()
         };
-        ctx.spawn(
+        let handle = ctx.spawn(
             async move {
                 let path_env = path_future.await;
                 get_pr_for_branch(&repo_path, path_env.as_deref())
@@ -2937,15 +2921,16 @@ impl DiffStateModel {
                     .unwrap_or(None)
             },
             |me, pr_info, ctx| {
+                me.refreshing_pr_info_handle = None;
                 if let Some(metadata) = &mut me.metadata {
                     metadata.pr_info = pr_info;
-                    metadata.pr_info_stale = false;
                     ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
                         InvalidationBehavior::PromptRefresh,
                     ));
                 }
             },
         );
+        self.refreshing_pr_info_handle = Some(handle);
     }
 
     #[cfg(not(feature = "local_fs"))]

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -432,6 +432,11 @@ impl ActionButton {
         ctx.notify();
     }
 
+    pub fn clear_tooltip(&mut self, ctx: &mut ViewContext<Self>) {
+        self.tooltip = None;
+        ctx.notify();
+    }
+
     pub fn set_tooltip_sublabel(
         &mut self,
         tooltip_sublabel: Option<impl Into<String>>,


### PR DESCRIPTION
## Description

Fixes APP-4263: the code review git operations header briefly showed incorrect PR-related actions while PR info for the current branch was still being refreshed.

`load_metadata_for_repo` returns `pr_info: None` because PR info is fetched separately via `refresh_pr_info` (`gh pr view`). That made the UI treat unknown PR state as "no PR" while the async lookup was in flight, which could briefly show `Create PR`. With the handle-only version, switching between two branches that both have PRs could also briefly fall back from `PR #N` to disabled `Commit` before resolving to `PR #M`.

### Fix

In `app/src/code_review/diff_state.rs`:

1. Track an in-flight PR lookup with `refreshing_pr_info_handle: Option<SpawnedFutureHandle>` instead of storing PR staleness in metadata.
2. Abort any previous PR lookup before starting a new one.
3. Carry forward cached `pr_info` through metadata refreshes so the header does not clear to disabled `Commit` while the next branch's PR lookup is pending.

In `app/src/code_review/code_review_view.rs`:

1. Gate `Create PR` on `!is_pr_info_refreshing()` so an unknown/pending PR lookup is not treated as "no PR".
2. If cached PR info is being carried while a new lookup is pending, keep the previous `PR #N` label visible but disable the button/menu item with a "Refreshing PR info" tooltip so it cannot open a stale PR.
3. Once the lookup resolves, update the header to the new branch's `PR #M`, `Create PR`, or disabled `Commit` state as appropriate.

## Testing

Not run in this update per request.

Expected/manual behavior:
- Main/master → feature branch: no `Create PR` flicker while `gh pr view` is pending.
- Branch with PR → branch with PR: no disabled `Commit` interstitial; previous PR label remains disabled until the new PR info resolves.
- Branch with PR → branch without PR: previous PR label remains disabled briefly, then transitions to `Create PR` if the branch is eligible.
- Dropdown `Create PR` and commit-dialog create-PR intent remain unavailable while PR info is refreshing.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode


UPDATED LOOM: https://www.loom.com/share/4c94527c09914af9b295e49b4719159a
