### PR TITLE
Fix settings popup items (View as / Density) being unclickable

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1449,23 +1449,11 @@ fn render_vertical_tabs_panel(
         .with_child(Shrinkable::new(1., scrollable_groups).finish())
         .finish();
 
-    let panel_with_popup: Box<dyn Element> = if state.show_settings_popup {
-        let popup = render_settings_popup(state, app);
-        let mut stack = Stack::new().with_child(panel_content);
-        stack.add_positioned_overlay_child(
-            popup,
-            OffsetPositioning::offset_from_save_position_element(
-                VERTICAL_TABS_SETTINGS_BUTTON_POSITION_ID,
-                vec2f(0., 4.),
-                PositionedElementOffsetBounds::WindowByPosition,
-                PositionedElementAnchor::BottomLeft,
-                ChildAnchor::TopLeft,
-            ),
-        );
-        stack.finish()
-    } else {
-        panel_content
-    };
+    // The settings popup is rendered at the workspace level (with Dismiss for click-outside-
+    // to-close). Rendering it here again shares MouseStateHandle instances across two Hoverable
+    // trees; click_count.take() is consumed by this copy first, leaving the workspace copy
+    // with None and silently dropping all clicks on the popup items.
+    let panel_with_popup: Box<dyn Element> = panel_content;
 
     let drag_side = match side {
         super::PanelPosition::Left => DragBarSide::Right,


### PR DESCRIPTION
## Description

Fixes #9539

`render_vertical_tabs_panel` was rendering the settings popup a second time as a panel-level overlay, in addition to the workspace-level rendering (wrapped in `Dismiss`) that already handles positioning and click-outside-to-close.

Both renders call `render_settings_popup` with the same `&VerticalTabsPanelState`, so every `Hoverable` button in the popup ends up sharing the same `MouseStateHandle`. On `LeftMouseUp`, warpui's `Broadcast` dispatch sends the event to both overlay instances. The panel-level copy (dispatched first, lower z-index, covered by the workspace overlay) consumes `click_count.take()` then bails because `is_mouse_over_element` returns `false`. The workspace-level copy then finds `click_count = None` and silently skips firing the handler — so no action is ever dispatched.

**Fix:** remove the redundant panel-level popup render. The workspace-level `Dismiss` rendering already handles everything correctly.

```rust
// Removed from render_vertical_tabs_panel:
let panel_with_popup: Box<dyn Element> = if state.show_settings_popup {
    let popup = render_settings_popup(state, app);
    let mut stack = Stack::new().with_child(panel_content);
    stack.add_positioned_overlay_child(popup, ...);
    stack.finish()
} else {
    panel_content
};

// Replaced with:
let panel_with_popup: Box<dyn Element> = panel_content;
```

## Testing

- Opened settings popup → clicked "Panes" / "Tabs" under **View as**: panel switches correctly ✓
- Clicked **Compact** / **Expanded** under **Density**: layout updates correctly ✓
- Clicked outside the popup: popup dismisses correctly ✓
- `cargo build --bin warp-oss` passes ✓

Tested on Arch Linux, Hyprland 0.54.3 (Wayland).

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed vertical tabs settings popup items (View as, Density, Pane title as) being unclickable