### PR TITLE
fix: route CLIAgent::Pi to the default session listener (#9663)

### DIFF
--- a/app/src/terminal/cli_agent_sessions/listener/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod.rs
@@ -46,24 +46,27 @@ pub fn is_agent_supported(agent: &CLIAgent) -> bool {
             | CLIAgent::Codex
             | CLIAgent::Gemini
             | CLIAgent::Auggie
+            | CLIAgent::Pi
     )
 }
 
 /// Creates the appropriate handler for the given CLI agent.
 fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
     match agent {
-        // Auggie is supported via the community-maintained auggie-warp plugin
-        // (https://github.com/augmentmoogi/auggie-warp), which emits the same
+        // Auggie and Pi are supported via community-maintained plugins
+        // (https://github.com/augmentmoogi/auggie-warp,
+        // https://github.com/badlogic/pi-mono), which emit the same
         // structured OSC 777 events as the first-party Claude/OpenCode/Gemini
-        // plugins. We don't ship an install flow for it — we just listen.
-        CLIAgent::Claude | CLIAgent::OpenCode | CLIAgent::Gemini | CLIAgent::Auggie => {
-            Some(Box::new(DefaultSessionListener))
-        }
+        // plugins. We don't ship install flows for them — we just listen.
+        CLIAgent::Claude
+        | CLIAgent::OpenCode
+        | CLIAgent::Gemini
+        | CLIAgent::Auggie
+        | CLIAgent::Pi => Some(Box::new(DefaultSessionListener)),
         CLIAgent::Codex => Some(Box::new(CodexSessionHandler)),
         CLIAgent::Amp
         | CLIAgent::Droid
         | CLIAgent::Copilot
-        | CLIAgent::Pi
         | CLIAgent::CursorCli
         | CLIAgent::Goose
         | CLIAgent::Unknown => None,
@@ -279,6 +282,46 @@ mod tests {
         let event = CLIAgentEvent {
             v: 1,
             agent: CLIAgent::Auggie,
+            event: CLIAgentEventType::Stop,
+            session_id: None,
+            cwd: None,
+            project: None,
+            payload: CLIAgentEventPayload::default(),
+        };
+        assert!(handler.handle_event(event).is_some());
+    }
+
+    #[test]
+    fn pi_is_supported() {
+        assert!(is_agent_supported(&CLIAgent::Pi));
+    }
+
+    #[test]
+    fn pi_uses_default_handler_with_rich_status() {
+        assert!(agent_supports_rich_status(&CLIAgent::Pi));
+    }
+
+    #[test]
+    fn pi_default_handler_skips_session_start() {
+        let mut handler = DefaultSessionListener;
+        let event = CLIAgentEvent {
+            v: 1,
+            agent: CLIAgent::Pi,
+            event: CLIAgentEventType::SessionStart,
+            session_id: None,
+            cwd: None,
+            project: None,
+            payload: CLIAgentEventPayload::default(),
+        };
+        assert!(handler.handle_event(event).is_none());
+    }
+
+    #[test]
+    fn pi_default_handler_forwards_stop() {
+        let mut handler = DefaultSessionListener;
+        let event = CLIAgentEvent {
+            v: 1,
+            agent: CLIAgent::Pi,
             event: CLIAgentEventType::Stop,
             session_id: None,
             cwd: None,

--- a/app/src/terminal/cli_agent_sessions/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/mod_tests.rs
@@ -223,6 +223,20 @@ fn parse_auggie_stop_notification() {
 }
 
 #[test]
+fn parse_pi_stop_notification() {
+    // Mirrors what the community pi-mono plugin emits on the Stop hook —
+    // matches the Auggie shape and uses `"agent":"pi"`, which `resolve_agent`
+    // already maps to `CLIAgent::Pi` via `command_prefix()`.
+    let body = r#"{"v":1,"agent":"pi","event":"stop","session_id":"abc","cwd":"/tmp/proj","project":"proj","query":"write a haiku","response":"Memory is safe"}"#;
+    let notif = parse_event(Some("warp://cli-agent"), body).unwrap();
+
+    assert_eq!(notif.agent, CLIAgent::Pi);
+    assert_eq!(notif.event, CLIAgentEventType::Stop);
+    assert_eq!(notif.payload.query.as_deref(), Some("write a haiku"));
+    assert_eq!(notif.payload.response.as_deref(), Some("Memory is safe"));
+}
+
+#[test]
 fn apply_event_preserves_input_session() {
     let input_state = CLIAgentInputState::Open {
         entrypoint: CLIAgentInputEntrypoint::CtrlG,


### PR DESCRIPTION
## Description

Resolves #9663.

`CLIAgent::Pi` was sitting in the `None` arm of `create_handler` in `app/src/terminal/cli_agent_sessions/listener/mod.rs`, so OSC 777 events from the community [pi-mono](https://github.com/badlogic/pi-mono) plugin parsed into a `CLIAgentEvent` and then got dropped — no toast, no session UI for Pi today, despite the parser already accepting `\"agent\":\"pi\"`.

This PR mirrors the Auggie precedent established in [`specs/APP-4067/TECH.md`](specs/APP-4067/TECH.md): a community-maintained plugin emitting the same structured OSC 777 protocol can join the `DefaultSessionListener` arm without any new handler code.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (#9663 is `ready-to-implement`.)

Resolves #9663.

## Changes

- `is_agent_supported` — add `CLIAgent::Pi` to the supported set.
- `create_handler` — move `CLIAgent::Pi` from the catch-all `None` arm into the `DefaultSessionListener` arm. Comment expanded to reference both auggie-warp and pi-mono.

The parser already accepts `\"agent\":\"pi\"` because `resolve_agent` in `event/v1.rs` iterates `enum_iterator::all::<CLIAgent>()` and matches on `command_prefix()` — Pi's prefix has been `\"pi\"` since it was added. No parser changes are needed.

## Testing

Added five new tests covering the same shapes as the existing Auggie tests:

| Test | Location | What it checks |
|---|---|---|
| `pi_is_supported` | `listener/mod.rs` | Regression cover: `is_agent_supported(&CLIAgent::Pi)` returns true. |
| `pi_uses_default_handler_with_rich_status` | `listener/mod.rs` | `agent_supports_rich_status` agrees the handler exists and reports rich status. |
| `pi_default_handler_skips_session_start` | `listener/mod.rs` | Handler-level: `SessionStart` is skipped (matches Auggie's contract). |
| `pi_default_handler_forwards_stop` | `listener/mod.rs` | Handler-level: `Stop` events are forwarded. |
| `parse_pi_stop_notification` | `mod_tests.rs` | End-to-end: `\"agent\":\"pi\"` payload parses into a `CLIAgentEvent` with `CLIAgent::Pi` and the expected fields. |

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Notifications and session UI from the community-maintained pi-mono plugin (Pi CLI agent) are now wired through Warp's default session listener. Thanks @lonexreb!