### PR TITLE
Fix issue on dev with agent history menu not working.

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -2631,14 +2631,6 @@ impl Input {
         });
         if FeatureFlag::InlineHistoryMenu.is_enabled() {
             ctx.subscribe_to_view(&inline_history_menu_view, |me, _, event, ctx| {
-                // Only the active view's events should be processed. When
-                // CloudModeInputV2 is enabled and we're composing for an
-                // ambient agent, the cloud-mode-v2 wrapper is the active view
-                // and this regular view's events must be ignored, otherwise
-                // both views would write to the buffer and the second write
-                // would desync from this view's selection, tripping the
-                // `mismatched` check in `handle_editor_event` and closing the
-                // menu.
                 if me.is_cloud_mode_input_v2_composing(ctx) {
                     return;
                 }
@@ -2666,9 +2658,6 @@ impl Input {
             });
             if FeatureFlag::InlineHistoryMenu.is_enabled() {
                 ctx.subscribe_to_view(&view, |me, _, event, ctx| {
-                    // Mirror of the regular view's guard: this wrapper is
-                    // only the active view when we're composing for an
-                    // ambient agent in cloud-mode-v2.
                     if !me.is_cloud_mode_input_v2_composing(ctx) {
                         return;
                     }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -2631,6 +2631,17 @@ impl Input {
         });
         if FeatureFlag::InlineHistoryMenu.is_enabled() {
             ctx.subscribe_to_view(&inline_history_menu_view, |me, _, event, ctx| {
+                // Only the active view's events should be processed. When
+                // CloudModeInputV2 is enabled and we're composing for an
+                // ambient agent, the cloud-mode-v2 wrapper is the active view
+                // and this regular view's events must be ignored, otherwise
+                // both views would write to the buffer and the second write
+                // would desync from this view's selection, tripping the
+                // `mismatched` check in `handle_editor_event` and closing the
+                // menu.
+                if me.is_cloud_mode_input_v2_composing(ctx) {
+                    return;
+                }
                 me.handle_inline_history_menu_event(event, ctx);
             });
         }
@@ -2655,6 +2666,12 @@ impl Input {
             });
             if FeatureFlag::InlineHistoryMenu.is_enabled() {
                 ctx.subscribe_to_view(&view, |me, _, event, ctx| {
+                    // Mirror of the regular view's guard: this wrapper is
+                    // only the active view when we're composing for an
+                    // ambient agent in cloud-mode-v2.
+                    if !me.is_cloud_mode_input_v2_composing(ctx) {
+                        return;
+                    }
                     me.handle_inline_history_menu_event(event, ctx);
                 });
             }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Fixes https://warpdev.slack.com/archives/C08KTPNQN65/p1777573039998779.

The issue was that there were two views subscribing the up arrow event and both would handle it. Both the normal history menu and the cloud mode-only history menu would emit events in rapid succession. We now make sure that only one of the views ever fires off events, since only one history menu should be active at a time.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?
-->

Before, hitting the up arrow in the agent conversation view would cause the buggy behavior Roland described: the first query would get inserted into the buffer and the history menu would appear to never open. Now, it WAI.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

