### PR TITLE
Remove LessHorizontalTerminalPadding feature flag

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -465,7 +465,6 @@ default = [
     "shared_with_me",
     "block_toolbelt_save_as_workflow",
     "remove_alt_screen_padding",
-    "less_horizontal_terminal_padding",
     "session_sharing_acls",
     "external_agent_mode_context",
     "shell_selector",
@@ -778,7 +777,6 @@ alacritty_settings_import = []
 shared_with_me = []
 ai_rules = []
 am_workflows = []
-less_horizontal_terminal_padding = []
 shell_selector = []
 shared_session_long_running_commands = []
 block_toolbelt_save_as_workflow = []

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2473,8 +2473,6 @@ pub fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::AIRules,
         #[cfg(feature = "ssh_tmux_wrapper")]
         FeatureFlag::SSHTmuxWrapper,
-        #[cfg(feature = "less_horizontal_terminal_padding")]
-        FeatureFlag::LessHorizontalTerminalPadding,
         #[cfg(feature = "shell_selector")]
         FeatureFlag::ShellSelector,
         #[cfg(feature = "block_toolbelt_save_as_workflow")]

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -749,11 +749,7 @@ lazy_static! {
 
     /// The padding between the left of the element and where the grid contents (either via the
     /// `BlockList` or the `AltScreen`) should be rendered.
-    pub static ref PADDING_LEFT: f32 = if FeatureFlag::LessHorizontalTerminalPadding.is_enabled() {
-        16.
-    } else {
-        20.
-    };
+    pub static ref PADDING_LEFT: f32 = 16.;
 }
 
 #[derive(Default)]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -142,10 +142,6 @@ pub enum FeatureFlag {
     /// Routes SSH sessions through the tmux-backed SSH wrapper.
     SSHTmuxWrapper,
 
-    /// Reduces the amount of horizontal padding in the blocklist
-    /// from 20px to 16px.
-    LessHorizontalTerminalPadding,
-
     /// Enables the shell selector, allowing us to open a new tab in
     /// a shell other than the default shell.
     ShellSelector,


### PR DESCRIPTION
## Description
Removes the stale `LessHorizontalTerminalPadding` feature flag. The flag was already enabled by default in `app/Cargo.toml`, so the 16px horizontal terminal padding is the established behavior. This PR removes the flag definition, the `cfg`-gated registration, the runtime check around `PADDING_LEFT`, and the corresponding `[features]` entries.

Changes:
- `crates/warp_features/src/lib.rs`: remove `FeatureFlag::LessHorizontalTerminalPadding` variant and doc comment.
- `app/Cargo.toml`: remove `less_horizontal_terminal_padding` feature definition and its `default` entry.
- `app/src/lib.rs`: remove the `#[cfg(feature = "less_horizontal_terminal_padding")]` block in `enabled_features`.
- `app/src/terminal/view.rs`: simplify `PADDING_LEFT` to unconditionally use `16.`.

## Linked Issue
N/A — flag cleanup.

## Testing
- `cargo fmt -p warp -p warp_features`
- `cargo check -p warp_features`
- `cargo check -p warp`

All green. No behavioral change is expected since the flag was already enabled by default.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/0ac2dc3f-546a-4698-9001-7d6d387b4a5e_
_Run: https://oz.staging.warp.dev/runs/019ddfa0-137c-7d72-adad-b33467733a58_

_This PR was generated with [Oz](https://warp.dev/oz)._
