### PR TITLE
Add specs for #9155: search sessions by custom tab and pane names

### DIFF
--- a/specs/GH9155/product.md
+++ b/specs/GH9155/product.md
@@ -1,0 +1,100 @@
+# PRODUCT.md — Search sessions by custom tab and pane names
+
+Issue: https://github.com/warpdotdev/warp/issues/9155
+
+## Summary
+
+Make user-assigned custom names for tabs and panes discoverable through every session-search surface in Warp. A user who has renamed a tab (e.g. "deploy") or a specific pane within a tab (e.g. "logs") can find that session by typing the name they chose, whether they search from the command palette or the vertical-tabs sidebar's "search tabs…" input. In the command-palette result row, the matched name is surfaced and highlighted so the user can see which tab or pane each result corresponds to.
+
+Figma: none provided.
+
+## Problem
+
+Today the two session-search surfaces handle custom names inconsistently:
+
+- The command-palette session search indexes prompt, command, and hint text only — neither custom tab names nor custom pane names participate.
+- The vertical-tabs sidebar's "search tabs…" input includes custom names in some display modes but silently drops the custom *tab* name in Panes mode (the mode where each pane is its own row), so typing a renamed tab's name returns no results in the sidebar even though the name is visible on screen.
+
+Users who rename tabs and panes expect the name they assigned to be the most reliable way to find a session. The current behavior contradicts that expectation in both surfaces.
+
+## Goals / Non-goals
+
+In scope:
+
+- Command-palette session search matches against the user-set custom tab name and custom pane name.
+- The command-palette result row displays the custom tab name and/or custom pane name when set, with highlighting.
+- The vertical-tabs sidebar search matches against the user-set custom tab name and custom pane name in every sidebar display mode (summary, focused-session, panes), without regressing existing matches on prompt, command, hint, generated title, or subtitle.
+- Behavior is consistent across the two surfaces and across the underlying search paths each surface uses; the user perceives the same matching rules everywhere.
+
+Out of scope:
+
+- Tab-rename and pane-rename UX themselves (the rename actions, inline editor, telemetry events) — unchanged.
+- Indexing auto-generated tab and pane titles (the fallbacks shown when no custom name is set) as new "custom-name" fields. Auto-generated titles continue to be reachable via the existing prompt / command / generated-title match surfaces wherever they are reachable today.
+- Visual redesign of either surface beyond the additions described in the result-row invariants.
+- Other search surfaces (command-history search, settings search, etc.).
+- Changes to how custom tab and pane names are persisted across restarts — existing persistence behavior is unchanged.
+
+## Behavior
+
+Session search appears on two surfaces; both must follow these invariants:
+
+- **Command palette** — the cross-tab session navigator opened from the command palette.
+- **Vertical-tabs sidebar** — the "search tabs…" input at the top of the side panel; filters the sidebar's visible rows in every display mode it offers (summary, focused-session, panes).
+
+A session may have up to two custom names attached:
+
+- A **custom tab name**, set on the tab containing the session — applies to every session (pane) in that tab.
+- A **custom pane name**, set on the specific pane the session occupies — applies to only that one session.
+
+Both, either, or neither may be set. Where the behavior is identical for both, "custom name" refers to either one. Unless an invariant is explicitly scoped to one surface, it applies to both.
+
+1. **Searchable text — custom names only.** When a tab has a non-empty custom tab name, that name participates in session search for every session in that tab. When a pane has a non-empty custom pane name, that name participates in session search for the one session in that pane. Tabs and panes without a custom name behave exactly as they do today — no new match surface is introduced for them.
+
+2. **Empty and whitespace-only name handling.** A custom name that is zero-length, or consists entirely of whitespace, is not indexed for search and produces no leading label in the command-palette result row. Leading and trailing whitespace around an otherwise non-empty name is ignored for indexing and for the result-row label; interior whitespace is preserved. This applies equally to custom tab names and custom pane names. (Sidebar header rendering of custom names is unchanged by this feature; whitespace consistency in `PaneGroup::set_title` is tracked separately — see tech.md Follow-ups.)
+
+3. **Case-insensitive substring match.** Typing any case-insensitive substring of a session's custom tab name or custom pane name returns that session as a hit on every session-search surface. The match behavior is identical regardless of which underlying search path serves the query; the user perceives a single, consistent search.
+
+4. **Multi-byte / non-ASCII names.** Custom names containing multi-byte characters (CJK, emoji, accented characters) match the same way as multi-byte content already does for prompt / command / generated title. Highlight ranges remain correct — no off-by-one between byte and character indexing.
+
+5. **Restored sessions are searchable.** Custom tab and pane names persisted in a previous Warp run and restored on launch become searchable by their restored values as soon as restoration completes, with no extra user action.
+
+6. **Renames take effect on the next search.** Setting, changing, or clearing a custom tab name or custom pane name is reflected in the very next session-search invocation on either surface. A cleared name produces no stale match; a freshly-set name is immediately findable. The sidebar's filtered view re-evaluates against the active query as soon as the rename commits.
+
+7. **Multi-pane tabs.**
+   - A tab containing multiple panes has at most one custom tab name, shared by every session in that tab. A query that matches the tab name returns each of those sessions.
+   - Each pane in a multi-pane tab can independently have its own custom pane name. A query that matches a single pane's custom name returns only that pane's session — not its siblings in the same tab.
+   - A session can be matched on its tab name, on its own pane name, or on both, independently.
+   - In the command palette, sessions sharing a matching tab name appear as separate result rows, not collapsed.
+   - In the sidebar, a tab-name match keeps the tab visible and shows every pane row in it that the user would normally see in that mode; a pane-name-only match keeps the tab visible but filters that tab's pane list to the matching pane(s).
+
+8. **Multi-window.** Custom tab and pane names from every open window participate in search wherever cross-window session search already reaches today, consistent with existing cross-window behavior.
+
+9. **No duplicated rows on multi-field match (command palette).** When a query matches a session on more than one field — any combination of custom tab name, custom pane name, prompt, command, hint — the session appears exactly once in the result list. Every matched field is reflected in highlighting (see invariant 13).
+
+10. **Sidebar parity across display modes.** In every vertical-tabs display mode (summary, focused-session, panes), typing a substring of a tab's custom name keeps that tab visible in the filtered view, and typing a substring of a pane's custom name keeps the pane (and its containing tab) visible. There is no display mode in which a custom name is shown on screen but not searchable. This explicitly includes Panes mode, where today the tab-level custom name renders as a group header but is not in the search index.
+
+11. **Sidebar — no regression to existing matches.** Every query that produced a sidebar match before this change still produces the same match — generated tab titles, subtitles, terminal prompt/command, and pane titles remain reachable. Adding custom-name search must not produce false negatives.
+
+12. **Result row — labels shown when set (command palette).** Whenever a session in the command-palette result list has a custom tab name and/or a custom pane name, the row displays each set name as a leading label at the start of the primary text line, ahead of the existing prompt/command/hint content. Labels are shown whether or not the current query matched them.
+    - When only a custom tab name is set: the tab name is shown as a single leading label.
+    - When only a custom pane name is set: the pane name is shown as a single leading label.
+    - When both are set: both are shown together with the tab name first followed by the pane name, visually distinguished as two segments so the user can tell tab-level context apart from pane-level context.
+    - **Open question:** the exact visual treatment between the two segments (separator character, spacing, weight, color) is a design decision and should match the Figma when one is provided.
+
+13. **Result row — no label when neither set (command palette).** When a session has neither a custom tab name nor a custom pane name, the result-row layout is unchanged from today: no leading label, no empty placeholder, no extra whitespace.
+
+14. **Result row — highlighting (command palette).** When the query matches a substring of a custom tab name or custom pane name, that substring is visually highlighted within the corresponding label using the same highlight treatment used today for prompt/command/hint matches. When the query matches multiple fields (e.g. both labels, or a label and another field), all matching segments are highlighted simultaneously in their respective regions of the row.
+
+15. **Result row — overflow (command palette).** Long custom names truncate within the result row using the same truncation rules already applied to prompt/command/hint, without pushing other row content off-screen. When truncation is necessary and the query matched a label, the truncation preserves the matched substring in the visible portion of that label (e.g. by anchoring truncation away from the match) so the user can see why the row matched. When both labels are present and the combined label width exceeds the available space, both labels share that space rather than one starving the other entirely.
+
+16. **No length cap introduced.** This feature does not impose new maximum lengths on custom tab names or custom pane names beyond whatever the rename UX already enforces. Whatever name the user is allowed to set is fully indexed for search and fully available for display (subject to the truncation rules in invariant 15).
+
+17. **Sidebar display unchanged.** This feature does not change how the vertical-tabs sidebar renders custom tab or pane names today. Tab-name group headers, pane-row titles, and existing affordances render the same as before. The change in the sidebar is search behavior only.
+
+18. **Active tab and active pane not excluded.** A session belonging to the currently-focused tab or pane can still appear in command-palette results and sidebar matches when the query matches it. This change does not introduce filtering by focus state.
+
+19. **Theming and accessibility.** The new command-palette leading labels and their highlights render correctly across all themes (light, dark, custom). When both a tab-name label and a pane-name label are shown, the visual relationship between them (separator, weight) renders correctly across all themes. Each label's text is exposed to assistive technologies as part of the row's accessible name, alongside the existing prompt/command/hint content. No label text is announced only visually.
+
+20. **No regression for unmatched queries.** A query that does not appear in any custom tab name, custom pane name, prompt, command, hint, generated title, or subtitle returns the same set of results (empty or otherwise) it would have returned before this change, on either surface. Adding custom-name search must not produce false negatives for previously-matching queries.
+
+21. **Rename UX and telemetry are unchanged.** The tab-rename and pane-rename UX (inline editors, Enter/Escape behavior, setting and clearing custom names) and existing rename telemetry events are unchanged by this feature. This is purely a search-and-display addition; renaming itself does not gain new side effects.

--- a/specs/GH9155/tech.md
+++ b/specs/GH9155/tech.md
@@ -1,0 +1,147 @@
+# TECH.md — Search sessions by custom tab and pane names
+
+Issue: https://github.com/warpdotdev/warp/issues/9155
+Sibling docs: [product.md](product.md) (behavior contract).
+
+## Context
+
+This change makes user-set custom tab and pane names searchable on both session-search surfaces. Behavior is fully specified in `product.md`. This spec describes the implementation only.
+
+Two concrete gaps to close:
+
+- **Command palette:** `SessionNavigationData` carries no custom-name fields, and `searchable_session_string_and_ranges` indexes only prompt + command + hint ([search.rs:127-190](app/src/search/command_palette/navigation/search.rs#L127-L190)). Both names need to enter the document and the searchable string.
+- **Vertical-tabs sidebar:** the `!uses_outer_group_container(display_granularity)` gate at [vertical_tabs.rs:1022-1024](app/src/workspace/view/vertical_tabs.rs#L1022-L1024) drops `pane_group.custom_title` from per-pane search fragments in Panes mode only. Removing the gate at the search-input layer (without touching render) closes the gap.
+
+Two facts settled during spec review:
+
+- `PaneConfiguration.custom_vertical_tabs_title` already round-trips through SQLite via migration `2026-04-17-020439_add_custom_vertical_tabs_title_to_pane_leaves`, with save at [sqlite.rs:1075](app/src/persistence/sqlite.rs#L1075) and restore at [sqlite.rs:2607](app/src/persistence/sqlite.rs#L2607). No persistence work needed (PRODUCT invariant 5).
+- In Panes mode, threading the tab `custom_title` into `title_override` is sufficient on its own: every pane in a tab-name-matched tab independently passes `pane_matches_query` because `pane_search_text_fragments` already includes `display_title_override` ([vertical_tabs.rs:2861-2874](app/src/workspace/view/vertical_tabs.rs#L2861)). No render-side change required.
+
+## Proposed changes
+
+### Data model — extend `SessionNavigationData`
+
+Add two fields to [`SessionNavigationData`](app/src/session_management.rs#L18-L35):
+
+- `custom_tab_name: Option<String>`
+- `custom_pane_name: Option<String>`
+
+Both normalized through a new `normalize_custom_name(&str) -> Option<String>` helper that trims and returns `None` for empty / whitespace-only input. Single helper shared between palette population and any future caller (PRODUCT invariant 2).
+
+Populate in [`PaneGroup::pane_sessions`](app/src/pane_group/mod.rs#L2353-L2361):
+
+- `custom_tab_name` from `pane_group.custom_title(app)`.
+- `custom_pane_name` from `pane.custom_vertical_tabs_title()` ([pane/mod.rs:735](app/src/pane_group/pane/mod.rs#L735)).
+
+Both run through `normalize_custom_name`. Extend `SessionNavigationData::new`'s signature and the `TerminalPane::session_navigation_data` call site to thread the new fields through.
+
+### Palette — searchable string + highlights
+
+Extend [`searchable_session_string_and_ranges`](app/src/search/command_palette/navigation/search.rs#L127-L190) to prepend the names. Concat order matches PRODUCT invariant 12's visual order (tab first, then pane):
+
+```
+[custom_tab_name?] [custom_pane_name?] prompt [command] [hint]
+```
+
+Char-counted ranges are tracked alongside the existing `command_range` / `hint_text_range` on `SearchableSessionStringRanges`:
+
+- `custom_tab_name_range: Option<Range<usize>>`
+- `custom_pane_name_range: Option<Range<usize>>`
+
+Extend [`SessionHighlightIndices`](app/src/search/command_palette/navigation/search.rs#L54-L87):
+
+- `custom_tab_name_indices: Option<Vec<usize>>`
+- `custom_pane_name_indices: Option<Vec<usize>>`
+
+Construction follows the same pattern as `command_indices` (filter matched indices into the named range, subtract `range.start`). Both backends call `SessionHighlightIndices::new` with the same ranges struct, so fuzzy and Tantivy paths get the highlight extension for free. Multi-byte handling continues to flow through `byte_indices_to_char_indices` on the Tantivy path (PRODUCT invariant 4).
+
+The Tantivy schema at [search.rs:259-266](app/src/search/command_palette/navigation/search.rs#L259) is **unchanged**: custom names live in the same single `session` field. Ranking via per-field boost was considered and explicitly dropped — the simpler concat keeps highlights, multi-byte handling, and tie-break (last-focus-ts) untouched with no schema delta. Both backends rebuild from `all_sessions` per query — Tantivy via `searcher.build_index(documents)` at [search.rs:278-296](app/src/search/command_palette/navigation/search.rs#L278-L296), fuzzy by in-memory iteration — so renames take effect on the next search with no invalidation hook (PRODUCT invariant 6).
+
+### Palette — result row render
+
+Update [`SearchItem`](app/src/search/command_palette/navigation/search_item.rs) and [`render.rs`](app/src/search/command_palette/navigation/render.rs):
+
+- Read `custom_tab_name`, `custom_pane_name`, and the two new highlight index vecs from `MatchedSession`.
+- Emit zero, one, or two leading label segments at the start of the row's primary line per PRODUCT invariants 12–13.
+- Apply the existing prompt/command/hint highlight treatment to each label using the new index vecs (PRODUCT invariant 14).
+- Truncation around the matched substring (PRODUCT invariant 15): when a label region needs truncation and the query matched inside it, anchor the truncation away from the match window. Reuse the line-truncation primitive used today for prompt/command/hint. When both labels are present and combined width exceeds available space, share rather than starve.
+- Theming + accessibility (PRODUCT invariant 19): use existing themed text styles so themes work for free; add label text to the row's accessible name alongside prompt/command/hint.
+
+Visual treatment between the two segments (separator, weight, color) is a design open question (referenced in PRODUCT invariant 12). The contract — two distinguishable segments, tab first, both highlight-capable — is fixed here; pixel decisions defer to design.
+
+### Sidebar — close the Panes-mode gap
+
+The sidebar has **two** filter sites that build per-pane `PaneProps` to feed `pane_matches_query`. Both must drop the `!uses_outer_group_container(display_granularity)` gate so the tab `custom_title` reaches the per-pane fragments in Panes mode:
+
+- [`matching_tab_indices`](app/src/workspace/view/vertical_tabs.rs#L980-L1035) at [vertical_tabs.rs:1022-1024](app/src/workspace/view/vertical_tabs.rs#L1022-L1024) — drives keyboard tab navigation ([`activate_prev_tab` / `activate_next_tab`](app/src/workspace/view.rs#L10076)).
+- [`render_groups`](app/src/workspace/view/vertical_tabs.rs#L1490-L1620) at [vertical_tabs.rs:1547-1549](app/src/workspace/view/vertical_tabs.rs#L1547-L1549) — drives the visible Panes-mode list.
+
+The edit is identical at both:
+
+```rust
+// before
+let title_override = (!uses_outer_group_container(display_granularity))
+    .then(|| pane_group.custom_title(app))
+    .flatten();
+
+// after
+let title_override = pane_group.custom_title(app);
+```
+
+Both edits are render-safe: the `PaneProps` constructed in these branches are throwaway match-only objects consumed by `pane_matches_query` and discarded; they are never rendered. The render-side gate lives independently at [vertical_tabs.rs:1777](app/src/workspace/view/vertical_tabs.rs#L1777) (`displayed_tab_title_override`, used by `render_tab_group` at lines 1828 / 1881) and is **untouched** — the tab name still renders only as a group header in Panes mode, not on each pane row (PRODUCT invariant 17). The sidebar already includes the tab `custom_title` in Summary mode and the pane `custom_vertical_tabs_title` in FocusedSession + Panes modes; no other sidebar changes are required (PRODUCT invariants 1, 10, 11). Sidebar remains window-scoped — both filter sites iterate `workspace.tabs` for the current window only — so PRODUCT invariant 8 (multi-window) is satisfied via the palette's existing `all_sessions(app)` window walk, not by any sidebar change.
+
+Whitespace-only handling is already correct: `search_fragments_contain_query` ([vertical_tabs.rs:2854](app/src/workspace/view/vertical_tabs.rs#L2854)) skips whitespace-only fragments today. Names are normalized at the source via `normalize_custom_name` so display offsets agree with palette match ranges.
+
+### End-to-end flow (palette)
+
+1. User renames a tab → `finish_tab_rename` → `pane_group.set_title(...)`. No event-bus publish; no invalidation needed.
+2. User opens the command palette and types a query.
+3. `FullTextSessionSearcher::search` (or `FuzzySessionSearcher::search`) calls `SessionNavigationData::all_sessions(app)`.
+4. `all_sessions` walks windows → workspaces → `PaneGroup::pane_sessions`, which now populates `custom_tab_name` and `custom_pane_name` from live state.
+5. `searchable_session_string_and_ranges` produces the concat string + char-indexed ranges (now including the two new name ranges).
+6. Backend matches; `SessionHighlightIndices::new` partitions matched indices into per-field index vecs.
+7. `SearchItem` / `render.rs` reads names + per-field highlight indices and renders zero, one, or two leading labels with the existing highlight treatment.
+
+## Testing and validation
+
+Each numbered invariant in `product.md` (1–21 after the boost was dropped) maps to a concrete check.
+
+| Invariant | Mechanism |
+|---|---|
+| 1 (custom names indexed) | Unit tests on `searchable_session_string_and_ranges` covering Some/Some, Some/None, None/Some, None/None × {tab, pane}. |
+| 2 (whitespace-only → None) | Unit test on `normalize_custom_name`. |
+| 3 (case-insensitive substring) | One regression test per backend (fuzzy + Tantivy). |
+| 4 (multi-byte) | Extend [search_tests.rs](app/src/search/command_palette/navigation/search_tests.rs) — emoji + CJK custom names, byte-vs-char highlight ranges. |
+| 5 (restored sessions) | Integration test: set names, restart, query. Persistence already verified to round-trip. |
+| 6 (renames take effect immediately) | Integration test: rename, immediately query, assert hit. Falls out of per-query rebuild. |
+| 7 (multi-pane) | Integration test: tab with two panes, names on tab + one pane; query each independently, assert correct row count. |
+| 8 (multi-window) | Integration test with two windows; existing cross-window plumbing through `app.window_ids()`. |
+| 9 (no dup rows on multi-field match) | Unit test: query that hits multiple ranges produces one `MatchedSession`. |
+| 10 (sidebar parity) | Integration test in each of Summary, FocusedSession, Panes modes. |
+| 11 (no sidebar regression) | Existing sidebar tests in `vertical_tabs.rs` test module stay green. |
+| 12–15 (row render + truncation) | Snapshot / widget tests for `SearchItem` covering 0/1/2-label cases, highlights, and anchored truncation at narrow widths. |
+| 16 (no length cap) | Covered by absence of cap code; manual review confirms no new validation gate. |
+| 17 (sidebar render unchanged) | Existing sidebar render tests stay green; no edits to `PaneProps::displayed_title` or the sidebar render path. |
+| 18 (active session not excluded) | Explicit test: focused session passes filter when query matches its name. |
+| 19 (theming/a11y) | Storybook check across light / dark / custom themes; assistive-name test. |
+| 20 (no false negatives) | Property test: pre-change query set produces the same hit set after the change. |
+| 21 (rename UX / telemetry unchanged) | No edits to `finish_tab_rename` ([view.rs:1301-1321](app/src/workspace/view.rs#L1301-L1321)), `set_custom_pane_name` ([view.rs:5218](app/src/workspace/view.rs#L5218)), or `TabRenameEvent` ([events.rs:417-421](app/src/server/telemetry/events.rs#L417-L421)) — assert by file scope. |
+
+Manual validation pass:
+
+1. Three tabs; rename one "deploy", split it into two panes, rename one pane "logs".
+2. Command palette: query `deploy` → both pane rows under that tab appear with the leading "deploy" label highlighted. Query `logs` → only that one row, with both labels rendered.
+3. Sidebar Panes mode: query `deploy` → all panes under that tab visible. Query `logs` → only that pane.
+4. Multi-byte: rename to "デプロイ" and "🚀 prod"; query a partial of each.
+5. Quit and relaunch. Re-query — names still findable.
+
+## Risks and mitigations
+
+- **Sidebar gate change scope.** Removing the gate at the two filter sites could leak `title_override` into render call sites if those weren't kept gated. *Mitigation:* the change is scoped to the two filter-only call sites (`matching_tab_indices` line 1022 and `render_groups` line 1547), where the resulting `PaneProps` are throwaway match-only objects consumed by `pane_matches_query`. The render-side `displayed_tab_title_override` at vertical_tabs.rs:1777 (used by `render_tab_group`) is untouched, so PRODUCT invariant 17 holds.
+- **Truncation around match for two labels.** Two side-by-side labels with potentially-different match offsets is the trickiest UI piece. *Mitigation:* prototype against the existing `prompt`/`command` truncation behavior; cover with snapshot tests at narrow widths.
+- **Per-query rebuild cost.** Adding two char-range computations per session is negligible against the existing per-query Tantivy build. No measurement needed unless a benchmark regression appears.
+
+## Follow-ups
+
+- Pixel-perfect label visual treatment (separator / spacing / weight between tab- and pane-name segments — PRODUCT invariant 12) is a design open question; this spec captures the contract only.
+- **Sidebar-header whitespace normalization for tab names.** `PaneGroup::set_title` ([pane_group/mod.rs:4781](app/src/pane_group/mod.rs#L4781)) doesn't trim, while `PaneConfiguration::set_custom_vertical_tabs_title` ([pane/mod.rs:775](app/src/pane_group/pane/mod.rs#L775)) does. A whitespace-only custom tab name renders today as a tab-header containing visible spaces. Pre-existing behavior independent of search; track separately in a new GitHub issue.


### PR DESCRIPTION
## Description

Spec PR for #9155 — make user-set custom tab and pane names searchable on both session-search surfaces (command palette + vertical-tabs sidebar).

Today's two surfaces handle custom names inconsistently: the command palette indexes neither name, and the sidebar drops the custom tab name in Panes mode even though it renders on screen. Users who rename tabs and panes expect those names to be the most reliable way to find a session.

This PR adds the behavior contract and implementation plan; no code yet.

- `specs/GH9155/product.md` — 21 numbered, testable behavior invariants covering both surfaces, both name kinds, edge cases (whitespace-only, multi-byte, restored sessions, multi-window), and result-row rendering.
- `specs/GH9155/tech.md` — implementation plan: extend `SessionNavigationData` with `custom_tab_name` / `custom_pane_name` (normalized via a shared `normalize_custom_name`), prepend them in the palette's searchable string with per-field highlight ranges, and drop the `!uses_outer_group_container` gate at `matching_tab_indices` to close the sidebar's Panes-mode gap.

## Linked Issue

Refs #9155.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

No code in this PR. `tech.md`'s "Testing and validation" section maps each of the 21 product invariants to a concrete unit / integration / snapshot test that the implementation PR will land.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode