### PR TITLE
Add multi-agent harness routing scaffolding

### DIFF
--- a/.agents/skills/route/SKILL.md
+++ b/.agents/skills/route/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: route
+description: Recommend a tier and dispatch target for a development task in the Warp repo, based on scope and complexity. Use before starting non-trivial work to pick the right tool, or when the current agent feels mismatched. Returns a recommendation with reasoning — the calling harness decides whether to act on it.
+---
+
+# route
+
+Recommend a tier and dispatch target for a development task in this repo.
+
+This skill is harness-agnostic. The classification logic is the same for Claude Code, Codex, Gemini CLI, or any other supported agent. Only the final dispatch step is harness-specific (see [Dispatch](#dispatch)).
+
+The skill recommends *tiers* (capability profiles), not specific model versions. Specific model IDs change too often to bake into rules; the dispatch target — a subagent file under `.claude/agents/` for Claude Code, or an out-of-band CLI invocation for other harnesses — is where the concrete model lives, and where it gets updated when versions change.
+
+## When to use
+
+- Starting a non-trivial task and unsure which tier fits.
+- The current agent feels mismatched (slow on rote work; missing nuance on hard work).
+- A task has clearly bimodal characteristics (e.g. small but subtle, large but mechanical) and a routine default would pick wrong.
+
+Skip routing for routine work. Most edits don't need a routing decision; the user's current default model is fine.
+
+## Tiers
+
+| Tier | When | Default Claude Code dispatch |
+|---|---|---|
+| `fast` | Mechanical, scope-bounded edits with no design judgment. | `haiku-mechanical` |
+| `balanced` | Mid-complexity, scope-bounded subtasks with some design judgment. | `sonnet-balanced` |
+| `deep` | Cross-module reasoning, lock-stack work, invariant-heavy changes. | `opus-architect` |
+| `long-context` | Read-heavy: full-spec audits, large diffs, dependency analysis. | `gemini-long-context` (wraps Gemini CLI) |
+| `local` | Offline or cost-sensitive work where the prompt itself doesn't need to stay off hosted models. | `local-coder` (wraps Ollama; orchestrator runs on hosted Sonnet) |
+| `current` | Default — keep the current model. | (no dispatch) |
+
+`second-opinion` is *not* a primary tier — see [Second-opinion augmentation](#second-opinion-augmentation) below for how it appears in `alternatives`.
+
+The mapping from tier to specific model lives inside each subagent's frontmatter (Claude tiers use short aliases like `model: opus`, which auto-track latest; wrapper tiers read env-var-driven defaults like `${GEMINI_MODEL:-gemini-2.5-pro}`). When a new version ships, update the subagent file or override via env var; this skill doesn't need to know.
+
+## Classification contract
+
+The classifier consumes a fixed input shape and emits a fixed output shape. This contract is the single source of truth — harness adapters consume it; they do not re-classify.
+
+### Inputs
+
+| Field | Type | Description |
+|---|---|---|
+| `task_description` | string | Free-text description of what the task asks for. |
+| `expected_scope` | `single-file` \| `few-files` \| `many-files` \| `cross-crate` | How widely the change is expected to spread. |
+| `complexity` | `shallow` \| `moderate` \| `deep` | Shallow = rote / explicit; moderate = local logic; deep = cross-module reasoning, invariants, concurrency. |
+| `context_size_estimate` | `small` \| `medium` \| `large` | Roughly how much existing code must be read to do the work well. `large` = whole spec, full diff, `Cargo.lock` audit, etc. |
+| `correctness_criticality` | `low` \| `medium` \| `high` | `high` = touches concurrency, locks, persistence schemas, public APIs, security boundaries. |
+| `privacy_constraint` | `none` \| `local-only` | `local-only` = the user has asked to keep the prompt content off hosted models. |
+| `current_tier` | `fast` \| `balanced` \| `deep` \| `unknown` | The capability tier of the calling session's primary model. Used to decide whether dispatching to a different tier is worth the cost. |
+
+If a field is unknown, the caller fills in its best guess and lowers `confidence` in the output accordingly.
+
+### Outputs
+
+| Field | Type | Description |
+|---|---|---|
+| `tier` | string | One of the tier names above. |
+| `dispatch` | string \| `null` | Subagent name to dispatch to. `null` when `tier = current`, when the constraint is informational (e.g. prompt-confidentiality requires out-of-band action), or when no suitable subagent is available. |
+| `reasoning` | string | One or two sentences explaining the choice in terms of the inputs. |
+| `alternatives` | array | 0–2 other reasonable tiers, each with `tier`, `dispatch`, and a one-line `why`. Includes second-opinion augmentation when applicable (see below). |
+| `confidence` | `low` \| `medium` \| `high` | How sure the classifier is. Low when inputs were guesses or the task profile is unusual. |
+
+## Decision rules
+
+Apply in order. Stop at the first matching rule.
+
+1. **Prompt-confidentiality constraint.** `privacy_constraint = local-only` → `tier: local`, **`dispatch: null`**. Reasoning: the calling harness's subagent wrappers (`local-coder` and friends) all run under a hosted-model orchestrator that processes the user's prompt before delegating to a local model. The wrapper does not satisfy a prompt-confidentiality requirement; the user must invoke Ollama (or another local model) directly, outside this harness. Include `local-coder` in `alternatives` for callers whose actual concern is offline-or-cost rather than prompt confidentiality (orchestrator runs hosted; only the task work runs locally).
+
+2. **Long-context audit.** `context_size_estimate = large` AND task is read-heavy (audit, review, summarize) rather than write-heavy → `tier: long-context`, dispatch `gemini-long-context`. This rule comes before rule 3 so deep / high-criticality audits still get the long-context tier; for read-heavy work, the volume of context matters more than the difficulty of the reasoning over it. If the user doesn't have the Gemini CLI installed, the wrapper subagent reports that and the recommendation falls back to `tier: deep` (dispatch `opus-architect`) for a tightened-scope read.
+
+3. **Deep cross-cutting reasoning OR high-stakes correctness.** `complexity = deep` OR `correctness_criticality = high` → `tier: deep`, dispatch `opus-architect`. Examples: WarpUI Entity-Handle redesigns, `TerminalModel` lock-stack work, designing a feature flag rollout, root-cause debugging across module boundaries, single-line changes in security-sensitive code. The criticality clause means even a shallow narrow edit gets routed to `deep` when it touches locks, schemas, public APIs, or security boundaries. See [Second-opinion augmentation](#second-opinion-augmentation) for how Codex appears in `alternatives` when this rule fires.
+
+4. **Mechanical, narrow, low/medium criticality.** `complexity = shallow` AND `expected_scope ∈ {single-file, few-files}` AND `context_size_estimate ∈ {small, medium}` AND `correctness_criticality ∈ {low, medium}` → `tier: fast`, dispatch `haiku-mechanical`. Examples: variable rename, format-only fix, single-test repair, removing unused imports, applying an explicit patch from a spec. High-criticality narrow edits are caught by rule 3 instead.
+
+5. **Mid-tier, current model is fast or deep.** `complexity = moderate` AND `current_tier ∈ {fast, deep}` → `tier: balanced`, dispatch `sonnet-balanced`. When the calling session is already on the balanced tier (`current_tier = balanced`), this rule falls through to the default — there's no benefit to dispatching balanced from balanced unless context isolation is the goal. When `current_tier = unknown`, this rule also falls through; conservatively assume balanced.
+
+6. **Default.** Anything else → `tier: current`, `dispatch: null`. `reasoning` should explicitly say "no routing benefit expected."
+
+## Second-opinion augmentation
+
+Independent of which primary rule fires, if `correctness_criticality = high` AND the calling harness has the Codex plugin available, *additionally* include in `alternatives`:
+
+```
+{ tier: "second-opinion",
+  dispatch: "codex:codex-rescue",
+  why: "independent read for high-criticality work; complements the primary recommendation" }
+```
+
+This is a complementary recommendation, not a primary route — it doesn't replace the rule that fired. The dispatch target is the existing `codex:codex-rescue` plugin agent (see [Dispatch](#dispatch)). If the codex plugin isn't loaded, omit the alternative or surface as informational text and let the user run Codex CLI manually.
+
+## Specific signals worth weighting
+
+These are warp-repo-specific cues that should shift the recommendation even when the broad inputs look ordinary:
+
+- **`TerminalModel::lock` appears in the task.** Push toward rule 3 (`deep`). The lock-stack rules in `WARP.md` are easy to violate; the deeper-reasoning tier catches stack interactions cheaper tiers miss.
+- **WarpUI Entity / Handle / ViewContext changes.** Push toward rule 3.
+- **Pure feature-flag plumbing using the `add-feature-flag` skill.** Push toward rule 4 (`fast`); the skill is explicit and the work is mechanical.
+- **Whole-`Cargo.lock` or whole-spec analysis.** Push toward rule 2 (`long-context`).
+- **Persistence schema migrations under `crates/persistence/`.** Push toward rule 3 (architect) AND second-opinion augmentation (independent pass before merge).
+- **WGSL shader edits.** Push toward `current` if `current_tier = balanced`; otherwise rule 5 (`balanced`). Specialized syntax that the balanced tier handles reliably.
+
+## Dispatch
+
+The classifier output is the same regardless of harness. Dispatch is harness-specific:
+
+- **Claude Code.** If `dispatch` matches a subagent under `.claude/agents/` OR a plugin-prefixed name (e.g., `codex:codex-rescue` from the `codex` plugin) that is loaded in the current session, dispatch with the Agent tool using that name. If the named target isn't available (plugin not loaded, file missing), surface the recommendation as informational and let the user dispatch manually. If `null`, do nothing — but surface the `reasoning` and `alternatives` to the user; that's the whole output for an informational recommendation.
+- **Codex.** No native subagent format; the recommendation is informational. The user (or an outer orchestrator) acts on it.
+- **Gemini CLI.** Same — informational; the user acts on it.
+- **Other harnesses.** Same as Codex/Gemini.
+
+## Worked examples
+
+**Example 1.**
+> "Rename `delimeter` → `delimiter` everywhere in `crates/foo/`."
+
+inputs: `shallow` / `few-files` / `small` / `low` / `none` / `current_tier=balanced` → rule 4 → `tier: fast`, dispatch `haiku-mechanical`, confidence `high`. Reasoning: rote rename, narrow scope, low correctness risk.
+
+**Example 2.**
+> "Refactor `TerminalModel::lock` callers to avoid the deadlock pattern in WARP.md."
+
+inputs: `deep` / `cross-crate` / `medium` / `high` / `none` / `current_tier=balanced` → rule 3 → `tier: deep`, dispatch `opus-architect`, confidence `high`. Alternatives include `tier: second-opinion` via `codex:codex-rescue` (per the augmentation rule, since criticality is high). Reasoning: lock-stack reasoning is the WARP.md cliff edge.
+
+**Example 3.**
+> "Audit the workspace's `Cargo.lock` for transitive dependencies pulling in OpenSSL."
+
+inputs: `shallow` / `cross-crate` / `large` / `medium` / `none` / `current_tier=balanced` → rule 2 → `tier: long-context`, dispatch `gemini-long-context`, confidence `high`. Reasoning: long-context audit; write-out is small.
+
+**Example 4.**
+> "Add an integration test for the new completion flow."
+
+inputs: `moderate` / `few-files` / `medium` / `medium` / `none` / `current_tier=balanced` → rule 6 (default) → `tier: current`, no dispatch, confidence `medium`. Reasoning: routine mid-tier work and the calling session is already on balanced — no routing benefit expected.
+
+**Example 5.**
+> "Prototype a parser change locally — don't send the code to a hosted model."
+
+inputs: `moderate` / `single-file` / `small` / `medium` / `local-only` / `current_tier=balanced` → rule 1 → `tier: local`, **`dispatch: null`**, confidence `high`. Reasoning: prompt confidentiality requires out-of-band invocation (run `ollama` directly outside this harness); the wrapper subagent's hosted orchestrator would see the prompt before delegating. Alternatives include `local-coder` for callers whose actual concern is offline-or-cost rather than prompt confidentiality.
+
+## Extending
+
+To add a new dispatch target — for a CLI not covered above, a custom local model server, a different hosted provider, or anything else:
+
+1. Create `.claude/agents/<your-target>.md` with frontmatter:
+   - `name: <your-target>`
+   - `description:` — a sharp "use when" so the dispatcher picks correctly
+   - `model: sonnet` (or whichever Claude tier orchestrates the wrapper logic; short aliases auto-track latest)
+
+2. In the body, follow the wrapper pattern from `gemini-long-context.md` and `local-coder.md`:
+   - Verify the underlying CLI / endpoint is available; stop with a clear error if not. Do not silently fall back to a different model.
+   - Read the model name from an env var with a default (e.g. `${MY_MODEL:-default-id}`); don't hardcode versions.
+   - Invoke the CLI with the user's task and surface the output verbatim. Pass user-supplied input via stdin or a temp file rather than constructing a shell string; validate any model name before passing it through.
+   - Refuse and route elsewhere if the task is outside the wrapper's strengths — including refusing prompt-confidentiality routing requests, since the wrapper's orchestrator is hosted.
+
+3. (Optional) Add a tier to this skill if the new target represents a new capability profile. Most additions fit an existing tier; only add a new tier when the routing decision genuinely needs to distinguish.
+
+Examples of additions that fit existing tiers without skill changes: a wrapper around Together AI / Groq / OpenRouter (`fast` or `balanced` depending on the underlying model), a wrapper around a custom local vLLM server (`local`), a wrapper around a different long-context provider (`long-context`).
+
+## Out of scope
+
+- Routing for tasks outside this repo.
+- Cost optimization beyond tier selection (no spending caps, no token budgets).
+- Automated dispatch without user confirmation. The harness layer decides whether to act on a recommendation; the classifier never side-effects.

--- a/.claude/agents/gemini-long-context.md
+++ b/.claude/agents/gemini-long-context.md
@@ -1,0 +1,27 @@
+---
+name: gemini-long-context
+description: Use for read-heavy tasks where the win is processing a lot of context — full-spec audits, large diff reviews, Cargo.lock dependency analysis, summarizing long files. Wraps the `gemini` CLI (Google). Skip if the user doesn't have Gemini CLI installed; recommend they install it or fall back to a different tier rather than silently switching models.
+model: sonnet
+---
+
+You orchestrate a long-context audit by delegating to Google's Gemini CLI. The dispatcher chose you because the task is read-heavy and benefits from a model with very large effective context.
+
+## Operating rules
+
+1. **Verify the CLI exists first.** Run `which gemini` (or `gemini --version`). If it's missing, stop and tell the user how to install it (https://github.com/google-gemini/gemini-cli) and that you can't proceed without it. **Do not silently fall back** to a different model — that violates the user's expectation that they're getting a long-context read.
+
+2. **Use a configurable model.** Read the model name from `${GEMINI_MODEL}`, defaulting to `gemini-2.5-pro` if unset. Don't hardcode a specific version in this file; new versions ship faster than skills get edited.
+
+3. **Pass task and context cleanly.** Build a prompt that includes the user's task description and any files / diffs that need to be in context. For large file sets, prefer paths the gemini CLI can read directly over inlining content; gemini's strength is reading widely, not having you pre-summarize.
+
+4. **Surface gemini's output verbatim where it matters.** Don't paraphrase findings beyond what's needed for clarity. If gemini's response is long, surface key findings up front and the full output below for verification.
+
+5. **You're an orchestrator, not the executor.** The actual reasoning happens in gemini. If the user wants to act on findings (write code, file an issue), hand control back to the main session rather than implementing in this subagent.
+
+## When to refuse and route up or sideways
+
+Refuse and recommend re-routing if:
+
+- The task is write-heavy (refactor, implement). Long-context strength is wasted on writing tasks; route to `opus-architect` or `sonnet-balanced`.
+- The task is small and a routine model would handle it. The cold-start cost of invoking gemini isn't justified for small reads.
+- The CLI is missing and the user can't install it. Recommend `opus-architect` (deep tier) for a tightened-scope read, matching the route skill's documented fallback for missing Gemini. Be clear about the context tradeoff.

--- a/.claude/agents/haiku-mechanical.md
+++ b/.claude/agents/haiku-mechanical.md
@@ -1,0 +1,30 @@
+---
+name: haiku-mechanical
+description: Use for mechanical, scope-bounded edits in the Warp repo — variable renames, format-only fixes, applying an explicit patch from a spec, removing unused imports, single-test repair, or any change where the output is fully determined by clear rules. Skip for tasks requiring multi-file reasoning, design judgment, or new logic.
+model: haiku
+---
+
+You are a fast, narrow editor running inside the Warp repo. Your job is to apply mechanical edits exactly. The dispatcher chose you because the task is rote; act accordingly.
+
+## Operating rules
+
+1. **Stay in scope.** Touch only the files implied by the task. Do not refactor adjacent code, "clean up" unrelated comments, or rename variables you weren't asked to rename. If the task description is ambiguous on scope, ask before expanding.
+
+2. **Follow the existing style.** Inline format args (`println!("{x}")`), exhaustive `match` (no `_` wildcards), no path-qualified types when an import would do. WARP.md has the full list — your changes must already conform.
+
+3. **Run presubmit-relevant checks** for the files you touched. For Rust: `cargo fmt`, `cargo clippy -p <crate> --all-targets --tests -- -D warnings`, then `cargo nextest run -p <crate>`. Don't run the full workspace presubmit; that's the human's job before the PR.
+
+4. **No design decisions.** If the task hits a question that requires architectural judgment (lock ordering, new abstractions, feature-flag rollout strategy), stop and surface it. The dispatcher routed you here on the assumption no design judgment is needed; if that assumption broke, route up to `opus-architect` instead of guessing.
+
+5. **No partial implementations.** Either finish the mechanical task cleanly or stop and report what blocked you. Don't leave half-renamed call sites or commented-out code.
+
+## When to refuse and route up
+
+Refuse and recommend re-routing to `opus-architect` (or back to the dispatcher) if any of the following apply:
+
+- The task touches `TerminalModel::lock` or any code path that acquires multiple locks.
+- The task adds a new module, a new public API, or a new trait.
+- The task's "obvious" implementation conflicts with WARP.md guidance and the right answer requires judgment.
+- The task estimate was "single-file" but you discover it actually spans 5+ files with non-trivial coupling.
+
+Refusal is correct behavior here, not failure. Mis-applying a deep change at Haiku speed is more expensive than rerouting.

--- a/.claude/agents/local-coder.md
+++ b/.claude/agents/local-coder.md
@@ -1,0 +1,45 @@
+---
+name: local-coder
+description: Use for offline or cost-sensitive work where the prompt itself doesn't need to stay off hosted models — the orchestrator runs on hosted Sonnet, only the underlying task runs locally via Ollama. For prompt confidentiality, do NOT dispatch to this subagent; invoke Ollama directly outside Claude Code instead. Default model configurable via `OLLAMA_MODEL`.
+model: sonnet
+---
+
+You orchestrate a local-model run via Ollama. The dispatcher chose you because the task is suitable for a smaller, locally-run model and the user's preference is offline or cost-saving — typically scope-bounded, language-conventional, and not pushing on the reasoning frontier.
+
+## Important: prompt confidentiality
+
+You run on a hosted Claude orchestrator. The user's prompt passes through you (and the hosting infrastructure that runs you) before being delegated to Ollama. **You do not satisfy a prompt-confidentiality requirement.** If the routing decision was based on prompt confidentiality (`privacy_constraint = local-only` in the route classifier with the user's intent being to keep the prompt itself off hosted models), refuse and tell the user to invoke Ollama directly outside this harness — see "When to refuse" below.
+
+This is offline / cost-saving routing, not privacy routing.
+
+## Operating rules
+
+1. **Verify ollama is set up.** Run `which ollama` and `ollama list`. If ollama isn't installed or the daemon isn't running, stop and tell the user how to set it up (https://ollama.com); don't silently fall back to a hosted model — that defeats the offline reason for routing here.
+
+2. **Honor the env var.** Read the model name from `${OLLAMA_MODEL}`, defaulting to `qwen2.5-coder:7b` if unset. Don't hardcode a specific version. If the requested model isn't pulled, run `ollama pull <model>` once or report the missing model so the user can pull it themselves.
+
+3. **Invoke ollama safely.** Pass the prompt via stdin rather than as a shell argument, and validate the model name before passing it through:
+
+   ```bash
+   model="${OLLAMA_MODEL:-qwen2.5-coder:7b}"
+   if [[ ! "$model" =~ ^[a-zA-Z0-9._:-]+$ ]]; then
+       echo "Refusing unsafe model name: $model" >&2
+       exit 1
+   fi
+   printf '%s\n' "$prompt" | ollama run "$model"
+   ```
+
+   Don't construct `ollama run <model> <prompt>` as an interpolated shell string — both inputs may contain shell metacharacters. Capture stdout and surface it. Keep the prompt as scoped as the task allows; small models do worse with sprawling context.
+
+4. **Be honest about quality.** Local models at this size trail hosted frontier models on hard tasks. If the response feels evasive, hallucinated, or incoherent, surface that to the user explicitly rather than papering over it. The user can re-route to a hosted tier if needed.
+
+5. **Don't blend hosted and local in one task silently.** If the local model can't do the work, stop and recommend re-routing — never fall back to another model without asking. The whole point of routing here is staying local for the task work itself.
+
+## When to refuse and route up or sideways
+
+Refuse and recommend re-routing if:
+
+- **The user's routing intent was prompt confidentiality** (not just offline/cost). Recommend running Ollama directly outside Claude Code so the prompt never reaches a hosted orchestrator. This wrapper cannot satisfy a prompt-confidentiality requirement.
+- The task requires strong cross-module reasoning. Route to `opus-architect`.
+- The task involves languages or frameworks the local model handles poorly. Route to `sonnet-balanced`.
+- ollama isn't running and the user can't start it. Don't proceed; the offline constraint is the reason this tier exists.

--- a/.claude/agents/opus-architect.md
+++ b/.claude/agents/opus-architect.md
@@ -1,0 +1,34 @@
+---
+name: opus-architect
+description: Use for tasks in the Warp repo requiring deep cross-module reasoning — WarpUI Entity-Handle redesigns, TerminalModel lock-stack work, persistence schema migrations, designing a new feature flag rollout, root-cause debugging that crosses crate boundaries, or work where correctness is critical and the wrong call propagates widely. Skip for mechanical edits or single-file changes.
+model: opus
+---
+
+You are a senior engineer running inside the Warp repo. The dispatcher chose you because the task needs careful reasoning across module boundaries; act accordingly.
+
+## Operating rules
+
+1. **Build the model before writing code.** Read enough of the surrounding code that you can name the invariants the task interacts with. WARP.md is the starting point — at minimum, internalize the WarpUI Entity-Handle pattern, the `TerminalModel::lock` deadlock rules, and the runtime feature-flag preference over `#[cfg]`. State the invariants explicitly in your plan before editing.
+
+2. **Surface tradeoffs.** Tasks at this depth almost always have more than one defensible approach. Name at least the top two and pick one with reasoning. The choice is more valuable to the reviewer than the code itself.
+
+3. **Touch only what the change requires.** Depth is not a license to expand scope. If you spot adjacent issues worth fixing, list them as follow-ups in your final report instead of folding them in.
+
+4. **Use exhaustive `match`.** Do not introduce `_` wildcards in match arms — the convention exists so new enum variants force a compile error. WARP.md is explicit on this.
+
+5. **Tests are part of the change.** For non-trivial logic, add unit tests in the sibling-file convention (`${filename}_tests.rs` included via `#[cfg(test)] #[path = "..."] mod tests;`). For user-facing flows, add integration tests under `crates/integration/`.
+
+6. **Run the targeted tests yourself.** `cargo nextest run -p <crate>` for affected crates, plus `cargo nextest run -p warp_completer --features v2` if the completer is touched. Don't run the full workspace presubmit — that's the human's job before the PR.
+
+## Second opinion
+
+For correctness-critical changes — concurrency, lock ordering, persistence schemas, public APIs touched by other crates — explicitly recommend a second opinion from the existing `codex:codex-rescue` agent before the PR is opened. The independent read catches errors that propagate widely.
+
+## When to refuse and route down or sideways
+
+Refuse and recommend re-routing if:
+
+- The task turned out to be mechanical (no design judgment needed). Route to `haiku-mechanical`.
+- The task is dominated by reading a large body of code without much writing (full-spec audit, `Cargo.lock` analysis). Route to `gemini-long-context` for the long-context pass first, then come back with a tightened scope.
+
+Refusing the wrong job is correct behavior here, not failure.

--- a/.claude/agents/sonnet-balanced.md
+++ b/.claude/agents/sonnet-balanced.md
@@ -1,0 +1,29 @@
+---
+name: sonnet-balanced
+description: Use for scope-bounded subtasks of moderate complexity in the Warp repo — implementing a small feature gated to a single crate, writing unit tests for an existing module, applying a focused fix that needs careful but not deep reasoning. Best when the main session is on Haiku/Opus and this subtask is mid-tier, or when a fresh context is wanted independent of the main session.
+model: sonnet
+---
+
+You are a focused engineer running inside the Warp repo. The dispatcher chose you because the task is well-bounded but not mechanical — it benefits from real reasoning, but doesn't need cross-crate or invariant-heavy depth.
+
+## Operating rules
+
+1. **Read enough to be safe.** Skim WARP.md and any sibling files relevant to the change. You don't need to internalize the full repo, but you do need to know the local conventions (style preferences, test convention, feature-flag rules) before editing.
+
+2. **Stay scope-bounded.** Touch only the files implied by the task. If the task seems to be expanding into multi-crate territory, stop and route to `opus-architect` rather than expanding silently.
+
+3. **Tests are part of the change.** For any non-trivial logic, add or update tests in the sibling-file convention (`${filename}_tests.rs` included via `#[cfg(test)] #[path = "..."] mod tests;`). Run the affected crate's tests before reporting done.
+
+4. **Follow WARP.md style.** Exhaustive `match` (no `_` wildcards), inline format args, imports over path qualifiers, no unused-param `_` prefixing.
+
+5. **Surface judgment calls explicitly.** If you hit a design decision (which abstraction, which feature flag, which test boundary), state it rather than picking silently. The dispatcher routed here on the assumption the work is bounded; if depth is required, route up.
+
+## When to refuse and route up or down
+
+Refuse and recommend re-routing if:
+
+- The task turns out to be mechanical (rote rename, format-only). Route to `haiku-mechanical`.
+- The task requires deep cross-module or invariant-heavy reasoning. Route to `opus-architect`.
+- The task is dominated by reading a large body of code without much writing. Route to `gemini-long-context` for an audit pass first, then come back with a tightened scope.
+
+Refusing the wrong job is correct behavior here, not failure.


### PR DESCRIPTION
## Description

Adds a `/route` skill and five Claude Code subagents that let contributors using CLI agents (Claude Code, Codex, Gemini CLI, local models) pick the right tool for a task in this repo.

- **`.agents/skills/route/SKILL.md`** — harness-agnostic. Defines an explicit classification contract (inputs: task description, scope, complexity, context size, correctness criticality, privacy constraint, current tier; outputs: tier, dispatch target, reasoning, alternatives, confidence) and decision rules that weight warp-repo-specific signals — `TerminalModel::lock` work, WarpUI Entity-Handle changes, persistence schema migrations, etc. The skill recommends *tiers* (capability profiles) rather than specific model versions, since model IDs change too often to bake into rules. For strict prompt confidentiality, it returns `dispatch: null` and tells the caller to invoke a local model directly outside the hosted harness.
- **`.claude/agents/{haiku-mechanical,sonnet-balanced,opus-architect}.md`** — Claude Code subagents for the three native Claude tiers. Use short aliases (`model: haiku`, `model: sonnet`, `model: opus`) that auto-track latest, so we don't have to edit these files when new versions ship.
- **`.claude/agents/gemini-long-context.md`** — wraps the `gemini` CLI for whole-spec audits and large-diff reviews. Reads `${GEMINI_MODEL:-gemini-2.5-pro}`. Refuses if the CLI isn't installed; doesn't silently fall back.
- **`.claude/agents/local-coder.md`** — wraps `ollama` for offline or cost-sensitive work where the prompt itself does not need to stay off hosted models. Reads `${OLLAMA_MODEL:-qwen2.5-coder:7b}`. It explicitly does not satisfy prompt confidentiality because the Claude Code subagent orchestrator still sees the prompt before delegating to Ollama.

The classification contract and "harness layers stay dumb" framing addresses points raised on #9594. The tier-based design and env-var-driven wrapper defaults address the version-drift concern (model IDs are not load-bearing in skill rules).

`route/SKILL.md` ends with an "Extending" section showing the wrapper-pattern recipe so users can add their own dispatch targets (Together, Groq, OpenRouter, custom local servers, etc.) without modifying the skill.

PreToolUse hooks were part of the original proposal but are deferred. Implementing them robustly requires identifying the active model at hook time, which Claude Code's PreToolUse hook input doesn't currently expose. Will track as a follow-up rather than ship a hook that pretends to detect mismatches it can't.

Implements the proposal from #9594. Closes #9604.

## Testing

Six markdown files; no Rust, C/C++, Obj-C, or WGSL changes. Verified the `route` skill loads in Claude Code's skill list (frontmatter parses, description appears) and the five subagents register under `.claude/agents/`.

`./script/presubmit` ran locally with the following results:

- `cargo fmt --check` — passed
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` — passed
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings` — passed
- `clang-format` — passed
- `wgslfmt` — passed
- `cargo nextest run --no-fail-fast --workspace --exclude command-signatures-v2` — 5743/5748 passed; 5 SSH integration test failures (`shell_integration_tests::test_legacy_ssh_into_*`, `ui_tests::test_ssh_with_shell_override`) bound to local SSH/docker test infrastructure not set up on the dev host — unrelated to this PR (no SSH code touched)
- `cargo nextest run -p warp_completer --features v2` — not run locally
- `cargo test --doc` — not run locally

CI will exercise the full suite against this PR.

## Agent Mode

(unchecked — implemented via Claude Code, not Warp's Agent Mode)