### PR TITLE
fix(terminal): scroll output with Page Up/Down from prompt (#9008)

### DIFF
--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -371,12 +371,16 @@ pub fn init(ctx: &mut AppContext) {
         FixedBinding::new(
             "pageup",
             EditorAction::PageUp,
-            id!("EditorView") & !id!("IMEOpen"),
+            id!("EditorView")
+                & !id!("IMEOpen")
+                & !id!(flags::TERMINAL_INPUT_PAGE_KEYS_HANDLED_BY_INPUT),
         ),
         FixedBinding::new(
             "pagedown",
             EditorAction::PageDown,
-            id!("EditorView") & !id!("IMEOpen"),
+            id!("EditorView")
+                & !id!("IMEOpen")
+                & !id!(flags::TERMINAL_INPUT_PAGE_KEYS_HANDLED_BY_INPUT),
         ),
         // Some editable bindings currently have more than 1 action.
         // Below's the list of those.

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -469,6 +469,10 @@ pub mod flags {
     /// When set, ctrl-enter should accept a prompt suggestion rather than insert a newline.
     /// This flag is set by the terminal Input when there's a pending passive code diff.
     pub const CTRL_ENTER_ACCEPTS_PROMPT_SUGGESTION: &str = "CtrlEnterAcceptsPromptSuggestion";
+    /// When set, the terminal input owns Page Up / Page Down so the editor's fixed bindings
+    /// should not match.
+    pub const TERMINAL_INPUT_PAGE_KEYS_HANDLED_BY_INPUT: &str =
+        "TerminalInputPageKeysHandledByInput";
     pub const HAS_PENDING_PROMPT_SUGGESTION: &str = "HasPendingPromptSuggestion";
     pub const ACTIVE_AGENT_VIEW: &str = "ActiveAgentView";
     pub const ACTIVE_INLINE_AGENT_VIEW: &str = "ActiveInlineAgentView";

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -941,6 +941,8 @@ pub enum InputEmptyStateChangeReason {
 pub enum Event {
     AutosuggestionAccepted,
     ClearSelectedBlock,
+    PageUp,
+    PageDown,
     SelectRecentBlocks {
         /// Select the `count` most recent blocks.
         count: usize,
@@ -7820,8 +7822,12 @@ impl Input {
             }
         });
         send_telemetry_from_ctx!(event, ctx);
-        self.editor
-            .update(ctx, |input, ctx| input.move_page_up(ctx));
+        if self.suggestions_mode_model.as_ref(ctx).is_visible() {
+            self.editor
+                .update(ctx, |input, ctx| input.move_page_up(ctx));
+        } else {
+            ctx.emit(Event::PageUp);
+        }
     }
 
     /// Asks the currently active inline menu whether the buffer should be restored on dismiss
@@ -8146,8 +8152,12 @@ impl Input {
             }
         });
         send_telemetry_from_ctx!(event, ctx);
-        self.editor
-            .update(ctx, |input, ctx| input.move_page_down(ctx));
+        if self.suggestions_mode_model.as_ref(ctx).is_visible() {
+            self.editor
+                .update(ctx, |input, ctx| input.move_page_down(ctx));
+        } else {
+            ctx.emit(Event::PageDown);
+        }
     }
 
     fn maybe_generate_autosuggestion(&mut self, ctx: &mut ViewContext<Self>) {

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -1076,6 +1076,8 @@ pub enum InputAction {
     CtrlR,
     CtrlD,
     Up,
+    PageUp,
+    PageDown,
     ClearScreen,
     SelectAndRefreshVoltron(VoltronItem),
     ShowAiCommandSearch,
@@ -1793,6 +1795,23 @@ pub fn init(app: &mut AppContext) {
     )
     .with_context_predicate(id!("Input"))
     .with_key_binding("ctrl-l")]);
+
+    app.register_editable_bindings([
+        EditableBinding::new(
+            "terminal:scroll_up_one_page",
+            "Scroll terminal output up one page",
+            InputAction::PageUp,
+        )
+        .with_context_predicate(id!("Input") & !id!("IMEOpen"))
+        .with_key_binding("pageup"),
+        EditableBinding::new(
+            "terminal:scroll_down_one_page",
+            "Scroll terminal output down one page",
+            InputAction::PageDown,
+        )
+        .with_context_predicate(id!("Input") & !id!("IMEOpen"))
+        .with_key_binding("pagedown"),
+    ]);
 
     app.register_editable_bindings([EditableBinding::new(
         "workspace:edit_prompt",
@@ -2558,6 +2577,10 @@ impl Input {
                     include_ai_context_menu: false,
                     delegate_paste_handling: true,
                     keymap_context_modifier: Some(Box::new(move |context, app| {
+                        context
+                            .set
+                            .insert(flags::TERMINAL_INPUT_PAGE_KEYS_HANDLED_BY_INPUT);
+
                         // When ctrl-enter is bound to accepting prompt suggestions and there's
                         // a pending passive code diff, suggested prompt, or prompt suggestion
                         // banner, set a flag so the editor's ctrl-enter binding doesn't match
@@ -14076,6 +14099,8 @@ impl TypedActionView for Input {
         match action {
             InputAction::FocusInputBox => self.focus_input_box(ctx),
             InputAction::Up => self.editor_up(ctx),
+            InputAction::PageUp => self.editor_page_up(ctx),
+            InputAction::PageDown => self.editor_page_down(ctx),
             InputAction::CtrlD => self.ctrl_d(ctx),
             InputAction::CtrlR => self.ctrl_r(ctx),
             InputAction::ClearScreen => self.clear_screen(ctx),

--- a/app/src/terminal/input_test.rs
+++ b/app/src/terminal/input_test.rs
@@ -50,6 +50,7 @@ use crate::workspaces::team_tester::TeamTesterStatus;
 use crate::workspaces::update_manager::TeamUpdateManager;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
+use crate::terminal::block_list_viewport::ScrollPosition;
 use crate::terminal::local_tty::shell::ShellStarter;
 use crate::terminal::model::ansi::{Handler, PrecmdValue};
 use crate::terminal::model::block::SerializedBlock;
@@ -6264,5 +6265,173 @@ fn test_terminal_only_escape_locks_shell_mode() {
         });
         assert_eq!(config.input_type, InputType::Shell);
         assert!(config.is_locked);
+    });
+}
+
+#[test]
+fn test_page_up_and_down_scroll_terminal_from_prompt() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
+        let (input, editor) = terminal.read(&app, |terminal, ctx| {
+            let input = terminal.input().clone();
+            let editor = input.as_ref(ctx).editor().clone();
+            (input, editor)
+        });
+
+        terminal.update(&mut app, |terminal, _| {
+            terminal
+                .model
+                .lock()
+                .simulate_block("ls", &"\n".repeat(1000));
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.user_insert("echo first line\necho second line", ctx);
+        });
+        editor.update(&mut app, |editor, ctx| {
+            editor.move_to_buffer_end(ctx);
+            editor.handle_action(&EditorAction::PageUp, ctx);
+        });
+
+        assert_eq!(
+            input.read(&app, |input, ctx| input.buffer_text(ctx)),
+            "echo first line\necho second line"
+        );
+        let scroll_position_after_page_up =
+            terminal.read(&app, |terminal, _| terminal.scroll_position());
+        assert!(matches!(
+            scroll_position_after_page_up,
+            ScrollPosition::FixedAtPosition { .. }
+        ));
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.handle_action(&EditorAction::PageDown, ctx);
+        });
+
+        assert_eq!(
+            input.read(&app, |input, ctx| input.buffer_text(ctx)),
+            "echo first line\necho second line"
+        );
+        let scroll_position_after_page_down =
+            terminal.read(&app, |terminal, _| terminal.scroll_position());
+        assert_ne!(
+            scroll_position_after_page_down,
+            scroll_position_after_page_up
+        );
+    });
+}
+
+#[test]
+fn test_page_up_and_down_do_not_scroll_terminal_when_suggestions_are_visible() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let history_file_commands = vec![
+            "echo alpha\necho beta".to_string(),
+            "git status\ngit diff".to_string(),
+        ];
+        let terminal =
+            add_window_with_bootstrapped_terminal(&mut app, Some(history_file_commands), None)
+                .await;
+        let (input, editor) = terminal.read(&app, |terminal, ctx| {
+            let input = terminal.input().clone();
+            let editor = input.as_ref(ctx).editor().clone();
+            (input, editor)
+        });
+
+        terminal.update(&mut app, |terminal, _| {
+            terminal
+                .model
+                .lock()
+                .simulate_block("ls", &"\n".repeat(1000));
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.handle_action(&InputAction::Up, ctx);
+            assert!(input.suggestions_mode_model.as_ref(ctx).is_visible());
+        });
+
+        let initial_scroll_position = terminal.read(&app, |terminal, _| terminal.scroll_position());
+        let initial_buffer = input.read(&app, |input, ctx| input.buffer_text(ctx));
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.handle_action(&EditorAction::PageUp, ctx);
+            editor.handle_action(&EditorAction::PageDown, ctx);
+        });
+
+        terminal.read(&app, |terminal, _| {
+            assert_eq!(terminal.scroll_position(), initial_scroll_position);
+        });
+        input.read(&app, |input, ctx| {
+            assert_eq!(input.buffer_text(ctx), initial_buffer);
+            assert!(input.suggestions_mode_model.as_ref(ctx).is_visible());
+        });
+    });
+}
+
+#[test]
+fn test_page_up_and_down_scroll_terminal_with_vim_mode_enabled() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
+        let (input, editor) = terminal.read(&app, |terminal, ctx| {
+            let input = terminal.input().clone();
+            let editor = input.as_ref(ctx).editor().clone();
+            (input, editor)
+        });
+
+        terminal.update(&mut app, |terminal, _| {
+            terminal
+                .model
+                .lock()
+                .simulate_block("ls", &"\n".repeat(1000));
+        });
+
+        AppEditorSettings::handle(&app).update(&mut app, |settings, settings_ctx| {
+            let _ = settings.vim_mode.set_value(true, settings_ctx);
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.user_insert("echo first line\necho second line", ctx);
+        });
+        editor.update(&mut app, |editor, ctx| {
+            editor.vim_keystroke(&Keystroke::parse("escape").unwrap(), ctx);
+        });
+        editor.read(&app, |editor, ctx| {
+            assert_eq!(editor.vim_mode(ctx), Some(VimMode::Normal));
+        });
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.handle_action(&EditorAction::PageUp, ctx);
+        });
+
+        assert_eq!(
+            input.read(&app, |input, ctx| input.buffer_text(ctx)),
+            "echo first line\necho second line"
+        );
+        let scroll_position_after_page_up =
+            terminal.read(&app, |terminal, _| terminal.scroll_position());
+        assert!(matches!(
+            scroll_position_after_page_up,
+            ScrollPosition::FixedAtPosition { .. }
+        ));
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.handle_action(&EditorAction::PageDown, ctx);
+        });
+
+        assert_eq!(
+            input.read(&app, |input, ctx| input.buffer_text(ctx)),
+            "echo first line\necho second line"
+        );
+        let scroll_position_after_page_down =
+            terminal.read(&app, |terminal, _| terminal.scroll_position());
+        assert_ne!(
+            scroll_position_after_page_down,
+            scroll_position_after_page_up
+        );
     });
 }

--- a/app/src/terminal/input_test.rs
+++ b/app/src/terminal/input_test.rs
@@ -36,6 +36,7 @@ use crate::server::server_api::ServerApiProvider;
 use crate::server::sync_queue::SyncQueue;
 
 use crate::server::telemetry::context_provider::AppTelemetryContextProvider;
+use crate::settings::import::model::ImportedConfigModel;
 use crate::settings::{AliasExpansionSettings, AppEditorSettings, InputBoxType, PrivacySettings};
 use crate::settings_view::keybindings::KeybindingChangedNotifier;
 #[cfg(windows)]
@@ -86,7 +87,7 @@ use unindent::Unindent;
 #[cfg(feature = "voice_input")]
 use voice_input::VoiceInputToggledFrom;
 use warpui::platform::WindowStyle;
-use warpui::{App, ReadModel, UpdateView};
+use warpui::{App, ReadModel, UpdateView, WindowId};
 
 use crate::terminal::universal_developer_input::UniversalDeveloperInputButtonBarEvent;
 
@@ -114,6 +115,7 @@ pub fn initialize_app(app: &mut App) {
     app.add_singleton_model(|_| Prompt::mock());
     app.add_singleton_model(SyncQueue::mock);
     app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(ImportedConfigModel::new);
     app.add_singleton_model(UserWorkspaces::default_mock);
     app.add_singleton_model(TeamTesterStatus::mock);
     app.add_singleton_model(TeamUpdateManager::mock);
@@ -258,6 +260,16 @@ pub async fn add_window_with_bootstrapped_terminal(
     history_file_commands: Option<Vec<String>>,
     session_info: Option<SessionInfo>,
 ) -> ViewHandle<TerminalView> {
+    add_window_with_bootstrapped_terminal_and_window_id(app, history_file_commands, session_info)
+        .await
+        .1
+}
+
+pub async fn add_window_with_bootstrapped_terminal_and_window_id(
+    app: &mut App,
+    history_file_commands: Option<Vec<String>>,
+    session_info: Option<SessionInfo>,
+) -> (WindowId, ViewHandle<TerminalView>) {
     let tips_model = app.add_model(|_| TipsCompleted::default());
 
     let shell_starter_source = ShellStarter::init(Default::default())
@@ -273,7 +285,7 @@ pub async fn add_window_with_bootstrapped_terminal(
         .with_shell_type(shell_type);
     let history_file_commands = history_file_commands.unwrap_or_default();
 
-    let (_, terminal) = app.add_window(WindowStyle::NotStealFocus, move |ctx| {
+    let (window_id, terminal) = app.add_window(WindowStyle::NotStealFocus, move |ctx| {
         TerminalView::new_for_test(tips_model, None, ctx)
     });
 
@@ -302,7 +314,7 @@ pub async fn add_window_with_bootstrapped_terminal(
     input.update(app, |input, ctx| {
         input.set_active_block_metadata(BlockMetadata::new(Some(session_id), None), false, ctx);
     });
-    terminal
+    (window_id, terminal)
 }
 
 /// Simulates being in a particular directory, for the purposes of completion
@@ -6433,5 +6445,70 @@ fn test_page_up_and_down_scroll_terminal_with_vim_mode_enabled() {
             scroll_position_after_page_down,
             scroll_position_after_page_up
         );
+    });
+}
+
+#[test]
+fn test_custom_terminal_page_scroll_binding_applies_when_prompt_is_focused() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let (window_id, terminal) =
+            add_window_with_bootstrapped_terminal_and_window_id(&mut app, None, None).await;
+        let (input, editor) = terminal.read(&app, |terminal, ctx| {
+            let input = terminal.input().clone();
+            let editor = input.as_ref(ctx).editor().clone();
+            (input, editor)
+        });
+
+        terminal.update(&mut app, |terminal, _| {
+            terminal
+                .model
+                .lock()
+                .simulate_block("ls", &"\n".repeat(1000));
+        });
+
+        app.update(|ctx| {
+            ctx.set_custom_trigger(
+                "terminal:scroll_up_one_page".to_owned(),
+                warpui::keymap::Trigger::Keystrokes(
+                    vec![Keystroke::parse("shift-pageup").unwrap()],
+                ),
+            );
+        });
+
+        let focus_path = [terminal.id(), input.id(), editor.id()];
+
+        let handled = app
+            .dispatch_keystroke(
+                window_id,
+                &focus_path,
+                &Keystroke::parse("pageup").unwrap(),
+                false,
+            )
+            .unwrap();
+        assert!(!handled);
+        terminal.read(&app, |terminal, _| {
+            assert_eq!(
+                terminal.scroll_position(),
+                ScrollPosition::FollowsBottomOfMostRecentBlock
+            );
+        });
+
+        let handled = app
+            .dispatch_keystroke(
+                window_id,
+                &focus_path,
+                &Keystroke::parse("shift-pageup").unwrap(),
+                false,
+            )
+            .unwrap();
+        assert!(handled);
+        terminal.read(&app, |terminal, _| {
+            assert!(matches!(
+                terminal.scroll_position(),
+                ScrollPosition::FixedAtPosition { .. }
+            ));
+        });
     });
 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -19726,6 +19726,8 @@ impl TerminalView {
     fn handle_input_event(&mut self, event: &InputEvent, ctx: &mut ViewContext<Self>) {
         match event {
             InputEvent::Enter => self.clear_prompt_suggestions(ctx),
+            InputEvent::PageUp => self.page_up(ctx),
+            InputEvent::PageDown => self.page_down(ctx),
             InputEvent::ExecuteCommand(event) => {
                 self.update_scroll_position_locking(
                     ScrollPositionUpdate::AfterCommandExecutionStarted,

--- a/app/src/terminal/view/init.rs
+++ b/app/src/terminal/view/init.rs
@@ -646,7 +646,10 @@ pub fn init(app: &mut AppContext) {
         )
         .with_key_binding("pageup")
         .with_context_predicate(
-            id!("Terminal") & !id!("IMEOpen") & id!("TerminalView_NonEmptyBlockList"),
+            id!("Terminal")
+                & !id!("IMEOpen")
+                & id!("TerminalView_NonEmptyBlockList")
+                & !id!("EditorFocused"),
         ),
         EditableBinding::new(
             "terminal:scroll_down_one_page",
@@ -655,7 +658,10 @@ pub fn init(app: &mut AppContext) {
         )
         .with_key_binding("pagedown")
         .with_context_predicate(
-            id!("Terminal") & !id!("IMEOpen") & id!("TerminalView_NonEmptyBlockList"),
+            id!("Terminal")
+                & !id!("IMEOpen")
+                & id!("TerminalView_NonEmptyBlockList")
+                & !id!("EditorFocused"),
         ),
     ]);
 

--- a/app/src/terminal/view/init.rs
+++ b/app/src/terminal/view/init.rs
@@ -162,16 +162,6 @@ pub fn init(app: &mut AppContext) {
             TerminalAction::ControlSequence("\x1b[3~".as_bytes().to_vec()),
             id!("Terminal") & !id!("IMEOpen"),
         ),
-        FixedBinding::new(
-            "pageup",
-            TerminalAction::PageUp,
-            id!("Terminal") & !id!("IMEOpen"),
-        ),
-        FixedBinding::new(
-            "pagedown",
-            TerminalAction::PageDown,
-            id!("Terminal") & !id!("IMEOpen"),
-        ),
         // Resume conversation keybinding
         FixedBinding::new_per_platform(
             PerPlatformKeystroke {
@@ -646,6 +636,27 @@ pub fn init(app: &mut AppContext) {
             },
         )
         .with_context_predicate(id!("Terminal") & id!("TerminalView_NonEmptyBlockList")),
+    ]);
+
+    app.register_editable_bindings([
+        EditableBinding::new(
+            "terminal:scroll_up_one_page",
+            "Scroll terminal output up one page",
+            TerminalAction::PageUp,
+        )
+        .with_key_binding("pageup")
+        .with_context_predicate(
+            id!("Terminal") & !id!("IMEOpen") & id!("TerminalView_NonEmptyBlockList"),
+        ),
+        EditableBinding::new(
+            "terminal:scroll_down_one_page",
+            "Scroll terminal output down one page",
+            TerminalAction::PageDown,
+        )
+        .with_key_binding("pagedown")
+        .with_context_predicate(
+            id!("Terminal") & !id!("IMEOpen") & id!("TerminalView_NonEmptyBlockList"),
+        ),
     ]);
 
     app.register_editable_bindings([EditableBinding::new(

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -4,7 +4,11 @@ use warpui::{
     App,
 };
 
-use crate::{util::bindings::keybinding_name_to_display_string, workspace::WorkspaceAction};
+use crate::{
+    terminal,
+    util::bindings::{keybinding_name_to_display_string, trigger_to_keystroke},
+    workspace::WorkspaceAction,
+};
 
 #[test]
 fn test_keybinding_name_to_display_string() {
@@ -69,6 +73,27 @@ fn test_keybinding_name_to_display_string() {
                 keybinding_name_to_display_string("workspace:toggle_resource_center", ctx)
                     .as_deref()
             );
+        });
+    });
+}
+
+#[test]
+fn test_terminal_page_scroll_bindings_are_editable() {
+    App::test((), |mut app| async move {
+        app.update(terminal::init);
+
+        app.update(|ctx| {
+            let page_up = ctx
+                .editable_bindings()
+                .find(|binding| binding.name == "terminal:scroll_up_one_page")
+                .and_then(|binding| trigger_to_keystroke(binding.trigger));
+            let page_down = ctx
+                .editable_bindings()
+                .find(|binding| binding.name == "terminal:scroll_down_one_page")
+                .and_then(|binding| trigger_to_keystroke(binding.trigger));
+
+            assert_eq!(page_up, Keystroke::parse("pageup").ok());
+            assert_eq!(page_down, Keystroke::parse("pagedown").ok());
         });
     });
 }


### PR DESCRIPTION
## Description

Fixes [warpdotdev/warp#9008](https://github.com/warpdotdev/warp/issues/9008).

While focus is in the **prompt**, **Page Up** / **Page Down** previously behaved only as **editor navigation** (`move_page_up` / `move_page_down` on the buffer), so terminal scrollback did not move—despite docs describing terminal scrolling.

This PR:

1. **Routes paging by UI state:** When **suggestions / history menus are not visible**, Page Up/Down emit **`Input` → `TerminalView`** scroll intents (`page_up` / `page_down`). When **those menus are visible**, paging stays **editor-local** so menus keep working as before.

2. **Makes shortcuts discoverable and editable:** Replaces fixed `pageup`/`pagedown` bindings with **`EditableBinding`** entries:
   - `terminal:scroll_up_one_page` — “Scroll terminal output up one page” (default **Page Up**)
   - `terminal:scroll_down_one_page` — “Scroll terminal output down one page” (default **Page Down**)  
   Context matches terminal scroll usage (`Terminal`, non-empty block list, IME closed).

3. **Tests:** Regression coverage for prompt → terminal scroll (buffer unchanged), guard when suggestions are visible (scroll unchanged), and Vim normal-mode routing still scrolling terminal output.

## Testing

- `cargo fmt --check`
- `cargo test --lib` with filters for the new paging tests and bindings registration test (or equivalent `cargo nextest run -p warp` filters locally).

## Server API dependencies

N/A — client-only terminal/input/bindings behavior.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed Page Up and Page Down from the prompt so they scroll terminal output when the suggestion menu is closed; shortcuts appear under Keyboard Shortcuts as editable scroll actions (`terminal:scroll_up_one_page` / `terminal:scroll_down_one_page`).