### PR TITLE
chore: assign / route to @warpdotdev/oss-maintainers in STAKEHOLDERS

### DIFF
--- a/.github/STAKEHOLDERS
+++ b/.github/STAKEHOLDERS
@@ -7,7 +7,7 @@
 # Source of truth: warpdotdev/feedback-triage-bot ownership-areas.md
 
 # Default fallback: FA leads are tagged when no more specific path matches
-/ @vorporeal @alokedesai @zachbai @bnavetta @szgupta @jefflloyd
+/ @warpdotdev/oss-maintainers
 
 ###########################################################################
 # Team: App


### PR DESCRIPTION
## Description
Update the default fallback owner for the root `/` pattern in `.github/STAKEHOLDERS` from the list of FA leads to the `@warpdotdev/oss-maintainers` team.

## Linked Issue
N/A — small ownership update.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
N/A — no UI changes.

## Testing
No code changes; this only updates the STAKEHOLDERS file used by the triage workflow.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/5d3add1a-47d9-4eb8-9400-a84b51e9f920_
_Run: https://oz.staging.warp.dev/runs/019ddf7c-4acd-7a1d-8470-5f40af986b2b_

_This PR was generated with [Oz](https://warp.dev/oz)._
