### PR TITLE
fix(windows): exclude error-codes.md filenames from autoupdate error detection

### DIFF
--- a/app/src/autoupdate/windows.rs
+++ b/app/src/autoupdate/windows.rs
@@ -152,9 +152,10 @@ pub(super) fn check_and_report_update_errors(ctx: &mut AppContext) {
             // Recent Inno Setup versions try to enable a security feature which is unavailable on
             // Windows 10 versions prior to 22H2 and this call fails. The failure is benign.
             b"setprocessmitigationpolicy failed with error code 87",
-            // Bundled skill files whose names contain "error" (e.g. error-codes.md) appear in
-            // "Dest filename:" log lines and produce false positives.
+            // Bundled skill files whose names contain "error" appear in "Dest filename:" log lines
+            // and produce false positives.
             b"error-codes.md",
+            b"error-recovery.md",
         ];
 
         let mut error_count = memchr::memmem::find_iter(&contents_lowercase, b"error").count();

--- a/app/src/autoupdate/windows.rs
+++ b/app/src/autoupdate/windows.rs
@@ -152,6 +152,9 @@ pub(super) fn check_and_report_update_errors(ctx: &mut AppContext) {
             // Recent Inno Setup versions try to enable a security feature which is unavailable on
             // Windows 10 versions prior to 22H2 and this call fails. The failure is benign.
             b"setprocessmitigationpolicy failed with error code 87",
+            // Bundled skill files whose names contain "error" (e.g. error-codes.md) appear in
+            // "Dest filename:" log lines and produce false positives.
+            b"error-codes.md",
         ];
 
         let mut error_count = memchr::memmem::find_iter(&contents_lowercase, b"error").count();


### PR DESCRIPTION
Migrated from warpdotdev/warp-internal#25002 via `script/migrate-private-to-public`.

## Commits

- 0cdfcc9 fix(windows): exclude error-codes.md filenames from autoupdate error detection
- 896c318 add another pattern
