### PR TITLE
Fix meta+enter/tab/escape sending literal key names in legacy encoding

### DIFF
--- a/crates/warp_terminal/src/model/escape_sequences.rs
+++ b/crates/warp_terminal/src/model/escape_sequences.rs
@@ -550,6 +550,9 @@ fn cursor_movement_keystroke_to_escape_sequence(
 /// further than a HashMap.
 fn map_special_key_to_bytes(key: &str) -> Option<&[u8]> {
     match key {
+        "enter" | "numpadenter" => Some("\r".as_bytes()),
+        "tab" => Some("\t".as_bytes()),
+        "escape" => Some("\x1b".as_bytes()),
         "backspace" => Some("\x7f".as_bytes()),
         "insert" => Some("\x1b[2~".as_bytes()),
         "delete" => Some("\x1b[3~".as_bytes()),


### PR DESCRIPTION
Fixes #9517

## Description

Meta+enter (among others) was sending the ESC plus the literal string `enter` instead of anything reasonable! This has been bothering me for ages and is because `meta_keystroke_to_escape_sequence` falls back to sending the key name as literal ASCII bytes when the key isn't in map_special_key_to_bytes.

Add the missing entries to map_special_key_to_bytes:
- enter/numpadenter → CR (\r)
- tab → HT (\t)
- escape → ESC (\x1b)

## Testing

Didn't add tests as I think they'd just be repeating the implementation.

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed Option+Enter, Option+Tab, and Option+Escape sending literal key names instead of correct escape sequences