### PR TITLE
fix(themes): Handle tilde in theme paths

### DIFF
--- a/app/src/themes/theme.rs
+++ b/app/src/themes/theme.rs
@@ -151,16 +151,7 @@ impl ThemeKind {
 }
 
 #[derive(
-    Debug,
-    Clone,
-    Hash,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    PartialOrd,
-    Ord,
-    schemars::JsonSchema,
+    Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, schemars::JsonSchema,
 )]
 #[schemars(description = "A user-provided custom theme.")]
 pub struct CustomTheme {

--- a/app/src/themes/theme.rs
+++ b/app/src/themes/theme.rs
@@ -1,9 +1,9 @@
 use super::default_themes::*;
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::iter::FromIterator;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use warp_core::ui::color::pick_foreground_color;
 use warpui::assets::asset_cache::AssetSource;
 use warpui::{
@@ -161,14 +161,37 @@ impl ThemeKind {
     PartialOrd,
     Ord,
     schemars::JsonSchema,
-    settings_value::SettingsValue,
 )]
 #[schemars(description = "A user-provided custom theme.")]
 pub struct CustomTheme {
     #[schemars(description = "The display name of the custom theme.")]
     name: String,
+    #[serde(
+        deserialize_with = "deserialize_tilde_path",
+        serialize_with = "serialize_tilde_path"
+    )]
     #[schemars(description = "The file path to the custom theme definition.")]
     path: PathBuf,
+}
+
+// The SettingsValue derive bypasses serde, so use the serde passthrough instead.
+// This ensures the #[serde(deserialize_with/serialize_with)] annotations on
+// the path field are respected when reading/writing settings.toml.
+impl settings_value::SettingsValue for CustomTheme {}
+
+fn deserialize_tilde_path<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let path = PathBuf::deserialize(deserializer)?;
+    Ok(expand_tilde(path))
+}
+
+fn serialize_tilde_path<S>(path: &Path, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    contract_tilde(path.to_path_buf()).serialize(serializer)
 }
 
 impl CustomTheme {

--- a/app/src/themes/theme.rs
+++ b/app/src/themes/theme.rs
@@ -165,9 +165,7 @@ pub struct CustomTheme {
     path: PathBuf,
 }
 
-// The SettingsValue derive bypasses serde, so use the serde passthrough instead.
-// This ensures the #[serde(deserialize_with/serialize_with)] annotations on
-// the path field are respected when reading/writing settings.toml.
+// Use serde passthrough to respect #[serde] annotations on path field for tilde expansion.
 impl settings_value::SettingsValue for CustomTheme {}
 
 fn deserialize_tilde_path<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>

--- a/app/src/themes/theme.rs
+++ b/app/src/themes/theme.rs
@@ -172,15 +172,25 @@ fn deserialize_tilde_path<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let path = PathBuf::deserialize(deserializer)?;
-    Ok(expand_tilde(path))
+    // Normalize backslashes to forward slashes for cross-platform compatibility.
+    let raw = String::deserialize(deserializer)?;
+    let normalized = raw.replace('\\', "/");
+    Ok(expand_tilde(PathBuf::from(normalized)))
 }
 
 fn serialize_tilde_path<S>(path: &Path, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    contract_tilde(path.to_path_buf()).serialize(serializer)
+    let contracted = contract_tilde(path.to_path_buf());
+    // Normalize to forward slashes for cross-platform portability.
+    // Windows would emit backslashes, which Unix treats as filename characters.
+    let portable = contracted
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/");
+    portable.serialize(serializer)
 }
 
 impl CustomTheme {

--- a/app/src/themes/theme_test.rs
+++ b/app/src/themes/theme_test.rs
@@ -97,11 +97,15 @@ fn custom_theme_to_file_value_uses_tilde_test() {
     let path_in_file = file_value["path"]
         .as_str()
         .expect("path should be a string");
+
+    // Normalize path separators to forward slashes for cross-platform comparison
+    let normalized_path_in_file = path_in_file.replace('\\', "/");
+
     assert!(
-        path_in_file.starts_with("~/"),
-        "path in settings file should start with '~/', got: {path_in_file}"
+        normalized_path_in_file.starts_with("~/"),
+        "path in settings file should start with '~/', got: {normalized_path_in_file}"
     );
-    assert_eq!(path_in_file, "~/.warp/themes/my_theme.yaml");
+    assert_eq!(normalized_path_in_file, "~/.warp/themes/my_theme.yaml");
 }
 
 #[test]

--- a/app/src/themes/theme_test.rs
+++ b/app/src/themes/theme_test.rs
@@ -1,5 +1,129 @@
 use super::*;
 use crate::util::color::OPAQUE;
+use settings_value::SettingsValue as _;
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn custom_theme_tilde_path_expansion_test() {
+    use dirs::home_dir;
+
+    let home = home_dir().expect("home dir must exist for this test");
+
+    // A Custom ThemeKind stored in JSON (as used in settings) with a tilde path.
+    let json = serde_json::json!({
+        "Custom": {
+            "name": "My Theme",
+            "path": "~/.warp/themes/my_theme.yaml"
+        }
+    });
+
+    let theme_kind: ThemeKind = serde_json::from_value(json).expect("should deserialize");
+
+    let expected_path = home.join(".warp/themes/my_theme.yaml");
+    match theme_kind {
+        ThemeKind::Custom(custom) => {
+            assert_eq!(
+                custom.path(),
+                expected_path,
+                "tilde should be expanded to home dir"
+            );
+        }
+        other => panic!("expected ThemeKind::Custom, got {other:?}"),
+    }
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn custom_theme_tilde_path_expansion_via_settings_value_test() {
+    use dirs::home_dir;
+
+    let home = home_dir().expect("home dir must exist for this test");
+
+    // Simulate loading from the TOML settings file via the SettingsValue path
+    // (which bypasses serde and previously skipped tilde expansion).
+    let file_value = serde_json::json!({
+        "name": "My Theme",
+        "path": "~/.warp/themes/my_theme.yaml"
+    });
+
+    let custom = CustomTheme::from_file_value(&file_value)
+        .expect("SettingsValue::from_file_value should succeed");
+
+    let expected_path = home.join(".warp/themes/my_theme.yaml");
+    assert_eq!(
+        custom.path(),
+        expected_path,
+        "tilde should be expanded via SettingsValue::from_file_value"
+    );
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn custom_theme_absolute_path_unchanged_test() {
+    let json = serde_json::json!({
+        "Custom": {
+            "name": "My Theme",
+            "path": "/absolute/path/to/theme.yaml"
+        }
+    });
+
+    let theme_kind: ThemeKind = serde_json::from_value(json).expect("should deserialize");
+
+    match theme_kind {
+        ThemeKind::Custom(custom) => {
+            assert_eq!(
+                custom.path(),
+                std::path::PathBuf::from("/absolute/path/to/theme.yaml"),
+                "absolute path should be unchanged"
+            );
+        }
+        other => panic!("expected ThemeKind::Custom, got {other:?}"),
+    }
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn custom_theme_to_file_value_uses_tilde_test() {
+    use dirs::home_dir;
+
+    let home = home_dir().expect("home dir must exist for this test");
+
+    // Build a CustomTheme with an absolute path under the home dir.
+    let absolute_path = home.join(".warp/themes/my_theme.yaml");
+    let custom = CustomTheme::new("My Theme".to_string(), absolute_path);
+
+    // to_file_value should store the path with ~ so settings.toml stays portable.
+    let file_value = settings_value::SettingsValue::to_file_value(&custom);
+    let path_in_file = file_value["path"]
+        .as_str()
+        .expect("path should be a string");
+    assert!(
+        path_in_file.starts_with("~/"),
+        "path in settings file should start with '~/', got: {path_in_file}"
+    );
+    assert_eq!(path_in_file, "~/.warp/themes/my_theme.yaml");
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn custom_theme_settings_value_round_trip_test() {
+    use dirs::home_dir;
+
+    let home = home_dir().expect("home dir must exist for this test");
+
+    // Start with an absolute path.
+    let absolute_path = home.join(".warp/themes/my_theme.yaml");
+    let original = CustomTheme::new("My Theme".to_string(), absolute_path.clone());
+
+    // Serialize → deserialize via SettingsValue (the settings file code path).
+    let file_value = settings_value::SettingsValue::to_file_value(&original);
+    let restored = CustomTheme::from_file_value(&file_value)
+        .expect("round-trip via SettingsValue should succeed");
+
+    // The restored path should be the expanded absolute path, not a tilde path.
+    assert_eq!(restored.path(), absolute_path);
+    assert_eq!(restored.name(), original.name());
+}
 
 #[test]
 #[cfg(not(target_family = "wasm"))]

--- a/app/src/themes/theme_test.rs
+++ b/app/src/themes/theme_test.rs
@@ -37,8 +37,7 @@ fn custom_theme_tilde_path_expansion_test() {
 fn custom_theme_tilde_path_expansion_via_settings_value_test() {
     let home = home_dir().expect("home dir must exist for this test");
 
-    // Simulate loading from the TOML settings file via the SettingsValue path
-    // (which bypasses serde and previously skipped tilde expansion).
+    // Test tilde expansion via SettingsValue path (which previously skipped expansion).
     let file_value = serde_json::json!({
         "name": "My Theme",
         "path": "~/.warp/themes/my_theme.yaml"

--- a/app/src/themes/theme_test.rs
+++ b/app/src/themes/theme_test.rs
@@ -1,12 +1,12 @@
 use super::*;
 use crate::util::color::OPAQUE;
+use dirs::home_dir;
 use settings_value::SettingsValue as _;
+use std::path::PathBuf;
 
 #[test]
 #[cfg(not(target_family = "wasm"))]
 fn custom_theme_tilde_path_expansion_test() {
-    use dirs::home_dir;
-
     let home = home_dir().expect("home dir must exist for this test");
 
     // A Custom ThemeKind stored in JSON (as used in settings) with a tilde path.
@@ -35,8 +35,6 @@ fn custom_theme_tilde_path_expansion_test() {
 #[test]
 #[cfg(not(target_family = "wasm"))]
 fn custom_theme_tilde_path_expansion_via_settings_value_test() {
-    use dirs::home_dir;
-
     let home = home_dir().expect("home dir must exist for this test");
 
     // Simulate loading from the TOML settings file via the SettingsValue path
@@ -73,7 +71,7 @@ fn custom_theme_absolute_path_unchanged_test() {
         ThemeKind::Custom(custom) => {
             assert_eq!(
                 custom.path(),
-                std::path::PathBuf::from("/absolute/path/to/theme.yaml"),
+                PathBuf::from("/absolute/path/to/theme.yaml"),
                 "absolute path should be unchanged"
             );
         }
@@ -84,8 +82,6 @@ fn custom_theme_absolute_path_unchanged_test() {
 #[test]
 #[cfg(not(target_family = "wasm"))]
 fn custom_theme_to_file_value_uses_tilde_test() {
-    use dirs::home_dir;
-
     let home = home_dir().expect("home dir must exist for this test");
 
     // Build a CustomTheme with an absolute path under the home dir.
@@ -111,8 +107,6 @@ fn custom_theme_to_file_value_uses_tilde_test() {
 #[test]
 #[cfg(not(target_family = "wasm"))]
 fn custom_theme_settings_value_round_trip_test() {
-    use dirs::home_dir;
-
     let home = home_dir().expect("home dir must exist for this test");
 
     // Start with an absolute path.

--- a/app/src/themes/theme_test.rs
+++ b/app/src/themes/theme_test.rs
@@ -93,14 +93,7 @@ fn custom_theme_to_file_value_uses_tilde_test() {
         .as_str()
         .expect("path should be a string");
 
-    // Normalize path separators to forward slashes for cross-platform comparison
-    let normalized_path_in_file = path_in_file.replace('\\', "/");
-
-    assert!(
-        normalized_path_in_file.starts_with("~/"),
-        "path in settings file should start with '~/', got: {normalized_path_in_file}"
-    );
-    assert_eq!(normalized_path_in_file, "~/.warp/themes/my_theme.yaml");
+    assert_eq!(path_in_file, "~/.warp/themes/my_theme.yaml");
 }
 
 #[test]
@@ -120,6 +113,35 @@ fn custom_theme_settings_value_round_trip_test() {
     // The restored path should be the expanded absolute path, not a tilde path.
     assert_eq!(restored.path(), absolute_path);
     assert_eq!(restored.name(), original.name());
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn custom_theme_portable_path_round_trip_test() {
+    let home = home_dir().expect("home dir must exist for this test");
+
+    // Simulate a settings file value from Windows (tilde-contracted, forward slashes).
+    let portable_json = serde_json::json!({
+        "Custom": {
+            "name": "My Theme",
+            "path": "~/.warp/themes/my_theme.yaml"
+        }
+    });
+
+    let theme_kind: ThemeKind =
+        serde_json::from_value(portable_json).expect("should deserialize portable path");
+
+    let expected_path = home.join(".warp/themes/my_theme.yaml");
+    match theme_kind {
+        ThemeKind::Custom(custom) => {
+            assert_eq!(
+                custom.path(),
+                expected_path,
+                "forward-slash path should expand to correct native path"
+            );
+        }
+        other => panic!("expected ThemeKind::Custom, got {other:?}"),
+    }
 }
 
 #[test]
@@ -187,4 +209,116 @@ fn in_memory_theme_generation_test() {
             Some("mountains".to_string()),
         )
     );
+}
+
+/// Simulates reading a settings file written by an old Windows client (before the fix) where backslashes were used as path separators in the stored value.
+/// The deserializer must treat `\` as a separator, not a filename character.
+#[test]
+#[cfg(windows)]
+fn custom_theme_deserialize_windows_backslash_absolute_path_test() {
+    let json = serde_json::json!({
+        "Custom": {
+            "name": "My Theme",
+            "path": "C:\\Users\\example\\AppData\\Roaming\\warp\\Warp\\data\\themes\\my_theme.yaml"
+        }
+    });
+
+    let theme_kind: ThemeKind =
+        serde_json::from_value(json).expect("should deserialize Windows backslash path");
+
+    match theme_kind {
+        ThemeKind::Custom(custom) => {
+            let path = custom.path();
+            let components: Vec<_> = path.components().collect();
+            assert!(
+                components.len() > 2,
+                "path should have multiple components, got {components:?}"
+            );
+            assert_eq!(
+                path.file_name().unwrap().to_string_lossy(),
+                "my_theme.yaml",
+                "file_name should be 'my_theme.yaml', got {:?}",
+                path.file_name()
+            );
+        }
+        other => panic!("expected ThemeKind::Custom, got {other:?}"),
+    }
+}
+
+/// Simulates reading a settings file written by an old Windows client where the
+/// path was tilde-contracted but still used backslashes as separators.
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn custom_theme_deserialize_windows_tilde_backslash_path_test() {
+    let home = home_dir().expect("home dir must exist for this test");
+
+    let json = serde_json::json!({
+        "Custom": {
+            "name": "My Theme",
+            "path": "~\\AppData\\Roaming\\warp\\Warp\\data\\themes\\my_theme.yaml"
+        }
+    });
+
+    let theme_kind: ThemeKind =
+        serde_json::from_value(json).expect("should deserialize Windows tilde+backslash path");
+
+    match theme_kind {
+        ThemeKind::Custom(custom) => {
+            let path = custom.path();
+            assert!(
+                path.starts_with(&home),
+                "path {path:?} should start with home dir {home:?}"
+            );
+            assert_eq!(
+                path.file_name().unwrap().to_string_lossy(),
+                "my_theme.yaml",
+                "file_name should be 'my_theme.yaml', got {:?}",
+                path.file_name()
+            );
+        }
+        other => panic!("expected ThemeKind::Custom, got {other:?}"),
+    }
+}
+
+/// Verifies that serialization never emits backslashes regardless of platform.
+#[test]
+fn custom_theme_serialize_no_backslashes_test() {
+    let path: PathBuf = ["some", "nested", "themes", "my_theme.yaml"]
+        .iter()
+        .collect();
+    let custom = CustomTheme::new("My Theme".to_string(), path);
+
+    let json = serde_json::to_value(&custom).expect("should serialize");
+    let path_str = json["path"].as_str().expect("path should be a string");
+
+    assert!(
+        !path_str.contains('\\'),
+        "serialized path should not contain backslashes, got: {path_str}"
+    );
+}
+
+/// Windows round-trip: serialize a native path to a forward-slash string, then deserialize it back to the original path.
+#[test]
+#[cfg(windows)]
+fn custom_theme_windows_round_trip_test() {
+    let original_path = PathBuf::from(
+        "C:\\Users\\example\\AppData\\Roaming\\warp\\Warp\\data\\themes\\my_theme.yaml",
+    );
+    let original = CustomTheme::new("My Theme".to_string(), original_path.clone());
+
+    let json = serde_json::to_value(&original).expect("should serialize");
+    let path_str = json["path"].as_str().expect("path should be a string");
+
+    assert!(
+        !path_str.contains('\\'),
+        "serialized path should use forward slashes only, got: {path_str}"
+    );
+    assert_eq!(
+        path_str,
+        "C:/Users/example/AppData/Roaming/warp/Warp/data/themes/my_theme.yaml"
+    );
+
+    let restored: CustomTheme =
+        serde_json::from_value(json).expect("should deserialize Windows path");
+    assert_eq!(restored.path(), original_path);
 }

--- a/crates/warp_core/src/ui/theme/mod.rs
+++ b/crates/warp_core/src/ui/theme/mod.rs
@@ -94,7 +94,7 @@ fn default_image_opacity() -> Opacity {
 /// Performs tilde expansion to expand a _leading_ tilde to the user's home dir. Any intermediate
 /// tildes are not expanded. If the path does not begin with a tilde, then the existing path is
 /// returned unchanged.
-fn expand_tilde(path: PathBuf) -> PathBuf {
+pub fn expand_tilde(path: PathBuf) -> PathBuf {
     let home_dir = match home_dir() {
         Some(home_dir) => home_dir,
         None => return path,
@@ -102,6 +102,21 @@ fn expand_tilde(path: PathBuf) -> PathBuf {
 
     match path.strip_prefix("~") {
         Ok(stripped) => home_dir.join(stripped),
+        Err(_) => path,
+    }
+}
+
+/// Replaces a leading home-directory prefix with `~`. This is the inverse of
+/// [`expand_tilde`]. If the path does not begin with the user's home directory,
+/// or the home directory cannot be determined, the path is returned unchanged.
+pub fn contract_tilde(path: PathBuf) -> PathBuf {
+    let home_dir = match home_dir() {
+        Some(home_dir) => home_dir,
+        None => return path,
+    };
+
+    match path.strip_prefix(&home_dir) {
+        Ok(stripped) => PathBuf::from("~").join(stripped),
         Err(_) => path,
     }
 }

--- a/crates/warp_core/src/ui/theme/theme_tests.rs
+++ b/crates/warp_core/src/ui/theme/theme_tests.rs
@@ -339,3 +339,31 @@ fn infer_from_foreground_color_test() {
         ColorScheme::DarkOnLight
     );
 }
+
+#[cfg(not(windows))]
+#[test]
+fn contract_tilde_replaces_home_prefix() {
+    let home = dirs::home_dir().expect("home dir must exist");
+    let abs = home.join(".warp/themes/my_theme.yaml");
+    let contracted = contract_tilde(abs.clone());
+    assert_eq!(
+        contracted,
+        std::path::PathBuf::from("~/.warp/themes/my_theme.yaml")
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn contract_tilde_leaves_non_home_paths_unchanged() {
+    let path = std::path::PathBuf::from("/etc/warp/theme.yaml");
+    assert_eq!(contract_tilde(path.clone()), path);
+}
+
+#[cfg(not(windows))]
+#[test]
+fn expand_contract_tilde_round_trips() {
+    let tilde_path = std::path::PathBuf::from("~/.warp/themes/my_theme.yaml");
+    let expanded = expand_tilde(tilde_path.clone());
+    let contracted = contract_tilde(expanded);
+    assert_eq!(contracted, tilde_path);
+}


### PR DESCRIPTION
## Description
When using settings sync between machines with different usernames, custom theme gets reset every time the settings sync. [_All settings reference_ mention `~/.warp/themes/my-theme.yaml`](https://docs.warp.dev/terminal/settings/all-settings#themes), so figured it should support it. It didn't, so I (with some help from Copilot) have added it.

## Linked Issue
Mainly targeted at my own use case, but probably also #6678.

## Screenshots / Videos
<img width="1280" height="800" alt="Screenshot 2026-04-30 at 19 21 19" src="https://github.com/user-attachments/assets/b56b04ea-c43d-419b-b91c-5f3fdecf1fa5" />

## Testing
Verified in real-world with `./script/run`/`cargo run` using paths with and without `~`.
**Tested only on macOS** - I don't have access to a Windows or Linux machine as of right now.

Also added tests for themes (`theme_test.rs`) and `warp_core` (`theme_tests.rs`). If they seem redundant, please let me know and I'll remove one of them.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [x] Copilot-assisted - This PR was created using Copilot assistance.

---

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->
CHANGELOG-IMPROVEMENT: Added support for tilde (`~`) in custom theme paths.