### PR TITLE
Fix/blurry text and image rendering on linux+bsd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.12.0"
-source = "git+https://github.com/rudrabhoj/cosmic-text-warpdev.git?rev=53dc2b66c31f39411feb9eaf6bf1f43c437e3903#53dc2b66c31f39411feb9eaf6bf1f43c437e3903"
+source = "git+https://github.com/rudrabhoj/cosmic-text-warpdev.git?rev=353eb39c738d834c5c3a0f41b92de042b1026b8a#353eb39c738d834c5c3a0f41b92de042b1026b8a"
 dependencies = [
  "bitflags 2.9.4",
  "fontdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.12.0"
-source = "git+https://github.com/warpdotdev/cosmic-text.git?rev=15198beba692162201c0ea8b15222cf5643ea068#15198beba692162201c0ea8b15222cf5643ea068"
+source = "git+https://github.com/rudrabhoj/cosmic-text-warpdev.git?rev=53dc2b66c31f39411feb9eaf6bf1f43c437e3903#53dc2b66c31f39411feb9eaf6bf1f43c437e3903"
 dependencies = [
  "bitflags 2.9.4",
  "fontdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.12.0"
-source = "git+https://github.com/rudrabhoj/cosmic-text-warpdev.git?rev=353eb39c738d834c5c3a0f41b92de042b1026b8a#353eb39c738d834c5c3a0f41b92de042b1026b8a"
+source = "git+https://github.com/rudrabhoj/cosmic-text-warpdev.git?rev=abafdc9e7501076744c13ef7268a1933513a43ce#abafdc9e7501076744c13ef7268a1933513a43ce"
 dependencies = [
  "bitflags 2.9.4",
  "fontdb",

--- a/app/src/appearance.rs
+++ b/app/src/appearance.rs
@@ -145,6 +145,14 @@ impl AppearanceManager {
         // wallpaper visibly dominates and the gate is worth its cost).
         // AppearanceManager is registered before any window is created,
         // so the initial seed below lands ahead of the first frame.
+        //
+        // TODO: this is one bit per window. Local opaque regions inside a
+        // translucent window (the active block's row background, modal
+        // scrims, etc.) still fall through to the mono path even though
+        // the rect immediately under the glyph is opaque and LCD would be
+        // safe there. A per-glyph route based on the underlying rect's
+        // alpha would fix it, but Scene::draw_glyph has no view of which
+        // rect sits behind a given glyph today.
         const LCD_GATE_OPACITY_THRESHOLD: u8 = 70;
         ctx.subscribe_to_model(&WindowSettings::handle(ctx), move |_, event, ctx| {
             if matches!(event, WindowSettingsChangedEvent::BackgroundOpacity { .. }) {

--- a/app/src/appearance.rs
+++ b/app/src/appearance.rs
@@ -26,6 +26,7 @@ use crate::{
         ThemeSettings,
     },
     themes::theme::{ThemeKind, WarpTheme},
+    window_settings::{WindowSettings, WindowSettingsChangedEvent},
     ASSETS,
 };
 
@@ -130,6 +131,29 @@ impl AppearanceManager {
                 _ => {}
             },
         );
+
+        // Mirror the window-translucency user setting into the
+        // AppContext-level latch consumed by `rendering_config()`. Done
+        // here (rather than in the renderer) because the setting lives in
+        // the app crate. The latch gates the LCD subpixel pipeline off on
+        // heavily translucent windows, where its `ColorWrites::COLOR`
+        // would otherwise let the compositor blend the desktop into the
+        // glyph strokes themselves. The threshold trades the small bleed
+        // at mild translucency (where it is barely perceptible and the
+        // mono path's lower edge resolution would be a worse regression)
+        // against the heavy bleed at strong translucency (where the
+        // wallpaper visibly dominates and the gate is worth its cost).
+        // AppearanceManager is registered before any window is created,
+        // so the initial seed below lands ahead of the first frame.
+        const LCD_GATE_OPACITY_THRESHOLD: u8 = 30;
+        ctx.subscribe_to_model(&WindowSettings::handle(ctx), move |_, event, ctx| {
+            if matches!(event, WindowSettingsChangedEvent::BackgroundOpacity { .. }) {
+                let opacity = *WindowSettings::as_ref(ctx).background_opacity.value();
+                ctx.set_transparent_background(opacity < LCD_GATE_OPACITY_THRESHOLD);
+            }
+        });
+        let initial_opacity = *WindowSettings::as_ref(ctx).background_opacity.value();
+        ctx.set_transparent_background(initial_opacity < LCD_GATE_OPACITY_THRESHOLD);
 
         Self {
             transient_theme: None,

--- a/app/src/appearance.rs
+++ b/app/src/appearance.rs
@@ -145,7 +145,7 @@ impl AppearanceManager {
         // wallpaper visibly dominates and the gate is worth its cost).
         // AppearanceManager is registered before any window is created,
         // so the initial seed below lands ahead of the first frame.
-        const LCD_GATE_OPACITY_THRESHOLD: u8 = 30;
+        const LCD_GATE_OPACITY_THRESHOLD: u8 = 70;
         ctx.subscribe_to_model(&WindowSettings::handle(ctx), move |_, event, ctx| {
             if matches!(event, WindowSettingsChangedEvent::BackgroundOpacity { .. }) {
                 let opacity = *WindowSettings::as_ref(ctx).background_opacity.value();

--- a/app/src/search/command_palette/navigation/render.rs
+++ b/app/src/search/command_palette/navigation/render.rs
@@ -219,6 +219,7 @@ fn render_prompt_ps1(
         cell_dimensions.y().into_pixels(),
         0.0.into_pixels(),
         0.0.into_pixels(),
+        1.0,
     );
     let enforce_minimum_contrast = *FontSettings::as_ref(app).enforce_minimum_contrast;
     let obfuscate_secrets = get_secret_obfuscation_mode(app);

--- a/app/src/terminal/grid_renderer_test.rs
+++ b/app/src/terminal/grid_renderer_test.rs
@@ -216,6 +216,7 @@ fn test_calculate_selection_bounds() {
         Pixels::new(4.),
         Pixels::new(8.),
         Pixels::new(16.),
+        1.0,
     )
     .with_rows_and_columns(151, 151);
 

--- a/app/src/terminal/local_tty/unix.rs
+++ b/app/src/terminal/local_tty/unix.rs
@@ -672,8 +672,10 @@ impl ToWinsize for &SizeInfo {
         winsize {
             ws_row: self.rows as libc::c_ushort,
             ws_col: self.columns as libc::c_ushort,
-            ws_xpixel: self.pane_width_px().as_f32() as libc::c_ushort,
-            ws_ypixel: self.pane_height_px().as_f32() as libc::c_ushort,
+            ws_xpixel: (self.pane_width_px().as_f32() * self.scale_factor).round()
+                as libc::c_ushort,
+            ws_ypixel: (self.pane_height_px().as_f32() * self.scale_factor).round()
+                as libc::c_ushort,
         }
     }
 }

--- a/app/src/terminal/mod.rs
+++ b/app/src/terminal/mod.rs
@@ -326,6 +326,10 @@ pub struct SizeInfo {
 
     /// Vertical window padding.
     padding_y_px: Pixels,
+
+    /// The device pixel ratio (physical pixels per logical pixel) for the window
+    /// hosting this terminal pane, e.g. 1.0, 1.25, 1.5, 2.0.
+    scale_factor: f32,
 }
 
 /// Helper struct containing the cell size and window padding info.
@@ -350,6 +354,7 @@ impl SizeInfo {
         cell_height_px: Pixels,
         padding_x_px: Pixels,
         padding_y_px: Pixels,
+        scale_factor: f32,
     ) -> SizeInfo {
         let rows = (pane_size_px.y() - 2. * padding_y_px.as_f32()) / cell_height_px.as_f32();
         let columns = (pane_size_px.x() - 2. * padding_x_px.as_f32()) / cell_width_px.as_f32();
@@ -363,6 +368,7 @@ impl SizeInfo {
             cell_height_px,
             padding_x_px: padding_x_px.floor(),
             padding_y_px: padding_y_px.floor(),
+            scale_factor,
         }
     }
 
@@ -377,6 +383,7 @@ impl SizeInfo {
             1.0.into_pixels(), /* cell_height */
             Pixels::zero(),    /* padding_x */
             Pixels::zero(),    /* padding_y */
+            1.0,               /* scale_factor */
         )
     }
 

--- a/app/src/terminal/model/alt_screen.rs
+++ b/app/src/terminal/model/alt_screen.rs
@@ -616,6 +616,10 @@ impl ansi::Handler for AltScreen {
         self.ansi_handler().text_area_size_pixels(writer);
     }
 
+    fn cell_pixel_size<W: io::Write>(&mut self, writer: &mut W) {
+        self.ansi_handler().cell_pixel_size(writer);
+    }
+
     fn text_area_size_chars<W: io::Write>(&mut self, writer: &mut W) {
         self.ansi_handler().text_area_size_chars(writer);
     }

--- a/app/src/terminal/model/ansi/handler.rs
+++ b/app/src/terminal/model/ansi/handler.rs
@@ -233,6 +233,9 @@ pub trait Handler {
     /// Report text area size in pixels.
     fn text_area_size_pixels<W: io::Write>(&mut self, _: &mut W);
 
+    /// Report single cell size in physical pixels (CSI 16t → \x1b[6;height;widtht).
+    fn cell_pixel_size<W: io::Write>(&mut self, _: &mut W);
+
     /// Report text area size in characters.
     fn text_area_size_chars<W: io::Write>(&mut self, _: &mut W);
 

--- a/app/src/terminal/model/ansi/mod.rs
+++ b/app/src/terminal/model/ansi/mod.rs
@@ -1447,6 +1447,7 @@ where
             }
             ('t', None) => match next_param_or(1) as usize {
                 14 => handler.text_area_size_pixels(writer),
+                16 => handler.cell_pixel_size(writer),
                 18 => handler.text_area_size_chars(writer),
                 22 => handler.push_title(),
                 23 => handler.pop_title(),

--- a/app/src/terminal/model/ansi/mod_test.rs
+++ b/app/src/terminal/model/ansi/mod_test.rs
@@ -159,6 +159,8 @@ impl Handler for MockHandler {
 
     fn text_area_size_pixels<W: io::Write>(&mut self, _: &mut W) {}
 
+    fn cell_pixel_size<W: io::Write>(&mut self, _: &mut W) {}
+
     fn text_area_size_chars<W: io::Write>(&mut self, _: &mut W) {}
 
     fn command_finished(&mut self, data: CommandFinishedValue) {

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -3207,6 +3207,10 @@ impl ansi::Handler for Block {
         delegate!(self.text_area_size_pixels(writer));
     }
 
+    fn cell_pixel_size<W: std::io::Write>(&mut self, writer: &mut W) {
+        delegate!(self.cell_pixel_size(writer));
+    }
+
     fn text_area_size_chars<W: std::io::Write>(&mut self, writer: &mut W) {
         delegate!(self.text_area_size_chars(writer));
     }

--- a/app/src/terminal/model/blockgrid.rs
+++ b/app/src/terminal/model/blockgrid.rs
@@ -939,6 +939,10 @@ impl ansi::Handler for BlockGrid {
         self.ansi_handler().text_area_size_pixels(writer);
     }
 
+    fn cell_pixel_size<W: io::Write>(&mut self, writer: &mut W) {
+        self.ansi_handler().cell_pixel_size(writer);
+    }
+
     fn text_area_size_chars<W: io::Write>(&mut self, writer: &mut W) {
         self.ansi_handler().text_area_size_chars(writer);
     }

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -3657,6 +3657,10 @@ impl ansi::Handler for BlockList {
         delegate!(self.text_area_size_pixels(writer));
     }
 
+    fn cell_pixel_size<W: io::Write>(&mut self, writer: &mut W) {
+        delegate!(self.cell_pixel_size(writer));
+    }
+
     fn text_area_size_chars<W: io::Write>(&mut self, writer: &mut W) {
         delegate!(self.text_area_size_chars(writer));
     }

--- a/app/src/terminal/model/early_output.rs
+++ b/app/src/terminal/model/early_output.rs
@@ -638,6 +638,10 @@ impl ansi::Handler for EarlyOutputHandler<'_> {
         delegate!(self.text_area_size_pixels(writer));
     }
 
+    fn cell_pixel_size<W: std::io::Write>(&mut self, writer: &mut W) {
+        delegate!(self.cell_pixel_size(writer));
+    }
+
     fn text_area_size_chars<W: std::io::Write>(&mut self, writer: &mut W) {
         delegate!(self.text_area_size_chars(writer));
     }

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -1212,6 +1212,13 @@ impl ansi::Handler for GridHandler {
         let _ = write!(writer, "\x1b[4;{height};{width}t");
     }
 
+    fn cell_pixel_size<W: std::io::Write>(&mut self, writer: &mut W) {
+        let sf = self.ansi_handler_state.scale_factor;
+        let cell_w_phys = ((self.ansi_handler_state.cell_width as f32) * sf).round() as usize;
+        let cell_h_phys = ((self.ansi_handler_state.cell_height as f32) * sf).round() as usize;
+        let _ = write!(writer, "\x1b[6;{cell_h_phys};{cell_w_phys}t");
+    }
+
     fn text_area_size_chars<W: std::io::Write>(&mut self, writer: &mut W) {
         let _ = write!(writer, "\x1b[8;{};{}t", self.visible_rows(), self.columns());
     }

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -1215,13 +1215,18 @@ impl ansi::Handler for GridHandler {
 
     fn text_area_size_pixels<W: std::io::Write>(&mut self, writer: &mut W) {
         let sf = self.ansi_handler_state.scale_factor;
-        // Use the pre-truncation `_px` fields so a 9.6-px logical cell at
-        // 1.25× scale reports as 12 (round of 9.6 * 1.25), not 11 (round
-        // of trunc(9.6) * 1.25).
-        let cell_w_phys = (self.ansi_handler_state.cell_width_px.as_f32() * sf).round() as usize;
-        let cell_h_phys = (self.ansi_handler_state.cell_height_px.as_f32() * sf).round() as usize;
-        let width = cell_w_phys * self.columns();
-        let height = cell_h_phys * self.visible_rows();
+        // Round the *total* width and height once after multiplying by the
+        // grid extents and the scale factor. Rounding per-cell first and
+        // then multiplying by columns or rows accumulates the per-cell
+        // rounding error: at 1.25x scale a 9.7-px cell rounds to 12 phys
+        // px, so 80 columns reports 960 instead of the correct
+        // round(9.7 * 1.25 * 80) = 970, a 10-pixel drift. CSI 16t
+        // (cell_pixel_size) is intentionally per-cell so it can keep its
+        // own rounding.
+        let cell_w_logical = self.ansi_handler_state.cell_width_px.as_f32();
+        let cell_h_logical = self.ansi_handler_state.cell_height_px.as_f32();
+        let width = (cell_w_logical * self.columns() as f32 * sf).round() as usize;
+        let height = (cell_h_logical * self.visible_rows() as f32 * sf).round() as usize;
         let _ = write!(writer, "\x1b[4;{height};{width}t");
     }
 

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -56,6 +56,14 @@ pub(super) struct State {
     /// Information about cell dimensions.
     pub cell_width: usize,
     pub cell_height: usize,
+    /// Pre-truncation logical cell dimensions kept alongside the integer
+    /// fields above. The integer values are what most call sites in this
+    /// module expect (cell-count math, image sizing in cells); the
+    /// `_px` variants preserve the fractional input so CSI 14t / 16t
+    /// can multiply by `scale_factor` before rounding and report the
+    /// correct physical-pixel cell size on fractional-DPI displays.
+    pub cell_width_px: warpui_core::units::Pixels,
+    pub cell_height_px: warpui_core::units::Pixels,
     pub scale_factor: f32,
 
     /// Mode flags.
@@ -129,6 +137,8 @@ impl State {
         Self {
             cell_width: size_info.cell_width_px.as_f32() as usize,
             cell_height: size_info.cell_height_px.as_f32() as usize,
+            cell_width_px: size_info.cell_width_px,
+            cell_height_px: size_info.cell_height_px,
             scale_factor: size_info.scale_factor,
             mode: Default::default(),
             tabs,
@@ -1205,8 +1215,11 @@ impl ansi::Handler for GridHandler {
 
     fn text_area_size_pixels<W: std::io::Write>(&mut self, writer: &mut W) {
         let sf = self.ansi_handler_state.scale_factor;
-        let cell_w_phys = ((self.ansi_handler_state.cell_width as f32) * sf).round() as usize;
-        let cell_h_phys = ((self.ansi_handler_state.cell_height as f32) * sf).round() as usize;
+        // Use the pre-truncation `_px` fields so a 9.6-px logical cell at
+        // 1.25× scale reports as 12 (round of 9.6 * 1.25), not 11 (round
+        // of trunc(9.6) * 1.25).
+        let cell_w_phys = (self.ansi_handler_state.cell_width_px.as_f32() * sf).round() as usize;
+        let cell_h_phys = (self.ansi_handler_state.cell_height_px.as_f32() * sf).round() as usize;
         let width = cell_w_phys * self.columns();
         let height = cell_h_phys * self.visible_rows();
         let _ = write!(writer, "\x1b[4;{height};{width}t");
@@ -1214,8 +1227,8 @@ impl ansi::Handler for GridHandler {
 
     fn cell_pixel_size<W: std::io::Write>(&mut self, writer: &mut W) {
         let sf = self.ansi_handler_state.scale_factor;
-        let cell_w_phys = ((self.ansi_handler_state.cell_width as f32) * sf).round() as usize;
-        let cell_h_phys = ((self.ansi_handler_state.cell_height as f32) * sf).round() as usize;
+        let cell_w_phys = (self.ansi_handler_state.cell_width_px.as_f32() * sf).round() as usize;
+        let cell_h_phys = (self.ansi_handler_state.cell_height_px.as_f32() * sf).round() as usize;
         let _ = write!(writer, "\x1b[6;{cell_h_phys};{cell_w_phys}t");
     }
 

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -62,8 +62,8 @@ pub(super) struct State {
     /// `_px` variants preserve the fractional input so CSI 14t / 16t
     /// can multiply by `scale_factor` before rounding and report the
     /// correct physical-pixel cell size on fractional-DPI displays.
-    pub cell_width_px: warpui_core::units::Pixels,
-    pub cell_height_px: warpui_core::units::Pixels,
+    pub cell_width_px: warpui::units::Pixels,
+    pub cell_height_px: warpui::units::Pixels,
     pub scale_factor: f32,
 
     /// Mode flags.

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -56,6 +56,7 @@ pub(super) struct State {
     /// Information about cell dimensions.
     pub cell_width: usize,
     pub cell_height: usize,
+    pub scale_factor: f32,
 
     /// Mode flags.
     pub mode: TermMode,
@@ -128,6 +129,7 @@ impl State {
         Self {
             cell_width: size_info.cell_width_px.as_f32() as usize,
             cell_height: size_info.cell_height_px.as_f32() as usize,
+            scale_factor: size_info.scale_factor,
             mode: Default::default(),
             tabs,
             cursor_style: Default::default(),
@@ -1202,8 +1204,11 @@ impl ansi::Handler for GridHandler {
     }
 
     fn text_area_size_pixels<W: std::io::Write>(&mut self, writer: &mut W) {
-        let width = self.ansi_handler_state.cell_width * self.columns();
-        let height = self.ansi_handler_state.cell_height * self.visible_rows();
+        let sf = self.ansi_handler_state.scale_factor;
+        let cell_w_phys = ((self.ansi_handler_state.cell_width as f32) * sf).round() as usize;
+        let cell_h_phys = ((self.ansi_handler_state.cell_height as f32) * sf).round() as usize;
+        let width = cell_w_phys * self.columns();
+        let height = cell_h_phys * self.visible_rows();
         let _ = write!(writer, "\x1b[4;{height};{width}t");
     }
 

--- a/app/src/terminal/model/grid/resize.rs
+++ b/app/src/terminal/model/grid/resize.rs
@@ -19,6 +19,7 @@ impl GridHandler {
     pub fn resize(&mut self, size: SizeInfo) {
         self.ansi_handler_state.cell_width = size.cell_width_px.as_f32() as usize;
         self.ansi_handler_state.cell_height = size.cell_height_px.as_f32() as usize;
+        self.ansi_handler_state.scale_factor = size.scale_factor;
 
         let old_cols = self.columns();
         let old_rows = self.visible_rows();

--- a/app/src/terminal/model/grid/resize.rs
+++ b/app/src/terminal/model/grid/resize.rs
@@ -19,6 +19,8 @@ impl GridHandler {
     pub fn resize(&mut self, size: SizeInfo) {
         self.ansi_handler_state.cell_width = size.cell_width_px.as_f32() as usize;
         self.ansi_handler_state.cell_height = size.cell_height_px.as_f32() as usize;
+        self.ansi_handler_state.cell_width_px = size.cell_width_px;
+        self.ansi_handler_state.cell_height_px = size.cell_height_px;
         self.ansi_handler_state.scale_factor = size.scale_factor;
 
         let old_cols = self.columns();

--- a/app/src/terminal/model/header_grid.rs
+++ b/app/src/terminal/model/header_grid.rs
@@ -1141,6 +1141,10 @@ impl ansi::Handler for HeaderGrid {
         delegate_with_writer!(self.text_area_size_pixels(writer));
     }
 
+    fn cell_pixel_size<W: std::io::Write>(&mut self, writer: &mut W) {
+        delegate_with_writer!(self.cell_pixel_size(writer));
+    }
+
     fn text_area_size_chars<W: std::io::Write>(&mut self, writer: &mut W) {
         delegate_with_writer!(self.text_area_size_chars(writer));
     }

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -2750,6 +2750,10 @@ impl ansi::Handler for TerminalModel {
         delegate!(self.text_area_size_pixels(writer));
     }
 
+    fn cell_pixel_size<W: std::io::Write>(&mut self, writer: &mut W) {
+        delegate!(self.cell_pixel_size(writer));
+    }
+
     fn text_area_size_chars<W: std::io::Write>(&mut self, writer: &mut W) {
         delegate!(self.text_area_size_chars(writer));
     }

--- a/app/src/terminal/terminal_manager.rs
+++ b/app/src/terminal/terminal_manager.rs
@@ -65,6 +65,7 @@ pub(super) fn compute_block_size(initial_size: Vector2F, ctx: &mut AppContext) -
             appearance.monospace_font_family(),
             appearance.monospace_font_size(),
             appearance.ui_builder().line_height_ratio(),
+            1.0, // overwritten immediately on first layout when ViewContext is available
         )
     };
     let maximum_grid_size = *TerminalSettings::as_ref(ctx).maximum_grid_size.value();

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -1214,6 +1214,13 @@ impl SizeUpdateBuilder {
         let input_mode = *InputModeSettings::as_ref(ctx).input_mode.value();
         let model = view.model.lock();
 
+        let scale_factor = ctx
+            .windows()
+            .platform_window(ctx.window_id())
+            .as_ref()
+            .map(|w| w.backing_scale_factor())
+            .unwrap_or(1.0);
+
         let new_size = create_size_info(
             self.new_pane_size_px,
             &model,
@@ -1222,6 +1229,7 @@ impl SizeUpdateBuilder {
             appearance.monospace_font_family(),
             appearance.monospace_font_size(),
             appearance.line_height_ratio(),
+            scale_factor,
             ctx,
         );
 
@@ -26517,6 +26525,7 @@ pub fn create_size_info_for_blocklist(
     font_family_id: FamilyId,
     font_size: f32,
     line_height_ratio: f32,
+    scale_factor: f32,
 ) -> SizeInfo {
     let cell_size_px =
         grid_cell_dimensions(font_cache, font_family_id, font_size, line_height_ratio);
@@ -26531,6 +26540,7 @@ pub fn create_size_info_for_blocklist(
         cell_size_px.y().into_pixels(),
         padding_x,
         padding_y,
+        scale_factor,
     )
 }
 
@@ -26545,6 +26555,7 @@ pub fn create_size_info(
     font_family_id: FamilyId,
     font_size: f32,
     line_height_ratio: f32,
+    scale_factor: f32,
     ctx: &AppContext,
 ) -> SizeInfo {
     let cell_size_px =
@@ -26570,6 +26581,7 @@ pub fn create_size_info(
                 cell_size_px.y().into_pixels(),
                 uniform_padding,
                 uniform_padding,
+                scale_factor,
             )
         }
         _ => create_size_info_for_blocklist(
@@ -26578,6 +26590,7 @@ pub fn create_size_info(
             font_family_id,
             font_size,
             line_height_ratio,
+            scale_factor,
         ),
     }
 }

--- a/app/src/terminal/view/testing.rs
+++ b/app/src/terminal/view/testing.rs
@@ -58,6 +58,7 @@ impl TerminalView {
             1.0.into_pixels(),
             Pixels::zero(),
             Pixels::zero(),
+            1.0,
         );
         let (wakeups_tx, wakeups_rx) = async_channel::unbounded();
         let (events_tx, events_rx) = async_channel::unbounded();

--- a/crates/warpui/Cargo.toml
+++ b/crates/warpui/Cargo.toml
@@ -88,7 +88,7 @@ font-kit.workspace = true
 bimap = "0.6.2"
 bytemuck.workspace = true
 command.workspace = true
-cosmic-text = { git = "https://github.com/warpdotdev/cosmic-text.git", rev = "15198beba692162201c0ea8b15222cf5643ea068" }
+cosmic-text = { git = "https://github.com/rudrabhoj/cosmic-text-warpdev.git", rev = "53dc2b66c31f39411feb9eaf6bf1f43c437e3903" }
 derivative.workspace = true
 fontdb = "0.23.0"
 memmap2 = "0.9.3"

--- a/crates/warpui/Cargo.toml
+++ b/crates/warpui/Cargo.toml
@@ -88,7 +88,7 @@ font-kit.workspace = true
 bimap = "0.6.2"
 bytemuck.workspace = true
 command.workspace = true
-cosmic-text = { git = "https://github.com/rudrabhoj/cosmic-text-warpdev.git", rev = "53dc2b66c31f39411feb9eaf6bf1f43c437e3903" }
+cosmic-text = { git = "https://github.com/rudrabhoj/cosmic-text-warpdev.git", rev = "353eb39c738d834c5c3a0f41b92de042b1026b8a" }
 derivative.workspace = true
 fontdb = "0.23.0"
 memmap2 = "0.9.3"

--- a/crates/warpui/Cargo.toml
+++ b/crates/warpui/Cargo.toml
@@ -88,7 +88,7 @@ font-kit.workspace = true
 bimap = "0.6.2"
 bytemuck.workspace = true
 command.workspace = true
-cosmic-text = { git = "https://github.com/rudrabhoj/cosmic-text-warpdev.git", rev = "353eb39c738d834c5c3a0f41b92de042b1026b8a" }
+cosmic-text = { git = "https://github.com/rudrabhoj/cosmic-text-warpdev.git", rev = "abafdc9e7501076744c13ef7268a1933513a43ce" }
 derivative.workspace = true
 fontdb = "0.23.0"
 memmap2 = "0.9.3"

--- a/crates/warpui/src/platform/mac/fonts.rs
+++ b/crates/warpui/src/platform/mac/fonts.rs
@@ -573,8 +573,15 @@ impl crate::platform::FontDB for FontDB {
         point_size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        lcd_subpixel: bool,
         glyph_config: &rendering::GlyphConfig,
     ) -> Result<RectI> {
+        // CoreText handles subpixel rendering internally via its own
+        // antialiasing settings (CGContextSetShouldSmoothFonts and the
+        // user's "Use font smoothing when available" preference). We do
+        // not opt into the cosmic-text/swash subpixel path on macOS, so
+        // this flag is intentionally ignored here.
+        let _ = lcd_subpixel;
         self.rasterizer
             .glyph_raster_bounds(font_id, point_size, glyph_id, scale, glyph_config)
     }
@@ -583,6 +590,7 @@ impl crate::platform::FontDB for FontDB {
         Ok(self.font(font_id).typographic_bounds(glyph_id)?.to_i32())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn rasterize_glyph(
         &self,
         font_id: FontId,
@@ -590,9 +598,13 @@ impl crate::platform::FontDB for FontDB {
         glyph_id: GlyphId,
         scale: Vector2F,
         subpixel_alignment: SubpixelAlignment,
+        lcd_subpixel: bool,
         glyph_config: &rendering::GlyphConfig,
         format: RasterFormat,
     ) -> Result<RasterizedGlyph> {
+        // See glyph_raster_bounds above: CoreText owns the subpixel
+        // decision on macOS, so the flag is a no-op here.
+        let _ = lcd_subpixel;
         self.rasterizer.rasterize_glyph(
             font_id,
             point_size,

--- a/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
@@ -627,20 +627,27 @@ impl<'a> Frame<'a> {
             let glyph_position = glyph.position * scale_factor;
             let subpixel_alignment = SubpixelAlignment::new(glyph_position);
 
+            // Subpixel rasterization is not used on macOS: CoreText handles
+            // its own subpixel decisions, and the cosmic-text/swash subpixel
+            // path is wired only into the wgpu/Linux/BSD renderer.
+            let lcd_subpixel = false;
             match self.resources.glyph_cache.get(
                 glyph.glyph_key,
                 self.scene.scale_factor(),
                 subpixel_alignment,
+                lcd_subpixel,
                 &|atlas_size| create_new_texture_atlas(atlas_size, self.ctx.device),
                 &insert_glyph_into_texture,
-                &|glyph_key, scale, alignment| {
-                    self.ctx.glyph_raster_bounds(glyph_key, scale, alignment)
+                &|glyph_key, scale, lcd_subpixel, glyph_config| {
+                    self.ctx
+                        .glyph_raster_bounds(glyph_key, scale, lcd_subpixel, glyph_config)
                 },
-                &|glyph_key, scale, subpixel_alignment, glyph_config, format| {
+                &|glyph_key, scale, subpixel_alignment, lcd_subpixel, glyph_config, format| {
                     self.ctx.rasterize_glyph(
                         glyph_key,
                         scale,
                         subpixel_alignment,
+                        lcd_subpixel,
                         glyph_config,
                         format,
                     )
@@ -925,24 +932,34 @@ pub(super) struct MetalDrawContext<'a> {
 }
 
 impl MetalDrawContext<'_> {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn rasterize_glyph(
         &self,
         glyph_key: GlyphKey,
         scale: Vector2F,
         subpixel_alignment: SubpixelAlignment,
+        lcd_subpixel: bool,
         glyph_config: &rendering::GlyphConfig,
         format: canvas::RasterFormat,
     ) -> anyhow::Result<RasterizedGlyph> {
-        (self.rasterize_glyph_fn)(glyph_key, scale, subpixel_alignment, glyph_config, format)
+        (self.rasterize_glyph_fn)(
+            glyph_key,
+            scale,
+            subpixel_alignment,
+            lcd_subpixel,
+            glyph_config,
+            format,
+        )
     }
 
     pub(super) fn glyph_raster_bounds(
         &self,
         glyph_key: GlyphKey,
         scale: Vector2F,
+        lcd_subpixel: bool,
         glyph_config: &rendering::GlyphConfig,
     ) -> anyhow::Result<RectI> {
-        (self.glyph_raster_bounds_fn)(glyph_key, scale, glyph_config)
+        (self.glyph_raster_bounds_fn)(glyph_key, scale, lcd_subpixel, glyph_config)
     }
 }
 
@@ -970,17 +987,19 @@ impl super::super::Renderer for Renderer {
             device: metal_device,
             drawable,
             drawable_size: window.physical_size(),
-            rasterize_glyph_fn: &|glyph_key, scale, subpixel_alignment, glyph_config, format| {
-                font_cache.rasterized_glyph(
-                    glyph_key,
-                    scale,
-                    subpixel_alignment,
-                    glyph_config,
-                    format,
-                )
-            },
-            glyph_raster_bounds_fn: &|glyph_key, scale, alignment| {
-                font_cache.glyph_raster_bounds(glyph_key, scale, alignment)
+            rasterize_glyph_fn:
+                &|glyph_key, scale, subpixel_alignment, lcd_subpixel, glyph_config, format| {
+                    font_cache.rasterized_glyph(
+                        glyph_key,
+                        scale,
+                        subpixel_alignment,
+                        lcd_subpixel,
+                        glyph_config,
+                        format,
+                    )
+                },
+            glyph_raster_bounds_fn: &|glyph_key, scale, lcd_subpixel, glyph_config| {
+                font_cache.glyph_raster_bounds(glyph_key, scale, lcd_subpixel, glyph_config)
             },
         };
 

--- a/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
@@ -993,17 +993,21 @@ impl super::super::Renderer for Renderer {
             device: metal_device,
             drawable,
             drawable_size: window.physical_size(),
-            rasterize_glyph_fn:
-                &|glyph_key, scale, subpixel_alignment, lcd_subpixel, glyph_config, format| {
-                    font_cache.rasterized_glyph(
-                        glyph_key,
-                        scale,
-                        subpixel_alignment,
-                        lcd_subpixel,
-                        glyph_config,
-                        format,
-                    )
-                },
+            rasterize_glyph_fn: &|glyph_key,
+                                  scale,
+                                  subpixel_alignment,
+                                  lcd_subpixel,
+                                  glyph_config,
+                                  format| {
+                font_cache.rasterized_glyph(
+                    glyph_key,
+                    scale,
+                    subpixel_alignment,
+                    lcd_subpixel,
+                    glyph_config,
+                    format,
+                )
+            },
             glyph_raster_bounds_fn: &|glyph_key, scale, lcd_subpixel, glyph_config| {
                 font_cache.glyph_raster_bounds(glyph_key, scale, lcd_subpixel, glyph_config)
             },

--- a/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
@@ -1,4 +1,4 @@
-use crate::rendering::atlas::{AllocatedRegion, TextureId};
+use crate::rendering::atlas::{AllocatedRegion, AtlasTextureKind, TextureId};
 use crate::rendering::{get_best_dash_gap, GlyphCache, GlyphRasterBoundsFn, RasterizeGlyphFn};
 use warpui_core::{
     fonts::{self, SubpixelAlignment},
@@ -621,22 +621,27 @@ impl<'a> Frame<'a> {
 
         let scale_factor = self.scene.scale_factor();
 
-        let mut texture_to_glyph: HashMap<TextureId, Vec<shader::PerGlyphUniforms>> =
-            HashMap::new();
+        let mut texture_to_glyph: HashMap<
+            (AtlasTextureKind, TextureId),
+            Vec<shader::PerGlyphUniforms>,
+        > = HashMap::new();
         for glyph in &layer.glyphs {
             let glyph_position = glyph.position * scale_factor;
             let subpixel_alignment = SubpixelAlignment::new(glyph_position);
 
             // Subpixel rasterization is not used on macOS: CoreText handles
             // its own subpixel decisions, and the cosmic-text/swash subpixel
-            // path is wired only into the wgpu/Linux/BSD renderer.
+            // path is wired only into the wgpu/Linux/BSD renderer. The kind
+            // dimension on the cache key still has to be supplied; with
+            // lcd_subpixel=false the cache always returns the Generic kind,
+            // but the create-texture callback ignores it for the same reason.
             let lcd_subpixel = false;
             match self.resources.glyph_cache.get(
                 glyph.glyph_key,
                 self.scene.scale_factor(),
                 subpixel_alignment,
                 lcd_subpixel,
-                &|atlas_size| create_new_texture_atlas(atlas_size, self.ctx.device),
+                &|atlas_size, _kind| create_new_texture_atlas(atlas_size, self.ctx.device),
                 &insert_glyph_into_texture,
                 &|glyph_key, scale, lcd_subpixel, glyph_config| {
                     self.ctx
@@ -683,10 +688,11 @@ impl<'a> Frame<'a> {
                         gto.is_emoji,
                     );
 
-                    if let Some(per_glyph_uniforms) = texture_to_glyph.get_mut(&gto.texture_id) {
+                    let key = (gto.kind, gto.texture_id);
+                    if let Some(per_glyph_uniforms) = texture_to_glyph.get_mut(&key) {
                         per_glyph_uniforms.push(uniform);
                     } else {
-                        texture_to_glyph.insert(gto.texture_id, vec![uniform]);
+                        texture_to_glyph.insert(key, vec![uniform]);
                     }
                 }
                 Ok(None) => {}
@@ -703,7 +709,7 @@ impl<'a> Frame<'a> {
             return;
         }
 
-        for (texture_id, per_glyph_uniforms) in texture_to_glyph {
+        for ((kind, texture_id), per_glyph_uniforms) in texture_to_glyph {
             let per_glyph_uniforms_buffer = new_metal_buffer(
                 self.ctx.device,
                 &per_glyph_uniforms,
@@ -723,7 +729,7 @@ impl<'a> Frame<'a> {
             let texture = self
                 .resources
                 .glyph_cache
-                .texture(&texture_id)
+                .texture(kind, &texture_id)
                 .expect("texture ID should be in atlas");
 
             self.command_encoder.set_fragment_texture(0, Some(texture));

--- a/crates/warpui/src/platform/mac/rendering/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/renderer.rs
@@ -59,12 +59,5 @@ fn get_gpu_device_info(device: &metal::Device) -> GPUDeviceInfo {
         driver_name: String::new(),
         driver_info: String::new(),
         backend: GPUBackend::Metal,
-        // The Metal renderer doesn't expose dual-source blending through
-        // this codepath and doesn't drive a wgpu surface, so both LCD
-        // subpixel gating bits are reported off; macOS falls through to
-        // CoreText / Metal's existing glyph path which handles its own
-        // sharpness without our wgpu pipeline.
-        supports_dual_source_blending: false,
-        surface_is_transparent: false,
     }
 }

--- a/crates/warpui/src/platform/mac/rendering/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/renderer.rs
@@ -59,5 +59,11 @@ fn get_gpu_device_info(device: &metal::Device) -> GPUDeviceInfo {
         driver_name: String::new(),
         driver_info: String::new(),
         backend: GPUBackend::Metal,
+        // The Metal renderer does not feed the LCD subpixel pipeline that
+        // consumes this flag, so it is reported off here. Required to make
+        // the Mac-only build (and the dead-code arm of the wgpu-on-Mac
+        // build) compile after `supports_dual_source_blending` was added
+        // to `GPUDeviceInfo` for the wgpu rendering path.
+        supports_dual_source_blending: false,
     }
 }

--- a/crates/warpui/src/platform/mac/rendering/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/renderer.rs
@@ -59,5 +59,12 @@ fn get_gpu_device_info(device: &metal::Device) -> GPUDeviceInfo {
         driver_name: String::new(),
         driver_info: String::new(),
         backend: GPUBackend::Metal,
+        // The Metal renderer doesn't expose dual-source blending through
+        // this codepath and doesn't drive a wgpu surface, so both LCD
+        // subpixel gating bits are reported off; macOS falls through to
+        // CoreText / Metal's existing glyph path which handles its own
+        // sharpness without our wgpu pipeline.
+        supports_dual_source_blending: false,
+        surface_is_transparent: false,
     }
 }

--- a/crates/warpui/src/platform/mac/rendering/wgpu/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/wgpu/renderer.rs
@@ -9,17 +9,18 @@ impl super::super::Renderer for Renderer {
             self,
             scene,
             window.unwrap_wgpu_resources(),
-            &|glyph_key, scale, subpixel_alignment, glyph_config, format| {
+            &|glyph_key, scale, subpixel_alignment, lcd_subpixel, glyph_config, format| {
                 font_cache.rasterized_glyph(
                     glyph_key,
                     scale,
                     subpixel_alignment,
+                    lcd_subpixel,
                     glyph_config,
                     format,
                 )
             },
-            &|glyph_key, scale, alignment| {
-                font_cache.glyph_raster_bounds(glyph_key, scale, alignment)
+            &|glyph_key, scale, lcd_subpixel, glyph_config| {
+                font_cache.glyph_raster_bounds(glyph_key, scale, lcd_subpixel, glyph_config)
             },
             window.physical_size(),
             None,

--- a/crates/warpui/src/rendering/atlas/mod.rs
+++ b/crates/warpui/src/rendering/atlas/mod.rs
@@ -7,27 +7,16 @@ use pathfinder_geometry::rect::{RectF, RectI};
 use thiserror::Error;
 
 /// Distinguishes the kinds of glyph atlases that the renderer maintains.
+/// Each kind carries a different texture format and is consumed by
+/// different fragment-shader logic.
 ///
-/// The kinds carry different texture formats and are sampled by different
-/// fragment-shader logic:
-///
-/// - `Generic` is the monochrome coverage atlas, `R8Unorm` (one byte per
-///   texel). Used for non-emoji glyphs that take the grayscale fallback
-///   path (transparent windows, GPUs without dual-source blending, or
-///   anything else that opts out of LCD subpixel rendering). The atlas
-///   stores the alpha byte produced by swash's `Format::Alpha` rasterizer.
-///
-/// - `Subpixel` is a `Bgra8Unorm` atlas that stores three independent
-///   coverage values per texel, one per LCD subpixel in BGR order, produced
-///   by swash's subpixel rasterizer. The subpixel render pipeline composites
-///   it through dual-source blending so each subpixel weights the
-///   destination colour independently.
-///
-/// - `Polychrome` is a `Bgra8Unorm` atlas that stores actual RGBA colour
-///   data for emoji glyphs (the `Source::ColorOutline` and
-///   `Source::ColorBitmap` swash sources). The fragment shader samples
-///   it as colour rather than as coverage; the surrounding text colour is
-///   ignored.
+/// - `Generic` (R8Unorm): single-byte coverage from `Format::Alpha`,
+///   used by non-emoji glyphs on the grayscale fallback path.
+/// - `Subpixel` (Bgra8Unorm): three per-LCD-subpixel coverage values in
+///   BGR order from swash's subpixel rasterizer, composited via the
+///   dual-source-blend pipeline.
+/// - `Polychrome` (Bgra8Unorm): real RGBA colour for emoji glyphs from
+///   `Source::ColorOutline` / `Source::ColorBitmap`; sampled as colour.
 ///
 /// Atlases of different kinds never share textures: an allocated rectangle
 /// is meaningful only within its kind's manager.

--- a/crates/warpui/src/rendering/atlas/mod.rs
+++ b/crates/warpui/src/rendering/atlas/mod.rs
@@ -6,6 +6,30 @@ pub(crate) use manager::{Manager, TextureId};
 use pathfinder_geometry::rect::{RectF, RectI};
 use thiserror::Error;
 
+/// Distinguishes the kinds of glyph atlases that the renderer maintains.
+///
+/// The kinds carry different texture formats and are sampled by different
+/// render pipelines:
+///
+/// - `Generic` is the default `Rgba8Unorm` atlas used for grayscale glyph
+///   coverage and color emoji. The fragment shader interprets the sampled
+///   value as either coverage (when [`super::scene::Glyph`] is monochrome)
+///   or as RGBA color (when the rasterized glyph is an emoji).
+///
+/// - `Subpixel` is a `Bgra8Unorm` atlas that stores three independent
+///   coverage values per texel, one per LCD subpixel in BGR order, produced
+///   by swash's subpixel rasterizer. The subpixel render pipeline composites
+///   it through dual-source blending so each subpixel weights the
+///   destination color independently.
+///
+/// Atlases of different kinds never share textures: an allocated rectangle
+/// is meaningful only within its kind's manager.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum AtlasTextureKind {
+    Generic,
+    Subpixel,
+}
+
 /// A region of an atlas that has been allocated.
 #[derive(Copy, Debug, Clone)]
 pub(crate) struct AllocatedRegion {

--- a/crates/warpui/src/rendering/atlas/mod.rs
+++ b/crates/warpui/src/rendering/atlas/mod.rs
@@ -9,18 +9,25 @@ use thiserror::Error;
 /// Distinguishes the kinds of glyph atlases that the renderer maintains.
 ///
 /// The kinds carry different texture formats and are sampled by different
-/// render pipelines:
+/// fragment-shader logic:
 ///
-/// - `Generic` is the default `Rgba8Unorm` atlas used for grayscale glyph
-///   coverage and color emoji. The fragment shader interprets the sampled
-///   value as either coverage (when [`super::scene::Glyph`] is monochrome)
-///   or as RGBA color (when the rasterized glyph is an emoji).
+/// - `Generic` is the monochrome coverage atlas, `R8Unorm` (one byte per
+///   texel). Used for non-emoji glyphs that take the grayscale fallback
+///   path (transparent windows, GPUs without dual-source blending, or
+///   anything else that opts out of LCD subpixel rendering). The atlas
+///   stores the alpha byte produced by swash's `Format::Alpha` rasterizer.
 ///
 /// - `Subpixel` is a `Bgra8Unorm` atlas that stores three independent
 ///   coverage values per texel, one per LCD subpixel in BGR order, produced
 ///   by swash's subpixel rasterizer. The subpixel render pipeline composites
 ///   it through dual-source blending so each subpixel weights the
-///   destination color independently.
+///   destination colour independently.
+///
+/// - `Polychrome` is a `Bgra8Unorm` atlas that stores actual RGBA colour
+///   data for emoji glyphs (the `Source::ColorOutline` and
+///   `Source::ColorBitmap` swash sources). The fragment shader samples
+///   it as colour rather than as coverage; the surrounding text colour is
+///   ignored.
 ///
 /// Atlases of different kinds never share textures: an allocated rectangle
 /// is meaningful only within its kind's manager.
@@ -28,6 +35,7 @@ use thiserror::Error;
 pub(crate) enum AtlasTextureKind {
     Generic,
     Subpixel,
+    Polychrome,
 }
 
 /// A region of an atlas that has been allocated.

--- a/crates/warpui/src/rendering/atlas/mod.rs
+++ b/crates/warpui/src/rendering/atlas/mod.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 ///
 /// Atlases of different kinds never share textures: an allocated rectangle
 /// is meaningful only within its kind's manager.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum AtlasTextureKind {
     Generic,
     Subpixel,

--- a/crates/warpui/src/rendering/glyph_cache.rs
+++ b/crates/warpui/src/rendering/glyph_cache.rs
@@ -15,8 +15,8 @@ const ATLAS_SIZE: usize = 1024;
 /// Callback to create a texture at a given size with a given kind.
 ///
 /// The kind tells the backend which texture format to allocate so that the
-/// returned texture is sampleable by the render pipeline that will consume
-/// it (`Generic` is `Rgba8Unorm`, `Subpixel` is `Bgra8Unorm`).
+/// returned texture is sampleable by the consuming render pipeline
+/// (`Generic` is `R8Unorm`, `Subpixel` and `Polychrome` are `Bgra8Unorm`).
 type CreateTextureCallback<'a, T> = dyn Fn(usize, AtlasTextureKind) -> T + 'a;
 
 /// Callback to insert [`RasterizedGlyph`] at a region identified by [`AllocatedRegion`] into a
@@ -26,9 +26,9 @@ type InsertIntoTextureCallback<'a, T> = dyn Fn(AllocatedRegion, &RasterizedGlyph
 /// Callback to compute the bounds of a glyph when rasterized.
 ///
 /// The `bool` argument is `lcd_subpixel`: true requests LCD subpixel
-/// rasterization, false requests grayscale. The flag affects the produced
-/// bitmap's pixel dimensions on backends whose subpixel mode produces wider
-/// bitmaps than grayscale, so it must participate in cache key uniqueness.
+/// rasterization, false grayscale. The flag affects the bitmap's pixel
+/// dimensions on backends where subpixel produces wider output, so it
+/// must participate in cache-key uniqueness.
 pub(crate) type GlyphRasterBoundsFn<'a> =
     dyn Fn(GlyphKey, Vector2F, bool, &rendering::GlyphConfig) -> Result<RectI> + 'a;
 
@@ -47,12 +47,10 @@ pub(crate) type RasterizeGlyphFn<'a> = dyn Fn(
 
 /// A cache that caches glyphs in texture atlases of various kinds.
 ///
-/// Each [`AtlasTextureKind`] has its own [`atlas::Manager`] and texture list
-/// so allocations of one kind never share a texture with allocations of
-/// another. The kind a glyph is routed to is derived from a combination of
-/// the rasterizer's `is_emoji` result and the cache key's `lcd_subpixel`
-/// flag at insertion time: emoji always go to `Polychrome`, non-emoji
-/// subpixel glyphs to `Subpixel`, everything else to `Generic`.
+/// Each [`AtlasTextureKind`] has its own [`atlas::Manager`] and texture
+/// list, so allocations of one kind never share a texture with another.
+/// Routing at insertion time: emoji go to `Polychrome`, non-emoji subpixel
+/// glyphs to `Subpixel`, everything else to `Generic`.
 pub struct GlyphCache<Texture> {
     generic_textures: Vec<Texture>,
     subpixel_textures: Vec<Texture>,
@@ -201,14 +199,11 @@ impl<Texture> GlyphCache<Texture> {
             crate::fonts::canvas::RasterFormat::Rgba32,
         )?;
 
-        // Route the glyph to the atlas whose format matches its pixel data:
-        //   - Emoji always go to Polychrome (Bgra8Unorm) because their
-        //     bytes are real RGBA colour and need full per-channel storage.
-        //   - Non-emoji glyphs that requested LCD subpixel rendering go to
-        //     Subpixel (Bgra8Unorm); their bytes encode three independent
-        //     coverage values per texel.
-        //   - Everything else, the grayscale fallback path, goes to Generic
-        //     (R8Unorm) which holds a single coverage byte per texel.
+        // Route to the atlas whose format matches the pixel data:
+        //   - Emoji -> Polychrome (Bgra8Unorm), real RGBA colour.
+        //   - lcd_subpixel non-emoji -> Subpixel (Bgra8Unorm), three
+        //     independent coverage values per texel.
+        //   - Everything else -> Generic (R8Unorm), one coverage byte.
         let kind = if rasterized_glyph.is_emoji {
             AtlasTextureKind::Polychrome
         } else if lcd_subpixel {

--- a/crates/warpui/src/rendering/glyph_cache.rs
+++ b/crates/warpui/src/rendering/glyph_cache.rs
@@ -49,15 +49,19 @@ pub(crate) type RasterizeGlyphFn<'a> = dyn Fn(
 ///
 /// Each [`AtlasTextureKind`] has its own [`atlas::Manager`] and texture list
 /// so allocations of one kind never share a texture with allocations of
-/// another. The kind a glyph is routed to is derived from its
-/// [`GlyphCacheKey::lcd_subpixel`] flag at insertion time.
+/// another. The kind a glyph is routed to is derived from a combination of
+/// the rasterizer's `is_emoji` result and the cache key's `lcd_subpixel`
+/// flag at insertion time: emoji always go to `Polychrome`, non-emoji
+/// subpixel glyphs to `Subpixel`, everything else to `Generic`.
 pub struct GlyphCache<Texture> {
     generic_textures: Vec<Texture>,
     subpixel_textures: Vec<Texture>,
+    polychrome_textures: Vec<Texture>,
     cache: HashMap<GlyphCacheKey, GlyphTextureOffset>,
     glyph_config: rendering::GlyphConfig,
     generic_manager: atlas::Manager,
     subpixel_manager: atlas::Manager,
+    polychrome_manager: atlas::Manager,
 }
 
 #[derive(Hash, PartialEq, Eq)]
@@ -103,10 +107,12 @@ impl<Texture> GlyphCache<Texture> {
         GlyphCache {
             generic_textures: Vec::new(),
             subpixel_textures: Vec::new(),
+            polychrome_textures: Vec::new(),
             cache: HashMap::new(),
             glyph_config,
             generic_manager: atlas::Manager::new(ATLAS_SIZE),
             subpixel_manager: atlas::Manager::new(ATLAS_SIZE),
+            polychrome_manager: atlas::Manager::new(ATLAS_SIZE),
         }
     }
 
@@ -131,6 +137,7 @@ impl<Texture> GlyphCache<Texture> {
         match kind {
             AtlasTextureKind::Generic => &self.generic_textures,
             AtlasTextureKind::Subpixel => &self.subpixel_textures,
+            AtlasTextureKind::Polychrome => &self.polychrome_textures,
         }
     }
 
@@ -138,6 +145,7 @@ impl<Texture> GlyphCache<Texture> {
         match kind {
             AtlasTextureKind::Generic => &mut self.generic_textures,
             AtlasTextureKind::Subpixel => &mut self.subpixel_textures,
+            AtlasTextureKind::Polychrome => &mut self.polychrome_textures,
         }
     }
 
@@ -145,6 +153,7 @@ impl<Texture> GlyphCache<Texture> {
         match kind {
             AtlasTextureKind::Generic => &mut self.generic_manager,
             AtlasTextureKind::Subpixel => &mut self.subpixel_manager,
+            AtlasTextureKind::Polychrome => &mut self.polychrome_manager,
         }
     }
 
@@ -192,12 +201,17 @@ impl<Texture> GlyphCache<Texture> {
             crate::fonts::canvas::RasterFormat::Rgba32,
         )?;
 
-        // Color glyphs (emoji) and grayscale-rasterized glyphs both share the
-        // Generic atlas. Only glyphs whose pixel data is genuine LCD subpixel
-        // coverage go into the Subpixel atlas; that path requires the
-        // dual-source-blend pipeline to interpret the per-channel coverage
-        // correctly.
-        let kind = if lcd_subpixel && !rasterized_glyph.is_emoji {
+        // Route the glyph to the atlas whose format matches its pixel data:
+        //   - Emoji always go to Polychrome (Bgra8Unorm) because their
+        //     bytes are real RGBA colour and need full per-channel storage.
+        //   - Non-emoji glyphs that requested LCD subpixel rendering go to
+        //     Subpixel (Bgra8Unorm); their bytes encode three independent
+        //     coverage values per texel.
+        //   - Everything else, the grayscale fallback path, goes to Generic
+        //     (R8Unorm) which holds a single coverage byte per texel.
+        let kind = if rasterized_glyph.is_emoji {
+            AtlasTextureKind::Polychrome
+        } else if lcd_subpixel {
             AtlasTextureKind::Subpixel
         } else {
             AtlasTextureKind::Generic

--- a/crates/warpui/src/rendering/glyph_cache.rs
+++ b/crates/warpui/src/rendering/glyph_cache.rs
@@ -212,7 +212,9 @@ impl<Texture> GlyphCache<Texture> {
             AtlasTextureKind::Generic
         };
 
-        let texture_offset = self.manager_for(kind).insert(rasterized_glyph.canvas.size)?;
+        let texture_offset = self
+            .manager_for(kind)
+            .insert(rasterized_glyph.canvas.size)?;
         let idx = texture_offset.texture_id.as_usize();
         let textures = self.textures_for_mut(kind);
         if idx >= textures.len() {

--- a/crates/warpui/src/rendering/glyph_cache.rs
+++ b/crates/warpui/src/rendering/glyph_cache.rs
@@ -1,5 +1,5 @@
 use crate::fonts::{canvas, RasterizedGlyph};
-use crate::rendering::atlas::{self, AllocatedRegion, TextureId};
+use crate::rendering::atlas::{self, AllocatedRegion, AtlasTextureKind, TextureId};
 use crate::{fonts::SubpixelAlignment, rendering, scene::GlyphKey};
 use anyhow::Result;
 use ordered_float::OrderedFloat;
@@ -12,8 +12,12 @@ use std::collections::HashMap;
 
 const ATLAS_SIZE: usize = 1024;
 
-/// Callback to create a texture at a given size.
-type CreateTextureCallback<'a, T> = dyn Fn(usize) -> T + 'a;
+/// Callback to create a texture at a given size with a given kind.
+///
+/// The kind tells the backend which texture format to allocate so that the
+/// returned texture is sampleable by the render pipeline that will consume
+/// it (`Generic` is `Rgba8Unorm`, `Subpixel` is `Bgra8Unorm`).
+type CreateTextureCallback<'a, T> = dyn Fn(usize, AtlasTextureKind) -> T + 'a;
 
 /// Callback to insert [`RasterizedGlyph`] at a region identified by [`AllocatedRegion`] into a
 /// texture, `T`.
@@ -41,12 +45,19 @@ pub(crate) type RasterizeGlyphFn<'a> = dyn Fn(
     ) -> Result<RasterizedGlyph>
     + 'a;
 
-/// A cache that caches glyphs in a texture atlas.  
+/// A cache that caches glyphs in texture atlases of various kinds.
+///
+/// Each [`AtlasTextureKind`] has its own [`atlas::Manager`] and texture list
+/// so allocations of one kind never share a texture with allocations of
+/// another. The kind a glyph is routed to is derived from its
+/// [`GlyphCacheKey::lcd_subpixel`] flag at insertion time.
 pub struct GlyphCache<Texture> {
-    textures: Vec<Texture>,
+    generic_textures: Vec<Texture>,
+    subpixel_textures: Vec<Texture>,
     cache: HashMap<GlyphCacheKey, GlyphTextureOffset>,
     glyph_config: rendering::GlyphConfig,
-    atlas_manager: atlas::Manager,
+    generic_manager: atlas::Manager,
+    subpixel_manager: atlas::Manager,
 }
 
 #[derive(Hash, PartialEq, Eq)]
@@ -74,8 +85,13 @@ impl GlyphCacheKey {
 }
 
 /// A glyph within a texture atlas.
+///
+/// `kind` and `texture_id` together address a specific atlas texture: the
+/// `kind` selects which per-kind list of textures the [`GlyphCache`] holds,
+/// and `texture_id` indexes into that list.
 #[derive(Copy, Debug, Clone)]
 pub(crate) struct GlyphTextureOffset {
+    pub kind: AtlasTextureKind,
     pub texture_id: TextureId,
     pub allocated_region: AllocatedRegion,
     pub raster_bounds: RectF,
@@ -85,10 +101,12 @@ pub(crate) struct GlyphTextureOffset {
 impl<Texture> GlyphCache<Texture> {
     pub(crate) fn new(glyph_config: rendering::GlyphConfig) -> Self {
         GlyphCache {
-            textures: Vec::new(),
+            generic_textures: Vec::new(),
+            subpixel_textures: Vec::new(),
             cache: HashMap::new(),
             glyph_config,
-            atlas_manager: atlas::Manager::new(ATLAS_SIZE),
+            generic_manager: atlas::Manager::new(ATLAS_SIZE),
+            subpixel_manager: atlas::Manager::new(ATLAS_SIZE),
         }
     }
 
@@ -100,16 +118,41 @@ impl<Texture> GlyphCache<Texture> {
         }
     }
 
-    /// Returns the texture identified by [`TextureId`].
-    pub(crate) fn texture(&self, texture_id: &TextureId) -> Option<&Texture> {
-        self.textures.get(texture_id.as_usize())
+    /// Returns the texture for the atlas of the given `kind` at `texture_id`.
+    pub(crate) fn texture(
+        &self,
+        kind: AtlasTextureKind,
+        texture_id: &TextureId,
+    ) -> Option<&Texture> {
+        self.textures_for(kind).get(texture_id.as_usize())
+    }
+
+    fn textures_for(&self, kind: AtlasTextureKind) -> &Vec<Texture> {
+        match kind {
+            AtlasTextureKind::Generic => &self.generic_textures,
+            AtlasTextureKind::Subpixel => &self.subpixel_textures,
+        }
+    }
+
+    fn textures_for_mut(&mut self, kind: AtlasTextureKind) -> &mut Vec<Texture> {
+        match kind {
+            AtlasTextureKind::Generic => &mut self.generic_textures,
+            AtlasTextureKind::Subpixel => &mut self.subpixel_textures,
+        }
+    }
+
+    fn manager_for(&mut self, kind: AtlasTextureKind) -> &mut atlas::Manager {
+        match kind {
+            AtlasTextureKind::Generic => &mut self.generic_manager,
+            AtlasTextureKind::Subpixel => &mut self.subpixel_manager,
+        }
     }
 
     /// Returns a [`GlyphTextureOffset`] identified by [`GlyphKey`]. If the [`GlyphKey`] has not
     /// been previously cached, the glyph is rasterized and inserted into the texture via the
     /// `insert_into_texture` callback. If a new texture needs to be created (since a previous
-    /// texture is now fill), the `create_texture` callback is called to construct a new texture
-    /// atlas.
+    /// texture is now full), the `create_texture` callback is called to construct a new texture
+    /// atlas of the appropriate kind.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn get(
         &mut self,
@@ -125,48 +168,59 @@ impl<Texture> GlyphCache<Texture> {
         let cache_key =
             GlyphCacheKey::new(glyph_key, scale_factor, subpixel_alignment, lcd_subpixel);
 
-        match self.cache.get(&cache_key) {
-            None => {
-                let bounds = raster_bounds_fn(
-                    glyph_key,
-                    Vector2F::splat(scale_factor),
-                    lcd_subpixel,
-                    &self.glyph_config,
-                )?;
-
-                if bounds.size() == Vector2I::zero() {
-                    return Ok(None);
-                }
-
-                let rasterized_glyph = rasterize_glyph_fn(
-                    glyph_key,
-                    Vector2F::splat(scale_factor),
-                    subpixel_alignment,
-                    lcd_subpixel,
-                    &self.glyph_config,
-                    crate::fonts::canvas::RasterFormat::Rgba32,
-                )?;
-
-                let texture_offset = self.atlas_manager.insert(rasterized_glyph.canvas.size)?;
-                let idx = texture_offset.texture_id.as_usize();
-                if idx >= self.textures.len() {
-                    self.textures
-                        .resize_with(idx + 1, || create_texture(ATLAS_SIZE));
-                }
-                let texture = &mut self.textures[idx];
-                insert_into_texture(texture_offset.allocated_region, &rasterized_glyph, texture);
-
-                let glyph_texture_offset = GlyphTextureOffset {
-                    texture_id: texture_offset.texture_id,
-                    raster_bounds: bounds.to_f32(),
-                    is_emoji: rasterized_glyph.is_emoji,
-                    allocated_region: texture_offset.allocated_region,
-                };
-
-                self.cache.insert(cache_key, glyph_texture_offset);
-                Ok(Some(glyph_texture_offset))
-            }
-            Some(gto) => Ok(Some(*gto)),
+        if let Some(gto) = self.cache.get(&cache_key) {
+            return Ok(Some(*gto));
         }
+
+        let bounds = raster_bounds_fn(
+            glyph_key,
+            Vector2F::splat(scale_factor),
+            lcd_subpixel,
+            &self.glyph_config,
+        )?;
+
+        if bounds.size() == Vector2I::zero() {
+            return Ok(None);
+        }
+
+        let rasterized_glyph = rasterize_glyph_fn(
+            glyph_key,
+            Vector2F::splat(scale_factor),
+            subpixel_alignment,
+            lcd_subpixel,
+            &self.glyph_config,
+            crate::fonts::canvas::RasterFormat::Rgba32,
+        )?;
+
+        // Color glyphs (emoji) and grayscale-rasterized glyphs both share the
+        // Generic atlas. Only glyphs whose pixel data is genuine LCD subpixel
+        // coverage go into the Subpixel atlas; that path requires the
+        // dual-source-blend pipeline to interpret the per-channel coverage
+        // correctly.
+        let kind = if lcd_subpixel && !rasterized_glyph.is_emoji {
+            AtlasTextureKind::Subpixel
+        } else {
+            AtlasTextureKind::Generic
+        };
+
+        let texture_offset = self.manager_for(kind).insert(rasterized_glyph.canvas.size)?;
+        let idx = texture_offset.texture_id.as_usize();
+        let textures = self.textures_for_mut(kind);
+        if idx >= textures.len() {
+            textures.resize_with(idx + 1, || create_texture(ATLAS_SIZE, kind));
+        }
+        let texture = &mut textures[idx];
+        insert_into_texture(texture_offset.allocated_region, &rasterized_glyph, texture);
+
+        let glyph_texture_offset = GlyphTextureOffset {
+            kind,
+            texture_id: texture_offset.texture_id,
+            raster_bounds: bounds.to_f32(),
+            is_emoji: rasterized_glyph.is_emoji,
+            allocated_region: texture_offset.allocated_region,
+        };
+
+        self.cache.insert(cache_key, glyph_texture_offset);
+        Ok(Some(glyph_texture_offset))
     }
 }

--- a/crates/warpui/src/rendering/glyph_cache.rs
+++ b/crates/warpui/src/rendering/glyph_cache.rs
@@ -20,14 +20,22 @@ type CreateTextureCallback<'a, T> = dyn Fn(usize) -> T + 'a;
 type InsertIntoTextureCallback<'a, T> = dyn Fn(AllocatedRegion, &RasterizedGlyph, &mut T) + 'a;
 
 /// Callback to compute the bounds of a glyph when rasterized.
+///
+/// The `bool` argument is `lcd_subpixel`: true requests LCD subpixel
+/// rasterization, false requests grayscale. The flag affects the produced
+/// bitmap's pixel dimensions on backends whose subpixel mode produces wider
+/// bitmaps than grayscale, so it must participate in cache key uniqueness.
 pub(crate) type GlyphRasterBoundsFn<'a> =
-    dyn Fn(GlyphKey, Vector2F, &rendering::GlyphConfig) -> Result<RectI> + 'a;
+    dyn Fn(GlyphKey, Vector2F, bool, &rendering::GlyphConfig) -> Result<RectI> + 'a;
 
 /// Callback to rasterize a glyph.
+///
+/// The `bool` argument is `lcd_subpixel`; see [`GlyphRasterBoundsFn`].
 pub(crate) type RasterizeGlyphFn<'a> = dyn Fn(
         GlyphKey,
         Vector2F,
         SubpixelAlignment,
+        bool,
         &rendering::GlyphConfig,
         canvas::RasterFormat,
     ) -> Result<RasterizedGlyph>
@@ -46,14 +54,21 @@ struct GlyphCacheKey {
     glyph_key: GlyphKey,
     scale_factor: OrderedFloat<f32>,
     subpixel_alignment: SubpixelAlignment,
+    lcd_subpixel: bool,
 }
 
 impl GlyphCacheKey {
-    fn new(glyph_key: GlyphKey, scale_factor: f32, subpixel_alignment: SubpixelAlignment) -> Self {
+    fn new(
+        glyph_key: GlyphKey,
+        scale_factor: f32,
+        subpixel_alignment: SubpixelAlignment,
+        lcd_subpixel: bool,
+    ) -> Self {
         GlyphCacheKey {
             glyph_key,
             scale_factor: scale_factor.into(),
             subpixel_alignment,
+            lcd_subpixel,
         }
     }
 }
@@ -101,17 +116,23 @@ impl<Texture> GlyphCache<Texture> {
         glyph_key: GlyphKey,
         scale_factor: f32,
         subpixel_alignment: SubpixelAlignment,
+        lcd_subpixel: bool,
         create_texture: &CreateTextureCallback<'_, Texture>,
         insert_into_texture: &InsertIntoTextureCallback<'_, Texture>,
         raster_bounds_fn: &GlyphRasterBoundsFn<'_>,
         rasterize_glyph_fn: &RasterizeGlyphFn<'_>,
     ) -> Result<Option<GlyphTextureOffset>> {
-        let cache_key = GlyphCacheKey::new(glyph_key, scale_factor, subpixel_alignment);
+        let cache_key =
+            GlyphCacheKey::new(glyph_key, scale_factor, subpixel_alignment, lcd_subpixel);
 
         match self.cache.get(&cache_key) {
             None => {
-                let bounds =
-                    raster_bounds_fn(glyph_key, Vector2F::splat(scale_factor), &self.glyph_config)?;
+                let bounds = raster_bounds_fn(
+                    glyph_key,
+                    Vector2F::splat(scale_factor),
+                    lcd_subpixel,
+                    &self.glyph_config,
+                )?;
 
                 if bounds.size() == Vector2I::zero() {
                     return Ok(None);
@@ -121,6 +142,7 @@ impl<Texture> GlyphCache<Texture> {
                     glyph_key,
                     Vector2F::splat(scale_factor),
                     subpixel_alignment,
+                    lcd_subpixel,
                     &self.glyph_config,
                     crate::fonts::canvas::RasterFormat::Rgba32,
                 )?;

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -329,8 +329,10 @@ impl Pipeline {
         // Sort by atlas kind so draw() can issue one set_pipeline per kind
         // run; HashMap iteration order would otherwise interleave kinds and
         // force redundant pipeline switches.
-        let mut entries: Vec<((AtlasTextureKind, TextureId), Vec<shaders::GlyphInstanceData>)> =
-            texture_to_glyph.into_iter().collect();
+        let mut entries: Vec<(
+            (AtlasTextureKind, TextureId),
+            Vec<shaders::GlyphInstanceData>,
+        )> = texture_to_glyph.into_iter().collect();
         entries.sort_by_key(|((kind, _), _)| *kind);
 
         let mut start_offset = per_frame_state.glyph_data.len();

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -116,9 +116,16 @@ impl Pipeline {
             cache: None,
         });
 
+        // Nearest sampling is required for glyph atlas textures. The glyph rasterizer
+        // bakes sub-pixel X offsets into each cached bitmap (SubpixelAlignment), and the
+        // quad is snapped to the nearest physical pixel, so no GPU-side interpolation is
+        // needed or wanted. Linear sampling would blend adjacent atlas texels for any
+        // UV that lands between texel centers, which happens systematically at fractional
+        // DPI scales (1.25×, 1.5×) where sub-pixel bucket offsets don't align exactly
+        // with physical pixel boundaries — producing visibly blurry text.
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            mag_filter: FilterMode::Linear,
-            min_filter: FilterMode::Linear,
+            mag_filter: FilterMode::Nearest,
+            min_filter: FilterMode::Nearest,
             ..Default::default()
         });
 

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -257,10 +257,11 @@ impl Pipeline {
         for glyph in &layer.glyphs {
             let glyph_position = glyph.position * scale_factor;
             let subpixel_alignment = SubpixelAlignment::new(glyph_position);
-            // Subpixel rendering is wired into the glyph classification step
-            // upstream (see commit that adds Glyph::lcd_subpixel). Until that
-            // lands, all glyphs route through the grayscale path.
-            let lcd_subpixel = false;
+            // Scene-time classification has already decided whether this
+            // glyph wants the LCD subpixel path; the cache routes to the
+            // correct atlas kind and pipeline_for_kind picks the matching
+            // pipeline at draw time.
+            let lcd_subpixel = glyph.lcd_subpixel;
             match self.glyph_cache.get(
                 glyph.glyph_key,
                 scene.scale_factor(),

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -292,10 +292,20 @@ impl Pipeline {
                         Some(GlyphFade::Horizontal { start, end }) => (start, end),
                     };
 
-                    // Adjust the horizontal position by the subpixel alignment
-                    // so that we only shift the glyph over by the amount that
-                    // isn't accounted for in the subpixel-rasterized glyph.
-                    let glyph_position = glyph_position - subpixel_alignment.to_offset();
+                    // Snap the quad origin to an integer physical pixel.
+                    // The rasterizer has already baked the subpixel offset
+                    // for this bucket into the cached bitmap, so the quad
+                    // does not need to carry the fractional remainder; an
+                    // integer-aligned quad maps fragment centres exactly to
+                    // texel centres, which is what makes Linear sampling
+                    // equivalent to Nearest and frees the vertex shader
+                    // from having to floor anything itself.
+                    //
+                    // Bucket quantisation introduces at most 1/(2*STEPS)
+                    // pixels of horizontal positioning error; a future
+                    // commit raises STEPS from 3 to 4 to halve that error
+                    // and match Zed's resolution.
+                    let glyph_position = glyph_position.floor();
 
                     // Make sure to pass the glyph size in the atlas
                     // Not the size of the render bounds (which may be smaller)

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -210,16 +210,19 @@ impl Pipeline {
             None
         };
 
-        // Nearest sampling is required for glyph atlas textures. The glyph rasterizer
-        // bakes sub-pixel X offsets into each cached bitmap (SubpixelAlignment), and the
-        // quad is snapped to the nearest physical pixel, so no GPU-side interpolation is
-        // needed or wanted. Linear sampling would blend adjacent atlas texels for any
-        // UV that lands between texel centers, which happens systematically at fractional
-        // DPI scales (1.25×, 1.5×) where sub-pixel bucket offsets don't align exactly
-        // with physical pixel boundaries — producing visibly blurry text.
+        // Linear sampling is safe now that quad origins are floored to
+        // integer physical pixels at scene-build time. With integer-aligned
+        // quads of 1:1 pixel-to-texel scale, fragment centres map exactly
+        // to texel centres; Linear and Nearest produce identical output for
+        // those samples and the GPU avoids the on-the-fly snap that Nearest
+        // requires. Linear is also more forgiving if a future change ever
+        // produces sub-texel UV coordinates inside a bucket: it degrades
+        // gracefully instead of suddenly aliasing.
+        //
+        // This matches gpui's atlas_sampler in Zed.
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            mag_filter: FilterMode::Nearest,
-            min_filter: FilterMode::Nearest,
+            mag_filter: FilterMode::Linear,
+            min_filter: FilterMode::Linear,
             ..Default::default()
         });
 

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -133,13 +133,11 @@ impl Pipeline {
             cache: None,
         });
 
-        // Build the subpixel pipeline only on hardware that exposes
-        // dual-source blending. We compile a separate WGSL module that
-        // concatenates glyph_shader.wgsl with glyph_subpixel_shader.wgsl
-        // and prepends the `enable dual_source_blending;` directive that
-        // WGSL requires when a shader uses @blend_src attributes. Both
-        // pipelines share the vertex stage (vs_main) and bind group layout;
-        // only the fragment stage and blend state differ.
+        // Build the subpixel pipeline only when dual-source blending is
+        // available. The combined module concatenates the two WGSL files and
+        // prepends `enable dual_source_blending;` (required by WGSL whenever
+        // a shader uses @blend_src). The vertex stage and bind-group layout
+        // are shared with the mono pipeline.
         let subpixel_render_pipeline = if device
             .features()
             .contains(wgpu::Features::DUAL_SOURCE_BLENDING)
@@ -155,12 +153,10 @@ impl Pipeline {
                 source: wgpu::ShaderSource::Wgsl(Cow::Owned(combined_source)),
             });
 
-            // Dual-source blend equation. Each LCD subpixel of the destination
-            // is multiplied by its own coverage from the index-1 fragment
-            // output; the index-0 output supplies the unmodulated text colour.
-            // ColorWrites::COLOR keeps the framebuffer alpha unchanged so the
-            // window's compositing alpha is not corrupted by the per-channel
-            // coverage values.
+            // Dual-source blend: each destination LCD subpixel is multiplied
+            // by its own index-1 coverage; index 0 supplies the unmodulated
+            // text colour. ColorWrites::COLOR keeps the framebuffer alpha
+            // intact so the compositor's alpha is not corrupted by coverage.
             let subpixel_blend = wgpu::BlendState {
                 color: wgpu::BlendComponent {
                     src_factor: wgpu::BlendFactor::Src1,
@@ -209,16 +205,11 @@ impl Pipeline {
             None
         };
 
-        // Linear sampling is safe now that quad origins are floored to
-        // integer physical pixels at scene-build time. With integer-aligned
-        // quads of 1:1 pixel-to-texel scale, fragment centres map exactly
-        // to texel centres; Linear and Nearest produce identical output for
-        // those samples and the GPU avoids the on-the-fly snap that Nearest
-        // requires. Linear is also more forgiving if a future change ever
-        // produces sub-texel UV coordinates inside a bucket: it degrades
-        // gracefully instead of suddenly aliasing.
-        //
-        // This matches gpui's atlas_sampler in Zed.
+        // Linear sampling: quad origins are floored to integer physical
+        // pixels at scene-build time, so fragment centres land on texel
+        // centres and Linear is identical to Nearest in practice while
+        // degrading gracefully if a future change introduces sub-texel UVs.
+        // Matches gpui's atlas_sampler in Zed.
         let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             mag_filter: FilterMode::Linear,
             min_filter: FilterMode::Linear,
@@ -259,10 +250,9 @@ impl Pipeline {
         for glyph in &layer.glyphs {
             let glyph_position = glyph.position * scale_factor;
             let subpixel_alignment = SubpixelAlignment::new(glyph_position);
-            // Scene-time classification has already decided whether this
-            // glyph wants the LCD subpixel path; the cache routes to the
-            // correct atlas kind and pipeline_for_kind picks the matching
-            // pipeline at draw time.
+            // Scene-time classification has decided whether this glyph wants
+            // the LCD subpixel path; the cache routes to the matching atlas
+            // and pipeline_for_kind picks the pipeline at draw time.
             let lcd_subpixel = glyph.lcd_subpixel;
             match self.glyph_cache.get(
                 glyph.glyph_key,
@@ -294,19 +284,10 @@ impl Pipeline {
                         Some(GlyphFade::Horizontal { start, end }) => (start, end),
                     };
 
-                    // Snap the quad origin to an integer physical pixel.
-                    // The rasterizer has already baked the subpixel offset
-                    // for this bucket into the cached bitmap, so the quad
-                    // does not need to carry the fractional remainder; an
-                    // integer-aligned quad maps fragment centres exactly to
-                    // texel centres, which is what makes Linear sampling
-                    // equivalent to Nearest and frees the vertex shader
-                    // from having to floor anything itself.
-                    //
-                    // Bucket quantisation introduces at most 1/(2*STEPS)
-                    // pixels of horizontal positioning error; a future
-                    // commit raises STEPS from 3 to 4 to halve that error
-                    // and match Zed's resolution.
+                    // Snap the quad origin to an integer physical pixel. The
+                    // rasterizer has already baked this bucket's subpixel
+                    // offset into the cached bitmap, so an integer-aligned
+                    // quad maps fragment centres exactly to texel centres.
                     let glyph_position = glyph_position.floor();
 
                     // Make sure to pass the glyph size in the atlas
@@ -346,12 +327,8 @@ impl Pipeline {
         }
 
         // Sort by atlas kind so draw() can issue one set_pipeline per kind
-        // run instead of one per state. The HashMap iteration order is
-        // non-deterministic, so without this sort runs of identical-kind
-        // batches could end up interleaved and force redundant pipeline
-        // switches. Within a kind, keeping insertion order via the
-        // texture_id is enough to keep the instance buffer offsets
-        // monotonically increasing.
+        // run; HashMap iteration order would otherwise interleave kinds and
+        // force redundant pipeline switches.
         let mut entries: Vec<((AtlasTextureKind, TextureId), Vec<shaders::GlyphInstanceData>)> =
             texture_to_glyph.into_iter().collect();
         entries.sort_by_key(|((kind, _), _)| *kind);
@@ -408,10 +385,9 @@ impl Pipeline {
 
         render_pass.set_vertex_buffer(1, buffer.slice(..));
 
-        // Track the last pipeline we bound so we only re-issue set_pipeline
-        // on transitions. Glyph batches are typically dominated by one kind
-        // (a paragraph of mono text or a row of subpixel text), so this
-        // collapses runs of the same kind into a single state change.
+        // Re-issue set_pipeline only on kind transitions; glyph batches are
+        // dominated by runs of one kind, so this collapses them into a
+        // single state change.
         let mut active_kind: Option<AtlasTextureKind> = None;
 
         for per_texture_state in &layer_state.textures {
@@ -436,20 +412,15 @@ impl Pipeline {
         }
     }
 
-    /// Picks the render pipeline that matches the atlas kind. The Subpixel
-    /// kind requires the dual-source-blend pipeline; if that pipeline was
-    /// never built (the GPU does not expose dual-source blending) the
-    /// renderer falls back to the mono pipeline. Scene-time classification
-    /// should not produce Subpixel glyphs in that case, but the fallback
-    /// keeps us from panicking if it ever does.
+    /// Picks the render pipeline for an atlas kind. Subpixel needs the
+    /// dual-source-blend pipeline; if that pipeline was not built (no
+    /// hardware support) the renderer falls back to the mono pipeline so a
+    /// stray Subpixel glyph cannot panic the draw loop.
     fn pipeline_for_kind(&self, kind: AtlasTextureKind) -> &RenderPipeline {
         match kind {
-            // Generic and Polychrome both ride the mono pipeline. The
-            // is_emoji flag in the per-glyph instance data switches the
-            // fragment shader between coverage-and-text-colour mode and
-            // direct-RGBA-sample mode, which is what the polychrome atlas
-            // contains. Subpixel has its own pipeline only because of the
-            // dual-source-blend equation it needs.
+            // Generic and Polychrome share the mono pipeline; the is_emoji
+            // flag in the per-glyph data switches the fragment shader
+            // between coverage and direct-RGBA modes.
             AtlasTextureKind::Generic | AtlasTextureKind::Polychrome => &self.render_pipeline,
             AtlasTextureKind::Subpixel => self
                 .subpixel_render_pipeline

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -33,6 +33,11 @@ use super::util::create_buffer_init;
 pub(super) struct Pipeline {
     glyph_cache: GlyphCache<TextureWithBindGroup>,
     render_pipeline: RenderPipeline,
+    /// Render pipeline that composites LCD subpixel glyphs through dual-source
+    /// blending. Created only when the device exposes the corresponding
+    /// feature; otherwise the renderer silently falls back to the mono
+    /// pipeline for any glyphs that were classified as Subpixel.
+    subpixel_render_pipeline: Option<RenderPipeline>,
     texture_bind_group_layout: BindGroupLayout,
     sampler: Sampler,
 }
@@ -117,7 +122,7 @@ impl Pipeline {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: Some("fs_main"),
-                targets: &[Some(color_target)],
+                targets: &[Some(color_target.clone())],
                 compilation_options: Default::default(),
             }),
             primitive: wgpu::PrimitiveState::default(),
@@ -128,6 +133,82 @@ impl Pipeline {
             // so we are unlikely to get much value out of this for the platforms Warp supports.
             cache: None,
         });
+
+        // Build the subpixel pipeline only on hardware that exposes
+        // dual-source blending. We compile a separate WGSL module that
+        // concatenates glyph_shader.wgsl with glyph_subpixel_shader.wgsl
+        // and prepends the `enable dual_source_blending;` directive that
+        // WGSL requires when a shader uses @blend_src attributes. Both
+        // pipelines share the vertex stage (vs_main) and bind group layout;
+        // only the fragment stage and blend state differ.
+        let subpixel_render_pipeline = if device
+            .features()
+            .contains(wgpu::Features::DUAL_SOURCE_BLENDING)
+        {
+            const SUBPIXEL_SHADER_PRELUDE: &str = "enable dual_source_blending;\n";
+            let combined_source = format!(
+                "{SUBPIXEL_SHADER_PRELUDE}{}\n{}",
+                include_str!("../shaders/glyph_shader.wgsl"),
+                include_str!("../shaders/glyph_subpixel_shader.wgsl"),
+            );
+            let subpixel_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Glyph Subpixel Shader"),
+                source: wgpu::ShaderSource::Wgsl(Cow::Owned(combined_source)),
+            });
+
+            // Dual-source blend equation. Each LCD subpixel of the destination
+            // is multiplied by its own coverage from the index-1 fragment
+            // output; the index-0 output supplies the unmodulated text colour.
+            // ColorWrites::COLOR keeps the framebuffer alpha unchanged so the
+            // window's compositing alpha is not corrupted by the per-channel
+            // coverage values.
+            let subpixel_blend = wgpu::BlendState {
+                color: wgpu::BlendComponent {
+                    src_factor: wgpu::BlendFactor::Src1,
+                    dst_factor: wgpu::BlendFactor::OneMinusSrc1,
+                    operation: wgpu::BlendOperation::Add,
+                },
+                alpha: wgpu::BlendComponent {
+                    src_factor: wgpu::BlendFactor::One,
+                    dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                    operation: wgpu::BlendOperation::Add,
+                },
+            };
+            let subpixel_target = wgpu::ColorTargetState {
+                format: color_target.format,
+                blend: Some(subpixel_blend),
+                write_mask: wgpu::ColorWrites::COLOR,
+            };
+
+            Some(
+                device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                    label: Some("Glyph Subpixel Render pipeline"),
+                    layout: Some(&glyph_pipeline_layout),
+                    vertex: wgpu::VertexState {
+                        module: &subpixel_shader,
+                        entry_point: Some("vs_main"),
+                        buffers: &[
+                            shader_types::Vertex::desc(),
+                            shaders::GlyphInstanceData::desc(),
+                        ],
+                        compilation_options: Default::default(),
+                    },
+                    fragment: Some(wgpu::FragmentState {
+                        module: &subpixel_shader,
+                        entry_point: Some("fs_subpixel_main"),
+                        targets: &[Some(subpixel_target)],
+                        compilation_options: Default::default(),
+                    }),
+                    primitive: wgpu::PrimitiveState::default(),
+                    depth_stencil: None,
+                    multisample: wgpu::MultisampleState::default(),
+                    multiview_mask: None,
+                    cache: None,
+                }),
+            )
+        } else {
+            None
+        };
 
         // Nearest sampling is required for glyph atlas textures. The glyph rasterizer
         // bakes sub-pixel X offsets into each cached bitmap (SubpixelAlignment), and the
@@ -145,6 +226,7 @@ impl Pipeline {
         Self {
             glyph_cache: GlyphCache::new(glyph_config),
             render_pipeline,
+            subpixel_render_pipeline,
             texture_bind_group_layout,
             sampler,
         }
@@ -250,8 +332,19 @@ impl Pipeline {
             return None;
         }
 
+        // Sort by atlas kind so draw() can issue one set_pipeline per kind
+        // run instead of one per state. The HashMap iteration order is
+        // non-deterministic, so without this sort runs of identical-kind
+        // batches could end up interleaved and force redundant pipeline
+        // switches. Within a kind, keeping insertion order via the
+        // texture_id is enough to keep the instance buffer offsets
+        // monotonically increasing.
+        let mut entries: Vec<((AtlasTextureKind, TextureId), Vec<shaders::GlyphInstanceData>)> =
+            texture_to_glyph.into_iter().collect();
+        entries.sort_by_key(|((kind, _), _)| *kind);
+
         let mut start_offset = per_frame_state.glyph_data.len();
-        let per_texture_data = texture_to_glyph
+        let per_texture_data = entries
             .into_iter()
             .map(|((kind, texture_id), mut glyph_instance_data)| {
                 let len = glyph_instance_data.len();
@@ -300,10 +393,21 @@ impl Pipeline {
             return;
         };
 
-        render_pass.set_pipeline(&self.render_pipeline);
         render_pass.set_vertex_buffer(1, buffer.slice(..));
 
+        // Track the last pipeline we bound so we only re-issue set_pipeline
+        // on transitions. Glyph batches are typically dominated by one kind
+        // (a paragraph of mono text or a row of subpixel text), so this
+        // collapses runs of the same kind into a single state change.
+        let mut active_kind: Option<AtlasTextureKind> = None;
+
         for per_texture_state in &layer_state.textures {
+            if active_kind != Some(per_texture_state.kind) {
+                let pipeline = self.pipeline_for_kind(per_texture_state.kind);
+                render_pass.set_pipeline(pipeline);
+                active_kind = Some(per_texture_state.kind);
+            }
+
             let texture_with_view = self
                 .glyph_cache
                 .texture(per_texture_state.kind, &per_texture_state.texture_id)
@@ -316,6 +420,22 @@ impl Pipeline {
                 0,
                 per_texture_state.start_offset as u32..end_offset as u32,
             );
+        }
+    }
+
+    /// Picks the render pipeline that matches the atlas kind. The Subpixel
+    /// kind requires the dual-source-blend pipeline; if that pipeline was
+    /// never built (the GPU does not expose dual-source blending) the
+    /// renderer falls back to the mono pipeline. Scene-time classification
+    /// should not produce Subpixel glyphs in that case, but the fallback
+    /// keeps us from panicking if it ever does.
+    fn pipeline_for_kind(&self, kind: AtlasTextureKind) -> &RenderPipeline {
+        match kind {
+            AtlasTextureKind::Generic => &self.render_pipeline,
+            AtlasTextureKind::Subpixel => self
+                .subpixel_render_pipeline
+                .as_ref()
+                .unwrap_or(&self.render_pipeline),
         }
     }
 }

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -160,10 +160,15 @@ impl Pipeline {
         for glyph in &layer.glyphs {
             let glyph_position = glyph.position * scale_factor;
             let subpixel_alignment = SubpixelAlignment::new(glyph_position);
+            // Subpixel rendering is wired into the glyph classification step
+            // upstream (see commit that adds Glyph::lcd_subpixel). Until that
+            // lands, all glyphs route through the grayscale path.
+            let lcd_subpixel = false;
             match self.glyph_cache.get(
                 glyph.glyph_key,
                 scene.scale_factor(),
                 subpixel_alignment,
+                lcd_subpixel,
                 &|size| {
                     TextureWithBindGroup::new(
                         size,

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -247,13 +247,22 @@ impl Pipeline {
             (AtlasTextureKind, TextureId),
             Vec<shaders::GlyphInstanceData>,
         > = HashMap::new();
+        // Per-renderer override on the scene-time classification. The
+        // scene flag comes from a process-wide AppContext atomic, so a
+        // multi-window deployment where adapters disagree about
+        // dual-source-blending support can hand a Subpixel-classified
+        // glyph to a renderer whose subpixel_render_pipeline was never
+        // built. Routing such a glyph through the cache would put it in
+        // the Bgra8Unorm Subpixel atlas; pipeline_for_kind's mono
+        // fallback then samples that atlas with fs_main, which only
+        // reads the .r channel and would render with the wrong alpha
+        // shape. Anding with the local pipeline state here keeps the
+        // cache, atlas, and pipeline choices consistent.
+        let renderer_supports_subpixel = self.subpixel_render_pipeline.is_some();
         for glyph in &layer.glyphs {
             let glyph_position = glyph.position * scale_factor;
             let subpixel_alignment = SubpixelAlignment::new(glyph_position);
-            // Scene-time classification has decided whether this glyph wants
-            // the LCD subpixel path; the cache routes to the matching atlas
-            // and pipeline_for_kind picks the pipeline at draw time.
-            let lcd_subpixel = glyph.lcd_subpixel;
+            let lcd_subpixel = glyph.lcd_subpixel && renderer_supports_subpixel;
             match self.glyph_cache.get(
                 glyph.glyph_key,
                 scene.scale_factor(),

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -5,13 +5,18 @@ use crate::rendering::wgpu::texture_with_bind_group::TextureWithBindGroup;
 
 fn format_for_kind(kind: AtlasTextureKind) -> wgpu::TextureFormat {
     match kind {
-        // The generic atlas holds grayscale coverage replicated into RGBA
-        // (for non-emoji glyphs) and full-colour emoji bitmaps. Both fit in
-        // four 8-bit channels of unsigned-normalised data.
-        AtlasTextureKind::Generic => wgpu::TextureFormat::Rgba8Unorm,
+        // The generic atlas holds non-emoji grayscale coverage as a single
+        // unsigned-normalised byte per texel. R8Unorm is exactly the right
+        // shape for that: no wasted channels, no expansion at upload time.
+        AtlasTextureKind::Generic => wgpu::TextureFormat::R8Unorm,
         // The subpixel atlas holds three independent coverage values per
-        // texel in BGR order, matching swash's `subpixel_bgra` output.
+        // texel; the upload path swaps R and B on the CPU side so the
+        // shader can read .rgb and get logical RGB without a swizzle.
         AtlasTextureKind::Subpixel => wgpu::TextureFormat::Bgra8Unorm,
+        // The polychrome atlas holds full RGBA emoji bitmaps; the upload
+        // path performs the same R<->B swap so the texture's BGRA storage
+        // ends up matching the shader's expected RGB read order.
+        AtlasTextureKind::Polychrome => wgpu::TextureFormat::Bgra8Unorm,
     }
 }
 use crate::rendering::wgpu::{resources, shader_types};
@@ -445,7 +450,13 @@ impl Pipeline {
     /// keeps us from panicking if it ever does.
     fn pipeline_for_kind(&self, kind: AtlasTextureKind) -> &RenderPipeline {
         match kind {
-            AtlasTextureKind::Generic => &self.render_pipeline,
+            // Generic and Polychrome both ride the mono pipeline. The
+            // is_emoji flag in the per-glyph instance data switches the
+            // fragment shader between coverage-and-text-colour mode and
+            // direct-RGBA-sample mode, which is what the polychrome atlas
+            // contains. Subpixel has its own pipeline only because of the
+            // dual-source-blend equation it needs.
+            AtlasTextureKind::Generic | AtlasTextureKind::Polychrome => &self.render_pipeline,
             AtlasTextureKind::Subpixel => self
                 .subpixel_render_pipeline
                 .as_ref()

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -1,7 +1,19 @@
 use crate::fonts::SubpixelAlignment;
-use crate::rendering::atlas::TextureId;
+use crate::rendering::atlas::{AtlasTextureKind, TextureId};
 use crate::rendering::wgpu::renderer::WGPUContext;
 use crate::rendering::wgpu::texture_with_bind_group::TextureWithBindGroup;
+
+fn format_for_kind(kind: AtlasTextureKind) -> wgpu::TextureFormat {
+    match kind {
+        // The generic atlas holds grayscale coverage replicated into RGBA
+        // (for non-emoji glyphs) and full-colour emoji bitmaps. Both fit in
+        // four 8-bit channels of unsigned-normalised data.
+        AtlasTextureKind::Generic => wgpu::TextureFormat::Rgba8Unorm,
+        // The subpixel atlas holds three independent coverage values per
+        // texel in BGR order, matching swash's `subpixel_bgra` output.
+        AtlasTextureKind::Subpixel => wgpu::TextureFormat::Bgra8Unorm,
+    }
+}
 use crate::rendering::wgpu::{resources, shader_types};
 use crate::rendering::{GlyphCache, GlyphConfig};
 use crate::scene::{GlyphFade, Layer};
@@ -36,6 +48,7 @@ pub(super) struct LayerState {
 }
 
 pub(super) struct PerTextureState {
+    kind: AtlasTextureKind,
     texture_id: TextureId,
     start_offset: usize,
     len: usize,
@@ -155,8 +168,10 @@ impl Pipeline {
 
         let scale_factor = scene.scale_factor();
 
-        let mut texture_to_glyph: HashMap<TextureId, Vec<shaders::GlyphInstanceData>> =
-            HashMap::new();
+        let mut texture_to_glyph: HashMap<
+            (AtlasTextureKind, TextureId),
+            Vec<shaders::GlyphInstanceData>,
+        > = HashMap::new();
         for glyph in &layer.glyphs {
             let glyph_position = glyph.position * scale_factor;
             let subpixel_alignment = SubpixelAlignment::new(glyph_position);
@@ -169,9 +184,10 @@ impl Pipeline {
                 scene.scale_factor(),
                 subpixel_alignment,
                 lcd_subpixel,
-                &|size| {
+                &|size, kind| {
                     TextureWithBindGroup::new(
                         size,
+                        format_for_kind(kind),
                         &ctx.resources.device,
                         &self.texture_bind_group_layout,
                         &self.sampler,
@@ -216,7 +232,7 @@ impl Pipeline {
                     );
 
                     texture_to_glyph
-                        .entry(gto.texture_id)
+                        .entry((gto.kind, gto.texture_id))
                         .or_default()
                         .push(glyph_instance_data);
                 }
@@ -237,11 +253,12 @@ impl Pipeline {
         let mut start_offset = per_frame_state.glyph_data.len();
         let per_texture_data = texture_to_glyph
             .into_iter()
-            .map(|(texture_id, mut glyph_instance_data)| {
+            .map(|((kind, texture_id), mut glyph_instance_data)| {
                 let len = glyph_instance_data.len();
                 per_frame_state.glyph_data.append(&mut glyph_instance_data);
 
                 let state = PerTextureState {
+                    kind,
                     texture_id,
                     start_offset,
                     len,
@@ -289,7 +306,7 @@ impl Pipeline {
         for per_texture_state in &layer_state.textures {
             let texture_with_view = self
                 .glyph_cache
-                .texture(&per_texture_state.texture_id)
+                .texture(per_texture_state.kind, &per_texture_state.texture_id)
                 .expect("texture ID should be in atlas");
 
             render_pass.set_bind_group(1, texture_with_view.bind_group(), &[]);

--- a/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/glyph.rs
@@ -2,23 +2,6 @@ use crate::fonts::SubpixelAlignment;
 use crate::rendering::atlas::{AtlasTextureKind, TextureId};
 use crate::rendering::wgpu::renderer::WGPUContext;
 use crate::rendering::wgpu::texture_with_bind_group::TextureWithBindGroup;
-
-fn format_for_kind(kind: AtlasTextureKind) -> wgpu::TextureFormat {
-    match kind {
-        // The generic atlas holds non-emoji grayscale coverage as a single
-        // unsigned-normalised byte per texel. R8Unorm is exactly the right
-        // shape for that: no wasted channels, no expansion at upload time.
-        AtlasTextureKind::Generic => wgpu::TextureFormat::R8Unorm,
-        // The subpixel atlas holds three independent coverage values per
-        // texel; the upload path swaps R and B on the CPU side so the
-        // shader can read .rgb and get logical RGB without a swizzle.
-        AtlasTextureKind::Subpixel => wgpu::TextureFormat::Bgra8Unorm,
-        // The polychrome atlas holds full RGBA emoji bitmaps; the upload
-        // path performs the same R<->B swap so the texture's BGRA storage
-        // ends up matching the shader's expected RGB read order.
-        AtlasTextureKind::Polychrome => wgpu::TextureFormat::Bgra8Unorm,
-    }
-}
 use crate::rendering::wgpu::{resources, shader_types};
 use crate::rendering::{GlyphCache, GlyphConfig};
 use crate::scene::{GlyphFade, Layer};
@@ -34,6 +17,17 @@ use wgpu::{
 };
 
 use super::util::create_buffer_init;
+
+fn format_for_kind(kind: AtlasTextureKind) -> wgpu::TextureFormat {
+    match kind {
+        // R8Unorm: one coverage byte per texel for non-emoji grayscale.
+        AtlasTextureKind::Generic => wgpu::TextureFormat::R8Unorm,
+        // Bgra8Unorm: three per-channel coverage values, sampled as .rgb.
+        AtlasTextureKind::Subpixel => wgpu::TextureFormat::Bgra8Unorm,
+        // Bgra8Unorm: full RGBA emoji bitmaps after a CPU R<->B swap on upload.
+        AtlasTextureKind::Polychrome => wgpu::TextureFormat::Bgra8Unorm,
+    }
+}
 
 pub(super) struct Pipeline {
     glyph_cache: GlyphCache<TextureWithBindGroup>,

--- a/crates/warpui/src/rendering/wgpu/renderer/image.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/image.rs
@@ -1,9 +1,9 @@
 use crate::image_cache::StaticImage;
-use pathfinder_geometry::rect::RectF;
 use crate::rendering::texture_cache::{TextureCache, TextureCacheIndex};
 use crate::rendering::wgpu::{resources, shader_types};
 use crate::scene::Layer;
 use crate::Scene;
+use pathfinder_geometry::rect::RectF;
 use std::borrow::Cow;
 use std::sync::{atomic::AtomicBool, Arc};
 use wgpu::util::BufferInitDescriptor;

--- a/crates/warpui/src/rendering/wgpu/renderer/image.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/image.rs
@@ -139,12 +139,12 @@ impl Pipeline {
         };
         let scale_factor = scene.scale_factor();
         for image in &layer.images {
-            // Floor the physical-pixel origin so the quad starts on an exact pixel
-            // boundary. At fractional DPI (1.25×, 1.5×) the raw scaled origin is
-            // often fractional (e.g. 62.5 px). With FilterMode::Linear that shifts
-            // every UV sample away from its texel center, smearing adjacent texels
-            // into each other — the source of image blur. Flooring only the origin
-            // preserves the image size so the texture continues to fill the quad.
+            // Floor the physical-pixel origin so the quad starts on an exact
+            // pixel boundary. At fractional DPI (1.25x, 1.5x) the raw scaled
+            // origin is often fractional (e.g. 62.5 px); with Linear
+            // filtering that shifts every UV sample off its texel centre and
+            // smears adjacent texels, which is the visible image blur. Only
+            // the origin is floored so the size still fills the quad.
             let physical_origin = (image.bounds.origin() * scale_factor).floor();
             let physical_size = image.bounds.size() * scale_factor;
             let bounds = RectF::new(physical_origin, physical_size);

--- a/crates/warpui/src/rendering/wgpu/renderer/image.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/image.rs
@@ -1,4 +1,5 @@
 use crate::image_cache::StaticImage;
+use pathfinder_geometry::rect::RectF;
 use crate::rendering::texture_cache::{TextureCache, TextureCacheIndex};
 use crate::rendering::wgpu::{resources, shader_types};
 use crate::scene::Layer;
@@ -138,7 +139,15 @@ impl Pipeline {
         };
         let scale_factor = scene.scale_factor();
         for image in &layer.images {
-            let bounds = image.bounds * scale_factor;
+            // Floor the physical-pixel origin so the quad starts on an exact pixel
+            // boundary. At fractional DPI (1.25×, 1.5×) the raw scaled origin is
+            // often fractional (e.g. 62.5 px). With FilterMode::Linear that shifts
+            // every UV sample away from its texel center, smearing adjacent texels
+            // into each other — the source of image blur. Flooring only the origin
+            // preserves the image size so the texture continues to fill the quad.
+            let physical_origin = (image.bounds.origin() * scale_factor).floor();
+            let physical_size = image.bounds.size() * scale_factor;
+            let bounds = RectF::new(physical_origin, physical_size);
             let min_dimension = f32::min(bounds.height(), bounds.width());
             let corner_radius = crate::rendering::CornerRadius::from_ui_corner_radius(
                 image.corner_radius,
@@ -147,7 +156,7 @@ impl Pipeline {
             );
 
             per_frame_state.image_data.push(ImageInstanceData::new(
-                image.bounds * scale_factor,
+                bounds,
                 ColorModifier::Image {
                     opacity: (image.opacity * 255.) as u8,
                 },
@@ -162,8 +171,12 @@ impl Pipeline {
         }
 
         for icon in &layer.icons {
+            // Same origin-floor as images above.
+            let physical_origin = (icon.bounds.origin() * scale_factor).floor();
+            let physical_size = icon.bounds.size() * scale_factor;
+            let icon_bounds = RectF::new(physical_origin, physical_size);
             per_frame_state.image_data.push(ImageInstanceData::new(
-                icon.bounds * scale_factor,
+                icon_bounds,
                 ColorModifier::Icon { color: icon.color },
                 crate::rendering::CornerRadius::default(),
             ));

--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -67,6 +67,17 @@ pub struct Resources {
     pub surface: Surface<'static>,
     pub surface_config: RefCell<SurfaceConfiguration>,
     pub supported_backends: Vec<wgpu::Backend>,
+    /// Cached gamma-correction polynomial vector, computed once at
+    /// renderer creation from the WARP_FONTS_GAMMA env var (or the
+    /// 1.8 default). Re-read by configure_render_pass on every frame
+    /// to populate the glyph shader's uniform buffer.
+    pub gamma_ratios: [f32; 4],
+    /// Cached Stage 1 contrast factor for the grayscale glyph path.
+    /// From WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST or the default 1.0.
+    pub grayscale_enhanced_contrast: f32,
+    /// Cached Stage 1 contrast factor for the subpixel glyph path.
+    /// From WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST or the default 0.5.
+    pub subpixel_enhanced_contrast: f32,
     uniforms: uniforms::Uniforms,
     quad: quad::Resources,
 }
@@ -122,6 +133,13 @@ impl Resources {
             let uniforms = uniforms::Uniforms::new(&device);
             let quad = quad::Resources::new(&device);
 
+            // Read gamma and contrast settings once at renderer creation.
+            // Subsequent env-var changes are not picked up; the renderer
+            // would have to be rebuilt. Acceptable because these knobs
+            // exist for tuning, not for live theming.
+            let (gamma_ratios, grayscale_enhanced_contrast, subpixel_enhanced_contrast) =
+                warpui_core::rendering::gamma::read_env_gamma_settings();
+
             let device_lost = Arc::new(AtomicBool::new(false));
 
             let device_lost_clone = device_lost.clone();
@@ -138,6 +156,9 @@ impl Resources {
                 surface,
                 surface_config: surface_config.into(),
                 supported_backends: supported_backends.into_iter().collect(),
+                gamma_ratios,
+                grayscale_enhanced_contrast,
+                subpixel_enhanced_contrast,
                 uniforms,
                 quad,
             })

--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -111,7 +111,13 @@ impl Resources {
                 adapter_info.name,
             );
 
-            on_gpu_device_selected(device_info_from_adapter_info(adapter_info));
+            let supports_dual_source_blending = device
+                .features()
+                .contains(wgpu::Features::DUAL_SOURCE_BLENDING);
+            on_gpu_device_selected(device_info_from_adapter_info(
+                adapter_info,
+                supports_dual_source_blending,
+            ));
 
             let uniforms = uniforms::Uniforms::new(&device);
             let quad = quad::Resources::new(&device);
@@ -231,7 +237,10 @@ impl Resources {
     }
 }
 
-fn device_info_from_adapter_info(adapter_info: wgpu::AdapterInfo) -> GPUDeviceInfo {
+fn device_info_from_adapter_info(
+    adapter_info: wgpu::AdapterInfo,
+    supports_dual_source_blending: bool,
+) -> GPUDeviceInfo {
     let device_type = match adapter_info.device_type {
         DeviceType::Other => GPUDeviceType::Other,
         DeviceType::IntegratedGpu => GPUDeviceType::IntegratedGpu,
@@ -253,6 +262,7 @@ fn device_info_from_adapter_info(adapter_info: wgpu::AdapterInfo) -> GPUDeviceIn
         driver_name: adapter_info.driver,
         driver_info: adapter_info.driver_info,
         backend,
+        supports_dual_source_blending,
     }
 }
 

--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -124,18 +124,9 @@ impl Resources {
             let supports_dual_source_blending = device
                 .features()
                 .contains(wgpu::Features::DUAL_SOURCE_BLENDING);
-            // Snapshot transparency once. alpha_mode is fixed at renderer
-            // creation: create_surface_config picks it from the adapter's
-            // alpha_modes and surface_config never rewrites it later (only
-            // width/height change in update_surface_size). Treat anything
-            // other than CompositeAlphaMode::Opaque as transparent;
-            // Inherit is platform-defined and not safe to assume opaque.
-            let surface_is_transparent =
-                !matches!(surface_config.alpha_mode, CompositeAlphaMode::Opaque,);
             on_gpu_device_selected(device_info_from_adapter_info(
                 adapter_info,
                 supports_dual_source_blending,
-                surface_is_transparent,
             ));
 
             let uniforms = uniforms::Uniforms::new(&device);
@@ -267,7 +258,6 @@ impl Resources {
 fn device_info_from_adapter_info(
     adapter_info: wgpu::AdapterInfo,
     supports_dual_source_blending: bool,
-    surface_is_transparent: bool,
 ) -> GPUDeviceInfo {
     let device_type = match adapter_info.device_type {
         DeviceType::Other => GPUDeviceType::Other,
@@ -291,7 +281,6 @@ fn device_info_from_adapter_info(
         driver_info: adapter_info.driver_info,
         backend,
         supports_dual_source_blending,
-        surface_is_transparent,
     }
 }
 

--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -142,6 +142,26 @@ impl Resources {
         self.uniforms.bind_group_layout()
     }
 
+    /// Whether the active GPU device exposes dual-source blending. This is
+    /// the prerequisite for the subpixel glyph render pipeline; when false,
+    /// the renderer falls back to the grayscale path for all glyphs.
+    pub fn supports_dual_source_blending(&self) -> bool {
+        self.device
+            .features()
+            .contains(wgpu::Features::DUAL_SOURCE_BLENDING)
+    }
+
+    /// Whether the configured surface composites without an opaque alpha
+    /// channel. Returns true for any [`CompositeAlphaMode`] other than
+    /// `Opaque`, including `Inherit` which the wgpu docs describe as
+    /// platform-defined and therefore not safe to assume opaque.
+    pub fn surface_is_transparent(&self) -> bool {
+        !matches!(
+            self.surface_config.borrow().alpha_mode,
+            CompositeAlphaMode::Opaque
+        )
+    }
+
     pub fn configure_render_pass<'a>(
         &'a self,
         render_pass: &mut wgpu::RenderPass<'a>,
@@ -603,12 +623,29 @@ async fn initialize_device(
 
     limits.max_mesh_output_layers = 0;
 
+    // Opt into dual-source blending when the adapter exposes it. The feature
+    // maps to Vulkan core 1.0 dualSrcBlend, Metal MSL 1.2+ dual-source
+    // outputs, and DX12 dual-source blend states; it is widely available on
+    // desktop hardware but not universal on mobile. Requesting a feature the
+    // adapter does not expose causes request_device to fail, so the check
+    // against adapter.features() is the gate. When the feature is not
+    // available, the LCD subpixel rendering path falls back to grayscale at
+    // scene build time.
+    let mut required_features = wgpu::Features::empty();
+    if adapter
+        .features()
+        .contains(wgpu::Features::DUAL_SOURCE_BLENDING)
+    {
+        required_features |= wgpu::Features::DUAL_SOURCE_BLENDING;
+    }
+
     let (device, queue) = match adapter
         .request_device(&wgpu::DeviceDescriptor {
             // Use the broadest/most permissive device requirements
             // so that we can run on as many machines as possible.
             // If we use any WGSL features that aren't included in
             // these defaults, we can add specific overrides as needed.
+            required_features,
             required_limits: limits,
             ..Default::default()
         })

--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -67,16 +67,15 @@ pub struct Resources {
     pub surface: Surface<'static>,
     pub surface_config: RefCell<SurfaceConfiguration>,
     pub supported_backends: Vec<wgpu::Backend>,
-    /// Cached gamma-correction polynomial vector, computed once at
-    /// renderer creation from the WARP_FONTS_GAMMA env var (or the
-    /// 1.8 default). Re-read by configure_render_pass on every frame
-    /// to populate the glyph shader's uniform buffer.
+    /// Gamma-correction polynomial computed at renderer creation from
+    /// WARP_FONTS_GAMMA (default 1.8). Re-uploaded each frame as part of
+    /// the glyph shader's uniform buffer.
     pub gamma_ratios: [f32; 4],
-    /// Cached Stage 1 contrast factor for the grayscale glyph path.
-    /// From WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST or the default 1.0.
+    /// Stage 1 contrast factor for the grayscale path, from
+    /// WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST (default 1.0).
     pub grayscale_enhanced_contrast: f32,
-    /// Cached Stage 1 contrast factor for the subpixel glyph path.
-    /// From WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST or the default 0.5.
+    /// Stage 1 contrast factor for the subpixel path, from
+    /// WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST (default 0.5).
     pub subpixel_enhanced_contrast: f32,
     uniforms: uniforms::Uniforms,
     quad: quad::Resources,
@@ -133,10 +132,9 @@ impl Resources {
             let uniforms = uniforms::Uniforms::new(&device);
             let quad = quad::Resources::new(&device);
 
-            // Read gamma and contrast settings once at renderer creation.
-            // Subsequent env-var changes are not picked up; the renderer
-            // would have to be rebuilt. Acceptable because these knobs
-            // exist for tuning, not for live theming.
+            // Read gamma and contrast settings once at renderer creation;
+            // these knobs are for tuning, not live theming, so subsequent
+            // env-var changes are not picked up.
             let (gamma_ratios, grayscale_enhanced_contrast, subpixel_enhanced_contrast) =
                 warpui_core::rendering::gamma::read_env_gamma_settings();
 
@@ -169,18 +167,17 @@ impl Resources {
         self.uniforms.bind_group_layout()
     }
 
-    /// Whether the active GPU device exposes dual-source blending. This is
-    /// the prerequisite for the subpixel glyph render pipeline; when false,
-    /// the renderer falls back to the grayscale path for all glyphs.
+    /// Whether the GPU exposes dual-source blending. Prerequisite for the
+    /// subpixel pipeline; false means all glyphs go through the grayscale
+    /// path.
     pub fn supports_dual_source_blending(&self) -> bool {
         self.device
             .features()
             .contains(wgpu::Features::DUAL_SOURCE_BLENDING)
     }
 
-    /// Whether the configured surface composites without an opaque alpha
-    /// channel. Returns true for any [`CompositeAlphaMode`] other than
-    /// `Opaque`, including `Inherit` which the wgpu docs describe as
+    /// Whether the surface composites with anything other than opaque alpha.
+    /// `Inherit` is treated as transparent because wgpu documents it as
     /// platform-defined and therefore not safe to assume opaque.
     pub fn surface_is_transparent(&self) -> bool {
         !matches!(
@@ -654,14 +651,11 @@ async fn initialize_device(
 
     limits.max_mesh_output_layers = 0;
 
-    // Opt into dual-source blending when the adapter exposes it. The feature
-    // maps to Vulkan core 1.0 dualSrcBlend, Metal MSL 1.2+ dual-source
-    // outputs, and DX12 dual-source blend states; it is widely available on
-    // desktop hardware but not universal on mobile. Requesting a feature the
-    // adapter does not expose causes request_device to fail, so the check
-    // against adapter.features() is the gate. When the feature is not
-    // available, the LCD subpixel rendering path falls back to grayscale at
-    // scene build time.
+    // Opt into dual-source blending when the adapter exposes it (Vulkan
+    // dualSrcBlend, Metal MSL 1.2+, DX12). request_device fails if a
+    // feature the adapter doesn't expose is required, so gate on
+    // adapter.features(). When unavailable, scene-build classification
+    // routes glyphs to the grayscale path.
     let mut required_features = wgpu::Features::empty();
     if adapter
         .features()

--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -176,16 +176,6 @@ impl Resources {
             .contains(wgpu::Features::DUAL_SOURCE_BLENDING)
     }
 
-    /// Whether the surface composites with anything other than opaque alpha.
-    /// `Inherit` is treated as transparent because wgpu documents it as
-    /// platform-defined and therefore not safe to assume opaque.
-    pub fn surface_is_transparent(&self) -> bool {
-        !matches!(
-            self.surface_config.borrow().alpha_mode,
-            CompositeAlphaMode::Opaque
-        )
-    }
-
     pub fn configure_render_pass<'a>(
         &'a self,
         render_pass: &mut wgpu::RenderPass<'a>,

--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -124,9 +124,18 @@ impl Resources {
             let supports_dual_source_blending = device
                 .features()
                 .contains(wgpu::Features::DUAL_SOURCE_BLENDING);
+            // Snapshot transparency once. alpha_mode is fixed at renderer
+            // creation: create_surface_config picks it from the adapter's
+            // alpha_modes and surface_config never rewrites it later (only
+            // width/height change in update_surface_size). Treat anything
+            // other than CompositeAlphaMode::Opaque as transparent;
+            // Inherit is platform-defined and not safe to assume opaque.
+            let surface_is_transparent =
+                !matches!(surface_config.alpha_mode, CompositeAlphaMode::Opaque,);
             on_gpu_device_selected(device_info_from_adapter_info(
                 adapter_info,
                 supports_dual_source_blending,
+                surface_is_transparent,
             ));
 
             let uniforms = uniforms::Uniforms::new(&device);
@@ -258,6 +267,7 @@ impl Resources {
 fn device_info_from_adapter_info(
     adapter_info: wgpu::AdapterInfo,
     supports_dual_source_blending: bool,
+    surface_is_transparent: bool,
 ) -> GPUDeviceInfo {
     let device_type = match adapter_info.device_type {
         DeviceType::Other => GPUDeviceType::Other,
@@ -281,6 +291,7 @@ fn device_info_from_adapter_info(
         driver_info: adapter_info.driver_info,
         backend,
         supports_dual_source_blending,
+        surface_is_transparent,
     }
 }
 

--- a/crates/warpui/src/rendering/wgpu/resources/uniforms.rs
+++ b/crates/warpui/src/rendering/wgpu/resources/uniforms.rs
@@ -62,7 +62,15 @@ impl Uniforms {
         drawable_size: Vector2F,
         resources: &Resources,
     ) {
-        let uniforms = shader_types::Uniforms::new(drawable_size);
+        // The surface's CompositeAlphaMode determines whether the compositor
+        // expects the framebuffer's RGB to already be multiplied by alpha.
+        // Pass that bit into the shader so blend_color in glyph_shader.wgsl
+        // knows whether to apply the multiplication.
+        let premultiplied_alpha = matches!(
+            resources.surface_config.borrow().alpha_mode,
+            wgpu::CompositeAlphaMode::PreMultiplied,
+        );
+        let uniforms = shader_types::Uniforms::new(drawable_size, premultiplied_alpha);
         resources
             .queue
             .write_buffer(&self.buffer, 0, bytemuck::cast_slice(&[uniforms]));

--- a/crates/warpui/src/rendering/wgpu/resources/uniforms.rs
+++ b/crates/warpui/src/rendering/wgpu/resources/uniforms.rs
@@ -17,7 +17,14 @@ impl Uniforms {
             label: Some("Quad Uniforms Bind Group Layout"),
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
+                // The glyph fragment shader now reads gamma_ratios,
+                // grayscale_enhanced_contrast, and
+                // subpixel_enhanced_contrast from this uniform buffer in
+                // addition to the viewport_size the vertex stage needs,
+                // so the binding has to be visible to both stages. Adding
+                // FRAGMENT here is permissive: shaders that only read in
+                // the vertex stage continue to work without change.
+                visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: false,

--- a/crates/warpui/src/rendering/wgpu/resources/uniforms.rs
+++ b/crates/warpui/src/rendering/wgpu/resources/uniforms.rs
@@ -66,19 +66,16 @@ impl Uniforms {
         drawable_size: Vector2F,
         resources: &Resources,
     ) {
-        // CompositeAlphaMode tells us whether the compositor expects the
-        // framebuffer's RGB to be already multiplied by alpha; pass that
-        // through so blend_color in glyph_shader.wgsl can apply the multiply.
-        let premultiplied_alpha = matches!(
-            resources.surface_config.borrow().alpha_mode,
-            wgpu::CompositeAlphaMode::PreMultiplied,
-        );
         // Gamma and Stage 1 contrast factors are cached on Resources but
         // re-uploaded per-frame so the uniform buffer's payload stays
-        // self-contained.
+        // self-contained. The CompositeAlphaMode is intentionally not
+        // sampled here: the pipeline's BlendState::ALPHA_BLENDING
+        // already converts straight-alpha shader output into the
+        // pre-multiplied framebuffer that the PreMultiplied compositor
+        // expects, so the shader does not need to pre-multiply on its
+        // side.
         let uniforms = shader_types::Uniforms::new(
             drawable_size,
-            premultiplied_alpha,
             resources.gamma_ratios,
             resources.grayscale_enhanced_contrast,
             resources.subpixel_enhanced_contrast,

--- a/crates/warpui/src/rendering/wgpu/resources/uniforms.rs
+++ b/crates/warpui/src/rendering/wgpu/resources/uniforms.rs
@@ -17,13 +17,10 @@ impl Uniforms {
             label: Some("Quad Uniforms Bind Group Layout"),
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
-                // The glyph fragment shader now reads gamma_ratios,
-                // grayscale_enhanced_contrast, and
-                // subpixel_enhanced_contrast from this uniform buffer in
-                // addition to the viewport_size the vertex stage needs,
-                // so the binding has to be visible to both stages. Adding
-                // FRAGMENT here is permissive: shaders that only read in
-                // the vertex stage continue to work without change.
+                // The glyph fragment shader reads gamma_ratios and the two
+                // enhanced_contrast factors from this buffer, on top of the
+                // viewport_size the vertex stage needs. Visibility has to
+                // cover both stages.
                 visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
@@ -69,18 +66,16 @@ impl Uniforms {
         drawable_size: Vector2F,
         resources: &Resources,
     ) {
-        // The surface's CompositeAlphaMode determines whether the compositor
-        // expects the framebuffer's RGB to already be multiplied by alpha.
-        // Pass that bit into the shader so blend_color in glyph_shader.wgsl
-        // knows whether to apply the multiplication.
+        // CompositeAlphaMode tells us whether the compositor expects the
+        // framebuffer's RGB to be already multiplied by alpha; pass that
+        // through so blend_color in glyph_shader.wgsl can apply the multiply.
         let premultiplied_alpha = matches!(
             resources.surface_config.borrow().alpha_mode,
             wgpu::CompositeAlphaMode::PreMultiplied,
         );
-        // Gamma and Stage 1 contrast factors are cached on the Resources
-        // struct; populating them per-frame instead of per-renderer keeps
-        // the uniform buffer's payload self-contained even though these
-        // values do not change between frames.
+        // Gamma and Stage 1 contrast factors are cached on Resources but
+        // re-uploaded per-frame so the uniform buffer's payload stays
+        // self-contained.
         let uniforms = shader_types::Uniforms::new(
             drawable_size,
             premultiplied_alpha,

--- a/crates/warpui/src/rendering/wgpu/resources/uniforms.rs
+++ b/crates/warpui/src/rendering/wgpu/resources/uniforms.rs
@@ -70,7 +70,17 @@ impl Uniforms {
             resources.surface_config.borrow().alpha_mode,
             wgpu::CompositeAlphaMode::PreMultiplied,
         );
-        let uniforms = shader_types::Uniforms::new(drawable_size, premultiplied_alpha);
+        // Gamma and Stage 1 contrast factors are cached on the Resources
+        // struct; populating them per-frame instead of per-renderer keeps
+        // the uniform buffer's payload self-contained even though these
+        // values do not change between frames.
+        let uniforms = shader_types::Uniforms::new(
+            drawable_size,
+            premultiplied_alpha,
+            resources.gamma_ratios,
+            resources.grayscale_enhanced_contrast,
+            resources.subpixel_enhanced_contrast,
+        );
         resources
             .queue
             .write_buffer(&self.buffer, 0, bytemuck::cast_slice(&[uniforms]));

--- a/crates/warpui/src/rendering/wgpu/shader_types.rs
+++ b/crates/warpui/src/rendering/wgpu/shader_types.rs
@@ -218,11 +218,10 @@ impl RectData {
 #[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
 pub(super) struct Uniforms {
     viewport_size: Vector2F,
-    /// 1 when the surface composites with premultiplied alpha, 0 otherwise.
-    /// Drives whether the glyph shader pre-multiplies RGB by alpha; wrong
-    /// values let glyph colour bleed through transparent windows.
-    premultiplied_alpha: u32,
-    _padding0: u32,
+    /// Eight bytes of padding so `gamma_ratios` lands at offset 16 to
+    /// match the `vec4<f32>` alignment WGSL requires. The shader-side
+    /// `Uniforms` struct mirrors this layout.
+    _padding_after_viewport: [u32; 2],
     /// ClearType / DirectWrite gamma-correction polynomial coefficients,
     /// applied in Stage 2 of the alpha-correction formula.
     gamma_ratios: Vector4F,
@@ -240,15 +239,13 @@ pub(super) struct Uniforms {
 impl Uniforms {
     pub(super) fn new(
         size: pathfinder_geometry::vector::Vector2F,
-        premultiplied_alpha: bool,
         gamma_ratios: [f32; 4],
         grayscale_enhanced_contrast: f32,
         subpixel_enhanced_contrast: f32,
     ) -> Self {
         Self {
             viewport_size: size.into(),
-            premultiplied_alpha: if premultiplied_alpha { 1 } else { 0 },
-            _padding0: 0,
+            _padding_after_viewport: [0; 2],
             gamma_ratios: vec4f(
                 gamma_ratios[0],
                 gamma_ratios[1],

--- a/crates/warpui/src/rendering/wgpu/shader_types.rs
+++ b/crates/warpui/src/rendering/wgpu/shader_types.rs
@@ -218,26 +218,21 @@ impl RectData {
 #[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
 pub(super) struct Uniforms {
     viewport_size: Vector2F,
-    /// 1 when the active surface composites with premultiplied alpha,
-    /// 0 otherwise. The glyph fragment shader uses it to decide whether
-    /// to scale the output RGB by the final alpha; getting this wrong on
-    /// transparent compositors makes glyph colours leak through windows
-    /// behind them.
+    /// 1 when the surface composites with premultiplied alpha, 0 otherwise.
+    /// Drives whether the glyph shader pre-multiplies RGB by alpha; wrong
+    /// values let glyph colour bleed through transparent windows.
     premultiplied_alpha: u32,
     _padding0: u32,
-    /// Four-element ClearType / DirectWrite gamma-correction polynomial
-    /// coefficients. Computed on the host from the user's gamma setting
-    /// and uploaded once per frame; the shader uses them in Stage 2 of
-    /// the alpha-correction formula.
+    /// ClearType / DirectWrite gamma-correction polynomial coefficients,
+    /// applied in Stage 2 of the alpha-correction formula.
     gamma_ratios: Vector4F,
-    /// Stage 1 contrast factor applied to grayscale glyph coverage,
-    /// modulated per-glyph by the brightness-aware multiplier. 1.0 by
-    /// default; set WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST to override.
+    /// Stage 1 contrast factor for the grayscale path, modulated per-glyph
+    /// by the brightness-aware multiplier. Defaults to 1.0; override via
+    /// WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST.
     grayscale_enhanced_contrast: f32,
-    /// Stage 1 contrast factor for LCD subpixel coverage. 0.5 by default
-    /// because per-channel coverage already supplies most of the
-    /// perceptual sharpness; set WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST
-    /// to override.
+    /// Stage 1 contrast factor for the LCD subpixel path. Defaults to 0.5
+    /// because per-channel coverage already supplies most of the perceptual
+    /// sharpness; override via WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST.
     subpixel_enhanced_contrast: f32,
     _padding1: [u32; 2],
 }

--- a/crates/warpui/src/rendering/wgpu/shader_types.rs
+++ b/crates/warpui/src/rendering/wgpu/shader_types.rs
@@ -218,17 +218,26 @@ impl RectData {
 #[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
 pub(super) struct Uniforms {
     viewport_size: Vector2F,
-    // The shader-side paired struct will automatically be padded as necessary,
-    // so we add any necessary padding bytes here by adjusting the size of this
-    // byte array.
-    _struct_padding_bytes: [u8; 8],
+    /// 1 when the active surface composites with premultiplied alpha,
+    /// 0 otherwise. The glyph fragment shader uses it to decide whether
+    /// to scale the output RGB by the final alpha; getting this wrong on
+    /// transparent compositors makes glyph colours leak through windows
+    /// behind them.
+    premultiplied_alpha: u32,
+    /// Padding to keep the struct 16-byte aligned. WGSL inserts the
+    /// matching pad on its side so the layout matches.
+    _padding: u32,
 }
 
 impl Uniforms {
-    pub(super) fn new(size: pathfinder_geometry::vector::Vector2F) -> Self {
+    pub(super) fn new(
+        size: pathfinder_geometry::vector::Vector2F,
+        premultiplied_alpha: bool,
+    ) -> Self {
         Self {
             viewport_size: size.into(),
-            _struct_padding_bytes: Default::default(),
+            premultiplied_alpha: if premultiplied_alpha { 1 } else { 0 },
+            _padding: 0,
         }
     }
 }

--- a/crates/warpui/src/rendering/wgpu/shader_types.rs
+++ b/crates/warpui/src/rendering/wgpu/shader_types.rs
@@ -224,20 +224,45 @@ pub(super) struct Uniforms {
     /// transparent compositors makes glyph colours leak through windows
     /// behind them.
     premultiplied_alpha: u32,
-    /// Padding to keep the struct 16-byte aligned. WGSL inserts the
-    /// matching pad on its side so the layout matches.
-    _padding: u32,
+    _padding0: u32,
+    /// Four-element ClearType / DirectWrite gamma-correction polynomial
+    /// coefficients. Computed on the host from the user's gamma setting
+    /// and uploaded once per frame; the shader uses them in Stage 2 of
+    /// the alpha-correction formula.
+    gamma_ratios: Vector4F,
+    /// Stage 1 contrast factor applied to grayscale glyph coverage,
+    /// modulated per-glyph by the brightness-aware multiplier. 1.0 by
+    /// default; set WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST to override.
+    grayscale_enhanced_contrast: f32,
+    /// Stage 1 contrast factor for LCD subpixel coverage. 0.5 by default
+    /// because per-channel coverage already supplies most of the
+    /// perceptual sharpness; set WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST
+    /// to override.
+    subpixel_enhanced_contrast: f32,
+    _padding1: [u32; 2],
 }
 
 impl Uniforms {
     pub(super) fn new(
         size: pathfinder_geometry::vector::Vector2F,
         premultiplied_alpha: bool,
+        gamma_ratios: [f32; 4],
+        grayscale_enhanced_contrast: f32,
+        subpixel_enhanced_contrast: f32,
     ) -> Self {
         Self {
             viewport_size: size.into(),
             premultiplied_alpha: if premultiplied_alpha { 1 } else { 0 },
-            _padding: 0,
+            _padding0: 0,
+            gamma_ratios: vec4f(
+                gamma_ratios[0],
+                gamma_ratios[1],
+                gamma_ratios[2],
+                gamma_ratios[3],
+            ),
+            grayscale_enhanced_contrast,
+            subpixel_enhanced_contrast,
+            _padding1: [0; 2],
         }
     }
 }

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
@@ -54,9 +54,13 @@ fn light_on_dark_contrast(enhanced_contrast: f32, color: vec3<f32>) -> f32 {
 
 struct Uniforms {
     viewport_size: vec2<f32>,
-    // 1 if the surface composites with premultiplied alpha, 0 otherwise.
-    premultiplied_alpha: u32,
-    _padding0: u32,
+    // Eight bytes of padding so gamma_ratios lands at offset 16. Earlier
+    // versions used these bytes for a premultiplied_alpha flag, but the
+    // ALPHA_BLENDING pipeline blend already produces a pre-multiplied
+    // framebuffer from a straight-alpha source (src_factor=SrcAlpha
+    // multiplies by alpha at the blend stage), so the shader does not
+    // need to pre-multiply on its side.
+    _padding_after_viewport: vec2<u32>,
     // ClearType / DirectWrite gamma-correction polynomial coefficients.
     gamma_ratios: vec4<f32>,
     // Stage 1 contrast factor for the grayscale path. Default 1.0.
@@ -64,15 +68,6 @@ struct Uniforms {
     // Stage 1 contrast factor for the subpixel path. Default 0.5.
     subpixel_enhanced_contrast: f32,
     _padding1: vec2<u32>,
-}
-
-// On premultiplied-alpha surfaces, scale RGB by the final alpha so the
-// compositor reads the framebuffer correctly. For Opaque surfaces the flag
-// stays zero and RGB passes through unchanged (the multiplication would
-// just darken edge pixels for no reason).
-fn blend_color(color: vec3<f32>, alpha: f32, premultiplied_alpha: u32) -> vec4<f32> {
-    let multiplier = select(1.0, alpha, premultiplied_alpha != 0u);
-    return vec4<f32>(color * multiplier, alpha);
 }
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -165,5 +160,10 @@ fn fs_main(in: GlyphVertexShaderOutput) -> @location(0) vec4<f32> {
     // Apply the fade.
     color.a *= saturate(in.fade_alpha);
 
-    return blend_color(color.rgb, color.a, uniforms.premultiplied_alpha);
+    // Emit straight-alpha RGBA. The pipeline's BlendState::ALPHA_BLENDING
+    // applies SrcAlpha at the blend stage, which converts this straight
+    // source into the pre-multiplied framebuffer the PreMultiplied
+    // compositor expects. Pre-multiplying here would double-apply alpha
+    // and darken AA edges by a factor of alpha.
+    return color;
 }

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
@@ -35,6 +35,12 @@ fn enhance_contrast(alpha: f32, k: f32) -> f32 {
 // and 256/255×4 for indices 1,3.
 const GAMMA_RATIOS: vec4<f32> = vec4<f32>(0.148, -0.895, 1.476, -0.325);
 
+// Contrast factor magnitudes the two paths use as input to enhance_contrast,
+// modulated per-glyph by light_on_dark_contrast below. Values match Zed's
+// gpui defaults; commit Q makes them configurable through a uniform.
+const GRAYSCALE_ENHANCED_CONTRAST: f32 = 1.0;
+const SUBPIXEL_ENHANCED_CONTRAST: f32 = 0.5;
+
 fn apply_alpha_correction(a: f32, b: f32, g: vec4<f32>) -> f32 {
     let brightness_adjustment = g.x * b + g.y;
     let correction = brightness_adjustment * a + (g.z * b + g.w);
@@ -55,6 +61,17 @@ fn apply_alpha_correction3(a: vec3<f32>, b: vec3<f32>, g: vec4<f32>) -> vec3<f32
     let brightness_adjustment = g.x * b + g.y;
     let correction = brightness_adjustment * a + (g.z * b + g.w);
     return a + a * (1.0 - a) * correction;
+}
+
+// Brightness-aware modulation of the contrast factor. Despite the name,
+// this returns ZERO contrast boost for bright (light) text on dark
+// backgrounds because such text already has high contrast and additional
+// boost only thickens it. Mid-gray and darker text gets the full factor.
+// Adapted from Zed's gpui apply_contrast_and_gamma_correction.
+fn light_on_dark_contrast(enhanced_contrast: f32, color: vec3<f32>) -> f32 {
+    let brightness = glyph_color_brightness(color);
+    let multiplier = saturate(4.0 * (0.75 - brightness));
+    return enhanced_contrast * multiplier;
 }
 
 struct Uniforms {
@@ -147,11 +164,16 @@ fn fs_main(in: GlyphVertexShaderOutput) -> @location(0) vec4<f32> {
     // Use the input color for non-emoji, and the sampled color for emoji.
     var color: vec4<f32> = mix(in.color, tex_color, f32(in.is_emoji));
 
-    // Stage 1: brightness-scaled contrast boost (Windows Terminal formula).
-    let k = glyph_color_brightness(color.rgb);
-    let contrasted = enhance_contrast(tex_color.r, k);
-    // Stage 2: gamma-incorrect-target polynomial correction (ClearType / Zed formula).
-    let gamma_corrected = apply_alpha_correction(contrasted, k, GAMMA_RATIOS);
+    // Stage 1: brightness-modulated contrast boost. light_on_dark_contrast
+    // returns zero for bright text on dark backgrounds (where additional
+    // boost only over-thickens), and the full factor for darker text.
+    let enhanced_contrast = light_on_dark_contrast(GRAYSCALE_ENHANCED_CONTRAST, color.rgb);
+    let contrasted = enhance_contrast(tex_color.r, enhanced_contrast);
+    // Stage 2: gamma-incorrect-target polynomial correction. Brightness here
+    // is the scalar luminance of the text colour, used both to gate Stage 1
+    // above and to weight the polynomial below.
+    let brightness = glyph_color_brightness(color.rgb);
+    let gamma_corrected = apply_alpha_correction(contrasted, brightness, GAMMA_RATIOS);
     color.a *= max(gamma_corrected, f32(in.is_emoji));
 
     // Apply the fade.

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
@@ -30,16 +30,10 @@ fn enhance_contrast(alpha: f32, k: f32) -> f32 {
     return alpha * (k + 1.0) / (alpha * k + 1.0);
 }
 
-// Gamma correction ratios for gamma=1.8 (index 8 in Microsoft's ClearType table).
-// Computed as: ratios[i] * NORM, where NORM = 65536/(255²)×4 for indices 0,2
-// and 256/255×4 for indices 1,3.
-const GAMMA_RATIOS: vec4<f32> = vec4<f32>(0.148, -0.895, 1.476, -0.325);
-
-// Contrast factor magnitudes the two paths use as input to enhance_contrast,
-// modulated per-glyph by light_on_dark_contrast below. Values match Zed's
-// gpui defaults; commit Q makes them configurable through a uniform.
-const GRAYSCALE_ENHANCED_CONTRAST: f32 = 1.0;
-const SUBPIXEL_ENHANCED_CONTRAST: f32 = 0.5;
+// GAMMA_RATIOS, GRAYSCALE_ENHANCED_CONTRAST, and SUBPIXEL_ENHANCED_CONTRAST
+// now arrive through the Uniforms buffer below; they are populated by the
+// host from WARP_FONTS_GAMMA / WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST /
+// WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST on renderer creation.
 
 fn apply_alpha_correction(a: f32, b: f32, g: vec4<f32>) -> f32 {
     let brightness_adjustment = g.x * b + g.y;
@@ -79,9 +73,17 @@ struct Uniforms {
     // 1 when the active surface composites with premultiplied alpha,
     // 0 otherwise. Drives blend_color below.
     premultiplied_alpha: u32,
-    // Pad to 16 bytes; wgpu uniform buffer bindings need to be a multiple
-    // of 16 on platforms like WebGL.
-    _padding: u32,
+    _padding0: u32,
+    // ClearType / DirectWrite gamma-correction polynomial coefficients,
+    // computed on the host from WARP_FONTS_GAMMA.
+    gamma_ratios: vec4<f32>,
+    // Stage 1 contrast factor for the grayscale path. From
+    // WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST or default 1.0.
+    grayscale_enhanced_contrast: f32,
+    // Stage 1 contrast factor for the LCD subpixel path. From
+    // WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST or default 0.5.
+    subpixel_enhanced_contrast: f32,
+    _padding1: vec2<u32>,
 }
 
 // If the surface uses premultiplied alpha, scale the output RGB by the
@@ -179,13 +181,13 @@ fn fs_main(in: GlyphVertexShaderOutput) -> @location(0) vec4<f32> {
     // Stage 1: brightness-modulated contrast boost. light_on_dark_contrast
     // returns zero for bright text on dark backgrounds (where additional
     // boost only over-thickens), and the full factor for darker text.
-    let enhanced_contrast = light_on_dark_contrast(GRAYSCALE_ENHANCED_CONTRAST, color.rgb);
+    let enhanced_contrast = light_on_dark_contrast(uniforms.grayscale_enhanced_contrast, color.rgb);
     let contrasted = enhance_contrast(tex_color.r, enhanced_contrast);
     // Stage 2: gamma-incorrect-target polynomial correction. Brightness here
     // is the scalar luminance of the text colour, used both to gate Stage 1
     // above and to weight the polynomial below.
     let brightness = glyph_color_brightness(color.rgb);
-    let gamma_corrected = apply_alpha_correction(contrasted, brightness, GAMMA_RATIOS);
+    let gamma_corrected = apply_alpha_correction(contrasted, brightness, uniforms.gamma_ratios);
     color.a *= max(gamma_corrected, f32(in.is_emoji));
 
     // Apply the fade.

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
@@ -1,17 +1,26 @@
-// Brightness-scaled contrast enhancement for glyph alpha masks.
+// Two-stage alpha correction for glyph coverage masks.
 //
-// Linear sRGB blending makes light-on-dark text appear too thin because AA fringe
-// pixels blend perceptually darker than expected. Dark-on-light text has the opposite
-// problem — it already looks heavier than its geometric coverage.
+// Stage 1 — contrast boost (enhance_contrast):
+//   Fonts are designed assuming gamma-space blending. At 1.25× or 1.5× DPI
+//   the glyph rasterizer produces AA coverage values that map to the right
+//   perceived weight ONLY if blended in gamma space. Our pipeline does that
+//   (non-sRGB surface, no linearisation). Still, mid-coverage fringe pixels
+//   look slightly too thin for bright (white) text because the hardware gamma
+//   curve is not perfectly 2.2. The Windows Terminal DWrite formula
+//   enhance_contrast(α, k) = α*(k+1)/(αk+1) applies a brightness-scaled
+//   boost: brighter text (higher k) gets a stronger push.
 //
-// To compensate, we compute the text color's brightness (k) and use it to boost the
-// glyph alpha through enhance_contrast(). Brighter text gets a stronger boost;
-// dark text is left unchanged.
+// Stage 2 — gamma-incorrect-target correction (apply_alpha_correction):
+//   This is the ClearType / DirectWrite polynomial correction that accounts
+//   for the difference between the true display gamma and the gamma=1.0
+//   assumption built into the coverage values. It further boosts mid-range
+//   coverage to match what a physically-perfect gamma-2.2 pipeline would
+//   produce. Derived from Microsoft's gamma correction lookup table via Zed.
+//   GAMMA_RATIOS correspond to gamma=1.8, a good default for Linux/BSD.
+//   Reference: https://github.com/zed-industries/zed/blob/main/crates/gpui_wgpu/src/shaders.wgsl
 //
-// enhance_contrast() adapted from DWrite_EnhanceContrast in Windows Terminal's DirectWrite shader:
-// https://github.com/microsoft/terminal/blob/1283c0f5b99a2961673249fa77c6b986efb5086c/src/renderer/atlas/dwrite.hlsl
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
+// Both stages are skipped for emoji (is_emoji=1): tex_color already contains
+// the final RGBA.
 fn glyph_color_brightness(color: vec3<f32>) -> f32 {
     // REC. 601 luminance coefficients for perceived brightness.
     return dot(color, vec3<f32>(0.30, 0.59, 0.11));
@@ -19,6 +28,33 @@ fn glyph_color_brightness(color: vec3<f32>) -> f32 {
 
 fn enhance_contrast(alpha: f32, k: f32) -> f32 {
     return alpha * (k + 1.0) / (alpha * k + 1.0);
+}
+
+// Gamma correction ratios for gamma=1.8 (index 8 in Microsoft's ClearType table).
+// Computed as: ratios[i] * NORM, where NORM = 65536/(255²)×4 for indices 0,2
+// and 256/255×4 for indices 1,3.
+const GAMMA_RATIOS: vec4<f32> = vec4<f32>(0.148, -0.895, 1.476, -0.325);
+
+fn apply_alpha_correction(a: f32, b: f32, g: vec4<f32>) -> f32 {
+    let brightness_adjustment = g.x * b + g.y;
+    let correction = brightness_adjustment * a + (g.z * b + g.w);
+    return a + a * (1.0 - a) * correction;
+}
+
+// Per-channel variants used by the subpixel fragment shader. Each LCD
+// subpixel has its own coverage, so the contrast and gamma correction are
+// applied independently to R, G, and B. The brightness term is also
+// vec3 so each component contributes only to its own correction; for a
+// monochrome text colour all three components are equal and the result
+// matches the scalar formula above.
+fn enhance_contrast3(alpha: vec3<f32>, k: f32) -> vec3<f32> {
+    return alpha * (k + 1.0) / (alpha * k + 1.0);
+}
+
+fn apply_alpha_correction3(a: vec3<f32>, b: vec3<f32>, g: vec4<f32>) -> vec3<f32> {
+    let brightness_adjustment = g.x * b + g.y;
+    let correction = brightness_adjustment * a + (g.z * b + g.w);
+    return a + a * (1.0 - a) * correction;
 }
 
 struct Uniforms {
@@ -111,11 +147,12 @@ fn fs_main(in: GlyphVertexShaderOutput) -> @location(0) vec4<f32> {
     // Use the input color for non-emoji, and the sampled color for emoji.
     var color: vec4<f32> = mix(in.color, tex_color, f32(in.is_emoji));
 
-    // Scale contrast boost by text brightness:
-    // light text (white=1) gets full boost; dark text (black=0) gets none.
+    // Stage 1: brightness-scaled contrast boost (Windows Terminal formula).
     let k = glyph_color_brightness(color.rgb);
     let contrasted = enhance_contrast(tex_color.r, k);
-    color.a *= max(contrasted, f32(in.is_emoji));
+    // Stage 2: gamma-incorrect-target polynomial correction (ClearType / Zed formula).
+    let gamma_corrected = apply_alpha_correction(contrasted, k, GAMMA_RATIOS);
+    color.a *= max(gamma_corrected, f32(in.is_emoji));
 
     // Apply the fade.
     color.a *= saturate(in.fade_alpha);

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
@@ -116,14 +116,13 @@ fn vs_main(
     var size: vec2<f32> = glyph.bounds.zw;
     var pixel_pos: vec2<f32> = glyph.vertex_position * size + origin;
 
-    // Use floor here to vertically align the glyph to the pixel grid.
-    // If it's not aligned to the grid, the fragment shader will do its
-    // own interpolation, which makes it so we don't use the anti-aliasing
-    // from core text, which is what we want.  We don't force the glyph to a
-    // horizontal pixel position because we rasterize the glyph at multiple
-    // subpixel positions, and so the very slight linear interpolation here
-    // won't produce a fuzzy glyph, just a correctly-positioned one.
-    pixel_pos = vec2(pixel_pos.x, floor(pixel_pos.y));
+    // No flooring needed here. The Rust side already snaps glyph quad
+    // origins to integer physical pixels at scene-build time, so both
+    // bounds.xy and bounds.zw arrive as whole numbers; the multiply-add
+    // above produces integer pixel_pos at the vertices and integer-stepped
+    // values at fragment centres. Flooring again would either be a no-op
+    // or shift the quad by less than one pixel and reintroduce the very
+    // sub-pixel mismatch the upstream pre-floor was meant to fix.
 
     // Evaluating the glyphs fade effect. Note that the fade may go in two different directions:
     // - Right to left (default) - where the opaque side is on the right, and transparent on the left

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
@@ -76,9 +76,22 @@ fn light_on_dark_contrast(enhanced_contrast: f32, color: vec3<f32>) -> f32 {
 
 struct Uniforms {
     viewport_size: vec2<f32>,
-    // Padding necessary to ensure that the uniforms is 16 bytes. Some wgpu-supported devices (such as webgl) require
-    // buffer bindings to be a multiple of 16 bytes.
-    padding: vec2<f32>
+    // 1 when the active surface composites with premultiplied alpha,
+    // 0 otherwise. Drives blend_color below.
+    premultiplied_alpha: u32,
+    // Pad to 16 bytes; wgpu uniform buffer bindings need to be a multiple
+    // of 16 on platforms like WebGL.
+    _padding: u32,
+}
+
+// If the surface uses premultiplied alpha, scale the output RGB by the
+// final alpha so the framebuffer ends up in the form the compositor
+// expects. For Opaque surfaces, the compositor ignores alpha entirely and
+// the multiplication would actually darken edge pixels for no reason; the
+// flag stays zero in that case and RGB passes through unchanged.
+fn blend_color(color: vec3<f32>, alpha: f32, premultiplied_alpha: u32) -> vec4<f32> {
+    let multiplier = select(1.0, alpha, premultiplied_alpha != 0u);
+    return vec4<f32>(color * multiplier, alpha);
 }
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -177,5 +190,9 @@ fn fs_main(in: GlyphVertexShaderOutput) -> @location(0) vec4<f32> {
 
     // Apply the fade.
     color.a *= saturate(in.fade_alpha);
-    return color;
+
+    // Apply premultiplied-alpha conversion if the surface needs it. For
+    // opaque surfaces the multiplication is suppressed inside blend_color
+    // and the original RGB passes through unchanged.
+    return blend_color(color.rgb, color.a, uniforms.premultiplied_alpha);
 }

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_shader.wgsl
@@ -1,26 +1,15 @@
-// Two-stage alpha correction for glyph coverage masks.
+// Two-stage alpha correction for glyph coverage masks. Skipped for emoji
+// (is_emoji=1) where tex_color already contains the final RGBA.
 //
-// Stage 1 — contrast boost (enhance_contrast):
-//   Fonts are designed assuming gamma-space blending. At 1.25× or 1.5× DPI
-//   the glyph rasterizer produces AA coverage values that map to the right
-//   perceived weight ONLY if blended in gamma space. Our pipeline does that
-//   (non-sRGB surface, no linearisation). Still, mid-coverage fringe pixels
-//   look slightly too thin for bright (white) text because the hardware gamma
-//   curve is not perfectly 2.2. The Windows Terminal DWrite formula
-//   enhance_contrast(α, k) = α*(k+1)/(αk+1) applies a brightness-scaled
-//   boost: brighter text (higher k) gets a stronger push.
+// Stage 1, enhance_contrast: applies the Windows Terminal DWrite formula
+// alpha*(k+1)/(alpha*k+1) to push mid-coverage fringe pixels darker. The
+// boost is brightness-scaled.
 //
-// Stage 2 — gamma-incorrect-target correction (apply_alpha_correction):
-//   This is the ClearType / DirectWrite polynomial correction that accounts
-//   for the difference between the true display gamma and the gamma=1.0
-//   assumption built into the coverage values. It further boosts mid-range
-//   coverage to match what a physically-perfect gamma-2.2 pipeline would
-//   produce. Derived from Microsoft's gamma correction lookup table via Zed.
-//   GAMMA_RATIOS correspond to gamma=1.8, a good default for Linux/BSD.
-//   Reference: https://github.com/zed-industries/zed/blob/main/crates/gpui_wgpu/src/shaders.wgsl
-//
-// Both stages are skipped for emoji (is_emoji=1): tex_color already contains
-// the final RGBA.
+// Stage 2, apply_alpha_correction: the ClearType / DirectWrite polynomial
+// that corrects for the gap between the true display gamma and the gamma=1.0
+// assumption baked into the rasterizer's coverage values. GAMMA_RATIOS
+// targets gamma=1.8, a Linux/BSD-friendly default.
+// Reference: https://github.com/zed-industries/zed/blob/main/crates/gpui_wgpu/src/shaders.wgsl
 fn glyph_color_brightness(color: vec3<f32>) -> f32 {
     // REC. 601 luminance coefficients for perceived brightness.
     return dot(color, vec3<f32>(0.30, 0.59, 0.11));
@@ -30,10 +19,10 @@ fn enhance_contrast(alpha: f32, k: f32) -> f32 {
     return alpha * (k + 1.0) / (alpha * k + 1.0);
 }
 
-// GAMMA_RATIOS, GRAYSCALE_ENHANCED_CONTRAST, and SUBPIXEL_ENHANCED_CONTRAST
-// now arrive through the Uniforms buffer below; they are populated by the
-// host from WARP_FONTS_GAMMA / WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST /
-// WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST on renderer creation.
+// gamma_ratios, grayscale_enhanced_contrast, and subpixel_enhanced_contrast
+// arrive through the Uniforms buffer below, populated by the host from
+// WARP_FONTS_GAMMA / WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST /
+// WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST at renderer creation.
 
 fn apply_alpha_correction(a: f32, b: f32, g: vec4<f32>) -> f32 {
     let brightness_adjustment = g.x * b + g.y;
@@ -41,12 +30,9 @@ fn apply_alpha_correction(a: f32, b: f32, g: vec4<f32>) -> f32 {
     return a + a * (1.0 - a) * correction;
 }
 
-// Per-channel variants used by the subpixel fragment shader. Each LCD
-// subpixel has its own coverage, so the contrast and gamma correction are
-// applied independently to R, G, and B. The brightness term is also
-// vec3 so each component contributes only to its own correction; for a
-// monochrome text colour all three components are equal and the result
-// matches the scalar formula above.
+// Per-channel variants for the subpixel fragment shader: each LCD subpixel
+// gets its own contrast and gamma correction. Falls back to the scalar
+// formula above when all three components are equal.
 fn enhance_contrast3(alpha: vec3<f32>, k: f32) -> vec3<f32> {
     return alpha * (k + 1.0) / (alpha * k + 1.0);
 }
@@ -57,11 +43,9 @@ fn apply_alpha_correction3(a: vec3<f32>, b: vec3<f32>, g: vec4<f32>) -> vec3<f32
     return a + a * (1.0 - a) * correction;
 }
 
-// Brightness-aware modulation of the contrast factor. Despite the name,
-// this returns ZERO contrast boost for bright (light) text on dark
-// backgrounds because such text already has high contrast and additional
-// boost only thickens it. Mid-gray and darker text gets the full factor.
-// Adapted from Zed's gpui apply_contrast_and_gamma_correction.
+// Despite the name, returns ZERO boost for bright text on dark backgrounds
+// (already high contrast; extra boost just thickens). Mid-gray and darker
+// text gets the full factor. From Zed's apply_contrast_and_gamma_correction.
 fn light_on_dark_contrast(enhanced_contrast: f32, color: vec3<f32>) -> f32 {
     let brightness = glyph_color_brightness(color);
     let multiplier = saturate(4.0 * (0.75 - brightness));
@@ -70,27 +54,22 @@ fn light_on_dark_contrast(enhanced_contrast: f32, color: vec3<f32>) -> f32 {
 
 struct Uniforms {
     viewport_size: vec2<f32>,
-    // 1 when the active surface composites with premultiplied alpha,
-    // 0 otherwise. Drives blend_color below.
+    // 1 if the surface composites with premultiplied alpha, 0 otherwise.
     premultiplied_alpha: u32,
     _padding0: u32,
-    // ClearType / DirectWrite gamma-correction polynomial coefficients,
-    // computed on the host from WARP_FONTS_GAMMA.
+    // ClearType / DirectWrite gamma-correction polynomial coefficients.
     gamma_ratios: vec4<f32>,
-    // Stage 1 contrast factor for the grayscale path. From
-    // WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST or default 1.0.
+    // Stage 1 contrast factor for the grayscale path. Default 1.0.
     grayscale_enhanced_contrast: f32,
-    // Stage 1 contrast factor for the LCD subpixel path. From
-    // WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST or default 0.5.
+    // Stage 1 contrast factor for the subpixel path. Default 0.5.
     subpixel_enhanced_contrast: f32,
     _padding1: vec2<u32>,
 }
 
-// If the surface uses premultiplied alpha, scale the output RGB by the
-// final alpha so the framebuffer ends up in the form the compositor
-// expects. For Opaque surfaces, the compositor ignores alpha entirely and
-// the multiplication would actually darken edge pixels for no reason; the
-// flag stays zero in that case and RGB passes through unchanged.
+// On premultiplied-alpha surfaces, scale RGB by the final alpha so the
+// compositor reads the framebuffer correctly. For Opaque surfaces the flag
+// stays zero and RGB passes through unchanged (the multiplication would
+// just darken edge pixels for no reason).
 fn blend_color(color: vec3<f32>, alpha: f32, premultiplied_alpha: u32) -> vec4<f32> {
     let multiplier = select(1.0, alpha, premultiplied_alpha != 0u);
     return vec4<f32>(color * multiplier, alpha);
@@ -131,13 +110,10 @@ fn vs_main(
     var size: vec2<f32> = glyph.bounds.zw;
     var pixel_pos: vec2<f32> = glyph.vertex_position * size + origin;
 
-    // No flooring needed here. The Rust side already snaps glyph quad
-    // origins to integer physical pixels at scene-build time, so both
-    // bounds.xy and bounds.zw arrive as whole numbers; the multiply-add
-    // above produces integer pixel_pos at the vertices and integer-stepped
-    // values at fragment centres. Flooring again would either be a no-op
-    // or shift the quad by less than one pixel and reintroduce the very
-    // sub-pixel mismatch the upstream pre-floor was meant to fix.
+    // No flooring here: the Rust side already snaps quad origins to integer
+    // physical pixels, so pixel_pos is integer at the vertices. Flooring
+    // again would shift the quad by < 1 pixel and reintroduce the sub-pixel
+    // mismatch the pre-floor was meant to fix.
 
     // Evaluating the glyphs fade effect. Note that the fade may go in two different directions:
     // - Right to left (default) - where the opaque side is on the right, and transparent on the left
@@ -178,14 +154,10 @@ fn fs_main(in: GlyphVertexShaderOutput) -> @location(0) vec4<f32> {
     // Use the input color for non-emoji, and the sampled color for emoji.
     var color: vec4<f32> = mix(in.color, tex_color, f32(in.is_emoji));
 
-    // Stage 1: brightness-modulated contrast boost. light_on_dark_contrast
-    // returns zero for bright text on dark backgrounds (where additional
-    // boost only over-thickens), and the full factor for darker text.
+    // Stage 1: brightness-modulated contrast boost.
     let enhanced_contrast = light_on_dark_contrast(uniforms.grayscale_enhanced_contrast, color.rgb);
     let contrasted = enhance_contrast(tex_color.r, enhanced_contrast);
-    // Stage 2: gamma-incorrect-target polynomial correction. Brightness here
-    // is the scalar luminance of the text colour, used both to gate Stage 1
-    // above and to weight the polynomial below.
+    // Stage 2: gamma-correction polynomial weighted by the text's luminance.
     let brightness = glyph_color_brightness(color.rgb);
     let gamma_corrected = apply_alpha_correction(contrasted, brightness, uniforms.gamma_ratios);
     color.a *= max(gamma_corrected, f32(in.is_emoji));
@@ -193,8 +165,5 @@ fn fs_main(in: GlyphVertexShaderOutput) -> @location(0) vec4<f32> {
     // Apply the fade.
     color.a *= saturate(in.fade_alpha);
 
-    // Apply premultiplied-alpha conversion if the surface needs it. For
-    // opaque surfaces the multiplication is suppressed inside blend_color
-    // and the original RGB passes through unchanged.
     return blend_color(color.rgb, color.a, uniforms.premultiplied_alpha);
 }

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
@@ -16,12 +16,11 @@ struct SubpixelFragmentOutput {
 
 @fragment
 fn fs_subpixel_main(in: GlyphVertexShaderOutput) -> SubpixelFragmentOutput {
-    // Read the three subpixel coverages from BGRA storage and reorder to
-    // logical RGB. The non-emoji upload path deliberately skips the CPU
-    // R<->B swap because swash's subpixel layout into Bgra8Unorm storage
-    // already produces the channel order this swizzle expects.
-    let coverage_bgr = textureSample(glyphAtlasTexture, glyphAtlasSampler, in.texture_coordinate).rgb;
-    let coverage = coverage_bgr.bgr;
+    // Read the three subpixel coverages as logical RGB. The upload path
+    // (texture_with_bind_group.rs) swaps swash's RGBA-ordered bytes into
+    // canonical BGRA before write_texture, so a Bgra8Unorm sample yields
+    // (R-cov, G-cov, B-cov) directly with no swizzle.
+    let coverage = textureSample(glyphAtlasTexture, glyphAtlasSampler, in.texture_coordinate).rgb;
 
     // Stage 1: brightness-modulated contrast boost. The subpixel base factor
     // is half the grayscale one because per-channel coverage already

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
@@ -1,23 +1,14 @@
-// Subpixel glyph fragment shader.
-//
-// This file is concatenated with glyph_shader.wgsl by the renderer when
-// the device exposes wgpu::Features::DUAL_SOURCE_BLENDING; the directive
-// `enable dual_source_blending;` is prepended at compile time. It must
-// not be compiled standalone because it relies on declarations from
-// glyph_shader.wgsl: the vertex output struct GlyphVertexShaderOutput,
-// the texture/sampler bindings glyphAtlasTexture and glyphAtlasSampler,
-// and the gamma-correction helpers glyph_color_brightness, GAMMA_RATIOS,
-// enhance_contrast3, and apply_alpha_correction3.
-//
-// The mono and subpixel pipelines share the same vertex stage (vs_main
-// from glyph_shader.wgsl); only the fragment stage and blend equation
-// differ.
+// Subpixel glyph fragment shader. Concatenated with glyph_shader.wgsl at
+// pipeline-build time (with `enable dual_source_blending;` prepended) when
+// the device exposes wgpu::Features::DUAL_SOURCE_BLENDING. Must not be
+// compiled standalone: it depends on the vertex output struct, texture
+// bindings, and gamma helpers from glyph_shader.wgsl, and shares vs_main
+// with the mono pipeline.
 
-// Dual-source blending output: location 0 has two sources at indices 0 and 1.
-// The pipeline blend factors Src1 and OneMinusSrc1 reference the index-1
-// output to weight each LCD subpixel of the destination independently. The
-// foreground RGB at index 0 is the unmodulated text color; the index-1
-// channel carries per-subpixel coverage as the effective alpha source.
+// Dual-source output: index 0 carries the unmodulated foreground RGB,
+// index 1 carries per-subpixel coverage. The pipeline's Src1 /
+// OneMinusSrc1 blend factors use index 1 to weight each LCD subpixel of
+// the destination independently.
 struct SubpixelFragmentOutput {
     @location(0) @blend_src(0) foreground: vec4<f32>,
     @location(0) @blend_src(1) alpha: vec4<f32>,
@@ -25,44 +16,31 @@ struct SubpixelFragmentOutput {
 
 @fragment
 fn fs_subpixel_main(in: GlyphVertexShaderOutput) -> SubpixelFragmentOutput {
-    // Sample three independent coverage values from the BGRA8 subpixel
-    // atlas. The .rgb swizzle reorders BGR storage to logical RGB, which
-    // is what the per-channel contrast helpers expect. The non-emoji
-    // branch of the upload path (texture_with_bind_group.rs) deliberately
-    // does NOT R<->B swap subpixel data on the CPU, because swash's
-    // subpixel byte ordering combined with the Bgra8Unorm storage already
-    // produces channels in the order this swizzle expects.
+    // Read the three subpixel coverages from BGRA storage and reorder to
+    // logical RGB. The non-emoji upload path deliberately skips the CPU
+    // R<->B swap because swash's subpixel layout into Bgra8Unorm storage
+    // already produces the channel order this swizzle expects.
     let coverage_bgr = textureSample(glyphAtlasTexture, glyphAtlasSampler, in.texture_coordinate).rgb;
     let coverage = coverage_bgr.bgr;
 
-    // Stage 1: brightness-modulated contrast boost. The subpixel path uses
-    // a smaller base factor than the grayscale path because per-channel
-    // coverage already provides perceptual sharpness; an additional full
-    // contrast boost on top of that pushes mid-coverage values toward 1.0
-    // and reverses the subpixel fringe gradient, producing heavier and
-    // softer text. light_on_dark_contrast further drops the factor to zero
-    // for bright-on-dark, so white terminal text gets no Stage 1 boost.
+    // Stage 1: brightness-modulated contrast boost. The subpixel base factor
+    // is half the grayscale one because per-channel coverage already
+    // supplies most of the perceptual sharpness; a full boost on top
+    // saturates the fringe gradient and produces heavy, soft text.
     let enhanced_contrast = light_on_dark_contrast(uniforms.subpixel_enhanced_contrast, in.color.rgb);
     let contrasted = enhance_contrast3(coverage, enhanced_contrast);
 
-    // Stage 2: gamma-incorrect-target polynomial correction. The brightness
-    // argument is the text colour itself (vec3) so each channel corrects
-    // against the matching component of the destination, which is what
-    // dual-source blending will combine with.
+    // Stage 2: gamma-correction polynomial, with the text colour itself as
+    // the brightness vector so each channel corrects against the matching
+    // destination component the blend will combine with.
     let gamma_corrected = apply_alpha_correction3(contrasted, in.color.rgb, uniforms.gamma_ratios);
 
-    // Apply the fade from the vertex stage. Saturate prevents overshoot
-    // outside the fade region from boosting alpha past 1.
     let fade = saturate(in.fade_alpha);
 
     var out: SubpixelFragmentOutput;
-    // Index-0 output: unmodulated text colour. Alpha is 1.0 because the
-    // dual-source blend uses index-1 as the alpha factor; the alpha
-    // channel of index-0 is ignored by the BlendFactor::Src1 equation.
+    // Index 0: the index-0 alpha is ignored by Src1 blending, hence 1.0.
     out.foreground = vec4<f32>(in.color.rgb, 1.0);
-    // Index-1 output: per-subpixel coverage scaled by text alpha and fade.
-    // BlendFactor::Src1 uses this as the multiplier for the destination
-    // colour's RGB channels.
+    // Index 1: per-subpixel coverage scaled by the text alpha and fade.
     out.alpha = vec4<f32>(gamma_corrected * in.color.a * fade, in.color.a * fade);
     return out;
 }

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
@@ -42,14 +42,14 @@ fn fs_subpixel_main(in: GlyphVertexShaderOutput) -> SubpixelFragmentOutput {
     // and reverses the subpixel fringe gradient, producing heavier and
     // softer text. light_on_dark_contrast further drops the factor to zero
     // for bright-on-dark, so white terminal text gets no Stage 1 boost.
-    let enhanced_contrast = light_on_dark_contrast(SUBPIXEL_ENHANCED_CONTRAST, in.color.rgb);
+    let enhanced_contrast = light_on_dark_contrast(uniforms.subpixel_enhanced_contrast, in.color.rgb);
     let contrasted = enhance_contrast3(coverage, enhanced_contrast);
 
     // Stage 2: gamma-incorrect-target polynomial correction. The brightness
     // argument is the text colour itself (vec3) so each channel corrects
     // against the matching component of the destination, which is what
     // dual-source blending will combine with.
-    let gamma_corrected = apply_alpha_correction3(contrasted, in.color.rgb, GAMMA_RATIOS);
+    let gamma_corrected = apply_alpha_correction3(contrasted, in.color.rgb, uniforms.gamma_ratios);
 
     // Apply the fade from the vertex stage. Saturate prevents overshoot
     // outside the fade region from boosting alpha past 1.

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
@@ -1,0 +1,60 @@
+// Subpixel glyph fragment shader.
+//
+// This file is concatenated with glyph_shader.wgsl by the renderer when
+// the device exposes wgpu::Features::DUAL_SOURCE_BLENDING; the directive
+// `enable dual_source_blending;` is prepended at compile time. It must
+// not be compiled standalone because it relies on declarations from
+// glyph_shader.wgsl: the vertex output struct GlyphVertexShaderOutput,
+// the texture/sampler bindings glyphAtlasTexture and glyphAtlasSampler,
+// and the gamma-correction helpers glyph_color_brightness, GAMMA_RATIOS,
+// enhance_contrast3, and apply_alpha_correction3.
+//
+// The mono and subpixel pipelines share the same vertex stage (vs_main
+// from glyph_shader.wgsl); only the fragment stage and blend equation
+// differ.
+
+// Dual-source blending output: location 0 has two sources at indices 0 and 1.
+// The pipeline blend factors Src1 and OneMinusSrc1 reference the index-1
+// output to weight each LCD subpixel of the destination independently. The
+// foreground RGB at index 0 is the unmodulated text color; the index-1
+// channel carries per-subpixel coverage as the effective alpha source.
+struct SubpixelFragmentOutput {
+    @location(0) @blend_src(0) foreground: vec4<f32>,
+    @location(0) @blend_src(1) alpha: vec4<f32>,
+}
+
+@fragment
+fn fs_subpixel_main(in: GlyphVertexShaderOutput) -> SubpixelFragmentOutput {
+    // Sample three independent coverage values from the BGRA8 subpixel
+    // atlas. The .rgb swizzle reorders BGR storage to logical RGB, which
+    // is what the per-channel contrast helpers expect.
+    let coverage_bgr = textureSample(glyphAtlasTexture, glyphAtlasSampler, in.texture_coordinate).rgb;
+    let coverage = coverage_bgr.bgr;
+
+    // Stage 1: brightness-scaled contrast boost, applied per-channel. The
+    // scalar k is the perceived luminance of the text colour and matches
+    // the mono path so light-on-dark glyphs get the same fattening effect.
+    let k = glyph_color_brightness(in.color.rgb);
+    let contrasted = enhance_contrast3(coverage, k);
+
+    // Stage 2: gamma-incorrect-target polynomial correction. The brightness
+    // argument is the text colour itself (vec3) so each channel corrects
+    // against the matching component of the destination, which is what
+    // dual-source blending will combine with.
+    let gamma_corrected = apply_alpha_correction3(contrasted, in.color.rgb, GAMMA_RATIOS);
+
+    // Apply the fade from the vertex stage. Saturate prevents overshoot
+    // outside the fade region from boosting alpha past 1.
+    let fade = saturate(in.fade_alpha);
+
+    var out: SubpixelFragmentOutput;
+    // Index-0 output: unmodulated text colour. Alpha is 1.0 because the
+    // dual-source blend uses index-1 as the alpha factor; the alpha
+    // channel of index-0 is ignored by the BlendFactor::Src1 equation.
+    out.foreground = vec4<f32>(in.color.rgb, 1.0);
+    // Index-1 output: per-subpixel coverage scaled by text alpha and fade.
+    // BlendFactor::Src1 uses this as the multiplier for the destination
+    // colour's RGB channels.
+    out.alpha = vec4<f32>(gamma_corrected * in.color.a * fade, in.color.a * fade);
+    return out;
+}

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
@@ -31,11 +31,15 @@ fn fs_subpixel_main(in: GlyphVertexShaderOutput) -> SubpixelFragmentOutput {
     let coverage_bgr = textureSample(glyphAtlasTexture, glyphAtlasSampler, in.texture_coordinate).rgb;
     let coverage = coverage_bgr.bgr;
 
-    // Stage 1: brightness-scaled contrast boost, applied per-channel. The
-    // scalar k is the perceived luminance of the text colour and matches
-    // the mono path so light-on-dark glyphs get the same fattening effect.
-    let k = glyph_color_brightness(in.color.rgb);
-    let contrasted = enhance_contrast3(coverage, k);
+    // Stage 1: brightness-modulated contrast boost. The subpixel path uses
+    // a smaller base factor than the grayscale path because per-channel
+    // coverage already provides perceptual sharpness; an additional full
+    // contrast boost on top of that pushes mid-coverage values toward 1.0
+    // and reverses the subpixel fringe gradient, producing heavier and
+    // softer text. light_on_dark_contrast further drops the factor to zero
+    // for bright-on-dark, so white terminal text gets no Stage 1 boost.
+    let enhanced_contrast = light_on_dark_contrast(SUBPIXEL_ENHANCED_CONTRAST, in.color.rgb);
+    let contrasted = enhance_contrast3(coverage, enhanced_contrast);
 
     // Stage 2: gamma-incorrect-target polynomial correction. The brightness
     // argument is the text colour itself (vec3) so each channel corrects

--- a/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
+++ b/crates/warpui/src/rendering/wgpu/shaders/glyph_subpixel_shader.wgsl
@@ -27,7 +27,11 @@ struct SubpixelFragmentOutput {
 fn fs_subpixel_main(in: GlyphVertexShaderOutput) -> SubpixelFragmentOutput {
     // Sample three independent coverage values from the BGRA8 subpixel
     // atlas. The .rgb swizzle reorders BGR storage to logical RGB, which
-    // is what the per-channel contrast helpers expect.
+    // is what the per-channel contrast helpers expect. The non-emoji
+    // branch of the upload path (texture_with_bind_group.rs) deliberately
+    // does NOT R<->B swap subpixel data on the CPU, because swash's
+    // subpixel byte ordering combined with the Bgra8Unorm storage already
+    // produces channels in the order this swizzle expects.
     let coverage_bgr = textureSample(glyphAtlasTexture, glyphAtlasSampler, in.texture_coordinate).rgb;
     let coverage = coverage_bgr.bgr;
 

--- a/crates/warpui/src/rendering/wgpu/texture_with_bind_group.rs
+++ b/crates/warpui/src/rendering/wgpu/texture_with_bind_group.rs
@@ -8,22 +8,25 @@ use wgpu::{
 
 /// Helper struct that includes a [`Texture`] and its corresponding [`BindGroup`] for use in the
 /// `GlyphCache`.
+///
+/// The format is recorded so [`Self::insert_glyph_into_texture`] can convert
+/// the rasterizer's RGBA32 output into the layout this texture expects.
 pub(super) struct TextureWithBindGroup {
     texture: Texture,
     /// The [`BindGroup`] associated with the `texture`. We compute this whenever we need to create
     /// a new texture as a performance optimization to ensure we don't create it on every render.
     bind_group: BindGroup,
+    format: TextureFormat,
 }
 
 impl TextureWithBindGroup {
     /// Creates a new atlas texture of the given pixel `format`.
     ///
-    /// The format determines how downstream pipelines interpret samples:
-    /// `Rgba8Unorm` is used for the generic glyph atlas (grayscale coverage
-    /// replicated into RGBA, plus color emoji), and `Bgra8Unorm` is used for
-    /// the subpixel atlas where each channel encodes coverage of a single
-    /// LCD subpixel. Both formats are 4 bytes per texel, so the upload path
-    /// in [`Self::insert_glyph_into_texture`] is shared.
+    /// Three formats are used in practice: `R8Unorm` for the monochrome
+    /// coverage atlas (one byte per texel), and `Bgra8Unorm` for both the
+    /// subpixel coverage atlas and the polychrome (emoji) atlas (four
+    /// bytes per texel). The format dictates the upload-path conversion in
+    /// [`Self::insert_glyph_into_texture`] below.
     pub(super) fn new(
         size: usize,
         format: TextureFormat,
@@ -65,6 +68,7 @@ impl TextureWithBindGroup {
         Self {
             texture,
             bind_group,
+            format,
         }
     }
 
@@ -74,7 +78,60 @@ impl TextureWithBindGroup {
         glyph: &RasterizedGlyph,
         queue: &Queue,
     ) {
-        let bytes_per_row: u32 = 4 * (glyph.canvas.size.x() as u32);
+        // Convert the rasterizer's four-byte-per-pixel canvas into whatever
+        // layout the destination texture expects. There are three cases:
+        //
+        //   R8Unorm (Generic, non-emoji grayscale): extract the alpha byte.
+        //   The rasterizer replicates the A8 mask into RGBA32, so picking
+        //   the first byte of each four-byte group recovers the original
+        //   coverage exactly.
+        //
+        //   Bgra8Unorm + emoji glyph (Polychrome): swash returns RGBA in
+        //   memory order but the texture reads its bytes as BGRA, so we
+        //   swap R and B per pixel on the CPU side. After this swap the
+        //   fragment shader's straight .rgb sample yields logical RGB.
+        //
+        //   Bgra8Unorm + non-emoji subpixel coverage (Subpixel): swash has
+        //   a documented quirk where its subpixel format produces what the
+        //   subpixel fragment shader treats as already-correctly-ordered
+        //   bytes for our Bgra8Unorm upload combined with its existing
+        //   .rgb sample. No CPU swap is needed; doing one would re-break
+        //   the subpixel ordering. Keep this branch separate so the same
+        //   format does not silently apply the emoji-only swap.
+        let pixel_count = (region.pixel_region.width() * region.pixel_region.height()) as usize;
+        let upload_bytes: std::borrow::Cow<'_, [u8]>;
+        let bytes_per_row = match self.format {
+            TextureFormat::R8Unorm => {
+                let mut compact = Vec::with_capacity(pixel_count);
+                for chunk in glyph.canvas.pixels.chunks_exact(4) {
+                    compact.push(chunk[0]);
+                }
+                upload_bytes = std::borrow::Cow::Owned(compact);
+                region.pixel_region.width() as u32
+            }
+            TextureFormat::Bgra8Unorm if glyph.is_emoji => {
+                let mut swapped = glyph.canvas.pixels.clone();
+                for pixel in swapped.chunks_exact_mut(4) {
+                    pixel.swap(0, 2);
+                }
+                upload_bytes = std::borrow::Cow::Owned(swapped);
+                4 * region.pixel_region.width() as u32
+            }
+            TextureFormat::Bgra8Unorm => {
+                upload_bytes = std::borrow::Cow::Borrowed(glyph.canvas.pixels.as_slice());
+                4 * region.pixel_region.width() as u32
+            }
+            other => {
+                debug_assert!(
+                    false,
+                    "unexpected glyph atlas format {:?}; upload assumes R8Unorm or Bgra8Unorm",
+                    other,
+                );
+                upload_bytes = std::borrow::Cow::Borrowed(glyph.canvas.pixels.as_slice());
+                4 * region.pixel_region.width() as u32
+            }
+        };
+
         queue.write_texture(
             wgpu::TexelCopyTextureInfo {
                 texture: &self.texture,
@@ -86,7 +143,7 @@ impl TextureWithBindGroup {
                 },
                 aspect: wgpu::TextureAspect::All,
             },
-            glyph.canvas.pixels.as_slice(),
+            upload_bytes.as_ref(),
             TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some(bytes_per_row),

--- a/crates/warpui/src/rendering/wgpu/texture_with_bind_group.rs
+++ b/crates/warpui/src/rendering/wgpu/texture_with_bind_group.rs
@@ -79,19 +79,20 @@ impl TextureWithBindGroup {
         queue: &Queue,
     ) {
         // Convert the rasterizer's RGBA32 canvas into the destination
-        // texture's layout. Three cases:
+        // texture's layout. Two cases:
         //
         //   R8Unorm (Generic): extract the alpha byte. The rasterizer
         //   replicates the A8 mask into RGBA32, so the first byte of each
         //   four-byte group is the original coverage.
         //
-        //   Bgra8Unorm + emoji (Polychrome): swash returns RGBA but the
-        //   texture stores BGRA, so swap R and B per pixel.
-        //
-        //   Bgra8Unorm + subpixel non-emoji: swash's subpixel byte order
-        //   already matches the Bgra8Unorm upload + .rgb sample combo. A
-        //   swap here would re-break the ordering. Kept as a separate arm
-        //   so the format alone cannot silently apply the emoji swap.
+        //   Bgra8Unorm (Polychrome emoji and Subpixel non-emoji): swash's
+        //   Color and SubpixelMask outputs are both RGBA-ordered in memory.
+        //   The Subpixel case looks BGRA from its Format::subpixel_bgra
+        //   name but zeno actually writes byte 0 = R-coverage and byte 2 =
+        //   B-coverage (zeno mask.rs render() with sample offsets
+        //   [+0.3, 0, -0.3]). Swap R and B per pixel so the texture's bytes
+        //   match its declared BGRA layout, mirroring zed's gpui_wgpu
+        //   cosmic_text_system.rs which calls out the same swash quirk.
         let pixel_count = (region.pixel_region.width() * region.pixel_region.height()) as usize;
         let upload_bytes: std::borrow::Cow<'_, [u8]>;
         let bytes_per_row = match self.format {
@@ -103,16 +104,12 @@ impl TextureWithBindGroup {
                 upload_bytes = std::borrow::Cow::Owned(compact);
                 region.pixel_region.width() as u32
             }
-            TextureFormat::Bgra8Unorm if glyph.is_emoji => {
+            TextureFormat::Bgra8Unorm => {
                 let mut swapped = glyph.canvas.pixels.clone();
                 for pixel in swapped.chunks_exact_mut(4) {
                     pixel.swap(0, 2);
                 }
                 upload_bytes = std::borrow::Cow::Owned(swapped);
-                4 * region.pixel_region.width() as u32
-            }
-            TextureFormat::Bgra8Unorm => {
-                upload_bytes = std::borrow::Cow::Borrowed(glyph.canvas.pixels.as_slice());
                 4 * region.pixel_region.width() as u32
             }
             other => {

--- a/crates/warpui/src/rendering/wgpu/texture_with_bind_group.rs
+++ b/crates/warpui/src/rendering/wgpu/texture_with_bind_group.rs
@@ -114,9 +114,8 @@ impl TextureWithBindGroup {
             }
             other => {
                 debug_assert!(
-                    false,
-                    "unexpected glyph atlas format {:?}; upload assumes R8Unorm or Bgra8Unorm",
-                    other,
+                    matches!(self.format, TextureFormat::R8Unorm | TextureFormat::Bgra8Unorm),
+                    "unexpected glyph atlas format {other:?}; upload assumes R8Unorm or Bgra8Unorm",
                 );
                 upload_bytes = std::borrow::Cow::Borrowed(glyph.canvas.pixels.as_slice());
                 4 * region.pixel_region.width() as u32

--- a/crates/warpui/src/rendering/wgpu/texture_with_bind_group.rs
+++ b/crates/warpui/src/rendering/wgpu/texture_with_bind_group.rs
@@ -16,8 +16,17 @@ pub(super) struct TextureWithBindGroup {
 }
 
 impl TextureWithBindGroup {
+    /// Creates a new atlas texture of the given pixel `format`.
+    ///
+    /// The format determines how downstream pipelines interpret samples:
+    /// `Rgba8Unorm` is used for the generic glyph atlas (grayscale coverage
+    /// replicated into RGBA, plus color emoji), and `Bgra8Unorm` is used for
+    /// the subpixel atlas where each channel encodes coverage of a single
+    /// LCD subpixel. Both formats are 4 bytes per texel, so the upload path
+    /// in [`Self::insert_glyph_into_texture`] is shared.
     pub(super) fn new(
         size: usize,
+        format: TextureFormat,
         device: &wgpu::Device,
         bind_group_layout: &BindGroupLayout,
         sampler: &Sampler,
@@ -32,7 +41,7 @@ impl TextureWithBindGroup {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: TextureFormat::Rgba8Unorm,
+            format,
             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
             view_formats: &[],
         });

--- a/crates/warpui/src/rendering/wgpu/texture_with_bind_group.rs
+++ b/crates/warpui/src/rendering/wgpu/texture_with_bind_group.rs
@@ -9,8 +9,8 @@ use wgpu::{
 /// Helper struct that includes a [`Texture`] and its corresponding [`BindGroup`] for use in the
 /// `GlyphCache`.
 ///
-/// The format is recorded so [`Self::insert_glyph_into_texture`] can convert
-/// the rasterizer's RGBA32 output into the layout this texture expects.
+/// The format is recorded so [`Self::insert_glyph_into_texture`] can
+/// convert the rasterizer's RGBA32 output into the texture's layout.
 pub(super) struct TextureWithBindGroup {
     texture: Texture,
     /// The [`BindGroup`] associated with the `texture`. We compute this whenever we need to create
@@ -22,10 +22,10 @@ pub(super) struct TextureWithBindGroup {
 impl TextureWithBindGroup {
     /// Creates a new atlas texture of the given pixel `format`.
     ///
-    /// Three formats are used in practice: `R8Unorm` for the monochrome
-    /// coverage atlas (one byte per texel), and `Bgra8Unorm` for both the
-    /// subpixel coverage atlas and the polychrome (emoji) atlas (four
-    /// bytes per texel). The format dictates the upload-path conversion in
+    /// Two formats are used: `R8Unorm` for the monochrome coverage atlas
+    /// (one byte per texel) and `Bgra8Unorm` for both the subpixel coverage
+    /// atlas and the polychrome (emoji) atlas (four bytes per texel). The
+    /// format drives the upload-path conversion in
     /// [`Self::insert_glyph_into_texture`] below.
     pub(super) fn new(
         size: usize,
@@ -78,26 +78,20 @@ impl TextureWithBindGroup {
         glyph: &RasterizedGlyph,
         queue: &Queue,
     ) {
-        // Convert the rasterizer's four-byte-per-pixel canvas into whatever
-        // layout the destination texture expects. There are three cases:
+        // Convert the rasterizer's RGBA32 canvas into the destination
+        // texture's layout. Three cases:
         //
-        //   R8Unorm (Generic, non-emoji grayscale): extract the alpha byte.
-        //   The rasterizer replicates the A8 mask into RGBA32, so picking
-        //   the first byte of each four-byte group recovers the original
-        //   coverage exactly.
+        //   R8Unorm (Generic): extract the alpha byte. The rasterizer
+        //   replicates the A8 mask into RGBA32, so the first byte of each
+        //   four-byte group is the original coverage.
         //
-        //   Bgra8Unorm + emoji glyph (Polychrome): swash returns RGBA in
-        //   memory order but the texture reads its bytes as BGRA, so we
-        //   swap R and B per pixel on the CPU side. After this swap the
-        //   fragment shader's straight .rgb sample yields logical RGB.
+        //   Bgra8Unorm + emoji (Polychrome): swash returns RGBA but the
+        //   texture stores BGRA, so swap R and B per pixel.
         //
-        //   Bgra8Unorm + non-emoji subpixel coverage (Subpixel): swash has
-        //   a documented quirk where its subpixel format produces what the
-        //   subpixel fragment shader treats as already-correctly-ordered
-        //   bytes for our Bgra8Unorm upload combined with its existing
-        //   .rgb sample. No CPU swap is needed; doing one would re-break
-        //   the subpixel ordering. Keep this branch separate so the same
-        //   format does not silently apply the emoji-only swap.
+        //   Bgra8Unorm + subpixel non-emoji: swash's subpixel byte order
+        //   already matches the Bgra8Unorm upload + .rgb sample combo. A
+        //   swap here would re-break the ordering. Kept as a separate arm
+        //   so the format alone cannot silently apply the emoji swap.
         let pixel_count = (region.pixel_region.width() * region.pixel_region.height()) as usize;
         let upload_bytes: std::borrow::Cow<'_, [u8]>;
         let bytes_per_row = match self.format {

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -880,7 +880,15 @@ impl platform::FontDB for FontDB {
         lcd_subpixel: bool,
         glyph_config: &GlyphConfig,
     ) -> Result<RectI> {
-        Self::glyph_raster_bounds(self, font_id, size, glyph_id, scale, lcd_subpixel, glyph_config)
+        Self::glyph_raster_bounds(
+            self,
+            font_id,
+            size,
+            glyph_id,
+            scale,
+            lcd_subpixel,
+            glyph_config,
+        )
     }
 
     #[cfg(feature = "fontkit-rasterizer")]

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -855,6 +855,7 @@ impl platform::FontDB for FontDB {
         size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        lcd_subpixel: bool,
         glyph_config: &GlyphConfig,
     ) -> Result<RectI> {
         let fonts = self
@@ -863,6 +864,8 @@ impl platform::FontDB for FontDB {
         for font in fonts {
             self.load_font_kit_font(font)?
         }
+        // font-kit has no LCD subpixel rasterizer; the flag is a no-op here.
+        let _ = lcd_subpixel;
         self.font_kit_rasterizer
             .glyph_raster_bounds(font_id, size, glyph_id, scale, glyph_config)
     }
@@ -874,9 +877,10 @@ impl platform::FontDB for FontDB {
         size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        lcd_subpixel: bool,
         glyph_config: &GlyphConfig,
     ) -> Result<RectI> {
-        Self::glyph_raster_bounds(self, font_id, size, glyph_id, scale, glyph_config)
+        Self::glyph_raster_bounds(self, font_id, size, glyph_id, scale, lcd_subpixel, glyph_config)
     }
 
     #[cfg(feature = "fontkit-rasterizer")]
@@ -887,6 +891,7 @@ impl platform::FontDB for FontDB {
         glyph_id: GlyphId,
         scale: Vector2F,
         subpixel_alignment: SubpixelAlignment,
+        lcd_subpixel: bool,
         glyph_config: &GlyphConfig,
         format: RasterFormat,
     ) -> Result<RasterizedGlyph> {
@@ -896,6 +901,8 @@ impl platform::FontDB for FontDB {
         for font in fonts {
             self.load_font_kit_font(font)?
         }
+        // font-kit has no LCD subpixel rasterizer; the flag is a no-op here.
+        let _ = lcd_subpixel;
         self.font_kit_rasterizer.rasterize_glyph(
             font_id,
             size,
@@ -915,6 +922,7 @@ impl platform::FontDB for FontDB {
         glyph_id: GlyphId,
         scale: Vector2F,
         subpixel_alignment: SubpixelAlignment,
+        lcd_subpixel: bool,
         glyph_config: &GlyphConfig,
         format: RasterFormat,
     ) -> Result<RasterizedGlyph> {
@@ -925,6 +933,7 @@ impl platform::FontDB for FontDB {
             glyph_id,
             scale,
             subpixel_alignment,
+            lcd_subpixel,
             glyph_config,
             format,
         )

--- a/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
+++ b/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
@@ -10,6 +10,14 @@ use cosmic_text::{CacheKey, CacheKeyFlags};
 use pathfinder_geometry::rect::RectI;
 use pathfinder_geometry::vector::{vec2i, Vector2F, Vector2I};
 
+fn cache_key_flags(lcd_subpixel: bool) -> CacheKeyFlags {
+    if lcd_subpixel {
+        CacheKeyFlags::SUBPIXEL_BGRA
+    } else {
+        CacheKeyFlags::empty()
+    }
+}
+
 impl FontDB {
     pub(super) fn glyph_raster_bounds(
         &self,
@@ -17,6 +25,7 @@ impl FontDB {
         size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        lcd_subpixel: bool,
         _glyph_config: &GlyphConfig,
     ) -> Result<RectI> {
         let Ok(_typographic_bounds) = self
@@ -46,7 +55,7 @@ impl FontDB {
                     glyph_id as u16,
                     size * scale.x(),
                     (0., 0.),
-                    CacheKeyFlags::empty(),
+                    cache_key_flags(lcd_subpixel),
                 )
                 .0,
             )
@@ -66,11 +75,12 @@ impl FontDB {
         glyph_id: GlyphId,
         scale: Vector2F,
         subpixel_alignment: SubpixelAlignment,
+        lcd_subpixel: bool,
         glyph_config: &GlyphConfig,
         requested_format: RasterFormat,
     ) -> Result<RasterizedGlyph> {
         let raster_bounds =
-            self.glyph_raster_bounds(font_id, size, glyph_id, scale, glyph_config)?;
+            self.glyph_raster_bounds(font_id, size, glyph_id, scale, lcd_subpixel, glyph_config)?;
 
         let id = *self
             .text_layout_system
@@ -89,7 +99,7 @@ impl FontDB {
                     glyph_id as u16,
                     size * scale.x(),
                     (subpixel_alignment.to_offset().x(), 0.),
-                    CacheKeyFlags::empty(),
+                    cache_key_flags(lcd_subpixel),
                 )
                 .0,
             )

--- a/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
+++ b/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
@@ -12,10 +12,13 @@ use pathfinder_geometry::vector::{vec2i, Vector2F, Vector2I};
 
 fn cache_key_flags(lcd_subpixel: bool) -> CacheKeyFlags {
     if lcd_subpixel {
-        // Pair SUBPIXEL_BGRA with OUTLINE_ONLY so swash skips the COLR /
-        // CBDT colour sources and produces just the scalable outline that
-        // the subpixel format needs. Emoji never request this path.
-        CacheKeyFlags::SUBPIXEL_BGRA | CacheKeyFlags::OUTLINE_ONLY
+        // Request subpixel coverage but keep swash's full source list
+        // [ColorOutline, ColorBitmap, Outline]. Scene::draw_glyph sets
+        // lcd_subpixel from device + surface state without knowing whether
+        // the glyph is emoji, so adding OUTLINE_ONLY here would strip the
+        // colour sources from emoji glyphs and stop them routing to the
+        // Polychrome atlas.
+        CacheKeyFlags::SUBPIXEL_BGRA
     } else {
         CacheKeyFlags::empty()
     }

--- a/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
+++ b/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
@@ -12,7 +12,14 @@ use pathfinder_geometry::vector::{vec2i, Vector2F, Vector2I};
 
 fn cache_key_flags(lcd_subpixel: bool) -> CacheKeyFlags {
     if lcd_subpixel {
-        CacheKeyFlags::SUBPIXEL_BGRA
+        // Subpixel rasterization is only ever requested for non-emoji
+        // glyphs; emoji always go through the grayscale path on Generic
+        // atlas with the existing color-source fallback. Pair SUBPIXEL_BGRA
+        // with OUTLINE_ONLY so swash skips the COLR / CBDT lookups for
+        // these glyphs and produces only the scalable outline result that
+        // the subpixel format expects, matching gpui's monochrome
+        // rasterization path.
+        CacheKeyFlags::SUBPIXEL_BGRA | CacheKeyFlags::OUTLINE_ONLY
     } else {
         CacheKeyFlags::empty()
     }

--- a/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
+++ b/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
@@ -12,13 +12,9 @@ use pathfinder_geometry::vector::{vec2i, Vector2F, Vector2I};
 
 fn cache_key_flags(lcd_subpixel: bool) -> CacheKeyFlags {
     if lcd_subpixel {
-        // Subpixel rasterization is only ever requested for non-emoji
-        // glyphs; emoji always go through the grayscale path on Generic
-        // atlas with the existing color-source fallback. Pair SUBPIXEL_BGRA
-        // with OUTLINE_ONLY so swash skips the COLR / CBDT lookups for
-        // these glyphs and produces only the scalable outline result that
-        // the subpixel format expects, matching gpui's monochrome
-        // rasterization path.
+        // Pair SUBPIXEL_BGRA with OUTLINE_ONLY so swash skips the COLR /
+        // CBDT colour sources and produces just the scalable outline that
+        // the subpixel format needs. Emoji never request this path.
         CacheKeyFlags::SUBPIXEL_BGRA | CacheKeyFlags::OUTLINE_ONLY
     } else {
         CacheKeyFlags::empty()

--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -799,17 +799,18 @@ impl Window {
         renderer.render(
             scene.as_ref(),
             resources,
-            &|glyph_key, scale, subpixel_alignment, glyph_config, format| {
+            &|glyph_key, scale, subpixel_alignment, lcd_subpixel, glyph_config, format| {
                 font_cache.rasterized_glyph(
                     glyph_key,
                     scale,
                     subpixel_alignment,
+                    lcd_subpixel,
                     glyph_config,
                     format,
                 )
             },
-            &|glyph_key, scale, alignment| {
-                font_cache.glyph_raster_bounds(glyph_key, scale, alignment)
+            &|glyph_key, scale, lcd_subpixel, glyph_config| {
+                font_cache.glyph_raster_bounds(glyph_key, scale, lcd_subpixel, glyph_config)
             },
             inner.surface_size,
             Some(Box::new(|| {

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -617,13 +617,6 @@ pub struct AppContext {
     /// borrowing the AppContext, since the callback is invoked synchronously
     /// from inside the GPU resource creation path.
     gpu_supports_lcd_subpixel: Arc<AtomicBool>,
-    /// Latched bit reporting whether the most recent window's surface
-    /// composites with a non-opaque alpha. Stored alongside
-    /// `gpu_supports_lcd_subpixel` and populated from the same callback
-    /// so `rendering_config()` can gate the LCD subpixel path on opaque
-    /// surfaces; per-channel coverage on a translucent surface corrupts
-    /// the compositor's alpha.
-    gpu_surface_is_transparent: Arc<AtomicBool>,
     global_actions: HashMap<String, Vec<Box<GlobalActionCallback>>>,
     keystroke_matcher: Matcher,
     next_task_id: usize,
@@ -786,7 +779,6 @@ impl AppContext {
             presenters: Default::default(),
             rendering_config: Default::default(),
             gpu_supports_lcd_subpixel: Arc::new(AtomicBool::new(false)),
-            gpu_surface_is_transparent: Arc::new(AtomicBool::new(false)),
             keystroke_matcher: Default::default(),
             disabled_key_bindings_windows: Default::default(),
             next_task_id: 0,
@@ -943,7 +935,6 @@ impl AppContext {
         // Stored separately because the on_gpu_device_info_reported
         // callback that sets them runs without a mutable AppContext borrow.
         config.lcd_subpixel_supported = self.gpu_supports_lcd_subpixel.load(Ordering::Acquire);
-        config.surface_is_transparent = self.gpu_surface_is_transparent.load(Ordering::Acquire);
         config
     }
 
@@ -2335,18 +2326,15 @@ impl AppContext {
             .insert(window_id, Rc::new(RefCell::new(Presenter::new(window_id))));
 
         // Wrap the user-supplied GPU-info callback so we can latch the
-        // dual-source-blending capability and surface-transparency flag
-        // into AppContext before forwarding to the user. The callback is
-        // called synchronously from inside Resources::new, so the latches
-        // are observable on the next call to rendering_config(). Using
-        // Arc<AtomicBool>s keeps the wrapper Send + Sync and avoids needing
-        // a mutable AppContext borrow.
+        // dual-source-blending capability into AppContext before forwarding
+        // to the user. The callback is called synchronously from inside
+        // Resources::new, so the latch is observable on the next call to
+        // rendering_config(). Using an Arc<AtomicBool> keeps the wrapper
+        // Send + Sync and avoids needing a mutable AppContext borrow.
         let user_callback = on_gpu_driver_reported.unwrap_or_else(|| Box::new(|_| {}));
         let lcd_supported = Arc::clone(&self.gpu_supports_lcd_subpixel);
-        let surface_transparent = Arc::clone(&self.gpu_surface_is_transparent);
         let on_gpu_info: Box<rendering::OnGPUDeviceSelected> = Box::new(move |info| {
             lcd_supported.store(info.supports_dual_source_blending, Ordering::Release);
-            surface_transparent.store(info.surface_is_transparent, Ordering::Release);
             user_callback(info);
         });
 

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -934,9 +934,7 @@ impl AppContext {
         // Merge in GPU capability flags learned at window-renderer init.
         // Stored separately because the on_gpu_device_info_reported
         // callback that sets them runs without a mutable AppContext borrow.
-        config.lcd_subpixel_supported = self
-            .gpu_supports_lcd_subpixel
-            .load(Ordering::Acquire);
+        config.lcd_subpixel_supported = self.gpu_supports_lcd_subpixel.load(Ordering::Acquire);
         config
     }
 

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -38,7 +38,7 @@ use std::{
     pin::pin,
     rc::{self, Rc},
     sync::{
-        atomic::{AtomicI64, Ordering},
+        atomic::{AtomicBool, AtomicI64, Ordering},
         Arc, OnceLock,
     },
 };
@@ -611,6 +611,12 @@ pub struct AppContext {
     presenters: HashMap<WindowId, Rc<RefCell<Presenter>>>,
     /// Configuration options related to rendering of the application.
     rendering_config: rendering::Config,
+    /// Latched bit reporting whether any window's renderer has reported
+    /// dual-source blending support. Stored in an Arc<AtomicBool> so the
+    /// `on_gpu_device_info_reported` callback can write to it without
+    /// borrowing the AppContext, since the callback is invoked synchronously
+    /// from inside the GPU resource creation path.
+    gpu_supports_lcd_subpixel: Arc<AtomicBool>,
     global_actions: HashMap<String, Vec<Box<GlobalActionCallback>>>,
     keystroke_matcher: Matcher,
     next_task_id: usize,
@@ -772,6 +778,7 @@ impl AppContext {
             global_actions: Default::default(),
             presenters: Default::default(),
             rendering_config: Default::default(),
+            gpu_supports_lcd_subpixel: Arc::new(AtomicBool::new(false)),
             keystroke_matcher: Default::default(),
             disabled_key_bindings_windows: Default::default(),
             next_task_id: 0,
@@ -923,7 +930,14 @@ impl AppContext {
     }
 
     pub fn rendering_config(&self) -> rendering::Config {
-        self.rendering_config
+        let mut config = self.rendering_config;
+        // Merge in GPU capability flags learned at window-renderer init.
+        // Stored separately because the on_gpu_device_info_reported
+        // callback that sets them runs without a mutable AppContext borrow.
+        config.lcd_subpixel_supported = self
+            .gpu_supports_lcd_subpixel
+            .load(Ordering::Acquire);
+        config
     }
 
     pub fn update_rendering_config<U>(&mut self, update_fn: U)
@@ -2313,6 +2327,19 @@ impl AppContext {
         self.presenters
             .insert(window_id, Rc::new(RefCell::new(Presenter::new(window_id))));
 
+        // Wrap the user-supplied GPU-info callback so we can latch the
+        // dual-source-blending capability into AppContext before forwarding
+        // to the user. The callback is called synchronously from inside
+        // Resources::new, so the latch is observable on the next call to
+        // rendering_config(). Using an Arc<AtomicBool> keeps the wrapper
+        // Send + Sync and avoids needing a mutable AppContext borrow.
+        let user_callback = on_gpu_driver_reported.unwrap_or_else(|| Box::new(|_| {}));
+        let lcd_supported = Arc::clone(&self.gpu_supports_lcd_subpixel);
+        let on_gpu_info: Box<rendering::OnGPUDeviceSelected> = Box::new(move |info| {
+            lcd_supported.store(info.supports_dual_source_blending, Ordering::Release);
+            user_callback(info);
+        });
+
         let window_options = WindowOptions {
             bounds: window_bounds,
             fullscreen_state,
@@ -2323,7 +2350,7 @@ impl AppContext {
             background_blur_texture,
             gpu_power_preference: self.rendering_config.gpu_power_preference,
             backend_preference: self.rendering_config.backend_preference,
-            on_gpu_device_info_reported: on_gpu_driver_reported.unwrap_or(Box::new(|_| {})),
+            on_gpu_device_info_reported: on_gpu_info,
             window_instance,
         };
 

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -617,6 +617,13 @@ pub struct AppContext {
     /// borrowing the AppContext, since the callback is invoked synchronously
     /// from inside the GPU resource creation path.
     gpu_supports_lcd_subpixel: Arc<AtomicBool>,
+    /// Latched bit reporting whether the user has configured a translucent
+    /// window background (the `appearance.window.override_opacity` setting
+    /// is below 100%). Updated from the app layer's `WindowSettings`
+    /// observer; consumed in `rendering_config()` to gate the LCD subpixel
+    /// path. Atomic so the observer can write without a mutable
+    /// AppContext borrow.
+    transparent_background_active: Arc<AtomicBool>,
     global_actions: HashMap<String, Vec<Box<GlobalActionCallback>>>,
     keystroke_matcher: Matcher,
     next_task_id: usize,
@@ -779,6 +786,7 @@ impl AppContext {
             presenters: Default::default(),
             rendering_config: Default::default(),
             gpu_supports_lcd_subpixel: Arc::new(AtomicBool::new(false)),
+            transparent_background_active: Arc::new(AtomicBool::new(false)),
             keystroke_matcher: Default::default(),
             disabled_key_bindings_windows: Default::default(),
             next_task_id: 0,
@@ -935,7 +943,18 @@ impl AppContext {
         // Stored separately because the on_gpu_device_info_reported
         // callback that sets them runs without a mutable AppContext borrow.
         config.lcd_subpixel_supported = self.gpu_supports_lcd_subpixel.load(Ordering::Acquire);
+        config.transparent_background = self.transparent_background_active.load(Ordering::Acquire);
         config
+    }
+
+    /// Update the latched window-translucency bit consumed by
+    /// `rendering_config()`. Called by the app layer when
+    /// `WindowSettings::background_opacity` changes (and once at startup
+    /// to seed the initial value). `&self` because the underlying field
+    /// is an `Arc<AtomicBool>`; no exclusive borrow needed.
+    pub fn set_transparent_background(&self, transparent: bool) {
+        self.transparent_background_active
+            .store(transparent, Ordering::Release);
     }
 
     pub fn update_rendering_config<U>(&mut self, update_fn: U)

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -611,12 +611,15 @@ pub struct AppContext {
     presenters: HashMap<WindowId, Rc<RefCell<Presenter>>>,
     /// Configuration options related to rendering of the application.
     rendering_config: rendering::Config,
-    /// Latched bit reporting whether any window's renderer has reported
-    /// dual-source blending support. Stored in an Arc<AtomicBool> so the
-    /// `on_gpu_device_info_reported` callback can write to it without
-    /// borrowing the AppContext, since the callback is invoked synchronously
-    /// from inside the GPU resource creation path.
-    gpu_supports_lcd_subpixel: Arc<AtomicBool>,
+    /// Latched bits reporting whether each window's renderer has reported
+    /// dual-source blending support. Keyed by `WindowId` because adapter
+    /// capabilities are per-window: a process with a discrete-GPU window
+    /// and a CPU-fallback window must not have one's report overwrite the
+    /// other's. Each entry is an `Arc<AtomicBool>` so the
+    /// `on_gpu_device_info_reported` callback can write to its window's
+    /// bit without borrowing the AppContext, since the callback runs
+    /// synchronously from inside the GPU resource creation path.
+    gpu_supports_lcd_subpixel_per_window: HashMap<WindowId, Arc<AtomicBool>>,
     /// Latched bit reporting whether the user has configured a translucent
     /// window background (the `appearance.window.override_opacity` setting
     /// is below 100%). Updated from the app layer's `WindowSettings`
@@ -785,7 +788,7 @@ impl AppContext {
             global_actions: Default::default(),
             presenters: Default::default(),
             rendering_config: Default::default(),
-            gpu_supports_lcd_subpixel: Arc::new(AtomicBool::new(false)),
+            gpu_supports_lcd_subpixel_per_window: HashMap::default(),
             transparent_background_active: Arc::new(AtomicBool::new(false)),
             keystroke_matcher: Default::default(),
             disabled_key_bindings_windows: Default::default(),
@@ -939,12 +942,27 @@ impl AppContext {
 
     pub fn rendering_config(&self) -> rendering::Config {
         let mut config = self.rendering_config;
-        // Merge in GPU capability flags learned at window-renderer init.
-        // Stored separately because the on_gpu_device_info_reported
-        // callback that sets them runs without a mutable AppContext borrow.
-        config.lcd_subpixel_supported = self.gpu_supports_lcd_subpixel.load(Ordering::Acquire);
+        // `lcd_subpixel_supported` is intentionally not populated here:
+        // adapter capabilities are per-window, not process-wide. Callers
+        // that build a Scene for a specific window should override the
+        // field with `gpu_supports_lcd_subpixel(window_id)`. Callers that
+        // only need glyph or backend defaults (settings UI, tests) get
+        // the conservative `false` from `Config::default()` and the bit
+        // is unused on those paths.
         config.transparent_background = self.transparent_background_active.load(Ordering::Acquire);
         config
+    }
+
+    /// Read the latched dual-source-blending support for a specific
+    /// window's renderer. Used by the Scene-build call sites to populate
+    /// `Config.lcd_subpixel_supported` against the actual capabilities
+    /// of the window the scene will be drawn into, not whichever window
+    /// reported its capabilities last process-wide.
+    pub fn gpu_supports_lcd_subpixel(&self, window_id: WindowId) -> bool {
+        self.gpu_supports_lcd_subpixel_per_window
+            .get(&window_id)
+            .map(|atomic| atomic.load(Ordering::Acquire))
+            .unwrap_or(false)
     }
 
     /// Update the latched window-translucency bit consumed by
@@ -2345,13 +2363,17 @@ impl AppContext {
             .insert(window_id, Rc::new(RefCell::new(Presenter::new(window_id))));
 
         // Wrap the user-supplied GPU-info callback so we can latch the
-        // dual-source-blending capability into AppContext before forwarding
-        // to the user. The callback is called synchronously from inside
-        // Resources::new, so the latch is observable on the next call to
-        // rendering_config(). Using an Arc<AtomicBool> keeps the wrapper
-        // Send + Sync and avoids needing a mutable AppContext borrow.
+        // dual-source-blending capability for *this* window into
+        // AppContext before forwarding to the user. The callback is
+        // called synchronously from inside Resources::new, so the latch
+        // is observable on the next call to gpu_supports_lcd_subpixel.
+        // The atomic is keyed per-window so multi-adapter setups (a
+        // discrete-GPU window plus a fallback-adapter window, etc.) do
+        // not race each other through a single global bit.
         let user_callback = on_gpu_driver_reported.unwrap_or_else(|| Box::new(|_| {}));
-        let lcd_supported = Arc::clone(&self.gpu_supports_lcd_subpixel);
+        let lcd_supported = Arc::new(AtomicBool::new(false));
+        self.gpu_supports_lcd_subpixel_per_window
+            .insert(window_id, Arc::clone(&lcd_supported));
         let on_gpu_info: Box<rendering::OnGPUDeviceSelected> = Box::new(move |info| {
             lcd_supported.store(info.supports_dual_source_blending, Ordering::Release);
             user_callback(info);
@@ -2600,6 +2622,7 @@ impl AppContext {
         self.presenters.remove(&window_id);
         self.invalidation_callbacks.remove(&window_id);
         self.window_invalidations.remove(&window_id);
+        self.gpu_supports_lcd_subpixel_per_window.remove(&window_id);
         autotracking::close_window(window_id);
 
         let mut subscriptions = HashMap::new();
@@ -2745,10 +2768,9 @@ impl AppContext {
 
     /// Builds a new scene for the given window.
     fn build_scene(&mut self, window_id: WindowId, window: &dyn WindowContext) -> Rc<Scene> {
-        let mut scene = Rc::new(Scene::new(
-            window.backing_scale_factor(),
-            self.rendering_config(),
-        ));
+        let mut config = self.rendering_config();
+        config.lcd_subpixel_supported = self.gpu_supports_lcd_subpixel(window_id);
+        let mut scene = Rc::new(Scene::new(window.backing_scale_factor(), config));
         let Some(presenter) = self.presenter(window_id) else {
             return scene;
         };

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -617,6 +617,13 @@ pub struct AppContext {
     /// borrowing the AppContext, since the callback is invoked synchronously
     /// from inside the GPU resource creation path.
     gpu_supports_lcd_subpixel: Arc<AtomicBool>,
+    /// Latched bit reporting whether the most recent window's surface
+    /// composites with a non-opaque alpha. Stored alongside
+    /// `gpu_supports_lcd_subpixel` and populated from the same callback
+    /// so `rendering_config()` can gate the LCD subpixel path on opaque
+    /// surfaces; per-channel coverage on a translucent surface corrupts
+    /// the compositor's alpha.
+    gpu_surface_is_transparent: Arc<AtomicBool>,
     global_actions: HashMap<String, Vec<Box<GlobalActionCallback>>>,
     keystroke_matcher: Matcher,
     next_task_id: usize,
@@ -779,6 +786,7 @@ impl AppContext {
             presenters: Default::default(),
             rendering_config: Default::default(),
             gpu_supports_lcd_subpixel: Arc::new(AtomicBool::new(false)),
+            gpu_surface_is_transparent: Arc::new(AtomicBool::new(false)),
             keystroke_matcher: Default::default(),
             disabled_key_bindings_windows: Default::default(),
             next_task_id: 0,
@@ -935,6 +943,7 @@ impl AppContext {
         // Stored separately because the on_gpu_device_info_reported
         // callback that sets them runs without a mutable AppContext borrow.
         config.lcd_subpixel_supported = self.gpu_supports_lcd_subpixel.load(Ordering::Acquire);
+        config.surface_is_transparent = self.gpu_surface_is_transparent.load(Ordering::Acquire);
         config
     }
 
@@ -2326,15 +2335,18 @@ impl AppContext {
             .insert(window_id, Rc::new(RefCell::new(Presenter::new(window_id))));
 
         // Wrap the user-supplied GPU-info callback so we can latch the
-        // dual-source-blending capability into AppContext before forwarding
-        // to the user. The callback is called synchronously from inside
-        // Resources::new, so the latch is observable on the next call to
-        // rendering_config(). Using an Arc<AtomicBool> keeps the wrapper
-        // Send + Sync and avoids needing a mutable AppContext borrow.
+        // dual-source-blending capability and surface-transparency flag
+        // into AppContext before forwarding to the user. The callback is
+        // called synchronously from inside Resources::new, so the latches
+        // are observable on the next call to rendering_config(). Using
+        // Arc<AtomicBool>s keeps the wrapper Send + Sync and avoids needing
+        // a mutable AppContext borrow.
         let user_callback = on_gpu_driver_reported.unwrap_or_else(|| Box::new(|_| {}));
         let lcd_supported = Arc::clone(&self.gpu_supports_lcd_subpixel);
+        let surface_transparent = Arc::clone(&self.gpu_surface_is_transparent);
         let on_gpu_info: Box<rendering::OnGPUDeviceSelected> = Box::new(move |info| {
             lcd_supported.store(info.supports_dual_source_blending, Ordering::Release);
+            surface_transparent.store(info.surface_is_transparent, Ordering::Release);
             user_callback(info);
         });
 

--- a/crates/warpui_core/src/fonts.rs
+++ b/crates/warpui_core/src/fonts.rs
@@ -207,7 +207,7 @@ pub struct FontInfo {
     pub is_monospace: bool,
 }
 
-type RasterBoundsKey = (GlyphKey, (OrderedFloat<f32>, OrderedFloat<f32>));
+type RasterBoundsKey = (GlyphKey, (OrderedFloat<f32>, OrderedFloat<f32>), bool);
 
 pub struct Cache {
     selections: DashMap<(FamilyId, Properties), FontId>,
@@ -403,11 +403,14 @@ impl Cache {
         &self,
         glyph_key: GlyphKey,
         scale: Vector2F,
+        lcd_subpixel: bool,
         glyph_config: &rendering::GlyphConfig,
     ) -> Result<RectI> {
-        let entry = self
-            .raster_bounds
-            .entry((glyph_key, (scale.x().into(), scale.y().into())));
+        let entry = self.raster_bounds.entry((
+            glyph_key,
+            (scale.x().into(), scale.y().into()),
+            lcd_subpixel,
+        ));
         let bounds = match entry {
             Entry::Occupied(entry) => entry.into_ref(),
             Entry::Vacant(entry) => entry.insert(self.platform.glyph_raster_bounds(
@@ -415,6 +418,7 @@ impl Cache {
                 glyph_key.font_size.into(),
                 glyph_key.glyph_id,
                 scale,
+                lcd_subpixel,
                 glyph_config,
             )),
         };
@@ -424,11 +428,13 @@ impl Cache {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn rasterized_glyph(
         &self,
         glyph_key: GlyphKey,
         scale: Vector2F,
         subpixel_alignment: SubpixelAlignment,
+        lcd_subpixel: bool,
         glyph_config: &rendering::GlyphConfig,
         format: canvas::RasterFormat,
     ) -> Result<RasterizedGlyph> {
@@ -438,6 +444,7 @@ impl Cache {
             glyph_key.glyph_id,
             scale,
             subpixel_alignment,
+            lcd_subpixel,
             glyph_config,
             format,
         )

--- a/crates/warpui_core/src/fonts.rs
+++ b/crates/warpui_core/src/fonts.rs
@@ -172,7 +172,16 @@ pub struct SubpixelAlignment(u8);
 
 impl SubpixelAlignment {
     /// The number of subdivisions to slice a pixel into.
-    const STEPS: u8 = 3;
+    ///
+    /// Four buckets give a maximum quantisation error of 0.125 px when the
+    /// quad origin is later floored, matching gpui's SUBPIXEL_VARIANTS_X.
+    /// The value used to be three; the renderer formerly compensated by
+    /// passing the bucket offset back to the quad position, but that left
+    /// quads at fractional pixels and forced Nearest sampling. With the
+    /// quad now floored at scene-build time, the quantisation step is the
+    /// only remaining horizontal positioning error and a finer grid pays
+    /// for itself in fewer atlas cache misses near bucket boundaries.
+    const STEPS: u8 = 4;
 
     /// Quantizes the horizontal component of the provided position to the
     /// nearest subpixel position, where `Self::STEPS` is the number of possible

--- a/crates/warpui_core/src/fonts_test.rs
+++ b/crates/warpui_core/src/fonts_test.rs
@@ -2,39 +2,48 @@ use super::*;
 
 #[test]
 fn test_subpixel_alignment_computation() {
+    // STEPS = 4. Bucket offsets are 0.0, 0.25, 0.5, 0.75. The bucket index
+    // is round(fract * 4) % 4.
+
     {
-        // Default case - a non-fractional offset should have an alignment
-        // value of zero.
+        // Default case: a non-fractional offset has alignment zero.
         let pos = vec2f(0., 0.);
         let alignment = SubpixelAlignment::new(pos);
         assert_eq!(alignment.0, 0);
     }
     {
-        // 0.1 rounds down to 0 (not up to 0.33 -> 1)
+        // 0.1 * 4 = 0.4, rounds to 0.
         let pos = vec2f(0.1, 0.);
         let alignment = SubpixelAlignment::new(pos);
         assert_eq!(alignment.0, 0);
     }
     {
-        // y-position doesn't affect computation
+        // y-position never participates: only the horizontal fractional
+        // remainder is bucketed.
         let pos = vec2f(0.1, 0.33);
         let alignment = SubpixelAlignment::new(pos);
         assert_eq!(alignment.0, 0);
     }
     {
-        // 0.2 rounds up to 0.33 -> 1
+        // 0.2 * 4 = 0.8, rounds to 1 -> 0.25 offset.
         let pos = vec2f(0.2, 0.);
         let alignment = SubpixelAlignment::new(pos);
         assert_eq!(alignment.0, 1);
     }
     {
-        // 0.66 doesn't round, and converts to 2
-        let pos = vec2f(0.66, 0.);
+        // 0.5 * 4 = 2.0, rounds to 2 -> 0.5 offset.
+        let pos = vec2f(0.5, 0.);
         let alignment = SubpixelAlignment::new(pos);
         assert_eq!(alignment.0, 2);
     }
     {
-        // 0.9 rounds up to 1.0 -> 0
+        // 0.66 * 4 = 2.64, rounds to 3 -> 0.75 offset.
+        let pos = vec2f(0.66, 0.);
+        let alignment = SubpixelAlignment::new(pos);
+        assert_eq!(alignment.0, 3);
+    }
+    {
+        // 0.9 * 4 = 3.6, rounds to 4, then % 4 wraps back to 0.
         let pos = vec2f(0.9, 0.);
         let alignment = SubpixelAlignment::new(pos);
         assert_eq!(alignment.0, 0);

--- a/crates/warpui_core/src/platform/mod.rs
+++ b/crates/warpui_core/src/platform/mod.rs
@@ -404,12 +404,20 @@ pub trait FontDB: 'static {
     fn glyph_advance(&self, font_id: FontId, glyph_id: GlyphId) -> Result<Vector2I>;
 
     /// Computes the size of the canvas needed to rasterize the glyph.
+    ///
+    /// `lcd_subpixel` selects between grayscale alpha rasterization (false)
+    /// and three-channel LCD subpixel rasterization (true). Backends that
+    /// do not produce different pixel dimensions for the two modes may
+    /// ignore this parameter; backends whose subpixel mode produces wider
+    /// bitmaps must honour it.
+    #[allow(clippy::too_many_arguments)]
     fn glyph_raster_bounds(
         &self,
         font_id: FontId,
         size: f32,
         glyph_id: GlyphId,
         scale: Vector2F,
+        lcd_subpixel: bool,
         glyph_config: &rendering::GlyphConfig,
     ) -> Result<RectI>;
 
@@ -417,6 +425,11 @@ pub trait FontDB: 'static {
     fn glyph_typographic_bounds(&self, font_id: FontId, glyph_id: GlyphId) -> Result<RectI>;
 
     /// Rasterizes a single glyph so it can be rendered to the screen.
+    ///
+    /// `lcd_subpixel` requests three-channel LCD subpixel coverage instead
+    /// of grayscale alpha. The resulting bitmap is intended to be composited
+    /// with dual-source blending; backends without subpixel support fall
+    /// back to grayscale silently.
     #[allow(clippy::too_many_arguments)]
     fn rasterize_glyph(
         &self,
@@ -425,6 +438,7 @@ pub trait FontDB: 'static {
         glyph_id: GlyphId,
         scale: Vector2F,
         subpixel_alignment: SubpixelAlignment,
+        lcd_subpixel: bool,
         glyph_config: &rendering::GlyphConfig,
         format: RasterFormat,
     ) -> Result<RasterizedGlyph>;

--- a/crates/warpui_core/src/platform/test/delegate.rs
+++ b/crates/warpui_core/src/platform/test/delegate.rs
@@ -588,6 +588,7 @@ impl platform::FontDB for FontDB {
         _size: f32,
         _glyph_id: crate::fonts::GlyphId,
         _scale: Vector2F,
+        _lcd_subpixel: bool,
         _glyph_config: &crate::rendering::GlyphConfig,
     ) -> Result<pathfinder_geometry::rect::RectI> {
         Ok(pathfinder_geometry::rect::RectI::default())
@@ -608,6 +609,7 @@ impl platform::FontDB for FontDB {
         _glyph_id: crate::fonts::GlyphId,
         _scale: Vector2F,
         _subpixel_alignment: crate::fonts::SubpixelAlignment,
+        _lcd_subpixel: bool,
         _glyph_config: &crate::rendering::GlyphConfig,
         _format: crate::fonts::canvas::RasterFormat,
     ) -> Result<crate::fonts::RasterizedGlyph> {

--- a/crates/warpui_core/src/presenter.rs
+++ b/crates/warpui_core/src/presenter.rs
@@ -409,7 +409,9 @@ impl Presenter {
         max_texture_dimension_2d: Option<u32>,
         ctx: &mut AppContext,
     ) -> (Scene, Option<Instant>, HashSet<AssetHandle>) {
-        let mut scene = Scene::new(scale_factor, ctx.rendering_config());
+        let mut config = ctx.rendering_config();
+        config.lcd_subpixel_supported = ctx.gpu_supports_lcd_subpixel(self.window_id);
+        let mut scene = Scene::new(scale_factor, config);
         let mut repaint_at = None;
         let mut pending_assets = HashSet::new();
 

--- a/crates/warpui_core/src/rendering/gamma.rs
+++ b/crates/warpui_core/src/rendering/gamma.rs
@@ -1,47 +1,38 @@
 //! Gamma correction tables and helpers for the glyph fragment shaders.
 //!
-//! The numbers in [`get_gamma_correction_ratios`] come from Microsoft's
-//! ClearType reference implementation as reproduced by gpui's text
-//! rendering pipeline. Each row is a four-coefficient polynomial that
-//! corrects coverage values produced by the rasterizer (which assumes
-//! gamma = 1.0) for the actual perceived gamma of the destination
-//! display, the gamma the user wants the rendered glyph to look correct
-//! at.
+//! The coefficients in [`get_gamma_correction_ratios`] come from Microsoft's
+//! ClearType reference, via gpui. Each row is a four-coefficient polynomial
+//! that corrects rasterizer-produced coverage (which assumes gamma=1.0) for
+//! the destination display's actual perceived gamma.
 //!
 //! The shader applies the correction as
 //!     corrected = a + a * (1 - a) * ((g.x*b + g.y) * a + (g.z*b + g.w))
 //! where `a` is the raw coverage, `b` is the text colour brightness, and
 //! `g` is the four-element vector returned here.
 
-/// Default gamma to use when the env var is unset. 1.8 is the
-/// macOS / Linux compromise gpui uses; it produces text that reads as
-/// "neither too thick nor too thin" on the typical desktop displays
-/// this renderer targets.
+/// Default gamma when the env var is unset. 1.8 is gpui's macOS/Linux
+/// compromise: text reads as neither too thick nor too thin on typical
+/// desktop displays.
 pub const DEFAULT_GAMMA: f32 = 1.8;
 
-/// Default Stage 1 contrast factor for the grayscale glyph path. Matches
-/// gpui's `grayscale_enhanced_contrast` default.
+/// Default Stage 1 contrast factor for the grayscale path. Matches gpui.
 pub const DEFAULT_GRAYSCALE_ENHANCED_CONTRAST: f32 = 1.0;
 
-/// Default Stage 1 contrast factor for the LCD subpixel glyph path.
-/// Half the grayscale value because per-channel coverage already supplies
-/// most of the perceptual sharpness; piling on a full grayscale-strength
-/// boost saturates the fringe and reverses the subpixel resolution gain.
+/// Default Stage 1 contrast factor for the subpixel path. Half the
+/// grayscale value because per-channel coverage already supplies the
+/// perceptual sharpness; full grayscale strength saturates the fringe and
+/// reverses the subpixel resolution gain.
 pub const DEFAULT_SUBPIXEL_ENHANCED_CONTRAST: f32 = 0.5;
 
-/// Computes the four-element gamma-correction ratio vector that the
-/// fragment shader expects in its uniform buffer.
+/// Computes the four-element gamma-correction ratio vector the fragment
+/// shader expects in its uniform buffer.
 ///
-/// `gamma` is clamped to the range [1.0, 2.2] in 0.1 increments before
-/// the lookup; values outside that range are pinned to the closest
-/// supported entry. Calling with the default 1.8 returns the same
-/// numbers the shaders previously had hardcoded.
+/// `gamma` is rounded to the nearest 0.1 in [1.0, 2.2]; values outside that
+/// range are pinned to the closest supported entry.
 pub fn get_gamma_correction_ratios(gamma: f32) -> [f32; 4] {
-    // Coefficients sourced from Microsoft's ClearType reference,
-    // reproduced from gpui's gamma table. Each row corresponds to a
-    // gamma value of 1.0, 1.1, ..., 2.2 in steps of 0.1; the divisions
-    // by 4 are part of the original encoding and are kept literal so
-    // the table reads identically to the upstream.
+    // Rows correspond to gamma 1.0, 1.1, ..., 2.2 in 0.1 steps. The
+    // /4.0 divisions are part of the original encoding and are kept
+    // literal so the table reads identically to the gpui upstream.
     const RATIOS: [[f32; 4]; 13] = [
         [0.0000 / 4.0, 0.0000 / 4.0, 0.0000 / 4.0, 0.0000 / 4.0],
         [0.0166 / 4.0, -0.0807 / 4.0, 0.2227 / 4.0, -0.0751 / 4.0],
@@ -58,9 +49,8 @@ pub fn get_gamma_correction_ratios(gamma: f32) -> [f32; 4] {
         [0.2031 / 4.0, -1.3864 / 4.0, 1.9851 / 4.0, -0.3501 / 4.0],
     ];
 
-    // Normalisation constants from Microsoft's reference. NORM13 applies
-    // to the indices that produce a 16-bit-shifted result, NORM24 to the
-    // 8-bit-shifted indices.
+    // Normalisation constants from Microsoft's reference: NORM13 for
+    // 16-bit-shifted indices, NORM24 for 8-bit-shifted indices.
     const NORM13: f32 = ((0x10000 as f64) / (255.0 * 255.0) * 4.0) as f32;
     const NORM24: f32 = ((0x100 as f64) / 255.0 * 4.0) as f32;
 
@@ -75,8 +65,8 @@ pub fn get_gamma_correction_ratios(gamma: f32) -> [f32; 4] {
 }
 
 /// Reads the user-configurable gamma and Stage 1 contrast factors from
-/// process env vars and falls back to the defaults above when an env
-/// var is unset or fails to parse. Returns
+/// process env vars, falling back to the defaults above when an env var is
+/// unset or fails to parse. Returns
 /// `(gamma_ratios, grayscale_enhanced_contrast, subpixel_enhanced_contrast)`.
 pub fn read_env_gamma_settings() -> ([f32; 4], f32, f32) {
     let gamma = std::env::var("WARP_FONTS_GAMMA")

--- a/crates/warpui_core/src/rendering/gamma.rs
+++ b/crates/warpui_core/src/rendering/gamma.rs
@@ -1,0 +1,98 @@
+//! Gamma correction tables and helpers for the glyph fragment shaders.
+//!
+//! The numbers in [`get_gamma_correction_ratios`] come from Microsoft's
+//! ClearType reference implementation as reproduced by gpui's text
+//! rendering pipeline. Each row is a four-coefficient polynomial that
+//! corrects coverage values produced by the rasterizer (which assumes
+//! gamma = 1.0) for the actual perceived gamma of the destination
+//! display, the gamma the user wants the rendered glyph to look correct
+//! at.
+//!
+//! The shader applies the correction as
+//!     corrected = a + a * (1 - a) * ((g.x*b + g.y) * a + (g.z*b + g.w))
+//! where `a` is the raw coverage, `b` is the text colour brightness, and
+//! `g` is the four-element vector returned here.
+
+/// Default gamma to use when the env var is unset. 1.8 is the
+/// macOS / Linux compromise gpui uses; it produces text that reads as
+/// "neither too thick nor too thin" on the typical desktop displays
+/// this renderer targets.
+pub const DEFAULT_GAMMA: f32 = 1.8;
+
+/// Default Stage 1 contrast factor for the grayscale glyph path. Matches
+/// gpui's `grayscale_enhanced_contrast` default.
+pub const DEFAULT_GRAYSCALE_ENHANCED_CONTRAST: f32 = 1.0;
+
+/// Default Stage 1 contrast factor for the LCD subpixel glyph path.
+/// Half the grayscale value because per-channel coverage already supplies
+/// most of the perceptual sharpness; piling on a full grayscale-strength
+/// boost saturates the fringe and reverses the subpixel resolution gain.
+pub const DEFAULT_SUBPIXEL_ENHANCED_CONTRAST: f32 = 0.5;
+
+/// Computes the four-element gamma-correction ratio vector that the
+/// fragment shader expects in its uniform buffer.
+///
+/// `gamma` is clamped to the range [1.0, 2.2] in 0.1 increments before
+/// the lookup; values outside that range are pinned to the closest
+/// supported entry. Calling with the default 1.8 returns the same
+/// numbers the shaders previously had hardcoded.
+pub fn get_gamma_correction_ratios(gamma: f32) -> [f32; 4] {
+    // Coefficients sourced from Microsoft's ClearType reference,
+    // reproduced from gpui's gamma table. Each row corresponds to a
+    // gamma value of 1.0, 1.1, ..., 2.2 in steps of 0.1; the divisions
+    // by 4 are part of the original encoding and are kept literal so
+    // the table reads identically to the upstream.
+    const RATIOS: [[f32; 4]; 13] = [
+        [0.0000 / 4.0, 0.0000 / 4.0, 0.0000 / 4.0, 0.0000 / 4.0],
+        [0.0166 / 4.0, -0.0807 / 4.0, 0.2227 / 4.0, -0.0751 / 4.0],
+        [0.0350 / 4.0, -0.1760 / 4.0, 0.4325 / 4.0, -0.1370 / 4.0],
+        [0.0543 / 4.0, -0.2821 / 4.0, 0.6302 / 4.0, -0.1876 / 4.0],
+        [0.0739 / 4.0, -0.3963 / 4.0, 0.8167 / 4.0, -0.2287 / 4.0],
+        [0.0933 / 4.0, -0.5161 / 4.0, 0.9926 / 4.0, -0.2616 / 4.0],
+        [0.1121 / 4.0, -0.6395 / 4.0, 1.1588 / 4.0, -0.2877 / 4.0],
+        [0.1300 / 4.0, -0.7649 / 4.0, 1.3159 / 4.0, -0.3080 / 4.0],
+        [0.1469 / 4.0, -0.8911 / 4.0, 1.4644 / 4.0, -0.3234 / 4.0],
+        [0.1627 / 4.0, -1.0170 / 4.0, 1.6051 / 4.0, -0.3347 / 4.0],
+        [0.1773 / 4.0, -1.1420 / 4.0, 1.7385 / 4.0, -0.3426 / 4.0],
+        [0.1908 / 4.0, -1.2652 / 4.0, 1.8650 / 4.0, -0.3476 / 4.0],
+        [0.2031 / 4.0, -1.3864 / 4.0, 1.9851 / 4.0, -0.3501 / 4.0],
+    ];
+
+    // Normalisation constants from Microsoft's reference. NORM13 applies
+    // to the indices that produce a 16-bit-shifted result, NORM24 to the
+    // 8-bit-shifted indices.
+    const NORM13: f32 = ((0x10000 as f64) / (255.0 * 255.0) * 4.0) as f32;
+    const NORM24: f32 = ((0x100 as f64) / 255.0 * 4.0) as f32;
+
+    let index = ((gamma * 10.0).round() as usize).clamp(10, 22) - 10;
+    let ratios = RATIOS[index];
+    [
+        ratios[0] * NORM13,
+        ratios[1] * NORM24,
+        ratios[2] * NORM13,
+        ratios[3] * NORM24,
+    ]
+}
+
+/// Reads the user-configurable gamma and Stage 1 contrast factors from
+/// process env vars and falls back to the defaults above when an env
+/// var is unset or fails to parse. Returns
+/// `(gamma_ratios, grayscale_enhanced_contrast, subpixel_enhanced_contrast)`.
+pub fn read_env_gamma_settings() -> ([f32; 4], f32, f32) {
+    let gamma = std::env::var("WARP_FONTS_GAMMA")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_GAMMA)
+        .clamp(1.0, 2.2);
+    let grayscale = std::env::var("WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_GRAYSCALE_ENHANCED_CONTRAST)
+        .max(0.0);
+    let subpixel = std::env::var("WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_SUBPIXEL_ENHANCED_CONTRAST)
+        .max(0.0);
+    (get_gamma_correction_ratios(gamma), grayscale, subpixel)
+}

--- a/crates/warpui_core/src/rendering/gpu_info.rs
+++ b/crates/warpui_core/src/rendering/gpu_info.rs
@@ -72,6 +72,11 @@ pub struct GPUDeviceInfo {
     pub driver_info: String,
     /// The backend (e.g. Metal vs Vulkan vs OpenGL) we using when rendering.
     pub backend: GPUBackend,
+    /// Whether the device exposes dual-source blending. Reported here so
+    /// the application can update its [`super::Config::lcd_subpixel_supported`]
+    /// flag when a window's renderer is created; the LCD subpixel glyph
+    /// path requires dual-source blending to composite per-channel coverage.
+    pub supports_dual_source_blending: bool,
 }
 
 impl Display for GPUDeviceType {

--- a/crates/warpui_core/src/rendering/gpu_info.rs
+++ b/crates/warpui_core/src/rendering/gpu_info.rs
@@ -77,13 +77,6 @@ pub struct GPUDeviceInfo {
     /// flag when a window's renderer is created; the LCD subpixel glyph
     /// path requires dual-source blending to composite per-channel coverage.
     pub supports_dual_source_blending: bool,
-    /// Whether the rendering surface composites with a non-opaque alpha
-    /// (translucent windows / alpha-aware compositors). Reported alongside
-    /// [`Self::supports_dual_source_blending`] so the application can
-    /// populate [`super::Config::surface_is_transparent`]; LCD subpixel
-    /// rendering must fall back to grayscale on transparent surfaces or
-    /// the per-channel coverage corrupts the compositor's alpha channel.
-    pub surface_is_transparent: bool,
 }
 
 impl Display for GPUDeviceType {

--- a/crates/warpui_core/src/rendering/gpu_info.rs
+++ b/crates/warpui_core/src/rendering/gpu_info.rs
@@ -77,6 +77,13 @@ pub struct GPUDeviceInfo {
     /// flag when a window's renderer is created; the LCD subpixel glyph
     /// path requires dual-source blending to composite per-channel coverage.
     pub supports_dual_source_blending: bool,
+    /// Whether the rendering surface composites with a non-opaque alpha
+    /// (translucent windows / alpha-aware compositors). Reported alongside
+    /// [`Self::supports_dual_source_blending`] so the application can
+    /// populate [`super::Config::surface_is_transparent`]; LCD subpixel
+    /// rendering must fall back to grayscale on transparent surfaces or
+    /// the per-channel coverage corrupts the compositor's alpha channel.
+    pub surface_is_transparent: bool,
 }
 
 impl Display for GPUDeviceType {

--- a/crates/warpui_core/src/rendering/mod.rs
+++ b/crates/warpui_core/src/rendering/mod.rs
@@ -77,23 +77,11 @@ pub struct Config {
     pub backend_preference: Option<GraphicsBackend>,
 
     /// Whether the renderer supports compositing glyphs through LCD subpixel
-    /// rasterization. This is set to true only when the GPU exposes the
-    /// dual-source blending feature and the renderer has built the
-    /// corresponding pipeline. Scene-time glyph classification consults this
-    /// flag together with [`Self::surface_is_transparent`] to decide whether
-    /// a given glyph can take the subpixel path.
+    /// rasterization. Set to true only when the GPU exposes the dual-source
+    /// blending feature and the renderer has built the corresponding
+    /// pipeline. Scene-time glyph classification consults this flag to
+    /// decide whether a given glyph can take the subpixel path.
     pub lcd_subpixel_supported: bool,
-
-    /// Whether the rendering surface composites with a non-opaque alpha
-    /// (translucent windows, alpha-aware compositors, etc.).
-    ///
-    /// The field is named in the negative so a `Default` of `false` reflects
-    /// the safe assumption: most surfaces are opaque, and subpixel coverage
-    /// only corrupts the destination alpha channel when the compositor
-    /// actually reads it. When this is true, scene-time classification must
-    /// fall back to grayscale glyphs even on hardware that supports
-    /// dual-source blending.
-    pub surface_is_transparent: bool,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/warpui_core/src/rendering/mod.rs
+++ b/crates/warpui_core/src/rendering/mod.rs
@@ -1,3 +1,4 @@
+pub mod gamma;
 mod gpu_info;
 pub mod texture_cache;
 pub use gpu_info::{GPUBackend, GPUDeviceInfo, GPUDeviceType, OnGPUDeviceSelected};

--- a/crates/warpui_core/src/rendering/mod.rs
+++ b/crates/warpui_core/src/rendering/mod.rs
@@ -82,6 +82,23 @@ pub struct Config {
     /// pipeline. Scene-time glyph classification consults this flag to
     /// decide whether a given glyph can take the subpixel path.
     pub lcd_subpixel_supported: bool,
+
+    /// Whether the active window's background is heavily translucent
+    /// (the `appearance.window.override_opacity` user setting is below
+    /// the LCD gate threshold defined in the app layer). Glyph
+    /// classification uses this to disable the LCD subpixel path on
+    /// strongly translucent surfaces, where the per-channel coverage
+    /// pipeline's `ColorWrites::COLOR` leaves the framebuffer alpha at
+    /// the background quad's translucent value, letting the compositor
+    /// blend the desktop into the glyph strokes themselves. The mono
+    /// pipeline's `ColorWrites::all()` writes alpha = 1.0 at covered
+    /// pixels so this bleed does not occur there. The gate threshold is
+    /// intentionally not "any translucency" because the mono path loses
+    /// edge resolution at fractional DPI; trading off mild bleed against
+    /// edge sharpness keeps mild translucency on the LCD path. Inspired
+    /// by zed's `should_use_subpixel_rendering` gate on
+    /// `WindowBackgroundAppearance != Opaque`.
+    pub transparent_background: bool,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/warpui_core/src/rendering/mod.rs
+++ b/crates/warpui_core/src/rendering/mod.rs
@@ -74,6 +74,25 @@ pub struct Config {
     pub gpu_power_preference: GPUPowerPreference,
 
     pub backend_preference: Option<GraphicsBackend>,
+
+    /// Whether the renderer supports compositing glyphs through LCD subpixel
+    /// rasterization. This is set to true only when the GPU exposes the
+    /// dual-source blending feature and the renderer has built the
+    /// corresponding pipeline. Scene-time glyph classification consults this
+    /// flag together with [`Self::surface_is_transparent`] to decide whether
+    /// a given glyph can take the subpixel path.
+    pub lcd_subpixel_supported: bool,
+
+    /// Whether the rendering surface composites with a non-opaque alpha
+    /// (translucent windows, alpha-aware compositors, etc.).
+    ///
+    /// The field is named in the negative so a `Default` of `false` reflects
+    /// the safe assumption: most surfaces are opaque, and subpixel coverage
+    /// only corrupts the destination alpha channel when the compositor
+    /// actually reads it. When this is true, scene-time classification must
+    /// fall back to grayscale glyphs even on hardware that supports
+    /// dual-source blending.
+    pub surface_is_transparent: bool,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/warpui_core/src/scene.rs
+++ b/crates/warpui_core/src/scene.rs
@@ -659,16 +659,22 @@ impl Scene {
         font_size: f32,
         color: ColorU,
     ) -> &mut Glyph {
-        // Subpixel rasterisation is gated on the renderer having actually
-        // built the dual-source-blend pipeline. The other half of the
-        // historical concern (per-channel coverage corrupting the
-        // compositor's alpha on transparent surfaces) is already handled
-        // one layer down: the subpixel render pipeline declares
-        // `wgpu::ColorWrites::COLOR`, so the per-channel pass writes RGB
-        // only and never touches the framebuffer's alpha. Whatever alpha
-        // the background pass wrote is what the compositor reads,
-        // regardless of the swapchain's `CompositeAlphaMode`.
-        let lcd_subpixel = self.rendering_config.lcd_subpixel_supported;
+        // Subpixel rasterisation is gated on two conditions: the renderer
+        // built the dual-source-blend pipeline, and the window background
+        // is not heavily translucent. The strongly translucent case has
+        // to be excluded because the subpixel pipeline declares
+        // `ColorWrites::COLOR`, which preserves whatever alpha the
+        // background quad wrote; when that alpha is well below 1.0 the
+        // compositor blends the desktop into the glyph strokes
+        // themselves. Routing those glyphs through the mono pipeline
+        // (its `ColorWrites::all()` plus ALPHA_BLENDING drives
+        // framebuffer alpha to 1.0 at covered pixels) avoids the bleed
+        // at the cost of edge sharpness; the gate threshold (defined in
+        // the app layer) keeps mild translucency on the LCD path so most
+        // users do not pay that cost. Inspired by zed's
+        // `should_use_subpixel_rendering` gate.
+        let lcd_subpixel = self.rendering_config.lcd_subpixel_supported
+            && !self.rendering_config.transparent_background;
 
         // TODO: Support hit testing on glyphs?
         let layer = self.active_layer();

--- a/crates/warpui_core/src/scene.rs
+++ b/crates/warpui_core/src/scene.rs
@@ -94,12 +94,10 @@ pub struct Glyph {
     pub position: Vector2F,
     pub fade: Option<GlyphFade>,
     pub color: ColorU,
-    /// Whether this glyph should be rasterized as LCD subpixel coverage and
-    /// composited through the dual-source-blend pipeline. Set by
-    /// [`Scene::draw_glyph`] using the renderer's reported capabilities and
-    /// the surface's transparency state. The renderer treats this as a
-    /// preference, not an obligation: a glyph tagged true on a backend that
-    /// has no subpixel pipeline silently falls back to grayscale.
+    /// Whether this glyph should take the LCD subpixel path. Set by
+    /// [`Scene::draw_glyph`] from the renderer's capabilities and the
+    /// surface's transparency. Treated as a preference: a backend without a
+    /// subpixel pipeline silently falls back to grayscale.
     pub lcd_subpixel: bool,
 }
 
@@ -661,14 +659,12 @@ impl Scene {
         font_size: f32,
         color: ColorU,
     ) -> &mut Glyph {
-        // Decide whether this glyph should take the LCD subpixel path.
         // Subpixel rasterisation is only correct when the GPU reports
         // dual-source blending (so the renderer has a pipeline that can
-        // consume the per-channel coverage) and when the surface composites
-        // with a fully opaque alpha (otherwise per-channel coverage would
-        // corrupt the destination alpha that the compositor reads). Both
-        // checks happen at scene-build time so a single classification
-        // decision flows through the cache key and the renderer dispatch.
+        // consume the per-channel coverage) and when the surface is opaque
+        // (otherwise per-channel coverage corrupts the compositor's alpha).
+        // Classifying once here lets the cache key and renderer dispatch
+        // share the decision.
         let lcd_subpixel = self.rendering_config.lcd_subpixel_supported
             && !self.rendering_config.surface_is_transparent;
 

--- a/crates/warpui_core/src/scene.rs
+++ b/crates/warpui_core/src/scene.rs
@@ -94,6 +94,13 @@ pub struct Glyph {
     pub position: Vector2F,
     pub fade: Option<GlyphFade>,
     pub color: ColorU,
+    /// Whether this glyph should be rasterized as LCD subpixel coverage and
+    /// composited through the dual-source-blend pipeline. Set by
+    /// [`Scene::draw_glyph`] using the renderer's reported capabilities and
+    /// the surface's transparency state. The renderer treats this as a
+    /// preference, not an obligation: a glyph tagged true on a backend that
+    /// has no subpixel pipeline silently falls back to grayscale.
+    pub lcd_subpixel: bool,
 }
 
 #[derive(Clone, Default)]
@@ -654,6 +661,17 @@ impl Scene {
         font_size: f32,
         color: ColorU,
     ) -> &mut Glyph {
+        // Decide whether this glyph should take the LCD subpixel path.
+        // Subpixel rasterisation is only correct when the GPU reports
+        // dual-source blending (so the renderer has a pipeline that can
+        // consume the per-channel coverage) and when the surface composites
+        // with a fully opaque alpha (otherwise per-channel coverage would
+        // corrupt the destination alpha that the compositor reads). Both
+        // checks happen at scene-build time so a single classification
+        // decision flows through the cache key and the renderer dispatch.
+        let lcd_subpixel = self.rendering_config.lcd_subpixel_supported
+            && !self.rendering_config.surface_is_transparent;
+
         // TODO: Support hit testing on glyphs?
         let layer = self.active_layer();
         layer.glyphs.push(Glyph {
@@ -665,6 +683,7 @@ impl Scene {
             position,
             color,
             fade: None,
+            lcd_subpixel,
         });
         layer.glyphs.last_mut().unwrap()
     }

--- a/crates/warpui_core/src/scene.rs
+++ b/crates/warpui_core/src/scene.rs
@@ -659,14 +659,16 @@ impl Scene {
         font_size: f32,
         color: ColorU,
     ) -> &mut Glyph {
-        // Subpixel rasterisation is only correct when the GPU reports
-        // dual-source blending (so the renderer has a pipeline that can
-        // consume the per-channel coverage) and when the surface is opaque
-        // (otherwise per-channel coverage corrupts the compositor's alpha).
-        // Classifying once here lets the cache key and renderer dispatch
-        // share the decision.
-        let lcd_subpixel = self.rendering_config.lcd_subpixel_supported
-            && !self.rendering_config.surface_is_transparent;
+        // Subpixel rasterisation is gated on the renderer having actually
+        // built the dual-source-blend pipeline. The other half of the
+        // historical concern (per-channel coverage corrupting the
+        // compositor's alpha on transparent surfaces) is already handled
+        // one layer down: the subpixel render pipeline declares
+        // `wgpu::ColorWrites::COLOR`, so the per-channel pass writes RGB
+        // only and never touches the framebuffer's alpha. Whatever alpha
+        // the background pass wrote is what the compositor reads,
+        // regardless of the swapchain's `CompositeAlphaMode`.
+        let lcd_subpixel = self.rendering_config.lcd_subpixel_supported;
 
         // TODO: Support hit testing on glyphs?
         let layer = self.active_layer();


### PR DESCRIPTION
## Summary

Three rendering bugs on Warp's wgpu backend, all visible on Linux and BSD at fractional DPI scale factors (1.25×, 1.5×, 1.75×). This PR doesn't touch the Metal renderer macOS uses.

This PR fixes:

1. Glyphs and images blur at fractional DPI scales.
2. Glyphs render in grayscale only, looking blurrier and softer than wezterm or alacritty (which use FreeType ) and Zed (which has its own LCD subpixel pipeline in `gpui_wgpu`). Here we try our best to match zed's approach with similar results, as our stack matched theirs- cosmic-text/swash. This should be fine in most cases, only case where FreeType might be superior in is autohinting unhinted fonts for displays needing them.
3. TUIs that draw images per cell (yazi, other kitty-graphics consumers) render their previews at the wrong resolution on fractional-scale displays.

## 1. Fractional-DPI blur (commit `cb90e4b`)

cosmic-text/swash bakes a sub-pixel X offset into each cached bitmap based on the cache key's `SubpixelAlignment` bucket index, then the renderer subtracts the bucket offset back from the quad position so the visible glyph centre lines up with the requested logical position. That subtract-back leaves a residual fractional offset of up to ±0.17 px at `STEPS=3` (walked the math against the version of `crates/warpui_core/src/fonts.rs` and `glyph.rs` in effect at `cb90e4b`). With `FilterMode::Linear`, the resulting fractional UV-to-texel mapping interpolated across adjacent atlas texels and produced the visible blur.

Images and icons had the analogous bug at the geometry level: their quad origins weren't rounded at all, so a logical (50, 30) origin became physical (62.5, 37.5) at 1.25×. Linear sampling at the 0.5 px offset shifted every UV off its texel centre.

`cb90e4b` makes two changes in two files (`glyph.rs` and `image.rs`):

- Floor image and icon quad origins at submission. This is the right fix and survives unchanged through the rest of the branch.
- Switch the glyph atlas sampler from `Linear` to `Nearest`. This was a pragmatic mitigation that avoided the bleed without addressing the fractional-quad cause on the glyph side. It was undone later in `22756fd` once the proper fix landed in `4086854`: glyph quads are now floored at scene-build time, the bucket-offset subtract is removed, and the sampler returns to `Linear` because integer-aligned quads at 1:1 pixel-to-texel scale make Linear and Nearest equivalent for our samples. Linear also degrades more gracefully under any future change that introduces sub-texel UVs.

## 2. Grayscale-only glyph rendering: porting Zed's gpui_wgpu pipeline

With the blur issues somewhat reduced, glyphs were sharp but still grayscale-only, visibly thinner and softer than wezterm/alacritty (FreeType + LCD subpixel) or Zed itself (whose `gpui_wgpu` renderer has its own LCD subpixel pipeline using dual-source blending).

The remaining 14 commits port `gpui_wgpu`'s text-rendering path into Warp's wgpu renderer, adapted to fit cosmic-text/swash and the existing atlas architecture. Each piece below was validated against the matching code in `zed-industries/zed/main/crates/gpui_wgpu` before porting.

- **Three atlas kinds.** `Generic` (R8Unorm, single-byte grayscale coverage), `Subpixel` (Bgra8Unorm, three per-channel coverages from swash's `Format::subpixel_bgra()`), `Polychrome` (Bgra8Unorm, RGBA emoji bitmaps). Routing decided at rasterization time from the rasterizer's `is_emoji` result and the scene-built `lcd_subpixel` flag.
- **A second fragment shader** assembled at pipeline-build time by concatenating the mono shader with the subpixel shader and prepending `enable dual_source_blending;`. Same technique as gpui_wgpu (`gpui_wgpu/src/wgpu_renderer.rs:657`, `"enable dual_source_blending;\n{base_shader_source}\n{subpixel_shader_source}"`). The subpixel shader emits `@blend_src(0)` and `@blend_src(1)` outputs; a `Src1 / OneMinusSrc1` blend equation multiplies each LCD subpixel of the destination by its own coverage. Blend state matches gpui_wgpu byte for byte.
- **Two-stage gamma correction in the shader**, ported from gpui_wgpu's `apply_contrast_and_gamma_correction`. Stage 1 is gpui's `enhance_contrast(α, k) = α(k+1)/(αk+1)` brightness-modulated contrast boost, with the boost driven to zero for bright text on dark backgrounds via gpui's `light_on_dark_contrast` (so white terminal text on a dark theme isn't over-thickened). Stage 2 is gpui's `apply_alpha_correction` ClearType-derived polynomial over four `gamma_ratios` coefficients. The coefficient table is copied verbatim from gpui's `gamma.rs`.
- **Defaults match gpui_wgpu exactly**, verified against `gpui_wgpu/src/wgpu_renderer.rs:1881-1894`:

  | Knob | Default | gpui_wgpu env var |
  |:-----|:-------:|:------------------|
  | `WARP_FONTS_GAMMA` | 1.8 | `ZED_FONTS_GAMMA` (clamped to [1.0, 2.2]) |
  | `WARP_FONTS_GRAYSCALE_ENHANCED_CONTRAST` | 1.0 | `ZED_FONTS_GRAYSCALE_ENHANCED_CONTRAST` |
  | `WARP_FONTS_SUBPIXEL_ENHANCED_CONTRAST` | 0.5 | `ZED_FONTS_SUBPIXEL_ENHANCED_CONTRAST` |

- **Scene-time gating.** `Glyph::lcd_subpixel = true` only when the device exposes `wgpu::Features::DUAL_SOURCE_BLENDING` and the surface is opaque (`lcd_subpixel_supported && !surface_is_transparent`). Transparent surfaces silently fall back to grayscale: per-channel coverage on a translucent surface corrupts the compositor's alpha channel and lets glyph colour leak through to whatever sits behind the window.
- **Cosmic-text fork bump** to expose `Format::subpixel_bgra()` and the new `OUTLINE_ONLY` cache-key flag. `OUTLINE_ONLY` skips the COLR/CBDT colour-source lookups that swash would otherwise try first for non-emoji glyphs, matching what gpui does in `gpui_wgpu/src/cosmic_text_system.rs:344` (it bypasses cosmic-text entirely and constructs `Render::new` itself with only `Source::Outline`).
- **Subpixel positioning buckets bumped from 3 to 4.** Halves the worst-case horizontal positioning error from 1/(2·3) ≈ 0.167 px to 1/(2·4) = 0.125 px.
- **Glyph quad origins floored at scene-build time** (`4086854`). Replaces the old subtract-back-the-bucket-offset line described in Section 1 with a `glyph_position.floor()`. Combined with swash baking the bucket offset into the bitmap, fragment centres now land exactly on texel centres. The atlas sampler returns to `Linear` in the next commit (`22756fd`).

## 3. TUI image-preview cell sizes (commits `779f278`, `308139a`)

yazi and similar TUIs query the terminal for physical-pixel measurements before pre-scaling images: cell size via `CSI 16t`, text-area size via `CSI 14t`, the pixel grid via `TIOCGWINSZ`'s `ws_xpixel` / `ws_ypixel`. Warp was returning logical pixels in all three places, with `CSI 16t` not implemented at all. On a 1.25× display, the image yazi prepared was sized for an 80%-resolution cell, then the terminal displayed it in the larger physical cell, blurring it. Fixed by threading the DPI scale through `SizeInfo`, reporting physical pixels from all three sources, and adding `CSI 16t` support.

## Cosmic-text dependency

Section 2 needs two new `CacheKeyFlags` bits (`SUBPIXEL_BGRA`, `OUTLINE_ONLY`) that don't yet exist in `warpdotdev/cosmic-text`. To test this PR, meanwhile, `crates/warpui/Cargo.toml` temporarily points at my personal fork [rudrabhoj/cosmic-text-warpdev](https://github.com/rudrabhoj/cosmic-text-warpdev) on the `subpixel-bgra` branch, which is two commits ahead of and zero behind `warpdotdev/cosmic-text@warpdotdev/0.12.0`.

Those two commits are submitted upstream as warpdotdev/cosmic-text#9 (against `warpdotdev/0.12.0`). Once that merges, the `Cargo.toml` `rev` in this PR will flip from the personal fork to the new tip of `warpdotdev/cosmic-text@warpdotdev/0.12.0`. The renderer code in this PR doesn't depend on which git URL the dependency resolves through, only the `rev` string.

## FreeBSD fixes dependency
I tested this on FreeBSD+wayland first, which means it depends on  PR #9362 to compile (FreeBSD support there). Once that merges, those commits roll into `master` and this PR's diff collapses to just the rendering work.

## Result
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/e8b94e9c-0fb7-43b4-af4c-f4a2d925d1b4" />

Left is Warp running with wayland on fractional scaled (1.25) niri wm on FreeBSD, right is zed ide. Closely matches the rendering quality of zed on linux/bsd/wayland.

In this zoomed image, upper is zed, lower is warp:
<img width="1528" height="299" alt="image" src="https://github.com/user-attachments/assets/26eec37e-4fbb-4c43-9b3e-ec6c9cdf8548" />


Overall, this PR should improve quality of life for Linux and FreeBSD users a lot.



## PS
FreeBSD fixes PR which this dependent upon is merged. Our fixes in cosmic-text still are not merged though so for now to test my repo could be used, meanwhile.

I am also attaching screenshots from Linux, zoomed, First three lines are from Warp Linux AppImage, and last three lines are from warp oss after applying this pr:
<img width="1827" height="886" alt="image" src="https://github.com/user-attachments/assets/f569f119-14b8-41c9-a8ca-566322a4818e" />

You can see that now it renders with significantly better anti alias without apparent blur, closely matches the performance of SOTA renderer of our tech stack (Cosmic Text+wgpu)- zed. 