### PR TITLE
Add header icon to Git dialog and dialog component

### DIFF
--- a/app/src/code_review/git_dialog/mod.rs
+++ b/app/src/code_review/git_dialog/mod.rs
@@ -674,6 +674,20 @@ impl GitDialog {
         }
     }
 
+    fn header_icon(&self) -> Icon {
+        match &self.mode {
+            GitDialogMode::Commit(_) => Icon::GitCommit,
+            GitDialogMode::Push(state) => {
+                if state.publish {
+                    Icon::UploadCloud
+                } else {
+                    Icon::ArrowUp
+                }
+            }
+            GitDialogMode::CreatePr(_) => Icon::Github,
+        }
+    }
+
     fn render_body(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         match &self.mode {
@@ -687,6 +701,7 @@ impl GitDialog {
     /// it in centered overlay chrome with a blurred background.
     fn render_dialog(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
 
         let close = ChildView::new(&self.close_button).finish();
         let cancel = ChildView::new(&self.cancel_button).finish();
@@ -695,6 +710,25 @@ impl GitDialog {
             .finish();
 
         let body = self.render_body(app);
+
+        let surface2 = theme.surface_2();
+        let icon_color = theme.main_text_color(surface2).into_solid();
+        let header_icon = Container::new(
+            ConstrainedBox::new(
+                IconElement::new(
+                    <Icon as Into<&'static str>>::into(self.header_icon()),
+                    icon_color,
+                )
+                .finish(),
+            )
+            .with_width(16.)
+            .with_height(16.)
+            .finish(),
+        )
+        .with_uniform_padding(8.)
+        .with_background(surface2)
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+        .finish();
 
         let dialog = Dialog::new(
             self.title().to_string(),
@@ -705,6 +739,7 @@ impl GitDialog {
                 ..dialog_styles(appearance)
             },
         )
+        .with_header_icon(header_icon)
         .with_close_button(close)
         .with_child(body)
         .with_separator()

--- a/app/src/ui_components/dialog.rs
+++ b/app/src/ui_components/dialog.rs
@@ -151,8 +151,8 @@ impl UiComponent for Dialog {
                 )
             };
 
-        let mut main_content = Flex::column()
-            .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+        let mut main_content =
+            Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
 
         if let Some(header_icon) = self.header_icon {
             // Icon + close button in the top row, title on its own row below.

--- a/app/src/ui_components/dialog.rs
+++ b/app/src/ui_components/dialog.rs
@@ -22,6 +22,9 @@ pub struct Dialog {
     child: Option<Box<dyn Element>>,
     styles: UiComponentStyles,
     close_button: Option<Box<dyn Element>>,
+    /// Optional icon rendered above the title. When set, the header row becomes
+    /// `[icon] … [close button]` with the title on its own row below.
+    header_icon: Option<Box<dyn Element>>,
     show_separator: bool,
 }
 
@@ -51,6 +54,7 @@ impl Dialog {
             bottom_row: Default::default(),
             bottom_row_left: Default::default(),
             close_button: None,
+            header_icon: None,
             show_separator: false,
         }
     }
@@ -62,6 +66,13 @@ impl Dialog {
 
     pub fn with_close_button(mut self, close_button: Box<dyn Element>) -> Self {
         self.close_button = Some(close_button);
+        self
+    }
+
+    /// Sets an icon element rendered in the top row alongside the close button,
+    /// with the dialog title displayed below that row.
+    pub fn with_header_icon(mut self, icon: Box<dyn Element>) -> Self {
+        self.header_icon = Some(icon);
         self
     }
 
@@ -90,28 +101,18 @@ impl UiComponent for Dialog {
     type ElementType = Dismiss;
 
     fn build(self) -> Dismiss {
-        let mut header = Flex::row()
-            .with_main_axis_size(MainAxisSize::Max)
-            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(
-                Shrinkable::new(
-                    1.,
-                    Text::new(
-                        self.title,
-                        self.styles.font_family_id.expect("FamilyId set"),
-                        self.styles.font_size.expect("Font size set"),
-                    )
-                    .with_style(self.styles.font_properties())
-                    .with_color(self.styles.font_color.unwrap_or_default())
-                    .finish(),
-                )
-                .finish(),
-            );
-
-        if let Some(close_button) = self.close_button {
-            header.add_child(close_button);
-        }
+        let title_element = Shrinkable::new(
+            1.,
+            Text::new(
+                self.title,
+                self.styles.font_family_id.expect("FamilyId set"),
+                self.styles.font_size.expect("Font size set"),
+            )
+            .with_style(self.styles.font_properties())
+            .with_color(self.styles.font_color.unwrap_or_default())
+            .finish(),
+        )
+        .finish();
 
         let footer = Flex::row()
             .with_main_axis_size(MainAxisSize::Max)
@@ -151,12 +152,44 @@ impl UiComponent for Dialog {
             };
 
         let mut main_content = Flex::column()
-            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_child(
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+
+        if let Some(header_icon) = self.header_icon {
+            // Icon + close button in the top row, title on its own row below.
+            let mut icon_row = Flex::row()
+                .with_main_axis_size(MainAxisSize::Max)
+                .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_child(header_icon);
+            if let Some(close_button) = self.close_button {
+                icon_row.add_child(close_button);
+            }
+            main_content.add_child(
+                Container::new(icon_row.finish())
+                    .with_padding_bottom(12.)
+                    .finish(),
+            );
+            main_content.add_child(
+                Container::new(title_element)
+                    .with_padding_bottom(DIALOG_PADDING)
+                    .finish(),
+            );
+        } else {
+            // Original layout: title and close button share the same row.
+            let mut header = Flex::row()
+                .with_main_axis_size(MainAxisSize::Max)
+                .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_child(title_element);
+            if let Some(close_button) = self.close_button {
+                header.add_child(close_button);
+            }
+            main_content.add_child(
                 Container::new(header.finish())
                     .with_padding_bottom(DIALOG_PADDING)
                     .finish(),
             );
+        }
 
         if let Some(body) = self.body {
             main_content.add_child(


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Adds a header icon to each Git dialog (commit, push/publish, create PR). The icon appears in the top-left corner alongside the close button, with the dialog title on its own row below.

**What:** Adds a `header_icon` field and `with_header_icon()` builder method to the shared `Dialog` component. Each Git dialog mode returns a mode-appropriate icon (`GitCommit`, `ArrowUp`, `UploadCloud`, `Github`) rendered as a 32×32 rounded square with a `surface_2` background.

**Why:** Improves visual polish of the Git dialogs.

**How:** The `Dialog` component is extended minimally — when a header icon is provided, the top row renders `[icon] … [close button]` and the title drops to its own row below. No structural changes to callers that don't use the new API.

fixes [APP-4292
](https://linear.app/warpdotdev/issue/APP-4292/icons-in-dialog-headers)
<img width="485" height="616" alt="image" src="https://github.com/user-attachments/assets/f7d3635c-6526-4a82-819a-cc87712b9b0b" />
<img width="497" height="334" alt="image" src="https://github.com/user-attachments/assets/48d18f37-285d-40d7-a0ec-0af8604ff181" />
<img width="484" height="313" alt="image" src="https://github.com/user-attachments/assets/63c50772-4e8e-484a-b7ea-78ed8180177b" />


## Testing
Visually verified via `cargo run`. No new automated tests added — this is a pure UI layout change with no logic.

## Server API dependencies
N/A — client-only UI change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
