### PR TITLE
Add cloud mode keybinding hint to agent welcome screen (APP-4337)

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -19,6 +19,7 @@ use crate::ai::blocklist::agent_view::shortcuts::AgentShortcutViewModel;
 use crate::ai::blocklist::agent_view::zero_state_block::render_ambient_credits_banner;
 use crate::ai::blocklist::agent_view::{
     agent_view_bg_fill, AgentViewController, AgentViewControllerEvent,
+    ENTER_CLOUD_AGENT_VIEW_NEW_CONVERSATION_KEYSTROKE,
 };
 use crate::ai::blocklist::{
     BlocklistAIContextEvent, BlocklistAIContextModel, BlocklistAIHistoryEvent,
@@ -65,6 +66,7 @@ pub struct AgentMessageBarMouseStates {
     pub toggle_slash_commands: MouseStateHandle,
     pub toggle_plan: MouseStateHandle,
     pub toggle_conversation_menu: MouseStateHandle,
+    pub start_cloud_conversation: MouseStateHandle,
     pub toggle_code_review: MouseStateHandle,
     pub clear_attached_context: MouseStateHandle,
     /// Mouse state handle for the "Get Figma MCP" contextual button.
@@ -592,6 +594,21 @@ impl MessageProvider<AgentMessageArgs<'_>> for ZeroStateMessageProducer {
                     mouse_states.toggle_conversation_menu.clone(),
                 ));
             }
+        }
+
+        if !is_cloud_agent && !has_conversation_been_updated_since_agent_view_entry {
+            items.push(MessageItem::clickable(
+                vec![
+                    MessageItem::keystroke(
+                        ENTER_CLOUD_AGENT_VIEW_NEW_CONVERSATION_KEYSTROKE.clone(),
+                    ),
+                    MessageItem::text("new cloud conversation"),
+                ],
+                |ctx| {
+                    ctx.dispatch_typed_action(TerminalAction::EnterCloudAgentView);
+                },
+                mouse_states.start_cloud_conversation.clone(),
+            ));
         }
 
         // Code review only works locally.


### PR DESCRIPTION
Closes #10077

## Description

Add a "new cloud conversation" keybinding hint (⌥⌘↵ on macOS / Ctrl+Alt+Enter elsewhere) to the agent message bar's zero state toolbelt. The hint appears alongside the existing shortcuts (`? for help`, `/ for commands`, `⌘ Y open conversation`, `⇧ ⌘ + for code review`) when the user is in a local agent conversation that hasn't been updated yet.

This addresses feedback that the cloud mode entry point is too hidden — previously there was no mention of cloud mode on the agent welcome screen's bottom toolbelt.

**Investigation notes:** The "new cloud agent conversation" hint was never previously in the bottom toolbelt (`ZeroStateMessageProducer` in `agent_message_bar.rs`). It exists in the agent view zero state block body, but only when there are no recent conversations. Once a user has past conversations, the recent conversations section replaces all keyboard shortcut hints (including the cloud one), making cloud mode effectively undiscoverable.

## Testing

- Verified the code compiles with `cargo check -p warp`
- Verified `cargo fmt` and `cargo clippy -p warp` pass cleanly
- The change is a straightforward addition of a `MessageItem::clickable` hint following the same pattern as the existing "open conversation" and "code review" hints

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Added a cloud mode keybinding hint to the agent welcome screen so users can discover how to start a cloud conversation

_Conversation: https://staging.warp.dev/conversation/5f04d821-7492-4c54-8a13-169e5a72ebd9_
_Run: https://oz.staging.warp.dev/runs/019ddc39-ae00-7f20-9a93-064f2de4a03e_
_This PR was generated with [Oz](https://warp.dev/oz)._