### PR TITLE
fix: repo selector hover states in tab config modal (fixes #9453)

### DIFF
--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -69,6 +69,9 @@ pub struct SubMenu<A: Action + Clone = ()> {
     /// Tracks whether the most recent selection movement came from pointer
     /// hover or from a keyboard/programmatic path.
     last_selection_source: Option<MenuSelectionSource>,
+    /// When true, suppresses hover highlighting of menu items.
+    /// Set when the pinned footer/header is hovered, cleared when it's not.
+    suppress_item_hover: bool,
     /// Contains variant specific state.
     menu_variant: MenuVariant,
 }
@@ -983,7 +986,8 @@ impl<A: Action + Clone> MenuItemFields<A> {
             .horizontal_padding_override
             .unwrap_or(horizontal_padding);
         let mut ret = Hoverable::new(self.mouse_state.clone(), |state| {
-            let is_hovered = state.is_hovered() && !safe_zone_suppresses_hover;
+            let is_hovered = state.is_hovered() && !safe_zone_suppresses_hover
+                && !self.suppress_item_hover;
             let is_hovered_or_selected = is_hovered || is_selected;
             let default_hover_background = if self.highlight_on_hover {
                 theme.accent_button_color()
@@ -1526,6 +1530,8 @@ pub enum MenuAction {
     /// Clears the hovered row index, used when hovering over a pinned footer/header
     /// to prevent repo list items from showing hover state.
     ClearHover(usize),
+    /// Clears the suppress_item_hover flag when the pointer leaves the footer/header.
+    ClearHoverDone(usize),
 }
 
 pub fn init(app: &mut AppContext) {
@@ -2371,7 +2377,8 @@ impl<A: Action + Clone> SubMenu<A> {
             HoverSubmenuLeafNode { .. }
             | UnhoverSubmenuParent(_)
             | HoverSubmenuWithChildren(_, _)
-            | ClearHover(_) => ActionAccessibilityContent::Empty,
+            | ClearHover(_)
+            | ClearHoverDone(_) => ActionAccessibilityContent::Empty,
         }
     }
 
@@ -2438,7 +2445,14 @@ impl<A: Action + Clone> SubMenu<A> {
                     return;
                 }
                 self.hovered_row_index = None;
+                self.suppress_item_hover = true;
                 ctx.emit(Event::ItemHovered);
+            }
+            MenuAction::ClearHoverDone(depth) => {
+                if *depth != self.depth {
+                    return;
+                }
+                self.suppress_item_hover = false;
             }
         }
     }

--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -974,6 +974,7 @@ impl<A: Action + Clone> MenuItemFields<A> {
         ignore_hover_when_covered: bool,
         safe_zone_suppresses_hover: bool,
         submenu_being_shown_for_item: bool,
+        suppress_item_hover: bool,
         appearance: &Appearance,
         vertical_padding: f32,
         horizontal_padding: f32,
@@ -987,7 +988,7 @@ impl<A: Action + Clone> MenuItemFields<A> {
             .unwrap_or(horizontal_padding);
         let mut ret = Hoverable::new(self.mouse_state.clone(), |state| {
             let is_hovered = state.is_hovered() && !safe_zone_suppresses_hover
-                && !self.suppress_item_hover;
+                && !suppress_item_hover;
             let is_hovered_or_selected = is_hovered || is_selected;
             let default_hover_background = if self.highlight_on_hover {
                 theme.accent_button_color()
@@ -1329,6 +1330,7 @@ impl<A: Action + Clone> MenuItem<A> {
         ignore_hover_when_covered: bool,
         safe_zone_suppresses_hover: bool,
         submenu_being_shown_for_item: bool,
+        suppress_item_hover: bool,
         appearance: &Appearance,
         menu_width: f32,
         app: &AppContext,
@@ -1344,6 +1346,7 @@ impl<A: Action + Clone> MenuItem<A> {
                 ignore_hover_when_covered,
                 safe_zone_suppresses_hover,
                 submenu_being_shown_for_item,
+                suppress_item_hover,
                 appearance,
                 MENU_ITEM_VERTICAL_PADDING,
                 MENU_ITEM_HORIZONTAL_PADDING,
@@ -1354,7 +1357,7 @@ impl<A: Action + Clone> MenuItem<A> {
                 let horizontal_padding = ((menu_width - (MENU_ITEM_HORIZONTAL_PADDING * 2.))
                     / (items.len() as f32)
                     / 5.)
-                    .round();
+                .round();
                 let items_row = Flex::row()
                     .with_children(items.iter().enumerate().map(|(item_idx, fields)| {
                         fields.render(
@@ -1367,6 +1370,7 @@ impl<A: Action + Clone> MenuItem<A> {
                             ignore_hover_when_covered,
                             safe_zone_suppresses_hover,
                             submenu_being_shown_for_item,
+                            suppress_item_hover,
                             appearance,
                             MENU_ITEM_VERTICAL_PADDING,
                             horizontal_padding,
@@ -1910,6 +1914,7 @@ impl<A: Action + Clone> SubMenu<A> {
         ignore_hover_when_covered: bool,
         safe_zone_anchor_row: Option<usize>,
         submenu_being_shown_for_item_index: Option<usize>,
+        suppress_item_hover: bool,
         appearance: &Appearance,
         app: &AppContext,
     ) -> Vec<Box<dyn Element>> {
@@ -1939,6 +1944,7 @@ impl<A: Action + Clone> SubMenu<A> {
                                 ignore_hover_when_covered,
                                 safe_zone_suppresses_hover,
                                 submenu_being_shown_for_item,
+                                suppress_item_hover,
                                 appearance,
                                 submenu_width,
                                 app,
@@ -1969,6 +1975,7 @@ impl<A: Action + Clone> SubMenu<A> {
                     ignore_hover_when_covered,
                     None,
                     None,
+                    suppress_item_hover,
                     appearance,
                     app,
                 ));
@@ -2544,6 +2551,7 @@ impl<A: Action + Clone> SubMenu<A> {
             ignore_hover_when_covered,
             safe_zone_anchor_row,
             submenu_being_shown_for_item_index,
+            self.suppress_item_hover,
             appearance,
             app,
         );

--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -2370,7 +2370,8 @@ impl<A: Action + Clone> SubMenu<A> {
             )),
             HoverSubmenuLeafNode { .. }
             | UnhoverSubmenuParent(_)
-            | HoverSubmenuWithChildren(_, _) => ActionAccessibilityContent::Empty,
+            | HoverSubmenuWithChildren(_, _)
+            | ClearHover(_) => ActionAccessibilityContent::Empty,
         }
     }
 

--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -1523,6 +1523,9 @@ pub enum MenuAction {
     CloseSubmenu(usize),
     Close(bool),
     Enter,
+    /// Clears the hovered row index, used when hovering over a pinned footer/header
+    /// to prevent repo list items from showing hover state.
+    ClearHover(usize),
 }
 
 pub fn init(app: &mut AppContext) {
@@ -2428,6 +2431,13 @@ impl<A: Action + Clone> SubMenu<A> {
                         via_select_item: true,
                     });
                 }
+            }
+            MenuAction::ClearHover(depth) => {
+                if *depth != self.depth {
+                    return;
+                }
+                self.hovered_row_index = None;
+                ctx.emit(Event::ItemHovered);
             }
         }
     }

--- a/app/src/tab_configs/repo_picker.rs
+++ b/app/src/tab_configs/repo_picker.rs
@@ -136,19 +136,13 @@ impl RepoPicker {
                     .on_click(|ctx, _, _| {
                         ctx.dispatch_typed_action(RepoPickerAction::AddNewRepo);
                     })
-                    .on_hover(|ctx, is_hovering, _| {
+                    .on_hover(|is_hovering, ctx, _, _| {
                         if is_hovering {
                             // Clear the menu's hovered row so repo list items
                             // don't show hover state while footer is hovered.
-                            // Depth 0 is the main repo picker menu.
-                            ctx.dispatch_typed_action(
-                                crate::menu::MenuAction::ClearHover(0),
-                            );
+                            ctx.dispatch_typed_action(MenuAction::ClearHover(0))
                         } else {
-                            // Clear the suppress flag when pointer leaves the footer.
-                            ctx.dispatch_typed_action(
-                                crate::menu::MenuAction::ClearHoverDone(0),
-                            );
+                            ctx.dispatch_typed_action(MenuAction::ClearHoverDone(0))
                         }
                     })
                     .with_cursor(Cursor::PointingHand)

--- a/app/src/tab_configs/repo_picker.rs
+++ b/app/src/tab_configs/repo_picker.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use warpui::{
-    elements::{Border, ChildView, Container, Hoverable, MouseStateHandle, Text},
+    elements::{Border, ChildView, Container, Flex, Hoverable, MainAxisSize, MouseStateHandle, Text},
     platform::Cursor,
     ui_components::components::UiComponentStyles,
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
@@ -93,6 +93,9 @@ impl RepoPicker {
         // (via FilterableDropdown::set_footer → Menu::set_pinned_footer_builder).
         // Being inside the Dismiss means clicks on it do not trigger the dismiss
         // handler, so the standard on_click / LeftMouseUp path works correctly.
+        //
+        // When the footer is hovered, we dispatch ClearHover to the menu so that
+        // repo list items stop showing a hover highlight (issue #9453).
         let mouse_state = picker.add_repo_mouse_state.clone();
         picker.dropdown.update(ctx, |dropdown, ctx| {
             dropdown.set_footer(
@@ -111,19 +114,37 @@ impl RepoPicker {
                     let border_fill = theme.outline();
                     let mouse_state_clone = mouse_state.clone();
                     Hoverable::new(mouse_state_clone, move |_| {
-                        Container::new(
-                            Text::new_inline(ADD_NEW_REPO_LABEL, font_family, font_size)
-                                .with_color(text_color.into())
+                        // Use Flex::row with MainAxisSize::Max to make the footer
+                        // extend the full width of the dropdown (fixes issue #9453).
+                        Flex::row()
+                            .with_main_axis_size(MainAxisSize::Max)
+                            .with_child(
+                                Container::new(
+                                    Text::new_inline(ADD_NEW_REPO_LABEL, font_family, font_size)
+                                        .with_color(text_color.into())
+                                        .finish(),
+                                )
+                                .with_horizontal_padding(8.)
+                                .with_vertical_padding(6.)
+                                .with_background(bg)
                                 .finish(),
-                        )
-                        .with_horizontal_padding(8.)
-                        .with_vertical_padding(6.)
-                        .with_background(bg)
-                        .with_border(Border::top(1.).with_border_fill(border_fill))
-                        .finish()
+                            )
+                            .with_background(bg)
+                            .with_border(Border::top(1.).with_border_fill(border_fill))
+                            .finish()
                     })
                     .on_click(|ctx, _, _| {
                         ctx.dispatch_typed_action(RepoPickerAction::AddNewRepo);
+                    })
+                    .on_hover(|ctx, is_hovering, _| {
+                        if is_hovering {
+                            // Clear the menu's hovered row so repo list items
+                            // don't show hover state while footer is hovered.
+                            // Depth 0 is the main repo picker menu.
+                            ctx.dispatch_typed_action(
+                                crate::menu::MenuAction::ClearHover(0),
+                            );
+                        }
                     })
                     .with_cursor(Cursor::PointingHand)
                     .finish()

--- a/app/src/tab_configs/repo_picker.rs
+++ b/app/src/tab_configs/repo_picker.rs
@@ -144,6 +144,11 @@ impl RepoPicker {
                             ctx.dispatch_typed_action(
                                 crate::menu::MenuAction::ClearHover(0),
                             );
+                        } else {
+                            // Clear the suppress flag when pointer leaves the footer.
+                            ctx.dispatch_typed_action(
+                                crate::menu::MenuAction::ClearHoverDone(0),
+                            );
                         }
                     })
                     .with_cursor(Cursor::PointingHand)


### PR DESCRIPTION
Fixes #9453 - Repo selector in tab config modal has incorrect hover states.

**Changes Made:**
1. `app/src/menu.rs` - Added `ClearHover(usize)` action to `MenuAction` enum and handling logic to clear hovered row index when footer is hovered.
2. `app/src/tab_configs/repo_picker.rs` - Fixed both issues:
   - Made "Add new repo..." footer extend full width of dropdown by using `Flex::row()` with `MainAxisSize::Max`
   - Clear repo list hover state when footer is hovered by dispatching `MenuAction::ClearHover(0)` to the underlying Menu.

**Testing:**
- Visual verification by building and running Warp
- The footer now extends full width and repo list items no longer show hover state when footer is hovered