### PR TITLE
Bump core-text version to fix font descriptor leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "core-foundation"
 version = "0.10.1"
-source = "git+https://github.com/servo/core-foundation-rs?rev=0bcad1e103ead6bd71c4e5f85598ada9508e3a82#0bcad1e103ead6bd71c4e5f85598ada9508e3a82"
+source = "git+https://github.com/servo/core-foundation-rs?rev=6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff#6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3116,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
-source = "git+https://github.com/servo/core-foundation-rs?rev=0bcad1e103ead6bd71c4e5f85598ada9508e3a82#0bcad1e103ead6bd71c4e5f85598ada9508e3a82"
+source = "git+https://github.com/servo/core-foundation-rs?rev=6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff#6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff"
 
 [[package]]
 name = "core-graphics"
@@ -3147,11 +3147,11 @@ dependencies = [
 [[package]]
 name = "core-graphics"
 version = "0.25.0"
-source = "git+https://github.com/servo/core-foundation-rs?rev=0bcad1e103ead6bd71c4e5f85598ada9508e3a82#0bcad1e103ead6bd71c4e5f85598ada9508e3a82"
+source = "git+https://github.com/servo/core-foundation-rs?rev=6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff#6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation 0.10.1",
- "core-graphics-types 0.2.0 (git+https://github.com/servo/core-foundation-rs?rev=0bcad1e103ead6bd71c4e5f85598ada9508e3a82)",
+ "core-graphics-types 0.2.0 (git+https://github.com/servo/core-foundation-rs?rev=6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff)",
  "foreign-types 0.5.0",
  "libc",
 ]
@@ -3181,15 +3181,15 @@ dependencies = [
 [[package]]
 name = "core-graphics-types"
 version = "0.2.0"
-source = "git+https://github.com/servo/core-foundation-rs?rev=0bcad1e103ead6bd71c4e5f85598ada9508e3a82#0bcad1e103ead6bd71c4e5f85598ada9508e3a82"
+source = "git+https://github.com/servo/core-foundation-rs?rev=6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff#6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff"
 dependencies = [
  "core-foundation 0.10.1",
 ]
 
 [[package]]
 name = "core-text"
-version = "21.0.0"
-source = "git+https://github.com/servo/core-foundation-rs?rev=0bcad1e103ead6bd71c4e5f85598ada9508e3a82#0bcad1e103ead6bd71c4e5f85598ada9508e3a82"
+version = "21.1.0"
+source = "git+https://github.com/servo/core-foundation-rs?rev=6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff#6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff"
 dependencies = [
  "core-foundation 0.10.1",
  "core-graphics 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -474,10 +474,15 @@ inherits = "dev"
 opt-level = "s"
 
 [patch.crates-io]
-core-foundation = { git = "https://github.com/servo/core-foundation-rs", rev = "0bcad1e103ead6bd71c4e5f85598ada9508e3a82" }
-core-foundation-sys = { git = "https://github.com/servo/core-foundation-rs", rev = "0bcad1e103ead6bd71c4e5f85598ada9508e3a82" }
-core-graphics = { git = "https://github.com/servo/core-foundation-rs", rev = "0bcad1e103ead6bd71c4e5f85598ada9508e3a82" }
-core-text = { git = "https://github.com/servo/core-foundation-rs", rev = "0bcad1e103ead6bd71c4e5f85598ada9508e3a82" }
+# Pinned to the merge commit of servo/core-foundation-rs#746, which fixes a
+# double-retain bug in `CTFontCollection::get_descriptors` that leaks the
+# CoreText font-descriptor NSArray on every call. The fix is not yet in any
+# crates.io release; the latest published `core-text` (21.1.0) was cut from
+# a commit that predates the merge.
+core-foundation = { git = "https://github.com/servo/core-foundation-rs", rev = "6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff" }
+core-foundation-sys = { git = "https://github.com/servo/core-foundation-rs", rev = "6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff" }
+core-graphics = { git = "https://github.com/servo/core-foundation-rs", rev = "6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff" }
+core-text = { git = "https://github.com/servo/core-foundation-rs", rev = "6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff" }
 objc = { git = "https://github.com/warpdotdev/rust-objc.git", rev = "5b656827fa9f863ef0eb22e444a3fedac009e78a" }
 pathfinder_simd = { git = "https://github.com/warpdotdev/pathfinder.git", rev = "34128a129ca6aee168fbc5060a4f21b4f7e486a9" }
 yaml-rust = { git = "https://github.com/warpdotdev/yaml-rust.git", rev = "51684719d0102ca85ff4b21cec39877a0c669e19" }


### PR DESCRIPTION
## Description

On macOS, Warp uses Apple's CoreText framework (through the Rust `core-text` crate) to load and pick fonts. The Rust function that asks CoreText for a list of font descriptors had a reference-counting bug: it kept that list alive forever instead of releasing it. The result was a memory leak every time Warp loaded fonts or built a fallback chain for characters the active font can't draw (e.g. CJK, emoji).

This PR bumps our pinned revision of [`servo/core-foundation-rs`](https://github.com/servo/core-foundation-rs), which provides `core-foundation`, `core-foundation-sys`, `core-graphics`, and `core-text`, to pull in the upstream fix. `core-text` itself moves from `21.0.0` to `21.1.0`. We have to stay on a git pin because the latest crates.io release predates the fix.

Full revision range: [`0bcad1e…6f844cf`](https://github.com/servo/core-foundation-rs/compare/0bcad1e103ead6bd71c4e5f85598ada9508e3a82...6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff). Commits in the range
- [`ab22f7a`](https://github.com/servo/core-foundation-rs/commit/ab22f7a) — Add a new `CTFont::has_table` helper ([#739](https://github.com/servo/core-foundation-rs/pull/739)). Pure addition; nothing in Warp uses it today.
- [`7342edd`](https://github.com/servo/core-foundation-rs/commit/7342edd) — Typo fix in a test comment ([#740](https://github.com/servo/core-foundation-rs/pull/740)). No code change.
- [`3944c6a`](https://github.com/servo/core-foundation-rs/commit/3944c6a) — Upstream MSRV bump (1.65 → 1.68) and macOS CI matrix refresh ([#747](https://github.com/servo/core-foundation-rs/pull/747)). Warp builds on a newer toolchain, so this is invisible to us.
- [`6a8e54e`](https://github.com/servo/core-foundation-rs/commit/6a8e54e) — Publish `core-text` 21.1.0 ([#738](https://github.com/servo/core-foundation-rs/pull/738)). Crate version bump only.
- [`6f844cf`](https://github.com/servo/core-foundation-rs/commit/6f844cf) — **The reason for this PR.** Fixes the memory leak in `CTFontCollection::get_descriptors` ([#746](https://github.com/servo/core-foundation-rs/pull/746)) so the descriptor array is released when it goes out of scope.

We call the fixed function in two places, both in `crates/warpui/src/platform/mac/fonts.rs`:
- Once at startup, to list every installed font family for the font picker and the fallback database.
- Repeatedly during normal use, when loading a newly-selected font or picking the Apple Symbols fallback for characters the active font can't render.

Both paths previously leaked an array of font descriptors on every call; after this bump they don't. No app-side code changes were required.

## Testing
Tested manually on macOS: launch Warp, open the font picker in Settings -> Appearance, switch fonts a few times, and exercise a fallback-heavy buffer (CJK and emoji) to make sure rendering still works:

<img height="300" alt="Screenshot 2026-04-30 at 14 36 26" src="https://github.com/user-attachments/assets/069ba0ae-3ba2-4ef4-9414-8e4413aa3e36" />
<img height="300" alt="Screenshot 2026-04-30 at 14 52 58" src="https://github.com/user-attachments/assets/042e7b59-0011-40e2-a0dd-b2034748c5c5" />
<img height="130" alt="Screenshot 2026-04-30 at 15 02 12" src="https://github.com/user-attachments/assets/26751a72-c3b7-4234-b3ad-cff38b85f9e7" />


Then ran `leaks --fullStacks --groupByType` against the running process after repeatedly switching font families and putting special characters in the blocklist and input editor. Font-related leaks are gone from the `leaks` output.

## Server API dependencies
N/A — client-only dependency bump.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed a macOS memory leak that occurred when Warp enumerated system fonts or built a font fallback chain.
