### PR TITLE
fix: clear stale permission text from tab title after agent stops

### DIFF
--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -176,6 +176,10 @@ impl CLIAgentSession {
             CLIAgentEventType::Stop => {
                 self.session_context.query = event.payload.query.clone();
                 self.session_context.response = event.payload.response.clone();
+                // Clear stale summary from PermissionRequest so the tab title
+                // falls back to the final response instead of showing the last
+                // permission prompt text.
+                self.session_context.summary = None;
                 CLIAgentSessionStatus::Success
             }
             CLIAgentEventType::PermissionRequest => {

--- a/app/src/terminal/cli_agent_sessions/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/mod_tests.rs
@@ -408,3 +408,72 @@ fn session_start_without_plugin_version_leaves_none() {
     session.apply_event(&event);
     assert_eq!(session.plugin_version, None);
 }
+
+#[test]
+fn stop_event_clears_stale_permission_summary() {
+    // Regression test: after a PermissionRequest sets summary,
+    // a following Stop event must clear it so the tab title
+    // does not show stale permission-request text.
+    let mut session = CLIAgentSession {
+        agent: CLIAgent::Claude,
+        status: CLIAgentSessionStatus::InProgress,
+        session_context: CLIAgentSessionContext::default(),
+        input_state: CLIAgentInputState::Closed,
+        should_auto_toggle_input: false,
+        listener: None,
+        plugin_version: None,
+        draft_text: None,
+        remote_host: None,
+        custom_command_prefix: None,
+    };
+
+    // PermissionRequest sets summary.
+    let perm_event = CLIAgentEvent {
+        v: 1,
+        agent: CLIAgent::Claude,
+        event: CLIAgentEventType::PermissionRequest,
+        session_id: Some("abc".to_owned()),
+        cwd: Some("/tmp".to_owned()),
+        project: Some("proj".to_owned()),
+        payload: CLIAgentEventPayload {
+            summary: Some("Wants to run Bash: rm -rf /tmp".to_owned()),
+            tool_name: Some("Bash".to_owned()),
+            tool_input_preview: Some("rm -rf /tmp".to_owned()),
+            ..Default::default()
+        },
+    };
+    session.apply_event(&perm_event);
+    assert_eq!(
+        session.session_context.summary.as_deref(),
+        Some("Wants to run Bash: rm -rf /tmp")
+    );
+    assert!(matches!(
+        session.status,
+        CLIAgentSessionStatus::Blocked { .. }
+    ));
+
+    // Stop event clears summary.
+    let stop_event = CLIAgentEvent {
+        v: 1,
+        agent: CLIAgent::Claude,
+        event: CLIAgentEventType::Stop,
+        session_id: Some("abc".to_owned()),
+        cwd: Some("/tmp".to_owned()),
+        project: Some("proj".to_owned()),
+        payload: CLIAgentEventPayload {
+            query: Some("fix the bug".to_owned()),
+            response: Some("Done, all tests pass.".to_owned()),
+            ..Default::default()
+        },
+    };
+    session.apply_event(&stop_event);
+    assert_eq!(session.session_context.summary, None);
+    assert_eq!(
+        session.session_context.response.as_deref(),
+        Some("Done, all tests pass.")
+    );
+    assert!(matches!(
+        session.status,
+        CLIAgentSessionStatus::Success
+    ));
+}

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3078,7 +3078,7 @@ fn terminal_agent_text(terminal_view: &TerminalView, app: &AppContext) -> Termin
         agent_text.conversation_display_title.is_some() || agent_text.is_oz_agent;
 
     if let Some(session) = cli_agent_session {
-        agent_text.cli_agent_title = session.session_context.title_like_text();
+        agent_text.cli_agent_title = session.session_context.display_title();
         agent_text.cli_agent_latest_user_prompt = session.session_context.latest_user_prompt();
     }
 

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3078,7 +3078,7 @@ fn terminal_agent_text(terminal_view: &TerminalView, app: &AppContext) -> Termin
         agent_text.conversation_display_title.is_some() || agent_text.is_oz_agent;
 
     if let Some(session) = cli_agent_session {
-        agent_text.cli_agent_title = session.session_context.display_title();
+        agent_text.cli_agent_title = session.session_context.title_like_text();
         agent_text.cli_agent_latest_user_prompt = session.session_context.latest_user_prompt();
     }
 


### PR DESCRIPTION
When a CLI agent finishes (Stop event), the summary field still holds the last PermissionRequest text. This causes the tab title to show stale permission prompts instead of the agent's final response.

Fix: clear summary on Stop so title_like_text() returns None and the title falls back to the conversation title or terminal title.

Changes:
- cli_agent_sessions/mod.rs: Add  on Stop event
- cli_agent_sessions/mod_tests.rs: Add regression test for PermissionRequest → Stop transition

This is a cleaner version of #9566 that addresses the review feedback:
- Removed the redundant response_text() fallback
- Only clears summary (minimal fix)
- Added regression test to prevent future regressions