### PR TITLE
APP-4336: Track CLI agent rich input prompts for up-arrow history

### DIFF
--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -35,6 +35,7 @@ use crate::persistence::ModelEvent;
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::model::block::BlockId;
 use crate::terminal::view::blocklist_filter;
+use crate::terminal::CLIAgent;
 use crate::GlobalResourceHandlesProvider;
 use crate::{
     ai::agent::{
@@ -248,6 +249,17 @@ pub struct BlocklistAIHistoryModel {
     /// Populated at startup from the local DB and kept in sync at runtime
     /// via `set_parent_for_conversation` and `restore_conversations`.
     children_by_parent: HashMap<AIConversationId, Vec<AIConversationId>>,
+
+    /// Prompts the user submitted via the CLI agent (Full Terminal Use) rich input,
+    /// keyed by the originating [`crate::terminal::TerminalView`] [`EntityId`].
+    ///
+    /// These prompts are written directly to the CLI agent's PTY rather than being
+    /// part of an AI conversation, so they don't end up in any
+    /// [`AIConversation::root_task_exchanges`]. They are tracked here so they can
+    /// be surfaced in the up-arrow inline history menu.
+    ///
+    /// In-memory only for now; persistence across restarts is a follow-up.
+    cli_agent_prompts_for_terminal_view: HashMap<EntityId, Vec<CLIAgentPromptHistory>>,
 
     #[cfg(feature = "local_fs")]
     db_connection: Option<Arc<Mutex<SqliteConnection>>>,
@@ -1646,6 +1658,71 @@ impl BlocklistAIHistoryModel {
             .contains(&terminal_view_id)
     }
 
+    /// Records a prompt the user submitted via the CLI agent (Full Terminal Use) rich input
+    /// composer.
+    ///
+    /// These prompts are written directly to the CLI agent's PTY rather than being part of an
+    /// AI conversation, so this is the only place they get tracked for up-arrow history.
+    /// Empty/whitespace-only prompts are ignored. Identical, consecutive prompts are coalesced
+    /// to a single entry to avoid spamming the history.
+    pub fn record_cli_agent_prompt(
+        &mut self,
+        terminal_view_id: EntityId,
+        agent: CLIAgent,
+        query_text: String,
+        working_directory: Option<String>,
+    ) {
+        let trimmed = query_text.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+
+        let entries = self
+            .cli_agent_prompts_for_terminal_view
+            .entry(terminal_view_id)
+            .or_default();
+
+        if entries
+            .last()
+            .is_some_and(|last| last.query_text == trimmed)
+        {
+            return;
+        }
+
+        entries.push(CLIAgentPromptHistory {
+            query_text: trimmed.to_owned(),
+            start_time: Local::now(),
+            output_status: AIQueryHistoryOutputStatus::Completed,
+            working_directory,
+            history_order: HistoryOrder::CurrentSession,
+            agent,
+        });
+    }
+
+    /// Returns CLI agent (Full Terminal Use) prompts as [`AIQueryHistory`] entries with the
+    /// appropriate [`HistoryOrder`] for the calling terminal view.
+    pub(crate) fn all_cli_agent_prompts(
+        &self,
+        terminal_view_id: Option<EntityId>,
+    ) -> impl Iterator<Item = AIQueryHistory> + '_ {
+        self.cli_agent_prompts_for_terminal_view
+            .iter()
+            .flat_map(move |(tv_id, prompts)| {
+                let history_order = if terminal_view_id.is_some_and(|id| id == *tv_id) {
+                    HistoryOrder::CurrentSession
+                } else {
+                    HistoryOrder::DifferentSession
+                };
+                prompts.iter().map(move |prompt| AIQueryHistory {
+                    query_text: prompt.query_text.clone(),
+                    start_time: prompt.start_time,
+                    output_status: prompt.output_status.clone(),
+                    working_directory: prompt.working_directory.clone(),
+                    history_order,
+                })
+            })
+    }
+
     /// Returns [`AIQueryHistory`]s from all sources: live conversations, cleared conversations,
     /// and persisted queries from conversations not loaded in memory.
     ///
@@ -2030,6 +2107,7 @@ impl BlocklistAIHistoryModel {
         self.all_conversations_metadata.clear();
         self.agent_id_to_conversation_id.clear();
         self.server_token_to_conversation_id.clear();
+        self.cli_agent_prompts_for_terminal_view.clear();
     }
 }
 
@@ -2280,6 +2358,29 @@ impl AIQueryHistory {
             history_order,
         }
     }
+}
+
+/// History entry for a prompt the user submitted to a CLI agent (Full Terminal Use)
+/// via the rich input composer.
+///
+/// Distinct from [`AIQueryHistory`] only in that it carries the originating [`CLIAgent`],
+/// which lets us tab-separate Base agent prompts from FTU prompts in the inline history menu
+/// in a follow-up.
+#[derive(Debug, Clone)]
+pub struct CLIAgentPromptHistory {
+    pub query_text: String,
+    pub start_time: DateTime<Local>,
+    pub output_status: AIQueryHistoryOutputStatus,
+    pub working_directory: Option<String>,
+    /// Used by callers that need to know whether the prompt belongs to the current session.
+    /// Currently set to [`HistoryOrder::CurrentSession`] at insertion time and overridden by
+    /// `all_cli_agent_prompts` based on the requested terminal view.
+    #[allow(dead_code)]
+    pub history_order: HistoryOrder,
+    /// The CLI agent the prompt was sent to. Will be used to tab-separate Base agent prompts
+    /// from FTU prompts in the inline history menu in a follow-up.
+    #[allow(dead_code)]
+    pub agent: CLIAgent,
 }
 
 fn ai_exchange_to_query_history(

--- a/app/src/terminal/history/up_arrow.rs
+++ b/app/src/terminal/history/up_arrow.rs
@@ -111,19 +111,28 @@ impl History {
             );
         }
 
-        let ai_queries = BlocklistAIHistoryModel::handle(app)
-            .as_ref(app)
+        let history_model = BlocklistAIHistoryModel::handle(app).as_ref(app);
+        let ai_queries = history_model
             .all_ai_queries(Some(terminal_view_id))
             .filter(|query| {
                 !ignored_suggestions.is_ignored(&query.query_text, SuggestionType::AIQuery)
             })
             .map(|entry| HistoryInputSuggestion::AIQuery { entry });
 
+        let cli_agent_prompts = history_model
+            .all_cli_agent_prompts(Some(terminal_view_id))
+            .filter(|query| {
+                !ignored_suggestions.is_ignored(&query.query_text, SuggestionType::AIQuery)
+            })
+            .map(|entry| HistoryInputSuggestion::AIQuery { entry });
+
+        let prompts = ai_queries.chain(cli_agent_prompts);
+
         let suggestions: Vec<HistoryInputSuggestion<'a>> =
             match (config.include_commands, config.include_prompts) {
-                (true, true) => commands.chain(ai_queries).collect(),
+                (true, true) => commands.chain(prompts).collect(),
                 (true, false) => commands.collect(),
-                (false, true) => ai_queries.collect(),
+                (false, true) => prompts.collect(),
                 (false, false) => vec![],
             };
 

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -52,7 +52,10 @@ use warpui::{
 };
 
 use crate::{
-    ai::blocklist::{agent_view::agent_view_bg_fill, block::cli_controller::CLISubagentEvent},
+    ai::blocklist::{
+        agent_view::agent_view_bg_fill, block::cli_controller::CLISubagentEvent,
+        BlocklistAIHistoryModel,
+    },
     cmd_or_ctrl_shift,
     server::telemetry::{CLIAgentType, CLISubagentControlState, TelemetryEvent},
     settings::{
@@ -634,9 +637,10 @@ impl TerminalView {
         }
 
         let prompt_length = text.chars().count();
-        let cli_agent: Option<CLIAgentType> = CLIAgentSessionsModel::as_ref(ctx)
+        let agent = CLIAgentSessionsModel::as_ref(ctx)
             .session(self.view_id)
-            .map(|s| s.agent.into());
+            .map(|s| s.agent);
+        let cli_agent: Option<CLIAgentType> = agent.map(Into::into);
         if let Some(cli_agent) = cli_agent {
             send_telemetry_from_ctx!(
                 TelemetryEvent::CLIAgentRichInputSubmitted {
@@ -647,8 +651,18 @@ impl TerminalView {
             );
         }
 
-        // Clear any saved draft so submitted text isn't restored on the next open.
+        // Record the prompt in the AI history so it surfaces in the up-arrow inline history menu.
+        // Prompts written via the rich input go straight to the CLI agent's PTY and never become
+        // exchanges in an AI conversation, so this is the only place they get tracked for history.
         let view_id = self.view_id;
+        if let Some(agent) = agent {
+            let text_for_history = text.clone();
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, move |history, _| {
+                history.record_cli_agent_prompt(view_id, agent, text_for_history, None);
+            });
+        }
+
+        // Clear any saved draft so submitted text isn't restored on the next open.
         CLIAgentSessionsModel::handle(ctx).update(ctx, |sessions_model, _| {
             sessions_model.clear_draft(view_id);
         });


### PR DESCRIPTION
## Description
Fixes [APP-4336](https://linear.app/warp/issue/APP-4336): Show LRC prompts in up-arrow history.

Prompts a user submits via the CLI agent (Full Terminal Use) rich input composer are written directly to the agent's PTY, so they never became AI exchanges and were missing from the up-arrow inline history menu. This PR tracks those submissions and surfaces them in up-arrow history.

## Implementation
- New `cli_agent_prompts_for_terminal_view` map on `BlocklistAIHistoryModel`, plus a `record_cli_agent_prompt` setter and an `all_cli_agent_prompts` getter that emits `AIQueryHistory` entries with the right `HistoryOrder`.
- New `CLIAgentPromptHistory` struct that carries the originating `CLIAgent` so we can tab-separate Base vs FTU prompts later.
- `submit_cli_agent_rich_input` now records each non-empty submission into the history model before delegating to the existing PTY pipeline.
- `History::up_arrow_suggestions_for_terminal_view` chains the new prompts in alongside `all_ai_queries`, reusing the existing dedupe path so identical text from a Base prompt and an FTU prompt collapse correctly.

The tracking is in-memory only for now and the inline history menu still surfaces all prompts under the existing `Prompts` tab.

## Out of scope (tracked as TODOs in the plan)
- SQLite persistence so prompts survive restarts.
- Splitting `Prompts` into separate `Agent` and `Full terminal use` tabs in the inline history menu, mirroring the model selector at `app/src/terminal/input/models/view.rs (75-90)`.
- The "prompt dropping" issue from the same Slack thread \u2014 separate ticket.

## Validation
- `cargo check -p warp` clean (no new warnings).
- `cargo fmt -- --check` passes.
- `cargo clippy -p warp --all-targets --all-features --tests -- -D warnings` passes (only pre-existing third-party `minimp4-sys` C warnings remain).
- Manual test pending: open a Claude Code (or similar) CLI session, submit prompts via the rich input, then up-arrow in the same terminal view.

_Conversation: https://staging.warp.dev/conversation/f2d943d2-18fe-4631-8085-6baa0f2df5e4_
_Run: https://oz.staging.warp.dev/runs/019ddb4f-b6ca-78c5-aa17-7b4e10205a1a_
_Plans_:
- _[APP-4336: Show LRC prompts in up-arrow history](https://staging.warp.dev/drive/notebook/zIDbnnD6hXpJ0q9bu06G8J)_

_This PR was generated with [Oz](https://warp.dev/oz)._
