### PR TITLE
fix: clear permission-scoped state when leaving the permission flow (#9525)

### DIFF
--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -148,6 +148,17 @@ impl CLIAgentSession {
         self.remote_host.is_some()
     }
 
+    /// Clears state populated by `PermissionRequest`. Called whenever the
+    /// session leaves the permission flow (the user replied, a new prompt
+    /// is submitted, or the session ends successfully) so the permission
+    /// summary doesn't leak into later UI surfaces — most visibly the tab
+    /// title, which can fall back to `summary` when `query` is unset.
+    fn clear_permission_scoped_state(&mut self) {
+        self.session_context.summary = None;
+        self.session_context.tool_name = None;
+        self.session_context.tool_input_preview = None;
+    }
+
     /// Applies an event to this session, updating context and status.
     /// Returns the new status if it changed, or `None` if the event was irrelevant.
     fn apply_event(&mut self, event: &CLIAgentEvent) -> Option<CLIAgentSessionStatus> {
@@ -165,6 +176,7 @@ impl CLIAgentSession {
             CLIAgentEventType::PromptSubmit => {
                 self.session_context.query = event.payload.query.clone();
                 self.session_context.response = None;
+                self.clear_permission_scoped_state();
                 CLIAgentSessionStatus::InProgress
             }
             CLIAgentEventType::ToolComplete => {
@@ -176,6 +188,7 @@ impl CLIAgentSession {
             CLIAgentEventType::Stop => {
                 self.session_context.query = event.payload.query.clone();
                 self.session_context.response = event.payload.response.clone();
+                self.clear_permission_scoped_state();
                 CLIAgentSessionStatus::Success
             }
             CLIAgentEventType::PermissionRequest => {
@@ -197,6 +210,7 @@ impl CLIAgentSession {
                 if !matches!(self.status, CLIAgentSessionStatus::Blocked { .. }) {
                     return None;
                 }
+                self.clear_permission_scoped_state();
                 CLIAgentSessionStatus::InProgress
             }
             // IdlePrompt means the agent is sitting at its prompt waiting for input.

--- a/app/src/terminal/cli_agent_sessions/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/mod_tests.rs
@@ -408,3 +408,171 @@ fn session_start_without_plugin_version_leaves_none() {
     session.apply_event(&event);
     assert_eq!(session.plugin_version, None);
 }
+
+/// Constructs a session with permission-scoped state already populated, as if
+/// a `PermissionRequest` had just been received and the agent is now Blocked.
+/// Used by the GH-9525 regression tests below.
+fn blocked_claude_session_with_permission_state() -> CLIAgentSession {
+    CLIAgentSession {
+        agent: CLIAgent::Claude,
+        status: CLIAgentSessionStatus::Blocked {
+            message: Some("Wants to run bash: rm -rf /tmp".to_owned()),
+        },
+        session_context: CLIAgentSessionContext {
+            summary: Some("Wants to run bash: rm -rf /tmp".to_owned()),
+            tool_name: Some("Bash".to_owned()),
+            tool_input_preview: Some("rm -rf /tmp".to_owned()),
+            ..Default::default()
+        },
+        input_state: CLIAgentInputState::Closed,
+        should_auto_toggle_input: false,
+        listener: None,
+        plugin_version: None,
+        draft_text: None,
+        remote_host: None,
+        custom_command_prefix: None,
+    }
+}
+
+#[test]
+fn stop_clears_permission_scoped_state() {
+    // GH-9525: after a PermissionRequest sets `summary`, the Stop event must
+    // clear it. Otherwise the tab title falls back to the stale permission
+    // text instead of reflecting the now-completed session.
+    let mut session = blocked_claude_session_with_permission_state();
+
+    let event = CLIAgentEvent {
+        v: 1,
+        agent: CLIAgent::Claude,
+        event: CLIAgentEventType::Stop,
+        session_id: Some("abc".to_owned()),
+        cwd: None,
+        project: None,
+        payload: CLIAgentEventPayload {
+            query: Some("write a haiku".to_owned()),
+            response: Some("Memory is safe".to_owned()),
+            ..Default::default()
+        },
+    };
+
+    session.apply_event(&event);
+
+    assert_eq!(session.session_context.summary, None);
+    assert_eq!(session.session_context.tool_name, None);
+    assert_eq!(session.session_context.tool_input_preview, None);
+    assert_eq!(
+        session.session_context.query.as_deref(),
+        Some("write a haiku"),
+    );
+    assert_eq!(
+        session.session_context.response.as_deref(),
+        Some("Memory is safe"),
+    );
+    assert!(matches!(session.status, CLIAgentSessionStatus::Success));
+}
+
+#[test]
+fn permission_replied_clears_permission_scoped_state() {
+    // When the user replies to a permission prompt the agent transitions back
+    // to InProgress; the now-stale summary/tool fields must be cleared so they
+    // don't leak into UI surfaces during the next turn.
+    let mut session = blocked_claude_session_with_permission_state();
+
+    let event = CLIAgentEvent {
+        v: 1,
+        agent: CLIAgent::Claude,
+        event: CLIAgentEventType::PermissionReplied,
+        session_id: Some("abc".to_owned()),
+        cwd: None,
+        project: None,
+        payload: CLIAgentEventPayload::default(),
+    };
+
+    session.apply_event(&event);
+
+    assert_eq!(session.session_context.summary, None);
+    assert_eq!(session.session_context.tool_name, None);
+    assert_eq!(session.session_context.tool_input_preview, None);
+    assert!(matches!(session.status, CLIAgentSessionStatus::InProgress));
+}
+
+#[test]
+fn prompt_submit_clears_permission_scoped_state() {
+    // PromptSubmit already clears `response`; clearing the permission-scoped
+    // fields keeps the same hygiene if the user manages to start a new turn
+    // while permission state is still populated (e.g. an abandoned permission
+    // flow that was not closed by an explicit PermissionReplied).
+    let mut session = blocked_claude_session_with_permission_state();
+    session.session_context.response = Some("stale response".to_owned());
+
+    let event = CLIAgentEvent {
+        v: 1,
+        agent: CLIAgent::Claude,
+        event: CLIAgentEventType::PromptSubmit,
+        session_id: Some("abc".to_owned()),
+        cwd: None,
+        project: None,
+        payload: CLIAgentEventPayload {
+            query: Some("next prompt".to_owned()),
+            ..Default::default()
+        },
+    };
+
+    session.apply_event(&event);
+
+    assert_eq!(session.session_context.summary, None);
+    assert_eq!(session.session_context.tool_name, None);
+    assert_eq!(session.session_context.tool_input_preview, None);
+    assert_eq!(session.session_context.response, None);
+    assert_eq!(session.session_context.query.as_deref(), Some("next prompt"));
+    assert!(matches!(session.status, CLIAgentSessionStatus::InProgress));
+}
+
+#[test]
+fn permission_request_still_populates_summary_and_tool_fields() {
+    // Sanity: clearing permission-scoped state on Stop/Reply/Submit must not
+    // also break the PermissionRequest path that initially populates them.
+    let mut session = CLIAgentSession {
+        agent: CLIAgent::Claude,
+        status: CLIAgentSessionStatus::InProgress,
+        session_context: CLIAgentSessionContext::default(),
+        input_state: CLIAgentInputState::Closed,
+        should_auto_toggle_input: false,
+        listener: None,
+        plugin_version: None,
+        draft_text: None,
+        remote_host: None,
+        custom_command_prefix: None,
+    };
+
+    let event = CLIAgentEvent {
+        v: 1,
+        agent: CLIAgent::Claude,
+        event: CLIAgentEventType::PermissionRequest,
+        session_id: Some("abc".to_owned()),
+        cwd: None,
+        project: None,
+        payload: CLIAgentEventPayload {
+            summary: Some("Wants to run bash: rm -rf /tmp".to_owned()),
+            tool_name: Some("Bash".to_owned()),
+            tool_input_preview: Some("rm -rf /tmp".to_owned()),
+            ..Default::default()
+        },
+    };
+
+    session.apply_event(&event);
+
+    assert_eq!(
+        session.session_context.summary.as_deref(),
+        Some("Wants to run bash: rm -rf /tmp"),
+    );
+    assert_eq!(session.session_context.tool_name.as_deref(), Some("Bash"));
+    assert_eq!(
+        session.session_context.tool_input_preview.as_deref(),
+        Some("rm -rf /tmp"),
+    );
+    assert!(matches!(
+        session.status,
+        CLIAgentSessionStatus::Blocked { .. },
+    ));
+}

--- a/app/src/terminal/cli_agent_sessions/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/mod_tests.rs
@@ -524,7 +524,10 @@ fn prompt_submit_clears_permission_scoped_state() {
     assert_eq!(session.session_context.tool_name, None);
     assert_eq!(session.session_context.tool_input_preview, None);
     assert_eq!(session.session_context.response, None);
-    assert_eq!(session.session_context.query.as_deref(), Some("next prompt"));
+    assert_eq!(
+        session.session_context.query.as_deref(),
+        Some("next prompt")
+    );
     assert!(matches!(session.status, CLIAgentSessionStatus::InProgress));
 }
 


### PR DESCRIPTION
## Description

Resolves #9525.

`PermissionRequest` populates `session_context.summary` (plus `tool_name` / `tool_input_preview`) so the tab can show e.g. *\"Wants to run bash: …\"*. Nothing was clearing those fields when the permission flow ended, so after the session reached `Success` the tab kept showing the stale permission text — the bug the reporter hit on Claude Code + [claude-code-warp](https://github.com/warpdotdev/claude-code-warp).

### Root cause

The title path under `AgentTabTextPreference::ConversationTitle` reads `session_context.title_like_text()` directly, which is `summary`. So even after `Stop` repopulates `query` and `response`, the tab keeps showing whatever the last `PermissionRequest` set in `summary`.

```rust
// app/src/workspace/view/vertical_tabs.rs:3081
agent_text.cli_agent_title = session.session_context.title_like_text();
```

### Fix

Introduce `CLIAgentSession::clear_permission_scoped_state()` and call it on the three transitions that close out the permission flow:

| Transition | Why |
|---|---|
| `Stop` | Session completed; permission state is no longer relevant — primary repro path. |
| `PermissionReplied` | User answered; status returns to InProgress. |
| `PromptSubmit` | Defensive: the user starting a new turn invalidates any leftover permission state (mirrors the existing `response = None` reset already on this arm). |

`PermissionRequest` itself still populates these fields, so the Blocked-state UI is unchanged.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (#9525 is `ready-to-implement`.)

Resolves #9525.

## Testing

Four new unit tests in `app/src/terminal/cli_agent_sessions/mod_tests.rs`:

| Test | What it checks |
|---|---|
| `stop_clears_permission_scoped_state` | Primary GH-9525 regression: `summary`/`tool_name`/`tool_input_preview` are cleared and `query`/`response` are repopulated when `Stop` follows `PermissionRequest`. |
| `permission_replied_clears_permission_scoped_state` | Covers the user-replied path; status returns to InProgress with permission state cleared. |
| `prompt_submit_clears_permission_scoped_state` | Covers the abandoned-permission path; clears `response` (existing behavior) and the permission fields (new behavior). |
| `permission_request_still_populates_summary_and_tool_fields` | Sanity: the population path is unaffected — `PermissionRequest` still sets all three fields and transitions to Blocked. |

Each test starts from a Blocked session with permission state populated (factored into a `blocked_claude_session_with_permission_state()` helper), applies the relevant event, and asserts the post-state.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Tab titles for plugin-backed CLI agents (e.g. Claude Code via claude-code-warp) no longer keep showing stale permission-prompt text after a session completes. Thanks @lonexreb!