### PR TITLE
fix: run tab config commands from configured directory

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -59,7 +59,7 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::{mpsc::SyncSender, Arc};
 
@@ -115,7 +115,7 @@ use crate::code::view::CodeView;
 use crate::drive::items::WarpDriveItemId;
 use crate::drive::{CloudObjectTypeAndId, OpenWarpDriveObjectArgs};
 use crate::features::FeatureFlag;
-use crate::launch_configs::launch_config::{self, PaneMode, PaneTemplateType};
+use crate::launch_configs::launch_config::{self, CommandTemplate, PaneMode, PaneTemplateType};
 use crate::persistence::ModelEvent;
 use crate::report_if_error;
 use crate::resource_center::{
@@ -1240,6 +1240,28 @@ impl PaneGroup {
         }
     }
 
+    fn startup_directory_for_template_cwd(cwd: &Path) -> Option<PathBuf> {
+        if cwd.as_os_str().is_empty() || !cwd.exists() {
+            return None;
+        }
+
+        dunce::canonicalize(cwd).ok()
+    }
+
+    fn pending_command_for_template_commands(
+        cwd: Option<&Path>,
+        commands: &[CommandTemplate],
+    ) -> String {
+        let command = commands.iter().map(|cmd| &cmd.exec).join(" && ");
+
+        let Some(cwd) = cwd else {
+            return command;
+        };
+        let cwd = cwd.display().to_string();
+        let cwd = shell_words::quote(&cwd);
+        format!("cd {cwd} && {command}")
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn pane_tree_from_template(
         root: PaneTemplateType,
@@ -1307,6 +1329,7 @@ impl PaneGroup {
                     None
                 };
 
+                let startup_directory = Self::startup_directory_for_template_cwd(&cwd);
                 let (view, terminal_manager) = match pane_mode {
                     PaneMode::Cloud => {
                         Self::create_ambient_agent_terminal(resources, view_size, ctx)
@@ -1314,7 +1337,7 @@ impl PaneGroup {
                     PaneMode::Terminal | PaneMode::Agent => PaneGroup::create_session(
                         // Use cwd from the template iff such path exists, otherwise None
                         // TODO(CORE-3187): On Windows, support WSL directory restoration.
-                        Some(cwd).filter(|p| p.exists()),
+                        startup_directory.clone(),
                         HashMap::new(),
                         IsSharedSessionCreator::No,
                         resources,
@@ -1331,7 +1354,10 @@ impl PaneGroup {
 
                 // Runs saved commands on start (terminal and agent modes only).
                 if !commands.is_empty() && !matches!(pane_mode, PaneMode::Cloud) {
-                    let exec = commands.iter().map(|cmd| &cmd.exec).join(" && ");
+                    let exec = Self::pending_command_for_template_commands(
+                        startup_directory.as_deref(),
+                        &commands,
+                    );
                     view.update(ctx, |terminal, ctx| {
                         terminal.set_pending_command(exec.as_str(), ctx);
                     });

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -74,6 +74,7 @@ use crate::{
 use repo_metadata::RepoMetadataModel;
 use repo_metadata::{repositories::DetectedRepositories, watcher::DirectoryWatcher};
 use std::collections::HashMap;
+use std::path::Path;
 use uuid::Uuid;
 use warp_core::features::FeatureFlag;
 use watcher::HomeDirectoryWatcher;
@@ -92,6 +93,52 @@ use warpui::{
     platform::{WindowBounds, WindowStyle},
     App, ModelHandle,
 };
+
+#[test]
+fn test_tab_config_pending_command_changes_to_template_cwd_first() {
+    let commands = vec![CommandTemplate {
+        exec: "pwd".to_string(),
+    }];
+
+    assert_eq!(
+        PaneGroup::pending_command_for_template_commands(
+            Some(Path::new("/Users/me/projects/website")),
+            &commands
+        ),
+        "cd /Users/me/projects/website && pwd"
+    );
+}
+
+#[test]
+fn test_tab_config_pending_command_uses_resolved_template_cwd() {
+    let commands = vec![CommandTemplate {
+        exec: "pwd".to_string(),
+    }];
+    let cwd = PaneGroup::startup_directory_for_template_cwd(Path::new("."));
+    let cwd = cwd.expect("current directory should exist");
+    let cwd_display = cwd.display().to_string();
+    let quoted_cwd = shell_words::quote(&cwd_display);
+
+    assert!(cwd.is_absolute());
+    assert_eq!(
+        PaneGroup::pending_command_for_template_commands(Some(cwd.as_path()), &commands),
+        format!("cd {quoted_cwd} && pwd")
+    );
+}
+
+#[test]
+fn test_tab_config_pending_command_skips_missing_template_cwd() {
+    let commands = vec![CommandTemplate {
+        exec: "pwd".to_string(),
+    }];
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let cwd = PaneGroup::startup_directory_for_template_cwd(&temp_dir.path().join("missing"));
+
+    assert_eq!(
+        PaneGroup::pending_command_for_template_commands(cwd.as_deref(), &commands),
+        "pwd"
+    );
+}
 
 fn initialize_app(app: &mut App) {
     initialize_settings_for_tests(app);


### PR DESCRIPTION
Closes #9130.

## Summary
- Prefix tab config startup commands with `cd <directory>` when the pane declares a `directory`.
- Shell-quote the rendered directory path before composing the startup command.
- Add a regression test for command composition so tab config commands run from the configured directory.

## Root Cause
Tab configs passed the pane `directory` as the terminal startup directory, then separately injected `commands` through the pending-command path. If the shell was not in that startup directory by the time the pending command executed, the command ran from the default directory. Composing the pending command with an explicit `cd` makes the execution order deterministic.

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p warp pane_group::tests::test_tab_config_pending_command_changes_to_template_cwd_first`
- `cargo test -p warp tab_configs::`

## Server API dependencies
No server API dependencies.

## Agent Mode
- [ ] Warp Agent Mode
