### PR TITLE
[QUALITY-569] Stage 1: orchestrate tool (client)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14894,7 +14894,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=aa2f9cde164a5b48ac01087d417d1188771f9b6d#aa2f9cde164a5b48ac01087d417d1188771f9b6d"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=02997b8fc6a468783642d93bf1bfa89fb7f42502#02997b8fc6a468783642d93bf1bfa89fb7f42502"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "aa2f9cde164a5b48ac01087d417d1188771f9b6d" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "02997b8fc6a468783642d93bf1bfa89fb7f42502" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -511,7 +511,8 @@ impl ConvertToExchanges for &api::Task {
                 | api::message::Message::DebugOutput(_)
                 | api::message::Message::ArtifactEvent(_)
                 | api::message::Message::MessagesReceivedFromAgents(_)
-                | api::message::Message::ModelUsed(_) => false,
+                | api::message::Message::ModelUsed(_)
+                | api::message::Message::OrchestrationConfigSnapshot(_) => false,
             };
 
             if !added_message_as_exchange_input {
@@ -1542,6 +1543,76 @@ pub(crate) fn convert_tool_call_result_to_input(
                 context,
             })
         }
+        Some(ToolCallResultType::RunAgentsResult(result)) => {
+            use ai::agent::action_result::{
+                RunAgentsAgentOutcome, RunAgentsAgentOutcomeKind, RunAgentsLaunchedExecutionMode,
+                RunAgentsResult,
+            };
+            let run_agents_result = match &result.outcome {
+                Some(api::run_agents_result::Outcome::Launched(launched)) => {
+                    let execution_mode = match &launched.resolved_execution_mode {
+                        Some(api::run_agents_result::launched::ResolvedExecutionMode::Remote(
+                            remote,
+                        )) => RunAgentsLaunchedExecutionMode::Remote {
+                            environment_id: remote.environment_id.clone(),
+                            worker_host: remote.worker_host.clone(),
+                            computer_use_enabled: remote.computer_use_enabled,
+                        },
+                        Some(api::run_agents_result::launched::ResolvedExecutionMode::Local(_))
+                        | None => RunAgentsLaunchedExecutionMode::Local,
+                    };
+                    let agents = launched
+                        .agents
+                        .iter()
+                        .map(|outcome| RunAgentsAgentOutcome {
+                            name: outcome.name.clone(),
+                            kind: match &outcome.result {
+                                Some(api::run_agents_result::agent_outcome::Result::Launched(
+                                    launched_agent,
+                                )) => RunAgentsAgentOutcomeKind::Launched {
+                                    agent_id: launched_agent.agent_id.clone(),
+                                },
+                                Some(api::run_agents_result::agent_outcome::Result::Failed(
+                                    failed,
+                                )) => RunAgentsAgentOutcomeKind::Failed {
+                                    error: failed.error.clone(),
+                                },
+                                None => RunAgentsAgentOutcomeKind::Failed {
+                                    error: String::new(),
+                                },
+                            },
+                        })
+                        .collect();
+                    RunAgentsResult::Launched {
+                        model_id: launched.resolved_model_id.clone(),
+                        harness_type:
+                            crate::ai::agent::api::convert_from::convert_run_agents_harness(
+                                launched.resolved_harness.as_ref(),
+                            )
+                            .unwrap_or_default(),
+                        execution_mode,
+                        agents,
+                    }
+                }
+                Some(api::run_agents_result::Outcome::Denied(denied)) => RunAgentsResult::Denied {
+                    reason: denied.reason.clone(),
+                },
+                Some(api::run_agents_result::Outcome::Failure(failure)) => {
+                    RunAgentsResult::Failure {
+                        error: failure.error.clone(),
+                    }
+                }
+                None => RunAgentsResult::Cancelled,
+            };
+            Some(AIAgentInput::ActionResult {
+                result: AIAgentActionResult {
+                    id: tool_call_id.into(),
+                    task_id: task_id.clone(),
+                    result: AIAgentActionResultType::RunAgents(run_agents_result),
+                },
+                context,
+            })
+        }
         // Deprecated/unused result types or absent result.
         Some(ToolCallResultType::SuggestCreatePlan(..))
         | Some(ToolCallResultType::SuggestPlan(..))
@@ -1675,6 +1746,9 @@ fn create_cancelled_result_for_tool_call(
         }
         ToolType::SendMessageToAgent(_) => {
             AIAgentActionResultType::SendMessageToAgent(SendMessageToAgentResult::Cancelled)
+        }
+        ToolType::RunAgents(_) => {
+            AIAgentActionResultType::RunAgents(ai::agent::action_result::RunAgentsResult::Cancelled)
         }
         // These tools are deprecated.
         ToolType::SuggestCreatePlan(_) | ToolType::SuggestPlan(_) => return None,
@@ -1877,7 +1951,8 @@ where
                 | api::message::Message::DebugOutput(_)
                 | api::message::Message::ArtifactEvent(_)
                 | api::message::Message::InvokeSkill(_)
-                | api::message::Message::ModelUsed(_) => {
+                | api::message::Message::ModelUsed(_)
+                | api::message::Message::OrchestrationConfigSnapshot(_) => {
                     message.timestamp.as_ref().map(|timestamp| {
                         proto_timestamp_to_local_datetime(timestamp.seconds, timestamp.nanos)
                     })

--- a/app/src/ai/agent/api/convert_from.rs
+++ b/app/src/ai/agent/api/convert_from.rs
@@ -11,8 +11,9 @@ use crate::ai::agent::todos::AIAgentTodoList;
 use crate::ai::agent::{
     util::parse_markdown_into_text_and_code_sections, AIAgentAction, AIAgentActionType,
     AIAgentCitation, AIAgentInput, AIAgentOutputMessage, AIAgentText, AIAgentTodo,
-    ArtifactCreatedData, MessageId, StartAgentExecutionMode, SuggestedAgentModeWorkflow,
-    SuggestedRule, Suggestions, TodoOperation,
+    ArtifactCreatedData, MessageId, RunAgentsAgentRunConfig, RunAgentsExecutionMode,
+    RunAgentsRequest, StartAgentExecutionMode, SuggestedAgentModeWorkflow, SuggestedRule,
+    Suggestions, TodoOperation,
 };
 use crate::ai::agent::{
     CloneRepositoryURL, SubagentCall, SubagentType, SummarizationType, WebFetchStatus,
@@ -81,6 +82,22 @@ fn convert_start_agent_v2_harness_type(
         .filter(|harness_type| !harness_type.trim().is_empty())
 }
 
+/// Maps the proto `Harness` oneof to a client-side string identifier
+/// (e.g. "oz", "claude"). Returns `None` for an unset variant.
+pub(crate) fn convert_run_agents_harness(harness: Option<&api::Harness>) -> Option<String> {
+    let variant = harness?.variant.as_ref()?;
+    Some(
+        match variant {
+            api::harness::Variant::Oz(_) => "oz",
+            api::harness::Variant::ClaudeCode(_) => "claude",
+            api::harness::Variant::OpenCode(_) => "opencode",
+            api::harness::Variant::Gemini(_) => "gemini",
+            api::harness::Variant::Codex(_) => "codex",
+        }
+        .to_string(),
+    )
+}
+
 fn convert_start_agent_execution_mode(
     execution_mode: Option<api::start_agent::ExecutionMode>,
 ) -> StartAgentExecutionMode {
@@ -92,6 +109,50 @@ fn convert_start_agent_execution_mode(
             StartAgentExecutionMode::local_with_defaults()
         }
     }
+}
+
+fn convert_run_agents_execution_mode(
+    execution_mode: Option<api::run_agents::ExecutionMode>,
+) -> RunAgentsExecutionMode {
+    match execution_mode {
+        Some(api::run_agents::ExecutionMode::Remote(remote)) => RunAgentsExecutionMode::Remote {
+            environment_id: remote.environment_id,
+            worker_host: remote.worker_host,
+            computer_use_enabled: remote.computer_use_enabled,
+        },
+        Some(api::run_agents::ExecutionMode::Local(_)) | None => RunAgentsExecutionMode::Local,
+    }
+}
+
+fn convert_run_agents(run_agents: api::RunAgents) -> AIAgentActionType {
+    let api::RunAgents {
+        summary,
+        base_prompt,
+        skills,
+        model_id,
+        harness,
+        agent_run_configs,
+        execution_mode,
+    } = run_agents;
+    AIAgentActionType::RunAgents(RunAgentsRequest {
+        summary,
+        base_prompt,
+        skills: skills
+            .into_iter()
+            .filter_map(convert_skill_reference)
+            .collect(),
+        model_id,
+        harness_type: convert_run_agents_harness(harness.as_ref()).unwrap_or_default(),
+        execution_mode: convert_run_agents_execution_mode(execution_mode),
+        agent_run_configs: agent_run_configs
+            .into_iter()
+            .map(|config| RunAgentsAgentRunConfig {
+                name: config.name,
+                prompt: config.prompt,
+                title: config.title,
+            })
+            .collect(),
+    })
 }
 
 fn convert_start_agent_v2_execution_mode(
@@ -569,7 +630,11 @@ impl ConvertAPIMessageToClientOutputMessage for api::Message {
             | api::message::Message::CodeReview(_)
             | api::message::Message::ServerEvent(_)
             | api::message::Message::InvokeSkill(_)
-            | api::message::Message::PassiveSuggestionResult(_) => {
+            | api::message::Message::PassiveSuggestionResult(_)
+            // Stage 2 plan-card config snapshot: hydrated separately by the
+            // plan card's `AIDocumentModel` subscription, not via the
+            // exchange/output stream. No client output message representation.
+            | api::message::Message::OrchestrationConfigSnapshot(_) => {
                 Ok(MaybeAIAgentOutputMessage::NoClientRepresentation)
             }
         }
@@ -759,6 +824,9 @@ impl ConvertAPIToolCallToAIAgentAction for api::message::ToolCall {
                         },
                     ),
                 })
+            }
+            api::message::tool_call::Tool::RunAgents(orchestrate) => {
+                create_standard_action(convert_run_agents(orchestrate))
             }
             api::message::tool_call::Tool::SendMessageToAgent(send_message) => {
                 create_standard_action(AIAgentActionType::SendMessageToAgent {

--- a/app/src/ai/agent/api/convert_to.rs
+++ b/app/src/ai/agent/api/convert_to.rs
@@ -692,6 +692,9 @@ impl TryFrom<AIAgentActionResult> for api::request::input::user_inputs::user_inp
             AIAgentActionResultType::AskUserQuestion(ask_user_question_result) => {
                 Some(ask_user_question_result.into())
             }
+            AIAgentActionResultType::RunAgents(orchestrate_result) => {
+                Some(orchestrate_result.try_into()?)
+            }
         };
         Ok(
             api::request::input::user_inputs::user_input::Input::ToolCallResult(

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -213,11 +213,17 @@ fn get_supported_tools(params: &RequestParams) -> Vec<api::ToolType> {
     }
 
     if params.orchestration_enabled {
+        // Always advertise the legacy start-agent tool so the server
+        // can fall back to it when its own orchestrate flag is off.
+        // When RunAgents is also enabled, advertise it alongside.
         supported_tools.push(if FeatureFlag::OrchestrationV2.is_enabled() {
             api::ToolType::StartAgentV2
         } else {
             api::ToolType::StartAgent
         });
+        if FeatureFlag::RunAgentsTool.is_enabled() && FeatureFlag::OrchestrationV2.is_enabled() {
+            supported_tools.push(api::ToolType::RunAgents);
+        }
         supported_tools.push(api::ToolType::SendMessageToAgent);
     }
 

--- a/app/src/ai/agent/conversation_yaml.rs
+++ b/app/src/ai/agent/conversation_yaml.rs
@@ -243,7 +243,8 @@ fn write_task_messages(
             | Message::SystemQuery(_)
             | Message::CodeReview(_)
             | Message::ServerEvent(_)
-            | Message::InvokeSkill(_) => {}
+            | Message::InvokeSkill(_)
+            | Message::OrchestrationConfigSnapshot(_) => {}
         }
     }
     Ok(())
@@ -507,6 +508,19 @@ fn write_tool_call_args(out: &mut String, tool: &Tool) {
                 out.push_str(&format!("  - deleted: {}\n", df.file_path));
             }
         }
+        Tool::RunAgents(o) => {
+            out.push_str(&format!(
+                "summary: \"{}\"\n",
+                escape_yaml_string(&o.summary)
+            ));
+            out.push_str("agents:\n");
+            for cfg in &o.agent_run_configs {
+                out.push_str(&format!(
+                    "  - name: \"{}\"\n",
+                    escape_yaml_string(&cfg.name)
+                ));
+            }
+        }
         // No additional args worth serializing.
         Tool::ReadShellCommandOutput(_)
         | Tool::UseComputer(_)
@@ -526,6 +540,27 @@ fn write_tool_call_args(out: &mut String, tool: &Tool) {
 /// Writes content from structured tool call results.
 fn write_tool_call_result_content(out: &mut String, result: &ToolCallResultType) {
     match result {
+        ToolCallResultType::RunAgentsResult(r) => match &r.outcome {
+            Some(api::run_agents_result::Outcome::Launched(launched)) => {
+                out.push_str("status: launched\n");
+                out.push_str(&format!("agent_count: {}\n", launched.agents.len()));
+            }
+            Some(api::run_agents_result::Outcome::Denied(denied)) => {
+                out.push_str("status: launch_denied\n");
+                out.push_str(&format!(
+                    "reason: \"{}\"\n",
+                    escape_yaml_string(&denied.reason)
+                ));
+            }
+            Some(api::run_agents_result::Outcome::Failure(failure)) => {
+                out.push_str("status: failure\n");
+                out.push_str(&format!(
+                    "error: \"{}\"\n",
+                    escape_yaml_string(&failure.error)
+                ));
+            }
+            None => {}
+        },
         ToolCallResultType::StartAgentV2(r) => match &r.result {
             Some(api::start_agent_v2_result::Result::Success(s)) => {
                 out.push_str(&format!("agent_id: {}\n", s.agent_id));

--- a/app/src/ai/agent/redaction.rs
+++ b/app/src/ai/agent/redaction.rs
@@ -260,6 +260,9 @@ pub(crate) fn redact_inputs(inputs: &mut [AIAgentInput]) {
                     AIAgentActionResultType::AskUserQuestion(result) => {
                         redact_ask_user_question_result(result);
                     }
+                    // Orchestrate results contain agent IDs / canonical error
+                    // strings only; no user-provided text to redact.
+                    AIAgentActionResultType::RunAgents(_) => {}
                 }
             }
             AIAgentInput::FetchReviewComments { repo_path, context } => {

--- a/app/src/ai/agent/task/helper.rs
+++ b/app/src/ai/agent/task/helper.rs
@@ -139,6 +139,7 @@ impl ToolExt for api::message::tool_call::Tool {
             Tool::AskUserQuestion(_) => "ask_user_question",
             Tool::SendMessageToAgent(_) => "send_message_to_agent",
             Tool::TransferShellCommandControlToUser(_) => "transfer_shell_command_control",
+            Tool::RunAgents(_) => "orchestrate",
         }
     }
 }

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -1515,6 +1515,7 @@ impl AgentConversationsModel {
             // UpdateTaskDescription, last_updated uses exchange.start_time which is set at append time).
             | BlocklistAIHistoryEvent::UpdatedStreamingExchange { .. }
             | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
+            | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
             => {}
         }
     }

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1986,6 +1986,7 @@ impl AgentDriver {
                 | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
                 | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
                 | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. } => (),
+            BlocklistAIHistoryEvent::NewConversationRequestComplete { .. } => (),
             }
         });
 

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -303,6 +303,8 @@ pub mod text {
                 // SendMessageToAgent is a client-side orchestration action, not used in SDK
                 AIAgentActionResultType::SendMessageToAgent(_) => Ok(()),
                 AIAgentActionResultType::AskUserQuestion(_) => Ok(()),
+                // RunAgents is a desktop-client-only action; not used in the SDK.
+                AIAgentActionResultType::RunAgents(_) => Ok(()),
             },
         }
     }
@@ -427,6 +429,8 @@ pub mod text {
                         )?;
                     }
                     AIAgentActionType::AskUserQuestion { .. } => (),
+                    // RunAgents is desktop-client-only; SDK driver renders nothing.
+                    AIAgentActionType::RunAgents(_) => (),
                 },
                 AIAgentOutputMessageType::TodoOperation(operation) => match operation {
                     TodoOperation::UpdateTodos { todos } => {
@@ -1108,6 +1112,9 @@ pub mod json {
                     | AIAgentActionType::SendMessageToAgent { .. }
                     | AIAgentActionType::TransferShellCommandControlToUser { .. } => None,
                     AIAgentActionType::AskUserQuestion { .. } => None,
+                    // RunAgents is desktop-client-only; SDK has no JSON
+                    // representation for it.
+                    AIAgentActionType::RunAgents(_) => None,
                 },
                 AIAgentOutputMessageType::TodoOperation(operation) => match operation {
                     TodoOperation::UpdateTodos { todos } => Some(JsonMessage::UpdateTodos {

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -29,12 +29,15 @@ pub(crate) use execute::apply_edits;
 pub(crate) use execute::coerce_integer_args;
 pub(crate) use execute::FileReadResult;
 pub(crate) use execute::MalformedFinalLineProxyEvent;
+#[cfg(test)]
+pub(crate) use execute::{compose_run_agents_child_prompt, run_agents_to_start_agent_mode};
 pub use execute::{
     read_local_file_context, EditAcceptAndContinueClickedEvent, EditAcceptClickedEvent,
     EditResolvedEvent, EditStats, NewConversationDecision, PromptSuggestionExecutor,
     ReadFileContextResult, RequestFileEditsExecutor, RequestFileEditsFormatKind,
-    RequestFileEditsTelemetryEvent, ShellCommandExecutor, ShellCommandExecutorEvent,
-    StartAgentExecutor, StartAgentExecutorEvent, StartAgentRequest,
+    RequestFileEditsTelemetryEvent, RunAgentsExecutor, RunAgentsExecutorEvent,
+    RunAgentsSpawningSnapshot, ShellCommandExecutor, ShellCommandExecutorEvent, StartAgentExecutor,
+    StartAgentExecutorEvent, StartAgentRequest, StartAgentRequestId,
 };
 
 use futures::future::{join_all, BoxFuture};
@@ -400,6 +403,10 @@ impl BlocklistAIActionModel {
         self.executor.as_ref(app).start_agent_executor().clone()
     }
 
+    pub fn run_agents_executor(&self, app: &AppContext) -> ModelHandle<RunAgentsExecutor> {
+        self.executor.as_ref(app).run_agents_executor().clone()
+    }
+
     pub fn ask_user_question_executor(
         &self,
         app: &AppContext,
@@ -674,6 +681,60 @@ impl BlocklistAIActionModel {
                 }
             }
         }
+    }
+
+    /// Dispatches a `RunAgents` action with the user-edited request
+    /// from the confirmation card.
+    pub fn execute_run_agents(
+        &mut self,
+        action_id: &AIAgentActionId,
+        request: ai::agent::action::RunAgentsRequest,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let mut found: Option<(AIConversationId, AIAgentAction)> = None;
+        for (conv_id, queue) in self.pending_actions.iter_mut() {
+            if let Some(idx) = queue.iter().position(|a| &a.id == action_id) {
+                if let Some(action) = queue.remove(idx) {
+                    found = Some((*conv_id, action));
+                }
+                break;
+            }
+        }
+        let Some((conversation_id, action)) = found else {
+            log::warn!(
+                "BlocklistAIActionModel::execute_run_agents: no pending action for {action_id:?}"
+            );
+            return;
+        };
+        if !matches!(action.action, AIAgentActionType::RunAgents(_)) {
+            log::warn!(
+                "BlocklistAIActionModel::execute_run_agents: pending action {action_id:?} is not RunAgents; re-queueing"
+            );
+            self.pending_actions
+                .entry(conversation_id)
+                .or_default()
+                .push_front(action);
+            return;
+        }
+        let task_id = action.task_id.clone();
+        let action_id_clone = action_id.clone();
+
+        self.executor.update(ctx, |executor, exec_ctx| {
+            executor.execute_run_agents(
+                action_id_clone,
+                request,
+                conversation_id,
+                task_id,
+                exec_ctx,
+            );
+        });
+
+        self.update_conversation_in_progress_status(conversation_id, ctx);
+        self.add_running_action(
+            conversation_id,
+            action_id.clone(),
+            RunningActionPhase::Serial,
+        );
     }
 
     /// Attempts to execute the next pending action for the active conversation.

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -11,6 +11,7 @@ pub(super) mod read_mcp_resource;
 pub(super) mod read_skill;
 pub(super) mod request_computer_use;
 pub(super) mod request_file_edits;
+pub(super) mod run_agents;
 pub(super) mod search_codebase;
 pub(super) mod send_message;
 pub(super) mod shell_command;
@@ -43,10 +44,15 @@ pub use request_file_edits::{
     EditAcceptAndContinueClickedEvent, EditAcceptClickedEvent, EditResolvedEvent, EditStats,
     RequestFileEditsExecutor, RequestFileEditsFormatKind, RequestFileEditsTelemetryEvent,
 };
+#[cfg(test)]
+pub use run_agents::{compose_run_agents_child_prompt, run_agents_to_start_agent_mode};
+pub use run_agents::{RunAgentsExecutor, RunAgentsExecutorEvent, RunAgentsSpawningSnapshot};
 pub use send_message::SendMessageToAgentExecutor;
 use serde::{Deserialize, Serialize};
 pub use shell_command::{ShellCommandExecutor, ShellCommandExecutorEvent};
-pub use start_agent::{StartAgentExecutor, StartAgentExecutorEvent, StartAgentRequest};
+pub use start_agent::{
+    StartAgentExecutor, StartAgentExecutorEvent, StartAgentRequest, StartAgentRequestId,
+};
 pub use suggest_new_conversation::NewConversationDecision;
 use suggest_new_conversation::SuggestNewConversationExecutor;
 pub use suggest_prompt::PromptSuggestionExecutor;
@@ -83,9 +89,9 @@ use crate::ai::{agent::AnyFileContent, paths::host_native_absolute_path};
 use crate::{
     ai::{
         agent::{
-            conversation::AIConversationId, AIAgentAction, AIAgentActionId, AIAgentActionResult,
-            AIAgentActionResultType, AIAgentActionType, CancellationReason, FileContext,
-            FileLocations, ServerOutputId,
+            conversation::AIConversationId, task::TaskId, AIAgentAction, AIAgentActionId,
+            AIAgentActionResult, AIAgentActionResultType, AIAgentActionType, CancellationReason,
+            FileContext, FileLocations, ServerOutputId,
         },
         ambient_agents::AmbientAgentTaskId,
         get_relevant_files::controller::GetRelevantFilesController,
@@ -258,6 +264,7 @@ pub struct BlocklistAIActionExecutor {
     read_skill_executor: ModelHandle<ReadSkillExecutor>,
     fetch_conversation_executor: ModelHandle<FetchConversationExecutor>,
     start_agent_executor: ModelHandle<StartAgentExecutor>,
+    run_agents_executor: ModelHandle<RunAgentsExecutor>,
     send_message_executor: ModelHandle<SendMessageToAgentExecutor>,
     ask_user_question_executor: ModelHandle<AskUserQuestionExecutor>,
     /// The actions currently executing asynchronously, keyed by action ID.
@@ -323,6 +330,8 @@ impl BlocklistAIActionExecutor {
         let read_skill_executor = ctx.add_model(|_| ReadSkillExecutor::new());
         let fetch_conversation_executor = ctx.add_model(|_| FetchConversationExecutor::new());
         let start_agent_executor = ctx.add_model(StartAgentExecutor::new);
+        let run_agents_executor =
+            ctx.add_model(|_| RunAgentsExecutor::new(start_agent_executor.clone()));
         let send_message_executor = ctx.add_model(|_| SendMessageToAgentExecutor::new());
         let ask_user_question_executor =
             ctx.add_model(|_| AskUserQuestionExecutor::new(terminal_view_id));
@@ -348,6 +357,7 @@ impl BlocklistAIActionExecutor {
             read_skill_executor,
             fetch_conversation_executor,
             start_agent_executor,
+            run_agents_executor,
             send_message_executor,
             ask_user_question_executor,
         }
@@ -383,6 +393,10 @@ impl BlocklistAIActionExecutor {
 
     pub fn start_agent_executor(&self) -> &ModelHandle<StartAgentExecutor> {
         &self.start_agent_executor
+    }
+
+    pub fn run_agents_executor(&self) -> &ModelHandle<RunAgentsExecutor> {
+        &self.run_agents_executor
     }
 
     pub fn action_phase(&self, action: &AIAgentAction, ctx: &AppContext) -> RunningActionPhase {
@@ -516,6 +530,9 @@ impl BlocklistAIActionExecutor {
                 .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
             AIAgentActionType::AskUserQuestion { .. } => self
                 .ask_user_question_executor
+                .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
+            AIAgentActionType::RunAgents(_) => self
+                .run_agents_executor
                 .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
         }
     }
@@ -702,6 +719,12 @@ impl BlocklistAIActionExecutor {
                 .ask_user_question_executor
                 .update(ctx, |executor, ctx| executor.execute(input, ctx))
                 .into(),
+            // Standard executor path (un-edited request). The card
+            // view's Accept uses `execute_run_agents` instead.
+            AIAgentActionType::RunAgents(_) => self
+                .run_agents_executor
+                .update(ctx, |executor, ctx| executor.execute(input, ctx))
+                .into(),
         };
 
         let action_id = action_clone.id.clone();
@@ -831,6 +854,78 @@ impl BlocklistAIActionExecutor {
         }
     }
 
+    /// Dispatches a `RunAgents` action with a user-edited request
+    /// (from the confirmation card's Accept handler).
+    pub fn execute_run_agents(
+        &mut self,
+        action_id: AIAgentActionId,
+        request: ai::agent::action::RunAgentsRequest,
+        conversation_id: AIConversationId,
+        task_id: TaskId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.is_shared_session_viewer() {
+            log::warn!("RunAgents dispatch attempted in shared-session-viewer mode; ignoring");
+            return;
+        }
+        if self.async_executing_actions.contains_key(&action_id) {
+            log::warn!("RunAgents dispatch reentered for {action_id:?}; ignoring");
+            return;
+        }
+
+        let receiver = self.run_agents_executor.update(ctx, |executor, exec_ctx| {
+            executor.dispatch_run_agents(
+                action_id.clone(),
+                request.clone(),
+                conversation_id,
+                exec_ctx,
+            )
+        });
+
+        // Synthesize an AIAgentAction for cancellation and task_id
+        // plumbing.
+        let action = AIAgentAction {
+            id: action_id.clone(),
+            task_id,
+            action: AIAgentActionType::RunAgents(request),
+            requires_result: true,
+        };
+        self.async_executing_actions.insert(
+            action_id.clone(),
+            AsyncExecutingAction {
+                action,
+                conversation_id,
+            },
+        );
+        ctx.emit(BlocklistAIActionExecutorEvent::ExecutingAction {
+            action_id: action_id.clone(),
+        });
+
+        ctx.spawn(
+            async move { receiver.recv().await },
+            move |me, result, ctx| {
+                let Some(running) = me.async_executing_actions.remove(&action_id) else {
+                    return;
+                };
+                let result_type = match result {
+                    Ok(r) => AIAgentActionResultType::RunAgents(r),
+                    Err(_) => AIAgentActionResultType::RunAgents(
+                        ai::agent::action_result::RunAgentsResult::Cancelled,
+                    ),
+                };
+                ctx.emit(BlocklistAIActionExecutorEvent::FinishedAction {
+                    result: Arc::new(AIAgentActionResult {
+                        id: action_id,
+                        task_id: running.action.task_id,
+                        result: result_type,
+                    }),
+                    conversation_id: running.conversation_id,
+                    cancellation_reason: None,
+                });
+            },
+        );
+    }
+
     fn should_autoexecute(&self, input: ExecuteActionInput, ctx: &mut ModelContext<Self>) -> bool {
         match input.action.action {
             AIAgentActionType::RequestCommandOutput { .. }
@@ -901,6 +996,9 @@ impl BlocklistAIActionExecutor {
                 .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
             AIAgentActionType::AskUserQuestion { .. } => self
                 .ask_user_question_executor
+                .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
+            AIAgentActionType::RunAgents(_) => self
+                .run_agents_executor
                 .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
         }
     }

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -1,0 +1,372 @@
+//! Async executor for `AIAgentActionType::RunAgents`.
+//!
+//! Fans out per-child via [`super::start_agent::StartAgentExecutor::dispatch`]
+//! and aggregates the outcomes into a single `RunAgentsResult`.
+use std::collections::HashMap;
+use std::time::Duration;
+
+use ai::agent::action::{RunAgentsAgentRunConfig, RunAgentsExecutionMode, RunAgentsRequest};
+use ai::agent::action_result::{
+    RunAgentsAgentOutcome, RunAgentsAgentOutcomeKind, RunAgentsLaunchedExecutionMode,
+    RunAgentsResult,
+};
+use ai::skills::SkillReference;
+use futures::{future::BoxFuture, FutureExt};
+use warpui::{Entity, ModelContext, ModelHandle};
+
+use super::start_agent::{StartAgentExecutor, StartAgentOutcome};
+use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::{
+    AIAgentAction, AIAgentActionId, AIAgentActionResultType, AIAgentActionType,
+    StartAgentExecutionMode,
+};
+use crate::ai::blocklist::BlocklistAIHistoryModel;
+use warpui::SingletonEntity;
+
+/// Per-child spawn timeout. If a child agent doesn't report back within
+/// this window (e.g. binary not found, server error), the slot is failed
+/// rather than hanging the "Spawning agents" UI indefinitely.
+const SPAWN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Snapshot of an in-flight dispatch, carried through
+/// [`RunAgentsExecutorEvent::SpawningStarted`].
+#[derive(Debug, Clone, Copy)]
+pub struct RunAgentsSpawningSnapshot {
+    pub agent_count: usize,
+}
+
+/// In-flight tracking per `RunAgents` action (idempotency guard).
+struct PendingRunAgents;
+
+pub struct RunAgentsExecutor {
+    pending: HashMap<AIAgentActionId, PendingRunAgents>,
+    start_agent_executor: ModelHandle<StartAgentExecutor>,
+}
+
+/// Lifecycle events for in-flight dispatches.
+pub enum RunAgentsExecutorEvent {
+    SpawningStarted {
+        action_id: AIAgentActionId,
+        snapshot: RunAgentsSpawningSnapshot,
+    },
+    SpawningFinished {
+        action_id: AIAgentActionId,
+    },
+}
+
+impl Entity for RunAgentsExecutor {
+    type Event = RunAgentsExecutorEvent;
+}
+
+impl RunAgentsExecutor {
+    pub fn new(start_agent_executor: ModelHandle<StartAgentExecutor>) -> Self {
+        Self {
+            pending: HashMap::new(),
+            start_agent_executor,
+        }
+    }
+
+    pub fn is_pending(&self, action_id: &AIAgentActionId) -> bool {
+        self.pending.contains_key(action_id)
+    }
+
+    /// Fans out per-child dispatches and returns a receiver for the
+    /// aggregate `RunAgentsResult`. Validation failures short-circuit
+    /// synchronously.
+    pub fn dispatch_run_agents(
+        &mut self,
+        action_id: AIAgentActionId,
+        request: RunAgentsRequest,
+        parent_conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) -> async_channel::Receiver<RunAgentsResult> {
+        let (sender, receiver) = async_channel::bounded(1);
+
+        if self.pending.contains_key(&action_id) {
+            log::warn!("RunAgentsExecutor: dispatch reentered for {action_id:?}; rejecting");
+            let _ = sender.try_send(RunAgentsResult::Cancelled);
+            return receiver;
+        }
+
+        if let Err(error) = validate_request(&request) {
+            log::warn!("RunAgentsExecutor: validation failure: {error}");
+            let _ = sender.try_send(RunAgentsResult::Failure { error });
+            return receiver;
+        }
+
+        let snapshot = RunAgentsSpawningSnapshot {
+            agent_count: request.agent_run_configs.len(),
+        };
+        self.pending.insert(action_id.clone(), PendingRunAgents);
+        ctx.emit(RunAgentsExecutorEvent::SpawningStarted {
+            action_id: action_id.clone(),
+            snapshot,
+        });
+
+        let parent_run_id = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&parent_conversation_id)
+            .and_then(|c| c.run_id());
+
+        let RunAgentsRequest {
+            execution_mode: run_execution_mode,
+            harness_type,
+            model_id,
+            skills,
+            agent_run_configs,
+            base_prompt,
+            ..
+        } = request;
+
+        let mut slots: Vec<ChildSlot> = Vec::with_capacity(agent_run_configs.len());
+        for cfg in &agent_run_configs {
+            let prompt = compose_run_agents_child_prompt(&base_prompt, &cfg.prompt);
+            let mode = match run_agents_to_start_agent_mode(
+                &run_execution_mode,
+                &harness_type,
+                &model_id,
+                &skills,
+                cfg,
+            ) {
+                Ok(mode) => mode,
+                Err(err) => {
+                    slots.push(ChildSlot::Failed(err));
+                    continue;
+                }
+            };
+            if matches!(run_execution_mode, RunAgentsExecutionMode::Remote { .. })
+                && parent_run_id.is_none()
+            {
+                slots.push(ChildSlot::Failed(
+                    "Remote child agents require the parent run_id to be available.".to_string(),
+                ));
+                continue;
+            }
+            let recv = self.start_agent_executor.update(ctx, |executor, exec_ctx| {
+                executor.dispatch(
+                    cfg.name.clone(),
+                    prompt,
+                    mode,
+                    None, /* lifecycle_subscription */
+                    parent_conversation_id,
+                    parent_run_id.clone(),
+                    exec_ctx,
+                )
+            });
+            slots.push(ChildSlot::Pending(recv));
+        }
+
+        let agent_run_configs_for_result = agent_run_configs.clone();
+        let action_id_for_aggr = action_id.clone();
+        let run_model_id = model_id.clone();
+        let run_harness_type = harness_type.clone();
+        let run_execution_mode_for_aggr = run_execution_mode.clone();
+
+        ctx.spawn(
+            async move {
+                let mut outcomes: Vec<RunAgentsAgentOutcomeKind> = Vec::with_capacity(slots.len());
+                for slot in slots {
+                    let kind = match slot {
+                        ChildSlot::Failed(error) => RunAgentsAgentOutcomeKind::Failed { error },
+                        ChildSlot::Pending(recv) => {
+                            let timeout = warpui::r#async::Timer::after(SPAWN_TIMEOUT);
+                            match futures::future::select(Box::pin(recv.recv()), Box::pin(timeout))
+                                .await
+                            {
+                                futures::future::Either::Left((
+                                    Ok(StartAgentOutcome::Started { agent_id }),
+                                    _,
+                                )) => RunAgentsAgentOutcomeKind::Launched { agent_id },
+                                futures::future::Either::Left((
+                                    Ok(StartAgentOutcome::Error(error)),
+                                    _,
+                                )) => RunAgentsAgentOutcomeKind::Failed { error },
+                                futures::future::Either::Left((Err(_), _)) => {
+                                    RunAgentsAgentOutcomeKind::Failed {
+                                        error: "Cancelled before launch".to_string(),
+                                    }
+                                }
+                                futures::future::Either::Right((_, _)) => {
+                                    log::warn!(
+                                        "Agent spawn timed out after {} seconds",
+                                        SPAWN_TIMEOUT.as_secs()
+                                    );
+                                    RunAgentsAgentOutcomeKind::Failed {
+                                        error: format!(
+                                            "Agent failed to start within {} seconds. \
+                                             The harness binary may not be installed.",
+                                            SPAWN_TIMEOUT.as_secs()
+                                        ),
+                                    }
+                                }
+                            }
+                        }
+                    };
+                    outcomes.push(kind);
+                }
+                outcomes
+            },
+            move |me, outcomes, ctx| {
+                let agents: Vec<RunAgentsAgentOutcome> = agent_run_configs_for_result
+                    .iter()
+                    .zip(outcomes)
+                    .map(|(cfg, kind)| RunAgentsAgentOutcome {
+                        name: cfg.name.clone(),
+                        kind,
+                    })
+                    .collect();
+                let launched_mode = match &run_execution_mode_for_aggr {
+                    RunAgentsExecutionMode::Local => RunAgentsLaunchedExecutionMode::Local,
+                    RunAgentsExecutionMode::Remote {
+                        environment_id,
+                        worker_host,
+                        computer_use_enabled,
+                    } => RunAgentsLaunchedExecutionMode::Remote {
+                        environment_id: environment_id.clone(),
+                        worker_host: worker_host.clone(),
+                        computer_use_enabled: *computer_use_enabled,
+                    },
+                };
+                let result = RunAgentsResult::Launched {
+                    model_id: run_model_id,
+                    harness_type: run_harness_type,
+                    execution_mode: launched_mode,
+                    agents,
+                };
+                me.pending.remove(&action_id_for_aggr);
+                ctx.emit(RunAgentsExecutorEvent::SpawningFinished {
+                    action_id: action_id_for_aggr,
+                });
+                let _ = sender.try_send(result);
+            },
+        );
+
+        receiver
+    }
+
+    pub(super) fn execute(
+        &mut self,
+        input: ExecuteActionInput,
+        ctx: &mut ModelContext<Self>,
+    ) -> impl Into<AnyActionExecution> {
+        let AIAgentAction { action, id, .. } = input.action;
+        let AIAgentActionType::RunAgents(request) = action else {
+            return ActionExecution::InvalidAction;
+        };
+        let request = request.clone();
+        let action_id = id.clone();
+        let parent_conversation_id = input.conversation_id;
+        let receiver = self.dispatch_run_agents(action_id, request, parent_conversation_id, ctx);
+
+        ActionExecution::new_async(
+            async move { receiver.recv().await },
+            |result, _| match result {
+                Ok(r) => AIAgentActionResultType::RunAgents(r),
+                Err(_) => AIAgentActionResultType::RunAgents(RunAgentsResult::Cancelled),
+            },
+        )
+    }
+
+    pub(super) fn should_autoexecute(
+        &self,
+        _input: ExecuteActionInput,
+        _ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        // Confirmation card always required.
+        false
+    }
+
+    pub(super) fn preprocess_action(
+        &mut self,
+        _action: PreprocessActionInput,
+        _ctx: &mut ModelContext<Self>,
+    ) -> BoxFuture<'static, ()> {
+        futures::future::ready(()).boxed()
+    }
+}
+
+enum ChildSlot {
+    Failed(String),
+    Pending(async_channel::Receiver<StartAgentOutcome>),
+}
+
+/// Defence-in-depth validation; mirrors the card view's
+/// `accept_disabled_reason` check.
+fn validate_request(request: &RunAgentsRequest) -> Result<(), String> {
+    if request.agent_run_configs.is_empty() {
+        return Err("orchestrate: empty agent_run_configs".to_string());
+    }
+    if matches!(
+        request.execution_mode,
+        RunAgentsExecutionMode::Remote { .. }
+    ) && request.harness_type.eq_ignore_ascii_case("opencode")
+    {
+        return Err("Remote child agents do not support the opencode harness yet.".to_string());
+    }
+    Ok(())
+}
+
+/// Joins `base_prompt` and a per-agent prompt with `"\n\n"`,
+/// falling back to whichever is non-empty.
+pub fn compose_run_agents_child_prompt(base_prompt: &str, per_agent_prompt: &str) -> String {
+    let base_trimmed = base_prompt.trim();
+    let per_agent_trimmed = per_agent_prompt.trim();
+    match (base_trimmed.is_empty(), per_agent_trimmed.is_empty()) {
+        (false, false) => format!("{base_prompt}\n\n{per_agent_prompt}"),
+        (false, true) => base_prompt.to_string(),
+        (true, false) => per_agent_prompt.to_string(),
+        (true, true) => String::new(),
+    }
+}
+
+/// Translates run-wide config into a per-child
+/// [`StartAgentExecutionMode`]. Returns `Err` for rejected
+/// combinations (e.g. OpenCode+Remote).
+pub fn run_agents_to_start_agent_mode(
+    run_execution_mode: &RunAgentsExecutionMode,
+    run_harness_type: &str,
+    run_model_id: &str,
+    run_skills: &[SkillReference],
+    cfg: &RunAgentsAgentRunConfig,
+) -> Result<StartAgentExecutionMode, String> {
+    match run_execution_mode {
+        RunAgentsExecutionMode::Local => {
+            let trimmed = run_harness_type.trim();
+            // Propagate run-wide model selection for local launches.
+            let trimmed_model_id = run_model_id.trim();
+            let model_id = (!trimmed_model_id.is_empty()).then(|| trimmed_model_id.to_string());
+            if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("oz") {
+                Ok(StartAgentExecutionMode::Local {
+                    harness_type: None,
+                    model_id,
+                })
+            } else {
+                Ok(StartAgentExecutionMode::Local {
+                    harness_type: Some(trimmed.to_string()),
+                    model_id,
+                })
+            }
+        }
+        RunAgentsExecutionMode::Remote {
+            environment_id,
+            worker_host,
+            computer_use_enabled,
+        } => {
+            // OpenCode is unsupported on Remote.
+            if run_harness_type.eq_ignore_ascii_case("opencode") {
+                return Err(
+                    "Remote child agents do not support the opencode harness yet.".to_string(),
+                );
+            }
+            Ok(StartAgentExecutionMode::Remote {
+                environment_id: environment_id.clone(),
+                skill_references: run_skills.to_vec(),
+                model_id: run_model_id.to_string(),
+                computer_use_enabled: *computer_use_enabled,
+                worker_host: worker_host.clone(),
+                harness_type: run_harness_type.to_string(),
+                title: cfg.title.clone(),
+            })
+        }
+    }
+}

--- a/app/src/ai/blocklist/action_model/execute/start_agent.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use futures::{future::BoxFuture, FutureExt};
 use warpui::{Entity, ModelContext, SingletonEntity};
 
@@ -14,10 +16,12 @@ use warp_core::features::FeatureFlag;
 
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
 
-/// The result sent back to the executor after observing the child agent's lifecycle.
-enum StartAgentDecision {
-    /// The child conversation was created successfully.
-    Started { agent_id: String },
+/// Per-request outcome of a StartAgent dispatch.
+#[derive(Debug, Clone)]
+pub enum StartAgentOutcome {
+    Started {
+        agent_id: String,
+    },
     /// An error occurred while starting the agent.
     Error(String),
 }
@@ -31,10 +35,21 @@ fn invalid_local_child_harness_error(harness_type: &str) -> String {
     }
 }
 
-/// Groups the data for a single StartAgent invocation as it flows from the
-/// executor through the terminal view and pane group into the controller.
+/// Opaque, monotonically increasing request identifier.
+/// Disambiguates parallel in-flight StartAgent requests.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Default)]
+pub struct StartAgentRequestId(u64);
+
+impl StartAgentRequestId {
+    #[cfg(test)]
+    pub const fn from_raw_for_test(value: u64) -> Self {
+        Self(value)
+    }
+}
+
 #[derive(Clone)]
 pub struct StartAgentRequest {
+    pub id: StartAgentRequestId,
     pub name: String,
     pub prompt: String,
     pub execution_mode: StartAgentExecutionMode,
@@ -43,19 +58,16 @@ pub struct StartAgentRequest {
     pub parent_run_id: Option<String>,
 }
 
-/// Tracks a single in-flight StartAgent action. At most one can be pending at
-/// a time because StartAgent actions execute serially (RunningActionPhase::Serial).
 struct PendingStartAgent {
     parent_conversation_id: AIConversationId,
-    /// Set when `StartedNewConversation` fires for a conversation whose
-    /// `parent_conversation_id` matches.
+    /// Set once the child conversation is synchronously created.
     child_conversation_id: Option<AIConversationId>,
-    sender: async_channel::Sender<StartAgentDecision>,
+    sender: async_channel::Sender<StartAgentOutcome>,
 }
 
 pub struct StartAgentExecutor {
-    /// The currently pending StartAgent action, if any.
-    pending: Option<PendingStartAgent>,
+    pending: HashMap<StartAgentRequestId, PendingStartAgent>,
+    next_request_id: u64,
 }
 
 impl StartAgentExecutor {
@@ -63,7 +75,37 @@ impl StartAgentExecutor {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         ctx.subscribe_to_model(&history_model, Self::handle_history_event);
 
-        Self { pending: None }
+        Self {
+            pending: HashMap::new(),
+            next_request_id: 0,
+        }
+    }
+
+    fn next_request_id(&mut self) -> StartAgentRequestId {
+        let id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1);
+        StartAgentRequestId(id)
+    }
+
+    /// Links a pending request to its freshly-created child
+    /// conversation so subsequent history events can find it.
+    fn record_child_conversation(
+        &mut self,
+        request_id: StartAgentRequestId,
+        child_conversation_id: AIConversationId,
+    ) {
+        if let Some(pending) = self.pending.get_mut(&request_id) {
+            pending.child_conversation_id = Some(child_conversation_id);
+        }
+    }
+
+    fn find_pending_by_child(
+        &self,
+        child_conversation_id: &AIConversationId,
+    ) -> Option<StartAgentRequestId> {
+        self.pending.iter().find_map(|(id, pending)| {
+            (pending.child_conversation_id.as_ref() == Some(child_conversation_id)).then_some(*id)
+        })
     }
 
     fn handle_history_event(
@@ -72,41 +114,19 @@ impl StartAgentExecutor {
         ctx: &mut ModelContext<Self>,
     ) {
         match event {
-            BlocklistAIHistoryEvent::StartedNewConversation {
-                new_conversation_id,
-                ..
-            } => {
-                let Some(pending) = self.pending.as_mut() else {
-                    return;
-                };
-                if pending.child_conversation_id.is_some() {
-                    return;
-                }
-                let history = BlocklistAIHistoryModel::as_ref(ctx);
-                let Some(conversation) = history.conversation(new_conversation_id) else {
-                    return;
-                };
-                if conversation.parent_conversation_id() == Some(pending.parent_conversation_id) {
-                    pending.child_conversation_id = Some(*new_conversation_id);
-                }
-            }
             BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
                 conversation_id, ..
             } => {
-                let matches = self
-                    .pending
-                    .as_ref()
-                    .is_some_and(|p| p.child_conversation_id.as_ref() == Some(conversation_id));
-                if !matches {
+                let Some(request_id) = self.find_pending_by_child(conversation_id) else {
                     return;
-                }
-                let pending = self.pending.take().unwrap();
+                };
+                let pending = self.pending.remove(&request_id).unwrap();
                 let agent_id = BlocklistAIHistoryModel::as_ref(ctx)
                     .conversation(conversation_id)
                     .and_then(|c| c.orchestration_agent_id());
                 match agent_id {
                     Some(id) => {
-                        let _ = pending.sender.try_send(StartAgentDecision::Started {
+                        let _ = pending.sender.try_send(StartAgentOutcome::Started {
                             agent_id: id.clone(),
                         });
                         if FeatureFlag::OrchestrationV2.is_enabled() {
@@ -128,7 +148,7 @@ impl StartAgentExecutor {
                             "ConversationServerTokenAssigned fired but no agent identifier for \
                              {conversation_id:?}"
                         );
-                        let _ = pending.sender.try_send(StartAgentDecision::Error(
+                        let _ = pending.sender.try_send(StartAgentOutcome::Error(
                             "Server did not assign an agent identifier".to_string(),
                         ));
                         if !FeatureFlag::OrchestrationV2.is_enabled() {
@@ -147,13 +167,9 @@ impl StartAgentExecutor {
             BlocklistAIHistoryEvent::UpdatedConversationStatus {
                 conversation_id, ..
             } => {
-                let matches = self
-                    .pending
-                    .as_ref()
-                    .is_some_and(|p| p.child_conversation_id.as_ref() == Some(conversation_id));
-                if !matches {
+                let Some(request_id) = self.find_pending_by_child(conversation_id) else {
                     return;
-                }
+                };
                 let history = BlocklistAIHistoryModel::as_ref(ctx);
                 let Some(conversation) = history.conversation(conversation_id) else {
                     return;
@@ -163,10 +179,10 @@ impl StartAgentExecutor {
                     conversation.status_error_message(),
                 );
                 if let Some(error_msg) = error_msg {
-                    let pending = self.pending.take().unwrap();
+                    let pending = self.pending.remove(&request_id).unwrap();
                     let _ = pending
                         .sender
-                        .try_send(StartAgentDecision::Error(error_msg.clone()));
+                        .try_send(StartAgentOutcome::Error(error_msg.clone()));
                     if !FeatureFlag::OrchestrationV2.is_enabled() {
                         OrchestrationEventService::handle(ctx).update(ctx, |svc, ctx| {
                             svc.emit_child_startup_errored(
@@ -179,7 +195,14 @@ impl StartAgentExecutor {
                     }
                 }
             }
-            BlocklistAIHistoryEvent::CreatedSubtask { .. }
+            BlocklistAIHistoryEvent::NewConversationRequestComplete {
+                request_id,
+                conversation_id,
+            } => {
+                self.record_child_conversation(*request_id, *conversation_id);
+            }
+            BlocklistAIHistoryEvent::StartedNewConversation { .. }
+            | BlocklistAIHistoryEvent::CreatedSubtask { .. }
             | BlocklistAIHistoryEvent::UpgradedTask { .. }
             | BlocklistAIHistoryEvent::AppendedExchange { .. }
             | BlocklistAIHistoryEvent::ReassignedExchange { .. }
@@ -231,7 +254,10 @@ impl StartAgentExecutor {
         let version = *version;
         let parent_conversation_id = input.conversation_id;
         let (execution_mode, parent_run_id) = match execution_mode.clone() {
-            StartAgentExecutionMode::Local { harness_type: None } => {
+            StartAgentExecutionMode::Local {
+                harness_type: None,
+                model_id,
+            } => {
                 // Legacy local Oz child agents do not use
                 // StartAgentRequest.parent_run_id. Instead, the child
                 // conversation is linked back to its parent on the first
@@ -241,10 +267,17 @@ impl StartAgentExecutor {
                 // child agents and local third-party harness children need
                 // parent_run_id here because their run is spawned before that
                 // first child request exists.
-                (StartAgentExecutionMode::Local { harness_type: None }, None)
+                (
+                    StartAgentExecutionMode::Local {
+                        harness_type: None,
+                        model_id,
+                    },
+                    None,
+                )
             }
             StartAgentExecutionMode::Local {
                 harness_type: Some(harness_type),
+                model_id,
             } => {
                 let Some(harness) = Harness::parse_local_child_harness(&harness_type) else {
                     return ActionExecution::Sync(AIAgentActionResultType::StartAgent(
@@ -282,6 +315,7 @@ impl StartAgentExecutor {
                 (
                     StartAgentExecutionMode::Local {
                         harness_type: Some(harness.to_string()),
+                        model_id,
                     },
                     Some(parent_run_id),
                 )
@@ -357,13 +391,18 @@ impl StartAgentExecutor {
         };
 
         let (sender, receiver) = async_channel::bounded(1);
-        self.pending = Some(PendingStartAgent {
-            parent_conversation_id,
-            child_conversation_id: None,
-            sender,
-        });
+        let request_id = self.next_request_id();
+        self.pending.insert(
+            request_id,
+            PendingStartAgent {
+                parent_conversation_id,
+                child_conversation_id: None,
+                sender,
+            },
+        );
 
         ctx.emit(StartAgentExecutorEvent::CreateAgent(StartAgentRequest {
+            id: request_id,
             name: name.clone(),
             prompt,
             execution_mode,
@@ -374,13 +413,13 @@ impl StartAgentExecutor {
 
         ActionExecution::new_async(async move { receiver.recv().await }, move |result, _ctx| {
             match result {
-                Ok(StartAgentDecision::Started { agent_id }) => {
+                Ok(StartAgentOutcome::Started { agent_id }) => {
                     AIAgentActionResultType::StartAgent(StartAgentResult::Success {
                         agent_id,
                         version,
                     })
                 }
-                Ok(StartAgentDecision::Error(error)) => {
+                Ok(StartAgentOutcome::Error(error)) => {
                     AIAgentActionResultType::StartAgent(StartAgentResult::Error { error, version })
                 }
                 Err(_) => {
@@ -388,6 +427,41 @@ impl StartAgentExecutor {
                 }
             }
         })
+    }
+
+    /// Dispatch a pre-validated StartAgent request. Returns a receiver
+    /// for the resulting [`StartAgentOutcome`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn dispatch(
+        &mut self,
+        name: String,
+        prompt: String,
+        execution_mode: StartAgentExecutionMode,
+        lifecycle_subscription: Option<Vec<LifecycleEventType>>,
+        parent_conversation_id: AIConversationId,
+        parent_run_id: Option<String>,
+        ctx: &mut ModelContext<Self>,
+    ) -> async_channel::Receiver<StartAgentOutcome> {
+        let (sender, receiver) = async_channel::bounded(1);
+        let request_id = self.next_request_id();
+        self.pending.insert(
+            request_id,
+            PendingStartAgent {
+                parent_conversation_id,
+                child_conversation_id: None,
+                sender,
+            },
+        );
+        ctx.emit(StartAgentExecutorEvent::CreateAgent(StartAgentRequest {
+            id: request_id,
+            name,
+            prompt,
+            execution_mode,
+            lifecycle_subscription,
+            parent_conversation_id,
+            parent_run_id,
+        }));
+        receiver
     }
 
     pub(super) fn preprocess_action(

--- a/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
@@ -9,6 +9,8 @@ use crate::ai::blocklist::BlocklistAIHistoryModel;
 use ai::agent::action_result::StartAgentVersion;
 use warp_core::features::FeatureFlag;
 use warpui::{App, EntityId};
+
+const FIRST_REQUEST_ID: StartAgentRequestId = StartAgentRequestId::from_raw_for_test(0);
 fn build_start_agent_action(
     version: StartAgentVersion,
     execution_mode: StartAgentExecutionMode,
@@ -68,12 +70,20 @@ fn execute_returns_error_when_child_startup_is_blocked_before_initialization() {
             )
         });
 
+        history_model.update(&mut app, |model, ctx| {
+            model.record_new_conversation_request_complete(
+                FIRST_REQUEST_ID,
+                child_conversation_id,
+                ctx,
+            );
+        });
+
         executor.read(&app, |executor, _| {
             assert_eq!(
                 executor
                     .pending
-                    .as_ref()
-                    .and_then(|pending| pending.child_conversation_id),
+                    .values()
+                    .find_map(|pending| pending.child_conversation_id),
                 Some(child_conversation_id)
             );
         });
@@ -102,7 +112,7 @@ fn execute_returns_error_when_child_startup_is_blocked_before_initialization() {
         ));
 
         executor.read(&app, |executor, _| {
-            assert!(executor.pending.is_none());
+            assert!(executor.pending.is_empty());
         });
     });
 }
@@ -146,6 +156,14 @@ fn execute_returns_detailed_error_when_child_startup_fails_before_initialization
                 parent_conversation_id,
                 ctx,
             )
+        });
+
+        history_model.update(&mut app, |model, ctx| {
+            model.record_new_conversation_request_complete(
+                FIRST_REQUEST_ID,
+                child_conversation_id,
+                ctx,
+            );
         });
 
         history_model.update(&mut app, |history_model, ctx| {
@@ -277,6 +295,171 @@ fn execute_returns_error_when_local_harness_child_missing_parent_run_id() {
                     == "Local harness child agents require the parent run_id to be available."
                     && version == StartAgentVersion::V2
         ));
+    });
+}
+
+#[test]
+fn parallel_dispatch_keeps_two_pendings_distinguishable_by_request_id() {
+    App::test((), |mut app| async move {
+        let _orchestration_v2 = FeatureFlag::OrchestrationV2.override_enabled(true);
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let executor = app.add_model(StartAgentExecutor::new);
+        let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+        });
+
+        let action_a = build_start_agent_action(
+            StartAgentVersion::V1,
+            StartAgentExecutionMode::local_with_defaults(),
+        );
+        let action_b = build_start_agent_action(
+            StartAgentVersion::V1,
+            StartAgentExecutionMode::local_with_defaults(),
+        );
+        executor.update(&mut app, |executor, ctx| {
+            let _: AnyActionExecution = executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action_a,
+                        conversation_id: parent_conversation_id,
+                    },
+                    ctx,
+                )
+                .into();
+            let _: AnyActionExecution = executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action_b,
+                        conversation_id: parent_conversation_id,
+                    },
+                    ctx,
+                )
+                .into();
+        });
+
+        executor.read(&app, |executor, _| {
+            assert_eq!(executor.pending.len(), 2, "both pendings should be live");
+            assert!(executor.pending.contains_key(&FIRST_REQUEST_ID));
+            assert!(executor
+                .pending
+                .contains_key(&StartAgentRequestId::from_raw_for_test(1)));
+        });
+    });
+}
+
+#[test]
+fn parallel_pendings_each_resolve_independently_via_recorded_child_id() {
+    App::test((), |mut app| async move {
+        let _orchestration_v2 = FeatureFlag::OrchestrationV2.override_enabled(true);
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let executor = app.add_model(StartAgentExecutor::new);
+        let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+        });
+
+        let action_a = build_start_agent_action(
+            StartAgentVersion::V1,
+            StartAgentExecutionMode::local_with_defaults(),
+        );
+        let action_b = build_start_agent_action(
+            StartAgentVersion::V1,
+            StartAgentExecutionMode::local_with_defaults(),
+        );
+        let exec_a = executor.update(&mut app, |executor, ctx| {
+            let result: AnyActionExecution = executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action_a,
+                        conversation_id: parent_conversation_id,
+                    },
+                    ctx,
+                )
+                .into();
+            result
+        });
+        let exec_b = executor.update(&mut app, |executor, ctx| {
+            let result: AnyActionExecution = executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action_b,
+                        conversation_id: parent_conversation_id,
+                    },
+                    ctx,
+                )
+                .into();
+            result
+        });
+        let (
+            AnyActionExecution::Async {
+                execute_future: future_a,
+                on_complete: complete_a,
+            },
+            AnyActionExecution::Async {
+                execute_future: future_b,
+                on_complete: complete_b,
+            },
+        ) = (exec_a, exec_b)
+        else {
+            panic!("expected async executions");
+        };
+
+        let child_a = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "Agent A".to_string(),
+                parent_conversation_id,
+                ctx,
+            )
+        });
+        let child_b = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "Agent B".to_string(),
+                parent_conversation_id,
+                ctx,
+            )
+        });
+
+        history_model.update(&mut app, |model, ctx| {
+            model.record_new_conversation_request_complete(FIRST_REQUEST_ID, child_a, ctx);
+            model.record_new_conversation_request_complete(
+                StartAgentRequestId::from_raw_for_test(1),
+                child_b,
+                ctx,
+            );
+        });
+
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status_with_error_message(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Error,
+                Some("Agent B init failed".to_string()),
+                ctx,
+            );
+        });
+
+        let async_b = future_b.await;
+        let result_b = app.update(|ctx| complete_b(async_b, ctx));
+        assert!(matches!(
+            result_b,
+            AIAgentActionResultType::StartAgent(StartAgentResult::Error { error, .. })
+                if error == "Agent B init failed"
+        ));
+
+        executor.read(&app, |executor, _| {
+            assert_eq!(
+                executor.pending.len(),
+                1,
+                "only child_b's pending should have been removed"
+            );
+            assert!(executor.pending.contains_key(&FIRST_REQUEST_ID));
+        });
+
+        drop(future_a);
+        drop(complete_a);
     });
 }
 

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -263,6 +263,48 @@ impl OrchestrationPillBar {
     }
 }
 
+/// Renders a non-interactive agent pill using the same deterministic-color
+/// + initial-letter avatar as the live pill bar.
+pub fn render_static_agent_pill(name: &str, app: &AppContext) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+    let avatar_color = pill_avatar_color(name, theme);
+    let avatar_glyph = AvatarGlyph::Letter(pill_initial(name));
+    let avatar = render_avatar_disc(avatar_color, avatar_glyph, theme, appearance);
+    let label_text = Text::new(
+        name.to_string(),
+        appearance.ui_font_family(),
+        appearance.monospace_font_size() - 1.,
+    )
+    .with_color(internal_colors::text_main(theme, theme.background()))
+    .soft_wrap(false)
+    .with_clip(ClipConfig::ellipsis())
+    .finish();
+
+    let row = Flex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_main_axis_size(MainAxisSize::Min)
+        .with_spacing(6.)
+        .with_child(avatar)
+        .with_child(
+            ConstrainedBox::new(label_text)
+                .with_max_width(PILL_LABEL_MAX_WIDTH)
+                .finish(),
+        )
+        .finish();
+
+    ConstrainedBox::new(
+        Container::new(row)
+            .with_padding_left(PILL_HORIZONTAL_PADDING_LEFT)
+            .with_padding_right(PILL_HORIZONTAL_PADDING_RIGHT)
+            .with_background_color(internal_colors::fg_overlay_2(theme).into())
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(PILL_RADIUS)))
+            .finish(),
+    )
+    .with_height(PILL_HEIGHT)
+    .finish()
+}
+
 /// Returns the label to use for the orchestrator pill. Prefers the explicitly
 /// set agent name, falling back to "Orchestrator" so the pill is meaningful
 /// even before any naming has happened.

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -87,6 +87,9 @@ use crate::ai::blocklist::inline_action::ask_user_question_view::{
 use crate::ai::blocklist::inline_action::aws_bedrock_credentials_error::{
     AwsBedrockCredentialsErrorEvent, AwsBedrockCredentialsErrorView,
 };
+use crate::ai::blocklist::inline_action::run_agents_card_view::{
+    self, RunAgentsCardView, RunAgentsCardViewEvent,
+};
 use crate::ai::blocklist::inline_action::search_codebase::{
     SearchCodebaseView, SearchCodebaseViewEvent,
 };
@@ -181,7 +184,7 @@ use crate::terminal::{ShellLaunchData, TerminalView};
 use crate::view_components::DismissibleToast;
 use crate::workspace::{ForkAIConversationParams, ForkedConversationDestination, WorkspaceAction};
 use crate::{report_error, report_if_error, ToastStack};
-use ai::agent::action::{AskUserQuestionItem, InsertReviewComment};
+use ai::agent::action::{AskUserQuestionItem, InsertReviewComment, RunAgentsRequest};
 
 use crate::editor::InteractionState;
 use crate::server::telemetry::{AutonomySettingToggleSource, InteractionSource};
@@ -265,6 +268,7 @@ pub fn init(app: &mut AppContext) {
     ask_user_question_view::init(app);
     code_diff_view::init(app);
     requested_command::init(app);
+    run_agents_card_view::init(app);
     cli::init(app);
 }
 
@@ -934,6 +938,9 @@ pub struct AIBlock {
     imported_comments: HashMap<AIAgentActionId, ImportedCommentGroup>,
     has_imported_comments: bool,
 
+    /// Per-action `RunAgentsCardView`, lazily created.
+    run_agents_card_views: HashMap<AIAgentActionId, ViewHandle<RunAgentsCardView>>,
+
     /// Handle for the background link detection task, kept so we can abort a previous
     /// detection when a new one is spawned (e.g. on shell data change).
     link_detection_handle: Option<SpawnedFutureHandle>,
@@ -1351,6 +1358,7 @@ impl AIBlock {
             aws_bedrock_credentials_error_view: None,
             imported_comments: Default::default(),
             has_imported_comments: false,
+            run_agents_card_views: Default::default(),
             link_detection_handle: None,
             #[cfg(feature = "local_fs")]
             resolved_code_block_paths: Default::default(),
@@ -1861,6 +1869,10 @@ impl AIBlock {
                     .read_from_skill_button_handles
                     .entry(action.id.clone())
                     .or_default();
+            }
+
+            if let AIAgentActionType::RunAgents(req) = &action.action {
+                self.ensure_run_agents_card_view(&action.id, req, ctx);
             }
 
             // Ensure a button component exists for UseComputer actions.
@@ -4456,6 +4468,14 @@ impl AIBlock {
         {
             ctx.focus(ask_user_question_view);
             did_focus_subview = true;
+        } else if let Some(card_view) =
+            pending_action_id.and_then(|id| self.run_agents_card_views.get(id))
+        {
+            // If there's a blocking RunAgents card, focus it so its
+            // own keybindings (`enter -> Accept`, `cmdorctrl-e ->
+            // ToggleEdit`, etc.) resolve.
+            ctx.focus(card_view);
+            did_focus_subview = true;
         } else if let Some(keyboard_navigable_buttons) = self.keyboard_navigable_buttons.as_ref() {
             // If there's buttons to take action on, focus those.
             ctx.focus(keyboard_navigable_buttons);
@@ -5836,9 +5856,34 @@ impl TypedActionView for AIBlock {
                 self.cancel_action(action_id, ctx);
             }
             AIBlockAction::ExecuteNextPendingAction => {
-                self.action_model.update(ctx, |action_model, ctx| {
-                    action_model.execute_next_action_for_user(self.conversation_id(), ctx)
-                });
+                // If the next pending action is a RunAgents tool call,
+                // delegate to the per-card view's Accept handler so
+                // Enter routes through the executor-backed dispatch
+                // path. (Focus normally goes to the card view via
+                // `focus_subview_if_necessary`, in which case the
+                // card's own keybinding fires; this handler covers
+                // the case where focus is still on AIBlock.)
+                let run_agents_id = self
+                    .action_model
+                    .as_ref(ctx)
+                    .get_pending_actions_for_conversation(&self.client_ids.conversation_id)
+                    .filter(|action| matches!(action.action, AIAgentActionType::RunAgents(_)))
+                    .last()
+                    .map(|action| action.id.clone());
+                if let Some(run_agents_id) = run_agents_id {
+                    if let Some(card_view) = self.run_agents_card_views.get(&run_agents_id).cloned()
+                    {
+                        card_view.update(ctx, |view, ctx_view| view.accept(ctx_view));
+                    } else {
+                        log::warn!(
+                            "ExecuteNextPendingAction: no RunAgentsCardView for {run_agents_id:?}"
+                        );
+                    }
+                } else {
+                    self.action_model.update(ctx, |action_model, ctx| {
+                        action_model.execute_next_action_for_user(self.conversation_id(), ctx)
+                    });
+                }
             }
             AIBlockAction::ExecuteRequestedAction { action_id } => {
                 self.action_model.update(ctx, |action_model, ctx| {
@@ -6395,6 +6440,54 @@ impl TypedActionView for AIBlock {
     }
 }
 
+impl AIBlock {
+    /// Lazily create the per-action `RunAgentsCardView` so the
+    /// orchestrate confirmation card can render on its first frame.
+    /// Idempotent: re-running with an already-populated entry leaves
+    /// it unchanged. The view drives Accept dispatch through
+    /// [`BlocklistAIActionModel::execute_run_agents`] itself; only
+    /// `RejectRequested` flows back here so the existing
+    /// [`Self::cancel_action`] entry point handles cancellation.
+    fn ensure_run_agents_card_view(
+        &mut self,
+        action_id: &AIAgentActionId,
+        request: &RunAgentsRequest,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if let Some(existing_view) = self.run_agents_card_views.get(action_id) {
+            // The view was created on an earlier streaming chunk that may
+            // have carried a partial/empty request. Re-sync the edit state
+            // from the latest (potentially more complete) request so the
+            // card renders the correct agent count, summary, etc.
+            existing_view.update(ctx, |view, ctx| {
+                view.update_request(request, ctx);
+            });
+            return;
+        }
+        let action_id_clone = action_id.clone();
+        let request_clone = request.clone();
+        let action_model = self.action_model.clone();
+        let run_agents_executor = self.action_model.as_ref(ctx).run_agents_executor(ctx);
+        let block_model = self.model.clone();
+        let view = ctx.add_typed_action_view(move |ctx_view| {
+            RunAgentsCardView::new(
+                action_id_clone,
+                &request_clone,
+                action_model,
+                run_agents_executor,
+                block_model,
+                ctx_view,
+            )
+        });
+        let action_id_for_event = action_id.clone();
+        ctx.subscribe_to_view(&view, move |me, _, event, ctx| match event {
+            RunAgentsCardViewEvent::RejectRequested => {
+                me.cancel_action(&action_id_for_event, ctx);
+            }
+        });
+        self.run_agents_card_views.insert(action_id.clone(), view);
+    }
+}
 #[cfg(test)]
 #[path = "block_tests.rs"]
 mod tests;

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -1108,6 +1108,7 @@ impl View for AIBlock {
                     .aws_bedrock_credentials_error_view
                     .as_ref(),
                 imported_comments: &self.imported_comments,
+                run_agents_card_views: &self.run_agents_card_views,
                 #[cfg(feature = "local_fs")]
                 resolved_code_block_paths: &self.resolved_code_block_paths,
                 #[cfg(feature = "local_fs")]

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -134,6 +134,7 @@ pub const LOAD_OUTPUT_MESSAGE: &str = "Warping...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_ADJUSTING: &str = "Adjusting tasks...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_PASSIVE_CODE_GEN: &str = "Generating fix...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_CREATING_DIFF: &str = "Creating diff...";
+pub const LOAD_OUTPUT_MESSAGE_FOR_RUN_AGENTS: &str = "Spawning agents...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_PREPARING_QUESTION: &str = "Preparing question...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_GENERATING_PLAN: &str = "Generating plan...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_UPDATING_PLAN: &str = "Updating plan...";
@@ -246,6 +247,19 @@ pub fn render_warping_indicator<V: View>(
         })
     });
 
+    let is_last_message_run_agents = output_to_render.as_ref().is_some_and(|output| {
+        let output = output.get();
+        output.messages.last().is_some_and(|m| {
+            matches!(
+                m.message,
+                AIAgentOutputMessageType::Action(AIAgentAction {
+                    action: AIAgentActionType::RunAgents(_),
+                    ..
+                })
+            )
+        })
+    });
+
     let is_last_message_asking_user_question = output_to_render.as_ref().is_some_and(|output| {
         let output = output.get();
         output.messages.last().is_some_and(|m| {
@@ -331,6 +345,8 @@ pub fn render_warping_indicator<V: View>(
         LOAD_OUTPUT_MESSAGE_FOR_PASSIVE_CODE_GEN.to_string()
     } else if is_last_message_requesting_file_edits {
         LOAD_OUTPUT_MESSAGE_FOR_CREATING_DIFF.to_string()
+    } else if is_last_message_run_agents && FeatureFlag::RunAgentsTool.is_enabled() {
+        LOAD_OUTPUT_MESSAGE_FOR_RUN_AGENTS.to_string()
     } else if is_last_message_asking_user_question {
         LOAD_OUTPUT_MESSAGE_FOR_PREPARING_QUESTION.to_string()
     } else if is_searching_web {

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -127,6 +127,7 @@ use super::{
     render_citation_chips, todos::render_completed_todo_items, WithContentItemSpacing,
     CONTENT_ITEM_VERTICAL_MARGIN,
 };
+use crate::ai::blocklist::inline_action::run_agents_card_view::RunAgentsCardView;
 use warpui::{
     elements::{
         Align, Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment,
@@ -147,11 +148,11 @@ const BLOCKED_ACTION_MESSAGE_FOR_UPLOADING_ARTIFACT: &str = "Grant access to upl
 /// Data required to render the AI block output component.
 #[derive(Copy, Clone)]
 pub(crate) struct Props<'a> {
-    pub(super) model: &'a dyn AIBlockModel<View = AIBlock>,
+    pub(crate) model: &'a dyn AIBlockModel<View = AIBlock>,
     pub(super) state_handles: &'a AIBlockStateHandles,
     pub(super) action_buttons: &'a HashMap<AIAgentActionId, ActionButtons>,
     pub(super) view_screenshot_buttons: &'a HashMap<AIAgentActionId, ui_components::button::Button>,
-    pub(super) action_model: &'a ModelHandle<BlocklistAIActionModel>,
+    pub(crate) action_model: &'a ModelHandle<BlocklistAIActionModel>,
     pub(super) editor_views: &'a [EmbeddedCodeEditorView],
     pub(super) current_working_directory: Option<&'a String>,
     pub(super) shell_launch_data: Option<&'a ShellLaunchData>,
@@ -192,6 +193,12 @@ pub(crate) struct Props<'a> {
     pub(super) aws_bedrock_credentials_error_view:
         Option<&'a ViewHandle<AwsBedrockCredentialsErrorView>>,
     pub(super) imported_comments: &'a HashMap<AIAgentActionId, ImportedCommentGroup>,
+    /// Per-orchestrate-action card view. Each `RunAgentsCardView` owns
+    /// its own edit state, button + picker handles, and in-flight
+    /// spawning snapshot; AIBlock just lazily creates the view per
+    /// `AIAgentActionId` and embeds it via `ChildView` when the action
+    /// is rendered. Multi-card lifecycle = AIBlock lifecycle.
+    pub(crate) run_agents_card_views: &'a HashMap<AIAgentActionId, ViewHandle<RunAgentsCardView>>,
     #[cfg(feature = "local_fs")]
     pub(crate) resolved_code_block_paths:
         &'a HashMap<std::path::PathBuf, Option<std::path::PathBuf>>,
@@ -767,6 +774,25 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                                 &output_message.id,
                                 app,
                             ));
+                        }
+                        AIAgentOutputMessageType::Action(AIAgentAction {
+                            action: AIAgentActionType::RunAgents(_req),
+                            id,
+                            ..
+                        }) if FeatureFlag::RunAgentsTool.is_enabled() => {
+                            // Embed the per-action `RunAgentsCardView`
+                            // via `ChildView`. The view itself handles
+                            // the streaming gate and in-flight dispatch
+                            // states (a card is mid-dispatch when its
+                            // `is_spawning()` getter returns true).
+                            should_render_footer = false;
+                            should_render_suggestions = false;
+                            if let Some(card_view) = props.run_agents_card_views.get(id) {
+                                let is_spawning = card_view.as_ref(app).is_spawning();
+                                if !status.is_streaming() || is_spawning {
+                                    output_items.add_child(ChildView::new(card_view).finish());
+                                }
+                            }
                         }
                         AIAgentOutputMessageType::Action(AIAgentAction {
                             action:

--- a/app/src/ai/blocklist/block_tests.rs
+++ b/app/src/ai/blocklist/block_tests.rs
@@ -1,7 +1,14 @@
 use super::{CollapsibleElementState, CollapsibleExpansionState};
+use crate::ai::agent::StartAgentExecutionMode;
+use crate::ai::blocklist::action_model::{
+    compose_run_agents_child_prompt, run_agents_to_start_agent_mode,
+};
 use crate::settings::AISettings;
 use crate::test_util::settings::initialize_settings_for_tests;
+use ai::agent::action::{RunAgentsAgentRunConfig, RunAgentsExecutionMode};
+use ai::skills::SkillReference;
 use settings::Setting;
+use std::path::PathBuf;
 use warpui::{App, SingletonEntity};
 
 #[test]
@@ -84,4 +91,121 @@ fn manual_reexpand_while_streaming_stays_expanded_after_finish() {
             }
         ));
     });
+}
+
+#[test]
+fn compose_child_prompt_concatenates_when_both_non_empty() {
+    let composed = compose_run_agents_child_prompt("base", "do X");
+    assert_eq!(composed, "base\n\ndo X");
+}
+
+#[test]
+fn compose_child_prompt_uses_base_only_when_per_agent_empty() {
+    let composed = compose_run_agents_child_prompt("base", "");
+    assert_eq!(composed, "base");
+}
+
+#[test]
+fn compose_child_prompt_uses_per_agent_only_when_base_empty() {
+    let composed = compose_run_agents_child_prompt("", "do X");
+    assert_eq!(composed, "do X");
+}
+
+#[test]
+fn compose_child_prompt_returns_empty_when_both_empty() {
+    let composed = compose_run_agents_child_prompt("", "");
+    assert_eq!(composed, "");
+}
+
+#[test]
+fn compose_child_prompt_treats_whitespace_only_base_as_empty() {
+    let composed = compose_run_agents_child_prompt("   \n", "do X");
+    assert_eq!(composed, "do X");
+}
+
+fn agent_cfg() -> RunAgentsAgentRunConfig {
+    RunAgentsAgentRunConfig {
+        name: "child".to_string(),
+        prompt: "do X".to_string(),
+        title: "Child".to_string(),
+    }
+}
+
+#[test]
+fn remote_arm_propagates_skills_into_skill_references() {
+    let skills = vec![
+        SkillReference::BundledSkillId("writing-pr-descriptions".to_string()),
+        SkillReference::Path(PathBuf::from("/tmp/skill/SKILL.md")),
+    ];
+    let mode = run_agents_to_start_agent_mode(
+        &RunAgentsExecutionMode::Remote {
+            environment_id: "env-1".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: true,
+        },
+        "oz",
+        "auto",
+        &skills,
+        &agent_cfg(),
+    )
+    .expect("Remote+oz must convert");
+    let StartAgentExecutionMode::Remote {
+        skill_references,
+        environment_id,
+        worker_host,
+        harness_type,
+        model_id,
+        computer_use_enabled,
+        title,
+    } = mode
+    else {
+        panic!("expected Remote start-agent mode");
+    };
+    assert_eq!(skill_references, skills);
+    assert_eq!(environment_id, "env-1");
+    assert_eq!(worker_host, "warp");
+    assert_eq!(harness_type, "oz");
+    assert_eq!(model_id, "auto");
+    assert!(computer_use_enabled);
+    assert_eq!(title, "Child");
+}
+
+#[test]
+fn remote_arm_with_empty_skills_propagates_empty_vec() {
+    let mode = run_agents_to_start_agent_mode(
+        &RunAgentsExecutionMode::Remote {
+            environment_id: "env-1".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: false,
+        },
+        "claude",
+        "auto",
+        &[],
+        &agent_cfg(),
+    )
+    .expect("Remote+claude must convert");
+    let StartAgentExecutionMode::Remote {
+        skill_references, ..
+    } = mode
+    else {
+        panic!("expected Remote start-agent mode");
+    };
+    assert!(skill_references.is_empty());
+}
+
+#[test]
+fn remote_arm_rejects_opencode() {
+    let err = run_agents_to_start_agent_mode(
+        &RunAgentsExecutionMode::Remote {
+            environment_id: "env-1".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: false,
+        },
+        "opencode",
+        "auto",
+        &[],
+        &agent_cfg(),
+    )
+    .expect_err("Remote+opencode must be rejected");
+    assert!(err.to_lowercase().contains("opencode"));
 }

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -2204,6 +2204,13 @@ pub enum BlocklistAIHistoryEvent {
         conversation_id: AIConversationId,
         terminal_view_id: EntityId,
     },
+
+    /// Links an executor-minted request to a freshly-created
+    /// conversation.
+    NewConversationRequestComplete {
+        request_id: crate::ai::blocklist::StartAgentRequestId,
+        conversation_id: AIConversationId,
+    },
 }
 
 impl BlocklistAIHistoryEvent {
@@ -2270,7 +2277,25 @@ impl BlocklistAIHistoryEvent {
             BlocklistAIHistoryEvent::UpdatedConversationMetadata {
                 terminal_view_id, ..
             } => *terminal_view_id,
+            // NewConversationRequestComplete is executor-scoped and has no
+            // terminal_view_id.
+            BlocklistAIHistoryEvent::NewConversationRequestComplete { .. } => None,
         }
+    }
+}
+
+impl BlocklistAIHistoryModel {
+    /// Emits [`BlocklistAIHistoryEvent::NewConversationRequestComplete`].
+    pub fn record_new_conversation_request_complete(
+        &mut self,
+        request_id: crate::ai::blocklist::StartAgentRequestId,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        ctx.emit(BlocklistAIHistoryEvent::NewConversationRequestComplete {
+            request_id,
+            conversation_id,
+        });
     }
 }
 

--- a/app/src/ai/blocklist/inline_action/mod.rs
+++ b/app/src/ai/blocklist/inline_action/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod requested_action;
 pub(crate) mod requested_command;
 pub(crate) mod requested_command_attribution;
 pub(crate) mod requested_script;
+pub(crate) mod run_agents_card_view;
 pub(super) mod search_codebase;
 pub(crate) mod search_results_common;
 pub(crate) mod suggested_unit_tests;

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -1,0 +1,1400 @@
+//! Inline view for the orchestrate (`RunAgents`) confirmation card.
+//!
+//! Each card is a `View` keyed by `AIAgentActionId`, embedded by
+//! `AIBlock` via `ChildView`. Keybindings and Accept dispatch live on
+//! the view; only `RejectRequested` flows back to the parent.
+use ai::agent::action::{RunAgentsAgentRunConfig, RunAgentsExecutionMode, RunAgentsRequest};
+use ai::agent::action_result::{RunAgentsAgentOutcomeKind, RunAgentsResult};
+use ai::skills::SkillReference;
+use pathfinder_color::ColorU;
+use std::rc::Rc;
+use warpui::elements::{
+    Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty,
+    Expanded, Flex, Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement,
+    Radius, Text,
+};
+use warpui::keymap::{FixedBinding, Keystroke};
+use warpui::platform::Cursor;
+use warpui::ui_components::button::ButtonVariant;
+use warpui::ui_components::components::{Coords, UiComponentStyles};
+use warpui::{
+    AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
+    ViewHandle,
+};
+
+use warp_cli::agent::Harness;
+use warp_core::channel::{Channel, ChannelState};
+use warp_core::ui::color::blend::Blend;
+use warp_core::ui::theme::Fill;
+
+use crate::ai::agent::icons;
+use crate::ai::agent::{AIAgentActionId, AIAgentActionResultType};
+use crate::ai::blocklist::action_model::{
+    AIActionStatus, BlocklistAIActionEvent, BlocklistAIActionModel, RunAgentsExecutor,
+    RunAgentsExecutorEvent, RunAgentsSpawningSnapshot,
+};
+use crate::ai::blocklist::agent_view::orchestration_pill_bar::render_static_agent_pill;
+use crate::ai::blocklist::block::model::AIBlockModel;
+use crate::ai::blocklist::block::view_impl::WithContentItemSpacing;
+use crate::ai::blocklist::block::AIBlock;
+use crate::ai::blocklist::inline_action::inline_action_header::{HeaderConfig, InteractionMode};
+use crate::ai::blocklist::inline_action::inline_action_icons;
+use crate::ai::blocklist::inline_action::requested_action::{
+    render_requested_action_row_for_text, CTRL_C_KEYSTROKE, ENTER_KEYSTROKE,
+};
+use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
+use crate::ai::execution_profiles::model_menu_items::available_model_menu_items;
+use crate::ai::harness_display;
+use crate::appearance::Appearance;
+use crate::menu::{MenuItem, MenuItemFields};
+use crate::ui_components::blended_colors;
+use crate::ui_components::icons::Icon;
+use crate::view_components::action_button::{ButtonSize, KeystrokeSource, NakedTheme};
+use crate::view_components::compactible_action_button::{
+    CompactibleActionButton, RenderCompactibleActionButton, MEDIUM_SIZE_SWITCH_THRESHOLD,
+};
+use crate::view_components::compactible_split_action_button::CompactibleSplitActionButton;
+use crate::view_components::dropdown::{Dropdown, DropdownAction, DropdownEvent, DropdownStyle};
+use crate::view_components::{FilterableDropdown, FilterableDropdownEvent};
+use crate::LLMPreferences;
+
+const RUN_AGENTS_WARP_WORKER_HOST: &str = "warp";
+
+const RUN_AGENTS_CARD_TITLE: &str = "Can I add additional agents to this task?";
+
+const RUN_AGENTS_ENV_NONE_LABEL: &str = "(no environment)";
+
+const RUN_AGENTS_EDITOR_OPEN: &str = "RunAgentsEditorOpen";
+
+const RUN_AGENTS_PICKER_HEIGHT: f32 = 36.;
+const RUN_AGENTS_PICKER_BORDER_WIDTH: f32 = 1.;
+const RUN_AGENTS_PICKER_FONT_SIZE: f32 = 14.;
+const ORCHESTRATE_PICKER_RADIUS: f32 = 4.;
+
+pub fn init(app: &mut AppContext) {
+    use warpui::keymap::macros::*;
+
+    app.register_fixed_bindings([
+        FixedBinding::new(
+            "enter",
+            RunAgentsCardViewAction::Accept,
+            id!(RunAgentsCardView::ui_name()),
+        ),
+        FixedBinding::new(
+            "numpadenter",
+            RunAgentsCardViewAction::Accept,
+            id!(RunAgentsCardView::ui_name()),
+        ),
+        FixedBinding::new(
+            "ctrl-c",
+            RunAgentsCardViewAction::Reject,
+            id!(RunAgentsCardView::ui_name()),
+        ),
+        FixedBinding::new(
+            "cmdorctrl-e",
+            RunAgentsCardViewAction::ToggleEdit,
+            id!(RunAgentsCardView::ui_name()),
+        ),
+        // Esc closes the editor; Reject is Ctrl-C.
+        FixedBinding::new(
+            "escape",
+            RunAgentsCardViewAction::DiscardEdits,
+            id!(RunAgentsCardView::ui_name()) & id!(RUN_AGENTS_EDITOR_OPEN),
+        ),
+    ]);
+}
+
+/// Per-action edit state for the orchestrate confirmation card.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunAgentsEditState {
+    pub is_editor_open: bool,
+    pub model_id: String,
+    pub harness_type: String,
+    pub execution_mode: RunAgentsExecutionMode,
+    pub agent_run_configs: Vec<RunAgentsAgentRunConfig>,
+    pub base_prompt: String,
+    pub summary: String,
+    /// Run-wide skills propagated to each child at dispatch.
+    pub skills: Vec<SkillReference>,
+}
+
+impl RunAgentsEditState {
+    pub fn from_request(req: &RunAgentsRequest) -> Self {
+        Self {
+            is_editor_open: false,
+            model_id: req.model_id.clone(),
+            harness_type: req.harness_type.clone(),
+            execution_mode: req.execution_mode.clone(),
+            agent_run_configs: req.agent_run_configs.clone(),
+            base_prompt: req.base_prompt.clone(),
+            summary: req.summary.clone(),
+            skills: req.skills.clone(),
+        }
+    }
+
+    /// Toggle Local <-> Cloud. Resets OpenCode to Oz when switching
+    /// to Cloud (unsupported combination).
+    pub fn toggle_execution_mode_to_remote(&mut self, is_remote: bool) {
+        if is_remote {
+            if self.harness_type.eq_ignore_ascii_case("opencode") {
+                self.harness_type = "oz".to_string();
+            }
+            // TODO(QUALITY-569): expose worker_host as an editable picker.
+            if !self.execution_mode.is_remote() {
+                self.execution_mode = RunAgentsExecutionMode::Remote {
+                    environment_id: String::new(),
+                    worker_host: "warp".to_string(),
+                    computer_use_enabled: false,
+                };
+            }
+        } else {
+            self.execution_mode = RunAgentsExecutionMode::Local;
+        }
+    }
+
+    pub fn set_environment_id(&mut self, environment_id: String) {
+        if let RunAgentsExecutionMode::Remote {
+            environment_id: id, ..
+        } = &mut self.execution_mode
+        {
+            *id = environment_id;
+        }
+    }
+
+    pub fn set_worker_host(&mut self, worker_host: String) {
+        if let RunAgentsExecutionMode::Remote {
+            worker_host: wh, ..
+        } = &mut self.execution_mode
+        {
+            *wh = worker_host;
+        }
+    }
+
+    /// Returns `Some(reason)` if Accept must be disabled.
+    /// Only hard block: OpenCode+Cloud.
+    pub fn accept_disabled_reason(&self) -> Option<&'static str> {
+        match &self.execution_mode {
+            RunAgentsExecutionMode::Remote { .. }
+                if self.harness_type.eq_ignore_ascii_case("opencode") =>
+            {
+                Some(
+                    "OpenCode is not supported on Cloud yet. Switch to Local or pick a different harness.",
+                )
+            }
+            RunAgentsExecutionMode::Local | RunAgentsExecutionMode::Remote { .. } => None,
+        }
+    }
+
+    pub fn to_request(&self) -> RunAgentsRequest {
+        RunAgentsRequest {
+            summary: self.summary.clone(),
+            base_prompt: self.base_prompt.clone(),
+            skills: self.skills.clone(),
+            model_id: self.model_id.clone(),
+            harness_type: self.harness_type.clone(),
+            execution_mode: self.execution_mode.clone(),
+            agent_run_configs: self.agent_run_configs.clone(),
+        }
+    }
+}
+
+/// Per-action UI handles. Picker views are lazily created on first
+/// editor open.
+#[derive(Default, Clone)]
+struct RunAgentsCardHandles {
+    reject_button: Option<CompactibleActionButton>,
+    edit_button: Option<CompactibleActionButton>,
+    accept_button: Option<CompactibleSplitActionButton>,
+    local_toggle: MouseStateHandle,
+    cloud_toggle: MouseStateHandle,
+    model_picker: Option<ViewHandle<Dropdown<RunAgentsCardViewAction>>>,
+    harness_picker: Option<ViewHandle<Dropdown<RunAgentsCardViewAction>>>,
+    environment_picker: Option<ViewHandle<FilterableDropdown<RunAgentsCardViewAction>>>,
+    host_picker: Option<ViewHandle<Dropdown<RunAgentsCardViewAction>>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum RunAgentsCardViewAction {
+    Accept,
+    Reject,
+    ToggleEdit,
+    DiscardEdits,
+    ExecutionModeToggled { is_remote: bool },
+    ModelChanged { model_id: String },
+    HarnessChanged { harness_type: String },
+    EnvironmentChanged { environment_id: String },
+    WorkerHostChanged { worker_host: String },
+}
+
+#[derive(Clone, Debug)]
+pub enum RunAgentsCardViewEvent {
+    RejectRequested,
+}
+
+pub struct RunAgentsCardView {
+    action_id: AIAgentActionId,
+    state: RunAgentsEditState,
+    /// Snapshot of the request as received from the tool call, used to
+    /// reset on "Discard edits".
+    original_request: RunAgentsRequest,
+    handles: RunAgentsCardHandles,
+    spawning: Option<RunAgentsSpawningSnapshot>,
+
+    action_model: ModelHandle<BlocklistAIActionModel>,
+    block_model: Rc<dyn AIBlockModel<View = AIBlock>>,
+}
+
+fn is_opencode_on_remote(request: &RunAgentsRequest) -> bool {
+    matches!(
+        request.execution_mode,
+        RunAgentsExecutionMode::Remote { .. }
+    ) && request.harness_type.eq_ignore_ascii_case("opencode")
+}
+
+impl RunAgentsCardView {
+    pub fn new(
+        action_id: AIAgentActionId,
+        request: &RunAgentsRequest,
+        action_model: ModelHandle<BlocklistAIActionModel>,
+        run_agents_executor: ModelHandle<RunAgentsExecutor>,
+        block_model: Rc<dyn AIBlockModel<View = AIBlock>>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        let reject_keystroke = CTRL_C_KEYSTROKE.clone();
+        let edit_keystroke =
+            Keystroke::parse("cmdorctrl-e").expect("orchestrate edit keystroke literal must parse");
+        let accept_keystroke = ENTER_KEYSTROKE.clone();
+
+        let reject_button = CompactibleActionButton::new(
+            "Reject".to_string(),
+            Some(KeystrokeSource::Fixed(reject_keystroke)),
+            ButtonSize::Small,
+            RunAgentsCardViewAction::Reject,
+            Icon::X,
+            std::sync::Arc::new(NakedTheme),
+            ctx,
+        );
+        let edit_button = CompactibleActionButton::new(
+            "Edit".to_string(),
+            Some(KeystrokeSource::Fixed(edit_keystroke)),
+            ButtonSize::Small,
+            RunAgentsCardViewAction::ToggleEdit,
+            Icon::Pencil,
+            std::sync::Arc::new(NakedTheme),
+            ctx,
+        );
+        // Both primary and chevron click route to Accept.
+        let accept_button = CompactibleSplitActionButton::new(
+            "Accept".to_string(),
+            Some(KeystrokeSource::Fixed(accept_keystroke)),
+            ButtonSize::Small,
+            RunAgentsCardViewAction::Accept,
+            RunAgentsCardViewAction::Accept,
+            Icon::Check,
+            true,
+            None,
+            ctx,
+        );
+
+        let action_id_for_subscription = action_id.clone();
+        ctx.subscribe_to_model(&run_agents_executor, move |me, _, event, ctx| match event {
+            RunAgentsExecutorEvent::SpawningStarted {
+                action_id,
+                snapshot,
+            } if action_id == &action_id_for_subscription => {
+                me.spawning = Some(*snapshot);
+                ctx.notify();
+            }
+            RunAgentsExecutorEvent::SpawningFinished { action_id }
+                if action_id == &action_id_for_subscription =>
+            {
+                me.spawning = None;
+                ctx.notify();
+            }
+            RunAgentsExecutorEvent::SpawningStarted { .. }
+            | RunAgentsExecutorEvent::SpawningFinished { .. } => {}
+        });
+
+        // Re-render when this action finishes (e.g. cancelled via
+        // Ctrl+C at the terminal level) so render() picks up the
+        // Finished status from the action model.
+        let action_id_for_finished = action_id.clone();
+        ctx.subscribe_to_model(&action_model, move |_, _, event, ctx| {
+            if let BlocklistAIActionEvent::FinishedAction { action_id, .. } = event {
+                if action_id == &action_id_for_finished {
+                    ctx.notify();
+                }
+            }
+        });
+
+        Self {
+            action_id,
+            state: RunAgentsEditState::from_request(request),
+            original_request: request.clone(),
+            handles: RunAgentsCardHandles {
+                reject_button: Some(reject_button),
+                edit_button: Some(edit_button),
+                accept_button: Some(accept_button),
+                ..Default::default()
+            },
+            spawning: None,
+            action_model,
+            block_model,
+        }
+    }
+
+    pub fn is_spawning(&self) -> bool {
+        self.spawning.is_some()
+    }
+
+    /// Re-sync edit state from the latest streaming request.
+    /// No-op when the editor is open (user edits take precedence).
+    pub fn update_request(&mut self, request: &RunAgentsRequest, ctx: &mut ViewContext<Self>) {
+        if self.state.is_editor_open || self.spawning.is_some() {
+            return;
+        }
+        let new_state = RunAgentsEditState::from_request(request);
+        if self.state != new_state {
+            self.state = new_state;
+            self.original_request = request.clone();
+            ctx.notify();
+        }
+    }
+
+    /// Validates and dispatches the resolved request.
+    pub fn accept(&mut self, ctx: &mut ViewContext<Self>) {
+        self.handle_accept(ctx);
+    }
+
+    fn handle_accept(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.spawning.is_some() {
+            return;
+        }
+        let request = self.state.to_request();
+        if is_opencode_on_remote(&request) {
+            log::warn!(
+                "RunAgentsCardView: refusing Accept for OpenCode+Cloud (unsupported per spec)"
+            );
+            return;
+        }
+        // Close the editor before dispatching.
+        if self.state.is_editor_open {
+            self.state.is_editor_open = false;
+            self.sync_card_buttons(ctx);
+        }
+        let action_id = self.action_id.clone();
+        self.action_model.update(ctx, |action_model, action_ctx| {
+            action_model.execute_run_agents(&action_id, request, action_ctx);
+        });
+    }
+
+    fn handle_toggle_edit(&mut self, ctx: &mut ViewContext<Self>) {
+        self.state.is_editor_open = !self.state.is_editor_open;
+
+        // Lazily build picker views on first editor open.
+        if self.state.is_editor_open {
+            self.ensure_pickers(ctx);
+        }
+
+        self.sync_card_buttons(ctx);
+        ctx.notify();
+    }
+
+    /// Swap Edit ↔ "Discard edits" label/keystroke.
+    fn sync_card_buttons(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(edit_button) = self.handles.edit_button.as_mut() else {
+            return;
+        };
+        let (label, keystroke) = if self.state.is_editor_open {
+            (
+                "Discard edits".to_string(),
+                Keystroke::parse("escape")
+                    .expect("orchestrate discard-edits keystroke literal must parse"),
+            )
+        } else {
+            (
+                "Edit".to_string(),
+                Keystroke::parse("cmdorctrl-e")
+                    .expect("orchestrate edit keystroke literal must parse"),
+            )
+        };
+        edit_button.set_label(label, ctx);
+        edit_button.set_keybinding(Some(KeystrokeSource::Fixed(keystroke)), ctx);
+    }
+
+    /// Lazily construct the picker dropdown views (idempotent).
+    fn ensure_pickers(&mut self, ctx: &mut ViewContext<Self>) {
+        // Shared picker styling.
+        let picker_padding = Coords {
+            top: 8.,
+            bottom: 8.,
+            left: 12.,
+            right: 12.,
+        };
+        let picker_corner_radius =
+            CornerRadius::with_all(Radius::Pixels(ORCHESTRATE_PICKER_RADIUS));
+        let theme = Appearance::as_ref(ctx).theme();
+        // The picker bg is a translucent overlay (surface_overlay_1 =
+        // fg at 5%). Composite it against the card background to derive
+        // opaque border and text colors that work on any theme.
+        let picker_background_theme: Fill = theme.surface_overlay_1();
+        let composited_bg = theme
+            .background()
+            .blend(&picker_background_theme)
+            .into_solid();
+        let picker_border_color_warpui: warpui::elements::Fill = theme.surface_2().into();
+        let picker_font_color = blended_colors::text_main(theme, composited_bg);
+        let picker_background_warpui: warpui::elements::Fill = picker_background_theme.into();
+        let picker_styles = UiComponentStyles {
+            height: Some(RUN_AGENTS_PICKER_HEIGHT),
+            background: Some(picker_background_warpui),
+            border_color: Some(picker_border_color_warpui),
+            border_width: Some(RUN_AGENTS_PICKER_BORDER_WIDTH),
+            border_radius: Some(picker_corner_radius),
+            font_size: Some(RUN_AGENTS_PICKER_FONT_SIZE),
+            font_color: Some(picker_font_color),
+            padding: Some(picker_padding),
+            ..Default::default()
+        };
+
+        let initial_model_id_default = self
+            .block_model
+            .base_model(ctx)
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+        let state_snapshot = self.state.clone();
+
+        if self.handles.model_picker.is_none() {
+            let initial_model_id = if state_snapshot.model_id.trim().is_empty() {
+                initial_model_id_default.clone()
+            } else {
+                state_snapshot.model_id.clone()
+            };
+            let dropdown_handle = Self::new_standard_picker_dropdown(
+                picker_padding,
+                picker_corner_radius,
+                picker_background_warpui,
+                picker_border_color_warpui,
+                picker_font_color,
+                ctx,
+            );
+            dropdown_handle.update(ctx, |dropdown, ctx_dropdown| {
+                let llm_prefs = LLMPreferences::as_ref(ctx_dropdown);
+                let choices: Vec<_> = llm_prefs.get_base_llm_choices_for_agent_mode().collect();
+                let initial_index = choices
+                    .iter()
+                    .position(|llm| llm.id.to_string() == initial_model_id);
+                let items = available_model_menu_items(
+                    choices,
+                    move |llm| {
+                        DropdownAction::SelectActionAndClose(
+                            RunAgentsCardViewAction::ModelChanged {
+                                model_id: llm.id.to_string(),
+                            },
+                        )
+                    },
+                    None,
+                    None,
+                    false,
+                    false,
+                    ctx_dropdown,
+                );
+                dropdown.set_rich_items(items, ctx_dropdown);
+                if let Some(idx) = initial_index {
+                    dropdown.set_selected_by_index(idx, ctx_dropdown);
+                }
+            });
+            Self::subscribe_picker_close(&dropdown_handle, ctx);
+            self.handles.model_picker = Some(dropdown_handle);
+        }
+
+        if self.handles.harness_picker.is_none() {
+            let initial_harness = state_snapshot.harness_type.clone();
+            let dropdown_handle = Self::new_standard_picker_dropdown(
+                picker_padding,
+                picker_corner_radius,
+                picker_background_warpui,
+                picker_border_color_warpui,
+                picker_font_color,
+                ctx,
+            );
+            dropdown_handle.update(ctx, |dropdown, ctx_dropdown| {
+                let mut items: Vec<MenuItem<DropdownAction<RunAgentsCardViewAction>>> = Vec::new();
+                let mut selected_idx = None;
+                // TODO: Re-enable Harness::Gemini once it is supported as
+                // a multi-agent harness (currently causes an infinite
+                // "Spawning agents" hang).
+                for (idx, harness) in [Harness::Oz, Harness::Claude, Harness::Codex]
+                    .into_iter()
+                    .enumerate()
+                {
+                    let mut fields = MenuItemFields::new(harness_display::display_name(harness))
+                        .with_icon(harness_display::icon_for(harness));
+                    if let Some(color) = harness_display::brand_color(harness) {
+                        fields = fields.with_override_icon_color(Fill::from(color));
+                    }
+                    let harness_str = harness.to_string();
+                    fields = fields.with_on_select_action(DropdownAction::SelectActionAndClose(
+                        RunAgentsCardViewAction::HarnessChanged {
+                            harness_type: harness_str.clone(),
+                        },
+                    ));
+                    if harness_str.eq_ignore_ascii_case(&initial_harness) {
+                        selected_idx = Some(idx);
+                    }
+                    items.push(MenuItem::Item(fields));
+                }
+                dropdown.set_rich_items(items, ctx_dropdown);
+                if let Some(idx) = selected_idx {
+                    dropdown.set_selected_by_index(idx, ctx_dropdown);
+                }
+            });
+            Self::subscribe_picker_close(&dropdown_handle, ctx);
+            self.handles.harness_picker = Some(dropdown_handle);
+        }
+
+        if self.handles.environment_picker.is_none() {
+            let initial_env = match &state_snapshot.execution_mode {
+                RunAgentsExecutionMode::Remote { environment_id, .. } => environment_id.clone(),
+                RunAgentsExecutionMode::Local => String::new(),
+            };
+            let picker_styles_clone = picker_styles;
+            let dropdown_handle = ctx.add_typed_action_view(move |ctx_dropdown| {
+                let mut dropdown = FilterableDropdown::<RunAgentsCardViewAction>::new(ctx_dropdown);
+                dropdown.set_use_overlay_layer(false, ctx_dropdown);
+                dropdown.set_main_axis_size(MainAxisSize::Max, ctx_dropdown);
+                dropdown.set_button_variant(ButtonVariant::Secondary);
+                dropdown.set_style(picker_styles_clone);
+                dropdown.set_top_bar_height(RUN_AGENTS_PICKER_HEIGHT, ctx_dropdown);
+                dropdown
+            });
+            dropdown_handle.update(ctx, |dropdown, ctx_dropdown| {
+                dropdown.set_menu_width(280.0, ctx_dropdown);
+                let all_envs = CloudAmbientAgentEnvironment::get_all(ctx_dropdown);
+                let mut sorted_envs: Vec<(String, String)> = all_envs
+                    .iter()
+                    .map(|env| (env.id.uid(), env.model().string_model.name.clone()))
+                    .collect();
+                sorted_envs.sort_by(|a, b| a.1.cmp(&b.1));
+
+                let mut items: Vec<MenuItem<DropdownAction<RunAgentsCardViewAction>>> = Vec::new();
+                let mut selected_name: Option<String> = None;
+                items.push(MenuItem::Item(
+                    MenuItemFields::new(RUN_AGENTS_ENV_NONE_LABEL).with_on_select_action(
+                        DropdownAction::SelectActionAndClose(
+                            RunAgentsCardViewAction::EnvironmentChanged {
+                                environment_id: String::new(),
+                            },
+                        ),
+                    ),
+                ));
+                if initial_env.is_empty() {
+                    selected_name = Some(RUN_AGENTS_ENV_NONE_LABEL.to_string());
+                }
+                for (env_id, env_name) in &sorted_envs {
+                    if env_id == &initial_env {
+                        selected_name = Some(env_name.clone());
+                    }
+                    let env_id_for_item = env_id.clone();
+                    items.push(MenuItem::Item(
+                        MenuItemFields::new(env_name).with_on_select_action(
+                            DropdownAction::SelectActionAndClose(
+                                RunAgentsCardViewAction::EnvironmentChanged {
+                                    environment_id: env_id_for_item,
+                                },
+                            ),
+                        ),
+                    ));
+                }
+                dropdown.set_rich_items(items, ctx_dropdown);
+                if let Some(name) = selected_name {
+                    dropdown.set_selected_by_name(&name, ctx_dropdown);
+                }
+            });
+            ctx.subscribe_to_view(&dropdown_handle, |me, _, event, ctx| {
+                if let FilterableDropdownEvent::Close = event {
+                    me.refocus_after_picker_close(ctx);
+                }
+            });
+            self.handles.environment_picker = Some(dropdown_handle);
+        }
+
+        if self.handles.host_picker.is_none() {
+            let initial_host = match &state_snapshot.execution_mode {
+                RunAgentsExecutionMode::Remote { worker_host, .. } => worker_host.clone(),
+                RunAgentsExecutionMode::Local => RUN_AGENTS_WARP_WORKER_HOST.to_string(),
+            };
+            let dropdown_handle = Self::new_standard_picker_dropdown(
+                picker_padding,
+                picker_corner_radius,
+                picker_background_warpui,
+                picker_border_color_warpui,
+                picker_font_color,
+                ctx,
+            );
+            dropdown_handle.update(ctx, |dropdown, ctx_dropdown| {
+                let hosts: &[&str] = if matches!(ChannelState::channel(), Channel::Local) {
+                    &["warp", "local-dev"]
+                } else {
+                    &["warp"]
+                };
+                let mut items: Vec<MenuItem<DropdownAction<RunAgentsCardViewAction>>> = Vec::new();
+                let mut selected_idx = None;
+                for (idx, &host) in hosts.iter().enumerate() {
+                    let fields = MenuItemFields::new(host).with_on_select_action(
+                        DropdownAction::SelectActionAndClose(
+                            RunAgentsCardViewAction::WorkerHostChanged {
+                                worker_host: host.to_string(),
+                            },
+                        ),
+                    );
+                    if host.eq_ignore_ascii_case(&initial_host) {
+                        selected_idx = Some(idx);
+                    }
+                    items.push(MenuItem::Item(fields));
+                }
+                dropdown.set_rich_items(items, ctx_dropdown);
+                if let Some(idx) = selected_idx {
+                    dropdown.set_selected_by_index(idx, ctx_dropdown);
+                }
+            });
+            Self::subscribe_picker_close(&dropdown_handle, ctx);
+            self.handles.host_picker = Some(dropdown_handle);
+        }
+
+        // Dropdown's internal selection display is unreliable in this
+        // view tree, so we explicitly drive it.
+        self.sync_picker_selections(ctx);
+    }
+
+    /// Shared dropdown construction with the standard orchestrate-card
+    /// styling (border, radius, background, font). Both the model and
+    /// harness pickers use identical chrome; only their item lists differ.
+    fn new_standard_picker_dropdown(
+        padding: Coords,
+        corner_radius: CornerRadius,
+        background: warpui::elements::Fill,
+        border_color: warpui::elements::Fill,
+        font_color: ColorU,
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<Dropdown<RunAgentsCardViewAction>> {
+        ctx.add_typed_action_view(move |ctx_dropdown| {
+            let mut dropdown = Dropdown::<RunAgentsCardViewAction>::new(ctx_dropdown);
+            dropdown.set_use_overlay_layer(false, ctx_dropdown);
+            dropdown.set_main_axis_size(MainAxisSize::Max, ctx_dropdown);
+            dropdown.set_style(DropdownStyle::ActionButtonSecondary, ctx_dropdown);
+            dropdown.set_top_bar_height(RUN_AGENTS_PICKER_HEIGHT, ctx_dropdown);
+            dropdown.set_padding(padding, ctx_dropdown);
+            dropdown.set_border_radius(corner_radius, ctx_dropdown);
+            dropdown.set_background(background, ctx_dropdown);
+            dropdown.set_border_color(border_color, ctx_dropdown);
+            dropdown.set_border_width(RUN_AGENTS_PICKER_BORDER_WIDTH, ctx_dropdown);
+            dropdown.set_font_size(RUN_AGENTS_PICKER_FONT_SIZE, ctx_dropdown);
+            dropdown.set_font_color(font_color, ctx_dropdown);
+            dropdown
+        })
+    }
+
+    fn subscribe_picker_close(
+        dropdown_handle: &ViewHandle<Dropdown<RunAgentsCardViewAction>>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        ctx.subscribe_to_view(dropdown_handle, move |me, _, event, ctx| {
+            if let DropdownEvent::Close = event {
+                me.refocus_after_picker_close(ctx);
+            }
+        });
+    }
+
+    /// Restore focus after a picker dropdown closes.
+    fn refocus_after_picker_close(&self, ctx: &mut ViewContext<Self>) {
+        ctx.focus_self();
+    }
+
+    fn sync_picker_selections(&mut self, ctx: &mut ViewContext<Self>) {
+        let state = self.state.clone();
+        if let Some(model_picker) = self.handles.model_picker.clone() {
+            let target_model_id = state.model_id.clone();
+            model_picker.update(ctx, |dropdown, ctx_dropdown| {
+                let llm_prefs = LLMPreferences::as_ref(ctx_dropdown);
+                let choices: Vec<_> = llm_prefs.get_base_llm_choices_for_agent_mode().collect();
+                if let Some(idx) = choices
+                    .iter()
+                    .position(|llm| llm.id.to_string() == target_model_id)
+                {
+                    dropdown.set_selected_by_index(idx, ctx_dropdown);
+                }
+            });
+        }
+        if let Some(harness_picker) = self.handles.harness_picker.clone() {
+            let target =
+                Harness::parse_orchestration_harness(&state.harness_type).unwrap_or(Harness::Oz);
+            let display = harness_display::display_name(target).to_string();
+            harness_picker.update(ctx, |dropdown, ctx_dropdown| {
+                dropdown.set_selected_by_name(&display, ctx_dropdown);
+            });
+        }
+        if let Some(environment_picker) = self.handles.environment_picker.clone() {
+            let env_id = match &state.execution_mode {
+                RunAgentsExecutionMode::Remote { environment_id, .. } => environment_id.clone(),
+                RunAgentsExecutionMode::Local => String::new(),
+            };
+            environment_picker.update(ctx, |dropdown, ctx_dropdown| {
+                if env_id.is_empty() {
+                    dropdown.set_selected_by_name(RUN_AGENTS_ENV_NONE_LABEL, ctx_dropdown);
+                    return;
+                }
+                let all_envs = CloudAmbientAgentEnvironment::get_all(ctx_dropdown);
+                if let Some(env) = all_envs.iter().find(|e| e.id.uid() == env_id) {
+                    dropdown.set_selected_by_name(&env.model().string_model.name, ctx_dropdown);
+                }
+            });
+        }
+        if let Some(host_picker) = self.handles.host_picker.clone() {
+            let worker_host = match &state.execution_mode {
+                RunAgentsExecutionMode::Remote { worker_host, .. } => worker_host.clone(),
+                RunAgentsExecutionMode::Local => RUN_AGENTS_WARP_WORKER_HOST.to_string(),
+            };
+            host_picker.update(ctx, |dropdown, ctx_dropdown| {
+                dropdown.set_selected_by_name(&worker_host, ctx_dropdown);
+            });
+        }
+    }
+}
+
+impl Entity for RunAgentsCardView {
+    type Event = RunAgentsCardViewEvent;
+}
+
+impl View for RunAgentsCardView {
+    fn ui_name() -> &'static str {
+        "RunAgentsCardView"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let status = self
+            .action_model
+            .as_ref(app)
+            .get_action_status(&self.action_id);
+
+        if let Some(AIActionStatus::Finished(result)) = &status {
+            if let AIAgentActionResultType::RunAgents(orchestrate_result) = &result.result {
+                return render_terminal_state(orchestrate_result, appearance, app);
+            }
+            log::error!(
+                "Unexpected action result type for orchestrate: {:?}",
+                result.result
+            );
+            return Empty::new().finish();
+        }
+
+        // In-flight dispatch: check both spawning snapshot and action
+        // status because the event arrives one tick after the status.
+        if let Some(snapshot) = &self.spawning {
+            return render_spawning_card(snapshot, appearance, app);
+        }
+        if matches!(status, Some(AIActionStatus::RunningAsync)) {
+            let snapshot = RunAgentsSpawningSnapshot {
+                agent_count: self.state.agent_run_configs.len(),
+            };
+            return render_spawning_card(&snapshot, appearance, app);
+        }
+
+        // Restored-from-history: dispatch state is lost, render as
+        // Cancelled.
+        if self.block_model.is_restored() {
+            return render_status_only_card(
+                "Spawn agents cancelled".to_string(),
+                appearance,
+                StatusKind::Cancelled,
+                app,
+            );
+        }
+
+        let is_blocked = matches!(status, Some(AIActionStatus::Blocked));
+        render_confirmation_card(&self.state, &self.handles, is_blocked, app)
+    }
+
+    fn keymap_context(&self, _app: &AppContext) -> warpui::keymap::Context {
+        let mut context = Self::default_keymap_context();
+        if self.state.is_editor_open {
+            context.set.insert(RUN_AGENTS_EDITOR_OPEN);
+        }
+        context
+    }
+}
+
+impl TypedActionView for RunAgentsCardView {
+    type Action = RunAgentsCardViewAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            RunAgentsCardViewAction::Accept => {
+                self.handle_accept(ctx);
+            }
+            RunAgentsCardViewAction::Reject => {
+                ctx.emit(RunAgentsCardViewEvent::RejectRequested);
+            }
+            RunAgentsCardViewAction::ToggleEdit => {
+                self.handle_toggle_edit(ctx);
+            }
+            RunAgentsCardViewAction::DiscardEdits => {
+                if self.state.is_editor_open {
+                    // Reset to the original tool-call values.
+                    self.state = RunAgentsEditState::from_request(&self.original_request);
+                    self.sync_card_buttons(ctx);
+                    self.sync_picker_selections(ctx);
+                    ctx.notify();
+                }
+            }
+            RunAgentsCardViewAction::ExecutionModeToggled { is_remote } => {
+                self.state.toggle_execution_mode_to_remote(*is_remote);
+                // Local→Cloud may reset OpenCode→Oz; sync pickers.
+                self.sync_picker_selections(ctx);
+                ctx.notify();
+            }
+            RunAgentsCardViewAction::ModelChanged { model_id } => {
+                self.state.model_id = model_id.clone();
+                // Do NOT call sync_picker_selections here — this runs
+                // mid-update and would cause a circular view update.
+                ctx.notify();
+            }
+            RunAgentsCardViewAction::HarnessChanged { harness_type } => {
+                self.state.harness_type = harness_type.clone();
+                // See ModelChanged note.
+                ctx.notify();
+            }
+            RunAgentsCardViewAction::EnvironmentChanged { environment_id } => {
+                self.state.set_environment_id(environment_id.clone());
+                // See ModelChanged note.
+                ctx.notify();
+            }
+            RunAgentsCardViewAction::WorkerHostChanged { worker_host } => {
+                self.state.set_worker_host(worker_host.clone());
+                ctx.notify();
+            }
+        }
+    }
+}
+
+fn render_confirmation_card(
+    state: &RunAgentsEditState,
+    handles: &RunAgentsCardHandles,
+    is_blocked: bool,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+
+    let header = render_header(handles, app);
+    let body = render_body(state, app);
+
+    let mut content = Flex::column()
+        .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+        .with_child(header)
+        .with_child(body);
+
+    if state.is_editor_open {
+        content.add_child(render_editor(state, handles, app));
+    }
+
+    let border_color = if is_blocked {
+        theme.accent()
+    } else {
+        theme.surface_2()
+    };
+
+    Container::new(content.finish())
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+        .with_border(Border::all(1.).with_border_fill(border_color))
+        .finish()
+        .with_content_item_spacing()
+        .finish()
+}
+
+fn render_header(handles: &RunAgentsCardHandles, app: &AppContext) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let mut config = HeaderConfig::new(RUN_AGENTS_CARD_TITLE, app)
+        .with_icon(icons::yellow_stop_icon(appearance))
+        .with_corner_radius_override(CornerRadius::with_top(Radius::Pixels(8.)));
+
+    if let (Some(reject), Some(edit), Some(accept)) = (
+        handles.reject_button.as_ref(),
+        handles.edit_button.as_ref(),
+        handles.accept_button.as_ref(),
+    ) {
+        let action_buttons: Vec<Rc<dyn RenderCompactibleActionButton>> = vec![
+            Rc::new(reject.clone()),
+            Rc::new(edit.clone()),
+            Rc::new(accept.clone()),
+        ];
+        config = config.with_interaction_mode(InteractionMode::ActionButtons {
+            action_buttons,
+            size_switch_threshold: MEDIUM_SIZE_SWITCH_THRESHOLD,
+        });
+    }
+
+    config.render(app)
+}
+
+fn render_body(state: &RunAgentsEditState, app: &AppContext) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+    let mut column = Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+
+    column.add_child(render_summary(state, appearance));
+    column.add_child(render_agents_section(state, app));
+
+    Container::new(column.finish())
+        .with_horizontal_padding(16.)
+        .with_vertical_padding(12.)
+        .with_background_color(theme.background().into_solid())
+        .with_corner_radius(CornerRadius::with_bottom(Radius::Pixels(8.)))
+        .finish()
+}
+
+fn render_summary(state: &RunAgentsEditState, appearance: &Appearance) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let summary = if state.summary.trim().is_empty() {
+        format!(
+            "Spawn {} agent(s) to address this task.",
+            state.agent_run_configs.len()
+        )
+    } else {
+        state.summary.clone()
+    };
+    let summary_text = Text::new(
+        summary,
+        appearance.ui_font_family(),
+        appearance.monospace_font_size(),
+    )
+    .with_color(blended_colors::text_main(theme, theme.background()))
+    .with_selectable(true)
+    .finish();
+
+    Container::new(summary_text)
+        .with_margin_bottom(12.)
+        .finish()
+}
+
+fn render_agents_section(state: &RunAgentsEditState, app: &AppContext) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+    let label = Text::new(
+        format!("Agents ({})", state.agent_run_configs.len()),
+        appearance.ui_font_family(),
+        appearance.monospace_font_size() - 1.,
+    )
+    .with_color(blended_colors::text_disabled(theme, theme.background()))
+    .finish();
+
+    let mut pills_row = Flex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_main_axis_size(MainAxisSize::Min)
+        .with_spacing(4.);
+    for cfg in &state.agent_run_configs {
+        pills_row.add_child(render_static_agent_pill(&cfg.name, app));
+    }
+
+    Flex::column()
+        .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+        .with_child(Container::new(label).with_margin_bottom(6.).finish())
+        .with_child(pills_row.finish())
+        .finish()
+}
+
+fn render_terminal_state(
+    result: &RunAgentsResult,
+    appearance: &Appearance,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let (label, kind) = format_terminal_state(result);
+    render_status_only_card(label, appearance, kind, app)
+}
+
+pub(crate) fn format_terminal_state(result: &RunAgentsResult) -> (String, StatusKind) {
+    match result {
+        RunAgentsResult::Launched { agents, .. } => {
+            let total = agents.len();
+            let launched = agents
+                .iter()
+                .filter(|a| matches!(a.kind, RunAgentsAgentOutcomeKind::Launched { .. }))
+                .count();
+            let label = if launched == total {
+                if total == 1 {
+                    "Spawned 1 agent".to_string()
+                } else {
+                    format!("Spawned {total} agents")
+                }
+            } else {
+                format!("Spawned {launched} of {total} agents")
+            };
+            let kind = if launched == total {
+                StatusKind::Success
+            } else {
+                StatusKind::Mixed
+            };
+            (label, kind)
+        }
+        RunAgentsResult::Denied { reason } => {
+            let body = if reason.is_empty() {
+                "Orchestration is currently disabled. Re-enable on the plan card to launch."
+                    .to_string()
+            } else {
+                format!(
+                    "Orchestration is currently disabled. Re-enable on the plan card to launch. ({reason})"
+                )
+            };
+            (body, StatusKind::Cancelled)
+        }
+        RunAgentsResult::Failure { error } => {
+            let label = if error.is_empty() {
+                "Failed to start orchestration".to_string()
+            } else {
+                format!("Failed to start orchestration: {error}")
+            };
+            (label, StatusKind::Failure)
+        }
+        RunAgentsResult::Cancelled => ("Spawn agents cancelled".to_string(), StatusKind::Cancelled),
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum StatusKind {
+    Spawning,
+    Success,
+    Mixed,
+    Failure,
+    Cancelled,
+}
+
+fn render_spawning_card(
+    snapshot: &RunAgentsSpawningSnapshot,
+    appearance: &Appearance,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let total = snapshot.agent_count;
+    let label = if total == 1 {
+        "Spawning 1 agent\u{2026}".to_string()
+    } else {
+        format!("Spawning {total} agents\u{2026}")
+    };
+    render_status_only_card(label, appearance, StatusKind::Spawning, app)
+}
+
+fn render_status_only_card(
+    label: String,
+    appearance: &Appearance,
+    kind: StatusKind,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let icon = match kind {
+        StatusKind::Spawning | StatusKind::Mixed => icons::yellow_running_icon(appearance).finish(),
+        StatusKind::Success => inline_action_icons::green_check_icon(appearance).finish(),
+        StatusKind::Failure => inline_action_icons::red_x_icon(appearance).finish(),
+        StatusKind::Cancelled => inline_action_icons::cancelled_icon(appearance).finish(),
+    };
+    let row = render_requested_action_row_for_text(
+        label.into(),
+        appearance.ui_font_family(),
+        Some(icon),
+        None,
+        false,
+        false,
+        app,
+    );
+    Container::new(
+        Container::new(row)
+            .with_background_color(blended_colors::neutral_2(theme))
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+            .finish(),
+    )
+    .with_margin_left(16.)
+    .with_margin_right(16.)
+    .finish()
+    .with_agent_output_item_spacing(app)
+    .finish()
+}
+
+fn render_editor(
+    state: &RunAgentsEditState,
+    handles: &RunAgentsCardHandles,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+    let mut column = Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+
+    let divider = Container::new(
+        ConstrainedBox::new(Empty::new().finish())
+            .with_height(1.)
+            .finish(),
+    )
+    .with_background_color(theme.surface_2().into_solid())
+    .finish();
+    column.add_child(divider);
+
+    column.add_child(
+        Container::new(render_mode_toggle(state, handles, appearance))
+            .with_margin_top(12.)
+            .finish(),
+    );
+    column.add_child(render_picker_row_quad(state, handles, appearance));
+
+    if let Some(reason) = state.accept_disabled_reason() {
+        column.add_child(render_validation_error(
+            reason,
+            theme.ui_error_color(),
+            appearance,
+        ));
+    } else if let Some(message) = empty_env_recommendation_message(state, app) {
+        column.add_child(render_validation_error(
+            message,
+            theme.ui_warning_color(),
+            appearance,
+        ));
+    }
+
+    Container::new(column.finish())
+        .with_horizontal_padding(16.)
+        .with_padding_bottom(12.)
+        .with_background_color(theme.background().into_solid())
+        .with_corner_radius(CornerRadius::with_bottom(Radius::Pixels(8.)))
+        .finish()
+}
+
+fn render_picker_row_quad(
+    state: &RunAgentsEditState,
+    handles: &RunAgentsCardHandles,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let is_remote = state.execution_mode.is_remote();
+    let main_axis_size = if is_remote {
+        MainAxisSize::Max
+    } else {
+        MainAxisSize::Min
+    };
+    let mut row = Flex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+        .with_main_axis_size(main_axis_size)
+        .with_main_axis_alignment(MainAxisAlignment::Start)
+        .with_spacing(12.);
+
+    const LOCAL_PICKER_WIDTH: f32 = 220.;
+    let add_picker = |row: &mut Flex, label: &str, picker: Option<Box<dyn Element>>| {
+        let column = render_picker_column(label, picker, appearance);
+        if is_remote {
+            row.add_child(Expanded::new(1.0, column).finish());
+        } else {
+            row.add_child(
+                ConstrainedBox::new(column)
+                    .with_width(LOCAL_PICKER_WIDTH)
+                    .finish(),
+            );
+        }
+    };
+
+    add_picker(
+        &mut row,
+        "Agent harness",
+        handles
+            .harness_picker
+            .as_ref()
+            .map(|p| ChildView::new(p).finish()),
+    );
+    if is_remote {
+        add_picker(
+            &mut row,
+            "Host",
+            handles
+                .host_picker
+                .as_ref()
+                .map(|p| ChildView::new(p).finish()),
+        );
+        add_picker(
+            &mut row,
+            "Environment",
+            handles
+                .environment_picker
+                .as_ref()
+                .map(|p| ChildView::new(p).finish()),
+        );
+    }
+    add_picker(
+        &mut row,
+        "Base model",
+        handles
+            .model_picker
+            .as_ref()
+            .map(|p| ChildView::new(p).finish()),
+    );
+
+    Container::new(row.finish()).with_margin_top(12.).finish()
+}
+
+fn render_picker_column(
+    label: &str,
+    picker: Option<Box<dyn Element>>,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let label_el = Text::new(
+        label.to_string(),
+        appearance.ui_font_family(),
+        appearance.monospace_font_size() - 1.,
+    )
+    .with_color(blended_colors::text_disabled(theme, theme.surface_1()))
+    .finish();
+
+    let body: Box<dyn Element> = picker.unwrap_or_else(|| Empty::new().finish());
+    Flex::column()
+        .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+        .with_child(label_el)
+        .with_child(body)
+        .finish()
+}
+
+fn render_mode_toggle(
+    state: &RunAgentsEditState,
+    handles: &RunAgentsCardHandles,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let is_remote = state.execution_mode.is_remote();
+    let label = Text::new(
+        "Agent location".to_string(),
+        appearance.ui_font_family(),
+        appearance.monospace_font_size() - 1.,
+    )
+    .with_color(blended_colors::text_disabled(theme, theme.surface_1()))
+    .finish();
+
+    let local_segment = render_segment_button(
+        "Local",
+        !is_remote,
+        RunAgentsCardViewAction::ExecutionModeToggled { is_remote: false },
+        handles.local_toggle.clone(),
+        appearance,
+    );
+    let cloud_segment = render_segment_button(
+        "Cloud",
+        is_remote,
+        RunAgentsCardViewAction::ExecutionModeToggled { is_remote: true },
+        handles.cloud_toggle.clone(),
+        appearance,
+    );
+
+    let segment_outer_bg = warp_core::ui::theme::color::internal_colors::fg_overlay_2(theme);
+    let segments_row = Flex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+        .with_main_axis_alignment(MainAxisAlignment::Start)
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_child(Expanded::new(1.0, cloud_segment).finish())
+        .with_child(Expanded::new(1.0, local_segment).finish())
+        .finish();
+    let segmented_control = Container::new(segments_row)
+        .with_padding_top(4.)
+        .with_padding_bottom(4.)
+        .with_padding_left(4.)
+        .with_padding_right(4.)
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(6.)))
+        .with_background(segment_outer_bg)
+        .finish();
+    let segmented_control = ConstrainedBox::new(segmented_control)
+        .with_width(205.)
+        .finish();
+
+    Flex::column()
+        .with_cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_child(Container::new(label).with_margin_bottom(6.).finish())
+        .with_child(segmented_control)
+        .finish()
+}
+
+fn render_segment_button(
+    label: &str,
+    is_active: bool,
+    on_click: RunAgentsCardViewAction,
+    mouse_state: MouseStateHandle,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let label_owned = label.to_string();
+    let font_family = appearance.ui_font_family();
+    let font_size = appearance.monospace_font_size() + 1.;
+    let active_text_color = blended_colors::text_main(theme, theme.surface_1());
+    let inactive_text_color = blended_colors::text_disabled(theme, theme.surface_1());
+    let segment_active_bg = warp_core::ui::theme::color::internal_colors::fg_overlay_4(theme);
+    Hoverable::new(mouse_state, move |_| {
+        let text = Text::new(label_owned.clone(), font_family, font_size)
+            .with_color(if is_active {
+                active_text_color
+            } else {
+                inactive_text_color
+            })
+            .finish();
+        let centered = warpui::elements::Align::new(text).finish();
+        let mut container = Container::new(centered)
+            .with_vertical_padding(6.)
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
+        if is_active {
+            container = container.with_background(segment_active_bg);
+        }
+        container.finish()
+    })
+    .on_click(move |ctx, _, _| {
+        ctx.dispatch_typed_action(on_click.clone());
+    })
+    .with_cursor(Cursor::PointingHand)
+    .finish()
+}
+
+fn render_validation_error(
+    reason: impl Into<String>,
+    color: ColorU,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    Container::new(
+        Text::new(
+            reason.into(),
+            appearance.ui_font_family(),
+            appearance.monospace_font_size() - 1.,
+        )
+        .with_color(color)
+        .finish(),
+    )
+    .with_margin_bottom(8.)
+    .finish()
+}
+
+fn empty_env_recommendation_message(
+    state: &RunAgentsEditState,
+    app: &AppContext,
+) -> Option<String> {
+    let RunAgentsExecutionMode::Remote {
+        environment_id,
+        worker_host,
+        ..
+    } = &state.execution_mode
+    else {
+        return None;
+    };
+    if !environment_id.trim().is_empty() {
+        return None;
+    }
+    if !worker_host.eq_ignore_ascii_case(RUN_AGENTS_WARP_WORKER_HOST) {
+        return None;
+    }
+    let env_count = CloudAmbientAgentEnvironment::get_all(app).len();
+    Some(if env_count > 0 {
+        "We recommend selecting an environment for cloud agents.".to_string()
+    } else {
+        "We recommend creating an environment for cloud agents.".to_string()
+    })
+}
+
+#[cfg(test)]
+#[path = "run_agents_card_view_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
@@ -1,0 +1,335 @@
+use ai::agent::action::{RunAgentsAgentRunConfig, RunAgentsExecutionMode, RunAgentsRequest};
+use ai::agent::action_result::{
+    RunAgentsAgentOutcome, RunAgentsAgentOutcomeKind, RunAgentsLaunchedExecutionMode,
+    RunAgentsResult,
+};
+use ai::skills::SkillReference;
+use std::path::PathBuf;
+
+use super::RunAgentsEditState;
+
+fn make_request(harness: &str, mode: RunAgentsExecutionMode) -> RunAgentsRequest {
+    make_request_with_skills(harness, mode, Vec::new())
+}
+
+fn make_request_with_skills(
+    harness: &str,
+    mode: RunAgentsExecutionMode,
+    skills: Vec<SkillReference>,
+) -> RunAgentsRequest {
+    RunAgentsRequest {
+        summary: "summary".to_string(),
+        base_prompt: "base".to_string(),
+        skills,
+        model_id: "auto".to_string(),
+        harness_type: harness.to_string(),
+        execution_mode: mode,
+        agent_run_configs: vec![RunAgentsAgentRunConfig {
+            name: "child".to_string(),
+            prompt: "do work".to_string(),
+            title: "Child agent".to_string(),
+        }],
+    }
+}
+
+#[test]
+fn local_to_cloud_initializes_remote_with_empty_environment() {
+    let mut state =
+        RunAgentsEditState::from_request(&make_request("oz", RunAgentsExecutionMode::Local));
+    assert!(matches!(
+        state.execution_mode,
+        RunAgentsExecutionMode::Local
+    ));
+
+    state.toggle_execution_mode_to_remote(true);
+    let RunAgentsExecutionMode::Remote {
+        environment_id,
+        worker_host,
+        computer_use_enabled,
+    } = state.execution_mode
+    else {
+        panic!("expected Remote after toggle");
+    };
+    assert_eq!(environment_id, "");
+    assert_eq!(worker_host, "warp");
+    assert!(!computer_use_enabled);
+}
+
+#[test]
+fn cloud_to_local_drops_environment() {
+    let mut state = RunAgentsEditState::from_request(&make_request(
+        "oz",
+        RunAgentsExecutionMode::Remote {
+            environment_id: "env-1".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: false,
+        },
+    ));
+    state.toggle_execution_mode_to_remote(false);
+    assert!(matches!(
+        state.execution_mode,
+        RunAgentsExecutionMode::Local
+    ));
+}
+
+#[test]
+fn local_to_cloud_resets_opencode_to_oz() {
+    let mut state =
+        RunAgentsEditState::from_request(&make_request("opencode", RunAgentsExecutionMode::Local));
+    state.toggle_execution_mode_to_remote(true);
+    assert_eq!(state.harness_type, "oz");
+}
+
+#[test]
+fn cloud_without_env_no_longer_disables_accept() {
+    let state = RunAgentsEditState::from_request(&make_request(
+        "oz",
+        RunAgentsExecutionMode::Remote {
+            environment_id: String::new(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: false,
+        },
+    ));
+    assert!(
+        state.accept_disabled_reason().is_none(),
+        "Cloud without env should NOT disable Accept (soft recommendation only)"
+    );
+}
+
+#[test]
+fn cloud_with_opencode_disables_accept() {
+    // Bypass the toggle helper to test the validation gate directly.
+    let state = RunAgentsEditState::from_request(&make_request(
+        "opencode",
+        RunAgentsExecutionMode::Remote {
+            environment_id: "env-1".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: false,
+        },
+    ));
+    let reason = state.accept_disabled_reason();
+    assert!(reason.is_some(), "Cloud + OpenCode should disable Accept");
+    assert!(reason.unwrap().contains("OpenCode"));
+}
+
+#[test]
+fn local_with_any_harness_does_not_disable_accept() {
+    for harness in ["oz", "claude", "gemini", "opencode"] {
+        let state =
+            RunAgentsEditState::from_request(&make_request(harness, RunAgentsExecutionMode::Local));
+        assert!(
+            state.accept_disabled_reason().is_none(),
+            "Local + {harness} should allow Accept"
+        );
+    }
+}
+
+#[test]
+fn cloud_with_env_and_non_opencode_harness_allows_accept() {
+    for harness in ["oz", "claude", "gemini"] {
+        let state = RunAgentsEditState::from_request(&make_request(
+            harness,
+            RunAgentsExecutionMode::Remote {
+                environment_id: "env-1".to_string(),
+                worker_host: "warp".to_string(),
+                computer_use_enabled: false,
+            },
+        ));
+        assert!(
+            state.accept_disabled_reason().is_none(),
+            "Cloud + env + {harness} should allow Accept"
+        );
+    }
+}
+
+#[test]
+fn set_environment_id_no_op_in_local_mode() {
+    let mut state =
+        RunAgentsEditState::from_request(&make_request("oz", RunAgentsExecutionMode::Local));
+    state.set_environment_id("env-1".to_string());
+    assert!(matches!(
+        state.execution_mode,
+        RunAgentsExecutionMode::Local
+    ));
+}
+
+#[test]
+fn set_environment_id_updates_remote() {
+    let mut state = RunAgentsEditState::from_request(&make_request(
+        "oz",
+        RunAgentsExecutionMode::Remote {
+            environment_id: "old".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: false,
+        },
+    ));
+    state.set_environment_id("new-env".to_string());
+    let RunAgentsExecutionMode::Remote { environment_id, .. } = state.execution_mode else {
+        panic!("expected Remote");
+    };
+    assert_eq!(environment_id, "new-env");
+}
+
+#[test]
+fn to_request_round_trips_request_fields() {
+    let req = make_request_with_skills(
+        "claude",
+        RunAgentsExecutionMode::Remote {
+            environment_id: "env-2".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: true,
+        },
+        vec![
+            SkillReference::BundledSkillId("writing-pr-descriptions".to_string()),
+            SkillReference::Path(PathBuf::from("/tmp/skill/SKILL.md")),
+        ],
+    );
+    let state = RunAgentsEditState::from_request(&req);
+    let round_tripped = state.to_request();
+    assert_eq!(round_tripped.summary, req.summary);
+    assert_eq!(round_tripped.base_prompt, req.base_prompt);
+    assert_eq!(round_tripped.model_id, req.model_id);
+    assert_eq!(round_tripped.harness_type, req.harness_type);
+    assert_eq!(round_tripped.execution_mode, req.execution_mode);
+    assert_eq!(round_tripped.agent_run_configs, req.agent_run_configs);
+    assert_eq!(round_tripped.skills, req.skills);
+}
+
+mod format_terminal_state_tests {
+    use super::super::{format_terminal_state, StatusKind};
+    use super::*;
+
+    fn launched(name: &str, agent_id: &str) -> RunAgentsAgentOutcome {
+        RunAgentsAgentOutcome {
+            name: name.to_string(),
+            kind: RunAgentsAgentOutcomeKind::Launched {
+                agent_id: agent_id.to_string(),
+            },
+        }
+    }
+
+    fn failed(name: &str, error: &str) -> RunAgentsAgentOutcome {
+        RunAgentsAgentOutcome {
+            name: name.to_string(),
+            kind: RunAgentsAgentOutcomeKind::Failed {
+                error: error.to_string(),
+            },
+        }
+    }
+
+    fn launched_result(agents: Vec<RunAgentsAgentOutcome>) -> RunAgentsResult {
+        RunAgentsResult::Launched {
+            model_id: "auto".to_string(),
+            harness_type: "oz".to_string(),
+            execution_mode: RunAgentsLaunchedExecutionMode::Local,
+            agents,
+        }
+    }
+
+    #[test]
+    fn launched_singular_uses_singular_label() {
+        let result = launched_result(vec![launched("child", "a-1")]);
+        let (label, kind) = format_terminal_state(&result);
+        assert_eq!(label, "Spawned 1 agent");
+        assert!(matches!(kind, StatusKind::Success));
+    }
+
+    #[test]
+    fn launched_plural_uses_plural_label() {
+        let result = launched_result(vec![
+            launched("a", "a-1"),
+            launched("b", "a-2"),
+            launched("c", "a-3"),
+        ]);
+        let (label, kind) = format_terminal_state(&result);
+        assert_eq!(label, "Spawned 3 agents");
+        assert!(matches!(kind, StatusKind::Success));
+    }
+
+    #[test]
+    fn launched_partial_uses_x_of_y_label_and_mixed_status() {
+        let result = launched_result(vec![
+            launched("a", "a-1"),
+            failed("b", "boom"),
+            launched("c", "a-3"),
+        ]);
+        let (label, kind) = format_terminal_state(&result);
+        assert_eq!(label, "Spawned 2 of 3 agents");
+        assert!(matches!(kind, StatusKind::Mixed));
+    }
+
+    #[test]
+    fn failure_with_error_includes_error_text() {
+        let (label, kind) = format_terminal_state(&RunAgentsResult::Failure {
+            error: "server rejected request".to_string(),
+        });
+        assert_eq!(
+            label,
+            "Failed to start orchestration: server rejected request"
+        );
+        assert!(matches!(kind, StatusKind::Failure));
+    }
+
+    #[test]
+    fn failure_with_empty_error_uses_short_label() {
+        let (label, kind) = format_terminal_state(&RunAgentsResult::Failure {
+            error: String::new(),
+        });
+        assert_eq!(label, "Failed to start orchestration");
+        assert!(matches!(kind, StatusKind::Failure));
+    }
+
+    #[test]
+    fn denied_with_reason_appends_reason() {
+        let (label, kind) = format_terminal_state(&RunAgentsResult::Denied {
+            reason: "disapproved".to_string(),
+        });
+        assert!(label.contains("disapproved"));
+        assert!(matches!(kind, StatusKind::Cancelled));
+    }
+
+    #[test]
+    fn denied_without_reason_uses_short_label() {
+        let (label, kind) = format_terminal_state(&RunAgentsResult::Denied {
+            reason: String::new(),
+        });
+        assert!(!label.contains("()"));
+        assert!(matches!(kind, StatusKind::Cancelled));
+    }
+
+    #[test]
+    fn cancelled_uses_cancelled_status() {
+        let (label, kind) = format_terminal_state(&RunAgentsResult::Cancelled);
+        assert_eq!(label, "Spawn agents cancelled");
+        assert!(matches!(kind, StatusKind::Cancelled));
+    }
+}
+
+#[test]
+fn local_to_cloud_idempotent_when_already_remote() {
+    let mut state = RunAgentsEditState::from_request(&make_request(
+        "oz",
+        RunAgentsExecutionMode::Remote {
+            environment_id: "env-1".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: true,
+        },
+    ));
+    state.toggle_execution_mode_to_remote(true);
+    let RunAgentsExecutionMode::Remote {
+        environment_id,
+        computer_use_enabled,
+        ..
+    } = state.execution_mode
+    else {
+        panic!("expected Remote");
+    };
+    assert_eq!(
+        environment_id, "env-1",
+        "toggle to Remote when already Remote should not clobber env"
+    );
+    assert!(
+        computer_use_enabled,
+        "toggle to Remote when already Remote should not clobber computer_use"
+    );
+}

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -32,6 +32,7 @@ pub(crate) use action_model::{
     apply_edits, read_local_file_context, BlocklistAIActionEvent, BlocklistAIActionModel,
     FileReadResult, ReadFileContextResult, RequestFileEditsFormatKind, ShellCommandExecutor,
     ShellCommandExecutorEvent, StartAgentExecutor, StartAgentExecutorEvent, StartAgentRequest,
+    StartAgentRequestId,
 };
 
 #[cfg(any(test, feature = "integration_tests"))]

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -365,7 +365,8 @@ impl OrchestrationEventStreamer {
             | BlocklistAIHistoryEvent::UpdatedTodoList { .. }
             | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. }
             | BlocklistAIHistoryEvent::SplitConversation { .. }
-            | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. } => {}
+            | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
+            | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. } => {}
         }
     }
 

--- a/app/src/ai/blocklist/persistence.rs
+++ b/app/src/ai/blocklist/persistence.rs
@@ -319,6 +319,9 @@ impl From<&AIAgentActionType> for PersistedAIAgentActionType {
             },
             AIAgentActionType::StartAgent { .. } => Self::NotPersisted,
             AIAgentActionType::SendMessageToAgent { .. } => Self::NotPersisted,
+            // Orchestrate is rendered from the in-history tool call message;
+            // there is no per-action state we need to persist locally.
+            AIAgentActionType::RunAgents(_) => Self::NotPersisted,
         }
     }
 }

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -22,7 +22,7 @@ use crate::{
         ambient_agents::{task::HarnessConfig, AgentConfigSnapshot},
         blocklist::{
             agent_view::AgentViewEntryOrigin, orchestration_events::OrchestrationEventService,
-            BlocklistAIHistoryModel,
+            BlocklistAIHistoryModel, StartAgentRequest,
         },
         llms::LLMPreferences,
         skills::SkillManager,
@@ -55,8 +55,6 @@ use crate::{
 
 #[cfg(feature = "local_fs")]
 use crate::ai::blocklist::BlocklistAIHistoryEvent;
-#[cfg(not(target_family = "wasm"))]
-use crate::pane_group::child_agent::HiddenChildAgentTaskContext;
 #[cfg(not(target_family = "wasm"))]
 use crate::server::server_api::ServerApiProvider;
 
@@ -115,6 +113,22 @@ fn resolve_runtime_skills(
 
 fn serialize_proto_to_base64<M: prost::Message>(message: &M) -> String {
     BASE64_STANDARD.encode(message.encode_to_vec())
+}
+
+/// Overrides the child's preferred agent-mode LLM. `None` is a no-op
+/// (inherits the parent's LLM via `propagate_parent_agent_settings`).
+fn apply_child_model_id_override(
+    child_terminal_view_id: EntityId,
+    model_id: Option<&str>,
+    ctx: &mut ViewContext<PaneGroup>,
+) {
+    let Some(model_id) = model_id.map(str::trim).filter(|m| !m.is_empty()) else {
+        return;
+    };
+    let llm_id: ai::LLMId = model_id.into();
+    LLMPreferences::handle(ctx).update(ctx, |llm_prefs, ctx| {
+        llm_prefs.update_preferred_agent_mode_llm(&llm_id, child_terminal_view_id, ctx);
+    });
 }
 
 fn register_legacy_local_lifecycle_subscription(
@@ -559,7 +573,7 @@ impl PaneContent for TerminalPane {
                     Ok(ShareableLink::Pane { url })
                 } else {
                     Err(ShareableLinkError::Unexpected(String::from(
-                        "Failed to retrieve shared session link",
+                        "Failed to retreive shared session link",
                     )))
                 }
             }
@@ -1118,325 +1132,442 @@ fn handle_terminal_view_event(
                 }
             }
             Event::StartAgentConversation(request) => {
-                let request = request.clone();
-                match request.execution_mode.clone() {
-                    StartAgentExecutionMode::Local { harness_type: None } => {
-                        if let Some(HiddenChildAgentConversation {
-                            terminal_view: new_terminal_view,
-                            conversation_id,
-                            ..
-                        }) = create_hidden_child_agent_conversation(
-                            group,
-                            pane_id,
-                            request.name,
-                            request.parent_conversation_id,
-                            HashMap::new(),
-                            None,
-                            ctx,
-                        ) {
-                            register_legacy_local_lifecycle_subscription(
-                                request.parent_conversation_id,
-                                conversation_id,
-                                request.lifecycle_subscription,
-                                ctx,
-                            );
-
-                            new_terminal_view.update(ctx, |terminal_view, ctx| {
-                                terminal_view
-                                    .ai_controller()
-                                    .update(ctx, |controller, ctx| {
-                                        controller.send_agent_query_in_conversation(
-                                            request.prompt,
-                                            conversation_id,
-                                            ctx,
-                                        );
-                                    });
-
-                                terminal_view.enter_agent_view(
-                                    None,
-                                    Some(conversation_id),
-                                    AgentViewEntryOrigin::ChildAgent,
-                                    ctx,
-                                );
-                            });
-                        }
-                    }
-                    #[cfg(not(target_family = "wasm"))]
-                    StartAgentExecutionMode::Local {
-                        harness_type: Some(harness_type),
-                    } => {
-                        let startup_directory =
-                            group.startup_path_for_new_session(Some(terminal_pane_id), ctx);
-                        let launch_startup_directory = startup_directory.clone();
-                        let ai_client = ServerApiProvider::handle(ctx).as_ref(ctx).get_ai_client();
-                        let parent_pane_id = pane_id;
-                        let request_name = request.name.clone();
-                        let parent_conversation_id = request.parent_conversation_id;
-                        let parent_run_id = request.parent_run_id.clone();
-                        let prompt = request.prompt.clone();
-                        let shell_type = group
-                            .terminal_view_from_pane_id(parent_pane_id, ctx)
-                            .and_then(|terminal_view| {
-                                terminal_view.as_ref(ctx).active_session_shell_type(ctx)
-                            });
-
-                        let _ = ctx.spawn(
-                            async move {
-                                prepare_local_harness_child_launch(
-                                    prompt,
-                                    harness_type,
-                                    parent_run_id,
-                                    shell_type,
-                                    launch_startup_directory,
-                                    ai_client,
-                                )
-                                .await
-                            },
-                            move |group, result, ctx| match result {
-                                Ok(launch) => {
-                                    let PreparedLocalHarnessLaunch {
-                                        command,
-                                        env_vars,
-                                        run_id,
-                                        task_id,
-                                    } = launch;
-                                    if let Some(HiddenChildAgentConversation {
-                                        terminal_view: new_terminal_view,
-                                        terminal_view_id,
-                                        conversation_id,
-                                        ..
-                                    }) = create_hidden_child_agent_conversation(
-                                        group,
-                                        parent_pane_id,
-                                        request_name.clone(),
-                                        parent_conversation_id,
-                                        env_vars,
-                                        Some(HiddenChildAgentTaskContext {
-                                            task_id,
-                                            working_dir: startup_directory.clone(),
-                                        }),
-                                        ctx,
-                                    ) {
-                                        BlocklistAIHistoryModel::handle(ctx).update(
-                                            ctx,
-                                            |history_model, ctx| {
-                                                history_model.assign_run_id_for_conversation(
-                                                    conversation_id,
-                                                    run_id,
-                                                    Some(task_id),
-                                                    terminal_view_id,
-                                                    ctx,
-                                                );
-                                            },
-                                        );
-
-                                        new_terminal_view.update(ctx, |terminal_view, ctx| {
-                                            terminal_view.enter_agent_view(
-                                                None,
-                                                Some(conversation_id),
-                                                AgentViewEntryOrigin::ChildAgent,
-                                                ctx,
-                                            );
-                                            terminal_view.execute_command_or_set_pending(
-                                                &command,
-                                                ctx,
-                                            );
-                                        });
-                                    } else {
-                                        create_error_child_agent_conversation(
-                                            group,
-                                            parent_pane_id,
-                                            request_name,
-                                            parent_conversation_id,
-                                            "Failed to create a hidden pane for the local child harness."
-                                                .to_string(),
-                                            ctx,
-                                        );
-                                    }
-                                }
-                                Err(error_message) => {
-                                    create_error_child_agent_conversation(
-                                        group,
-                                        parent_pane_id,
-                                        request_name,
-                                        parent_conversation_id,
-                                        error_message,
-                                        ctx,
-                                    );
-                                }
-                            },
-                        );
-                    }
-                    #[cfg(target_family = "wasm")]
-                    StartAgentExecutionMode::Local { .. } => {
-                        create_error_child_agent_conversation(
-                            group,
-                            pane_id,
-                            request.name,
-                            request.parent_conversation_id,
-                            "Local harness child agents are not supported in WASM builds."
-                                .to_string(),
-                            ctx,
-                        );
-                    }
-                    StartAgentExecutionMode::Remote {
-                        environment_id,
-                        skill_references,
-                        model_id,
-                        computer_use_enabled,
-                        worker_host,
-                        harness_type,
-                        title,
-                    } => {
-                        let Some(parent_run_id) = request.parent_run_id.clone() else {
-                            log::error!(
-                                "Remote StartAgent request missing parent_run_id for {:?}",
-                                request.parent_conversation_id
-                            );
-                            return;
-                        };
-
-                        let new_pane_id =
-                            group.insert_ambient_agent_pane_hidden_for_child_agent(pane_id, ctx);
-
-                        if let Some(new_terminal_view) =
-                            group.terminal_view_from_pane_id(new_pane_id, ctx)
-                        {
-                            let terminal_view_id = new_terminal_view.id();
-                            let conversation_id = BlocklistAIHistoryModel::handle(ctx).update(
-                                ctx,
-                                |history_model, ctx| {
-                                    let id = history_model.start_new_child_conversation(
-                                        terminal_view_id,
-                                        request.name,
-                                        request.parent_conversation_id,
-                                        ctx,
-                                    );
-                                    // Mark as remote so the parent's TaskStatusSyncModel
-                                    // skips status reporting — the remote worker handles it.
-                                    if let Some(c) = history_model.conversation_mut(&id) {
-                                        c.mark_as_remote_child();
-                                    }
-                                    id
-                                },
-                            );
-
-                            let runtime_skills = match resolve_runtime_skills(
-                                &skill_references,
-                                ctx,
-                            ) {
-                                Ok(runtime_skills) => runtime_skills,
-                                Err(unresolved_references) => {
-                                    let error_message = format!(
-                                        "Failed to resolve child agent skills: {}",
-                                        unresolved_references.join(", ")
-                                    );
-                                    log::error!(
-                                        "Failed to resolve StartAgentV2 skill references for remote child {:?}: {}",
-                                        conversation_id,
-                                        unresolved_references.join(", ")
-                                    );
-                                    BlocklistAIHistoryModel::handle(ctx).update(
-                                        ctx,
-                                        |history_model, ctx| {
-                                            history_model
-                                                .update_conversation_status_with_error_message(
-                                                    terminal_view_id,
-                                                    conversation_id,
-                                                    ConversationStatus::Error,
-                                                    Some(error_message),
-                                                    ctx,
-                                                );
-                                        },
-                                    );
-                                    return;
-                                }
-                            };
-                            // Treat an empty environment_id as "no environment specified" so the
-                            // spawn request leaves the config.environment_id field unset. The
-                            // server's StartAgent producer defaults to the parent's environment
-                            // when available, so an empty value here means the caller explicitly
-                            // opted into running with an empty environment.
-                            let environment_id =
-                                Some(environment_id).filter(|s| !s.trim().is_empty());
-                            // Unrecognized harness types collapse to None so the server picks
-                            // its default, matching the behavior of an empty `harness_type`.
-                            // We deliberately do NOT round-trip `Harness::Unknown` to the server;
-                            // that variant is for representing server-originated unknowns to the
-                            // user, not for writes.
-                            let harness_override = if harness_type.is_empty() {
-                                None
-                            } else {
-                                match <Harness as clap::ValueEnum>::from_str(&harness_type, true) {
-                                    Ok(harness) => Some(HarnessConfig::from_harness_type(harness)),
-                                    Err(_) => {
-                                        log::warn!(
-                                            "Unknown harness type from StartAgentV2 proto: {harness_type:?}; omitting harness override so the server picks its default"
-                                        );
-                                        None
-                                    }
-                                }
-                            };
-                            let spawn_request = SpawnAgentRequest {
-                                prompt: request.prompt,
-                                // Agents spawned during orchestrations are always run in normal mode.
-                                mode: UserQueryMode::Normal,
-                                config: Some(AgentConfigSnapshot {
-                                    environment_id,
-                                    model_id: (!model_id.is_empty()).then_some(model_id),
-                                    worker_host: (!worker_host.is_empty()).then_some(worker_host),
-                                    computer_use_enabled: Some(computer_use_enabled),
-                                    harness: harness_override,
-                                    ..Default::default()
-                                }),
-                                title: (!title.is_empty()).then_some(title),
-                                team: None,
-                                skill: None,
-                                attachments: vec![],
-                                interactive: Some(true),
-                                parent_run_id: Some(parent_run_id),
-                                runtime_skills,
-                                referenced_attachments: vec![],
-                            };
-
-                            new_terminal_view.update(ctx, |terminal_view, ctx| {
-                                terminal_view.enter_agent_view(
-                                    None,
-                                    Some(conversation_id),
-                                    AgentViewEntryOrigin::CloudAgent,
-                                    ctx,
-                                );
-                                if let Some(ambient_agent_view_model) =
-                                    terminal_view.ambient_agent_view_model()
-                                {
-                                    ambient_agent_view_model.update(ctx, |model, ctx| {
-                                        model.set_conversation_id(Some(conversation_id));
-                                        model.spawn_agent_with_request(spawn_request, ctx);
-                                    });
-                                } else {
-                                    log::error!(
-                                        "Remote StartAgent child pane missing ambient agent view model"
-                                    );
-                                }
-                            });
-
-                            group
-                                .child_agent_panes
-                                .insert(conversation_id, new_pane_id.into());
-                        } else {
-                            log::error!(
-                                "Failed to get terminal view for new remote StartAgent pane"
-                            );
-                            group.discard_pane(new_pane_id.into(), ctx);
-                        }
-                    }
-                }
+                dispatch_start_agent_conversation(
+                    group,
+                    pane_id,
+                    terminal_pane_id,
+                    request.clone(),
+                    ctx,
+                );
             }
             _ => {}
         }
     } else {
         log::warn!("Session {terminal_pane_id:?} not found");
     }
+}
+
+/// Dispatches a StartAgent request to the appropriate per-mode helper.
+/// Each helper echoes the child conversation id back via
+/// [`BlocklistAIHistoryModel::record_new_conversation_request_complete`].
+#[cfg_attr(target_family = "wasm", allow(unused_variables))]
+fn dispatch_start_agent_conversation(
+    group: &mut PaneGroup,
+    parent_pane_id: PaneId,
+    terminal_pane_id: TerminalPaneId,
+    request: StartAgentRequest,
+    ctx: &mut ViewContext<PaneGroup>,
+) {
+    match request.execution_mode.clone() {
+        StartAgentExecutionMode::Local {
+            harness_type: None,
+            model_id,
+        } => {
+            launch_local_no_harness_child(group, parent_pane_id, request, model_id, ctx);
+        }
+        #[cfg(not(target_family = "wasm"))]
+        StartAgentExecutionMode::Local {
+            harness_type: Some(harness_type),
+            model_id,
+        } => {
+            launch_local_harness_child(
+                group,
+                parent_pane_id,
+                terminal_pane_id,
+                request,
+                harness_type,
+                model_id,
+                ctx,
+            );
+        }
+        #[cfg(target_family = "wasm")]
+        StartAgentExecutionMode::Local { .. } => {
+            create_error_child_agent_conversation(
+                group,
+                parent_pane_id,
+                request.name,
+                request.parent_conversation_id,
+                "Local harness child agents are not supported in WASM builds.".to_string(),
+                ctx,
+            );
+        }
+        StartAgentExecutionMode::Remote {
+            environment_id,
+            skill_references,
+            model_id,
+            computer_use_enabled,
+            worker_host,
+            harness_type,
+            title,
+        } => {
+            launch_remote_child(
+                group,
+                parent_pane_id,
+                request,
+                RemoteLaunchFields {
+                    environment_id,
+                    skill_references,
+                    model_id,
+                    computer_use_enabled,
+                    worker_host,
+                    harness_type,
+                    title,
+                },
+                ctx,
+            );
+        }
+    }
+}
+
+/// Sets up a hidden child pane for a Local-no-harness agent and
+/// dispatches the prompt. Returns the child `AIConversationId` on
+/// success.
+fn launch_local_no_harness_child(
+    group: &mut PaneGroup,
+    parent_pane_id: PaneId,
+    request: StartAgentRequest,
+    model_id: Option<String>,
+    ctx: &mut ViewContext<PaneGroup>,
+) -> Option<AIConversationId> {
+    // model_id is applied below via apply_child_model_id_override.
+    let request_id = request.id;
+    let HiddenChildAgentConversation {
+        terminal_view: new_terminal_view,
+        terminal_view_id,
+        conversation_id,
+        ..
+    } = create_hidden_child_agent_conversation(
+        group,
+        parent_pane_id,
+        request.name,
+        request.parent_conversation_id,
+        HashMap::new(),
+        None,
+        ctx,
+    )?;
+
+    apply_child_model_id_override(terminal_view_id, model_id.as_deref(), ctx);
+
+    BlocklistAIHistoryModel::handle(ctx).update(ctx, |model, ctx| {
+        model.record_new_conversation_request_complete(request_id, conversation_id, ctx);
+    });
+
+    register_legacy_local_lifecycle_subscription(
+        request.parent_conversation_id,
+        conversation_id,
+        request.lifecycle_subscription,
+        ctx,
+    );
+
+    new_terminal_view.update(ctx, |terminal_view, ctx| {
+        terminal_view
+            .ai_controller()
+            .update(ctx, |controller, ctx| {
+                controller.send_agent_query_in_conversation(request.prompt, conversation_id, ctx);
+            });
+
+        terminal_view.enter_agent_view(
+            None,
+            Some(conversation_id),
+            AgentViewEntryOrigin::ChildAgent,
+            ctx,
+        );
+    });
+
+    Some(conversation_id)
+}
+
+/// Asynchronously prepares a local harness launch, then creates the
+/// hidden child pane and executes the launch command.
+#[cfg(not(target_family = "wasm"))]
+#[allow(clippy::too_many_arguments)]
+fn launch_local_harness_child(
+    group: &mut PaneGroup,
+    parent_pane_id: PaneId,
+    terminal_pane_id: TerminalPaneId,
+    request: StartAgentRequest,
+    harness_type: String,
+    model_id: Option<String>,
+    ctx: &mut ViewContext<PaneGroup>,
+) {
+    let startup_directory = group.startup_path_for_new_session(Some(terminal_pane_id), ctx);
+    let ai_client = ServerApiProvider::handle(ctx).as_ref(ctx).get_ai_client();
+    let request_id = request.id;
+    let request_name = request.name.clone();
+    let parent_conversation_id = request.parent_conversation_id;
+    let parent_run_id = request.parent_run_id.clone();
+    let prompt = request.prompt.clone();
+    let lifecycle_subscription = request.lifecycle_subscription.clone();
+    let shell_type = group
+        .terminal_view_from_pane_id(parent_pane_id, ctx)
+        .and_then(|terminal_view| terminal_view.as_ref(ctx).active_session_shell_type(ctx));
+
+    let _ = ctx.spawn(
+        async move {
+            prepare_local_harness_child_launch(
+                prompt,
+                harness_type,
+                parent_run_id,
+                shell_type,
+                startup_directory,
+                ai_client,
+            )
+            .await
+        },
+        move |group, result, ctx| match result {
+            Ok(launch) => {
+                let PreparedLocalHarnessLaunch {
+                    command,
+                    env_vars,
+                    run_id,
+                    task_id,
+                } = launch;
+                if let Some(HiddenChildAgentConversation {
+                    terminal_view: new_terminal_view,
+                    terminal_view_id,
+                    conversation_id,
+                    ..
+                }) = create_hidden_child_agent_conversation(
+                    group,
+                    parent_pane_id,
+                    request_name.clone(),
+                    parent_conversation_id,
+                    env_vars,
+                    None,
+                    ctx,
+                ) {
+                    apply_child_model_id_override(terminal_view_id, model_id.as_deref(), ctx);
+
+                    BlocklistAIHistoryModel::handle(ctx).update(ctx, |model, ctx| {
+                        model.record_new_conversation_request_complete(
+                            request_id,
+                            conversation_id,
+                            ctx,
+                        );
+                    });
+
+                    BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                        history_model.assign_run_id_for_conversation(
+                            conversation_id,
+                            run_id,
+                            Some(task_id),
+                            terminal_view_id,
+                            ctx,
+                        );
+                    });
+
+                    register_legacy_local_lifecycle_subscription(
+                        parent_conversation_id,
+                        conversation_id,
+                        lifecycle_subscription.clone(),
+                        ctx,
+                    );
+
+                    new_terminal_view.update(ctx, |terminal_view, ctx| {
+                        terminal_view.execute_command_or_set_pending(&command, ctx);
+                        terminal_view.enter_agent_view(
+                            None,
+                            Some(conversation_id),
+                            AgentViewEntryOrigin::ChildAgent,
+                            ctx,
+                        );
+                    });
+                } else {
+                    create_error_child_agent_conversation(
+                        group,
+                        parent_pane_id,
+                        request_name,
+                        parent_conversation_id,
+                        "Failed to create a hidden pane for the local child harness.".to_string(),
+                        ctx,
+                    );
+                }
+            }
+            Err(error_message) => {
+                create_error_child_agent_conversation(
+                    group,
+                    parent_pane_id,
+                    request_name,
+                    parent_conversation_id,
+                    error_message,
+                    ctx,
+                );
+            }
+        },
+    );
+}
+
+/// Fields destructured from `StartAgentExecutionMode::Remote` so they can be
+/// passed through to [`launch_remote_child`] as a single argument cluster.
+struct RemoteLaunchFields {
+    environment_id: String,
+    skill_references: Vec<ai::skills::SkillReference>,
+    model_id: String,
+    computer_use_enabled: bool,
+    worker_host: String,
+    harness_type: String,
+    title: String,
+}
+
+/// Sets up a hidden ambient-agent pane for a Remote child agent: creates the
+/// child conversation, marks it as remote, resolves runtime skills (silently
+/// bailing with a status update on resolution failure), constructs the
+/// `SpawnAgentRequest`, enters the agent view, and kicks off the spawn via
+/// the ambient agent view model. Returns the freshly-created
+/// `AIConversationId` on success.
+///
+/// The executor handle is used to echo the child conversation id back to
+/// the executor's pending table via
+/// [`StartAgentExecutor::record_child_conversation`] so the
+/// `ConversationServerTokenAssigned` event that fires when
+/// `model.spawn_agent_with_request` resolves can be matched back to this
+/// request.
+fn launch_remote_child(
+    group: &mut PaneGroup,
+    parent_pane_id: PaneId,
+    request: StartAgentRequest,
+    fields: RemoteLaunchFields,
+    ctx: &mut ViewContext<PaneGroup>,
+) -> Option<AIConversationId> {
+    let RemoteLaunchFields {
+        environment_id,
+        skill_references,
+        model_id,
+        computer_use_enabled,
+        worker_host,
+        harness_type,
+        title,
+    } = fields;
+
+    let request_id = request.id;
+    let Some(parent_run_id) = request.parent_run_id.clone() else {
+        log::error!(
+            "Remote StartAgent request missing parent_run_id for {:?}",
+            request.parent_conversation_id
+        );
+        return None;
+    };
+
+    let new_pane_id = group.insert_ambient_agent_pane_hidden_for_child_agent(parent_pane_id, ctx);
+
+    let Some(new_terminal_view) = group.terminal_view_from_pane_id(new_pane_id, ctx) else {
+        log::error!("Failed to get terminal view for new remote StartAgent pane");
+        group.discard_pane(new_pane_id.into(), ctx);
+        return None;
+    };
+
+    let terminal_view_id = new_terminal_view.id();
+    let conversation_id = BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+        let id = history_model.start_new_child_conversation(
+            terminal_view_id,
+            request.name,
+            request.parent_conversation_id,
+            ctx,
+        );
+        // Mark as remote so the parent's TaskStatusSyncModel skips status
+        // reporting — the remote worker handles it.
+        if let Some(c) = history_model.conversation_mut(&id) {
+            c.mark_as_remote_child();
+        }
+        id
+    });
+
+    BlocklistAIHistoryModel::handle(ctx).update(ctx, |model, ctx| {
+        model.record_new_conversation_request_complete(request_id, conversation_id, ctx);
+    });
+
+    let runtime_skills = match resolve_runtime_skills(&skill_references, ctx) {
+        Ok(runtime_skills) => runtime_skills,
+        Err(unresolved_references) => {
+            let error_message = format!(
+                "Failed to resolve child agent skills: {}",
+                unresolved_references.join(", ")
+            );
+            log::error!(
+                "Failed to resolve StartAgentV2 skill references for remote child {:?}: {}",
+                conversation_id,
+                unresolved_references.join(", ")
+            );
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                history_model.update_conversation_status_with_error_message(
+                    terminal_view_id,
+                    conversation_id,
+                    ConversationStatus::Error,
+                    Some(error_message),
+                    ctx,
+                );
+            });
+            return None;
+        }
+    };
+
+    // Treat an empty environment_id as "no environment specified" so the
+    // spawn request leaves the config.environment_id field unset. The
+    // server's StartAgent producer defaults to the parent's environment
+    // when available, so an empty value here means the caller explicitly
+    // opted into running with an empty environment.
+    let environment_id = Some(environment_id).filter(|s| !s.trim().is_empty());
+    // Unrecognized harness types collapse to None so the server picks
+    // its default, matching the behavior of an empty `harness_type`.
+    // We deliberately do NOT round-trip `Harness::Unknown` to the server;
+    // that variant is for representing server-originated unknowns to the
+    // user, not for writes.
+    let harness_override = if harness_type.is_empty() {
+        None
+    } else {
+        match <Harness as clap::ValueEnum>::from_str(&harness_type, true) {
+            Ok(harness) => Some(HarnessConfig::from_harness_type(harness)),
+            Err(_) => {
+                log::warn!(
+                    "Unknown harness type from StartAgentV2 proto: {harness_type:?}; omitting harness override so the server picks its default"
+                );
+                None
+            }
+        }
+    };
+    let spawn_request = SpawnAgentRequest {
+        prompt: request.prompt,
+        mode: UserQueryMode::Normal,
+        config: Some(AgentConfigSnapshot {
+            environment_id,
+            model_id: (!model_id.is_empty()).then_some(model_id),
+            worker_host: (!worker_host.is_empty()).then_some(worker_host),
+            computer_use_enabled: Some(computer_use_enabled),
+            harness: harness_override,
+            ..Default::default()
+        }),
+        title: (!title.is_empty()).then_some(title),
+        team: None,
+        skill: None,
+        attachments: vec![],
+        interactive: Some(true),
+        parent_run_id: Some(parent_run_id),
+        runtime_skills,
+        referenced_attachments: vec![],
+    };
+
+    new_terminal_view.update(ctx, |terminal_view, ctx| {
+        terminal_view.enter_agent_view(
+            None,
+            Some(conversation_id),
+            AgentViewEntryOrigin::CloudAgent,
+            ctx,
+        );
+        if let Some(ambient_agent_view_model) = terminal_view.ambient_agent_view_model() {
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.set_conversation_id(Some(conversation_id));
+                model.spawn_agent_with_request(spawn_request, ctx);
+            });
+        } else {
+            log::error!("Remote StartAgent child pane missing ambient agent view model");
+        }
+    });
+
+    group
+        .child_agent_panes
+        .insert(conversation_id, new_pane_id.into());
+
+    Some(conversation_id)
 }
 
 #[cfg(feature = "local_fs")]
@@ -1500,7 +1631,7 @@ fn handle_ai_history_event(
             }
 
             // Do not persist AI queries from shared ambient agent sessions that we've viewed,
-            // as these were sent as part of an ambient agent run and shouldn't pollute the up arrow history.
+            // as these were sent as part of an ambient agent run and shouldn't polute the up arrow history.
             if is_shared_ambient_agent_session {
                 return;
             }
@@ -1575,6 +1706,7 @@ fn handle_ai_history_event(
         | BlocklistAIHistoryEvent::UpgradedTask { .. }
         | BlocklistAIHistoryEvent::UpdatedConversationMetadata { .. }
         | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
-        | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. } => (),
+        | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
+        | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. } => (),
     }
 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -1974,8 +1974,12 @@ pub enum Event {
         variant: CloudAgentCapacityModalVariant,
     },
     FreeTierLimitCheckTriggered,
-    /// Emitted when the StartAgent executor needs the workspace to create a new child
-    /// agent conversation in a split pane.
+    /// Emitted when the StartAgent executor needs the workspace to create
+    /// a new child agent conversation in a split pane. The freshly-created
+    /// child conversation id is echoed back to the executor via
+    /// [`BlocklistAIHistoryModel::record_new_conversation_request_complete`]
+    /// so the executor can disambiguate per-request pendings when multiple
+    /// StartAgent requests are in flight in parallel.
     StartAgentConversation(StartAgentRequest),
     /// Emitted when the user clicks a child agent row in the status card to reveal
     /// its hidden pane.
@@ -5442,7 +5446,8 @@ impl TerminalView {
             | BlocklistAIHistoryEvent::UpdatedConversationMetadata { .. }
             | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
             | BlocklistAIHistoryEvent::DeletedConversation { .. }
-            | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. } => {}
+            | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
+            | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. } => {}
         }
         ctx.notify();
     }
@@ -6385,7 +6390,7 @@ impl TerminalView {
 
     fn handle_start_agent_executor_event(
         &mut self,
-        _: ModelHandle<StartAgentExecutor>,
+        _executor: ModelHandle<StartAgentExecutor>,
         event: &StartAgentExecutorEvent,
         ctx: &mut ViewContext<Self>,
     ) {

--- a/app/src/view_components/dropdown.rs
+++ b/app/src/view_components/dropdown.rs
@@ -3,8 +3,8 @@ use std::fmt::Debug;
 use pathfinder_color::ColorU;
 use warpui::{
     elements::{
-        Border, ChildAnchor, ChildView, ConstrainedBox, Container, Element, Icon,
-        MainAxisAlignment, MainAxisSize, MouseStateHandle, OffsetPositioning, ParentElement,
+        Border, ChildAnchor, ChildView, ConstrainedBox, Container, CornerRadius, Element, Fill,
+        Icon, MainAxisAlignment, MainAxisSize, MouseStateHandle, OffsetPositioning, ParentElement,
         PositionedElementAnchor, PositionedElementOffsetBounds, SavePosition, Stack,
     },
     fonts::FamilyId,
@@ -82,8 +82,36 @@ pub struct Dropdown<A: Action + Clone> {
     font_color: Option<ColorU>,
     font_size: Option<f32>,
     padding: Option<Coords>,
+    /// Optional override for the top-bar background fill, applied on top
+    /// of the variant's default style. Used by callers that need a
+    /// per-call appearance distinct from the shared `DropdownStyle`
+    /// variants (e.g. orchestrate confirmation card pickers per Figma
+    /// 4340:117057).
+    background: Option<Fill>,
+    /// Optional override for the top-bar border fill. See `background`.
+    border_color: Option<Fill>,
+    /// Optional override for the top-bar border width.
+    border_width: Option<f32>,
+    /// Optional override for the top-bar corner radius.
+    border_radius: Option<CornerRadius>,
     vertical_margin: f32,
     top_bar_height: f32,
+    /// When true (default), the open menu is attached to the dropdown's
+    /// stack via `add_positioned_overlay_child`, painting it in an
+    /// `Overlay` layer that escapes parent clip bounds. When false, the
+    /// menu is attached via `add_positioned_child` and paints in the
+    /// parent's Normal layer, the same way other AIBlock-internal
+    /// menus (e.g. the accept-and-autoexecute split-button menu in
+    /// `requested_command.rs` / `code_diff_view.rs`) do.
+    ///
+    /// Setting this to `false` is required for dropdowns rendered
+    /// inside a `SelectableArea` whose menu items would otherwise lose
+    /// `LeftMouseDown` / `LeftMouseUp` (hover still works) due to an
+    /// interaction between `Menu`'s `prevent_interaction_with_other_elements`
+    /// full-window hit-recording rect and the surrounding
+    /// `SelectableArea`. Tracked as P1.1 for the orchestrate
+    /// confirmation card pickers.
+    use_overlay_layer: bool,
 }
 
 #[derive(Clone)]
@@ -191,9 +219,43 @@ where
             font_color: None,
             font_size: None,
             padding: None,
+            background: None,
+            border_color: None,
+            border_width: None,
+            border_radius: None,
             vertical_margin: DROPDOWN_PADDING,
             top_bar_height: TOP_MENU_BAR_HEIGHT,
+            use_overlay_layer: true,
         }
+    }
+
+    /// Controls whether the open menu is rendered in an `Overlay`
+    /// layer (default) or attached as a positioned child in the
+    /// dropdown stack's Normal layer. See the field-level docs on
+    /// `use_overlay_layer` for when each is appropriate.
+    pub fn set_use_overlay_layer(&mut self, use_overlay_layer: bool, ctx: &mut ViewContext<Self>) {
+        self.use_overlay_layer = use_overlay_layer;
+        ctx.notify();
+    }
+
+    pub fn set_background(&mut self, background: Fill, ctx: &mut ViewContext<Self>) {
+        self.background = Some(background);
+        ctx.notify();
+    }
+
+    pub fn set_border_color(&mut self, border_color: Fill, ctx: &mut ViewContext<Self>) {
+        self.border_color = Some(border_color);
+        ctx.notify();
+    }
+
+    pub fn set_border_width(&mut self, border_width: f32, ctx: &mut ViewContext<Self>) {
+        self.border_width = Some(border_width);
+        ctx.notify();
+    }
+
+    pub fn set_border_radius(&mut self, border_radius: CornerRadius, ctx: &mut ViewContext<Self>) {
+        self.border_radius = Some(border_radius);
+        ctx.notify();
     }
 
     pub fn with_drop_shadow(mut self) -> Self {
@@ -458,6 +520,10 @@ where
                 font_color: self.font_color,
                 font_size: self.font_size,
                 padding: self.padding,
+                background: self.background,
+                border_color: self.border_color,
+                border_width: self.border_width,
+                border_radius: self.border_radius,
                 ..Default::default()
             })
             .set_clicked_styles(None);
@@ -547,16 +613,18 @@ where
                     .with_drop_shadow(DropShadow::default())
                     .finish();
             }
-            dropdown_stack.add_positioned_overlay_child(
-                menu,
-                OffsetPositioning::offset_from_save_position_element(
-                    self.top_bar_label(),
-                    vec2f(0., 0.),
-                    PositionedElementOffsetBounds::WindowByPosition,
-                    self.element_anchor,
-                    self.child_anchor,
-                ),
+            let positioning = OffsetPositioning::offset_from_save_position_element(
+                self.top_bar_label(),
+                vec2f(0., 0.),
+                PositionedElementOffsetBounds::WindowByPosition,
+                self.element_anchor,
+                self.child_anchor,
             );
+            if self.use_overlay_layer {
+                dropdown_stack.add_positioned_overlay_child(menu, positioning);
+            } else {
+                dropdown_stack.add_positioned_child(menu, positioning);
+            }
         }
         Container::new(dropdown_stack.finish())
             .with_margin_top(self.vertical_margin)

--- a/app/src/view_components/filterable_dropdown.rs
+++ b/app/src/view_components/filterable_dropdown.rs
@@ -68,6 +68,11 @@ pub struct FilterableDropdown<A: Action + Clone> {
     menu_width: Option<f32>,
     vertical_margin: f32,
     top_bar_height: f32,
+    /// See `Dropdown::use_overlay_layer`. Mirrors the same opt-out for
+    /// `FilterableDropdown` callers (the orchestrate environment
+    /// picker) that need to render in the parent's Normal layer
+    /// instead of an overlay.
+    use_overlay_layer: bool,
 }
 
 impl<A> FilterableDropdown<A>
@@ -125,7 +130,23 @@ where
             menu_width: None,
             vertical_margin: DROPDOWN_PADDING,
             top_bar_height: TOP_MENU_BAR_HEIGHT,
+            use_overlay_layer: true,
         }
+    }
+
+    /// See `Dropdown::set_use_overlay_layer`.
+    pub fn set_use_overlay_layer(&mut self, use_overlay_layer: bool, ctx: &mut ViewContext<Self>) {
+        self.use_overlay_layer = use_overlay_layer;
+        ctx.notify();
+    }
+
+    /// Override the top-bar height.
+    /// so callers (e.g. the orchestrate environment picker) that mix
+    /// `Dropdown` and `FilterableDropdown` in the same row can size them
+    /// identically.
+    pub fn set_top_bar_height(&mut self, height: f32, ctx: &mut ViewContext<Self>) {
+        self.top_bar_height = height;
+        ctx.notify();
     }
 
     pub fn set_menu_header_text_override<F>(&mut self, formatter: F)
@@ -712,26 +733,28 @@ where
 
         let mut dropdown_stack = Stack::new().with_child(self.render_top_bar(appearance));
         if self.is_expanded {
-            dropdown_stack.add_positioned_overlay_child(
-                dropdown_menu,
-                if self.orientation == FilterableDropdownOrientation::Down {
-                    OffsetPositioning::offset_from_save_position_element(
-                        self.top_bar_label(),
-                        vec2f(0., 0.),
-                        PositionedElementOffsetBounds::WindowByPosition,
-                        PositionedElementAnchor::BottomLeft,
-                        ChildAnchor::TopLeft,
-                    )
-                } else {
-                    OffsetPositioning::offset_from_save_position_element(
-                        self.top_bar_label(),
-                        vec2f(0., 0.),
-                        PositionedElementOffsetBounds::WindowByPosition,
-                        PositionedElementAnchor::TopLeft,
-                        ChildAnchor::BottomLeft,
-                    )
-                },
-            );
+            let positioning = if self.orientation == FilterableDropdownOrientation::Down {
+                OffsetPositioning::offset_from_save_position_element(
+                    self.top_bar_label(),
+                    vec2f(0., 0.),
+                    PositionedElementOffsetBounds::WindowByPosition,
+                    PositionedElementAnchor::BottomLeft,
+                    ChildAnchor::TopLeft,
+                )
+            } else {
+                OffsetPositioning::offset_from_save_position_element(
+                    self.top_bar_label(),
+                    vec2f(0., 0.),
+                    PositionedElementOffsetBounds::WindowByPosition,
+                    PositionedElementAnchor::TopLeft,
+                    ChildAnchor::BottomLeft,
+                )
+            };
+            if self.use_overlay_layer {
+                dropdown_stack.add_positioned_overlay_child(dropdown_menu, positioning);
+            } else {
+                dropdown_stack.add_positioned_child(dropdown_menu, positioning);
+            }
         }
         Container::new(dropdown_stack.finish())
             .with_margin_top(self.vertical_margin)

--- a/app/src/view_components/mod.rs
+++ b/app/src/view_components/mod.rs
@@ -26,7 +26,9 @@ pub use copyable_text_field::*;
 pub use dismissible_toast::*;
 pub use dropdown::{Dropdown, DropdownEvent, DropdownItem};
 pub use feature_popup::*;
-pub use filterable_dropdown::{FilterableDropdown, FilterableDropdownOrientation};
+pub use filterable_dropdown::{
+    FilterableDropdown, FilterableDropdownEvent, FilterableDropdownOrientation,
+};
 pub use markdown_toggle_view::{MarkdownToggleEvent, MarkdownToggleView};
 pub use submittable_text_input::*;
 pub use warning_box::*;

--- a/crates/ai/src/agent/action/mod.rs
+++ b/crates/ai/src/agent/action/mod.rs
@@ -16,8 +16,8 @@ use crate::{
             FileGlobV2Result, GrepResult, InsertReviewCommentsResult, ReadDocumentsResult,
             ReadFilesResult, ReadMCPResourceResult, ReadShellCommandOutputResult, ReadSkillResult,
             RequestCommandOutputResult, RequestComputerUseResult, RequestFileEditsResult,
-            SearchCodebaseResult, SendMessageToAgentResult, StartAgentResult, StartAgentVersion,
-            SuggestNewConversationResult, SuggestPromptResult,
+            RunAgentsResult, SearchCodebaseResult, SendMessageToAgentResult, StartAgentResult,
+            StartAgentVersion, SuggestNewConversationResult, SuggestPromptResult,
             TransferShellCommandControlToUserResult, UploadArtifactResult, UseComputerResult,
             WriteToLongRunningShellCommandResult,
         },
@@ -167,6 +167,54 @@ pub enum AIAgentActionType {
     AskUserQuestion {
         questions: Vec<AskUserQuestionItem>,
     },
+
+    /// AI requested batched orchestration of one-or-more child agents that
+    /// share run-wide configuration (model, harness, execution mode).
+    /// The full per-child prompt is computed at dispatch time as
+    /// `base_prompt + "\n\n" + agent_run_configs[i].prompt` (or just
+    /// `base_prompt` when the per-agent `prompt` is empty).
+    RunAgents(RunAgentsRequest),
+}
+
+/// Run-wide + per-agent configuration for a `RunAgents` tool call.
+///
+/// Mirrors the proto `RunAgents` message. Server-resolved fields
+/// (`model_id`, `harness_type`, `execution_mode`'s remote details) are
+/// folded in by the server's final tool-call re-emission once the
+/// payload is complete; the client renders the full layout from a
+/// fully-resolved instance only.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RunAgentsRequest {
+    pub summary: String,
+    pub base_prompt: String,
+    pub skills: Vec<SkillReference>,
+    pub model_id: String,
+    pub harness_type: String,
+    pub execution_mode: RunAgentsExecutionMode,
+    pub agent_run_configs: Vec<RunAgentsAgentRunConfig>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum RunAgentsExecutionMode {
+    Local,
+    Remote {
+        environment_id: String,
+        worker_host: String,
+        computer_use_enabled: bool,
+    },
+}
+
+impl RunAgentsExecutionMode {
+    pub fn is_remote(&self) -> bool {
+        matches!(self, Self::Remote { .. })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RunAgentsAgentRunConfig {
+    pub name: String,
+    pub prompt: String,
+    pub title: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -175,6 +223,11 @@ pub enum StartAgentExecutionMode {
         /// `None` selects the legacy embedded local child-agent flow.
         /// `Some(...)` selects a third-party CLI harness to launch locally.
         harness_type: Option<String>,
+        /// `None` inherits the parent agent's preferred LLM (legacy behavior).
+        /// `Some(_)` overrides the child's preferred LLM with the supplied
+        /// model id (used by the orchestrate confirmation card so the user's
+        /// model selection is honored on local launches).
+        model_id: Option<String>,
     },
     Remote {
         environment_id: String,
@@ -190,12 +243,16 @@ pub enum StartAgentExecutionMode {
 impl StartAgentExecutionMode {
     /// Constructs a local execution mode using the legacy v1 default harness.
     pub fn local_with_defaults() -> Self {
-        Self::Local { harness_type: None }
+        Self::Local {
+            harness_type: None,
+            model_id: None,
+        }
     }
     /// Constructs a local execution mode for a specific third-party harness.
     pub fn local_harness(harness_type: String) -> Self {
         Self::Local {
             harness_type: Some(harness_type),
+            model_id: None,
         }
     }
     /// Constructs a remote execution mode using the legacy v1 defaults for
@@ -317,6 +374,7 @@ impl AIAgentActionType {
             Self::AskUserQuestion { .. } => {
                 AIAgentActionResultType::AskUserQuestion(AskUserQuestionResult::Cancelled)
             }
+            Self::RunAgents(_) => AIAgentActionResultType::RunAgents(RunAgentsResult::Cancelled),
         }
     }
 
@@ -361,6 +419,9 @@ impl AIAgentActionType {
             }
             Self::AskUserQuestion { questions } => {
                 format!("Ask user {} question(s)", questions.len())
+            }
+            Self::RunAgents(req) => {
+                format!("Orchestrate {} agent(s)", req.agent_run_configs.len())
             }
         }
     }
@@ -533,6 +594,15 @@ impl Display for AIAgentActionType {
             }
             AIAgentActionType::AskUserQuestion { questions } => {
                 write!(f, "AskUserQuestion: {} question(s)", questions.len())
+            }
+            AIAgentActionType::RunAgents(req) => {
+                let names = req
+                    .agent_run_configs
+                    .iter()
+                    .map(|c| c.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "Orchestrate: summary='{}' agents=[{names}]", req.summary,)
             }
         }
     }

--- a/crates/ai/src/agent/action_result/convert.rs
+++ b/crates/ai/src/agent/action_result/convert.rs
@@ -1287,6 +1287,121 @@ impl From<AskUserQuestionResult> for api::request::input::tool_call_result::Resu
     }
 }
 
+impl From<RunAgentsLaunchedExecutionMode>
+    for api::run_agents_result::launched::ResolvedExecutionMode
+{
+    fn from(mode: RunAgentsLaunchedExecutionMode) -> Self {
+        match mode {
+            RunAgentsLaunchedExecutionMode::Local => {
+                api::run_agents_result::launched::ResolvedExecutionMode::Local(
+                    api::run_agents::Local {},
+                )
+            }
+            RunAgentsLaunchedExecutionMode::Remote {
+                environment_id,
+                worker_host,
+                computer_use_enabled,
+            } => api::run_agents_result::launched::ResolvedExecutionMode::Remote(
+                api::run_agents::Remote {
+                    environment_id,
+                    worker_host,
+                    computer_use_enabled,
+                },
+            ),
+        }
+    }
+}
+
+impl From<RunAgentsAgentOutcome> for api::run_agents_result::AgentOutcome {
+    fn from(outcome: RunAgentsAgentOutcome) -> Self {
+        let result = match outcome.kind {
+            RunAgentsAgentOutcomeKind::Launched { agent_id } => {
+                api::run_agents_result::agent_outcome::Result::Launched(
+                    api::run_agents_result::LaunchedAgent { agent_id },
+                )
+            }
+            RunAgentsAgentOutcomeKind::Failed { error } => {
+                api::run_agents_result::agent_outcome::Result::Failed(
+                    api::run_agents_result::FailedAgent { error },
+                )
+            }
+        };
+        api::run_agents_result::AgentOutcome {
+            name: outcome.name,
+            result: Some(result),
+        }
+    }
+}
+
+/// Maps a client-side harness string identifier (e.g. "oz", "claude")
+/// to the new proto `Harness` oneof. Returns `None` for empty,
+/// unrecognized, or `"unknown"` strings; callers leave
+/// `resolved_harness` unset in that case.
+pub(super) fn build_api_harness(harness_type: &str) -> Option<api::Harness> {
+    let normalized = harness_type.trim().to_ascii_lowercase().replace('_', "-");
+    let variant = match normalized.as_str() {
+        "oz" => api::harness::Variant::Oz(api::harness::Oz {}),
+        "claude" | "claude-code" => api::harness::Variant::ClaudeCode(api::harness::ClaudeCode {}),
+        "opencode" | "open-code" => api::harness::Variant::OpenCode(api::harness::OpenCode {}),
+        "gemini" => api::harness::Variant::Gemini(api::harness::Gemini {}),
+        "codex" => api::harness::Variant::Codex(api::harness::Codex {}),
+        _ => return None,
+    };
+    Some(api::Harness {
+        variant: Some(variant),
+    })
+}
+
+impl TryFrom<RunAgentsResult> for api::request::input::tool_call_result::Result {
+    type Error = ConvertToAPITypeError;
+
+    fn try_from(result: RunAgentsResult) -> Result<Self, Self::Error> {
+        match result {
+            RunAgentsResult::Launched {
+                model_id,
+                harness_type,
+                execution_mode,
+                agents,
+            } => Ok(
+                api::request::input::tool_call_result::Result::RunAgentsResult(
+                    api::RunAgentsResult {
+                        outcome: Some(api::run_agents_result::Outcome::Launched(
+                            api::run_agents_result::Launched {
+                                resolved_model_id: model_id,
+                                resolved_harness: build_api_harness(&harness_type),
+                                resolved_execution_mode: Some(execution_mode.into()),
+                                agents: agents.into_iter().map(Into::into).collect(),
+                            },
+                        )),
+                    },
+                ),
+            ),
+            RunAgentsResult::Denied { reason } => Ok(
+                api::request::input::tool_call_result::Result::RunAgentsResult(
+                    api::RunAgentsResult {
+                        outcome: Some(api::run_agents_result::Outcome::Denied(
+                            api::run_agents_result::Denied { reason },
+                        )),
+                    },
+                ),
+            ),
+            RunAgentsResult::Failure { error } => Ok(
+                api::request::input::tool_call_result::Result::RunAgentsResult(
+                    api::RunAgentsResult {
+                        outcome: Some(api::run_agents_result::Outcome::Failure(
+                            api::run_agents_result::Failure { error },
+                        )),
+                    },
+                ),
+            ),
+            // Reject is conveyed by the generic ToolCallResult.Cancel marker
+            // synthesized server-side on the next user input; nothing for the
+            // client to send on the wire here.
+            RunAgentsResult::Cancelled => Err(ConvertToAPITypeError::Ignore),
+        }
+    }
+}
+
 impl TryFrom<InsertReviewCommentsResult> for api::request::input::tool_call_result::Result {
     type Error = ConvertToAPITypeError;
 

--- a/crates/ai/src/agent/action_result/mod.rs
+++ b/crates/ai/src/agent/action_result/mod.rs
@@ -95,6 +95,10 @@ pub enum AIAgentActionResultType {
     TransferShellCommandControlToUser(TransferShellCommandControlToUserResult),
     /// The result of asking the user a question.
     AskUserQuestion(AskUserQuestionResult),
+
+    /// The result of an orchestrate tool call: launched (with per-agent
+    /// outcomes), launch denied (Stage 2), failure, or cancelled.
+    RunAgents(RunAgentsResult),
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -161,6 +165,7 @@ impl Display for AIAgentActionResultType {
             AIAgentActionResultType::SendMessageToAgent(result) => result.fmt(f),
             AIAgentActionResultType::TransferShellCommandControlToUser(result) => result.fmt(f),
             AIAgentActionResultType::AskUserQuestion(result) => result.fmt(f),
+            AIAgentActionResultType::RunAgents(result) => result.fmt(f),
             AIAgentActionResultType::OpenCodeReview | AIAgentActionResultType::InitProject => {
                 Ok(())
             }
@@ -753,6 +758,9 @@ impl AIAgentActionResultType {
             AIAgentActionResultType::AskUserQuestion(_) => {
                 "The user's answers to clarifying questions"
             }
+            AIAgentActionResultType::RunAgents(_) => {
+                "The result of an orchestrate batch of child agents"
+            }
         }
     }
 
@@ -790,6 +798,7 @@ impl AIAgentActionResultType {
                 | TransferShellCommandControlToUserResult::CommandFinished { .. },
             ) => true,
             Self::AskUserQuestion(AskUserQuestionResult::Success { .. }) => true,
+            Self::RunAgents(RunAgentsResult::Launched { .. }) => true,
             _ => false,
         }
     }
@@ -818,7 +827,10 @@ impl AIAgentActionResultType {
             | Self::AskUserQuestion(AskUserQuestionResult::Error(_))
             | Self::TransferShellCommandControlToUser(
                 TransferShellCommandControlToUserResult::Error(_),
-            ) => true,
+            )
+            | Self::RunAgents(RunAgentsResult::Failure { .. } | RunAgentsResult::Denied { .. }) => {
+                true
+            }
             _ => false,
         }
     }
@@ -860,7 +872,8 @@ impl AIAgentActionResultType {
             | Self::StartAgent(StartAgentResult::Cancelled { .. })
             | Self::SendMessageToAgent(SendMessageToAgentResult::Cancelled)
             // SkippedByAutoApprove is intentionally excluded: the agent should continue.
-            | Self::AskUserQuestion(AskUserQuestionResult::Cancelled) => true,
+            | Self::AskUserQuestion(AskUserQuestionResult::Cancelled)
+            | Self::RunAgents(RunAgentsResult::Cancelled) => true,
             _ => false,
         }
     }
@@ -1225,6 +1238,83 @@ impl Display for StartAgentResult {
             }
             StartAgentResult::Error { error, .. } => write!(f, "Start agent error: {error}"),
             StartAgentResult::Cancelled { .. } => write!(f, "Start agent cancelled"),
+        }
+    }
+}
+
+/// The terminal outcome of an orchestrate tool call.
+///
+/// Mirrors the proto `RunAgentsResult` oneof, with an additional
+/// `Cancelled` variant used internally by the action machinery when the
+/// user clicks Reject. The proto wire form for cancellation is the
+/// generic `ToolCallResult.Cancel` marker; the conversion code emits
+/// `ConvertToAPITypeError::Ignore` for `Cancelled` so the input
+/// interceptor can synthesize the marker on the next outbound input.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RunAgentsResult {
+    /// Orchestration launched. Carries the resolved configuration and one
+    /// `AgentOutcome` per `agent_run_configs[]` entry, in input order.
+    Launched {
+        model_id: String,
+        harness_type: String,
+        execution_mode: RunAgentsLaunchedExecutionMode,
+        agents: Vec<RunAgentsAgentOutcome>,
+    },
+    /// Declined for a non-error reason (currently disapproval).
+    Denied { reason: String },
+    /// Actual error path: server-side validation rejected the call, or the
+    /// client could not begin the launch sequence at all.
+    Failure { error: String },
+    /// User rejected via the Reject button. Wire form is the generic
+    /// `ToolCallResult.Cancel` marker, synthesized by the server's input
+    /// interceptor on the next user input.
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RunAgentsLaunchedExecutionMode {
+    Local,
+    Remote {
+        environment_id: String,
+        worker_host: String,
+        computer_use_enabled: bool,
+    },
+}
+
+/// Per-agent outcome reported in `RunAgentsResult::Launched.agents`.
+/// Order mirrors the input order of `RunAgents.agent_run_configs[]`,
+/// regardless of which `CreateAgentTask` call returned first.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunAgentsAgentOutcome {
+    pub name: String,
+    pub kind: RunAgentsAgentOutcomeKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RunAgentsAgentOutcomeKind {
+    Launched { agent_id: String },
+    Failed { error: String },
+}
+
+impl Display for RunAgentsResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RunAgentsResult::Launched { agents, .. } => {
+                let launched = agents
+                    .iter()
+                    .filter(|a| matches!(a.kind, RunAgentsAgentOutcomeKind::Launched { .. }))
+                    .count();
+                write!(
+                    f,
+                    "Orchestrate launched ({launched}/{} agents started)",
+                    agents.len()
+                )
+            }
+            RunAgentsResult::Denied { reason } => {
+                write!(f, "Orchestrate launch denied: {reason}")
+            }
+            RunAgentsResult::Failure { error } => write!(f, "Orchestrate failure: {error}"),
+            RunAgentsResult::Cancelled => write!(f, "Orchestrate cancelled"),
         }
     }
 }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -715,6 +715,15 @@ pub enum FeatureFlag {
     /// real time.
     OrchestrationV2,
 
+    /// Gates client-side support for the `orchestrate` tool, which batches
+    /// multiple child agents into a single tool call with an inline
+    /// confirmation card. When enabled, the client advertises
+    /// `RequestSettings.SupportsOrchestrate = true` and the server's
+    /// orchestrate tool replaces `start_agent` / `start_agent_v2` for
+    /// orchestration-capable conversations. Layered on top of
+    /// `OrchestrationV2`; has no effect when v2 is off.
+    RunAgentsTool,
+
     /// Renders a horizontal pill bar in the agent view pane header showing the
     /// orchestrator agent and all of its child agents, with click-to-switch
     /// behavior between siblings.
@@ -915,6 +924,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::RememberFastForwardState,
     FeatureFlag::HOANotifications,
     FeatureFlag::OrchestrationV2,
+    FeatureFlag::RunAgentsTool,
     FeatureFlag::GeminiNotifications,
     FeatureFlag::LocalDockerSandbox,
     FeatureFlag::VerticalTabsSummaryMode,


### PR DESCRIPTION
## Description

Client-side implementation of the `RunAgents` orchestration tool, paired with server PR https://github.com/warpdotdev/warp-server/pull/10809.

### What
- **RunAgentsCardView**: confirmation card UI with inline editor for model, harness, environment, host, and execution mode (Local/Cloud)
- **RunAgentsExecutor**: executor that dispatches accepted requests, spawning child agent conversations via `StartAgentExecutor`
- **Cancel handling**: card subscribes to `FinishedAction` events so Ctrl+C (both card-level and terminal-level) shows the cancelled state
- **Harness support**: Oz, Claude, Gemini, Codex with brand icons; local-dev host gated on `Channel::Local`
- **Spawning card**: in-flight "Spawning N agents..." status while children are being launched
- **Proto adoption**: `RunAgents` request/result types, `Harness` oneof shape, `StartAgentV2` advertised alongside `Orchestrate`

### Demo
https://www.loom.com/share/dacad55f436b42d29191bf54461ab3cf

## Testing
- Manual validation of accept, reject (Ctrl+C), edit/discard, picker interactions, local and cloud execution modes
- Existing tests updated for new harness list and import ordering

## Server API dependencies
- [x] Does this change rely on a new server API?
  - Server PR: https://github.com/warpdotdev/warp-server/pull/10809

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>