### PR TITLE
remove file path on path conversion error messages

### DIFF
--- a/app/src/code/inline_diff.rs
+++ b/app/src/code/inline_diff.rs
@@ -128,9 +128,15 @@ impl InlineDiffView {
         let file_id = match session_type {
             DiffSessionType::Local => {
                 let Some(local_path) = file_path.to_local_path() else {
-                    log::error!(
-                        "Failed to convert StandardizedPath to local path: {file_path}; \
-                         diff will be read-only",
+                    crate::safe_error!(
+                        safe: (
+                            "Failed to convert StandardizedPath to local path; diff will be \
+                            read-only"
+                        ),
+                        full: (
+                            "Failed to convert StandardizedPath to local path: {file_path}; diff \
+                            will be read-only"
+                        ),
                     );
                     return;
                 };

--- a/app/src/code/inline_diff.rs
+++ b/app/src/code/inline_diff.rs
@@ -136,7 +136,7 @@ impl InlineDiffView {
                         full: (
                             "Failed to convert StandardizedPath to local path: {file_path}; diff \
                             will be read-only"
-                        ),
+                        )
                     );
                     return;
                 };


### PR DESCRIPTION
Closes #10071

Migrated from warpdotdev/warp-internal#24950 via `script/migrate-private-to-public`.

## Commits

- 56f1d90 remove file path on path conversion error messages
- 8c17c38 fix macro syntax