### PR TITLE
Enable IME on Linux/Wayland

### DIFF
--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -1422,6 +1422,13 @@ fn create_window(
         }
     }
 
+    #[cfg(target_os = "linux")]
+    if let Ok(window) = created_window.as_ref() {
+        // On Linux/Wayland, winit only sends `zwp_text_input_v3.enable()` when IME is allowed,
+        // so without this call IME stays inactive and non-Latin input (CJK, etc.) is unusable.
+        window.set_ime_allowed(true);
+    }
+
     created_window
 }
 


### PR DESCRIPTION
Closes #9383.

### Description

`set_ime_allowed(true)` was only being called inside the `#[cfg(windows)]` block in `crates/warpui/src/windowing/winit/window.rs::create_window` (the block that ends around line 1421 on master). On Linux/Wayland, winit's text-input plugin only sends `zwp_text_input_v3.enable()` to the compositor after `set_ime_allowed(true)` is called — without that call IME stays inactive, so non-Latin input methods (CJK in particular) appear to do nothing in Warp.

### Fix

Add a parallel `#[cfg(target_os = "linux")]` block right after the Windows one calling the same method on the created window. macOS continues to use the native NSTextInputClient route and does not need this winit hint.

A repo-wide grep for `set_ime_allowed` confirms there is no other Linux-specific call site that was already covering this — the previous behaviour was "Windows-only" by oversight, not by design.

```rust
#[cfg(target_os = "linux")]
if let Ok(window) = created_window.as_ref() {
    // On Linux/Wayland, winit only sends `zwp_text_input_v3.enable()` when IME is allowed,
    // so without this call IME stays inactive and non-Latin input (CJK, etc.) is unusable.
    window.set_ime_allowed(true);
}
```

### Testing

- `cargo fmt -p warpui -- --check` — passes.
- Compile-only verification possible from my checkout (Metal toolchain unavailable for full `cargo nextest`, mirroring #9277). The change is a 7-line addition that mirrors the existing Windows block exactly.
- Functional verification needs a Wayland session, which I can't run locally; CI on Linux runners should cover compilation. A maintainer with a Wayland setup could confirm IME behaviour with a CJK input method.

### Coordination with #9536

PR #9536 (open) modifies the same file but inside `maybe_adjust_window_vertically` (lines ~1433+ on master, adding 3 lines that early-return on maximize/fullscreen). My edit lands in `create_window` on lines 1422–1428, which #9536 does not touch — no merge conflict expected.

### Server API

No server changes.

### Agent Mode

Not applicable.

### Changelog Entries

`CHANGELOG-BUG-FIX`: IME (input method) now activates on Linux/Wayland, restoring CJK and other non-Latin input that had been silently broken since first launch.