### PR TITLE
Add 'Show in Finder' option to detected file link tooltip [APP-3346]

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2294,6 +2294,8 @@ struct TerminalViewMouseStates {
 
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
     open_in_warp_tooltip: MouseStateHandle,
+    #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+    show_in_file_explorer_tooltip: MouseStateHandle,
     jump_to_bottom_of_block_button: MouseStateHandle,
 
     // Mouse state for the pane header ambient agent indicator tooltip.

--- a/app/src/terminal/view/tooltips.rs
+++ b/app/src/terminal/view/tooltips.rs
@@ -77,6 +77,27 @@ fn open_in_warp_tooltip(
     })
 }
 
+/// Returns a GridTooltipLink for revealing the file in the platform's file explorer
+/// (Finder on macOS, file manager on Linux/Windows).
+#[cfg(feature = "local_fs")]
+fn show_in_file_explorer_tooltip(
+    path: std::path::PathBuf,
+    mouse_state: MouseStateHandle,
+) -> GridTooltipLink {
+    let text = if cfg!(target_os = "macos") {
+        "Show in Finder"
+    } else {
+        "Show containing folder"
+    }
+    .to_string();
+    GridTooltipLink {
+        text,
+        action: TerminalAction::ShowInFileExplorer(path),
+        mouse_state,
+        detail: None,
+    }
+}
+
 impl TerminalView {
     /// Renders the link and/or secrets tooltips on top of the grid
     /// Expects at least one of the two tooltips to be visible.
@@ -192,6 +213,7 @@ impl TerminalView {
         #[cfg_attr(not(feature = "local_fs"), allow(unused_mut))]
         if let Some(link) = &self.open_grid_link_tool_tip {
             let mut open_in_warp = None;
+            let mut show_in_file_explorer = None;
             let modifier = directly_open_link_keybinding_string();
             let mut detail = Some(format!("[{modifier} Click]"));
             #[cfg(feature = "local_fs")]
@@ -199,12 +221,16 @@ impl TerminalView {
                 if let GridHighlightedLink::File(file_link) = link {
                     if let Some(path) = file_link.get_inner().absolute_path() {
                         open_in_warp = open_in_warp_tooltip(
-                            path,
+                            path.clone(),
                             file_link.get_inner().line_and_column_num,
                             &mut detail,
                             self.mouse_states.open_in_warp_tooltip.clone(),
                             app,
                         );
+                        show_in_file_explorer = Some(show_in_file_explorer_tooltip(
+                            path,
+                            self.mouse_states.show_in_file_explorer_tooltip.clone(),
+                        ));
                     }
                 }
             }
@@ -217,12 +243,14 @@ impl TerminalView {
             });
 
             links.extend(open_in_warp);
+            links.extend(show_in_file_explorer);
         }
 
         #[cfg_attr(not(feature = "local_fs"), allow(unused_mut))]
         if let Some(tooltip_info) = &self.open_rich_content_link_tool_tip {
             element_id = tooltip_info.position_id.to_owned();
             let mut open_in_warp = None;
+            let mut show_in_file_explorer = None;
             let modifier_string = directly_open_link_keybinding_string();
             let mut detail = Some(format!("[{modifier_string} Click]"));
 
@@ -241,6 +269,10 @@ impl TerminalView {
                         self.mouse_states.open_in_warp_tooltip.clone(),
                         app,
                     );
+                    show_in_file_explorer = Some(show_in_file_explorer_tooltip(
+                        absolute_path.clone(),
+                        self.mouse_states.show_in_file_explorer_tooltip.clone(),
+                    ));
                 }
             }
 
@@ -252,6 +284,7 @@ impl TerminalView {
             });
 
             links.extend(open_in_warp);
+            links.extend(show_in_file_explorer);
         }
 
         let secret_redaction = get_secret_obfuscation_mode(app);


### PR DESCRIPTION
## Description
Fixes [APP-3346](https://linear.app/warpdotdev/issue/APP-3346): adds a "Show in Finder" / "Show containing folder" option to the tooltip that appears when hovering a detected file link in the terminal grid as well as rich content (e.g. inside an AI block).

Previously the tooltip only offered "Open file" (default action) and, when applicable, "Open in Warp". The right-click context menu already supported `Show in Finder` via `TerminalAction::ShowInFileExplorer`, so this PR simply surfaces that option in the hover tooltip too. The label is platform-aware (`Show in Finder` on macOS, `Show containing folder` elsewhere), matching the existing right-click context-menu wording.

Implementation:
- Added a `show_in_file_explorer_tooltip` mouse state on `TerminalViewMouseStates`.
- Added a small `show_in_file_explorer_tooltip` helper in `terminal/view/tooltips.rs` that builds a `GridTooltipLink` dispatching `TerminalAction::ShowInFileExplorer`.
- Pushed the new tooltip link in both the grid file-link tooltip path (`GridHighlightedLink::File`) and the rich-content link tooltip path (`RichContentLink::FilePath`).

The new tooltip option is gated on `feature = "local_fs"` (matching the existing file-link/`Open in Warp` plumbing), and only appears when the highlighted link resolves to an absolute file path.

## Testing

Tested manually
<img width="418" height="160" alt="Screenshot 2026-04-29 at 3 04 54 PM" src="https://github.com/user-attachments/assets/2ea6e485-b277-4dfd-8e57-1e9ecafbdc04" />


## Server API dependencies
N/A — no server API changes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Added a "Show in Finder" (macOS) / "Show containing folder" (Linux/Windows) option to the tooltip that appears when clicking a detected file link.

_Conversation: https://staging.warp.dev/conversation/344c5765-22c4-451d-b190-4034d49c1601_
_Run: https://oz.staging.warp.dev/runs/019ddab0-5923-7be9-9819-2daf1232d648_

_This PR was generated with [Oz](https://warp.dev/oz)._
