### PR TITLE
Fix copy keybinding to prioritize input text over selected blocks (APP-4330)

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -14889,6 +14889,21 @@ impl TerminalView {
             }
             return;
         }
+
+        // Prioritize selected text in the input over selected blocks (APP-4330):
+        // it's possible to have both a block and input text selected at the same
+        // time, and in that case the user almost always means to copy the input.
+        let selected_input_text = self.input.read(ctx, |input, ctx| {
+            input
+                .editor()
+                .read(ctx, |editor, ctx| editor.selected_text(ctx))
+        });
+        if !selected_input_text.is_empty() {
+            ctx.clipboard()
+                .write(ClipboardContent::plain_text(selected_input_text));
+            return;
+        }
+
         if !self.selected_blocks.is_empty() {
             self.copy_blocks(BlockEntity::CommandAndOutput, ctx);
         }


### PR DESCRIPTION
## Description
Fixes [APP-4330](https://linear.app/warp/issue/APP-4330): the global Copy keybinding (Ctrl/Cmd-Shift-C) was copying selected block content even when the user had text highlighted in the input editor.

You can have a block selected and text highlighted in the input editor at the same time. In that case, the user almost always intends to copy the actively-selected input text, not the block.

This change updates `TerminalView::copy` to check for selected text in the input editor before falling back to copying selected blocks. The priority is now:
1. Selected text in CLI subagent views (unchanged)
2. Selected text in the cloud mode error screen (unchanged)
3. Selected text in the terminal grid / block (unchanged)
4. **Selected text in the input editor (new)**
5. Selected blocks (unchanged)

## Testing
Manual testing:
- Select a block (block card is highlighted) AND highlight text in the input editor.
- Press Ctrl/Cmd-Shift-C.
- Confirm the highlighted input text is copied to the clipboard, not the block contents.
- Confirm copying still works as before when only a block is selected, when only block grid text is selected, etc.

https://www.loom.com/share/573b5d4a75ca42a8ad6c40900363edbd

## Server API dependencies
N/A — client-only change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Copy keybinding now prioritizes selected text in the input over a selected block when both are active.
