### PR TITLE
fixes #9486 skill discovery issue in subdirectories

### DIFF
--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -8,26 +8,26 @@ use super::{
         HomeSkillSubscriber, ProjectSkillSubscriber, SkillRepositoryMessage, SymlinkSkillSubscriber,
     },
     utils::{
-        find_skill_directories_in_tree, is_home_provider_path, is_home_skill_directory,
-        is_skill_file, read_skills_from_directories,
+        find_skill_directories_in_tree, find_skill_directories_on_fs, is_home_provider_path,
+        is_home_skill_directory, is_skill_file, read_skills_from_directories,
     },
 };
 use watcher::{BulkFilesystemWatcherEvent, HomeDirectoryWatcher, HomeDirectoryWatcherEvent};
 
 use crate::server::datetime_ext::DateTimeExt;
 use crate::warp_managed_paths_watcher::{
-    filter_repository_update_by_prefix, warp_managed_skill_dirs, WarpManagedPathsWatcher,
-    WarpManagedPathsWatcherEvent,
+    WarpManagedPathsWatcher, WarpManagedPathsWatcherEvent, filter_repository_update_by_prefix,
+    warp_managed_skill_dirs,
 };
 use ai::skills::{
-    home_skills_path, parse_skill, ParsedSkill, SkillProvider, SKILL_PROVIDER_DEFINITIONS,
+    ParsedSkill, SKILL_PROVIDER_DEFINITIONS, SkillProvider, home_skills_path, parse_skill,
 };
 use async_channel::Sender;
 use chrono::{DateTime, Duration, Utc};
 use repo_metadata::{
+    DirectoryWatcher, RepoMetadataModel, RepositoryUpdate,
     repositories::{DetectedRepositories, RepoDetectionSource},
     repository::{Repository, SubscriberId},
-    DirectoryWatcher, RepoMetadataModel, RepositoryUpdate,
 };
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 
@@ -169,8 +169,8 @@ impl SkillWatcher {
         //
         // The order of these events doesn't matter - both are idempotent and serve different purposes.
         ctx.subscribe_to_model(&RepoMetadataModel::handle(ctx), |me, event, ctx| {
-            use repo_metadata::wrapper_model::RepoMetadataEvent;
             use repo_metadata::RepositoryIdentifier;
+            use repo_metadata::wrapper_model::RepoMetadataEvent;
             match event {
                 RepoMetadataEvent::RepositoryUpdated {
                     id: RepositoryIdentifier::Local(path),
@@ -258,12 +258,30 @@ impl SkillWatcher {
     fn scan_repository_for_skills(&mut self, repo_path: &Path, ctx: &mut ModelContext<Self>) {
         let repo_metadata = RepoMetadataModel::as_ref(ctx);
 
-        // Find all skill directories in the tree
-        let skill_dirs = find_skill_directories_in_tree(repo_path, repo_metadata, ctx);
-        if skill_dirs.is_empty() {
-            return;
+        // Primary scan: query the in-memory file tree (fast, synchronous).
+        let tree_skill_dirs = find_skill_directories_in_tree(repo_path, repo_metadata, ctx);
+        if !tree_skill_dirs.is_empty() {
+            Self::spawn_read_skills_from_directories(tree_skill_dirs.iter().cloned(), ctx);
         }
-        Self::spawn_read_skills_from_directories(skill_dirs, ctx);
+
+        // Supplemental scan: walk the filesystem directly to catch skill directories
+        // inside gitignored or lazy-loaded subtrees that are absent from the indexed tree.
+        // Skills found by both passes are de-duplicated in SkillManager::handle_skills_added.
+        let tree_dirs_set: HashSet<PathBuf> = tree_skill_dirs.into_iter().collect();
+        let repo_path_owned = repo_path.to_path_buf();
+        ctx.spawn(
+            async move {
+                find_skill_directories_on_fs(&repo_path_owned)
+                    .into_iter()
+                    .filter(|dir| !tree_dirs_set.contains(dir))
+                    .collect::<Vec<_>>()
+            },
+            |_me, additional_dirs, ctx| {
+                if !additional_dirs.is_empty() {
+                    Self::spawn_read_skills_from_directories(additional_dirs, ctx);
+                }
+            },
+        );
     }
 
     fn spawn_read_skills_from_directories(

--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -6,8 +6,8 @@ use std::{
 use crate::ai::skills::skill_manager::SkillWatcherEvent;
 use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
 use repo_metadata::{
-    repositories::DetectedRepositories, DirectoryWatcher, RepoMetadataModel, RepositoryUpdate,
-    TargetFile,
+    DirectoryWatcher, RepoMetadataModel, RepositoryUpdate, TargetFile,
+    repositories::DetectedRepositories,
 };
 use tempfile::TempDir;
 use warp_util::standardized_path::StandardizedPath;

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -1,15 +1,17 @@
 use std::{
     collections::HashSet,
+    ffi::OsStr,
     path::{Path, PathBuf},
     sync::LazyLock,
 };
 
 use ai::skills::{
-    home_skills_path, read_skills, ParsedSkill, SkillProvider, SKILL_PROVIDER_DEFINITIONS,
+    ParsedSkill, SKILL_PROVIDER_DEFINITIONS, SkillProvider, home_skills_path, read_skills,
 };
 use anyhow::Error;
 use regex::Regex;
-use repo_metadata::{local_model::GetContentsArgs, RepoContent, RepoMetadataModel};
+use repo_metadata::{RepoContent, RepoMetadataModel, local_model::GetContentsArgs};
+use walkdir::WalkDir;
 use warpui::AppContext;
 
 use crate::warp_managed_paths_watcher::warp_managed_skill_dirs;
@@ -53,6 +55,53 @@ pub fn find_skill_directories_in_tree(
             RepoContent::File(f) => f.path.to_local_path_lossy(),
         })
         .collect()
+}
+
+/// Finds skill directories by walking the filesystem directly, bypassing the indexed file tree.
+///
+/// This is used as a supplement to [`find_skill_directories_in_tree`] to catch skill directories
+/// inside gitignored or lazy-loaded subtrees that are absent from the in-memory tree.
+///
+/// The walk skips `.git` directories and stops recursing once a skill directory is found
+/// (no skills-within-skills nesting is supported).
+pub fn find_skill_directories_on_fs(repo_path: &Path) -> Vec<PathBuf> {
+    let skill_path_suffixes: Vec<PathBuf> = SKILL_PROVIDER_DEFINITIONS
+        .iter()
+        .map(|p| p.skills_path.clone())
+        .collect();
+
+    let mut result = Vec::new();
+    let mut iter = WalkDir::new(repo_path).follow_links(false).into_iter();
+
+    loop {
+        let entry = match iter.next() {
+            None => break,
+            Some(Err(_)) => continue,
+            Some(Ok(e)) => e,
+        };
+
+        if !entry.file_type().is_dir() {
+            continue;
+        }
+
+        let path = entry.path();
+
+        if entry.file_name() == OsStr::new(".git") {
+            iter.skip_current_dir();
+            continue;
+        }
+
+        let is_skill_dir = skill_path_suffixes
+            .iter()
+            .any(|suffix| path.ends_with(suffix));
+
+        if is_skill_dir {
+            result.push(path.to_path_buf());
+            iter.skip_current_dir();
+        }
+    }
+
+    result
 }
 
 /// Reads all skills from the given skill directories.

--- a/app/src/ai/skills/file_watchers/utils_tests.rs
+++ b/app/src/ai/skills/file_watchers/utils_tests.rs
@@ -1,15 +1,15 @@
 use repo_metadata::{
+    DirectoryWatcher, RepoMetadataModel,
     entry::{DirectoryEntry, Entry, FileMetadata},
     file_tree_store::FileTreeState,
     repositories::DetectedRepositories,
-    DirectoryWatcher, RepoMetadataModel,
 };
 use virtual_fs::{Stub, VirtualFS};
 use warpui::App;
 
 use super::{
-    extract_skill_parent_directory, find_skill_directories_in_tree, is_home_provider_path,
-    is_home_skill_directory, is_skill_file, read_skills_from_directories,
+    extract_skill_parent_directory, find_skill_directories_in_tree, find_skill_directories_on_fs,
+    is_home_provider_path, is_home_skill_directory, is_skill_file, read_skills_from_directories,
 };
 
 // ============================================================================
@@ -722,5 +722,97 @@ fn find_skill_directories_in_tree_empty_repo() {
                 assert!(skill_dirs.is_empty());
             });
         });
+    });
+}
+
+// ============================================================================
+// Tests for find_skill_directories_on_fs
+// ============================================================================
+
+#[test]
+fn find_skill_directories_on_fs_finds_root_skills() {
+    VirtualFS::test("find_on_fs_root", |dirs, mut vfs| {
+        let repo = dirs.tests().join("repo");
+
+        vfs.mkdir("repo/.agents/skills/root-skill")
+            .mkdir("repo/.claude/skills/claude-skill")
+            .with_files(vec![
+                Stub::FileWithContent(
+                    "repo/.agents/skills/root-skill/SKILL.md",
+                    "---\nname: root-skill\ndescription: test\n---\n# root-skill",
+                ),
+                Stub::FileWithContent(
+                    "repo/.claude/skills/claude-skill/SKILL.md",
+                    "---\nname: claude-skill\ndescription: test\n---\n# claude-skill",
+                ),
+            ]);
+
+        let skill_dirs = find_skill_directories_on_fs(&repo);
+        assert_eq!(skill_dirs.len(), 2);
+        assert!(skill_dirs.contains(&repo.join(".agents/skills")));
+        assert!(skill_dirs.contains(&repo.join(".claude/skills")));
+    });
+}
+
+/// Regression test for warpdotdev/warp#9486:
+/// Skills in a subdirectory's `.agents/skills/` were not discovered when the
+/// subdirectory (or its `.agents/` folder) was gitignored and therefore absent
+/// from the indexed file tree. `find_skill_directories_on_fs` must find them
+/// regardless of gitignore status.
+#[test]
+fn find_skill_directories_on_fs_finds_subdirectory_skills() {
+    VirtualFS::test("find_on_fs_subdir", |dirs, mut vfs| {
+        let repo = dirs.tests().join("repo");
+
+        vfs.mkdir("repo/.agents/skills/root-skill")
+            .mkdir("repo/sub-project/.agents/skills/sub-skill")
+            .with_files(vec![
+                Stub::FileWithContent(
+                    "repo/.agents/skills/root-skill/SKILL.md",
+                    "---\nname: root-skill\ndescription: test\n---\n# root-skill",
+                ),
+                Stub::FileWithContent(
+                    "repo/sub-project/.agents/skills/sub-skill/SKILL.md",
+                    "---\nname: sub-skill\ndescription: test\n---\n# sub-skill",
+                ),
+            ]);
+
+        let skill_dirs = find_skill_directories_on_fs(&repo);
+        assert_eq!(skill_dirs.len(), 2);
+        assert!(skill_dirs.contains(&repo.join(".agents/skills")));
+        assert!(skill_dirs.contains(&repo.join("sub-project/.agents/skills")));
+
+        // Verify skills can be read from the discovered directories.
+        let skills = read_skills_from_directories(skill_dirs);
+        assert_eq!(skills.len(), 2);
+        let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"root-skill"));
+        assert!(names.contains(&"sub-skill"));
+    });
+}
+
+#[test]
+fn find_skill_directories_on_fs_skips_git_internals() {
+    VirtualFS::test("find_on_fs_git", |dirs, mut vfs| {
+        let repo = dirs.tests().join("repo");
+
+        // Create a real skill dir and a fake one inside .git (should be skipped).
+        vfs.mkdir("repo/.agents/skills/real-skill")
+            .mkdir("repo/.git/.agents/skills/fake-skill")
+            .with_files(vec![
+                Stub::FileWithContent(
+                    "repo/.agents/skills/real-skill/SKILL.md",
+                    "---\nname: real-skill\ndescription: test\n---\n# real-skill",
+                ),
+                Stub::FileWithContent(
+                    "repo/.git/.agents/skills/fake-skill/SKILL.md",
+                    "---\nname: fake-skill\ndescription: test\n---\n# fake-skill",
+                ),
+            ]);
+
+        let skill_dirs = find_skill_directories_on_fs(&repo);
+        assert_eq!(skill_dirs.len(), 1);
+        assert!(skill_dirs.contains(&repo.join(".agents/skills")));
+        assert!(!skill_dirs.contains(&repo.join(".git/.agents/skills")));
     });
 }


### PR DESCRIPTION
Skills stored in .agents/skills/ (or other provider paths like .claude/skills/) inside a subdirectory of the repo were silently not discovered when that subdirectory — or its .agents/ folder — was gitignored. 

Root cause: The indexed file tree (RepoMetadataModel) is built with IgnoredPathStrategy::IncludeLazy: gitignored directories appear in the tree but with loaded: false and empty children. The find_skill_directories_in_tree traversal never reaches skill dirs nested inside them, so only skills at the repo root (when .agents/ is not gitignored there) were discovered.

Fix: Add find_skill_directories_on_fs which walks the filesystem directly using walkdir, bypassing the indexed tree entirely. It skips .git and short-circuits once a skill directory is found. This is called as a supplemental async pass in scan_repository_for_skills alongside the existing tree-based scan. Skills found by both passes are deduplicated by SkillManager::handle_skills_added, which already uses HashSet for skill paths, making double-registration idempotent.                                                    

Testing: Added regression tests for find_skill_directories_on_fs covering root skills, subdirectory skills (the failing scenario from #9486), and .git exclusion.

- Changelog:
      - Bug fix: "Skills in .agents/skills/ inside subdirectories of a git repo are now discovered correctly, even when the subdirectory or its .agents/ folder is gitignored." 