### PR TITLE
Cap word length and separator count in filepath detection

### DIFF
--- a/app/src/util/link_detection.rs
+++ b/app/src/util/link_detection.rs
@@ -227,11 +227,6 @@ const MAX_SEPARATORS_PER_WORD: usize = 256;
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 fn separator_byte_indices_for_file_path_search(word: &str) -> Vec<i32> {
     if word.len() > MAX_WORD_LEN_FOR_FILE_PATH {
-        log::debug!(
-            "link_detection: skipping file path search for token of {} bytes (cap is {})",
-            word.len(),
-            MAX_WORD_LEN_FOR_FILE_PATH,
-        );
         return Vec::new();
     }
     // To include any substrings starting at the beginning of the word, we
@@ -242,10 +237,6 @@ fn separator_byte_indices_for_file_path_search(word: &str) -> Vec<i32> {
     for (i, c) in word.char_indices() {
         if FILE_LINK_SEPARATORS.contains(&c) {
             if separator_byte_indices.len() > MAX_SEPARATORS_PER_WORD {
-                log::debug!(
-                    "link_detection: skipping file path search for token with > {} separator characters",
-                    MAX_SEPARATORS_PER_WORD,
-                );
                 return Vec::new();
             }
             separator_byte_indices.push(i as i32);
@@ -255,7 +246,8 @@ fn separator_byte_indices_for_file_path_search(word: &str) -> Vec<i32> {
     // in natural language we might use a file path at the end of a sentence, and want
     // to detect them without including the trailing period. But trailing
     // periods can also be part of a valid file path.
-    if word.ends_with('.') {
+    let word_ends_with_period = word.ends_with('.');
+    if word_ends_with_period {
         separator_byte_indices.push((word.len() - 1) as i32);
     }
     // To include any substrings ending at the end of the word, we pretend there's

--- a/app/src/util/link_detection.rs
+++ b/app/src/util/link_detection.rs
@@ -213,35 +213,69 @@ fn addr_of(s: &str) -> usize {
     s.as_ptr() as usize
 }
 
-/// Given a word with no whitespace in it, returns all the possible file paths within the word
-/// from longest to shortest. File paths within a word can be split by a list of FILE_LINK_SEPARATORS,
-/// and those separators may be part of file paths themselves.
-/// Possible file paths begin after a separator and end before a separator.
-/// For example, given /path/to/file:16:hello, it will return
-/// ["/path/to/file:16:hello", "/path/to/file:16", "/path/to/file", "16:hello", "hello"]
+/// Maximum byte length of a token to search for file paths in. Used as a guard against scanning huge non-path tokens.
+/// - Linux PATH_MAX: 4096 bytes.
+/// - macOS PATH_MAX: 1024 bytes.
+/// - Windows long-path cap: 32,767 UTF-16 units = 98,301 bytes.
+const MAX_WORD_LEN_FOR_FILE_PATH: usize = 96 * 1024;
+/// Maximum [`FILE_LINK_SEPARATORS`] characters per token, to bound candidate substrings.
+/// 256 keeps per-token allocations under ~1 MiB and is far above any real path.
+const MAX_SEPARATORS_PER_WORD: usize = 256;
+
+/// Returns separator byte indices in `word`, framed by virtual separators at
+/// -1 and `word.len()`. Returns empty if either safety cap is exceeded.
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
-fn possible_file_paths_in_word(word: &str) -> impl Iterator<Item = &str> {
+fn separator_byte_indices_for_file_path_search(word: &str) -> Vec<i32> {
+    if word.len() > MAX_WORD_LEN_FOR_FILE_PATH {
+        log::debug!(
+            "link_detection: skipping file path search for token of {} bytes (cap is {})",
+            word.len(),
+            MAX_WORD_LEN_FOR_FILE_PATH,
+        );
+        return Vec::new();
+    }
     // To include any substrings starting at the beginning of the word, we
     // pretend there's a separator before the first character.
-    let mut separator_byte_indices = vec![-1];
+    let mut indices = vec![-1];
     // We use char_indices() to get byte indices of each char which are used to index the string,
     // rather than chars().enumerate() would give char indices.
     for (i, c) in word.char_indices() {
         if FILE_LINK_SEPARATORS.contains(&c) {
-            separator_byte_indices.push(i as i32);
+            if indices.len() > MAX_SEPARATORS_PER_WORD {
+                log::debug!(
+                    "link_detection: skipping file path search for token with > {} separator characters",
+                    MAX_SEPARATORS_PER_WORD,
+                );
+                return Vec::new();
+            }
+            indices.push(i as i32);
         }
     }
     // Consider trailing periods to be separators. This is because
     // in natural language we might use a file path at the end of a sentence, and want
     // to detect them without including the trailing period. But trailing
     // periods can also be part of a valid file path.
-    let word_ends_with_period = word.ends_with('.');
-    if word_ends_with_period {
-        separator_byte_indices.push((word.len() - 1) as i32);
+    if word.ends_with('.') {
+        indices.push((word.len() - 1) as i32);
     }
     // To include any substrings ending at the end of the word, we pretend there's
     // a separator after the last character.
-    separator_byte_indices.push(word.len() as i32);
+    indices.push(word.len() as i32);
+    indices
+}
+
+/// Given a word with no whitespace in it, returns all the possible file paths within the word
+/// from longest to shortest. File paths within a word can be split by a list of FILE_LINK_SEPARATORS,
+/// and those separators may be part of file paths themselves.
+/// Possible file paths begin after a separator and end before a separator.
+/// For example, given /path/to/file:16:hello, it will return
+/// ["/path/to/file:16:hello", "/path/to/file:16", "/path/to/file", "16:hello", "hello"]
+///
+/// Tokens exceeding [`MAX_WORD_LEN_FOR_FILE_PATH`] or [`MAX_SEPARATORS_PER_WORD`]
+/// yield no candidates to bound the substring enumeration.
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+fn possible_file_paths_in_word(word: &str) -> impl Iterator<Item = &str> {
+    let separator_byte_indices = separator_byte_indices_for_file_path_search(word);
     let mut possible_path_byte_ranges = vec![];
     for (i, start_index) in separator_byte_indices.iter().cloned().enumerate() {
         for end_index in separator_byte_indices.iter().skip(i + 1).cloned() {

--- a/app/src/util/link_detection.rs
+++ b/app/src/util/link_detection.rs
@@ -236,19 +236,19 @@ fn separator_byte_indices_for_file_path_search(word: &str) -> Vec<i32> {
     }
     // To include any substrings starting at the beginning of the word, we
     // pretend there's a separator before the first character.
-    let mut indices = vec![-1];
+    let mut separator_byte_indices = vec![-1];
     // We use char_indices() to get byte indices of each char which are used to index the string,
     // rather than chars().enumerate() would give char indices.
     for (i, c) in word.char_indices() {
         if FILE_LINK_SEPARATORS.contains(&c) {
-            if indices.len() > MAX_SEPARATORS_PER_WORD {
+            if separator_byte_indices.len() > MAX_SEPARATORS_PER_WORD {
                 log::debug!(
                     "link_detection: skipping file path search for token with > {} separator characters",
                     MAX_SEPARATORS_PER_WORD,
                 );
                 return Vec::new();
             }
-            indices.push(i as i32);
+            separator_byte_indices.push(i as i32);
         }
     }
     // Consider trailing periods to be separators. This is because
@@ -256,12 +256,12 @@ fn separator_byte_indices_for_file_path_search(word: &str) -> Vec<i32> {
     // to detect them without including the trailing period. But trailing
     // periods can also be part of a valid file path.
     if word.ends_with('.') {
-        indices.push((word.len() - 1) as i32);
+        separator_byte_indices.push((word.len() - 1) as i32);
     }
     // To include any substrings ending at the end of the word, we pretend there's
     // a separator after the last character.
-    indices.push(word.len() as i32);
-    indices
+    separator_byte_indices.push(word.len() as i32);
+    separator_byte_indices
 }
 
 /// Given a word with no whitespace in it, returns all the possible file paths within the word

--- a/app/src/util/link_detection_test.rs
+++ b/app/src/util/link_detection_test.rs
@@ -108,20 +108,3 @@ fn test_possible_file_paths_in_word_accepts_token_at_separator_count_cap() {
     }
     assert!(possible_file_paths_in_word(&at_cap).next().is_some());
 }
-
-#[test]
-fn test_possible_file_paths_in_word_keeps_realistic_paths_within_limits() {
-    let word = "/a/b/c/d/e/f/g/h/i/j/k/l/m/n.rs:42:7";
-    let possible_paths = possible_file_paths_in_word(word).collect_vec();
-    assert!(possible_paths.contains(&"/a/b/c/d/e/f/g/h/i/j/k/l/m/n.rs"));
-    assert!(possible_paths.contains(&"/a/b/c/d/e/f/g/h/i/j/k/l/m/n.rs:42"));
-}
-
-#[test]
-fn test_possible_file_paths_in_word_handles_pathological_token() {
-    let pathological: String = (0..1000)
-        .map(|i| format!("\"key{i}\":\"value{i}\","))
-        .collect();
-    assert!(pathological.len() < MAX_WORD_LEN_FOR_FILE_PATH);
-    assert!(possible_file_paths_in_word(&pathological).next().is_none());
-}

--- a/app/src/util/link_detection_test.rs
+++ b/app/src/util/link_detection_test.rs
@@ -73,3 +73,55 @@ fn test_possible_file_paths_in_word_multibyte() {
         ]
     );
 }
+
+#[test]
+fn test_possible_file_paths_in_word_skips_oversized_token() {
+    let oversized = "a".repeat(MAX_WORD_LEN_FOR_FILE_PATH + 1);
+    assert!(possible_file_paths_in_word(&oversized).next().is_none());
+}
+
+#[test]
+fn test_possible_file_paths_in_word_accepts_token_at_word_length_cap() {
+    let at_cap = "a".repeat(MAX_WORD_LEN_FOR_FILE_PATH);
+    let possible_paths = possible_file_paths_in_word(&at_cap).collect_vec();
+    assert_eq!(possible_paths, vec![at_cap.as_str()]);
+}
+
+#[test]
+fn test_possible_file_paths_in_word_skips_token_with_too_many_separators() {
+    let too_many_separators = ":".repeat(MAX_SEPARATORS_PER_WORD + 1);
+    assert!(possible_file_paths_in_word(&too_many_separators)
+        .next()
+        .is_none());
+}
+
+#[test]
+fn test_possible_file_paths_in_word_accepts_token_at_separator_count_cap() {
+    // A token with separators interleaved between letters: e.g. "a:a:a:...:a".
+    // Has exactly MAX_SEPARATORS_PER_WORD ':' characters and is non-empty
+    // between them, so we expect at least one candidate (e.g. "a").
+    let mut at_cap = String::with_capacity(MAX_SEPARATORS_PER_WORD * 2 + 1);
+    at_cap.push('a');
+    for _ in 0..MAX_SEPARATORS_PER_WORD {
+        at_cap.push(':');
+        at_cap.push('a');
+    }
+    assert!(possible_file_paths_in_word(&at_cap).next().is_some());
+}
+
+#[test]
+fn test_possible_file_paths_in_word_keeps_realistic_paths_within_limits() {
+    let word = "/a/b/c/d/e/f/g/h/i/j/k/l/m/n.rs:42:7";
+    let possible_paths = possible_file_paths_in_word(word).collect_vec();
+    assert!(possible_paths.contains(&"/a/b/c/d/e/f/g/h/i/j/k/l/m/n.rs"));
+    assert!(possible_paths.contains(&"/a/b/c/d/e/f/g/h/i/j/k/l/m/n.rs:42"));
+}
+
+#[test]
+fn test_possible_file_paths_in_word_handles_pathological_token() {
+    let pathological: String = (0..1000)
+        .map(|i| format!("\"key{i}\":\"value{i}\","))
+        .collect();
+    assert!(pathological.len() < MAX_WORD_LEN_FOR_FILE_PATH);
+    assert!(possible_file_paths_in_word(&pathological).next().is_none());
+}


### PR DESCRIPTION
## Description

When a terminal command finishes, Warp scans the block's output for file paths so it can show command suggestions about relevant files. The scanner works token by token (whitespace‑separated): for each token it enumerates every possible substring between path‑boundary characters like `:`, `(`, `)`, `[`, `]`, `\`, etc., then sorts the candidates from longest to shortest to pick the one that resolves to a real file.

That's fine on normal terminal output, but if any token in a block is large and contains many of those boundary characters (long URL‑encoded query strings, base64 blobs, JSON one‑liners, ANSI debug dumps, etc.) the substring enumeration is quadratic in the boundary count. A heap profile from a long‑running session showed the file‑path scanner accounting for ~12 GB out of 12.9 GB of live allocations coming from `detect_file_paths`.

This change caps the work the scanner does per token. Tokens that are either:

- longer than 96 KiB (the worst‑case Windows long path), or
- contain more than 256 path‑boundary characters

yield no path candidates. Real paths on every supported platform fit comfortably under both caps. Both bail‑out paths log at debug level so we can detect if real paths in the wild are being rejected.

We could also replace the quadratic enumeration with a lazy length‑descending iterator so the caller's first‑match short‑circuit avoids materializing all candidates at all. That's tracked separately.

## Testing

Added unit tests covering the two new caps.

## Server API dependencies

None.

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Prevent Warp from consuming too much memory when identifying filepaths in long block outputs.