### PR TITLE
fix: align OSS .desktop Exec with packaged binary name (#9381)

### DIFF
--- a/app/channels/oss/dev.warp.WarpOss.desktop
+++ b/app/channels/oss/dev.warp.WarpOss.desktop
@@ -7,7 +7,7 @@ Type=Application
 Name=WarpOss
 GenericName=TerminalEmulator
 
-Exec=warp-oss %U
+Exec=warp-terminal-oss %U
 StartupWMClass=dev.warp.WarpOss
 
 Keywords=shell;prompt;command;commandline;cmd;


### PR DESCRIPTION
## Description

Fixes #9381.

The OSS channel's `.desktop` file uses `Exec=warp-oss`, but Linux packaging actually exposes the launcher as `warp-terminal-oss`:

- `script/linux/bundle_{deb,rpm,arch,appimage}` all set `PACKAGE_NAME="warp-terminal$CHANNEL_SUFFIX"`, which yields `warp-terminal-oss` for the OSS channel.
- The `deb` postinst (`resources/linux/debian/app/postinst.template`) creates `/usr/bin/warp-terminal-oss`.
- The `rpm` spec (`resources/linux/rpm/app/warp.spec.template`) creates `%{_bindir}/warp-terminal-oss`.
- The Arch `PKGBUILD` template installs `/usr/bin/warp-terminal-oss`.
- The AUR package (per the bug report) does the same.

So when a user clicks the WarpOSS application-menu entry, the launcher tries to run a non-existent `warp-oss` and fails.

This PR updates `app/channels/oss/dev.warp.WarpOss.desktop`:

```
-Exec=warp-oss %U
+Exec=warp-terminal-oss %U
```

After the change, the OSS channel follows the same convention as every other channel:

| Channel  | `Exec=`                  |
| -------- | ------------------------ |
| stable   | `warp-terminal`          |
| preview  | `warp-terminal-preview`  |
| dev      | `warp-terminal-dev`      |
| local    | `warp-terminal-local`    |
| **oss**  | **`warp-terminal-oss`**  |

### AppImage compatibility

`script/linux/bundle_appimage` runs:

```sh
sed -i -E 's/Exec=warp-terminal/Exec=warp/' "$STAGE_DIR/usr/share/applications/$BUNDLE_ID.desktop"
```

Before this PR, the OSS line `Exec=warp-oss` did not match the pattern, so the sed was a no-op for OSS. After this PR, `Exec=warp-terminal-oss` is rewritten to `Exec=warp-oss`, which matches the bundled `BINARY_NAME=warp-oss`. Behavior inside the AppImage is unchanged.

## Testing

- Validated all five channel `.desktop` files with `desktop-file-validate` — all pass.
- Verified via grep that no source file referenced the old `Exec=warp-oss` form, so this is the only place the value lives.
- Manually traced the bundling/install paths for deb, rpm, arch, and AppImage to confirm the new value is correct in each context (described above).

This is a packaging-data-only change (single line in a `.desktop` file) — no Rust source is touched, no tests are affected.

## Server API dependencies

- [ ] Is this change necessary to make the client compatible with a desired server API breaking change? — No, packaging-only fix.

## Agent Mode

- [ ] Warp Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed Linux WarpOSS application-menu launcher pointing to a non-existent `warp-oss` binary; the `.desktop` Exec line now matches the installed `warp-terminal-oss` launcher.