### PR TITLE
Add WARP_SESSION_ID env var and warp://session/<id> deep link

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1771,6 +1771,10 @@ fn initialize_app(
     // Add a singleton model to maintain state of shared session across all windows.
     ctx.add_singleton_model(terminal::shared_session::manager::Manager::new);
 
+    // Tracks `WarpSessionId -> TerminalView` so the `warp://session/<id>`
+    // deep link can focus the originating tab/pane.
+    ctx.add_singleton_model(terminal::WarpSessionRegistry::new);
+
     ctx.add_singleton_model(
         terminal::shared_session::permissions_manager::SessionPermissionsManager::new,
     );

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -82,6 +82,7 @@ use crate::terminal::model::session::Sessions;
 
 use crate::terminal::model_events::ModelEventDispatcher;
 use crate::terminal::safe_mode_settings::get_secret_obfuscation_mode;
+use crate::terminal::session_id::{WarpSessionId, WarpSessionRegistry};
 use crate::terminal::session_settings::{SessionSettings, SessionSettingsChangedEvent};
 use crate::terminal::shared_session::manager::Manager;
 use crate::terminal::shared_session::settings::SharedSessionSettings;
@@ -175,6 +176,11 @@ pub struct TerminalManager {
     /// connection ongoing.
     #[allow(dead_code)]
     session_sharer: Rc<RefCell<Option<ModelHandle<Network>>>>,
+
+    /// Stable identifier for this terminal session, exposed to the shell as
+    /// `WARP_SESSION_ID` and used as the key in [`WarpSessionRegistry`] for
+    /// the `warp://session/<id>` deep link.
+    warp_session_id: WarpSessionId,
 }
 
 impl Drop for TerminalManager {
@@ -216,7 +222,7 @@ impl TerminalManager {
     #[allow(clippy::too_many_arguments)]
     pub fn create_model(
         startup_directory: Option<PathBuf>,
-        env_vars: HashMap<OsString, OsString>,
+        mut env_vars: HashMap<OsString, OsString>,
         is_shared_session_creator: IsSharedSessionCreator,
         resources: TerminalViewResources,
         restored_blocks: Option<&Vec<SerializedBlockListItem>>,
@@ -229,6 +235,16 @@ impl TerminalManager {
         initial_input_config: Option<InputConfig>,
         ctx: &mut AppContext,
     ) -> ModelHandle<Box<dyn crate::terminal::TerminalManager>> {
+        // Mint a stable identifier for this session and surface it to the
+        // shell via `WARP_SESSION_ID`. Caller-provided overrides still win
+        // because they are merged into `env_vars` last in the spawn paths;
+        // we therefore use `entry().or_insert_with` to avoid clobbering an
+        // explicit override (e.g. tests or session restoration).
+        let warp_session_id = WarpSessionId::new();
+        env_vars
+            .entry(OsString::from("WARP_SESSION_ID"))
+            .or_insert_with(|| warp_session_id.to_string().into());
+
         // Create all the necessary channels we need for communication.
         let (wakeups_tx, wakeups_rx) = async_channel::unbounded();
         let (events_tx, events_rx) = async_channel::unbounded();
@@ -390,6 +406,12 @@ impl TerminalManager {
                 false,
                 ctx,
             )
+        });
+
+        // Make this session findable by `warp://session/<id>` deep links.
+        // We hold a weak handle so closing the pane naturally drops it.
+        WarpSessionRegistry::handle(ctx).update(ctx, |registry, _ctx| {
+            registry.register(warp_session_id, view.downgrade());
         });
 
         // We need to append the session restoration separator to the block list if there are any
@@ -747,6 +769,7 @@ impl TerminalManager {
 
             inactive_pty_reads_rx,
             session_sharer,
+            warp_session_id,
         };
 
         let terminal_manager_model = ctx.add_model(|ctx| {
@@ -2508,9 +2531,19 @@ impl crate::terminal::TerminalManager for TerminalManager {
         // The detach type is intentionally ignored: a sharer always stops sharing immediately,
         // even on a reversible `HiddenForClose` detach. This is desirable for security — a sharer
         // should not continue accepting commands from viewers while the session is not visible.
-        _detach_type: crate::pane_group::pane::DetachType,
+        detach_type: crate::pane_group::pane::DetachType,
         app: &mut AppContext,
     ) {
+        // Drop the registry entry on permanent close so deep links to a
+        // closed pane immediately fall through to the "no live session"
+        // branch instead of relying on weak-handle pruning at lookup time.
+        if matches!(detach_type, crate::pane_group::pane::DetachType::Closed) {
+            let session_id = self.warp_session_id;
+            WarpSessionRegistry::handle(app).update(app, |registry, _ctx| {
+                registry.unregister(&session_id);
+            });
+        }
+
         let shared_session_status = self.model.lock().shared_session_status().clone();
         if shared_session_status.is_sharer() {
             let is_confirm_close_session =

--- a/app/src/terminal/mod.rs
+++ b/app/src/terminal/mod.rs
@@ -68,6 +68,7 @@ pub mod resizable_data;
 pub mod rich_history;
 pub mod safe_mode_settings;
 mod secret_regex_updater;
+pub mod session_id;
 pub mod session_settings;
 pub mod settings;
 mod share_block_modal;
@@ -91,6 +92,7 @@ pub(crate) mod cli_agent_sessions;
 
 pub use mock_terminal_manager::MockTerminalManager;
 use model_events::{ModelEvent, ModelEventDispatcher};
+pub use session_id::{WarpSessionId, WarpSessionRegistry};
 pub use share_block_modal::{ShareBlockModal, ShareBlockModalEvent, ShareBlockType};
 pub use terminal_manager::TerminalManager;
 

--- a/app/src/terminal/session_id.rs
+++ b/app/src/terminal/session_id.rs
@@ -1,0 +1,153 @@
+//! Per-session identifier exposed to local shells via `WARP_SESSION_ID`
+//! and used by the `warp://session/<id>` deep link to focus a specific
+//! Warp tab/pane.
+//!
+//! See `app/src/uri/mod.rs` for the deep-link handler and
+//! `app/src/terminal/local_tty/terminal_manager.rs` for the env-var
+//! injection point.
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+
+use uuid::Uuid;
+use warpui::{
+    AppContext, Entity, EntityId, ModelContext, SingletonEntity, ViewHandle, WeakViewHandle,
+};
+
+use crate::terminal::TerminalView;
+
+/// A stable, per-pane session identifier.
+///
+/// Generated when a local PTY-backed `TerminalView` is created, exposed to
+/// the shell via the `WARP_SESSION_ID` environment variable, and used as
+/// the lookup key for the `warp://session/<id>` deep link.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct WarpSessionId(Uuid);
+
+impl WarpSessionId {
+    /// Generate a fresh random session id.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Returns the underlying UUID.
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+}
+
+impl Default for WarpSessionId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for WarpSessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Use the canonical hyphenated lowercase form so external tools
+        // that pass the value through `open warp://session/$WARP_SESSION_ID`
+        // get a stable, parseable representation.
+        self.0.as_hyphenated().fmt(f)
+    }
+}
+
+impl FromStr for WarpSessionId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Uuid::parse_str(s).map(Self)
+    }
+}
+
+/// Singleton registry mapping `WarpSessionId` -> `TerminalView`.
+///
+/// Backed by weak handles so a closed terminal pane is naturally garbage
+/// collected; lookups also opportunistically prune dead entries. Entries
+/// are inserted by the local TTY `TerminalManager` after the view is
+/// created and removed when the manager is dropped.
+pub struct WarpSessionRegistry {
+    sessions: HashMap<WarpSessionId, WeakViewHandle<TerminalView>>,
+}
+
+impl Default for WarpSessionRegistry {
+    fn default() -> Self {
+        Self::new_inner()
+    }
+}
+
+impl WarpSessionRegistry {
+    /// Constructor compatible with `AppContext::add_singleton_model`.
+    pub fn new(_ctx: &mut ModelContext<Self>) -> Self {
+        Self::new_inner()
+    }
+
+    fn new_inner() -> Self {
+        Self {
+            sessions: HashMap::new(),
+        }
+    }
+
+    /// Register a new session. Subsequent `warp://session/<id>` deep
+    /// links matching this id will route to `view`.
+    pub fn register(&mut self, id: WarpSessionId, view: WeakViewHandle<TerminalView>) {
+        self.sessions.insert(id, view);
+    }
+
+    /// Forget a session id. Safe to call multiple times.
+    pub fn unregister(&mut self, id: &WarpSessionId) {
+        self.sessions.remove(id);
+    }
+
+    /// Look up the live `TerminalView` for `id`, if one is still alive.
+    ///
+    /// The registry stores weak handles so a closed pane reports `None`
+    /// without any explicit cleanup. Stale entries are reclaimed when the
+    /// owning [`TerminalManager`] observes its `on_view_detached` close
+    /// hook.
+    pub fn lookup_view(
+        &self,
+        id: &WarpSessionId,
+        ctx: &AppContext,
+    ) -> Option<ViewHandle<TerminalView>> {
+        self.sessions.get(id)?.upgrade(ctx)
+    }
+
+    /// Look up the `EntityId` of the `TerminalView` for `id`, if any.
+    pub fn lookup_view_id(&self, id: &WarpSessionId, ctx: &AppContext) -> Option<EntityId> {
+        self.lookup_view(id, ctx).map(|view| view.id())
+    }
+}
+
+impl Entity for WarpSessionRegistry {
+    type Event = ();
+}
+
+impl SingletonEntity for WarpSessionRegistry {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warp_session_id_round_trip() {
+        let id = WarpSessionId::new();
+        let formatted = id.to_string();
+        let parsed: WarpSessionId = formatted.parse().expect("formatted id should parse");
+        assert_eq!(id, parsed);
+        // Hyphenated form is 36 chars (8-4-4-4-12).
+        assert_eq!(formatted.len(), 36);
+    }
+
+    #[test]
+    fn warp_session_id_rejects_garbage() {
+        assert!("not-a-uuid".parse::<WarpSessionId>().is_err());
+        assert!("".parse::<WarpSessionId>().is_err());
+    }
+
+    #[test]
+    fn warp_session_id_new_returns_unique_values() {
+        let a = WarpSessionId::new();
+        let b = WarpSessionId::new();
+        assert_ne!(a, b);
+    }
+}

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -13,6 +13,7 @@ use crate::linear::{LinearAction, LinearIssueWork};
 use crate::root_view::{open_new_window_get_handles, OpenLaunchConfigArg};
 use crate::server::ids::ServerId;
 use crate::server::telemetry::{LaunchConfigUiLocation, TelemetryEvent};
+use crate::terminal::WarpSessionRegistry;
 use crate::util::openable_file_type::{is_file_openable_in_warp, is_markdown_file};
 use crate::workspace::{Workspace, WorkspaceAction, WorkspaceRegistry};
 use crate::{cloud_object::ObjectType, workspace::ToastStack};
@@ -63,6 +64,9 @@ pub enum UriHost {
     Launch,
     /// Supports joining shared sessions via a warp:// URI.
     SharedSession,
+    /// Focuses an existing local terminal session by its `WARP_SESSION_ID`.
+    /// e.g. `warp://session/<uuid>`
+    Session,
     /// Supports viewing AI conversations via a warp:// URI.
     Conversation,
     /// Supports WD object actions
@@ -92,6 +96,7 @@ impl FromStr for UriHost {
             "shared_session" if FeatureFlag::ViewingSharedSessions.is_enabled() => {
                 Ok(Self::SharedSession)
             }
+            "session" => Ok(Self::Session),
             "conversation" => Ok(Self::Conversation),
             "drive" => Ok(Self::Drive),
             "settings" => Ok(Self::Settings),
@@ -215,6 +220,12 @@ impl UriHost {
                 } else {
                     log::warn!("Failed to join shared session with uri={url}");
                 }
+            }
+            UriHost::Session => {
+                // We expect the uri to have the WARP_SESSION_ID UUID as the
+                // last segment, e.g. `warp://session/<uuid>`. Look up the
+                // owning terminal view in the registry and focus its tab/pane.
+                handle_session_focus(url, ctx);
             }
             UriHost::Conversation => {
                 // We expect the uri to have the conversation ID as the last segment.
@@ -464,6 +475,10 @@ impl UriHost {
             Self::Team | Self::Drive | Self::Settings => W::default(),
             // These URLs always open new windows.
             Self::Launch | Self::SharedSession | Self::Conversation | Self::Home => W::Nothing,
+            // The session deep link does its own per-session window focus
+            // inside `handle_session_focus`, so the host-level window hint
+            // is a no-op.
+            Self::Session => W::Nothing,
             // This will actually be handled by [`Action::window_behavior_hint`].
             Self::Action => W::Nothing,
             // TODO(vorporeal): probably want to focus the window with the MCP pane open
@@ -1143,6 +1158,44 @@ fn open_window_with_action(active_window_id: Option<WindowId>, action: &str, ctx
     }
 }
 
+/// Implements `warp://session/<id>` deep links: parse the trailing UUID,
+/// look it up in the [`WarpSessionRegistry`], then mirror the
+/// `Action::FocusCloudMode` flow to focus the matching window/tab/pane.
+fn handle_session_focus(url: &Url, ctx: &mut AppContext) {
+    let Some(session_id_str) = url.path_segments().into_iter().flatten().last() else {
+        log::warn!("warp://session/<id> URI is missing the session id segment");
+        return;
+    };
+    let Ok(session_id) = crate::terminal::WarpSessionId::from_str(session_id_str) else {
+        log::warn!("warp://session/<id> URI has an invalid session id");
+        return;
+    };
+
+    let terminal_view_id = WarpSessionRegistry::as_ref(ctx).lookup_view_id(&session_id, ctx);
+    let Some(terminal_view_id) = terminal_view_id else {
+        // Either the URI has a stale id or the session was already closed —
+        // either way there's nothing to focus, so we just no-op.
+        log::warn!("No live Warp session found for warp://session/<id> URI");
+        return;
+    };
+
+    let Some((window_id, workspace)) = find_workspace_for_terminal_view(terminal_view_id, ctx)
+    else {
+        log::warn!(
+            "Found a Warp session for warp://session/<id> URI but it is no longer in any workspace"
+        );
+        return;
+    };
+
+    ctx.windows().show_window_and_focus_app(window_id);
+    workspace.update(ctx, |workspace, ctx| {
+        workspace.handle_action(
+            &WorkspaceAction::FocusTerminalViewInWorkspace { terminal_view_id },
+            ctx,
+        );
+    });
+}
+
 fn find_workspace_for_terminal_view(
     terminal_view_id: EntityId,
     ctx: &mut AppContext,
@@ -1299,6 +1352,7 @@ fn validate_custom_uri(url: &Url) -> Result<UriHost> {
         UriHost::Action
         | UriHost::Launch
         | UriHost::SharedSession
+        | UriHost::Session
         | UriHost::Conversation
         | UriHost::Drive
         | UriHost::Team

--- a/app/src/uri/uri_test.rs
+++ b/app/src/uri/uri_test.rs
@@ -573,3 +573,34 @@ fn test_parse_tab_path_bare_tilde() {
     let home = dirs::home_dir().expect("HOME must be set for this test");
     assert_eq!(parse_tab_path(&url), Some(home));
 }
+
+/// `warp://session/<uuid>` must be recognized as a valid custom URI host
+/// so the focus-session deep link reaches `UriHost::handle`.
+#[test]
+fn test_validate_custom_uri_accepts_session_host() {
+    let url = Url::parse(&format!(
+        "{}://session/550e8400-e29b-41d4-a716-446655440000",
+        ChannelState::url_scheme()
+    ))
+    .unwrap();
+    let host = validate_custom_uri(&url).expect("session URI should validate");
+    assert_eq!(host, UriHost::Session);
+}
+
+/// `UriHost::from_str` must map the literal `"session"` host to
+/// `UriHost::Session` regardless of feature flags.
+#[test]
+fn test_uri_host_session_from_str() {
+    assert_eq!(UriHost::from_str("session").unwrap(), UriHost::Session);
+}
+
+/// `WarpSessionId` parses any well-formed UUID and rejects malformed ones,
+/// which is the prerequisite for the `warp://session/<id>` lookup.
+#[test]
+fn test_warp_session_id_from_str() {
+    use crate::terminal::WarpSessionId;
+    let raw = "550e8400-e29b-41d4-a716-446655440000";
+    let id = WarpSessionId::from_str(raw).expect("valid UUID parses");
+    assert_eq!(id.to_string(), raw);
+    assert!(WarpSessionId::from_str("not-a-uuid").is_err());
+}


### PR DESCRIPTION

## Summary

Adds the `WARP_SESSION_ID` environment variable and `warp://session/<id>` deep link so external integrations (notification scripts, IDE plugins, CI tools) can focus the specific Warp window/tab/pane that produced a notification, rather than just bringing the app to the foreground.

## Changes

- New `WarpSessionId` (UUID newtype) and `WarpSessionRegistry` singleton in `app/src/terminal/session_id.rs`. The registry maps `WarpSessionId -> WeakViewHandle<TerminalView>` and is registered alongside the other terminal singletons in `app/src/lib.rs`.
- `local_tty::TerminalManager::create_model` now mints a fresh `WarpSessionId` per session, injects `WARP_SESSION_ID=<uuid>` into the existing `env_vars` `HashMap` (which flows through both the Unix `build_host_shell_command` / `build_docker_sandbox_command` and the Windows `get_shell_environment_variables` paths), and registers the id immediately after the `TerminalView` is created. The id is unregistered on permanent pane close (`DetachType::Closed`) and naturally falls out of the registry as a stale weak handle if that hook is missed.
- New `UriHost::Session` variant in `app/src/uri/mod.rs`. `warp://session/<uuid>` parses the trailing UUID, looks up the live `TerminalView` in the registry, and reuses the `Action::FocusCloudMode` flow (`find_workspace_for_terminal_view` + `show_window_and_focus_app` + `WorkspaceAction::FocusTerminalViewInWorkspace`) to focus the matching window/tab/pane. `validate_custom_uri` is updated to allow arbitrary paths under the new `session` host.

## Example

```bash
$ echo $WARP_SESSION_ID
550e8400-e29b-41d4-a716-446655440000

# From any external tool:
$ open "warp://session/$WARP_SESSION_ID"
```

The id is stable for the lifetime of the tab/pane (the issue's "persist for the lifetime of the tab/pane" requirement) because it's bound to the underlying `TerminalView`.

## Tests

Added unit tests in `app/src/uri/uri_test.rs` and `app/src/terminal/session_id.rs` covering:

- `WarpSessionId` `Display`/`FromStr` round-trip and rejection of malformed input.
- `UriHost::from_str("session")` mapping.
- `validate_custom_uri` accepting `warp://session/<uuid>`.

I was unable to run `cargo nextest`/`cargo check` locally because this sandbox could not install the macOS Metal Toolchain that `crates/warpui/build.rs` requires; CI should exercise the full presubmit (clippy, nextest, fmt) on this branch.

## Notes

- Mock and remote-tty terminal managers do not own a local PTY and are intentionally excluded.
- Docker sandbox env propagation into the container is a pre-existing concern; this change sets `WARP_SESSION_ID` consistently with the other `WARP_*` env vars but does not touch container-side propagation.

_Conversation: https://app.warp.dev/conversation/05eaeedd-712d-406e-8be5-f1d41df8d7d9_
_Run: https://oz.warp.dev/runs/019ddca5-ea9d-7e09-ae22-6f876a8552dd_
_Plans_:
- _[Implement WARP_SESSION_ID env var and warp://session/<id> deep link](https://app.warp.dev/drive/notebook/mMOELzaPe3WbGACEU8lITs)_

_This PR was generated with [Oz](https://warp.dev/oz)._
