### PR TITLE
Recognize the image/jpg MIME alias when downloading artifacts

### DIFF
--- a/app/src/ai/artifact_download.rs
+++ b/app/src/ai/artifact_download.rs
@@ -17,7 +17,7 @@ pub(crate) fn sanitized_basename(path_or_filename: &str) -> Option<String> {
 pub(crate) fn extension_for_content_type(content_type: &str) -> Option<&'static str> {
     match content_type {
         "image/gif" => Some("gif"),
-        "image/jpeg" => Some("jpg"),
+        "image/jpeg" | "image/jpg" => Some("jpg"),
         "image/png" => Some("png"),
         "image/webp" => Some("webp"),
         "application/json" => Some("json"),
@@ -149,6 +149,13 @@ mod tests {
             sanitized_basename("outputs/report.txt"),
             Some("report.txt".to_string())
         );
+    }
+
+    #[test]
+    #[cfg(feature = "local_fs")]
+    fn extension_for_content_type_recognizes_image_jpg_alias() {
+        assert_eq!(extension_for_content_type("image/jpg"), Some("jpg"));
+        assert_eq!(extension_for_content_type("image/jpeg"), Some("jpg"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

`extension_for_content_type` in `app/src/ai/artifact_download.rs` only mapped `image/jpeg` to a `.jpg` extension, but two adjacent code paths already treat `image/jpg` (the non-standard alias still emitted by some tools and CDNs) as an equivalent JPEG type:

- `app/src/util/image.rs:29` — `SUPPORTED_IMAGE_MIME_TYPES` lists both `image/jpeg` and `image/jpg`.
- `app/src/terminal/input.rs:10044` — the paste-image handler matches `\"image/jpeg\" | \"image/jpg\" => \"jpg\"`.

So an artifact served with `Content-Type: image/jpg` would pass the supported-types check elsewhere in the app but get a missing/wrong extension when saved through `artifact_download`. This patch lines that one path up with the rest of the codebase by treating `image/jpg` as an alias for `image/jpeg`, and adds a unit test that pins both spellings.

## Testing

- Added unit test `extension_for_content_type_recognizes_image_jpg_alias` covering both `image/jpg` and `image/jpeg`.
- `cargo fmt -p warp -- --check` ✅
- `cargo nextest` skipped locally — Metal toolchain isn't available on my machine, same situation as #9277. CI will exercise the test.

## Server API

- [ ] Yes
- [x] No

## Agent Mode

- [ ] Yes
- [x] No

## Changelog Entries

- CHANGELOG-BUG-FIX: Fixed downloaded image artifacts served with `Content-Type: image/jpg` getting the wrong file extension.