### PR TITLE
Fix git operations button alignment in code review header

### DIFF
--- a/app/src/code_review/code_review_header/header_revamp.rs
+++ b/app/src/code_review/code_review_header/header_revamp.rs
@@ -127,7 +127,11 @@ impl CodeReviewHeader {
             );
         }
 
-        Some(Container::new(stack.finish()).with_margin_right(4.).finish())
+        Some(
+            Container::new(stack.finish())
+                .with_margin_right(4.)
+                .finish(),
+        )
     }
 
     /// Like `render_header_dropdown_button` but without `margin_left(4.)`,

--- a/app/src/code_review/code_review_header/header_revamp.rs
+++ b/app/src/code_review/code_review_header/header_revamp.rs
@@ -114,9 +114,7 @@ impl CodeReviewHeader {
             );
         }
 
-        let button_row = Container::new(row.finish()).with_margin_right(4.).finish();
-
-        let mut stack = Stack::new().with_child(button_row);
+        let mut stack = Stack::new().with_child(row.finish());
         if code_review_header_fields.git_operations_menu_open {
             stack.add_positioned_overlay_child(
                 ChildView::new(&code_review_header_fields.git_operations_menu).finish(),
@@ -129,7 +127,7 @@ impl CodeReviewHeader {
             );
         }
 
-        Some(stack.finish())
+        Some(Container::new(stack.finish()).with_margin_right(4.).finish())
     }
 
     /// Like `render_header_dropdown_button` but without `margin_left(4.)`,

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -1272,6 +1272,7 @@ impl CodeReviewView {
             Menu::new()
                 .prevent_interaction_with_other_elements()
                 .with_drop_shadow()
+                .with_width(140.)
         });
         ctx.subscribe_to_view(&git_operations_menu, |me, _, event, ctx| match event {
             MenuEvent::ItemSelected | MenuEvent::Close { .. } => {


### PR DESCRIPTION
## Description
Fix alignment and width of the git operations dropdown menu in the code review header (behind the `GitOperationsInCodeReview` feature flag).

**What:** Two fixes to the git operations button/menu in `render_git_operations_button`:
1. The dropdown menu was too wide (defaulting to 186px). Set it to 140px via `.with_width(140.)` on the `Menu` view at construction time. (aligned with the [Figma mocks here](https://www.figma.com/design/T2CtyXgIdjtrLfC03K1n1H/Code-review-2.0?node-id=6138-21140&p=f&m=dev))
2. The dropdown was misaligned with the button/chevron. The `margin_right(4.)` was previously applied inside the `Stack`, inflating the Stack's layout box by 4px and causing the `BottomRight`/`TopRight` overlay anchor to overshoot. Moved the margin to a wrapping `Container` outside the Stack so the Stack's right edge is flush with the chevron's right edge.

**Why:** The menu appeared too wide and visually misaligned with the button it belongs to.

**How:** In `header_revamp.rs`, removed the intermediate `Container` wrapping the button row inside the `Stack` and instead wrap the finished `Stack` in a `Container::new(...).with_margin_right(4.)`. In `code_review_view.rs`, chain `.with_width(120.)` onto the `Menu::new()` builder so the menu's internal `submenu_width` is set correctly.

Fixes [APP-4180](https://linear.app/warpdotdev/issue/APP-4180/this-dropdown-menu-is-not-properly-right-aligned-also-i-think-it)

<img width="380" height="183" alt="image" src="https://github.com/user-attachments/assets/52d7de8c-cc5e-4b8d-b60e-76b99862394d" />
