### PR TITLE
ci: bump actions/setup-node from v3.9.1 to v6.4.0

### DIFF
--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -127,7 +127,7 @@ runs:
         fi
 
     - name: Install Node
-      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 20.9.0
 


### PR DESCRIPTION
## Summary
- Bumps `actions/setup-node` in `.github/actions/prepare_environment/action.yml` from v3.9.1 (Nov 2023) to v6.4.0 (Apr 2026).
- Motivation: the v3 line runs on a Node 16 action runtime, which GitHub Actions has been deprecating. v4 → Node 20, v5/v6 → Node 24.
- The only input we pass is `node-version: 20.9.0`. None of the inputs whose semantics changed across majors (`cache`, `always-auth`, `registry-url`) are used here, so the upgrade is behaviorally inert for our usage.

## Test plan
- [ ] CI passes on Linux, macOS, and Windows runners that exercise `prepare_environment`.
- [ ] No new deprecation warnings related to `setup-node` in the action logs.