### PR TITLE
docs: surface #oss-contributors Slack channel in README, CONTRIBUTING, and FAQ

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 Thanks for helping improve Warp! This guide explains how to open issues, propose changes, and get your work reviewed.
 
+> [!TIP]
+> **Chat with us in Slack.** Connect with other contributors and the Warp team in the [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB) channel — a good place for ad-hoc questions, design discussion, and pairing with maintainers as you work through an issue or PR. New here? [Join the Warp Slack community](https://go.warp.dev/join-preview) first, then hop into `#oss-contributors`.
+
 ## TL;DR
 
 - Bug fixes are welcome for any issue. All bugs are marked as `ready-to-implement`.
@@ -163,6 +166,6 @@ See [`SECURITY.md`](SECURITY.md) for our security disclosure policy and private 
 
 ## Getting Help
 
+- Chat with other contributors and the Warp team in [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB) on the [Warp Slack community](https://go.warp.dev/join-preview) (join the workspace first if you're new).
 - Browse the [Warp docs](https://docs.warp.dev/).
-- Join the [Slack Community](https://go.warp.dev/join-preview) to ask questions and connect with other contributors.
 - Open a [GitHub issue](https://github.com/warpdotdev/warp/issues) for bugs or feature requests.

--- a/FAQ.md
+++ b/FAQ.md
@@ -136,7 +136,7 @@ Yes — that's what AGPL is for. The license prevents fully-proprietary relaunch
 
 - The [Warp docs](https://docs.warp.dev/) for using the product.
 - [GitHub Issues](https://github.com/warpdotdev/warp/issues) for bug reports and feature requests.
-- The [Slack community](https://go.warp.dev/join-preview) for general questions and discussion.
+- The [Slack community](https://go.warp.dev/join-preview) for general questions and discussion — contributors chat with each other and the Warp team in [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB).
 - Mention **@oss-maintainers** on an issue or PR to escalate to the team.
 
 ### How do I report a security vulnerability?

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The rest of the code in this repository is licensed under the [AGPL v3](LICENSE-
 
 Warp's client codebase is open source and lives in this repository. We welcome community contributions and have designed a lightweight workflow to help new contributors get started. For the full contribution flow, read our [CONTRIBUTING.md](CONTRIBUTING.md) guide.
 
+> [!TIP]
+> **Chat with contributors and the Warp team** in the [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB) Slack channel — a good place for ad-hoc questions, design discussion, and pairing with maintainers. New here? [Join the Warp Slack community](https://go.warp.dev/join-preview) first, then jump into `#oss-contributors`.
+
 ### Issue to PR
 
 Before filing, [search existing issues](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) for your bug or feature request. If nothing exists, [file an issue](https://github.com/warpdotdev/warp/issues/new/choose) using our templates. Security vulnerabilities should be reported privately as described in [CONTRIBUTING.md](CONTRIBUTING.md#reporting-security-issues).
@@ -74,7 +77,7 @@ Interested in joining the team? See our [open roles](https://www.warp.dev/career
 ## Support and Questions
 
 1. See our [docs](https://docs.warp.dev/) for a comprehensive guide to Warp's features.
-2. Join our [Slack Community](https://go.warp.dev/join-preview) to connect with other users and get help from the Warp team.
+2. Join our [Slack Community](https://go.warp.dev/join-preview) to connect with other users and get help from the Warp team — contributors hang out in [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB).
 3. Try our [Preview build](https://www.warp.dev/download-preview) to test the latest experimental features.
 4. Mention **@oss-maintainers** on any issue to escalate to the team — for example, if you encounter problems with the automated agents.
 


### PR DESCRIPTION
## Description

Surface the **`#oss-contributors`** Slack channel ([link](https://warpcommunity.slack.com/archives/C0B0LM8N4DB)) as the dedicated place for contributors to chat with each other and the Warp team in the docs new contributors actually read.

- **`README.md`** — adds a `[!TIP]` callout under "Open Source & Contributing", and updates the "Support and Questions" bullet to point at `#oss-contributors`.
- **`CONTRIBUTING.md`** — adds a `[!TIP]` callout near the top so contributors see it as soon as they land, and updates the "Getting Help" bullet at the bottom.
- **`FAQ.md`** — updates the "Where do I get help?" bullet.

The existing [`go.warp.dev/join-preview`](https://go.warp.dev/join-preview) link is preserved as the workspace on-ramp for people who aren't yet in the Warp Slack.

## Testing

Docs-only change — rendered the markdown locally to confirm the GitHub-flavored `[!TIP]` callouts and Slack/`go.warp.dev` links render correctly.

## Server API dependencies

N/A — docs only.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

<!-- Docs-only change; no changelog entry. -->

---

[Conversation](https://staging.warp.dev/conversation/1011b077-6ef3-4516-857f-85043490d114)

Co-Authored-By: Oz <oz-agent@warp.dev>
