### PR TITLE
Add Monolith cockpit operator workflow

### DIFF
--- a/MONOLITH_COCKPIT_PLAN.md
+++ b/MONOLITH_COCKPIT_PLAN.md
@@ -1,0 +1,81 @@
+# Monolith Cockpit MVP Execution Plan
+
+## Repository
+
+- Local fork path: `/Users/master/projects/warp-monolith`
+- Branch: `monolith-cockpit-mvp`
+- Upstream source: `https://github.com/warpdotdev/warp.git`
+
+## Product Shape
+
+The MVP turns Warp into a Monolith operator cockpit without changing the Monolith API or MCP server yet.
+
+The core hierarchy is:
+
+```text
+tenant -> VM/runtime host -> agent runtime -> terminal/git/agent actions
+```
+
+Phase 1 leans on Warp's existing terminal panes, Git-aware shell state, agent conversations, Warp Drive workflows, and MCP settings. VM access continues through `gcloud` and SSH.
+
+## Milestones
+
+### M0: Fork and orientation
+
+- Clone Warp OSS into the local fork path.
+- Preserve upstream as the update source.
+- Map existing MCP settings, left-panel navigation, panes, terminal launch paths, and secure-storage APIs.
+
+### M1: Cockpit shell
+
+- Add a Monolith cockpit tab to Warp's left tool panel.
+- Render the tenant > VM > runtime hierarchy.
+- Keep the first view local/static so it compiles before wiring live data.
+
+Status: implemented.
+
+### M2: Platform auth
+
+- Add Monolith local settings for API URL and cockpit profile metadata.
+- Add a platform-admin API key entry area inside the existing MCP Servers settings page.
+- Store the key in Warp secure storage, not in `settings.toml`.
+
+Status: implemented.
+
+### M3: Local inventory
+
+- Load tenant/VM/runtime data from a local cockpit profile file.
+- Keep the schema explicit and reviewable.
+- Do not expose fleet-wide VM inventory through user-scoped MCP tools.
+
+Status: implemented for local JSON profiles through `monolith.cockpit.profile_path`.
+
+### M4: Operator actions
+
+- Open VM shell panes through generated `gcloud compute ssh ...` commands.
+- Open runtime workdir panes on the selected VM.
+- Provide launch helpers for logs, git status, deploy, pause, stop, and start.
+
+Status: implemented as cockpit buttons that open new Warp terminal tabs preloaded with `gcloud compute ssh ...` commands.
+
+### M5: Agentic workflows
+
+- Start Warp agent/Codex conversations with selected tenant/VM/runtime context.
+- Add guarded workflows for updating agent runtime code and committing changes.
+- Keep destructive or fleet-wide mutations behind platform-admin auth and explicit operator action.
+
+### Backlog: tenant fleet chat
+
+- Add a tenant-select action that opens a Warp chat/agent workspace scoped to that tenant.
+- Bind chat context to the selected tenant, environment, VMs, runtimes, API URL, and MCP/server authority.
+- Ensure chat tools can manage only the selected tenant by default; platform-admin fleet-wide actions require explicit elevation.
+- Let the operator ask for fleet summaries, runtime health, SSH sessions, logs, deploys, starts, pauses, restarts, and code changes from that tenant chat.
+- Keep staging/prod visible in the chat context and require typed confirmation before production writes.
+
+## Guardrails
+
+- Phase 1 must not require Monolith backend changes.
+- API keys are secrets and must use secure storage.
+- `settings.toml` may hold API URL and local profile paths, but not credentials.
+- Platform-admin authority is required for fleet-wide VM or runtime discovery.
+- Tenant/user-scoped MCP users must never see all platform VMs.

--- a/app/src/app_state.rs
+++ b/app/src/app_state.rs
@@ -300,6 +300,7 @@ pub enum LeftPanelDisplayedTab {
     GlobalSearch,
     WarpDrive,
     ConversationListView,
+    MonolithCockpit,
 }
 
 impl From<ToolPanelView> for LeftPanelDisplayedTab {
@@ -309,6 +310,7 @@ impl From<ToolPanelView> for LeftPanelDisplayedTab {
             ToolPanelView::GlobalSearch { .. } => LeftPanelDisplayedTab::GlobalSearch,
             ToolPanelView::WarpDrive => LeftPanelDisplayedTab::WarpDrive,
             ToolPanelView::ConversationListView => LeftPanelDisplayedTab::ConversationListView,
+            ToolPanelView::MonolithCockpit => LeftPanelDisplayedTab::MonolithCockpit,
         }
     }
 }

--- a/app/src/settings/init.rs
+++ b/app/src/settings/init.rs
@@ -37,7 +37,7 @@ use super::{
     native_preference::NativePreferenceSettings, AISettings, AccessibilitySettings,
     AliasExpansionSettings, AppEditorSettings, BlockVisibilitySettings, ChangelogSettings,
     CodeSettings, DebugSettings, EmacsBindingsSettings, FontSettings, FontSettingsChangedEvent,
-    GPUSettings, InputBoxType, InputModeSettings, InputSettings, PaneSettings,
+    GPUSettings, InputBoxType, InputModeSettings, InputSettings, MonolithSettings, PaneSettings,
     SameLinePromptBlockSettings, ScrollSettings, SelectionSettings, SshSettings, ThemeSettings,
     VimBannerSettings, WarpDrivePrivacySettings,
 };
@@ -69,6 +69,7 @@ pub fn register_all_settings(ctx: &mut AppContext) {
     CommandSearchSettings::register(ctx);
     AliasExpansionSettings::register(ctx);
     CodeSettings::register(ctx);
+    MonolithSettings::register(ctx);
     LigatureSettings::register(ctx);
     GPUSettings::register(ctx);
     ChangelogSettings::register(ctx);

--- a/app/src/settings/mod.rs
+++ b/app/src/settings/mod.rs
@@ -22,6 +22,7 @@ mod input_mode;
 mod linux;
 pub mod macros;
 pub mod manager;
+mod monolith;
 pub mod native_preference;
 mod onboarding;
 mod pane;
@@ -54,6 +55,7 @@ pub use input::*;
 pub use input_mode::*;
 #[cfg(target_os = "linux")]
 pub use linux::*;
+pub use monolith::*;
 pub use native_preference::*;
 pub use onboarding::*;
 pub use pane::*;

--- a/app/src/settings/monolith.rs
+++ b/app/src/settings/monolith.rs
@@ -1,0 +1,40 @@
+use settings::{macros::define_settings_group, SupportedPlatforms, SyncToCloud};
+
+define_settings_group!(MonolithSettings, settings: [
+    api_url: MonolithApiUrl {
+        type: String,
+        default: "https://api.monolith.raava.ai".to_string(),
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Never,
+        private: false,
+        toml_path: "monolith.api.url",
+        description: "Base URL for the Monolith Fleet API used by the cockpit and Monolith MCP server.",
+    },
+    default_tenant_id: MonolithDefaultTenantId {
+        type: String,
+        default: "".to_string(),
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Never,
+        private: false,
+        toml_path: "monolith.cockpit.default_tenant_id",
+        description: "Optional default tenant selected by the Monolith cockpit.",
+    },
+    cockpit_environment: MonolithCockpitEnvironment {
+        type: String,
+        default: "staging".to_string(),
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Never,
+        private: false,
+        toml_path: "monolith.cockpit.environment",
+        description: "Active Monolith cockpit environment profile: staging or prod.",
+    },
+    cockpit_profile_path: MonolithCockpitProfilePath {
+        type: String,
+        default: "".to_string(),
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Never,
+        private: false,
+        toml_path: "monolith.cockpit.profile_path",
+        description: "Optional local JSON profile for tenant, VM, and runtime inventory used by the Monolith cockpit MVP.",
+    },
+]);

--- a/app/src/settings_view/mcp_servers/list_page.rs
+++ b/app/src/settings_view/mcp_servers/list_page.rs
@@ -4,7 +4,7 @@ use crate::modal::Modal;
 use crate::modal::ModalEvent;
 use crate::modal::ModalViewState;
 use crate::server::telemetry::{MCPTemplateInstallationSource, TelemetryEvent};
-use crate::settings::{AISettings, AISettingsChangedEvent};
+use crate::settings::{AISettings, AISettingsChangedEvent, MonolithSettings};
 use crate::settings_view::mcp_servers_page::InstallOrigin;
 use crate::settings_view::settings_page::{
     build_toggle_element, render_body_item_label, LocalOnlyIconState, ToggleState,
@@ -54,7 +54,7 @@ use crate::{
     workspaces::user_workspaces::UserWorkspaces,
 };
 use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
-use settings::ToggleableSetting as _;
+use settings::{Setting as _, ToggleableSetting as _};
 use std::cmp::Ordering;
 use std::{collections::HashMap, path::PathBuf};
 use strum::IntoEnumIterator;
@@ -66,7 +66,7 @@ use warpui::{
     elements::{
         Align, Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment,
         Expanded, Fill, Flex, FormattedTextElement, HighlightedHyperlink, MainAxisAlignment,
-        MainAxisSize, ParentElement, Radius, Text,
+        MainAxisSize, Padding, ParentElement, Radius, Shrinkable, Text,
     },
     ui_components::{
         components::{Coords, UiComponent, UiComponentStyles},
@@ -74,6 +74,7 @@ use warpui::{
     },
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
 };
+use warpui_extras::secure_storage::AppContextExt;
 
 const DESCRIPTION_TEXT: &str = "Add MCP servers to extend the Warp Agent's capabilities. MCP servers expose data sources or tools to agents through a standardized interface, essentially acting like plugins. Add a custom server, or use the presets to get started with popular servers. You can also find team servers that have been shared with you here. ";
 
@@ -99,10 +100,12 @@ pub enum MCPServersListPageViewEvent {
 pub enum MCPServersListPageViewAction {
     Add,
     ToggleFileBasedMcp,
+    SaveMonolithApiKey,
 }
 
 const EMPTY_STATE_TEXT: &str = "Once you add a MCP server, it will be shown here.";
 const NO_SEARCH_RESULTS_TEXT: &str = "No search results found";
+const MONOLITH_API_KEY_STORAGE_KEY: &str = "monolith.platform_admin_api_key";
 
 pub struct MCPServersListPageView {
     server_cards: HashMap<ServerCardItemId, ViewHandle<ServerCardView>>,
@@ -113,6 +116,8 @@ pub struct MCPServersListPageView {
     search_editor: ViewHandle<EditorView>,
     search_bar: ViewHandle<SearchBar>,
     add_button: ViewHandle<ActionButton>,
+    monolith_api_key_editor: ViewHandle<EditorView>,
+    monolith_api_key_save_button: ViewHandle<ActionButton>,
     file_based_mcp_toggle: SwitchStateHandle,
 }
 
@@ -237,6 +242,27 @@ impl MCPServersListPageView {
                 .on_click(|ctx| ctx.dispatch_typed_action(MCPServersListPageViewAction::Add))
         });
 
+        let monolith_api_key_editor = {
+            let options = SingleLineEditorOptions {
+                is_password: true,
+                text: TextOptions::ui_text(None, appearance.as_ref(ctx)),
+                propagate_and_no_op_vertical_navigation_keys:
+                    PropagateAndNoOpNavigationKeys::Always,
+                ..Default::default()
+            };
+            let editor = ctx.add_typed_action_view(|ctx| EditorView::single_line(options, ctx));
+            editor.update(ctx, |editor, ctx| {
+                editor.set_placeholder_text("Platform admin API key", ctx);
+            });
+            editor
+        };
+
+        let monolith_api_key_save_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Save", NakedTheme).on_click(|ctx| {
+                ctx.dispatch_typed_action(MCPServersListPageViewAction::SaveMonolithApiKey)
+            })
+        });
+
         let mut me = Self {
             server_cards: Default::default(),
             gallery_server_cards,
@@ -245,6 +271,8 @@ impl MCPServersListPageView {
             search_editor,
             search_bar,
             add_button,
+            monolith_api_key_editor,
+            monolith_api_key_save_button,
             file_based_mcp_toggle: Default::default(),
         };
 
@@ -1180,6 +1208,94 @@ impl MCPServersListPageView {
             .finish()
     }
 
+    fn render_monolith_auth_section(
+        &self,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let settings = MonolithSettings::as_ref(app);
+        let api_url = settings.api_url.value();
+        let has_saved_key = app
+            .secure_storage()
+            .read_value(MONOLITH_API_KEY_STORAGE_KEY)
+            .is_ok_and(|value| !value.is_empty());
+        let status_text = if has_saved_key {
+            "platform admin key saved"
+        } else {
+            "platform admin key required"
+        };
+
+        let header = Flex::row()
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(
+                Text::new("Monolith platform access", appearance.ui_font_family(), 13.)
+                    .with_color(theme.active_ui_text_color().into_solid())
+                    .finish(),
+            )
+            .with_child(
+                Text::new(status_text, appearance.ui_font_family(), 11.)
+                    .with_color(theme.disabled_ui_text_color().into_solid())
+                    .finish(),
+            )
+            .finish();
+
+        let description = Text::new(
+            "Used by the Monolith MCP server and cockpit actions that call Fleet API. Store only a platform-admin key here; tenant/user keys must not authorize fleet-wide VM inventory.",
+            appearance.ui_font_family(),
+            12.,
+        )
+        .with_color(theme.nonactive_ui_text_color().into_solid())
+        .finish();
+
+        let api_url_line = Flex::row()
+            .with_spacing(6.)
+            .with_child(
+                Text::new("API", appearance.ui_font_family(), 12.)
+                    .with_color(theme.disabled_ui_text_color().into_solid())
+                    .finish(),
+            )
+            .with_child(
+                Text::new(api_url.clone(), appearance.ui_font_family(), 12.)
+                    .with_color(theme.main_text_color(theme.background()).into_solid())
+                    .finish(),
+            )
+            .finish();
+
+        let key_row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(8.)
+            .with_child(
+                Shrinkable::new(
+                    1.,
+                    Container::new(ChildView::new(&self.monolith_api_key_editor).finish())
+                        .with_padding(Padding::uniform(6.).with_left(10.).with_right(10.))
+                        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+                        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+                        .finish(),
+                )
+                .finish(),
+            )
+            .with_child(ChildView::new(&self.monolith_api_key_save_button).finish())
+            .finish();
+
+        Container::new(
+            Flex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                .with_spacing(8.)
+                .with_child(header)
+                .with_child(description)
+                .with_child(api_url_line)
+                .with_child(key_row)
+                .finish(),
+        )
+        .with_padding(Padding::uniform(12.))
+        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(6.)))
+        .finish()
+    }
+
     fn render_page_body(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
         let description_fragments = vec![
             FormattedTextFragment::plain_text(DESCRIPTION_TEXT),
@@ -1252,6 +1368,7 @@ impl MCPServersListPageView {
             page.add_child(empty_state);
         } else {
             page.add_child(self.render_controls());
+            page.add_child(self.render_monolith_auth_section(appearance, app));
 
             if FeatureFlag::FileBasedMcp.is_enabled() {
                 page.add_child(self.render_file_based_mcp_section(appearance, app));
@@ -1818,6 +1935,26 @@ impl TypedActionView for MCPServersListPageView {
                     if let Err(e) = settings.file_based_mcp_enabled.toggle_and_save_value(ctx) {
                         log::warn!("Failed to toggle file-based MCP setting: {e:?}");
                     }
+                });
+                ctx.notify();
+            }
+            MCPServersListPageViewAction::SaveMonolithApiKey => {
+                let api_key = self.monolith_api_key_editor.as_ref(ctx).buffer_text(ctx);
+                if api_key.trim().is_empty() {
+                    if let Err(e) = ctx
+                        .secure_storage()
+                        .remove_value(MONOLITH_API_KEY_STORAGE_KEY)
+                    {
+                        log::warn!("Failed to remove Monolith API key from secure storage: {e:?}");
+                    }
+                } else if let Err(e) = ctx
+                    .secure_storage()
+                    .write_value(MONOLITH_API_KEY_STORAGE_KEY, api_key.trim())
+                {
+                    log::warn!("Failed to save Monolith API key to secure storage: {e:?}");
+                }
+                self.monolith_api_key_editor.update(ctx, |editor, ctx| {
+                    editor.clear_buffer_and_reset_undo_stack(ctx);
                 });
                 ctx.notify();
             }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -8,6 +8,7 @@ pub(crate) mod free_tier_limit_hit_modal;
 pub mod global_search;
 pub(crate) mod launch_modal;
 pub(crate) mod left_panel;
+pub(crate) mod monolith_cockpit;
 pub(crate) mod onboarding;
 pub(crate) mod openwarp_launch_modal;
 pub(crate) mod right_panel;
@@ -3771,6 +3772,7 @@ impl Workspace {
                 },
                 LeftPanelDisplayedTab::WarpDrive => ToolPanelView::WarpDrive,
                 LeftPanelDisplayedTab::ConversationListView => ToolPanelView::ConversationListView,
+                LeftPanelDisplayedTab::MonolithCockpit => ToolPanelView::MonolithCockpit,
             };
             lp.restore_active_view_from_snapshot(active_view, ctx);
             lp.set_active_pane_group(pane_group.clone(), &self.working_directories_model, ctx);
@@ -16600,6 +16602,7 @@ impl Workspace {
                         ToolPanelView::GlobalSearch { .. } => "Global search",
                         ToolPanelView::WarpDrive => "Warp Drive",
                         ToolPanelView::ConversationListView => "Agent conversations",
+                        ToolPanelView::MonolithCockpit => "Monolith cockpit",
                     }
                 } else {
                     "Tools panel"
@@ -16654,6 +16657,7 @@ impl Workspace {
                 ToolPanelView::GlobalSearch { .. } => "Global search",
                 ToolPanelView::WarpDrive => "Warp Drive",
                 ToolPanelView::ConversationListView => "Agent conversations",
+                ToolPanelView::MonolithCockpit => "Monolith cockpit",
             }
         } else {
             "Tools panel"
@@ -19570,6 +19574,7 @@ impl Workspace {
         if WarpDriveSettings::is_warp_drive_enabled(ctx) {
             views.push(ToolPanelView::WarpDrive);
         }
+        views.push(ToolPanelView::MonolithCockpit);
         views
     }
 

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -39,6 +39,7 @@ use crate::workspace::view::conversation_list::view::{
 use crate::workspace::view::global_search::view::{
     Event as GlobalSearchViewEvent, GlobalSearchEntryFocus, GlobalSearchView,
 };
+use crate::workspace::view::monolith_cockpit::MonolithCockpitView;
 use crate::workspace::view::{
     LEFT_PANEL_AGENT_CONVERSATIONS_BINDING_NAME, LEFT_PANEL_GLOBAL_SEARCH_BINDING_NAME,
     LEFT_PANEL_PROJECT_EXPLORER_BINDING_NAME, LEFT_PANEL_WARP_DRIVE_BINDING_NAME,
@@ -67,6 +68,7 @@ struct MouseStateHandles {
     global_search_button: MouseStateHandle,
     warp_drive_button: MouseStateHandle,
     conversation_list_view_button: MouseStateHandle,
+    monolith_cockpit_button: MouseStateHandle,
 }
 
 #[derive(Clone, Debug)]
@@ -75,6 +77,7 @@ pub enum LeftPanelAction {
     GlobalSearch { entry_focus: GlobalSearchEntryFocus },
     WarpDrive,
     ConversationListView,
+    MonolithCockpit,
 }
 
 pub enum LeftPanelEvent {
@@ -101,6 +104,7 @@ pub enum ToolPanelView {
     GlobalSearch { entry_focus: GlobalSearchEntryFocus },
     WarpDrive,
     ConversationListView,
+    MonolithCockpit,
 }
 
 /// Encapsulates the active view state to enforce that all mutations go through
@@ -167,6 +171,7 @@ pub struct LeftPanelView {
     close_button_mouse_state: MouseStateHandle,
     warp_drive_view: ViewHandle<DrivePanel>,
     conversation_list_view: ViewHandle<ConversationListView>,
+    monolith_cockpit_view: ViewHandle<MonolithCockpitView>,
     active_view: active_view_state::ActiveViewState,
     toolbelt_buttons: Vec<ToolbeltButtonConfig>,
     active_pane_group: Option<WeakViewHandle<PaneGroup>>,
@@ -211,6 +216,7 @@ impl LeftPanelView {
         };
         let warp_drive_view = ctx.add_typed_action_view(DrivePanel::new);
         let conversation_list_view = ctx.add_typed_action_view(ConversationListView::new);
+        let monolith_cockpit_view = ctx.add_typed_action_view(MonolithCockpitView::new);
 
         ctx.subscribe_to_view(&warp_drive_view, |_me, _, event, ctx| {
             ctx.emit(LeftPanelEvent::WarpDrive(event.clone()));
@@ -308,6 +314,7 @@ impl LeftPanelView {
             close_button_mouse_state: Default::default(),
             warp_drive_view,
             conversation_list_view,
+            monolith_cockpit_view,
             active_view: active_view_state::new(active_view),
             toolbelt_buttons,
             active_pane_group: None,
@@ -437,6 +444,19 @@ impl LeftPanelView {
                     action: LeftPanelAction::ConversationListView,
                     render_with_active_state: false,
                     tooltip_keybinding: toolbelt_tooltip_keybinding(&tooltip_keybinding_names, ctx),
+                    tooltip_keybinding_names,
+                }
+            }
+            ToolPanelView::MonolithCockpit => {
+                let tooltip_keybinding_names = vec![];
+
+                ToolbeltButtonConfig {
+                    icon: Icon::Dataflow,
+                    active_icon: Some(Icon::Dataflow),
+                    tooltip_text: "Monolith cockpit".to_string(),
+                    action: LeftPanelAction::MonolithCockpit,
+                    render_with_active_state: false,
+                    tooltip_keybinding: None,
                     tooltip_keybinding_names,
                 }
             }
@@ -682,6 +702,9 @@ impl LeftPanelView {
                     view.on_left_panel_focused(ctx);
                 });
             }
+            ToolPanelView::MonolithCockpit => {
+                ctx.focus(&self.monolith_cockpit_view);
+            }
         }
     }
 
@@ -834,6 +857,9 @@ impl LeftPanelView {
                 LeftPanelAction::ConversationListView => {
                     self.active_view.get() == ToolPanelView::ConversationListView
                 }
+                LeftPanelAction::MonolithCockpit => {
+                    self.active_view.get() == ToolPanelView::MonolithCockpit
+                }
             };
         }
     }
@@ -975,6 +1001,9 @@ impl LeftPanelView {
                 active_view_state::set(self, ToolPanelView::ConversationListView, ctx);
                 send_telemetry_from_ctx!(TelemetryEvent::ConversationListViewOpened, ctx);
             }
+            LeftPanelAction::MonolithCockpit => {
+                active_view_state::set(self, ToolPanelView::MonolithCockpit, ctx);
+            }
         }
     }
 
@@ -1074,6 +1103,7 @@ impl View for LeftPanelView {
                 }
                 ToolPanelView::WarpDrive => ctx.focus(&self.warp_drive_view),
                 ToolPanelView::ConversationListView => ctx.focus(&self.conversation_list_view),
+                ToolPanelView::MonolithCockpit => ctx.focus(&self.monolith_cockpit_view),
             }
         }
     }
@@ -1088,6 +1118,7 @@ impl View for LeftPanelView {
             self.mouse_state_handles
                 .conversation_list_view_button
                 .clone(),
+            self.mouse_state_handles.monolith_cockpit_button.clone(),
         ];
 
         // If there is only one button in the toolbelt row,
@@ -1145,6 +1176,9 @@ impl View for LeftPanelView {
             .finish(),
             ToolPanelView::ConversationListView => {
                 Shrinkable::new(1.0, ChildView::new(&self.conversation_list_view).finish()).finish()
+            }
+            ToolPanelView::MonolithCockpit => {
+                Shrinkable::new(1.0, ChildView::new(&self.monolith_cockpit_view).finish()).finish()
             }
         };
 

--- a/app/src/workspace/view/monolith_cockpit.rs
+++ b/app/src/workspace/view/monolith_cockpit.rs
@@ -1,0 +1,848 @@
+use crate::{
+    appearance::Appearance, root_view::SubshellCommandArg, settings::MonolithSettings,
+    terminal::shell::ShellType,
+};
+use serde::Deserialize;
+use settings::Setting as _;
+use std::{collections::HashSet, path::Path};
+use warp_core::ui::Icon;
+use warpui::elements::{
+    Border, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox, Container, CornerRadius,
+    CrossAxisAlignment, Element, Fill, Flex, Hoverable, MainAxisAlignment, MainAxisSize,
+    MouseStateHandle, Padding, ParentElement, Radius, ScrollbarWidth, Shrinkable, Text,
+};
+use warpui::fonts::{Properties, Weight};
+use warpui::platform::Cursor;
+use warpui::{AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext};
+
+const OPEN_SUBSHELL_ACTION: &str =
+    "root_view:open_new_tab_insert_subshell_command_and_bootstrap_if_supported";
+const STAGING_API_URL: &str = "https://raava-fleet-api-staging-lmbn6fkciq-ue.a.run.app";
+const PROD_API_URL: &str = "https://api.fleetos.raavasolutions.com";
+const GCP_PROJECT: &str = "raava-481318";
+const STAGING_PROFILE_PATH: &str =
+    "/Users/master/projects/warp-monolith/examples/monolith-cockpit-profile.live.json";
+const PROD_PROFILE_PATH: &str =
+    "/Users/master/projects/warp-monolith/examples/monolith-cockpit-profile.prod.json";
+
+#[derive(Clone, Debug, Deserialize)]
+struct RuntimeProfile {
+    name: String,
+    status: String,
+    workdir: String,
+    git_ref: String,
+    #[serde(default)]
+    service_name: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct HostProfile {
+    name: String,
+    zone: String,
+    status: String,
+    #[serde(default)]
+    project: Option<String>,
+    runtimes: Vec<RuntimeProfile>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct TenantProfile {
+    name: String,
+    environment: String,
+    hosts: Vec<HostProfile>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct CockpitProfile {
+    tenants: Vec<TenantProfile>,
+}
+
+#[derive(Clone, Debug)]
+pub enum MonolithCockpitAction {
+    OpenCommand { command: String },
+    ToggleTenant { tenant_name: String },
+    SwitchEnvironment { environment: String },
+}
+
+pub struct MonolithCockpitView {
+    button_mouse_states: Vec<MouseStateHandle>,
+    tenant_mouse_states: Vec<MouseStateHandle>,
+    environment_mouse_states: Vec<MouseStateHandle>,
+    cloud_mouse_states: Vec<MouseStateHandle>,
+    scroll_state: ClippedScrollStateHandle,
+    expanded_tenants: HashSet<String>,
+}
+
+impl MonolithCockpitView {
+    pub fn new(_: &mut ViewContext<Self>) -> Self {
+        Self {
+            button_mouse_states: (0..512).map(|_| MouseStateHandle::default()).collect(),
+            tenant_mouse_states: (0..128).map(|_| MouseStateHandle::default()).collect(),
+            environment_mouse_states: (0..2).map(|_| MouseStateHandle::default()).collect(),
+            cloud_mouse_states: (0..3).map(|_| MouseStateHandle::default()).collect(),
+            scroll_state: ClippedScrollStateHandle::default(),
+            expanded_tenants: HashSet::new(),
+        }
+    }
+
+    fn default_profile() -> CockpitProfile {
+        CockpitProfile {
+            tenants: Vec::new(),
+        }
+    }
+
+    fn load_profile(app: &AppContext) -> (CockpitProfile, Option<String>) {
+        let profile_path = MonolithSettings::as_ref(app).cockpit_profile_path.value();
+        if profile_path.trim().is_empty() {
+            return (Self::default_profile(), None);
+        }
+
+        match std::fs::read_to_string(Path::new(profile_path)) {
+            Ok(contents) => match serde_json::from_str::<CockpitProfile>(&contents) {
+                Ok(profile) => (profile, Some(format!("profile: {profile_path}"))),
+                Err(error) => (
+                    Self::default_profile(),
+                    Some(format!("profile parse failed: {error}")),
+                ),
+            },
+            Err(error) => (
+                Self::default_profile(),
+                Some(format!("profile read failed: {error}")),
+            ),
+        }
+    }
+
+    fn shell_escape(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+
+    fn gcloud_ssh_prefix(host: &HostProfile) -> String {
+        let mut command = format!("gcloud compute ssh {}", Self::shell_escape(&host.name));
+        if !host.zone.trim().is_empty() {
+            command.push_str(&format!(" --zone {}", Self::shell_escape(&host.zone)));
+        }
+        if let Some(project) = host
+            .project
+            .as_ref()
+            .filter(|project| !project.trim().is_empty())
+        {
+            command.push_str(&format!(" --project {}", Self::shell_escape(project)));
+        }
+        command
+    }
+
+    fn remote_command(host: &HostProfile, command: &str) -> String {
+        format!(
+            "{} --command {}",
+            Self::gcloud_ssh_prefix(host),
+            Self::shell_escape(command)
+        )
+    }
+
+    fn runtime_service_name(runtime: &RuntimeProfile) -> String {
+        runtime
+            .service_name
+            .clone()
+            .unwrap_or_else(|| format!("monolith-agent-{}", runtime.name))
+    }
+
+    fn section_label(label: &str, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        Text::new(label.to_string(), appearance.ui_font_family(), 11.)
+            .with_color(theme.disabled_ui_text_color().into_solid())
+            .with_style(Properties::default().weight(Weight::Semibold))
+            .finish()
+    }
+
+    fn value_line(label: &str, value: &str, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_spacing(6.)
+            .with_child(
+                Text::new(label.to_string(), appearance.ui_font_family(), 12.)
+                    .with_color(theme.disabled_ui_text_color().into_solid())
+                    .finish(),
+            )
+            .with_child(
+                Text::new(value.to_string(), appearance.ui_font_family(), 12.)
+                    .with_color(theme.main_text_color(theme.background()).into_solid())
+                    .finish(),
+            )
+            .finish()
+    }
+
+    fn next_mouse_state(
+        mouse_states: &[MouseStateHandle],
+        button_index: &mut usize,
+    ) -> MouseStateHandle {
+        let index = *button_index;
+        *button_index += 1;
+        mouse_states.get(index).cloned().unwrap_or_default()
+    }
+
+    fn action_button(
+        label: &str,
+        command: String,
+        mouse_state: MouseStateHandle,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        let button = Container::new(
+            Text::new(label.to_string(), appearance.ui_font_family(), 11.)
+                .with_color(theme.active_ui_text_color().into_solid())
+                .finish(),
+        )
+        .with_padding(Padding::uniform(4.).with_left(8.).with_right(8.))
+        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+        .finish();
+
+        Hoverable::new(mouse_state, |_| button)
+            .with_cursor(Cursor::PointingHand)
+            .on_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(MonolithCockpitAction::OpenCommand {
+                    command: command.clone(),
+                });
+            })
+            .finish()
+    }
+
+    fn environment_button(
+        label: &str,
+        environment: &str,
+        is_active: bool,
+        mouse_state: MouseStateHandle,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let environment = environment.to_string();
+
+        let mut button = Container::new(
+            Text::new(label.to_string(), appearance.ui_font_family(), 11.)
+                .with_color(theme.active_ui_text_color().into_solid())
+                .with_style(Properties::default().weight(Weight::Semibold))
+                .finish(),
+        )
+        .with_padding(Padding::uniform(5.).with_left(9.).with_right(9.))
+        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
+
+        if is_active {
+            button = button.with_background(theme.surface_3());
+        }
+
+        Hoverable::new(mouse_state, |_| button.finish())
+            .with_cursor(Cursor::PointingHand)
+            .on_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(MonolithCockpitAction::SwitchEnvironment {
+                    environment: environment.clone(),
+                });
+            })
+            .finish()
+    }
+
+    fn render_environment_switcher(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let settings = MonolithSettings::as_ref(app);
+        let active_environment = settings.cockpit_environment.value();
+        let api_url = settings.api_url.value();
+        let is_prod = active_environment == "prod";
+
+        Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(7.)
+            .with_child(
+                Flex::row()
+                    .with_spacing(6.)
+                    .with_child(Self::environment_button(
+                        "staging",
+                        "staging",
+                        !is_prod,
+                        self.environment_mouse_states
+                            .first()
+                            .cloned()
+                            .unwrap_or_default(),
+                        app,
+                    ))
+                    .with_child(Self::environment_button(
+                        "prod",
+                        "prod",
+                        is_prod,
+                        self.environment_mouse_states
+                            .get(1)
+                            .cloned()
+                            .unwrap_or_default(),
+                        app,
+                    ))
+                    .finish(),
+            )
+            .with_child(
+                Text::new(api_url.clone(), appearance.ui_font_family(), 10.)
+                    .with_color(
+                        Appearance::as_ref(app)
+                            .theme()
+                            .disabled_ui_text_color()
+                            .into_solid(),
+                    )
+                    .finish(),
+            )
+            .finish()
+    }
+
+    fn render_cloud_toolbar(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        let setup_command = format!(
+            "gcloud auth login && printf '\\nMonolith cockpit passes --project {} explicitly; it does not mutate global gcloud project or ADC credentials.\\n'",
+            Self::shell_escape(GCP_PROJECT),
+        );
+        let status_command = format!(
+            "printf 'account: '; gcloud auth list --filter=status:ACTIVE --format='value(account)'; printf 'project: '; gcloud config get-value project; gcloud compute instances list --project {} --filter={} --format='table(name,zone.basename(),status,labels.raava-tenant,labels.raava-agent)'",
+            Self::shell_escape(GCP_PROJECT),
+            Self::shell_escape("labels.raava-managed=true"),
+        );
+        let project_command = format!(
+            "printf 'cockpit project: {}\\n'; printf 'global gcloud project: '; gcloud config get-value project",
+            Self::shell_escape(GCP_PROJECT),
+        );
+
+        Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(6.)
+            .with_child(
+                Text::new(
+                    format!("cloud: gcloud / {}", GCP_PROJECT),
+                    appearance.ui_font_family(),
+                    10.,
+                )
+                .with_color(theme.disabled_ui_text_color().into_solid())
+                .finish(),
+            )
+            .with_child(
+                Flex::row()
+                    .with_spacing(6.)
+                    .with_child(Self::action_button(
+                        "auth",
+                        setup_command,
+                        self.cloud_mouse_states.first().cloned().unwrap_or_default(),
+                        app,
+                    ))
+                    .with_child(Self::action_button(
+                        "status",
+                        status_command,
+                        self.cloud_mouse_states.get(1).cloned().unwrap_or_default(),
+                        app,
+                    ))
+                    .with_child(Self::action_button(
+                        "project",
+                        project_command,
+                        self.cloud_mouse_states.get(2).cloned().unwrap_or_default(),
+                        app,
+                    ))
+                    .finish(),
+            )
+            .finish()
+    }
+
+    fn runtime_card(
+        tenant: &TenantProfile,
+        host: &HostProfile,
+        runtime: &RuntimeProfile,
+        mouse_states: &[MouseStateHandle],
+        button_index: &mut usize,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let service_name = Self::runtime_service_name(runtime);
+        let prod_locked = tenant.environment.contains("prod");
+        let inactive_target = tenant.environment.contains("offboarded")
+            || host.status.contains("terminated")
+            || host.status.contains("unknown");
+        let mutation_guard = |action: &str, reason: &str| {
+            let message = format!(
+                "Monolith cockpit blocked {action} for {}/{}/{}: {reason}",
+                tenant.name, host.name, runtime.name
+            );
+            format!("printf '%s\\n' {}", Self::shell_escape(&message))
+        };
+
+        let runtime_shell = Self::remote_command(
+            host,
+            &format!(
+                "cd {} && exec ${{SHELL:-bash}} -l",
+                Self::shell_escape(&runtime.workdir)
+            ),
+        );
+        let git_status = Self::remote_command(
+            host,
+            &format!(
+                "cd {} && git status --short --branch",
+                Self::shell_escape(&runtime.workdir)
+            ),
+        );
+        let logs = Self::remote_command(
+            host,
+            &format!(
+                "cd {} && (test -d logs && tail -n 200 -f logs/*.log || journalctl --user -u {} -f)",
+                Self::shell_escape(&runtime.workdir),
+                Self::shell_escape(&service_name),
+            ),
+        );
+        let deploy = if prod_locked {
+            mutation_guard("deploy", "prod writes require explicit elevated workflow")
+        } else if inactive_target {
+            mutation_guard("deploy", "target is offboarded, terminated, or unknown")
+        } else {
+            Self::remote_command(
+                host,
+                &format!(
+                    "cd {} && ./deploy.sh --tenant {} --runtime {}",
+                    Self::shell_escape(&runtime.workdir),
+                    Self::shell_escape(&tenant.name),
+                    Self::shell_escape(&runtime.name),
+                ),
+            )
+        };
+        let start = if prod_locked {
+            mutation_guard("start", "prod writes require explicit elevated workflow")
+        } else if inactive_target {
+            mutation_guard("start", "target is offboarded, terminated, or unknown")
+        } else {
+            Self::remote_command(
+                host,
+                &format!(
+                    "systemctl --user start {}",
+                    Self::shell_escape(&service_name)
+                ),
+            )
+        };
+        let pause = if prod_locked {
+            mutation_guard("pause", "prod writes require explicit elevated workflow")
+        } else if inactive_target {
+            mutation_guard("pause", "target is offboarded, terminated, or unknown")
+        } else {
+            Self::remote_command(
+                host,
+                &format!(
+                    "systemctl --user stop {}",
+                    Self::shell_escape(&service_name)
+                ),
+            )
+        };
+        let restart = if prod_locked {
+            mutation_guard("restart", "prod writes require explicit elevated workflow")
+        } else if inactive_target {
+            mutation_guard("restart", "target is offboarded, terminated, or unknown")
+        } else {
+            Self::remote_command(
+                host,
+                &format!(
+                    "systemctl --user restart {}",
+                    Self::shell_escape(&service_name)
+                ),
+            )
+        };
+
+        let header = Flex::row()
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(
+                Flex::row()
+                    .with_spacing(8.)
+                    .with_child(
+                        ConstrainedBox::new(
+                            Icon::Dataflow
+                                .to_warpui_icon(theme.sub_text_color(theme.background()))
+                                .finish(),
+                        )
+                        .with_width(14.)
+                        .with_height(14.)
+                        .finish(),
+                    )
+                    .with_child(
+                        Text::new(runtime.name.clone(), appearance.ui_font_family(), 13.)
+                            .with_color(theme.active_ui_text_color().into_solid())
+                            .with_style(Properties::default().weight(Weight::Semibold))
+                            .finish(),
+                    )
+                    .finish(),
+            )
+            .with_child(
+                Text::new(runtime.status.clone(), appearance.ui_font_family(), 11.)
+                    .with_color(theme.disabled_ui_text_color().into_solid())
+                    .finish(),
+            )
+            .finish();
+
+        Container::new(
+            Flex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                .with_spacing(8.)
+                .with_child(header)
+                .with_child(Self::value_line("workdir", &runtime.workdir, app))
+                .with_child(Self::value_line("git", &runtime.git_ref, app))
+                .with_child(Self::value_line("service", &service_name, app))
+                .with_child(
+                    Flex::row()
+                        .with_spacing(6.)
+                        .with_child(Self::action_button(
+                            "shell",
+                            runtime_shell,
+                            Self::next_mouse_state(mouse_states, button_index),
+                            app,
+                        ))
+                        .with_child(Self::action_button(
+                            "git",
+                            git_status,
+                            Self::next_mouse_state(mouse_states, button_index),
+                            app,
+                        ))
+                        .with_child(Self::action_button(
+                            "logs",
+                            logs,
+                            Self::next_mouse_state(mouse_states, button_index),
+                            app,
+                        ))
+                        .finish(),
+                )
+                .with_child(
+                    Flex::row()
+                        .with_spacing(6.)
+                        .with_child(Self::action_button(
+                            "deploy",
+                            deploy,
+                            Self::next_mouse_state(mouse_states, button_index),
+                            app,
+                        ))
+                        .with_child(Self::action_button(
+                            "start",
+                            start,
+                            Self::next_mouse_state(mouse_states, button_index),
+                            app,
+                        ))
+                        .with_child(Self::action_button(
+                            "pause",
+                            pause,
+                            Self::next_mouse_state(mouse_states, button_index),
+                            app,
+                        ))
+                        .with_child(Self::action_button(
+                            "restart",
+                            restart,
+                            Self::next_mouse_state(mouse_states, button_index),
+                            app,
+                        ))
+                        .finish(),
+                )
+                .finish(),
+        )
+        .with_padding(Padding::uniform(10.))
+        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+        .finish()
+    }
+
+    fn host_card(
+        host: &HostProfile,
+        tenant: &TenantProfile,
+        mouse_states: &[MouseStateHandle],
+        button_index: &mut usize,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let ssh_command = Self::gcloud_ssh_prefix(host);
+
+        let mut runtimes = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(8.);
+        for runtime in &host.runtimes {
+            runtimes.add_child(Self::runtime_card(
+                tenant,
+                host,
+                runtime,
+                mouse_states,
+                button_index,
+                app,
+            ));
+        }
+
+        Container::new(
+            Flex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                .with_spacing(8.)
+                .with_child(
+                    Flex::row()
+                        .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                        .with_child(
+                            Text::new(host.name.clone(), appearance.ui_font_family(), 13.)
+                                .with_color(theme.active_ui_text_color().into_solid())
+                                .with_style(Properties::default().weight(Weight::Semibold))
+                                .finish(),
+                        )
+                        .with_child(Self::action_button(
+                            "ssh",
+                            ssh_command,
+                            Self::next_mouse_state(mouse_states, button_index),
+                            app,
+                        ))
+                        .finish(),
+                )
+                .with_child(Self::value_line("zone", &host.zone, app))
+                .with_child(Self::value_line("status", &host.status, app))
+                .with_child(Self::value_line(
+                    "runtimes",
+                    &host.runtimes.len().to_string(),
+                    app,
+                ))
+                .with_child(runtimes.finish())
+                .finish(),
+        )
+        .with_padding(Padding::uniform(12.))
+        .with_background(theme.surface_2())
+        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+        .finish()
+    }
+
+    fn tenant_card(
+        tenant: &TenantProfile,
+        is_expanded: bool,
+        tenant_mouse_state: MouseStateHandle,
+        mouse_states: &[MouseStateHandle],
+        button_index: &mut usize,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        let mut hosts = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(10.);
+        for host in &tenant.hosts {
+            hosts.add_child(Self::host_card(
+                host,
+                tenant,
+                mouse_states,
+                button_index,
+                app,
+            ));
+        }
+
+        let chevron_icon = if is_expanded {
+            Icon::ChevronDown
+        } else {
+            Icon::ChevronRight
+        };
+
+        let tenant_name = tenant.name.clone();
+        let header = Hoverable::new(tenant_mouse_state, |_| {
+            Container::new(
+                Flex::row()
+                    .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_child(
+                        Text::new(tenant.name.clone(), appearance.ui_font_family(), 14.)
+                            .with_color(theme.active_ui_text_color().into_solid())
+                            .with_style(Properties::default().weight(Weight::Bold))
+                            .finish(),
+                    )
+                    .with_child(
+                        ConstrainedBox::new(
+                            chevron_icon
+                                .to_warpui_icon(theme.nonactive_ui_text_color())
+                                .finish(),
+                        )
+                        .with_width(14.)
+                        .with_height(14.)
+                        .finish(),
+                    )
+                    .finish(),
+            )
+            .with_padding(Padding::uniform(2.))
+            .finish()
+        })
+        .with_cursor(Cursor::PointingHand)
+        .on_click(move |ctx, _, _| {
+            ctx.dispatch_typed_action(MonolithCockpitAction::ToggleTenant {
+                tenant_name: tenant_name.clone(),
+            });
+        })
+        .finish();
+
+        let mut content = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(10.)
+            .with_child(header)
+            .with_child(Self::value_line("environment", &tenant.environment, app))
+            .with_child(Self::value_line(
+                "vms",
+                &tenant.hosts.len().to_string(),
+                app,
+            ));
+
+        if is_expanded {
+            content.add_child(hosts.finish());
+        }
+
+        Container::new(content.finish())
+            .with_padding(Padding::uniform(12.))
+            .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(6.)))
+            .finish()
+    }
+
+    fn tenant_is_expanded(&self, tenant: &TenantProfile) -> bool {
+        self.expanded_tenants.contains(&tenant.name)
+    }
+}
+
+impl Entity for MonolithCockpitView {
+    type Event = ();
+}
+
+impl TypedActionView for MonolithCockpitView {
+    type Action = MonolithCockpitAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            MonolithCockpitAction::OpenCommand { command } => ctx.dispatch_global_action(
+                OPEN_SUBSHELL_ACTION,
+                SubshellCommandArg {
+                    command: command.clone(),
+                    shell_type: ShellType::from_name("bash"),
+                },
+            ),
+            MonolithCockpitAction::ToggleTenant { tenant_name } => {
+                if !self.expanded_tenants.insert(tenant_name.clone()) {
+                    self.expanded_tenants.remove(tenant_name);
+                }
+            }
+            MonolithCockpitAction::SwitchEnvironment { environment } => {
+                MonolithSettings::handle(ctx).update(ctx, |settings, ctx| {
+                    let (api_url, profile_path) = if environment == "prod" {
+                        (PROD_API_URL, PROD_PROFILE_PATH)
+                    } else {
+                        (STAGING_API_URL, STAGING_PROFILE_PATH)
+                    };
+                    let _ = settings
+                        .cockpit_environment
+                        .set_value(environment.clone(), ctx);
+                    let _ = settings.api_url.set_value(api_url.to_string(), ctx);
+                    let _ = settings
+                        .cockpit_profile_path
+                        .set_value(profile_path.to_string(), ctx);
+                });
+            }
+        }
+    }
+}
+
+impl View for MonolithCockpitView {
+    fn ui_name() -> &'static str {
+        "MonolithCockpitView"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let (profile, profile_status) = Self::load_profile(app);
+
+        let mut tenants = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(12.);
+        let mut button_index = 0;
+        for (tenant_index, tenant) in profile.tenants.iter().enumerate() {
+            let tenant_mouse_state = self
+                .tenant_mouse_states
+                .get(tenant_index)
+                .cloned()
+                .unwrap_or_default();
+            tenants.add_child(Self::tenant_card(
+                tenant,
+                self.tenant_is_expanded(tenant),
+                tenant_mouse_state,
+                &self.button_mouse_states,
+                &mut button_index,
+                app,
+            ));
+        }
+
+        let mut body = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_spacing(14.)
+            .with_child(
+                Text::new("Monolith", appearance.ui_font_family(), 18.)
+                    .with_color(theme.active_ui_text_color().into_solid())
+                    .with_style(Properties::default().weight(Weight::Bold))
+                    .finish(),
+            )
+            .with_child(self.render_environment_switcher(app))
+            .with_child(self.render_cloud_toolbar(app))
+            .with_child(Self::section_label("TENANT > VM > AGENT RUNTIME", app))
+            .with_child(
+                Text::new(
+                    "Select a tenant runtime, open VM shells through gcloud, inspect logs and Git, then run guarded lifecycle commands in Warp.",
+                    appearance.ui_font_family(),
+                    12.,
+                )
+                .with_color(theme.nonactive_ui_text_color().into_solid())
+                .finish(),
+            );
+
+        if let Some(status) = profile_status {
+            body.add_child(
+                Text::new(status, appearance.ui_font_family(), 11.)
+                    .with_color(theme.disabled_ui_text_color().into_solid())
+                    .finish(),
+            );
+        }
+
+        if profile.tenants.is_empty() {
+            body.add_child(
+                Text::new(
+                    "No live Monolith cockpit profile is configured.".to_string(),
+                    appearance.ui_font_family(),
+                    12.,
+                )
+                .with_color(theme.disabled_ui_text_color().into_solid())
+                .finish(),
+            );
+        }
+
+        body.add_child(tenants.finish());
+
+        let scrollable = ClippedScrollable::vertical(
+            self.scroll_state.clone(),
+            Container::new(body.finish())
+                .with_padding(Padding::uniform(12.))
+                .finish(),
+            ScrollbarWidth::Auto,
+            theme.nonactive_ui_detail().into(),
+            theme.active_ui_detail().into(),
+            Fill::None,
+        )
+        .with_overlayed_scrollbar()
+        .finish();
+
+        Shrinkable::new(
+            1.0,
+            Container::new(scrollable)
+                .with_padding(Padding::uniform(0.))
+                .finish(),
+        )
+        .finish()
+    }
+}

--- a/app/src/workspace/view/monolith_cockpit.rs
+++ b/app/src/workspace/view/monolith_cockpit.rs
@@ -92,6 +92,8 @@ pub enum TenantFilter {
     Active,
     Offboarded,
     WithVms,
+    RunningAgents,
+    DownAgents,
 }
 
 pub struct MonolithCockpitView {
@@ -111,7 +113,7 @@ impl MonolithCockpitView {
             button_mouse_states: (0..512).map(|_| MouseStateHandle::default()).collect(),
             tenant_mouse_states: (0..128).map(|_| MouseStateHandle::default()).collect(),
             environment_mouse_states: (0..2).map(|_| MouseStateHandle::default()).collect(),
-            cloud_mouse_states: (0..8).map(|_| MouseStateHandle::default()).collect(),
+            cloud_mouse_states: (0..16).map(|_| MouseStateHandle::default()).collect(),
             scroll_state: ClippedScrollStateHandle::default(),
             expanded_tenants: HashSet::new(),
             tenant_filter: TenantFilter::All,
@@ -216,6 +218,16 @@ impl MonolithCockpitView {
             TenantFilter::Active => Self::tenant_status_label(tenant) == "active",
             TenantFilter::Offboarded => Self::tenant_status_label(tenant) == "offboarded",
             TenantFilter::WithVms => !tenant.hosts.is_empty(),
+            TenantFilter::RunningAgents => tenant.hosts.iter().any(|host| {
+                host.runtimes
+                    .iter()
+                    .any(|runtime| Self::runtime_matches_filter(runtime, filter))
+            }),
+            TenantFilter::DownAgents => tenant.hosts.iter().any(|host| {
+                host.runtimes
+                    .iter()
+                    .any(|runtime| Self::runtime_matches_filter(runtime, filter))
+            }),
         }
     }
 
@@ -225,6 +237,55 @@ impl MonolithCockpitView {
             TenantFilter::Active => "active",
             TenantFilter::Offboarded => "offboarded",
             TenantFilter::WithVms => "with vms",
+            TenantFilter::RunningAgents => "running agents",
+            TenantFilter::DownAgents => "down agents",
+        }
+    }
+
+    fn runtime_matches_filter(runtime: &RuntimeProfile, filter: TenantFilter) -> bool {
+        match filter {
+            TenantFilter::RunningAgents => runtime.status.contains("running"),
+            TenantFilter::DownAgents => !runtime.status.contains("running"),
+            _ => true,
+        }
+    }
+
+    fn host_matches_filter(host: &HostProfile, filter: TenantFilter) -> bool {
+        match filter {
+            TenantFilter::RunningAgents | TenantFilter::DownAgents => host
+                .runtimes
+                .iter()
+                .any(|runtime| Self::runtime_matches_filter(runtime, filter)),
+            _ => true,
+        }
+    }
+
+    fn visible_runtime_count(tenant: &TenantProfile, filter: TenantFilter) -> usize {
+        tenant
+            .hosts
+            .iter()
+            .flat_map(|host| &host.runtimes)
+            .filter(|runtime| Self::runtime_matches_filter(runtime, filter))
+            .count()
+    }
+
+    fn filter_count(profile: &CockpitProfile, filter: TenantFilter) -> usize {
+        match filter {
+            TenantFilter::RunningAgents => profile
+                .tenants
+                .iter()
+                .map(Self::running_runtime_count)
+                .sum::<usize>(),
+            TenantFilter::DownAgents => profile
+                .tenants
+                .iter()
+                .map(|tenant| Self::runtime_count(tenant) - Self::running_runtime_count(tenant))
+                .sum::<usize>(),
+            _ => profile
+                .tenants
+                .iter()
+                .filter(|tenant| Self::tenant_matches_filter(tenant, filter))
+                .count(),
         }
     }
 
@@ -448,14 +509,8 @@ VMs and runtimes:\n{}",
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
 
-        let display_label = if is_active {
-            format!("selected: {label}")
-        } else {
-            label.to_string()
-        };
-
         let mut button = Container::new(
-            Text::new(display_label, appearance.ui_font_family(), 11.)
+            Text::new(label.to_string(), appearance.ui_font_family(), 11.)
                 .with_color(theme.active_ui_text_color().into_solid())
                 .with_style(Properties::default().weight(if is_active {
                     Weight::Semibold
@@ -469,7 +524,9 @@ VMs and runtimes:\n{}",
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
 
         if is_active {
-            button = button.with_background(theme.surface_3());
+            button = button
+                .with_background(theme.surface_3())
+                .with_border(Border::all(1.).with_border_fill(theme.active_ui_detail()));
         }
 
         Hoverable::new(mouse_state, |_| button.finish())
@@ -977,6 +1034,7 @@ VMs and runtimes:\n{}",
     fn host_card(
         host: &HostProfile,
         tenant: &TenantProfile,
+        filter: TenantFilter,
         mouse_states: &[MouseStateHandle],
         button_index: &mut usize,
         app: &AppContext,
@@ -988,7 +1046,11 @@ VMs and runtimes:\n{}",
         let mut runtimes = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_spacing(8.);
-        for runtime in &host.runtimes {
+        for runtime in host
+            .runtimes
+            .iter()
+            .filter(|runtime| Self::runtime_matches_filter(runtime, filter))
+        {
             runtimes.add_child(Self::runtime_card(
                 tenant,
                 host,
@@ -1008,9 +1070,20 @@ VMs and runtimes:\n{}",
                         .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
                         .with_cross_axis_alignment(CrossAxisAlignment::Center)
                         .with_child(
-                            Text::new(host.name.clone(), appearance.ui_font_family(), 13.)
-                                .with_color(theme.active_ui_text_color().into_solid())
-                                .with_style(Properties::default().weight(Weight::Semibold))
+                            Flex::row()
+                                .with_spacing(6.)
+                                .with_child(
+                                    Text::new("VM", appearance.ui_font_family(), 10.)
+                                        .with_color(theme.disabled_ui_text_color().into_solid())
+                                        .with_style(Properties::default().weight(Weight::Semibold))
+                                        .finish(),
+                                )
+                                .with_child(
+                                    Text::new(host.name.clone(), appearance.ui_font_family(), 13.)
+                                        .with_color(theme.active_ui_text_color().into_solid())
+                                        .with_style(Properties::default().weight(Weight::Semibold))
+                                        .finish(),
+                                )
                                 .finish(),
                         )
                         .with_child(Self::action_button(
@@ -1025,14 +1098,20 @@ VMs and runtimes:\n{}",
                 .with_child(Self::value_line("status", &host.status, app))
                 .with_child(Self::value_line(
                     "runtimes",
-                    &host.runtimes.len().to_string(),
+                    &format!(
+                        "{} / {} visible",
+                        host.runtimes
+                            .iter()
+                            .filter(|runtime| Self::runtime_matches_filter(runtime, filter))
+                            .count(),
+                        host.runtimes.len()
+                    ),
                     app,
                 ))
                 .with_child(runtimes.finish())
                 .finish(),
         )
-        .with_padding(Padding::uniform(12.))
-        .with_background(theme.surface_2())
+        .with_padding(Padding::uniform(8.).with_left(12.))
         .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
         .finish()
@@ -1046,6 +1125,8 @@ VMs and runtimes:\n{}",
         button_index: &mut usize,
         active_environment: &str,
         api_url: &str,
+        filter: TenantFilter,
+        is_selected: bool,
         app: &AppContext,
     ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
@@ -1054,10 +1135,15 @@ VMs and runtimes:\n{}",
         let mut hosts = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_spacing(10.);
-        for host in &tenant.hosts {
+        for host in tenant
+            .hosts
+            .iter()
+            .filter(|host| Self::host_matches_filter(host, filter))
+        {
             hosts.add_child(Self::host_card(
                 host,
                 tenant,
+                filter,
                 mouse_states,
                 button_index,
                 app,
@@ -1138,40 +1224,50 @@ VMs and runtimes:\n{}",
 
         let mut content = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_spacing(10.)
-            .with_child(header)
-            .with_child(Self::value_line("environment", &tenant.environment, app))
-            .with_child(Self::value_line(
-                "vms",
-                &tenant.hosts.len().to_string(),
-                app,
-            ))
-            .with_child(Self::value_line(
-                "runtimes",
-                &format!(
-                    "{} / {} running",
-                    Self::running_runtime_count(tenant),
-                    Self::runtime_count(tenant)
-                ),
-                app,
-            ))
-            .with_child(
+            .with_spacing(8.)
+            .with_child(header);
+
+        if is_expanded {
+            content.add_child(
+                Flex::row()
+                    .with_spacing(6.)
+                    .with_child(Self::status_chip(&tenant.environment, app))
+                    .with_child(Self::status_chip(
+                        &format!("vms {}", tenant.hosts.len()),
+                        app,
+                    ))
+                    .with_child(Self::status_chip(
+                        &format!(
+                            "runtimes {} / {} visible",
+                            Self::visible_runtime_count(tenant, filter),
+                            Self::runtime_count(tenant)
+                        ),
+                        app,
+                    ))
+                    .finish(),
+            );
+            content.add_child(
                 Flex::row()
                     .with_spacing(6.)
                     .with_child(chat_button)
                     .with_child(copy_context_button)
                     .finish(),
             );
-
-        if is_expanded {
             content.add_child(hosts.finish());
         }
 
-        Container::new(content.finish())
-            .with_padding(Padding::uniform(12.))
+        let mut container = Container::new(content.finish())
+            .with_padding(Padding::uniform(8.).with_left(10.).with_right(10.))
             .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
-            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(6.)))
-            .finish()
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
+
+        if is_selected {
+            container = container
+                .with_background(theme.surface_2())
+                .with_border(Border::all(1.).with_border_fill(theme.active_ui_detail()));
+        }
+
+        container.finish()
     }
 
     fn tenant_is_expanded(&self, tenant: &TenantProfile) -> bool {
@@ -1229,9 +1325,11 @@ impl TypedActionView for MonolithCockpitView {
                 ctx.notify();
             }
             MonolithCockpitAction::ToggleTenant { tenant_name } => {
+                self.selected_tenant = Some(tenant_name.clone());
                 if !self.expanded_tenants.insert(tenant_name.clone()) {
                     self.expanded_tenants.remove(tenant_name);
                 }
+                ctx.notify();
             }
             MonolithCockpitAction::SwitchEnvironment { environment } => {
                 MonolithSettings::handle(ctx).update(ctx, |settings, ctx| {
@@ -1289,6 +1387,10 @@ impl View for MonolithCockpitView {
                 &mut button_index,
                 &active_environment,
                 &api_url,
+                self.tenant_filter,
+                self.selected_tenant
+                    .as_ref()
+                    .is_some_and(|selected| selected == &tenant.name),
                 app,
             ));
         }
@@ -1342,33 +1444,68 @@ impl View for MonolithCockpitView {
             Flex::row()
                 .with_spacing(6.)
                 .with_child(Self::tenant_filter_button(
-                    "all",
+                    &format!("all {}", Self::filter_count(&profile, TenantFilter::All)),
                     TenantFilter::All,
                     self.tenant_filter == TenantFilter::All,
                     Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
                     app,
                 ))
                 .with_child(Self::tenant_filter_button(
-                    "active",
+                    &format!(
+                        "active {}",
+                        Self::filter_count(&profile, TenantFilter::Active)
+                    ),
                     TenantFilter::Active,
                     self.tenant_filter == TenantFilter::Active,
                     Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
                     app,
                 ))
                 .with_child(Self::tenant_filter_button(
-                    "offboarded",
+                    &format!(
+                        "offboarded {}",
+                        Self::filter_count(&profile, TenantFilter::Offboarded)
+                    ),
                     TenantFilter::Offboarded,
                     self.tenant_filter == TenantFilter::Offboarded,
                     Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
                     app,
                 ))
                 .with_child(Self::tenant_filter_button(
-                    "with vms",
+                    &format!(
+                        "with vms {}",
+                        Self::filter_count(&profile, TenantFilter::WithVms)
+                    ),
                     TenantFilter::WithVms,
                     self.tenant_filter == TenantFilter::WithVms,
                     Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
                     app,
                 ))
+                .with_child(Self::tenant_filter_button(
+                    &format!(
+                        "running {}",
+                        Self::filter_count(&profile, TenantFilter::RunningAgents)
+                    ),
+                    TenantFilter::RunningAgents,
+                    self.tenant_filter == TenantFilter::RunningAgents,
+                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    app,
+                ))
+                .with_child(Self::tenant_filter_button(
+                    &format!(
+                        "down {}",
+                        Self::filter_count(&profile, TenantFilter::DownAgents)
+                    ),
+                    TenantFilter::DownAgents,
+                    self.tenant_filter == TenantFilter::DownAgents,
+                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    app,
+                ))
+                .finish(),
+        );
+
+        body.add_child(
+            Flex::row()
+                .with_spacing(6.)
                 .with_child(Self::typed_button(
                     "expand all",
                     MonolithCockpitAction::ExpandAllTenants { tenant_names },

--- a/app/src/workspace/view/monolith_cockpit.rs
+++ b/app/src/workspace/view/monolith_cockpit.rs
@@ -71,6 +71,7 @@ pub enum MonolithCockpitAction {
         tenant_name: String,
         context: String,
     },
+    ClearSelectedTenant,
     ShowTenantFilter {
         filter: TenantFilter,
     },
@@ -101,6 +102,9 @@ pub struct MonolithCockpitView {
     tenant_mouse_states: Vec<MouseStateHandle>,
     environment_mouse_states: Vec<MouseStateHandle>,
     cloud_mouse_states: Vec<MouseStateHandle>,
+    filter_mouse_states: Vec<MouseStateHandle>,
+    fleet_control_mouse_states: Vec<MouseStateHandle>,
+    tenant_context_mouse_states: Vec<MouseStateHandle>,
     scroll_state: ClippedScrollStateHandle,
     expanded_tenants: HashSet<String>,
     tenant_filter: TenantFilter,
@@ -114,6 +118,9 @@ impl MonolithCockpitView {
             tenant_mouse_states: (0..128).map(|_| MouseStateHandle::default()).collect(),
             environment_mouse_states: (0..2).map(|_| MouseStateHandle::default()).collect(),
             cloud_mouse_states: (0..16).map(|_| MouseStateHandle::default()).collect(),
+            filter_mouse_states: (0..16).map(|_| MouseStateHandle::default()).collect(),
+            fleet_control_mouse_states: (0..8).map(|_| MouseStateHandle::default()).collect(),
+            tenant_context_mouse_states: (0..4).map(|_| MouseStateHandle::default()).collect(),
             scroll_state: ClippedScrollStateHandle::default(),
             expanded_tenants: HashSet::new(),
             tenant_filter: TenantFilter::All,
@@ -755,15 +762,41 @@ VMs and runtimes:\n{}",
                             ))
                             .finish(),
                     )
-                    .with_child(Self::typed_button(
-                        "copy context",
-                        MonolithCockpitAction::CopyTenantContext {
-                            tenant_name: tenant.name.clone(),
-                            context,
-                        },
-                        self.cloud_mouse_states.get(4).cloned().unwrap_or_default(),
-                        app,
-                    ))
+                    .with_child(
+                        Flex::row()
+                            .with_spacing(6.)
+                            .with_child(Self::primary_typed_button(
+                                "exit tenant",
+                                MonolithCockpitAction::ClearSelectedTenant,
+                                self.tenant_context_mouse_states
+                                    .first()
+                                    .cloned()
+                                    .unwrap_or_default(),
+                                app,
+                            ))
+                            .with_child(Self::typed_button(
+                                "copy context",
+                                MonolithCockpitAction::CopyTenantContext {
+                                    tenant_name: tenant.name.clone(),
+                                    context,
+                                },
+                                self.tenant_context_mouse_states
+                                    .get(1)
+                                    .cloned()
+                                    .unwrap_or_default(),
+                                app,
+                            ))
+                            .finish(),
+                    )
+                    .with_child(
+                        Text::new(
+                            "Tenant scope is active. Exit tenant returns the cockpit to full-fleet browsing.",
+                            appearance.ui_font_family(),
+                            11.,
+                        )
+                        .with_color(theme.disabled_ui_text_color().into_solid())
+                        .finish(),
+                    )
                     .finish(),
             )
             .with_padding(Padding::uniform(10.))
@@ -1314,19 +1347,41 @@ impl TypedActionView for MonolithCockpitView {
                     .write(ClipboardContent::plain_text(context.clone()));
                 ctx.notify();
             }
+            MonolithCockpitAction::ClearSelectedTenant => {
+                self.selected_tenant = None;
+                ctx.notify();
+            }
             MonolithCockpitAction::ShowTenantFilter { filter } => {
                 self.tenant_filter = *filter;
-                if matches!(
-                    filter,
-                    TenantFilter::RunningAgents | TenantFilter::DownAgents | TenantFilter::WithVms
-                ) {
-                    let (profile, _) = Self::load_profile(ctx);
-                    self.expanded_tenants = profile
+                let (profile, _) = Self::load_profile(ctx);
+                self.expanded_tenants = match filter {
+                    TenantFilter::All => {
+                        self.selected_tenant = None;
+                        HashSet::new()
+                    }
+                    TenantFilter::Active | TenantFilter::Offboarded => profile
+                        .tenants
+                        .iter()
+                        .filter(|tenant| {
+                            Self::tenant_matches_filter(tenant, *filter) && !tenant.hosts.is_empty()
+                        })
+                        .map(|tenant| tenant.name.clone())
+                        .collect(),
+                    TenantFilter::WithVms
+                    | TenantFilter::RunningAgents
+                    | TenantFilter::DownAgents => profile
                         .tenants
                         .iter()
                         .filter(|tenant| Self::tenant_matches_filter(tenant, *filter))
                         .map(|tenant| tenant.name.clone())
-                        .collect();
+                        .collect(),
+                };
+                if self.selected_tenant.as_ref().is_some_and(|selected| {
+                    !profile.tenants.iter().any(|tenant| {
+                        &tenant.name == selected && Self::tenant_matches_filter(tenant, *filter)
+                    })
+                }) {
+                    self.selected_tenant = None;
                 }
                 ctx.notify();
             }
@@ -1462,7 +1517,7 @@ impl View for MonolithCockpitView {
             .iter()
             .map(|tenant| tenant.name.clone())
             .collect::<Vec<_>>();
-        let mut header_button_index = 0;
+        let mut filter_button_index = 0;
         body.add_child(
             Flex::row()
                 .with_spacing(6.)
@@ -1470,7 +1525,7 @@ impl View for MonolithCockpitView {
                     &format!("all {}", Self::filter_count(&profile, TenantFilter::All)),
                     TenantFilter::All,
                     self.tenant_filter == TenantFilter::All,
-                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    Self::next_mouse_state(&self.filter_mouse_states, &mut filter_button_index),
                     app,
                 ))
                 .with_child(Self::tenant_filter_button(
@@ -1480,7 +1535,7 @@ impl View for MonolithCockpitView {
                     ),
                     TenantFilter::Active,
                     self.tenant_filter == TenantFilter::Active,
-                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    Self::next_mouse_state(&self.filter_mouse_states, &mut filter_button_index),
                     app,
                 ))
                 .with_child(Self::tenant_filter_button(
@@ -1490,9 +1545,15 @@ impl View for MonolithCockpitView {
                     ),
                     TenantFilter::Offboarded,
                     self.tenant_filter == TenantFilter::Offboarded,
-                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    Self::next_mouse_state(&self.filter_mouse_states, &mut filter_button_index),
                     app,
                 ))
+                .finish(),
+        );
+
+        body.add_child(
+            Flex::row()
+                .with_spacing(6.)
                 .with_child(Self::tenant_filter_button(
                     &format!(
                         "with vms {}",
@@ -1500,7 +1561,7 @@ impl View for MonolithCockpitView {
                     ),
                     TenantFilter::WithVms,
                     self.tenant_filter == TenantFilter::WithVms,
-                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    Self::next_mouse_state(&self.filter_mouse_states, &mut filter_button_index),
                     app,
                 ))
                 .with_child(Self::tenant_filter_button(
@@ -1510,7 +1571,7 @@ impl View for MonolithCockpitView {
                     ),
                     TenantFilter::RunningAgents,
                     self.tenant_filter == TenantFilter::RunningAgents,
-                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    Self::next_mouse_state(&self.filter_mouse_states, &mut filter_button_index),
                     app,
                 ))
                 .with_child(Self::tenant_filter_button(
@@ -1520,25 +1581,32 @@ impl View for MonolithCockpitView {
                     ),
                     TenantFilter::DownAgents,
                     self.tenant_filter == TenantFilter::DownAgents,
-                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    Self::next_mouse_state(&self.filter_mouse_states, &mut filter_button_index),
                     app,
                 ))
                 .finish(),
         );
 
+        let mut fleet_control_button_index = 0;
         body.add_child(
             Flex::row()
                 .with_spacing(6.)
                 .with_child(Self::typed_button(
                     "expand all",
                     MonolithCockpitAction::ExpandAllTenants { tenant_names },
-                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    Self::next_mouse_state(
+                        &self.fleet_control_mouse_states,
+                        &mut fleet_control_button_index,
+                    ),
                     app,
                 ))
                 .with_child(Self::typed_button(
                     "collapse all",
                     MonolithCockpitAction::CollapseAllTenants,
-                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    Self::next_mouse_state(
+                        &self.fleet_control_mouse_states,
+                        &mut fleet_control_button_index,
+                    ),
                     app,
                 ))
                 .finish(),

--- a/app/src/workspace/view/monolith_cockpit.rs
+++ b/app/src/workspace/view/monolith_cockpit.rs
@@ -71,6 +71,9 @@ pub enum MonolithCockpitAction {
         tenant_name: String,
         context: String,
     },
+    SetTenantContext {
+        tenant_name: String,
+    },
     ClearSelectedTenant,
     ShowTenantFilter {
         filter: TenantFilter,
@@ -123,7 +126,7 @@ impl MonolithCockpitView {
             tenant_context_mouse_states: (0..4).map(|_| MouseStateHandle::default()).collect(),
             scroll_state: ClippedScrollStateHandle::default(),
             expanded_tenants: HashSet::new(),
-            tenant_filter: TenantFilter::All,
+            tenant_filter: TenantFilter::WithVms,
             selected_tenant: None,
         }
     }
@@ -433,7 +436,7 @@ VMs and runtimes:\n{}",
                 .with_color(theme.active_ui_text_color().into_solid())
                 .finish(),
         )
-        .with_padding(Padding::uniform(4.).with_left(8.).with_right(8.))
+        .with_padding(Padding::uniform(3.).with_left(7.).with_right(7.))
         .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
         .finish();
@@ -462,7 +465,7 @@ VMs and runtimes:\n{}",
                 .with_color(theme.active_ui_text_color().into_solid())
                 .finish(),
         )
-        .with_padding(Padding::uniform(4.).with_left(8.).with_right(8.))
+        .with_padding(Padding::uniform(3.).with_left(7.).with_right(7.))
         .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
         .finish();
@@ -485,14 +488,14 @@ VMs and runtimes:\n{}",
         let theme = appearance.theme();
 
         let button = Container::new(
-            Text::new(label.to_string(), appearance.ui_font_family(), 12.)
+            Text::new(label.to_string(), appearance.ui_font_family(), 11.)
                 .with_color(theme.active_ui_text_color().into_solid())
                 .with_style(Properties::default().weight(Weight::Semibold))
                 .finish(),
         )
-        .with_padding(Padding::uniform(7.).with_left(10.).with_right(10.))
-        .with_background(theme.surface_3())
-        .with_border(Border::all(1.).with_border_fill(theme.active_ui_detail()))
+        .with_padding(Padding::uniform(4.).with_left(8.).with_right(8.))
+        .with_background(theme.surface_2())
+        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
         .finish();
 
@@ -524,14 +527,14 @@ VMs and runtimes:\n{}",
                 }))
                 .finish(),
         )
-        .with_padding(Padding::uniform(5.).with_left(9.).with_right(9.))
+        .with_padding(Padding::uniform(3.).with_left(7.).with_right(7.))
         .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
 
         if is_active {
             button = button
                 .with_background(theme.surface_3())
-                .with_border(Border::all(1.).with_border_fill(theme.active_ui_detail()));
+                .with_border(Border::all(1.).with_border_fill(theme.surface_3()));
         }
 
         let button = button.finish();
@@ -553,7 +556,7 @@ VMs and runtimes:\n{}",
                 .with_color(theme.nonactive_ui_text_color().into_solid())
                 .finish(),
         )
-        .with_padding(Padding::uniform(3.).with_left(6.).with_right(6.))
+        .with_padding(Padding::uniform(2.).with_left(5.).with_right(5.))
         .with_background(theme.surface_2())
         .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
@@ -729,76 +732,90 @@ VMs and runtimes:\n{}",
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
         let context = Self::tenant_context(tenant, active_environment, api_url);
+        let prompt = Self::tenant_chat_prompt(tenant, active_environment, api_url);
 
         Some(
             Container::new(
                 Flex::column()
                     .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-                    .with_spacing(8.)
-                    .with_child(Self::section_label("CURRENT TENANT", app))
-                    .with_child(
-                        Text::new(tenant.name.clone(), appearance.ui_font_family(), 14.)
-                            .with_color(theme.active_ui_text_color().into_solid())
-                            .with_style(Properties::default().weight(Weight::Bold))
-                            .finish(),
-                    )
+                    .with_spacing(7.)
+                    .with_child(Self::section_label("TENANT CONTEXT", app))
                     .with_child(
                         Flex::row()
-                            .with_spacing(6.)
-                            .with_child(Self::status_chip(&tenant.environment, app))
-                            .with_child(Self::status_chip(
-                                &format!("vms {}", tenant.hosts.len()),
-                                app,
-                            ))
-                            .with_child(Self::status_chip(
-                                &format!(
-                                    "runtimes {} / {} running",
-                                    Self::running_runtime_count(tenant),
-                                    Self::runtime_count(tenant)
-                                ),
-                                app,
-                            ))
+                            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                            .with_child(
+                                Flex::column()
+                                    .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                                    .with_spacing(4.)
+                                    .with_child(
+                                        Text::new(
+                                            tenant.name.clone(),
+                                            appearance.ui_font_family(),
+                                            13.,
+                                        )
+                                        .with_color(theme.active_ui_text_color().into_solid())
+                                        .with_style(Properties::default().weight(Weight::Semibold))
+                                        .finish(),
+                                    )
+                                    .with_child(Self::muted_text(
+                                        format!(
+                                            "{} · {} vms · {} / {} running",
+                                            tenant.environment,
+                                            tenant.hosts.len(),
+                                            Self::running_runtime_count(tenant),
+                                            Self::runtime_count(tenant)
+                                        ),
+                                        11.,
+                                        app,
+                                    ))
+                                    .finish(),
+                            )
+                            .with_child(
+                                Flex::row()
+                                    .with_spacing(6.)
+                                    .with_child(Self::primary_typed_button(
+                                        "chat",
+                                        MonolithCockpitAction::StartTenantChat {
+                                            tenant_name: tenant.name.clone(),
+                                            prompt,
+                                        },
+                                        self.tenant_context_mouse_states
+                                            .first()
+                                            .cloned()
+                                            .unwrap_or_default(),
+                                        app,
+                                    ))
+                                    .with_child(Self::typed_button(
+                                        "copy",
+                                        MonolithCockpitAction::CopyTenantContext {
+                                            tenant_name: tenant.name.clone(),
+                                            context,
+                                        },
+                                        self.tenant_context_mouse_states
+                                            .get(1)
+                                            .cloned()
+                                            .unwrap_or_default(),
+                                        app,
+                                    ))
+                                    .with_child(Self::typed_button(
+                                        "clear",
+                                        MonolithCockpitAction::ClearSelectedTenant,
+                                        self.tenant_context_mouse_states
+                                            .get(2)
+                                            .cloned()
+                                            .unwrap_or_default(),
+                                        app,
+                                    ))
+                                    .finish(),
+                            )
                             .finish(),
-                    )
-                    .with_child(
-                        Flex::row()
-                            .with_spacing(6.)
-                            .with_child(Self::primary_typed_button(
-                                "exit tenant",
-                                MonolithCockpitAction::ClearSelectedTenant,
-                                self.tenant_context_mouse_states
-                                    .first()
-                                    .cloned()
-                                    .unwrap_or_default(),
-                                app,
-                            ))
-                            .with_child(Self::typed_button(
-                                "copy context",
-                                MonolithCockpitAction::CopyTenantContext {
-                                    tenant_name: tenant.name.clone(),
-                                    context,
-                                },
-                                self.tenant_context_mouse_states
-                                    .get(1)
-                                    .cloned()
-                                    .unwrap_or_default(),
-                                app,
-                            ))
-                            .finish(),
-                    )
-                    .with_child(
-                        Text::new(
-                            "Tenant scope is active. Exit tenant returns the cockpit to full-fleet browsing.",
-                            appearance.ui_font_family(),
-                            11.,
-                        )
-                        .with_color(theme.disabled_ui_text_color().into_solid())
-                        .finish(),
                     )
                     .finish(),
             )
-            .with_padding(Padding::uniform(10.))
-            .with_border(Border::all(1.).with_border_fill(theme.active_ui_detail()))
+            .with_padding(Padding::uniform(8.).with_left(10.).with_right(10.))
+            .with_background(theme.surface_1())
+            .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
             .with_corner_radius(CornerRadius::with_all(Radius::Pixels(6.)))
             .finish(),
         )
@@ -982,7 +999,7 @@ VMs and runtimes:\n{}",
                         .finish(),
                     )
                     .with_child(
-                        Text::new(runtime.name.clone(), appearance.ui_font_family(), 13.)
+                        Text::new(runtime.name.clone(), appearance.ui_font_family(), 12.)
                             .with_color(theme.active_ui_text_color().into_solid())
                             .with_style(Properties::default().weight(Weight::Semibold))
                             .finish(),
@@ -990,7 +1007,7 @@ VMs and runtimes:\n{}",
                     .finish(),
             )
             .with_child(
-                Text::new(runtime.status.clone(), appearance.ui_font_family(), 11.)
+                Text::new(runtime.status.clone(), appearance.ui_font_family(), 10.)
                     .with_color(theme.disabled_ui_text_color().into_solid())
                     .finish(),
             )
@@ -1111,7 +1128,7 @@ VMs and runtimes:\n{}",
                                         .finish(),
                                 )
                                 .with_child(
-                                    Text::new(host.name.clone(), appearance.ui_font_family(), 13.)
+                                    Text::new(host.name.clone(), appearance.ui_font_family(), 12.)
                                         .with_color(theme.active_ui_text_color().into_solid())
                                         .with_style(Properties::default().weight(Weight::Semibold))
                                         .finish(),
@@ -1154,8 +1171,6 @@ VMs and runtimes:\n{}",
         tenant_mouse_state: MouseStateHandle,
         mouse_states: &[MouseStateHandle],
         button_index: &mut usize,
-        active_environment: &str,
-        api_url: &str,
         filter: TenantFilter,
         is_selected: bool,
         app: &AppContext,
@@ -1165,7 +1180,7 @@ VMs and runtimes:\n{}",
 
         let mut hosts = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_spacing(10.);
+            .with_spacing(8.);
         for host in tenant
             .hosts
             .iter()
@@ -1188,26 +1203,18 @@ VMs and runtimes:\n{}",
         };
 
         let tenant_name = tenant.name.clone();
-        let prompt = Self::tenant_chat_prompt(tenant, active_environment, api_url);
-        let context = Self::tenant_context(tenant, active_environment, api_url);
-        let chat_button = Self::primary_typed_button(
-            "chat",
-            MonolithCockpitAction::StartTenantChat {
-                tenant_name: tenant.name.clone(),
-                prompt,
-            },
-            Self::next_mouse_state(mouse_states, button_index),
-            app,
-        );
-        let copy_context_button = Self::typed_button(
-            "copy context",
-            MonolithCockpitAction::CopyTenantContext {
-                tenant_name: tenant.name.clone(),
-                context,
-            },
-            Self::next_mouse_state(mouse_states, button_index),
-            app,
-        );
+        let set_current_button = if is_selected {
+            None
+        } else {
+            Some(Self::typed_button(
+                "set current",
+                MonolithCockpitAction::SetTenantContext {
+                    tenant_name: tenant.name.clone(),
+                },
+                Self::next_mouse_state(mouse_states, button_index),
+                app,
+            ))
+        };
 
         let header = Hoverable::new(tenant_mouse_state, |_| {
             Container::new(
@@ -1218,9 +1225,9 @@ VMs and runtimes:\n{}",
                         Flex::row()
                             .with_spacing(6.)
                             .with_child(
-                                Text::new(tenant.name.clone(), appearance.ui_font_family(), 14.)
+                                Text::new(tenant.name.clone(), appearance.ui_font_family(), 13.)
                                     .with_color(theme.active_ui_text_color().into_solid())
-                                    .with_style(Properties::default().weight(Weight::Bold))
+                                    .with_style(Properties::default().weight(Weight::Semibold))
                                     .finish(),
                             )
                             .with_child(Self::status_chip(
@@ -1255,7 +1262,7 @@ VMs and runtimes:\n{}",
 
         let mut content = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_spacing(8.)
+            .with_spacing(7.)
             .with_child(header);
 
         if is_expanded {
@@ -1270,13 +1277,14 @@ VMs and runtimes:\n{}",
                 12.,
                 app,
             ));
-            content.add_child(
-                Flex::row()
-                    .with_spacing(6.)
-                    .with_child(chat_button)
-                    .with_child(copy_context_button)
-                    .finish(),
-            );
+            if let Some(set_current_button) = set_current_button {
+                content.add_child(
+                    Flex::row()
+                        .with_spacing(6.)
+                        .with_child(set_current_button)
+                        .finish(),
+                );
+            }
             content.add_child(hosts.finish());
         }
 
@@ -1286,9 +1294,7 @@ VMs and runtimes:\n{}",
             .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
 
         if is_selected {
-            container = container
-                .with_background(theme.surface_2())
-                .with_border(Border::all(1.).with_border_fill(theme.active_ui_detail()));
+            container = container.with_background(theme.surface_1());
         }
 
         container.finish()
@@ -1336,6 +1342,10 @@ impl TypedActionView for MonolithCockpitView {
                     .write(ClipboardContent::plain_text(context.clone()));
                 ctx.notify();
             }
+            MonolithCockpitAction::SetTenantContext { tenant_name } => {
+                self.selected_tenant = Some(tenant_name.clone());
+                ctx.notify();
+            }
             MonolithCockpitAction::ClearSelectedTenant => {
                 self.selected_tenant = None;
                 ctx.notify();
@@ -1344,10 +1354,7 @@ impl TypedActionView for MonolithCockpitView {
                 self.tenant_filter = *filter;
                 let (profile, _) = Self::load_profile(ctx);
                 self.expanded_tenants = match filter {
-                    TenantFilter::All => {
-                        self.selected_tenant = None;
-                        HashSet::new()
-                    }
+                    TenantFilter::All => HashSet::new(),
                     TenantFilter::Active | TenantFilter::Offboarded => profile
                         .tenants
                         .iter()
@@ -1365,13 +1372,6 @@ impl TypedActionView for MonolithCockpitView {
                         .map(|tenant| tenant.name.clone())
                         .collect(),
                 };
-                if self.selected_tenant.as_ref().is_some_and(|selected| {
-                    !profile.tenants.iter().any(|tenant| {
-                        &tenant.name == selected && Self::tenant_matches_filter(tenant, *filter)
-                    })
-                }) {
-                    self.selected_tenant = None;
-                }
                 ctx.notify();
             }
             MonolithCockpitAction::ExpandAllTenants { tenant_names } => {
@@ -1383,13 +1383,14 @@ impl TypedActionView for MonolithCockpitView {
                 ctx.notify();
             }
             MonolithCockpitAction::ToggleTenant { tenant_name } => {
-                self.selected_tenant = Some(tenant_name.clone());
                 if !self.expanded_tenants.insert(tenant_name.clone()) {
                     self.expanded_tenants.remove(tenant_name);
                 }
                 ctx.notify();
             }
             MonolithCockpitAction::SwitchEnvironment { environment } => {
+                self.selected_tenant = None;
+                self.expanded_tenants.clear();
                 MonolithSettings::handle(ctx).update(ctx, |settings, ctx| {
                     let (api_url, profile_path) = if environment == "prod" {
                         (PROD_API_URL, PROD_PROFILE_PATH)
@@ -1443,8 +1444,6 @@ impl View for MonolithCockpitView {
                 tenant_mouse_state,
                 &self.button_mouse_states,
                 &mut button_index,
-                &active_environment,
-                &api_url,
                 self.tenant_filter,
                 self.selected_tenant
                     .as_ref()
@@ -1473,17 +1472,6 @@ impl View for MonolithCockpitView {
             body.add_child(selected_context);
         }
 
-        body.add_child(Self::section_label("TENANT > VM > AGENT RUNTIME", app));
-        body.add_child(
-            Text::new(
-                "Select a tenant runtime, open VM shells through gcloud, inspect logs and Git, then run guarded lifecycle commands in Warp.",
-                appearance.ui_font_family(),
-                12.,
-            )
-            .with_color(theme.nonactive_ui_text_color().into_solid())
-            .finish(),
-        );
-
         if let Some(status) = profile_status {
             body.add_child(
                 Text::new(status, appearance.ui_font_family(), 11.)
@@ -1493,15 +1481,6 @@ impl View for MonolithCockpitView {
         }
 
         body.add_child(Self::section_label("FLEET CONTROLS", app));
-        body.add_child(
-            Text::new(
-                format!("filter: {}", Self::tenant_filter_label(self.tenant_filter)),
-                appearance.ui_font_family(),
-                11.,
-            )
-            .with_color(theme.disabled_ui_text_color().into_solid())
-            .finish(),
-        );
         let tenant_names = filtered_tenants
             .iter()
             .map(|tenant| tenant.name.clone())
@@ -1581,7 +1560,7 @@ impl View for MonolithCockpitView {
             Flex::row()
                 .with_spacing(6.)
                 .with_child(Self::typed_button(
-                    "expand all",
+                    "expand",
                     MonolithCockpitAction::ExpandAllTenants { tenant_names },
                     Self::next_mouse_state(
                         &self.fleet_control_mouse_states,
@@ -1590,7 +1569,7 @@ impl View for MonolithCockpitView {
                     app,
                 ))
                 .with_child(Self::typed_button(
-                    "collapse all",
+                    "collapse",
                     MonolithCockpitAction::CollapseAllTenants,
                     Self::next_mouse_state(
                         &self.fleet_control_mouse_states,

--- a/app/src/workspace/view/monolith_cockpit.rs
+++ b/app/src/workspace/view/monolith_cockpit.rs
@@ -392,23 +392,21 @@ VMs and runtimes:\n{}",
             .finish()
     }
 
-    fn value_line(label: &str, value: &str, app: &AppContext) -> Box<dyn Element> {
+    fn muted_text(value: impl Into<String>, size: f32, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
 
-        Flex::row()
-            .with_main_axis_size(MainAxisSize::Min)
-            .with_spacing(6.)
-            .with_child(
-                Text::new(label.to_string(), appearance.ui_font_family(), 12.)
-                    .with_color(theme.disabled_ui_text_color().into_solid())
-                    .finish(),
-            )
-            .with_child(
-                Text::new(value.to_string(), appearance.ui_font_family(), 12.)
-                    .with_color(theme.main_text_color(theme.background()).into_solid())
-                    .finish(),
-            )
+        Text::new(value.into(), appearance.ui_font_family(), size)
+            .with_color(theme.disabled_ui_text_color().into_solid())
+            .finish()
+    }
+
+    fn meta_text(value: impl Into<String>, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        Text::new(value.into(), appearance.ui_font_family(), 12.)
+            .with_color(theme.nonactive_ui_text_color().into_solid())
             .finish()
     }
 
@@ -1001,11 +999,15 @@ VMs and runtimes:\n{}",
         Container::new(
             Flex::column()
                 .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-                .with_spacing(8.)
+                .with_spacing(7.)
                 .with_child(header)
-                .with_child(Self::value_line("workdir", &runtime.workdir, app))
-                .with_child(Self::value_line("git", &runtime.git_ref, app))
-                .with_child(Self::value_line("service", &service_name, app))
+                .with_child(Self::meta_text(
+                    format!(
+                        "{} · git {} · {}",
+                        runtime.workdir, runtime.git_ref, service_name
+                    ),
+                    app,
+                ))
                 .with_child(
                     Flex::row()
                         .with_spacing(6.)
@@ -1027,11 +1029,6 @@ VMs and runtimes:\n{}",
                             Self::next_mouse_state(mouse_states, button_index),
                             app,
                         ))
-                        .finish(),
-                )
-                .with_child(
-                    Flex::row()
-                        .with_spacing(6.)
                         .with_child(Self::action_button(
                             "deploy",
                             deploy,
@@ -1060,7 +1057,7 @@ VMs and runtimes:\n{}",
                 )
                 .finish(),
         )
-        .with_padding(Padding::uniform(10.))
+        .with_padding(Padding::uniform(8.).with_left(10.).with_right(10.))
         .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
         .finish()
@@ -1099,7 +1096,7 @@ VMs and runtimes:\n{}",
         Container::new(
             Flex::column()
                 .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-                .with_spacing(8.)
+                .with_spacing(7.)
                 .with_child(
                     Flex::row()
                         .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
@@ -1129,12 +1126,11 @@ VMs and runtimes:\n{}",
                         ))
                         .finish(),
                 )
-                .with_child(Self::value_line("zone", &host.zone, app))
-                .with_child(Self::value_line("status", &host.status, app))
-                .with_child(Self::value_line(
-                    "runtimes",
-                    &format!(
-                        "{} / {} visible",
+                .with_child(Self::meta_text(
+                    format!(
+                        "{} · {} · {} / {} runtimes visible",
+                        host.zone,
+                        host.status,
                         host.runtimes
                             .iter()
                             .filter(|runtime| Self::runtime_matches_filter(runtime, filter))
@@ -1146,7 +1142,7 @@ VMs and runtimes:\n{}",
                 .with_child(runtimes.finish())
                 .finish(),
         )
-        .with_padding(Padding::uniform(8.).with_left(12.))
+        .with_padding(Padding::uniform(8.).with_left(10.).with_right(10.))
         .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
         .finish()
@@ -1195,7 +1191,7 @@ VMs and runtimes:\n{}",
         let prompt = Self::tenant_chat_prompt(tenant, active_environment, api_url);
         let context = Self::tenant_context(tenant, active_environment, api_url);
         let chat_button = Self::primary_typed_button(
-            "manage tenant in chat",
+            "chat",
             MonolithCockpitAction::StartTenantChat {
                 tenant_name: tenant.name.clone(),
                 prompt,
@@ -1263,24 +1259,17 @@ VMs and runtimes:\n{}",
             .with_child(header);
 
         if is_expanded {
-            content.add_child(
-                Flex::row()
-                    .with_spacing(6.)
-                    .with_child(Self::status_chip(&tenant.environment, app))
-                    .with_child(Self::status_chip(
-                        &format!("vms {}", tenant.hosts.len()),
-                        app,
-                    ))
-                    .with_child(Self::status_chip(
-                        &format!(
-                            "runtimes {} / {} visible",
-                            Self::visible_runtime_count(tenant, filter),
-                            Self::runtime_count(tenant)
-                        ),
-                        app,
-                    ))
-                    .finish(),
-            );
+            content.add_child(Self::muted_text(
+                format!(
+                    "{} · {} vms · {} / {} runtimes visible",
+                    tenant.environment,
+                    tenant.hosts.len(),
+                    Self::visible_runtime_count(tenant, filter),
+                    Self::runtime_count(tenant)
+                ),
+                12.,
+                app,
+            ));
             content.add_child(
                 Flex::row()
                     .with_spacing(6.)

--- a/app/src/workspace/view/monolith_cockpit.rs
+++ b/app/src/workspace/view/monolith_cockpit.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use settings::Setting as _;
 use std::{collections::HashSet, path::Path};
 use warp_core::ui::Icon;
+use warpui::clipboard::ClipboardContent;
 use warpui::elements::{
     Border, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox, Container, CornerRadius,
     CrossAxisAlignment, Element, Fill, Flex, Hoverable, MainAxisAlignment, MainAxisSize,
@@ -59,13 +60,30 @@ struct CockpitProfile {
 
 #[derive(Clone, Debug)]
 pub enum MonolithCockpitAction {
-    OpenCommand { command: String },
-    StartTenantChat { prompt: String },
-    ShowTenantFilter { filter: TenantFilter },
-    ExpandAllTenants { tenant_names: Vec<String> },
+    OpenCommand {
+        command: String,
+    },
+    StartTenantChat {
+        tenant_name: String,
+        prompt: String,
+    },
+    CopyTenantContext {
+        tenant_name: String,
+        context: String,
+    },
+    ShowTenantFilter {
+        filter: TenantFilter,
+    },
+    ExpandAllTenants {
+        tenant_names: Vec<String>,
+    },
     CollapseAllTenants,
-    ToggleTenant { tenant_name: String },
-    SwitchEnvironment { environment: String },
+    ToggleTenant {
+        tenant_name: String,
+    },
+    SwitchEnvironment {
+        environment: String,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -84,6 +102,7 @@ pub struct MonolithCockpitView {
     scroll_state: ClippedScrollStateHandle,
     expanded_tenants: HashSet<String>,
     tenant_filter: TenantFilter,
+    selected_tenant: Option<String>,
 }
 
 impl MonolithCockpitView {
@@ -96,6 +115,7 @@ impl MonolithCockpitView {
             scroll_state: ClippedScrollStateHandle::default(),
             expanded_tenants: HashSet::new(),
             tenant_filter: TenantFilter::All,
+            selected_tenant: None,
         }
     }
 
@@ -239,6 +259,16 @@ impl MonolithCockpitView {
         active_environment: &str,
         api_url: &str,
     ) -> String {
+        format!(
+            "/agent You are managing one Monolith tenant from the Warp cockpit.\n{}\n\n\
+Operate only within this tenant by default. Start read-only: summarize health, risk, and the safest next actions. \
+Before any write, show the exact command, target tenant, target VM/runtime, environment, and ask for explicit confirmation. \
+Production writes require explicit elevated workflow confirmation.",
+            Self::tenant_context(tenant, active_environment, api_url)
+        )
+    }
+
+    fn tenant_context(tenant: &TenantProfile, active_environment: &str, api_url: &str) -> String {
         let host_lines = if tenant.hosts.is_empty() {
             "- no VMs listed in the current cockpit profile".to_string()
         } else {
@@ -267,16 +297,12 @@ impl MonolithCockpitView {
         };
 
         format!(
-            "/agent You are managing one Monolith tenant from the Warp cockpit.\n\
-Tenant: {}\n\
+            "Tenant: {}\n\
 Tenant environment/status: {}\n\
 Active cockpit environment: {}\n\
 Fleet API: {}\n\
 GCP project: {}\n\
-VMs and runtimes:\n{}\n\n\
-Operate only within this tenant by default. Start read-only: summarize health, risk, and the safest next actions. \
-Before any write, show the exact command, target tenant, target VM/runtime, environment, and ask for explicit confirmation. \
-Production writes require explicit elevated workflow confirmation.",
+VMs and runtimes:\n{}",
             tenant.name, tenant.environment, active_environment, api_url, GCP_PROJECT, host_lines
         )
     }
@@ -556,6 +582,7 @@ Production writes require explicit elevated workflow confirmation.",
     fn render_cloud_toolbar(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
+        let active_environment = MonolithSettings::as_ref(app).cockpit_environment.value();
 
         let setup_command = format!(
             "gcloud auth login && printf '\\nMonolith cockpit passes --project {} explicitly; it does not mutate global gcloud project or ADC credentials.\\n'",
@@ -569,6 +596,14 @@ Production writes require explicit elevated workflow confirmation.",
         let project_command = format!(
             "printf 'cockpit project: {}\\n'; printf 'global gcloud project: '; gcloud config get-value project",
             Self::shell_escape(GCP_PROJECT),
+        );
+        let access_check_command = format!(
+            "printf 'gcloud account: '; gcloud auth list --filter=status:ACTIVE --format='value(account)'; printf 'cockpit project: {}\\n'; gcloud compute instances list --project {} --filter={} --format='value(name)' >/dev/null && printf 'gcloud vm inventory: ok\\n'; if [ -f ~/.monolith/platform-admin-keys.env ]; then . ~/.monolith/platform-admin-keys.env; if [ {} = prod ]; then api_key=\"$MONOLITH_PROD_PLATFORM_ADMIN_KEY\"; api_url=\"$MONOLITH_PROD_API_URL\"; else api_key=\"$MONOLITH_STAGING_PLATFORM_ADMIN_KEY\"; api_url=\"$MONOLITH_STAGING_API_URL\"; fi; if [ -n \"$api_key\" ]; then curl -fsS -H \"Authorization: Bearer $api_key\" \"$api_url/health\" >/dev/null && printf 'fleet api auth/health: ok\\n' || printf 'fleet api auth/health: failed\\n'; else printf 'fleet api key: missing for {}\\n'; fi; else printf 'local key file: missing ~/.monolith/platform-admin-keys.env\\n'; fi",
+            Self::shell_escape(GCP_PROJECT),
+            Self::shell_escape(GCP_PROJECT),
+            Self::shell_escape("labels.raava-managed=true"),
+            Self::shell_escape(active_environment),
+            Self::shell_escape(active_environment),
         );
 
         Flex::column()
@@ -604,9 +639,79 @@ Production writes require explicit elevated workflow confirmation.",
                         self.cloud_mouse_states.get(2).cloned().unwrap_or_default(),
                         app,
                     ))
+                    .with_child(Self::action_button(
+                        "check access",
+                        access_check_command,
+                        self.cloud_mouse_states.get(3).cloned().unwrap_or_default(),
+                        app,
+                    ))
                     .finish(),
             )
             .finish()
+    }
+
+    fn render_selected_tenant_context(
+        &self,
+        profile: &CockpitProfile,
+        active_environment: &str,
+        api_url: &str,
+        app: &AppContext,
+    ) -> Option<Box<dyn Element>> {
+        let tenant_name = self.selected_tenant.as_ref()?;
+        let tenant = profile
+            .tenants
+            .iter()
+            .find(|tenant| &tenant.name == tenant_name)?;
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let context = Self::tenant_context(tenant, active_environment, api_url);
+
+        Some(
+            Container::new(
+                Flex::column()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                    .with_spacing(8.)
+                    .with_child(Self::section_label("CURRENT TENANT", app))
+                    .with_child(
+                        Text::new(tenant.name.clone(), appearance.ui_font_family(), 14.)
+                            .with_color(theme.active_ui_text_color().into_solid())
+                            .with_style(Properties::default().weight(Weight::Bold))
+                            .finish(),
+                    )
+                    .with_child(
+                        Flex::row()
+                            .with_spacing(6.)
+                            .with_child(Self::status_chip(&tenant.environment, app))
+                            .with_child(Self::status_chip(
+                                &format!("vms {}", tenant.hosts.len()),
+                                app,
+                            ))
+                            .with_child(Self::status_chip(
+                                &format!(
+                                    "runtimes {} / {} running",
+                                    Self::running_runtime_count(tenant),
+                                    Self::runtime_count(tenant)
+                                ),
+                                app,
+                            ))
+                            .finish(),
+                    )
+                    .with_child(Self::typed_button(
+                        "copy context",
+                        MonolithCockpitAction::CopyTenantContext {
+                            tenant_name: tenant.name.clone(),
+                            context,
+                        },
+                        self.cloud_mouse_states.get(4).cloned().unwrap_or_default(),
+                        app,
+                    ))
+                    .finish(),
+            )
+            .with_padding(Padding::uniform(10.))
+            .with_border(Border::all(1.).with_border_fill(theme.active_ui_detail()))
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(6.)))
+            .finish(),
+        )
     }
 
     fn render_cockpit_summary(
@@ -967,9 +1072,22 @@ Production writes require explicit elevated workflow confirmation.",
 
         let tenant_name = tenant.name.clone();
         let prompt = Self::tenant_chat_prompt(tenant, active_environment, api_url);
+        let context = Self::tenant_context(tenant, active_environment, api_url);
         let chat_button = Self::primary_typed_button(
             "manage tenant in chat",
-            MonolithCockpitAction::StartTenantChat { prompt },
+            MonolithCockpitAction::StartTenantChat {
+                tenant_name: tenant.name.clone(),
+                prompt,
+            },
+            Self::next_mouse_state(mouse_states, button_index),
+            app,
+        );
+        let copy_context_button = Self::typed_button(
+            "copy context",
+            MonolithCockpitAction::CopyTenantContext {
+                tenant_name: tenant.name.clone(),
+                context,
+            },
             Self::next_mouse_state(mouse_states, button_index),
             app,
         );
@@ -1037,7 +1155,13 @@ Production writes require explicit elevated workflow confirmation.",
                 ),
                 app,
             ))
-            .with_child(chat_button);
+            .with_child(
+                Flex::row()
+                    .with_spacing(6.)
+                    .with_child(chat_button)
+                    .with_child(copy_context_button)
+                    .finish(),
+            );
 
         if is_expanded {
             content.add_child(hosts.finish());
@@ -1071,12 +1195,26 @@ impl TypedActionView for MonolithCockpitView {
                     shell_type: ShellType::from_name("bash"),
                 },
             ),
-            MonolithCockpitAction::StartTenantChat { prompt } => {
+            MonolithCockpitAction::StartTenantChat {
+                tenant_name,
+                prompt,
+            } => {
+                self.selected_tenant = Some(tenant_name.clone());
                 ctx.dispatch_typed_action(&WorkspaceAction::InsertInInput {
                     content: prompt.clone(),
                     replace_buffer: true,
                     ensure_agent_mode: true,
                 });
+                ctx.notify();
+            }
+            MonolithCockpitAction::CopyTenantContext {
+                tenant_name,
+                context,
+            } => {
+                self.selected_tenant = Some(tenant_name.clone());
+                ctx.clipboard()
+                    .write(ClipboardContent::plain_text(context.clone()));
+                ctx.notify();
             }
             MonolithCockpitAction::ShowTenantFilter { filter } => {
                 self.tenant_filter = *filter;
@@ -1167,17 +1305,24 @@ impl View for MonolithCockpitView {
             )
             .with_child(self.render_environment_switcher(app))
             .with_child(self.render_cloud_toolbar(app))
-            .with_child(self.render_cockpit_summary(&profile, app))
-            .with_child(Self::section_label("TENANT > VM > AGENT RUNTIME", app))
-            .with_child(
-                Text::new(
-                    "Select a tenant runtime, open VM shells through gcloud, inspect logs and Git, then run guarded lifecycle commands in Warp.",
-                    appearance.ui_font_family(),
-                    12.,
-                )
-                .with_color(theme.nonactive_ui_text_color().into_solid())
-                .finish(),
-            );
+            .with_child(self.render_cockpit_summary(&profile, app));
+
+        if let Some(selected_context) =
+            self.render_selected_tenant_context(&profile, &active_environment, &api_url, app)
+        {
+            body.add_child(selected_context);
+        }
+
+        body.add_child(Self::section_label("TENANT > VM > AGENT RUNTIME", app));
+        body.add_child(
+            Text::new(
+                "Select a tenant runtime, open VM shells through gcloud, inspect logs and Git, then run guarded lifecycle commands in Warp.",
+                appearance.ui_font_family(),
+                12.,
+            )
+            .with_color(theme.nonactive_ui_text_color().into_solid())
+            .finish(),
+        );
 
         if let Some(status) = profile_status {
             body.add_child(

--- a/app/src/workspace/view/monolith_cockpit.rs
+++ b/app/src/workspace/view/monolith_cockpit.rs
@@ -1,6 +1,6 @@
 use crate::{
     appearance::Appearance, root_view::SubshellCommandArg, settings::MonolithSettings,
-    terminal::shell::ShellType,
+    terminal::shell::ShellType, workspace::WorkspaceAction,
 };
 use serde::Deserialize;
 use settings::Setting as _;
@@ -60,8 +60,20 @@ struct CockpitProfile {
 #[derive(Clone, Debug)]
 pub enum MonolithCockpitAction {
     OpenCommand { command: String },
+    StartTenantChat { prompt: String },
+    ShowTenantFilter { filter: TenantFilter },
+    ExpandAllTenants { tenant_names: Vec<String> },
+    CollapseAllTenants,
     ToggleTenant { tenant_name: String },
     SwitchEnvironment { environment: String },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TenantFilter {
+    All,
+    Active,
+    Offboarded,
+    WithVms,
 }
 
 pub struct MonolithCockpitView {
@@ -71,6 +83,7 @@ pub struct MonolithCockpitView {
     cloud_mouse_states: Vec<MouseStateHandle>,
     scroll_state: ClippedScrollStateHandle,
     expanded_tenants: HashSet<String>,
+    tenant_filter: TenantFilter,
 }
 
 impl MonolithCockpitView {
@@ -79,9 +92,10 @@ impl MonolithCockpitView {
             button_mouse_states: (0..512).map(|_| MouseStateHandle::default()).collect(),
             tenant_mouse_states: (0..128).map(|_| MouseStateHandle::default()).collect(),
             environment_mouse_states: (0..2).map(|_| MouseStateHandle::default()).collect(),
-            cloud_mouse_states: (0..3).map(|_| MouseStateHandle::default()).collect(),
+            cloud_mouse_states: (0..8).map(|_| MouseStateHandle::default()).collect(),
             scroll_state: ClippedScrollStateHandle::default(),
             expanded_tenants: HashSet::new(),
+            tenant_filter: TenantFilter::All,
         }
     }
 
@@ -136,6 +150,134 @@ impl MonolithCockpitView {
             "{} --command {}",
             Self::gcloud_ssh_prefix(host),
             Self::shell_escape(command)
+        )
+    }
+
+    fn tenant_status_label(tenant: &TenantProfile) -> &'static str {
+        if tenant.environment.contains("offboarded") {
+            "offboarded"
+        } else if tenant.environment.contains("active") {
+            "active"
+        } else {
+            "unknown"
+        }
+    }
+
+    fn tenant_environment_label(tenant: &TenantProfile) -> &'static str {
+        if tenant.environment.contains("prod") {
+            "prod"
+        } else if tenant.environment.contains("staging") {
+            "staging"
+        } else {
+            "env"
+        }
+    }
+
+    fn runtime_count(tenant: &TenantProfile) -> usize {
+        tenant
+            .hosts
+            .iter()
+            .map(|host| host.runtimes.len())
+            .sum::<usize>()
+    }
+
+    fn running_runtime_count(tenant: &TenantProfile) -> usize {
+        tenant
+            .hosts
+            .iter()
+            .flat_map(|host| &host.runtimes)
+            .filter(|runtime| runtime.status.contains("running"))
+            .count()
+    }
+
+    fn tenant_matches_filter(tenant: &TenantProfile, filter: TenantFilter) -> bool {
+        match filter {
+            TenantFilter::All => true,
+            TenantFilter::Active => Self::tenant_status_label(tenant) == "active",
+            TenantFilter::Offboarded => Self::tenant_status_label(tenant) == "offboarded",
+            TenantFilter::WithVms => !tenant.hosts.is_empty(),
+        }
+    }
+
+    fn tenant_filter_label(filter: TenantFilter) -> &'static str {
+        match filter {
+            TenantFilter::All => "all",
+            TenantFilter::Active => "active",
+            TenantFilter::Offboarded => "offboarded",
+            TenantFilter::WithVms => "with vms",
+        }
+    }
+
+    fn cockpit_summary(profile: &CockpitProfile) -> (usize, usize, usize, usize, usize) {
+        let tenants = profile.tenants.len();
+        let active = profile
+            .tenants
+            .iter()
+            .filter(|tenant| tenant.environment.contains("active"))
+            .count();
+        let offboarded = profile
+            .tenants
+            .iter()
+            .filter(|tenant| tenant.environment.contains("offboarded"))
+            .count();
+        let vms = profile
+            .tenants
+            .iter()
+            .map(|tenant| tenant.hosts.len())
+            .sum::<usize>();
+        let runtimes = profile
+            .tenants
+            .iter()
+            .map(Self::runtime_count)
+            .sum::<usize>();
+
+        (tenants, active, offboarded, vms, runtimes)
+    }
+
+    fn tenant_chat_prompt(
+        tenant: &TenantProfile,
+        active_environment: &str,
+        api_url: &str,
+    ) -> String {
+        let host_lines = if tenant.hosts.is_empty() {
+            "- no VMs listed in the current cockpit profile".to_string()
+        } else {
+            tenant
+                .hosts
+                .iter()
+                .map(|host| {
+                    let runtime_names = if host.runtimes.is_empty() {
+                        "no runtimes".to_string()
+                    } else {
+                        host.runtimes
+                            .iter()
+                            .map(|runtime| {
+                                format!("{}:{}:{}", runtime.name, runtime.status, runtime.workdir)
+                            })
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    };
+                    format!(
+                        "- {} zone={} status={} runtimes=[{}]",
+                        host.name, host.zone, host.status, runtime_names
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        format!(
+            "/agent You are managing one Monolith tenant from the Warp cockpit.\n\
+Tenant: {}\n\
+Tenant environment/status: {}\n\
+Active cockpit environment: {}\n\
+Fleet API: {}\n\
+GCP project: {}\n\
+VMs and runtimes:\n{}\n\n\
+Operate only within this tenant by default. Start read-only: summarize health, risk, and the safest next actions. \
+Before any write, show the exact command, target tenant, target VM/runtime, environment, and ask for explicit confirmation. \
+Production writes require explicit elevated workflow confirmation.",
+            tenant.name, tenant.environment, active_environment, api_url, GCP_PROJECT, host_lines
         )
     }
 
@@ -212,6 +354,80 @@ impl MonolithCockpitView {
                 });
             })
             .finish()
+    }
+
+    fn typed_button(
+        label: &str,
+        action: MonolithCockpitAction,
+        mouse_state: MouseStateHandle,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        let button = Container::new(
+            Text::new(label.to_string(), appearance.ui_font_family(), 11.)
+                .with_color(theme.active_ui_text_color().into_solid())
+                .finish(),
+        )
+        .with_padding(Padding::uniform(4.).with_left(8.).with_right(8.))
+        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+        .finish();
+
+        Hoverable::new(mouse_state, |_| button)
+            .with_cursor(Cursor::PointingHand)
+            .on_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(action.clone());
+            })
+            .finish()
+    }
+
+    fn tenant_filter_button(
+        label: &str,
+        filter: TenantFilter,
+        is_active: bool,
+        mouse_state: MouseStateHandle,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        let mut button = Container::new(
+            Text::new(label.to_string(), appearance.ui_font_family(), 11.)
+                .with_color(theme.active_ui_text_color().into_solid())
+                .finish(),
+        )
+        .with_padding(Padding::uniform(4.).with_left(8.).with_right(8.))
+        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
+
+        if is_active {
+            button = button.with_background(theme.surface_3());
+        }
+
+        Hoverable::new(mouse_state, |_| button.finish())
+            .with_cursor(Cursor::PointingHand)
+            .on_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(MonolithCockpitAction::ShowTenantFilter { filter });
+            })
+            .finish()
+    }
+
+    fn status_chip(label: &str, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        Container::new(
+            Text::new(label.to_string(), appearance.ui_font_family(), 10.)
+                .with_color(theme.nonactive_ui_text_color().into_solid())
+                .finish(),
+        )
+        .with_padding(Padding::uniform(3.).with_left(6.).with_right(6.))
+        .with_background(theme.surface_2())
+        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+        .finish()
     }
 
     fn environment_button(
@@ -351,6 +567,55 @@ impl MonolithCockpitView {
                     .finish(),
             )
             .finish()
+    }
+
+    fn render_cockpit_summary(
+        &self,
+        profile: &CockpitProfile,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let settings = MonolithSettings::as_ref(app);
+        let active_environment = settings.cockpit_environment.value();
+        let is_prod = active_environment == "prod";
+        let write_mode = if is_prod {
+            "prod locked"
+        } else {
+            "staging guarded"
+        };
+        let (tenants, active, offboarded, vms, runtimes) = Self::cockpit_summary(profile);
+
+        Container::new(
+            Flex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                .with_spacing(8.)
+                .with_child(Self::section_label("OPERATOR STATUS", app))
+                .with_child(
+                    Flex::row()
+                        .with_spacing(6.)
+                        .with_child(Self::status_chip(&format!("tenants {tenants}"), app))
+                        .with_child(Self::status_chip(&format!("active {active}"), app))
+                        .with_child(Self::status_chip(&format!("offboarded {offboarded}"), app))
+                        .with_child(Self::status_chip(&format!("vms {vms}"), app))
+                        .with_child(Self::status_chip(&format!("runtimes {runtimes}"), app))
+                        .finish(),
+                )
+                .with_child(
+                    Text::new(
+                        format!("write mode: {write_mode}"),
+                        appearance.ui_font_family(),
+                        11.,
+                    )
+                    .with_color(theme.disabled_ui_text_color().into_solid())
+                    .finish(),
+                )
+                .finish(),
+        )
+        .with_padding(Padding::uniform(10.))
+        .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(6.)))
+        .finish()
     }
 
     fn runtime_card(
@@ -622,6 +887,8 @@ impl MonolithCockpitView {
         tenant_mouse_state: MouseStateHandle,
         mouse_states: &[MouseStateHandle],
         button_index: &mut usize,
+        active_environment: &str,
+        api_url: &str,
         app: &AppContext,
     ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
@@ -647,15 +914,33 @@ impl MonolithCockpitView {
         };
 
         let tenant_name = tenant.name.clone();
+        let prompt = Self::tenant_chat_prompt(tenant, active_environment, api_url);
+        let chat_button = Self::typed_button(
+            "chat",
+            MonolithCockpitAction::StartTenantChat { prompt },
+            Self::next_mouse_state(mouse_states, button_index),
+            app,
+        );
+
         let header = Hoverable::new(tenant_mouse_state, |_| {
             Container::new(
                 Flex::row()
                     .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
                     .with_cross_axis_alignment(CrossAxisAlignment::Center)
                     .with_child(
-                        Text::new(tenant.name.clone(), appearance.ui_font_family(), 14.)
-                            .with_color(theme.active_ui_text_color().into_solid())
-                            .with_style(Properties::default().weight(Weight::Bold))
+                        Flex::row()
+                            .with_spacing(6.)
+                            .with_child(
+                                Text::new(tenant.name.clone(), appearance.ui_font_family(), 14.)
+                                    .with_color(theme.active_ui_text_color().into_solid())
+                                    .with_style(Properties::default().weight(Weight::Bold))
+                                    .finish(),
+                            )
+                            .with_child(Self::status_chip(
+                                Self::tenant_environment_label(tenant),
+                                app,
+                            ))
+                            .with_child(Self::status_chip(Self::tenant_status_label(tenant), app))
                             .finish(),
                     )
                     .with_child(
@@ -690,7 +975,17 @@ impl MonolithCockpitView {
                 "vms",
                 &tenant.hosts.len().to_string(),
                 app,
-            ));
+            ))
+            .with_child(Self::value_line(
+                "runtimes",
+                &format!(
+                    "{} / {} running",
+                    Self::running_runtime_count(tenant),
+                    Self::runtime_count(tenant)
+                ),
+                app,
+            ))
+            .with_child(chat_button);
 
         if is_expanded {
             content.add_child(hosts.finish());
@@ -724,6 +1019,25 @@ impl TypedActionView for MonolithCockpitView {
                     shell_type: ShellType::from_name("bash"),
                 },
             ),
+            MonolithCockpitAction::StartTenantChat { prompt } => {
+                ctx.dispatch_typed_action(&WorkspaceAction::InsertInInput {
+                    content: prompt.clone(),
+                    replace_buffer: true,
+                    ensure_agent_mode: true,
+                });
+            }
+            MonolithCockpitAction::ShowTenantFilter { filter } => {
+                self.tenant_filter = *filter;
+                ctx.notify();
+            }
+            MonolithCockpitAction::ExpandAllTenants { tenant_names } => {
+                self.expanded_tenants = tenant_names.iter().cloned().collect();
+                ctx.notify();
+            }
+            MonolithCockpitAction::CollapseAllTenants => {
+                self.expanded_tenants.clear();
+                ctx.notify();
+            }
             MonolithCockpitAction::ToggleTenant { tenant_name } => {
                 if !self.expanded_tenants.insert(tenant_name.clone()) {
                     self.expanded_tenants.remove(tenant_name);
@@ -758,12 +1072,20 @@ impl View for MonolithCockpitView {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
         let (profile, profile_status) = Self::load_profile(app);
+        let settings = MonolithSettings::as_ref(app);
+        let active_environment = settings.cockpit_environment.value().clone();
+        let api_url = settings.api_url.value().clone();
+        let filtered_tenants = profile
+            .tenants
+            .iter()
+            .filter(|tenant| Self::tenant_matches_filter(tenant, self.tenant_filter))
+            .collect::<Vec<_>>();
 
         let mut tenants = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_spacing(12.);
         let mut button_index = 0;
-        for (tenant_index, tenant) in profile.tenants.iter().enumerate() {
+        for (tenant_index, tenant) in filtered_tenants.iter().enumerate() {
             let tenant_mouse_state = self
                 .tenant_mouse_states
                 .get(tenant_index)
@@ -775,6 +1097,8 @@ impl View for MonolithCockpitView {
                 tenant_mouse_state,
                 &self.button_mouse_states,
                 &mut button_index,
+                &active_environment,
+                &api_url,
                 app,
             ));
         }
@@ -791,6 +1115,7 @@ impl View for MonolithCockpitView {
             )
             .with_child(self.render_environment_switcher(app))
             .with_child(self.render_cloud_toolbar(app))
+            .with_child(self.render_cockpit_summary(&profile, app))
             .with_child(Self::section_label("TENANT > VM > AGENT RUNTIME", app))
             .with_child(
                 Text::new(
@@ -810,10 +1135,74 @@ impl View for MonolithCockpitView {
             );
         }
 
+        let tenant_names = filtered_tenants
+            .iter()
+            .map(|tenant| tenant.name.clone())
+            .collect::<Vec<_>>();
+        let mut header_button_index = 0;
+        body.add_child(
+            Flex::row()
+                .with_spacing(6.)
+                .with_child(Self::tenant_filter_button(
+                    "all",
+                    TenantFilter::All,
+                    self.tenant_filter == TenantFilter::All,
+                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    app,
+                ))
+                .with_child(Self::tenant_filter_button(
+                    "active",
+                    TenantFilter::Active,
+                    self.tenant_filter == TenantFilter::Active,
+                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    app,
+                ))
+                .with_child(Self::tenant_filter_button(
+                    "offboarded",
+                    TenantFilter::Offboarded,
+                    self.tenant_filter == TenantFilter::Offboarded,
+                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    app,
+                ))
+                .with_child(Self::tenant_filter_button(
+                    "with vms",
+                    TenantFilter::WithVms,
+                    self.tenant_filter == TenantFilter::WithVms,
+                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    app,
+                ))
+                .with_child(Self::typed_button(
+                    "expand all",
+                    MonolithCockpitAction::ExpandAllTenants { tenant_names },
+                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    app,
+                ))
+                .with_child(Self::typed_button(
+                    "collapse all",
+                    MonolithCockpitAction::CollapseAllTenants,
+                    Self::next_mouse_state(&self.cloud_mouse_states, &mut header_button_index),
+                    app,
+                ))
+                .finish(),
+        );
+
         if profile.tenants.is_empty() {
             body.add_child(
                 Text::new(
                     "No live Monolith cockpit profile is configured.".to_string(),
+                    appearance.ui_font_family(),
+                    12.,
+                )
+                .with_color(theme.disabled_ui_text_color().into_solid())
+                .finish(),
+            );
+        } else if filtered_tenants.is_empty() {
+            body.add_child(
+                Text::new(
+                    format!(
+                        "No tenants match filter: {}",
+                        Self::tenant_filter_label(self.tenant_filter)
+                    ),
                     appearance.ui_font_family(),
                     12.,
                 )

--- a/app/src/workspace/view/monolith_cockpit.rs
+++ b/app/src/workspace/view/monolith_cockpit.rs
@@ -383,6 +383,35 @@ Production writes require explicit elevated workflow confirmation.",
             .finish()
     }
 
+    fn primary_typed_button(
+        label: &str,
+        action: MonolithCockpitAction,
+        mouse_state: MouseStateHandle,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        let button = Container::new(
+            Text::new(label.to_string(), appearance.ui_font_family(), 12.)
+                .with_color(theme.active_ui_text_color().into_solid())
+                .with_style(Properties::default().weight(Weight::Semibold))
+                .finish(),
+        )
+        .with_padding(Padding::uniform(7.).with_left(10.).with_right(10.))
+        .with_background(theme.surface_3())
+        .with_border(Border::all(1.).with_border_fill(theme.active_ui_detail()))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+        .finish();
+
+        Hoverable::new(mouse_state, |_| button)
+            .with_cursor(Cursor::PointingHand)
+            .on_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(action.clone());
+            })
+            .finish()
+    }
+
     fn tenant_filter_button(
         label: &str,
         filter: TenantFilter,
@@ -393,12 +422,23 @@ Production writes require explicit elevated workflow confirmation.",
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
 
+        let display_label = if is_active {
+            format!("selected: {label}")
+        } else {
+            label.to_string()
+        };
+
         let mut button = Container::new(
-            Text::new(label.to_string(), appearance.ui_font_family(), 11.)
+            Text::new(display_label, appearance.ui_font_family(), 11.)
                 .with_color(theme.active_ui_text_color().into_solid())
+                .with_style(Properties::default().weight(if is_active {
+                    Weight::Semibold
+                } else {
+                    Weight::Normal
+                }))
                 .finish(),
         )
-        .with_padding(Padding::uniform(4.).with_left(8.).with_right(8.))
+        .with_padding(Padding::uniform(5.).with_left(9.).with_right(9.))
         .with_border(Border::all(1.).with_border_fill(theme.surface_3()))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
 
@@ -579,10 +619,15 @@ Production writes require explicit elevated workflow confirmation.",
         let settings = MonolithSettings::as_ref(app);
         let active_environment = settings.cockpit_environment.value();
         let is_prod = active_environment == "prod";
-        let write_mode = if is_prod {
-            "prod locked"
+        let environment_label = if is_prod {
+            "PRODUCTION COCKPIT"
         } else {
-            "staging guarded"
+            "STAGING COCKPIT"
+        };
+        let write_mode = if is_prod {
+            "production writes locked behind explicit confirmation"
+        } else {
+            "staging writes guarded"
         };
         let (tenants, active, offboarded, vms, runtimes) = Self::cockpit_summary(profile);
 
@@ -590,7 +635,14 @@ Production writes require explicit elevated workflow confirmation.",
             Flex::column()
                 .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
                 .with_spacing(8.)
-                .with_child(Self::section_label("OPERATOR STATUS", app))
+                .with_child(
+                    Flex::row()
+                        .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                        .with_child(Self::section_label(environment_label, app))
+                        .with_child(Self::status_chip(&format!("api {active_environment}"), app))
+                        .finish(),
+                )
                 .with_child(
                     Flex::row()
                         .with_spacing(6.)
@@ -603,7 +655,7 @@ Production writes require explicit elevated workflow confirmation.",
                 )
                 .with_child(
                     Text::new(
-                        format!("write mode: {write_mode}"),
+                        format!("operator mode: {write_mode}"),
                         appearance.ui_font_family(),
                         11.,
                     )
@@ -915,8 +967,8 @@ Production writes require explicit elevated workflow confirmation.",
 
         let tenant_name = tenant.name.clone();
         let prompt = Self::tenant_chat_prompt(tenant, active_environment, api_url);
-        let chat_button = Self::typed_button(
-            "chat",
+        let chat_button = Self::primary_typed_button(
+            "manage tenant in chat",
             MonolithCockpitAction::StartTenantChat { prompt },
             Self::next_mouse_state(mouse_states, button_index),
             app,
@@ -1135,6 +1187,7 @@ impl View for MonolithCockpitView {
             );
         }
 
+        body.add_child(Self::section_label("FLEET CONTROLS", app));
         let tenant_names = filtered_tenants
             .iter()
             .map(|tenant| tenant.name.clone())

--- a/app/src/workspace/view/monolith_cockpit.rs
+++ b/app/src/workspace/view/monolith_cockpit.rs
@@ -529,7 +529,9 @@ VMs and runtimes:\n{}",
                 .with_border(Border::all(1.).with_border_fill(theme.active_ui_detail()));
         }
 
-        Hoverable::new(mouse_state, |_| button.finish())
+        let button = button.finish();
+
+        Hoverable::new(mouse_state, |_| button)
             .with_cursor(Cursor::PointingHand)
             .on_click(move |ctx, _, _| {
                 ctx.dispatch_typed_action(MonolithCockpitAction::ShowTenantFilter { filter });
@@ -1314,6 +1316,18 @@ impl TypedActionView for MonolithCockpitView {
             }
             MonolithCockpitAction::ShowTenantFilter { filter } => {
                 self.tenant_filter = *filter;
+                if matches!(
+                    filter,
+                    TenantFilter::RunningAgents | TenantFilter::DownAgents | TenantFilter::WithVms
+                ) {
+                    let (profile, _) = Self::load_profile(ctx);
+                    self.expanded_tenants = profile
+                        .tenants
+                        .iter()
+                        .filter(|tenant| Self::tenant_matches_filter(tenant, *filter))
+                        .map(|tenant| tenant.name.clone())
+                        .collect();
+                }
                 ctx.notify();
             }
             MonolithCockpitAction::ExpandAllTenants { tenant_names } => {
@@ -1435,6 +1449,15 @@ impl View for MonolithCockpitView {
         }
 
         body.add_child(Self::section_label("FLEET CONTROLS", app));
+        body.add_child(
+            Text::new(
+                format!("filter: {}", Self::tenant_filter_label(self.tenant_filter)),
+                appearance.ui_font_family(),
+                11.,
+            )
+            .with_color(theme.disabled_ui_text_color().into_solid())
+            .finish(),
+        );
         let tenant_names = filtered_tenants
             .iter()
             .map(|tenant| tenant.name.clone())

--- a/examples/monolith-cockpit-profile.example.json
+++ b/examples/monolith-cockpit-profile.example.json
@@ -1,0 +1,32 @@
+{
+  "tenants": [
+    {
+      "name": "acme-health",
+      "environment": "staging",
+      "hosts": [
+        {
+          "name": "agent-vm-acme-staging-01",
+          "zone": "us-central1-a",
+          "project": "monolith-staging",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "jarvis",
+              "status": "running",
+              "workdir": "/srv/monolith/agents/jarvis",
+              "git_ref": "main",
+              "service_name": "monolith-agent-jarvis"
+            },
+            {
+              "name": "support-triage",
+              "status": "paused",
+              "workdir": "/srv/monolith/agents/support-triage",
+              "git_ref": "release/2026-04",
+              "service_name": "monolith-agent-support-triage"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/monolith-cockpit-profile.live.json
+++ b/examples/monolith-cockpit-profile.live.json
@@ -1,0 +1,185 @@
+{
+  "tenants": [
+    {
+      "name": "acme-corp",
+      "environment": "staging / active",
+      "hosts": []
+    },
+    {
+      "name": "fit-roofing-co",
+      "environment": "staging / offboarded",
+      "hosts": [
+        {
+          "name": "raava-fit-gcp-hermes-direct",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "terminated",
+          "runtimes": [
+            {
+              "name": "gcp-hermes-direct",
+              "status": "stopped",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        },
+        {
+          "name": "raava-fit-gcp-hermes-direct-c",
+          "zone": "us-east1-c",
+          "project": "raava-481318",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "gcp-hermes-direct",
+              "status": "running",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "harness-eval-20260429",
+      "environment": "staging / active",
+      "hosts": []
+    },
+    {
+      "name": "healing-with-strength",
+      "environment": "staging / offboarded",
+      "hosts": [
+        {
+          "name": "raava-acme-corp-jarvis-gce",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "terminated",
+          "runtimes": [
+            {
+              "name": "jarvis-gce",
+              "status": "stopped",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        },
+        {
+          "name": "raava-healing-with-strength-hws-coo-ea",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "hws-coo-ea",
+              "status": "running",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ijt-capital",
+      "environment": "staging / offboarded",
+      "hosts": [
+        {
+          "name": "raava-ijt-capital-aurum",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "aurum",
+              "status": "running",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "raava",
+      "environment": "staging / offboarded",
+      "hosts": [
+        {
+          "name": "raava-raava-fleet-commander",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "fleet-commander",
+              "status": "running",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "schwarz-group",
+      "environment": "staging / gcp-only",
+      "hosts": [
+        {
+          "name": "schwarz-group-jschwarz-ea",
+          "zone": "us-east1-d",
+          "project": "raava-481318",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "jschwarz-ea",
+              "status": "running",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "staging-validator",
+      "environment": "staging / active",
+      "hosts": [
+        {
+          "name": "raava-staging-staging-validator-discord-add-later-1-gce",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "terminated",
+          "runtimes": [
+            {
+              "name": "discord-add-later-1-gce",
+              "status": "stopped",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        },
+        {
+          "name": "raava-staging-staging-validator-discord-launch-truth-1-gce",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "terminated",
+          "runtimes": [
+            {
+              "name": "discord-launch-truth-1-gce",
+              "status": "stopped",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/monolith-cockpit-profile.prod.json
+++ b/examples/monolith-cockpit-profile.prod.json
@@ -1,0 +1,184 @@
+{
+  "tenants": [
+    {
+      "name": "acme-corp",
+      "environment": "prod / offboarded",
+      "hosts": []
+    },
+    {
+      "name": "codex-smoke-1776096636",
+      "environment": "prod / offboarded",
+      "hosts": []
+    },
+    {
+      "name": "codex-smoke-1776097324",
+      "environment": "prod / offboarded",
+      "hosts": []
+    },
+    {
+      "name": "fit",
+      "environment": "prod / offboarded",
+      "hosts": [
+        {
+          "name": "raava-fit-gcp-hermes-direct",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "terminated",
+          "runtimes": [
+            {
+              "name": "gcp-hermes-direct",
+              "status": "stopped",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        },
+        {
+          "name": "raava-fit-gcp-hermes-direct-c",
+          "zone": "us-east1-c",
+          "project": "raava-481318",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "gcp-hermes-direct",
+              "status": "running",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fit-roofin",
+      "environment": "prod / offboarded",
+      "hosts": []
+    },
+    {
+      "name": "fit-roofing-co",
+      "environment": "prod / active",
+      "hosts": []
+    },
+    {
+      "name": "fit-roofing-construction",
+      "environment": "prod / offboarded",
+      "hosts": []
+    },
+    {
+      "name": "healing-with-strength",
+      "environment": "prod / active",
+      "hosts": [
+        {
+          "name": "raava-acme-corp-jarvis-gce",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "terminated",
+          "runtimes": [
+            {
+              "name": "jarvis-gce",
+              "status": "stopped",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        },
+        {
+          "name": "raava-healing-with-strength-hws-coo-ea",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "hws-coo-ea",
+              "status": "running",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ijt-capital",
+      "environment": "prod / active",
+      "hosts": [
+        {
+          "name": "raava-ijt-capital-aurum",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "aurum",
+              "status": "running",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "isaiah-cruzs-fleet",
+      "environment": "prod / offboarded",
+      "hosts": []
+    },
+    {
+      "name": "open-invite",
+      "environment": "prod / active",
+      "hosts": []
+    },
+    {
+      "name": "raava",
+      "environment": "prod / active",
+      "hosts": [
+        {
+          "name": "raava-raava-fleet-commander",
+          "zone": "us-east1-b",
+          "project": "raava-481318",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "fleet-commander",
+              "status": "running",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "raava-demo",
+      "environment": "prod / offboarded",
+      "hosts": []
+    },
+    {
+      "name": "schwarz-group",
+      "environment": "prod / active",
+      "hosts": [
+        {
+          "name": "schwarz-group-jschwarz-ea",
+          "zone": "us-east1-d",
+          "project": "raava-481318",
+          "status": "ssh ready",
+          "runtimes": [
+            {
+              "name": "jschwarz-ea",
+              "status": "running",
+              "workdir": "/home/agent/hermes-agent",
+              "git_ref": "unknown",
+              "service_name": "hermes-gateway"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a Monolith cockpit panel for tenant > VM > agent runtime operations.
- Add staging/prod environment switching, profile-backed fleet views, tenant scoping, gcloud SSH/runtime actions, and guarded prod lifecycle commands.
- Add MCP/settings affordance for Monolith platform admin configuration.

## Verification
- cargo check -p warp --bin warp-oss
- TERM=xterm-256color NO_COLOR=1 CLICOLOR=0 ./script/run --dont-open
- Relaunched target/debug/bundle/osx/WarpOss.app locally

## Notes
Direct push to warpdotdev/warp was rejected for zaycruz, so this PR is opened from the writable fork.