### PR TITLE
Allow loginless startup and add Windows OSS build

### DIFF
--- a/.github/workflows/build_windows_oss.yml
+++ b/.github/workflows/build_windows_oss.yml
@@ -1,0 +1,81 @@
+name: Build Windows OSS
+
+on:
+  push:
+    paths:
+      - ".github/workflows/build_windows_oss.yml"
+      - ".cargo/**"
+      - "app/**"
+      - "command-signatures-v2/**"
+      - "crates/**"
+      - "resources/**"
+      - "script/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "rust-toolchain.toml"
+  pull_request:
+    paths:
+      - ".github/workflows/build_windows_oss.yml"
+      - ".cargo/**"
+      - "app/**"
+      - "command-signatures-v2/**"
+      - "crates/**"
+      - "resources/**"
+      - "script/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "rust-toolchain.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-windows-oss-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_windows_oss:
+    name: Build Windows OSS installer
+    runs-on: windows-latest
+    timeout-minutes: 180
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/prepare_environment
+        with:
+          target_os: windows
+          cache_key: windows-oss-x64
+          is_self_hosted: false
+          install_release_deps: true
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: |
+          choco install innosetup --no-progress -y
+          $innoSetupPath = "${env:ProgramFiles(x86)}\Inno Setup 6"
+          if (Test-Path $innoSetupPath) {
+            $innoSetupPath >> $env:GITHUB_PATH
+          }
+
+      - name: Build Windows OSS installer
+        id: bundle
+        shell: bash
+        run: script/bundle --channel oss --arch x64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Windows OSS installer
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: warp-oss-windows-x64-installer
+          path: ${{ steps.bundle.outputs.installer_path }}
+          if-no-files-found: error
+
+      - name: Upload Windows OSS debug symbols
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: warp-oss-windows-x64-pdb
+          path: ${{ steps.bundle.outputs.pdb_file_path }}
+          if-no-files-found: warn

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -1693,6 +1693,34 @@ enum AuthOnboardingState {
     Terminal(ViewHandle<Workspace>),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LoggedOutStartupDestination {
+    Workspace,
+    Onboarding,
+    Auth,
+}
+
+fn logged_out_startup_destination(
+    force_login: bool,
+    skip_firebase_anonymous_user: bool,
+    open_warp_new_settings_modes: bool,
+    agent_onboarding: bool,
+    has_completed_local_onboarding: bool,
+) -> LoggedOutStartupDestination {
+    if skip_firebase_anonymous_user {
+        LoggedOutStartupDestination::Workspace
+    } else if force_login {
+        LoggedOutStartupDestination::Auth
+    } else if open_warp_new_settings_modes
+        && agent_onboarding
+        && !has_completed_local_onboarding
+    {
+        LoggedOutStartupDestination::Onboarding
+    } else {
+        LoggedOutStartupDestination::Auth
+    }
+}
+
 pub struct RootView {
     auth_onboarding_state: AuthOnboardingState,
     server_time: Option<Arc<ServerTime>>,
@@ -1760,32 +1788,39 @@ impl RootView {
                 if #[cfg(target_family = "wasm")] {
                     AuthOnboardingState::WebImport(AuthOnboardingTarget::Workspace(workspace_args.into()))
                 } else {
-                    // When OpenWarpNewSettingsModes is enabled, show onboarding before login for
-                    // users who haven't completed it yet (tracked via a local UserPreferences key).
-                    let has_completed_local_onboarding = FeatureFlag::OpenWarpNewSettingsModes.is_enabled()
-                        && has_completed_local_onboarding(ctx);
-                    let should_show_pre_login_onboarding = FeatureFlag::OpenWarpNewSettingsModes.is_enabled()
-                        && FeatureFlag::AgentOnboarding.is_enabled()
-                        && !has_completed_local_onboarding;
-                    if FeatureFlag::ForceLogin.is_enabled() {
-                        // ForceLogin is true for Preview
-                        AuthOnboardingState::Auth(workspace_args.into())
-                    } else if should_show_pre_login_onboarding {
-                        let workspace_args_box: Box<WorkspaceArgs> = workspace_args.into();
-                        let onboarding_view = Self::create_agent_onboarding_view(ctx);
-                        onboarding_view.update(ctx, |view, ctx| {
-                            view.start_onboarding(ctx);
-                        });
-                        AuthOnboardingState::Onboarding {
-                            onboarding_view,
-                            target: AuthOnboardingTarget::Workspace(workspace_args_box),
+                    // Choose the logged-out native startup path. Loginless mode wins so
+                    // startup never blocks on auth when the user can use Warp without an account.
+                    let open_warp_new_settings_modes =
+                        FeatureFlag::OpenWarpNewSettingsModes.is_enabled();
+                    let local_onboarding_completed =
+                        open_warp_new_settings_modes && has_completed_local_onboarding(ctx);
+
+                    match logged_out_startup_destination(
+                        FeatureFlag::ForceLogin.is_enabled(),
+                        FeatureFlag::SkipFirebaseAnonymousUser.is_enabled(),
+                        open_warp_new_settings_modes,
+                        FeatureFlag::AgentOnboarding.is_enabled(),
+                        local_onboarding_completed,
+                    ) {
+                        LoggedOutStartupDestination::Workspace => {
+                            // Loginless mode should never block startup on auth or pre-login
+                            // onboarding; gated cloud features can still request auth later.
+                            AuthOnboardingState::Terminal(workspace_args.create_workspace(ctx))
                         }
-                    } else if FeatureFlag::SkipFirebaseAnonymousUser.is_enabled() {
-                        // When SkipFirebaseAnonymousUser is enabled, skip the login screen
-                        // entirely and go directly into the workspace.
-                        AuthOnboardingState::Terminal(workspace_args.create_workspace(ctx))
-                    } else {
-                        AuthOnboardingState::Auth(workspace_args.into())
+                        LoggedOutStartupDestination::Onboarding => {
+                            let workspace_args_box: Box<WorkspaceArgs> = workspace_args.into();
+                            let onboarding_view = Self::create_agent_onboarding_view(ctx);
+                            onboarding_view.update(ctx, |view, ctx| {
+                                view.start_onboarding(ctx);
+                            });
+                            AuthOnboardingState::Onboarding {
+                                onboarding_view,
+                                target: AuthOnboardingTarget::Workspace(workspace_args_box),
+                            }
+                        }
+                        LoggedOutStartupDestination::Auth => {
+                            AuthOnboardingState::Auth(workspace_args.into())
+                        }
                     }
                 }
             }

--- a/app/src/root_view_tests.rs
+++ b/app/src/root_view_tests.rs
@@ -1,7 +1,10 @@
 use warp_core::user_preferences::GetUserPreferences as _;
 use warpui::{App, SingletonEntity};
 
-use super::{has_completed_local_onboarding, RootView, HAS_COMPLETED_ONBOARDING_KEY};
+use super::{
+    has_completed_local_onboarding, logged_out_startup_destination,
+    LoggedOutStartupDestination, RootView, HAS_COMPLETED_ONBOARDING_KEY,
+};
 use crate::auth::auth_manager::AuthManager;
 use crate::auth::AuthStateProvider;
 use crate::server::server_api::ServerApiProvider;
@@ -22,6 +25,49 @@ fn set_local_onboarding_completed(app: &mut App, completed: bool) {
             )
             .unwrap();
     });
+}
+
+#[test]
+fn test_skip_firebase_anonymous_user_bypasses_startup_login() {
+    assert_eq!(
+        logged_out_startup_destination(
+            true,  // force_login
+            true,  // skip_firebase_anonymous_user
+            true,  // open_warp_new_settings_modes
+            true,  // agent_onboarding
+            false, // has_completed_local_onboarding
+        ),
+        LoggedOutStartupDestination::Workspace,
+        "logged-out native startup should go straight to the app when loginless mode is enabled"
+    );
+}
+
+#[test]
+fn test_force_login_still_wins_when_loginless_mode_is_disabled() {
+    assert_eq!(
+        logged_out_startup_destination(
+            true,  // force_login
+            false, // skip_firebase_anonymous_user
+            true,  // open_warp_new_settings_modes
+            true,  // agent_onboarding
+            false, // has_completed_local_onboarding
+        ),
+        LoggedOutStartupDestination::Auth
+    );
+}
+
+#[test]
+fn test_pre_login_onboarding_still_runs_when_loginless_mode_is_disabled() {
+    assert_eq!(
+        logged_out_startup_destination(
+            false, // force_login
+            false, // skip_firebase_anonymous_user
+            true,  // open_warp_new_settings_modes
+            true,  // agent_onboarding
+            false, // has_completed_local_onboarding
+        ),
+        LoggedOutStartupDestination::Onboarding
+    );
 }
 
 /// Regression test for the bug fixed by introducing


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
