### PR TITLE
fix | new/changed/removed skills appear without restart when ~/.agents is a symlink

### DIFF
--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -27,7 +27,7 @@ use chrono::{DateTime, Duration, Utc};
 use repo_metadata::{
     repositories::{DetectedRepositories, RepoDetectionSource},
     repository::{Repository, SubscriberId},
-    DirectoryWatcher, RepoMetadataModel, RepositoryUpdate,
+    DirectoryWatcher, RepoMetadataModel, RepositoryUpdate, TargetFile,
 };
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 
@@ -56,11 +56,29 @@ pub struct SkillWatcher {
     /// Tracks watchers on home provider directories (e.g. ~/.agents, ~/.claude) so they
     /// can be cleaned up when the directory is deleted.
     home_provider_watchers: HashMap<PathBuf, (ModelHandle<Repository>, SubscriberId)>,
+    /// Canonical (symlink-resolved) provider directory → originals (user-facing).
+    ///
+    /// Invariant: after translation at the entry of `handle_repository_update`,
+    /// downstream code sees only *original* paths, matching `home_skills_path()`.
+    /// Watches register via `from_local_canonicalized`, so kernel/FSEvents emit
+    /// canonical paths; downstream filters (`is_skill_file`,
+    /// `is_home_skill_directory`) compare against the un-canonicalized form.
+    ///
+    /// Originals are kept because provider identity lives in the symlink prefix:
+    /// `~/.agents` and `~/.claude` may both resolve to the same canonical
+    /// directory but are different `SkillProvider`s. The set holds multiple
+    /// originals when providers share a target; events fan out to each.
+    ///
+    /// Mirrors `symlink_canonical_to_originals` at the skill-file layer.
+    /// Refs warpdotdev/warp#8897.
+    home_provider_canonical_to_originals: HashMap<PathBuf, HashSet<PathBuf>>,
     /// Maps canonical (resolved) SKILL.md paths → set of original symlink-based paths.
     /// Multiple symlinks can resolve to the same canonical file, so we track all of them.
     /// Used to detect changes to the real files behind symlinked skill directories
     /// on platforms where the OS-level watcher (e.g. FSEvents on macOS) does not
     /// follow symlinks.
+    ///
+    /// See also `home_provider_canonical_to_originals` at the provider-parent layer.
     symlink_canonical_to_originals: HashMap<PathBuf, HashSet<PathBuf>>,
     /// Watchers for resolved symlink target directories, keyed by canonical
     /// parent directory. Used both as a dedup guard (skip if already watching)
@@ -137,6 +155,8 @@ impl SkillWatcher {
         // Note: This will not create watchers for provider directories that haven't been created yet.
         // We use a separate HomeDirectoryWatcher to detect when those are created and start watching them after they are created.
         let mut home_provider_watchers = HashMap::new();
+        let mut home_provider_canonical_to_originals: HashMap<PathBuf, HashSet<PathBuf>> =
+            HashMap::new();
         if let Some(home_path) = home_dir {
             Self::spawn_read_skills_from_directories(warp_managed_skill_dirs(), ctx);
             let skills_parent_paths: HashSet<PathBuf> = SKILL_PROVIDER_DEFINITIONS
@@ -154,6 +174,7 @@ impl SkillWatcher {
                     &parent_path,
                     &repository_message_tx,
                     &mut home_provider_watchers,
+                    &mut home_provider_canonical_to_originals,
                     ctx,
                 );
             }
@@ -218,6 +239,7 @@ impl SkillWatcher {
             queued_project_directory_creations: Vec::new(),
             watcher_event_tx,
             home_provider_watchers,
+            home_provider_canonical_to_originals,
             symlink_canonical_to_originals: HashMap::new(),
             symlink_target_watchers: HashMap::new(),
         }
@@ -309,11 +331,114 @@ impl SkillWatcher {
         }
     }
 
+    /// If `path` falls under a registered canonical home-provider directory, return
+    /// the rewritten path under each original (symlinked) provider. Multiple originals
+    /// can resolve to the same canonical (e.g. `~/.agents` and `~/.claude` both
+    /// pointing at a shared dir), so we fan out to all of them. Returns `path`
+    /// unchanged in a single-element vec if it doesn't match any known canonical.
+    fn translate_canonical_to_original_paths(&self, path: &Path) -> Vec<PathBuf> {
+        // Pick the deepest (longest) matching canonical so nested registrations
+        // resolve deterministically. `HashMap` iteration order is unstable, so
+        // first-match-wins would translate the same input two different ways.
+        let best = self
+            .home_provider_canonical_to_originals
+            .iter()
+            .filter_map(|(canonical, originals)| {
+                path.strip_prefix(canonical)
+                    .ok()
+                    .map(|rel| (canonical, originals, rel))
+            })
+            .max_by_key(|(canonical, _, _)| canonical.as_os_str().len());
+        match best {
+            Some((_, originals, rel)) => originals.iter().map(|orig| orig.join(rel)).collect(),
+            None => vec![path.to_path_buf()],
+        }
+    }
+
+    fn translate_canonical_paths(&self, update: &RepositoryUpdate) -> RepositoryUpdate {
+        let fan_out = |tf: &TargetFile| -> Vec<TargetFile> {
+            self.translate_canonical_to_original_paths(&tf.path)
+                .into_iter()
+                .map(|p| TargetFile::new(p, tf.is_ignored))
+                .collect()
+        };
+        let mut moved = HashMap::new();
+        let mut salvaged_added: Vec<TargetFile> = Vec::new();
+        let mut salvaged_deleted: Vec<TargetFile> = Vec::new();
+        for (to, from) in &update.moved {
+            let to_paths = self.translate_canonical_to_original_paths(&to.path);
+            let from_paths = self.translate_canonical_to_original_paths(&from.path);
+            // Same canonical on both sides → fan-outs match, paired correctly.
+            // Different canonicals with equal fan-out → arbitrary pairing, but the
+            // aggregate adds/deletes still match what downstream expects.
+            // Mismatched fan-outs → can't pair the move, but salvage both sides as
+            // independent add/delete events. `notify` can report a cross-boundary
+            // rename without a separate add, so dropping would lose the destination
+            // skill entirely (e.g. `mv` from outside a provider into a shared-
+            // canonical provider with multiple originals).
+            if to_paths.len() != from_paths.len() {
+                log::debug!(
+                    "skill_watcher: splitting move with mismatched canonical fan-out into add+delete: from={} to={}",
+                    from.path.display(),
+                    to.path.display()
+                );
+                salvaged_added.extend(
+                    to_paths
+                        .into_iter()
+                        .map(|p| TargetFile::new(p, to.is_ignored)),
+                );
+                salvaged_deleted.extend(
+                    from_paths
+                        .into_iter()
+                        .map(|p| TargetFile::new(p, from.is_ignored)),
+                );
+                continue;
+            }
+            for (to_p, from_p) in to_paths.into_iter().zip(from_paths) {
+                moved.insert(
+                    TargetFile::new(to_p, to.is_ignored),
+                    TargetFile::new(from_p, from.is_ignored),
+                );
+            }
+        }
+        RepositoryUpdate {
+            added: update
+                .added
+                .iter()
+                .flat_map(fan_out)
+                .chain(salvaged_added)
+                .collect(),
+            modified: update.modified.iter().flat_map(fan_out).collect(),
+            deleted: update
+                .deleted
+                .iter()
+                .flat_map(fan_out)
+                .chain(salvaged_deleted)
+                .collect(),
+            moved,
+            // Non-path fields pass through; new path-bearing fields need fan_out.
+            commit_updated: update.commit_updated,
+            index_lock_detected: update.index_lock_detected,
+        }
+    }
+
     fn handle_repository_update(
         &mut self,
         update: &RepositoryUpdate,
         ctx: &mut ModelContext<Self>,
     ) {
+        // Translation boundary: rewrite event paths from canonical to original form
+        // when symlinked provider parents are registered. See
+        // `home_provider_canonical_to_originals` for the full rationale.
+        // Short-circuits to a no-op when no provider translation is needed.
+        let translated;
+        let update = if self.home_provider_canonical_to_originals.is_empty() {
+            update
+        } else {
+            translated = self.translate_canonical_paths(update);
+            &translated
+        };
+
         let mut queued_project_directories = HashSet::new();
         let mut home_path_additions = HashSet::new();
         let mut deleted_paths = Vec::new();
@@ -783,6 +908,10 @@ impl SkillWatcher {
                     repo.stop_watching(subscriber_id, ctx);
                 });
             }
+            Self::remove_home_provider_original_mapping(
+                &mut self.home_provider_canonical_to_originals,
+                deleted_path,
+            );
         }
 
         if !deleted_paths.is_empty() {
@@ -799,6 +928,7 @@ impl SkillWatcher {
                 &added_path,
                 &self.repository_message_tx,
                 &mut self.home_provider_watchers,
+                &mut self.home_provider_canonical_to_originals,
                 ctx,
             );
         }
@@ -817,13 +947,30 @@ impl SkillWatcher {
         }
     }
 
-    /// Watch a provider path in the home directory (e.g. ~/.agents), storing the handle
-    /// and subscriber ID in `home_provider_watchers` so the watcher can be cleaned up
-    /// when the directory is deleted.
+    /// Removes `original` from every canonical entry; drops canonical entries
+    /// whose set becomes empty. Shared between provider deletion and rollback
+    /// when watcher registration fails — the canonical map must reflect only
+    /// providers whose watches actually committed.
+    fn remove_home_provider_original_mapping(
+        map: &mut HashMap<PathBuf, HashSet<PathBuf>>,
+        original: &Path,
+    ) {
+        map.retain(|_, originals| {
+            originals.remove(original);
+            !originals.is_empty()
+        });
+    }
+
+    /// Registers a home provider path and stores the watcher handle for cleanup.
+    /// If the watch canonicalizes to a different local path, records the original
+    /// path for later event translation. On registration failure (sync or async),
+    /// any canonical mapping inserted is rolled back so the map only reflects
+    /// committed watches.
     fn watch_home_provider_path(
         path: &Path,
         repository_message_tx: &Sender<SkillRepositoryMessage>,
         home_provider_watchers: &mut HashMap<PathBuf, (ModelHandle<Repository>, SubscriberId)>,
+        home_provider_canonical_to_originals: &mut HashMap<PathBuf, HashSet<PathBuf>>,
         ctx: &mut ModelContext<Self>,
     ) {
         let Ok(std_path) =
@@ -832,8 +979,18 @@ impl SkillWatcher {
             return;
         };
 
+        if let Some(canonical) = std_path.to_local_path() {
+            if canonical != path {
+                home_provider_canonical_to_originals
+                    .entry(canonical)
+                    .or_default()
+                    .insert(path.to_path_buf());
+            }
+        }
+
         let subscriber = Box::new(HomeSkillSubscriber {
             message_tx: repository_message_tx.clone(),
+            provider_path: path.to_path_buf(),
         });
 
         let parent_path_display = std_path.to_string();
@@ -844,6 +1001,10 @@ impl SkillWatcher {
             Err(err) => {
                 log::warn!(
                     "Failed to register home skills directory {parent_path_display} for watching: {err}"
+                );
+                Self::remove_home_provider_original_mapping(
+                    home_provider_canonical_to_originals,
+                    path,
                 );
                 return;
             }
@@ -861,8 +1022,13 @@ impl SkillWatcher {
                 log::warn!(
                     "Failed to start watching home skills directory {parent_path_display}: {err}"
                 );
-                // Remove the stored watcher since registration failed.
+                // Remove the stored watcher and roll back the canonical mapping
+                // so neither map reflects a registration that didn't commit.
                 me.home_provider_watchers.remove(&path_owned);
+                Self::remove_home_provider_original_mapping(
+                    &mut me.home_provider_canonical_to_originals,
+                    &path_owned,
+                );
                 repo_handle.update(ctx, |repo, ctx| {
                     repo.stop_watching(subscriber_id, ctx);
                 });

--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -1,19 +1,43 @@
 use std::{
     collections::{HashMap, HashSet},
     fs,
+    future::Future,
+    pin::Pin,
 };
 
 use crate::ai::skills::skill_manager::SkillWatcherEvent;
 use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
 use repo_metadata::{
-    repositories::DetectedRepositories, DirectoryWatcher, RepoMetadataModel, RepositoryUpdate,
-    TargetFile,
+    repositories::DetectedRepositories,
+    repository::{Repository, RepositorySubscriber},
+    DirectoryWatcher, RepoMetadataModel, RepositoryUpdate, TargetFile,
 };
 use tempfile::TempDir;
 use warp_util::standardized_path::StandardizedPath;
-use warpui::App;
+use warpui::{App, SingletonEntity};
 
 use super::SkillWatcher;
+
+struct NoopRepositorySubscriber;
+
+impl RepositorySubscriber for NoopRepositorySubscriber {
+    fn on_scan(
+        &mut self,
+        _repository: &Repository,
+        _ctx: &mut warpui::ModelContext<Repository>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+        Box::pin(async {})
+    }
+
+    fn on_files_updated(
+        &mut self,
+        _repository: &Repository,
+        _update: &RepositoryUpdate,
+        _ctx: &mut warpui::ModelContext<Repository>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+        Box::pin(async {})
+    }
+}
 
 /// Helper function for creating a single skill file
 fn create_skill_file(dir: &TempDir, name: &str, description: &str, content: &str) -> ParsedSkill {
@@ -82,6 +106,411 @@ fn test_handle_repository_update_single_skill_added() {
                 skills: vec![skill]
             }
         );
+    });
+}
+
+/// Regression test for warpdotdev/warp#8897: when the provider parent (e.g. `~/.agents`)
+/// is itself a symlink, file events fire under the canonical (resolved) path. Without
+/// translation, the downstream filter — which compares against un-canonicalized
+/// `home_skills_path()` — would silently drop them.
+#[test]
+fn test_handle_repository_update_translates_canonical_paths_for_symlinked_provider() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        // The actual file lives at the *original* (un-canonicalized) location.
+        let skill = create_skill_file(&temp_dir, "test", "Test skill", "Test content");
+        let original_provider = temp_dir.path().join(".agents");
+        let canonical_provider = temp_dir.path().join("dotfiles-agents");
+
+        // Populate the canonical→originals map as `watch_home_provider_path` would
+        // have done after `dunce::canonicalize` resolved the symlink at registration.
+        skill_watcher_handle.update(&mut app, |watcher, _ctx| {
+            watcher
+                .home_provider_canonical_to_originals
+                .entry(canonical_provider.clone())
+                .or_default()
+                .insert(original_provider);
+        });
+
+        // Event arrives with the canonical path (what FSEvents would emit when the
+        // watch was registered on the symlink target).
+        let canonical_skill_path = canonical_provider
+            .join("skills")
+            .join("test")
+            .join("SKILL.md");
+        let update = RepositoryUpdate {
+            added: HashSet::from([TargetFile::new(canonical_skill_path, false)]),
+            modified: HashSet::new(),
+            deleted: HashSet::new(),
+            moved: HashMap::new(),
+            commit_updated: false,
+            index_lock_detected: false,
+        };
+
+        skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
+            skill_watcher.handle_repository_update(&update, ctx);
+        });
+
+        // The dispatched skill has the *original* path — translation worked, the
+        // filter recognized it, and parse_skill read from the symlink-side location.
+        let event = rx.recv().await.unwrap();
+        assert_eq!(
+            event,
+            SkillWatcherEvent::SkillsAdded {
+                skills: vec![skill]
+            }
+        );
+        // Pin event cardinality: exactly one event, no duplicates from translation.
+        assert!(rx.try_recv().is_err());
+    });
+}
+
+/// Regression test for the multi-provider shared-canonical case: when two provider
+/// parents (e.g. `~/.agents` and `~/.claude`) both symlink to the same directory,
+/// a single canonical event must fan out to all originals so each provider's view
+/// of the skill stays in sync.
+#[test]
+fn test_handle_repository_update_fans_out_to_all_originals_for_shared_canonical() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        // Create the same skill file under both .agents and .claude so parse_skill
+        // succeeds when called on either translated path.
+        let skill_agents = create_skill_file(&temp_dir, "test", "Test skill", "Test content");
+        let skill_content = fs::read_to_string(&skill_agents.path).unwrap();
+        let claude_skill_dir = temp_dir.path().join(".claude").join("skills").join("test");
+        fs::create_dir_all(&claude_skill_dir).unwrap();
+        let claude_skill_path = claude_skill_dir.join("SKILL.md");
+        fs::write(&claude_skill_path, skill_content).unwrap();
+
+        let agents_provider = temp_dir.path().join(".agents");
+        let claude_provider = temp_dir.path().join(".claude");
+        let canonical_provider = temp_dir.path().join("shared-dotfiles");
+
+        // Both originals resolve to the same canonical.
+        skill_watcher_handle.update(&mut app, |watcher, _ctx| {
+            let entry = watcher
+                .home_provider_canonical_to_originals
+                .entry(canonical_provider.clone())
+                .or_default();
+            entry.insert(agents_provider);
+            entry.insert(claude_provider);
+        });
+
+        let canonical_skill_path = canonical_provider
+            .join("skills")
+            .join("test")
+            .join("SKILL.md");
+        let update = RepositoryUpdate {
+            added: HashSet::from([TargetFile::new(canonical_skill_path, false)]),
+            modified: HashSet::new(),
+            deleted: HashSet::new(),
+            moved: HashMap::new(),
+            commit_updated: false,
+            index_lock_detected: false,
+        };
+
+        skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
+            skill_watcher.handle_repository_update(&update, ctx);
+        });
+
+        // Two events — one per original provider. HashSet iteration is unordered,
+        // so collect paths into a set for order-independent comparison.
+        let mut paths_seen: HashSet<_> = HashSet::new();
+        for _ in 0..2 {
+            match rx.recv().await.unwrap() {
+                SkillWatcherEvent::SkillsAdded { skills } => {
+                    assert_eq!(skills.len(), 1);
+                    paths_seen.insert(skills[0].path.clone());
+                }
+                other => panic!("Expected SkillsAdded, got {:?}", other),
+            }
+        }
+        assert!(paths_seen.contains(&skill_agents.path));
+        assert!(paths_seen.contains(&claude_skill_path));
+        // Pin event cardinality: exactly two events from fan-out, no extras.
+        assert!(rx.try_recv().is_err());
+    });
+}
+
+/// When a `moved` event has mismatched canonical fan-out (e.g. `mv` from outside
+/// a provider into a shared-canonical provider with two originals), the move
+/// can't be paired but must not be dropped — `notify` can report a cross-boundary
+/// rename without a separate add, so dropping would lose the destination skill.
+/// This test pins that the destination side is salvaged as an add (fanned out
+/// to all originals) and the source side as a delete.
+#[test]
+fn test_handle_repository_update_salvages_mismatched_moves_as_add_and_delete() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        // Two providers symlinked to the same canonical (shared-canonical setup).
+        let skill_content = r#"---
+name: test
+description: Test skill
+---
+Test content
+"#;
+        let agents_skill_dir = temp_dir.path().join(".agents").join("skills").join("test");
+        fs::create_dir_all(&agents_skill_dir).unwrap();
+        let agents_skill_path = agents_skill_dir.join("SKILL.md");
+        fs::write(&agents_skill_path, skill_content).unwrap();
+        let claude_skill_dir = temp_dir.path().join(".claude").join("skills").join("test");
+        fs::create_dir_all(&claude_skill_dir).unwrap();
+        let claude_skill_path = claude_skill_dir.join("SKILL.md");
+        fs::write(&claude_skill_path, skill_content).unwrap();
+
+        let agents_provider = temp_dir.path().join(".agents");
+        let claude_provider = temp_dir.path().join(".claude");
+        let canonical_provider = temp_dir.path().join("shared-dotfiles");
+
+        skill_watcher_handle.update(&mut app, |watcher, _ctx| {
+            let entry = watcher
+                .home_provider_canonical_to_originals
+                .entry(canonical_provider.clone())
+                .or_default();
+            entry.insert(agents_provider.clone());
+            entry.insert(claude_provider.clone());
+        });
+
+        // Cross-boundary rename: source outside any canonical, destination
+        // inside the shared-canonical provider. Fan-out lengths: 1 (source
+        // pass-through) vs 2 (destination expands to both originals).
+        let outside_source = temp_dir.path().join("outside-source-SKILL.md");
+        let canonical_destination = canonical_provider
+            .join("skills")
+            .join("test")
+            .join("SKILL.md");
+        let mut moved = HashMap::new();
+        moved.insert(
+            TargetFile::new(canonical_destination, false),
+            TargetFile::new(outside_source.clone(), false),
+        );
+        let update = RepositoryUpdate {
+            added: HashSet::new(),
+            modified: HashSet::new(),
+            deleted: HashSet::new(),
+            moved,
+            commit_updated: false,
+            index_lock_detected: false,
+        };
+
+        skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
+            skill_watcher.handle_repository_update(&update, ctx);
+        });
+
+        // Two SkillsAdded events expected (one per original at the destination).
+        // The source side becomes a SkillsDeleted with the un-translated path.
+        let mut added_paths: HashSet<_> = HashSet::new();
+        let mut deleted_paths: HashSet<_> = HashSet::new();
+        for _ in 0..3 {
+            match rx.recv().await.unwrap() {
+                SkillWatcherEvent::SkillsAdded { skills } => {
+                    assert_eq!(skills.len(), 1);
+                    added_paths.insert(skills[0].path.clone());
+                }
+                SkillWatcherEvent::SkillsDeleted { paths } => {
+                    deleted_paths.extend(paths);
+                }
+            }
+        }
+
+        assert!(added_paths.contains(&agents_skill_path));
+        assert!(added_paths.contains(&claude_skill_path));
+        assert!(deleted_paths.contains(&outside_source));
+        // Pin cardinality: no extra events beyond 2 adds + 1 delete.
+        assert!(rx.try_recv().is_err());
+    });
+}
+
+/// Pins the deepest-prefix matching invariant for `translate_canonical_to_original_paths`.
+/// `HashMap` iteration order is unstable, so a first-match-wins implementation would
+/// translate the same input two different ways across runs when canonicals nest.
+/// Deepest match must always win.
+#[test]
+fn test_translate_canonical_picks_deepest_prefix_match() {
+    let (tx, _rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        let shallow_canonical = temp_dir.path().join("shared");
+        let deep_canonical = shallow_canonical.join("nested");
+        let shallow_original = temp_dir.path().join(".shallow-orig");
+        let deep_original = temp_dir.path().join(".deep-orig");
+
+        skill_watcher_handle.update(&mut app, |watcher, _ctx| {
+            watcher
+                .home_provider_canonical_to_originals
+                .entry(shallow_canonical.clone())
+                .or_default()
+                .insert(shallow_original.clone());
+            watcher
+                .home_provider_canonical_to_originals
+                .entry(deep_canonical.clone())
+                .or_default()
+                .insert(deep_original.clone());
+        });
+
+        let input = deep_canonical.join("skills").join("test").join("SKILL.md");
+
+        skill_watcher_handle.read(&app, |watcher, _ctx| {
+            let translated = watcher.translate_canonical_to_original_paths(&input);
+            // Deepest match: rel = "skills/test/SKILL.md" joined under .deep-orig.
+            let expected = deep_original.join("skills").join("test").join("SKILL.md");
+            assert_eq!(translated, vec![expected]);
+            // The shallow translation (rel = "nested/skills/...") must NOT be the result.
+            let shallow_wrong = shallow_original
+                .join("nested")
+                .join("skills")
+                .join("test")
+                .join("SKILL.md");
+            assert!(!translated.contains(&shallow_wrong));
+        });
+    });
+}
+
+#[test]
+fn test_handle_home_files_changed_keeps_remaining_original_for_shared_canonical() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        let agents_provider = temp_dir.path().join(".agents");
+        let claude_provider = temp_dir.path().join(".claude");
+        let canonical_provider = temp_dir.path().join("shared-dotfiles");
+        fs::create_dir_all(&canonical_provider).unwrap();
+
+        let skill_content = r#"---
+name: test
+description: Test skill
+---
+Test content
+"#;
+        let claude_skill_dir = claude_provider.join("skills").join("test");
+        fs::create_dir_all(&claude_skill_dir).unwrap();
+        let claude_skill_path = claude_skill_dir.join("SKILL.md");
+        fs::write(&claude_skill_path, skill_content).unwrap();
+
+        skill_watcher_handle.update(&mut app, |watcher, ctx| {
+            let canonical_path =
+                StandardizedPath::from_local_canonicalized(&canonical_provider).unwrap();
+            let repo_handle = DirectoryWatcher::handle(ctx)
+                .update(ctx, |directory_watcher, ctx| {
+                    directory_watcher.add_directory(canonical_path, ctx)
+                })
+                .unwrap();
+
+            let agents_start = repo_handle.update(ctx, |repo, ctx| {
+                repo.start_watching(Box::new(NoopRepositorySubscriber), ctx)
+            });
+            let claude_start = repo_handle.update(ctx, |repo, ctx| {
+                repo.start_watching(Box::new(NoopRepositorySubscriber), ctx)
+            });
+
+            watcher.home_provider_watchers.insert(
+                agents_provider.clone(),
+                (repo_handle.clone(), agents_start.subscriber_id),
+            );
+            watcher.home_provider_watchers.insert(
+                claude_provider.clone(),
+                (repo_handle, claude_start.subscriber_id),
+            );
+
+            let originals = watcher
+                .home_provider_canonical_to_originals
+                .entry(canonical_provider.clone())
+                .or_default();
+            originals.insert(agents_provider.clone());
+            originals.insert(claude_provider.clone());
+        });
+
+        let delete_event = watcher::BulkFilesystemWatcherEvent {
+            deleted: HashSet::from([agents_provider.clone()]),
+            ..Default::default()
+        };
+        skill_watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher.handle_home_files_changed(&delete_event, ctx);
+        });
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsDeleted {
+                paths: vec![agents_provider.clone()]
+            }
+        );
+
+        skill_watcher_handle.read(&app, |watcher, ctx| {
+            assert!(!watcher
+                .home_provider_watchers
+                .contains_key(&agents_provider));
+            let (repo_handle, _) = watcher
+                .home_provider_watchers
+                .get(&claude_provider)
+                .expect("remaining provider watcher should stay registered");
+            assert_eq!(repo_handle.read(ctx, |repo, _| repo.watcher_count()), 1);
+
+            let originals = watcher
+                .home_provider_canonical_to_originals
+                .get(&canonical_provider)
+                .expect("canonical entry should remain for the remaining original");
+            assert_eq!(originals.len(), 1);
+            assert!(!originals.contains(&agents_provider));
+            assert!(originals.contains(&claude_provider));
+        });
+
+        let canonical_skill_path = canonical_provider
+            .join("skills")
+            .join("test")
+            .join("SKILL.md");
+        let update = RepositoryUpdate {
+            added: HashSet::from([TargetFile::new(canonical_skill_path, false)]),
+            modified: HashSet::new(),
+            deleted: HashSet::new(),
+            moved: HashMap::new(),
+            commit_updated: false,
+            index_lock_detected: false,
+        };
+
+        skill_watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher.handle_repository_update(&update, ctx);
+        });
+
+        let event = rx.recv().await.unwrap();
+        let SkillWatcherEvent::SkillsAdded { skills } = event else {
+            panic!("Expected SkillsAdded event");
+        };
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].path, claude_skill_path);
+        assert!(rx.try_recv().is_err());
     });
 }
 

--- a/app/src/ai/skills/file_watchers/subscribers.rs
+++ b/app/src/ai/skills/file_watchers/subscribers.rs
@@ -1,4 +1,7 @@
-use std::pin::Pin;
+use std::{
+    path::{Path, PathBuf},
+    pin::Pin,
+};
 
 use futures::Future;
 
@@ -6,6 +9,33 @@ use ai::skills::{read_skills, ParsedSkill, SKILL_PROVIDER_DEFINITIONS};
 use async_channel::Sender;
 use repo_metadata::{repository::RepositorySubscriber, Repository, RepositoryUpdate};
 use warpui::ModelContext;
+
+/// Resolve the skills directory for a home provider and read its skills.
+///
+/// `provider_path` is the user-facing (original) provider directory — e.g.
+/// `~/.agents`. Must be in original form, not the canonical (symlink-resolved)
+/// form, because `home_skills_path()`-derived candidates are built off
+/// `dirs::home_dir()` and the un-resolved `definition.skills_path`. A canonical
+/// `provider_path` would never prefix-match the candidate and the function
+/// would return `None`, missing all skills under symlinked providers — the
+/// shape of the original hot-reload bug at the startup-scan layer.
+///
+/// Returns `None` if `home_dir` is absent or no provider definition matches.
+pub(super) fn scan_skills_for_home_provider(
+    provider_path: &Path,
+    home_dir: Option<&Path>,
+) -> Option<Vec<ParsedSkill>> {
+    let home_dir = home_dir?;
+    let skills_path = SKILL_PROVIDER_DEFINITIONS.iter().find_map(|definition| {
+        let candidate_path = home_dir.join(definition.skills_path.clone());
+        if candidate_path.starts_with(provider_path) {
+            Some(candidate_path)
+        } else {
+            None
+        }
+    })?;
+    Some(read_skills(&skills_path))
+}
 
 /// Messages sent from [`RepositorySubscriber`]s to [`SkillManager`].
 pub enum SkillRepositoryMessage {
@@ -88,35 +118,30 @@ impl RepositorySubscriber for SymlinkSkillSubscriber {
 /// A repository subscriber for home skills directories that forwards file change events to [`SkillManager`].
 pub struct HomeSkillSubscriber {
     pub message_tx: Sender<SkillRepositoryMessage>,
+    /// User-facing provider path (e.g. `~/.agents`). Used by `on_scan` to
+    /// derive the skills directory; differs from the watched repository's
+    /// canonical root when the provider parent is symlinked. Incremental
+    /// events take a different path (translated in
+    /// `SkillWatcher::handle_repository_update`).
+    pub provider_path: PathBuf,
 }
 
 impl RepositorySubscriber for HomeSkillSubscriber {
     fn on_scan(
         &mut self,
-        repository: &Repository,
+        _repository: &Repository,
         _ctx: &mut ModelContext<Repository>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
-        // For a home skills directory, this is the provider directory. E.g. ~/.agents
-        let repo_path = repository.root_dir().to_local_path_lossy();
+        let provider_path = self.provider_path.clone();
         let home_dir = dirs::home_dir();
         let tx = self.message_tx.clone();
 
         Box::pin(async move {
-            if let Some(home_dir) = home_dir {
-                let skills_path = SKILL_PROVIDER_DEFINITIONS.iter().find_map(|definition| {
-                    let candidate_path = home_dir.join(definition.skills_path.clone());
-                    if candidate_path.starts_with(&repo_path) {
-                        Some(candidate_path)
-                    } else {
-                        None
-                    }
-                });
-                if let Some(skills_path) = skills_path {
-                    let skills = read_skills(&skills_path);
-                    let _ = tx
-                        .send(SkillRepositoryMessage::HomeInitialScan { skills })
-                        .await;
-                }
+            if let Some(skills) = scan_skills_for_home_provider(&provider_path, home_dir.as_deref())
+            {
+                let _ = tx
+                    .send(SkillRepositoryMessage::HomeInitialScan { skills })
+                    .await;
             }
         })
     }
@@ -135,5 +160,62 @@ impl RepositorySubscriber for HomeSkillSubscriber {
                 .send(SkillRepositoryMessage::RepositoryUpdate { update })
                 .await;
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Regression test: when the provider parent is symlinked, `on_scan` must
+    /// derive the skills directory from the *original* (user-facing)
+    /// `provider_path`, not from the repository's canonical root. A real
+    /// `~/.agents` symlinked to a dotfiles location must still scan its skills
+    /// at startup. This pins the contract on the helper that `on_scan` delegates to.
+    #[test]
+    fn scan_skills_for_home_provider_finds_skills_under_original_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path();
+        let skill_dir = home.join(".agents").join("skills").join("test");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: test\ndescription: Test skill\n---\nbody\n",
+        )
+        .unwrap();
+
+        let provider_path = home.join(".agents");
+
+        let skills = scan_skills_for_home_provider(&provider_path, Some(home)).expect(
+            "expected a matching SKILL_PROVIDER_DEFINITIONS entry under the original provider path",
+        );
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "test");
+    }
+
+    /// Inverse of the above: a path that doesn't match any provider definition
+    /// (e.g. the canonical-form path the buggy code would have passed) returns
+    /// `None`. Pins that the `provider_path` parameter is what drives the
+    /// lookup — substituting a non-matching path (the bug shape) suppresses the
+    /// scan entirely.
+    #[test]
+    fn scan_skills_for_home_provider_returns_none_for_unmatched_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path();
+        let skill_dir = home.join(".agents").join("skills").join("test");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: test\ndescription: Test skill\n---\nbody\n",
+        )
+        .unwrap();
+
+        let canonical_provider_no_match = home.join("dotfiles-agents");
+        let skills = scan_skills_for_home_provider(&canonical_provider_no_match, Some(home));
+        assert!(skills.is_none());
     }
 }

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -382,37 +382,66 @@ impl SkillManager {
     }
 
     fn handle_path_deleted(&mut self, path: &Path) {
+        let mut touched_names = HashSet::new();
         // Delete all skills that are affected by this deleted path
         for (dir, skill_paths) in &self.directory_skills.clone() {
             if dir.starts_with(path) {
                 // Delete this entire entry and remove all skill_paths under this directory from cache
                 for skill_path in skill_paths {
-                    let skill = self.skills_by_path.remove(skill_path);
-                    if let Some(skill) = skill {
-                        self.skills_by_name
-                            .entry(skill.name.clone())
-                            .or_default()
-                            .remove(skill_path);
+                    if let Some(name) = self.remove_skill_path_from_indexes(skill_path) {
+                        touched_names.insert(name);
                     }
                 }
-                self.directory_skills.remove(dir);
             } else if path.starts_with(dir) {
                 // Remove all skills under this directory that is a child of the deleted path
                 for skill_path in skill_paths {
                     if skill_path.starts_with(path) {
-                        let skill = self.skills_by_path.remove(skill_path);
-                        if let Some(skill) = skill {
-                            self.skills_by_name
-                                .entry(skill.name.clone())
-                                .or_default()
-                                .remove(skill_path);
+                        if let Some(name) = self.remove_skill_path_from_indexes(skill_path) {
+                            touched_names.insert(name);
                         }
-                        self.directory_skills
-                            .entry(dir.clone())
-                            .or_default()
-                            .remove(skill_path);
                     }
                 }
+            }
+        }
+
+        // Skills can be reachable through multiple provider paths that resolve to the
+        // same file. Until the storage model deduplicates those at write time, deleting
+        // one path can leave same-name sibling paths whose files are also gone.
+        self.prune_stale_skill_paths_for_names(&touched_names);
+    }
+
+    fn remove_skill_path_from_indexes(&mut self, skill_path: &Path) -> Option<String> {
+        self.directory_skills.retain(|_, skill_paths| {
+            skill_paths.remove(skill_path);
+            !skill_paths.is_empty()
+        });
+
+        let skill = self.skills_by_path.remove(skill_path)?;
+        let remove_name_entry = if let Some(paths) = self.skills_by_name.get_mut(&skill.name) {
+            paths.remove(skill_path);
+            paths.is_empty()
+        } else {
+            false
+        };
+        if remove_name_entry {
+            self.skills_by_name.remove(&skill.name);
+        }
+        Some(skill.name)
+    }
+
+    fn prune_stale_skill_paths_for_names(&mut self, names: &HashSet<String>) {
+        for name in names {
+            let stale_paths: Vec<PathBuf> = self
+                .skills_by_name
+                .get(name)
+                .into_iter()
+                .flat_map(|paths| paths.iter())
+                .filter(|path| !path.exists())
+                .cloned()
+                .collect();
+
+            for stale_path in stale_paths {
+                self.remove_skill_path_from_indexes(&stale_path);
             }
         }
     }

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -340,6 +340,70 @@ fn cloud_environment_skills_always_included() {
 }
 
 #[test]
+fn handle_skills_deleted_prunes_stale_same_name_paths() {
+    let temp = TempDir::new().unwrap();
+    let base = dunce::canonicalize(temp.path()).unwrap();
+
+    let deleted_path = base.join(".agents/skills/diag-test/SKILL.md");
+    let stale_sibling_path = base.join(".claude/skills/diag-test/SKILL.md");
+    let live_sibling_path = base.join(".codex/skills/diag-test/SKILL.md");
+
+    fs::create_dir_all(live_sibling_path.parent().unwrap()).unwrap();
+    fs::write(&live_sibling_path, "# live skill").unwrap();
+
+    let skill = |path: PathBuf, provider: SkillProvider| ParsedSkill {
+        name: "diag-test".to_string(),
+        description: "Diagnostic skill".to_string(),
+        path,
+        content: "# Diagnostic skill".to_string(),
+        line_range: None,
+        provider,
+        scope: SkillScope::Project,
+    };
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
+        app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        let skill_manager_handle = app.add_singleton_model(SkillManager::new);
+
+        skill_manager_handle.update(&mut app, |manager, _ctx| {
+            manager.handle_skills_added(vec![
+                skill(deleted_path.clone(), SkillProvider::Agents),
+                skill(stale_sibling_path.clone(), SkillProvider::Claude),
+                skill(live_sibling_path.clone(), SkillProvider::Codex),
+            ]);
+
+            assert_eq!(manager.skill_paths_by_name("diag-test").len(), 3);
+            manager.handle_skills_deleted(vec![deleted_path.clone()]);
+        });
+
+        skill_manager_handle.read(&app, |manager, _ctx| {
+            assert!(manager.skill_by_path(&deleted_path).is_none());
+            assert!(manager.skill_by_path(&stale_sibling_path).is_none());
+            assert!(manager.skill_by_path(&live_sibling_path).is_some());
+
+            assert_eq!(
+                manager.skill_paths_by_name("diag-test"),
+                vec![live_sibling_path.clone()]
+            );
+
+            let remaining_directory_paths: HashSet<PathBuf> = manager
+                .directory_skills
+                .values()
+                .flat_map(|paths| paths.iter().cloned())
+                .collect();
+            assert_eq!(
+                remaining_directory_paths,
+                HashSet::from([live_sibling_path])
+            );
+        });
+    });
+}
+
+#[test]
 fn test_read_bundled_skills_with_variable_substitution() {
     let temp_dir = TempDir::new().unwrap();
     let skills_dir = temp_dir.path();


### PR DESCRIPTION
cc @peicodes

## Summary

Skills under a symlinked provider parent (e.g. `~/.agents` → `~/dotfiles/agents`) were silently losing hot-reload: new skills didn't appear, edits showed stale state until restart.

**Root cause.** `SkillWatcher` registers each provider parent via `from_local_canonicalized`, which resolves symlinks. FSEvents/notify then fires events with the *canonical* paths. Downstream filters (`is_skill_file`, `is_home_skill_directory`) compare incoming events against the *un-canonicalized* `home_skills_path()`, so events under a symlinked provider parent never match — they're dropped silently.

**Fix.** Mirror the existing `symlink_canonical_to_originals` pattern at the provider-parent layer: store a `canonical → original` mapping at the registration step, then rewrite event paths at the entry of `handle_repository_update` before the filter runs. Filter logic stays unchanged; downstream code keeps operating on user-facing paths.

Refs #8897.

## Notes on the implementation

- **Map keys come from `StandardizedPath::to_local_path()`** on the same `StandardizedPath` used to register the watcher. Map keys and event paths share one path-processing pipeline, so they cannot drift in encoding.
- **`translate_canonical_to_original_paths` picks the deepest matching canonical** so nested registrations resolve deterministically (`HashMap` iteration is otherwise unstable).
- **Registration-failure rollback is symmetric.** Both sync (`add_directory` Err) and async (`registration_future` Err) failure paths roll back the canonical mapping via the shared `remove_home_provider_original_mapping` helper.
- **Mismatched-fan-out `moved` events are split into independent add+delete entries** (each side translated per its own canonical match). `notify` can report a cross-boundary rename without a separate add, so dropping such events would lose the destination skill.

## Tests

`skill_watcher_tests.rs` adds five regression tests, each asserting exact event cardinality:
- `test_handle_repository_update_translates_canonical_paths_for_symlinked_provider` — basic translation.
- `test_handle_repository_update_fans_out_to_all_originals_for_shared_canonical` — multi-provider shared canonical fan-out.
- `test_translate_canonical_picks_deepest_prefix_match` — deepest-prefix invariant for nested canonicals.
- `test_handle_home_files_changed_keeps_remaining_original_for_shared_canonical` — cleanup symmetry; pins the `Repository::stop_watching` contract.
- `test_handle_repository_update_salvages_mismatched_moves_as_add_and_delete` — cross-boundary rename salvage.

## Test plan

- [x] `cargo test -p warp skill_watcher_tests` — all 13 tests pass
- [x] `cargo fmt -p warp` — clean
- [x] `cargo clippy -p warp --no-deps` — no new warnings on changed files
- [x] Manual dogfood: with `~/.agents` symlinked to a dotfiles-managed location, new skills appear without restart.

## Known follow-up (deferred)

When two providers symlink to the same canonical, `watch_home_provider_path` registers one `HomeSkillSubscriber` per original on the same shared `Repository`. Each FSEvents/notify update is then delivered once per subscriber, so events get amplified N×N before translation. Realistic-impact cone is narrow (multi-provider shared-canonical setups); downstream skill registration is idempotent on path so this is wasteful but not user-visible-broken. Fix requires keying the watcher lifecycle by canonical instead of original (refcounted by originals) — structural refactor deferred to a focused follow-up to keep this PR scoped to the silent-drop bug.