### PR TITLE
Skip onboarding UIs in SDK/headless mode

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -387,6 +387,7 @@ use std::time::Duration;
 #[cfg(target_os = "macos")]
 use std::time::{SystemTime, UNIX_EPOCH};
 use warp_core::context_flag::ContextFlag;
+use warp_core::execution_mode::AppExecutionMode;
 use warp_core::semantic_selection::SemanticSelection;
 use warp_util::path::{user_friendly_path, LineAndColumnArg};
 use warpui::fonts::Weight;
@@ -6700,6 +6701,12 @@ impl Workspace {
     }
 
     fn should_trigger_get_started_onboarding(&self, ctx: &mut ViewContext<Self>) -> bool {
+        // Onboarding requires a real user to interact with it; suppress when
+        // running in a headless mode like the SDK/CLI.
+        if !AppExecutionMode::as_ref(ctx).can_show_onboarding() {
+            return false;
+        }
+
         if !FeatureFlag::GetStartedTab.is_enabled() {
             return false;
         }
@@ -6732,6 +6739,12 @@ impl Workspace {
     /// If the user is new and therefore has not seen the in app onboarding,
     /// triggers the welcome block to be shown after bootstrapping is completed.
     fn check_and_trigger_onboarding(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        // Onboarding requires a real user to interact with it; suppress when
+        // running in a headless mode like the SDK/CLI.
+        if !AppExecutionMode::as_ref(ctx).can_show_onboarding() {
+            return false;
+        }
+
         if !self.auth_state.is_onboarded().unwrap_or_default() {
             if self.should_show_agent_onboarding(ctx) {
                 // If the user is anonymous, we shouldn't trigger agent onboarding.

--- a/app/src/workspace/view/onboarding.rs
+++ b/app/src/workspace/view/onboarding.rs
@@ -10,6 +10,7 @@ use onboarding::{ProjectOnboardingSettings, SelectedSettings};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use warp_core::execution_mode::AppExecutionMode;
 use warpui::{SingletonEntity as _, ViewContext};
 
 /// Configuration for starting the agent onboarding tutorial.
@@ -87,6 +88,12 @@ impl Workspace {
         tutorial: OnboardingTutorial,
         ctx: &mut ViewContext<Self>,
     ) {
+        // Onboarding requires a real user to interact with it; skip when running
+        // in a headless mode like the SDK/CLI.
+        if !AppExecutionMode::as_ref(ctx).can_show_onboarding() {
+            return;
+        }
+
         match tutorial {
             OnboardingTutorial::InitProject {
                 ref path,
@@ -143,6 +150,12 @@ impl Workspace {
         intention: OnboardingIntention,
         ctx: &mut ViewContext<Self>,
     ) {
+        // Onboarding requires a real user to interact with it; skip when running
+        // in a headless mode like the SDK/CLI.
+        if !AppExecutionMode::as_ref(ctx).can_show_onboarding() {
+            return;
+        }
+
         // With new onboarding, skip the guided tour when AI is not enabled
         // (e.g. terminal-intent users or users who disabled AI).
         if FeatureFlag::OpenWarpNewSettingsModes.is_enabled()
@@ -237,7 +250,12 @@ impl Workspace {
         );
     }
 
-    pub(crate) fn should_show_agent_onboarding(&self, _ctx: &mut ViewContext<Self>) -> bool {
+    pub(crate) fn should_show_agent_onboarding(&self, ctx: &mut ViewContext<Self>) -> bool {
+        // Onboarding requires a real user to interact with it; suppress when
+        // running in a headless mode like the SDK/CLI.
+        if !AppExecutionMode::as_ref(ctx).can_show_onboarding() {
+            return false;
+        }
         FeatureFlag::AgentOnboarding.is_enabled()
     }
 }

--- a/crates/warp_core/src/execution_mode.rs
+++ b/crates/warp_core/src/execution_mode.rs
@@ -74,6 +74,13 @@ impl AppExecutionMode {
         self.is_app()
     }
 
+    /// Whether the app can show interactive onboarding UIs (e.g. the onboarding
+    /// callout tutorial). Onboarding requires a user to interact with it, so it
+    /// is disabled in headless modes like SDK/CLI.
+    pub fn can_show_onboarding(&self) -> bool {
+        self.is_app()
+    }
+
     /// Whether the app can sync agent conversations (tasks and cloud conversation metadata).
     /// In CLI mode, we don't need this data since there's no user viewing it.
     pub fn can_fetch_agent_runs_for_management(&self) -> bool {


### PR DESCRIPTION
## Description

The onboarding flow managed by `OnboardingCalloutModel` was getting triggered when Warp runs in headless SDK/CLI mode. There is no real user to interact with the callout in those runs, so the tutorial would silently take over the input and discard the prompt the SDK had submitted.

This PR adds an `AppExecutionMode::can_show_onboarding` gate (which mirrors the other `is_app()`-based capability checks) and uses it to skip every onboarding entry point in SDK mode:

- `Workspace::start_agent_onboarding_tutorial`
- `Workspace::dispatch_tutorial_when_bootstrapped`
- `Workspace::should_show_agent_onboarding`
- `Workspace::should_trigger_get_started_onboarding`
- `Workspace::check_and_trigger_onboarding`

In `App` mode behavior is unchanged.

## Testing

`cargo check -p warp_core` and `cargo check -p warp` both pass.

## Server API dependencies

No server changes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Don't trigger the agent onboarding tutorial when Warp is running in headless SDK/CLI mode.

_Conversation: https://staging.warp.dev/conversation/e7e67056-a174-4995-9fb0-54c104d09d12_
_Run: https://oz.staging.warp.dev/runs/019dde8f-ff05-716f-8c3a-e7644e40f40d_

_This PR was generated with [Oz](https://warp.dev/oz)._
