### PR TITLE
Remove LessHorizontalTerminalPadding feature flag

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -465,7 +465,6 @@ default = [
     "shared_with_me",
     "block_toolbelt_save_as_workflow",
     "remove_alt_screen_padding",
-    "less_horizontal_terminal_padding",
     "session_sharing_acls",
     "external_agent_mode_context",
     "shell_selector",
@@ -778,7 +777,6 @@ alacritty_settings_import = []
 shared_with_me = []
 ai_rules = []
 am_workflows = []
-less_horizontal_terminal_padding = []
 shell_selector = []
 shared_session_long_running_commands = []
 block_toolbelt_save_as_workflow = []

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2473,8 +2473,6 @@ pub fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::AIRules,
         #[cfg(feature = "ssh_tmux_wrapper")]
         FeatureFlag::SSHTmuxWrapper,
-        #[cfg(feature = "less_horizontal_terminal_padding")]
-        FeatureFlag::LessHorizontalTerminalPadding,
         #[cfg(feature = "shell_selector")]
         FeatureFlag::ShellSelector,
         #[cfg(feature = "block_toolbelt_save_as_workflow")]

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -749,11 +749,7 @@ lazy_static! {
 
     /// The padding between the left of the element and where the grid contents (either via the
     /// `BlockList` or the `AltScreen`) should be rendered.
-    pub static ref PADDING_LEFT: f32 = if FeatureFlag::LessHorizontalTerminalPadding.is_enabled() {
-        16.
-    } else {
-        20.
-    };
+    pub static ref PADDING_LEFT: f32 = 16.;
 }
 
 #[derive(Default)]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -142,10 +142,6 @@ pub enum FeatureFlag {
     /// Routes SSH sessions through the tmux-backed SSH wrapper.
     SSHTmuxWrapper,
 
-    /// Reduces the amount of horizontal padding in the blocklist
-    /// from 20px to 16px.
-    LessHorizontalTerminalPadding,
-
     /// Enables the shell selector, allowing us to open a new tab in
     /// a shell other than the default shell.
     ShellSelector,


### PR DESCRIPTION
## Summary

- Removes the `LessHorizontalTerminalPadding` feature flag, which has been enabled in `default` features in `app/Cargo.toml` and is stable in production.
- Unconditionally sets `PADDING_LEFT` to `16.` in `app/src/terminal/view.rs` (the value previously enabled by the flag).
- Removes the flag variant from `FeatureFlag` enum, the `#[cfg]`/variant registration in `app/src/lib.rs`, and the `[features]` entry in `app/Cargo.toml`.

## Test plan
- [ ] Build the app and verify terminal horizontal padding is 16px as expected
- [ ] Check that no `LessHorizontalTerminalPadding` references remain in Rust source files

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._