### PR TITLE
Fix feature flag path in cleanup workflow

### DIFF
--- a/.github/workflows/feature_flag_cleanup.yml
+++ b/.github/workflows/feature_flag_cleanup.yml
@@ -43,7 +43,7 @@ jobs:
             There will always be at least one such flag.
 
             ## Context
-            Feature flags are defined in warp_core/src/features.rs. They're enabled by default in app/Cargo.toml, using the default feature list. The mapping between Cargo features and app features is in the enabled_features function of app/src/lib.rs.
+            Feature flags are defined in crates/warp_core/src/features.rs. They're enabled by default in app/Cargo.toml, using the default feature list. The mapping between Cargo features and app features is in the enabled_features function of app/src/lib.rs.
 
             ## Recommended Procedure
             1. Use `git blame` on the Cargo.toml file to identify when each feature flag was enabled by default.


### PR DESCRIPTION
Closes #10074

## Description

Fix the feature flag file path in the agent prompt within the cleanup workflow. The path was `warp_core/src/features.rs` but the actual path in this repo is `crates/warp_core/src/features.rs`.

## Linked Issue

Related to fixing the feature flag cleanup agent to create PRs in `warp` instead of `warp-internal` (see warpdotdev/warp-internal PR removing the duplicate workflow).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/ae995a7b-f9a5-4e96-8e8e-b3f71da89497_
_Run: https://oz.staging.warp.dev/runs/019ddf33-fefc-7acb-9a98-7676d106d624_

_This PR was generated with [Oz](https://warp.dev/oz)._