### PR TITLE
docs: mention Oz OSS credits form in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Warp's client codebase is open source and lives in this repository. We welcome c
 > **Chat with contributors and the Warp team** in the [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB) Slack channel — a good place for ad-hoc questions, design discussion, and pairing with maintainers. New here? [Join the Warp Slack community](https://go.warp.dev/join-preview) first, then jump into `#oss-contributors`.
 
 > [!TIP]
-> Maintain another open source project? [Apply for free Oz credits](https://tally.so/r/LZWxqG) to bring agentic workflows like issue triage, PR review, and community management to your repo.
+> Maintaining a popular open-source project? [Apply for Oz credits](https://tally.so/r/LZWxqG) to bring agentic workflows like issue triage, PR review, and community management to your repo.
 
 ### Issue to PR
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Warp's client codebase is open source and lives in this repository. We welcome c
 > [!TIP]
 > **Chat with contributors and the Warp team** in the [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB) Slack channel — a good place for ad-hoc questions, design discussion, and pairing with maintainers. New here? [Join the Warp Slack community](https://go.warp.dev/join-preview) first, then jump into `#oss-contributors`.
 
+> [!TIP]
+> Maintain another open source project? [Apply for free Oz credits](https://tally.so/r/LZWxqG) to bring agentic workflows like issue triage, PR review, and community management to your repo.
+
 ### Issue to PR
 
 Before filing, [search existing issues](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) for your bug or feature request. If nothing exists, [file an issue](https://github.com/warpdotdev/warp/issues/new/choose) using our templates. Security vulnerabilities should be reported privately as described in [CONTRIBUTING.md](CONTRIBUTING.md#reporting-security-issues).

--- a/README.md
+++ b/README.md
@@ -50,10 +50,7 @@ The rest of the code in this repository is licensed under the [AGPL v3](LICENSE-
 Warp's client codebase is open source and lives in this repository. We welcome community contributions and have designed a lightweight workflow to help new contributors get started. For the full contribution flow, read our [CONTRIBUTING.md](CONTRIBUTING.md) guide.
 
 > [!TIP]
-> **Chat with contributors and the Warp team** in the [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB) Slack channel — a good place for ad-hoc questions, design discussion, and pairing with maintainers. New here? [Join the Warp Slack community](https://go.warp.dev/join-preview) first, then jump into `#oss-contributors`.
-
-> [!TIP]
-> Maintaining a popular open-source project? [Apply for Oz credits](https://tally.so/r/LZWxqG) to bring agentic workflows like issue triage, PR review, and community management to your repo.
+> Maintaining a popular open-source project? [Apply for Oz credits](https://tally.so/r/LZWxqG) to bring [agentic workflows](https://github.com/warpdotdev/oz-for-oss) like issue triage, PR review, and community management to your repo.
 
 ### Issue to PR
 
@@ -80,7 +77,7 @@ Interested in joining the team? See our [open roles](https://www.warp.dev/career
 ## Support and Questions
 
 1. See our [docs](https://docs.warp.dev/) for a comprehensive guide to Warp's features.
-2. Join our [Slack Community](https://go.warp.dev/join-preview) to connect with other users and get help from the Warp team — contributors hang out in [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB).
+2. Join our [Slack Community](https://go.warp.dev/join-preview) to connect with other users and get help from the Warp team.
 3. Try our [Preview build](https://www.warp.dev/download-preview) to test the latest experimental features.
 4. Mention **@oss-maintainers** on any issue to escalate to the team — for example, if you encounter problems with the automated agents.
 


### PR DESCRIPTION
## Description
Adds a brief TIP in the README's "Open Source & Contributing" section pointing maintainers of other open source projects to the application form for free Oz credits: https://tally.so/r/LZWxqG.

The mention is intentionally tiny — a single TIP block — and lives in the contributing section since the audience is OSS maintainers landing on this repo.

## Testing
Docs-only change. Verified the rendered TIP/link in the README preview locally.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Agent conversation](https://staging.warp.dev/conversation/88848789-7a8b-41ab-939d-d7fc66b632af)

Co-Authored-By: Oz <oz-agent@warp.dev>
