### PR TITLE
Fix terminal background darkening in horizontal tabs mode (APP-4328)

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18190,7 +18190,7 @@ impl Workspace {
         let mut main_content = Flex::row();
 
         // In horizontal tabs mode, config-driven panels render inside this row
-        // so they share the same background/corner-radius wrapper from render_main_panel.
+        // alongside the terminal area.
         // In vertical tabs mode, panels are rendered in render_panels instead.
         if !vertical_tabs_active {
             let config = TabSettings::as_ref(app)
@@ -18755,21 +18755,14 @@ impl Workspace {
         container.finish()
     }
 
-    fn render_main_panel(
-        &self,
-        app: &AppContext,
-        terminal_view: Box<dyn Element>,
-    ) -> Box<dyn Element> {
-        if FeatureFlag::VerticalTabs.is_enabled() && *TabSettings::as_ref(app).use_vertical_tabs {
-            Shrinkable::new(1.0, terminal_view).finish()
-        } else {
-            let main_content = Container::new(terminal_view)
-                .with_background(util::get_terminal_background_fill(self.window_id, app))
-                .with_corner_radius(*PANEL_CORNER_RADIUS)
-                .finish();
-
-            Shrinkable::new(1.0, main_content).finish()
-        }
+    fn render_main_panel(&self, terminal_view: Box<dyn Element>) -> Box<dyn Element> {
+        // The terminal background fill is already painted by the outer workspace
+        // container in `render`, so we must not paint it again here.
+        // Otherwise the (semi-transparent) overlay alpha compounds and makes the
+        // terminal pane look darker than the rest of the workspace, which is
+        // particularly visible when the active theme has a background image or
+        // a custom window opacity. See APP-4328.
+        Shrinkable::new(1.0, terminal_view).finish()
     }
 
     fn render_panel_separator(app: &AppContext) -> Box<dyn Element> {
@@ -18815,8 +18808,7 @@ impl Workspace {
             && *TabSettings::as_ref(app).use_vertical_tabs;
 
         // In vertical tabs mode, config-driven panels are rendered here.
-        // In horizontal tabs mode, they're rendered inside render_banner_and_active_tab
-        // so they share the same background/corner-radius wrapper.
+        // In horizontal tabs mode, they're rendered inside render_banner_and_active_tab.
         if vertical_tabs_active {
             let config = TabSettings::as_ref(app)
                 .header_toolbar_chip_selection
@@ -18852,7 +18844,7 @@ impl Workspace {
         if prev_panel_added {
             panels_view.add_child(Self::render_panel_separator(app));
         }
-        panels_view = panels_view.with_child(self.render_main_panel(app, terminal_view));
+        panels_view = panels_view.with_child(self.render_main_panel(terminal_view));
         prev_panel_added = true;
 
         if vertical_tabs_active {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -21913,7 +21913,9 @@ impl View for Workspace {
             // Hide the vertical tab rail for simplified WASM views (notebooks, shared sessions, etc.)
             let panels_row = self.render_panels(app, Shrinkable::new(1.0, content).finish(), true);
             outer_column.add_child(Shrinkable::new(1.0, panels_row).finish());
-            outer_column.finish()
+            Container::new(outer_column.finish())
+                .with_background(util::get_terminal_background_fill(self.window_id, app))
+                .finish()
         } else {
             let mut outer_column = Flex::column();
             if tab_bar_mode == ShowTabBar::Stacked {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18755,16 +18755,6 @@ impl Workspace {
         container.finish()
     }
 
-    fn render_main_panel(&self, terminal_view: Box<dyn Element>) -> Box<dyn Element> {
-        // The terminal background fill is already painted by the outer workspace
-        // container in `render`, so we must not paint it again here.
-        // Otherwise the (semi-transparent) overlay alpha compounds and makes the
-        // terminal pane look darker than the rest of the workspace, which is
-        // particularly visible when the active theme has a background image or
-        // a custom window opacity. See APP-4328.
-        Shrinkable::new(1.0, terminal_view).finish()
-    }
-
     fn render_panel_separator(app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         ConstrainedBox::new(
@@ -18844,7 +18834,9 @@ impl Workspace {
         if prev_panel_added {
             panels_view.add_child(Self::render_panel_separator(app));
         }
-        panels_view = panels_view.with_child(self.render_main_panel(terminal_view));
+        // The outer workspace container in `render` already paints the terminal
+        // background fill, so don't paint it again here (see APP-4328).
+        panels_view = panels_view.with_child(Shrinkable::new(1.0, terminal_view).finish());
         prev_panel_added = true;
 
         if vertical_tabs_active {


### PR DESCRIPTION
## Description

In horizontal tabs mode, we were double-layering the terminal background. This didn't make a visual difference for non-image backgrounds, but for image backgrounds it caused the image to be a bit darker (because we double-overlayed a semi-transparent fg)

## Testing
prod on left and fixed version on right:
<img width="3456" height="2168" alt="image" src="https://github.com/user-attachments/assets/dba1ca30-1fad-4824-afe5-1db8c8694bd3" />

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fix the terminal pane background appearing darker in horizontal tabs mode when the active theme has a background image or a custom window opacity.

_Conversation: https://staging.warp.dev/conversation/8268a6d0-8a49-4954-8d7a-47bd5b66c615_
_Run: https://oz.staging.warp.dev/runs/019dda9b-8a0f-7e9f-a5bf-13a23092352e_

_This PR was generated with [Oz](https://warp.dev/oz)._
