### PR TITLE
Auto-open rich input for non-Oz harness cloud agent sessions

### DIFF
--- a/app/src/terminal/shared_session/shared_handlers.rs
+++ b/app/src/terminal/shared_session/shared_handlers.rs
@@ -402,11 +402,21 @@ pub(crate) fn apply_cli_agent_state_update(
                 });
             }
 
+            // For cloud agent sessions with non-Oz harnesses, auto-open rich
+            // input when creating a new CLI agent session so the viewer gets the
+            // composer immediately (byte-sharing has roundtrip lag without it).
+            let effective_rich_input_open =
+                if !already_exists && view.as_ref(ctx).is_shared_ambient_agent_session() {
+                    true
+                } else {
+                    *is_rich_input_open
+                };
+
             // Update the rich input state.
             let currently_open = CLIAgentSessionsModel::as_ref(ctx).is_input_open(view_id);
-            if currently_open != *is_rich_input_open {
+            if currently_open != effective_rich_input_open {
                 view.update(ctx, |view, ctx| {
-                    if *is_rich_input_open {
+                    if effective_rich_input_open {
                         view.open_cli_agent_rich_input(
                             CLIAgentInputEntrypoint::SharedSessionSync,
                             ctx,


### PR DESCRIPTION
## Description
Auto-open rich input when a CLI agent session is first created on a shared ambient agent viewer (non-Oz harness cloud sessions). Byte-sharing without rich input has roundtrip lag, so the composer should appear immediately.

The override only fires for **new** session creation (`!already_exists`), not subsequent state-change syncs, so the user can still close it manually.

## Linked Issue
- [REMOTE-1541](https://linear.app/warpdotdev/issue/REMOTE-1541/enable-rich-input-on-non-oz-harness-shared-sessions)

## Testing
Pulled and tested locally—works correctly when starting a new session. 

Loom: https://www.loom.com/share/e906308611794d97b76ec46cbe757354

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/4240a5e7-2d0f-4593-bed0-cf43a6402b35_
_Run: https://oz.staging.warp.dev/runs/019de002-1796-7008-af23-4bca38b3869d_

_This PR was generated with [Oz](https://warp.dev/oz)._
