### PR TITLE
Add vkodithala as co-owner of skills, MCP, and long-running commands

### DIFF
--- a/.github/STAKEHOLDERS
+++ b/.github/STAKEHOLDERS
@@ -76,9 +76,9 @@
 /crates/onboarding/ @kevinchevalier
 
 # MCP and skills
-/app/src/ai/mcp/ @peicodes
-/app/src/ai/skills/ @peicodes
-/crates/mcp/ @peicodes
+/app/src/ai/mcp/ @peicodes @vkodithala
+/app/src/ai/skills/ @peicodes @vkodithala
+/crates/mcp/ @peicodes @vkodithala
 
 # Conversation management / credit usage footer / input UI / natural-language detection
 /app/src/ai/active_agent_views_model.rs @harryalbert
@@ -145,6 +145,9 @@
 
 # Grep tool call UI
 /app/src/ai/blocklist/action_model/execute/grep.rs @vkodithala
+
+# Long-running shell commands
+/app/src/ai/blocklist/action_model/execute/shell_command.rs @vkodithala
 
 ###########################################################################
 # Team: Platform

--- a/.github/STAKEHOLDERS
+++ b/.github/STAKEHOLDERS
@@ -80,6 +80,14 @@
 /app/src/ai/skills/ @peicodes @vkodithala
 /crates/mcp/ @peicodes @vkodithala
 
+# File-based MCP (overrides MCP and skills above)
+/app/src/ai/mcp/file_based_manager.rs @vkodithala
+/app/src/ai/mcp/file_based_manager_tests.rs @vkodithala
+/app/src/ai/mcp/file_mcp_watcher.rs @vkodithala
+/app/src/ai/mcp/file_mcp_watcher_tests.rs @vkodithala
+/app/src/ai/mcp/dummy_file_based_manager.rs @vkodithala
+/app/src/ai/mcp/dummy_file_mcp_watcher.rs @vkodithala
+
 # Conversation management / credit usage footer / input UI / natural-language detection
 /app/src/ai/active_agent_views_model.rs @harryalbert
 /app/src/ai/conversation_navigation/ @harryalbert


### PR DESCRIPTION
## Description
Adds `@vkodithala` as a co-owner on skills, MCP, and long-running shell commands in `.github/STAKEHOLDERS`, so issue and PR triage routes those areas to me as well.

- Skills: `/app/src/ai/skills/`
- MCP: `/app/src/ai/mcp/` and `/crates/mcp/`
- Long-running shell commands: `/app/src/ai/blocklist/action_model/execute/shell_command.rs` (new entry)

## Linked Issue
N/A — focus area / ownership update.

## Testing
Documentation-only change to `.github/STAKEHOLDERS`; no code or tests affected.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>