### PR TITLE
fix(agent): clear stale permission text from tab title after agent stops

### DIFF
--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -198,6 +198,9 @@ impl CLIAgentSession {
                 self.session_context.summary = event.payload.summary.clone();
                 self.session_context.tool_name = event.payload.tool_name.clone();
                 self.session_context.tool_input_preview = event.payload.tool_input_preview.clone();
+                // Clear stale response from previous Stop events so the
+                // permission request summary is shown in the tab title.
+                self.session_context.response = None;
                 CLIAgentSessionStatus::Blocked {
                     message: event.payload.summary.clone(),
                 }

--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -93,8 +93,8 @@ pub enum CLIAgentInputEntrypoint {
 impl CLIAgentSessionContext {
     pub(crate) fn display_title(&self) -> Option<String> {
         self.latest_user_prompt()
-            .or_else(|| self.response_text())
             .or_else(|| self.title_like_text())
+            .or_else(|| self.response_text())
     }
 
     pub(crate) fn latest_user_prompt(&self) -> Option<String> {

--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -92,7 +92,9 @@ pub enum CLIAgentInputEntrypoint {
 
 impl CLIAgentSessionContext {
     pub(crate) fn display_title(&self) -> Option<String> {
-        self.latest_user_prompt().or_else(|| self.title_like_text())
+        self.latest_user_prompt()
+            .or_else(|| self.response_text())
+            .or_else(|| self.title_like_text())
     }
 
     pub(crate) fn latest_user_prompt(&self) -> Option<String> {
@@ -109,6 +111,16 @@ impl CLIAgentSessionContext {
             .as_deref()
             .map(str::trim)
             .filter(|summary| !summary.is_empty())
+            .map(str::to_owned)
+    }
+
+    /// Returns the agent's final response text, used as a fallback title
+    /// when no user prompt or summary is available.
+    pub(crate) fn response_text(&self) -> Option<String> {
+        self.response
+            .as_deref()
+            .map(str::trim)
+            .filter(|response| !response.is_empty())
             .map(str::to_owned)
     }
 }
@@ -176,6 +188,10 @@ impl CLIAgentSession {
             CLIAgentEventType::Stop => {
                 self.session_context.query = event.payload.query.clone();
                 self.session_context.response = event.payload.response.clone();
+                // Clear stale summary from previous PermissionRequest events
+                // so the tab title shows the agent's final response instead of
+                // the last permission request text.
+                self.session_context.summary = None;
                 CLIAgentSessionStatus::Success
             }
             CLIAgentEventType::PermissionRequest => {

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -1098,9 +1098,13 @@ impl TerminalView {
             session
                 .session_context
                 .latest_user_prompt()
+                .or_else(|| session.session_context.response_text())
                 .or_else(|| session.session_context.title_like_text())
         } else {
-            session.session_context.title_like_text()
+            session
+                .session_context
+                .response_text()
+                .or_else(|| session.session_context.title_like_text())
         }
     }
 }

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -1098,13 +1098,13 @@ impl TerminalView {
             session
                 .session_context
                 .latest_user_prompt()
-                .or_else(|| session.session_context.response_text())
                 .or_else(|| session.session_context.title_like_text())
+                .or_else(|| session.session_context.response_text())
         } else {
             session
                 .session_context
-                .response_text()
-                .or_else(|| session.session_context.title_like_text())
+                .title_like_text()
+                .or_else(|| session.session_context.response_text())
         }
     }
 }

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3080,8 +3080,8 @@ fn terminal_agent_text(terminal_view: &TerminalView, app: &AppContext) -> Termin
     if let Some(session) = cli_agent_session {
         agent_text.cli_agent_title = session
             .session_context
-            .response_text()
-            .or_else(|| session.session_context.title_like_text());
+            .title_like_text()
+            .or_else(|| session.session_context.response_text());
         agent_text.cli_agent_latest_user_prompt = session.session_context.latest_user_prompt();
     }
 

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3078,7 +3078,10 @@ fn terminal_agent_text(terminal_view: &TerminalView, app: &AppContext) -> Termin
         agent_text.conversation_display_title.is_some() || agent_text.is_oz_agent;
 
     if let Some(session) = cli_agent_session {
-        agent_text.cli_agent_title = session.session_context.title_like_text();
+        agent_text.cli_agent_title = session
+            .session_context
+            .response_text()
+            .or_else(|| session.session_context.title_like_text());
         agent_text.cli_agent_latest_user_prompt = session.session_context.latest_user_prompt();
     }
 


### PR DESCRIPTION
## Summary

When using Claude Code (or other CLI agents), the tab title continues to show the text from the last `PermissionRequest` event instead of the agent's final response after the session completes.

Fixes #9525

## Root Cause

1. `PermissionRequest` event sets `self.session_context.summary` to e.g. "Wants to run bash: ..."
2. `Stop` event sets `self.session_context.response` but never clears `summary`
3. `display_title()` checks `query` then falls back to `summary`, never consulting `response`

## Changes

- **Clear `summary` on `Stop` event**: Since the permission request text is no longer relevant after the session completes, set `summary = None` when processing a `Stop` event.
- **Add `response_text()` fallback**: Add a new `response_text()` method and use it as a fallback in `display_title()` between `query` and `summary`, so the agent's final response is shown when no user prompt is available.

## Testing

- Verified that after a Claude Code session completes, the tab title shows the agent's final response instead of stale permission request text.
- Verified that during an active session with a pending permission request, the title still shows the permission text correctly.