### PR TITLE
fix(bootstrap): add Node.js/yarn prerequisite checks to bootstrap scripts

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -36,6 +36,10 @@ Environment variables:
 - `./script/run-clang-format.py -r --extensions 'c,h,cpp,m' ./crates/warpui/src/ ./app/src/` - Format C/C++/Obj-C code
 - `find . -name "*.wgsl" -exec wgslfmt --check {} +` - Check WGSL shader formatting
 
+### Prerequisites
+- **Node.js 18.14.1+** — Required by the `command-signatures-v2` crate, which compiles a TypeScript helper at build time using yarn.
+- **yarn** — Required by the `command-signatures-v2` build script. Enable via `corepack enable` after installing Node.js.
+
 ### Platform Setup
 - `./script/bootstrap` - Platform-specific setup (calls platform-specific bootstrap scripts)
 - `./script/install_cargo_build_deps` - Install Cargo build dependencies

--- a/script/linux/install_build_deps
+++ b/script/linux/install_build_deps
@@ -53,6 +53,38 @@ else
   echo -e "⚠️  ${red}Unknown Linux distribution; necessary build dependencies may not be installed!${reset}"
 fi
 
+# Check for Node.js (required by command-signatures-v2 crate).
+# The build.rs in that crate compiles a TypeScript helper using yarn,
+# which requires Node.js 18.14.1+ and yarn (typically via corepack).
+REQUIRED_NODE_VERSION="18.14.1"
+if ! command -v node &>/dev/null; then
+  echo -e "${red}Error: Node.js is not installed.${reset}"
+  echo "Node.js $REQUIRED_NODE_VERSION+ is required to build the command-signatures-v2 crate."
+  echo "Install it via your system package manager, nvm, fnm, or volta:"
+  echo "  https://nodejs.org/en/download"
+  exit 1
+fi
+
+NODE_VERSION="$(node --version | sed 's/^v//')"
+if [[ "$(printf '%s\n' "$REQUIRED_NODE_VERSION" "$NODE_VERSION" | sort -V | head -n1)" != "$REQUIRED_NODE_VERSION" ]]; then
+  echo -e "${red}Error: Node.js $NODE_VERSION is too old.${reset}"
+  echo "Node.js $REQUIRED_NODE_VERSION+ is required. Current version: $NODE_VERSION"
+  echo "Upgrade via your system package manager, nvm, fnm, or volta."
+  exit 1
+fi
+
+# Check for yarn (required by command-signatures-v2 crate).
+# yarn is typically enabled via `corepack enable` after installing Node.js.
+if ! command -v yarn &>/dev/null; then
+  echo -e "${red}Error: yarn is not installed.${reset}"
+  echo "yarn is required to build the command-signatures-v2 crate."
+  echo "Enable it via corepack (ships with Node.js):"
+  echo "  corepack enable"
+  exit 1
+fi
+
+echo "✅ Node.js $(node --version) and yarn $(yarn --version) detected."
+
 # Install Rust.
 "$PWD"/script/install_rust
 

--- a/script/linux/install_build_deps
+++ b/script/linux/install_build_deps
@@ -74,11 +74,25 @@ if [[ "$(printf '%s\n' "$REQUIRED_NODE_VERSION" "$NODE_VERSION" | sort -V | head
 fi
 
 # Check for yarn (required by command-signatures-v2 crate).
+# The crate uses Yarn 4 via Corepack, not Yarn 1 from Homebrew.
 # yarn is typically enabled via `corepack enable` after installing Node.js.
 if ! command -v yarn &>/dev/null; then
   echo -e "${red}Error: yarn is not installed.${reset}"
   echo "yarn is required to build the command-signatures-v2 crate."
   echo "Enable it via corepack (ships with Node.js):"
+  echo "  corepack enable"
+  exit 1
+fi
+
+# Verify yarn version is 4.x (Corepack-managed), not 1.x (Homebrew).
+YARN_VERSION="$(yarn --version 2>/dev/null)"
+YARN_MAJOR="$(echo "$YARN_VERSION" | cut -d. -f1)"
+if [ "$YARN_MAJOR" -lt 4 ] 2>/dev/null; then
+  echo -e "${red}Error: yarn $YARN_VERSION detected, but Yarn 4+ is required.${reset}"
+  echo "The command-signatures-v2 crate requires Yarn 4 via Corepack."
+  echo "If you have yarn installed via Homebrew, remove it first:"
+  echo "  brew uninstall yarn"
+  echo "Then enable Corepack:"
   echo "  corepack enable"
   exit 1
 fi

--- a/script/linux/install_build_deps
+++ b/script/linux/install_build_deps
@@ -85,7 +85,7 @@ if ! command -v yarn &>/dev/null; then
 fi
 
 # Verify yarn version is 4.x (Corepack-managed), not 1.x (Homebrew).
-YARN_VERSION="$(yarn --version 2>/dev/null)"
+YARN_VERSION="$(cd "$PWD"/crates/command-signatures-v2/js && yarn --version 2>/dev/null)"
 YARN_MAJOR="$(echo "$YARN_VERSION" | cut -d. -f1)"
 if [ "$YARN_MAJOR" -lt 4 ] 2>/dev/null; then
   echo -e "${red}Error: yarn $YARN_VERSION detected, but Yarn 4+ is required.${reset}"

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -72,7 +72,7 @@ if ! command -v yarn >/dev/null 2>&1; then
 fi
 
 # Verify yarn version is 4.x (Corepack-managed), not 1.x (Homebrew).
-YARN_VERSION="$(yarn --version 2>/dev/null)"
+YARN_VERSION="$(cd "$PWD"/crates/command-signatures-v2/js && yarn --version 2>/dev/null)"
 YARN_MAJOR="$(echo "$YARN_VERSION" | cut -d. -f1)"
 if [ "$YARN_MAJOR" -lt 4 ] 2>/dev/null; then
     echo "Error: yarn $YARN_VERSION detected, but Yarn 4+ is required."

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -29,6 +29,39 @@ if ! command -v cargo; then
     exit 1
 fi
 
+# Check for Node.js (required by command-signatures-v2 crate).
+# The build.rs in that crate compiles a TypeScript helper using yarn,
+# which requires Node.js 18.14.1+ and yarn (typically via corepack).
+REQUIRED_NODE_VERSION="18.14.1"
+if ! command -v node >/dev/null 2>&1; then
+    echo "Error: Node.js is not installed."
+    echo "Node.js $REQUIRED_NODE_VERSION+ is required to build the command-signatures-v2 crate."
+    echo "Install it via: brew install node"
+    echo "  or use a version manager like nvm, fnm, or volta."
+    exit 1
+fi
+
+NODE_VERSION="$(node --version | sed 's/^v//')"
+# Use awk for version comparison since sh doesn't support sort -V
+if ! echo "$REQUIRED_NODE_VERSION" "$NODE_VERSION" | awk '{if ($2 < $1) exit 1; else exit 0}'; then
+    echo "Error: Node.js $NODE_VERSION is too old."
+    echo "Node.js $REQUIRED_NODE_VERSION+ is required."
+    echo "Upgrade via: brew upgrade node"
+    exit 1
+fi
+
+# Check for yarn (required by command-signatures-v2 crate).
+# yarn is typically enabled via `corepack enable` after installing Node.js.
+if ! command -v yarn >/dev/null 2>&1; then
+    echo "Error: yarn is not installed."
+    echo "yarn is required to build the command-signatures-v2 crate."
+    echo "Enable it via corepack (ships with Node.js):"
+    echo "  corepack enable"
+    exit 1
+fi
+
+echo "✅ Node.js $(node --version) and yarn $(yarn --version) detected."
+
 # Install various binaries through cargo.
 "$PWD"/script/install_cargo_test_deps
 "$PWD"/script/install_cargo_release_deps

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -61,11 +61,25 @@ if [ "$node_major" -lt "$req_major" ] || \
 fi
 
 # Check for yarn (required by command-signatures-v2 crate).
+# The crate uses Yarn 4 via Corepack, not Yarn 1 from Homebrew.
 # yarn is typically enabled via `corepack enable` after installing Node.js.
 if ! command -v yarn >/dev/null 2>&1; then
     echo "Error: yarn is not installed."
     echo "yarn is required to build the command-signatures-v2 crate."
     echo "Enable it via corepack (ships with Node.js):"
+    echo "  corepack enable"
+    exit 1
+fi
+
+# Verify yarn version is 4.x (Corepack-managed), not 1.x (Homebrew).
+YARN_VERSION="$(yarn --version 2>/dev/null)"
+YARN_MAJOR="$(echo "$YARN_VERSION" | cut -d. -f1)"
+if [ "$YARN_MAJOR" -lt 4 ] 2>/dev/null; then
+    echo "Error: yarn $YARN_VERSION detected, but Yarn 4+ is required."
+    echo "The command-signatures-v2 crate requires Yarn 4 via Corepack."
+    echo "If you have yarn installed via Homebrew, remove it first:"
+    echo "  brew uninstall yarn"
+    echo "Then enable Corepack:"
     echo "  corepack enable"
     exit 1
 fi

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -42,8 +42,18 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 NODE_VERSION="$(node --version | sed 's/^v//')"
-# Use awk for version comparison since sh doesn't support sort -V
-if ! echo "$REQUIRED_NODE_VERSION" "$NODE_VERSION" | awk '{if ($2 < $1) exit 1; else exit 0}'; then
+# Compare semantic versions properly (not lexicographically).
+# Split into major.minor.patch and compare each component.
+node_major="$(echo "$NODE_VERSION" | cut -d. -f1)"
+node_minor="$(echo "$NODE_VERSION" | cut -d. -f2)"
+node_patch="$(echo "$NODE_VERSION" | cut -d. -f3)"
+req_major="$(echo "$REQUIRED_NODE_VERSION" | cut -d. -f1)"
+req_minor="$(echo "$REQUIRED_NODE_VERSION" | cut -d. -f2)"
+req_patch="$(echo "$REQUIRED_NODE_VERSION" | cut -d. -f3)"
+
+if [ "$node_major" -lt "$req_major" ] || \
+   { [ "$node_major" -eq "$req_major" ] && [ "$node_minor" -lt "$req_minor" ]; } || \
+   { [ "$node_major" -eq "$req_major" ] && [ "$node_minor" -eq "$req_minor" ] && [ "$node_patch" -lt "$req_patch" ]; }; then
     echo "Error: Node.js $NODE_VERSION is too old."
     echo "Node.js $REQUIRED_NODE_VERSION+ is required."
     echo "Upgrade via: brew upgrade node"


### PR DESCRIPTION
## Summary

The command-signatures-v2 crate compiles a TypeScript helper at cargo build time using yarn, which requires Node.js 18.14.1+ and yarn (typically via corepack enable) on PATH. None of the bootstrap scripts verify either is present, so a fresh checkout fails partway through cargo build rather than at bootstrap time.

Fixes #9544

## Changes

- **script/linux/install_build_deps**: Add Node.js version check (>=18.14.1) and yarn 4+ version check
- **script/macos/bootstrap**: Add Node.js version check (>=18.14.1) and yarn 4+ version check
- **WARP.md**: Document Node.js and yarn as prerequisites

## How it works

The checks run during bootstrap (before Rust installation):
1. Verify node is installed and >=18.14.1 (proper semantic version comparison)
2. Verify yarn is available and version 4+ (rejects Yarn 1 from Homebrew)
3. Print detected versions on success
4. Exit with clear error message if either check fails

## Addressing previous review feedback

- Fixed version comparison to use proper numeric comparison (not lexicographic)
- Added yarn version check to reject Yarn 1.x (Homebrew) and require Yarn 4+ (Corepack)