### PR TITLE
Don't add ToggleConversationListView menu item when its flag is off

### DIFF
--- a/app/src/app_menus.rs
+++ b/app/src/app_menus.rs
@@ -381,7 +381,21 @@ fn make_new_view_menu(ctx: &AppContext) -> Menu {
         updateable_custom_item_without_checkmark(CustomAction::NavigationPalette, ctx),
         updateable_custom_item_without_checkmark(CustomAction::LaunchConfigPalette, ctx),
         updateable_custom_item_without_checkmark(CustomAction::FilesPalette, ctx),
-        updateable_custom_item_without_checkmark(CustomAction::ToggleConversationListView, ctx),
+    ];
+
+    // The `ToggleConversationListView` action only has a registered
+    // description and key bindings when this flag is enabled (see
+    // `crate::workspace::mod`). Inserting it unconditionally caused
+    // `default_name` to trip its `debug_assert!` in OSS/dogfood/preview
+    // builds and rendered `<NO DESCRIPTION>` in release builds.
+    if FeatureFlag::AgentViewConversationListView.is_enabled() {
+        items.push(updateable_custom_item_without_checkmark(
+            CustomAction::ToggleConversationListView,
+            ctx,
+        ));
+    }
+
+    items.extend([
         updateable_custom_item_without_checkmark(CustomAction::ToggleProjectExplorer, ctx),
         updateable_custom_item_without_checkmark(CustomAction::ToggleGlobalSearch, ctx),
         MenuItem::Separator,
@@ -435,7 +449,7 @@ fn make_new_view_menu(ctx: &AppContext) -> Menu {
             },
             None,
         )),
-    ];
+    ]);
 
     let is_compact_mode = matches!(
         TerminalSettings::handle(ctx)


### PR DESCRIPTION
Closes #9535.

### Description

`make_new_view_menu` in `app/src/app_menus.rs` was always inserting the `CustomAction::ToggleConversationListView` menu item:

```rust
updateable_custom_item_without_checkmark(CustomAction::ToggleConversationListView, ctx),
```

But that action's keybindings and description are gated on `FeatureFlag::AgentViewConversationListView` at both keybinding sites:

- `app/src/workspace/mod.rs:738-746` — `LEFT_PANEL_AGENT_CONVERSATIONS_BINDING_NAME`
- `app/src/workspace/mod.rs:797-809` — `TOGGLE_CONVERSATION_LIST_VIEW_BINDING_NAME` (which is the binding that registers the description used by `default_name`)

The flag is registered behind `#[cfg(feature = "agent_view_conversation_list_view")]` (`app/src/lib.rs:2677-2678`), so it stays off in OSS, dogfood, preview, and release. With the menu item present but no description registered, `default_name` (lines 100-106 of the same file) hits its `debug_assert!` and crashes `warp-oss` debug builds; release builds render `<NO DESCRIPTION>`.

### Fix

Split the menu's vec literal so `ToggleConversationListView` is `push`-ed conditionally on `FeatureFlag::AgentViewConversationListView.is_enabled()`, mirroring the gating already used at the keybinding sites. Order of remaining items is preserved.

I deliberately left the `debug_assert!` in `default_name` alone — it is correctly catching a real bug class, and softening it would mask the next misalignment of this kind.

### Testing

- `cargo fmt -p warp -- --check` — passes.
- I did not add a unit test. `app/src/app_menus.rs` has no existing `#[cfg(test)]` module or sibling `_tests.rs`, and constructing an `AppContext`, registering keybindings, and walking the resulting `Menu` to assert presence/absence of an item under both flag states would balloon the diff far beyond the one-line semantic gating change. Happy to add one if a maintainer prefers.
- Could not run `cargo nextest` locally (Metal toolchain unavailable on this machine — same situation as #9277).

### Server API

No server changes.

### Agent Mode

Not applicable.

### Changelog Entries

`CHANGELOG-BUG-FIX`: The View menu no longer crashes `warp-oss` debug builds (or renders `<NO DESCRIPTION>` in release) by including a flag-gated menu item without its description.