### PR TITLE
Add libclang-dev and clang-format to Linux bootstrap deps

### DIFF
--- a/script/linux/install_build_deps
+++ b/script/linux/install_build_deps
@@ -33,6 +33,12 @@ if [[ "$(source /etc/os-release; echo $ID $ID_LIKE)" = *"debian"* ]]; then
     brotli
     # Needed for voice input
     libasound2-dev
+    # Needed by bindgen (used by minimp4-sys, pulled in by warpui_core's
+    # integration_tests feature) — pulls in libclang-common-*-dev which
+    # provides clang's resource-dir builtin headers.
+    libclang-dev
+    # Required by script/presubmit's clang-format check on C/C++/Obj-C sources.
+    clang-format
   )
   sudo apt-get install -y "${PACKAGES[@]}"
 


### PR DESCRIPTION
## Description

Adds `libclang-dev` and `clang-format` to the Debian/Ubuntu package list installed by `script/linux/install_build_deps` (run via `script/linux/bootstrap`).

Without these, `script/presubmit` fails on a fresh Linux machine that only ran `script/linux/bootstrap`:
- `clang-format` is invoked directly by the presubmit's C/C++/Obj-C format check.
- `libclang-dev` pulls in `libclang-common-*-dev`, which provides clang's resource-dir builtin headers that bindgen needs when nextest builds `minimp4-sys` (pulled in via `warpui_core`'s `integration_tests` feature).

Fixes #9526.

## Testing

Manually verified on a fresh Ubuntu setup that `script/linux/bootstrap` followed by `script/presubmit` no longer fails on the clang-format check or the bindgen build for `minimp4-sys`. No automated tests added — this is a build-deps-only change to a shell script.

## Server API dependencies

N/A — no server API changes.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode