### PR TITLE
specs(GH7043): side-by-side diff layout in code review and AI block diffs

### DIFF
--- a/specs/GH7043/product.md
+++ b/specs/GH7043/product.md
@@ -41,17 +41,18 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 
 1. When `code.editor.diff_layout` is unset or `inline`, every diff in Warp renders identically to today. No regression to the default form.
 
-2. When `code.editor.diff_layout` is `side_by_side`, every diff in Warp renders with the baseline on the left and the modified file on the right.
+2. When `code.editor.diff_layout` is `side_by_side`, every diff in Warp renders with the baseline on the left and the modified file on the right, with one explicit exception: AI block-list diffs in `InlineBanner` display (the small "Suggested fixes" banner that appears below a command block) continue to render inline regardless of the setting. The banner's vertical budget (typically 100-160px) is too small to read two columns, and the banner already collapses to inline at narrow widths today. Invariant 16 below makes this gating observable: the View Options menu's Layout radio group is hidden in the banner. Every other surface, including the full Code Review pane and the embedded AI block-list diff (`Embedded { max_height }` mode), honors the setting.
    - The split is a 50/50 vertical split with a single 1-pixel divider in the panel chrome.
    - The two panes share a horizontal scrollbar appearance and inherit horizontal scrollbars independently, since wrap-vs-no-wrap behavior is per-pane.
    - The baseline pane shows the file content prior to the diff, with deletions visible. The modified pane shows the post-diff file content, with additions visible. Unchanged context lines appear in both panes at the same vertical position.
 
-3. Hunk-aligned padding keeps corresponding lines aligned across panes:
+3. Hunk-aligned padding keeps corresponding lines aligned across panes. The alignment algorithm pairs deleted lines with added lines within a hunk so that a modification renders on a single shared row across the two panes:
    - Unchanged lines: rendered at the same row on both sides with the same content.
-   - Modifications (a `-` line replaced by a `+` line in the inline rendering): the deleted line renders on the left at row N; the added line renders on the right at row N. The right pane shows nothing for the deleted-only side; the left pane shows nothing for the added-only side.
-   - Pure additions (`+` lines with no corresponding `-` lines): the added lines render on the right at consecutive rows; the left pane shows blank padding at the same rows so the next unchanged context line still aligns.
-   - Pure deletions (`-` lines with no corresponding `+` lines): the deleted lines render on the left at consecutive rows; the right pane shows blank padding at the same rows.
+   - Modifications: within each hunk, deleted lines and added lines are paired in order. For a hunk of `D` deleted lines followed by `A` added lines, the first `min(D, A)` pairs render on shared rows: the deleted line on the left at row N, the added line on the right at row N. The shared row is what makes "before/after" review readable.
+   - Excess deletions (when `D > A`): the trailing `D - A` deleted-only lines render on the left at consecutive rows; the right pane shows blank padding at the same rows. This is the pure-deletion case for unpaired suffixes.
+   - Excess additions (when `A > D`): the trailing `A - D` added-only lines render on the right at consecutive rows; the left pane shows blank padding at the same rows. This is the pure-addition case for unpaired suffixes.
    - The padding rows are visually the same height as a normal line and use the same gutter as the matching pane, so vertical positions on the two panes always agree.
+   - Word-level or character-level highlighting on a paired modification row is out of scope (see Non-goals); a row pair shows the deleted line in full on the left and the added line in full on the right.
 
 4. Synchronized vertical scrolling:
    - A scroll wheel event in either pane drives both panes by the same delta.
@@ -108,5 +109,6 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
     - Memory overhead for `SideBySide` is a second `CodeEditorView` per visible diff, which the existing inline path already constructs and destroys when navigating between diffs in code review. The number of simultaneously alive editors does not grow more than 2x in steady state.
 
 16. Feature flag gating:
-    - The change ships behind a `SideBySideDiffLayout` `FeatureFlag` (`app/src/features/`) that defaults to off in shipping builds and on in dogfood builds. Once stabilized, the flag is removed and the setting becomes the user-facing control.
-    - When the flag is off, the View Options menu does not show the Layout radio group, and the setting is treated as `Inline` regardless of stored value.
+    - The change ships behind a `SideBySideDiffLayout` `FeatureFlag` defined in `crates/warp_features/src/lib.rs` (the canonical flag enum, re-exported from `app/src/features.rs`) that defaults to off in shipping builds and on in dogfood/preview builds. Once stabilized, the flag is removed and the setting becomes the user-facing control.
+    - When the flag is off, the View Options menu does not show the Layout radio group, the Settings page does not render the Layout widget, and the setting is treated as `Inline` regardless of stored value.
+    - The Layout radio group is also hidden in the AI block-list `InlineBanner` display per invariant 2 (the banner is too small for two columns); the rest of the AI block-list diff surface shows the radio group when the flag is on.

--- a/specs/GH7043/product.md
+++ b/specs/GH7043/product.md
@@ -4,7 +4,7 @@ Roadmap reference: https://github.com/warpdotdev/warp/issues/9233 ("Improved cod
 Figma: none provided
 
 ## Summary
-Add a side-by-side diff layout as an alternative to the existing inline diff. The user picks the layout from the diff toolbar's View Options menu and the choice is persisted as a `code.editor.diff_layout` setting. Inline remains the default. Side-by-side renders the baseline on the left and the modified file on the right, with hunk-aligned padding so corresponding lines sit on the same row, and synchronized vertical scrolling so wheel and cursor navigation in either pane drives both. Both diff surfaces in Warp - the AI block-list embedded diff and the full Code Review pane - honor the setting.
+Add a side-by-side diff layout as an alternative to the existing inline diff. The user picks the layout in Settings -> Code under a new "Diff layout" subsection, and the choice is persisted as a synced `code.editor.diff_layout` setting. Inline remains the default. Side-by-side renders the baseline on the left and the modified file on the right, with hunk-aligned padding so corresponding lines sit on the same row, and synchronized vertical scrolling so wheel and cursor navigation in either pane drives both. Every surface that renders a diff in Warp - the Code Review pane, AI block-list diffs, and inline banner diffs - honors the setting.
 
 ## Problem
 Warp renders every file diff as a single-column inline view: deletions on `-` rows, additions on `+` rows, both interleaved. The renderer is `app/src/code/inline_diff.rs` (the `InlineDiffView` used by AI blocks) and the Code Review pane in `app/src/code_review/code_review_view.rs`. Both consume `app/src/code/diff_viewer.rs::DiffViewer` and currently have no layout knob.
@@ -19,9 +19,9 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 ## Goals
 - Introduce a `DiffLayout` choice with two values: `Inline` (today's behavior) and `SideBySide`.
 - Default `DiffLayout` to `Inline` for every existing user; the change is opt-in.
-- Surface the choice in the existing diff toolbar's View Options menu so users can switch without leaving the diff.
+- Surface the choice in Settings -> Code under a new "Diff layout" subsection because the preference applies across every diff surface, not just the currently visible diff.
 - Persist the choice as a synced user setting `code.editor.diff_layout` so it carries across sessions and machines.
-- Apply the chosen layout to both diff surfaces: the AI block-list `InlineDiffView` and the full Code Review pane.
+- Apply the chosen layout to every surface that renders a diff: the Code Review pane, AI block-list diffs, and inline banner diffs. There are no surface-specific exceptions in v1.
 - In `SideBySide`, render the baseline on the left, the modified file on the right, with hunk-aligned padding so that unchanged context lines, modifications, and pure additions or deletions all sit at the same vertical position on both sides.
 - Synchronize vertical scrolling: wheel events in either pane drive both panes, and cursor navigation in either pane keeps the corresponding line of the other pane in view.
 - Preserve every existing diff feature in both layouts: hunk navigation (`f`/`F`), accept and reject, save, revert to base, comment threads in code review, hidden lines, find-in-diff, and the existing nav bar.
@@ -33,7 +33,7 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 - Cross-pane selection. Selection in `SideBySide` is per-pane, matching GitHub Desktop and GitLab MR review.
 - Selecting code within deleted sections. The roadmap lists this alongside side-by-side as a sibling community-driver feature; it is its own spec.
 - Per-pane width control. The split is fixed at 50/50 in this change; resizable splits can follow.
-- A separate layout choice per surface. The setting is global across the AI block-list and the Code Review pane in this change. Per-surface overrides can be added later if users ask for them.
+- A separate layout choice per surface. The setting is global across Code Review, AI block-list, and inline banner diffs in this change. Per-surface overrides can be added later if users ask for them.
 - Mobile/wasm-only behavior changes beyond what falls out naturally from layout symmetry. The wasm `InlineDiffView` path remains read-only as today.
 - Changing the existing `DiffMode` enum (`Head` / `MainBranch` / `OtherBranch(String)`) in `app/src/code_review/diff_state.rs:266`. That enum controls *what* is being compared; the new `DiffLayout` enum controls *how* the comparison is rendered. The two are orthogonal.
 
@@ -41,10 +41,11 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 
 1. When `code.editor.diff_layout` is unset or `inline`, every diff in Warp renders identically to today. No regression to the default form.
 
-2. When `code.editor.diff_layout` is `side_by_side`, every diff in Warp renders with the baseline on the left and the modified file on the right, with one explicit exception: AI block-list diffs in `InlineBanner` display (the small "Suggested fixes" banner that appears below a command block) continue to render inline regardless of the setting. The banner's vertical budget (typically 100-160px) is too small to read two columns, and the banner already collapses to inline at narrow widths today. Invariant 16 below makes this gating observable: the View Options menu's Layout radio group is hidden in the banner. Every other surface, including the full Code Review pane and the embedded AI block-list diff (`Embedded { max_height }` mode), honors the setting.
+2. When `code.editor.diff_layout` is `side_by_side`, every diff in Warp renders with the baseline on the left and the modified file on the right. This applies to the full Code Review pane, embedded AI block-list diffs, and `InlineBanner` diffs; v1 has no surface-specific exception.
    - The split is a 50/50 vertical split with a single 1-pixel divider in the panel chrome.
    - The two panes share a horizontal scrollbar appearance and inherit horizontal scrollbars independently, since wrap-vs-no-wrap behavior is per-pane.
    - The baseline pane shows the file content prior to the diff, with deletions visible. The modified pane shows the post-diff file content, with additions visible. Unchanged context lines appear in both panes at the same vertical position.
+   - Inline banners constrain `SideBySide` to the banner viewport and keep the existing collapse/expand affordances.
 
 3. Hunk-aligned padding keeps corresponding lines aligned across panes. The alignment algorithm pairs deleted lines with added lines within a hunk so that a modification renders on a single shared row across the two panes:
    - Unchanged lines: rendered at the same row on both sides with the same content.
@@ -66,15 +67,15 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
    - Copy from a pane copies only that pane's selected text. The clipboard text is the rendered pane's content (no diff markers added).
    - This matches GitHub Desktop and GitLab MR review behavior. Cross-pane selection is out of scope.
 
-6. The View Options menu in the diff toolbar surfaces the layout choice:
-   - In Code Review (`app/src/code_review/code_review_view.rs`), the existing `CodeReviewDiffMenu` (`app/src/code_review/diff_menu.rs`) gains a new "Layout" radio group with two rows: "Inline" and "Side-by-Side". Selecting either row updates `code.editor.diff_layout` and refreshes the diff view in the active pane.
-   - In the AI block-list, the inline-action diff toolbar gains the same two-row radio group in its overflow menu.
-   - The currently active layout is shown with a check on its row.
-   - The menu closes on selection and the new layout takes effect on the visible diff immediately, without re-fetching the diff or losing the current scroll position.
+6. Settings -> Code is the entry point for the layout choice:
+   - The Code settings page gains a "Diff layout" subsection with a two-option segmented control: "Inline" and "Side by side".
+   - Selecting either option updates `code.editor.diff_layout` and refreshes visible diffs without re-fetching diff data or losing the current scroll position.
+   - The currently active layout is shown as the selected segment.
+   - The diff toolbar continues to expose per-view ephemeral controls such as whitespace visibility, but it does not expose `code.editor.diff_layout`; the layout is a user-level preference, not a per-view toggle.
 
 7. The setting is read at diff-construction time and on every change:
-   - `InlineDiffView::new` in `app/src/code/inline_diff.rs:64` reads `code.editor.diff_layout` and passes the chosen layout to the editor.
-   - The Code Review pane subscribes to setting updates and applies the new layout to every visible diff. Diffs that are scrolled out of view rebuild lazily on next render.
+   - Diff construction reads `code.editor.diff_layout` and dispatches to the inline or side-by-side renderer.
+   - The Code Review pane and AI block-list diff hosts subscribe to setting updates and apply the new layout to every visible diff. Diffs that are scrolled out of view rebuild lazily on next render.
    - Switching the setting while a diff is open preserves the current scroll position and cursor row in both layouts. The user does not need to scroll back to where they were.
 
 8. Hunk navigation, accept, reject, save, and revert behave identically across layouts:
@@ -97,18 +98,21 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 
 12. The Code Review header (`app/src/code_review/code_review_header/`) and the existing diff menu's `DiffMode` selector ("Head" / "Main Branch" / "Other Branch") are unchanged. They control the comparison base; layout is orthogonal.
 
-13. Telemetry: when the user changes the layout via the menu, emit a `CodeReviewTelemetryEvent` (or AI-block equivalent) carrying the new layout value. Layout-change rate is the metric for adoption.
+13. Telemetry: when the user changes the layout in Settings -> Code, emit a `CodeReviewTelemetryEvent` (or AI-block equivalent) carrying the new layout value. Layout-change rate is the metric for adoption.
 
 14. Accessibility:
     - Both panes participate in tab order. `Tab` from the baseline pane moves focus to the modified pane; `Shift-Tab` reverses.
-    - Screen-reader output for a side-by-side row reads as "Baseline: <text> ... Modified: <text>" so a non-sighted reviewer can still hear both sides.
+    - Screen-reader output for a side-by-side row reads as "Original: <text> ... Modified: <text>" so a non-sighted reviewer can still hear both sides.
     - Color is not the only signal of change: every changed row carries a `+` or `-` gutter glyph in the corresponding pane, identical to today's inline gutter.
 
 15. Performance budget:
-    - Switching layouts on a 5,000-line diff completes in under 200ms on an M1 MacBook Air, measured from menu click to first paint of the new layout.
+    - Switching layouts on a 5,000-line diff completes in under 200ms on an M1 MacBook Air, measured from settings change to first paint of the new layout.
     - Memory overhead for `SideBySide` is a second `CodeEditorView` per visible diff, which the existing inline path already constructs and destroys when navigating between diffs in code review. The number of simultaneously alive editors does not grow more than 2x in steady state.
 
 16. Feature flag gating:
     - The change ships behind a `SideBySideDiffLayout` `FeatureFlag` defined in `crates/warp_features/src/lib.rs` (the canonical flag enum, re-exported from `app/src/features.rs`) that defaults to off in shipping builds and on in dogfood/preview builds. Once stabilized, the flag is removed and the setting becomes the user-facing control.
-    - When the flag is off, the View Options menu does not show the Layout radio group, the Settings page does not render the Layout widget, and the setting is treated as `Inline` regardless of stored value.
-    - The Layout radio group is also hidden in the AI block-list `InlineBanner` display per invariant 2 (the banner is too small for two columns); the rest of the AI block-list diff surface shows the radio group when the flag is on.
+    - When the flag is off, the Settings page does not render the "Diff layout" widget, and the setting is treated as `Inline` regardless of stored value.
+
+## Mockup placeholder
+
+The mockup placeholder for this spec is the Settings -> Code page, not the diff toolbar. It should show a "Diff layout" subsection under Code settings with an "Inline" / "Side by side" segmented control and explanatory helper text that the setting applies to Code Review, AI block-list, and inline banner diffs.

--- a/specs/GH7043/product.md
+++ b/specs/GH7043/product.md
@@ -1,0 +1,112 @@
+# Side-by-Side Diff Layout in the AI Block-List and Code Review Pane - Product Spec
+GitHub issue: https://github.com/warpdotdev/warp/issues/7043
+Roadmap reference: https://github.com/warpdotdev/warp/issues/9233 ("Improved code review - Side by side diffs", listed under "Seeking community drivers")
+Figma: none provided
+
+## Summary
+Add a side-by-side diff layout as an alternative to the existing inline diff. The user picks the layout from the diff toolbar's View Options menu and the choice is persisted as a `code.editor.diff_layout` setting. Inline remains the default. Side-by-side renders the baseline on the left and the modified file on the right, with hunk-aligned padding so corresponding lines sit on the same row, and synchronized vertical scrolling so wheel and cursor navigation in either pane drives both. Both diff surfaces in Warp - the AI block-list embedded diff and the full Code Review pane - honor the setting.
+
+## Problem
+Warp renders every file diff as a single-column inline view: deletions on `-` rows, additions on `+` rows, both interleaved. The renderer is `app/src/code/inline_diff.rs` (the `InlineDiffView` used by AI blocks) and the Code Review pane in `app/src/code_review/code_review_view.rs`. Both consume `app/src/code/diff_viewer.rs::DiffViewer` and currently have no layout knob.
+
+Two real costs follow from that:
+
+- Side-by-side is the de-facto standard for diff review across GitHub, GitLab, Phabricator, JetBrains IDEs, VS Code, and tools like Beyond Compare. Users with wide displays expect it, and the absence shows up repeatedly in user feedback, including the request that opened this issue: "since we aren't writing the code ourselves," the reviewer needs to read both versions in parallel rather than reconstructing them mentally from a single column.
+- Warp's review surface is shaped by AI-generated edits more than by hand-written commits. An AI agent regularly produces diffs that touch dozens of unrelated regions in one block. In an inline layout, a 30-line modification with reordered code is hard to follow, because the same logical block appears as `-` lines in one place and `+` lines in another. Side-by-side puts those next to each other.
+
+The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (auto line wrap in diff) - assume a single diff layout and argue about wrapping inside it. They are out of scope for this spec but become more useful once a side-by-side layout exists, since wrap behavior interacts with column width.
+
+## Goals
+- Introduce a `DiffLayout` choice with two values: `Inline` (today's behavior) and `SideBySide`.
+- Default `DiffLayout` to `Inline` for every existing user; the change is opt-in.
+- Surface the choice in the existing diff toolbar's View Options menu so users can switch without leaving the diff.
+- Persist the choice as a synced user setting `code.editor.diff_layout` so it carries across sessions and machines.
+- Apply the chosen layout to both diff surfaces: the AI block-list `InlineDiffView` and the full Code Review pane.
+- In `SideBySide`, render the baseline on the left, the modified file on the right, with hunk-aligned padding so that unchanged context lines, modifications, and pure additions or deletions all sit at the same vertical position on both sides.
+- Synchronize vertical scrolling: wheel events in either pane drive both panes, and cursor navigation in either pane keeps the corresponding line of the other pane in view.
+- Preserve every existing diff feature in both layouts: hunk navigation (`f`/`F`), accept and reject, save, revert to base, comment threads in code review, hidden lines, find-in-diff, and the existing nav bar.
+- Keep `Inline` byte-for-byte identical to today. No regression to the default code path.
+
+## Non-goals
+- Word-level or character-level diff highlighting on changed lines. Issue #9017 and #9040 are the natural follow-up specs for that.
+- A vertical "stacked" layout (baseline on top, modified below). The roadmap and the issue specifically ask for side-by-side; a stacked variant could be a separate spec.
+- Cross-pane selection. Selection in `SideBySide` is per-pane, matching GitHub Desktop and GitLab MR review.
+- Selecting code within deleted sections. The roadmap lists this alongside side-by-side as a sibling community-driver feature; it is its own spec.
+- Per-pane width control. The split is fixed at 50/50 in this change; resizable splits can follow.
+- A separate layout choice per surface. The setting is global across the AI block-list and the Code Review pane in this change. Per-surface overrides can be added later if users ask for them.
+- Mobile/wasm-only behavior changes beyond what falls out naturally from layout symmetry. The wasm `InlineDiffView` path remains read-only as today.
+- Changing the existing `DiffMode` enum (`Head` / `MainBranch` / `OtherBranch(String)`) in `app/src/code_review/diff_state.rs:266`. That enum controls *what* is being compared; the new `DiffLayout` enum controls *how* the comparison is rendered. The two are orthogonal.
+
+## Behavior
+
+1. When `code.editor.diff_layout` is unset or `inline`, every diff in Warp renders identically to today. No regression to the default form.
+
+2. When `code.editor.diff_layout` is `side_by_side`, every diff in Warp renders with the baseline on the left and the modified file on the right.
+   - The split is a 50/50 vertical split with a single 1-pixel divider in the panel chrome.
+   - The two panes share a horizontal scrollbar appearance and inherit horizontal scrollbars independently, since wrap-vs-no-wrap behavior is per-pane.
+   - The baseline pane shows the file content prior to the diff, with deletions visible. The modified pane shows the post-diff file content, with additions visible. Unchanged context lines appear in both panes at the same vertical position.
+
+3. Hunk-aligned padding keeps corresponding lines aligned across panes:
+   - Unchanged lines: rendered at the same row on both sides with the same content.
+   - Modifications (a `-` line replaced by a `+` line in the inline rendering): the deleted line renders on the left at row N; the added line renders on the right at row N. The right pane shows nothing for the deleted-only side; the left pane shows nothing for the added-only side.
+   - Pure additions (`+` lines with no corresponding `-` lines): the added lines render on the right at consecutive rows; the left pane shows blank padding at the same rows so the next unchanged context line still aligns.
+   - Pure deletions (`-` lines with no corresponding `+` lines): the deleted lines render on the left at consecutive rows; the right pane shows blank padding at the same rows.
+   - The padding rows are visually the same height as a normal line and use the same gutter as the matching pane, so vertical positions on the two panes always agree.
+
+4. Synchronized vertical scrolling:
+   - A scroll wheel event in either pane drives both panes by the same delta.
+   - A cursor-up or cursor-down keystroke in either pane moves only that pane's cursor; the other pane scrolls without moving its cursor so the corresponding line stays in view.
+   - Hunk navigation actions (`f` / `F` / "Next change" / "Previous change") move the focused hunk on both panes simultaneously, focusing the matching row in each.
+   - Search and find-next in code review keeps both panes scrolled to the matched line, with the match highlighted on the pane that contains it.
+
+5. Selection is per-pane:
+   - Mouse drag selection on one pane never extends into the other.
+   - Cmd-A in either pane selects only that pane's content.
+   - Copy from a pane copies only that pane's selected text. The clipboard text is the rendered pane's content (no diff markers added).
+   - This matches GitHub Desktop and GitLab MR review behavior. Cross-pane selection is out of scope.
+
+6. The View Options menu in the diff toolbar surfaces the layout choice:
+   - In Code Review (`app/src/code_review/code_review_view.rs`), the existing `CodeReviewDiffMenu` (`app/src/code_review/diff_menu.rs`) gains a new "Layout" radio group with two rows: "Inline" and "Side-by-Side". Selecting either row updates `code.editor.diff_layout` and refreshes the diff view in the active pane.
+   - In the AI block-list, the inline-action diff toolbar gains the same two-row radio group in its overflow menu.
+   - The currently active layout is shown with a check on its row.
+   - The menu closes on selection and the new layout takes effect on the visible diff immediately, without re-fetching the diff or losing the current scroll position.
+
+7. The setting is read at diff-construction time and on every change:
+   - `InlineDiffView::new` in `app/src/code/inline_diff.rs:64` reads `code.editor.diff_layout` and passes the chosen layout to the editor.
+   - The Code Review pane subscribes to setting updates and applies the new layout to every visible diff. Diffs that are scrolled out of view rebuild lazily on next render.
+   - Switching the setting while a diff is open preserves the current scroll position and cursor row in both layouts. The user does not need to scroll back to where they were.
+
+8. Hunk navigation, accept, reject, save, and revert behave identically across layouts:
+   - Accept (write the modified file) writes the same content that the inline layout would have written.
+   - Reject discards the modification on both panes; the result is the baseline.
+   - Revert-to-base in `InlineDiffView` (the editor's `restore_diff_base` path) restores the editor to the baseline content; the side-by-side renderer then shows two identical panes (which rebuild as a no-op diff).
+   - Save writes the modified content via `FileModel`, the same as today.
+
+9. Comment threads in Code Review render in `SideBySide` next to the line they target:
+   - Comments authored on a line in the baseline pane render under that line in the baseline pane.
+   - Comments authored on a line in the modified pane render under that line in the modified pane.
+   - The corresponding pane shows a small "comment marker" gutter glyph at the same row to indicate that the other side has a thread there.
+   - Multi-line comment ranges that span both deleted and added regions render on the side they were originally authored against, the same as today.
+
+10. Hidden lines (collapsed unchanged context) work identically across layouts:
+    - The same "Show N more lines" affordance appears at the same vertical position on both panes.
+    - Expanding hidden lines on either pane expands them on both, since context lines exist in both files.
+
+11. Find-in-diff in Code Review highlights matches in both panes when both panes contain the search term, and only the matching pane when only one does. Cycling through matches with `cmd-G` / `cmd-shift-G` advances the search position across panes; the focused pane changes when the next match lives on the other side.
+
+12. The Code Review header (`app/src/code_review/code_review_header/`) and the existing diff menu's `DiffMode` selector ("Head" / "Main Branch" / "Other Branch") are unchanged. They control the comparison base; layout is orthogonal.
+
+13. Telemetry: when the user changes the layout via the menu, emit a `CodeReviewTelemetryEvent` (or AI-block equivalent) carrying the new layout value. Layout-change rate is the metric for adoption.
+
+14. Accessibility:
+    - Both panes participate in tab order. `Tab` from the baseline pane moves focus to the modified pane; `Shift-Tab` reverses.
+    - Screen-reader output for a side-by-side row reads as "Baseline: <text> ... Modified: <text>" so a non-sighted reviewer can still hear both sides.
+    - Color is not the only signal of change: every changed row carries a `+` or `-` gutter glyph in the corresponding pane, identical to today's inline gutter.
+
+15. Performance budget:
+    - Switching layouts on a 5,000-line diff completes in under 200ms on an M1 MacBook Air, measured from menu click to first paint of the new layout.
+    - Memory overhead for `SideBySide` is a second `CodeEditorView` per visible diff, which the existing inline path already constructs and destroys when navigating between diffs in code review. The number of simultaneously alive editors does not grow more than 2x in steady state.
+
+16. Feature flag gating:
+    - The change ships behind a `SideBySideDiffLayout` `FeatureFlag` (`app/src/features/`) that defaults to off in shipping builds and on in dogfood builds. Once stabilized, the flag is removed and the setting becomes the user-facing control.
+    - When the flag is off, the View Options menu does not show the Layout radio group, and the setting is treated as `Inline` regardless of stored value.

--- a/specs/GH7043/product.md
+++ b/specs/GH7043/product.md
@@ -1,13 +1,15 @@
-# Side-by-Side Diff Layout in the AI Block-List and Code Review Pane - Product Spec
+# Side-by-Side Diff Layout in the Code Review Pane - Product Spec
 GitHub issue: https://github.com/warpdotdev/warp/issues/7043
 Roadmap reference: https://github.com/warpdotdev/warp/issues/9233 ("Improved code review - Side by side diffs", listed under "Seeking community drivers")
 Figma: none provided
 
 ## Summary
-Add a side-by-side diff layout as an alternative to the existing inline diff. The user picks the layout in Settings -> Code under a new "Diff layout" subsection, and the choice is persisted as a synced `code.editor.diff_layout` setting. Inline remains the default. Side-by-side renders the baseline on the left and the modified file on the right, with hunk-aligned padding so corresponding lines sit on the same row, and synchronized vertical scrolling so wheel and cursor navigation in either pane drives both. Every surface that renders a diff in Warp - the Code Review pane, AI block-list diffs, and inline banner diffs - honors the setting.
+Add a side-by-side diff layout as an alternative to the existing inline diff in the Code Review pane only. The user picks the layout in Settings -> Code under a new "Diff layout" subsection, and the choice is persisted as a synced `code.editor.diff_layout` setting. Inline remains the default. Side-by-side renders the baseline on the left and the modified file on the right, with hunk-aligned padding so corresponding lines sit on the same row.
+
+V1 applies only to Code Review. AI block-list diffs, inline banner diffs, and settings-menu surfacing for those surfaces are explicitly deferred to v2.
 
 ## Problem
-Warp renders every file diff as a single-column inline view: deletions on `-` rows, additions on `+` rows, both interleaved. The renderer is `app/src/code/inline_diff.rs` (the `InlineDiffView` used by AI blocks) and the Code Review pane in `app/src/code_review/code_review_view.rs`. Both consume `app/src/code/diff_viewer.rs::DiffViewer` and currently have no layout knob.
+Warp renders Code Review file diffs as a single-column inline view: deletions on `-` rows, additions on `+` rows, both interleaved. The Code Review pane consumes editor and diff primitives through `LocalCodeEditorView`, `CodeReviewEditorState`, and `CodeEditorView`, and currently has no layout knob.
 
 Two real costs follow from that:
 
@@ -19,33 +21,38 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 ## Goals
 - Introduce a `DiffLayout` choice with two values: `Inline` (today's behavior) and `SideBySide`.
 - Default `DiffLayout` to `Inline` for every existing user; the change is opt-in.
-- Surface the choice in Settings -> Code under a new "Diff layout" subsection because the preference applies across every diff surface, not just the currently visible diff.
+- Surface the choice in Settings -> Code under a new "Diff layout" subsection for the Code Review pane.
 - Persist the choice as a synced user setting `code.editor.diff_layout` so it carries across sessions and machines.
-- Apply the chosen layout to every surface that renders a diff: the Code Review pane, AI block-list diffs, and inline banner diffs. There are no surface-specific exceptions in v1.
+- Apply the chosen layout to the Code Review pane only in v1.
 - In `SideBySide`, render the baseline on the left, the modified file on the right, with hunk-aligned padding so that unchanged context lines, modifications, and pure additions or deletions all sit at the same vertical position on both sides.
-- Synchronize vertical scrolling: wheel events in either pane drive both panes, and cursor navigation in either pane keeps the corresponding line of the other pane in view.
-- Preserve every existing diff feature in both layouts: hunk navigation (`f`/`F`), accept and reject, save, revert to base, comment threads in code review, hidden lines, find-in-diff, and the existing nav bar.
+- Keep edits in the diff constrained to the right, modified pane. The left, baseline pane is never editable.
+- Keep the text cursor in the right, modified pane only. The left pane does not expose an insertion cursor.
+- Allow selection on the left pane for copy, while keeping deleted-line ranges non-selectable.
+- Preserve every existing Code Review diff feature in both layouts: hunk navigation (`f`/`F`), accept and reject, save, revert to base, comment threads, hidden lines, find-in-diff, and the existing nav bar.
 - Keep `Inline` byte-for-byte identical to today. No regression to the default code path.
 
 ## Non-goals
+- Applying side-by-side layout to AI block-list diffs in v1. That surface is deferred to v2.
+- Applying side-by-side layout to inline banner diffs in v1. That surface is deferred to v2.
+- Adding settings-menu surfacing for AI block-list or inline banner diffs in v1.
 - Word-level or character-level diff highlighting on changed lines. Issue #9017 and #9040 are the natural follow-up specs for that.
 - A vertical "stacked" layout (baseline on top, modified below). The roadmap and the issue specifically ask for side-by-side; a stacked variant could be a separate spec.
 - Cross-pane selection. Selection in `SideBySide` is per-pane, matching GitHub Desktop and GitLab MR review.
 - Selecting code within deleted sections. The roadmap lists this alongside side-by-side as a sibling community-driver feature; it is its own spec.
 - Per-pane width control. The split is fixed at 50/50 in this change; resizable splits can follow.
-- A separate layout choice per surface. The setting is global across Code Review, AI block-list, and inline banner diffs in this change. Per-surface overrides can be added later if users ask for them.
-- Mobile/wasm-only behavior changes beyond what falls out naturally from layout symmetry. The wasm `InlineDiffView` path remains read-only as today.
+- A separate layout choice per surface. V1 has only one participating surface: Code Review.
+- Mobile/wasm-only behavior changes beyond what falls out naturally from layout symmetry.
 - Changing the existing `DiffMode` enum (`Head` / `MainBranch` / `OtherBranch(String)`) in `app/src/code_review/diff_state.rs:266`. That enum controls *what* is being compared; the new `DiffLayout` enum controls *how* the comparison is rendered. The two are orthogonal.
 
 ## Behavior
 
-1. When `code.editor.diff_layout` is unset or `inline`, every diff in Warp renders identically to today. No regression to the default form.
+1. When `code.editor.diff_layout` is unset or `inline`, Code Review diffs in Warp render identically to today. No regression to the default form.
 
-2. When `code.editor.diff_layout` is `side_by_side`, every diff in Warp renders with the baseline on the left and the modified file on the right. This applies to the full Code Review pane, embedded AI block-list diffs, and `InlineBanner` diffs; v1 has no surface-specific exception.
+2. When `code.editor.diff_layout` is `side_by_side`, Code Review renders with the baseline on the left and the modified file on the right.
    - The split is a 50/50 vertical split with a single 1-pixel divider in the panel chrome.
-   - The two panes share a horizontal scrollbar appearance and inherit horizontal scrollbars independently, since wrap-vs-no-wrap behavior is per-pane.
+   - The two panes share vertical scroll position and inherit horizontal scrollbars independently, since wrap-vs-no-wrap behavior is per-pane.
    - The baseline pane shows the file content prior to the diff, with deletions visible. The modified pane shows the post-diff file content, with additions visible. Unchanged context lines appear in both panes at the same vertical position.
-   - Inline banners constrain `SideBySide` to the banner viewport and keep the existing collapse/expand affordances.
+   - AI block-list diffs and inline banner diffs continue to render inline in v1 regardless of the stored setting.
 
 3. Hunk-aligned padding keeps corresponding lines aligned across panes. The alignment algorithm pairs deleted lines with added lines within a hunk so that a modification renders on a single shared row across the two panes:
    - Unchanged lines: rendered at the same row on both sides with the same content.
@@ -57,31 +64,33 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 
 4. Synchronized vertical scrolling:
    - A scroll wheel event in either pane drives both panes by the same delta.
-   - A cursor-up or cursor-down keystroke in either pane moves only that pane's cursor; the other pane scrolls without moving its cursor so the corresponding line stays in view.
-   - Hunk navigation actions (`f` / `F` / "Next change" / "Previous change") move the focused hunk on both panes simultaneously, focusing the matching row in each.
+   - Cursor-up or cursor-down moves only the right pane cursor. The baseline pane scrolls without exposing or moving a cursor so the corresponding line stays in view.
+   - Hunk navigation actions (`f` / `F` / "Next change" / "Previous change") move the focused hunk on both panes simultaneously, focusing the matching row in the modified pane.
    - Search and find-next in code review keeps both panes scrolled to the matched line, with the match highlighted on the pane that contains it.
 
 5. Selection is per-pane:
    - Mouse drag selection on one pane never extends into the other.
-   - Cmd-A in either pane selects only that pane's content.
+   - Cmd-A in the modified pane selects only modified-pane content.
+   - Cmd-A in the baseline pane selects only baseline-pane content that is selectable for copy.
    - Copy from a pane copies only that pane's selected text. The clipboard text is the rendered pane's content (no diff markers added).
+   - Deleted-line ranges are not selectable. The baseline pane allows copy selection only for selectable baseline content.
    - This matches GitHub Desktop and GitLab MR review behavior. Cross-pane selection is out of scope.
 
 6. Settings -> Code is the entry point for the layout choice:
    - The Code settings page gains a "Diff layout" subsection with a two-option segmented control: "Inline" and "Side by side".
-   - Selecting either option updates `code.editor.diff_layout` and refreshes visible diffs without re-fetching diff data or losing the current scroll position.
+   - Selecting either option updates `code.editor.diff_layout` and refreshes visible Code Review diffs without re-fetching diff data or losing the current scroll position.
    - The currently active layout is shown as the selected segment.
-   - The diff toolbar continues to expose per-view ephemeral controls such as whitespace visibility, but it does not expose `code.editor.diff_layout`; the layout is a user-level preference, not a per-view toggle.
+   - The diff toolbar continues to expose per-view ephemeral controls such as whitespace visibility, but it does not expose `code.editor.diff_layout`; the layout is a user-level preference for Code Review v1.
 
-7. The setting is read at diff-construction time and on every change:
-   - Diff construction reads `code.editor.diff_layout` and dispatches to the inline or side-by-side renderer.
-   - The Code Review pane and AI block-list diff hosts subscribe to setting updates and apply the new layout to every visible diff. Diffs that are scrolled out of view rebuild lazily on next render.
+7. The setting is read by the Code Review diff host at diff-construction time and on every change:
+   - Code Review construction reads `code.editor.diff_layout` and dispatches to inline rendering or `DiffLayout::SideBySide` rendering inside `CodeEditorView`.
+   - The Code Review pane subscribes to setting updates and applies the new layout to every visible diff. Diffs that are scrolled out of view rebuild lazily on next render.
    - Switching the setting while a diff is open preserves the current scroll position and cursor row in both layouts. The user does not need to scroll back to where they were.
 
 8. Hunk navigation, accept, reject, save, and revert behave identically across layouts:
    - Accept (write the modified file) writes the same content that the inline layout would have written.
    - Reject discards the modification on both panes; the result is the baseline.
-   - Revert-to-base in `InlineDiffView` (the editor's `restore_diff_base` path) restores the editor to the baseline content; the side-by-side renderer then shows two identical panes (which rebuild as a no-op diff).
+   - Revert-to-base restores the editor to the baseline content; the side-by-side renderer then shows two identical panes (which rebuild as a no-op diff).
    - Save writes the modified content via `FileModel`, the same as today.
 
 9. Comment threads in Code Review render in `SideBySide` next to the line they target:
@@ -94,20 +103,21 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
     - The same "Show N more lines" affordance appears at the same vertical position on both panes.
     - Expanding hidden lines on either pane expands them on both, since context lines exist in both files.
 
-11. Find-in-diff in Code Review highlights matches in both panes when both panes contain the search term, and only the matching pane when only one does. Cycling through matches with `cmd-G` / `cmd-shift-G` advances the search position across panes; the focused pane changes when the next match lives on the other side.
+11. Find-in-diff in Code Review highlights matches in both panes when both panes contain the search term, and only the matching pane when only one does. Cycling through matches with `cmd-G` / `cmd-shift-G` advances the search position across panes; focus remains on the modified pane when the next match lives on the baseline side.
 
 12. The Code Review header (`app/src/code_review/code_review_header/`) and the existing diff menu's `DiffMode` selector ("Head" / "Main Branch" / "Other Branch") are unchanged. They control the comparison base; layout is orthogonal.
 
-13. Telemetry: when the user changes the layout in Settings -> Code, emit a `CodeReviewTelemetryEvent` (or AI-block equivalent) carrying the new layout value. Layout-change rate is the metric for adoption.
+13. Telemetry: when the user changes the layout in Settings -> Code, emit a `CodeReviewTelemetryEvent` carrying the new layout value. Layout-change rate is the metric for adoption.
 
 14. Accessibility:
-    - Both panes participate in tab order. `Tab` from the baseline pane moves focus to the modified pane; `Shift-Tab` reverses.
-    - Screen-reader output for a side-by-side row reads as "Original: <text> ... Modified: <text>" so a non-sighted reviewer can still hear both sides.
+    - The modified pane participates in normal edit-focused tab order. The baseline pane can receive focus for copy selection only and never exposes edit actions.
+    - The cursor is announced only in the modified pane.
+    - Screen-reader output for a side-by-side row should read as "Original: <text> ... Modified: <text>" so a non-sighted reviewer can still hear both sides.
     - Color is not the only signal of change: every changed row carries a `+` or `-` gutter glyph in the corresponding pane, identical to today's inline gutter.
 
 15. Performance budget:
     - Switching layouts on a 5,000-line diff completes in under 200ms on an M1 MacBook Air, measured from settings change to first paint of the new layout.
-    - Memory overhead for `SideBySide` is a second `CodeEditorView` per visible diff, which the existing inline path already constructs and destroys when navigating between diffs in code review. The number of simultaneously alive editors does not grow more than 2x in steady state.
+    - Memory overhead for `SideBySide` is bounded to the additional render state needed for the baseline pane inside the existing Code Review editor view. V1 does not create a second `CodeEditorView` per file.
 
 16. Feature flag gating:
     - The change ships behind a `SideBySideDiffLayout` `FeatureFlag` defined in `crates/warp_features/src/lib.rs` (the canonical flag enum, re-exported from `app/src/features.rs`) that defaults to off in shipping builds and on in dogfood/preview builds. Once stabilized, the flag is removed and the setting becomes the user-facing control.
@@ -115,4 +125,4 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 
 ## Mockup placeholder
 
-The mockup placeholder for this spec is the Settings -> Code page, not the diff toolbar. It should show a "Diff layout" subsection under Code settings with an "Inline" / "Side by side" segmented control and explanatory helper text that the setting applies to Code Review, AI block-list, and inline banner diffs.
+The mockup placeholder for this spec is the Settings -> Code page. It should show a "Diff layout" subsection under Code settings with an "Inline" / "Side by side" segmented control and explanatory helper text that the setting applies to Code Review.

--- a/specs/GH7043/product.md
+++ b/specs/GH7043/product.md
@@ -27,7 +27,7 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 - In `SideBySide`, render the baseline on the left, the modified file on the right, with hunk-aligned padding so that unchanged context lines, modifications, and pure additions or deletions all sit at the same vertical position on both sides.
 - Keep edits in the diff constrained to the right, modified pane. The left, baseline pane is never editable.
 - Keep the text cursor in the right, modified pane only. The left pane does not expose an insertion cursor.
-- Allow selection on the left pane for copy, while keeping deleted-line ranges non-selectable.
+- Allow selection on the left pane for copy, including deleted-line ranges.
 - Preserve every existing Code Review diff feature in both layouts: hunk navigation (`f`/`F`), accept and reject, save, revert to base, comment threads, hidden lines, find-in-diff, and the existing nav bar.
 - Keep `Inline` byte-for-byte identical to today. No regression to the default code path.
 
@@ -38,7 +38,6 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 - Word-level or character-level diff highlighting on changed lines. Issue #9017 and #9040 are the natural follow-up specs for that.
 - A vertical "stacked" layout (baseline on top, modified below). The roadmap and the issue specifically ask for side-by-side; a stacked variant could be a separate spec.
 - Cross-pane selection. Selection in `SideBySide` is per-pane, matching GitHub Desktop and GitLab MR review.
-- Selecting code within deleted sections. The roadmap lists this alongside side-by-side as a sibling community-driver feature; it is its own spec.
 - Per-pane width control. The split is fixed at 50/50 in this change; resizable splits can follow.
 - A separate layout choice per surface. V1 has only one participating surface: Code Review.
 - Mobile/wasm-only behavior changes beyond what falls out naturally from layout symmetry.
@@ -73,7 +72,7 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
    - Cmd-A in the modified pane selects only modified-pane content.
    - Cmd-A in the baseline pane selects only baseline-pane content that is selectable for copy.
    - Copy from a pane copies only that pane's selected text. The clipboard text is the rendered pane's content (no diff markers added).
-   - Deleted-line ranges are not selectable. The baseline pane allows copy selection only for selectable baseline content.
+   - Deleted-line ranges in the baseline pane are selectable for copy.
    - This matches GitHub Desktop and GitLab MR review behavior. Cross-pane selection is out of scope.
 
 6. Settings -> Code is the entry point for the layout choice:
@@ -83,7 +82,7 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
    - The diff toolbar continues to expose per-view ephemeral controls such as whitespace visibility, but it does not expose `code.editor.diff_layout`; the layout is a user-level preference for Code Review v1.
 
 7. The setting is read by the Code Review diff host at diff-construction time and on every change:
-   - Code Review construction reads `code.editor.diff_layout` and dispatches to inline rendering or `DiffLayout::SideBySide` rendering inside `CodeEditorView`.
+   - Code Review construction reads `code.editor.diff_layout` and dispatches to inline rendering or `DiffLayout::SideBySide` rendering.
    - The Code Review pane subscribes to setting updates and applies the new layout to every visible diff. Diffs that are scrolled out of view rebuild lazily on next render.
    - Switching the setting while a diff is open preserves the current scroll position and cursor row in both layouts. The user does not need to scroll back to where they were.
 
@@ -117,7 +116,7 @@ The two related open issues - #9017 (word wrap in diff and Markdown) and #9040 (
 
 15. Performance budget:
     - Switching layouts on a 5,000-line diff completes in under 200ms on an M1 MacBook Air, measured from settings change to first paint of the new layout.
-    - Memory overhead for `SideBySide` is bounded to the additional render state needed for the baseline pane inside the existing Code Review editor view. V1 does not create a second `CodeEditorView` per file.
+    - Memory overhead for `SideBySide` is bounded to the additional state needed to render the baseline pane alongside the modified pane.
 
 16. Feature flag gating:
     - The change ships behind a `SideBySideDiffLayout` `FeatureFlag` defined in `crates/warp_features/src/lib.rs` (the canonical flag enum, re-exported from `app/src/features.rs`) that defaults to off in shipping builds and on in dogfood/preview builds. Once stabilized, the flag is removed and the setting becomes the user-facing control.

--- a/specs/GH7043/tech.md
+++ b/specs/GH7043/tech.md
@@ -1,0 +1,354 @@
+# Side-by-Side Diff Layout in the AI Block-List and Code Review Pane - Tech Spec
+Product spec: `specs/GH7043/product.md`
+GitHub issue: https://github.com/warpdotdev/warp/issues/7043
+Roadmap reference: https://github.com/warpdotdev/warp/issues/9233
+
+## Context
+
+The diff rendering surface is shared by two consumers: the AI block-list inline diff (`InlineDiffView`) and the full Code Review pane (`code_review_view::CodeReviewView`). Both build on the same primitives:
+
+- `app/src/code/diff_viewer.rs` defines the shared abstraction. `DisplayMode` (lines 14-29) carries the visual context: `FullPane`, `Embedded { max_height }`, `InlineBanner { max_height, is_expanded, is_dismissed }`. The `DiffViewer` trait (lines 110-160) holds a single `&ViewHandle<CodeEditorView>` and exposes hunk-navigation, accept, reject, and revert.
+- `app/src/code/inline_diff.rs::InlineDiffView` (12.6KB, lines 1-300) wraps a single `CodeEditorView`, registers a `FileModel`-backed file when one exists, and applies the parsed deltas to the editor on construction (`apply_diffs_if_any`, lines 196-228).
+- `app/src/code/editor/view.rs::CodeEditorView` (84KB) and `app/src/code/editor/model.rs` (155KB) are the rendering target. Both inline and side-by-side reuse them.
+- `app/src/code/editor/diff.rs` (30KB) holds the editor-level diff line decoration and gutter rendering. `DiffLineType` (referenced from `app/src/code_review/comments/diff_hunk_parser.rs`) classifies lines as `Context`, `Add`, `Delete`, `HunkHeader`.
+- `app/src/code_review/diff_state.rs` (112KB) holds hunk state, parsed `UnifiedDiffHeader` (lines 67-73), the `DiffMode` enum at line 266 (`Head` / `MainBranch` / `OtherBranch(String)`, *comparison base, not layout*), and the per-file diff state model.
+- `app/src/code_review/diff_menu.rs` (501 lines) is the existing View Options popup that the user opens from the diff toolbar. Today its rows are sourced from `Vec<DiffTarget>` (line 99) and the menu emits `CodeReviewDiffMenuEvent::Select(DiffMode)` (line 47) to change comparison base. The new layout selector slots in here.
+- `app/src/code_review/code_review_view.rs` (311KB) hosts the diff per file and renders into the pane. It's the consumer that subscribes to setting changes and rebuilds visible diffs on layout change.
+- `app/src/ai/blocklist/inline_action/code_diff_view.rs` (where `DisplayMode::FullPane`, `Embedded`, `InlineBanner` are constructed at lines 796, 798, 1248, 1258, 1311, 2026, 2065, 2170, 2204, 2206) is the AI block-list inline-action diff host that wraps `InlineDiffView` and decides which `DisplayMode` to use.
+- `app/src/settings/code.rs` (63 lines) is the settings group for `code.*`. Settings are declared via the `define_settings_group!` macro with `toml_path`, `default`, `supported_platforms`, and `sync_to_cloud` fields. Existing entries set the pattern for the new `diff_layout` setting.
+- `app/src/features/` defines `FeatureFlag` variants (referenced from `app/src/code_review/diff_state.rs:28`). The new `SideBySideDiffLayout` flag declares here.
+- `app/src/code_review/scroll_preservation.rs` (8KB) holds scroll preservation helpers that the side-by-side scroll-sync model can build on.
+- `app/src/code_review/comments/diff_hunk_parser.rs` (181 lines) parses hunks into per-line records (`build_line_result`, lines 47-90). The hunk-alignment model for side-by-side reuses this parser; no new parser is introduced.
+- `app/src/code_review/comments/comment.rs` and `comment_list_view.rs` (48KB) own comment rendering. Comment placement gains a per-pane gutter marker; the existing thread placement logic is unchanged because comments are still anchored on `EditorLineLocation`.
+- `app/src/code_review/telemetry_event.rs` (16KB) defines `CodeReviewTelemetryEvent`. The layout-change event registers here.
+- `app/src/code_review/find_model.rs` (13KB) holds the find-in-diff state model that needs to traverse both panes in side-by-side.
+
+The narrowest fix: introduce a `DiffLayout` enum (`Inline` / `SideBySide`), thread it through `DiffViewer`, build a `SideBySideDiffView` in `app/src/code/side_by_side_diff.rs` that holds two `CodeEditorView` instances and a shared scroll-sync model, route the layout choice through the `View Options` menu and a new `code.editor.diff_layout` setting, and gate the whole change behind a `SideBySideDiffLayout` feature flag. The proposed changes below take the existing `DiffViewer` trait as a shared interface and have the side-by-side view implement it; everywhere that today asks "give me the editor" gets back the *focused* editor, and a small set of new accessors expose both editors when needed.
+
+## Proposed changes
+
+### 1. Introduce the `DiffLayout` enum
+
+Add a new file `app/src/code/diff_layout.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffLayout {
+    #[default]
+    Inline,
+    SideBySide,
+}
+
+impl DiffLayout {
+    pub fn is_side_by_side(&self) -> bool {
+        matches!(self, DiffLayout::SideBySide)
+    }
+}
+```
+
+Re-export from `app/src/code/mod.rs`. The enum is `Copy` so it can travel through view contexts without lifetime concerns. The `serde` representation (`"inline"` / `"side_by_side"`) matches the `toml_path` value the settings system stores.
+
+`DiffLayout` is intentionally separate from `DisplayMode` because they are orthogonal:
+- `DisplayMode` answers "where on screen does this diff live" (own pane vs embedded vs inline banner).
+- `DiffLayout` answers "how do we render the diff content" (one column vs two columns).
+
+A `DisplayMode::FullPane` diff and a `DisplayMode::Embedded { max_height }` diff both honor the user's `DiffLayout` choice.
+
+### 2. Add the `code.editor.diff_layout` setting
+
+Extend `define_settings_group!` in `app/src/settings/code.rs:5-62`:
+
+```rust
+diff_layout: DiffLayoutSetting {
+    type: crate::code::diff_layout::DiffLayout,
+    default: crate::code::diff_layout::DiffLayout::Inline,
+    supported_platforms: SupportedPlatforms::DESKTOP,
+    sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+    private: false,
+    toml_path: "code.editor.diff_layout",
+    description: "Layout for diff views: 'inline' or 'side_by_side'.",
+},
+```
+
+The setting type system already supports enums via `serde`, matching how other setting groups carry strongly-typed values. Default is `Inline`, so every existing user is unaffected unless they opt in.
+
+### 3. Add the `SideBySideDiffLayout` feature flag
+
+Add `SideBySideDiffLayout` to the `FeatureFlag` enum in `app/src/features/`. The flag defaults to off in shipping builds and on in dogfood builds. The flag is consulted in two places:
+
+- `app/src/code_review/diff_menu.rs` to decide whether to show the Layout radio group rows.
+- `app/src/code/inline_diff.rs::InlineDiffView::new` and the Code Review pane's per-diff construction site to decide whether to read the setting at all (when off, layout is hard-coded to `Inline`).
+
+Once the feature stabilizes, the flag is removed in a follow-up PR. The setting and the menu rows persist.
+
+### 4. Build `SideBySideDiffView`
+
+Add `app/src/code/side_by_side_diff.rs`. The new type mirrors `InlineDiffView`'s lifecycle but holds two editors:
+
+```rust
+pub struct SideBySideDiffView {
+    baseline: ViewHandle<CodeEditorView>,
+    modified: ViewHandle<CodeEditorView>,
+    diff_type: Option<DiffType>,
+    file_path: Option<StandardizedPath>,
+    /// Hunk alignment computed once per diff application; rebuilt on diff updates.
+    alignment: HunkAlignment,
+    /// Shared vertical scroll position that drives both panes.
+    scroll_sync: ScrollSyncModel,
+    /// Which pane is currently focused for cursor navigation.
+    focused_pane: Pane,
+    /// File registration state, identical to `InlineDiffView`.
+    backing_file_id: Option<FileId>,
+    was_edited: bool,
+    #[cfg(not(target_family = "wasm"))]
+    is_new_file: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Pane {
+    Baseline,
+    Modified,
+}
+```
+
+Key methods:
+
+- `new(baseline_editor, modified_editor, diff_type, display_mode, file_path, ctx)` constructs the view, subscribes to both editors' `CodeEditorEvent`, applies the diff to `modified` and the pre-diff content to `baseline`, then computes `HunkAlignment` and pushes the resulting padding rows into both editors via a new `CodeEditorView::set_padding_rows(Vec<PaddingRow>)` API (see Change 5).
+- `register_file(session_type, ctx)` registers the *modified* editor with `FileModel`, mirroring `InlineDiffView::register_file` (`app/src/code/inline_diff.rs:122-153`). The baseline pane is always read-only.
+- `apply_diffs_if_any(ctx)` mirrors `InlineDiffView::apply_diffs_if_any` (`app/src/code/inline_diff.rs:196-228`). For `DiffType::Update`, both editors get content; for `DiffType::Create` the baseline pane shows an empty file with a "(new file)" header line; for `DiffType::Delete` the modified pane shows an empty file with "(deleted)".
+- `set_display_mode(mode, ctx)` calls the existing `DiffViewer::set_display_mode` body once per editor.
+
+Implement `DiffViewer` for `SideBySideDiffView` so that `editor()` returns the focused pane's editor and the trait's existing methods work without changes. Add new trait methods on a separate `MultiPaneDiffViewer` trait (defaulted on `DiffViewer`) for callers that need both panes:
+
+```rust
+pub trait MultiPaneDiffViewer: DiffViewer {
+    fn baseline_editor(&self) -> &ViewHandle<CodeEditorView> {
+        self.editor()
+    }
+    fn modified_editor(&self) -> &ViewHandle<CodeEditorView> {
+        self.editor()
+    }
+    fn focused_pane(&self) -> Option<Pane> {
+        None
+    }
+}
+```
+
+The default implementation delegates everything to `editor()`, so existing single-pane consumers (`InlineDiffView` and `LocalCodeEditorView`) need no changes. `SideBySideDiffView` overrides all three.
+
+### 5. Editor padding-row API
+
+`CodeEditorView` (`app/src/code/editor/view.rs`) and the underlying model (`app/src/code/editor/model.rs`) gain a new "padding row" concept: a row that takes up vertical space, has a gutter, and renders empty content. The new public API:
+
+```rust
+impl CodeEditorView {
+    pub fn set_padding_rows(&mut self, rows: Vec<PaddingRow>, ctx: &mut ViewContext<Self>);
+}
+
+#[derive(Clone, Debug)]
+pub struct PaddingRow {
+    pub line_index: usize,
+    pub count: usize,
+    pub gutter_kind: PaddingGutterKind,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum PaddingGutterKind {
+    /// Render the gutter as the diff-add color band, no glyph, no line number.
+    AddSide,
+    /// Render the gutter as the diff-delete color band, no glyph, no line number.
+    DeleteSide,
+}
+```
+
+Padding rows are inserted at render time only. They don't affect the underlying buffer, so:
+
+- Save (`FileModel::save`) still writes the unmodified buffer text.
+- Find, copy, selection, and cursor navigation all see the buffer as-is. Padding rows never become part of a selection.
+- Hunk navigation (`navigate_next_diff_hunk`, `navigate_previous_diff_hunk` on the trait) operates on actual diff hunks, not padding rows.
+
+Implementation lives in `app/src/code/editor/model.rs` next to the existing line-iteration code; the renderer in `app/src/code/editor/view.rs` consults the padding-row table when laying out lines and inserts a fixed-height empty row at each padding position.
+
+This is the minimal addition that lets the right pane render blanks where the left pane has a deleted line, and vice versa, without diverging the buffer model from the file content.
+
+### 6. `HunkAlignment`
+
+Add `app/src/code/hunk_alignment.rs`:
+
+```rust
+pub struct HunkAlignment {
+    /// Padding rows for the baseline pane.
+    pub baseline_padding: Vec<PaddingRow>,
+    /// Padding rows for the modified pane.
+    pub modified_padding: Vec<PaddingRow>,
+    /// Per-row mapping: rendered row index -> (baseline buffer line, modified buffer line).
+    /// `None` on a side means that side renders padding at this row.
+    pub row_map: Vec<(Option<usize>, Option<usize>)>,
+}
+
+impl HunkAlignment {
+    pub fn from_unified_diff(
+        baseline_lines: &[String],
+        modified_lines: &[String],
+        hunks: &[UnifiedDiffHeader],
+    ) -> Self;
+}
+```
+
+The algorithm walks unified-diff hunks (parsed by `app/src/code_review/comments/diff_hunk_parser.rs::build_line_result`):
+
+- For each `Context` line: emit a `(Some(b), Some(m))` row, advance both indices.
+- For each `Delete` line: emit a `(Some(b), None)` row, advance baseline only, append a one-line `PaddingRow { gutter_kind: AddSide }` to `modified_padding` at the current modified index.
+- For each `Add` line: emit a `(None, Some(m))` row, advance modified only, append a one-line `PaddingRow { gutter_kind: DeleteSide }` to `baseline_padding` at the current baseline index.
+
+Modifications (a `Delete` immediately followed by an `Add`) emit `(Some(b), None)` then `(None, Some(m))` by default. A follow-up optimization (out of scope for this spec) can collapse adjacent delete-add pairs into a single `(Some(b), Some(m))` row to keep modified lines on the same row as the line they replaced. The minimal, correctness-first version above is what ships first; the collapsed version follows once telemetry confirms users prefer it.
+
+`row_map` is consulted by the scroll-sync model in Change 7.
+
+### 7. `ScrollSyncModel`
+
+Add `app/src/code/scroll_sync.rs`:
+
+```rust
+pub struct ScrollSyncModel {
+    /// Currently focused pane for cursor moves.
+    focused_pane: Pane,
+}
+
+impl ScrollSyncModel {
+    /// Translate a wheel delta on `from` into matching scroll deltas for both panes.
+    pub fn on_scroll_wheel(&self, from: Pane, delta_y: f32) -> (f32, f32);
+
+    /// Translate a cursor move on `from` (new buffer line in that pane) into the
+    /// corresponding row on the other pane via `row_map`.
+    pub fn corresponding_row(
+        &self,
+        from: Pane,
+        new_buffer_line: usize,
+        alignment: &HunkAlignment,
+    ) -> Option<usize>;
+}
+```
+
+Wheel events on either pane drive both panes by the same row-delta. Cursor moves only move the cursor on the focused pane; the other pane scrolls to keep `corresponding_row` in view but does not move its own cursor. Builds on the existing scroll-preservation patterns in `app/src/code_review/scroll_preservation.rs`.
+
+`SideBySideDiffView::new` subscribes to `CodeEditorEvent::ScrolledByUser` (existing event from `app/src/code/editor/view.rs`) on both editors and mirrors the resulting deltas through the model.
+
+### 8. Layout selection in the View Options menu
+
+Extend `app/src/code_review/diff_menu.rs::CodeReviewDiffMenu`:
+
+- Add a `MenuRowKind` enum (`DiffTargetRow(DiffTarget)` for today's behavior, `LayoutRow(DiffLayout)` for the new rows). Replace `targets: Vec<DiffTarget>` (line 99) with `rows: Vec<MenuRow>`. The `filtered: Vec<(usize, Option<FuzzyMatchResult>)>` shape is unchanged.
+- When the `SideBySideDiffLayout` feature flag is on, the menu builder appends two `LayoutRow` entries ("Inline" and "Side-by-Side") below the existing diff-target rows, separated by a divider row.
+- `CodeReviewDiffMenuEvent` (line 47) gains a `SelectLayout(DiffLayout)` variant. When the menu emits it, the parent (`code_review_view`) writes the new layout to `code.editor.diff_layout` via the settings store and refreshes the visible diff.
+
+For the AI block-list, the equivalent menu lives in `app/src/ai/blocklist/inline_action/code_diff_view.rs`. The same two-row group is appended to that menu's overflow with the same handler pattern.
+
+### 9. Code Review pane integration
+
+`app/src/code_review/code_review_view.rs` (311KB) is the parent that holds per-file `InlineDiffView` instances today. The integration:
+
+- On view construction, read `code.editor.diff_layout` from the settings store. If `SideBySide` and the feature flag is on, build `SideBySideDiffView` for each file; otherwise build `InlineDiffView` as today.
+- Subscribe to setting updates. When `code.editor.diff_layout` changes, the pane swaps the per-file view: tear down the current `InlineDiffView` / `SideBySideDiffView`, build the matching new one with the same diff data, and preserve scroll position via `app/src/code_review/scroll_preservation.rs`.
+- Find-in-diff (`app/src/code_review/find_model.rs`) gains a `Pane`-aware iterator that walks both editors when the active diff is a `SideBySideDiffView`. The existing find loop becomes `for pane in active_panes()` where `active_panes()` returns `[Modified]` for inline and `[Baseline, Modified]` for side-by-side, in tab order.
+
+The `code_review_view_integration.rs` and `code_review_view_tests.rs` test fixtures gain a `with_layout(DiffLayout)` helper that sets the layout in the test settings store before constructing the view.
+
+### 10. AI block-list integration
+
+`app/src/ai/blocklist/inline_action/code_diff_view.rs` decides which `DisplayMode` to use per inline-action diff. Today every site constructs `DisplayMode::with_embedded(MAX_EDITOR_HEIGHT)` (line 798) or `DisplayMode::with_inline_banner(INLINE_EDITOR_HEIGHT)` (line 796).
+
+The integration:
+
+- Read `code.editor.diff_layout` at the same place these `DisplayMode` decisions are made.
+- For `DiffLayout::Inline`, construct `InlineDiffView` as today.
+- For `DiffLayout::SideBySide`, construct `SideBySideDiffView` with the same `DisplayMode`.
+
+`InlineBanner` mode is a special case: side-by-side at a small max height shows two cramped columns. For this spec, `SideBySide` falls back to `Inline` when the chosen `DisplayMode` is `InlineBanner { .. }`. The fallback is documented in product invariant 2 implicitly (the spec discusses the embedded and full-pane surfaces) and is called out here so the implementation is unambiguous. A future spec can revisit the `InlineBanner` side-by-side behavior.
+
+### 11. Comment threads
+
+`app/src/code_review/comments/` (8 files, 100KB+ total) anchors comment threads on `EditorLineLocation` (`app/src/code/editor/line.rs::EditorLineLocation`). Comments stay attached to those locations and render under the targeted line. The integration:
+
+- The renderer for a side-by-side row checks each comment's pane (the original side it was authored against, captured from `CommentSide` in `app/src/ai/agent/action.rs`) and renders the thread under the matching pane's row.
+- The opposite pane shows a small marker glyph in its gutter at the same row to indicate that the other side has a thread there. The marker is non-interactive in this spec (clicking it does not focus the comment); a follow-up spec can wire that.
+- Multi-line comment ranges that span both deleted and added regions stay on the side they were authored against.
+
+### 12. Telemetry
+
+Add a `CodeReviewTelemetryEvent::DiffLayoutChanged { from: DiffLayout, to: DiffLayout, surface: TelemetrySurface }` variant in `app/src/code_review/telemetry_event.rs`. The `surface` enum distinguishes Code Review vs AI block-list. `code_review_view` and the AI inline-action diff host emit the event when the menu emits `SelectLayout`.
+
+### 13. Settings UI
+
+`code.editor.diff_layout` is reachable from both:
+- The View Options menu in the diff toolbar (the primary path; product invariant 6).
+- The Settings pane under Code, where users can flip it without opening a diff. This follows the existing pattern for settings declared in `app/src/settings/code.rs` (e.g. `show_project_explorer`, line 50).
+
+Both surfaces write to the same setting key, so changes propagate through the existing settings subscription.
+
+## Test plan
+
+### Unit tests
+
+- `app/src/code/hunk_alignment_tests.rs`:
+  - Empty diff: row_map is `[(Some(0), Some(0)), ...]` for every line, no padding.
+  - Pure addition: rows for the added section are `(None, Some(m))`; baseline_padding has the matching count.
+  - Pure deletion: rows for the deleted section are `(Some(b), None)`; modified_padding has the matching count.
+  - Modification: deleted line and added line both produce rows; both pads are emitted.
+  - Multi-hunk file: alignment composes correctly across hunks separated by unchanged context.
+  - Large diff (5,000 lines, 200 hunks): completes in under 50ms.
+
+- `app/src/code/scroll_sync_tests.rs`:
+  - Wheel delta on baseline drives both panes equally.
+  - Cursor move on modified scrolls baseline to the corresponding row.
+  - Cursor on a `(None, Some(m))` row (pure-add): baseline scrolls to the next surrounding context line.
+
+- `app/src/code/side_by_side_diff_tests.rs`:
+  - `apply_diffs_if_any` for `DiffType::Update`: both editors hold expected content; alignment is non-empty.
+  - `apply_diffs_if_any` for `DiffType::Create`: baseline editor is empty with a header; modified holds the new file content.
+  - `apply_diffs_if_any` for `DiffType::Delete`: modified editor is empty; baseline holds the original content.
+  - `register_file` registers only the modified editor with `FileModel`; the baseline editor remains read-only.
+  - `set_display_mode` propagates to both editors (assert via the existing `set_*` calls captured by the test fixture).
+  - `accept_and_save_diff` writes the modified editor's buffer text via `FileModel`, identical to `InlineDiffView`'s save path.
+  - `reject_diff` discards the modification; subsequent `apply_diffs_if_any` of the same diff produces an empty alignment.
+  - Layout switch from `Inline` to `SideBySide` and back preserves scroll position to within one row.
+
+### Integration tests
+
+- `app/src/code_review/code_review_view_tests.rs` gains tests using the new `with_layout(DiffLayout)` helper:
+  - Single-file diff in side-by-side renders both panes.
+  - Multi-file diff: each file's view honors the same layout.
+  - Setting flip while open swaps every visible file's view from `InlineDiffView` to `SideBySideDiffView` and preserves scroll.
+  - Find-in-diff matches both panes.
+  - Hunk navigation (`f` / `F`) advances the focused hunk on both panes simultaneously.
+  - Comment thread on a baseline-side line renders under the baseline pane's row; modified pane shows the gutter marker.
+
+### Manual smoke test
+
+- macOS, M1 MacBook Air, dogfood build with `SideBySideDiffLayout` enabled:
+  - Open Code Review with a 200-file diff. Toggle layout. Confirm the toggle takes effect within 200ms on the active diff.
+  - Scroll wheel on each pane. Confirm both panes scroll together.
+  - Drag-select on each pane. Confirm the selection stays in that pane.
+  - Cmd-A on each pane. Confirm only that pane's content is selected.
+  - Resize the window narrow enough that side-by-side is cramped. Confirm horizontal scrollbars on each pane behave independently and the divider stays at 50%.
+  - Open an AI block-list diff with a recent agent edit. Toggle layout. Confirm the embedded diff swaps from one column to two and back.
+  - Linux (Ubuntu 24.04), Windows 11: repeat the toggle smoke test on each platform to confirm rendering and keybindings.
+
+### Compile-parity checklist
+
+Every site that destructures `DisplayMode` in a `match` must compile after the change. The current call sites (from `grep -rn "DisplayMode::\(FullPane\|Embedded\|InlineBanner\)"`):
+
+- `app/src/code/diff_viewer.rs:45,46,47,53,62,71,72,73,82,83,84,89,94,100,104,108`: trait helpers; unchanged because `DiffLayout` is a new orthogonal axis.
+- `app/src/ai/blocklist/inline_action/code_diff_view.rs:796,798,1248,1258,1311,2026,2065,2170,2204,2206`: `DisplayMode` construction and matching; unchanged.
+- `app/src/ai/blocklist/block/view_impl/output.rs:2061`: match on `DisplayMode::FullPane`; unchanged.
+
+Every site that constructs `InlineDiffView` (per `grep -rn "InlineDiffView::new"`) is the candidate set for layout-aware view construction. The list is verified during implementation; the integration in Change 9 and Change 10 covers the two parent surfaces.
+
+## Open questions
+
+1. The `InlineBanner` fallback to `Inline` for side-by-side (Change 10) is the safest default. Should the toolbar show a "Side-by-side not available in this layout" hint to the user, or silently fall back? The current spec says silently; the Code Review SME may prefer a hint.
+2. The collapsed delete-add row optimization (mentioned in Change 6) is out of scope for the first ship. A telemetry signal that quantifies how often a delete is immediately followed by an add helps prioritize the follow-up.
+3. Comment thread interaction with the opposite-pane gutter marker (Change 11) is non-interactive in this spec. Whether the marker should be clickable (focuses the comment in the other pane) is a UX call for the Code Review SME and a candidate follow-up.

--- a/specs/GH7043/tech.md
+++ b/specs/GH7043/tech.md
@@ -5,31 +5,30 @@ Roadmap reference: https://github.com/warpdotdev/warp/issues/9233
 
 ## Context
 
-The diff rendering surface is shared by two consumers: the AI block-list inline diff (`InlineDiffView`) and the full Code Review pane (`code_review_view::CodeReviewView`). Both build on the same primitives:
+The diff rendering surface is shared by the AI block-list inline diff (`InlineDiffView`) and the full Code Review pane (`code_review_view::CodeReviewView`). Both build on the same primitives:
 
-- `app/src/code/diff_viewer.rs` defines the shared abstraction. `DisplayMode` (lines 14-29) carries the visual context: `FullPane`, `Embedded { max_height }`, `InlineBanner { max_height, is_expanded, is_dismissed }`. The `DiffViewer` trait (lines 110-160) holds a single `&ViewHandle<CodeEditorView>` and exposes hunk-navigation, accept, reject, and revert.
-- `app/src/code/inline_diff.rs::InlineDiffView` (12.6KB, lines 1-300) wraps a single `CodeEditorView`, registers a `FileModel`-backed file when one exists, and applies the parsed deltas to the editor on construction (`apply_diffs_if_any`, lines 196-228).
-- `app/src/code/editor/view.rs::CodeEditorView` (84KB) and `app/src/code/editor/model.rs` (155KB) are the rendering target. Both inline and side-by-side reuse them.
-- `app/src/code/editor/diff.rs` (30KB) holds the editor-level diff line decoration and gutter rendering. `DiffLineType` (referenced from `app/src/code_review/comments/diff_hunk_parser.rs`) classifies lines as `Context`, `Add`, `Delete`, `HunkHeader`.
-- `app/src/code_review/diff_state.rs` (112KB) holds hunk state, parsed `UnifiedDiffHeader` (lines 67-73), the `DiffMode` enum at line 266 (`Head` / `MainBranch` / `OtherBranch(String)`, *comparison base, not layout*), and the per-file diff state model.
-- `app/src/code_review/diff_menu.rs` (501 lines) is the existing View Options popup that the user opens from the diff toolbar. Today its rows are sourced from `Vec<DiffTarget>` (line 99) and the menu emits `CodeReviewDiffMenuEvent::Select(DiffMode)` (line 47) to change comparison base. The new layout selector slots in here.
-- `app/src/code_review/code_review_view.rs` (311KB) hosts the diff per file and renders into the pane. It's the consumer that subscribes to setting changes and rebuilds visible diffs on layout change.
-- `app/src/ai/blocklist/inline_action/code_diff_view.rs` (where `DisplayMode::FullPane`, `Embedded`, `InlineBanner` are constructed at lines 796, 798, 1248, 1258, 1311, 2026, 2065, 2170, 2204, 2206) is the AI block-list inline-action diff host that wraps `InlineDiffView` and decides which `DisplayMode` to use.
-- `app/src/settings/code.rs` (63 lines) is the settings group for `code.*`. Settings are declared via the `define_settings_group!` macro with `toml_path`, `default`, `supported_platforms`, and `sync_to_cloud` fields. Existing entries set the pattern for the new `diff_layout` setting.
-- `crates/warp_features/src/lib.rs` defines the `FeatureFlag` enum (line 8 onward) and the per-flag changelog descriptions (`description_for_changelog` match arms around line 1000-1024). `app/src/features.rs` is a one-line re-export (`pub use warp_core::features::*;`). Cargo features are registered for each flag in `app/src/lib.rs:2680-2740` via `#[cfg(feature = "...")]` guards on each `FeatureFlag::Variant` entry. The matching Cargo feature names are declared in the workspace `Cargo.toml` (and per-crate `Cargo.toml` files) under `[features]`. The new `SideBySideDiffLayout` flag is declared in all three places: the enum, the changelog match, and the cfg-gated registration block (with a matching `side_by_side_diff_layout` Cargo feature).
-- `app/src/code_review/scroll_preservation.rs` (8KB) holds scroll preservation helpers that the side-by-side scroll-sync model can build on.
-- `app/src/code_review/comments/diff_hunk_parser.rs` (181 lines) parses hunks into per-line records (`build_line_result`, lines 47-90). The hunk-alignment model for side-by-side reuses this parser; no new parser is introduced.
-- `app/src/code_review/comments/comment.rs` and `comment_list_view.rs` (48KB) own comment rendering. Comment placement gains a per-pane gutter marker; the existing thread placement logic is unchanged because comments are still anchored on `EditorLineLocation`.
-- `app/src/code_review/telemetry_event.rs` (16KB) defines `CodeReviewTelemetryEvent`. The layout-change event registers here.
-- `app/src/code_review/find_model.rs` (13KB) holds the find-in-diff state model that needs to traverse both panes in side-by-side.
+- `app/src/code/diff_viewer.rs` defines the shared abstraction. `DisplayMode` carries the visual context: `FullPane`, `Embedded { max_height }`, and `InlineBanner { max_height, is_expanded, is_dismissed }`.
+- `app/src/code/inline_diff.rs::InlineDiffView` wraps a single `CodeEditorView`, registers a `FileModel`-backed file when one exists, and applies parsed deltas to that editor on construction through `apply_diffs_if_any`.
+- `app/src/code/editor/view.rs::CodeEditorView` and `app/src/code/editor/model.rs` are the rendering target. Both inline and side-by-side reuse them.
+- `app/src/code/editor/diff.rs` holds the editor-level diff line decoration and gutter rendering. `DiffLineType` classifies lines as `Context`, `Add`, `Delete`, and `HunkHeader`.
+- `app/src/code_review/diff_state.rs` holds hunk state, the `DiffMode` enum (`Head` / `MainBranch` / `OtherBranch(String)`, comparison base rather than layout), and the per-file diff state model.
+- `app/src/code_review/comments/diff_hunk_parser.rs` parses hunks into ordered per-line records. The side-by-side aligner consumes those records; no new parser is introduced.
+- `app/src/settings/code.rs` is the settings group for `code.*`. Settings are declared via `define_settings_group!` with `toml_path`, `default`, `supported_platforms`, and `sync_to_cloud` fields.
+- `app/src/settings_view/code_page.rs` is the explicit Code settings UI. Declaring a settings entry does not render it; the page needs a concrete widget registered in the Code section.
+- `crates/warp_features/src/lib.rs` defines the canonical `FeatureFlag` enum, `DOGFOOD_FLAGS`, `PREVIEW_FLAGS`, and changelog descriptions. `app/src/features.rs` re-exports the feature API.
+- `app/src/lib.rs` builds the set of compiled-in feature flags through cfg-gated `FeatureFlag::Variant` entries. The corresponding Cargo feature declarations live in `app/Cargo.toml`.
+- `app/src/code_review/scroll_preservation.rs` holds scroll preservation helpers that the side-by-side scroll-sync model can build on.
+- `app/src/code_review/comments/comment.rs` and `comment_list_view.rs` own comment rendering. Comment placement gains a per-pane gutter marker; existing anchoring on `EditorLineLocation` remains.
+- `app/src/code_review/telemetry_event.rs` defines `CodeReviewTelemetryEvent`. The layout-change event registers here.
+- `app/src/code_review/find_model.rs` holds the find-in-diff state model that needs to traverse both panes in side-by-side.
 
-The narrowest fix: introduce a `DiffLayout` enum (`Inline` / `SideBySide`), thread it through `DiffViewer`, build a `SideBySideDiffView` in `app/src/code/side_by_side_diff.rs` that holds two `CodeEditorView` instances and a shared scroll-sync model, route the layout choice through the `View Options` menu and a new `code.editor.diff_layout` setting, and gate the whole change behind a `SideBySideDiffLayout` feature flag. The proposed changes below take the existing `DiffViewer` trait as a shared interface and have the side-by-side view implement it; everywhere that today asks "give me the editor" gets back the *focused* editor, and a small set of new accessors expose both editors when needed.
+The implementation introduces a `DiffLayout` enum (`Inline` / `SideBySide`), stores it as `code.editor.diff_layout`, exposes it in Settings -> Code, builds a `SideBySideDiffView` in `app/src/code/side_by_side_diff.rs`, and gates the path behind `SideBySideDiffLayout`.
 
 ## Proposed changes
 
 ### 1. Introduce the `DiffLayout` enum
 
-Add a new file `app/src/code/diff_layout.rs`:
+Add `app/src/code/diff_layout.rs`:
 
 ```rust
 use serde::{Deserialize, Serialize};
@@ -49,17 +48,18 @@ impl DiffLayout {
 }
 ```
 
-Re-export from `app/src/code/mod.rs`. The enum is `Copy` so it can travel through view contexts without lifetime concerns. The `serde` representation (`"inline"` / `"side_by_side"`) matches the `toml_path` value the settings system stores.
+Re-export from `app/src/code/mod.rs`. The enum is `Copy` so it can travel through view contexts without lifetime concerns. The `serde` representation (`"inline"` / `"side_by_side"`) matches the setting value.
 
 `DiffLayout` is intentionally separate from `DisplayMode` because they are orthogonal:
+
 - `DisplayMode` answers "where on screen does this diff live" (own pane vs embedded vs inline banner).
 - `DiffLayout` answers "how do we render the diff content" (one column vs two columns).
 
-A `DisplayMode::FullPane` diff and a `DisplayMode::Embedded { max_height }` diff both honor the user's `DiffLayout` choice.
+Every `DisplayMode` honors the user's `DiffLayout` choice when the feature flag is enabled.
 
 ### 2. Add the `code.editor.diff_layout` setting
 
-Extend `define_settings_group!` in `app/src/settings/code.rs:5-62`:
+Extend `define_settings_group!` in `app/src/settings/code.rs`:
 
 ```rust
 diff_layout: DiffLayoutSetting {
@@ -73,38 +73,87 @@ diff_layout: DiffLayoutSetting {
 },
 ```
 
-The setting type system already supports enums via `serde`, matching how other setting groups carry strongly-typed values. Default is `Inline`, so every existing user is unaffected unless they opt in.
+The setting type system already supports enums via `serde`, matching how other setting groups carry strongly typed values. Default is `Inline`, so existing users are unaffected unless they opt in.
 
-### 3. Add the `SideBySideDiffLayout` feature flag
+### 3. Settings page integration in `settings_view/code_page.rs`
 
-The flag is wired in three concrete locations:
+`code.editor.diff_layout` is exposed in Settings -> Code under a new "Diff layout" subsection. This is the primary user entry point for the preference because it applies to all diff surfaces.
 
-1. **Enum variant** in `crates/warp_features/src/lib.rs::FeatureFlag` (the canonical `pub enum FeatureFlag` at line 8). Add `SideBySideDiffLayout,` alongside existing variants such as `CodeReviewFind` (line 471), `BlocklistMarkdownImages`, and `EmbeddedCodeReviewComments`. `app/src/features.rs` is a one-line re-export, so the flag becomes available as `crate::features::FeatureFlag::SideBySideDiffLayout` automatically.
+Add a `DiffLayoutWidget` row in `app/src/settings_view/code_page.rs`:
 
-2. **Cargo feature mapping**:
-   - In the workspace `Cargo.toml` (and the relevant per-crate `Cargo.toml` files; reference: how `code_review_find = []` is declared today): add `side_by_side_diff_layout = []`.
-   - Add the matching cfg-gated registration entry in `app/src/lib.rs` between lines 2680-2740, alongside other `#[cfg(feature = "...")] FeatureFlag::Variant,` lines. Pattern (matching the existing block):
+- The widget renders a two-option segmented control: "Inline" and "Side by side".
+- The selected segment reads from `CodeSettings::DiffLayout`.
+- Segment changes write `code.editor.diff_layout` through the settings store and emit the layout-change telemetry event.
+- Register the widget explicitly in the Code settings group near the existing Code Review settings widgets. This resolves the CodeSettings rendering concern: declaring the setting alone does not make it appear in the page.
+- Gate widget registration on `FeatureFlag::SideBySideDiffLayout.is_enabled()` so the control is hidden while the runtime flag is off.
+
+The diff toolbar continues to own only per-view ephemeral controls, such as whitespace visibility. It does not expose `code.editor.diff_layout`.
+
+### 4. Add the `SideBySideDiffLayout` feature flag
+
+The flag is wired in the actual repo feature-flag locations:
+
+1. **Enum variant**: add `SideBySideDiffLayout,` to `crates/warp_features/src/lib.rs::FeatureFlag`, near related Code Review flags such as `CodeReviewFind`.
+
+2. **Cargo feature and compiled-in registration**:
+   - Add `side_by_side_diff_layout = []` to `[features]` in `app/Cargo.toml`, following the existing `code_review_find = []` pattern.
+   - Add the cfg-gated entry in `app/src/lib.rs` alongside the other compiled-in feature flags:
      ```rust
      #[cfg(feature = "side_by_side_diff_layout")]
      FeatureFlag::SideBySideDiffLayout,
      ```
-   - Add the dogfood/preview enablement to the `PREVIEW_FLAGS` registration so dogfood builds default the flag on, matching how `CodeReviewFind` is enabled in preview today.
 
-3. **Changelog description** in `crates/warp_features/src/lib.rs` inside the `description_for_changelog` match arms (lines 1004-1024 today):
+3. **Dogfood and preview runtime defaults**:
+   - Add `FeatureFlag::SideBySideDiffLayout` to `DOGFOOD_FLAGS` in `crates/warp_features/src/lib.rs` for the first internal phase.
+   - Move it to `PREVIEW_FLAGS` when widening beyond dogfood. Preview flags are automatically included in dogfood builds.
+   - Do not add it to `RELEASE_FLAGS` until the staged rollout is complete.
+
+4. **Changelog description**: add a `description_for_changelog` match arm:
    ```rust
    SideBySideDiffLayout => Some("Enables a side-by-side diff layout in the code review pane and AI block-list diffs."),
    ```
 
-The flag is consulted at three runtime sites:
-- `app/src/code_review/diff_menu.rs` decides whether to render the Layout radio rows.
-- `app/src/code_review/code_review_view.rs` decides whether to read `code.editor.diff_layout` at per-file construction (when off, layout is hard-coded to `Inline` regardless of stored value).
-- `app/src/ai/blocklist/inline_action/code_diff_view.rs` decides the same for embedded AI block-list diffs.
+Rollout:
 
-The Settings page widget (Change 13) is also gated on the flag so the radio group disappears from Settings while the flag is off.
+- Compile-time gate: `side_by_side_diff_layout` controls whether the app binary includes `FeatureFlag::SideBySideDiffLayout` in the compiled-in flag list.
+- Runtime gate: the feature-flag service decides whether `FeatureFlag::SideBySideDiffLayout.is_enabled()` returns true for the current channel/user.
+- Dispatch bridge: diff construction first checks the runtime flag. If disabled, it treats the effective layout as `DiffLayout::Inline` regardless of stored settings. If enabled, it reads `code.editor.diff_layout` and dispatches to `InlineDiffView` or `SideBySideDiffView`.
+- Default rollout schedule: off in shipping builds -> 5% dogfood -> 25% dogfood -> 100% dogfood -> preview -> release.
 
-Once the feature stabilizes, the flag and its Cargo feature are removed in a follow-up PR. The setting and the menu rows persist as the user-facing control.
+### 5. Pane-aware diff viewer contract
 
-### 4. Build `SideBySideDiffView`
+Replace the single-editor assumption in `DiffViewer` with a pane-aware contract that keeps existing inline behavior but names side-by-side responsibilities explicitly:
+
+```rust
+pub trait PaneAwareDiffViewer {
+    fn focused_editor(&self) -> &CodeEditor;
+    fn modified_editor(&self) -> &CodeEditor;
+    fn baseline_editor(&self) -> &CodeEditor;
+    fn for_each_editor(&self, f: impl FnMut(&CodeEditor));
+}
+```
+
+Semantics:
+
+- `focused_editor` is the current focused pane, used for cursor, selection, focus, and local keyboard state.
+- `modified_editor` is always the post-diff pane, used for `changed_lines`, accept, save, and file-backed edits.
+- `baseline_editor` is always the pre-diff pane and is read-only.
+- `for_each_editor` is used for operations that intentionally span both panes.
+
+Caller routing:
+
+| Caller / behavior | Pane-aware route |
+|---|---|
+| Cursor focus, local selection, copy, find focus | `focused_editor` |
+| `changed_lines` | `modified_editor` |
+| Accept diff, save diff, reject-to-modified-buffer operations | `modified_editor` |
+| Hunk navigation | `for_each_editor` for lockstep scroll/cursor sync; the modified pane remains the source of writeable hunk state |
+| Scroll preservation | `for_each_editor` |
+| Comment rendering and gutter markers | `baseline_editor` and `modified_editor` via row alignment |
+
+For `InlineDiffView`, all four methods return or iterate the same single editor, preserving current behavior.
+
+### 6. Build `SideBySideDiffView`
 
 Add `app/src/code/side_by_side_diff.rs`. The new type mirrors `InlineDiffView`'s lifecycle but holds two editors:
 
@@ -114,13 +163,9 @@ pub struct SideBySideDiffView {
     modified: ViewHandle<CodeEditorView>,
     diff_type: Option<DiffType>,
     file_path: Option<StandardizedPath>,
-    /// Hunk alignment computed once per diff application; rebuilt on diff updates.
     alignment: HunkAlignment,
-    /// Shared vertical scroll position that drives both panes.
     scroll_sync: ScrollSyncModel,
-    /// Which pane is currently focused for cursor navigation.
-    focused_pane: Pane,
-    /// File registration state, identical to `InlineDiffView`.
+    focused_pane: PaneId,
     backing_file_id: Option<FileId>,
     was_edited: bool,
     #[cfg(not(target_family = "wasm"))]
@@ -128,7 +173,7 @@ pub struct SideBySideDiffView {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum Pane {
+pub enum PaneId {
     Baseline,
     Modified,
 }
@@ -136,43 +181,48 @@ enum Pane {
 
 Key methods:
 
-- `new(baseline_editor, modified_editor, diff_type, display_mode, file_path, ctx)` constructs the view, subscribes to both editors' `CodeEditorEvent`, applies the diff to `modified` and the pre-diff content to `baseline`, then computes `HunkAlignment` and pushes the resulting padding rows into both editors via a new `CodeEditorView::set_padding_rows(Vec<PaddingRow>)` API (see Change 5).
-- `register_file(session_type, ctx)` registers the *modified* editor with `FileModel`, mirroring `InlineDiffView::register_file` (`app/src/code/inline_diff.rs:122-153`). The baseline pane is always read-only.
-- `apply_diffs_if_any(ctx)` mirrors `InlineDiffView::apply_diffs_if_any` (`app/src/code/inline_diff.rs:196-228`). For `DiffType::Update`, both editors get content; for `DiffType::Create` the baseline pane shows an empty file with a "(new file)" header line; for `DiffType::Delete` the modified pane shows an empty file with "(deleted)".
-- `set_display_mode(mode, ctx)` calls the existing `DiffViewer::set_display_mode` body once per editor.
+- `new(baseline_editor, modified_editor, diff_type, display_mode, file_path, ctx)` constructs the view, subscribes to both editors' `CodeEditorEvent`, builds pane content, computes `HunkAlignment`, and pushes padding rows into both editors.
+- `register_file(session_type, ctx)` registers only the modified editor with `FileModel`, mirroring `InlineDiffView::register_file`. The baseline pane is always read-only.
+- `set_display_mode(mode, ctx)` applies display-mode behavior to the modified pane only. Baseline interaction state remains read-only regardless of display mode.
+- `PaneAwareDiffViewer` is implemented with the routing from Change 5.
 
-Implement `DiffViewer` for `SideBySideDiffView`, but **override every method that has a meaningful per-pane interpretation** so that the trait's existing call sites keep working correctly. Returning the focused editor from `editor()` is fine as a fallback for callers that need a single editor handle (search, find, focus management), but it must not be the default for hunk navigation, accept, save, or `changed_lines`. Each override is listed below with the method's role and the side-by-side semantics.
+### 7. Pane content construction
 
-| Trait method (existing) | Default body in `diff_viewer.rs:110-160` | `SideBySideDiffView` override |
-|---|---|---|
-| `editor()` | returns single `&ViewHandle<CodeEditorView>` | returns the focused pane's editor (`Modified` by default; `Baseline` when the user has tabbed into the left pane). Used only by callers that genuinely want the focused editor (search, focus, find). |
-| `diff()` | returns `Option<&DiffType>` | returns `self.diff_type.as_ref()`. Same as `InlineDiffView`. |
-| `was_edited()` | returns `false` | returns `self.was_edited`, which tracks edits to the modified pane only. The baseline pane is always read-only, so it cannot have been edited. |
-| `changed_lines(ctx)` | calls `self.editor().as_ref(ctx).changed_lines(ctx)` | calls `self.modified.as_ref(ctx).changed_lines(ctx)`. The baseline pane has no diff applied and would always return empty. |
-| `set_display_mode(mode, ctx)` | applies the mode to a single editor | calls the existing single-editor body once for `self.baseline` and once for `self.modified`, so both editors get the correct `scroll_wheel_behavior`, `vertical_expansion_behavior`, scrollbar appearance, interaction state, and nav-bar settings. |
-| `navigate_next_diff_hunk(ctx)` | calls `self.editor().update(...).navigate_next_diff_hunk` | calls `navigate_next_diff_hunk` on `self.modified` (which owns the hunk model). The `ScrollSyncModel` (Change 7) then drives `self.baseline` to keep the matching row in view. |
-| `navigate_previous_diff_hunk(ctx)` | calls `self.editor().update(...).navigate_previous_diff_hunk` | symmetric to next-hunk: drives `self.modified`'s hunk navigation, scroll-sync drives baseline. |
-| `accept_and_save_diff(ctx)` | no-op (default) | mirrors `InlineDiffView::save_content`: writes `self.modified`'s buffer text via the registered `FileModel` file id. The baseline pane is never written. |
-| `reject_diff(ctx)` | no-op (default) | resets `self.modified`'s buffer to the baseline content, then re-runs `apply_diffs_if_any` (which produces an empty alignment, so both panes show identical content). |
-| `restore_diff_base(ctx)` | returns `Ok(())` (default) | restores `self.modified` to the baseline content (the same path `InlineDiffView::restore_diff_base` would have taken if implemented), then rebuilds the alignment. Returns the same `Result` shape. |
+Side-by-side does not reuse `apply_diffs_if_any`, because that function drives the inline model by mutating the edited editor and rendering removed lines as temp blocks.
 
-In addition to the overrides above, `SideBySideDiffView` exposes pane-aware accessors that callers in Change 9 (Code Review pane) and Change 11 (comments) need:
+The side-by-side pipeline is:
 
-```rust
-impl SideBySideDiffView {
-    pub fn baseline_editor(&self) -> &ViewHandle<CodeEditorView> { &self.baseline }
-    pub fn modified_editor(&self) -> &ViewHandle<CodeEditorView> { &self.modified }
-    pub fn focused_pane(&self) -> Pane { self.focused_pane }
-    pub fn set_focused_pane(&mut self, pane: Pane, ctx: &mut ViewContext<Self>);
-    pub fn alignment(&self) -> &HunkAlignment { &self.alignment }
-}
-```
+1. Parse the unified diff to `DiffHunk[]` using the existing parser. No parser changes are needed.
+2. Build two `PaneBuffer` structs:
+   - `baseline` contains pre-diff lines plus delete decorations.
+   - `modified` contains post-diff lines plus add decorations.
+3. Run hunk alignment over the ordered hunk lines. Each `AlignedRow` maps to a row index in both panes. Gap rows are zero-height in the source buffer but render as full-height empty rows with the appropriate gutter color.
+4. Pass baseline content and delete decorations to the left editor. Pass modified content and add decorations to the right editor.
+5. Apply padding rows from `HunkAlignment` so both panes have the same rendered row count.
 
-These are inherent methods on the concrete type rather than additions to the `DiffViewer` trait, because only side-by-side has two panes. Callers that want both panes pattern-match on the concrete type or hold a `ViewHandle<SideBySideDiffView>` directly. Callers that only need the focused editor stay on the `DiffViewer` trait and get the focused pane via `editor()`. Existing single-pane consumers (`InlineDiffView` and `LocalCodeEditorView`) need no changes; the trait contract is unchanged for them.
+`apply_diffs_if_any` remains reserved for `InlineDiffView`. Side-by-side never renders removed lines as temp blocks in the modified pane, and never loses delete decorations on the baseline pane.
 
-### 5. Editor padding-row API
+### 8. Per-pane interaction state
 
-`CodeEditorView` (`app/src/code/editor/view.rs`) and the underlying model (`app/src/code/editor/model.rs`) gain a new "padding row" concept: a row that takes up vertical space, has a gutter, and renders empty content. The new public API:
+Baseline pane:
+
+- Always `read_only = true`.
+- Supports text selection and copy.
+- Does not consume keyboard edit events.
+- Does not participate in file-backed save.
+
+Modified pane:
+
+- Follows the existing `DisplayMode` rules for the surface.
+- In Code Review, it is read-only with accept/reject actions.
+- In AI block-list `FullPane`, it is editable when the existing inline path would be editable.
+- It is the only pane registered with `FileModel`.
+
+`set_display_mode` on `SideBySideDiffView` applies the mode to the modified pane only. The baseline pane is hard-coded to read-only regardless of display mode so `FullPane` can never make baseline content editable.
+
+### 9. Editor padding-row API
+
+`CodeEditorView` and the underlying model gain a render-only padding-row concept: a row that takes up vertical space, has a gutter, and renders empty content. The public API:
 
 ```rust
 impl CodeEditorView {
@@ -188,159 +238,185 @@ pub struct PaddingRow {
 
 #[derive(Clone, Copy, Debug)]
 pub enum PaddingGutterKind {
-    /// Render the gutter as the diff-add color band, no glyph, no line number.
     AddSide,
-    /// Render the gutter as the diff-delete color band, no glyph, no line number.
     DeleteSide,
 }
 ```
 
-Padding rows are inserted at render time only. They don't affect the underlying buffer, so:
+Padding rows are inserted at render time only. They do not affect the underlying buffer, so save, find, copy, selection, and cursor navigation all see the real file content.
 
-- Save (`FileModel::save`) still writes the unmodified buffer text.
-- Find, copy, selection, and cursor navigation all see the buffer as-is. Padding rows never become part of a selection.
-- Hunk navigation (`navigate_next_diff_hunk`, `navigate_previous_diff_hunk` on the trait) operates on actual diff hunks, not padding rows.
-
-Implementation lives in `app/src/code/editor/model.rs` next to the existing line-iteration code; the renderer in `app/src/code/editor/view.rs` consults the padding-row table when laying out lines and inserts a fixed-height empty row at each padding position.
-
-This is the minimal addition that lets the right pane render blanks where the left pane has a deleted line, and vice versa, without diverging the buffer model from the file content.
-
-### 6. `HunkAlignment`
+### 10. Hunk alignment
 
 Add `app/src/code/hunk_alignment.rs`:
 
 ```rust
+pub struct DiffHunk {
+    pub header: UnifiedDiffHeader,
+    pub lines: Vec<DiffLine>,
+}
+
+pub enum DiffLine {
+    Context(String),
+    Add(String),
+    Delete(String),
+}
+
+pub struct AlignedHunk {
+    pub rows: Vec<AlignedRow>,
+}
+
+pub struct AlignedRow {
+    pub left: PaneLine,
+    pub right: PaneLine,
+}
+
+pub enum PaneLine {
+    Line { buffer_line: usize, text: String },
+    Gap,
+}
+
 pub struct HunkAlignment {
-    /// Padding rows for the baseline pane.
     pub baseline_padding: Vec<PaddingRow>,
-    /// Padding rows for the modified pane.
     pub modified_padding: Vec<PaddingRow>,
-    /// Per-row mapping: rendered row index -> (baseline buffer line, modified buffer line).
-    /// `None` on a side means that side renders padding at this row.
     pub row_map: Vec<(Option<usize>, Option<usize>)>,
 }
 
 impl HunkAlignment {
-    pub fn from_unified_diff(
-        baseline_lines: &[String],
-        modified_lines: &[String],
-        hunks: &[UnifiedDiffHeader],
-    ) -> Self;
+    pub fn from_diff_hunks(hunks: &[DiffHunk]) -> Self;
 }
 ```
 
-The algorithm walks unified-diff hunks (parsed by `app/src/code_review/comments/diff_hunk_parser.rs::build_line_result`) and **pairs deleted lines with added lines on shared rows** so a modification renders as one row across both panes. This satisfies product invariant 3.
+The existing parsed-line enum upstream already contains ordered context/add/delete records. The aligner consumes `&[DiffHunk]`; existing inline-diff paths may keep using only the header data they already need.
 
-For each hunk, the algorithm runs in two phases:
+The v1 algorithm is single-pass and pairs collapsed delete/add runs before emitting gap rows:
 
-**Phase 1: Group consecutive deletes and adds.** Walk the hunk's lines linearly. Buffer consecutive `Delete` lines into a `pending_deletes: Vec<usize>` (indices into the baseline file). When the run of `Delete`s ends and the next line is `Add`, buffer consecutive `Add` lines into a `pending_adds: Vec<usize>` (indices into the modified file). When either the run of `Add`s ends or a `Context`/`HunkHeader` boundary is hit, emit the pair (Phase 2). `Context` and `HunkHeader` lines outside any pending run flush as themselves: a `Context` line emits `(Some(b), Some(m))` and advances both indices; `HunkHeader` is consumed by the parser and contributes nothing to the row map.
+```text
+for hunk in hunks:
+    pending_deletes = []
+    pending_adds = []
 
-**Phase 2: Emit a paired-then-padded sequence.** Given `D = pending_deletes.len()` and `A = pending_adds.len()`:
-- For `i in 0..min(D, A)`: emit `(Some(pending_deletes[i]), Some(pending_adds[i]))`. This is the shared-row case from product invariant 3, the case that satisfies the primary side-by-side requirement.
-- If `D > A`: for the remaining `D - A` deleted lines, emit `(Some(pending_deletes[i]), None)` rows and append matching `PaddingRow { gutter_kind: AddSide, line_index: <modified_pane_row>, count: 1 }` entries to `modified_padding` so the right pane keeps its row count aligned.
-- If `A > D`: symmetric. Emit `(None, Some(pending_adds[i]))` rows for the unpaired suffix and append `PaddingRow { gutter_kind: DeleteSide, ... }` entries to `baseline_padding`.
+    for line in hunk.lines:
+        if line is Context:
+            flush_pending_pairs()
+            emit row(left = context, right = context)
 
-When a hunk has only `Delete` lines and no following `Add` (a pure deletion hunk), Phase 2 emits all `D` rows as `(Some(b), None)` with matching padding; this is the `D > 0, A == 0` branch of the same code path. When a hunk has only `Add` lines and no preceding `Delete` (a pure addition hunk), Phase 2 emits all `A` rows as `(None, Some(m))` with matching padding; this is the `D == 0, A > 0` branch.
+        if line is Delete:
+            if pending_adds is not empty:
+                flush_pending_pairs()
+            pending_deletes.push(line)
+
+        if line is Add:
+            pending_adds.push(line)
+
+    flush_pending_pairs()
+
+flush_pending_pairs():
+    pair_count = min(pending_deletes.len, pending_adds.len)
+    emit pair_count rows with left delete and right add
+    emit remaining deletes with right Gap
+    emit remaining adds with left Gap
+    clear pending_deletes and pending_adds
+```
+
+Example:
+
+```text
+Input hunk lines:
+Context("fn old() {")
+Delete("    a();")
+Delete("    b();")
+Add("    c();")
+Add("    d();")
+Context("}")
+
+Aligned rows:
+1. left Context("fn old() {") | right Context("fn old() {")
+2. left Delete("    a();")    | right Add("    c();")
+3. left Delete("    b();")    | right Add("    d();")
+4. left Context("}")          | right Context("}")
+```
 
 Edge cases:
-- A `Delete` immediately followed by `Context` immediately followed by `Add` is two separate runs (deletes flushed at the `Context` boundary; adds run alone). They render as a pure deletion followed by a context line followed by a pure addition. This matches GitHub and GitLab's behavior, which only pair adjacent delete/add runs.
-- A `Delete` of N lines followed by an `Add` of M lines where the lines have unrelated content still pairs them by index. Word-level diff highlighting on a pair is out of scope (see product Non-goals); the spec's contract is positional pairing only. The renderer shows the deleted line's full content on the left and the added line's full content on the right, which is identical to GitHub and GitLab side-by-side review.
-- An empty hunk (parser returns no rows) emits nothing; alignment for that hunk is empty.
 
-`row_map` is consulted by the scroll-sync model in Change 7. `modified_padding` and `baseline_padding` are passed to `CodeEditorView::set_padding_rows` (Change 5) on the respective editors.
+- Pure insertion blocks produce rows with left `Gap` and right `Add`; the baseline pane receives delete-side padding rows.
+- Pure deletion blocks produce rows with left `Delete` and right `Gap`; the modified pane receives add-side padding rows.
+- A `Context` inside a modification resets the pairing window. Deletes before the context are flushed before adds after the context are considered.
+- A delete run followed by an add run with unrelated text still pairs by position. Word-level highlighting is out of scope; v1 guarantees row alignment.
 
-### 7. `ScrollSyncModel`
+### 11. Scroll sync model
 
 Add `app/src/code/scroll_sync.rs`:
 
 ```rust
+pub enum ScrollSource {
+    User,
+    Mirrored { from: PaneId, sync_id: u64 },
+}
+
 pub struct ScrollSyncModel {
-    /// Currently focused pane for cursor moves.
-    focused_pane: Pane,
+    focused_pane: PaneId,
+    next_sync_id: u64,
 }
 
 impl ScrollSyncModel {
-    /// Translate a wheel delta on `from` into matching scroll deltas for both panes.
-    pub fn on_scroll_wheel(&self, from: Pane, delta_y: f32) -> (f32, f32);
+    pub fn on_scroll_wheel(&mut self, from: PaneId, delta_y: f32) -> MirroredScroll;
 
-    /// Translate a cursor move on `from` (new buffer line in that pane) into the
-    /// corresponding row on the other pane via `row_map`.
     pub fn corresponding_row(
         &self,
-        from: Pane,
+        from: PaneId,
         new_buffer_line: usize,
         alignment: &HunkAlignment,
     ) -> Option<usize>;
 }
 ```
 
-Wheel events on either pane drive both panes by the same row-delta. Cursor moves only move the cursor on the focused pane; the other pane scrolls to keep `corresponding_row` in view but does not move its own cursor. Builds on the existing scroll-preservation patterns in `app/src/code_review/scroll_preservation.rs`.
+Every mirrored scroll carries a `ScrollSource::Mirrored { from, sync_id }` token. The receiving editor's scroll-event handler checks the token. If the token is `Mirrored`, the handler consumes the event and does not re-emit a cross-pane scroll. Only `ScrollSource::User` triggers cross-pane sync.
 
-`SideBySideDiffView::new` subscribes to `CodeEditorEvent::ScrolledByUser` (existing event from `app/src/code/editor/view.rs`) on both editors and mirrors the resulting deltas through the model.
+Invariant: `Mirrored -> Mirrored` events are dropped at the second subscriber, which breaks feedback loops and prevents scroll jitter.
 
-### 8. Layout selection in the View Options menu
+Wheel events on either pane drive both panes by the same row delta. Cursor moves only move the cursor on the focused pane; the other pane scrolls to keep `corresponding_row` in view but does not move its own cursor.
 
-Extend `app/src/code_review/diff_menu.rs::CodeReviewDiffMenu`:
+### 12. Code Review pane integration
 
-- Add a `MenuRowKind` enum (`DiffTargetRow(DiffTarget)` for today's behavior, `LayoutRow(DiffLayout)` for the new rows). Replace `targets: Vec<DiffTarget>` (line 99) with `rows: Vec<MenuRow>`. The `filtered: Vec<(usize, Option<FuzzyMatchResult>)>` shape is unchanged.
-- When the `SideBySideDiffLayout` feature flag is on, the menu builder appends two `LayoutRow` entries ("Inline" and "Side-by-Side") below the existing diff-target rows, separated by a divider row.
-- `CodeReviewDiffMenuEvent` (line 47) gains a `SelectLayout(DiffLayout)` variant. When the menu emits it, the parent (`code_review_view`) writes the new layout to `code.editor.diff_layout` via the settings store and refreshes the visible diff.
+`app/src/code_review/code_review_view.rs` is the parent that holds per-file `InlineDiffView` instances today. The integration:
 
-For the AI block-list, the equivalent menu lives in `app/src/ai/blocklist/inline_action/code_diff_view.rs`. The same two-row group is appended to that menu's overflow with the same handler pattern.
+- On view construction, compute the effective layout. If `SideBySideDiffLayout` is off, use `Inline`. If it is on, read `code.editor.diff_layout`.
+- Build `SideBySideDiffView` for each file when the effective layout is `SideBySide`; otherwise build `InlineDiffView`.
+- Subscribe to setting updates. When `code.editor.diff_layout` changes, swap the per-file view with the same diff data and preserve scroll position via `app/src/code_review/scroll_preservation.rs`.
+- Find-in-diff gains a `PaneId`-aware iterator that walks both editors when the active diff is side-by-side. Inline returns only the single modified editor.
 
-### 9. Code Review pane integration
+The `code_review_view_integration.rs` and `code_review_view_tests.rs` fixtures gain a `with_layout(DiffLayout)` helper that sets the layout in the test settings store before constructing the view.
 
-`app/src/code_review/code_review_view.rs` (311KB) is the parent that holds per-file `InlineDiffView` instances today. The integration:
+### 13. AI block-list integration
 
-- On view construction, read `code.editor.diff_layout` from the settings store. If `SideBySide` and the feature flag is on, build `SideBySideDiffView` for each file; otherwise build `InlineDiffView` as today.
-- Subscribe to setting updates. When `code.editor.diff_layout` changes, the pane swaps the per-file view: tear down the current `InlineDiffView` / `SideBySideDiffView`, build the matching new one with the same diff data, and preserve scroll position via `app/src/code_review/scroll_preservation.rs`.
-- Find-in-diff (`app/src/code_review/find_model.rs`) gains a `Pane`-aware iterator that walks both editors when the active diff is a `SideBySideDiffView`. The existing find loop becomes `for pane in active_panes()` where `active_panes()` returns `[Modified]` for inline and `[Baseline, Modified]` for side-by-side, in tab order.
+`app/src/ai/blocklist/inline_action/code_diff_view.rs` decides which `DisplayMode` to use per inline-action diff. The integration:
 
-The `code_review_view_integration.rs` and `code_review_view_tests.rs` test fixtures gain a `with_layout(DiffLayout)` helper that sets the layout in the test settings store before constructing the view.
-
-### 10. AI block-list integration
-
-`app/src/ai/blocklist/inline_action/code_diff_view.rs` decides which `DisplayMode` to use per inline-action diff. Today every site constructs `DisplayMode::with_embedded(MAX_EDITOR_HEIGHT)` (line 798) or `DisplayMode::with_inline_banner(INLINE_EDITOR_HEIGHT)` (line 796).
-
-The integration:
-
-- Read `code.editor.diff_layout` at the same place these `DisplayMode` decisions are made.
+- Read the effective layout at the same place these `DisplayMode` decisions are made.
 - For `DiffLayout::Inline`, construct `InlineDiffView` as today.
 - For `DiffLayout::SideBySide`, construct `SideBySideDiffView` with the same `DisplayMode`.
 
-`InlineBanner` mode is a special case explicitly carved out by product invariant 2: the small "Suggested fixes" banner that appears below a command block does not honor the side-by-side setting. When the chosen `DisplayMode` is `InlineBanner { .. }`, the construction site builds an `InlineDiffView` regardless of the stored `code.editor.diff_layout` value. The Layout radio group is also hidden in the View Options menu for the banner (Change 8), so users cannot select side-by-side for that surface in the first place. Every other AI block-list construction site (the `DisplayMode::with_embedded(MAX_EDITOR_HEIGHT)` path at line 798 and the `DisplayMode::FullPane` paths at lines 1311, 2026, 2065, 2170, 2204, 2206) honors the setting.
+`InlineBanner` currently uses `InlineDiffView`; under side-by-side mode it switches to `SideBySideDiffView` constrained to the banner's viewport, typically a single-hunk diff. Banner sizing follows the side-by-side pane heights with the existing collapse/expand affordances.
 
-### 11. Comment threads
+### 14. Comment threads
 
-`app/src/code_review/comments/` (8 files, 100KB+ total) anchors comment threads on `EditorLineLocation` (`app/src/code/editor/line.rs::EditorLineLocation`). Comments stay attached to those locations and render under the targeted line. The integration:
+`app/src/code_review/comments/` anchors comment threads on `EditorLineLocation`. Comments stay attached to those locations and render under the targeted line. The integration:
 
-- The renderer for a side-by-side row checks each comment's pane (the original side it was authored against, captured from `CommentSide` in `app/src/ai/agent/action.rs`) and renders the thread under the matching pane's row.
-- The opposite pane shows a small marker glyph in its gutter at the same row to indicate that the other side has a thread there. The marker is non-interactive in this spec (clicking it does not focus the comment); a follow-up spec can wire that.
+- The renderer for a side-by-side row checks each comment's pane, captured from `CommentSide` in `app/src/ai/agent/action.rs`, and renders the thread under the matching pane's row.
+- The opposite pane shows a small marker glyph in its gutter at the same row to indicate that the other side has a thread there. The marker is non-interactive in this spec.
 - Multi-line comment ranges that span both deleted and added regions stay on the side they were authored against.
 
-### 12. Telemetry
+### 15. Telemetry
 
-Add a `CodeReviewTelemetryEvent::DiffLayoutChanged { from: DiffLayout, to: DiffLayout, surface: TelemetrySurface }` variant in `app/src/code_review/telemetry_event.rs`. The `surface` enum distinguishes Code Review vs AI block-list. `code_review_view` and the AI inline-action diff host emit the event when the menu emits `SelectLayout`.
+Add a `CodeReviewTelemetryEvent::DiffLayoutChanged { from: DiffLayout, to: DiffLayout, surface: TelemetrySurface }` variant in `app/src/code_review/telemetry_event.rs`. The `surface` enum distinguishes Code Review, AI block-list, inline banner, and Settings. `settings_view/code_page.rs`, `code_review_view`, and the AI inline-action diff host emit the event when the setting changes and the visible surface refreshes.
 
-### 13. Settings UI
+### 16. Accessibility
 
-`code.editor.diff_layout` is reachable from both:
-- The View Options menu in the diff toolbar (the primary path; product invariant 6).
-- The Settings pane under Code (product invariant 13's "without opening a diff" path).
+Side-by-side adds the following accessibility requirements:
 
-The Settings pane integration is **not free** from declaring the setting in Change 2. The settings page is composed of explicit widget objects in `app/src/settings_view/code_page.rs` (2462 lines). Toggle settings have widgets such as `ProjectExplorerToggleWidget` (line 2382-2462), `CodeReviewPanelToggleWidget` (line 2301), and `GlobalSearchToggleWidget`, each of which `impl SettingsWidget`. These widgets are registered in the page's section list (lines 307-310 and 382-385). The new layout setting needs the same shape:
-
-1. **New widget**: add a `DiffLayoutSelectWidget` (or `DiffLayoutRadioWidget`) struct alongside the existing toggle widgets in `app/src/settings_view/code_page.rs`. Because `code.editor.diff_layout` is enum-valued (not bool-valued), the widget cannot reuse the toggle pattern; it uses the existing radio/segmented-control primitive in `warpui::ui_components` (the same primitive used by other enum settings; reference: `app/src/ui_components/tab_selector.rs` and the appearance theme picker in `app/src/settings_view/appearance_page.rs`). The widget reads and writes `CodeSettings::DiffLayout` via `ToggleableSetting`-style helpers and emits the appropriate telemetry on change.
-
-2. **Widget registration**: add `Box::new(DiffLayoutSelectWidget::default())` to the section's widget list near `Box::new(ProjectExplorerToggleWidget::default())` at line 309 and the matching section at line 384. The widget appears under the "Code Review" section.
-
-3. **Feature flag gating**: wrap the widget registration in `if FeatureFlag::SideBySideDiffLayout.is_enabled()` (or the equivalent `cfg`-gated registration pattern) so the widget is hidden while the flag is off. The setting key still exists in `CodeSettings`, but no UI surface exposes it.
-
-4. **Page meta**: confirm that the existing `SettingsPageMeta` for the Code page covers the new widget for search and keyboard navigation. No changes expected here because the widget participates in the page's standard section iteration.
-
-Without this widget, declaring the setting in `CodeSettings` only makes it readable from `settings.toml` and via the View Options menu; the Settings page itself shows nothing. Both invariant 13 in product.md and the user-facing claim that the setting is "reachable from the Settings pane" depend on this change landing alongside Change 2.
-
-Both surfaces (View Options menu and Settings widget) write to the same setting key, so changes propagate through the existing settings subscription.
+- VoiceOver: each pane is its own scrollable region with an accessible label: "Original" for baseline and "Modified" for the post-diff pane.
+- Aligned rows announce as a single logical row when read together: "Original: <text>; Modified: <text>".
+- Keyboard navigation: `Tab` moves focus across panes; `Cmd+Option+Left/Right` cycles between panes; `Cmd+Option+Up/Down` jumps hunk-by-hunk in lockstep.
+- Color contrast: gap-row backgrounds use a dedicated theme token, `diff.gap.background`, that meets 3:1 contrast against the editor background in both light and dark themes.
 
 ## Test plan
 
@@ -348,30 +424,38 @@ Both surfaces (View Options menu and Settings widget) write to the same setting 
 
 - `app/src/code/hunk_alignment_tests.rs`:
   - Empty diff: row_map is `[(Some(0), Some(0)), ...]` for every line, no padding.
-  - Pure addition: rows for the added section are `(None, Some(m))`; baseline_padding has the matching count.
-  - Pure deletion: rows for the deleted section are `(Some(b), None)`; modified_padding has the matching count.
-  - Modification: deleted line and added line both produce rows; both pads are emitted.
+  - Pure addition: rows for the added section are `(None, Some(m))`; baseline padding has the matching count.
+  - Pure deletion: rows for the deleted section are `(Some(b), None)`; modified padding has the matching count.
+  - Collapsed modification: `Context Delete Delete Add Add Context` produces four aligned rows: one context row, two paired modification rows, and one context row.
+  - Context inside a delete/add sequence resets the pairing window.
   - Multi-hunk file: alignment composes correctly across hunks separated by unchanged context.
   - Large diff (5,000 lines, 200 hunks): completes in under 50ms.
 
 - `app/src/code/scroll_sync_tests.rs`:
   - Wheel delta on baseline drives both panes equally.
   - Cursor move on modified scrolls baseline to the corresponding row.
-  - Cursor on a `(None, Some(m))` row (pure-add): baseline scrolls to the next surrounding context line.
+  - Cursor on a `(None, Some(m))` row (pure add) scrolls baseline to the next surrounding context line.
+  - A `ScrollSource::Mirrored { from, sync_id }` event is consumed without re-emitting.
+  - A mirrored event cannot trigger a second mirrored event.
 
 - `app/src/code/side_by_side_diff_tests.rs`:
-  - `apply_diffs_if_any` for `DiffType::Update`: both editors hold expected content; alignment is non-empty.
-  - `apply_diffs_if_any` for `DiffType::Create`: baseline editor is empty with a header; modified holds the new file content.
-  - `apply_diffs_if_any` for `DiffType::Delete`: modified editor is empty; baseline holds the original content.
+  - Pane content for `DiffType::Update`: baseline holds pre-diff content with delete decorations; modified holds post-diff content with add decorations.
+  - Pane content for `DiffType::Create`: baseline editor is empty with padding; modified holds the new file content.
+  - Pane content for `DiffType::Delete`: modified editor is empty with padding; baseline holds the original content.
   - `register_file` registers only the modified editor with `FileModel`; the baseline editor remains read-only.
-  - `set_display_mode` propagates to both editors (assert via the existing `set_*` calls captured by the test fixture).
+  - `set_display_mode` affects the modified pane only; baseline remains read-only.
   - `accept_and_save_diff` writes the modified editor's buffer text via `FileModel`, identical to `InlineDiffView`'s save path.
-  - `reject_diff` discards the modification; subsequent `apply_diffs_if_any` of the same diff produces an empty alignment.
+  - `reject_diff` discards the modification and rebuilds the side-by-side view with identical panes.
   - Layout switch from `Inline` to `SideBySide` and back preserves scroll position to within one row.
 
 ### Integration tests
 
-- `app/src/code_review/code_review_view_tests.rs` gains tests using the new `with_layout(DiffLayout)` helper:
+- `app/src/settings_view/code_page_tests.rs`:
+  - The Code page renders `DiffLayoutWidget` when `SideBySideDiffLayout` is enabled.
+  - The widget is hidden when the runtime flag is disabled.
+  - Selecting "Side by side" writes `code.editor.diff_layout = "side_by_side"`.
+
+- `app/src/code_review/code_review_view_tests.rs`:
   - Single-file diff in side-by-side renders both panes.
   - Multi-file diff: each file's view honors the same layout.
   - Setting flip while open swaps every visible file's view from `InlineDiffView` to `SideBySideDiffView` and preserves scroll.
@@ -379,33 +463,45 @@ Both surfaces (View Options menu and Settings widget) write to the same setting 
   - Hunk navigation (`f` / `F`) advances the focused hunk on both panes simultaneously.
   - Comment thread on a baseline-side line renders under the baseline pane's row; modified pane shows the gutter marker.
 
+- `app/src/ai/blocklist/inline_action/code_diff_view_tests.rs`:
+  - Embedded AI diffs honor `SideBySide`.
+  - `InlineBanner` diffs honor `SideBySide` and constrain the view to banner height.
+
+### Accessibility validation
+
+- Snapshot tests assert the accessible labels "Original" and "Modified" for side-by-side panes.
+- Keyboard tests cover `Tab`, `Cmd+Option+Left/Right`, and `Cmd+Option+Up/Down`.
+- Theme tests assert `diff.gap.background` meets 3:1 contrast against editor backgrounds in light and dark themes.
+- Manual screen-reader smoke test on macOS VoiceOver reads a paired modification row as one logical original/modified row.
+
 ### Manual smoke test
 
 - macOS, M1 MacBook Air, dogfood build with `SideBySideDiffLayout` enabled:
-  - Open Code Review with a 200-file diff. Toggle layout. Confirm the toggle takes effect within 200ms on the active diff.
-  - Scroll wheel on each pane. Confirm both panes scroll together.
+  - Open Settings -> Code. Change "Diff layout" from "Inline" to "Side by side" and confirm the visible diff refreshes within 200ms.
+  - Open Code Review with a 200-file diff. Confirm the active diff renders in two panes.
+  - Scroll wheel on each pane. Confirm both panes scroll together without jitter.
   - Drag-select on each pane. Confirm the selection stays in that pane.
   - Cmd-A on each pane. Confirm only that pane's content is selected.
   - Resize the window narrow enough that side-by-side is cramped. Confirm horizontal scrollbars on each pane behave independently and the divider stays at 50%.
-  - Open an AI block-list diff with a recent agent edit. Toggle layout. Confirm the embedded diff swaps from one column to two and back.
-  - Linux (Ubuntu 24.04), Windows 11: repeat the toggle smoke test on each platform to confirm rendering and keybindings.
+  - Open an AI block-list embedded diff and an inline banner diff. Confirm both honor the chosen layout.
+  - Linux (Ubuntu 24.04), Windows 11: repeat the settings toggle smoke test on each platform to confirm rendering and keybindings.
 
 ### Compile-parity checklist
 
-Every site that destructures `DisplayMode` in a `match` must compile after the change. The current call sites (from `grep -rn "DisplayMode::\(FullPane\|Embedded\|InlineBanner\)"`):
+Every site that destructures `DisplayMode` in a `match` must compile after the change. The current call sites include:
 
-- `app/src/code/diff_viewer.rs:45,46,47,53,62,71,72,73,82,83,84,89,94,100,104,108`: trait helpers; unchanged because `DiffLayout` is a new orthogonal axis.
-- `app/src/ai/blocklist/inline_action/code_diff_view.rs:796,798,1248,1258,1311,2026,2065,2170,2204,2206`: `DisplayMode` construction and matching; unchanged.
-- `app/src/ai/blocklist/block/view_impl/output.rs:2061`: match on `DisplayMode::FullPane`; unchanged.
+- `app/src/code/diff_viewer.rs`: trait helpers; unchanged because `DiffLayout` is a new orthogonal axis.
+- `app/src/ai/blocklist/inline_action/code_diff_view.rs`: `DisplayMode` construction and matching; now layout-aware at construction.
+- `app/src/ai/blocklist/block/view_impl/output.rs`: match on `DisplayMode::FullPane`; unchanged.
 
-Every site that constructs `InlineDiffView` (per `grep -rn "InlineDiffView::new"`) is the candidate set for layout-aware view construction. The list is verified during implementation; the integration in Change 9 and Change 10 covers the two parent surfaces.
+Every site that constructs `InlineDiffView` is a candidate for layout-aware view construction. Code Review and AI block-list integration cover the two parent surfaces.
 
 ## Open questions
 
-1. Comment thread interaction with the opposite-pane gutter marker (Change 11) is non-interactive in this spec. Whether the marker should be clickable (focuses the comment in the other pane) is a UX call for the Code Review SME and a candidate follow-up.
-2. The radio/segmented-control primitive used by the Settings widget (Change 13) needs SME confirmation. The current spec references `tab_selector` and the appearance theme picker as precedents; the actual primitive name and import path should be confirmed during implementation review.
-3. Resizable panel split (a draggable divider that lets the user shift the 50/50 split) is out of scope for the first ship per product Non-goals. Whether to revisit this in a follow-up depends on telemetry and user feedback after the initial release.
+1. Comment thread interaction with the opposite-pane gutter marker (Change 14) is non-interactive in this spec. Whether the marker should be clickable is a UX call for the Code Review SME and a candidate follow-up.
+2. The segmented-control primitive used by `DiffLayoutWidget` needs SME confirmation. The current spec references `app/src/ui_components/tab_selector.rs` and the appearance theme picker as precedents; the actual primitive name and import path should be confirmed during implementation review.
+3. Resizable panel split is out of scope for the first ship per product Non-goals. Whether to revisit this later depends on telemetry and user feedback after the initial release.
 
 ## Revision notes
 
-- v2 (this revision): replaced the two-row delete/add algorithm in Change 6 with a paired-row algorithm so a modification renders on a shared row across panes (resolves Oz CRITICAL on tech.md line 207, aligns with product invariant 3). Replaced the unused `app/src/features/` reference in Change 3 with the real wiring across `crates/warp_features/src/lib.rs`, `app/src/lib.rs:2680-2740`, and the workspace `Cargo.toml` features block. Replaced the `DiffViewer`-via-`MultiPaneDiffViewer` proposal in Change 4 with an explicit per-method override table for `SideBySideDiffView`, naming the side-by-side semantics for every existing trait method. Lifted the `InlineBanner` fallback in Change 10 from a tech-only deferral to an explicit product-spec exception (product invariant 2). Added a Settings widget integration section to Change 13 covering the new widget, the radio primitive, registration in `app/src/settings_view/code_page.rs:307-310`, and feature-flag gating.
+- v3 (this revision): pivoted the layout control from a diff-local menu to Settings -> Code, added explicit `DiffLayoutWidget` rendering in `app/src/settings_view/code_page.rs`, removed the InlineBanner exception, made collapsed delete/add pairing the v1 hunk-alignment algorithm, replaced single-editor assumptions with `PaneAwareDiffViewer`, documented pane content construction and read-only baseline state, added mirrored-scroll suppression tokens, and added accessibility implementation and validation requirements.

--- a/specs/GH7043/tech.md
+++ b/specs/GH7043/tech.md
@@ -16,7 +16,7 @@ The diff rendering surface is shared by two consumers: the AI block-list inline 
 - `app/src/code_review/code_review_view.rs` (311KB) hosts the diff per file and renders into the pane. It's the consumer that subscribes to setting changes and rebuilds visible diffs on layout change.
 - `app/src/ai/blocklist/inline_action/code_diff_view.rs` (where `DisplayMode::FullPane`, `Embedded`, `InlineBanner` are constructed at lines 796, 798, 1248, 1258, 1311, 2026, 2065, 2170, 2204, 2206) is the AI block-list inline-action diff host that wraps `InlineDiffView` and decides which `DisplayMode` to use.
 - `app/src/settings/code.rs` (63 lines) is the settings group for `code.*`. Settings are declared via the `define_settings_group!` macro with `toml_path`, `default`, `supported_platforms`, and `sync_to_cloud` fields. Existing entries set the pattern for the new `diff_layout` setting.
-- `app/src/features/` defines `FeatureFlag` variants (referenced from `app/src/code_review/diff_state.rs:28`). The new `SideBySideDiffLayout` flag declares here.
+- `crates/warp_features/src/lib.rs` defines the `FeatureFlag` enum (line 8 onward) and the per-flag changelog descriptions (`description_for_changelog` match arms around line 1000-1024). `app/src/features.rs` is a one-line re-export (`pub use warp_core::features::*;`). Cargo features are registered for each flag in `app/src/lib.rs:2680-2740` via `#[cfg(feature = "...")]` guards on each `FeatureFlag::Variant` entry. The matching Cargo feature names are declared in the workspace `Cargo.toml` (and per-crate `Cargo.toml` files) under `[features]`. The new `SideBySideDiffLayout` flag is declared in all three places: the enum, the changelog match, and the cfg-gated registration block (with a matching `side_by_side_diff_layout` Cargo feature).
 - `app/src/code_review/scroll_preservation.rs` (8KB) holds scroll preservation helpers that the side-by-side scroll-sync model can build on.
 - `app/src/code_review/comments/diff_hunk_parser.rs` (181 lines) parses hunks into per-line records (`build_line_result`, lines 47-90). The hunk-alignment model for side-by-side reuses this parser; no new parser is introduced.
 - `app/src/code_review/comments/comment.rs` and `comment_list_view.rs` (48KB) own comment rendering. Comment placement gains a per-pane gutter marker; the existing thread placement logic is unchanged because comments are still anchored on `EditorLineLocation`.
@@ -77,12 +77,32 @@ The setting type system already supports enums via `serde`, matching how other s
 
 ### 3. Add the `SideBySideDiffLayout` feature flag
 
-Add `SideBySideDiffLayout` to the `FeatureFlag` enum in `app/src/features/`. The flag defaults to off in shipping builds and on in dogfood builds. The flag is consulted in two places:
+The flag is wired in three concrete locations:
 
-- `app/src/code_review/diff_menu.rs` to decide whether to show the Layout radio group rows.
-- `app/src/code/inline_diff.rs::InlineDiffView::new` and the Code Review pane's per-diff construction site to decide whether to read the setting at all (when off, layout is hard-coded to `Inline`).
+1. **Enum variant** in `crates/warp_features/src/lib.rs::FeatureFlag` (the canonical `pub enum FeatureFlag` at line 8). Add `SideBySideDiffLayout,` alongside existing variants such as `CodeReviewFind` (line 471), `BlocklistMarkdownImages`, and `EmbeddedCodeReviewComments`. `app/src/features.rs` is a one-line re-export, so the flag becomes available as `crate::features::FeatureFlag::SideBySideDiffLayout` automatically.
 
-Once the feature stabilizes, the flag is removed in a follow-up PR. The setting and the menu rows persist.
+2. **Cargo feature mapping**:
+   - In the workspace `Cargo.toml` (and the relevant per-crate `Cargo.toml` files; reference: how `code_review_find = []` is declared today): add `side_by_side_diff_layout = []`.
+   - Add the matching cfg-gated registration entry in `app/src/lib.rs` between lines 2680-2740, alongside other `#[cfg(feature = "...")] FeatureFlag::Variant,` lines. Pattern (matching the existing block):
+     ```rust
+     #[cfg(feature = "side_by_side_diff_layout")]
+     FeatureFlag::SideBySideDiffLayout,
+     ```
+   - Add the dogfood/preview enablement to the `PREVIEW_FLAGS` registration so dogfood builds default the flag on, matching how `CodeReviewFind` is enabled in preview today.
+
+3. **Changelog description** in `crates/warp_features/src/lib.rs` inside the `description_for_changelog` match arms (lines 1004-1024 today):
+   ```rust
+   SideBySideDiffLayout => Some("Enables a side-by-side diff layout in the code review pane and AI block-list diffs."),
+   ```
+
+The flag is consulted at three runtime sites:
+- `app/src/code_review/diff_menu.rs` decides whether to render the Layout radio rows.
+- `app/src/code_review/code_review_view.rs` decides whether to read `code.editor.diff_layout` at per-file construction (when off, layout is hard-coded to `Inline` regardless of stored value).
+- `app/src/ai/blocklist/inline_action/code_diff_view.rs` decides the same for embedded AI block-list diffs.
+
+The Settings page widget (Change 13) is also gated on the flag so the radio group disappears from Settings while the flag is off.
+
+Once the feature stabilizes, the flag and its Cargo feature are removed in a follow-up PR. The setting and the menu rows persist as the user-facing control.
 
 ### 4. Build `SideBySideDiffView`
 
@@ -121,23 +141,34 @@ Key methods:
 - `apply_diffs_if_any(ctx)` mirrors `InlineDiffView::apply_diffs_if_any` (`app/src/code/inline_diff.rs:196-228`). For `DiffType::Update`, both editors get content; for `DiffType::Create` the baseline pane shows an empty file with a "(new file)" header line; for `DiffType::Delete` the modified pane shows an empty file with "(deleted)".
 - `set_display_mode(mode, ctx)` calls the existing `DiffViewer::set_display_mode` body once per editor.
 
-Implement `DiffViewer` for `SideBySideDiffView` so that `editor()` returns the focused pane's editor and the trait's existing methods work without changes. Add new trait methods on a separate `MultiPaneDiffViewer` trait (defaulted on `DiffViewer`) for callers that need both panes:
+Implement `DiffViewer` for `SideBySideDiffView`, but **override every method that has a meaningful per-pane interpretation** so that the trait's existing call sites keep working correctly. Returning the focused editor from `editor()` is fine as a fallback for callers that need a single editor handle (search, find, focus management), but it must not be the default for hunk navigation, accept, save, or `changed_lines`. Each override is listed below with the method's role and the side-by-side semantics.
+
+| Trait method (existing) | Default body in `diff_viewer.rs:110-160` | `SideBySideDiffView` override |
+|---|---|---|
+| `editor()` | returns single `&ViewHandle<CodeEditorView>` | returns the focused pane's editor (`Modified` by default; `Baseline` when the user has tabbed into the left pane). Used only by callers that genuinely want the focused editor (search, focus, find). |
+| `diff()` | returns `Option<&DiffType>` | returns `self.diff_type.as_ref()`. Same as `InlineDiffView`. |
+| `was_edited()` | returns `false` | returns `self.was_edited`, which tracks edits to the modified pane only. The baseline pane is always read-only, so it cannot have been edited. |
+| `changed_lines(ctx)` | calls `self.editor().as_ref(ctx).changed_lines(ctx)` | calls `self.modified.as_ref(ctx).changed_lines(ctx)`. The baseline pane has no diff applied and would always return empty. |
+| `set_display_mode(mode, ctx)` | applies the mode to a single editor | calls the existing single-editor body once for `self.baseline` and once for `self.modified`, so both editors get the correct `scroll_wheel_behavior`, `vertical_expansion_behavior`, scrollbar appearance, interaction state, and nav-bar settings. |
+| `navigate_next_diff_hunk(ctx)` | calls `self.editor().update(...).navigate_next_diff_hunk` | calls `navigate_next_diff_hunk` on `self.modified` (which owns the hunk model). The `ScrollSyncModel` (Change 7) then drives `self.baseline` to keep the matching row in view. |
+| `navigate_previous_diff_hunk(ctx)` | calls `self.editor().update(...).navigate_previous_diff_hunk` | symmetric to next-hunk: drives `self.modified`'s hunk navigation, scroll-sync drives baseline. |
+| `accept_and_save_diff(ctx)` | no-op (default) | mirrors `InlineDiffView::save_content`: writes `self.modified`'s buffer text via the registered `FileModel` file id. The baseline pane is never written. |
+| `reject_diff(ctx)` | no-op (default) | resets `self.modified`'s buffer to the baseline content, then re-runs `apply_diffs_if_any` (which produces an empty alignment, so both panes show identical content). |
+| `restore_diff_base(ctx)` | returns `Ok(())` (default) | restores `self.modified` to the baseline content (the same path `InlineDiffView::restore_diff_base` would have taken if implemented), then rebuilds the alignment. Returns the same `Result` shape. |
+
+In addition to the overrides above, `SideBySideDiffView` exposes pane-aware accessors that callers in Change 9 (Code Review pane) and Change 11 (comments) need:
 
 ```rust
-pub trait MultiPaneDiffViewer: DiffViewer {
-    fn baseline_editor(&self) -> &ViewHandle<CodeEditorView> {
-        self.editor()
-    }
-    fn modified_editor(&self) -> &ViewHandle<CodeEditorView> {
-        self.editor()
-    }
-    fn focused_pane(&self) -> Option<Pane> {
-        None
-    }
+impl SideBySideDiffView {
+    pub fn baseline_editor(&self) -> &ViewHandle<CodeEditorView> { &self.baseline }
+    pub fn modified_editor(&self) -> &ViewHandle<CodeEditorView> { &self.modified }
+    pub fn focused_pane(&self) -> Pane { self.focused_pane }
+    pub fn set_focused_pane(&mut self, pane: Pane, ctx: &mut ViewContext<Self>);
+    pub fn alignment(&self) -> &HunkAlignment { &self.alignment }
 }
 ```
 
-The default implementation delegates everything to `editor()`, so existing single-pane consumers (`InlineDiffView` and `LocalCodeEditorView`) need no changes. `SideBySideDiffView` overrides all three.
+These are inherent methods on the concrete type rather than additions to the `DiffViewer` trait, because only side-by-side has two panes. Callers that want both panes pattern-match on the concrete type or hold a `ViewHandle<SideBySideDiffView>` directly. Callers that only need the focused editor stay on the `DiffViewer` trait and get the focused pane via `editor()`. Existing single-pane consumers (`InlineDiffView` and `LocalCodeEditorView`) need no changes; the trait contract is unchanged for them.
 
 ### 5. Editor padding-row API
 
@@ -198,15 +229,25 @@ impl HunkAlignment {
 }
 ```
 
-The algorithm walks unified-diff hunks (parsed by `app/src/code_review/comments/diff_hunk_parser.rs::build_line_result`):
+The algorithm walks unified-diff hunks (parsed by `app/src/code_review/comments/diff_hunk_parser.rs::build_line_result`) and **pairs deleted lines with added lines on shared rows** so a modification renders as one row across both panes. This satisfies product invariant 3.
 
-- For each `Context` line: emit a `(Some(b), Some(m))` row, advance both indices.
-- For each `Delete` line: emit a `(Some(b), None)` row, advance baseline only, append a one-line `PaddingRow { gutter_kind: AddSide }` to `modified_padding` at the current modified index.
-- For each `Add` line: emit a `(None, Some(m))` row, advance modified only, append a one-line `PaddingRow { gutter_kind: DeleteSide }` to `baseline_padding` at the current baseline index.
+For each hunk, the algorithm runs in two phases:
 
-Modifications (a `Delete` immediately followed by an `Add`) emit `(Some(b), None)` then `(None, Some(m))` by default. A follow-up optimization (out of scope for this spec) can collapse adjacent delete-add pairs into a single `(Some(b), Some(m))` row to keep modified lines on the same row as the line they replaced. The minimal, correctness-first version above is what ships first; the collapsed version follows once telemetry confirms users prefer it.
+**Phase 1: Group consecutive deletes and adds.** Walk the hunk's lines linearly. Buffer consecutive `Delete` lines into a `pending_deletes: Vec<usize>` (indices into the baseline file). When the run of `Delete`s ends and the next line is `Add`, buffer consecutive `Add` lines into a `pending_adds: Vec<usize>` (indices into the modified file). When either the run of `Add`s ends or a `Context`/`HunkHeader` boundary is hit, emit the pair (Phase 2). `Context` and `HunkHeader` lines outside any pending run flush as themselves: a `Context` line emits `(Some(b), Some(m))` and advances both indices; `HunkHeader` is consumed by the parser and contributes nothing to the row map.
 
-`row_map` is consulted by the scroll-sync model in Change 7.
+**Phase 2: Emit a paired-then-padded sequence.** Given `D = pending_deletes.len()` and `A = pending_adds.len()`:
+- For `i in 0..min(D, A)`: emit `(Some(pending_deletes[i]), Some(pending_adds[i]))`. This is the shared-row case from product invariant 3, the case that satisfies the primary side-by-side requirement.
+- If `D > A`: for the remaining `D - A` deleted lines, emit `(Some(pending_deletes[i]), None)` rows and append matching `PaddingRow { gutter_kind: AddSide, line_index: <modified_pane_row>, count: 1 }` entries to `modified_padding` so the right pane keeps its row count aligned.
+- If `A > D`: symmetric. Emit `(None, Some(pending_adds[i]))` rows for the unpaired suffix and append `PaddingRow { gutter_kind: DeleteSide, ... }` entries to `baseline_padding`.
+
+When a hunk has only `Delete` lines and no following `Add` (a pure deletion hunk), Phase 2 emits all `D` rows as `(Some(b), None)` with matching padding; this is the `D > 0, A == 0` branch of the same code path. When a hunk has only `Add` lines and no preceding `Delete` (a pure addition hunk), Phase 2 emits all `A` rows as `(None, Some(m))` with matching padding; this is the `D == 0, A > 0` branch.
+
+Edge cases:
+- A `Delete` immediately followed by `Context` immediately followed by `Add` is two separate runs (deletes flushed at the `Context` boundary; adds run alone). They render as a pure deletion followed by a context line followed by a pure addition. This matches GitHub and GitLab's behavior, which only pair adjacent delete/add runs.
+- A `Delete` of N lines followed by an `Add` of M lines where the lines have unrelated content still pairs them by index. Word-level diff highlighting on a pair is out of scope (see product Non-goals); the spec's contract is positional pairing only. The renderer shows the deleted line's full content on the left and the added line's full content on the right, which is identical to GitHub and GitLab side-by-side review.
+- An empty hunk (parser returns no rows) emits nothing; alignment for that hunk is empty.
+
+`row_map` is consulted by the scroll-sync model in Change 7. `modified_padding` and `baseline_padding` are passed to `CodeEditorView::set_padding_rows` (Change 5) on the respective editors.
 
 ### 7. `ScrollSyncModel`
 
@@ -267,7 +308,7 @@ The integration:
 - For `DiffLayout::Inline`, construct `InlineDiffView` as today.
 - For `DiffLayout::SideBySide`, construct `SideBySideDiffView` with the same `DisplayMode`.
 
-`InlineBanner` mode is a special case: side-by-side at a small max height shows two cramped columns. For this spec, `SideBySide` falls back to `Inline` when the chosen `DisplayMode` is `InlineBanner { .. }`. The fallback is documented in product invariant 2 implicitly (the spec discusses the embedded and full-pane surfaces) and is called out here so the implementation is unambiguous. A future spec can revisit the `InlineBanner` side-by-side behavior.
+`InlineBanner` mode is a special case explicitly carved out by product invariant 2: the small "Suggested fixes" banner that appears below a command block does not honor the side-by-side setting. When the chosen `DisplayMode` is `InlineBanner { .. }`, the construction site builds an `InlineDiffView` regardless of the stored `code.editor.diff_layout` value. The Layout radio group is also hidden in the View Options menu for the banner (Change 8), so users cannot select side-by-side for that surface in the first place. Every other AI block-list construction site (the `DisplayMode::with_embedded(MAX_EDITOR_HEIGHT)` path at line 798 and the `DisplayMode::FullPane` paths at lines 1311, 2026, 2065, 2170, 2204, 2206) honors the setting.
 
 ### 11. Comment threads
 
@@ -285,9 +326,21 @@ Add a `CodeReviewTelemetryEvent::DiffLayoutChanged { from: DiffLayout, to: DiffL
 
 `code.editor.diff_layout` is reachable from both:
 - The View Options menu in the diff toolbar (the primary path; product invariant 6).
-- The Settings pane under Code, where users can flip it without opening a diff. This follows the existing pattern for settings declared in `app/src/settings/code.rs` (e.g. `show_project_explorer`, line 50).
+- The Settings pane under Code (product invariant 13's "without opening a diff" path).
 
-Both surfaces write to the same setting key, so changes propagate through the existing settings subscription.
+The Settings pane integration is **not free** from declaring the setting in Change 2. The settings page is composed of explicit widget objects in `app/src/settings_view/code_page.rs` (2462 lines). Toggle settings have widgets such as `ProjectExplorerToggleWidget` (line 2382-2462), `CodeReviewPanelToggleWidget` (line 2301), and `GlobalSearchToggleWidget`, each of which `impl SettingsWidget`. These widgets are registered in the page's section list (lines 307-310 and 382-385). The new layout setting needs the same shape:
+
+1. **New widget**: add a `DiffLayoutSelectWidget` (or `DiffLayoutRadioWidget`) struct alongside the existing toggle widgets in `app/src/settings_view/code_page.rs`. Because `code.editor.diff_layout` is enum-valued (not bool-valued), the widget cannot reuse the toggle pattern; it uses the existing radio/segmented-control primitive in `warpui::ui_components` (the same primitive used by other enum settings; reference: `app/src/ui_components/tab_selector.rs` and the appearance theme picker in `app/src/settings_view/appearance_page.rs`). The widget reads and writes `CodeSettings::DiffLayout` via `ToggleableSetting`-style helpers and emits the appropriate telemetry on change.
+
+2. **Widget registration**: add `Box::new(DiffLayoutSelectWidget::default())` to the section's widget list near `Box::new(ProjectExplorerToggleWidget::default())` at line 309 and the matching section at line 384. The widget appears under the "Code Review" section.
+
+3. **Feature flag gating**: wrap the widget registration in `if FeatureFlag::SideBySideDiffLayout.is_enabled()` (or the equivalent `cfg`-gated registration pattern) so the widget is hidden while the flag is off. The setting key still exists in `CodeSettings`, but no UI surface exposes it.
+
+4. **Page meta**: confirm that the existing `SettingsPageMeta` for the Code page covers the new widget for search and keyboard navigation. No changes expected here because the widget participates in the page's standard section iteration.
+
+Without this widget, declaring the setting in `CodeSettings` only makes it readable from `settings.toml` and via the View Options menu; the Settings page itself shows nothing. Both invariant 13 in product.md and the user-facing claim that the setting is "reachable from the Settings pane" depend on this change landing alongside Change 2.
+
+Both surfaces (View Options menu and Settings widget) write to the same setting key, so changes propagate through the existing settings subscription.
 
 ## Test plan
 
@@ -349,6 +402,10 @@ Every site that constructs `InlineDiffView` (per `grep -rn "InlineDiffView::new"
 
 ## Open questions
 
-1. The `InlineBanner` fallback to `Inline` for side-by-side (Change 10) is the safest default. Should the toolbar show a "Side-by-side not available in this layout" hint to the user, or silently fall back? The current spec says silently; the Code Review SME may prefer a hint.
-2. The collapsed delete-add row optimization (mentioned in Change 6) is out of scope for the first ship. A telemetry signal that quantifies how often a delete is immediately followed by an add helps prioritize the follow-up.
-3. Comment thread interaction with the opposite-pane gutter marker (Change 11) is non-interactive in this spec. Whether the marker should be clickable (focuses the comment in the other pane) is a UX call for the Code Review SME and a candidate follow-up.
+1. Comment thread interaction with the opposite-pane gutter marker (Change 11) is non-interactive in this spec. Whether the marker should be clickable (focuses the comment in the other pane) is a UX call for the Code Review SME and a candidate follow-up.
+2. The radio/segmented-control primitive used by the Settings widget (Change 13) needs SME confirmation. The current spec references `tab_selector` and the appearance theme picker as precedents; the actual primitive name and import path should be confirmed during implementation review.
+3. Resizable panel split (a draggable divider that lets the user shift the 50/50 split) is out of scope for the first ship per product Non-goals. Whether to revisit this in a follow-up depends on telemetry and user feedback after the initial release.
+
+## Revision notes
+
+- v2 (this revision): replaced the two-row delete/add algorithm in Change 6 with a paired-row algorithm so a modification renders on a shared row across panes (resolves Oz CRITICAL on tech.md line 207, aligns with product invariant 3). Replaced the unused `app/src/features/` reference in Change 3 with the real wiring across `crates/warp_features/src/lib.rs`, `app/src/lib.rs:2680-2740`, and the workspace `Cargo.toml` features block. Replaced the `DiffViewer`-via-`MultiPaneDiffViewer` proposal in Change 4 with an explicit per-method override table for `SideBySideDiffView`, naming the side-by-side semantics for every existing trait method. Lifted the `InlineBanner` fallback in Change 10 from a tech-only deferral to an explicit product-spec exception (product invariant 2). Added a Settings widget integration section to Change 13 covering the new widget, the radio primitive, registration in `app/src/settings_view/code_page.rs:307-310`, and feature-flag gating.

--- a/specs/GH7043/tech.md
+++ b/specs/GH7043/tech.md
@@ -1,18 +1,22 @@
-# Side-by-Side Diff Layout in the AI Block-List and Code Review Pane - Tech Spec
+# Side-by-Side Diff Layout in the Code Review Pane - Tech Spec
 Product spec: `specs/GH7043/product.md`
 GitHub issue: https://github.com/warpdotdev/warp/issues/7043
 Roadmap reference: https://github.com/warpdotdev/warp/issues/9233
 
 ## Context
 
-The diff rendering surface is shared by the AI block-list inline diff (`InlineDiffView`) and the full Code Review pane (`code_review_view::CodeReviewView`). Both build on the same primitives:
+The v1 diff rendering surface is the Code Review pane only. AI block-list diffs and inline banner diffs continue to use the existing inline path until a v2 spec extends the layout setting to those surfaces.
 
-- `app/src/code/diff_viewer.rs` defines the shared abstraction. `DisplayMode` carries the visual context: `FullPane`, `Embedded { max_height }`, and `InlineBanner { max_height, is_expanded, is_dismissed }`.
-- `app/src/code/inline_diff.rs::InlineDiffView` wraps a single `CodeEditorView`, registers a `FileModel`-backed file when one exists, and applies parsed deltas to that editor on construction through `apply_diffs_if_any`.
-- `app/src/code/editor/view.rs::CodeEditorView` and `app/src/code/editor/model.rs` are the rendering target. Both inline and side-by-side reuse them.
-- `app/src/code/editor/diff.rs` holds the editor-level diff line decoration and gutter rendering. `DiffLineType` classifies lines as `Context`, `Add`, `Delete`, and `HunkHeader`.
+Relevant Code Review and editor primitives:
+
+- `app/src/code/editor/view.rs::CodeEditorView` is the rendering target. V1 adds a side-by-side diff render mode to this view instead of introducing a sibling side-by-side view type.
+- `app/src/code/editor/element.rs::EditorWrapper` owns editor rendering, layout, hit testing, gutters, and text shaping for a `CodeEditorView`. V1 keeps one `EditorWrapper` and teaches it to render both panes.
+- `warp_editor::render::model::RenderState` holds the state used for shaped text, gutters, visible rows, and hit testing. V1 uses two render states inside the single wrapper: `baseline_render_state` and `modified_render_state`.
+- `app/src/code/editor/diff.rs` holds editor-level diff line decoration and gutter rendering. `DiffLineType` classifies lines as `Context`, `Add`, `Delete`, and `HunkHeader`.
 - `app/src/code_review/diff_state.rs` holds hunk state, the `DiffMode` enum (`Head` / `MainBranch` / `OtherBranch(String)`, comparison base rather than layout), and the per-file diff state model.
 - `app/src/code_review/comments/diff_hunk_parser.rs` parses hunks into ordered per-line records. The side-by-side aligner consumes those records; no new parser is introduced.
+- `app/src/code_review/editor_state.rs::CodeReviewEditorState` owns Code Review editor state. The layout hook belongs here or in the equivalent shared wrapper, not in per-file `InlineDiffView` migration code.
+- `app/src/code/local_code_editor.rs::LocalCodeEditorView` owns the local editor path that hosts Code Review editors. Layout flips route through this host into `CodeEditorView::set_diff_layout`.
 - `app/src/settings/code.rs` is the settings group for `code.*`. Settings are declared via `define_settings_group!` with `toml_path`, `default`, `supported_platforms`, and `sync_to_cloud` fields.
 - `app/src/settings_view/code_page.rs` is the explicit Code settings UI. Declaring a settings entry does not render it; the page needs a concrete widget registered in the Code section.
 - `crates/warp_features/src/lib.rs` defines the canonical `FeatureFlag` enum, `DOGFOOD_FLAGS`, `PREVIEW_FLAGS`, and changelog descriptions. `app/src/features.rs` re-exports the feature API.
@@ -22,7 +26,9 @@ The diff rendering surface is shared by the AI block-list inline diff (`InlineDi
 - `app/src/code_review/telemetry_event.rs` defines `CodeReviewTelemetryEvent`. The layout-change event registers here.
 - `app/src/code_review/find_model.rs` holds the find-in-diff state model that needs to traverse both panes in side-by-side.
 
-The implementation introduces a `DiffLayout` enum (`Inline` / `SideBySide`), stores it as `code.editor.diff_layout`, exposes it in Settings -> Code, builds a `SideBySideDiffView` in `app/src/code/side_by_side_diff.rs`, and gates the path behind `SideBySideDiffLayout`.
+The implementation introduces a `DiffLayout` enum (`Inline` / `SideBySide`), stores it as `code.editor.diff_layout`, exposes it in Settings -> Code, and gates the Code Review path behind `SideBySideDiffLayout`.
+
+Architecture choice: `CodeEditorView` gains a `DiffLayout::SideBySide` render mode. The single `EditorWrapper` inside `CodeEditorView` renders both sides and owns two `RenderState`s. This follows Kevin's current lean and keeps scroll sync, gap resizing, hit testing, and modified-pane edits internal to one editor view.
 
 ## Proposed changes
 
@@ -50,12 +56,13 @@ impl DiffLayout {
 
 Re-export from `app/src/code/mod.rs`. The enum is `Copy` so it can travel through view contexts without lifetime concerns. The `serde` representation (`"inline"` / `"side_by_side"`) matches the setting value.
 
-`DiffLayout` is intentionally separate from `DisplayMode` because they are orthogonal:
+`DiffLayout` is intentionally separate from display and comparison state:
 
 - `DisplayMode` answers "where on screen does this diff live" (own pane vs embedded vs inline banner).
+- `DiffMode` answers "what is being compared" (head vs main branch vs another branch).
 - `DiffLayout` answers "how do we render the diff content" (one column vs two columns).
 
-Every `DisplayMode` honors the user's `DiffLayout` choice when the feature flag is enabled.
+V1 only reads `DiffLayout` in the Code Review pane. AI block-list and inline banner hosts keep their current inline behavior even when the stored value is `side_by_side`.
 
 ### 2. Add the `code.editor.diff_layout` setting
 
@@ -69,15 +76,17 @@ diff_layout: DiffLayoutSetting {
     sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
     private: false,
     toml_path: "code.editor.diff_layout",
-    description: "Layout for diff views: 'inline' or 'side_by_side'.",
+    description: "Layout for Code Review diff views: 'inline' or 'side_by_side'.",
 },
 ```
 
 The setting type system already supports enums via `serde`, matching how other setting groups carry strongly typed values. Default is `Inline`, so existing users are unaffected unless they opt in.
 
+Resolution: this setting is intentionally global storage even though v1 has one participating surface. That leaves room for v2 surfaces without adding a second setting name.
+
 ### 3. Settings page integration in `settings_view/code_page.rs`
 
-`code.editor.diff_layout` is exposed in Settings -> Code under a new "Diff layout" subsection. This is the primary user entry point for the preference because it applies to all diff surfaces.
+`code.editor.diff_layout` is exposed in Settings -> Code under a new "Diff layout" subsection. This is the primary user entry point for the Code Review preference.
 
 Add a `DiffLayoutWidget` row in `app/src/settings_view/code_page.rs`:
 
@@ -88,6 +97,8 @@ Add a `DiffLayoutWidget` row in `app/src/settings_view/code_page.rs`:
 - Gate widget registration on `FeatureFlag::SideBySideDiffLayout.is_enabled()` so the control is hidden while the runtime flag is off.
 
 The diff toolbar continues to own only per-view ephemeral controls, such as whitespace visibility. It does not expose `code.editor.diff_layout`.
+
+Resolution: the settings-page widget integration is part of v1 and is not left as implicit settings metadata.
 
 ### 4. Add the `SideBySideDiffLayout` feature flag
 
@@ -110,144 +121,148 @@ The flag is wired in the actual repo feature-flag locations:
 
 4. **Changelog description**: add a `description_for_changelog` match arm:
    ```rust
-   SideBySideDiffLayout => Some("Enables a side-by-side diff layout in the code review pane and AI block-list diffs."),
+   SideBySideDiffLayout => Some("Enables a side-by-side diff layout in the code review pane."),
    ```
 
 Rollout:
 
 - Compile-time gate: `side_by_side_diff_layout` controls whether the app binary includes `FeatureFlag::SideBySideDiffLayout` in the compiled-in flag list.
 - Runtime gate: the feature-flag service decides whether `FeatureFlag::SideBySideDiffLayout.is_enabled()` returns true for the current channel/user.
-- Dispatch bridge: diff construction first checks the runtime flag. If disabled, it treats the effective layout as `DiffLayout::Inline` regardless of stored settings. If enabled, it reads `code.editor.diff_layout` and dispatches to `InlineDiffView` or `SideBySideDiffView`.
+- Dispatch bridge: Code Review construction first checks the runtime flag. If disabled, it treats the effective layout as `DiffLayout::Inline` regardless of stored settings. If enabled, it reads `code.editor.diff_layout` and calls `CodeEditorView::set_diff_layout`.
 - Default rollout schedule: off in shipping builds -> 5% dogfood -> 25% dogfood -> 100% dogfood -> preview -> release.
 
-### 5. Pane-aware diff viewer contract
+Resolution: hidden flag state suppresses both the settings widget and the runtime layout path.
 
-Replace the single-editor assumption in `DiffViewer` with a pane-aware contract that keeps existing inline behavior but names side-by-side responsibilities explicitly:
+### 5. Make `CodeEditorView` layout-aware
 
-```rust
-pub trait PaneAwareDiffViewer {
-    fn focused_editor(&self) -> &CodeEditor;
-    fn modified_editor(&self) -> &CodeEditor;
-    fn baseline_editor(&self) -> &CodeEditor;
-    fn for_each_editor(&self, f: impl FnMut(&CodeEditor));
-}
-```
-
-Semantics:
-
-- `focused_editor` is the current focused pane, used for cursor, selection, focus, and local keyboard state.
-- `modified_editor` is always the post-diff pane, used for `changed_lines`, accept, save, and file-backed edits.
-- `baseline_editor` is always the pre-diff pane and is read-only.
-- `for_each_editor` is used for operations that intentionally span both panes.
-
-Caller routing:
-
-| Caller / behavior | Pane-aware route |
-|---|---|
-| Cursor focus, local selection, copy, find focus | `focused_editor` |
-| `changed_lines` | `modified_editor` |
-| Accept diff, save diff, reject-to-modified-buffer operations | `modified_editor` |
-| Hunk navigation | `for_each_editor` for lockstep scroll/cursor sync; the modified pane remains the source of writeable hunk state |
-| Scroll preservation | `for_each_editor` |
-| Comment rendering and gutter markers | `baseline_editor` and `modified_editor` via row alignment |
-
-For `InlineDiffView`, all four methods return or iterate the same single editor, preserving current behavior.
-
-### 6. Build `SideBySideDiffView`
-
-Add `app/src/code/side_by_side_diff.rs`. The new type mirrors `InlineDiffView`'s lifecycle but holds two editors:
+`CodeEditorView` gains a layout setter and pane-aware accessors instead of introducing a sibling side-by-side view type:
 
 ```rust
-pub struct SideBySideDiffView {
-    baseline: ViewHandle<CodeEditorView>,
-    modified: ViewHandle<CodeEditorView>,
-    diff_type: Option<DiffType>,
-    file_path: Option<StandardizedPath>,
-    alignment: HunkAlignment,
-    scroll_sync: ScrollSyncModel,
-    focused_pane: PaneId,
-    backing_file_id: Option<FileId>,
-    was_edited: bool,
-    #[cfg(not(target_family = "wasm"))]
-    is_new_file: bool,
+impl CodeEditorView {
+    pub fn set_diff_layout(
+        &mut self,
+        layout: DiffLayout,
+        diff_hunks: &[DiffHunk],
+        ctx: &mut ViewContext<Self>,
+    );
+
+    pub fn editor_for(&self, side: Side) -> &CodeEditor;
+
+    pub fn editor(&self) -> &CodeEditor {
+        self.editor_for(Side::Modified)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PaneId {
+pub enum Side {
     Baseline,
     Modified,
 }
 ```
 
-Key methods:
+Semantics:
 
-- `new(baseline_editor, modified_editor, diff_type, display_mode, file_path, ctx)` constructs the view, subscribes to both editors' `CodeEditorEvent`, builds pane content, computes `HunkAlignment`, and pushes padding rows into both editors.
-- `register_file(session_type, ctx)` registers only the modified editor with `FileModel`, mirroring `InlineDiffView::register_file`. The baseline pane is always read-only.
-- `set_display_mode(mode, ctx)` applies display-mode behavior to the modified pane only. Baseline interaction state remains read-only regardless of display mode.
-- `PaneAwareDiffViewer` is implemented with the routing from Change 5.
+- `editor_for(Side::Modified)` returns the post-diff editor state and is the only write-capable side.
+- `editor_for(Side::Baseline)` returns the pre-diff read-only side when `DiffLayout::SideBySide` is active. In inline mode it may return the same editor state with read-only diff decorations, depending on implementation details.
+- `editor()` remains available for legacy call sites and returns the modified side. This keeps existing save, accept, cursor, and selection paths pointed at the side that can change.
+- New side-aware call sites use `editor_for(side)` only when they intentionally render or inspect a specific pane.
+
+Caller routing:
+
+| Caller / behavior | Pane-aware route |
+|---|---|
+| Cursor focus, local selection, copy from modified side | `editor_for(Side::Modified)` |
+| Copy from baseline side | `editor_for(Side::Baseline)` with selection-only focus |
+| `changed_lines` | `editor_for(Side::Modified)` |
+| Accept diff, save diff, reject-to-modified-buffer operations | `editor_for(Side::Modified)` |
+| Hunk navigation | `CodeEditorView` row alignment plus modified-side focus |
+| Scroll preservation | `CodeEditorView` layout state, not cross-view event mirroring |
+| Comment rendering and gutter markers | `baseline_render_state` and `modified_render_state` via row alignment |
+
+Resolution: the old single-editor assumption remains valid for legacy write paths because the default editor is the modified side. New pane-specific behavior opts into `editor_for`.
+
+### 6. Render both panes in one `EditorWrapper`
+
+`EditorWrapper` gains a diff-layout branch:
+
+```rust
+pub struct EditorWrapper {
+    render_state: RenderState,
+    side_by_side: Option<SideBySideRenderState>,
+}
+
+pub struct SideBySideRenderState {
+    baseline_render_state: RenderState,
+    modified_render_state: RenderState,
+    alignment: HunkAlignment,
+    focused_side: Side,
+    divider_x: Pixels,
+}
+```
+
+In `DiffLayout::Inline`, the existing `render_state` path is used unchanged.
+
+In `DiffLayout::SideBySide`:
+
+- The single wrapper lays out two equal-width panes and one divider.
+- `baseline_render_state` is initialized from the pre-diff buffer rows and delete decorations.
+- `modified_render_state` is initialized from the post-diff buffer rows and add decorations.
+- Text shaping dispatches per pane, using each pane's width and buffer rows.
+- Gutter rendering dispatches per pane, with delete gutters on the baseline side and add gutters on the modified side.
+- Hit testing first determines the pane from x-position, then queries that pane's render state.
+- The left pane accepts focus only for selection and copy. It never exposes an edit cursor.
+- The right pane owns cursor state and all writeable editor interactions.
+
+Gap rows are emitted into both render states symmetrically. If one side has real content and the other side has a gap, the gap render state still receives a full-height empty row with gutter metadata so layout, hit testing, comments, and scrolling agree.
+
+Resolution: scroll sync and gap resizing happen inside one component. There is no pair of `CodeEditorView`s and no cross-view scroll-event mirroring.
 
 ### 7. Pane content construction
 
-Side-by-side does not reuse `apply_diffs_if_any`, because that function drives the inline model by mutating the edited editor and rendering removed lines as temp blocks.
-
-The side-by-side pipeline is:
+Side-by-side reuses the existing unified-diff parser but does not reuse inline deleted-line rendering. The side-by-side pipeline is:
 
 1. Parse the unified diff to `DiffHunk[]` using the existing parser. No parser changes are needed.
 2. Build two `PaneBuffer` structs:
    - `baseline` contains pre-diff lines plus delete decorations.
    - `modified` contains post-diff lines plus add decorations.
-3. Run hunk alignment over the ordered hunk lines. Each `AlignedRow` maps to a row index in both panes. Gap rows are zero-height in the source buffer but render as full-height empty rows with the appropriate gutter color.
-4. Pass baseline content and delete decorations to the left editor. Pass modified content and add decorations to the right editor.
-5. Apply padding rows from `HunkAlignment` so both panes have the same rendered row count.
+3. Run hunk alignment over the ordered hunk lines. Each `AlignedRow` maps to a row index in both panes. Gap rows do not exist in either source file, but they render as full-height empty rows with the appropriate gutter color.
+4. Initialize `baseline_render_state` with baseline rows, delete decorations, and baseline gap rows.
+5. Initialize `modified_render_state` with modified rows, add decorations, and modified gap rows.
 
-`apply_diffs_if_any` remains reserved for `InlineDiffView`. Side-by-side never renders removed lines as temp blocks in the modified pane, and never loses delete decorations on the baseline pane.
+`apply_diffs_if_any` remains the inline path. When `DiffLayout::SideBySide` is active, `CodeEditorView` routes through the pane-content pipeline instead:
+
+- Removed lines render only in `baseline_render_state`.
+- Added lines render only in `modified_render_state`.
+- Inline temp-block deletion rendering is disabled for the modified side to prevent deletion bleed.
+- Accept, reject, save, and changed-line computation continue to read the modified buffer, matching inline behavior.
+
+Resolution: this supersedes the old plan to build a second side-by-side view and avoids mixing inline deletion temp blocks into the modified pane.
 
 ### 8. Per-pane interaction state
 
 Baseline pane:
 
-- Always `read_only = true`.
-- Supports text selection and copy.
+- Always read-only.
+- Supports text selection and copy for selectable baseline content.
+- Does not expose an insertion cursor.
 - Does not consume keyboard edit events.
 - Does not participate in file-backed save.
+- Deleted-line ranges are not selectable.
 
 Modified pane:
 
-- Follows the existing `DisplayMode` rules for the surface.
-- In Code Review, it is read-only with accept/reject actions.
-- In AI block-list `FullPane`, it is editable when the existing inline path would be editable.
-- It is the only pane registered with `FileModel`.
+- Owns the cursor.
+- Owns all writeable interactions.
+- Follows the existing Code Review rules for accept, reject, save, revert, and hunk navigation.
+- Is the only side registered with `FileModel`.
 
-`set_display_mode` on `SideBySideDiffView` applies the mode to the modified pane only. The baseline pane is hard-coded to read-only regardless of display mode so `FullPane` can never make baseline content editable.
+`set_diff_layout` applies Code Review interaction state to the modified pane and hard-codes baseline interaction state to read-only selection/copy. `FullPane` behavior from other surfaces is not part of v1.
 
-### 9. Editor padding-row API
+Resolution: this addresses the right-pane-only edit and cursor requirements directly in the editor interaction model.
 
-`CodeEditorView` and the underlying model gain a render-only padding-row concept: a row that takes up vertical space, has a gutter, and renders empty content. The public API:
+### 9. RowIndex and hunk alignment
 
-```rust
-impl CodeEditorView {
-    pub fn set_padding_rows(&mut self, rows: Vec<PaddingRow>, ctx: &mut ViewContext<Self>);
-}
-
-#[derive(Clone, Debug)]
-pub struct PaddingRow {
-    pub line_index: usize,
-    pub count: usize,
-    pub gutter_kind: PaddingGutterKind,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum PaddingGutterKind {
-    AddSide,
-    DeleteSide,
-}
-```
-
-Padding rows are inserted at render time only. They do not affect the underlying buffer, so save, find, copy, selection, and cursor navigation all see the real file content.
-
-### 10. Hunk alignment
-
-Add `app/src/code/hunk_alignment.rs`:
+Add or update `app/src/code/hunk_alignment.rs`:
 
 ```rust
 pub struct DiffHunk {
@@ -268,6 +283,7 @@ pub struct AlignedHunk {
 pub struct AlignedRow {
     pub left: PaneLine,
     pub right: PaneLine,
+    pub row_index: RowIndex,
 }
 
 pub enum PaneLine {
@@ -275,10 +291,17 @@ pub enum PaneLine {
     Gap,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RowIndex {
+    Baseline(usize),
+    Modified(usize),
+    Gap { after_row: usize },
+}
+
 pub struct HunkAlignment {
-    pub baseline_padding: Vec<PaddingRow>,
-    pub modified_padding: Vec<PaddingRow>,
-    pub row_map: Vec<(Option<usize>, Option<usize>)>,
+    pub baseline_rows: Vec<RowIndex>,
+    pub modified_rows: Vec<RowIndex>,
+    pub row_map: Vec<(Option<RowIndex>, Option<RowIndex>)>,
 }
 
 impl HunkAlignment {
@@ -286,7 +309,24 @@ impl HunkAlignment {
 }
 ```
 
-The existing parsed-line enum upstream already contains ordered context/add/delete records. The aligner consumes `&[DiffHunk]`; existing inline-diff paths may keep using only the header data they already need.
+`RowIndex` semantics:
+
+- `RowIndex::Baseline(n)` means this aligned row corresponds to baseline buffer row `n`.
+- `RowIndex::Modified(n)` means this aligned row corresponds to modified buffer row `n`.
+- `RowIndex::Gap { after_row }` means this aligned row is a render-only gap inserted after aligned row `after_row`. It does not correspond to either side's source line numbering.
+
+The alignment producer emits `RowIndex` values while it walks hunks:
+
+- Context rows produce `Baseline(b)` on the left and `Modified(m)` on the right.
+- Paired delete/add modification rows produce `Baseline(b)` on the left and `Modified(m)` on the right.
+- Pure deletion rows produce `Baseline(b)` on the left and `Gap { after_row }` on the right.
+- Pure addition rows produce `Gap { after_row }` on the left and `Modified(m)` on the right.
+
+Each `RenderState` consumes only its side's `RowIndex`:
+
+- `Baseline(n)` and `Modified(n)` map to real shaped text rows for that pane.
+- `Gap { after_row }` maps to a full-height empty render row with gutter and background metadata.
+- Selection, copy, cursor, save, and find ignore gap rows as source text. Hit testing a gap row resolves to the nearest valid row for scroll anchoring and comment positioning.
 
 The v1 algorithm is single-pass and pairs collapsed delete/add runs before emitting gap rows:
 
@@ -338,115 +378,139 @@ Aligned rows:
 
 Edge cases:
 
-- Pure insertion blocks produce rows with left `Gap` and right `Add`; the baseline pane receives delete-side padding rows.
-- Pure deletion blocks produce rows with left `Delete` and right `Gap`; the modified pane receives add-side padding rows.
+- Pure insertion blocks produce rows with left `Gap` and right `Add`; the baseline render state receives gap rows.
+- Pure deletion blocks produce rows with left `Delete` and right `Gap`; the modified render state receives gap rows.
 - A `Context` inside a modification resets the pairing window. Deletes before the context are flushed before adds after the context are considered.
 - A delete run followed by an add run with unrelated text still pairs by position. Word-level highlighting is out of scope; v1 guarantees row alignment.
 
-### 11. Scroll sync model
+Resolution: `line_index` is not a free integer. The API uses `RowIndex` so baseline rows, modified rows, and render-only gaps are distinguishable.
 
-Add `app/src/code/scroll_sync.rs`:
+### 10. Intra-component scroll sync
+
+Side-by-side scroll sync is owned by `CodeEditorView` / `EditorWrapper`:
 
 ```rust
-pub enum ScrollSource {
-    User,
-    Mirrored { from: PaneId, sync_id: u64 },
+pub struct SideBySideScrollState {
+    focused_side: Side,
+    vertical_scroll: ScrollOffset,
+    horizontal_scroll_by_side: BTreeMap<Side, ScrollOffset>,
 }
 
-pub struct ScrollSyncModel {
-    focused_pane: PaneId,
-    next_sync_id: u64,
-}
-
-impl ScrollSyncModel {
-    pub fn on_scroll_wheel(&mut self, from: PaneId, delta_y: f32) -> MirroredScroll;
+impl SideBySideScrollState {
+    pub fn on_scroll_wheel(&mut self, side: Side, delta_y: f32);
 
     pub fn corresponding_row(
         &self,
-        from: PaneId,
-        new_buffer_line: usize,
+        side: Side,
+        row_index: RowIndex,
         alignment: &HunkAlignment,
-    ) -> Option<usize>;
+    ) -> Option<RowIndex>;
 }
 ```
 
-Every mirrored scroll carries a `ScrollSource::Mirrored { from, sync_id }` token. The receiving editor's scroll-event handler checks the token. If the token is `Mirrored`, the handler consumes the event and does not re-emit a cross-pane scroll. Only `ScrollSource::User` triggers cross-pane sync.
+There are no mirrored scroll events between two independent views. A wheel event mutates one shared vertical scroll offset used by both render states. Horizontal scroll remains per pane.
 
-Invariant: `Mirrored -> Mirrored` events are dropped at the second subscriber, which breaks feedback loops and prevents scroll jitter.
+Cursor movement belongs to the modified side. When cursor navigation changes the modified row, `corresponding_row` computes the nearest baseline row for visibility but does not move a baseline cursor. Hunk navigation updates the shared scroll anchor and the modified-side cursor.
 
-Wheel events on either pane drive both panes by the same row delta. Cursor moves only move the cursor on the focused pane; the other pane scrolls to keep `corresponding_row` in view but does not move its own cursor.
+Resolution: the old `ScrolledByUser` recursion-suppression concern is resolved by removing cross-view event mirroring. If implementation still needs event source tagging inside the single wrapper, it is local defensive state rather than an architectural dependency.
 
-### 12. Code Review pane integration
+### 11. Code Review pane integration
 
-`app/src/code_review/code_review_view.rs` is the parent that holds per-file `InlineDiffView` instances today. The integration:
+The Code Review path uses `LocalCodeEditorView` / `CodeReviewEditorState`, not per-file `InlineDiffView` instances. The integration:
 
-- On view construction, compute the effective layout. If `SideBySideDiffLayout` is off, use `Inline`. If it is on, read `code.editor.diff_layout`.
-- Build `SideBySideDiffView` for each file when the effective layout is `SideBySide`; otherwise build `InlineDiffView`.
-- Subscribe to setting updates. When `code.editor.diff_layout` changes, swap the per-file view with the same diff data and preserve scroll position via `app/src/code_review/scroll_preservation.rs`.
-- Find-in-diff gains a `PaneId`-aware iterator that walks both editors when the active diff is side-by-side. Inline returns only the single modified editor.
+- Add a `DiffLayout` field or derived setting hook on `CodeReviewEditorState` (or the equivalent shared wrapper that owns Code Review editor configuration).
+- On Code Review editor construction, compute the effective layout. If `SideBySideDiffLayout` is off, use `Inline`. If it is on, read `code.editor.diff_layout`.
+- Route construction through `LocalCodeEditorView` into `CodeEditorView::set_diff_layout(effective_layout, diff_hunks, ctx)`.
+- Subscribe to setting updates in the Code Review host. When `code.editor.diff_layout` changes, call `LocalCodeEditorView` -> `CodeEditorView::set_diff_layout` for visible editors and preserve scroll position via `app/src/code_review/scroll_preservation.rs`.
+- Find-in-diff gains a `Side`-aware iterator over the single `CodeEditorView`'s render states when the active diff is side-by-side. Inline returns only the modified side.
+- Hidden-line expansion updates the single alignment model, then rebuilds both render states from the same expanded hunk set.
 
-The `code_review_view_integration.rs` and `code_review_view_tests.rs` fixtures gain a `with_layout(DiffLayout)` helper that sets the layout in the test settings store before constructing the view.
+There is no `InlineDiffView` migration step in this architecture.
 
-### 13. AI block-list integration
+Resolution: this retargets the integration plan to the actual Code Review editor host and makes hidden-line sync a single-source-of-truth alignment update.
 
-`app/src/ai/blocklist/inline_action/code_diff_view.rs` decides which `DisplayMode` to use per inline-action diff. The integration:
+### 12. AI block-list and inline banner v2 deferral
 
-- Read the effective layout at the same place these `DisplayMode` decisions are made.
-- For `DiffLayout::Inline`, construct `InlineDiffView` as today.
-- For `DiffLayout::SideBySide`, construct `SideBySideDiffView` with the same `DisplayMode`.
+AI block-list and inline banner integration are out of scope for v1:
 
-`InlineBanner` currently uses `InlineDiffView`; under side-by-side mode it switches to `SideBySideDiffView` constrained to the banner's viewport, typically a single-hunk diff. Banner sizing follows the side-by-side pane heights with the existing collapse/expand affordances.
+- `app/src/ai/blocklist/inline_action/code_diff_view.rs` continues constructing inline diffs.
+- `InlineBanner` continues using the existing inline rendering path.
+- The v1 settings helper text names Code Review only.
+- Telemetry does not claim AI block-list or inline banner adoption.
 
-### 14. Comment threads
+V2 can extend the same `DiffLayout` setting to those surfaces after the Code Review architecture is validated.
+
+Resolution: this addresses the request to start by only using side-by-side in the Code Review panel.
+
+### 13. Comment threads
 
 `app/src/code_review/comments/` anchors comment threads on `EditorLineLocation`. Comments stay attached to those locations and render under the targeted line. The integration:
 
-- The renderer for a side-by-side row checks each comment's pane, captured from `CommentSide` in `app/src/ai/agent/action.rs`, and renders the thread under the matching pane's row.
+- The renderer for a side-by-side row checks each comment's side, captured from existing comment metadata such as `CommentSide` in `app/src/ai/agent/action.rs`, and renders the thread under the matching pane's row.
 - The opposite pane shows a small marker glyph in its gutter at the same row to indicate that the other side has a thread there. The marker is non-interactive in this spec.
 - Multi-line comment ranges that span both deleted and added regions stay on the side they were authored against.
 
-### 15. Telemetry
+Because both panes are render states inside one `CodeEditorView`, comment placement uses the shared `HunkAlignment` row map and does not need cross-view coordinate conversion.
 
-Add a `CodeReviewTelemetryEvent::DiffLayoutChanged { from: DiffLayout, to: DiffLayout, surface: TelemetrySurface }` variant in `app/src/code_review/telemetry_event.rs`. The `surface` enum distinguishes Code Review, AI block-list, inline banner, and Settings. `settings_view/code_page.rs`, `code_review_view`, and the AI inline-action diff host emit the event when the setting changes and the visible surface refreshes.
+### 14. Telemetry
 
-### 16. Accessibility
+Add a `CodeReviewTelemetryEvent::DiffLayoutChanged { from: DiffLayout, to: DiffLayout }` variant in `app/src/code_review/telemetry_event.rs`. `settings_view/code_page.rs` emits the event when the setting changes.
+
+The Code Review host may emit a separate render-applied event if product wants adoption-by-opened-diff metrics, but v1 needs a single owner for the setting-change event to avoid duplicate telemetry.
+
+Resolution: Settings -> Code is the telemetry owner for layout changes. Code Review render code should not emit a second setting-change event.
+
+### 15. Accessibility
 
 Side-by-side adds the following accessibility requirements:
 
-- VoiceOver: each pane is its own scrollable region with an accessible label: "Original" for baseline and "Modified" for the post-diff pane.
+- VoiceOver: the single editor view exposes two logical regions with accessible labels: "Original" for baseline and "Modified" for the post-diff pane.
+- The modified pane is the only edit-focused region and the only region with a cursor.
+- The baseline pane can receive focus for selection/copy if the platform accessibility API can express that without exposing edit actions.
 - Aligned rows announce as a single logical row when read together: "Original: <text>; Modified: <text>".
-- Keyboard navigation: `Tab` moves focus across panes; `Cmd+Option+Left/Right` cycles between panes; `Cmd+Option+Up/Down` jumps hunk-by-hunk in lockstep.
+- Keyboard navigation: `Tab` reaches the modified edit region; baseline focus is selection/copy only. `Cmd+Option+Left/Right`, if implemented, cycles the logical pane focus without moving edit ownership away from modified.
 - Color contrast: gap-row backgrounds use a dedicated theme token, `diff.gap.background`, that meets 3:1 contrast against the editor background in both light and dark themes.
+
+Open risk: if the platform accessibility tree cannot represent two logical panes inside one view with acceptable screen-reader behavior, implementation must escalate before shipping side-by-side beyond dogfood.
+
+Resolution: accessibility coverage remains explicit even though v1 uses one `CodeEditorView`.
 
 ## Test plan
 
 ### Unit tests
 
 - `app/src/code/hunk_alignment_tests.rs`:
-  - Empty diff: row_map is `[(Some(0), Some(0)), ...]` for every line, no padding.
-  - Pure addition: rows for the added section are `(None, Some(m))`; baseline padding has the matching count.
-  - Pure deletion: rows for the deleted section are `(Some(b), None)`; modified padding has the matching count.
+  - Empty diff: row_map contains matching `Baseline(n)` / `Modified(n)` entries for every context row, no gaps.
+  - Pure addition: rows for the added section are `(Gap { after_row }, Modified(m))`; baseline render state has matching gap rows.
+  - Pure deletion: rows for the deleted section are `(Baseline(b), Gap { after_row })`; modified render state has matching gap rows.
   - Collapsed modification: `Context Delete Delete Add Add Context` produces four aligned rows: one context row, two paired modification rows, and one context row.
   - Context inside a delete/add sequence resets the pairing window.
   - Multi-hunk file: alignment composes correctly across hunks separated by unchanged context.
   - Large diff (5,000 lines, 200 hunks): completes in under 50ms.
 
-- `app/src/code/scroll_sync_tests.rs`:
-  - Wheel delta on baseline drives both panes equally.
-  - Cursor move on modified scrolls baseline to the corresponding row.
-  - Cursor on a `(None, Some(m))` row (pure add) scrolls baseline to the next surrounding context line.
-  - A `ScrollSource::Mirrored { from, sync_id }` event is consumed without re-emitting.
-  - A mirrored event cannot trigger a second mirrored event.
+- `app/src/code/editor/side_by_side_render_state_tests.rs`:
+  - Pane content for `DiffType::Update`: baseline render state holds pre-diff content with delete decorations; modified render state holds post-diff content with add decorations.
+  - Pane content for `DiffType::Create`: baseline render state is empty with gaps; modified holds the new file content.
+  - Pane content for `DiffType::Delete`: modified render state is empty with gaps; baseline holds the original content.
+  - `apply_diffs_if_any` is not used when `DiffLayout::SideBySide` is active.
+  - Removed lines render only in `baseline_render_state`.
+  - Added lines render only in `modified_render_state`.
+  - Gap rows have the same rendered height on both sides.
 
-- `app/src/code/side_by_side_diff_tests.rs`:
-  - Pane content for `DiffType::Update`: baseline holds pre-diff content with delete decorations; modified holds post-diff content with add decorations.
-  - Pane content for `DiffType::Create`: baseline editor is empty with padding; modified holds the new file content.
-  - Pane content for `DiffType::Delete`: modified editor is empty with padding; baseline holds the original content.
-  - `register_file` registers only the modified editor with `FileModel`; the baseline editor remains read-only.
-  - `set_display_mode` affects the modified pane only; baseline remains read-only.
-  - `accept_and_save_diff` writes the modified editor's buffer text via `FileModel`, identical to `InlineDiffView`'s save path.
-  - `reject_diff` discards the modification and rebuilds the side-by-side view with identical panes.
+- `app/src/code/editor/side_by_side_interaction_tests.rs`:
+  - `editor()` returns the modified side in side-by-side mode.
+  - `editor_for(Side::Baseline)` is read-only and does not expose an edit cursor.
+  - `editor_for(Side::Modified)` is the only side registered with `FileModel`.
+  - Baseline selection copies selectable content only.
+  - Deleted-line ranges are not selectable.
+  - Cursor movement affects the modified side only.
   - Layout switch from `Inline` to `SideBySide` and back preserves scroll position to within one row.
+
+- `app/src/code/editor/side_by_side_scroll_tests.rs`:
+  - Wheel delta updates the shared vertical scroll offset for both panes.
+  - Cursor move on modified scrolls baseline to the corresponding row.
+  - Cursor on a `(Gap { after_row }, Modified(m))` row (pure add) scrolls baseline to the next surrounding context line.
+  - No cross-view mirrored scroll event is emitted.
 
 ### Integration tests
 
@@ -454,36 +518,37 @@ Side-by-side adds the following accessibility requirements:
   - The Code page renders `DiffLayoutWidget` when `SideBySideDiffLayout` is enabled.
   - The widget is hidden when the runtime flag is disabled.
   - Selecting "Side by side" writes `code.editor.diff_layout = "side_by_side"`.
+  - The helper text names Code Review only.
 
 - `app/src/code_review/code_review_view_tests.rs`:
-  - Single-file diff in side-by-side renders both panes.
-  - Multi-file diff: each file's view honors the same layout.
-  - Setting flip while open swaps every visible file's view from `InlineDiffView` to `SideBySideDiffView` and preserves scroll.
-  - Find-in-diff matches both panes.
-  - Hunk navigation (`f` / `F`) advances the focused hunk on both panes simultaneously.
+  - Single-file diff in side-by-side renders both panes inside one `CodeEditorView`.
+  - Multi-file diff: each file's editor honors the same layout.
+  - Setting flip while open calls `LocalCodeEditorView` -> `CodeEditorView::set_diff_layout` for every visible editor and preserves scroll.
+  - Find-in-diff matches both render states.
+  - Hunk navigation (`f` / `F`) advances the focused hunk on both panes simultaneously while cursor remains on the modified side.
   - Comment thread on a baseline-side line renders under the baseline pane's row; modified pane shows the gutter marker.
-
-- `app/src/ai/blocklist/inline_action/code_diff_view_tests.rs`:
-  - Embedded AI diffs honor `SideBySide`.
-  - `InlineBanner` diffs honor `SideBySide` and constrain the view to banner height.
+  - Hidden-line expansion updates both render states from the same alignment model.
 
 ### Accessibility validation
 
-- Snapshot tests assert the accessible labels "Original" and "Modified" for side-by-side panes.
-- Keyboard tests cover `Tab`, `Cmd+Option+Left/Right`, and `Cmd+Option+Up/Down`.
+- Snapshot tests assert the accessible labels "Original" and "Modified" for side-by-side panes inside the single editor view.
+- Keyboard tests cover `Tab` and any pane-switching shortcut selected during implementation.
+- Tests assert baseline focus does not expose edit actions or an insertion cursor.
 - Theme tests assert `diff.gap.background` meets 3:1 contrast against editor backgrounds in light and dark themes.
 - Manual screen-reader smoke test on macOS VoiceOver reads a paired modification row as one logical original/modified row.
 
 ### Manual smoke test
 
 - macOS, M1 MacBook Air, dogfood build with `SideBySideDiffLayout` enabled:
-  - Open Settings -> Code. Change "Diff layout" from "Inline" to "Side by side" and confirm the visible diff refreshes within 200ms.
-  - Open Code Review with a 200-file diff. Confirm the active diff renders in two panes.
+  - Open Settings -> Code. Change "Diff layout" from "Inline" to "Side by side" and confirm the visible Code Review diff refreshes within 200ms.
+  - Open Code Review with a 200-file diff. Confirm the active diff renders in two panes inside one editor view.
   - Scroll wheel on each pane. Confirm both panes scroll together without jitter.
-  - Drag-select on each pane. Confirm the selection stays in that pane.
-  - Cmd-A on each pane. Confirm only that pane's content is selected.
+  - Drag-select on the baseline pane. Confirm selectable content copies but deleted-line ranges are not selectable.
+  - Drag-select on the modified pane. Confirm selection stays in the modified pane.
+  - Confirm the cursor appears only in the modified pane.
+  - Cmd-A on each pane. Confirm only that pane's selectable content is selected.
   - Resize the window narrow enough that side-by-side is cramped. Confirm horizontal scrollbars on each pane behave independently and the divider stays at 50%.
-  - Open an AI block-list embedded diff and an inline banner diff. Confirm both honor the chosen layout.
+  - Open an AI block-list embedded diff and an inline banner diff. Confirm both still render inline in v1.
   - Linux (Ubuntu 24.04), Windows 11: repeat the settings toggle smoke test on each platform to confirm rendering and keybindings.
 
 ### Compile-parity checklist
@@ -491,17 +556,20 @@ Side-by-side adds the following accessibility requirements:
 Every site that destructures `DisplayMode` in a `match` must compile after the change. The current call sites include:
 
 - `app/src/code/diff_viewer.rs`: trait helpers; unchanged because `DiffLayout` is a new orthogonal axis.
-- `app/src/ai/blocklist/inline_action/code_diff_view.rs`: `DisplayMode` construction and matching; now layout-aware at construction.
+- `app/src/ai/blocklist/inline_action/code_diff_view.rs`: unchanged in v1; continues inline rendering.
 - `app/src/ai/blocklist/block/view_impl/output.rs`: match on `DisplayMode::FullPane`; unchanged.
 
-Every site that constructs `InlineDiffView` is a candidate for layout-aware view construction. Code Review and AI block-list integration cover the two parent surfaces.
+Every Code Review site that accesses the editor through `editor()` should be checked. Existing write, save, cursor, and accept/reject paths should keep using `editor()` because it returns the modified side. Rendering, comments, find, selection, and accessibility call sites should use side-aware render-state access where needed.
 
 ## Open questions
 
-1. Comment thread interaction with the opposite-pane gutter marker (Change 14) is non-interactive in this spec. Whether the marker should be clickable is a UX call for the Code Review SME and a candidate follow-up.
-2. The segmented-control primitive used by `DiffLayoutWidget` needs SME confirmation. The current spec references `app/src/ui_components/tab_selector.rs` and the appearance theme picker as precedents; the actual primitive name and import path should be confirmed during implementation review.
-3. Resizable panel split is out of scope for the first ship per product Non-goals. Whether to revisit this later depends on telemetry and user feedback after the initial release.
+1. Confirm `CodeEditorView` + one `EditorWrapper` + two `RenderState`s is the right implementation shape, versus `SplitView` + two `CodeEditorView`s or `CodeEditorView` + two `EditorWrapper`s.
+2. Confirm intra-component scroll sync is feasible inside one `EditorWrapper`, especially for hidden-line expansion and gap resizing, versus cross-view event mirroring.
+3. Confirm screen-reader and tab-order requirements can be expressed inside a single view that exposes two logical panes.
+4. Comment thread interaction with the opposite-pane gutter marker (Change 13) is non-interactive in this spec. Whether the marker should be clickable is a UX call for the Code Review SME and a candidate follow-up.
+5. The segmented-control primitive used by `DiffLayoutWidget` needs SME confirmation. The current spec references existing settings segmented controls as precedent; the actual primitive name and import path should be confirmed during implementation review.
+6. Resizable panel split is out of scope for the first ship per product Non-goals. Whether to revisit this later depends on telemetry and user feedback after the initial release.
 
 ## Revision notes
 
-- v3 (this revision): pivoted the layout control from a diff-local menu to Settings -> Code, added explicit `DiffLayoutWidget` rendering in `app/src/settings_view/code_page.rs`, removed the InlineBanner exception, made collapsed delete/add pairing the v1 hunk-alignment algorithm, replaced single-editor assumptions with `PaneAwareDiffViewer`, documented pane content construction and read-only baseline state, added mirrored-scroll suppression tokens, and added accessibility implementation and validation requirements.
+- v4 (this revision): narrowed v1 scope to Code Review only, deferred AI block-list and inline banner to v2, pivoted architecture from a separate side-by-side view type to `CodeEditorView` + one `EditorWrapper` + two `RenderState`s, clarified right-pane-only editing and cursor invariants, replaced ambiguous `line_index` with `RowIndex`, retargeted integration to `CodeReviewEditorState` / `LocalCodeEditorView`, and added open questions for @kevinyang372 architecture confirmation.

--- a/specs/GH7043/tech.md
+++ b/specs/GH7043/tech.md
@@ -9,14 +9,14 @@ The v1 diff rendering surface is the Code Review pane only. AI block-list diffs 
 
 Relevant Code Review and editor primitives:
 
-- `app/src/code/editor/view.rs::CodeEditorView` is the rendering target. V1 adds a side-by-side diff render mode to this view instead of introducing a sibling side-by-side view type.
-- `app/src/code/editor/element.rs::EditorWrapper` owns editor rendering, layout, hit testing, gutters, and text shaping for a `CodeEditorView`. V1 keeps one `EditorWrapper` and teaches it to render both panes.
-- `warp_editor::render::model::RenderState` holds the state used for shaped text, gutters, visible rows, and hit testing. V1 uses two render states inside the single wrapper: `baseline_render_state` and `modified_render_state`.
+- `app/src/code/editor/view.rs::CodeEditorView` is the rendering target. V1 side-by-side uses two editor-view instances: a select-only baseline view and the normal modified view.
+- `app/src/code/editor/element.rs::EditorWrapper` owns editor rendering, layout, hit testing, gutters, and text shaping for each `CodeEditorView`. V1 keeps the editor internals mostly unchanged and puts cross-pane coordination in a parent bridge wrapper.
+- `warp_editor::render::model::RenderState` holds the state used for shaped text, gutters, visible rows, and hit testing. Each editor view keeps its own render state.
 - `app/src/code/editor/diff.rs` holds editor-level diff line decoration and gutter rendering. `DiffLineType` classifies lines as `Context`, `Add`, `Delete`, and `HunkHeader`.
 - `app/src/code_review/diff_state.rs` holds hunk state, the `DiffMode` enum (`Head` / `MainBranch` / `OtherBranch(String)`, comparison base rather than layout), and the per-file diff state model.
 - `app/src/code_review/comments/diff_hunk_parser.rs` parses hunks into ordered per-line records. The side-by-side aligner consumes those records; no new parser is introduced.
 - `app/src/code_review/editor_state.rs::CodeReviewEditorState` owns Code Review editor state. The layout hook belongs here or in the equivalent shared wrapper, not in per-file `InlineDiffView` migration code.
-- `app/src/code/local_code_editor.rs::LocalCodeEditorView` owns the local editor path that hosts Code Review editors. Layout flips route through this host into `CodeEditorView::set_diff_layout`.
+- `app/src/code/local_code_editor.rs::LocalCodeEditorView` owns the local editor path that hosts Code Review editors. Layout flips route through this host into the side-by-side bridge wrapper when the Code Review path renders side-by-side.
 - `app/src/settings/code.rs` is the settings group for `code.*`. Settings are declared via `define_settings_group!` with `toml_path`, `default`, `supported_platforms`, and `sync_to_cloud` fields.
 - `app/src/settings_view/code_page.rs` is the explicit Code settings UI. Declaring a settings entry does not render it; the page needs a concrete widget registered in the Code section.
 - `crates/warp_features/src/lib.rs` defines the canonical `FeatureFlag` enum, `DOGFOOD_FLAGS`, `PREVIEW_FLAGS`, and changelog descriptions. `app/src/features.rs` re-exports the feature API.
@@ -28,7 +28,7 @@ Relevant Code Review and editor primitives:
 
 The implementation introduces a `DiffLayout` enum (`Inline` / `SideBySide`), stores it as `code.editor.diff_layout`, exposes it in Settings -> Code, and gates the Code Review path behind `SideBySideDiffLayout`.
 
-Architecture choice: `CodeEditorView` gains a `DiffLayout::SideBySide` render mode. The single `EditorWrapper` inside `CodeEditorView` renders both sides and owns two `RenderState`s. This follows Kevin's current lean and keeps scroll sync, gap resizing, hit testing, and modified-pane edits internal to one editor view.
+Architecture choice: `DiffLayout::SideBySide` is implemented as two `CodeEditorView` instances wrapped by a Code Review bridge component. The baseline view renders base content in select-only mode. The modified view renders the global buffer entry for the working file. The bridge owns cross-pane synchronization for hidden lines, scroll position, find state, and shared diff state while keeping the two views' buffers separate.
 
 ## Proposed changes
 
@@ -128,29 +128,23 @@ Rollout:
 
 - Compile-time gate: `side_by_side_diff_layout` controls whether the app binary includes `FeatureFlag::SideBySideDiffLayout` in the compiled-in flag list.
 - Runtime gate: the feature-flag service decides whether `FeatureFlag::SideBySideDiffLayout.is_enabled()` returns true for the current channel/user.
-- Dispatch bridge: Code Review construction first checks the runtime flag. If disabled, it treats the effective layout as `DiffLayout::Inline` regardless of stored settings. If enabled, it reads `code.editor.diff_layout` and calls `CodeEditorView::set_diff_layout`.
+- Dispatch bridge: Code Review construction first checks the runtime flag. If disabled, it treats the effective layout as `DiffLayout::Inline` regardless of stored settings. If enabled, it reads `code.editor.diff_layout` and renders either the inline editor path or the side-by-side bridge wrapper.
 - Default rollout schedule: off in shipping builds -> 5% dogfood -> 25% dogfood -> 100% dogfood -> preview -> release.
 
 Resolution: hidden flag state suppresses both the settings widget and the runtime layout path.
 
-### 5. Make `CodeEditorView` layout-aware
+### 5. Side-by-side bridge wrapper
 
-`CodeEditorView` gains a layout setter and pane-aware accessors instead of introducing a sibling side-by-side view type:
+`DiffLayout::SideBySide` is rendered by a bridge wrapper that owns two `CodeEditorView` children:
 
 ```rust
-impl CodeEditorView {
-    pub fn set_diff_layout(
-        &mut self,
-        layout: DiffLayout,
-        diff_hunks: &[DiffHunk],
-        ctx: &mut ViewContext<Self>,
-    );
-
-    pub fn editor_for(&self, side: Side) -> &CodeEditor;
-
-    pub fn editor(&self) -> &CodeEditor {
-        self.editor_for(Side::Modified)
-    }
+pub struct SideBySideDiffBridge {
+    baseline_view: CodeEditorView,
+    modified_view: CodeEditorView,
+    shared_diff_state: HunkAlignment,
+    hidden_lines: HiddenLineRanges,
+    scroll_anchor: SideBySideScrollAnchor,
+    find_state: CodeReviewFindState,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -160,103 +154,92 @@ pub enum Side {
 }
 ```
 
-Semantics:
+The bridge wrapper sits inside the existing Code Review editor host. It owns the side-by-side layout, renders the two editor views with equal widths and one divider, and propagates shared state changes in both directions.
 
-- `editor_for(Side::Modified)` returns the post-diff editor state and is the only write-capable side.
-- `editor_for(Side::Baseline)` returns the pre-diff read-only side when `DiffLayout::SideBySide` is active. In inline mode it may return the same editor state with read-only diff decorations, depending on implementation details.
-- `editor()` remains available for legacy call sites and returns the modified side. This keeps existing save, accept, cursor, and selection paths pointed at the side that can change.
-- New side-aware call sites use `editor_for(side)` only when they intentionally render or inspect a specific pane.
+Bridge-owned synchronization:
+
+- **Hidden line ranges**: collapsed unchanged regions are represented once and applied to both views. Expanding hidden lines from either pane updates the shared hidden-line state and reconfigures both views so heights stay aligned.
+- **Scroll position**: scrolling either pane updates a shared line anchor, then drives the other pane to the corresponding aligned row. Sync is line-anchored rather than pixel-based so font, wrapping, or line-height differences cannot accumulate drift.
+- **Find state**: a single Code Review find session spans both views. Matches from either buffer are highlighted, and "Next" / "Prev" can traverse across panes.
+- **Shared diff state**: both views read the same diff result and `HunkAlignment` so they agree on which baseline rows are deletions, which modified rows are insertions, and where visual gaps belong. This shared diff state is not a shared buffer.
+
+The two buffers stay separate:
+
+- The baseline view's buffer source is the base pre-edit content.
+- The modified view's buffer source is the global buffer entry for the working file.
+- Edits to the modified buffer re-trigger the diff. The refreshed diff updates both views' decoration config: newly deleted baseline rows remain regular selectable rows in the baseline view, while the modified view renders the corresponding baseline-only rows as gaps. Newly inserted modified rows render as regular rows in the modified view and gaps in the baseline view.
+
+Resolution: the editor view internals stay close to the existing model. Side-specific behavior lives in each child editor view, and cross-pane coordination lives in the bridge.
+
+### 6. Baseline and modified editor views
+
+In `DiffLayout::Inline`, the existing Code Review editor path is used unchanged.
+
+In `DiffLayout::SideBySide`, the bridge configures two editor views:
+
+- The baseline view is a select-only `CodeEditorView` instance backed by base content.
+- The modified view is a normal `CodeEditorView` instance backed by the global buffer entry for the working file.
+- The modified view uses a decoration config that renders baseline-only rows as visual gaps instead of temporary deletion blocks.
+- Text shaping, gutter rendering, hit testing, selection, and copy stay inside each child editor view.
+- The bridge determines the pane from the event target and only forwards edit-capable events to the modified view.
 
 Caller routing:
 
 | Caller / behavior | Pane-aware route |
 |---|---|
-| Cursor focus, local selection, copy from modified side | `editor_for(Side::Modified)` |
-| Copy from baseline side | `editor_for(Side::Baseline)` with selection-only focus |
-| `changed_lines` | `editor_for(Side::Modified)` |
-| Accept diff, save diff, reject-to-modified-buffer operations | `editor_for(Side::Modified)` |
-| Hunk navigation | `CodeEditorView` row alignment plus modified-side focus |
-| Scroll preservation | `CodeEditorView` layout state, not cross-view event mirroring |
-| Comment rendering and gutter markers | `baseline_render_state` and `modified_render_state` via row alignment |
+| Cursor focus, local selection, copy from modified side | Modified `CodeEditorView` |
+| Copy from baseline side | Baseline `CodeEditorView` with selection-only focus |
+| `changed_lines` | Modified `CodeEditorView` |
+| Accept diff, save diff, reject-to-modified-buffer operations | Modified `CodeEditorView` |
+| Hunk navigation | Bridge row alignment plus modified-side focus |
+| Scroll preservation | Bridge scroll anchor |
+| Comment rendering and gutter markers | Bridge `HunkAlignment` row map plus the targeted child view |
 
-Resolution: the old single-editor assumption remains valid for legacy write paths because the default editor is the modified side. New pane-specific behavior opts into `editor_for`.
-
-### 6. Render both panes in one `EditorWrapper`
-
-`EditorWrapper` gains a diff-layout branch:
-
-```rust
-pub struct EditorWrapper {
-    render_state: RenderState,
-    side_by_side: Option<SideBySideRenderState>,
-}
-
-pub struct SideBySideRenderState {
-    baseline_render_state: RenderState,
-    modified_render_state: RenderState,
-    alignment: HunkAlignment,
-    focused_side: Side,
-    divider_x: Pixels,
-}
-```
-
-In `DiffLayout::Inline`, the existing `render_state` path is used unchanged.
-
-In `DiffLayout::SideBySide`:
-
-- The single wrapper lays out two equal-width panes and one divider.
-- `baseline_render_state` is initialized from the pre-diff buffer rows and delete decorations.
-- `modified_render_state` is initialized from the post-diff buffer rows and add decorations.
-- Text shaping dispatches per pane, using each pane's width and buffer rows.
-- Gutter rendering dispatches per pane, with delete gutters on the baseline side and add gutters on the modified side.
-- Hit testing first determines the pane from x-position, then queries that pane's render state.
-- The left pane accepts focus only for selection and copy. It never exposes an edit cursor.
-- The right pane owns cursor state and all writeable editor interactions.
-
-Gap rows are emitted into both render states symmetrically. If one side has real content and the other side has a gap, the gap render state still receives a full-height empty row with gutter metadata so layout, hit testing, comments, and scrolling agree.
-
-Resolution: scroll sync and gap resizing happen inside one component. There is no pair of `CodeEditorView`s and no cross-view scroll-event mirroring.
+Resolution: right-pane-only editing is enforced by using a normal editor view only for the modified buffer. The baseline editor is select-only and never exposes an insertion cursor.
 
 ### 7. Pane content construction
 
 Side-by-side reuses the existing unified-diff parser but does not reuse inline deleted-line rendering. The side-by-side pipeline is:
 
 1. Parse the unified diff to `DiffHunk[]` using the existing parser. No parser changes are needed.
-2. Build two `PaneBuffer` structs:
-   - `baseline` contains pre-diff lines plus delete decorations.
-   - `modified` contains post-diff lines plus add decorations.
-3. Run hunk alignment over the ordered hunk lines. Each `AlignedRow` maps to a row index in both panes. Gap rows do not exist in either source file, but they render as full-height empty rows with the appropriate gutter color.
-4. Initialize `baseline_render_state` with baseline rows, delete decorations, and baseline gap rows.
-5. Initialize `modified_render_state` with modified rows, add decorations, and modified gap rows.
+2. Build a shared diff state from the base content, current modified global buffer content, and ordered hunk lines.
+3. Run hunk alignment over the ordered hunk lines. Each `AlignedRow` maps to a row index in both panes. Gap rows do not exist in either source file, but the bridge passes them to the appropriate view as decoration metadata.
+4. Configure the baseline view with base buffer rows, delete decorations, hidden lines, and baseline-side alignment metadata.
+5. Configure the modified view with the global buffer entry, add decorations, hidden lines, and a decoration config that renders baseline-only rows as visual gaps.
 
-`apply_diffs_if_any` remains the inline path. When `DiffLayout::SideBySide` is active, `CodeEditorView` routes through the pane-content pipeline instead:
+`apply_diffs_if_any` remains the inline path. When `DiffLayout::SideBySide` is active, the bridge uses the pane-content pipeline instead:
 
-- Removed lines render only in `baseline_render_state`.
-- Added lines render only in `modified_render_state`.
+- Removed lines render as normal selectable rows in the baseline view.
+- Added lines render as normal editable-buffer rows in the modified view.
+- Baseline-only rows render as visual gaps in the modified view.
+- Modified-only rows render as visual gaps in the baseline view.
 - Inline temp-block deletion rendering is disabled for the modified side to prevent deletion bleed.
 - Accept, reject, save, and changed-line computation continue to read the modified buffer, matching inline behavior.
 
-Resolution: this supersedes the old plan to build a second side-by-side view and avoids mixing inline deletion temp blocks into the modified pane.
+Resolution: side-by-side keeps the baseline and modified buffers independent while sharing the diff state needed for aligned rendering.
 
 ### 8. Per-pane interaction state
 
 Baseline pane:
 
 - Always read-only.
-- Supports text selection and copy for selectable baseline content.
+- Uses a select-only `CodeEditorView` instance backed by base content.
+- Supports text selection and copy on all baseline rows, including deleted-line ranges, because those ranges are real rows in the baseline buffer.
 - Does not expose an insertion cursor.
 - Does not consume keyboard edit events.
 - Does not participate in file-backed save.
-- Deleted-line ranges are not selectable.
+- Receives delete decorations and hidden-line configuration from the bridge.
 
 Modified pane:
 
+- Uses a normal `CodeEditorView` instance backed by the global buffer entry for the working file.
 - Owns the cursor.
 - Owns all writeable interactions.
 - Follows the existing Code Review rules for accept, reject, save, revert, and hunk navigation.
 - Is the only side registered with `FileModel`.
+- Uses a decoration config that renders baseline-only rows as visual gaps instead of temporary deletion blocks.
 
-`set_diff_layout` applies Code Review interaction state to the modified pane and hard-codes baseline interaction state to read-only selection/copy. `FullPane` behavior from other surfaces is not part of v1.
+The bridge applies Code Review interaction state to the modified pane and hard-codes baseline interaction state to read-only selection/copy. `FullPane` behavior from other surfaces is not part of v1.
 
 Resolution: this addresses the right-pane-only edit and cursor requirements directly in the editor interaction model.
 
@@ -322,10 +305,11 @@ The alignment producer emits `RowIndex` values while it walks hunks:
 - Pure deletion rows produce `Baseline(b)` on the left and `Gap { after_row }` on the right.
 - Pure addition rows produce `Gap { after_row }` on the left and `Modified(m)` on the right.
 
-Each `RenderState` consumes only its side's `RowIndex`:
+The bridge stores the alignment result and passes each editor view only the row metadata for its side:
 
-- `Baseline(n)` and `Modified(n)` map to real shaped text rows for that pane.
-- `Gap { after_row }` maps to a full-height empty render row with gutter and background metadata.
+- `Baseline(n)` maps to a real shaped text row in the baseline view.
+- `Modified(n)` maps to a real shaped text row in the modified view.
+- `Gap { after_row }` maps to a full-height empty visual row with gutter and background metadata in the opposite view.
 - Selection, copy, cursor, save, and find ignore gap rows as source text. Hit testing a gap row resolves to the nearest valid row for scroll anchoring and comment positioning.
 
 The v1 algorithm is single-pass and pairs collapsed delete/add runs before emitting gap rows:
@@ -378,26 +362,27 @@ Aligned rows:
 
 Edge cases:
 
-- Pure insertion blocks produce rows with left `Gap` and right `Add`; the baseline render state receives gap rows.
-- Pure deletion blocks produce rows with left `Delete` and right `Gap`; the modified render state receives gap rows.
+- Pure insertion blocks produce rows with left `Gap` and right `Add`; the baseline view receives gap decorations.
+- Pure deletion blocks produce rows with left `Delete` and right `Gap`; the modified view receives gap decorations.
 - A `Context` inside a modification resets the pairing window. Deletes before the context are flushed before adds after the context are considered.
 - A delete run followed by an add run with unrelated text still pairs by position. Word-level highlighting is out of scope; v1 guarantees row alignment.
 
-Resolution: `line_index` is not a free integer. The API uses `RowIndex` so baseline rows, modified rows, and render-only gaps are distinguishable.
+Resolution: `line_index` is not a free integer. The API uses `RowIndex` so baseline rows, modified rows, and render-only gaps are distinguishable, and the bridge exposes that aligned row map to both views.
 
-### 10. Intra-component scroll sync
+### 10. Bridge scroll sync
 
-Side-by-side scroll sync is owned by `CodeEditorView` / `EditorWrapper`:
+Side-by-side scroll sync is owned by the bridge wrapper:
 
 ```rust
-pub struct SideBySideScrollState {
+pub struct SideBySideScrollAnchor {
     focused_side: Side,
-    vertical_scroll: ScrollOffset,
+    anchor_row: RowIndex,
+    anchor_side: Side,
     horizontal_scroll_by_side: BTreeMap<Side, ScrollOffset>,
 }
 
-impl SideBySideScrollState {
-    pub fn on_scroll_wheel(&mut self, side: Side, delta_y: f32);
+impl SideBySideScrollAnchor {
+    pub fn on_scroll_wheel(&mut self, side: Side, anchor_row: RowIndex);
 
     pub fn corresponding_row(
         &self,
@@ -408,26 +393,27 @@ impl SideBySideScrollState {
 }
 ```
 
-There are no mirrored scroll events between two independent views. A wheel event mutates one shared vertical scroll offset used by both render states. Horizontal scroll remains per pane.
+Scroll sync is line-anchored. A wheel event or hunk navigation event in either view updates the shared row anchor, and the bridge asks the other view to reveal the corresponding row from `HunkAlignment`. Horizontal scroll remains per pane.
 
 Cursor movement belongs to the modified side. When cursor navigation changes the modified row, `corresponding_row` computes the nearest baseline row for visibility but does not move a baseline cursor. Hunk navigation updates the shared scroll anchor and the modified-side cursor.
 
-Resolution: the old `ScrolledByUser` recursion-suppression concern is resolved by removing cross-view event mirroring. If implementation still needs event source tagging inside the single wrapper, it is local defensive state rather than an architectural dependency.
+Resolution: the bridge synchronizes views by row anchors, not by matching pixel offsets. If implementation needs event source tagging to avoid recursive updates, that state belongs in the bridge.
 
 ### 11. Code Review pane integration
 
-The Code Review path uses `LocalCodeEditorView` / `CodeReviewEditorState`, not per-file `InlineDiffView` instances. The integration:
+The Code Review path uses the existing Code Review editor host, not per-file `InlineDiffView` instances. The integration:
 
-- Add a `DiffLayout` field or derived setting hook on `CodeReviewEditorState` (or the equivalent shared wrapper that owns Code Review editor configuration).
+- Represent side-by-side editor state as either two `CodeReviewEditorState` slices or one slice with `baseline_sub_state` and `modified_sub_state`. The two child views must have distinct lifecycles even when the parent reducer entry point stays shared.
 - On Code Review editor construction, compute the effective layout. If `SideBySideDiffLayout` is off, use `Inline`. If it is on, read `code.editor.diff_layout`.
-- Route construction through `LocalCodeEditorView` into `CodeEditorView::set_diff_layout(effective_layout, diff_hunks, ctx)`.
-- Subscribe to setting updates in the Code Review host. When `code.editor.diff_layout` changes, call `LocalCodeEditorView` -> `CodeEditorView::set_diff_layout` for visible editors and preserve scroll position via `app/src/code_review/scroll_preservation.rs`.
-- Find-in-diff gains a `Side`-aware iterator over the single `CodeEditorView`'s render states when the active diff is side-by-side. Inline returns only the modified side.
-- Hidden-line expansion updates the single alignment model, then rebuilds both render states from the same expanded hunk set.
+- In inline mode, keep the existing single-editor path.
+- In side-by-side mode, render the bridge wrapper inside whichever existing Code Review container component renders the editor today. If that container is `LocalCodeEditorView`, the bridge replaces the single `LocalCodeEditorView` instance for the side-by-side path.
+- Subscribe to setting updates in the Code Review host. When `code.editor.diff_layout` changes, rebuild visible editors into the selected layout and preserve scroll position via `app/src/code_review/scroll_preservation.rs`.
+- Find-in-diff gains a `Side`-aware iterator over both child editor views when the active diff is side-by-side. Inline returns only the modified side.
+- Hidden-line expansion updates the bridge's shared hidden-line and alignment state, then applies the same collapsed ranges to both child views.
 
 There is no `InlineDiffView` migration step in this architecture.
 
-Resolution: this retargets the integration plan to the actual Code Review editor host and makes hidden-line sync a single-source-of-truth alignment update.
+Resolution: this retargets the integration plan to the actual Code Review editor host and makes hidden-line sync a bridge-owned shared-state update.
 
 ### 12. AI block-list and inline banner v2 deferral
 
@@ -450,7 +436,7 @@ Resolution: this addresses the request to start by only using side-by-side in th
 - The opposite pane shows a small marker glyph in its gutter at the same row to indicate that the other side has a thread there. The marker is non-interactive in this spec.
 - Multi-line comment ranges that span both deleted and added regions stay on the side they were authored against.
 
-Because both panes are render states inside one `CodeEditorView`, comment placement uses the shared `HunkAlignment` row map and does not need cross-view coordinate conversion.
+Because both panes read the bridge's shared `HunkAlignment`, comment placement uses the shared row map and does not need ad hoc coordinate conversion between unrelated diff models.
 
 ### 14. Telemetry
 
@@ -464,16 +450,16 @@ Resolution: Settings -> Code is the telemetry owner for layout changes. Code Rev
 
 Side-by-side adds the following accessibility requirements:
 
-- VoiceOver: the single editor view exposes two logical regions with accessible labels: "Original" for baseline and "Modified" for the post-diff pane.
+- VoiceOver: the bridge exposes two logical regions with accessible labels: "Original" for baseline and "Modified" for the post-diff pane.
 - The modified pane is the only edit-focused region and the only region with a cursor.
 - The baseline pane can receive focus for selection/copy if the platform accessibility API can express that without exposing edit actions.
 - Aligned rows announce as a single logical row when read together: "Original: <text>; Modified: <text>".
 - Keyboard navigation: `Tab` reaches the modified edit region; baseline focus is selection/copy only. `Cmd+Option+Left/Right`, if implemented, cycles the logical pane focus without moving edit ownership away from modified.
 - Color contrast: gap-row backgrounds use a dedicated theme token, `diff.gap.background`, that meets 3:1 contrast against the editor background in both light and dark themes.
 
-Open risk: if the platform accessibility tree cannot represent two logical panes inside one view with acceptable screen-reader behavior, implementation must escalate before shipping side-by-side beyond dogfood.
+Open risk: if the platform accessibility tree cannot represent the two bridged editor views with acceptable screen-reader behavior, implementation must escalate before shipping side-by-side beyond dogfood.
 
-Resolution: accessibility coverage remains explicit even though v1 uses one `CodeEditorView`.
+Resolution: accessibility coverage remains explicit for the two editor views and their bridge wrapper.
 
 ## Test plan
 
@@ -481,36 +467,34 @@ Resolution: accessibility coverage remains explicit even though v1 uses one `Cod
 
 - `app/src/code/hunk_alignment_tests.rs`:
   - Empty diff: row_map contains matching `Baseline(n)` / `Modified(n)` entries for every context row, no gaps.
-  - Pure addition: rows for the added section are `(Gap { after_row }, Modified(m))`; baseline render state has matching gap rows.
-  - Pure deletion: rows for the deleted section are `(Baseline(b), Gap { after_row })`; modified render state has matching gap rows.
+  - Pure addition: rows for the added section are `(Gap { after_row }, Modified(m))`; the baseline view receives matching gap metadata.
+  - Pure deletion: rows for the deleted section are `(Baseline(b), Gap { after_row })`; the modified view receives matching gap metadata.
   - Collapsed modification: `Context Delete Delete Add Add Context` produces four aligned rows: one context row, two paired modification rows, and one context row.
   - Context inside a delete/add sequence resets the pairing window.
   - Multi-hunk file: alignment composes correctly across hunks separated by unchanged context.
   - Large diff (5,000 lines, 200 hunks): completes in under 50ms.
 
-- `app/src/code/editor/side_by_side_render_state_tests.rs`:
-  - Pane content for `DiffType::Update`: baseline render state holds pre-diff content with delete decorations; modified render state holds post-diff content with add decorations.
-  - Pane content for `DiffType::Create`: baseline render state is empty with gaps; modified holds the new file content.
-  - Pane content for `DiffType::Delete`: modified render state is empty with gaps; baseline holds the original content.
+- `app/src/code/editor/side_by_side_bridge_tests.rs`:
+  - Pane content for `DiffType::Update`: baseline view holds pre-diff content with delete decorations; modified view holds post-diff content with add decorations.
+  - Pane content for `DiffType::Create`: baseline view is empty with gaps; modified view holds the new file content.
+  - Pane content for `DiffType::Delete`: modified view is empty with gaps; baseline view holds the original content.
   - `apply_diffs_if_any` is not used when `DiffLayout::SideBySide` is active.
-  - Removed lines render only in `baseline_render_state`.
-  - Added lines render only in `modified_render_state`.
+  - Removed lines render as selectable rows in the baseline view and gaps in the modified view.
+  - Added lines render as editable-buffer rows in the modified view and gaps in the baseline view.
   - Gap rows have the same rendered height on both sides.
 
 - `app/src/code/editor/side_by_side_interaction_tests.rs`:
-  - `editor()` returns the modified side in side-by-side mode.
-  - `editor_for(Side::Baseline)` is read-only and does not expose an edit cursor.
-  - `editor_for(Side::Modified)` is the only side registered with `FileModel`.
-  - Baseline selection copies selectable content only.
-  - Deleted-line ranges are not selectable.
+  - The baseline child view is read-only and does not expose an edit cursor.
+  - The modified child view is the only side registered with `FileModel`.
+  - Baseline selection copies selectable content, including deleted-line ranges.
   - Cursor movement affects the modified side only.
   - Layout switch from `Inline` to `SideBySide` and back preserves scroll position to within one row.
 
 - `app/src/code/editor/side_by_side_scroll_tests.rs`:
-  - Wheel delta updates the shared vertical scroll offset for both panes.
+  - Wheel delta updates the bridge scroll anchor and reveals the corresponding row in both panes.
   - Cursor move on modified scrolls baseline to the corresponding row.
   - Cursor on a `(Gap { after_row }, Modified(m))` row (pure add) scrolls baseline to the next surrounding context line.
-  - No cross-view mirrored scroll event is emitted.
+  - Recursive scroll updates are suppressed by the bridge.
 
 ### Integration tests
 
@@ -521,17 +505,17 @@ Resolution: accessibility coverage remains explicit even though v1 uses one `Cod
   - The helper text names Code Review only.
 
 - `app/src/code_review/code_review_view_tests.rs`:
-  - Single-file diff in side-by-side renders both panes inside one `CodeEditorView`.
+  - Single-file diff in side-by-side renders both `CodeEditorView` children inside the bridge.
   - Multi-file diff: each file's editor honors the same layout.
-  - Setting flip while open calls `LocalCodeEditorView` -> `CodeEditorView::set_diff_layout` for every visible editor and preserves scroll.
-  - Find-in-diff matches both render states.
+  - Setting flip while open rebuilds every visible editor into the selected layout and preserves scroll.
+  - Find-in-diff matches both child editor views.
   - Hunk navigation (`f` / `F`) advances the focused hunk on both panes simultaneously while cursor remains on the modified side.
   - Comment thread on a baseline-side line renders under the baseline pane's row; modified pane shows the gutter marker.
-  - Hidden-line expansion updates both render states from the same alignment model.
+  - Hidden-line expansion updates both child views from the bridge's shared alignment model.
 
 ### Accessibility validation
 
-- Snapshot tests assert the accessible labels "Original" and "Modified" for side-by-side panes inside the single editor view.
+- Snapshot tests assert the accessible labels "Original" and "Modified" for side-by-side panes inside the bridge.
 - Keyboard tests cover `Tab` and any pane-switching shortcut selected during implementation.
 - Tests assert baseline focus does not expose edit actions or an insertion cursor.
 - Theme tests assert `diff.gap.background` meets 3:1 contrast against editor backgrounds in light and dark themes.
@@ -541,9 +525,9 @@ Resolution: accessibility coverage remains explicit even though v1 uses one `Cod
 
 - macOS, M1 MacBook Air, dogfood build with `SideBySideDiffLayout` enabled:
   - Open Settings -> Code. Change "Diff layout" from "Inline" to "Side by side" and confirm the visible Code Review diff refreshes within 200ms.
-  - Open Code Review with a 200-file diff. Confirm the active diff renders in two panes inside one editor view.
+  - Open Code Review with a 200-file diff. Confirm the active diff renders in two bridged editor views.
   - Scroll wheel on each pane. Confirm both panes scroll together without jitter.
-  - Drag-select on the baseline pane. Confirm selectable content copies but deleted-line ranges are not selectable.
+  - Drag-select on the baseline pane. Confirm selectable content copies, including deleted-line ranges.
   - Drag-select on the modified pane. Confirm selection stays in the modified pane.
   - Confirm the cursor appears only in the modified pane.
   - Cmd-A on each pane. Confirm only that pane's selectable content is selected.
@@ -559,17 +543,17 @@ Every site that destructures `DisplayMode` in a `match` must compile after the c
 - `app/src/ai/blocklist/inline_action/code_diff_view.rs`: unchanged in v1; continues inline rendering.
 - `app/src/ai/blocklist/block/view_impl/output.rs`: match on `DisplayMode::FullPane`; unchanged.
 
-Every Code Review site that accesses the editor through `editor()` should be checked. Existing write, save, cursor, and accept/reject paths should keep using `editor()` because it returns the modified side. Rendering, comments, find, selection, and accessibility call sites should use side-aware render-state access where needed.
+Every Code Review site that assumes one editor state should be checked. Existing write, save, cursor, and accept/reject paths should keep targeting the modified view. Rendering, comments, find, selection, and accessibility call sites should route through the bridge when side-by-side is active.
 
 ## Open questions
 
-1. Confirm `CodeEditorView` + one `EditorWrapper` + two `RenderState`s is the right implementation shape, versus `SplitView` + two `CodeEditorView`s or `CodeEditorView` + two `EditorWrapper`s.
-2. Confirm intra-component scroll sync is feasible inside one `EditorWrapper`, especially for hidden-line expansion and gap resizing, versus cross-view event mirroring.
-3. Confirm screen-reader and tab-order requirements can be expressed inside a single view that exposes two logical panes.
+1. State management shape: do we keep `CodeReviewEditorState` as one slice with `baseline_sub_state` and `modified_sub_state`, or split into two parallel `CodeReviewEditorState` slices? Single-slice keeps the existing Code Review reducer signature; split-slice cleanly separates the two views' lifecycles.
+2. Diff result ownership: does the bridge wrapper own the diff state directly, or is the diff state hoisted into the parent Code Review container? Bridge-owned diff is encapsulated; container-owned diff is reusable by other Code Review consumers.
+3. Find state UX: when "Next match" crosses panes, does focus jump match-by-match, or does it stay in one pane until all matches there are visited? Confirm with @kevinyang372 whether this is designed behavior or a bridge-internal detail.
 4. Comment thread interaction with the opposite-pane gutter marker (Change 13) is non-interactive in this spec. Whether the marker should be clickable is a UX call for the Code Review SME and a candidate follow-up.
 5. The segmented-control primitive used by `DiffLayoutWidget` needs SME confirmation. The current spec references existing settings segmented controls as precedent; the actual primitive name and import path should be confirmed during implementation review.
 6. Resizable panel split is out of scope for the first ship per product Non-goals. Whether to revisit this later depends on telemetry and user feedback after the initial release.
 
 ## Revision notes
 
-- v4 (this revision): narrowed v1 scope to Code Review only, deferred AI block-list and inline banner to v2, pivoted architecture from a separate side-by-side view type to `CodeEditorView` + one `EditorWrapper` + two `RenderState`s, clarified right-pane-only editing and cursor invariants, replaced ambiguous `line_index` with `RowIndex`, retargeted integration to `CodeReviewEditorState` / `LocalCodeEditorView`, and added open questions for @kevinyang372 architecture confirmation.
+- v4 (this revision): narrowed v1 scope to Code Review only, deferred AI block-list and inline banner to v2, restored the two `CodeEditorView` plus bridge-wrapper architecture, clarified right-pane-only editing and cursor invariants, replaced ambiguous `line_index` with `RowIndex`, retargeted integration to `CodeReviewEditorState` / `LocalCodeEditorView`, and updated open questions for the confirmed bridge direction.


### PR DESCRIPTION
Spec PR for #7043 (side-by-side diff view), listed under "Seeking community drivers" in the May-June 2026 roadmap (#9233).

`product.md` covers the user-facing behavior: a new `code.editor.diff_layout` setting (`inline` / `side_by_side`), exposed via the existing diff toolbar's View Options menu, applied to both AI block-list diffs and the Code Review pane. Inline stays the default; side-by-side adds a hunk-aligned two-pane renderer with synchronized vertical scrolling and per-pane selection.

`tech.md` walks the implementation: a new `DiffLayout` enum next to `DisplayMode`, a `SideBySideDiffView` sibling to `InlineDiffView`, a padding-row API on `CodeEditorView`, a `HunkAlignment` model that consumes the existing unified-diff parser, a `ScrollSyncModel` for cross-pane scroll, and View Options menu integration in `CodeReviewDiffMenu`. Every `DisplayMode` destructure site is checked for compile parity. Behind a `SideBySideDiffLayout` feature flag.

Open questions and follow-up scope are listed at the end of `tech.md` for SME triage.