### PR TITLE
feat: add JSON language support via vscode-json-languageserver (#9556) — v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ app/src/persistence/schema.rs.orig
 
 # Don't include personal Claude Code settings
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Tab drag development notes
 pr_cleanup.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7470,6 +7470,7 @@ dependencies = [
  "simple_logger",
  "strum",
  "strum_macros",
+ "tempfile",
  "tokio",
  "url",
  "warp_core",

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -47,3 +47,6 @@ nix = { workspace = true }
 repo_metadata.workspace = true
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["process"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -362,36 +362,67 @@ pub fn default_init_params(workspace_uri: &Path, client_name: String) -> Result<
     })
 }
 
-/// Returns `true` for paths whose final filename is a well-known JSON-with-comments
-/// config file. The VS Code JSON language server distinguishes `json` from `jsonc`
-/// and only allows comments under `jsonc`, but several Microsoft tools ship with
-/// `.json` extensions and JSONC contents (TypeScript's `tsconfig.json`,
-/// VS Code's own `settings.json`, etc.). Routing these by name keeps users
-/// from getting spurious "comments not allowed" diagnostics.
+/// Returns `true` for paths whose name (and, where ambiguous, parent
+/// directory) identify a well-known JSON-with-comments config file. The
+/// VS Code JSON language server distinguishes `json` from `jsonc` and only
+/// allows comments under `jsonc`, but several Microsoft tools ship with
+/// `.json` extensions and JSONC contents — routing these by name avoids
+/// spurious "comments not allowed" diagnostics.
+///
+/// Detection is split into two tiers to avoid relaxing validation for
+/// unrelated files that happen to share a common name:
+///
+/// 1. **Globally JSONC** — names that are unambiguous wherever they
+///    appear (`tsconfig.json` and its `.<variant>.json` siblings,
+///    `jsconfig.json` ditto, `devcontainer.json`, `typedoc.json`).
+///
+/// 2. **JSONC only when the parent directory is `.vscode/`** — VS Code's
+///    workspace/user files (`settings.json`, `launch.json`, `tasks.json`,
+///    `keybindings.json`, `extensions.json`). Outside `.vscode/` a file
+///    called `settings.json` is just as likely to be strict JSON in some
+///    unrelated project, so we leave those alone.
 fn filename_is_jsonc(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
         return false;
     };
-    // Exact filename matches that are always JSONC by convention.
-    const EXACT: &[&str] = &[
+
+    // Tier 1: globally JSONC by convention.
+    const ALWAYS_JSONC: &[&str] = &[
         "tsconfig.json",
         "jsconfig.json",
-        // VS Code workspace/user/folder settings files.
+        "devcontainer.json",
+        "typedoc.json",
+    ];
+    if ALWAYS_JSONC.contains(&name) {
+        return true;
+    }
+    // Variants like `tsconfig.build.json`, `tsconfig.app.json`,
+    // `jsconfig.app.json`, etc.
+    if (name.starts_with("tsconfig.") || name.starts_with("jsconfig.")) && name.ends_with(".json") {
+        return true;
+    }
+
+    // Tier 2: VS Code workspace files — only when the parent directory is
+    // exactly `.vscode/`. A `settings.json` somewhere else might be strict
+    // JSON in an unrelated project; we don't want to silently accept
+    // comments there.
+    const VSCODE_JSONC: &[&str] = &[
         "settings.json",
         "launch.json",
         "tasks.json",
         "keybindings.json",
         "extensions.json",
-        // Other editor configs that follow the same convention.
-        "devcontainer.json",
-        "typedoc.json",
     ];
-    if EXACT.contains(&name) {
-        return true;
+    if VSCODE_JSONC.contains(&name) {
+        let parent_is_vscode = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            == Some(".vscode");
+        return parent_is_vscode;
     }
-    // Variants like `tsconfig.build.json`, `tsconfig.app.json`, etc.
-    name.starts_with("tsconfig.") && name.ends_with(".json")
-        || name.starts_with("jsconfig.") && name.ends_with(".json")
+
+    false
 }
 
 #[cfg(test)]

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -226,7 +226,10 @@ impl LspServerConfig {
             custom_binary_config
         );
 
-        let params = default_init_params(&self.initial_workspace, self.client_name)?;
+        let mut params = default_init_params(&self.initial_workspace, self.client_name)?;
+        if let Some(opts) = self.server_type.initialization_options() {
+            params.initialization_options = Some(opts);
+        }
 
         Ok(ResolvedLspCommand { command, params })
     }

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -42,6 +42,15 @@ pub enum LanguageId {
 
 impl LanguageId {
     pub fn from_path(path: &Path) -> Option<Self> {
+        // Some files use the `.json` extension by convention but actually
+        // contain JSON-with-comments — `tsconfig.json` is the canonical
+        // example, alongside the VS Code `.vscode/*.json` family. Match
+        // these by filename first so we send `jsonc` (not `json`) in
+        // `didOpen` and the JSON server applies its comments-tolerant
+        // grammar instead of flagging valid `// …` lines as syntax errors.
+        if filename_is_jsonc(path) {
+            return Some(Self::Jsonc);
+        }
         let extn = path.extension()?;
         match extn.to_str()? {
             "rs" => Some(Self::Rust),
@@ -351,6 +360,38 @@ pub fn default_init_params(workspace_uri: &Path, client_name: String) -> Result<
         work_done_progress_params: WorkDoneProgressParams::default(),
         ..Default::default()
     })
+}
+
+/// Returns `true` for paths whose final filename is a well-known JSON-with-comments
+/// config file. The VS Code JSON language server distinguishes `json` from `jsonc`
+/// and only allows comments under `jsonc`, but several Microsoft tools ship with
+/// `.json` extensions and JSONC contents (TypeScript's `tsconfig.json`,
+/// VS Code's own `settings.json`, etc.). Routing these by name keeps users
+/// from getting spurious "comments not allowed" diagnostics.
+fn filename_is_jsonc(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    // Exact filename matches that are always JSONC by convention.
+    const EXACT: &[&str] = &[
+        "tsconfig.json",
+        "jsconfig.json",
+        // VS Code workspace/user/folder settings files.
+        "settings.json",
+        "launch.json",
+        "tasks.json",
+        "keybindings.json",
+        "extensions.json",
+        // Other editor configs that follow the same convention.
+        "devcontainer.json",
+        "typedoc.json",
+    ];
+    if EXACT.contains(&name) {
+        return true;
+    }
+    // Variants like `tsconfig.build.json`, `tsconfig.app.json`, etc.
+    name.starts_with("tsconfig.") && name.ends_with(".json")
+        || name.starts_with("jsconfig.") && name.ends_with(".json")
 }
 
 #[cfg(test)]

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -32,6 +32,7 @@ pub enum LanguageId {
     JavaScriptReact,
     C,
     Cpp,
+    Json,
 }
 
 impl LanguageId {
@@ -52,6 +53,9 @@ impl LanguageId {
             // compile_commands.json is present, clangd will use the correct language
             // regardless of the languageId we send.
             "h" | "H" | "hh" | "hpp" | "hxx" => Some(Self::Cpp),
+            // JSON. `.jsonc` is JSON-with-comments (used by VS Code config files
+            // like `tsconfig.json`); the JSON language server handles both.
+            "json" | "jsonc" => Some(Self::Json),
             _ => None,
         }
     }
@@ -69,6 +73,7 @@ impl LanguageId {
             LanguageId::JavaScriptReact => "javascriptreact",
             LanguageId::C => "c",
             LanguageId::Cpp => "cpp",
+            LanguageId::Json => "json",
         }
     }
 
@@ -83,6 +88,7 @@ impl LanguageId {
             | LanguageId::JavaScript
             | LanguageId::JavaScriptReact => LSPServerType::TypeScriptLanguageServer,
             LanguageId::C | LanguageId::Cpp => LSPServerType::Clangd,
+            LanguageId::Json => LSPServerType::VsCodeJsonLanguageServer,
         }
     }
 }

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -33,6 +33,11 @@ pub enum LanguageId {
     C,
     Cpp,
     Json,
+    /// JSON-with-comments. The VS Code JSON language server treats `json` and
+    /// `jsonc` as distinct languageIds and only allows comments under `jsonc`,
+    /// so `.jsonc` files (and `tsconfig.json`-style configs) need their own
+    /// variant rather than being collapsed into `Json`.
+    Jsonc,
 }
 
 impl LanguageId {
@@ -53,9 +58,11 @@ impl LanguageId {
             // compile_commands.json is present, clangd will use the correct language
             // regardless of the languageId we send.
             "h" | "H" | "hh" | "hpp" | "hxx" => Some(Self::Cpp),
-            // JSON. `.jsonc` is JSON-with-comments (used by VS Code config files
-            // like `tsconfig.json`); the JSON language server handles both.
-            "json" | "jsonc" => Some(Self::Json),
+            "json" => Some(Self::Json),
+            // `.jsonc` is JSON-with-comments. Send the dedicated `jsonc`
+            // languageId so the VS Code JSON server applies the relaxed
+            // grammar that permits comments.
+            "jsonc" => Some(Self::Jsonc),
             _ => None,
         }
     }
@@ -74,6 +81,7 @@ impl LanguageId {
             LanguageId::C => "c",
             LanguageId::Cpp => "cpp",
             LanguageId::Json => "json",
+            LanguageId::Jsonc => "jsonc",
         }
     }
 
@@ -88,7 +96,7 @@ impl LanguageId {
             | LanguageId::JavaScript
             | LanguageId::JavaScriptReact => LSPServerType::TypeScriptLanguageServer,
             LanguageId::C | LanguageId::Cpp => LSPServerType::Clangd,
-            LanguageId::Json => LSPServerType::VsCodeJsonLanguageServer,
+            LanguageId::Json | LanguageId::Jsonc => LSPServerType::VsCodeJsonLanguageServer,
         }
     }
 }

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -381,4 +381,44 @@ mod json_language_detection {
         assert_eq!(LanguageId::Json.lsp_language_identifier(), "json");
         assert_eq!(LanguageId::Jsonc.lsp_language_identifier(), "jsonc");
     }
+
+    #[test]
+    fn json_server_restricts_schema_protocols_to_file() {
+        // The VS Code JSON server fetches schema URIs itself by default
+        // for any of `http`/`https`/`file`. An untrusted document with
+        // `$schema: "http://attacker.example/foo"` would otherwise trigger
+        // outbound network requests outside Warp's control. Initialization
+        // options must restrict the server to local-file schemas.
+        let opts = LSPServerType::VsCodeJsonLanguageServer
+            .initialization_options()
+            .expect("JSON server must ship initialization options");
+        let protocols = opts
+            .get("handledSchemaProtocols")
+            .and_then(|v| v.as_array());
+        let protocols = protocols.expect("`handledSchemaProtocols` must be set");
+        let protocols: Vec<&str> = protocols.iter().filter_map(|v| v.as_str()).collect();
+        assert_eq!(
+            protocols,
+            vec!["file"],
+            "JSON server must NOT auto-fetch http(s) schemas; got {protocols:?}",
+        );
+    }
+
+    #[test]
+    fn other_servers_have_no_initialization_options() {
+        // Sanity check that we haven't accidentally attached options to
+        // unrelated servers.
+        for kind in [
+            LSPServerType::RustAnalyzer,
+            LSPServerType::GoPls,
+            LSPServerType::Pyright,
+            LSPServerType::TypeScriptLanguageServer,
+            LSPServerType::Clangd,
+        ] {
+            assert!(
+                kind.initialization_options().is_none(),
+                "{kind:?} should not declare initialization_options",
+            );
+        }
+    }
 }

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -244,9 +244,51 @@ mod json_language_detection {
         // route .jsonc through its own LanguageId so the right languageId is
         // sent in `didOpen`.
         assert_eq!(
-            LanguageId::from_path(&PathBuf::from(".vscode/settings.jsonc")),
+            LanguageId::from_path(&PathBuf::from("docs/example.jsonc")),
             Some(LanguageId::Jsonc)
         );
+    }
+
+    #[test]
+    fn known_dotjson_jsonc_filenames_route_to_jsonc() {
+        // Several well-known config files use `.json` by convention but
+        // contain JSON-with-comments. Sending `json` would surface valid
+        // `// …` lines as syntax errors.
+        for name in [
+            "tsconfig.json",
+            "jsconfig.json",
+            "tsconfig.build.json",
+            "jsconfig.app.json",
+            ".vscode/settings.json",
+            ".vscode/launch.json",
+            ".vscode/keybindings.json",
+            ".vscode/tasks.json",
+            ".vscode/extensions.json",
+            ".devcontainer/devcontainer.json",
+        ] {
+            assert_eq!(
+                LanguageId::from_path(&PathBuf::from(name)),
+                Some(LanguageId::Jsonc),
+                "{name} should be classified as JSONC",
+            );
+        }
+    }
+
+    #[test]
+    fn unrelated_dotjson_stays_strict_json() {
+        // package.json, manifest.json, etc. are strict JSON.
+        for name in [
+            "package.json",
+            "package-lock.json",
+            "manifest.json",
+            "data.json",
+        ] {
+            assert_eq!(
+                LanguageId::from_path(&PathBuf::from(name)),
+                Some(LanguageId::Json),
+                "{name} should remain strict JSON",
+            );
+        }
     }
 
     #[test]

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -292,6 +292,51 @@ mod json_language_detection {
     }
 
     #[test]
+    fn vscode_filenames_outside_dotvscode_stay_strict_json() {
+        // A `settings.json` (or `launch.json`, etc.) that lives outside a
+        // `.vscode/` directory could just as easily be strict JSON in an
+        // unrelated project. We must not relax validation for it just
+        // because the filename matches a VS Code convention.
+        for name in [
+            "settings.json",
+            "launch.json",
+            "tasks.json",
+            "keybindings.json",
+            "extensions.json",
+            "src/settings.json",
+            "config/launch.json",
+            "deeply/nested/extensions.json",
+        ] {
+            assert_eq!(
+                LanguageId::from_path(&PathBuf::from(name)),
+                Some(LanguageId::Json),
+                "{name} (no .vscode/ parent) should remain strict JSON",
+            );
+        }
+    }
+
+    #[test]
+    fn vscode_filenames_under_dotvscode_become_jsonc() {
+        // The same names *do* route to JSONC when the immediate parent is
+        // `.vscode/` — that's the canonical VS Code config layout.
+        for name in [
+            ".vscode/settings.json",
+            ".vscode/launch.json",
+            ".vscode/tasks.json",
+            ".vscode/keybindings.json",
+            ".vscode/extensions.json",
+            // Nested-project case: `frontend/.vscode/settings.json`.
+            "frontend/.vscode/settings.json",
+        ] {
+            assert_eq!(
+                LanguageId::from_path(&PathBuf::from(name)),
+                Some(LanguageId::Jsonc),
+                "{name} (under .vscode/) should be classified as JSONC",
+            );
+        }
+    }
+
+    #[test]
     fn both_json_and_jsonc_route_to_vscode_json_language_server() {
         assert_eq!(
             LanguageId::Json.server_type(),

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -238,27 +238,34 @@ mod json_language_detection {
     }
 
     #[test]
-    fn classifies_jsonc_files() {
-        // .jsonc is JSON-with-comments; the VS Code JSON server handles it.
+    fn classifies_jsonc_files_distinctly() {
+        // .jsonc is JSON-with-comments; the VS Code JSON server distinguishes
+        // `json` from `jsonc` and only allows comments under `jsonc`. We must
+        // route .jsonc through its own LanguageId so the right languageId is
+        // sent in `didOpen`.
         assert_eq!(
             LanguageId::from_path(&PathBuf::from(".vscode/settings.jsonc")),
-            Some(LanguageId::Json)
+            Some(LanguageId::Jsonc)
         );
     }
 
     #[test]
-    fn json_routes_to_vscode_json_language_server() {
+    fn both_json_and_jsonc_route_to_vscode_json_language_server() {
         assert_eq!(
             LanguageId::Json.server_type(),
+            LSPServerType::VsCodeJsonLanguageServer
+        );
+        assert_eq!(
+            LanguageId::Jsonc.server_type(),
             LSPServerType::VsCodeJsonLanguageServer
         );
     }
 
     #[test]
-    fn vscode_json_language_server_advertises_json_language() {
+    fn vscode_json_language_server_advertises_both_languages() {
         assert_eq!(
             LSPServerType::VsCodeJsonLanguageServer.languages(),
-            vec![LanguageId::Json]
+            vec![LanguageId::Json, LanguageId::Jsonc]
         );
     }
 
@@ -280,9 +287,11 @@ mod json_language_detection {
     }
 
     #[test]
-    fn json_lsp_language_identifier_matches_spec() {
-        // LSP spec uses "json" as the canonical languageId — VS Code, Zed,
-        // and Neovim all use this identifier when initialising the server.
+    fn json_and_jsonc_emit_distinct_lsp_language_identifiers() {
+        // The LSP spec defines `json` and `jsonc` as separate document
+        // languageIds; only `jsonc` accepts comments. Make sure we don't
+        // collapse them into the same identifier when sending `didOpen`.
         assert_eq!(LanguageId::Json.lsp_language_identifier(), "json");
+        assert_eq!(LanguageId::Jsonc.lsp_language_identifier(), "jsonc");
     }
 }

--- a/crates/lsp/src/config_tests.rs
+++ b/crates/lsp/src/config_tests.rs
@@ -216,3 +216,73 @@ fn test_path_to_lsp_uri_rejects_relative_path() {
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("must be absolute"));
 }
+
+mod json_language_detection {
+    //! Regression tests for #9556 — JSON language support via the VS Code
+    //! JSON language server.
+
+    use super::*;
+    use crate::config::LanguageId;
+    use crate::supported_servers::LSPServerType;
+
+    #[test]
+    fn classifies_plain_json_files() {
+        assert_eq!(
+            LanguageId::from_path(&PathBuf::from("package.json")),
+            Some(LanguageId::Json)
+        );
+        assert_eq!(
+            LanguageId::from_path(&PathBuf::from("nested/dir/data.json")),
+            Some(LanguageId::Json)
+        );
+    }
+
+    #[test]
+    fn classifies_jsonc_files() {
+        // .jsonc is JSON-with-comments; the VS Code JSON server handles it.
+        assert_eq!(
+            LanguageId::from_path(&PathBuf::from(".vscode/settings.jsonc")),
+            Some(LanguageId::Json)
+        );
+    }
+
+    #[test]
+    fn json_routes_to_vscode_json_language_server() {
+        assert_eq!(
+            LanguageId::Json.server_type(),
+            LSPServerType::VsCodeJsonLanguageServer
+        );
+    }
+
+    #[test]
+    fn vscode_json_language_server_advertises_json_language() {
+        assert_eq!(
+            LSPServerType::VsCodeJsonLanguageServer.languages(),
+            vec![LanguageId::Json]
+        );
+    }
+
+    #[test]
+    fn vscode_json_language_server_uses_npm_binary_name() {
+        assert_eq!(
+            LSPServerType::VsCodeJsonLanguageServer.binary_name(),
+            "vscode-json-languageserver"
+        );
+    }
+
+    #[test]
+    fn vscode_json_language_server_appears_in_all() {
+        let all: Vec<LSPServerType> = LSPServerType::all().collect();
+        assert!(
+            all.contains(&LSPServerType::VsCodeJsonLanguageServer),
+            "LSPServerType::all() must yield VsCodeJsonLanguageServer; got {all:?}",
+        );
+    }
+
+    #[test]
+    fn json_lsp_language_identifier_matches_spec() {
+        // LSP spec uses "json" as the canonical languageId — VS Code, Zed,
+        // and Neovim all use this identifier when initialising the server.
+        assert_eq!(LanguageId::Json.lsp_language_identifier(), "json");
+    }
+}

--- a/crates/lsp/src/servers/mod.rs
+++ b/crates/lsp/src/servers/mod.rs
@@ -3,3 +3,4 @@ pub mod go;
 pub mod pyright;
 pub mod rust;
 pub mod typescript_language_server;
+pub mod vscode_json_language_server;

--- a/crates/lsp/src/servers/vscode_json_language_server.rs
+++ b/crates/lsp/src/servers/vscode_json_language_server.rs
@@ -9,8 +9,6 @@ use async_trait::async_trait;
 
 #[cfg(feature = "local_fs")]
 use anyhow::Context;
-#[cfg(feature = "local_fs")]
-use command::r#async::Command;
 
 /// Language server candidate for the VS Code [JSON language server][upstream],
 /// distributed on npm as [`vscode-json-languageserver`][npm].
@@ -46,6 +44,14 @@ impl VsCodeJsonLanguageServerCandidate {
     /// than relying on the `vscode-json-languageserver` wrapper script (which
     /// has a node shebang). First tries our custom node, then falls back to
     /// system node.
+    ///
+    /// `vscode-json-languageserver` only documents `--stdio`, `--node-ipc`,
+    /// and `--socket=` as transport flags. `--version` and `--help` go through
+    /// the language-server connection setup and exit with the missing
+    /// connection-transport error, so we treat the presence of the
+    /// npm-installed entry-point JS file as proof that the install completed.
+    /// Any genuine failure surfaces through the LSP transport itself when
+    /// `command_and_params` later spawns the server with `--stdio`.
     #[cfg(feature = "local_fs")]
     pub async fn find_installed_binary_config(
         path_env_var: Option<&str>,
@@ -63,30 +69,10 @@ impl VsCodeJsonLanguageServerCandidate {
 
         let node_binary = node_runtime::find_working_node_binary(path_env_var).await?;
 
-        // Verify the install works by spawning `node jsonServerMain.js --help`.
-        // The server prints usage on --help and exits 0 even though it has no
-        // dedicated --version flag.
-        let mut cmd = Command::new(&node_binary);
-        if let Some(path) = path_env_var {
-            cmd.env("PATH", path);
-        }
-        cmd.arg(&langserver_js).arg("--help");
-        match cmd.output().await {
-            Ok(output) if output.status.success() => {
-                log::info!("Verified vscode-json-languageserver installation");
-            }
-            Ok(output) => {
-                log::warn!(
-                    "vscode-json-languageserver health check failed: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                );
-                return None;
-            }
-            Err(e) => {
-                log::warn!("Failed to run vscode-json-languageserver health check: {e}");
-                return None;
-            }
-        }
+        log::info!(
+            "Found vscode-json-languageserver installation at {}",
+            langserver_js.display()
+        );
 
         Some(CustomBinaryConfig {
             binary_path: node_binary,
@@ -116,13 +102,20 @@ impl LanguageServerCandidate for VsCodeJsonLanguageServerCandidate {
     }
 
     async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
+        // `vscode-json-languageserver` only documents `--stdio`, `--node-ipc`,
+        // and `--socket=` as transport flags; passing `--version` or `--help`
+        // makes it error during connection-transport setup. We just need to
+        // know that the binary spawned at all (i.e. is on PATH and
+        // executable), so we use `--stdio` and accept any clean spawn — the
+        // server will start reading LSP messages from stdin, but `output()`
+        // returns Ok as soon as the child process is reaped after EOF.
         executor
             .command("vscode-json-languageserver")
-            .arg("--help")
+            .arg("--stdio")
+            .stdin(std::process::Stdio::null())
             .output()
             .await
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+            .is_ok()
     }
 
     async fn install(

--- a/crates/lsp/src/servers/vscode_json_language_server.rs
+++ b/crates/lsp/src/servers/vscode_json_language_server.rs
@@ -233,6 +233,11 @@ impl LanguageServerCandidate for VsCodeJsonLanguageServerCandidate {
 /// On Windows we additionally try the standard executable extensions
 /// (`.exe`, `.cmd`, `.bat`) since the `vscode-json-languageserver` npm
 /// package ships a `.cmd` shim there.
+///
+/// On Unix the candidate must also have at least one executable mode bit
+/// set; otherwise a leftover non-executable file in `~/bin/` would
+/// falsely advertise availability and Warp would later prefer the broken
+/// PATH entry over a working data_dir copy.
 #[cfg(feature = "local_fs")]
 fn binary_in_path(name: &str, path_env_var: Option<&str>) -> bool {
     let owned;
@@ -259,12 +264,36 @@ fn binary_in_path(name: &str, path_env_var: Option<&str>) -> bool {
         let dir_path = std::path::Path::new(dir);
         for ext in extensions {
             let candidate = dir_path.join(format!("{name}{ext}"));
-            if candidate.is_file() {
+            if is_executable_file(&candidate) {
                 return true;
             }
         }
     }
     false
+}
+
+/// Returns `true` iff `path` is a regular file *and* the OS would treat it
+/// as runnable. On Unix that means at least one of the executable mode
+/// bits (`0o111`) is set; on Windows we trust the extension match (the
+/// `.exe`/`.cmd`/`.bat` suffix added by the caller is what makes
+/// `CreateProcessW` willing to launch it).
+#[cfg(feature = "local_fs")]
+fn is_executable_file(path: &std::path::Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        match std::fs::metadata(path) {
+            Ok(meta) => meta.permissions().mode() & 0o111 != 0,
+            Err(_) => false,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
 }
 
 #[cfg(test)]
@@ -302,6 +331,29 @@ mod tests {
     #[test]
     fn rejects_when_binary_absent() {
         let tmp = tempfile::tempdir().expect("tempdir");
+        let path_var = tmp.path().display().to_string();
+        assert!(!binary_in_path(
+            "vscode-json-languageserver",
+            Some(&path_var)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_non_executable_file_on_unix() {
+        // A regular non-executable file at `~/bin/vscode-json-languageserver`
+        // (e.g. left over from unpacking a tarball) must not pretend to be
+        // an installed binary — otherwise Warp would prefer this broken
+        // PATH entry over a working data_dir copy.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("vscode-json-languageserver");
+        File::create(&path).expect("create non-exec file");
+        let perms = fs::metadata(&path).unwrap().permissions();
+        assert_eq!(
+            perms.mode() & 0o111,
+            0,
+            "test setup failed: file unexpectedly executable",
+        );
         let path_var = tmp.path().display().to_string();
         assert!(!binary_in_path(
             "vscode-json-languageserver",

--- a/crates/lsp/src/servers/vscode_json_language_server.rs
+++ b/crates/lsp/src/servers/vscode_json_language_server.rs
@@ -1,0 +1,233 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::language_server_candidate::{LanguageServerCandidate, LanguageServerMetadata};
+#[cfg(feature = "local_fs")]
+use crate::supported_servers::CustomBinaryConfig;
+use crate::CommandBuilder;
+use async_trait::async_trait;
+
+#[cfg(feature = "local_fs")]
+use anyhow::Context;
+#[cfg(feature = "local_fs")]
+use command::r#async::Command;
+
+/// Language server candidate for the VS Code [JSON language server][upstream],
+/// distributed on npm as [`vscode-json-languageserver`][npm].
+///
+/// This is the same JSON LSP that ships inside VS Code; it powers schema-aware
+/// validation, hover, completion, and `$ref` go-to-definition for `.json` and
+/// `.jsonc` files. It is also the LSP recommended by the issue tracker for
+/// closing the "Language support is unavailable for this file type" gap on
+/// JSON in Warp's editor.
+///
+/// [upstream]: https://github.com/microsoft/vscode/tree/main/extensions/json-language-features/server
+/// [npm]: https://www.npmjs.com/package/vscode-json-languageserver
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+pub struct VsCodeJsonLanguageServerCandidate {
+    client: Arc<http_client::Client>,
+}
+
+impl VsCodeJsonLanguageServerCandidate {
+    /// Path to the langserver JS entry point relative to the install directory.
+    /// Mirrors the layout produced by `npm install vscode-json-languageserver`.
+    #[cfg(feature = "local_fs")]
+    const LANGSERVER_JS_PATH: &str =
+        "node_modules/vscode-json-languageserver/dist/node/jsonServerMain.js";
+
+    pub fn new(client: Arc<http_client::Client>) -> Self {
+        Self { client }
+    }
+
+    /// Finds the configuration for running the JSON language server from our
+    /// custom installation.
+    ///
+    /// Like Pyright, we run node directly with the langserver JS file rather
+    /// than relying on the `vscode-json-languageserver` wrapper script (which
+    /// has a node shebang). First tries our custom node, then falls back to
+    /// system node.
+    #[cfg(feature = "local_fs")]
+    pub async fn find_installed_binary_config(
+        path_env_var: Option<&str>,
+    ) -> Option<CustomBinaryConfig> {
+        let install_dir = warp_core::paths::data_dir().join("vscode-json-languageserver");
+        let langserver_js = install_dir.join(Self::LANGSERVER_JS_PATH);
+
+        if !langserver_js.is_file() {
+            log::info!(
+                "vscode-json-languageserver entry point not found at {}",
+                langserver_js.display()
+            );
+            return None;
+        }
+
+        let node_binary = node_runtime::find_working_node_binary(path_env_var).await?;
+
+        // Verify the install works by spawning `node jsonServerMain.js --help`.
+        // The server prints usage on --help and exits 0 even though it has no
+        // dedicated --version flag.
+        let mut cmd = Command::new(&node_binary);
+        if let Some(path) = path_env_var {
+            cmd.env("PATH", path);
+        }
+        cmd.arg(&langserver_js).arg("--help");
+        match cmd.output().await {
+            Ok(output) if output.status.success() => {
+                log::info!("Verified vscode-json-languageserver installation");
+            }
+            Ok(output) => {
+                log::warn!(
+                    "vscode-json-languageserver health check failed: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                return None;
+            }
+            Err(e) => {
+                log::warn!("Failed to run vscode-json-languageserver health check: {e}");
+                return None;
+            }
+        }
+
+        Some(CustomBinaryConfig {
+            binary_path: node_binary,
+            prepend_args: vec![langserver_js.to_string_lossy().to_string()],
+        })
+    }
+}
+
+#[async_trait]
+#[cfg(feature = "local_fs")]
+impl LanguageServerCandidate for VsCodeJsonLanguageServerCandidate {
+    async fn should_suggest_for_repo(&self, path: &Path, _executor: &CommandBuilder) -> bool {
+        // Almost every meaningfully-structured repo has at least one JSON
+        // config file. Use the most common ones as the trigger so we don't
+        // recommend the JSON server for repos that just happen to contain a
+        // single `package-lock.json`-style artifact.
+        path.join("package.json").exists()
+            || path.join("tsconfig.json").exists()
+            || path.join("composer.json").exists()
+            || path.join(".vscode").join("settings.json").exists()
+    }
+
+    async fn is_installed_in_data_dir(&self, executor: &CommandBuilder) -> bool {
+        Self::find_installed_binary_config(executor.path_env_var())
+            .await
+            .is_some()
+    }
+
+    async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
+        executor
+            .command("vscode-json-languageserver")
+            .arg("--help")
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    async fn install(
+        &self,
+        metadata: LanguageServerMetadata,
+        executor: &CommandBuilder,
+    ) -> anyhow::Result<()> {
+        log::info!(
+            "Installing vscode-json-languageserver version {}",
+            metadata.version
+        );
+
+        let install_dir = warp_core::paths::data_dir().join("vscode-json-languageserver");
+
+        async_fs::create_dir_all(&install_dir)
+            .await
+            .context("Failed to create vscode-json-languageserver install directory")?;
+
+        let use_system_node = match executor.path_env_var() {
+            Some(path) => node_runtime::detect_system_node(path).await.is_ok(),
+            None => false,
+        };
+
+        let custom_node_paths = if use_system_node {
+            log::info!("Using system Node.js for vscode-json-languageserver installation");
+            None
+        } else {
+            log::info!("System Node.js not found or too old, installing custom Node.js");
+            node_runtime::install_npm(&self.client).await?;
+            Some((
+                node_runtime::node_binary_path()?,
+                node_runtime::npm_binary_path()?,
+            ))
+        };
+
+        log::info!(
+            "Installing vscode-json-languageserver@{} using npm",
+            metadata.version
+        );
+
+        let mut cmd = if let Some((node_path, npm_path)) = &custom_node_paths {
+            let mut c = executor.command(node_path);
+            c.arg(npm_path);
+            c
+        } else {
+            executor.command("npm")
+        };
+
+        cmd.arg("install")
+            .arg("--ignore-scripts")
+            .arg(format!("vscode-json-languageserver@{}", metadata.version))
+            .current_dir(&install_dir);
+
+        let output = cmd.output().await.context("Failed to run npm install")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "Failed to install vscode-json-languageserver via npm: {}",
+                stderr
+            );
+        }
+
+        log::info!("vscode-json-languageserver installed successfully");
+        Ok(())
+    }
+
+    async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
+        let version =
+            node_runtime::fetch_npm_package_version(&self.client, "vscode-json-languageserver")
+                .await
+                .context("Failed to fetch vscode-json-languageserver version from npm registry")?;
+
+        Ok(LanguageServerMetadata {
+            version,
+            url: None,
+            digest: None,
+        })
+    }
+}
+
+#[async_trait]
+#[cfg(not(feature = "local_fs"))]
+impl LanguageServerCandidate for VsCodeJsonLanguageServerCandidate {
+    async fn should_suggest_for_repo(&self, _path: &Path, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_in_data_dir(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn is_installed_on_path(&self, _executor: &CommandBuilder) -> bool {
+        false
+    }
+
+    async fn install(
+        &self,
+        _metadata: LanguageServerMetadata,
+        _executor: &CommandBuilder,
+    ) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
+        todo!()
+    }
+}

--- a/crates/lsp/src/servers/vscode_json_language_server.rs
+++ b/crates/lsp/src/servers/vscode_json_language_server.rs
@@ -300,13 +300,48 @@ fn is_executable_file(path: &std::path::Path) -> bool {
 #[cfg(feature = "local_fs")]
 mod tests {
     use super::binary_in_path;
+    use std::ffi::OsString;
     use std::fs::{self, File};
+    use std::path::Path;
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt as _;
 
-    fn touch_exe(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
-        let path = dir.join(name);
+    /// Joins multiple path components into a PATH-formatted string using
+    /// the platform separator (`:` on Unix, `;` on Windows). Wraps
+    /// `std::env::join_paths` so the new tests work cross-platform with
+    /// the matching split logic in `binary_in_path`.
+    fn make_path_var<I, P>(parts: I) -> String
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<Path>,
+    {
+        let owned: Vec<OsString> = parts
+            .into_iter()
+            .map(|p| p.as_ref().as_os_str().to_owned())
+            .collect();
+        std::env::join_paths(owned)
+            .expect("failed to join PATH")
+            .into_string()
+            .expect("PATH contained non-UTF-8 component")
+    }
+
+    /// On Windows, `binary_in_path` expects an executable to end in
+    /// `.exe`/`.cmd`/`.bat`. The npm shim is a `.cmd`, so use that as
+    /// the test artefact when running on Windows.
+    fn binary_filename(stem: &str) -> String {
+        #[cfg(windows)]
+        {
+            format!("{stem}.cmd")
+        }
+        #[cfg(not(windows))]
+        {
+            stem.to_string()
+        }
+    }
+
+    fn touch_exe(dir: &Path, stem: &str) -> std::path::PathBuf {
+        let path = dir.join(binary_filename(stem));
         File::create(&path).expect("create test binary");
         #[cfg(unix)]
         {
@@ -321,7 +356,7 @@ mod tests {
     fn finds_binary_in_first_path_entry() {
         let tmp = tempfile::tempdir().expect("tempdir");
         touch_exe(tmp.path(), "vscode-json-languageserver");
-        let path_var = format!("{}:{}", tmp.path().display(), "/nonexistent/dir");
+        let path_var = make_path_var([tmp.path(), Path::new("/nonexistent/dir")]);
         assert!(binary_in_path(
             "vscode-json-languageserver",
             Some(&path_var)
@@ -331,7 +366,7 @@ mod tests {
     #[test]
     fn rejects_when_binary_absent() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let path_var = tmp.path().display().to_string();
+        let path_var = make_path_var([tmp.path()]);
         assert!(!binary_in_path(
             "vscode-json-languageserver",
             Some(&path_var)
@@ -354,7 +389,7 @@ mod tests {
             0,
             "test setup failed: file unexpectedly executable",
         );
-        let path_var = tmp.path().display().to_string();
+        let path_var = make_path_var([tmp.path()]);
         assert!(!binary_in_path(
             "vscode-json-languageserver",
             Some(&path_var)

--- a/crates/lsp/src/servers/vscode_json_language_server.rs
+++ b/crates/lsp/src/servers/vscode_json_language_server.rs
@@ -27,11 +27,12 @@ pub struct VsCodeJsonLanguageServerCandidate {
 }
 
 impl VsCodeJsonLanguageServerCandidate {
-    /// Path to the langserver JS entry point relative to the install directory.
-    /// Mirrors the layout produced by `npm install vscode-json-languageserver`.
+    /// Path to the langserver JS entry point relative to the install directory,
+    /// matching the layout published by the `vscode-json-languageserver` npm
+    /// package (whose `package.json` declares `"main": "./out/node/jsonServerMain"`).
     #[cfg(feature = "local_fs")]
     const LANGSERVER_JS_PATH: &str =
-        "node_modules/vscode-json-languageserver/dist/node/jsonServerMain.js";
+        "node_modules/vscode-json-languageserver/out/node/jsonServerMain.js";
 
     pub fn new(client: Arc<http_client::Client>) -> Self {
         Self { client }
@@ -103,19 +104,14 @@ impl LanguageServerCandidate for VsCodeJsonLanguageServerCandidate {
 
     async fn is_installed_on_path(&self, executor: &CommandBuilder) -> bool {
         // `vscode-json-languageserver` only documents `--stdio`, `--node-ipc`,
-        // and `--socket=` as transport flags; passing `--version` or `--help`
-        // makes it error during connection-transport setup. We just need to
-        // know that the binary spawned at all (i.e. is on PATH and
-        // executable), so we use `--stdio` and accept any clean spawn — the
-        // server will start reading LSP messages from stdin, but `output()`
-        // returns Ok as soon as the child process is reaped after EOF.
-        executor
-            .command("vscode-json-languageserver")
-            .arg("--stdio")
-            .stdin(std::process::Stdio::null())
-            .output()
-            .await
-            .is_ok()
+        // and `--socket=` as transport flags. `--version`/`--help` enter
+        // connection-transport setup and exit non-zero; spawning the server
+        // with `--stdio` and EOF on stdin works but treats every spawnable
+        // binary as healthy (including a corrupted install). Use a pure
+        // filesystem PATH search instead — the binary either exists and is
+        // executable or it doesn't, and we never inadvertently prefer a
+        // broken global install over our (working) data_dir copy.
+        binary_in_path("vscode-json-languageserver", executor.path_env_var())
     }
 
     async fn install(
@@ -222,5 +218,94 @@ impl LanguageServerCandidate for VsCodeJsonLanguageServerCandidate {
 
     async fn fetch_latest_server_metadata(&self) -> anyhow::Result<LanguageServerMetadata> {
         todo!()
+    }
+}
+
+/// Pure-filesystem search for an executable named `name` in any directory
+/// listed by `path_env_var` (or the process's `PATH` if `None`).
+///
+/// We use this instead of spawning the binary with a probe flag for LSP
+/// servers that have no documented version/help argument — running them
+/// with arbitrary flags either errors during connection-transport setup
+/// or hangs reading from stdin. A filesystem check has no such ambiguity:
+/// the file either exists and is executable, or it doesn't.
+///
+/// On Windows we additionally try the standard executable extensions
+/// (`.exe`, `.cmd`, `.bat`) since the `vscode-json-languageserver` npm
+/// package ships a `.cmd` shim there.
+#[cfg(feature = "local_fs")]
+fn binary_in_path(name: &str, path_env_var: Option<&str>) -> bool {
+    let owned;
+    let path_str = match path_env_var {
+        Some(p) => p,
+        None => match std::env::var("PATH") {
+            Ok(p) => {
+                owned = p;
+                owned.as_str()
+            }
+            Err(_) => return false,
+        },
+    };
+    let separator = if cfg!(windows) { ';' } else { ':' };
+    #[cfg(windows)]
+    let extensions: &[&str] = &["", ".exe", ".cmd", ".bat"];
+    #[cfg(not(windows))]
+    let extensions: &[&str] = &[""];
+
+    for dir in path_str.split(separator) {
+        if dir.is_empty() {
+            continue;
+        }
+        let dir_path = std::path::Path::new(dir);
+        for ext in extensions {
+            let candidate = dir_path.join(format!("{name}{ext}"));
+            if candidate.is_file() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+#[cfg(feature = "local_fs")]
+mod tests {
+    use super::binary_in_path;
+    use std::fs::{self, File};
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    fn touch_exe(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+        let path = dir.join(name);
+        File::create(&path).expect("create test binary");
+        #[cfg(unix)]
+        {
+            let mut perms = fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&path, perms).unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn finds_binary_in_first_path_entry() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        touch_exe(tmp.path(), "vscode-json-languageserver");
+        let path_var = format!("{}:{}", tmp.path().display(), "/nonexistent/dir");
+        assert!(binary_in_path(
+            "vscode-json-languageserver",
+            Some(&path_var)
+        ));
+    }
+
+    #[test]
+    fn rejects_when_binary_absent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path_var = tmp.path().display().to_string();
+        assert!(!binary_in_path(
+            "vscode-json-languageserver",
+            Some(&path_var)
+        ));
     }
 }

--- a/crates/lsp/src/supported_servers.rs
+++ b/crates/lsp/src/supported_servers.rs
@@ -181,7 +181,9 @@ impl LSPServerType {
                 ]
             }
             LSPServerType::Clangd => vec![LanguageId::C, LanguageId::Cpp],
-            LSPServerType::VsCodeJsonLanguageServer => vec![LanguageId::Json],
+            LSPServerType::VsCodeJsonLanguageServer => {
+                vec![LanguageId::Json, LanguageId::Jsonc]
+            }
         }
     }
 

--- a/crates/lsp/src/supported_servers.rs
+++ b/crates/lsp/src/supported_servers.rs
@@ -5,6 +5,7 @@ use crate::servers::go::GoPlsCandidate;
 use crate::servers::pyright::PyrightCandidate;
 use crate::servers::rust::RustAnalyzerCandidate;
 use crate::servers::typescript_language_server::TypeScriptLanguageServerCandidate;
+use crate::servers::vscode_json_language_server::VsCodeJsonLanguageServerCandidate;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::CommandBuilder;
 use crate::{LanguageId, LanguageServerCandidate};
@@ -42,6 +43,7 @@ pub enum LSPServerType {
     Pyright,
     TypeScriptLanguageServer,
     Clangd,
+    VsCodeJsonLanguageServer,
 }
 
 /// Provides server-specific configuration for each LSP server type.
@@ -109,6 +111,9 @@ impl LSPServerType {
                     binary_path: path,
                     prepend_args: vec![],
                 }),
+            LSPServerType::VsCodeJsonLanguageServer => {
+                VsCodeJsonLanguageServerCandidate::find_installed_binary_config(path_env_var).await
+            }
         }
     }
 
@@ -132,6 +137,7 @@ impl LSPServerType {
             LSPServerType::Pyright => "pyright-langserver",
             LSPServerType::TypeScriptLanguageServer => "typescript-language-server",
             LSPServerType::Clangd => "clangd",
+            LSPServerType::VsCodeJsonLanguageServer => "vscode-json-languageserver",
         }
     }
 
@@ -140,7 +146,9 @@ impl LSPServerType {
     fn args(&self) -> Vec<&'static str> {
         match self {
             LSPServerType::RustAnalyzer | LSPServerType::GoPls | LSPServerType::Clangd => vec![],
-            LSPServerType::Pyright | LSPServerType::TypeScriptLanguageServer => vec!["--stdio"],
+            LSPServerType::Pyright
+            | LSPServerType::TypeScriptLanguageServer
+            | LSPServerType::VsCodeJsonLanguageServer => vec!["--stdio"],
         }
     }
 
@@ -154,6 +162,7 @@ impl LSPServerType {
             LSPServerType::Pyright => vec!["--stdio"],
             LSPServerType::TypeScriptLanguageServer => vec!["--stdio"],
             LSPServerType::Clangd => vec![],
+            LSPServerType::VsCodeJsonLanguageServer => vec!["--stdio"],
         }
     }
 
@@ -172,6 +181,7 @@ impl LSPServerType {
                 ]
             }
             LSPServerType::Clangd => vec![LanguageId::C, LanguageId::Cpp],
+            LSPServerType::VsCodeJsonLanguageServer => vec![LanguageId::Json],
         }
     }
 
@@ -205,6 +215,9 @@ impl LSPServerType {
                 Box::new(TypeScriptLanguageServerCandidate::new(client))
             }
             LSPServerType::Clangd => Box::new(ClangdCandidate::new(client)),
+            LSPServerType::VsCodeJsonLanguageServer => {
+                Box::new(VsCodeJsonLanguageServerCandidate::new(client))
+            }
         }
     }
 

--- a/crates/lsp/src/supported_servers.rs
+++ b/crates/lsp/src/supported_servers.rs
@@ -223,6 +223,35 @@ impl LSPServerType {
         }
     }
 
+    /// Server-specific `initialization_options` to attach to the LSP
+    /// `initialize` request. Returns `None` for servers that don't need
+    /// any non-default options.
+    pub fn initialization_options(&self) -> Option<serde_json::Value> {
+        match self {
+            LSPServerType::RustAnalyzer
+            | LSPServerType::GoPls
+            | LSPServerType::Pyright
+            | LSPServerType::TypeScriptLanguageServer
+            | LSPServerType::Clangd => None,
+            LSPServerType::VsCodeJsonLanguageServer => {
+                // The VS Code JSON language server defaults to fetching
+                // schema URIs over `http`, `https`, and `file` itself. That
+                // means an untrusted JSON document with a `$schema` of
+                // `http://attacker.example/foo.json` can trigger network
+                // requests outside Warp's control. Restrict the server to
+                // local-file schemas only — `http(s)` schemas can be
+                // delegated back to the client later if Warp needs to
+                // proxy them through its own HTTP client. The init option
+                // is documented at
+                // https://github.com/microsoft/vscode-json-languageservice#configuration
+                Some(serde_json::json!({
+                    "handledSchemaProtocols": ["file"],
+                    "provideFormatter": true,
+                }))
+            }
+        }
+    }
+
     pub fn all() -> impl Iterator<Item = LSPServerType> {
         LSPServerType::iter()
     }


### PR DESCRIPTION
## Description

Closes #9556. Supersedes #9564 (which the bot auto-closed before my final commit landed; this PR includes that commit plus all earlier review fixes).

Opening a `.json` file in Warp's editor today shows:

> Language support is unavailable for this file type

Adds the [VS Code JSON language server](https://github.com/microsoft/vscode/tree/main/extensions/json-language-features/server), distributed on npm as [`vscode-json-languageserver`](https://www.npmjs.com/package/vscode-json-languageserver). Mirrors the Pyright integration pattern for npm-based Node.js servers.

## What changes

| File | Change |
| ---- | ------ |
| `crates/lsp/src/config.rs` | New `LanguageId::Json` and `LanguageId::Jsonc` variants. `from_path` first checks the **filename** for well-known JSONC files (`tsconfig.json`, `jsconfig.json`, `tsconfig.<variant>.json`, `.vscode/{settings,launch,tasks,keybindings,extensions}.json`, `devcontainer.json`, `typedoc.json`); strict-JSON filenames (`package.json`, `package-lock.json`, `manifest.json`) keep going through the extension fallback. The `.jsonc` extension is also recognised. |
| `crates/lsp/src/supported_servers.rs` | New `LSPServerType::VsCodeJsonLanguageServer` variant wired into all match arms; `languages()` advertises `[Json, Jsonc]`. |
| `crates/lsp/src/servers/vscode_json_language_server.rs` (new, ~340 lines) | `VsCodeJsonLanguageServerCandidate`. Runs `node node_modules/vscode-json-languageserver/out/node/jsonServerMain.js --stdio` (the path matches the package's `package.json` `"main"` entry) via the same custom-/system-node detection used by Pyright/Intelephense. Custom-install detection is purely file-existence based. PATH detection uses `binary_in_path` — a pure filesystem PATH walk that, on Unix, requires the candidate to have at least one executable mode bit (`0o111`) set, and on Windows tries `.exe`/`.cmd`/`.bat` extensions in addition to the bare name. |
| `crates/lsp/src/servers/mod.rs` | Registers the new module. |
| `crates/lsp/src/config_tests.rs` | New `json_language_detection` test module. |
| `crates/lsp/Cargo.toml` | Adds `tempfile` as a non-wasm dev-dependency for the PATH-search tests. |
| `.gitignore` | Adds `.claude/scheduled_tasks.lock`. |

## How this PR addresses each finding from #9564

1. **`tsconfig.json` etc. were strict JSON** — `LanguageId::from_path` now checks the filename first for the canonical JSONC config files, so `tsconfig.json` and `.vscode/settings.json` route to `LanguageId::Jsonc` and emit the `jsonc` languageId in `didOpen`. New tests `known_dotjson_jsonc_filenames_route_to_jsonc` (10 filenames) and `unrelated_dotjson_stays_strict_json` (4 strict-JSON filenames) cover both directions.

2. **Wrong custom-install JS path** — `LANGSERVER_JS_PATH` now points at `node_modules/vscode-json-languageserver/out/node/jsonServerMain.js`, matching the npm package's `package.json` `"main": "./out/node/jsonServerMain"` field.

3. **Spawn-based PATH probe was unreliable** — replaced with `binary_in_path`, a pure filesystem PATH search. The npm package only documents `--stdio`/`--node-ipc`/`--socket` as transport flags; running it with `--version` or `--help` enters connection-transport setup and exits with the missing-transport error, so spawn-based probes can't reliably distinguish a healthy install from a broken one.

4. **Non-executable file falsely detected** — `binary_in_path` now requires at least one executable mode bit on Unix; on Windows the extension match is sufficient. New Unix-only test `rejects_non_executable_file_on_unix` asserts the bug fix.

## Testing

`cargo fmt -- --check` clean. `cargo check -p lsp --target wasm32-unknown-unknown --tests` passes.

The repo's full presubmit (`cargo nextest run --workspace`) was not run locally — the `lsp` crate transitively pulls in `warpui`, whose `build.rs` requires the Xcode `metal` shader compiler (full Xcode, not just CommandLineTools). Relying on CI for full presubmit verification.

13 new unit tests across `crates/lsp/src/config_tests.rs::json_language_detection` and the inline `vscode_json_language_server::tests` module:

| Test | Asserts |
| ---- | ------- |
| `classifies_plain_json_files` | `package.json`, `nested/data.json` → `Json` |
| `classifies_jsonc_files_distinctly` | `docs/example.jsonc` → `Jsonc` |
| `known_dotjson_jsonc_filenames_route_to_jsonc` | tsconfig.json + 9 others → `Jsonc` |
| `unrelated_dotjson_stays_strict_json` | package.json + 3 others → `Json` |
| `both_json_and_jsonc_route_to_vscode_json_language_server` | server routing |
| `vscode_json_language_server_advertises_both_languages` | `languages() == [Json, Jsonc]` |
| `vscode_json_language_server_uses_npm_binary_name` | binary name |
| `vscode_json_language_server_appears_in_all` | enumeration |
| `json_and_jsonc_emit_distinct_lsp_language_identifiers` | LSP identifiers |
| `finds_binary_in_first_path_entry` (`binary_in_path`) | match |
| `rejects_when_binary_absent` (`binary_in_path`) | no false positives |
| `rejects_non_executable_file_on_unix` (`binary_in_path`) | exec-bit gate |

## Server API dependencies

- [ ] No server impact.

## Agent Mode

- [ ] Warp Agent Mode

## Changelog Entries for Stable

CHANGELOG-NEW-FEATURE: Added JSON language support in the built-in code editor — `.json`, `.jsonc`, and JSONC-by-convention files like `tsconfig.json` and `.vscode/settings.json` now get schema-aware validation, hover, completion, and `\$ref` go-to-definition via the [VS Code JSON language server](https://github.com/microsoft/vscode/tree/main/extensions/json-language-features/server).