### PR TITLE
add vertical tabs, tab configs, worktree, notifications, and rich input stakeholders

### DIFF
--- a/.github/STAKEHOLDERS
+++ b/.github/STAKEHOLDERS
@@ -46,7 +46,7 @@
 /app/src/terminal/input/ @vkodithala
 /app/src/pane_group/ @vkodithala
 /app/src/tab.rs @vkodithala
-/crates/warp_ripgrep/ @vkodithala @moirahuang @szgupta
+/crates/warp_ripgrep/ @moirahuang @szgupta
 
 # Command palette
 /app/src/command_palette.rs @acarl005
@@ -62,6 +62,11 @@
 /app/src/terminal/input/slash_commands/ @moirahuang
 /app/src/code/file_tree/ @moirahuang
 /app/src/workspace/view/global_search/ @moirahuang
+
+# Tab configs and worktrees
+/app/src/tab_configs/ @moirahuang
+/app/resources/tab_configs/ @moirahuang
+/crates/warp_util/src/worktree_names.rs @moirahuang
 
 # Onboarding / code review and git diff
 /app/src/ai/onboarding.rs @kevinchevalier
@@ -98,6 +103,10 @@
 
 # Agent mode
 /app/src/ai/agent/ @zachbai
+
+# Vertical tabs
+/app/src/workspace/view/vertical_tabs.rs @zachbai
+/app/src/workspace/view/vertical_tabs/ @zachbai
 
 # Image attachment, voice input, and passive suggestions
 /app/src/ai/attachment_utils.rs @Advait-M

--- a/.github/STAKEHOLDERS
+++ b/.github/STAKEHOLDERS
@@ -92,6 +92,11 @@
 /crates/input_classifier/ @harryalbert
 /crates/natural_language_detection/ @harryalbert
 
+# Notifications
+/app/src/notification.rs @harryalbert
+/app/src/ai/agent_management/notifications/ @harryalbert
+/app/src/terminal/view/inline_banner/ @harryalbert
+
 # Blocklist UX / modality and cloud mode UI / shell compatibility / completions and bootstrap / warpifying
 /app/src/ai/blocklist/ @zachbai
 /app/src/root_view.rs @zachbai
@@ -115,6 +120,10 @@
 /app/src/ai/blocklist/passive_suggestions/ @Advait-M
 /app/src/voice/ @Advait-M
 /crates/voice_input/ @Advait-M
+
+# Rich input
+/app/src/terminal/view/use_agent_footer/ @Advait-M
+/app/src/terminal/input/cli_agent.rs @Advait-M
 
 # UI framework
 /crates/warpui/ @vorporeal


### PR DESCRIPTION
## Description
Add vertical tabs, tab configs, worktree, notifications, and rich input stakeholders from the Warp team side

## Testing
N/A

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
