### PR TITLE
Show shell/distro icon in vertical tabs

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1238,6 +1238,8 @@ fn render_detail_kind_badge_icon(
                 .is_some()
             {
                 WarpIcon::Oz
+            } else if let Some(shell_indicator) = terminal_view.shell_indicator_type() {
+                shell_indicator.to_icon()
             } else {
                 WarpIcon::Terminal
             };


### PR DESCRIPTION
## Description

Vertical tabs currently render a generic terminal glyph for any pane that isn't a CLI agent or Oz session, so on Windows (mixed PowerShell + multiple WSL distros) every native and WSL tab looks identical. Horizontal tabs already differentiate them via `ShellIndicatorType::to_icon()` (see `app/src/tab.rs:1109-1112`). This PR plumbs the same accessor into the vertical-tabs render path.

The change is a single new `else if` arm in `render_detail_kind_badge_icon` (`app/src/workspace/view/vertical_tabs.rs`):

```rust
} else if let Some(shell_indicator) = terminal_view.shell_indicator_type() {
    shell_indicator.to_icon()
} else {
    WarpIcon::Terminal
};
```

When `shell_indicator_type()` returns `Some`, render the shell/distro icon (Powershell / GitBash / Ubuntu / Debian / Kali / Arch / Linux); otherwise fall through to the existing `WarpIcon::Terminal` default. The icon-color match already has a catch-all `_ => sub_text` arm that handles the new icon variants — no color logic changes needed.

### Reuses what's already there
- `ShellIndicatorType` and the `TryFrom<&ShellLaunchData>` impl — already exists in `app/src/shell_indicator.rs`
- `terminal_view.shell_indicator_type()` getter — already exists at `app/src/terminal/view.rs:24047`
- All seven referenced icons (Powershell, GitBash, Ubuntu, Debian, Kali, Arch, Linux) and their SVG assets — already in the codebase
- The exact same code path is already running in horizontal tabs via `tab.rs:1109-1112`

### Behavior on macOS
`ShellIndicatorType::try_from` only returns `Ok` for PowerShell, MSYS2/GitBash, WSL, or DockerSandbox launches. On macOS with bash/zsh/fish the impl returns `Err`, so `shell_indicator_type()` is `None` and the existing generic-Terminal icon is preserved — no behavior change for macOS users with default shells.

## Testing

No new tests added. The change is a 2-line plumbing fix that re-uses `ShellIndicatorType::to_icon()`, which is already exercised in production via horizontal tabs (`app/src/tab.rs:1109-1112`). Adding a vertical-tabs-specific unit test would duplicate that coverage and require non-trivial mock scaffolding for the icon-decision branch in `render_detail_kind_badge_icon`, which has no existing icon-decision tests in `vertical_tabs_tests.rs`.

**Local presubmit note:** `cargo fmt --check` passes locally. The full `./script/presubmit` requires the Metal Toolchain to compile shaders during the `warpui` build, and the asset downloads but doesn't activate without further intervention on this machine. Relying on CI for the full clippy/clippy-wasm/nextest matrix.

## Server API dependencies

This PR does not depend on any server API changes.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Vertical tabs now show a shell/distro icon (PowerShell, Git Bash, Ubuntu, Debian, Kali, Arch, Linux) for native shell and WSL panes, matching the existing horizontal-tabs behavior.

Fixes #9175