### PR TITLE
Add active_cursor_position to CodeEditorView for IME positioning

### DIFF
--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -80,8 +80,8 @@ use warpui::{
     prelude::RectF,
     text::point::Point,
     units::Pixels,
-    AppContext, BlurContext, Element, Entity, FocusContext, ModelHandle, SingletonEntity, View,
-    ViewContext, ViewHandle, WeakViewHandle, WindowId,
+    AppContext, BlurContext, CursorInfo, Element, Entity, FocusContext, ModelHandle,
+    SingletonEntity, View, ViewContext, ViewHandle, WeakViewHandle, WindowId,
 };
 
 mod actions;
@@ -2333,6 +2333,14 @@ impl View for CodeEditorView {
         if focus_ctx.is_self_focused() && self.goto_line_dialog.as_ref(ctx).is_open() {
             ctx.focus(&self.goto_line_dialog);
         }
+    }
+
+    fn active_cursor_position(&self, ctx: &ViewContext<Self>) -> Option<CursorInfo> {
+        let render_state = self.model.as_ref(ctx).render_state().as_ref(ctx);
+        let cursor_id = render_state.saved_positions().cursor_id();
+        let font_size = Appearance::as_ref(ctx).monospace_font_size();
+
+        ctx.element_position_by_id(cursor_id.as_str()).map(|position| CursorInfo { position, font_size })
     }
 
     fn on_blur(&mut self, blur_ctx: &BlurContext, ctx: &mut ViewContext<Self>) {

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -2340,7 +2340,11 @@ impl View for CodeEditorView {
         let cursor_id = render_state.saved_positions().cursor_id();
         let font_size = render_state.styles().base_text.font_size;
 
-        ctx.element_position_by_id(cursor_id.as_str()).map(|position| CursorInfo { position, font_size })
+        ctx.element_position_by_id(cursor_id.as_str())
+            .map(|position| CursorInfo {
+                position,
+                font_size,
+            })
     }
 
     fn on_blur(&mut self, blur_ctx: &BlurContext, ctx: &mut ViewContext<Self>) {

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -2338,7 +2338,7 @@ impl View for CodeEditorView {
     fn active_cursor_position(&self, ctx: &ViewContext<Self>) -> Option<CursorInfo> {
         let render_state = self.model.as_ref(ctx).render_state().as_ref(ctx);
         let cursor_id = render_state.saved_positions().cursor_id();
-        let font_size = Appearance::as_ref(ctx).monospace_font_size();
+        let font_size = render_state.styles().base_text.font_size;
 
         ctx.element_position_by_id(cursor_id.as_str()).map(|position| CursorInfo { position, font_size })
     }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
- Fixes IME candidate window positioning for the code editor on macOS.
- `CodeEditorView` now provides `active_cursor_position()` so the IME anchor can be derived from the code editor caret instead of falling back to stale positions from other inputs (e.g. terminal input).
- Uses current-frame caret geometry with a last-frame fallback to keep placement stable during fast composition/layout timing.

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->
- Manual (macOS):
  - Opened a workspace with both a terminal pane and a code editor pane.
  - Typed with Chinese IME in terminal first (candidate popup follows terminal caret).
  - Switched to code editor and typed with IME; verified candidate popup now anchors near the code editor caret instead of staying at terminal coordinates.
  - Repeated with mouse selection/caret moves in the code editor; verified IME popup remains correctly anchored in editor context.
- Automated:
  - Ran `cargo check -p warpui --lib` locally after changes.

No new automated tests were added because this bug is tied to macOS IME runtime behavior and AppKit caret query timing (`firstRectForCharacterRange`) that is difficult to reliably simulate in existing unit/integration test harnesses.

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: 
CHANGELOG-BUG-FIX: Fix macOS IME candidate popup positioning in code editor panes so it anchors to the editor caret instead of stale terminal/input positions.
CHANGELOG-BUG-FIX: 
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
