### PR TITLE
Reduce RAM requirements for release builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -378,12 +378,15 @@ derivative = "2.2.0"
 parquet = { version = "55.0.0", features = ["arrow"] }
 rmcp = { git = "https://github.com/warpdotdev/rmcp.git", rev = "c0f65dc441af7d714b9c453ac5e7ef641451abe3" }
 
-# Comment this to disable building with debug symbols
-# Building with debug symbols generates a dsym which we can use to get
-# better stack traces in sentry. But there is a cost of about 20% binary size
-# increase.
 [profile.release]
-debug = true
+# Use line-tables-only (debug = 1) rather than full debuginfo (debug = 2 /
+# `true`). Line tables are enough to symbolicate panics and Sentry stack
+# traces with file/line info, but they omit the per-variable/type DWARF that
+# dominates DWARF size. Dropping the type info significantly reduces rustc's
+# peak memory during ThinLTO + codegen (which was OOM-killing release builds
+# on CI), at the cost of not being able to inspect locals/types when
+# attaching a debugger to a release binary.
+debug = 1
 # Force the rust compiler to create a dSYM. Starting in 1.53 the default on MacOS is "unpacked".
 split-debuginfo = "packed"
 


### PR DESCRIPTION
## Description
Release builds (specifically the `release-lto` profile, which is `release` + `lto = "thin"`) have been OOM-killing rustc on CI. The dominant memory cost during ThinLTO + codegen is the full per-variable/type DWARF that `debug = true` emits, since rustc has to hold that DWARF for every transitively-linked rlib in memory while merging modules.

Dropping `[profile.release]` to `debug = 1` keeps line tables — which is all we need to symbolicate panics and Sentry stack traces with file/line info — and discards the type/variable DIEs that drive most of the memory pressure. The tradeoff is that attaching a debugger to a release binary will no longer show locals or rich type info; post-mortem backtraces are unaffected.

This is the lowest-side-effect change I could find that materially reduces peak rustc memory; if it isn't enough on its own, the next levers would be `codegen-units = 1` or backing off ThinLTO.

## Testing
Relying on CI to confirm the release build succeeds without OOMing. No runtime behavior changes.
