### PR TITLE
Check for Node.js and yarn at bootstrap time

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -41,6 +41,39 @@ Environment variables:
 - `./script/install_cargo_build_deps` - Install Cargo build dependencies
 - `./script/install_cargo_test_deps` - Install Cargo test dependencies
 
+### Node.js setup
+
+**Requirements:**
+
+- `node` >= 18.14.1 on PATH
+- `yarn` on PATH
+
+The `command-signatures-v2` crate compiles a small TypeScript helper at `cargo build` time, which is why these are needed.
+
+We deliberately do **not** auto-install Node for you; pick whatever toolchain manager you already use:
+
+- A version manager: nvm, fnm, volta, asdf, mise, etc.
+- A system package: `apt install nodejs npm` on recent Ubuntu, NodeSource, `brew install node` on macOS, `winget install OpenJS.NodeJS` on Windows.
+- Anything else that puts Node on PATH.
+
+Check whether `yarn` is already on PATH:
+
+```sh
+yarn --version
+```
+
+If that works, you're done — skip the rest of this step. Otherwise, enable yarn via corepack:
+
+```sh
+corepack enable
+```
+
+If Node was installed to a root-owned location (e.g. `apt install nodejs`, or system-wide on Windows), this may need `sudo` / an admin shell. Volta users can skip this — Volta manages yarn itself.
+
+Then re-run `./script/bootstrap`.
+
+If `yarn` is on PATH but `cargo build` still fails to find it, a brew-installed yarn may be shadowing corepack's shim. Run `brew uninstall yarn` and try again.
+
 ## Architecture Overview
 
 This is a Rust-based terminal emulator with a custom UI framework called **WarpUI**.

--- a/crates/command-signatures-v2/build.rs
+++ b/crates/command-signatures-v2/build.rs
@@ -14,13 +14,8 @@ fn main() -> anyhow::Result<()> {
             panic!(
                 r#"Failed to build command signatures JS: {e:?}.
 
-Most likely, this is fixed by:
-    1) Ensuring you have an up-to-date Node version; 18.14.1 (required for warp-server development) should suffice.
-    2) Running `corepack enable` (this can be done in any directory).
-    3) Removing a conflicting yarn installed by brew by running:
-        brew uninstall yarn
-
-If you continue to encounter issues, ensure you don't have conflicting Node installations, one of which might not be a sufficiently recent version.
+This usually means Node.js or yarn isn't on PATH, or `corepack enable` hasn't been run.
+See the "Node.js setup" section in WARP.md.
 "#
             )
         } else {

--- a/script/linux/install_build_deps
+++ b/script/linux/install_build_deps
@@ -56,5 +56,15 @@ fi
 # Install Rust.
 "$PWD"/script/install_rust
 
+# Node + yarn are required to build the command-signatures-v2 crate.
+if ! command -v node >/dev/null 2>&1; then
+  echo -e "${red}Build requires Node.js. See the 'Node.js setup' section in WARP.md.${reset}"
+  exit 1
+fi
+if ! command -v yarn >/dev/null 2>&1; then
+  echo -e "${red}Build requires yarn. Run \`corepack enable\` (may need sudo for system Node) or see WARP.md.${reset}"
+  exit 1
+fi
+
 # Install various build-time dependencies through cargo.
 "$PWD"/script/install_cargo_build_deps

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -29,6 +29,16 @@ if ! command -v cargo; then
     exit 1
 fi
 
+# Node + yarn are required to build the command-signatures-v2 crate.
+if ! command -v node >/dev/null 2>&1; then
+    echo "Build requires Node.js. See the 'Node.js setup' section in WARP.md."
+    exit 1
+fi
+if ! command -v yarn >/dev/null 2>&1; then
+    echo "Build requires yarn. Run \`corepack enable\` or see the 'Node.js setup' section in WARP.md."
+    exit 1
+fi
+
 # Install various binaries through cargo.
 "$PWD"/script/install_cargo_test_deps
 "$PWD"/script/install_cargo_release_deps

--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -22,6 +22,16 @@ if (-not (Get-Command -Name cargo -Type Application -ErrorAction SilentlyContinu
     exit 1
 }
 
+# Node + yarn are required to build the command-signatures-v2 crate.
+if (-not (Get-Command -Name node -Type Application -ErrorAction SilentlyContinue)) {
+    Write-Error "Build requires Node.js. See the 'Node.js setup' section in WARP.md."
+    exit 1
+}
+if (-not (Get-Command -Name yarn -Type Application -ErrorAction SilentlyContinue)) {
+    Write-Error "Build requires yarn. Run ``corepack enable`` (may need admin) or see WARP.md."
+    exit 1
+}
+
 # A bash executable should come with Git for Windows
 & "$gitBinDir\bash.exe" "$PWD\script\install_cargo_test_deps"
 


### PR DESCRIPTION
## Description

Fixes #9544.

The `command-signatures-v2` crate compiles a TypeScript helper at `cargo build` time using `yarn`, but none of the bootstrap scripts verified that Node or yarn were on PATH. Fresh checkouts succeeded at bootstrap and then failed deep inside a `build.rs` panic with inline setup instructions that were easy to miss.

**What changed:**

- Fail fast in `script/linux/install_build_deps`, `script/macos/bootstrap`, and `script/windows/bootstrap.ps1` if `node` or `yarn` is missing.
- Add a "Node.js setup" section to `WARP.md` covering version managers, system packages, the `yarn --version` / `corepack enable` flow, and the sudo / Volta caveats.
- Trim the `command-signatures-v2/build.rs` panic to point at that section instead of duplicating instructions inline.

**What this PR deliberately does not do:**

- **Auto-install Node.** How you install Node is opinionated — nvm, fnm, volta, asdf, mise, system package, NodeSource, brew, winget, etc. — and these don't compose well. We point at the options in WARP.md and let the developer pick.
- **Auto-run `corepack enable`.** Whether this works depends on how Node was installed: system-installed Node needs sudo / an admin shell, and Volta manages yarn itself so corepack would conflict. Running it unconditionally would silently break those setups.

## Testing

Manually verified on Linux:
- With `node` and `yarn` on PATH, `./script/linux/install_build_deps` proceeds normally.
- With `node` removed from PATH, the script exits with the new error message before invoking cargo.
- With `node` present but `yarn` missing, the script exits pointing at the WARP.md setup section.

No automated test coverage — these are bootstrap shell/PowerShell scripts that aren't exercised in CI.
