### PR TITLE
Revert "Fix schema generator binary recompilation during release bundling."

### DIFF
--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -240,7 +240,7 @@ fi
 if [[ "$ARTIFACT" == "cli" ]]; then
   echo "Preparing CLI resources directory"
   BUNDLED_RESOURCES_DIR="$OUT_DIR/resources"
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES"
+  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
 fi
 
 
@@ -269,8 +269,7 @@ export \
   APPIMAGE_NAME \
   BUILD_ARCH \
   ARTIFACT \
-  CARGO_PROFILE \
-  FEATURES
+  CARGO_PROFILE
 
 # Build the AppImage bundle.
 if [[ ${PACKAGES[@]} =~ "appimage" ]]; then

--- a/script/linux/bundle_install
+++ b/script/linux/bundle_install
@@ -13,9 +13,6 @@
 #   - EXECUTABLE_PATH: The path to the compiled executable we want to install.
 #   - BINARY_NAME: The name that the compiled executable should have on the target machine.
 #   - ARTIFACT: Which artifact to build: app or cli.
-#   - FEATURES: Comma-separated cargo features used to build the main binary.
-#                Used to invoke the settings schema generator with the same
-#                feature set so cargo can reuse compiled artifacts.
 
 set -e
 
@@ -47,8 +44,4 @@ if [[ "$ARTIFACT" == "app" ]]; then
 fi
 
 # Prepare the bundled resources directory.
-#
-# Pass FEATURES through so the settings schema generator builds with the same
-# feature set as the main binary; otherwise cargo will recompile any
-# dependencies whose enabled features differ.
-"$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "${TARGET_DIR}/${OPT_DIR}/resources" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES"
+"$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "${TARGET_DIR}/${OPT_DIR}/resources" "$RELEASE_CHANNEL" "$CARGO_PROFILE"

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -61,16 +61,6 @@ ARM_ARCH="aarch64"
 ARM_TARGET="$ARM_ARCH-apple-darwin"
 DEFAULT_ARCH="$(rustc --print cfg | grep target_arch)"
 
-# The Rust target triple corresponding to the build host. Used below to
-# decide whether to forward --target to `cargo run` for the settings schema
-# generator: that step needs to execute its compiled binary, so we can only
-# pass a target that's runnable on the host.
-if [[ "$DEFAULT_ARCH" == *"$INTEL_ARCH"* ]]; then
-    HOST_TARGET="$INTEL_TARGET"
-elif [[ "$DEFAULT_ARCH" == *"$ARM_ARCH"* ]]; then
-    HOST_TARGET="$ARM_TARGET"
-fi
-
 # Function to clean up temporary DMG files
 cleanup_dmg_files() {
     local target_dir="$1"
@@ -526,15 +516,7 @@ if [[ "$ARTIFACT" == "app" ]]; then
 
   BUNDLED_RESOURCES_DIR="$BUNDLE_DIR/$WARP_APP_NAME.app/Contents/Resources"
   echo "Preparing bundled resources..."
-  # Only forward --target to the schema generator when the build target is
-  # runnable on the host; otherwise `cargo run` would try to execute a
-  # cross-compiled binary and fail.
-  if [[ "$DEFAULT_TARGET" == "$HOST_TARGET" ]]; then
-    SCHEMA_CARGO_TARGET="$DEFAULT_TARGET"
-  else
-    SCHEMA_CARGO_TARGET=""
-  fi
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES" "$SCHEMA_CARGO_TARGET"
+  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
 
   "$WORKSPACE_ROOT_DIR/script/compile_icon" "$RELEASE_CHANNEL" "$BUNDLE_DIR/$WARP_APP_NAME.app"
 
@@ -606,15 +588,7 @@ elif [[ "$ARTIFACT" == "cli" ]]; then
 
   echo "Preparing CLI resources directory"
   BUNDLED_RESOURCES_DIR="$OUT_DIR/resources"
-  # Only forward --target to the schema generator when the build target is
-  # runnable on the host; otherwise `cargo run` would try to execute a
-  # cross-compiled binary and fail.
-  if [[ "$DEFAULT_TARGET" == "$HOST_TARGET" ]]; then
-    SCHEMA_CARGO_TARGET="$DEFAULT_TARGET"
-  else
-    SCHEMA_CARGO_TARGET=""
-  fi
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE" "$FEATURES" "$SCHEMA_CARGO_TARGET"
+  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
 
 
   # Set the primary binary path to output.

--- a/script/macos/run
+++ b/script/macos/run
@@ -116,10 +116,7 @@ echo "Preparing bundled resources..."
 if [ "${GENERATE_SCHEMA:-false}" != "true" ]; then
   export SKIP_SETTINGS_SCHEMA=1
 fi
-# Pass FEATURES through (and an empty cargo profile, since this script does
-# not configure one) so that the schema generation reuses the same compiled
-# artifacts as the cargo bundle invocation above.
-NO_LICENSES=1 "${REPO_ROOT}/script/prepare_bundled_resources" "$WARP_APP_PATH/Contents/Resources" "$WARP_CHANNEL" "" "$FEATURES"
+NO_LICENSES=1 "${REPO_ROOT}/script/prepare_bundled_resources" "$WARP_APP_PATH/Contents/Resources" "$WARP_CHANNEL"
 
 "${REPO_ROOT}/script/compile_icon" "$WARP_CHANNEL" "$WARP_APP_PATH"
 

--- a/script/prepare_bundled_resources
+++ b/script/prepare_bundled_resources
@@ -6,7 +6,7 @@
 # destination directory. It is used by macOS and Linux build scripts.
 #
 # Usage:
-#   prepare_bundled_resources <destination_directory> [channel] [cargo_profile] [cargo_features] [cargo_target]
+#   prepare_bundled_resources <destination_directory> [channel] [cargo_profile]
 #
 # Arguments:
 #   destination_directory:  The directory where resources should be installed.
@@ -17,25 +17,6 @@
 #   cargo_profile:          (Optional) Cargo build profile to use when
 #                           generating the settings schema. Reusing the same
 #                           profile as the main build avoids recompiling deps.
-#   cargo_features:         (Optional) Comma-separated cargo features to
-#                           enable when generating the settings schema.
-#                           Should match the features used to build the main
-#                           binary so that cargo can reuse the existing
-#                           compilation artifacts (otherwise dependencies
-#                           gated behind those features will be recompiled).
-#                           Also ensures that feature-gated settings are
-#                           included in the generated schema.
-#   cargo_target:           (Optional) Rust target triple to pass via
-#                           --target. Should match the target used to build
-#                           the main binary, for the same reason as
-#                           cargo_features.
-#                           NOTE: only set this when the target can be
-#                           executed on the build host (e.g. when not
-#                           cross-compiling, or when running through a
-#                           supported emulator like Rosetta). `cargo run`
-#                           will attempt to execute the resulting binary,
-#                           and a binary built for an unrunnable target
-#                           will fail at this step.
 #
 # Environment variables:
 #   SKIP_SETTINGS_SCHEMA: Set to "1" to skip generating the JSON settings
@@ -44,17 +25,15 @@
 
 set -e
 
-if [ $# -lt 1 ] || [ $# -gt 5 ]; then
-  echo "Error: Expected 1-5 arguments but received $#" >&2
-  echo "Usage: $0 <destination_directory> [channel] [cargo_profile] [cargo_features] [cargo_target]" >&2
+if [ $# -lt 1 ] || [ $# -gt 3 ]; then
+  echo "Error: Expected 1-3 arguments but received $#" >&2
+  echo "Usage: $0 <destination_directory> [channel] [cargo_profile]" >&2
   exit 1
 fi
 
 DEST_DIR="$1"
 CHANNEL="${2:-}"
 CARGO_PROFILE="${3:-}"
-CARGO_FEATURES="${4:-}"
-CARGO_TARGET="${5:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RESOURCES_SRC="$REPO_ROOT/resources"
@@ -147,21 +126,11 @@ if [ "${SKIP_SETTINGS_SCHEMA:-}" != "1" ]; then
   SCHEMA_OUTPUT="$DEST_DIR/settings_schema.json"
   echo "Generating settings schema at $SCHEMA_OUTPUT"
 
-  # Pass the same package, profile, features, and target as the main build
-  # so that cargo can reuse compilation artifacts (rather than recompiling
-  # any dependencies whose enabled features differ).  Also ensures that
-  # feature-gated settings are included in the generated schema.
-  SCHEMA_CMD=(cargo run --manifest-path "$REPO_ROOT/Cargo.toml" -p warp)
+  SCHEMA_CMD=(cargo run)
   if [ -n "$CARGO_PROFILE" ]; then
     SCHEMA_CMD+=(--profile "$CARGO_PROFILE")
   fi
-  if [ -n "$CARGO_FEATURES" ]; then
-    SCHEMA_CMD+=(--features "$CARGO_FEATURES")
-  fi
-  if [ -n "$CARGO_TARGET" ]; then
-    SCHEMA_CMD+=(--target "$CARGO_TARGET")
-  fi
-  SCHEMA_CMD+=(--bin generate_settings_schema --)
+  SCHEMA_CMD+=(--manifest-path "$REPO_ROOT/Cargo.toml" --bin generate_settings_schema --)
   if [ -n "$CHANNEL" ]; then
     SCHEMA_CMD+=(--channel "$CHANNEL")
   fi

--- a/script/windows/bundle.ps1
+++ b/script/windows/bundle.ps1
@@ -180,23 +180,7 @@ Write-Output "Built for $ARCH with executable at $BINARY_PATH"
 # Prepare bundled resources
 $BUNDLED_RESOURCES_DIR = "$CARGO_TARGET_OUTPUT_DIR\resources"
 Write-Output "Preparing bundled resources..."
-# Only forward --target to the schema generator when the build target is
-# runnable on the host; otherwise `cargo run` would try to execute a
-# cross-compiled binary (e.g. aarch64-pc-windows-msvc on an x64 runner)
-# and fail.
-if ($env:PROCESSOR_ARCHITECTURE -eq 'AMD64') {
-    $HOST_TARGET = 'x86_64-pc-windows-msvc'
-} elseif ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
-    $HOST_TARGET = 'aarch64-pc-windows-msvc'
-} else {
-    $HOST_TARGET = ''
-}
-if ($PLATFORM_TARGET -eq $HOST_TARGET) {
-    $SCHEMA_CARGO_TARGET = $PLATFORM_TARGET
-} else {
-    $SCHEMA_CARGO_TARGET = ''
-}
-& "$WINDOWS_INSTALLER_DIR\prepare_bundled_resources.ps1" -DestinationDir "$BUNDLED_RESOURCES_DIR" -Channel "$CHANNEL" -CargoProfile "$CARGO_PROFILE" -CargoFeatures "$FEATURES" -CargoTarget "$SCHEMA_CARGO_TARGET"
+& "$WINDOWS_INSTALLER_DIR\prepare_bundled_resources.ps1" -DestinationDir "$BUNDLED_RESOURCES_DIR" -Channel "$CHANNEL" -CargoProfile "$CARGO_PROFILE"
 if (-Not $?) {
     Write-Error "Failed to prepare bundled resources"
     exit 1

--- a/script/windows/prepare_bundled_resources.ps1
+++ b/script/windows/prepare_bundled_resources.ps1
@@ -5,29 +5,12 @@
 # destination directory. It is used by the Windows build script.
 #
 # Usage:
-#   prepare_bundled_resources.ps1 -DestinationDir <destination_directory> [-Channel <channel>] [-CargoProfile <profile>] [-CargoFeatures <features>] [-CargoTarget <target>]
+#   prepare_bundled_resources.ps1 <destination_directory>
 #
 # Arguments:
-#   DestinationDir:  The directory where resources should be installed.
-#                    Resources will be copied to subdirectories within this
-#                    path (e.g., $DEST_DIR\skills).
-#   Channel:         (Optional) Release channel. Used to include
-#                    channel-gated skills.
-#   CargoProfile:    (Optional) Cargo build profile to use when generating
-#                    the settings schema.
-#   CargoFeatures:   (Optional) Comma-separated cargo features to enable when
-#                    generating the settings schema. Should match the
-#                    features used to build the main binary so that cargo
-#                    can reuse the existing compilation artifacts.  Also
-#                    ensures that feature-gated settings are included in the
-#                    generated schema.
-#   CargoTarget:     (Optional) Rust target triple to pass via --target.
-#                    Should match the target used to build the main binary.
-#                    NOTE: only set this when the target can be executed on
-#                    the build host. `cargo run` will attempt to execute
-#                    the resulting binary, so this must be omitted when
-#                    cross-compiling to a target the host can't run
-#                    (e.g. aarch64-pc-windows-msvc on an x64 runner).
+#   destination_directory: The directory where resources should be installed.
+#                          Resources will be copied to subdirectories within
+#                          this path (e.g., $DEST_DIR\skills).
 
 Param(
     [Parameter(Mandatory = $true)]
@@ -37,13 +20,7 @@ Param(
     [String]$Channel = '',
 
     [Parameter(Mandatory = $false)]
-    [String]$CargoProfile = '',
-
-    [Parameter(Mandatory = $false)]
-    [String]$CargoFeatures = '',
-
-    [Parameter(Mandatory = $false)]
-    [String]$CargoTarget = ''
+    [String]$CargoProfile = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -187,22 +164,11 @@ if ($env:SKIP_SETTINGS_SCHEMA -ne '1') {
     $SchemaOutput = Join-Path $DestinationDir 'settings_schema.json'
     Write-Output "Generating settings schema at $SchemaOutput"
 
-    # Pass the same package, profile, features, and target as the main
-    # build so that cargo can reuse compilation artifacts (rather than
-    # recompiling any dependencies whose enabled features differ).  Also
-    # ensures that feature-gated settings are included in the generated
-    # schema.
-    $SchemaCmd = @('run', '--manifest-path', (Join-Path $RepoRoot 'Cargo.toml'), '-p', 'warp')
+    $SchemaCmd = @('run')
     if ($CargoProfile) {
         $SchemaCmd += @('--profile', $CargoProfile)
     }
-    if ($CargoFeatures) {
-        $SchemaCmd += @('--features', $CargoFeatures)
-    }
-    if ($CargoTarget) {
-        $SchemaCmd += @('--target', $CargoTarget)
-    }
-    $SchemaCmd += @('--bin', 'generate_settings_schema', '--')
+    $SchemaCmd += @('--manifest-path', (Join-Path $RepoRoot 'Cargo.toml'), '--bin', 'generate_settings_schema', '--')
     if ($Channel) {
         $SchemaCmd += @('--channel', $Channel)
     }


### PR DESCRIPTION
Reverts warpdotdev/warp#9632

Will look at in the future. Currently causing dev build issues like https://github.com/warpdotdev/warp-internal/actions/runs/25187609052/job/73853657131