### PR TITLE
Fix diff button when Show code review button toggle is off

### DIFF
--- a/app/src/workspace/tab_settings.rs
+++ b/app/src/workspace/tab_settings.rs
@@ -269,6 +269,10 @@ impl HeaderToolbarChipSelection {
             Self::Custom { right, .. } => right.clone(),
         }
     }
+
+    pub fn contains_item(&self, item: &super::header_toolbar_item::HeaderToolbarItemKind) -> bool {
+        self.left_items().contains(item) || self.right_items().contains(item)
+    }
 }
 
 settings::macros::implement_setting_for_enum!(

--- a/app/src/workspace/tab_settings_tests.rs
+++ b/app/src/workspace/tab_settings_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::test_util::settings::initialize_settings_for_tests;
+use crate::workspace::header_toolbar_item::HeaderToolbarItemKind;
 use settings::Setting;
 use warpui::{App, SingletonEntity};
 
@@ -55,4 +56,46 @@ fn show_vertical_tab_panel_in_restored_windows_uses_vertical_tabs_path() {
         ShowVerticalTabPanelInRestoredWindows::toml_key(),
         "show_panel_in_restored_windows"
     );
+}
+
+#[test]
+fn header_toolbar_chip_selection_default_contains_code_review() {
+    let config = HeaderToolbarChipSelection::Default;
+    assert!(config.contains_item(&HeaderToolbarItemKind::CodeReview));
+}
+
+#[test]
+fn header_toolbar_chip_selection_custom_without_code_review_reports_absent() {
+    let config = HeaderToolbarChipSelection::Custom {
+        left: vec![
+            HeaderToolbarItemKind::TabsPanel,
+            HeaderToolbarItemKind::ToolsPanel,
+        ],
+        right: vec![HeaderToolbarItemKind::NotificationsMailbox],
+    };
+    assert!(!config.contains_item(&HeaderToolbarItemKind::CodeReview));
+    assert!(config.contains_item(&HeaderToolbarItemKind::TabsPanel));
+    assert!(config.contains_item(&HeaderToolbarItemKind::ToolsPanel));
+    assert!(config.contains_item(&HeaderToolbarItemKind::NotificationsMailbox));
+    assert!(!config.contains_item(&HeaderToolbarItemKind::AgentManagement));
+}
+
+#[test]
+fn header_toolbar_chip_selection_custom_with_code_review_on_left_reports_present() {
+    let config = HeaderToolbarChipSelection::Custom {
+        left: vec![HeaderToolbarItemKind::CodeReview],
+        right: vec![],
+    };
+    assert!(config.contains_item(&HeaderToolbarItemKind::CodeReview));
+}
+
+#[test]
+fn header_toolbar_chip_selection_custom_empty_reports_all_absent() {
+    let config = HeaderToolbarChipSelection::Custom {
+        left: vec![],
+        right: vec![],
+    };
+    for item in HeaderToolbarItemKind::all_items() {
+        assert!(!config.contains_item(&item));
+    }
 }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -7979,10 +7979,6 @@ impl Workspace {
         context: Option<&CodeReviewPaneContext>,
         ctx: &mut ViewContext<Self>,
     ) {
-        if !*TabSettings::as_ref(ctx).show_code_review_button {
-            return;
-        }
-
         // If context is provided, use it directly. Otherwise, derive from active pane group.
         let context_data: Option<(
             Option<PathBuf>,
@@ -18285,6 +18281,18 @@ impl Workspace {
                     self.render_config_panel_maximized(pane_group, &config, app),
                     app,
                 );
+            } else if !config.contains_item(&HeaderToolbarItemKind::CodeReview) {
+                Self::add_panel_with_separator(
+                    &mut main_content,
+                    &mut prev_panel_added,
+                    self.render_config_panel(
+                        &HeaderToolbarItemKind::CodeReview,
+                        pane_group,
+                        &config,
+                        app,
+                    ),
+                    app,
+                );
             }
         } else if !is_right_maximized {
             main_content = main_content.with_child(Shrinkable::new(1.0, terminal_content).finish());
@@ -18915,6 +18923,18 @@ impl Workspace {
                     self.render_config_panel_maximized(pane_group, &config, app),
                     app,
                 );
+            } else if !config.contains_item(&HeaderToolbarItemKind::CodeReview) {
+                Self::add_panel_with_separator(
+                    &mut panels_view,
+                    &mut prev_panel_added,
+                    self.render_config_panel(
+                        &HeaderToolbarItemKind::CodeReview,
+                        pane_group,
+                        &config,
+                        app,
+                    ),
+                    app,
+                );
             }
         }
 
@@ -18974,7 +18994,7 @@ impl Workspace {
     }
 
     /// Renders a configurable panel for the given toolbar item, if it is open.
-    /// Returns `None` if the panel should not be rendered (item not available,
+    /// Returns `None` if the panel should not be rendered (item not supported,
     /// panel not open, or item is not a panel type).
     fn render_config_panel(
         &self,
@@ -18983,7 +19003,7 @@ impl Workspace {
         config: &HeaderToolbarChipSelection,
         app: &AppContext,
     ) -> Option<Box<dyn Element>> {
-        if !item.is_available(app) || !item.is_panel() {
+        if !item.is_supported(app) || !item.is_panel() {
             return None;
         }
         match item {
@@ -19029,7 +19049,7 @@ impl Workspace {
         if !pane_group.right_panel_open || !pane_group.is_right_panel_maximized {
             return None;
         }
-        if !HeaderToolbarItemKind::CodeReview.is_available(app) {
+        if !HeaderToolbarItemKind::CodeReview.is_supported(app) {
             return None;
         }
         Some(Shrinkable::new(1.0, ChildView::new(&self.right_panel_view).finish()).finish())


### PR DESCRIPTION
Closes #9196.

### Description

Two `show_code_review_button` gates were dropping panel-open requests on the floor when the user had hidden the toolbar button:

**1. Data-path gate at `Workspace::setup_code_review_panel` (`view.rs:7982`)**

```rust
if !*TabSettings::as_ref(ctx).show_code_review_button {
    return;
}
```

`update_right_panel_open_state` calls into this whenever the right panel is being opened (chip click, `Shift+Cmd+=` keybinding, etc.), so the early return silently swallowed every explicit user action.

**2. Render-path gate at `Workspace::render_config_panel` and `render_config_panel_maximized` (`view.rs:18981` / `19040`)**

```rust
if !item.is_available(app) || !item.is_panel() { return None; }
…
if !HeaderToolbarItemKind::CodeReview.is_available(app) { return None; }
```

`HeaderToolbarItemKind::is_available` for `CodeReview` returns `*TabSettings::as_ref(app).show_code_review_button.value()` (`header_toolbar_item.rs:89`). So even after fix #1 set `pane_group.right_panel_open = true` and `setup_code_review_panel` ran, the next render frame saw `is_available() == false` and returned `None` — the `right_panel_view` was never added to the layout.

This second gate is what @moirahuang flagged when their local repro still showed nothing happening after the first fix landed. The data was correct; the panel was just never composed into the UI.

### Fix

1. **Drop the early return at `setup_code_review_panel`.** The setting is meant to gate only the toolbar button's visibility (already enforced correctly by `header_toolbar_item.rs::is_available`, which feeds `render_header_toolbar_button` at `view.rs:17276`).
2. **Switch panel-render call sites from `is_available` → `is_supported`.** `is_available`'s own doc-comment says it's specifically *"Whether this item should be shown in the **toolbar** — checks both `is_supported` and user show/hide preferences."* Using it to gate panel rendering conflates two unrelated concerns. Panel rendering should only care about whether the feature is compiled in (`is_supported`), not whether the user has hidden the toolbar button.

For `CodeReview`, `is_supported` is `cfg!(feature = "local_fs")`. For the other variants in the same match (`TabsPanel`, `ToolsPanel`), `is_available` already equals `is_supported` (default `_ => true` arm in the inner match), so behaviour is unchanged. `AgentManagement` and `NotificationsMailbox` return `None` unconditionally inside `render_config_panel`, so the change is moot for them too.

### Caller audit for `setup_code_review_panel`

5 call sites in `view.rs`:

1. `view.rs:3681` — `TransferredTab` flow, only runs when the source tab already had `right_panel_open == true`.
2. `view.rs:8136` — `update_right_panel_open_state` with `should_open == true`. **The diff-button path** that #9196 is about.
3. `view.rs:13372` — `PaneFocused` event, gated on `right_panel_open` already true.
4. `view.rs:13490` — `RepoChanged` event, gated on `right_panel_open` already true.
5. `view.rs:14458` — session env update, gated on `right_panel_open` already true.

None of these need the `show_code_review_button` gate — they're either explicit user actions or gated on `right_panel_open` already being open. The toolbar button toggle continues to do its job at `render_header_toolbar_button` independently.

### Testing

Reproduced @moirahuang's test locally on macOS 26.4.1 (Apple Silicon) against `WarpOss.app` built from this branch:

1. Settings → "Show code review button" → **OFF**
2. `echo "x" >> README.md` inside a git repo
3. Click the diff stats chip on the prompt (`+1 -0`)

**Result:** Code review panel opens on the right showing the diff, while the toolbar button stays hidden — exactly the expected behaviour from issue #9196. Inverse case (toggle ON) also verified: toolbar button visible, panel still works the same.

- `cargo fmt -p warp -- --check` passes.
- `cargo nextest` skipped locally — Metal toolchain unavailable on my machine, mirroring #9277. CI will exercise the change.

### Server API

No server changes.

### Agent Mode

Not applicable.

### Changelog Entries

`CHANGELOG-BUG-FIX`: The diff button on the terminal prompt now opens the code review panel even when the toolbar's "Show code review button" toggle is disabled (regression from a recent release).