### PR TITLE
Fix CLI agent tab title showing stale permission request text after session completes

### DIFF
--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -96,21 +96,23 @@ impl CLIAgentSessionContext {
     }
 
     pub(crate) fn latest_user_prompt(&self) -> Option<String> {
-        self.query
-            .as_deref()
-            .map(str::trim)
-            .filter(|query| !query.is_empty())
-            .map(str::to_owned)
+        trim_non_empty(self.query.as_deref())
     }
 
-    /// Returns summary text suitable as a fallback title when no user prompt is available.
+    /// Returns text suitable as a fallback title when no user prompt is available.
+    /// Prefers `summary` (e.g. permission request text while blocked), then falls back
+    /// to `response` (the agent's final message after a Stop event).
     pub(crate) fn title_like_text(&self) -> Option<String> {
-        self.summary
-            .as_deref()
-            .map(str::trim)
-            .filter(|summary| !summary.is_empty())
-            .map(str::to_owned)
+        trim_non_empty(self.summary.as_deref())
+            .or_else(|| trim_non_empty(self.response.as_deref()))
     }
+}
+
+/// Trims whitespace and returns `Some` only if the result is non-empty.
+fn trim_non_empty(opt: Option<&str>) -> Option<String> {
+    opt.map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
 }
 
 /// A tracked CLI agent session.
@@ -176,6 +178,7 @@ impl CLIAgentSession {
             CLIAgentEventType::Stop => {
                 self.session_context.query = event.payload.query.clone();
                 self.session_context.response = event.payload.response.clone();
+                self.session_context.summary = None;
                 CLIAgentSessionStatus::Success
             }
             CLIAgentEventType::PermissionRequest => {

--- a/app/src/terminal/cli_agent_sessions/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/mod_tests.rs
@@ -483,7 +483,7 @@ fn display_title_shows_response_after_permission_request_then_stop() {
         cwd: None,
         project: None,
         payload: CLIAgentEventPayload {
-            query: Some("Clean up temp files".to_string()),
+            query: None,
             response: Some("Deleted all temp files successfully".to_string()),
             ..Default::default()
         },

--- a/app/src/terminal/cli_agent_sessions/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/mod_tests.rs
@@ -408,3 +408,97 @@ fn session_start_without_plugin_version_leaves_none() {
     session.apply_event(&event);
     assert_eq!(session.plugin_version, None);
 }
+
+#[test]
+fn title_like_text_falls_back_to_response_when_summary_is_empty() {
+    let context = CLIAgentSessionContext {
+        summary: None,
+        response: Some("Task completed successfully".to_string()),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        context.title_like_text(),
+        Some("Task completed successfully".to_string())
+    );
+}
+
+#[test]
+fn title_like_text_prefers_summary_over_response() {
+    let context = CLIAgentSessionContext {
+        summary: Some("Wants to run Bash: ls".to_string()),
+        response: Some("Task completed".to_string()),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        context.title_like_text(),
+        Some("Wants to run Bash: ls".to_string())
+    );
+}
+
+#[test]
+fn display_title_shows_response_after_permission_request_then_stop() {
+    let mut session = CLIAgentSession {
+        agent: CLIAgent::Claude,
+        status: CLIAgentSessionStatus::InProgress,
+        session_context: CLIAgentSessionContext::default(),
+        input_state: CLIAgentInputState::Closed,
+        should_auto_toggle_input: false,
+        listener: None,
+        plugin_version: None,
+        draft_text: None,
+        remote_host: None,
+        custom_command_prefix: None,
+    };
+
+    // First: a permission request sets the summary
+    let permission_event = CLIAgentEvent {
+        v: 1,
+        agent: CLIAgent::Claude,
+        event: CLIAgentEventType::PermissionRequest,
+        session_id: Some("abc".to_string()),
+        cwd: None,
+        project: None,
+        payload: CLIAgentEventPayload {
+            summary: Some("Wants to run Bash: rm -rf /tmp".to_string()),
+            tool_name: Some("Bash".to_string()),
+            tool_input_preview: Some("rm -rf /tmp".to_string()),
+            ..Default::default()
+        },
+    };
+
+    session.apply_event(&permission_event);
+    assert_eq!(
+        session.session_context.display_title(),
+        Some("Wants to run Bash: rm -rf /tmp".to_string())
+    );
+
+    // Then: a stop event sets response and clears summary
+    let stop_event = CLIAgentEvent {
+        v: 1,
+        agent: CLIAgent::Claude,
+        event: CLIAgentEventType::Stop,
+        session_id: Some("abc".to_string()),
+        cwd: None,
+        project: None,
+        payload: CLIAgentEventPayload {
+            query: Some("Clean up temp files".to_string()),
+            response: Some("Deleted all temp files successfully".to_string()),
+            ..Default::default()
+        },
+    };
+
+    session.apply_event(&stop_event);
+    assert_eq!(session.session_context.summary, None);
+    // display_title prefers query (latest user prompt) over response
+    assert_eq!(
+        session.session_context.display_title(),
+        Some("Clean up temp files".to_string())
+    );
+    // title_like_text falls back to response when summary is None
+    assert_eq!(
+        session.session_context.title_like_text(),
+        Some("Deleted all temp files successfully".to_string())
+    );
+}


### PR DESCRIPTION
## Description

Fixes #9525

When a CLI agent session (e.g. Claude Code) completes, the tab title continued displaying the last permission request summary instead of the agent's final response. This happened because `title_like_text()` only consulted `self.summary`, which was set by `PermissionRequest` but never cleared by `Stop`, and `self.response` was set but never used for the title.

**Changes:**
- `title_like_text()` now falls back to `self.response` after `self.summary`, so completed sessions show the agent's final message
- The `Stop` handler now clears `self.summary` since it is no longer relevant after session completion
- Extracted a `trim_non_empty()` helper to deduplicate the trim-filter-own pattern across three call sites in the same module

## Testing

Added three new unit tests:
- `title_like_text_falls_back_to_response_when_summary_is_empty` — verifies response is used when summary is None
- `title_like_text_prefers_summary_over_response` — verifies summary takes precedence when both are present
- `display_title_shows_response_after_permission_request_then_stop` — regression test for the full PermissionRequest -> Stop flow

## Server API dependencies

N/A

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fix CLI agent tab title showing stale permission request text instead of agent response after session completes