### PR TITLE
fix(build): Improve Xcode detection during macOS bootstrap

### DIFF
--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -5,12 +5,12 @@
 
 set -e
 
-if ! [ -d "/Applications/Xcode.app" ]; then
-    echo "Please install Xcode from the App Store before continuing."
+if ! xcode-select -p > /dev/null 2>&1; then
+    echo "Please install Xcode command line tools before continuing."
+    echo "You can install them by running: xcode-select --install"
     exit 1
 fi
 
-sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 # Mimic actually launching XCode, which performs some necessary set-up of the
 # development environment.
 xcodebuild -runFirstLaunch

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -5,9 +5,8 @@
 
 set -e
 
-if ! xcode-select -p > /dev/null 2>&1; then
-    echo "Please install Xcode command line tools before continuing."
-    echo "You can install them by running: xcode-select --install"
+if ! (xcode-select -p && command -v xcodebuild) > /dev/null 2>&1; then
+    echo "Please install Xcode before continuing."
     exit 1
 fi
 

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -15,14 +15,14 @@ fi
 # development environment.
 xcodebuild -runFirstLaunch
 
-if ! command -v brew; then
+if ! command -v brew > /dev/null 2>&1; then
     echo "Installing brew..."
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     echo "Please make sure brew is set correctly in your PATH"
     exit 1
 fi
 
-if ! command -v cargo; then
+if ! command -v cargo > /dev/null 2>&1; then
     echo "Installing rust..."
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     echo "Please start a new terminal session so that cargo is in your PATH"
@@ -51,11 +51,11 @@ brew install llvm
 # Install PSScriptAnalyzer for PowerShell linting
 pwsh -Command "Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser"
 
-if ! [ "$(command -v docker)" ]; then
+if ! command -v docker > /dev/null 2>&1; then
     brew install --cask docker
 fi
 
-if ! [ "$(command -v gcloud)" ]; then
+if ! command -v gcloud > /dev/null 2>&1; then
     brew install google-cloud-sdk
 fi
 


### PR DESCRIPTION
## Description
Xcode doesn't always live under `/Applications/Xcode.app` - it could be named `Xcode-beta.app` for beta releases, or `Xcode-26.2.app` if installed via [xcodes](https://github.com/XcodesOrg/XcodesApp). This PR aims to improve Xcode detection by actually using `xcode-select` and not checking if the app directory exists.

Also added null redirections for `command`, so it doesn't pollute log for no reason.

## Linked Issue
n/a

## Testing
Re-ran `./scripts/bootstrap` and verified it works correctly.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
