### PR TITLE
[codex] fix CLI agent and repo setup issues

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "Warp",
+  "build": {
+    "context": "..",
+    "dockerfile": "../docker/agent-dev/Dockerfile"
+  },
+  "workspaceFolder": "/workspaces/warp",
+  "remoteEnv": {
+    "CARGO_TARGET_DIR": "/workspaces/warp/target"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        "tamasfe.even-better-toml"
+      ]
+    }
+  }
+}

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -526,6 +526,7 @@ pub(super) struct ImportedCommentElementState {
     pub(super) open_in_code_review_button: ViewHandle<ActionButton>,
     pub(super) chevron_button: ViewHandle<ActionButton>,
     pub(super) header_click_handler: HeaderClickHandler,
+    pub(super) is_opened_in_code_review: bool,
 }
 
 impl ImportedCommentElementState {
@@ -585,6 +586,7 @@ impl ImportedCommentElementState {
             open_in_code_review_button,
             chevron_button,
             header_click_handler,
+            is_opened_in_code_review: false,
         }
     }
 }
@@ -613,6 +615,18 @@ impl ImportedCommentGroup {
 
     fn card_mut(&mut self, comment_index: usize) -> Option<&mut CommentViewCard> {
         self.cards.get_mut(comment_index)
+    }
+
+    fn mark_comment_opened_in_code_review(&mut self, comment_index: usize) {
+        if let Some(state) = self.element_states.get_mut(comment_index) {
+            state.is_opened_in_code_review = true;
+        }
+    }
+
+    fn mark_all_opened_in_code_review(&mut self) {
+        for state in &mut self.element_states {
+            state.is_opened_in_code_review = true;
+        }
     }
 
     fn set_buttons_disabled(&self, should_disable: bool, ctx: &mut ViewContext<AIBlock>) {
@@ -6287,19 +6301,29 @@ impl TypedActionView for AIBlock {
                 if let Some(group) = self.imported_comments.get_mut(action_id) {
                     let repo_path = group.repo_path.clone();
                     let base_branch = group.base_branch.clone();
-                    if let Some(card) = group.card_mut(*comment_index) {
+                    if let Some(comment) = group
+                        .cards
+                        .get(*comment_index)
+                        .map(|card| card.source().clone())
+                    {
+                        group.mark_comment_opened_in_code_review(*comment_index);
                         ctx.emit(AIBlockEvent::OpenImportedCommentInCodeReview {
                             repo_path,
-                            comment: Box::new(card.source().clone()),
+                            comment: Box::new(comment),
                             base_branch,
                         });
+                        ctx.notify();
                     }
                 }
             }
             AIBlockAction::OpenAllImportedCommentsInCodeReview => {
+                for group in self.imported_comments.values_mut() {
+                    group.mark_all_opened_in_code_review();
+                }
                 ctx.emit(AIBlockEvent::OpenAllImportedCommentsForConversation {
                     conversation_id: self.client_ids.conversation_id,
                 });
+                ctx.notify();
             }
             AIBlockAction::OpenCommentInGitHub { url } => {
                 ctx.open_url(url);

--- a/app/src/ai/blocklist/block/view_impl/imported_comments.rs
+++ b/app/src/ai/blocklist/block/view_impl/imported_comments.rs
@@ -12,7 +12,6 @@ pub(crate) fn render_imported_comments(
         .with_spacing(12.);
 
     for (card, state) in group.cards.iter().zip(group.element_states.iter()) {
-        let open_in_code_review = ChildView::new(&state.open_in_code_review_button).finish();
         let chevron = ChildView::new(&state.chevron_button).finish();
 
         let mut header_trailing = Flex::row()
@@ -23,10 +22,12 @@ pub(crate) fn render_imported_comments(
             header_trailing.add_child(ChildView::new(open_in_github).finish());
         }
 
-        let header_trailing = header_trailing
-            .with_child(open_in_code_review)
-            .with_child(chevron)
-            .finish();
+        if !state.is_opened_in_code_review {
+            header_trailing
+                .add_child(ChildView::new(&state.open_in_code_review_button).finish());
+        }
+
+        let header_trailing = header_trailing.with_child(chevron).finish();
 
         column.add_child(card.render(
             None,

--- a/app/src/ai/skills/resolve_skill_spec.rs
+++ b/app/src/ai/skills/resolve_skill_spec.rs
@@ -11,7 +11,10 @@
 //! - Applies consistent skill-directory precedence (e.g. `.claude/` vs `.codex/`, etc.).
 //! - Falls back to scanning disk when the manager cache has not warmed yet.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
 use ai::skills::{
     home_skills_path, parse_skill, ParsedSkill, SkillProvider, SKILL_PROVIDER_DEFINITIONS,
@@ -264,7 +267,7 @@ fn resolve_repo_qualified(
     candidate_repo_roots.sort();
 
     for repo_root in candidate_repo_roots {
-        match resolve_in_single_repo_root(spec, &repo_root, skill_manager) {
+        match resolve_in_single_repo_root(spec, &repo_root, None, skill_manager) {
             Ok(resolved) => return Ok(resolved),
             Err(ResolveSkillError::NotFound { .. }) => {}
             Err(err) => return Err(err),
@@ -323,7 +326,7 @@ fn resolve_unqualified(
         .get_root_for_path(working_dir);
 
     if let Some(repo_root) = repo_root {
-        match resolve_in_single_repo_root(spec, &repo_root, skill_manager) {
+        match resolve_in_single_repo_root(spec, &repo_root, Some(working_dir), skill_manager) {
             Ok(resolved) => return Ok(resolved),
             Err(ResolveSkillError::NotFound { .. }) => {}
             Err(err) => return Err(err),
@@ -365,6 +368,7 @@ fn resolve_unqualified(
 fn resolve_in_single_repo_root(
     spec: &SkillSpec,
     repo_root: &Path,
+    preferred_scope: Option<&Path>,
     skill_manager: &SkillManager,
 ) -> Result<ResolvedSkill, ResolveSkillError> {
     // If the skill_path is a full path, skip cache lookup and go straight to disk resolution.
@@ -387,13 +391,17 @@ fn resolve_in_single_repo_root(
         .filter(|p| repo_skill_paths.contains(p))
         .collect();
 
-    if let Some(best_path) = best_match_by_directory_precedence(cached_paths, Some(repo_root)) {
+    if let Some(best_path) =
+        best_match_by_working_directory_scope(cached_paths, repo_root, preferred_scope, spec)?
+    {
         let parsed = parsed_skill_from_manager_or_disk(skill_manager, &best_path)?;
         return Ok(to_resolved_skill(best_path, parsed));
     }
 
     // Cold start fallback: check disk in precedence order.
-    if let Some(resolved) = resolve_from_root_path_by_directory_scan(spec, repo_root)? {
+    if let Some(resolved) =
+        resolve_from_root_path_by_directory_scan_with_scope(spec, repo_root, preferred_scope)?
+    {
         return Ok(resolved);
     }
 
@@ -405,6 +413,14 @@ fn resolve_in_single_repo_root(
 fn resolve_from_root_path_by_directory_scan(
     spec: &SkillSpec,
     root: &Path,
+) -> Result<Option<ResolvedSkill>, ResolveSkillError> {
+    resolve_from_root_path_by_directory_scan_with_scope(spec, root, None)
+}
+
+fn resolve_from_root_path_by_directory_scan_with_scope(
+    spec: &SkillSpec,
+    root: &Path,
+    preferred_scope: Option<&Path>,
 ) -> Result<Option<ResolvedSkill>, ResolveSkillError> {
     // If the skill_path is a full path (contains "/" or ends with ".md"),
     // try to resolve it directly without iterating through SKILL_PROVIDER_DEFINITIONS.
@@ -430,6 +446,16 @@ fn resolve_from_root_path_by_directory_scan(
         return Ok(None);
     }
 
+    if let Some(preferred_scope) = preferred_scope.filter(|scope| scope.starts_with(root)) {
+        if let Some(resolved) =
+            resolve_from_provider_paths_in_ancestor_scope(spec, root, preferred_scope)?
+        {
+            return Ok(Some(resolved));
+        }
+
+        return resolve_from_descendant_provider_paths(spec, preferred_scope);
+    }
+
     // For simple skill names, first check provider directories directly under
     // the root in precedence order.
     if let Some(resolved) = resolve_from_provider_paths_at_root(spec, root)? {
@@ -439,6 +465,15 @@ fn resolve_from_root_path_by_directory_scan(
     // Then scan descendant directories. This catches skills scoped to a
     // subproject when the git root is a parent directory and SkillManager's
     // cache has not warmed yet.
+    resolve_from_descendant_provider_paths(spec, root)
+}
+
+fn resolve_from_descendant_provider_paths(
+    spec: &SkillSpec,
+    root: &Path,
+) -> Result<Option<ResolvedSkill>, ResolveSkillError> {
+    let mut matches = Vec::new();
+
     for entry in WalkDir::new(root)
         .follow_links(false)
         .min_depth(1)
@@ -451,9 +486,37 @@ fn resolve_from_root_path_by_directory_scan(
         if !entry.file_type().is_dir() {
             continue;
         }
-        if let Some(resolved) = resolve_from_provider_paths_at_root(spec, entry.path())? {
+        if let Some(path) = skill_path_from_provider_paths_at_root(spec, entry.path()) {
+            matches.push((entry.path().to_path_buf(), path));
+        }
+    }
+
+    let Some(path) = select_descendant_skill_path(spec, matches)? else {
+        return Ok(None);
+    };
+
+    parse_resolved_skill(path).map(Some)
+}
+
+fn resolve_from_provider_paths_in_ancestor_scope(
+    spec: &SkillSpec,
+    root: &Path,
+    preferred_scope: &Path,
+) -> Result<Option<ResolvedSkill>, ResolveSkillError> {
+    let mut current = Some(preferred_scope);
+    while let Some(candidate) = current {
+        if !candidate.starts_with(root) {
+            break;
+        }
+
+        if let Some(resolved) = resolve_from_provider_paths_at_root(spec, candidate)? {
             return Ok(Some(resolved));
         }
+
+        if candidate == root {
+            break;
+        }
+        current = candidate.parent();
     }
 
     Ok(None)
@@ -463,6 +526,14 @@ fn resolve_from_provider_paths_at_root(
     spec: &SkillSpec,
     root: &Path,
 ) -> Result<Option<ResolvedSkill>, ResolveSkillError> {
+    let Some(path) = skill_path_from_provider_paths_at_root(spec, root) else {
+        return Ok(None);
+    };
+
+    parse_resolved_skill(path).map(Some)
+}
+
+fn skill_path_from_provider_paths_at_root(spec: &SkillSpec, root: &Path) -> Option<PathBuf> {
     for provider in SKILL_PROVIDER_DEFINITIONS.iter() {
         let path = root
             .join(&provider.skills_path)
@@ -470,16 +541,51 @@ fn resolve_from_provider_paths_at_root(
             .join(SKILL_FILE_NAME);
 
         if path.exists() {
-            let parsed = parse_skill(&path).map_err(|err| ResolveSkillError::ParseFailed {
-                path: path.clone(),
-                message: err.to_string(),
-            })?;
-
-            return Ok(Some(to_resolved_skill(path, parsed)));
+            return Some(path);
         }
     }
 
-    Ok(None)
+    None
+}
+
+fn parse_resolved_skill(path: PathBuf) -> Result<ResolvedSkill, ResolveSkillError> {
+    let parsed = parse_skill(&path).map_err(|err| ResolveSkillError::ParseFailed {
+        path: path.clone(),
+        message: err.to_string(),
+    })?;
+
+    Ok(to_resolved_skill(path, parsed))
+}
+
+fn select_descendant_skill_path(
+    spec: &SkillSpec,
+    matches: Vec<(PathBuf, PathBuf)>,
+) -> Result<Option<PathBuf>, ResolveSkillError> {
+    if matches.is_empty() {
+        return Ok(None);
+    }
+
+    let mut matches_by_owner: BTreeMap<PathBuf, Vec<PathBuf>> = BTreeMap::new();
+    for (owner_dir, skill_path) in matches {
+        matches_by_owner.entry(owner_dir).or_default().push(skill_path);
+    }
+
+    if matches_by_owner.len() > 1 {
+        let candidates = matches_by_owner
+            .into_values()
+            .flatten()
+            .collect::<Vec<PathBuf>>();
+        return Err(ResolveSkillError::Ambiguous {
+            skill: spec.skill_identifier.clone(),
+            candidates,
+        });
+    }
+
+    let (owner_dir, paths) = matches_by_owner
+        .into_iter()
+        .next()
+        .expect("matches is not empty");
+    Ok(best_match_by_directory_precedence(paths, Some(&owner_dir)))
 }
 
 fn should_descend_into_for_skill_scan(entry: &DirEntry) -> bool {
@@ -566,6 +672,107 @@ fn best_match_by_directory_precedence(
     matches.into_iter().next()
 }
 
+fn best_match_by_working_directory_scope(
+    matches: Vec<PathBuf>,
+    repo_root: &Path,
+    preferred_scope: Option<&Path>,
+    spec: &SkillSpec,
+) -> Result<Option<PathBuf>, ResolveSkillError> {
+    let Some(preferred_scope) = preferred_scope.filter(|scope| scope.starts_with(repo_root)) else {
+        return best_match_without_preferred_scope(matches, repo_root, spec);
+    };
+
+    let mut ancestor_matches = Vec::new();
+    let mut descendant_matches: BTreeMap<PathBuf, Vec<PathBuf>> = BTreeMap::new();
+
+    for path in matches {
+        let Some(owner_dir) = skill_owner_directory_from_path(&path) else {
+            continue;
+        };
+
+        if preferred_scope.starts_with(&owner_dir) && owner_dir.starts_with(repo_root) {
+            let depth = owner_dir.components().count();
+            ancestor_matches.push((depth, owner_dir, path));
+        } else if owner_dir.starts_with(preferred_scope) {
+            descendant_matches.entry(owner_dir).or_default().push(path);
+        }
+    }
+
+    if !ancestor_matches.is_empty() {
+        ancestor_matches.sort_by(|a, b| {
+            b.0.cmp(&a.0)
+                .then_with(|| {
+                    directory_precedence_rank(&a.1, &a.2)
+                        .cmp(&directory_precedence_rank(&b.1, &b.2))
+                })
+                .then_with(|| a.2.cmp(&b.2))
+        });
+        return Ok(ancestor_matches.into_iter().next().map(|(_, _, path)| path));
+    }
+
+    if descendant_matches.len() > 1 {
+        let candidates = descendant_matches
+            .into_values()
+            .flatten()
+            .collect::<Vec<PathBuf>>();
+        return Err(ResolveSkillError::Ambiguous {
+            skill: spec.skill_identifier.clone(),
+            candidates,
+        });
+    }
+
+    let Some((owner_dir, paths)) = descendant_matches.into_iter().next() else {
+        return Ok(None);
+    };
+
+    Ok(best_match_by_directory_precedence(paths, Some(&owner_dir)))
+}
+
+fn best_match_without_preferred_scope(
+    matches: Vec<PathBuf>,
+    repo_root: &Path,
+    spec: &SkillSpec,
+) -> Result<Option<PathBuf>, ResolveSkillError> {
+    let mut root_matches = Vec::new();
+    let mut descendant_matches: BTreeMap<PathBuf, Vec<PathBuf>> = BTreeMap::new();
+
+    for path in matches {
+        let Some(owner_dir) = skill_owner_directory_from_path(&path) else {
+            continue;
+        };
+
+        if owner_dir == repo_root {
+            root_matches.push(path);
+        } else if owner_dir.starts_with(repo_root) {
+            descendant_matches.entry(owner_dir).or_default().push(path);
+        }
+    }
+
+    if !root_matches.is_empty() {
+        return Ok(best_match_by_directory_precedence(
+            root_matches,
+            Some(repo_root),
+        ));
+    }
+
+    if descendant_matches.len() > 1 {
+        let candidates = descendant_matches
+            .into_values()
+            .flatten()
+            .collect::<Vec<PathBuf>>();
+        return Err(ResolveSkillError::Ambiguous {
+            skill: spec.skill_identifier.clone(),
+            candidates,
+        });
+    }
+
+    let Some((owner_dir, paths)) = descendant_matches.into_iter().next() else {
+        return Ok(None);
+    };
+
+    Ok(best_match_by_directory_precedence(paths, Some(&owner_dir)))
+}
+
 fn directory_precedence_rank(root: &Path, skill_path: &Path) -> usize {
     for (idx, provider) in SKILL_PROVIDER_DEFINITIONS.iter().enumerate() {
         if skill_path.starts_with(root.join(&provider.skills_path)) {
@@ -574,6 +781,24 @@ fn directory_precedence_rank(root: &Path, skill_path: &Path) -> usize {
     }
 
     SKILL_PROVIDER_DEFINITIONS.len()
+}
+
+fn skill_owner_directory_from_path(skill_path: &Path) -> Option<PathBuf> {
+    let path_components: Vec<_> = skill_path.components().collect();
+
+    for provider in SKILL_PROVIDER_DEFINITIONS.iter() {
+        let provider_components: Vec<_> = provider.skills_path.components().collect();
+        for (idx, window) in path_components
+            .windows(provider_components.len())
+            .enumerate()
+        {
+            if window == provider_components.as_slice() {
+                return Some(PathBuf::from_iter(path_components.iter().take(idx).copied()));
+            }
+        }
+    }
+
+    None
 }
 
 fn get_git_remote_org(repo_path: &Path) -> Option<String> {

--- a/app/src/ai/skills/resolve_skill_spec.rs
+++ b/app/src/ai/skills/resolve_skill_spec.rs
@@ -18,6 +18,7 @@ use ai::skills::{
 };
 use command::blocking::Command;
 use command::r#async::Command as AsyncCommand;
+use walkdir::{DirEntry, WalkDir};
 use warp_cli::skill::SkillSpec;
 use warpui::AppContext;
 use warpui::SingletonEntity as _;
@@ -429,7 +430,39 @@ fn resolve_from_root_path_by_directory_scan(
         return Ok(None);
     }
 
-    // For simple skill names, iterate through SKILL_PROVIDER_DEFINITIONS in precedence order.
+    // For simple skill names, first check provider directories directly under
+    // the root in precedence order.
+    if let Some(resolved) = resolve_from_provider_paths_at_root(spec, root)? {
+        return Ok(Some(resolved));
+    }
+
+    // Then scan descendant directories. This catches skills scoped to a
+    // subproject when the git root is a parent directory and SkillManager's
+    // cache has not warmed yet.
+    for entry in WalkDir::new(root)
+        .follow_links(false)
+        .min_depth(1)
+        .into_iter()
+        .filter_entry(should_descend_into_for_skill_scan)
+    {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        if !entry.file_type().is_dir() {
+            continue;
+        }
+        if let Some(resolved) = resolve_from_provider_paths_at_root(spec, entry.path())? {
+            return Ok(Some(resolved));
+        }
+    }
+
+    Ok(None)
+}
+
+fn resolve_from_provider_paths_at_root(
+    spec: &SkillSpec,
+    root: &Path,
+) -> Result<Option<ResolvedSkill>, ResolveSkillError> {
     for provider in SKILL_PROVIDER_DEFINITIONS.iter() {
         let path = root
             .join(&provider.skills_path)
@@ -447,6 +480,24 @@ fn resolve_from_root_path_by_directory_scan(
     }
 
     Ok(None)
+}
+
+fn should_descend_into_for_skill_scan(entry: &DirEntry) -> bool {
+    let Some(file_name) = entry.file_name().to_str() else {
+        return true;
+    };
+
+    !matches!(
+        file_name,
+        ".git"
+            | ".hg"
+            | ".svn"
+            | "target"
+            | "node_modules"
+            | ".venv"
+            | "venv"
+            | ".direnv"
+    )
 }
 
 fn parsed_skill_from_manager_or_disk(

--- a/app/src/ai/skills/resolve_skill_spec_tests.rs
+++ b/app/src/ai/skills/resolve_skill_spec_tests.rs
@@ -223,3 +223,29 @@ fn resolve_simple_name_uses_directory_precedence() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn resolve_simple_name_finds_subdirectory_skill_when_git_root_is_parent() -> Result<()> {
+    let temp_dir = tempfile::TempDir::new().context("Failed to create temp dir")?;
+    let root = temp_dir.path();
+    let package_skill = root
+        .join("packages")
+        .join("frontend")
+        .join(".agents/skills/my-skill/SKILL.md");
+
+    write_skill_file(
+        &package_skill,
+        "my-skill",
+        "desc",
+        "# Package skill\n\nThis should resolve from a subdirectory.",
+    )?;
+
+    let spec = SkillSpec::without_repo("my-skill".to_string());
+    let resolved = resolve_from_root_path_by_directory_scan(&spec, root)?
+        .context("Expected to resolve skill by scanning subdirectories")?;
+
+    assert_eq!(resolved.skill_path, package_skill);
+    assert!(resolved.instructions.contains("Package skill"));
+
+    Ok(())
+}

--- a/app/src/ai/skills/resolve_skill_spec_tests.rs
+++ b/app/src/ai/skills/resolve_skill_spec_tests.rs
@@ -249,3 +249,118 @@ fn resolve_simple_name_finds_subdirectory_skill_when_git_root_is_parent() -> Res
 
     Ok(())
 }
+
+#[test]
+fn resolve_simple_name_prefers_current_subdirectory_scope_over_sibling() -> Result<()> {
+    let temp_dir = tempfile::TempDir::new().context("Failed to create temp dir")?;
+    let root = temp_dir.path();
+    let package_a_skill = root
+        .join("packages")
+        .join("a")
+        .join(".agents/skills/my-skill/SKILL.md");
+    let package_b_skill = root
+        .join("packages")
+        .join("b")
+        .join(".agents/skills/my-skill/SKILL.md");
+    let package_b_working_dir = root.join("packages").join("b").join("src");
+
+    fs::create_dir_all(&package_b_working_dir)
+        .context("Failed to create package b working dir")?;
+    write_skill_file(
+        &package_a_skill,
+        "my-skill",
+        "desc",
+        "# Package A skill\n\nDo not pick this sibling.",
+    )?;
+    write_skill_file(
+        &package_b_skill,
+        "my-skill",
+        "desc",
+        "# Package B skill\n\nUse this scoped skill.",
+    )?;
+
+    let spec = SkillSpec::without_repo("my-skill".to_string());
+    let resolved = resolve_from_root_path_by_directory_scan_with_scope(
+        &spec,
+        root,
+        Some(&package_b_working_dir),
+    )?
+    .context("Expected to resolve package b skill")?;
+
+    assert_eq!(resolved.skill_path, package_b_skill);
+    assert!(resolved.instructions.contains("Package B skill"));
+    assert!(!resolved.instructions.contains("Package A skill"));
+
+    Ok(())
+}
+
+#[test]
+fn resolve_simple_name_is_ambiguous_for_multiple_descendant_matches_without_scope() -> Result<()> {
+    let temp_dir = tempfile::TempDir::new().context("Failed to create temp dir")?;
+    let root = temp_dir.path();
+    let package_a_skill = root
+        .join("packages")
+        .join("a")
+        .join(".agents/skills/my-skill/SKILL.md");
+    let package_b_skill = root
+        .join("packages")
+        .join("b")
+        .join(".agents/skills/my-skill/SKILL.md");
+
+    write_skill_file(
+        &package_a_skill,
+        "my-skill",
+        "desc",
+        "# Package A skill\n\nAmbiguous.",
+    )?;
+    write_skill_file(
+        &package_b_skill,
+        "my-skill",
+        "desc",
+        "# Package B skill\n\nAmbiguous.",
+    )?;
+
+    let spec = SkillSpec::without_repo("my-skill".to_string());
+    let err = resolve_from_root_path_by_directory_scan(&spec, root)
+        .expect_err("Expected ambiguity for sibling package skills");
+
+    match err {
+        ResolveSkillError::Ambiguous { skill, candidates } => {
+            assert_eq!(skill, "my-skill");
+            assert_eq!(candidates.len(), 2);
+            assert!(candidates.contains(&package_a_skill));
+            assert!(candidates.contains(&package_b_skill));
+        }
+        other => panic!("Expected ambiguous error, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn cached_resolution_prefers_current_subdirectory_scope_over_sibling() -> Result<()> {
+    let temp_dir = tempfile::TempDir::new().context("Failed to create temp dir")?;
+    let root = temp_dir.path();
+    let package_a_skill = root
+        .join("packages")
+        .join("a")
+        .join(".agents/skills/my-skill/SKILL.md");
+    let package_b_skill = root
+        .join("packages")
+        .join("b")
+        .join(".agents/skills/my-skill/SKILL.md");
+    let package_b_working_dir = root.join("packages").join("b").join("src");
+
+    let spec = SkillSpec::without_repo("my-skill".to_string());
+    let resolved = best_match_by_working_directory_scope(
+        vec![package_a_skill, package_b_skill.clone()],
+        root,
+        Some(&package_b_working_dir),
+        &spec,
+    )?
+    .context("Expected cached path to resolve")?;
+
+    assert_eq!(resolved, package_b_skill);
+
+    Ok(())
+}

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -500,6 +500,8 @@ pub enum CLIAgentType {
     Auggie,
     Cursor,
     Goose,
+    Devin,
+    MistralVibe,
     Unknown,
 }
 

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -1,7 +1,7 @@
 //! CLI agent detection and configuration.
 //!
 //! This module provides types for detecting and working with CLI-based AI agents
-//! like Claude Code, Gemini CLI, Codex, Amp, and Droid.
+//! like Claude Code, Gemini CLI, Codex, Amp, Droid, Devin, and Mistral Vibe.
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -111,7 +111,8 @@ const GOOSE_COLOR: ColorU = ColorU {
     a: 255,
 };
 
-/// Represents a CLI agent (e.g., Claude Code, Gemini CLI, Codex, Amp, Droid, OpenCode, Copilot, Pi, Auggie, Cursor, Goose)
+/// Represents a CLI agent (e.g., Claude Code, Gemini CLI, Codex, Amp, Droid,
+/// OpenCode, Copilot, Pi, Auggie, Cursor, Goose, Devin, Mistral Vibe).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Sequence, Serialize, Deserialize)]
 pub enum CLIAgent {
     Claude,
@@ -125,6 +126,8 @@ pub enum CLIAgent {
     Auggie,
     CursorCli,
     Goose,
+    Devin,
+    MistralVibe,
     /// Represents an unknown/custom CLI agent matched by user-configured regex patterns.
     Unknown,
 }
@@ -144,6 +147,8 @@ impl CLIAgent {
             CLIAgent::Auggie => "auggie",
             CLIAgent::CursorCli => "agent",
             CLIAgent::Goose => "goose",
+            CLIAgent::Devin => "devin",
+            CLIAgent::MistralVibe => "vibe",
             CLIAgent::Unknown => "",
         }
     }
@@ -175,6 +180,8 @@ impl CLIAgent {
             CLIAgent::Auggie => "Auggie",
             CLIAgent::CursorCli => "Cursor",
             CLIAgent::Goose => "Goose",
+            CLIAgent::Devin => "Devin",
+            CLIAgent::MistralVibe => "Mistral Vibe",
             CLIAgent::Unknown => "CLI Agent",
         }
     }
@@ -193,6 +200,7 @@ impl CLIAgent {
             CLIAgent::Auggie => Some(Icon::AuggieLogo),
             CLIAgent::CursorCli => Some(Icon::CursorLogo),
             CLIAgent::Goose => Some(Icon::GooseLogo),
+            CLIAgent::Devin | CLIAgent::MistralVibe => None,
             CLIAgent::Unknown => None,
         }
     }
@@ -221,6 +229,12 @@ impl CLIAgent {
             CLIAgent::Auggie => &[SkillProvider::Agents],
             CLIAgent::CursorCli => &[SkillProvider::Agents],
             CLIAgent::Goose => &[SkillProvider::Agents],
+            CLIAgent::Devin => &[
+                SkillProvider::Agents,
+                SkillProvider::Devin,
+                SkillProvider::Windsurf,
+            ],
+            CLIAgent::MistralVibe => &[SkillProvider::Agents, SkillProvider::Vibe],
             CLIAgent::Unknown => &[],
         }
     }
@@ -243,7 +257,7 @@ impl CLIAgent {
     pub fn supports_bash_mode(&self) -> bool {
         matches!(
             self,
-            CLIAgent::Claude | CLIAgent::Codex | CLIAgent::OpenCode
+            CLIAgent::Claude | CLIAgent::Codex | CLIAgent::OpenCode | CLIAgent::MistralVibe
         )
     }
 
@@ -261,6 +275,7 @@ impl CLIAgent {
             CLIAgent::Auggie => Some(AUGGIE_COLOR),
             CLIAgent::CursorCli => Some(CURSOR_COLOR),
             CLIAgent::Goose => Some(GOOSE_COLOR),
+            CLIAgent::Devin | CLIAgent::MistralVibe => None,
             CLIAgent::Unknown => None,
         }
     }
@@ -522,6 +537,8 @@ impl From<CLIAgent> for CLIAgentType {
             CLIAgent::Auggie => CLIAgentType::Auggie,
             CLIAgent::CursorCli => CLIAgentType::Cursor,
             CLIAgent::Goose => CLIAgentType::Goose,
+            CLIAgent::Devin => CLIAgentType::Devin,
+            CLIAgent::MistralVibe => CLIAgentType::MistralVibe,
             CLIAgent::Unknown => CLIAgentType::Unknown,
         }
     }

--- a/app/src/terminal/cli_agent_sessions/listener/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod.rs
@@ -66,6 +66,8 @@ fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
         | CLIAgent::Pi
         | CLIAgent::CursorCli
         | CLIAgent::Goose
+        | CLIAgent::Devin
+        | CLIAgent::MistralVibe
         | CLIAgent::Unknown => None,
     }
 }

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
@@ -264,6 +264,8 @@ pub(crate) fn plugin_manager_for_with_shell(
         | CLIAgent::Auggie
         | CLIAgent::CursorCli
         | CLIAgent::Goose
+        | CLIAgent::Devin
+        | CLIAgent::MistralVibe
         | CLIAgent::Unknown => None,
     }
 }

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/mod_tests.rs
@@ -34,6 +34,8 @@ fn returns_none_for_unsupported_agents() {
     assert!(plugin_manager_for(CLIAgent::Amp).is_none());
     assert!(plugin_manager_for(CLIAgent::Droid).is_none());
     assert!(plugin_manager_for(CLIAgent::Copilot).is_none());
+    assert!(plugin_manager_for(CLIAgent::Devin).is_none());
+    assert!(plugin_manager_for(CLIAgent::MistralVibe).is_none());
     assert!(plugin_manager_for(CLIAgent::Unknown).is_none());
 }
 

--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -259,6 +259,8 @@ fn test_detect_known_agents() {
                 ("copilot", CLIAgent::Copilot),
                 ("agent", CLIAgent::CursorCli),
                 ("goose", CLIAgent::Goose),
+                ("devin", CLIAgent::Devin),
+                ("vibe", CLIAgent::MistralVibe),
             ] {
                 assert_eq!(
                     CLIAgent::detect(command, None, None, ctx),

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -126,7 +126,9 @@ fn rich_input_submit_strategy(agent: CLIAgent) -> RichInputSubmitStrategy {
         | CLIAgent::OpenCode
         | CLIAgent::Gemini
         | CLIAgent::Auggie
-        | CLIAgent::CursorCli => RichInputSubmitStrategy::DelayedEnter,
+        | CLIAgent::CursorCli
+        | CLIAgent::Devin
+        | CLIAgent::MistralVibe => RichInputSubmitStrategy::DelayedEnter,
         CLIAgent::Amp | CLIAgent::Droid | CLIAgent::Pi | CLIAgent::Goose | CLIAgent::Unknown => {
             RichInputSubmitStrategy::Inline
         }

--- a/crates/ai/src/skills/conversion.rs
+++ b/crates/ai/src/skills/conversion.rs
@@ -73,6 +73,13 @@ impl From<SkillProvider> for api::skill_descriptor::Provider {
             SkillProvider::Codex => api::skill_descriptor::provider::Type::Codex(()),
             SkillProvider::Cursor => api::skill_descriptor::provider::Type::Cursor(()),
             SkillProvider::Gemini => api::skill_descriptor::provider::Type::Gemini(()),
+            // The protobuf does not yet have dedicated variants for every
+            // third-party agent provider. Preserve compatibility by sending
+            // them as Agent Skills providers; local UI still keeps the exact
+            // provider via [`SkillProvider`].
+            SkillProvider::Vibe | SkillProvider::Devin | SkillProvider::Windsurf => {
+                api::skill_descriptor::provider::Type::Agents(())
+            }
             SkillProvider::Copilot => api::skill_descriptor::provider::Type::Copilot(()),
             SkillProvider::Droid => api::skill_descriptor::provider::Type::Droid(()),
             SkillProvider::Github => api::skill_descriptor::provider::Type::Github(()),

--- a/crates/ai/src/skills/skill_provider.rs
+++ b/crates/ai/src/skills/skill_provider.rs
@@ -1,8 +1,8 @@
 //! Skill provider definitions and utilities.
 //!
-//! This module defines the supported skill providers (i.e. Agents, Claude, Codex, Warp) and their
-//! associated skills directory paths. It provides utilities for looking up providers
-//! from paths and vice versa.
+//! This module defines supported skill providers and their associated skills
+//! directory paths. It provides utilities for looking up providers from paths
+//! and vice versa.
 use dirs::home_dir;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -14,7 +14,7 @@ use warp_core::ui::color::CLAUDE_ORANGE;
 use warp_core::ui::icons::Icon;
 use warp_core::ui::theme::Fill;
 
-/// Represents a skill provider/origin (Agents, Claude, Codex, or Warp).
+/// Represents a skill provider/origin.
 #[derive(
     Debug,
     Clone,
@@ -35,6 +35,9 @@ pub enum SkillProvider {
     Codex,
     Cursor,
     Gemini,
+    Vibe,
+    Devin,
+    Windsurf,
     Copilot,
     Droid,
     Github,
@@ -85,6 +88,9 @@ impl SkillProvider {
             SkillProvider::Warp
             | SkillProvider::Agents
             | SkillProvider::Cursor
+            | SkillProvider::Vibe
+            | SkillProvider::Devin
+            | SkillProvider::Windsurf
             | SkillProvider::Copilot
             | SkillProvider::Github => Icon::WarpLogoLight,
         }
@@ -127,6 +133,18 @@ pub static SKILL_PROVIDER_DEFINITIONS: LazyLock<Vec<SkillProviderDefinition>> =
             SkillProviderDefinition {
                 provider: SkillProvider::Gemini,
                 skills_path: PathBuf::from(".gemini").join("skills"),
+            },
+            SkillProviderDefinition {
+                provider: SkillProvider::Vibe,
+                skills_path: PathBuf::from(".vibe").join("skills"),
+            },
+            SkillProviderDefinition {
+                provider: SkillProvider::Devin,
+                skills_path: PathBuf::from(".devin").join("skills"),
+            },
+            SkillProviderDefinition {
+                provider: SkillProvider::Windsurf,
+                skills_path: PathBuf::from(".windsurf").join("skills"),
             },
             SkillProviderDefinition {
                 provider: SkillProvider::Copilot,

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "Warp development shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          linuxPackages = with pkgs; [
+            alsa-lib
+            fontconfig
+            libxkbcommon
+            mesa
+            vulkan-loader
+            wayland
+            xorg.libX11
+            xorg.libXcursor
+            xorg.libxcb
+            xorg.libXi
+          ];
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              brotli
+              clang
+              clang-tools
+              cmake
+              curl
+              expat
+              freetype
+              git
+              jq
+              libgit2
+              nodejs_24
+              openssl
+              pkg-config
+              protobuf
+              rustup
+              sqlite
+              unzip
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux linuxPackages;
+
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
+            shellHook = ''
+              export RUSTUP_TOOLCHAIN="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+              echo "Warp dev shell ready. Run 'rustup toolchain install' if the pinned toolchain is missing."
+            '';
+          };
+        });
+    };
+}

--- a/script/check_node_yarn
+++ b/script/check_node_yarn
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+missing=0
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required to build Warp's command-signatures package."
+  echo "Install Node.js 18 or newer, then rerun ./script/bootstrap."
+  missing=1
+else
+  node_version="$(node --version 2>/dev/null | sed 's/^v//')"
+  node_major="${node_version%%.*}"
+  if [ -z "$node_major" ] || [ "$node_major" -lt 18 ] 2>/dev/null; then
+    echo "Node.js 18 or newer is required; found $(node --version)."
+    missing=1
+  fi
+fi
+
+if ! command -v yarn >/dev/null 2>&1; then
+  echo "Yarn is required to build Warp's command-signatures package."
+  if command -v corepack >/dev/null 2>&1; then
+    echo "Run 'corepack enable' to install the Yarn shim for this Node.js installation."
+  else
+    echo "Install a Node.js distribution that includes corepack, then run 'corepack enable'."
+  fi
+  missing=1
+fi
+
+if [ "$missing" -ne 0 ]; then
+  exit 1
+fi
+
+echo "Node.js $(node --version) and Yarn $(yarn --version) are available."

--- a/script/linux/bootstrap
+++ b/script/linux/bootstrap
@@ -2,6 +2,23 @@
 
 set -e
 
+confirm_system_changes() {
+  if [[ "${WARP_BOOTSTRAP_ASSUME_YES:-}" == "1" ]]; then
+    return
+  fi
+
+  echo "This bootstrap script will run sudo commands and install system-wide developer dependencies."
+  read -r -p "Continue? [y/N] " answer
+  case "$answer" in
+    y|Y|yes|YES) ;;
+    *) echo "Bootstrap cancelled."; exit 1 ;;
+  esac
+}
+
+confirm_system_changes
+
+bash "$PWD"/script/check_node_yarn
+
 # Update the apt cache before installing dependencies.  It can be slow, so the install scripts
 # don't do it (to avoid doing it more than once).
 sudo apt update -y

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -5,10 +5,26 @@
 
 set -e
 
+confirm_system_changes() {
+    if [ "${WARP_BOOTSTRAP_ASSUME_YES:-}" = "1" ]; then
+        return
+    fi
+
+    echo "This bootstrap script will run sudo commands and install developer dependencies with Homebrew, cargo, and PowerShell."
+    printf "Continue? [y/N] "
+    read answer
+    case "$answer" in
+        y|Y|yes|YES) ;;
+        *) echo "Bootstrap cancelled."; exit 1 ;;
+    esac
+}
+
 if ! [ -d "/Applications/Xcode.app" ]; then
     echo "Please install Xcode from the App Store before continuing."
     exit 1
 fi
+
+confirm_system_changes
 
 sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 # Mimic actually launching XCode, which performs some necessary set-up of the
@@ -28,6 +44,8 @@ if ! command -v cargo; then
     echo "Please start a new terminal session so that cargo is in your PATH"
     exit 1
 fi
+
+bash "$PWD"/script/check_node_yarn
 
 # Install various binaries through cargo.
 "$PWD"/script/install_cargo_test_deps

--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -14,6 +14,15 @@ if (-not $gitBinDir) {
     exit 1
 }
 
+if ($env:WARP_BOOTSTRAP_ASSUME_YES -ne '1') {
+    Write-Output 'This bootstrap script will install developer dependencies with rustup, winget, and Google Cloud SDK.'
+    $answer = Read-Host 'Continue? [y/N]'
+    if ($answer -notin @('y', 'Y', 'yes', 'YES')) {
+        Write-Output 'Bootstrap cancelled.'
+        exit 1
+    }
+}
+
 if (-not (Get-Command -Name cargo -Type Application -ErrorAction SilentlyContinue)) {
     Write-Output 'Installing rust...'
     Invoke-WebRequest -Uri 'https://win.rustup.rs/x86_64' -OutFile "$env:Temp\rustup-init.exe"
@@ -21,6 +30,8 @@ if (-not (Get-Command -Name cargo -Type Application -ErrorAction SilentlyContinu
     Write-Output 'Please start a new terminal session so that cargo is in your PATH'
     exit 1
 }
+
+& "$PWD\script\windows\check_node_yarn.ps1"
 
 # A bash executable should come with Git for Windows
 & "$gitBinDir\bash.exe" "$PWD\script\install_cargo_test_deps"

--- a/script/windows/check_node_yarn.ps1
+++ b/script/windows/check_node_yarn.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = 'Stop'
+
+$missing = $false
+
+$node = Get-Command -Name node -Type Application -ErrorAction SilentlyContinue
+if (-not $node) {
+    Write-Output 'Node.js is required to build Warp''s command-signatures package. Install Node.js 18 or newer, then rerun .\script\bootstrap.ps1.'
+    $missing = $true
+} else {
+    $nodeVersion = (& node --version).Trim().TrimStart('v')
+    $nodeMajor = 0
+    if (-not [int]::TryParse(($nodeVersion -split '\.')[0], [ref]$nodeMajor) -or $nodeMajor -lt 18) {
+        Write-Output "Node.js 18 or newer is required; found $(& node --version)."
+        $missing = $true
+    }
+}
+
+$yarn = Get-Command -Name yarn -Type Application -ErrorAction SilentlyContinue
+if (-not $yarn) {
+    Write-Output 'Yarn is required to build Warp''s command-signatures package.'
+    if (Get-Command -Name corepack -Type Application -ErrorAction SilentlyContinue) {
+        Write-Output 'Run ''corepack enable'' to install the Yarn shim for this Node.js installation.'
+    } else {
+        Write-Output 'Install a Node.js distribution that includes corepack, then run ''corepack enable''.'
+    }
+    $missing = $true
+}
+
+if ($missing) {
+    exit 1
+}
+
+Write-Output "Node.js $(& node --version) and Yarn $(& yarn --version) are available."


### PR DESCRIPTION
## Summary
- recognize Devin CLI and Mistral Vibe as CLI agents, including telemetry and rich input handling
- add Vibe, Devin, and Windsurf skill provider directories and improve cold-start skill lookup for subproject `.agents/skills`
- hide imported comment "Open in code review" actions after comments are opened in the review panel
- add Node/Yarn bootstrap checks, explicit bootstrap consent prompts, a devcontainer, and a Nix dev shell

## Validation
- `bash -n script/check_node_yarn script/linux/bootstrap script/macos/bootstrap`
- `sh -n script/macos/bootstrap script/check_node_yarn`
- `node -e "JSON.parse(require('fs').readFileSync('.devcontainer/devcontainer.json', 'utf8')); console.log('devcontainer JSON OK')"`
- `git diff --check`

## Not run
- `cargo fmt --check` / Rust tests: `cargo` is not installed in this environment
- PowerShell validation: `pwsh` is not installed in this environment
- `nix flake check`: `nix` is not installed in this environment
- `script/check_node_yarn` reaches the intended failure in this environment because Yarn is missing and suggests `corepack enable`
