### PR TITLE
Enable git operations in code review feature

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -623,6 +623,7 @@ default = [
     "open_warp_new_settings_modes",
     "skip_firebase_anonymous_user",
     "settings_file",
+    "git_operations_in_code_review",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -926,7 +926,6 @@ pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
     // Remote server binary is not yet supported on Windows.
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,
-    FeatureFlag::GitOperationsInCodeReview,
 ];
 
 /// Features enabled for all release builds (i.e.: everything but WarpLocal).


### PR DESCRIPTION
This change enables the `git_operations_in_code_review` feature flag in the production environment. This allows the code review feature to perform Git operations.

*   The feature flag was added to the default features in `Cargo.toml`.
*   The feature flag was removed from the `PREVIEW_FLAGS` list in `warp_features/src/lib.rs`.