### PR TITLE
add Microsoft.VisualStudio.2022.BuildTools installation

### DIFF
--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -38,6 +38,7 @@ if (-not $haveMsvcBuildTools) {
     winget install -e --id Microsoft.VisualStudio.2022.BuildTools `
         --accept-package-agreements --accept-source-agreements `
         --override '--passive --wait --norestart --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --includeRecommended'
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 }
 
 # A bash executable should come with Git for Windows

--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -36,6 +36,7 @@ if (Test-Path $vswhere) {
 if (-not $haveMsvcBuildTools) {
     Write-Output 'Installing Visual Studio Build Tools (MSVC + Windows SDK)...'
     winget install -e --id Microsoft.VisualStudio.2022.BuildTools `
+        --accept-package-agreements --accept-source-agreements `
         --override '--passive --wait --norestart --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --includeRecommended'
 }
 

--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -29,6 +29,7 @@ $haveMsvcBuildTools = $false
 if (Test-Path $vswhere) {
     $vsInstall = & $vswhere -latest -products * `
         -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+                  Microsoft.VisualStudio.Component.Windows11SDK.22621 `
         -property installationPath
     if ($vsInstall) { $haveMsvcBuildTools = $true }
 }

--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -22,6 +22,24 @@ if (-not (Get-Command -Name cargo -Type Application -ErrorAction SilentlyContinu
     exit 1
 }
 
+# Visual Studio Build Tools (MSVC compiler + linker + Windows SDK) are required
+# to link Rust crates targeting x86_64-pc-windows-msvc. Without them, rustc falls
+# back to the GNU coreutils `link` from Git for Windows and fails with
+# `link: extra operand` errors.
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$haveMsvcBuildTools = $false
+if (Test-Path $vswhere) {
+    $vsInstall = & $vswhere -latest -products * `
+        -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+        -property installationPath
+    if ($vsInstall) { $haveMsvcBuildTools = $true }
+}
+if (-not $haveMsvcBuildTools) {
+    Write-Output 'Installing Visual Studio Build Tools (MSVC + Windows SDK)...'
+    winget install -e --id Microsoft.VisualStudio.2022.BuildTools `
+        --override '--passive --wait --norestart --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --includeRecommended'
+}
+
 # A bash executable should come with Git for Windows
 & "$gitBinDir\bash.exe" "$PWD\script\install_cargo_test_deps"
 

--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -28,8 +28,7 @@ $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.e
 $haveMsvcBuildTools = $false
 if (Test-Path $vswhere) {
     $vsInstall = & $vswhere -latest -products * `
-        -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-                  Microsoft.VisualStudio.Component.Windows11SDK.22621 `
+        -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 Microsoft.VisualStudio.Component.Windows11SDK.22621 `
         -property installationPath
     if ($vsInstall) { $haveMsvcBuildTools = $true }
 }

--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -22,10 +22,8 @@ if (-not (Get-Command -Name cargo -Type Application -ErrorAction SilentlyContinu
     exit 1
 }
 
-# Visual Studio Build Tools (MSVC compiler + linker + Windows SDK) are required
-# to link Rust crates targeting x86_64-pc-windows-msvc. Without them, rustc falls
-# back to the GNU coreutils `link` from Git for Windows and fails with
-# `link: extra operand` errors.
+# Visual Studio Build Tools (MSVC compiler + linker + Windows SDK) are required to link Rust crates
+# targeting x86_64-pc-windows-msvc.
 $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
 $haveMsvcBuildTools = $false
 if (Test-Path $vswhere) {


### PR DESCRIPTION
## Description

We have been saying that installing Visual Studio is required to build Warp. however, the whole thing isn't needed, just the MSVC Build Tools. That is available through winget and we can easily automate that in the script.

## Testing

This worked when setting up a dev env on a new Windows device.
