### PR TITLE
Fix :file tree refresh after move operations

### DIFF
--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -562,7 +562,7 @@ impl FileTreeView {
                                 } else {
                                     // For subdirectories, we need to refresh the specific directory
                                     // from the updated repository state
-                                    if let Some(updated_entry) = state.entry.get(root_path) {
+                                    if state.entry.contains(root_path) {
                                         root_dir.entry = state.entry.clone();
                                     }
                                 }

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -536,22 +536,36 @@ impl FileTreeView {
             RepoMetadataEvent::FileTreeEntryUpdated {
                 id: RepositoryIdentifier::Local(std_path),
             } => {
-                // Find root directories whose backing model entry matches this path.
-                let root_paths: Vec<StandardizedPath> = self
+                // Find all displayed directories that belong to the updated repository.
+                // This handles both direct repository root updates and updates to subdirectories
+                // within the repository (e.g., after file move operations).
+                let affected_root_paths: Vec<StandardizedPath> = self
                     .root_directories
                     .iter()
-                    .filter_map(|(root_path, root_dir)| {
-                        (**root_dir.entry.root_directory() == *std_path)
-                            .then_some(root_path.clone())
+                    .filter(|(_, root_dir)| {
+                        // Check if this root directory is within the updated repository
+                        let root_dir_path = root_dir.entry.root_directory();
+                        *root_dir_path == std_path || root_dir_path.starts_with(&std_path)
                     })
+                    .map(|(root_path, _)| root_path.clone())
                     .collect();
 
-                if !root_paths.is_empty() {
+                if !affected_root_paths.is_empty() {
                     let id = RepositoryIdentifier::Local(std_path.clone());
                     if let Some(state) = RepoMetadataModel::as_ref(ctx).get_repository(&id, ctx) {
-                        for root_path in root_paths {
-                            if let Some(root_dir) = self.root_directories.get_mut(&root_path) {
-                                root_dir.entry = state.entry.clone();
+                        // Update all affected root directories with the new repository state
+                        for root_path in &affected_root_paths {
+                            if let Some(root_dir) = self.root_directories.get_mut(root_path) {
+                                // If this is the repository root itself, update the entire entry
+                                if *root_dir.entry.root_directory() == std_path {
+                                    root_dir.entry = state.entry.clone();
+                                } else {
+                                    // For subdirectories, we need to refresh the specific directory
+                                    // from the updated repository state
+                                    if let Some(updated_entry) = state.entry.get(root_path) {
+                                        root_dir.entry = state.entry.clone();
+                                    }
+                                }
                             }
                         }
 

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -536,6 +536,13 @@ impl FileTreeView {
             RepoMetadataEvent::FileTreeEntryUpdated {
                 id: RepositoryIdentifier::Local(std_path),
             } => {
+                // Actions to perform after ending mutable borrow
+                #[derive(Debug)]
+                enum Action {
+                    RemoveLazyLoaded,
+                    RefreshLazyLoaded,
+                }
+                
                 // Find all displayed directories that belong to the updated repository.
                 // This handles both direct repository root updates and updates to subdirectories
                 // within the repository (e.g., after file move operations).
@@ -569,6 +576,9 @@ impl FileTreeView {
                 if !affected_root_paths.is_empty() {
                     let id = RepositoryIdentifier::Local(std_path.clone());
                     if let Some(state) = RepoMetadataModel::as_ref(ctx).get_repository(&id, ctx) {
+                        // Collect actions to perform after ending the mutable borrow
+                        let mut actions_to_perform = Vec::new();
+                        
                         // Update all affected root directories with the new repository state
                         for root_path in &affected_root_paths {
                             if let Some(root_dir) = self.root_directories.get_mut(root_path) {
@@ -585,21 +595,36 @@ impl FileTreeView {
                                             if state.entry.contains(root_path) {
                                                 // Path exists in repo - promote to repo-backed state
                                                 root_dir.entry = state.entry.clone();
-                                                self.remove_lazy_loaded_entry(root_path, ctx);
+                                                actions_to_perform.push((root_path.clone(), Action::RemoveLazyLoaded));
                                             } else {
                                                 // Path doesn't exist in repo - could be moved/deleted or ignored/excluded
                                                 // Check if the path still exists on filesystem to determine action
                                                 if root_path.to_local_path_lossy().exists() {
                                                     // Path exists but not in repo (likely ignored/excluded) - keep lazy-loaded
                                                     // Refresh the lazy-loaded entry to get current filesystem state
-                                                    self.register_and_refresh_lazy_loaded_directory(root_path, ctx);
+                                                    actions_to_perform.push((root_path.clone(), Action::RefreshLazyLoaded));
                                                 } else {
                                                     // Path doesn't exist on filesystem (moved/deleted) - clear the entry
                                                     root_dir.entry = state.entry.clone();
-                                                    self.remove_lazy_loaded_entry(root_path, ctx);
+                                                    actions_to_perform.push((root_path.clone(), Action::RemoveLazyLoaded));
                                                 }
                                             }
                                         }
+                                    }
+                                }
+                            }
+                        }
+                        
+                        // Perform the collected actions after ending the mutable borrow
+                        #[cfg(feature = "local_fs")]
+                        {
+                            for (path, action) in actions_to_perform {
+                                match action {
+                                    Action::RemoveLazyLoaded => {
+                                        self.remove_lazy_loaded_entry(&path, ctx);
+                                    }
+                                    Action::RefreshLazyLoaded => {
+                                        self.register_and_refresh_lazy_loaded_directory(&path, ctx);
                                     }
                                 }
                             }

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -576,16 +576,29 @@ impl FileTreeView {
                                 if **root_dir.entry.root_directory() == *std_path {
                                     root_dir.entry = state.entry.clone();
                                 } else {
-                                    // For lazy-loaded subdirectories, always update to clear stale entries
-                                    // even if the directory was moved or deleted (contains() would be false)
+                                    // For lazy-loaded subdirectories, update only when appropriate
                                     #[cfg(feature = "local_fs")]
                                     {
                                         if self.registered_lazy_loaded_paths.contains(root_path) {
-                                            root_dir.entry = state.entry.clone();
-                                            // When promoting a lazy-loaded root to repository-backed state,
-                                            // unregister the standalone lazy-loaded path to avoid
-                                            // obsolete watcher/model registrations
-                                            self.remove_lazy_loaded_entry(root_path, ctx);
+                                            // Only promote to repo-backed state if the repo contains this path
+                                            // or if the path no longer exists (moved/deleted)
+                                            if state.entry.contains(root_path) {
+                                                // Path exists in repo - promote to repo-backed state
+                                                root_dir.entry = state.entry.clone();
+                                                self.remove_lazy_loaded_entry(root_path, ctx);
+                                            } else {
+                                                // Path doesn't exist in repo - could be moved/deleted or ignored/excluded
+                                                // Check if the path still exists on filesystem to determine action
+                                                if root_path.to_local_path_lossy().exists() {
+                                                    // Path exists but not in repo (likely ignored/excluded) - keep lazy-loaded
+                                                    // Refresh the lazy-loaded entry to get current filesystem state
+                                                    self.register_and_refresh_lazy_loaded_directory(root_path, ctx);
+                                                } else {
+                                                    // Path doesn't exist on filesystem (moved/deleted) - clear the entry
+                                                    root_dir.entry = state.entry.clone();
+                                                    self.remove_lazy_loaded_entry(root_path, ctx);
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -542,10 +542,26 @@ impl FileTreeView {
                 let affected_root_paths: Vec<StandardizedPath> = self
                     .root_directories
                     .iter()
-                    .filter(|(_, root_dir)| {
+                    .filter(|(root_path, root_dir)| {
                         // Check if this root directory is within the updated repository
                         let root_dir_path = root_dir.entry.root_directory();
-                        **root_dir_path == *std_path || root_dir_path.starts_with(std_path)
+                        
+                        // Exact matching for repository-backed roots (to avoid contaminating nested repos)
+                        if **root_dir_path == *std_path {
+                            return true;
+                        }
+                        
+                        // Prefix matching only for lazy-loaded roots (to handle moved/deleted directories)
+                        #[cfg(feature = "local_fs")]
+                        {
+                            self.registered_lazy_loaded_paths.contains(root_path) 
+                                && root_dir_path.starts_with(std_path)
+                        }
+                        
+                        #[cfg(not(feature = "local_fs"))]
+                        {
+                            false
+                        }
                     })
                     .map(|(root_path, _)| root_path.clone())
                     .collect();
@@ -560,10 +576,13 @@ impl FileTreeView {
                                 if **root_dir.entry.root_directory() == *std_path {
                                     root_dir.entry = state.entry.clone();
                                 } else {
-                                    // For subdirectories, we need to refresh the specific directory
-                                    // from the updated repository state
-                                    if state.entry.contains(root_path) {
-                                        root_dir.entry = state.entry.clone();
+                                    // For lazy-loaded subdirectories, always update to clear stale entries
+                                    // even if the directory was moved or deleted (contains() would be false)
+                                    #[cfg(feature = "local_fs")]
+                                    {
+                                        if self.registered_lazy_loaded_paths.contains(root_path) {
+                                            root_dir.entry = state.entry.clone();
+                                        }
                                     }
                                 }
                             }

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -582,6 +582,10 @@ impl FileTreeView {
                                     {
                                         if self.registered_lazy_loaded_paths.contains(root_path) {
                                             root_dir.entry = state.entry.clone();
+                                            // When promoting a lazy-loaded root to repository-backed state,
+                                            // unregister the standalone lazy-loaded path to avoid
+                                            // obsolete watcher/model registrations
+                                            self.remove_lazy_loaded_entry(root_path, ctx);
                                         }
                                     }
                                 }

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -545,7 +545,7 @@ impl FileTreeView {
                     .filter(|(_, root_dir)| {
                         // Check if this root directory is within the updated repository
                         let root_dir_path = root_dir.entry.root_directory();
-                        *root_dir_path == std_path || root_dir_path.starts_with(&std_path)
+                        **root_dir_path == *std_path || root_dir_path.starts_with(std_path)
                     })
                     .map(|(root_path, _)| root_path.clone())
                     .collect();
@@ -557,7 +557,7 @@ impl FileTreeView {
                         for root_path in &affected_root_paths {
                             if let Some(root_dir) = self.root_directories.get_mut(root_path) {
                                 // If this is the repository root itself, update the entire entry
-                                if *root_dir.entry.root_directory() == std_path {
+                                if **root_dir.entry.root_directory() == *std_path {
                                     root_dir.entry = state.entry.clone();
                                 } else {
                                     // For subdirectories, we need to refresh the specific directory

--- a/app/src/code/file_tree/view/view_tests.rs
+++ b/app/src/code/file_tree/view/view_tests.rs
@@ -985,3 +985,121 @@ fn absorbed_descendant_is_unregistered_from_lazy_loaded_paths() {
         });
     });
 }
+
+#[test]
+fn file_tree_refreshes_after_file_move_operations() {
+    VirtualFS::test("file_tree_move_refresh", |dirs, mut vfs| {
+        vfs.mkdir("repo/.git/objects")
+            .mkdir("repo/src")
+            .mkdir("repo/new_dir")
+            .with_files(vec![
+                Stub::FileWithContent("repo/.git/HEAD", "ref: refs/heads/main"),
+                Stub::FileWithContent("repo/.git/config", "[core]\n\trepositoryformatversion = 0"),
+                Stub::FileWithContent("repo/src/main.rs", "fn main() {}\n"),
+                Stub::FileWithContent("repo/src/utils.rs", "pub fn helper() {}\n"),
+            ]);
+
+        let repo_root = dirs.tests().join("repo");
+        let canonical_repo_root =
+            warp_util::standardized_path::StandardizedPath::from_local_canonicalized(&repo_root)
+                .unwrap();
+
+        App::test((), |mut app| async move {
+            let (detected_repositories, repository_metadata_model) = initialize_app(&mut app);
+
+            let (_, file_tree_view) = app.add_window(WindowStyle::NotStealFocus, FileTreeView::new);
+
+            detected_repositories.update(&mut app, |repositories, _ctx| {
+                repositories.insert_test_repo_root(canonical_repo_root.clone());
+            });
+
+            file_tree_view.update(&mut app, |view, ctx| {
+                view.set_is_active(true, ctx);
+                view.set_root_directories(vec![repo_root.clone()], ctx);
+            });
+
+            // Wait for initial indexing to complete
+            file_tree_view.update(&mut app, |view, ctx| {
+                view.update_directory_contents(&[canonical_repo_root.clone()], false, ctx);
+            });
+
+            // Verify initial state - files should be in src/
+            file_tree_view.read(&app, |view, _ctx| {
+                let flattened_items = view.flattened_items();
+                let main_rs_path = canonical_repo_root.join("src/main.rs");
+                let utils_rs_path = canonical_repo_root.join("src/utils.rs");
+                
+                assert!(flattened_items.iter().any(|item| item.id.path == main_rs_path));
+                assert!(flattened_items.iter().any(|item| item.id.path == utils_rs_path));
+            });
+
+            // Simulate a file move operation by updating the repository state
+            let moved_repo_state = {
+                let moved_main_file = Entry::File(FileMetadata::new(
+                    repo_root.join("new_dir/main.rs"),
+                    false,
+                ));
+                let moved_utils_file = Entry::File(FileMetadata::new(
+                    repo_root.join("new_dir/utils.rs"),
+                    false,
+                ));
+                let new_dir = Entry::Directory(DirectoryEntry {
+                    path: warp_util::standardized_path::StandardizedPath::try_from_local(
+                        &repo_root.join("new_dir"),
+                    )
+                    .unwrap(),
+                    children: vec![moved_main_file, moved_utils_file],
+                    ignored: false,
+                    loaded: true,
+                });
+                let src_dir = Entry::Directory(DirectoryEntry {
+                    path: warp_util::standardized_path::StandardizedPath::try_from_local(
+                        &repo_root.join("src"),
+                    )
+                    .unwrap(),
+                    children: vec![],
+                    ignored: false,
+                    loaded: true,
+                });
+                let root = Entry::Directory(DirectoryEntry {
+                    path: std_path(&repo_root),
+                    children: vec![src_dir, new_dir],
+                    ignored: false,
+                    loaded: true,
+                });
+                FileTreeState::new(root, vec![], None)
+            };
+
+            // Update the repository metadata model with the new state
+            repository_metadata_model.update(&mut app, |model, ctx| {
+                model.add_repository_internal(
+                    canonical_repo_root.clone(),
+                    IndexedRepoState::Indexed(moved_repo_state),
+                    ctx,
+                ).unwrap();
+            });
+
+            // Emit a FileTreeEntryUpdated event (simulating what happens after a move operation)
+            repository_metadata_model.emit(repo_metadata::local_model::RepositoryMetadataEvent::FileTreeEntryUpdated {
+                path: canonical_repo_root.clone(),
+            });
+
+            // Verify that the file tree refreshed and files are no longer in the old location
+            file_tree_view.read(&app, |view, _ctx| {
+                let flattened_items = view.flattened_items();
+                let old_main_rs_path = canonical_repo_root.join("src/main.rs");
+                let old_utils_rs_path = canonical_repo_root.join("src/utils.rs");
+                let new_main_rs_path = canonical_repo_root.join("new_dir/main.rs");
+                let new_utils_rs_path = canonical_repo_root.join("new_dir/utils.rs");
+                
+                // Files should NOT be in the old location
+                assert!(!flattened_items.iter().any(|item| item.id.path == old_main_rs_path));
+                assert!(!flattened_items.iter().any(|item| item.id.path == old_utils_rs_path));
+                
+                // Files should be in the new location
+                assert!(flattened_items.iter().any(|item| item.id.path == new_main_rs_path));
+                assert!(flattened_items.iter().any(|item| item.id.path == new_utils_rs_path));
+            });
+        });
+    });
+}

--- a/app/src/code/file_tree/view/view_tests.rs
+++ b/app/src/code/file_tree/view/view_tests.rs
@@ -1033,12 +1033,13 @@ fn file_tree_refreshes_after_file_move_operations() {
 
             // Verify initial state - files should be in src/
             file_tree_view.read(&app, |view, _ctx| {
-                let flattened_items = view.flattened_items();
+                let root_dir = view.root_directories.get(&canonical_src_dir).unwrap();
+                let items = &root_dir.items;
                 let main_rs_path = canonical_src_dir.join("main.rs");
                 let utils_rs_path = canonical_src_dir.join("utils.rs");
                 
-                assert!(flattened_items.iter().any(|item| item.id.path == main_rs_path));
-                assert!(flattened_items.iter().any(|item| item.id.path == utils_rs_path));
+                assert!(items.iter().any(|item| item.path() == &main_rs_path));
+                assert!(items.iter().any(|item| item.path() == &utils_rs_path));
             });
 
             // Simulate a file move operation by updating the repository state
@@ -1090,19 +1091,20 @@ fn file_tree_refreshes_after_file_move_operations() {
 
             // Verify that the file tree refreshed and files are no longer in the old location
             file_tree_view.read(&app, |view, _ctx| {
-                let flattened_items = view.flattened_items();
+                let root_dir = view.root_directories.get(&canonical_src_dir).unwrap();
+                let items = &root_dir.items;
                 let old_main_rs_path = canonical_src_dir.join("main.rs");
                 let old_utils_rs_path = canonical_src_dir.join("utils.rs");
                 
                 // Files should NOT be in the old location (src directory)
-                assert!(!flattened_items.iter().any(|item| item.id.path == old_main_rs_path));
-                assert!(!flattened_items.iter().any(|item| item.id.path == old_utils_rs_path));
+                assert!(!items.iter().any(|item| item.path() == &old_main_rs_path));
+                assert!(!items.iter().any(|item| item.path() == &old_utils_rs_path));
                 
                 // The lazy-loaded src directory should be refreshed with the new repository state
                 // Since we're displaying src as a lazy-loaded directory, it should now be empty
                 // because the files were moved out of it in the updated repository state
-                let src_items: Vec<_> = flattened_items.iter()
-                    .filter(|item| item.id.path.starts_with(&canonical_src_dir))
+                let src_items: Vec<_> = items.iter()
+                    .filter(|item| item.path().starts_with(&canonical_src_dir))
                     .collect();
                 assert!(src_items.is_empty(), "src directory should be empty after files were moved");
             });

--- a/app/src/code/file_tree/view/view_tests.rs
+++ b/app/src/code/file_tree/view/view_tests.rs
@@ -1072,16 +1072,12 @@ fn file_tree_refreshes_after_file_move_operations() {
 
             // Update the repository metadata model with the new state
             repository_metadata_model.update(&mut app, |model, ctx| {
-                model.add_repository_internal(
-                    canonical_repo_root.clone(),
-                    IndexedRepoState::Indexed(moved_repo_state),
-                    ctx,
-                ).unwrap();
+                model.insert_test_state(canonical_repo_root.clone(), moved_repo_state, ctx);
             });
 
             // Emit a FileTreeEntryUpdated event (simulating what happens after a move operation)
-            repository_metadata_model.emit(repo_metadata::local_model::RepositoryMetadataEvent::FileTreeEntryUpdated {
-                path: canonical_repo_root.clone(),
+            repository_metadata_model.emit(repo_metadata::RepoMetadataEvent::FileTreeEntryUpdated {
+                id: repo_metadata::RepositoryIdentifier::local(canonical_repo_root.clone()),
             });
 
             // Verify that the file tree refreshed and files are no longer in the old location

--- a/app/src/code/file_tree/view/view_tests.rs
+++ b/app/src/code/file_tree/view/view_tests.rs
@@ -1103,8 +1103,11 @@ fn file_tree_refreshes_after_file_move_operations() {
                 // The lazy-loaded src directory should be refreshed with the new repository state
                 // Since we're displaying src as a lazy-loaded directory, it should now be empty
                 // because the files were moved out of it in the updated repository state
-                let src_items: Vec<_> = items.iter()
-                    .filter(|item| item.path().starts_with(&canonical_src_dir))
+                let src_items: Vec<_> = items
+                    .iter()
+                    .filter(|item| {
+                        item.path() != &canonical_src_dir && item.path().starts_with(&canonical_src_dir)
+                    })
                     .collect();
                 assert!(src_items.is_empty(), "src directory should be empty after files were moved");
             });

--- a/app/src/code/file_tree/view/view_tests.rs
+++ b/app/src/code/file_tree/view/view_tests.rs
@@ -1003,6 +1003,13 @@ fn file_tree_refreshes_after_file_move_operations() {
         let canonical_repo_root =
             warp_util::standardized_path::StandardizedPath::from_local_canonicalized(&repo_root)
                 .unwrap();
+        
+        // Test with a lazy-loaded subdirectory, not the repository root itself
+        // This tests the actual regression - lazy-loaded directories not refreshing
+        let src_dir = repo_root.join("src");
+        let canonical_src_dir =
+            warp_util::standardized_path::StandardizedPath::from_local_canonicalized(&src_dir)
+                .unwrap();
 
         App::test((), |mut app| async move {
             let (detected_repositories, repository_metadata_model) = initialize_app(&mut app);
@@ -1015,19 +1022,20 @@ fn file_tree_refreshes_after_file_move_operations() {
 
             file_tree_view.update(&mut app, |view, ctx| {
                 view.set_is_active(true, ctx);
-                view.set_root_directories(vec![repo_root.clone()], ctx);
+                // Display the lazy-loaded subdirectory, not the repo root
+                view.set_root_directories(vec![src_dir.clone()], ctx);
             });
 
             // Wait for initial indexing to complete
             file_tree_view.update(&mut app, |view, ctx| {
-                view.update_directory_contents(&[canonical_repo_root.clone()], false, ctx);
+                view.update_directory_contents(&[canonical_src_dir.clone()], false, ctx);
             });
 
             // Verify initial state - files should be in src/
             file_tree_view.read(&app, |view, _ctx| {
                 let flattened_items = view.flattened_items();
-                let main_rs_path = canonical_repo_root.join("src/main.rs");
-                let utils_rs_path = canonical_repo_root.join("src/utils.rs");
+                let main_rs_path = canonical_src_dir.join("main.rs");
+                let utils_rs_path = canonical_src_dir.join("utils.rs");
                 
                 assert!(flattened_items.iter().any(|item| item.id.path == main_rs_path));
                 assert!(flattened_items.iter().any(|item| item.id.path == utils_rs_path));
@@ -1083,18 +1091,20 @@ fn file_tree_refreshes_after_file_move_operations() {
             // Verify that the file tree refreshed and files are no longer in the old location
             file_tree_view.read(&app, |view, _ctx| {
                 let flattened_items = view.flattened_items();
-                let old_main_rs_path = canonical_repo_root.join("src/main.rs");
-                let old_utils_rs_path = canonical_repo_root.join("src/utils.rs");
-                let new_main_rs_path = canonical_repo_root.join("new_dir/main.rs");
-                let new_utils_rs_path = canonical_repo_root.join("new_dir/utils.rs");
+                let old_main_rs_path = canonical_src_dir.join("main.rs");
+                let old_utils_rs_path = canonical_src_dir.join("utils.rs");
                 
-                // Files should NOT be in the old location
+                // Files should NOT be in the old location (src directory)
                 assert!(!flattened_items.iter().any(|item| item.id.path == old_main_rs_path));
                 assert!(!flattened_items.iter().any(|item| item.id.path == old_utils_rs_path));
                 
-                // Files should be in the new location
-                assert!(flattened_items.iter().any(|item| item.id.path == new_main_rs_path));
-                assert!(flattened_items.iter().any(|item| item.id.path == new_utils_rs_path));
+                // The lazy-loaded src directory should be refreshed with the new repository state
+                // Since we're displaying src as a lazy-loaded directory, it should now be empty
+                // because the files were moved out of it in the updated repository state
+                let src_items: Vec<_> = flattened_items.iter()
+                    .filter(|item| item.id.path.starts_with(&canonical_src_dir))
+                    .collect();
+                assert!(src_items.is_empty(), "src directory should be empty after files were moved");
             });
         });
     });


### PR DESCRIPTION
<!-- PR TEMPLATE CONTENT -->

## Description
Fixes the file tree panel showing stale file locations after `mv`/`git mv` operations. Files were appearing in both old and new locations until manual refresh.

## Changes Made
- Updated `FileTreeEntryUpdated` event handler to properly refresh all directories within updated repository
- Added comprehensive test to prevent regression
- Fixed issue where exact path matching was too restrictive for move operations

## Issue Reference
Fixes #9592

## Testing
- Added new test [file_tree_refreshes_after_file_move_operations](cci:1://file:///d:/projects/open/warp/app/src/code/file_tree/view/view_tests.rs:988:0-1104:1)
- Verified existing tests still pass
- Manual testing with `mv` commands confirms fix works

CHANGELOG-BUG-FIX: File tree panel now properly refreshes after file move operations, eliminating stale file entries.