### PR TITLE
[APP-3106] Client: preserve user query modes in CloudMode

### DIFF
--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -2327,11 +2327,37 @@ impl PassiveSuggestionTrigger {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum UserQueryMode {
     #[default]
     Normal,
     Plan,
     Orchestrate,
+}
+
+pub fn extract_user_query_mode(query: String) -> (String, UserQueryMode) {
+    if let Some(query) = commands::strip_command_prefix(&query, commands::PLAN_NAME) {
+        (query, UserQueryMode::Plan)
+    } else if let Some(query) = commands::strip_command_prefix(&query, commands::ORCHESTRATE_NAME) {
+        (query, UserQueryMode::Orchestrate)
+    } else {
+        (query, UserQueryMode::Normal)
+    }
+}
+
+/// Reconstructs the display form of a user query that has been stripped via
+/// [`extract_user_query_mode`], by re-prepending the slash-command prefix
+/// associated with [`UserQueryMode`].
+///
+/// This is the inverse of [`extract_user_query_mode`] and the canonical way
+/// for UI to render a stored `(mode, query)` pair so the displayed prompt
+/// always matches what the user originally submitted.
+pub fn display_user_query_with_mode(mode: UserQueryMode, query: &str) -> String {
+    match mode {
+        UserQueryMode::Normal => query.to_owned(),
+        UserQueryMode::Plan => format!("{} {query}", commands::PLAN.name),
+        UserQueryMode::Orchestrate => format!("{} {query}", commands::ORCHESTRATE.name),
+    }
 }
 
 // TODO(zachbai): Refactor this to consolidate with `LongRunningCommandSnapshot` and `Snapshot`
@@ -2579,13 +2605,7 @@ impl AIAgentInput {
                 query,
                 user_query_mode,
                 ..
-            } => match user_query_mode {
-                UserQueryMode::Plan => Some(format!("{} {query}", commands::PLAN.name)),
-                UserQueryMode::Orchestrate => {
-                    Some(format!("{} {query}", commands::ORCHESTRATE.name))
-                }
-                UserQueryMode::Normal => Some(query.clone()),
-            },
+            } => Some(display_user_query_with_mode(*user_query_mode, query)),
             Self::CreateNewProject { query, .. } => Some(query.clone()),
             Self::CloneRepository {
                 clone_repo_url: url,

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -2327,7 +2327,6 @@ impl PassiveSuggestionTrigger {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
 pub enum UserQueryMode {
     #[default]
     Normal,

--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -3,6 +3,7 @@ use std::io::Write as _;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::ai::agent::extract_user_query_mode;
 use crate::ai::ambient_agents::spawn::{
     spawn_task, AmbientAgentEvent, SessionJoinInfo, TASK_STATUS_POLLING_DURATION,
 };
@@ -471,8 +472,10 @@ impl AmbientAgentRunner {
                 None
             };
 
+            let (prompt, mode) = extract_user_query_mode(prompt_string);
             let request = SpawnAgentRequest {
-                prompt: prompt_string,
+                prompt,
+                mode,
                 config,
                 title: None,
                 team: match (args.scope.team, args.scope.personal) {

--- a/app/src/ai/agent_sdk/mcp_config_tests.rs
+++ b/app/src/ai/agent_sdk/mcp_config_tests.rs
@@ -260,6 +260,7 @@ fn validation_rejects_invalid_entries() {
 
 #[test]
 fn serializes_mcp_servers_as_object_not_string() {
+    use crate::ai::agent::UserQueryMode;
     use crate::ai::ambient_agents::AgentConfigSnapshot;
     use crate::server::server_api::ai::SpawnAgentRequest;
 
@@ -270,6 +271,7 @@ fn serializes_mcp_servers_as_object_not_string() {
 
     let request = SpawnAgentRequest {
         prompt: "hello".to_string(),
+        mode: UserQueryMode::Normal,
         config: Some(AgentConfigSnapshot {
             mcp_servers: Some(mcp_servers),
             ..Default::default()

--- a/app/src/ai/ambient_agents/spawn_tests.rs
+++ b/app/src/ai/ambient_agents/spawn_tests.rs
@@ -6,6 +6,7 @@ use std::sync::{
 use chrono::Utc;
 use session_sharing_protocol::common::SessionId;
 
+use crate::ai::agent::UserQueryMode;
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
 use crate::server::server_api::ai::{MockAIClient, SpawnAgentResponse};
 use crate::terminal::shared_session;
@@ -62,6 +63,7 @@ async fn poll_stops_on_terminal_failure_like_state() {
     let ai_client = Arc::new(mock);
     let request = crate::server::server_api::ai::SpawnAgentRequest {
         prompt: "test".to_string(),
+        mode: UserQueryMode::Normal,
         config: None,
         title: None,
         team: None,
@@ -177,6 +179,7 @@ async fn poll_for_session_join_info_waits_until_link_is_available() {
     let ai_client = Arc::new(mock);
     let request = crate::server::server_api::ai::SpawnAgentRequest {
         prompt: "test".to_string(),
+        mode: UserQueryMode::Normal,
         config: None,
         title: None,
         team: None,

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -19,6 +19,7 @@
 //! ```
 
 pub(super) mod common;
+pub(crate) use common::user_query_mode_prefix_highlight_len;
 pub use common::FindContext;
 mod comments;
 mod header;

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -67,7 +67,8 @@ use crate::{
             icons::red_stop_icon, AIAgentAction, AIAgentActionType, AIAgentInput,
             AIAgentOutputMessageType, AIAgentTextSection, AgentOutputImage, AgentOutputImageLayout,
             AgentOutputMermaidDiagram, AgentOutputTable, AgentOutputTableRendering,
-            ProgrammingLanguage, RenderableAIError, SummarizationType, WebSearchStatus,
+            ProgrammingLanguage, RenderableAIError, SummarizationType, UserQueryMode,
+            WebSearchStatus,
         },
         blocklist::{
             block::{
@@ -3402,13 +3403,28 @@ pub struct UserQueryProps<'a> {
     pub find_context: Option<FindContext<'a>>,
     pub font_properties: &'a Properties,
 }
+pub(crate) fn user_query_mode_prefix_highlight_len(mode: UserQueryMode) -> Option<usize> {
+    match mode {
+        UserQueryMode::Normal => None,
+        UserQueryMode::Plan => Some(commands::PLAN.name.len()),
+        UserQueryMode::Orchestrate => Some(commands::ORCHESTRATE.name.len()),
+    }
+}
+
 pub(super) fn query_prefix_highlight_len(
     input: &AIAgentInput,
     displayed_query: &str,
 ) -> Option<usize> {
-    if displayed_query.starts_with(commands::PLAN.name) {
-        Some(commands::PLAN.name.len())
-    } else if displayed_query.starts_with(commands::CREATE_ENVIRONMENT.name) {
+    if let AIAgentInput::UserQuery {
+        user_query_mode, ..
+    } = input
+    {
+        if let Some(prefix_len) = user_query_mode_prefix_highlight_len(*user_query_mode) {
+            return Some(prefix_len);
+        }
+    }
+
+    if displayed_query.starts_with(commands::CREATE_ENVIRONMENT.name) {
         Some(commands::CREATE_ENVIRONMENT.name.len())
     } else if displayed_query.starts_with(commands::AGENT.name) {
         Some(commands::AGENT.name.len())

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -37,10 +37,10 @@ use crate::ai::document::ai_document_model::{
 use crate::ai::llms::LLMId;
 use crate::ai::{
     agent::{
-        conversation::AIConversationId, AIAgentActionResultType, AIAgentAttachment, AIAgentContext,
-        AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, AIIdentifiers, EntrypointType,
-        FinishedAIAgentOutput, RenderableAIError, RequestCost, RequestMetadata, StaticQueryType,
-        UserQueryMode,
+        conversation::AIConversationId, extract_user_query_mode, AIAgentActionResultType,
+        AIAgentAttachment, AIAgentContext, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus,
+        AIIdentifiers, EntrypointType, FinishedAIAgentOutput, RenderableAIError, RequestCost,
+        RequestMetadata, StaticQueryType, UserQueryMode,
     },
     llms::LLMPreferences,
     AIRequestUsageModel,
@@ -51,7 +51,6 @@ use crate::global_resource_handles::GlobalResourceHandlesProvider;
 use crate::network::NetworkStatus;
 use crate::notebooks::editor::model::FileLinkResolutionContext;
 use crate::persistence::ModelEvent;
-use crate::search::slash_command_menu::static_commands::commands;
 use crate::server::server_api::AIApiError;
 use crate::terminal::model::block::{
     formatted_terminal_contents_for_input, BlockId, CURSOR_MARKER,
@@ -607,15 +606,7 @@ impl BlocklistAIController {
             return;
         }
 
-        let (query, user_query_mode) = if let Some(q) =
-            commands::strip_command_prefix(&query, commands::PLAN_NAME)
-        {
-            (q, UserQueryMode::Plan)
-        } else if let Some(q) = commands::strip_command_prefix(&query, commands::ORCHESTRATE_NAME) {
-            (q, UserQueryMode::Orchestrate)
-        } else {
-            (query, UserQueryMode::Normal)
-        };
+        let (query, user_query_mode) = extract_user_query_mode(query);
 
         let should_prepend_finished_action_results = matches!(
             input_query.input_query,

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     pane_group::{self, Direction, Event::OpenConversationHistory, PaneGroup},
     persistence::{BlockCompleted, ModelEvent},
-    server::server_api::ai::SpawnAgentRequest,
+    server::server_api::ai::{SpawnAgentRequest, UserQueryMode},
     session_management::SessionNavigationData,
     terminal::cli_agent_sessions::CLIAgentSessionsModel,
     terminal::{
@@ -1371,6 +1371,8 @@ fn handle_terminal_view_event(
                             };
                             let spawn_request = SpawnAgentRequest {
                                 prompt: request.prompt,
+                                // Agents spawned during orchestrations are always run in normal mode.
+                                mode: UserQueryMode::Normal,
                                 config: Some(AgentConfigSnapshot {
                                     environment_id,
                                     model_id: (!model_id.is_empty()).then_some(model_id),

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -144,6 +144,7 @@ use warp_graphql::{
     },
 };
 
+pub use crate::ai::agent::UserQueryMode;
 // Re-export ambient agent types for backwards compatibility
 pub use crate::ai::ambient_agents::{
     task::{AttachmentInput, TaskAttachment},
@@ -180,6 +181,9 @@ impl TaskStatusUpdate {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SpawnAgentRequest {
     pub prompt: String,
+    /// The mode the agent should run in (normal, plan, or orchestrate).
+    /// Mirrors the `/plan` and `/orchestrate` slash commands available locally.
+    pub mode: UserQueryMode,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<AgentConfigSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -158,6 +158,23 @@ pub struct TaskStatusUpdate {
     pub message: String,
     pub error_code: Option<PlatformErrorCode>,
 }
+fn public_api_user_query_mode(mode: UserQueryMode) -> &'static str {
+    match mode {
+        UserQueryMode::Normal => "normal",
+        UserQueryMode::Plan => "plan",
+        UserQueryMode::Orchestrate => "orchestrate",
+    }
+}
+
+fn serialize_user_query_mode_for_public_api<S>(
+    mode: &UserQueryMode,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(public_api_user_query_mode(*mode))
+}
 
 impl TaskStatusUpdate {
     /// Create a status update with just a message (no error code).
@@ -181,8 +198,8 @@ impl TaskStatusUpdate {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SpawnAgentRequest {
     pub prompt: String,
-    /// The mode the agent should run in (normal, plan, or orchestrate).
-    /// Mirrors the `/plan` and `/orchestrate` slash commands available locally.
+    /// The public API accepts lowercase mode strings (`normal`, `plan`, or `orchestrate`).
+    #[serde(serialize_with = "serialize_user_query_mode_for_public_api")]
     pub mode: UserQueryMode,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<AgentConfigSnapshot>,

--- a/app/src/terminal/view/ambient_agent/block/query.rs
+++ b/app/src/terminal/view/ambient_agent/block/query.rs
@@ -6,8 +6,10 @@ use warpui::{
 };
 
 use crate::{
+    ai::agent::display_user_query_with_mode,
     ai::blocklist::block::view_impl::{
-        query::render_query, WithContentItemSpacing, CONTENT_VERTICAL_PADDING,
+        query::render_query, user_query_mode_prefix_highlight_len, WithContentItemSpacing,
+        CONTENT_VERTICAL_PADDING,
     },
     auth::AuthStateProvider,
     terminal::view::ambient_agent::{AmbientAgentViewModel, AmbientAgentViewModelEvent},
@@ -51,12 +53,24 @@ impl View for CloudModeInitialUserQuery {
             return Empty::new().finish();
         };
 
-        render_user_query(&request.prompt, &self.view_model, app)
+        // `request.prompt` was stripped of any `/plan` or `/orchestrate` prefix when the
+        // spawn request was built. Reconstruct the displayed prompt from `request.mode`
+        // so the cloud-mode bubble matches what the user typed (and what the local-mode
+        // path renders via `AIAgentInput::user_query`).
+        let display_prompt = display_user_query_with_mode(request.mode, &request.prompt);
+        let query_prefix_highlight_len = user_query_mode_prefix_highlight_len(request.mode);
+        render_user_query(
+            &display_prompt,
+            query_prefix_highlight_len,
+            &self.view_model,
+            app,
+        )
     }
 }
 
 fn render_user_query(
     prompt: &str,
+    query_prefix_highlight_len: Option<usize>,
     view_model: &ModelHandle<AmbientAgentViewModel>,
     app: &AppContext,
 ) -> Box<dyn Element> {
@@ -77,7 +91,7 @@ fn render_user_query(
             &Default::default(),
             &Default::default(),
             0,
-            None,
+            query_prefix_highlight_len,
             false,
             true,
             &[],

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -9,7 +9,7 @@ use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{Entity, EntityId, ModelContext, SingletonEntity};
 
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::{conversation::AIConversationId, extract_user_query_mode};
 use crate::ai::ambient_agents::spawn::{spawn_task, AmbientAgentEvent};
 use crate::ai::ambient_agents::task::HarnessConfig;
 use crate::ai::ambient_agents::telemetry::CloudAgentTelemetryEvent;
@@ -488,8 +488,10 @@ impl AmbientAgentViewModel {
             ..Default::default()
         });
 
+        let (prompt, mode) = extract_user_query_mode(prompt);
         let request = SpawnAgentRequest {
             prompt,
+            mode,
             config,
             title: None,
             team: None,

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -6,6 +6,7 @@ use warp_cli::agent::Harness;
 use warp_terminal::model::BlockId;
 
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
+use crate::ai::agent::display_user_query_with_mode;
 use crate::ai::AIRequestUsageModel;
 use warp_core::features::FeatureFlag;
 use warp_core::send_telemetry_from_ctx;
@@ -146,10 +147,16 @@ impl TerminalView {
                         // Non-oz runs: render the submitted prompt via the queued-prompt UI.
                         // The block is removed later by `HarnessCommandStarted` / failure /
                         // cancel / auth handlers.
+                        //
+                        // `request.prompt` is stored stripped of any `/plan` / `/orchestrate`
+                        // prefix; rebuild the display form from `request.mode` so the user sees
+                        // exactly what they typed.
                         let prompt = ambient_agent_view_model
                             .as_ref(ctx)
                             .request()
-                            .map(|request| request.prompt.clone())
+                            .map(|request| {
+                                display_user_query_with_mode(request.mode, &request.prompt)
+                            })
                             .unwrap_or_default();
                         if !prompt.is_empty() {
                             self.insert_cloud_mode_queued_user_query_block(prompt, ctx);


### PR DESCRIPTION
## Description

With my server changes in [this](https://github.com/warpdotdev/warp-server/pull/10678) PR, we now accept an explicit user query mode in ambient agent queries sent via the public API. This PR passes `UserQueryMode`through ambient agent requests so CloudMode preserves `/plan` and `/orchestrate` semantics, and shares prefix highlighting helpers across local and CloudMode query rendering.

Keeps local and CloudMode prompt bubbles visually consistent, and includes a drive-by change to fix `/orchestrate` prefix highlighting in rendered queries in the blocklist.

## Testing

Tested manually. Demo here.

## Server API dependencies

- [ ] Is this change necessary to make the client compatible with a desired server API breaking change?
- [ ] Does this change rely on a new server API?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server?

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)