### PR TITLE
Introduce `/harness`, `/host` and `/environment` slash commands to new cloud mode input.

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
@@ -236,10 +236,38 @@ impl EnvironmentSelector {
         self.is_menu_open
     }
 
+    pub fn open_menu(&mut self, ctx: &mut ViewContext<Self>) {
+        if !self.is_configuring(ctx) {
+            return;
+        }
+        self.set_menu_visibility(true, ctx);
+    }
+
     fn is_configuring(&self, ctx: &AppContext) -> bool {
         self.ambient_agent_model
             .as_ref(ctx)
             .is_configuring_ambient_agent()
+    }
+
+    fn highlight_selected_environment(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(selected_id) = self
+            .ambient_agent_model
+            .as_ref(ctx)
+            .selected_environment_id()
+            .cloned()
+        else {
+            return;
+        };
+
+        let mut environments = CloudAmbientAgentEnvironment::get_all(ctx);
+        sort_environments_by_recency(&mut environments);
+        let Some(index) = environments.iter().position(|env| env.id == selected_id) else {
+            return;
+        };
+
+        self.dropdown.update(ctx, |menu, ctx| {
+            menu.select_index(index, ctx);
+        });
     }
 
     fn set_menu_visibility(&mut self, is_open: bool, ctx: &mut ViewContext<Self>) {
@@ -251,6 +279,7 @@ impl EnvironmentSelector {
         if is_open {
             send_telemetry_from_ctx!(CloudAgentTelemetryEvent::EnvironmentSelectorOpened, ctx);
             ctx.focus(&self.dropdown);
+            self.highlight_selected_environment(ctx);
         }
         ctx.emit(EnvironmentSelectorEvent::MenuVisibilityChanged { open: is_open });
         ctx.notify();
@@ -328,6 +357,10 @@ impl EnvironmentSelector {
         self.dropdown.update(ctx, |menu, ctx| {
             menu.update_menu_items(menu_items, ctx);
         });
+
+        if self.is_menu_open {
+            self.highlight_selected_environment(ctx);
+        }
     }
 
     fn refresh_button(&mut self, ctx: &mut ViewContext<Self>) {

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -613,6 +613,9 @@ impl AgentInputFooter {
             ctx.subscribe_to_view(environment_selector, |_, _, event, ctx| match event {
                 EnvironmentSelectorEvent::MenuVisibilityChanged { open } => {
                     ctx.emit(AgentInputFooterEvent::ToggledChipMenu { open: *open });
+                    if !*open {
+                        ctx.emit(AgentInputFooterEvent::EnvironmentSelectorClosed);
+                    }
                 }
                 EnvironmentSelectorEvent::OpenEnvironmentManagementPane => {
                     ctx.emit(AgentInputFooterEvent::OpenEnvironmentManagementPane);
@@ -806,6 +809,18 @@ impl AgentInputFooter {
 
     pub fn open_v2_model_selector(&mut self, ctx: &mut ViewContext<Self>) {
         if let Some(selector) = self.v2_model_selector.clone() {
+            selector.update(ctx, |s, ctx| s.open_menu(ctx));
+        }
+    }
+
+    pub fn is_v2_environment_selector_open(&self, app: &AppContext) -> bool {
+        self.environment_selector
+            .as_ref()
+            .is_some_and(|s| s.as_ref(app).is_menu_open())
+    }
+
+    pub fn open_v2_environment_selector(&mut self, ctx: &mut ViewContext<Self>) {
+        if let Some(selector) = self.environment_selector.clone() {
             selector.update(ctx, |s, ctx| s.open_menu(ctx));
         }
     }
@@ -2421,6 +2436,7 @@ pub enum AgentInputFooterEvent {
     PromptAlert(PromptAlertEvent),
     ModelSelectorOpened,
     ModelSelectorClosed,
+    EnvironmentSelectorClosed,
     ToggleInlineModelSelector {
         initial_tab: InlineModelSelectorTab,
     },

--- a/app/src/context_chips/display_menu.rs
+++ b/app/src/context_chips/display_menu.rs
@@ -467,6 +467,15 @@ impl DisplayChipMenu {
         ctx.notify();
     }
 
+    pub fn select_index(&mut self, index: usize, ctx: &mut ViewContext<Self>) {
+        if index >= self.filtered_items.len() {
+            return;
+        }
+        self.is_footer_selected = false;
+        self.select(index, ctx);
+        self.list_state.scroll_to(self.selected_index);
+    }
+
     fn is_footer_selected(&self) -> bool {
         self.is_footer_selected
             || self

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -288,6 +288,39 @@ pub static MODEL: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     argument: None,
 });
 
+pub static HOST: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
+    name: "/host",
+    description: "Switch the cloud agent execution host",
+    icon_path: "bundled/svg/oz-cloud.svg",
+    availability: Availability::AGENT_VIEW
+        | Availability::AI_ENABLED
+        | Availability::CLOUD_AGENT_V2,
+    auto_enter_ai_mode: true,
+    argument: None,
+});
+
+pub static HARNESS: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
+    name: "/harness",
+    description: "Switch the cloud agent harness",
+    icon_path: "bundled/svg/oz.svg",
+    availability: Availability::AGENT_VIEW
+        | Availability::AI_ENABLED
+        | Availability::CLOUD_AGENT_V2,
+    auto_enter_ai_mode: true,
+    argument: None,
+});
+
+pub static ENVIRONMENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
+    name: "/environment",
+    description: "Switch the cloud agent environment",
+    icon_path: "bundled/svg/globe-04.svg",
+    availability: Availability::AGENT_VIEW
+        | Availability::AI_ENABLED
+        | Availability::CLOUD_AGENT_V2,
+    auto_enter_ai_mode: true,
+    argument: None,
+});
+
 pub static PROFILE: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/profile",
     description: "Switch the active execution profile",
@@ -672,6 +705,12 @@ fn all_commands() -> Vec<StaticCommand> {
 
     if FeatureFlag::SettingsFile.is_enabled() && cfg!(feature = "local_fs") {
         commands.push(OPEN_SETTINGS_FILE);
+    }
+
+    if FeatureFlag::CloudModeInputV2.is_enabled() {
+        commands.push(HOST.clone());
+        commands.push(HARNESS.clone());
+        commands.push(ENVIRONMENT.clone());
     }
 
     commands

--- a/app/src/search/slash_command_menu/static_commands/mod.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod.rs
@@ -35,6 +35,11 @@ bitflags! {
         /// Requires AI to be globally enabled.
         const AI_ENABLED = 1 << 7;
         const NOT_CLOUD_AGENT = 1 << 8;
+        /// Set on the session context iff the slash command data source was constructed via
+        /// `SlashCommandDataSource::for_cloud_mode_v2` *and* `FeatureFlag::CloudModeInputV2`
+        /// is enabled. Commands that require this bit are hidden everywhere except the V2
+        /// cloud-mode composing input.
+        const CLOUD_AGENT_V2 = 1 << 9;
     }
 }
 

--- a/app/src/search/slash_command_menu/static_commands/mod_test.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod_test.rs
@@ -165,23 +165,27 @@ fn codebase_context_requirement_not_satisfied_when_disabled() {
 // --- CLOUD_AGENT_V2 flag tests ---
 #[test]
 fn cloud_agent_v2_required_command_satisfied_in_v2_session() {
-    let command = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
+    let command =
+        Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
 
     // V2 cloud-mode composing input has AGENT_VIEW + AI_ENABLED + CLOUD_AGENT_V2 set.
-    let session = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
+    let session =
+        Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
     assert!(session.contains(command));
 }
 
 #[test]
 fn cloud_agent_v2_required_command_not_satisfied_outside_v2() {
-    let command = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
+    let command =
+        Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
 
     // A regular agent view session without the V2 bit must not match.
     let session = Availability::AGENT_VIEW | Availability::AI_ENABLED;
     assert!(!session.contains(command));
 
     // Local-mode agent view (NOT_CLOUD_AGENT instead of CLOUD_AGENT_V2) must not match either.
-    let session = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::NOT_CLOUD_AGENT;
+    let session =
+        Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::NOT_CLOUD_AGENT;
     assert!(!session.contains(command));
 }
 

--- a/app/src/search/slash_command_menu/static_commands/mod_test.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod_test.rs
@@ -162,6 +162,29 @@ fn codebase_context_requirement_not_satisfied_when_disabled() {
     assert!(!session.contains(command));
 }
 
+// --- CLOUD_AGENT_V2 flag tests ---
+#[test]
+fn cloud_agent_v2_required_command_satisfied_in_v2_session() {
+    let command = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
+
+    // V2 cloud-mode composing input has AGENT_VIEW + AI_ENABLED + CLOUD_AGENT_V2 set.
+    let session = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
+    assert!(session.contains(command));
+}
+
+#[test]
+fn cloud_agent_v2_required_command_not_satisfied_outside_v2() {
+    let command = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
+
+    // A regular agent view session without the V2 bit must not match.
+    let session = Availability::AGENT_VIEW | Availability::AI_ENABLED;
+    assert!(!session.contains(command));
+
+    // Local-mode agent view (NOT_CLOUD_AGENT instead of CLOUD_AGENT_V2) must not match either.
+    let session = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::NOT_CLOUD_AGENT;
+    assert!(!session.contains(command));
+}
+
 // --- AI_ENABLED flag tests ---
 
 #[test]

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -345,7 +345,9 @@ use super::{
 use crate::ai::blocklist::agent_view::{
     AgentInputFooter, AgentInputFooterEvent, AgentViewController,
 };
-use crate::terminal::view::ambient_agent::{HarnessSelector, HostSelector, NakedHeaderButtonTheme};
+use crate::terminal::view::ambient_agent::{
+    HarnessSelector, HarnessSelectorEvent, HostSelector, HostSelectorEvent, NakedHeaderButtonTheme,
+};
 use async_channel::Sender;
 use futures::stream::AbortHandle;
 use parking_lot::FairMutex;
@@ -2201,12 +2203,35 @@ impl Input {
                                 selector.set_button_theme(NakedHeaderButtonTheme, ctx);
                             });
                         }
+                        // Mirror the V2 model selector / host selector refocus path: when the
+                        // harness selector menu closes (item picked or dismissed via Esc /
+                        // click-outside), restore focus to the input editor so typing resumes
+                        // immediately. This powers the "input is focused after the harness
+                        // selector closes" UX for the `/harness` slash command.
+                        ctx.subscribe_to_view(&harness_selector, |me, _, event, ctx| {
+                            let HarnessSelectorEvent::MenuVisibilityChanged { open } = event;
+                            if !*open {
+                                me.focus_input_box(ctx);
+                            }
+                        });
                         harness_selector
                     },
                     host_selector: if FeatureFlag::CloudModeInputV2.is_enabled() {
-                        Some(ctx.add_typed_action_view(|ctx| {
+                        let view = ctx.add_typed_action_view(|ctx| {
                             HostSelector::new(menu_positioning_provider.clone(), ctx)
-                        }))
+                        });
+                        // Mirror the V2 model selector's `ModelSelectorClosed` -> refocus path:
+                        // when the host selector menu closes (item picked or dismissed via Esc /
+                        // click-outside), restore focus to the input editor so typing resumes
+                        // immediately. This is what powers the "input is focused after the host
+                        // selector closes" UX for the `/harness` slash command.
+                        ctx.subscribe_to_view(&view, |me, _, event, ctx| {
+                            let HostSelectorEvent::MenuVisibilityChanged { open } = event;
+                            if !*open {
+                                me.focus_input_box(ctx);
+                            }
+                        });
+                        Some(view)
                     } else {
                         None
                     },
@@ -2248,8 +2273,8 @@ impl Input {
                 AgentInputFooterEvent::ModelSelectorOpened => {
                     me.close_overlays(false, ctx);
                 }
-                AgentInputFooterEvent::ModelSelectorClosed => {
-                    // When the model selector menu closes (model was selected), focus the input field
+                AgentInputFooterEvent::ModelSelectorClosed
+                | AgentInputFooterEvent::EnvironmentSelectorClosed => {
                     me.focus_input_box(ctx);
                 }
                 AgentInputFooterEvent::ToggleInlineModelSelector { initial_tab } => {
@@ -3408,6 +3433,32 @@ impl Input {
         self.ambient_agent_view_state
             .as_ref()
             .and_then(|state| state.host_selector.as_ref())
+    }
+
+    /// Opens the V2 cloud-mode host selector popover, if the feature is enabled and the
+    /// selector is constructed. No-op otherwise. Used by the `/host` slash command to
+    /// programmatically open the same popover that the V2 footer's host button toggles.
+    pub(super) fn open_v2_host_selector(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(host_selector) = self.host_selector().cloned() else {
+            return;
+        };
+        host_selector.update(ctx, |selector, ctx| selector.open_menu(ctx));
+    }
+
+    /// Opens the V2 cloud-mode harness selector popover, if the feature is enabled and the
+    /// selector is constructed. No-op otherwise. Used by the `/harness` slash command to
+    /// programmatically open the same popover that the V2 footer's harness button toggles.
+    pub(super) fn open_v2_harness_selector(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(harness_selector) = self.harness_selector().cloned() else {
+            return;
+        };
+        harness_selector.update(ctx, |selector, ctx| selector.open_menu(ctx));
+    }
+
+    pub(super) fn open_v2_environment_selector(&mut self, ctx: &mut ViewContext<Self>) {
+        self.agent_input_footer
+            .clone()
+            .update(ctx, |footer, ctx| footer.open_v2_environment_selector(ctx));
     }
 
     /// Update the at button's disabled state based on whether AI context menu should render
@@ -14313,9 +14364,22 @@ impl View for Input {
             .agent_input_footer
             .as_ref(app)
             .is_v2_model_selector_open(app);
+        let is_v2_host_selector_open = self
+            .host_selector()
+            .is_some_and(|view| view.as_ref(app).is_menu_open());
+        let is_v2_harness_selector_open = self
+            .harness_selector()
+            .is_some_and(|view| view.as_ref(app).is_menu_open());
+        let is_v2_environment_selector_open = self
+            .agent_input_footer
+            .as_ref(app)
+            .is_v2_environment_selector_open(app);
         if is_profile_model_selector_open
             || is_agent_footer_model_selector_open
             || is_v2_model_selector_open
+            || is_v2_host_selector_open
+            || is_v2_harness_selector_open
+            || is_v2_environment_selector_open
         {
             ctx.set.insert("ProfileModelSelectorOpen");
         }

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -237,6 +237,9 @@ impl SlashCommandDataSource {
             session_context |= Availability::AI_ENABLED;
         }
 
+        if self.is_cloud_mode_v2 && FeatureFlag::CloudModeInputV2.is_enabled() {
+            session_context |= Availability::CLOUD_AGENT_V2;
+        }
         if !self.is_cloud_mode_v2 {
             session_context |= Availability::NOT_CLOUD_AGENT;
         }

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -709,6 +709,43 @@ impl Input {
                 // Open the skill selector menu for invocation - skill command will be inserted into buffer
                 self.open_invoke_skill_selector(ctx);
             }
+            host if command.name == commands::HOST.name => {
+                if !self.is_cloud_mode_input_v2_composing(ctx) {
+                    // Defensive: the command is registered only when the V2 flag is on and its
+                    // availability requires CLOUD_AGENT_V2, so this branch should be unreachable.
+                    return false;
+                }
+                self.suggestions_mode_model.update(ctx, |model, ctx| {
+                    model.set_mode(InputSuggestionsMode::Closed, ctx);
+                });
+                self.clear_buffer_and_reset_undo_stack(ctx);
+                self.open_v2_host_selector(ctx);
+                return true;
+            }
+            harness if command.name == commands::HARNESS.name => {
+                if !self.is_cloud_mode_input_v2_composing(ctx) {
+                    // Defensive: the command is registered only when the V2 flag is on and its
+                    // availability requires CLOUD_AGENT_V2, so this branch should be unreachable.
+                    return false;
+                }
+                self.suggestions_mode_model.update(ctx, |model, ctx| {
+                    model.set_mode(InputSuggestionsMode::Closed, ctx);
+                });
+                self.clear_buffer_and_reset_undo_stack(ctx);
+                self.open_v2_harness_selector(ctx);
+                return true;
+            }
+            environment if command.name == commands::ENVIRONMENT.name => {
+                if !self.is_cloud_mode_input_v2_composing(ctx) {
+                    return false;
+                }
+                self.suggestions_mode_model.update(ctx, |model, ctx| {
+                    model.set_mode(InputSuggestionsMode::Closed, ctx);
+                });
+                self.clear_buffer_and_reset_undo_stack(ctx);
+                self.open_v2_environment_selector(ctx);
+                return true;
+            }
             models if command.name == commands::MODEL.name => {
                 if self.is_cloud_mode_input_v2_composing(ctx) {
                     self.suggestions_mode_model.update(ctx, |model, ctx| {

--- a/app/src/terminal/view/ambient_agent/harness_selector.rs
+++ b/app/src/terminal/view/ambient_agent/harness_selector.rs
@@ -136,6 +136,22 @@ impl HarnessSelector {
         self.is_menu_open
     }
 
+    /// Programmatically opens the harness selector popover. No-op if already open.
+    pub fn open_menu(&mut self, ctx: &mut ViewContext<Self>) {
+        self.set_menu_visibility(true, ctx);
+    }
+
+    /// Highlights the currently-selected harness in the menu. Called when the menu
+    /// transitions from closed to open so the user has a clear starting point for arrow-key
+    /// navigation instead of an unselected list.
+    fn highlight_selected_harness(&mut self, ctx: &mut ViewContext<Self>) {
+        let harness = self.ambient_agent_model.as_ref(ctx).selected_harness();
+        let selected_action = HarnessSelectorAction::SelectHarness(harness);
+        self.menu.update(ctx, |menu, ctx| {
+            menu.set_selected_by_action(&selected_action, ctx);
+        });
+    }
+
     pub fn set_button_theme(
         &self,
         theme: impl ActionButtonTheme + 'static,
@@ -153,6 +169,7 @@ impl HarnessSelector {
         self.is_menu_open = is_open;
         if is_open {
             ctx.focus(&self.menu);
+            self.highlight_selected_harness(ctx);
         }
         ctx.emit(HarnessSelectorEvent::MenuVisibilityChanged { open: is_open });
         ctx.notify();

--- a/app/src/terminal/view/ambient_agent/host_selector.rs
+++ b/app/src/terminal/view/ambient_agent/host_selector.rs
@@ -123,6 +123,21 @@ impl HostSelector {
         self.is_menu_open
     }
 
+    /// Programmatically opens the host selector popover. No-op if already open.
+    pub fn open_menu(&mut self, ctx: &mut ViewContext<Self>) {
+        self.set_menu_visibility(true, ctx);
+    }
+
+    /// Highlights the currently-selected host in the menu. Called when the menu transitions
+    /// from closed to open so the user has a clear starting point for arrow-key navigation
+    /// instead of an unselected list.
+    fn highlight_selected_host(&mut self, ctx: &mut ViewContext<Self>) {
+        let selected_action = HostSelectorAction::SelectHost(self.selected);
+        self.menu.update(ctx, |menu, ctx| {
+            menu.set_selected_by_action(&selected_action, ctx);
+        });
+    }
+
     fn set_menu_visibility(&mut self, is_open: bool, ctx: &mut ViewContext<Self>) {
         if self.is_menu_open == is_open {
             return;
@@ -130,6 +145,7 @@ impl HostSelector {
         self.is_menu_open = is_open;
         if is_open {
             ctx.focus(&self.menu);
+            self.highlight_selected_host(ctx);
         }
         ctx.emit(HostSelectorEvent::MenuVisibilityChanged { open: is_open });
         ctx.notify();


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

WISOTT!

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

Here's a loom: https://www.loom.com/share/af45af8c7da24efcae9eea6adf953578

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

