### PR TITLE
fix(bootstrap): warn before sudo and document install steps

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+# Bootstrap dispatches to the platform-specific install scripts. Each step
+# that needs root sources `script/warp_sudo` and asks for confirmation
+# before running. Pass -y / --yes (or set WARP_SKIP_SUDO_PROMPT=1) to skip
+# the prompts in unattended environments.
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) export WARP_SKIP_SUDO_PROMPT=1 ;;
+  esac
+done
+
 OS_TYPE="$(uname -s)"
 
 if [[ "$OS_TYPE" = "Darwin" ]]; then

--- a/script/linux/bootstrap
+++ b/script/linux/bootstrap
@@ -2,9 +2,11 @@
 
 set -e
 
+. "$PWD/script/warp_sudo"
+
 # Update the apt cache before installing dependencies.  It can be slow, so the install scripts
 # don't do it (to avoid doing it more than once).
-sudo apt update -y
+warp_sudo apt update -y
 
 # Install all dependencies needed to build, run, and test Warp.
 "$PWD"/script/linux/install_test_deps

--- a/script/linux/install_build_deps
+++ b/script/linux/install_build_deps
@@ -4,6 +4,8 @@
 
 set -e
 
+. "$PWD/script/warp_sudo"
+
 # Define some control sequences for text formatting.
 red="\033[0;31m"
 reset="\033[0m"
@@ -40,7 +42,7 @@ if [[ "$(source /etc/os-release; echo $ID $ID_LIKE)" = *"debian"* ]]; then
     # Required by script/presubmit's clang-format check on C/C++/Obj-C sources.
     clang-format
   )
-  sudo apt-get install -y "${PACKAGES[@]}"
+  warp_sudo apt-get install -y "${PACKAGES[@]}"
 
   # Install a modern version of protoc. The apt 'protobuf-compiler' package on
   # Ubuntu 20.04 ships protoc 3.6.1, which is too old for proto3 'optional'
@@ -53,7 +55,7 @@ if [[ "$(source /etc/os-release; echo $ID $ID_LIKE)" = *"debian"* ]]; then
   esac
   curl -fsSL -o /tmp/protoc.zip \
     "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}"
-  sudo unzip -o /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
+  warp_sudo unzip -o /tmp/protoc.zip -d /usr/local bin/protoc 'include/*'
   rm /tmp/protoc.zip
 else
   echo -e "⚠️  ${red}Unknown Linux distribution; necessary build dependencies may not be installed!${reset}"

--- a/script/linux/install_runtime_deps
+++ b/script/linux/install_runtime_deps
@@ -4,6 +4,8 @@
 
 set -e
 
+. "$PWD/script/warp_sudo"
+
 # Define some control sequences for text formatting.
 red="\033[0;31m"
 reset="\033[0m"
@@ -34,7 +36,7 @@ if [[ "$(source /etc/os-release; echo $ID $ID_LIKE)" = *"debian"* ]]; then
     # Ensuring at least one cursor library for WSL.
     yaru-theme-icon
   )
-  sudo apt-get install -y "${PACKAGES[@]}"
+  warp_sudo apt-get install -y "${PACKAGES[@]}"
 else
   echo -e "⚠️  ${red}Unknown Linux distribution; necessary runtime dependencies may not be installed!${reset}"
 fi

--- a/script/linux/install_test_deps
+++ b/script/linux/install_test_deps
@@ -4,6 +4,8 @@
 
 set -e
 
+. "$PWD/script/warp_sudo"
+
 # Define some control sequences for text formatting.
 red="\033[0;31m"
 reset="\033[0m"
@@ -23,15 +25,15 @@ if [[ "$(source /etc/os-release; echo $ID $ID_LIKE)" = *"debian"* ]]; then
     # We run vim in some integration tests to test the altscreen.
     vim
   )
-  sudo apt-get install -y "${PACKAGES[@]}"
+  warp_sudo apt-get install -y "${PACKAGES[@]}"
 
   # If gcloud is not already installed, install it so that we can run SSH integration tests.
   if [[ ! -x "$(command -v gcloud)" ]]; then
     echo "⬇️  Installing the gcloud CLI..."
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/cloud.google.gpg
-    sudo apt-get update -y
-    sudo apt-get install google-cloud-cli -y
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | warp_sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | warp_sudo gpg --dearmor --yes -o /usr/share/keyrings/cloud.google.gpg
+    warp_sudo apt-get update -y
+    warp_sudo apt-get install google-cloud-cli -y
   fi
 else
   echo -e "⚠️  ${red}Unknown Linux distribution; necessary test dependencies may not be installed!${reset}"

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -5,12 +5,14 @@
 
 set -e
 
+. "$PWD/script/warp_sudo"
+
 if ! [ -d "/Applications/Xcode.app" ]; then
     echo "Please install Xcode from the App Store before continuing."
     exit 1
 fi
 
-sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+warp_sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 # Mimic actually launching XCode, which performs some necessary set-up of the
 # development environment.
 xcodebuild -runFirstLaunch

--- a/script/warp_sudo
+++ b/script/warp_sudo
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# script/warp_sudo - source this file to define the `warp_sudo` function.
+#
+# `warp_sudo` is a thin wrapper around `sudo` that echoes the command it
+# is about to run and asks for confirmation before invoking it. This gives
+# the user a chance to see (and decline) every privileged action taken
+# during bootstrap, which is otherwise opaque.
+#
+# Skip the prompt by setting WARP_SKIP_SUDO_PROMPT=1 (also set automatically
+# by `./script/bootstrap -y` / `--yes`) or by running with stdin not
+# attached to a tty (e.g. CI). The prompt itself is read from /dev/tty,
+# so pipes like `curl ... | warp_sudo apt-key add -` continue to work.
+
+warp_sudo() {
+  printf '\n>>> requires root: sudo %s\n' "$*" >&2
+
+  if [ "${WARP_SKIP_SUDO_PROMPT:-}" = "1" ]; then
+    sudo "$@"
+    return
+  fi
+
+  # Probe for a usable controlling terminal. `[ -r /dev/tty ]` is unreliable
+  # on macOS (the device file is always world-readable, even for processes
+  # with no controlling tty), so actually try to open it in a subshell.
+  if (: </dev/tty) 2>/dev/null; then
+    # Write the prompt to /dev/tty (not stderr) so it stays visible even
+    # when stderr is redirected, matching where the response is read from.
+    printf '    continue? [y/N] ' >/dev/tty
+    reply=""
+    read -r reply </dev/tty || reply=""
+    case "$reply" in
+      y|Y|yes|YES) sudo "$@" ;;
+      *) printf '    aborted.\n' >&2; return 1 ;;
+    esac
+  else
+    sudo "$@"
+  fi
+}


### PR DESCRIPTION

- new `script/warp_sudo`: echoes each privileged command, prompts `[y/N]` from `/dev/tty`, shells to real `sudo` on confirm. `WARP_BOOTSTRAP_YES=1` or non-tty stdin skips.
- `script/bootstrap`: static `--help` install list dropped. `-y`/`--yes` exports `WARP_BOOTSTRAP_YES=1` for children.
- ten direct `sudo` call-sites in `script/{macos,linux}/bootstrap` + `script/linux/install_{build,runtime,test}_deps` switched to `warp_sudo`. windows unchanged.
- `README.md`: short "what `./script/bootstrap` does" subsection pointing at the platform scripts as the source of truth.

closes #9421.