### PR TITLE
Add @harryalbert as CLI agent stakeholder

### DIFF
--- a/.github/STAKEHOLDERS
+++ b/.github/STAKEHOLDERS
@@ -132,8 +132,8 @@
 /crates/ui_components/ @vorporeal
 
 # Conversation rewind / CLI agent UI / macOS/Linux platform issues / performance issues
-/app/src/terminal/cli_agent.rs @zachbai
-/app/src/terminal/cli_agent_sessions/ @zachbai
+/app/src/terminal/cli_agent.rs @zachbai @harryalbert
+/app/src/terminal/cli_agent_sessions/ @zachbai @harryalbert
 /app/src/terminal/input/rewind/ @alokedesai
 /app/src/workspace/rewind_confirmation_dialog.rs @alokedesai
 /app/src/platform/mac/ @alokedesai

--- a/.github/STAKEHOLDERS
+++ b/.github/STAKEHOLDERS
@@ -133,6 +133,7 @@
 
 # Conversation rewind / CLI agent UI / macOS/Linux platform issues / performance issues
 /app/src/terminal/cli_agent.rs @zachbai @harryalbert
+/app/src/terminal/cli_agent_tests.rs @zachbai @harryalbert
 /app/src/terminal/cli_agent_sessions/ @zachbai @harryalbert
 /app/src/terminal/input/rewind/ @alokedesai
 /app/src/workspace/rewind_confirmation_dialog.rs @alokedesai


### PR DESCRIPTION
## Description

Adding myself as an owner for CLI agent related stuff so that I can be tagged on PRs like [this one](https://github.com/warpdotdev/warp/pull/9497) as a reviewer.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/c938473b-3518-4b15-aee6-0a7d7002a958_
_Run: https://oz.staging.warp.dev/runs/019ddb43-cd89-7392-b966-4f23248d8b3c_

_This PR was generated with [Oz](https://warp.dev/oz)._
