### PR TITLE
fix: sanitize subprocess call in generate-mappings.py

### DIFF
--- a/script/font_fallback/generate-families.py
+++ b/script/font_fallback/generate-families.py
@@ -23,8 +23,8 @@ from collections import defaultdict
 
 
 def list_fonts():
-    command = "gcloud storage ls --recursive 'gs://warp-static-assets/fallback-fonts/**.ttf'"
-    return subprocess.check_output(command, shell=True, text=True).splitlines()
+    command = ["gcloud", "storage", "ls", "--recursive", "gs://warp-static-assets/fallback-fonts/**.ttf"]
+    return subprocess.check_output(command, text=True).splitlines()
 
 
 def generate_families(font_uris):

--- a/script/font_fallback/generate-mappings.py
+++ b/script/font_fallback/generate-mappings.py
@@ -23,11 +23,10 @@ Usage:
 '''
 
 import os
-import subprocess
-import sys
 from operator import itemgetter
 from fontTools.ttLib import TTFont
 from collections import defaultdict
+from google.cloud import storage
 
 # Represents priority for each font, with a lower value being higher priority.
 # Since a code point can be supported by multiple fonts, the script will map the
@@ -74,10 +73,11 @@ def download_fallback_fonts():
         return
 
     os.mkdir(FONT_DOWNLOAD_DIR)
-    command = f"gcloud storage cp 'gs://warp-static-assets/fallback-fonts/**/*Regular*.ttf' '{FONT_DOWNLOAD_DIR}'"
-    return_code = subprocess.call(command, shell=True)
-    if return_code != 0:
-        sys.exit("Failed to download fonts from GCP")
+    client = storage.Client()
+    for blob in client.list_blobs("warp-static-assets", prefix="fallback-fonts/"):
+        name = os.path.basename(blob.name)
+        if name.endswith(".ttf") and "Regular" in name:
+            blob.download_to_filename(os.path.join(FONT_DOWNLOAD_DIR, name))
 
 
 def get_global_order(font_name):

--- a/script/font_fallback/requirements.txt
+++ b/script/font_fallback/requirements.txt
@@ -1,1 +1,2 @@
 fonttools==4.61.0
+google-cloud-storage>=2.0.0


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `script/font_fallback/generate-mappings.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `script/font_fallback/generate-mappings.py:78` |
| **CWE** | CWE-78 |

**Description**: Both generate-mappings.py (line 78) and generate-families.py (line 27) invoke subprocess with shell=True, passing the command string directly to the OS shell interpreter (/bin/sh on Unix). When shell=True is used, any shell metacharacters present in the command string are interpreted by the shell. If any portion of the command variable is derived from external input such as font names, file paths, or CLI arguments, an attacker can inject shell metacharacters (semicolons, pipes, backticks, $() subshells) to execute arbitrary OS commands with the privileges of the running process.

## Changes
- `script/font_fallback/generate-mappings.py`
- `script/font_fallback/generate-families.py`
- `script/font_fallback/requirements.txt`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
