### PR TITLE
Expose Rename Pane in keybindings, palette, and /rename-pane

### DIFF
--- a/app/src/app_menus.rs
+++ b/app/src/app_menus.rs
@@ -488,6 +488,7 @@ fn make_new_view_menu(ctx: &AppContext) -> Menu {
 fn make_new_tab_menu(ctx: &AppContext) -> Menu {
     let items = vec![
         updateable_custom_item_without_checkmark(CustomAction::RenameTab, ctx),
+        updateable_custom_item_without_checkmark(CustomAction::RenamePane, ctx),
         MenuItem::Separator,
         updateable_custom_item_without_checkmark(CustomAction::SplitPaneRight, ctx),
         updateable_custom_item_without_checkmark(CustomAction::SplitPaneLeft, ctx),

--- a/app/src/resource_center/utils.rs
+++ b/app/src/resource_center/utils.rs
@@ -96,6 +96,7 @@ pub const TERMINAL_KEYBINDINGS: &[&str] = &[
     "pane_group:navigate_left",
     "pane_group:navigate_next",
     "pane_group:navigate_prev",
+    "pane_group:rename",
     "pane_group:navigate_right",
     "pane_group:navigate_up",
     "pane_group:resize_down",

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -136,6 +136,15 @@ pub static RENAME_TAB: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand 
     argument: Some(Argument::required().with_hint_text("<tab name>")),
 });
 
+pub static RENAME_PANE: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
+    name: "/rename-pane",
+    description: "Rename the focused pane",
+    icon_path: "bundled/svg/pencil-line.svg",
+    availability: Availability::ALWAYS,
+    auto_enter_ai_mode: false,
+    argument: Some(Argument::required().with_hint_text("<pane name>")),
+});
+
 static SET_TAB_COLOR_HINT: LazyLock<String> = LazyLock::new(|| {
     let mut hint = String::from("<");
     for color in color_dot::TAB_COLOR_OPTIONS {
@@ -546,6 +555,7 @@ fn all_commands() -> Vec<StaticCommand> {
         NEW.clone(),
         PLAN.clone(),
         RENAME_TAB.clone(),
+        RENAME_PANE.clone(),
         SET_TAB_COLOR.clone(),
         USAGE,
         CONVERSATIONS,
@@ -669,6 +679,21 @@ mod tests {
         assert!(!argument.is_optional);
         assert!(!argument.should_execute_on_selection);
         assert_eq!(argument.hint_text, Some("<tab name>"));
+    }
+
+    #[test]
+    fn rename_pane_command_requires_argument() {
+        let command = COMMAND_REGISTRY
+            .get_command_with_name(RENAME_PANE.name)
+            .expect("expected /rename-pane to be registered");
+        let argument = command
+            .argument
+            .as_ref()
+            .expect("expected /rename-pane to require an argument");
+
+        assert!(!argument.is_optional);
+        assert!(!argument.should_execute_on_selection);
+        assert_eq!(argument.hint_text, Some("<pane name>"));
     }
 
     #[test]

--- a/app/src/search/slash_command_menu/static_commands/mod_test.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod_test.rs
@@ -180,7 +180,7 @@ fn ai_enabled_requirement_not_satisfied_when_ai_off() {
 
 #[test]
 fn commands_without_ai_enabled_remain_available_when_ai_off() {
-    // Commands like `/open-file`, `/rename-tab`, `/changelog` only set session-context bits.
+    // Commands like `/open-file`, `/rename-tab`, `/rename-pane`, `/changelog` only set session-context bits.
     // With AI off, `session_context` has no `AI_ENABLED` bit, but these should still match.
     let command_local = Availability::LOCAL;
     let command_always = Availability::ALWAYS;

--- a/app/src/terminal/input/slash_command_model_tests.rs
+++ b/app/src/terminal/input/slash_command_model_tests.rs
@@ -108,6 +108,49 @@ fn test_parse_rename_tab_slash_command_arguments() {
 }
 
 #[test]
+fn test_parse_rename_pane_slash_command_arguments() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let terminal = add_window_with_bootstrapped_terminal(
+            &mut app, None, /* history_file_commands */
+            None,
+        )
+        .await;
+        let input = terminal.read(&app, |terminal, _| terminal.input().clone());
+        let slash_command_data_source =
+            input.read(&app, |input, _| input.slash_command_data_source.clone());
+
+        slash_command_data_source.read(&app, |data_source, _| {
+            assert!(
+                data_source
+                    .parse_slash_command(commands::RENAME_PANE.name)
+                    .is_none(),
+                "expected /rename-pane without an argument not to parse"
+            );
+
+            let detected_with_argument = data_source
+                .parse_slash_command("/rename-pane Backend")
+                .expect("expected /rename-pane to parse with an argument");
+            assert_eq!(detected_with_argument.argument.as_deref(), Some("Backend"));
+
+            let detected_with_multi_word_argument = data_source
+                .parse_slash_command("/rename-pane Backend API")
+                .expect("expected /rename-pane to preserve the rest of the line as one argument");
+            assert_eq!(
+                detected_with_multi_word_argument.argument.as_deref(),
+                Some("Backend API")
+            );
+
+            let detected_with_empty_argument = data_source
+                .parse_slash_command("/rename-pane ")
+                .expect("expected /rename-pane to parse once the required argument is started");
+            assert_eq!(detected_with_empty_argument.argument.as_deref(), Some(""));
+        });
+    });
+}
+
+#[test]
 fn test_non_ai_commands_remain_active_when_ai_is_disabled() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);
@@ -138,6 +181,10 @@ fn test_non_ai_commands_remain_active_when_ai_is_disabled() {
             assert!(
                 active_command_names.contains(&commands::RENAME_TAB.name),
                 "/rename-tab should remain active when AI is off, got: {active_command_names:?}"
+            );
+            assert!(
+                active_command_names.contains(&commands::RENAME_PANE.name),
+                "/rename-pane should remain active when AI is off, got: {active_command_names:?}"
             );
 
             // Commands that require AI should be filtered out.

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -423,6 +423,20 @@ impl Input {
 
                 ctx.dispatch_typed_action(&WorkspaceAction::SetActiveTabName(name.to_owned()));
             }
+            rename_pane if command.name == commands::RENAME_PANE.name => {
+                let Some(name) = argument
+                    .map(|name| name.trim())
+                    .filter(|name| !name.is_empty())
+                else {
+                    show_error_toast(
+                        "Please provide a pane name after /rename-pane".to_owned(),
+                        ctx,
+                    );
+                    return true;
+                };
+
+                ctx.dispatch_typed_action(&WorkspaceAction::SetActivePaneName(name.to_owned()));
+            }
             set_tab_color if command.name == commands::SET_TAB_COLOR.name => {
                 let supported_options = || {
                     color_dot::TAB_COLOR_OPTIONS

--- a/app/src/util/bindings.rs
+++ b/app/src/util/bindings.rs
@@ -137,6 +137,8 @@ pub enum CustomAction {
     GoToLine,
     ToggleGlobalSearch,
     ToggleConversationListView,
+    /// Rename the focused pane (same as vertical-tabs context menu).
+    RenamePane,
 }
 
 lazy_static! {
@@ -441,6 +443,7 @@ pub fn custom_tag_to_keystroke(custom: CustomTag) -> Option<Keystroke> {
         | CustomAction::SplitPaneUp
         | CustomAction::ConfigureKeybindings
         | CustomAction::RenameTab
+        | CustomAction::RenamePane
         | CustomAction::CloseTab
         | CustomAction::CloseOtherTabs
         | CustomAction::CloseTabsRight

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -112,7 +112,9 @@ pub enum WorkspaceAction {
     RenamePane(PaneViewLocator),
     ResetPaneName(PaneViewLocator),
     RenameActiveTab,
+    RenameActivePane,
     SetActiveTabName(String),
+    SetActivePaneName(String),
     /// Sets the manual color override for the active tab.
     ///
     /// - `Color(_)` — apply that color.
@@ -726,7 +728,9 @@ impl WorkspaceAction {
             | RenamePane(_)
             | ResetPaneName(_)
             | RenameActiveTab
+            | RenameActivePane
             | SetActiveTabName(_)
+            | SetActivePaneName(_)
             | SetActiveTabColor(_)
             | CloseTab(_)
             | CloseActiveTab

--- a/app/src/workspace/action_tests.rs
+++ b/app/src/workspace/action_tests.rs
@@ -74,4 +74,6 @@ fn pane_name_actions_save_workspace_state() {
 
     assert!(WorkspaceAction::RenamePane(locator).should_save_app_state_on_action());
     assert!(WorkspaceAction::ResetPaneName(locator).should_save_app_state_on_action());
+    assert!(WorkspaceAction::RenameActivePane.should_save_app_state_on_action());
+    assert!(WorkspaceAction::SetActivePaneName("x".to_owned()).should_save_app_state_on_action());
 }

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -596,10 +596,8 @@ pub fn init(app: &mut AppContext) {
         .with_custom_action(CustomAction::ActivateNextPane),
         EditableBinding::new(
             "pane_group:rename",
-            BindingDescription::new("Rename the current pane").with_custom_description(
-                bindings::MAC_MENUS_CONTEXT,
-                "Rename Pane",
-            ),
+            BindingDescription::new("Rename the current pane")
+                .with_custom_description(bindings::MAC_MENUS_CONTEXT, "Rename Pane"),
             WorkspaceAction::RenameActivePane,
         )
         .with_context_predicate(id!("Workspace"))

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -595,6 +595,17 @@ pub fn init(app: &mut AppContext) {
         .with_group(bindings::BindingGroup::Navigation.as_str())
         .with_custom_action(CustomAction::ActivateNextPane),
         EditableBinding::new(
+            "pane_group:rename",
+            BindingDescription::new("Rename the current pane").with_custom_description(
+                bindings::MAC_MENUS_CONTEXT,
+                "Rename Pane",
+            ),
+            WorkspaceAction::RenameActivePane,
+        )
+        .with_context_predicate(id!("Workspace"))
+        .with_group(bindings::BindingGroup::Navigation.as_str())
+        .with_custom_action(CustomAction::RenamePane),
+        EditableBinding::new(
             "workspace:toggle_mouse_reporting",
             "Toggle Mouse Reporting",
             WorkspaceAction::ToggleMouseReporting,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5065,6 +5065,37 @@ impl Workspace {
         ctx.notify();
     }
 
+    pub fn rename_active_pane(&mut self, ctx: &mut ViewContext<Self>) {
+        let pane_group = self.active_tab_pane_group();
+        let locator = PaneViewLocator {
+            pane_group_id: pane_group.id(),
+            pane_id: pane_group.as_ref(ctx).focused_pane_id(ctx),
+        };
+        self.rename_pane(locator, ctx);
+    }
+
+    fn set_active_pane_name(&mut self, title: &str, ctx: &mut ViewContext<Self>) {
+        if self.current_workspace_state.is_any_pane_being_renamed() {
+            self.current_workspace_state.clear_pane_being_renamed();
+            self.clear_pane_name_editor(ctx);
+        }
+
+        let title = title.trim();
+        if title.is_empty() {
+            ctx.notify();
+            return;
+        }
+
+        let pane_group = self.active_tab_pane_group();
+        let locator = PaneViewLocator {
+            pane_group_id: pane_group.id(),
+            pane_id: pane_group.as_ref(ctx).focused_pane_id(ctx),
+        };
+        self.set_custom_pane_name(locator, title.to_owned(), ctx);
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
     /// Programmatically sets the manual color override for a tab.
     ///
     /// - `Color(_)` applies that color.
@@ -19698,7 +19729,9 @@ impl TypedActionView for Workspace {
             RenamePane(locator) => self.rename_pane(*locator, ctx),
             ResetPaneName(locator) => self.clear_pane_name(*locator, ctx),
             RenameActiveTab => self.rename_tab(self.active_tab_index, ctx),
+            RenameActivePane => self.rename_active_pane(ctx),
             SetActiveTabName(name) => self.set_active_tab_name(name, ctx),
+            SetActivePaneName(name) => self.set_active_pane_name(name, ctx),
             SetActiveTabColor(color) => self.set_tab_color(self.active_tab_index, *color, ctx),
             ToggleTabRightClickMenu { tab_index, anchor } => {
                 self.toggle_tab_right_click_menu(*tab_index, *anchor, ctx)


### PR DESCRIPTION
Register the existing pane rename flow for the focused pane:
- Add WorkspaceAction::RenameActivePane and SetActivePaneName(String)
- Add pane_group:rename editable binding (no default shortcut) and CustomAction::RenamePane
- Add macOS Tab menu item and resource center keybinding list entry
- Add /rename-pane static slash command mirroring /rename-tab

Fixes #9351

Made-with: Cursor

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
