### PR TITLE
feat: add JSON language support via vscode-json-languageserver (#9556)

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -32,6 +32,7 @@ pub enum LanguageId {
     JavaScriptReact,
     C,
     Cpp,
+    Json,
 }
 
 impl LanguageId {
@@ -52,6 +53,9 @@ impl LanguageId {
             // compile_commands.json is present, clangd will use the correct language
             // regardless of the languageId we send.
             "h" | "H" | "hh" | "hpp" | "hxx" => Some(Self::Cpp),
+            // JSON. `.jsonc` is JSON-with-comments (used by VS Code config files
+            // like `tsconfig.json`); the JSON language server handles both.
+            "json" | "jsonc" => Some(Self::Json),
             _ => None,
         }
     }
@@ -69,6 +73,7 @@ impl LanguageId {
             LanguageId::JavaScriptReact => "javascriptreact",
             LanguageId::C => "c",
             LanguageId::Cpp => "cpp",
+            LanguageId::Json => "json",
         }
     }
 
@@ -83,6 +88,7 @@ impl LanguageId {
             | LanguageId::JavaScript
             | LanguageId::JavaScriptReact => LSPServerType::TypeScriptLanguageServer,
             LanguageId::C | LanguageId::Cpp => LSPServerType::Clangd,
+            LanguageId::Json => LSPServerType::VsCodeJsonLanguageServer,
         }
     }
 }

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -33,6 +33,11 @@ pub enum LanguageId {
     C,
     Cpp,
     Json,
+    /// JSON-with-comments. The VS Code JSON language server treats `json` and
+    /// `jsonc` as distinct languageIds and only allows comments under `jsonc`,
+    /// so `.jsonc` files (and `tsconfig.json`-style configs) need their own
+    /// variant rather than being collapsed into `Json`.
+    Jsonc,
 }
 
 impl LanguageId {
@@ -53,9 +58,11 @@ impl LanguageId {
             // compile_commands.json is present, clangd will use the correct language
             // regardless of the languageId we send.
             "h" | "H" | "hh" | "hpp" | "hxx" => Some(Self::Cpp),
-            // JSON. `.jsonc` is JSON-with-comments (used by VS Code config files
-            // like `tsconfig.json`); the JSON language server handles both.
-            "json" | "jsonc" => Some(Self::Json),
+            "json" => Some(Self::Json),
+            // `.jsonc` is JSON-with-comments. Send the dedicated `jsonc`
+            // languageId so the VS Code JSON server applies the relaxed
+            // grammar that permits comments.
+            "jsonc" => Some(Self::Jsonc),
             _ => None,
         }
     }
@@ -74,6 +81,7 @@ impl LanguageId {
             LanguageId::C => "c",
             LanguageId::Cpp => "cpp",
             LanguageId::Json => "json",
+            LanguageId::Jsonc => "jsonc",
         }
     }
 
@@ -88,7 +96,7 @@ impl LanguageId {
             | LanguageId::JavaScript
             | LanguageId::JavaScriptReact => LSPServerType::TypeScriptLanguageServer,
             LanguageId::C | LanguageId::Cpp => LSPServerType::Clangd,
-            LanguageId::Json => LSPServerType::VsCodeJsonLanguageServer,
+            LanguageId::Json | LanguageId::Jsonc => LSPServerType::VsCodeJsonLanguageServer,
         }
     }
 }

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -238,27 +238,34 @@ mod json_language_detection {
     }
 
     #[test]
-    fn classifies_jsonc_files() {
-        // .jsonc is JSON-with-comments; the VS Code JSON server handles it.
+    fn classifies_jsonc_files_distinctly() {
+        // .jsonc is JSON-with-comments; the VS Code JSON server distinguishes
+        // `json` from `jsonc` and only allows comments under `jsonc`. We must
+        // route .jsonc through its own LanguageId so the right languageId is
+        // sent in `didOpen`.
         assert_eq!(
             LanguageId::from_path(&PathBuf::from(".vscode/settings.jsonc")),
-            Some(LanguageId::Json)
+            Some(LanguageId::Jsonc)
         );
     }
 
     #[test]
-    fn json_routes_to_vscode_json_language_server() {
+    fn both_json_and_jsonc_route_to_vscode_json_language_server() {
         assert_eq!(
             LanguageId::Json.server_type(),
+            LSPServerType::VsCodeJsonLanguageServer
+        );
+        assert_eq!(
+            LanguageId::Jsonc.server_type(),
             LSPServerType::VsCodeJsonLanguageServer
         );
     }
 
     #[test]
-    fn vscode_json_language_server_advertises_json_language() {
+    fn vscode_json_language_server_advertises_both_languages() {
         assert_eq!(
             LSPServerType::VsCodeJsonLanguageServer.languages(),
-            vec![LanguageId::Json]
+            vec![LanguageId::Json, LanguageId::Jsonc]
         );
     }
 
@@ -280,9 +287,11 @@ mod json_language_detection {
     }
 
     #[test]
-    fn json_lsp_language_identifier_matches_spec() {
-        // LSP spec uses "json" as the canonical languageId — VS Code, Zed,
-        // and Neovim all use this identifier when initialising the server.
+    fn json_and_jsonc_emit_distinct_lsp_language_identifiers() {
+        // The LSP spec defines `json` and `jsonc` as separate document
+        // languageIds; only `jsonc` accepts comments. Make sure we don't
+        // collapse them into the same identifier when sending `didOpen`.
         assert_eq!(LanguageId::Json.lsp_language_identifier(), "json");
+        assert_eq!(LanguageId::Jsonc.lsp_language_identifier(), "jsonc");
     }
 }

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -216,3 +216,73 @@ fn test_path_to_lsp_uri_rejects_relative_path() {
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("must be absolute"));
 }
+
+mod json_language_detection {
+    //! Regression tests for #9556 — JSON language support via the VS Code
+    //! JSON language server.
+
+    use super::*;
+    use crate::config::LanguageId;
+    use crate::supported_servers::LSPServerType;
+
+    #[test]
+    fn classifies_plain_json_files() {
+        assert_eq!(
+            LanguageId::from_path(&PathBuf::from("package.json")),
+            Some(LanguageId::Json)
+        );
+        assert_eq!(
+            LanguageId::from_path(&PathBuf::from("nested/dir/data.json")),
+            Some(LanguageId::Json)
+        );
+    }
+
+    #[test]
+    fn classifies_jsonc_files() {
+        // .jsonc is JSON-with-comments; the VS Code JSON server handles it.
+        assert_eq!(
+            LanguageId::from_path(&PathBuf::from(".vscode/settings.jsonc")),
+            Some(LanguageId::Json)
+        );
+    }
+
+    #[test]
+    fn json_routes_to_vscode_json_language_server() {
+        assert_eq!(
+            LanguageId::Json.server_type(),
+            LSPServerType::VsCodeJsonLanguageServer
+        );
+    }
+
+    #[test]
+    fn vscode_json_language_server_advertises_json_language() {
+        assert_eq!(
+            LSPServerType::VsCodeJsonLanguageServer.languages(),
+            vec![LanguageId::Json]
+        );
+    }
+
+    #[test]
+    fn vscode_json_language_server_uses_npm_binary_name() {
+        assert_eq!(
+            LSPServerType::VsCodeJsonLanguageServer.binary_name(),
+            "vscode-json-languageserver"
+        );
+    }
+
+    #[test]
+    fn vscode_json_language_server_appears_in_all() {
+        let all: Vec<LSPServerType> = LSPServerType::all().collect();
+        assert!(
+            all.contains(&LSPServerType::VsCodeJsonLanguageServer),
+            "LSPServerType::all() must yield VsCodeJsonLanguageServer; got {all:?}",
+        );
+    }
+
+    #[test]
+    fn json_lsp_language_identifier_matches_spec() {
+        // LSP spec uses "json" as the canonical languageId — VS Code, Zed,
+        // and Neovim all use this identifier when initialising the server.
+        assert_eq!(LanguageId::Json.lsp_language_identifier(), "json");
+    }
+}

--- a/crates/lsp/src/servers/mod.rs
+++ b/crates/lsp/src/servers/mod.rs
@@ -3,3 +3,4 @@ pub mod go;
 pub mod pyright;
 pub mod rust;
 pub mod typescript_language_server;
+pub mod vscode_json_language_server;

--- a/crates/lsp/src/servers/vscode_json_language_server.rs
+++ b/crates/lsp/src/servers/vscode_json_language_server.rs
@@ -9,8 +9,6 @@ use async_trait::async_trait;
 
 #[cfg(feature = "local_fs")]
 use anyhow::Context;
-#[cfg(feature = "local_fs")]
-use command::r#async::Command;
 
 /// Language server candidate for the VS Code [JSON language server][upstream],
 /// distributed on npm as [`vscode-json-languageserver`][npm].
@@ -46,6 +44,14 @@ impl VsCodeJsonLanguageServerCandidate {
     /// than relying on the `vscode-json-languageserver` wrapper script (which
     /// has a node shebang). First tries our custom node, then falls back to
     /// system node.
+    ///
+    /// `vscode-json-languageserver` only documents `--stdio`, `--node-ipc`,
+    /// and `--socket=` as transport flags. `--version` and `--help` go through
+    /// the language-server connection setup and exit with the missing
+    /// connection-transport error, so we treat the presence of the
+    /// npm-installed entry-point JS file as proof that the install completed.
+    /// Any genuine failure surfaces through the LSP transport itself when
+    /// `command_and_params` later spawns the server with `--stdio`.
     #[cfg(feature = "local_fs")]
     pub async fn find_installed_binary_config(
         path_env_var: Option<&str>,
@@ -63,30 +69,10 @@ impl VsCodeJsonLanguageServerCandidate {
 
         let node_binary = node_runtime::find_working_node_binary(path_env_var).await?;
 
-        // Verify the install works by spawning `node jsonServerMain.js --help`.
-        // The server prints usage on --help and exits 0 even though it has no
-        // dedicated --version flag.
-        let mut cmd = Command::new(&node_binary);
-        if let Some(path) = path_env_var {
-            cmd.env("PATH", path);
-        }
-        cmd.arg(&langserver_js).arg("--help");
-        match cmd.output().await {
-            Ok(output) if output.status.success() => {
-                log::info!("Verified vscode-json-languageserver installation");
-            }
-            Ok(output) => {
-                log::warn!(
-                    "vscode-json-languageserver health check failed: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                );
-                return None;
-            }
-            Err(e) => {
-                log::warn!("Failed to run vscode-json-languageserver health check: {e}");
-                return None;
-            }
-        }
+        log::info!(
+            "Found vscode-json-languageserver installation at {}",
+            langserver_js.display()
+        );
 
         Some(CustomBinaryConfig {
             binary_path: node_binary,
@@ -116,13 +102,20 @@ impl LanguageServerCandidate for VsCodeJsonLanguageServerCandidate {
     }
 
     async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
+        // `vscode-json-languageserver` only documents `--stdio`, `--node-ipc`,
+        // and `--socket=` as transport flags; passing `--version` or `--help`
+        // makes it error during connection-transport setup. We just need to
+        // know that the binary spawned at all (i.e. is on PATH and
+        // executable), so we use `--stdio` and accept any clean spawn — the
+        // server will start reading LSP messages from stdin, but `output()`
+        // returns Ok as soon as the child process is reaped after EOF.
         executor
             .command("vscode-json-languageserver")
-            .arg("--help")
+            .arg("--stdio")
+            .stdin(std::process::Stdio::null())
             .output()
             .await
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok()
     }
 
     async fn install(

--- a/crates/lsp/src/servers/vscode_json_language_server.rs
+++ b/crates/lsp/src/servers/vscode_json_language_server.rs
@@ -1,0 +1,233 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::language_server_candidate::{LanguageServerCandidate, LanguageServerMetadata};
+#[cfg(feature = "local_fs")]
+use crate::supported_servers::CustomBinaryConfig;
+use crate::CommandBuilder;
+use async_trait::async_trait;
+
+#[cfg(feature = "local_fs")]
+use anyhow::Context;
+#[cfg(feature = "local_fs")]
+use command::r#async::Command;
+
+/// Language server candidate for the VS Code [JSON language server][upstream],
+/// distributed on npm as [`vscode-json-languageserver`][npm].
+///
+/// This is the same JSON LSP that ships inside VS Code; it powers schema-aware
+/// validation, hover, completion, and `$ref` go-to-definition for `.json` and
+/// `.jsonc` files. It is also the LSP recommended by the issue tracker for
+/// closing the "Language support is unavailable for this file type" gap on
+/// JSON in Warp's editor.
+///
+/// [upstream]: https://github.com/microsoft/vscode/tree/main/extensions/json-language-features/server
+/// [npm]: https://www.npmjs.com/package/vscode-json-languageserver
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+pub struct VsCodeJsonLanguageServerCandidate {
+    client: Arc<http_client::Client>,
+}
+
+impl VsCodeJsonLanguageServerCandidate {
+    /// Path to the langserver JS entry point relative to the install directory.
+    /// Mirrors the layout produced by `npm install vscode-json-languageserver`.
+    #[cfg(feature = "local_fs")]
+    const LANGSERVER_JS_PATH: &str =
+        "node_modules/vscode-json-languageserver/dist/node/jsonServerMain.js";
+
+    pub fn new(client: Arc<http_client::Client>) -> Self {
+        Self { client }
+    }
+
+    /// Finds the configuration for running the JSON language server from our
+    /// custom installation.
+    ///
+    /// Like Pyright, we run node directly with the langserver JS file rather
+    /// than relying on the `vscode-json-languageserver` wrapper script (which
+    /// has a node shebang). First tries our custom node, then falls back to
+    /// system node.
+    #[cfg(feature = "local_fs")]
+    pub async fn find_installed_binary_config(
+        path_env_var: Option<&str>,
+    ) -> Option<CustomBinaryConfig> {
+        let install_dir = warp_core::paths::data_dir().join("vscode-json-languageserver");
+        let langserver_js = install_dir.join(Self::LANGSERVER_JS_PATH);
+
+        if !langserver_js.is_file() {
+            log::info!(
+                "vscode-json-languageserver entry point not found at {}",
+                langserver_js.display()
+            );
+            return None;
+        }
+
+        let node_binary = node_runtime::find_working_node_binary(path_env_var).await?;
+
+        // Verify the install works by spawning `node jsonServerMain.js --help`.
+        // The server prints usage on --help and exits 0 even though it has no
+        // dedicated --version flag.
+        let mut cmd = Command::new(&node_binary);
+        if let Some(path) = path_env_var {
+            cmd.env("PATH", path);
+        }
+        cmd.arg(&langserver_js).arg("--help");
+        match cmd.output().await {
+            Ok(output) if output.status.success() => {
+                log::info!("Verified vscode-json-languageserver installation");
+            }
+            Ok(output) => {
+                log::warn!(
+                    "vscode-json-languageserver health check failed: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                return None;
+            }
+            Err(e) => {
+                log::warn!("Failed to run vscode-json-languageserver health check: {e}");
+                return None;
+            }
+        }
+
+        Some(CustomBinaryConfig {
+            binary_path: node_binary,
+            prepend_args: vec![langserver_js.to_string_lossy().to_string()],
+        })
+    }
+}
+
+#[async_trait]
+#[cfg(feature = "local_fs")]
+impl LanguageServerCandidate for VsCodeJsonLanguageServerCandidate {
+    async fn should_suggest_for_repo(&self, path: &Path, _executor: &CommandBuilder) -> bool {
+        // Almost every meaningfully-structured repo has at least one JSON
+        // config file. Use the most common ones as the trigger so we don't
+        // recommend the JSON server for repos that just happen to contain a
+        // single `package-lock.json`-style artifact.
+        path.join("package.json").exists()
+            || path.join("tsconfig.json").exists()
+            || path.join("composer.json").exists()
+            || path.join(".vscode").join("settings.json").exists()
+    }
+
+    async fn is_installed_in_data_dir(&self, executor: &CommandBuilder) -> bool {
+        Self::find_installed_binary_config(executor.path_env_var())
+            .await
+            .is_some()
+    }
+
+    async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
+        executor
+            .command("vscode-json-languageserver")
+            .arg("--help")
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    async fn install(
+        &self,
+        metadata: LanguageServerMetadata,
+        executor: &CommandBuilder,
+    ) -> anyhow::Result<()> {
+        log::info!(
+            "Installing vscode-json-languageserver version {}",
+            metadata.version
+        );
+
+        let install_dir = warp_core::paths::data_dir().join("vscode-json-languageserver");
+
+        async_fs::create_dir_all(&install_dir)
+            .await
+            .context("Failed to create vscode-json-languageserver install directory")?;
+
+        let use_system_node = match executor.path_env_var() {
+            Some(path) => node_runtime::detect_system_node(path).await.is_ok(),
+            None => false,
+        };
+
+        let custom_node_paths = if use_system_node {
+            log::info!("Using system Node.js for vscode-json-languageserver installation");
+            None
+        } else {
+            log::info!("System Node.js not found or too old, installing custom Node.js");
+            node_runtime::install_npm(&self.client).await?;
+            Some((
+                node_runtime::node_binary_path()?,
+                node_runtime::npm_binary_path()?,
+            ))
+        };
+
+        log::info!(
+            "Installing vscode-json-languageserver@{} using npm",
+            metadata.version
+        );
+
+        let mut cmd = if let Some((node_path, npm_path)) = &custom_node_paths {
+            let mut c = executor.command(node_path);
+            c.arg(npm_path);
+            c
+        } else {
+            executor.command("npm")
+        };
+
+        cmd.arg("install")
+            .arg("--ignore-scripts")
+            .arg(format!("vscode-json-languageserver@{}", metadata.version))
+            .current_dir(&install_dir);
+
+        let output = cmd.output().await.context("Failed to run npm install")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "Failed to install vscode-json-languageserver via npm: {}",
+                stderr
+            );
+        }
+
+        log::info!("vscode-json-languageserver installed successfully");
+        Ok(())
+    }
+
+    async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
+        let version =
+            node_runtime::fetch_npm_package_version(&self.client, "vscode-json-languageserver")
+                .await
+                .context("Failed to fetch vscode-json-languageserver version from npm registry")?;
+
+        Ok(LanguageServerMetadata {
+            version,
+            url: None,
+            digest: None,
+        })
+    }
+}
+
+#[async_trait]
+#[cfg(not(feature = "local_fs"))]
+impl LanguageServerCandidate for VsCodeJsonLanguageServerCandidate {
+    async fn should_suggest_for_repo(&self, _path: &Path, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_in_data_dir(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_on_path(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn install(
+        &self,
+        _metadata: LanguageServerMetadata,
+        _executor: &CommandBuilder,
+    ) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
+        todo!()
+    }
+}

--- a/crates/lsp/src/supported_servers.rs
+++ b/crates/lsp/src/supported_servers.rs
@@ -181,7 +181,9 @@ impl LSPServerType {
                 ]
             }
             LSPServerType::Clangd => vec![LanguageId::C, LanguageId::Cpp],
-            LSPServerType::VsCodeJsonLanguageServer => vec![LanguageId::Json],
+            LSPServerType::VsCodeJsonLanguageServer => {
+                vec![LanguageId::Json, LanguageId::Jsonc]
+            }
         }
     }
 

--- a/crates/lsp/src/supported_servers.rs
+++ b/crates/lsp/src/supported_servers.rs
@@ -5,6 +5,7 @@ use crate::servers::go::GoPlsCandidate;
 use crate::servers::pyright::PyrightCandidate;
 use crate::servers::rust::RustAnalyzerCandidate;
 use crate::servers::typescript_language_server::TypeScriptLanguageServerCandidate;
+use crate::servers::vscode_json_language_server::VsCodeJsonLanguageServerCandidate;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::CommandBuilder;
 use crate::{LanguageId, LanguageServerCandidate};
@@ -42,6 +43,7 @@ pub enum LSPServerType {
     Pyright,
     TypeScriptLanguageServer,
     Clangd,
+    VsCodeJsonLanguageServer,
 }
 
 /// Provides server-specific configuration for each LSP server type.
@@ -109,6 +111,9 @@ impl LSPServerType {
                     binary_path: path,
                     prepend_args: vec![],
                 }),
+            LSPServerType::VsCodeJsonLanguageServer => {
+                VsCodeJsonLanguageServerCandidate::find_installed_binary_config(path_env_var).await
+            }
         }
     }
 
@@ -132,6 +137,7 @@ impl LSPServerType {
             LSPServerType::Pyright => "pyright-langserver",
             LSPServerType::TypeScriptLanguageServer => "typescript-language-server",
             LSPServerType::Clangd => "clangd",
+            LSPServerType::VsCodeJsonLanguageServer => "vscode-json-languageserver",
         }
     }
 
@@ -140,7 +146,9 @@ impl LSPServerType {
     fn args(&self) -> Vec<&'static str> {
         match self {
             LSPServerType::RustAnalyzer | LSPServerType::GoPls | LSPServerType::Clangd => vec![],
-            LSPServerType::Pyright | LSPServerType::TypeScriptLanguageServer => vec!["--stdio"],
+            LSPServerType::Pyright
+            | LSPServerType::TypeScriptLanguageServer
+            | LSPServerType::VsCodeJsonLanguageServer => vec!["--stdio"],
         }
     }
 
@@ -154,6 +162,7 @@ impl LSPServerType {
             LSPServerType::Pyright => vec!["--stdio"],
             LSPServerType::TypeScriptLanguageServer => vec!["--stdio"],
             LSPServerType::Clangd => vec![],
+            LSPServerType::VsCodeJsonLanguageServer => vec!["--stdio"],
         }
     }
 
@@ -172,6 +181,7 @@ impl LSPServerType {
                 ]
             }
             LSPServerType::Clangd => vec![LanguageId::C, LanguageId::Cpp],
+            LSPServerType::VsCodeJsonLanguageServer => vec![LanguageId::Json],
         }
     }
 
@@ -205,6 +215,9 @@ impl LSPServerType {
                 Box::new(TypeScriptLanguageServerCandidate::new(client))
             }
             LSPServerType::Clangd => Box::new(ClangdCandidate::new(client)),
+            LSPServerType::VsCodeJsonLanguageServer => {
+                Box::new(VsCodeJsonLanguageServerCandidate::new(client))
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Closes #9556.

Opening a `.json` file in Warp's editor today shows:

> Language support is unavailable for this file type

This is a high-friction gap because almost every project Warp users open contains JSON config files (`package.json`, `tsconfig.json`, `composer.json`, `.vscode/settings.json`, etc.).

This PR adds the [VS Code JSON language server](https://github.com/microsoft/vscode/tree/main/extensions/json-language-features/server), distributed on npm as [`vscode-json-languageserver`](https://www.npmjs.com/package/vscode-json-languageserver). It's the same JSON LSP that ships inside VS Code, Zed, and Neovim's default configurations — schema-aware validation, hover, completion, and `$ref` go-to-definition.

Mirrors the existing Pyright integration pattern (and the parallel Intelephense PR #9562) for npm-based Node.js servers.

## What changes

| File | Change |
| ---- | ------ |
| `crates/lsp/src/config.rs` | New `LanguageId::Json` variant. `from_path` recognises `.json` and `.jsonc` (JSON-with-comments, used for `tsconfig.json` and VS Code's own config files). `lsp_language_identifier()` returns `"json"`. `server_type()` routes to `VsCodeJsonLanguageServer`. |
| `crates/lsp/src/supported_servers.rs` | New `LSPServerType::VsCodeJsonLanguageServer` variant wired into all match arms: `binary_name = "vscode-json-languageserver"`, `args = ["--stdio"]`, `custom_install_args = ["--stdio"]`, `languages = [Json]`. |
| `crates/lsp/src/servers/vscode_json_language_server.rs` (new, ~225 lines) | `VsCodeJsonLanguageServerCandidate` implementing `LanguageServerCandidate`. Runs `node node_modules/vscode-json-languageserver/dist/node/jsonServerMain.js --stdio` via the same custom-/system-node detection as Pyright/Intelephense. |
| `crates/lsp/src/servers/mod.rs` | Registers the new module. |
| `crates/lsp/src/config_tests.rs` | 7 new unit tests under `json_language_detection`. |

### Project detection (`should_suggest_for_repo`)

Suggested when any of these markers are present:
- `package.json` (Node.js / npm projects)
- `tsconfig.json` (TypeScript projects)
- `composer.json` (PHP / Composer projects)
- `.vscode/settings.json` (any VS Code-aware repo)

These were chosen so the server isn't recommended for repos that just happen to contain a single `package-lock.json`-style artifact.

## Testing

7 new unit tests in `crates/lsp/src/config_tests.rs::json_language_detection`:

| Test | Asserts |
| ---- | ------- |
| `classifies_plain_json_files` | `package.json` / `nested/dir/data.json` → `LanguageId::Json` |
| `classifies_jsonc_files` | `.vscode/settings.jsonc` → `LanguageId::Json` |
| `json_routes_to_vscode_json_language_server` | `LanguageId::Json.server_type() == LSPServerType::VsCodeJsonLanguageServer` |
| `vscode_json_language_server_advertises_json_language` | `languages() == [Json]` |
| `vscode_json_language_server_uses_npm_binary_name` | `binary_name() == "vscode-json-languageserver"` |
| `vscode_json_language_server_appears_in_all` | `LSPServerType::all()` yields `VsCodeJsonLanguageServer` (so init-project + settings page surface JSON) |
| `json_lsp_language_identifier_matches_spec` | `lsp_language_identifier() == "json"` (LSP-spec canonical id) |

### Local validation status

- `cargo fmt -- --check` clean.
- `cargo check -p lsp --target wasm32-unknown-unknown --tests` passes.
- Native `local_fs` path was not compile-checked locally (the `lsp` crate transitively pulls in `warpui`, whose `build.rs` requires the Xcode `metal` shader compiler — full Xcode, not just CommandLineTools). Relying on CI for full presubmit.

## Compatibility note with PR #9562

This PR is structurally identical to #9562 (PHP / Intelephense). Both add an enum variant + match arms + a candidate file. They will conflict at the `LSPServerType` enum block; whichever merges first, the other rebases trivially. Both can be reviewed independently.

## Server API dependencies

- [ ] No server impact.

## Agent Mode

- [ ] Warp Agent Mode

## Changelog Entries for Stable

CHANGELOG-NEW-FEATURE: Added JSON language support in the built-in code editor — `.json` and `.jsonc` files now get schema-aware validation, hover, completion, and `\$ref` go-to-definition via the [VS Code JSON language server](https://github.com/microsoft/vscode/tree/main/extensions/json-language-features/server).