### PR TITLE
Add .claude/worktrees/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ app/src/persistence/schema.rs.orig
 # Don't include personal Claude Code settings
 .claude/settings.local.json
 
+# Don't include Claude Code worktrees
+.claude/worktrees/
+
 # Tab drag development notes
 pr_cleanup.md
 desired_behavior.md


### PR DESCRIPTION
## Summary
- Ignore `.claude/worktrees/` so Claude Code worktrees created under `.claude/` aren't surfaced as untracked files.

## Test plan
- [x] `git status` no longer shows `.claude/worktrees/` entries when a worktree exists there.