### PR TITLE
docs: attribute Alacritty/vte derivative code in two more files (#9522)

### DIFF
--- a/app/src/terminal/grid_renderer/cell_type.rs
+++ b/app/src/terminal/grid_renderer/cell_type.rs
@@ -1,3 +1,7 @@
+// The color-mapping helpers (`compute_fg_rgb`, `compute_bg_rgb`, and
+// `get_override_color`) below are adapted from the alacritty_terminal crate
+// under the Apache license; see: crates/warp_terminal/src/model/LICENSE-ALACRITTY.
+
 use pathfinder_color::ColorU;
 
 use crate::{

--- a/crates/warp_terminal/src/model/ansi/control_sequence_parameters.rs
+++ b/crates/warp_terminal/src/model/ansi/control_sequence_parameters.rs
@@ -1,3 +1,6 @@
+// The code in this file is adapted from the vte crate (an Alacritty project)
+// under the Apache license; see: crates/warp_terminal/src/model/LICENSE-ALACRITTY.
+
 //! This module exports abstractions for parameters of control sequence actions;
 //! e.g. actions to be executed after receiving a control sequence from the pty.
 //!


### PR DESCRIPTION
## Description

Refs #9522.

After #9513 bundled `LICENSE-ALACRITTY` and added attribution headers to the original tranche of derivative files, [@chrisduerr (Alacritty maintainer) followed up](https://github.com/warpdotdev/warp/issues/9522#issuecomment-4350152049) and named two specific files that were still missing attribution:

> - This is an almost verbatim copy of VTE's ansi.rs module:
>   `crates/warp_terminal/src/model/ansi/control_sequence_parameters.rs`
> - This function (and several others) are also verbatim copies:
>   `app/src/terminal/grid_renderer/cell_type.rs:L160`

This PR adds the same two-line "adapted from … under the Apache license" comment header that #9513 introduced, pointing to the same bundled `crates/warp_terminal/src/model/LICENSE-ALACRITTY`:

| File | Attribution |
| ---- | ----------- |
| `crates/warp_terminal/src/model/ansi/control_sequence_parameters.rs` | "adapted from the vte crate (an Alacritty project)" — file-wide |
| `app/src/terminal/grid_renderer/cell_type.rs` | "color-mapping helpers (`compute_fg_rgb`, `compute_bg_rgb`, `get_override_color`) below are adapted from the alacritty_terminal crate" — scoped because `Secret` / `IsFocused` / `CellType` at the top of the file are Warp-specific |

Both files now point to the existing `crates/warp_terminal/src/model/LICENSE-ALACRITTY` (Apache-2.0 — the same license `vte` and `alacritty_terminal` both ship under). No license-file changes are needed.

This is documentation/attribution only — no functional changes.

## Scope

This PR addresses the **two files explicitly cited** in #9522 by the Alacritty maintainer. The cited comment also says "this function and several others" — the "several others" likely includes the immediately-adjacent `compute_bg_rgb` and `get_override_color` helpers in the same `cell_type.rs` (they are similar verbatim ports), which is why this PR's attribution covers all three of them. A broader audit of files that *might* be derivative beyond what's explicitly cited is best done by Warp's team or the Alacritty maintainers directly, since it requires intimate knowledge of upstream history; happy to extend this PR to cover any additional files that get flagged.

## Testing

Documentation/comments only. `cargo fmt -- --check` clean. No code paths affected.

## Server API dependencies

- [ ] No server impact.

## Agent Mode

- [ ] Warp Agent Mode

## Changelog Entries for Stable

(None — internal/legal attribution metadata.)