### PR TITLE
Link shared sessions to local interactive oz runs

### DIFF
--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -120,6 +120,7 @@ use {
     crate::terminal::model::terminal_model::BlockIndex,
     crate::terminal::session_settings::NotificationsMode, nix::sys::termios::LocalFlags,
 };
+use crate::server::server_api::ServerApiProvider;
 
 type PtyController = writeable_pty::PtyController<mio_channel::Sender<Message>>;
 type RemoteServerController =
@@ -1482,6 +1483,35 @@ impl TerminalManager {
                 // Stream historical agent conversations so viewers have conversation and task context.
                 if FeatureFlag::AgentSharedSessions.is_enabled() {
                     Self::stream_historical_agent_conversations(&terminal_view, &model, ctx);
+                }
+
+                if FeatureFlag::LinkSharedSessionToLocalOzRun.is_enabled() {
+                    let history = BlocklistAIHistoryModel::handle(ctx);
+                    let task_id = history
+                        .as_ref(ctx)
+                        .active_conversation(terminal_view.id())
+                        .and_then(|c| c.task_id());
+
+                    if let Some(task_id) = task_id {
+                        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+                        let session_id = *session_id;
+                        ctx.spawn(
+                            async move {
+                                ai_client.update_agent_task(
+                                    task_id,
+                                    None,
+                                    Some(session_id),
+                                    None,
+                                    None
+                                ).await
+                            },
+                            |_network, result, _ctx| {
+                                if let Err(e) = result {
+                                    log::warn!("Failed to link shared session to local Oz run: {e}");
+                                }
+                            },
+                        );
+                    }
                 }
             }
             NetworkEvent::FailedToCreateSharedSession {

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -113,6 +113,7 @@ use super::recorder;
 use super::shell::ShellStarter;
 use super::{event_loop::EventLoop, shell::ShellStarterSource};
 
+use crate::server::server_api::ServerApiProvider;
 #[cfg(unix)]
 use {
     super::terminal_attributes::TerminalAttributesPoller,
@@ -120,7 +121,6 @@ use {
     crate::terminal::model::terminal_model::BlockIndex,
     crate::terminal::session_settings::NotificationsMode, nix::sys::termios::LocalFlags,
 };
-use crate::server::server_api::ServerApiProvider;
 
 type PtyController = writeable_pty::PtyController<mio_channel::Sender<Message>>;
 type RemoteServerController =
@@ -1495,22 +1495,24 @@ impl TerminalManager {
                     if let Some(task_id) = task_id {
                         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
                         let session_id = *session_id;
-                        ctx.spawn(
-                            async move {
-                                ai_client.update_agent_task(
-                                    task_id,
-                                    None,
-                                    Some(session_id),
-                                    None,
-                                    None
-                                ).await
-                            },
-                            |_network, result, _ctx| {
-                                if let Err(e) = result {
-                                    log::warn!("Failed to link shared session to local Oz run: {e}");
-                                }
-                            },
-                        );
+                        terminal_view.update(ctx, |_view, ctx| {
+                            ctx.spawn(
+                                async move {
+                                    ai_client.update_agent_task(
+                                        task_id,
+                                        None,
+                                        Some(session_id),
+                                        None,
+                                        None
+                                    ).await
+                                },
+                                |_view, result, _ctx| {
+                                    if let Err(e) = result {
+                                        log::warn!("Failed to link shared session to local Oz run: {e}");
+                                    }
+                                },
+                            );
+                        });
                     }
                 }
             }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -835,6 +835,8 @@ pub enum FeatureFlag {
     VerticalTabsSummaryMode,
 
     CloudModeInputV2,
+
+    LinkSharedSessionToLocalOzRun,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -911,6 +913,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::LocalDockerSandbox,
     FeatureFlag::VerticalTabsSummaryMode,
     FeatureFlag::CloudModeSetupV2,
+    FeatureFlag::LinkSharedSessionToLocalOzRun,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description

Linear: [REMOTE-1326](https://linear.app/warpdotdev/issue/REMOTE-1326/link-shared-sessions-to-local-interactive-oz-runs)

When a user starts sharing a terminal whose active AI conversation is backed by a local Oz run (i.e. there is an `AmbientAgentTaskId` on the conversation, e.g. local child harness panes or `warp agent run`), the new shared session is now linked to that Oz run on the server. The Oz runs page can then surface the shared session link alongside the run, matching the behavior cloud agents already get for free.

### Approach
Cloud agents already link shared sessions to runs via the GraphQL mutation `updateAgentTask({ taskId, sessionId })`, which writes `ai_tasks.shared_session_id` and `ai_tasks.shared_session_uuid` (see `warp-server/model/ai_tasks.go:686`). This PR mirrors that on the client for local interactive runs:

1. In the existing `NetworkEvent::SharedSessionCreatedSuccessfully` handler in `terminal_manager.rs`, look up the active conversation on the terminal view.
2. If that conversation has a `task_id`, fire `AIClient::update_agent_task(task_id, session_id=Some(...))`.
3. Failure is non-fatal — sharing still works, the row just isn't linked. We log a warning.

The hook fires for every share entry point uniformly (share modal, "Start Remote Control" footer, command palette, right-click menu) because they all funnel through the same `attempt_to_share_session` → `Network::new` → `SharedSessionCreatedSuccessfully` chokepoint.

### What's intentionally NOT in this PR
- **No protocol-crate or server change.** The existing `updateAgentTask` mutation is fully reusable; no need to extend `SessionSourceType` or the gRPC `CreateSessionRequest.cloud_agent_run_id` field. Quota/ACL bypass for local-share-creation could be a follow-up if needed; user-owned local runs already pass the user's own quota.
- **No unlink on session end.** The link is intentionally durable — `shared_session_uuid` is denormalized in `ai_tasks` precisely so it survives `shared_sessions` GC. Mirrors cloud-agent behavior.
- **No backfill for pre-existing shared sessions.** Only sessions created after this lands get linked.

### Feature flag
Gated behind `FeatureFlag::LinkSharedSessionToLocalOzRun` (default-on for dogfood builds, off otherwise).

## Testing

### Manual end-to-end
Per the local session-sharing testing notebook:
- Started session-sharing-server (`./script/server --features local_warp_server`)
- Started warp-server (`./script/server --with-client --with-local-session-sharing-server`)
- Started Warp client (`./script/run --features fast_dev,with_local_session_sharing_server`)

Then verified:
1. With an active local agent run (visible on the Oz runs page), clicking "Start Remote Control" on the agent pane creates a shared session and the corresponding `ai_tasks` row is updated with the new `shared_session_id` / `shared_session_uuid`.
2. Ending the session (via stop-sharing or inactivity) leaves the link intact on the run, matching the cloud-agent behavior.
3. With the feature flag off, no link is written.
4. Sharing a non-agent terminal (no `task_id` on the active conversation) is a no-op — no spurious mutation calls.

### Automated tests
No new unit tests added. Justification: the cloud-agent symmetric path (`SessionSourceType::AmbientAgent { task_id }` causing the harness to write the same link) has the same effective shape and is not unit-tested either; the codebase relies on integration/manual coverage for share-then-link flows. Wiring up a mock-`AIClient`-injected workspace test for this is a substantially larger lift than the change itself and would set a precedent that doesn't match the existing pattern. Behind a dogfood-only flag for safety while we exercise it.

Existing share-flow tests (`test_stop_sharing_session`, `test_stop_sharing_all_sessions_in_tab`, `test_tab_context_menu_share_session_items`, etc.) were re-run to confirm no regressions; the new code path is gated by the flag and these tests don't enable it.

## Server API dependencies
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

The `updateAgentTask` GraphQL mutation already exists and is in use by the cloud-agent harness today; this PR just adds another caller. No server change required.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Local interactive agent runs now link to their shared sessions on the Oz runs page, so you can jump from a run row back to the live shared session.
