### PR TITLE
add /continue-locally slash command

### DIFF
--- a/app/src/ai/agent_management/telemetry.rs
+++ b/app/src/ai/agent_management/telemetry.rs
@@ -111,6 +111,9 @@ pub enum AgentManagementTelemetryEvent {
     /// User clicked "Continue locally" in the details panel
     #[cfg(not(target_family = "wasm"))]
     DetailsPanelContinueLocally,
+    /// User invoked the /continue-locally slash command
+    #[cfg(not(target_family = "wasm"))]
+    SlashCommandContinueLocally,
     /// User clicked "Open in Warp" in the tombstone (wasm)
     #[cfg(target_family = "wasm")]
     TombstoneOpenInWarp,
@@ -192,6 +195,8 @@ impl TelemetryEvent for AgentManagementTelemetryEvent {
             AgentManagementTelemetryEvent::TombstoneContinueLocally => None,
             #[cfg(not(target_family = "wasm"))]
             AgentManagementTelemetryEvent::DetailsPanelContinueLocally => None,
+            #[cfg(not(target_family = "wasm"))]
+            AgentManagementTelemetryEvent::SlashCommandContinueLocally => None,
             #[cfg(target_family = "wasm")]
             AgentManagementTelemetryEvent::TombstoneOpenInWarp => None,
             AgentManagementTelemetryEvent::CloudRunCancelled { task_id } => {
@@ -244,6 +249,8 @@ impl TelemetryEventDesc for AgentManagementTelemetryEventDiscriminants {
             Self::TombstoneContinueLocally => "AgentManagement.TombstoneContinueLocally",
             #[cfg(not(target_family = "wasm"))]
             Self::DetailsPanelContinueLocally => "AgentManagement.DetailsPanelContinueLocally",
+            #[cfg(not(target_family = "wasm"))]
+            Self::SlashCommandContinueLocally => "AgentManagement.SlashCommandContinueLocally",
             #[cfg(target_family = "wasm")]
             Self::TombstoneOpenInWarp => "AgentManagement.TombstoneOpenInWarp",
             Self::CloudRunCancelled => "AgentManagement.CloudRunCancelled",
@@ -277,6 +284,10 @@ impl TelemetryEventDesc for AgentManagementTelemetryEventDiscriminants {
             #[cfg(not(target_family = "wasm"))]
             Self::DetailsPanelContinueLocally => {
                 "User clicked Continue locally in the details panel"
+            }
+            #[cfg(not(target_family = "wasm"))]
+            Self::SlashCommandContinueLocally => {
+                "User invoked /continue-locally to fork a cloud conversation locally"
             }
             #[cfg(target_family = "wasm")]
             Self::TombstoneOpenInWarp => "User clicked Open in Warp in the tombstone",

--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -734,10 +734,14 @@ impl MessageProvider<AgentMessageArgs<'_>> for ForkSlashCommandMessageProducer {
             return None;
         };
         let command_name = detected_command.command.name;
-        if command_name != commands::FORK.name
-            && command_name != commands::FORK_FROM.name
-            && command_name != commands::FORK_AND_COMPACT.name
-        {
+        let is_fork_family = command_name == commands::FORK.name
+            || command_name == commands::FORK_FROM.name
+            || command_name == commands::FORK_AND_COMPACT.name;
+        #[cfg(not(target_family = "wasm"))]
+        let is_continue_locally = command_name == commands::CONTINUE_LOCALLY.name;
+        #[cfg(target_family = "wasm")]
+        let is_continue_locally = false;
+        if !is_fork_family && !is_continue_locally {
             return None;
         }
         let modifier_keystroke = if cfg!(target_os = "macos") {
@@ -755,10 +759,11 @@ impl MessageProvider<AgentMessageArgs<'_>> for ForkSlashCommandMessageProducer {
             }
         };
 
-        // `/fork` opens in a new pane with Enter and a new tab with Cmd/Ctrl+Enter.
-        // Other fork-like commands open in the current pane with Enter and a new pane
-        // with Cmd/Ctrl+Enter.
-        let (primary_label, secondary_label) = if command_name == commands::FORK.name {
+        // `/fork` and `/continue-locally` open in a new pane with Enter and a new tab with
+        // Cmd/Ctrl+Enter. Other fork-like commands open in the current pane with Enter and a new
+        // pane with Cmd/Ctrl+Enter.
+        let primary_to_new_pane = command_name == commands::FORK.name || is_continue_locally;
+        let (primary_label, secondary_label) = if primary_to_new_pane {
             (" new pane", " new tab")
         } else {
             (" current pane", " new pane")

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -369,6 +369,20 @@ pub const FORK_FROM: StaticCommand = StaticCommand {
     argument: None,
 };
 
+pub static CONTINUE_LOCALLY: LazyLock<StaticCommand> = LazyLock::new(|| {
+    let hint_text = "<optional prompt to send in forked conversation>";
+    StaticCommand {
+        name: "/continue-locally",
+        description: "Continue this cloud conversation locally",
+        icon_path: "bundled/svg/arrow-split.svg",
+        availability: Availability::AGENT_VIEW
+            | Availability::ACTIVE_CONVERSATION
+            | Availability::AI_ENABLED,
+        auto_enter_ai_mode: true,
+        argument: Some(Argument::optional().with_hint_text(hint_text)),
+    }
+});
+
 pub const USAGE: StaticCommand = StaticCommand {
     name: "/usage",
     description: "Open billing and usage settings",
@@ -570,7 +584,11 @@ fn all_commands() -> Vec<StaticCommand> {
     }
 
     if !cfg!(target_family = "wasm") {
-        commands.extend([FORK.clone(), FORK_AND_COMPACT.clone()]);
+        commands.extend([
+            FORK.clone(),
+            FORK_AND_COMPACT.clone(),
+            CONTINUE_LOCALLY.clone(),
+        ]);
 
         if FeatureFlag::ForkFromCommand.is_enabled() {
             commands.push(FORK_FROM);
@@ -648,6 +666,33 @@ mod tests {
         assert!(!argument.is_optional);
         assert!(!argument.should_execute_on_selection);
         assert_eq!(argument.hint_text, Some("<tab name>"));
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn continue_locally_command_is_registered() {
+        let command = COMMAND_REGISTRY
+            .get_command_with_name(CONTINUE_LOCALLY.name)
+            .expect("expected /continue-locally to be registered");
+
+        assert_eq!(command.name, "/continue-locally");
+        assert_eq!(command.icon_path, "bundled/svg/arrow-split.svg");
+        assert!(command.auto_enter_ai_mode);
+        assert_eq!(
+            command.availability,
+            Availability::AGENT_VIEW | Availability::ACTIVE_CONVERSATION | Availability::AI_ENABLED
+        );
+
+        let argument = command
+            .argument
+            .as_ref()
+            .expect("expected /continue-locally to declare an argument");
+        assert!(argument.is_optional);
+        assert!(!argument.should_execute_on_selection);
+        assert_eq!(
+            argument.hint_text,
+            Some("<optional prompt to send in forked conversation>")
+        );
     }
 
     #[test]

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -15,6 +15,7 @@ use warp_core::ui::appearance::Appearance;
 use warpui::fonts::FamilyId;
 use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
+use crate::ai::agent_conversations_model::{AgentConversationsModel, AgentConversationsModelEvent};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::skills::{SkillDescriptor, SkillManager};
 use crate::search::data_source::{Query, QueryResult};
@@ -25,6 +26,8 @@ use crate::terminal::cli_agent_sessions::{
     CLIAgentInputState, CLIAgentSessionsModel, CLIAgentSessionsModelEvent,
 };
 use crate::terminal::model::session::SessionType;
+#[cfg(not(target_family = "wasm"))]
+use warp_cli::agent::Harness;
 use warp_core::ui::Icon as WarpIcon;
 
 use super::AcceptSlashCommandOrSavedPrompt;
@@ -32,6 +35,7 @@ use crate::{
     ai::blocklist::{
         agent_view::{AgentViewController, AgentViewControllerEvent},
         block::cli_controller::{CLISubagentController, CLISubagentEvent},
+        BlocklistAIHistoryEvent,
     },
     search::{
         slash_command_menu::{
@@ -125,6 +129,28 @@ impl SlashCommandDataSource {
                 }
             },
         );
+        // Recompute when the active conversation switches so commands gated on the active
+        // conversation's task (e.g. /continue-locally) update on navigation.
+        ctx.subscribe_to_model(&BlocklistAIHistoryModel::handle(ctx), |me, event, ctx| {
+            if matches!(
+                event,
+                BlocklistAIHistoryEvent::SetActiveConversation { .. }
+                    | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
+            ) {
+                me.recompute_active_commands(ctx);
+            }
+        });
+        // Recompute when task data is updated so commands gated on a conversation's task
+        // harness (e.g. /continue-locally) appear once the task fetch resolves.
+        ctx.subscribe_to_model(&AgentConversationsModel::handle(ctx), |me, event, ctx| {
+            if matches!(
+                event,
+                AgentConversationsModelEvent::TasksUpdated
+                    | AgentConversationsModelEvent::NewTasksReceived
+            ) {
+                me.recompute_active_commands(ctx);
+            }
+        });
 
         let mut me = Self {
             active_session,
@@ -203,6 +229,9 @@ impl SlashCommandDataSource {
 
         let is_orchestration_enabled = AISettings::as_ref(ctx).is_orchestration_enabled(ctx);
 
+        #[cfg(not(target_family = "wasm"))]
+        let active_conversation_is_cloud_oz = self.active_conversation_is_cloud_oz(ctx);
+
         let old_active_command_count = self.active_commands_by_id.len();
         self.active_commands_by_id = HashMap::from_iter(
             COMMAND_REGISTRY
@@ -217,6 +246,21 @@ impl SlashCommandDataSource {
                 .filter(|(_, command)| {
                     command.name != commands::FEEDBACK.name
                         || !crate::workspace::is_feedback_skill_available(ctx)
+                })
+                // /continue-locally only applies to cloud Oz conversations. Local conversations
+                // and non-Oz cloud runs (Claude, Gemini) are filtered out so the slash menu
+                // doesn't surface a no-op command.
+                .filter(|(_, command)| {
+                    #[cfg(not(target_family = "wasm"))]
+                    {
+                        command.name != commands::CONTINUE_LOCALLY.name
+                            || active_conversation_is_cloud_oz
+                    }
+                    #[cfg(target_family = "wasm")]
+                    {
+                        let _ = command;
+                        true
+                    }
                 })
                 // When CLI agent input is open, restrict to the explicit allowlist.
                 .filter(|(_, command)| {
@@ -270,6 +314,53 @@ impl SlashCommandDataSource {
             .session(self.terminal_view_id)
             .filter(|s| matches!(s.input_state, CLIAgentInputState::Open { .. }))
             .map(|s| s.agent.supported_skill_providers())
+    }
+
+    /// Returns true when the active conversation is associated with a cloud Oz
+    /// `AmbientAgentTask`. Used to gate `/continue-locally` to runs that can
+    /// actually be forked into a local Warp conversation.
+    ///
+    /// Permissive when the harness is not yet known: we consider an absent task or
+    /// missing `agent_config_snapshot.harness` to be Oz, matching the existing
+    /// tombstone gate (`conversation_ended_tombstone_view::render_action_buttons`).
+    /// Only an explicit non-Oz harness (Claude, Gemini, OpenCode, Unknown) hides the
+    /// command. Conversations without a `task_id` are local and never qualify.
+    #[cfg(not(target_family = "wasm"))]
+    fn active_conversation_is_cloud_oz(&self, ctx: &AppContext) -> bool {
+        let agent_view_state = self.agent_view_controller.as_ref(ctx).agent_view_state();
+        let conversation_id = match agent_view_state.active_conversation_id() {
+            Some(id) => id,
+            None => match BlocklistAIHistoryModel::as_ref(ctx)
+                .active_conversation(self.terminal_view_id)
+            {
+                Some(conv) => conv.id(),
+                None => return false,
+            },
+        };
+
+        let history = BlocklistAIHistoryModel::as_ref(ctx);
+        let Some(conversation) = history.conversation(&conversation_id) else {
+            return false;
+        };
+        let Some(task_id) = conversation.task_id() else {
+            return false;
+        };
+
+        let Some(task) = AgentConversationsModel::as_ref(ctx).get_task_data(&task_id) else {
+            // Task data not yet fetched. Permissive default: assume Oz so the command
+            // is reachable while the fetch is in flight; once the fetch resolves,
+            // `TasksUpdated` triggers a recompute and a non-Oz task hides the command.
+            return true;
+        };
+
+        match task
+            .agent_config_snapshot
+            .as_ref()
+            .and_then(|s| s.harness.as_ref())
+        {
+            Some(config) => config.harness_type == Harness::Oz,
+            None => true,
+        }
     }
 }
 

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -12,6 +12,12 @@ use warp_core::ui::appearance::Appearance;
 use warpui::clipboard::ClipboardContent;
 use warpui::{SingletonEntity, ViewContext};
 
+#[cfg(not(target_family = "wasm"))]
+use crate::ai::agent::conversation::AIConversationId;
+#[cfg(not(target_family = "wasm"))]
+use crate::ai::agent_conversations_model::AgentConversationsModel;
+#[cfg(not(target_family = "wasm"))]
+use crate::ai::agent_management::telemetry::AgentManagementTelemetryEvent;
 use crate::ai::blocklist::agent_view::{
     AgentViewEntryOrigin, DismissalStrategy, EphemeralMessage, ENTER_OR_EXIT_CONFIRMATION_WINDOW,
 };
@@ -38,6 +44,10 @@ use crate::view_components::DismissibleToast;
 use crate::workflows::{WorkflowSelectionSource, WorkflowSource, WorkflowType};
 use crate::workspace::{ForkedConversationDestination, ToastStack, WorkspaceAction};
 use crate::TelemetryEvent;
+#[cfg(not(target_family = "wasm"))]
+use warp_cli::agent::Harness;
+#[cfg(not(target_family = "wasm"))]
+use warpui::AppContext;
 
 #[derive(Debug, Clone)]
 pub enum AcceptSlashCommandOrSavedPrompt {
@@ -744,6 +754,48 @@ impl Input {
                 self.open_user_query_menu(UserQueryMenuAction::ForkFrom, ctx);
                 return true;
             }
+            #[cfg(not(target_family = "wasm"))]
+            continue_locally if command.name == commands::CONTINUE_LOCALLY.name => {
+                let Some(conversation_id) = self
+                    .ai_context_model
+                    .as_ref(ctx)
+                    .selected_conversation_id(ctx)
+                else {
+                    show_error_toast(
+                        "/continue-locally requires an active conversation".to_owned(),
+                        ctx,
+                    );
+                    return true;
+                };
+
+                if !conversation_is_cloud_oz_for_slash_command(conversation_id, ctx) {
+                    show_error_toast(
+                        "/continue-locally is only available for cloud Oz conversations".to_owned(),
+                        ctx,
+                    );
+                    return true;
+                }
+
+                let destination = if trigger.is_cmd_or_ctrl_enter() {
+                    ForkedConversationDestination::NewTab
+                } else {
+                    ForkedConversationDestination::SplitPane
+                };
+
+                send_telemetry_from_ctx!(
+                    AgentManagementTelemetryEvent::SlashCommandContinueLocally,
+                    ctx
+                );
+
+                ctx.dispatch_typed_action(&WorkspaceAction::ForkAIConversation {
+                    conversation_id,
+                    fork_from_exchange: None,
+                    summarize_after_fork: false,
+                    summarization_prompt: None,
+                    initial_prompt: argument.cloned(),
+                    destination,
+                });
+            }
             fork_and_compact if command.name == commands::FORK_AND_COMPACT.name => {
                 let Some(conversation_id) = self
                     .ai_context_model
@@ -977,5 +1029,38 @@ impl Input {
             | SlashCommandEntryState::Composing { .. }
             | SlashCommandEntryState::DisabledUntilEmptyBuffer => false,
         }
+    }
+}
+
+/// Returns true when the conversation with `conversation_id` is associated with a cloud Oz
+/// `AmbientAgentTask`. Used as the defensive runtime gate for `/continue-locally` so a
+/// keybinding-triggered execution can't fall through onto a non-cloud-Oz conversation after
+/// the menu has been recomputed. Mirrors `SlashCommandDataSource::active_conversation_is_cloud_oz`.
+#[cfg(not(target_family = "wasm"))]
+fn conversation_is_cloud_oz_for_slash_command(
+    conversation_id: AIConversationId,
+    ctx: &AppContext,
+) -> bool {
+    let history = BlocklistAIHistoryModel::as_ref(ctx);
+    let Some(conversation) = history.conversation(&conversation_id) else {
+        return false;
+    };
+    let Some(task_id) = conversation.task_id() else {
+        return false;
+    };
+
+    let Some(task) = AgentConversationsModel::as_ref(ctx).get_task_data(&task_id) else {
+        // Permissive: not yet fetched. Matches the data-source default so the command isn't
+        // wrongly blocked while the task fetch is in flight.
+        return true;
+    };
+
+    match task
+        .agent_config_snapshot
+        .as_ref()
+        .and_then(|s| s.harness.as_ref())
+    {
+        Some(config) => config.harness_type == Harness::Oz,
+        None => true,
     }
 }

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -103,7 +103,16 @@ pub enum ConversationRestorationInNewPaneType {
 
     /// Fork an existing conversation into this new pane.
     /// This is like Historical but requires special persistence handling.
-    Forked { conversation: AIConversation },
+    Forked {
+        conversation: AIConversation,
+        /// True when the fork is paired with a follow-up prompt or summarize that
+        /// will be sent immediately after restore.
+        /// We skip the `couldn't find original conversation directory` ephemeral
+        /// hint in that case so the warping indicator (gated on
+        /// `ephemeral_message_model.current_message().is_none()` in
+        /// `BlocklistAIStatusBar::render`) isn't suppressed by the hint.
+        has_initial_query: bool,
+    },
 
     /// Load a CLI agent conversation from its downloaded snapshot.
     HistoricalCLIAgent {
@@ -125,7 +134,10 @@ impl ConversationRestorationInNewPaneType {
     pub fn should_show_restore_context_hint(&self) -> bool {
         match self {
             Self::Startup { .. } => false,
-            Self::Historical { .. } | Self::Forked { .. } | Self::HistoricalCLIAgent { .. } => true,
+            Self::Forked {
+                has_initial_query, ..
+            } => !has_initial_query,
+            Self::Historical { .. } | Self::HistoricalCLIAgent { .. } => true,
         }
     }
 
@@ -643,7 +655,7 @@ impl TerminalView {
             ConversationRestorationInNewPaneType::Historical { conversation, .. } => {
                 vec![RestoredAIConversation::new(conversation)]
             }
-            ConversationRestorationInNewPaneType::Forked { conversation } => {
+            ConversationRestorationInNewPaneType::Forked { conversation, .. } => {
                 vec![RestoredAIConversation::new(conversation)]
             }
             ConversationRestorationInNewPaneType::HistoricalCLIAgent { conversation, .. } => {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11489,6 +11489,14 @@ impl Workspace {
             }
         });
 
+        // True when the fork is paired with a follow-up that fires immediately after restore
+        // (a prompt to send, or a `/summarize` triggered by `summarize_after_fork`).
+        // Used to suppress the `couldn't find original conversation directory` ephemeral hint
+        // for cloud-to-local forks, which would otherwise mask the warping indicator while the
+        // agent processes the follow-up. See `BlocklistAIStatusBar::render`'s
+        // `ephemeral_message_model.current_message().is_none()` gate.
+        let has_initial_query = summarize_after_fork || initial_prompt.is_some();
+
         // Load the conversation data asynchronously
         let future = history_model
             .as_ref(ctx)
@@ -11581,6 +11589,7 @@ impl Workspace {
                     None,
                     Some(ConversationRestorationInNewPaneType::Forked {
                         conversation: forked_conversation,
+                        has_initial_query,
                     }),
                     false,
                     ctx,
@@ -11627,6 +11636,7 @@ impl Workspace {
                     None, /* chosen_shell */
                     Some(ConversationRestorationInNewPaneType::Forked {
                         conversation: forked_conversation.clone(),
+                        has_initial_query,
                     }),
                     ctx,
                 );

--- a/specs/REMOTE-1515/PRODUCT.md
+++ b/specs/REMOTE-1515/PRODUCT.md
@@ -1,0 +1,30 @@
+# /continue-locally slash command — Product Spec
+
+Linear: REMOTE-1515. Figma: none provided.
+
+## Summary
+Add a `/continue-locally` slash command that forks the active cloud Oz agent conversation into a local Warp conversation from the input. It is a parity entrypoint for the existing "Continue locally" affordances on the conversation-ended tombstone (`app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs:485-491`) and on the conversation details panel (`app/src/ai/conversation_details_panel.rs:512-520`).
+
+## Behavior
+
+1. The command is registered with name `/continue-locally`, description "Continue this cloud conversation locally", and an optional argument with hint text `<optional prompt to send in forked conversation>`. It uses the same `bundled/svg/arrow-split.svg` icon as the rest of the fork family.
+
+2. The command appears in the slash-command menu (and is reachable via keybinding) only when the active conversation is associated with a cloud Oz `AmbientAgentTask`. For local conversations and for non-Oz cloud runs (Claude, Gemini), the command is hidden, matching the harness gate already used by the existing button entrypoints.
+
+3. Availability is independent of the cloud run's status: the command shows for in-progress, succeeded, blocked, errored, and cancelled cloud Oz runs. Hard prerequisites: AI is globally enabled and the input is in agent view (`AGENT_VIEW`). The command does not require `NO_LRC_CONTROL`, since long-running-command state is a property of the local terminal and is not relevant to a cloud run.
+
+4. Selecting the command from the slash menu inserts `/continue-locally ` into the input. The user may optionally type a prompt; that prompt is sent as the first user query in the forked local conversation after the fork completes. An empty / whitespace-only argument is treated as no argument (no follow-up prompt is sent).
+
+5. Pressing Enter forks into a split pane to the right of the current pane. Pressing Cmd+Enter (Ctrl+Enter on Linux/Windows) forks into a new tab. The agent input footer mirrors `/fork`'s tip: `Enter new pane` / `Cmd-Enter new tab`.
+
+6. The forked conversation is a local Warp Oz conversation seeded from the cloud run's transcript via the same pipeline as the existing button — same fork prefix, same destination handling. The source cloud run is never modified; the cloud agent continues running (or stays as it was) and the user's local Warp client gets a new local conversation forked from it.
+
+7. On success, the command shows a dismissible toast `Forked "<source conversation title>"` (titles longer than `MAX_FORK_TOAST_TITLE_LENGTH` are truncated with an ellipsis). This is the same toast as `/fork` — produced by `Workspace::show_fork_toast` — so the user gets a consistent acknowledgement that the cloud-to-local handoff completed regardless of which entrypoint they used.
+
+8. If the source conversation can't be loaded or the fork itself fails, the command surfaces the same dismissible error toasts as the existing button entrypoints ("Failed to load conversation for forking." or "Conversation forking failed."). If the active conversation is somehow not a cloud Oz run at execute time (e.g. via stale keybinding), the command shows an error toast and does not dispatch a fork.
+
+9. Telemetry: a successful invocation emits `AgentManagementTelemetryEvent::ConversationForked` (matching `/fork`) plus a new `AgentManagementTelemetryEvent::SlashCommandContinueLocally` event so cloud-to-local handoffs from the slash command can be measured separately from the tombstone and details-panel buttons. Existing `TombstoneContinueLocally` and `DetailsPanelContinueLocally` events are unchanged.
+
+## Non-goals
+- Surfacing this command in completed conversation transcript viewers, where input is hidden by design. The existing tombstone button remains the only entrypoint there.
+- Adding a `/continue-locally` button to wasm. Like `ContinueConversationLocally` itself, the command is `cfg(not(target_family = "wasm"))`.

--- a/specs/REMOTE-1515/TECH.md
+++ b/specs/REMOTE-1515/TECH.md
@@ -1,0 +1,147 @@
+# /continue-locally slash command — Tech Spec
+
+Pairs with `PRODUCT.md`.
+
+## Context
+The cloud-to-local fork pipeline already exists. `WorkspaceAction::ForkAIConversation` (`app/src/workspace/action.rs:462-475`) — and its narrower sibling `WorkspaceAction::ContinueConversationLocally` (`app/src/workspace/action.rs:478-481`) — both land in `Workspace::fork_ai_conversation` (`app/src/workspace/view.rs:11460-11668`), which loads the source conversation, calls `BlocklistAIHistoryModel::fork_conversation`, opens the fork in the chosen `ForkedConversationDestination`, and ends with `Self::show_fork_toast` (`app/src/workspace/view.rs:11744-11772`) producing the `Forked "<title>"` toast referenced by PRODUCT.md invariant 7.
+
+The two existing button entrypoints, both gated to Oz harness only, dispatch the narrower action:
+- Conversation details panel: `app/src/ai/conversation_details_panel.rs:512-520, 1981-1992`, with the harness gate at `continue_locally_conversation_id` (`app/src/ai/conversation_details_panel.rs:564-602`).
+- Conversation-ended tombstone: `app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs:485-520`, with the harness gate at `render_action_buttons` (`app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs:464-511`).
+
+Slash commands: definitions in `app/src/search/slash_command_menu/static_commands/commands.rs`, dynamic per-session filtering in `app/src/terminal/input/slash_commands/data_source/mod.rs:146-235`, and execution dispatch in `app/src/terminal/input/slash_commands/mod.rs:296-847`. `Availability` is a `u8` bitfield with all 8 bits already in use (`app/src/search/slash_command_menu/static_commands/mod.rs:18-37`), so the cloud-Oz availability constraint must be expressed as a runtime filter — `/orchestrate` and `/feedback` already use this pattern at lines 211-225 of the data source. `/fork`'s handler (`app/src/terminal/input/slash_commands/mod.rs:718-742`) is the closest template: it pulls `conversation_id` via `ai_context_model.selected_conversation_id`, picks the destination from `trigger.is_cmd_or_ctrl_enter()`, and dispatches `ForkAIConversation`.
+
+`AIConversation::task_id()` (`app/src/ai/agent/conversation.rs:718`) returns `Option<AmbientAgentTaskId>` for cloud-backed conversations. `AgentConversationsModel::get_task_data()` (`app/src/ai/agent_conversations_model.rs:1546-1548`) returns the in-memory `AmbientAgentTask`; the harness lives at `task.agent_config_snapshot.harness.harness_type` and defaults to `Harness::Oz` when the snapshot is present but no explicit harness is set (matching `enrich_from_task` in `conversation_ended_tombstone_view.rs:131-141`).
+
+## Proposed changes
+
+### 1. Static command definition
+`app/src/search/slash_command_menu/static_commands/commands.rs`
+
+Add a `CONTINUE_LOCALLY` `LazyLock<StaticCommand>` next to the rest of the fork family (`FORK`, `FORK_AND_COMPACT`, `FORK_FROM`):
+
+- `name: "/continue-locally"`
+- `description: "Continue this cloud conversation locally"`
+- `icon_path: "bundled/svg/arrow-split.svg"` (same as `FORK`)
+- `availability: Availability::AGENT_VIEW | Availability::ACTIVE_CONVERSATION | Availability::AI_ENABLED`
+- `auto_enter_ai_mode: true`
+- `argument: Some(Argument::optional().with_hint_text("<optional prompt to send in forked conversation>"))`
+
+Push it onto `all_commands()` inside the existing `if !cfg!(target_family = "wasm")` block (`commands.rs:572-578`) alongside `FORK` / `FORK_AND_COMPACT`. No feature flag — the underlying action and all gating are stable.
+
+### 2. Cloud-Oz runtime filter in the data source
+`app/src/terminal/input/slash_commands/data_source/mod.rs`
+
+Express PRODUCT.md invariant 2 as a runtime filter, mirroring `/orchestrate` and `/feedback`:
+
+```rust path=null start=null
+.filter(|(_, command)| {
+    command.name != commands::CONTINUE_LOCALLY.name
+        || self.active_conversation_is_cloud_oz(ctx)
+})
+```
+
+Add a private helper `fn active_conversation_is_cloud_oz(&self, ctx: &AppContext) -> bool` that, in order:
+
+1. Reads the active conversation id from `agent_view_controller.agent_view_state().active_conversation_id()` (returns false if `None`).
+2. Looks up the `AIConversation` in `BlocklistAIHistoryModel`. Reads `conversation.task_id()`; returns false if `None` (local conversation).
+3. Reads the task via `AgentConversationsModel::get_task_data(task_id)`.
+4. Returns true iff the task's `agent_config_snapshot.harness.harness_type` is `Harness::Oz`, or the snapshot is absent / harness is unset (the same permissive default the tombstone uses, so we don't hide the command while the task fetch is still pending — `Some(Harness::Claude)` / `Some(Harness::Gemini)` are the only states that hide the command).
+
+Subscribe `recompute_active_commands` to:
+- `AgentConversationsModelEvent::TasksUpdated` — so the menu updates as the task fetch resolves and as task harness becomes known.
+- `BlocklistAIHistoryEvent::SetActiveConversation` — so the menu updates when the active conversation switches (e.g. user navigates between cloud and local conversations).
+
+Both event types are already routed to other consumers; the subscription pattern follows the existing `ctx.subscribe_to_model` calls at `data_source/mod.rs:72-127`.
+
+### 3. Slash command handler
+`app/src/terminal/input/slash_commands/mod.rs`
+
+Add a handler arm in `Input::execute_slash_command_action` (next to the existing `/fork` arm at `slash_commands/mod.rs:718-742`):
+
+```rust path=null start=null
+continue_locally if command.name == commands::CONTINUE_LOCALLY.name => {
+    let Some(conversation_id) = self
+        .ai_context_model
+        .as_ref(ctx)
+        .selected_conversation_id(ctx)
+    else {
+        show_error_toast("/continue-locally requires an active conversation".to_owned(), ctx);
+        return true;
+    };
+
+    if !active_conversation_is_cloud_oz(conversation_id, ctx) {
+        show_error_toast(
+            "/continue-locally requires an active cloud Oz conversation".to_owned(),
+            ctx,
+        );
+        return true;
+    }
+
+    let destination = if trigger.is_cmd_or_ctrl_enter() {
+        ForkedConversationDestination::NewTab
+    } else {
+        ForkedConversationDestination::SplitPane
+    };
+
+    send_telemetry_from_ctx!(
+        AgentManagementTelemetryEvent::SlashCommandContinueLocally,
+        ctx
+    );
+
+    ctx.dispatch_typed_action(&WorkspaceAction::ForkAIConversation {
+        conversation_id,
+        fork_from_exchange: None,
+        summarize_after_fork: false,
+        summarization_prompt: None,
+        initial_prompt: argument.cloned(),
+        destination,
+    });
+}
+```
+
+`active_conversation_is_cloud_oz(conversation_id, ctx)` is a small private free function in the same module that performs the same harness lookup as the data source helper, factored to take an explicit `conversation_id` (the data source uses the agent view's active id; the handler already has it from `selected_conversation_id`). It is the defensive runtime gate from PRODUCT.md invariant 8.
+
+The handler is gated `cfg(not(target_family = "wasm"))`. Empty/whitespace `argument` is normalized to `None` by `ForkAIConversation`'s downstream `fork_ai_conversation` (`app/src/workspace/view.rs:11483-11490`), so PRODUCT.md invariant 4 is satisfied without further work here.
+
+Success toasts (PRODUCT.md invariant 7) and error toasts on fork failure (invariant 8) are produced by `Workspace::show_fork_toast` and the existing failure paths inside `fork_ai_conversation` — no toast plumbing in the slash command handler itself.
+
+### 4. Footer tip
+`app/src/ai/blocklist/agent_view/agent_message_bar.rs`
+
+Extend `ForkSlashCommandMessageProducer::produce_message` (lines 727-777) to also match `commands::CONTINUE_LOCALLY.name`. Add it to the existing equality check and reuse the `/fork` label branch (`(" new pane", " new tab")`), since `/continue-locally` follows the same `Enter → split pane`, `Cmd/Ctrl+Enter → new tab` mapping.
+
+### 5. Telemetry
+`app/src/ai/agent_management/telemetry.rs`
+
+Add a new variant `SlashCommandContinueLocally` to `AgentManagementTelemetryEvent` (`telemetry.rs:108-113`), wasm-gated like the existing `TombstoneContinueLocally` / `DetailsPanelContinueLocally`, with empty payload, `EnablementState::Always`, and the discriminant entries:
+
+- Name: `"AgentManagement.SlashCommandContinueLocally"`
+- Description: `"User invoked /continue-locally to fork a cloud conversation locally"`
+
+Fire it from the slash command handler immediately before dispatching `ForkAIConversation` (see §3). The existing `ConversationForked` event is fired downstream by the fork pipeline and does not need to be touched.
+
+## Testing and validation
+
+References below are to PRODUCT.md numbered invariants.
+
+Unit tests, colocated with the modules being changed:
+
+- `app/src/search/slash_command_menu/static_commands/mod_test.rs`: add a registration test for `/continue-locally` covering name, icon, optional argument with hint text, `auto_enter_ai_mode: true`, and the static availability set. (Inv. 1)
+- `app/src/terminal/input/slash_commands/data_source/` tests (matching the existing layout): cover the four cloud-Oz filter outcomes — local conversation (no `task_id`) hides the command (Inv. 2); cloud Oz task shows it (Inv. 2, 3); cloud Claude/Gemini task hides it (Inv. 2); cloud task whose data hasn't been fetched yet shows it permissively and recomputes on `TasksUpdated` (Inv. 2). Plus AI-disabled hides it via the static `AI_ENABLED` requirement (Inv. 3).
+- `app/src/ai/agent_management/telemetry.rs` discriminant tests: assert the new variant maps to the expected name and description, mirroring the existing test pattern for `DetailsPanelContinueLocally`. (Inv. 9)
+
+Manual:
+
+- Cloud Oz run, in-progress, agent input visible: `/continue-locally` appears in the slash menu; Enter forks into a split pane and shows `Forked "<title>"`; Cmd-Enter forks into a new tab. (Inv. 2, 3, 5, 6, 7)
+- Same run, type `/continue-locally do X next`, press Enter: forked conversation receives `do X next` as its first user query. (Inv. 4, 5, 6)
+- Source-load failure (simulate by clearing the conversation from history before pressing Enter): error toast surfaces with the existing copy. (Inv. 8)
+- Cloud Oz run viewed via shared session, completed but input still visible: command works as above. (Inv. 3)
+- Cloud Oz run viewed via completed transcript viewer: input is hidden; command is unreachable, existing tombstone button still works. (Inv. 2, Non-goals)
+- Cloud Claude run: command absent from menu. (Inv. 2)
+- Local conversation (no `task_id`): command absent from menu. (Inv. 2)
+
+Run `./script/presubmit` before opening the PR.
+
+## Follow-ups
+- If the menu visibility lag during the initial task fetch becomes noticeable in practice, switch the permissive `None` harness branch to fetch on demand via `AgentConversationsModel::get_or_async_fetch_task_data` (`app/src/ai/agent_conversations_model.rs:1564-1645`) and rely on the `TasksUpdated` recompute. We default to permissive for parity with the tombstone today.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

This PR adds a /continue-locally slash command to serve as another entrypoint for continuing a cloud conversation locally (does the same thing as clicking the continue locally button in the tombstone or info panel).

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

demo: https://www.loom.com/share/fb393e595c0b4aa9805cdaeedaa6fd06

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-IMPROVEMENT: Added a `/continue-locally` slash command to continue cloud conversations locally.