### PR TITLE
Format context window numbers with thousands separators

### DIFF
--- a/app/src/ai/execution_profiles/editor/mod.rs
+++ b/app/src/ai/execution_profiles/editor/mod.rs
@@ -28,6 +28,7 @@ use crate::{
 use ai::api_keys::{ApiKeyManager, ApiKeyManagerEvent};
 use itertools::Itertools;
 use regex::Regex;
+use thousands::Separable;
 use warp_core::ui::theme::color::internal_colors;
 use warpui::fonts::Properties;
 use warpui::platform::Cursor;
@@ -514,7 +515,7 @@ impl ExecutionProfileEditorView {
                 ..Default::default()
             };
             let mut editor = EditorView::single_line(options, ctx);
-            editor.set_buffer_text(&initial_context_window_value.to_string(), ctx);
+            editor.set_buffer_text(&initial_context_window_value.separate_with_commas(), ctx);
             editor
         });
         let last_synced_context_window_editor_value = Some(initial_context_window_value);
@@ -1366,14 +1367,14 @@ impl ExecutionProfileEditorView {
             return;
         };
 
-        let formatted = value.to_string();
+        let formatted = value.separate_with_commas();
         let should_update = if force {
             true
         } else {
             match self.last_synced_context_window_editor_value {
                 Some(last_value) => {
                     self.context_window_editor.as_ref(ctx).buffer_text(ctx)
-                        == last_value.to_string()
+                        == last_value.separate_with_commas()
                 }
                 None => true,
             }
@@ -1495,7 +1496,7 @@ impl TypedActionView for ExecutionProfileEditorView {
                 // in the input box without persisting to the profile yet.
                 // Persistence happens on SetContextWindowSize (drop / commit).
                 if self.configurable_context_window(ctx).is_some() {
-                    let formatted = value.to_string();
+                    let formatted = value.separate_with_commas();
                     self.context_window_editor.update(ctx, |editor, ctx| {
                         editor.system_reset_buffer_text(&formatted, ctx);
                     });

--- a/app/src/ai/execution_profiles/editor/ui_helpers.rs
+++ b/app/src/ai/execution_profiles/editor/ui_helpers.rs
@@ -7,6 +7,7 @@ use crate::view_components::{Dropdown, SubmittableTextInput};
 use crate::Appearance;
 use crate::TemplatableMCPServerManager;
 use pathfinder_geometry::vector::vec2f;
+use thousands::Separable;
 use uuid::Uuid;
 use warp_core::features::FeatureFlag;
 use warpui::elements::Dismiss;
@@ -315,8 +316,8 @@ fn render_context_window_row(
     )
     .with_color(appearance.theme().active_ui_text_color().into())
     .finish();
-    let min_label_text = min.to_string();
-    let max_label_text = max.to_string();
+    let min_label_text = min.separate_with_commas();
+    let max_label_text = max.separate_with_commas();
     let desc = Text::new(
         "The base model's working memory — how many tokens of your conversation, code, and documents it can consider at once. Larger windows enable longer conversations and more coherent responses over bigger codebases, at the cost of higher latency and compute usage.".to_string(),
         appearance.ui_font_family(),


### PR DESCRIPTION
## Description
Format the configurable context window's slider min/max labels and the input box value with thousands separators (e.g. `2,000,000` instead of `2000000`) for readability when users see big token counts in the agent profile editor.

The parser already strips whitespace and commas before `parse::<u32>()`, so users can keep typing the value either way (`2000000` or `2,000,000`); both work.

Uses the existing `thousands::Separable` dependency that's already pulled in by the billing/usage views.

## Linked Issue
N/A — small UX polish requested in the `pod-configurable-context-window` Slack thread.

## Screenshots / Videos
N/A — text formatting change only; numbers in the slider labels and input box now show commas.

## Testing
- `cargo check -p warp` passes locally.
- The input parser path was already comma-tolerant, so existing behavior for users typing without commas is preserved.
- Existing snap-value unit tests in `app/src/ai/execution_profiles/editor/mod_test.rs` are unaffected.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/43c853a0-864e-4ae0-a4ab-6598bb04b884_
_Run: https://oz.staging.warp.dev/runs/019ddfbd-77dd-7800-a296-9e46c87f97d3_

_This PR was generated with [Oz](https://warp.dev/oz)._
