### PR TITLE
Fix schema generator binary recompilation during release bundling.

### DIFF
--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -240,7 +240,7 @@ fi
 if [[ "$ARTIFACT" == "cli" ]]; then
   echo "Preparing CLI resources directory"
   BUNDLED_RESOURCES_DIR="$OUT_DIR/resources"
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
+  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES"
 fi
 
 
@@ -269,7 +269,8 @@ export \
   APPIMAGE_NAME \
   BUILD_ARCH \
   ARTIFACT \
-  CARGO_PROFILE
+  CARGO_PROFILE \
+  FEATURES
 
 # Build the AppImage bundle.
 if [[ ${PACKAGES[@]} =~ "appimage" ]]; then

--- a/script/linux/bundle_install
+++ b/script/linux/bundle_install
@@ -13,6 +13,9 @@
 #   - EXECUTABLE_PATH: The path to the compiled executable we want to install.
 #   - BINARY_NAME: The name that the compiled executable should have on the target machine.
 #   - ARTIFACT: Which artifact to build: app or cli.
+#   - FEATURES: Comma-separated cargo features used to build the main binary.
+#                Used to invoke the settings schema generator with the same
+#                feature set so cargo can reuse compiled artifacts.
 
 set -e
 
@@ -44,4 +47,8 @@ if [[ "$ARTIFACT" == "app" ]]; then
 fi
 
 # Prepare the bundled resources directory.
-"$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "${TARGET_DIR}/${OPT_DIR}/resources" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
+#
+# Pass FEATURES through so the settings schema generator builds with the same
+# feature set as the main binary; otherwise cargo will recompile any
+# dependencies whose enabled features differ.
+"$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "${TARGET_DIR}/${OPT_DIR}/resources" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES"

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -516,7 +516,7 @@ if [[ "$ARTIFACT" == "app" ]]; then
 
   BUNDLED_RESOURCES_DIR="$BUNDLE_DIR/$WARP_APP_NAME.app/Contents/Resources"
   echo "Preparing bundled resources..."
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
+  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES" "$DEFAULT_TARGET"
 
   "$WORKSPACE_ROOT_DIR/script/compile_icon" "$RELEASE_CHANNEL" "$BUNDLE_DIR/$WARP_APP_NAME.app"
 
@@ -588,7 +588,7 @@ elif [[ "$ARTIFACT" == "cli" ]]; then
 
   echo "Preparing CLI resources directory"
   BUNDLED_RESOURCES_DIR="$OUT_DIR/resources"
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
+  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES" "$DEFAULT_TARGET"
 
 
   # Set the primary binary path to output.

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -61,6 +61,16 @@ ARM_ARCH="aarch64"
 ARM_TARGET="$ARM_ARCH-apple-darwin"
 DEFAULT_ARCH="$(rustc --print cfg | grep target_arch)"
 
+# The Rust target triple corresponding to the build host. Used below to
+# decide whether to forward --target to `cargo run` for the settings schema
+# generator: that step needs to execute its compiled binary, so we can only
+# pass a target that's runnable on the host.
+if [[ "$DEFAULT_ARCH" == *"$INTEL_ARCH"* ]]; then
+    HOST_TARGET="$INTEL_TARGET"
+elif [[ "$DEFAULT_ARCH" == *"$ARM_ARCH"* ]]; then
+    HOST_TARGET="$ARM_TARGET"
+fi
+
 # Function to clean up temporary DMG files
 cleanup_dmg_files() {
     local target_dir="$1"
@@ -516,7 +526,15 @@ if [[ "$ARTIFACT" == "app" ]]; then
 
   BUNDLED_RESOURCES_DIR="$BUNDLE_DIR/$WARP_APP_NAME.app/Contents/Resources"
   echo "Preparing bundled resources..."
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES" "$DEFAULT_TARGET"
+  # Only forward --target to the schema generator when the build target is
+  # runnable on the host; otherwise `cargo run` would try to execute a
+  # cross-compiled binary and fail.
+  if [[ "$DEFAULT_TARGET" == "$HOST_TARGET" ]]; then
+    SCHEMA_CARGO_TARGET="$DEFAULT_TARGET"
+  else
+    SCHEMA_CARGO_TARGET=""
+  fi
+  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES" "$SCHEMA_CARGO_TARGET"
 
   "$WORKSPACE_ROOT_DIR/script/compile_icon" "$RELEASE_CHANNEL" "$BUNDLE_DIR/$WARP_APP_NAME.app"
 
@@ -588,7 +606,15 @@ elif [[ "$ARTIFACT" == "cli" ]]; then
 
   echo "Preparing CLI resources directory"
   BUNDLED_RESOURCES_DIR="$OUT_DIR/resources"
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES" "$DEFAULT_TARGET"
+  # Only forward --target to the schema generator when the build target is
+  # runnable on the host; otherwise `cargo run` would try to execute a
+  # cross-compiled binary and fail.
+  if [[ "$DEFAULT_TARGET" == "$HOST_TARGET" ]]; then
+    SCHEMA_CARGO_TARGET="$DEFAULT_TARGET"
+  else
+    SCHEMA_CARGO_TARGET=""
+  fi
+  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES" "$SCHEMA_CARGO_TARGET"
 
 
   # Set the primary binary path to output.

--- a/script/macos/run
+++ b/script/macos/run
@@ -116,7 +116,10 @@ echo "Preparing bundled resources..."
 if [ "${GENERATE_SCHEMA:-false}" != "true" ]; then
   export SKIP_SETTINGS_SCHEMA=1
 fi
-NO_LICENSES=1 "${REPO_ROOT}/script/prepare_bundled_resources" "$WARP_APP_PATH/Contents/Resources" "$WARP_CHANNEL"
+# Pass FEATURES through (and an empty cargo profile, since this script does
+# not configure one) so that the schema generation reuses the same compiled
+# artifacts as the cargo bundle invocation above.
+NO_LICENSES=1 "${REPO_ROOT}/script/prepare_bundled_resources" "$WARP_APP_PATH/Contents/Resources" "$WARP_CHANNEL" "" "$FEATURES"
 
 "${REPO_ROOT}/script/compile_icon" "$WARP_CHANNEL" "$WARP_APP_PATH"
 

--- a/script/prepare_bundled_resources
+++ b/script/prepare_bundled_resources
@@ -29,6 +29,13 @@
 #                           --target. Should match the target used to build
 #                           the main binary, for the same reason as
 #                           cargo_features.
+#                           NOTE: only set this when the target can be
+#                           executed on the build host (e.g. when not
+#                           cross-compiling, or when running through a
+#                           supported emulator like Rosetta). `cargo run`
+#                           will attempt to execute the resulting binary,
+#                           and a binary built for an unrunnable target
+#                           will fail at this step.
 #
 # Environment variables:
 #   SKIP_SETTINGS_SCHEMA: Set to "1" to skip generating the JSON settings

--- a/script/prepare_bundled_resources
+++ b/script/prepare_bundled_resources
@@ -6,7 +6,7 @@
 # destination directory. It is used by macOS and Linux build scripts.
 #
 # Usage:
-#   prepare_bundled_resources <destination_directory> [channel] [cargo_profile]
+#   prepare_bundled_resources <destination_directory> [channel] [cargo_profile] [cargo_features] [cargo_target]
 #
 # Arguments:
 #   destination_directory:  The directory where resources should be installed.
@@ -17,6 +17,18 @@
 #   cargo_profile:          (Optional) Cargo build profile to use when
 #                           generating the settings schema. Reusing the same
 #                           profile as the main build avoids recompiling deps.
+#   cargo_features:         (Optional) Comma-separated cargo features to
+#                           enable when generating the settings schema.
+#                           Should match the features used to build the main
+#                           binary so that cargo can reuse the existing
+#                           compilation artifacts (otherwise dependencies
+#                           gated behind those features will be recompiled).
+#                           Also ensures that feature-gated settings are
+#                           included in the generated schema.
+#   cargo_target:           (Optional) Rust target triple to pass via
+#                           --target. Should match the target used to build
+#                           the main binary, for the same reason as
+#                           cargo_features.
 #
 # Environment variables:
 #   SKIP_SETTINGS_SCHEMA: Set to "1" to skip generating the JSON settings
@@ -25,15 +37,17 @@
 
 set -e
 
-if [ $# -lt 1 ] || [ $# -gt 3 ]; then
-  echo "Error: Expected 1-3 arguments but received $#" >&2
-  echo "Usage: $0 <destination_directory> [channel] [cargo_profile]" >&2
+if [ $# -lt 1 ] || [ $# -gt 5 ]; then
+  echo "Error: Expected 1-5 arguments but received $#" >&2
+  echo "Usage: $0 <destination_directory> [channel] [cargo_profile] [cargo_features] [cargo_target]" >&2
   exit 1
 fi
 
 DEST_DIR="$1"
 CHANNEL="${2:-}"
 CARGO_PROFILE="${3:-}"
+CARGO_FEATURES="${4:-}"
+CARGO_TARGET="${5:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RESOURCES_SRC="$REPO_ROOT/resources"
@@ -126,11 +140,21 @@ if [ "${SKIP_SETTINGS_SCHEMA:-}" != "1" ]; then
   SCHEMA_OUTPUT="$DEST_DIR/settings_schema.json"
   echo "Generating settings schema at $SCHEMA_OUTPUT"
 
-  SCHEMA_CMD=(cargo run)
+  # Pass the same package, profile, features, and target as the main build
+  # so that cargo can reuse compilation artifacts (rather than recompiling
+  # any dependencies whose enabled features differ).  Also ensures that
+  # feature-gated settings are included in the generated schema.
+  SCHEMA_CMD=(cargo run --manifest-path "$REPO_ROOT/Cargo.toml" -p warp)
   if [ -n "$CARGO_PROFILE" ]; then
     SCHEMA_CMD+=(--profile "$CARGO_PROFILE")
   fi
-  SCHEMA_CMD+=(--manifest-path "$REPO_ROOT/Cargo.toml" --bin generate_settings_schema --)
+  if [ -n "$CARGO_FEATURES" ]; then
+    SCHEMA_CMD+=(--features "$CARGO_FEATURES")
+  fi
+  if [ -n "$CARGO_TARGET" ]; then
+    SCHEMA_CMD+=(--target "$CARGO_TARGET")
+  fi
+  SCHEMA_CMD+=(--bin generate_settings_schema --)
   if [ -n "$CHANNEL" ]; then
     SCHEMA_CMD+=(--channel "$CHANNEL")
   fi

--- a/script/windows/bundle.ps1
+++ b/script/windows/bundle.ps1
@@ -180,7 +180,7 @@ Write-Output "Built for $ARCH with executable at $BINARY_PATH"
 # Prepare bundled resources
 $BUNDLED_RESOURCES_DIR = "$CARGO_TARGET_OUTPUT_DIR\resources"
 Write-Output "Preparing bundled resources..."
-& "$WINDOWS_INSTALLER_DIR\prepare_bundled_resources.ps1" -DestinationDir "$BUNDLED_RESOURCES_DIR" -Channel "$CHANNEL" -CargoProfile "$CARGO_PROFILE"
+& "$WINDOWS_INSTALLER_DIR\prepare_bundled_resources.ps1" -DestinationDir "$BUNDLED_RESOURCES_DIR" -Channel "$CHANNEL" -CargoProfile "$CARGO_PROFILE" -CargoFeatures "$FEATURES" -CargoTarget "$PLATFORM_TARGET"
 if (-Not $?) {
     Write-Error "Failed to prepare bundled resources"
     exit 1

--- a/script/windows/bundle.ps1
+++ b/script/windows/bundle.ps1
@@ -180,7 +180,23 @@ Write-Output "Built for $ARCH with executable at $BINARY_PATH"
 # Prepare bundled resources
 $BUNDLED_RESOURCES_DIR = "$CARGO_TARGET_OUTPUT_DIR\resources"
 Write-Output "Preparing bundled resources..."
-& "$WINDOWS_INSTALLER_DIR\prepare_bundled_resources.ps1" -DestinationDir "$BUNDLED_RESOURCES_DIR" -Channel "$CHANNEL" -CargoProfile "$CARGO_PROFILE" -CargoFeatures "$FEATURES" -CargoTarget "$PLATFORM_TARGET"
+# Only forward --target to the schema generator when the build target is
+# runnable on the host; otherwise `cargo run` would try to execute a
+# cross-compiled binary (e.g. aarch64-pc-windows-msvc on an x64 runner)
+# and fail.
+if ($env:PROCESSOR_ARCHITECTURE -eq 'AMD64') {
+    $HOST_TARGET = 'x86_64-pc-windows-msvc'
+} elseif ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+    $HOST_TARGET = 'aarch64-pc-windows-msvc'
+} else {
+    $HOST_TARGET = ''
+}
+if ($PLATFORM_TARGET -eq $HOST_TARGET) {
+    $SCHEMA_CARGO_TARGET = $PLATFORM_TARGET
+} else {
+    $SCHEMA_CARGO_TARGET = ''
+}
+& "$WINDOWS_INSTALLER_DIR\prepare_bundled_resources.ps1" -DestinationDir "$BUNDLED_RESOURCES_DIR" -Channel "$CHANNEL" -CargoProfile "$CARGO_PROFILE" -CargoFeatures "$FEATURES" -CargoTarget "$SCHEMA_CARGO_TARGET"
 if (-Not $?) {
     Write-Error "Failed to prepare bundled resources"
     exit 1

--- a/script/windows/prepare_bundled_resources.ps1
+++ b/script/windows/prepare_bundled_resources.ps1
@@ -5,12 +5,24 @@
 # destination directory. It is used by the Windows build script.
 #
 # Usage:
-#   prepare_bundled_resources.ps1 <destination_directory>
+#   prepare_bundled_resources.ps1 -DestinationDir <destination_directory> [-Channel <channel>] [-CargoProfile <profile>] [-CargoFeatures <features>] [-CargoTarget <target>]
 #
 # Arguments:
-#   destination_directory: The directory where resources should be installed.
-#                          Resources will be copied to subdirectories within
-#                          this path (e.g., $DEST_DIR\skills).
+#   DestinationDir:  The directory where resources should be installed.
+#                    Resources will be copied to subdirectories within this
+#                    path (e.g., $DEST_DIR\skills).
+#   Channel:         (Optional) Release channel. Used to include
+#                    channel-gated skills.
+#   CargoProfile:    (Optional) Cargo build profile to use when generating
+#                    the settings schema.
+#   CargoFeatures:   (Optional) Comma-separated cargo features to enable when
+#                    generating the settings schema. Should match the
+#                    features used to build the main binary so that cargo
+#                    can reuse the existing compilation artifacts.  Also
+#                    ensures that feature-gated settings are included in the
+#                    generated schema.
+#   CargoTarget:     (Optional) Rust target triple to pass via --target.
+#                    Should match the target used to build the main binary.
 
 Param(
     [Parameter(Mandatory = $true)]
@@ -20,7 +32,13 @@ Param(
     [String]$Channel = '',
 
     [Parameter(Mandatory = $false)]
-    [String]$CargoProfile = ''
+    [String]$CargoProfile = '',
+
+    [Parameter(Mandatory = $false)]
+    [String]$CargoFeatures = '',
+
+    [Parameter(Mandatory = $false)]
+    [String]$CargoTarget = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -164,11 +182,22 @@ if ($env:SKIP_SETTINGS_SCHEMA -ne '1') {
     $SchemaOutput = Join-Path $DestinationDir 'settings_schema.json'
     Write-Output "Generating settings schema at $SchemaOutput"
 
-    $SchemaCmd = @('run')
+    # Pass the same package, profile, features, and target as the main
+    # build so that cargo can reuse compilation artifacts (rather than
+    # recompiling any dependencies whose enabled features differ).  Also
+    # ensures that feature-gated settings are included in the generated
+    # schema.
+    $SchemaCmd = @('run', '--manifest-path', (Join-Path $RepoRoot 'Cargo.toml'), '-p', 'warp')
     if ($CargoProfile) {
         $SchemaCmd += @('--profile', $CargoProfile)
     }
-    $SchemaCmd += @('--manifest-path', (Join-Path $RepoRoot 'Cargo.toml'), '--bin', 'generate_settings_schema', '--')
+    if ($CargoFeatures) {
+        $SchemaCmd += @('--features', $CargoFeatures)
+    }
+    if ($CargoTarget) {
+        $SchemaCmd += @('--target', $CargoTarget)
+    }
+    $SchemaCmd += @('--bin', 'generate_settings_schema', '--')
     if ($Channel) {
         $SchemaCmd += @('--channel', $Channel)
     }

--- a/script/windows/prepare_bundled_resources.ps1
+++ b/script/windows/prepare_bundled_resources.ps1
@@ -23,6 +23,11 @@
 #                    generated schema.
 #   CargoTarget:     (Optional) Rust target triple to pass via --target.
 #                    Should match the target used to build the main binary.
+#                    NOTE: only set this when the target can be executed on
+#                    the build host. `cargo run` will attempt to execute
+#                    the resulting binary, so this must be omitted when
+#                    cross-compiling to a target the host can't run
+#                    (e.g. aarch64-pc-windows-msvc on an x64 runner).
 
 Param(
     [Parameter(Mandatory = $true)]


### PR DESCRIPTION
## Description
The release bundling workflow runs `prepare_bundled_resources` after the main `cargo build`, and that script in turn invokes `cargo run --bin generate_settings_schema`. Until now we passed neither `--features` nor `--target` to this run, so cargo's resolver-v2 saw a different per-package feature unification than the main build and recompiled every dependency whose enabled features differed (`rust-embed` with `debug-embed`, `warp_core`'s `release_bundle`, sentry, jemalloc, etc.). This added significant time to release builds and pulled in extra system dependencies (e.g. protoc) for jobs that should otherwise just be packaging the prebuilt binary.

There was a secondary correctness issue: the schema generator iterates settings registered via `inventory::submit!`, and `#[cfg(feature = \"...\")]`-gated settings were silently omitted from the schema in any context whose feature set didn't match the main binary.

The fix threads the build's feature set (and target, where applicable) through to the schema-generator invocation, and makes package selection explicit with `-p warp`. With matching features and target, cargo reuses the existing compilation artifacts; with the same feature set, the generated schema is also faithful to what the bundled binary actually exposes.

## Testing
Verified `bash -n` syntax for the modified bash scripts and parsed the modified PowerShell files via `pwsh`. Bundling, schema generation, and CI behavior will be exercised by this PR's release builds.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/1bd5574f-df28-4c2e-867d-40d71ed7e827)