### PR TITLE
fix: extract Node.js/Yarn checks into shared script

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -41,6 +41,10 @@ Environment variables:
 - `./script/install_cargo_build_deps` - Install Cargo build dependencies
 - `./script/install_cargo_test_deps` - Install Cargo test dependencies
 
+### Prerequisites
+- **Node.js 18.14.1+** — Required by the `command-signatures-v2` crate, which compiles a TypeScript helper at build time using yarn.
+- **Yarn 4+ via Corepack** — Required by the `command-signatures-v2` build script. Enable via `corepack enable` after installing Node.js; avoid Yarn 1.x from package managers such as Homebrew.
+
 ## Architecture Overview
 
 This is a Rust-based terminal emulator with a custom UI framework called **WarpUI**.

--- a/script/check_node_yarn_deps.sh
+++ b/script/check_node_yarn_deps.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Check for Node.js and Yarn 4+ (required by command-signatures-v2 crate).
+# Source this script from bootstrap/install scripts:
+#   source "$PWD/script/check_node_yarn_deps.sh"
+
+REQUIRED_NODE_VERSION="18.14.1"
+
+# Check Node.js is installed
+if ! command -v node >/dev/null 2>&1; then
+    echo "Error: Node.js is not installed."
+    echo "Node.js $REQUIRED_NODE_VERSION+ is required to build the command-signatures-v2 crate."
+    echo "Install it via: https://nodejs.org/en/download"
+    echo "  or use a version manager like nvm, fnm, or volta."
+    return 1 2>/dev/null || exit 1
+fi
+
+# Check Node.js version
+NODE_VERSION="$(node --version | sed 's/^v//')"
+node_major="$(echo "$NODE_VERSION" | cut -d. -f1)"
+node_minor="$(echo "$NODE_VERSION" | cut -d. -f2)"
+node_patch="$(echo "$NODE_VERSION" | cut -d. -f3)"
+req_major="$(echo "$REQUIRED_NODE_VERSION" | cut -d. -f1)"
+req_minor="$(echo "$REQUIRED_NODE_VERSION" | cut -d. -f2)"
+req_patch="$(echo "$REQUIRED_NODE_VERSION" | cut -d. -f3)"
+
+if [ "$node_major" -lt "$req_major" ] || \
+   { [ "$node_major" -eq "$req_major" ] && [ "$node_minor" -lt "$req_minor" ]; } || \
+   { [ "$node_major" -eq "$req_major" ] && [ "$node_minor" -eq "$req_minor" ] && [ "$node_patch" -lt "$req_patch" ]; }; then
+    echo "Error: Node.js $NODE_VERSION is too old."
+    echo "Node.js $REQUIRED_NODE_VERSION+ is required."
+    echo "Upgrade via your system package manager or version manager."
+    return 1 2>/dev/null || exit 1
+fi
+
+# Check Yarn is installed
+if ! command -v yarn >/dev/null 2>&1; then
+    echo "Error: yarn is not installed."
+    echo "yarn is required to build the command-signatures-v2 crate."
+    echo "Enable it via corepack (ships with Node.js):"
+    echo "  corepack enable"
+    return 1 2>/dev/null || exit 1
+fi
+
+# Check Yarn version is 4+ (Corepack-managed, not Yarn 1.x from Homebrew/apt)
+JS_CRATE_DIR="$PWD/crates/command-signatures-v2/js"
+if ! YARN_VERSION="$(cd "$JS_CRATE_DIR" && yarn --version 2>/dev/null)"; then
+    echo "Error: Could not determine yarn version from $JS_CRATE_DIR."
+    echo "Ensure yarn is installed and Corepack is enabled:"
+    echo "  corepack enable"
+    return 1 2>/dev/null || exit 1
+fi
+
+YARN_MAJOR="$(echo "$YARN_VERSION" | cut -d. -f1)"
+if [ "$YARN_MAJOR" -lt 4 ] 2>/dev/null; then
+    echo "Error: yarn $YARN_VERSION detected, but Yarn 4+ is required."
+    echo "The command-signatures-v2 crate requires Yarn 4 via Corepack."
+    echo "If you have yarn installed via a system package, remove it first."
+    echo "Then enable Corepack:"
+    echo "  corepack enable"
+    return 1 2>/dev/null || exit 1
+fi
+
+echo "✅ Node.js $(node --version) and yarn $YARN_VERSION detected."

--- a/script/linux/bootstrap
+++ b/script/linux/bootstrap
@@ -6,6 +6,9 @@ set -e
 # don't do it (to avoid doing it more than once).
 sudo apt update -y
 
+# Check Node.js and Yarn 4+ prerequisites.
+source "$PWD/script/check_node_yarn_deps.sh"
+
 # Install all dependencies needed to build, run, and test Warp.
 "$PWD"/script/linux/install_test_deps
 

--- a/script/linux/install_build_deps
+++ b/script/linux/install_build_deps
@@ -59,6 +59,9 @@ else
   echo -e "⚠️  ${red}Unknown Linux distribution; necessary build dependencies may not be installed!${reset}"
 fi
 
+# Check Node.js and Yarn 4+ prerequisites.
+source "$PWD/script/check_node_yarn_deps.sh"
+
 # Install Rust.
 "$PWD"/script/install_rust
 

--- a/script/linux/install_build_deps
+++ b/script/linux/install_build_deps
@@ -59,9 +59,6 @@ else
   echo -e "⚠️  ${red}Unknown Linux distribution; necessary build dependencies may not be installed!${reset}"
 fi
 
-# Check Node.js and Yarn 4+ prerequisites.
-source "$PWD/script/check_node_yarn_deps.sh"
-
 # Install Rust.
 "$PWD"/script/install_rust
 

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -59,6 +59,10 @@ if ! [ "$(command -v gcloud)" ]; then
     brew install google-cloud-sdk
 fi
 
+# Check Node.js and Yarn 4+ prerequisites.
+# macOS uses /bin/sh so we can't use source, use . instead
+. "$PWD/script/check_node_yarn_deps.sh"
+
 if [[ -z $(gcloud auth print-identity-token) ]]; then
     echo "gcloud CLI authentication missing.  Press enter to continue..."
     read var


### PR DESCRIPTION
The Node.js and Yarn 4+ prerequisite checks were duplicated across bootstrap scripts. This PR extracts them into a shared script that's sourced from each location.

Changes:
- Create script/check_node_yarn_deps.sh with the validation logic
- Source it from script/linux/bootstrap and script/macos/bootstrap (NOT from install_build_deps since CI calls that before Node is installed)
- Add prerequisite docs to WARP.md

This is a cleaner version of #9571 that addresses the review feedback:
- Eliminates duplicated code
- Uses consistent version comparison logic
- Single source of truth for the checks
- Only checks in bootstrap scripts (developer-facing), not in CI-facing scripts

Fixes #9571