### PR TITLE
Replace deprecated apt-key with gpg --dearmor for gcloud install

### DIFF
--- a/script/linux/install_test_deps
+++ b/script/linux/install_test_deps
@@ -29,7 +29,7 @@ if [[ "$(source /etc/os-release; echo $ID $ID_LIKE)" = *"debian"* ]]; then
   if [[ ! -x "$(command -v gcloud)" ]]; then
     echo "⬇️  Installing the gcloud CLI..."
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
-    curl -f https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/cloud.google.gpg
     sudo apt-get update -y
     sudo apt-get install google-cloud-cli -y
   fi


### PR DESCRIPTION
## Description

Fixes #9534.

`script/linux/install_test_deps:32` registered Google Cloud SDK's apt
signing key via `apt-key`, which was removed from `apt` in 2.9.17
(2024-12) and is no longer present on Ubuntu 25.04+ and
Debian 13+. On those distros `script/linux/bootstrap` failed for any
contributor who didn't already have `gcloud` installed, with a confusing
`sudo: 'apt-key': command not found` / `curl: Failed writing body` pair.

Replaced the `apt-key` invocation with `gpg --dearmor`, which is the
documented replacement and works on every Debian-family release back to
Debian 9 / Ubuntu 16.04 — the same lower bound that the existing
`signed-by=/usr/share/keyrings/cloud.google.gpg` directive on the next
line already imposes. Also switched `curl -f` to `curl -fsSL`, the
standard quiet-but-fail-on-error flag set, and added `--yes` so a stale
keyring left from a partial previous bootstrap is overwritten cleanly.

```diff
-    curl -f https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/cloud.google.gpg
```

This is a strict superset of the previous behavior — it works everywhere
the old command worked and additionally on apt 3.0+ where `apt-key` is
gone.

## Testing

Manually ran the patched line on Ubuntu 25.10 (apt 3.1.6, no `apt-key`
binary): it produces `/usr/share/keyrings/cloud.google.gpg` and the
subsequent `apt-get update` / `apt-get install google-cloud-cli`
succeed. Re-ran a second time to confirm `--yes` overwrites the existing
keyring without prompting. No automated regression test added — this is
a one-line bootstrap script change whose failure mode is environmental
(absence of `apt-key` on the host) and CI runs on a distro where the
bug doesn't reproduce.

## Server API dependencies

No server API dependencies.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: 

Co-Authored-By: Warp <agent@warp.dev>