### PR TITLE
Skip AgentTips with unresolved keybinding placeholders

### DIFF
--- a/app/src/ai/agent_tips.rs
+++ b/app/src/ai/agent_tips.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 use std::time::Duration;
 use warpui::keymap::Keystroke;
-use warpui::r#async::SpawnedFutureHandle;
+use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
 /// Trait for tip implementations that can be displayed to users.
@@ -499,7 +499,37 @@ impl AITipModel<AgentTip> {
     /// This is the constructor used for the singleton model.
     pub fn new_for_agent_tips(ctx: &AppContext) -> Self {
         let tips = get_agent_tips(ctx);
-        Self::new(tips)
+        // Pick an applicable tip so we never show a raw "<keybinding>" placeholder on first render.
+        let current_tip = Self::pick_random_applicable_tip(&tips, None, ctx);
+
+        Self {
+            tips,
+            current_tip,
+            cooldown_handle: None,
+        }
+    }
+
+    /// Rebuilds the tip pool from current settings and invalidates the current tip
+    /// if it is no longer applicable. Resets the cooldown timer so the revalidated
+    /// tip is shown for the full cooldown period before the next rotation.
+    pub fn revalidate_tips(&mut self, ctx: &mut ModelContext<Self>) {
+        self.tips = get_agent_tips(ctx);
+
+        // If the current tip is no longer in the pool or no longer applicable, pick a new one.
+        let should_replace = self
+            .current_tip
+            .as_ref()
+            .map(|tip| !tip.is_tip_applicable(None, ctx))
+            .unwrap_or(true);
+
+        if should_replace {
+            let new_tip = Self::pick_random_applicable_tip(&self.tips, None, ctx);
+            if new_tip.is_some() || self.current_tip.is_some() {
+                self.current_tip = new_tip;
+                self.reset_cooldown(ctx);
+                ctx.notify();
+            }
+        }
     }
 
     /// Refreshes the current tip with a new random selection that is applicable
@@ -515,24 +545,16 @@ impl AITipModel<AgentTip> {
             return;
         }
 
-        use rand::seq::SliceRandom;
+        // Rebuild tips from current settings so changes (e.g. voice toggle) are picked up.
+        self.tips = get_agent_tips(ctx);
 
-        // Filter applicable tips based on working directory
-        let available_tips: Vec<AgentTip> = self
-            .tips
-            .iter()
-            .filter(|tip| tip.is_tip_applicable(current_working_directory, ctx))
-            .cloned()
-            .collect();
-
-        // Select a random tip
-        let mut rng = rand::thread_rng();
-        self.current_tip = available_tips.choose(&mut rng).cloned();
+        self.current_tip =
+            Self::pick_random_applicable_tip(&self.tips, current_working_directory, ctx);
 
         // Start 60-second cooldown
         let handle = ctx.spawn(
             async {
-                warpui::r#async::Timer::after(Duration::from_secs(60)).await;
+                Timer::after(Duration::from_secs(60)).await;
             },
             |me, _, _| {
                 me.cooldown_handle = None;
@@ -540,6 +562,39 @@ impl AITipModel<AgentTip> {
         );
         self.cooldown_handle = Some(handle);
         ctx.notify();
+    }
+
+    /// Picks a random applicable tip from the given pool, filtered by working directory.
+    /// Returns `None` if no tips are applicable.
+    fn pick_random_applicable_tip(
+        tips: &[AgentTip],
+        current_working_directory: Option<&str>,
+        ctx: &AppContext,
+    ) -> Option<AgentTip> {
+        use rand::seq::SliceRandom;
+        let available: Vec<&AgentTip> = tips
+            .iter()
+            .filter(|tip| tip.is_tip_applicable(current_working_directory, ctx))
+            .collect();
+        let mut rng = rand::thread_rng();
+        available.choose(&mut rng).cloned().cloned()
+    }
+
+    /// Resets the cooldown timer so the current tip is shown for the full
+    /// cooldown period before the next rotation.
+    fn reset_cooldown(&mut self, ctx: &mut ModelContext<Self>) {
+        if let Some(handle) = self.cooldown_handle.take() {
+            handle.abort();
+        }
+        let handle = ctx.spawn(
+            async {
+                Timer::after(Duration::from_secs(60)).await;
+            },
+            |me, _, _| {
+                me.cooldown_handle = None;
+            },
+        );
+        self.cooldown_handle = Some(handle);
     }
 }
 
@@ -564,7 +619,7 @@ impl AITipModel<crate::terminal::view::ambient_agent::CloudModeTip> {
         // Start 60-second cooldown
         let handle = ctx.spawn(
             async {
-                warpui::r#async::Timer::after(Duration::from_secs(60)).await;
+                Timer::after(Duration::from_secs(60)).await;
             },
             |me, _, _| {
                 me.cooldown_handle = None;
@@ -585,7 +640,7 @@ impl AITipModel<crate::terminal::view::ambient_agent::CloudModeTip> {
         // Start a new 60-second cooldown
         let handle = ctx.spawn(
             async {
-                warpui::r#async::Timer::after(Duration::from_secs(60)).await;
+                Timer::after(Duration::from_secs(60)).await;
             },
             |me, _, _| {
                 me.cooldown_handle = None;

--- a/app/src/ai/agent_tips.rs
+++ b/app/src/ai/agent_tips.rs
@@ -410,6 +410,12 @@ impl AITip for AgentTip {
                 .get_codebase_index_status_for_path(root, app)
                 .is_none();
         }
+        // Tips whose description references a keybinding placeholder should only be shown
+        // when the keybinding is actually configured, so we never display the raw
+        // "<keybinding>" string to users.
+        if self.description.contains("<keybinding>") && self.keystroke(app).is_none() {
+            return false;
+        }
         true
     }
 }

--- a/app/src/ai/agent_tips.rs
+++ b/app/src/ai/agent_tips.rs
@@ -519,7 +519,14 @@ impl AITipModel<AgentTip> {
         let should_replace = self
             .current_tip
             .as_ref()
-            .map(|tip| !tip.is_tip_applicable(None, ctx))
+            .map(|current_tip| {
+                let still_in_pool = self
+                    .tips
+                    .iter()
+                    .any(|tip| tip.description == current_tip.description);
+
+                !still_in_pool || !current_tip.is_tip_applicable(None, ctx)
+            })
             .unwrap_or(true);
 
         if should_replace {
@@ -577,7 +584,7 @@ impl AITipModel<AgentTip> {
             .filter(|tip| tip.is_tip_applicable(current_working_directory, ctx))
             .collect();
         let mut rng = rand::thread_rng();
-        available.choose(&mut rng).cloned().cloned()
+        available.choose(&mut rng).copied().cloned()
     }
 
     /// Resets the cooldown timer so the current tip is shown for the full

--- a/app/src/ai/agent_tips.rs
+++ b/app/src/ai/agent_tips.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 use std::time::Duration;
 use warpui::keymap::Keystroke;
-use warpui::r#async::SpawnedFutureHandle;
+use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
 /// Trait for tip implementations that can be displayed to users.
@@ -512,7 +512,37 @@ impl AITipModel<AgentTip> {
     /// This is the constructor used for the singleton model.
     pub fn new_for_agent_tips(ctx: &AppContext) -> Self {
         let tips = get_agent_tips(ctx);
-        Self::new(tips)
+        // Pick an applicable tip so we never show a raw "<keybinding>" placeholder on first render.
+        let current_tip = Self::pick_random_applicable_tip(&tips, None, ctx);
+
+        Self {
+            tips,
+            current_tip,
+            cooldown_handle: None,
+        }
+    }
+
+    /// Rebuilds the tip pool from current settings and invalidates the current tip
+    /// if it is no longer applicable. Resets the cooldown timer so the revalidated
+    /// tip is shown for the full cooldown period before the next rotation.
+    pub fn revalidate_tips(&mut self, ctx: &mut ModelContext<Self>) {
+        self.tips = get_agent_tips(ctx);
+
+        // If the current tip is no longer in the pool or no longer applicable, pick a new one.
+        let should_replace = self
+            .current_tip
+            .as_ref()
+            .map(|tip| !tip.is_tip_applicable(None, ctx))
+            .unwrap_or(true);
+
+        if should_replace {
+            let new_tip = Self::pick_random_applicable_tip(&self.tips, None, ctx);
+            if new_tip.is_some() || self.current_tip.is_some() {
+                self.current_tip = new_tip;
+                self.reset_cooldown(ctx);
+                ctx.notify();
+            }
+        }
     }
 
     /// Refreshes the current tip with a new random selection that is applicable
@@ -528,24 +558,16 @@ impl AITipModel<AgentTip> {
             return;
         }
 
-        use rand::seq::SliceRandom;
+        // Rebuild tips from current settings so changes (e.g. voice toggle) are picked up.
+        self.tips = get_agent_tips(ctx);
 
-        // Filter applicable tips based on working directory
-        let available_tips: Vec<AgentTip> = self
-            .tips
-            .iter()
-            .filter(|tip| tip.is_tip_applicable(current_working_directory, ctx))
-            .cloned()
-            .collect();
-
-        // Select a random tip
-        let mut rng = rand::thread_rng();
-        self.current_tip = available_tips.choose(&mut rng).cloned();
+        self.current_tip =
+            Self::pick_random_applicable_tip(&self.tips, current_working_directory, ctx);
 
         // Start 60-second cooldown
         let handle = ctx.spawn(
             async {
-                warpui::r#async::Timer::after(Duration::from_secs(60)).await;
+                Timer::after(Duration::from_secs(60)).await;
             },
             |me, _, _| {
                 me.cooldown_handle = None;
@@ -553,6 +575,39 @@ impl AITipModel<AgentTip> {
         );
         self.cooldown_handle = Some(handle);
         ctx.notify();
+    }
+
+    /// Picks a random applicable tip from the given pool, filtered by working directory.
+    /// Returns `None` if no tips are applicable.
+    fn pick_random_applicable_tip(
+        tips: &[AgentTip],
+        current_working_directory: Option<&str>,
+        ctx: &AppContext,
+    ) -> Option<AgentTip> {
+        use rand::seq::SliceRandom;
+        let available: Vec<&AgentTip> = tips
+            .iter()
+            .filter(|tip| tip.is_tip_applicable(current_working_directory, ctx))
+            .collect();
+        let mut rng = rand::thread_rng();
+        available.choose(&mut rng).cloned().cloned()
+    }
+
+    /// Resets the cooldown timer so the current tip is shown for the full
+    /// cooldown period before the next rotation.
+    fn reset_cooldown(&mut self, ctx: &mut ModelContext<Self>) {
+        if let Some(handle) = self.cooldown_handle.take() {
+            handle.abort();
+        }
+        let handle = ctx.spawn(
+            async {
+                Timer::after(Duration::from_secs(60)).await;
+            },
+            |me, _, _| {
+                me.cooldown_handle = None;
+            },
+        );
+        self.cooldown_handle = Some(handle);
     }
 }
 
@@ -577,7 +632,7 @@ impl AITipModel<crate::terminal::view::ambient_agent::CloudModeTip> {
         // Start 60-second cooldown
         let handle = ctx.spawn(
             async {
-                warpui::r#async::Timer::after(Duration::from_secs(60)).await;
+                Timer::after(Duration::from_secs(60)).await;
             },
             |me, _, _| {
                 me.cooldown_handle = None;
@@ -598,7 +653,7 @@ impl AITipModel<crate::terminal::view::ambient_agent::CloudModeTip> {
         // Start a new 60-second cooldown
         let handle = ctx.spawn(
             async {
-                warpui::r#async::Timer::after(Duration::from_secs(60)).await;
+                Timer::after(Duration::from_secs(60)).await;
             },
             |me, _, _| {
                 me.cooldown_handle = None;

--- a/app/src/ai/agent_tips.rs
+++ b/app/src/ai/agent_tips.rs
@@ -423,6 +423,12 @@ impl AITip for AgentTip {
         if matches!(self.kind, AgentTipKind::Handoff) {
             return AISettings::as_ref(app).is_cloud_handoff_enabled(app);
         }
+        // Tips whose description references a keybinding placeholder should only be shown
+        // when the keybinding is actually configured, so we never display the raw
+        // "<keybinding>" string to users.
+        if self.description.contains("<keybinding>") && self.keystroke(app).is_none() {
+            return false;
+        }
         true
     }
 }

--- a/app/src/ai/agent_tips.rs
+++ b/app/src/ai/agent_tips.rs
@@ -532,7 +532,14 @@ impl AITipModel<AgentTip> {
         let should_replace = self
             .current_tip
             .as_ref()
-            .map(|tip| !tip.is_tip_applicable(None, ctx))
+            .map(|current_tip| {
+                let still_in_pool = self
+                    .tips
+                    .iter()
+                    .any(|tip| tip.description == current_tip.description);
+
+                !still_in_pool || !current_tip.is_tip_applicable(None, ctx)
+            })
             .unwrap_or(true);
 
         if should_replace {
@@ -590,7 +597,7 @@ impl AITipModel<AgentTip> {
             .filter(|tip| tip.is_tip_applicable(current_working_directory, ctx))
             .collect();
         let mut rng = rand::thread_rng();
-        available.choose(&mut rng).cloned().cloned()
+        available.choose(&mut rng).copied().cloned()
     }
 
     /// Resets the cooldown timer so the current tip is shown for the full

--- a/app/src/ai/agent_tips.rs
+++ b/app/src/ai/agent_tips.rs
@@ -565,7 +565,7 @@ impl AITipModel<AgentTip> {
             return;
         }
 
-        // Rebuild tips from current settings so changes (e.g. voice toggle) are picked up.
+        // Rebuild tips from current settings so changes are picked up.
         self.tips = get_agent_tips(ctx);
 
         self.current_tip =

--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -296,6 +296,11 @@ impl BlocklistAIStatusBar {
             ctx.notify();
         });
 
+        ctx.observe(&AITipModel::handle(ctx), |me, tip_model, ctx| {
+            me.current_tip = tip_model.as_ref(ctx).current_tip().cloned();
+            ctx.notify();
+        });
+
         let summarization_cancel_dialog =
             ctx.add_typed_action_view(|_| SummarizationCancelDialog::default());
         ctx.subscribe_to_view(

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1825,9 +1825,9 @@ pub(crate) fn initialize_app(
     let tip_model_handle = ctx.add_singleton_model(|ctx| {
         ai::agent_tips::AITipModel::<ai::AgentTip>::new_for_agent_tips(ctx)
     });
-    // Rebuild the tip pool when voice-related settings change so that the voice tip
-    // appears/disappears without waiting for the next cooldown cycle.
     {
+        // Rebuild the tip pool when voice-related settings change so that the voice tip
+        // appears/disappears without waiting for the next cooldown cycle.
         let tip_model_handle_for_ai = tip_model_handle.clone();
         ctx.subscribe_to_model(&AISettings::handle(ctx), move |_, event, ctx| {
             if matches!(
@@ -1843,12 +1843,21 @@ pub(crate) fn initialize_app(
         // Also revalidate when workspace/team data changes (e.g. voice toggled at
         // the org level). Billing metadata — including `warp_ai_policy.is_voice_enabled`
         // — lives inside the team data, so `TeamsChanged` covers all policy updates.
+        let tip_model_handle_for_teams = tip_model_handle.clone();
         ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), move |_, event, ctx| {
             if matches!(event, UserWorkspacesEvent::TeamsChanged) {
-                tip_model_handle.update(ctx, |model, ctx| {
+                tip_model_handle_for_teams.update(ctx, |model, ctx| {
                     model.revalidate_tips(ctx);
                 });
             }
+        });
+        // Revalidate when any keybinding changes so tips with `<keybinding>`
+        // placeholders are hidden/shown when the referenced binding is cleared
+        // or reassigned.
+        ctx.subscribe_to_model(&KeybindingChangedNotifier::handle(ctx), move |_, _, ctx| {
+            tip_model_handle.update(ctx, |model, ctx| {
+                model.revalidate_tips(ctx);
+            });
         });
     }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -229,7 +229,9 @@ use crate::server::sync_queue::{QueueItem, SyncQueue};
 use crate::session_management::{RunningSessionSummary, SessionNavigationData};
 use crate::settings::cloud_preferences_syncer::initialize_cloud_preferences_syncer;
 use crate::settings::manager::SettingsManager;
-use crate::settings::{AccessibilitySettings, ScrollSettings, SelectionSettings};
+use crate::settings::{
+    AISettings, AISettingsChangedEvent, AccessibilitySettings, ScrollSettings, SelectionSettings,
+};
 use crate::settings_view::keybindings::KeybindingChangedNotifier;
 use crate::settings_view::DisplayCount;
 use crate::suggestions::ignored_suggestions_model::IgnoredSuggestionsModel;
@@ -291,7 +293,7 @@ use crate::terminal::CustomSecretRegexUpdater;
 use crate::util::bindings::is_binding_cross_platform;
 use crate::workspace::{PaneViewLocator, Workspace, WorkspaceAction};
 use crate::workspaces::update_manager::TeamUpdateManager;
-use crate::workspaces::user_workspaces::UserWorkspaces;
+use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
 use warp_logging::LogDestination;
 
 // Re-export the send_telemetry_from_ctx macro at the crate root level
@@ -1820,9 +1822,35 @@ pub(crate) fn initialize_app(
     ctx.add_singleton_model(LLMPreferences::new);
     ctx.add_singleton_model(HarnessAvailabilityModel::new);
 
-    ctx.add_singleton_model(|ctx| {
+    let tip_model_handle = ctx.add_singleton_model(|ctx| {
         ai::agent_tips::AITipModel::<ai::AgentTip>::new_for_agent_tips(ctx)
     });
+    // Rebuild the tip pool when voice-related settings change so that the voice tip
+    // appears/disappears without waiting for the next cooldown cycle.
+    {
+        let tip_model_handle_for_ai = tip_model_handle.clone();
+        ctx.subscribe_to_model(&AISettings::handle(ctx), move |_, event, ctx| {
+            if matches!(
+                event,
+                AISettingsChangedEvent::VoiceInputToggleKey { .. }
+                    | AISettingsChangedEvent::VoiceInputEnabled { .. }
+            ) {
+                tip_model_handle_for_ai.update(ctx, |model, ctx| {
+                    model.revalidate_tips(ctx);
+                });
+            }
+        });
+        // Also revalidate when workspace/team data changes (e.g. voice toggled at
+        // the org level). Billing metadata — including `warp_ai_policy.is_voice_enabled`
+        // — lives inside the team data, so `TeamsChanged` covers all policy updates.
+        ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), move |_, event, ctx| {
+            if matches!(event, UserWorkspacesEvent::TeamsChanged) {
+                tip_model_handle.update(ctx, |model, ctx| {
+                    model.revalidate_tips(ctx);
+                });
+            }
+        });
+    }
 
     timer.mark_interval_end("SINGLETON_MODELS_REGISTERED");
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -235,7 +235,9 @@ use crate::server::sync_queue::{QueueItem, SyncQueue};
 use crate::session_management::{RunningSessionSummary, SessionNavigationData};
 use crate::settings::cloud_preferences_syncer::initialize_cloud_preferences_syncer;
 use crate::settings::manager::SettingsManager;
-use crate::settings::{AccessibilitySettings, ScrollSettings, SelectionSettings};
+use crate::settings::{
+    AISettings, AISettingsChangedEvent, AccessibilitySettings, ScrollSettings, SelectionSettings,
+};
 use crate::settings_view::keybindings::KeybindingChangedNotifier;
 use crate::settings_view::DisplayCount;
 use crate::suggestions::ignored_suggestions_model::IgnoredSuggestionsModel;
@@ -301,7 +303,7 @@ use crate::terminal::CustomSecretRegexUpdater;
 use crate::util::bindings::is_binding_cross_platform;
 use crate::workspace::{PaneViewLocator, Workspace, WorkspaceAction};
 use crate::workspaces::update_manager::TeamUpdateManager;
-use crate::workspaces::user_workspaces::UserWorkspaces;
+use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
 use warp_logging::LogDestination;
 
 // Re-export the send_telemetry_from_ctx macro at the crate root level
@@ -1896,9 +1898,35 @@ pub(crate) fn initialize_app(
     ctx.add_singleton_model(LLMPreferences::new);
     ctx.add_singleton_model(HarnessAvailabilityModel::new);
 
-    ctx.add_singleton_model(|ctx| {
+    let tip_model_handle = ctx.add_singleton_model(|ctx| {
         ai::agent_tips::AITipModel::<ai::AgentTip>::new_for_agent_tips(ctx)
     });
+    // Rebuild the tip pool when voice-related settings change so that the voice tip
+    // appears/disappears without waiting for the next cooldown cycle.
+    {
+        let tip_model_handle_for_ai = tip_model_handle.clone();
+        ctx.subscribe_to_model(&AISettings::handle(ctx), move |_, event, ctx| {
+            if matches!(
+                event,
+                AISettingsChangedEvent::VoiceInputToggleKey { .. }
+                    | AISettingsChangedEvent::VoiceInputEnabled { .. }
+            ) {
+                tip_model_handle_for_ai.update(ctx, |model, ctx| {
+                    model.revalidate_tips(ctx);
+                });
+            }
+        });
+        // Also revalidate when workspace/team data changes (e.g. voice toggled at
+        // the org level). Billing metadata — including `warp_ai_policy.is_voice_enabled`
+        // — lives inside the team data, so `TeamsChanged` covers all policy updates.
+        ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), move |_, event, ctx| {
+            if matches!(event, UserWorkspacesEvent::TeamsChanged) {
+                tip_model_handle.update(ctx, |model, ctx| {
+                    model.revalidate_tips(ctx);
+                });
+            }
+        });
+    }
 
     timer.mark_interval_end("SINGLETON_MODELS_REGISTERED");
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -235,9 +235,7 @@ use crate::server::sync_queue::{QueueItem, SyncQueue};
 use crate::session_management::{RunningSessionSummary, SessionNavigationData};
 use crate::settings::cloud_preferences_syncer::initialize_cloud_preferences_syncer;
 use crate::settings::manager::SettingsManager;
-use crate::settings::{
-    AISettings, AISettingsChangedEvent, AccessibilitySettings, ScrollSettings, SelectionSettings,
-};
+use crate::settings::{AISettings, AccessibilitySettings, ScrollSettings, SelectionSettings};
 use crate::settings_view::keybindings::KeybindingChangedNotifier;
 use crate::settings_view::DisplayCount;
 use crate::suggestions::ignored_suggestions_model::IgnoredSuggestionsModel;
@@ -1902,19 +1900,13 @@ pub(crate) fn initialize_app(
         ai::agent_tips::AITipModel::<ai::AgentTip>::new_for_agent_tips(ctx)
     });
     {
-        // Rebuild the tip pool when voice-related settings change so that the voice tip
-        // appears/disappears without waiting for the next cooldown cycle.
+        // Rebuild the tip pool when AI settings change so tips whose applicability
+        // depends on AI settings appear/disappear without waiting for the next cooldown cycle.
         let tip_model_handle_for_ai = tip_model_handle.clone();
-        ctx.subscribe_to_model(&AISettings::handle(ctx), move |_, event, ctx| {
-            if matches!(
-                event,
-                AISettingsChangedEvent::VoiceInputToggleKey { .. }
-                    | AISettingsChangedEvent::VoiceInputEnabled { .. }
-            ) {
-                tip_model_handle_for_ai.update(ctx, |model, ctx| {
-                    model.revalidate_tips(ctx);
-                });
-            }
+        ctx.subscribe_to_model(&AISettings::handle(ctx), move |_, _, ctx| {
+            tip_model_handle_for_ai.update(ctx, |model, ctx| {
+                model.revalidate_tips(ctx);
+            });
         });
         // Also revalidate when workspace/team data changes (e.g. voice toggled at
         // the org level). Billing metadata — including `warp_ai_policy.is_voice_enabled`

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1901,9 +1901,9 @@ pub(crate) fn initialize_app(
     let tip_model_handle = ctx.add_singleton_model(|ctx| {
         ai::agent_tips::AITipModel::<ai::AgentTip>::new_for_agent_tips(ctx)
     });
-    // Rebuild the tip pool when voice-related settings change so that the voice tip
-    // appears/disappears without waiting for the next cooldown cycle.
     {
+        // Rebuild the tip pool when voice-related settings change so that the voice tip
+        // appears/disappears without waiting for the next cooldown cycle.
         let tip_model_handle_for_ai = tip_model_handle.clone();
         ctx.subscribe_to_model(&AISettings::handle(ctx), move |_, event, ctx| {
             if matches!(
@@ -1919,12 +1919,21 @@ pub(crate) fn initialize_app(
         // Also revalidate when workspace/team data changes (e.g. voice toggled at
         // the org level). Billing metadata — including `warp_ai_policy.is_voice_enabled`
         // — lives inside the team data, so `TeamsChanged` covers all policy updates.
+        let tip_model_handle_for_teams = tip_model_handle.clone();
         ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), move |_, event, ctx| {
             if matches!(event, UserWorkspacesEvent::TeamsChanged) {
-                tip_model_handle.update(ctx, |model, ctx| {
+                tip_model_handle_for_teams.update(ctx, |model, ctx| {
                     model.revalidate_tips(ctx);
                 });
             }
+        });
+        // Revalidate when any keybinding changes so tips with `<keybinding>`
+        // placeholders are hidden/shown when the referenced binding is cleared
+        // or reassigned.
+        ctx.subscribe_to_model(&KeybindingChangedNotifier::handle(ctx), move |_, _, ctx| {
+            tip_model_handle.update(ctx, |model, ctx| {
+                model.revalidate_tips(ctx);
+            });
         });
     }
 

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -188,6 +188,7 @@ fn initialize_app(app: &mut App) {
     });
     app.add_singleton_model(|ctx| PersistedWorkspace::new(vec![], HashMap::new(), None, ctx));
     app.add_singleton_model(|_| ProjectContextModel::default());
+    app.add_singleton_model(|ctx| crate::ai::agent_tips::AITipModel::new_for_agent_tips(ctx));
     app.add_singleton_model(|_| RestoredAgentConversations::new(vec![]));
     app.add_singleton_model(OneTimeModalModel::new);
     app.add_singleton_model(|_| WorkspaceRegistry::new());

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -197,6 +197,7 @@ fn initialize_app(app: &mut App) {
     });
     app.add_singleton_model(|ctx| PersistedWorkspace::new(vec![], HashMap::new(), None, ctx));
     app.add_singleton_model(|_| ProjectContextModel::default());
+    app.add_singleton_model(|ctx| crate::ai::agent_tips::AITipModel::new_for_agent_tips(ctx));
     app.add_singleton_model(|_| RestoredAgentConversations::new(vec![]));
     app.add_singleton_model(OneTimeModalModel::new);
     app.add_singleton_model(|_| WorkspaceRegistry::new());

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -203,6 +203,7 @@ pub fn initialize_app(app: &mut App) {
     });
     app.add_singleton_model(AgentConversationsModel::new);
     app.add_singleton_model(PersistedWorkspace::new_for_test);
+    app.add_singleton_model(|ctx| crate::ai::agent_tips::AITipModel::new_for_agent_tips(ctx));
     // `LocalShellState` captures the user's interactive login-shell PATH (used
     // for MCP/sbx executable resolution). Tests don't exercise that capture, so
     // register the singleton in its `NotLoaded` state to satisfy callers that

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -212,6 +212,7 @@ pub fn initialize_app(app: &mut App) {
     });
     app.add_singleton_model(AgentConversationsModel::new);
     app.add_singleton_model(PersistedWorkspace::new_for_test);
+    app.add_singleton_model(|ctx| crate::ai::agent_tips::AITipModel::new_for_agent_tips(ctx));
     // `LocalShellState` captures the user's interactive login-shell PATH (used
     // for MCP/sbx executable resolution). Tests don't exercise that capture, so
     // register the singleton in its `NotLoaded` state to satisfy callers that

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -6,6 +6,7 @@ use warp_core::ui::appearance::Appearance;
 
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent_conversations_model::AgentConversationsModel;
+use crate::ai::agent_tips::AITipModel;
 use crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier;
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::mcp::{
@@ -122,6 +123,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
     app.add_singleton_model(AuthManager::new_for_test);
     app.add_singleton_model(LLMPreferences::new);
     app.add_singleton_model(HarnessAvailabilityModel::new);
+    app.add_singleton_model(|ctx| AITipModel::new_for_agent_tips(ctx));
     app.add_singleton_model(SessionPermissionsManager::new);
     app.add_singleton_model(DirectoryWatcher::new);
     app.add_singleton_model(|_| DetectedRepositories::default());

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -6,6 +6,7 @@ use warp_core::ui::appearance::Appearance;
 
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent_conversations_model::AgentConversationsModel;
+use crate::ai::agent_tips::AITipModel;
 use crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier;
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::mcp::{
@@ -118,6 +119,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
     app.add_singleton_model(AuthManager::new_for_test);
     app.add_singleton_model(LLMPreferences::new);
     app.add_singleton_model(HarnessAvailabilityModel::new);
+    app.add_singleton_model(|ctx| AITipModel::new_for_agent_tips(ctx));
     app.add_singleton_model(SessionPermissionsManager::new);
     app.add_singleton_model(DirectoryWatcher::new);
     app.add_singleton_model(|_| DetectedRepositories::default());

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -63,6 +63,7 @@ use crate::terminal::shared_session::{SharedSessionScrollbackType, SharedSession
 
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent_conversations_model::AgentConversationsModel;
+use crate::ai::agent_tips::AITipModel;
 use crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier;
 use crate::ai::mcp::{
     gallery::MCPGalleryManager, templatable_manager::TemplatableMCPServerManager,
@@ -146,6 +147,7 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(SessionPermissionsManager::new);
     app.add_singleton_model(LLMPreferences::new);
     app.add_singleton_model(HarnessAvailabilityModel::new);
+    app.add_singleton_model(|ctx| AITipModel::new_for_agent_tips(ctx));
     app.add_singleton_model(|_| SettingsPaneManager::new());
     app.add_singleton_model(|_| AIFactManager::new());
 

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -60,6 +60,7 @@ use crate::terminal::shared_session::{SharedSessionScrollbackType, SharedSession
 
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent_conversations_model::AgentConversationsModel;
+use crate::ai::agent_tips::AITipModel;
 use crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier;
 use crate::ai::mcp::{
     gallery::MCPGalleryManager, templatable_manager::TemplatableMCPServerManager,
@@ -142,6 +143,7 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(SessionPermissionsManager::new);
     app.add_singleton_model(LLMPreferences::new);
     app.add_singleton_model(HarnessAvailabilityModel::new);
+    app.add_singleton_model(|ctx| AITipModel::new_for_agent_tips(ctx));
     app.add_singleton_model(|_| SettingsPaneManager::new());
     app.add_singleton_model(|_| AIFactManager::new());
 


### PR DESCRIPTION
## Description
* Reported in https://warpdev.slack.com/archives/C08KTPNQN65/p1777499214403939 
* Adds a check in  `AgentTip::is_tip_applicable` such that tips that expect a keybinding but don't have one are removed from the displayed list 
* Also updates the tip singleton model to refresh based on dependent settings and keybinding changes

## Testing
Verified locally with only the voice tip - when setting is disabled or when keybinding is not available, the tip is not applicable/not shown 
https://www.loom.com/share/dcfcf6a0b8b24be8aea1ca24dd27ddc9

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode