### PR TITLE
fix(windows): preserve typed characters from non-IME input methods (Unikey/EVKey)

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -1298,12 +1298,49 @@ impl EventLoop {
                 }
 
                 let event_text = event.text.as_ref().map(|text| text.to_string());
-                let warp_ui_event =
-                    convert_keyboard_input_event(event, window_state, is_synthetic)?;
-                Some(ConvertedEvent::KeyDownWithTypedCharacters {
-                    chars: event_text,
-                    event: warp_ui_event,
-                })
+                let event_state = event.state;
+                let is_unidentified_key =
+                    matches!(event.logical_key, keyboard::Key::Unidentified(_));
+                match convert_keyboard_input_event(event, window_state, is_synthetic) {
+                    Some(warp_ui_event) => Some(ConvertedEvent::KeyDownWithTypedCharacters {
+                        chars: event_text,
+                        event: warp_ui_event,
+                    }),
+                    None if is_unidentified_key
+                        && !is_synthetic
+                        && event_state == ElementState::Pressed =>
+                    {
+                        // Fallback for synthetic WM_CHAR messages injected by non-IME input
+                        // methods (e.g. Unikey/EVKey on Windows for Vietnamese Telex/VNI).
+                        // These input methods hook the keyboard at a low level and inject
+                        // pre-composed characters via `SendInput` instead of going through
+                        // the standard IME pipeline. The resulting key event has
+                        // `logical_key == Key::Unidentified(...)`, which causes
+                        // `convert_keyboard_input_event` to return `None`, but `event.text`
+                        // still carries the composed character (e.g. "ư", "ế").
+                        //
+                        // Without this branch the character is silently dropped, producing
+                        // the well-known "Vietnamese characters disappear while typing" bug
+                        // reported by users of Unikey, EVKey and similar IMEs on Windows.
+                        // Dispatching it as a `TypedCharacters` event lets the downstream
+                        // pipeline (terminal input, editor) receive the character.
+                        //
+                        // The arm guard ensures the fallback only runs for the intended
+                        // unidentified-key case:
+                        //   * `!is_synthetic` and `Pressed` mirror the early returns in
+                        //     `convert_keyboard_input_event`, so we don't re-introduce the
+                        //     focus-keypress bugs those checks exist to suppress (e.g.
+                        //     alt-tab inserting a `tab`, hotkey re-triggering window open).
+                        //   * `is_unidentified_key` excludes intentionally ignored
+                        //     identified keystrokes (`KEYS_TO_IGNORE`, e.g. `cmdorctrl-v`
+                        //     on web that needs to fall through to the browser paste
+                        //     handler) which also cause the converter to return `None`.
+                        event_text.map(|chars| {
+                            ConvertedEvent::Event(crate::event::Event::TypedCharacters { chars })
+                        })
+                    }
+                    None => None,
+                }
             }
             WindowEvent::Resized(_) => Some(ConvertedEvent::Resize),
             WindowEvent::Focused(is_focused) => {


### PR DESCRIPTION
## Description

### What
On Windows, Vietnamese characters silently disappeared while typing in
Warp when using the popular input methods Unikey or EVKey in Telex/VNI
mode. For example, typing `tieengs` would render as `tieeng` instead of
`tiếng`. This PR makes Warp preserve the composed character those tools
deliver via synthetic keyboard events.

### Why
Warp already handles standard IMEs (Microsoft IME, TSF) correctly via
`WindowEvent::Ime(Preedit | Commit)` in `handle_ime_event`. However,
the most common Vietnamese input methods on Windows do **not** go
through the IMM32/TSF pipeline. Instead they:

1. Install a low-level keyboard hook.
2. Watch raw keystrokes for Telex/VNI sequences (`aa` → `â`, `dd` →
   `đ`, `ow` → `ơ`, etc.).
3. When a sequence resolves, call `SendInput` to:
   - emit synthetic `Backspace` keys to erase the raw letters that
     were already delivered, and
   - emit a `WM_CHAR` carrying the composed Unicode character.

The injected `WM_CHAR` arrives at our winit event loop as a `KeyEvent`
with `event.text == Some("ư"|"ế"|...)` but
`logical_key == Key::Unidentified(...)` (no matching scan code).

`convert_keyboard_input_event` returns `None` for `Key::Unidentified`,
and the previous `?` operator in the `WindowEvent::KeyboardInput` arm
discarded the entire event – including the captured `event_text` –
causing the well-known "Vietnamese characters disappear while typing"
bug reported by Unikey/EVKey users.

This pattern can also affect other languages whose Windows input
methods rely on `SendInput` rather than the IME framework.

References:
- warpdotdev/Warp#341 (i18n IME tracking)
- warpdotdev/Warp#9012 (Windows IME preedit)

### How
Replace the `?` operator in `convert_window_event`'s
`WindowEvent::KeyboardInput` arm with an explicit `match`:

- When `convert_keyboard_input_event` returns `Some(warp_ui_event)`,
  behaviour is **byte-identical** to the previous code: a
  `KeyDownWithTypedCharacters` is produced, preserving every existing
  keystroke path, shortcut handling, and modifier-aware logic.
- When it returns `None` but `event.text` is present, dispatch the
  text directly as a `TypedCharacters` event. The downstream pipeline
  (terminal input, editor, Vim FSA, etc.) already consumes
  `TypedCharacters` from the IME `Commit` path and the WASM
  soft-keyboard path, so no further plumbing is required.

The new fallback only activates when both
`convert_keyboard_input_event` returns `None` AND `event.text` is
`Some(_)` – essentially the signature of an injected `WM_CHAR` with no
corresponding logical key, which is what `SendInput`-based IMEs
produce. No interface changes, no new dependencies, no changes to the
winit fork.

## Testing

### Manual smoke test (Windows 11 + Unikey 4.6 RC2, Telex, Unicode)

| Input         | Expected     | Result |
| ------------- | ------------ | ------ |
| `tieengs Vieetj` | `tiếng Việt` | ✓     |
| `dduwowngf`   | `đường`      | ✓     |
| `chuwx`       | `chữ`        | ✓     |
| Editing in the middle of a line | composed correctly | ✓ |

Verified with a custom build of `warp-oss` from this branch.

### Automated checks
- `cargo fmt --check -p warpui` passes.
- `cargo check -p warpui` passes.
- `cargo build --release -p warp --bin warp-oss` produces a working
  binary.

### No new tests added
The behaviour is platform-specific (Windows) and depends on a
third-party IME hooking the keyboard, which is impractical to exercise
in our existing test harness. The hot path is unchanged for non-IME
input, and the only new branch is a narrow fallback that mirrors the
existing IME `Commit` flow.

## Server API dependencies

None.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed Vietnamese characters being silently dropped on Windows when typing with Unikey or EVKey in Telex/VNI mode.

Co-Authored-By: Oz <oz-agent@warp.dev>
