### PR TITLE
[REMOTE-1318] Merge org and user command denylists with per-row editability

### DIFF
--- a/app/src/ai/blocklist/permissions.rs
+++ b/app/src/ai/blocklist/permissions.rs
@@ -398,18 +398,35 @@ impl BlocklistAIPermissions {
         profile_id: ClientProfileId,
     ) -> Vec<AgentModeCommandExecutionPredicate> {
         let autonomy_settings = Self::workspace_autonomy_settings(ctx);
+        let profiles_model = AIExecutionProfilesModel::as_ref(ctx);
+        let user_denylist = profiles_model
+            .get_profile_by_id(profile_id, ctx)
+            .unwrap_or_else(|| profiles_model.default_profile(ctx))
+            .data()
+            .command_denylist
+            .clone();
 
+        match autonomy_settings.execute_commands_denylist {
+            Some(org_denylist) => {
+                let mut merged = org_denylist;
+                for item in user_denylist {
+                    if !merged.contains(&item) {
+                        merged.push(item);
+                    }
+                }
+                merged
+            }
+            None => user_denylist,
+        }
+    }
+
+    pub fn get_org_execute_commands_denylist(
+        ctx: &AppContext,
+    ) -> Vec<AgentModeCommandExecutionPredicate> {
+        let autonomy_settings = Self::workspace_autonomy_settings(ctx);
         autonomy_settings
             .execute_commands_denylist
-            .unwrap_or_else(|| {
-                let profiles_model = AIExecutionProfilesModel::as_ref(ctx);
-                profiles_model
-                    .get_profile_by_id(profile_id, ctx)
-                    .unwrap_or_else(|| profiles_model.default_profile(ctx))
-                    .data()
-                    .command_denylist
-                    .clone()
-            })
+            .unwrap_or_default()
     }
 
     /// Returns a denylist of command regexes that AM should not auto-execute.

--- a/app/src/ai/blocklist/permissions_test.rs
+++ b/app/src/ai/blocklist/permissions_test.rs
@@ -642,7 +642,6 @@ fn test_can_autoexecute_command_denylist_precedence() {
 
         // Org + user denylists are merged: both should be active
         permissions.read(&app, |model, ctx| {
-            // git commands should be denied (from workspace/org denylist)
             let result = model.can_autoexecute_command(
                 &convo_id,
                 "git status",
@@ -660,7 +659,6 @@ fn test_can_autoexecute_command_denylist_precedence() {
                 )
             ));
 
-            // rm commands should ALSO still be denied (from user profile, merged in)
             let result = model.can_autoexecute_command(
                 &convo_id,
                 "rm file.txt",
@@ -1326,7 +1324,6 @@ fn test_merged_denylist_deduplication() {
 
         let rm_predicate = AgentModeCommandExecutionPredicate::new_regex("rm .*").unwrap();
 
-        // Add "rm .*" to user profile denylist
         profile_model.update(&mut app, |model, ctx| {
             model.add_to_command_denylist(
                 *model.active_profile(Some(terminal_view_id), ctx).id(),
@@ -1335,7 +1332,6 @@ fn test_merged_denylist_deduplication() {
             );
         });
 
-        // Also set workspace denylist with "rm .*" (duplicate) + "git .*"
         user_workspaces.update(&mut app, |model, ctx| {
             model.setup_test_workspace(ctx);
             model.update_ai_autonomy_settings(
@@ -1349,13 +1345,10 @@ fn test_merged_denylist_deduplication() {
             );
         });
 
-        // Merged list should have "rm .*" only once + "git .*"
         permissions.read(&app, |model, ctx| {
             let denylist = model.get_execute_commands_denylist(ctx, Some(terminal_view_id));
-            // "rm .*" should appear exactly once (deduplicated)
             let rm_count = denylist.iter().filter(|p| p.to_string() == "rm .*").count();
             assert_eq!(rm_count, 1, "duplicate entries should be deduplicated");
-            // "git .*" should also be present
             assert!(
                 denylist.iter().any(|p| p.to_string() == "git .*"),
                 "org entry 'git .*' should be in merged list"
@@ -1373,13 +1366,11 @@ fn test_get_org_execute_commands_denylist() {
             ..
         } = initialize_permissions_test(&mut app);
 
-        // No org override: should return empty
         permissions.read(&app, |_, ctx| {
             let org_list = BlocklistAIPermissions::get_org_execute_commands_denylist(ctx);
             assert!(org_list.is_empty());
         });
 
-        // Set org denylist
         user_workspaces.update(&mut app, |model, ctx| {
             model.setup_test_workspace(ctx);
             model.update_ai_autonomy_settings(
@@ -1414,7 +1405,6 @@ fn test_empty_org_denylist_allows_user_entries() {
             ..
         } = initialize_permissions_test(&mut app);
 
-        // Add user denylist entry
         profile_model.update(&mut app, |model, ctx| {
             model.add_to_command_denylist(
                 *model.active_profile(Some(terminal_view_id), ctx).id(),
@@ -1423,7 +1413,6 @@ fn test_empty_org_denylist_allows_user_entries() {
             );
         });
 
-        // Set org denylist to empty (Some([]))
         user_workspaces.update(&mut app, |model, ctx| {
             model.setup_test_workspace(ctx);
             model.update_ai_autonomy_settings(
@@ -1434,7 +1423,6 @@ fn test_empty_org_denylist_allows_user_entries() {
             );
         });
 
-        // User entry should still be active despite empty org override
         permissions.read(&app, |model, ctx| {
             let result = model.can_autoexecute_command(
                 &convo_id,

--- a/app/src/ai/blocklist/permissions_test.rs
+++ b/app/src/ai/blocklist/permissions_test.rs
@@ -640,9 +640,9 @@ fn test_can_autoexecute_command_denylist_precedence() {
             );
         });
 
-        // Test that workspace denylist overrides profile denylist
+        // Org + user denylists are merged: both should be active
         permissions.read(&app, |model, ctx| {
-            // git commands should now be denied
+            // git commands should be denied (from workspace/org denylist)
             let result = model.can_autoexecute_command(
                 &convo_id,
                 "git status",
@@ -660,7 +660,7 @@ fn test_can_autoexecute_command_denylist_precedence() {
                 )
             ));
 
-            // rm commands should now not be explicitly denylisted
+            // rm commands should ALSO still be denied (from user profile, merged in)
             let result = model.can_autoexecute_command(
                 &convo_id,
                 "rm file.txt",
@@ -670,12 +670,15 @@ fn test_can_autoexecute_command_denylist_precedence() {
                 Some(terminal_view_id),
                 ctx,
             );
-            assert!(!matches!(
-                result,
-                CommandExecutionPermission::Denied(
-                    CommandExecutionPermissionDeniedReason::ExplicitlyDenylisted
-                )
-            ));
+            assert!(
+                matches!(
+                    result,
+                    CommandExecutionPermission::Denied(
+                        CommandExecutionPermissionDeniedReason::ExplicitlyDenylisted
+                    )
+                ),
+                "user denylist entries should be merged with org denylist, not replaced"
+            );
         });
     })
 }
@@ -1305,6 +1308,146 @@ fn test_sandboxed_denylist_used_in_sandboxed_mode() {
                     )
                 ),
                 "rm file.txt should be denied by the sandboxed denylist"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_merged_denylist_deduplication() {
+    App::test((), |mut app| async move {
+        let PermissionsTestState {
+            permissions,
+            user_workspaces,
+            profile_model,
+            terminal_view_id,
+            ..
+        } = initialize_permissions_test(&mut app);
+
+        let rm_predicate = AgentModeCommandExecutionPredicate::new_regex("rm .*").unwrap();
+
+        // Add "rm .*" to user profile denylist
+        profile_model.update(&mut app, |model, ctx| {
+            model.add_to_command_denylist(
+                *model.active_profile(Some(terminal_view_id), ctx).id(),
+                &rm_predicate,
+                ctx,
+            );
+        });
+
+        // Also set workspace denylist with "rm .*" (duplicate) + "git .*"
+        user_workspaces.update(&mut app, |model, ctx| {
+            model.setup_test_workspace(ctx);
+            model.update_ai_autonomy_settings(
+                |settings| {
+                    settings.execute_commands_denylist = Some(vec![
+                        AgentModeCommandExecutionPredicate::new_regex("rm .*").unwrap(),
+                        AgentModeCommandExecutionPredicate::new_regex("git .*").unwrap(),
+                    ]);
+                },
+                ctx,
+            );
+        });
+
+        // Merged list should have "rm .*" only once + "git .*"
+        permissions.read(&app, |model, ctx| {
+            let denylist = model.get_execute_commands_denylist(ctx, Some(terminal_view_id));
+            // "rm .*" should appear exactly once (deduplicated)
+            let rm_count = denylist.iter().filter(|p| p.to_string() == "rm .*").count();
+            assert_eq!(rm_count, 1, "duplicate entries should be deduplicated");
+            // "git .*" should also be present
+            assert!(
+                denylist.iter().any(|p| p.to_string() == "git .*"),
+                "org entry 'git .*' should be in merged list"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_get_org_execute_commands_denylist() {
+    App::test((), |mut app| async move {
+        let PermissionsTestState {
+            permissions,
+            user_workspaces,
+            ..
+        } = initialize_permissions_test(&mut app);
+
+        // No org override: should return empty
+        permissions.read(&app, |_, ctx| {
+            let org_list = BlocklistAIPermissions::get_org_execute_commands_denylist(ctx);
+            assert!(org_list.is_empty());
+        });
+
+        // Set org denylist
+        user_workspaces.update(&mut app, |model, ctx| {
+            model.setup_test_workspace(ctx);
+            model.update_ai_autonomy_settings(
+                |settings| {
+                    settings.execute_commands_denylist =
+                        Some(vec![AgentModeCommandExecutionPredicate::new_regex(
+                            "git .*",
+                        )
+                        .unwrap()]);
+                },
+                ctx,
+            );
+        });
+
+        permissions.read(&app, |_, ctx| {
+            let org_list = BlocklistAIPermissions::get_org_execute_commands_denylist(ctx);
+            assert_eq!(org_list.len(), 1);
+            assert_eq!(org_list[0].to_string(), "git .*");
+        });
+    })
+}
+
+#[test]
+fn test_empty_org_denylist_allows_user_entries() {
+    App::test((), |mut app| async move {
+        let PermissionsTestState {
+            convo_id,
+            permissions,
+            user_workspaces,
+            profile_model,
+            terminal_view_id,
+            ..
+        } = initialize_permissions_test(&mut app);
+
+        // Add user denylist entry
+        profile_model.update(&mut app, |model, ctx| {
+            model.add_to_command_denylist(
+                *model.active_profile(Some(terminal_view_id), ctx).id(),
+                &AgentModeCommandExecutionPredicate::new_regex("rm .*").unwrap(),
+                ctx,
+            );
+        });
+
+        // Set org denylist to empty (Some([]))
+        user_workspaces.update(&mut app, |model, ctx| {
+            model.setup_test_workspace(ctx);
+            model.update_ai_autonomy_settings(
+                |settings| {
+                    settings.execute_commands_denylist = Some(vec![]);
+                },
+                ctx,
+            );
+        });
+
+        // User entry should still be active despite empty org override
+        permissions.read(&app, |model, ctx| {
+            let result = model.can_autoexecute_command(
+                &convo_id,
+                "rm file.txt",
+                EscapeChar::Backslash,
+                false,
+                None,
+                Some(terminal_view_id),
+                ctx,
+            );
+            assert!(
+                !result.is_allowed(),
+                "user denylist entry should be active even when org denylist is empty"
             );
         });
     })

--- a/app/src/ai/execution_profiles/editor/mod.rs
+++ b/app/src/ai/execution_profiles/editor/mod.rs
@@ -808,6 +808,7 @@ impl ExecutionProfileEditorView {
         ctx.subscribe_to_model(&workspace, |me, workspace, event, ctx| {
             if let UserWorkspacesEvent::TeamsChanged = event {
                 Self::update_all_editor_interaction_states(me, workspace, ctx);
+                me.update_mouse_state_handles(ctx);
                 ctx.notify();
             }
         });

--- a/app/src/ai/execution_profiles/editor/mod.rs
+++ b/app/src/ai/execution_profiles/editor/mod.rs
@@ -125,7 +125,6 @@ struct TooltipMouseStateHandles {
     call_mcp_servers_tooltip_mouse_state: MouseStateHandle,
     // Separate mouse state handles for text input editors (for workspace override tooltips)
     command_allowlist_editor_tooltip_mouse_state: MouseStateHandle,
-    command_denylist_editor_tooltip_mouse_state: MouseStateHandle,
     directory_allowlist_editor_tooltip_mouse_state: MouseStateHandle,
     mcp_allowlist_editor_tooltip_mouse_state: MouseStateHandle,
     mcp_denylist_editor_tooltip_mouse_state: MouseStateHandle,
@@ -253,6 +252,7 @@ pub struct ExecutionProfileEditorView {
     directory_allowlist_editor: ViewHandle<SubmittableTextInput>,
     command_allowlist_mouse_state_handles: Vec<MouseStateHandle>,
     command_denylist_mouse_state_handles: Vec<MouseStateHandle>,
+    command_denylist_tooltip_mouse_state_handles: Vec<MouseStateHandle>,
     directory_allowlist_mouse_state_handles: Vec<MouseStateHandle>,
     mcp_allowlist_dropdown: ViewHandle<FilterableDropdown<ExecutionProfileEditorViewAction>>,
     mcp_allowlist_mouse_state_handles: Vec<MouseStateHandle>,
@@ -628,6 +628,11 @@ impl ExecutionProfileEditorView {
             directory_allowlist_editor,
             command_allowlist_mouse_state_handles,
             command_denylist_mouse_state_handles,
+            command_denylist_tooltip_mouse_state_handles: profile_data
+                .command_denylist
+                .iter()
+                .map(|_| Default::default())
+                .collect(),
             directory_allowlist_mouse_state_handles,
             mcp_allowlist_dropdown,
             mcp_allowlist_mouse_state_handles,
@@ -840,6 +845,12 @@ impl ExecutionProfileEditorView {
             .collect();
 
         self.command_denylist_mouse_state_handles = current_permissions
+            .command_denylist
+            .iter()
+            .map(|_| Default::default())
+            .collect();
+
+        self.command_denylist_tooltip_mouse_state_handles = current_permissions
             .command_denylist
             .iter()
             .map(|_| Default::default())
@@ -1276,7 +1287,7 @@ impl ExecutionProfileEditorView {
 
         Self::update_editor_interaction_state(
             view.command_denylist_editor.as_ref(ctx).editor().clone(),
-            is_any_ai_enabled && !ai_autonomy_settings.has_override_for_execute_commands_denylist(),
+            is_any_ai_enabled,
             ctx,
         );
 

--- a/app/src/ai/execution_profiles/editor/ui_helpers.rs
+++ b/app/src/ai/execution_profiles/editor/ui_helpers.rs
@@ -751,7 +751,7 @@ fn render_command_denylist_section(
 ) -> Box<dyn Element> {
     use crate::ai::blocklist::BlocklistAIPermissions;
 
-    let ai_disabled = !AISettings::as_ref(app).is_command_denylist_editable(app);
+    let ai_disabled = !AISettings::as_ref(app).is_any_ai_enabled(app);
     let org_denylist = BlocklistAIPermissions::get_org_execute_commands_denylist(app);
     let mut tooltip_idx = 0usize;
 

--- a/app/src/ai/execution_profiles/editor/ui_helpers.rs
+++ b/app/src/ai/execution_profiles/editor/ui_helpers.rs
@@ -664,10 +664,12 @@ where
             item: display_fn(&item),
             mouse_state_handle,
             on_remove_action: on_remove_action(item),
+            is_disabled: !is_editable,
+            tooltip_mouse_state: None,
         })
         .collect();
 
-    let list = render_input_list(None, input_items, editor, !is_editable, appearance);
+    let list = render_input_list(None, input_items, editor, appearance);
     let list_element = if !is_editable {
         wrap_disabled_with_workspace_override_tooltip(list, tooltip_mouse_state, appearance)
     } else {
@@ -747,24 +749,58 @@ fn render_command_denylist_section(
     appearance: &Appearance,
     app: &warpui::AppContext,
 ) -> Box<dyn Element> {
-    let ai_settings = AISettings::as_ref(app);
-    let is_editable = ai_settings.is_command_denylist_editable(app);
+    use crate::ai::blocklist::BlocklistAIPermissions;
 
-    render_list_section(
+    let org_denylist = BlocklistAIPermissions::get_org_execute_commands_denylist(app);
+    let mut tooltip_idx = 0usize;
+
+    let input_items: Vec<InputListItem<ExecutionProfileEditorViewAction>> = profile_data
+        .command_denylist
+        .iter()
+        .cloned()
+        .zip(view.command_denylist_mouse_state_handles.iter().cloned())
+        .rev()
+        .map(|(predicate, mouse_state_handle)| {
+            let is_org = org_denylist.contains(&predicate);
+            let tooltip_mouse_state = if is_org {
+                let handle = view
+                    .command_denylist_tooltip_mouse_state_handles
+                    .get(tooltip_idx)
+                    .cloned();
+                tooltip_idx += 1;
+                handle
+            } else {
+                None
+            };
+            InputListItem {
+                item: predicate.to_string(),
+                mouse_state_handle,
+                on_remove_action: ExecutionProfileEditorViewAction::RemoveFromCommandDenylist {
+                    predicate,
+                },
+                is_disabled: is_org,
+                tooltip_mouse_state,
+            }
+        })
+        .collect();
+
+    let list = render_input_list(
+        None,
+        input_items,
+        Some(&view.command_denylist_editor),
+        appearance,
+    );
+
+    let mut column = Flex::column().with_child(create_section_header(
         "Command denylist",
         "Regular expressions to match commands that Oz should always ask permission to execute.",
-        &profile_data.command_denylist,
-        &view.command_denylist_mouse_state_handles,
-        Some(&view.command_denylist_editor),
-        None,
-        |predicate| ExecutionProfileEditorViewAction::RemoveFromCommandDenylist { predicate },
-        |item| item.to_string(),
         appearance,
-        is_editable,
-        view.tooltip_mouse_state_handles
-            .command_denylist_editor_tooltip_mouse_state
-            .clone(),
-    )
+    ));
+    column = column.with_child(list);
+
+    Container::new(column.finish())
+        .with_margin_bottom(16.)
+        .finish()
 }
 
 fn display_mcp_name(uuid: &Uuid, app: &AppContext) -> String {

--- a/app/src/ai/execution_profiles/editor/ui_helpers.rs
+++ b/app/src/ai/execution_profiles/editor/ui_helpers.rs
@@ -751,6 +751,7 @@ fn render_command_denylist_section(
 ) -> Box<dyn Element> {
     use crate::ai::blocklist::BlocklistAIPermissions;
 
+    let ai_disabled = !AISettings::as_ref(app).is_command_denylist_editable(app);
     let org_denylist = BlocklistAIPermissions::get_org_execute_commands_denylist(app);
     let mut tooltip_idx = 0usize;
 
@@ -778,7 +779,7 @@ fn render_command_denylist_section(
                 on_remove_action: ExecutionProfileEditorViewAction::RemoveFromCommandDenylist {
                     predicate,
                 },
-                is_disabled: is_org,
+                is_disabled: is_org || ai_disabled,
                 tooltip_mouse_state,
             }
         })

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1728,11 +1728,10 @@ impl AISettings {
     }
 
     pub fn is_command_denylist_editable(&self, app: &AppContext) -> bool {
-        let set_by_workspace = UserWorkspaces::as_ref(app)
-            .ai_autonomy_settings()
-            .has_override_for_execute_commands_denylist();
-
-        self.is_any_ai_enabled(app) && !set_by_workspace
+        // The denylist editor is always enabled when AI is on. Users can always
+        // add entries to make the denylist more restrictive, even when the org
+        // sets an override. Per-item removal is controlled at the row level.
+        self.is_any_ai_enabled(app)
     }
 
     pub fn is_command_allowlist_editable(&self, app: &AppContext) -> bool {

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1728,9 +1728,6 @@ impl AISettings {
     }
 
     pub fn is_command_denylist_editable(&self, app: &AppContext) -> bool {
-        // The denylist editor is always enabled when AI is on. Users can always
-        // add entries to make the denylist more restrictive, even when the org
-        // sets an override. Per-item removal is controlled at the row level.
         self.is_any_ai_enabled(app)
     }
 

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -1904,10 +1904,8 @@ impl AISettingsPageView {
             .collect();
 
         let org_denylist = BlocklistAIPermissions::get_org_execute_commands_denylist(ctx);
-        self.command_denylist_tooltip_mouse_state_handles = org_denylist
-            .iter()
-            .map(|_| Default::default())
-            .collect();
+        self.command_denylist_tooltip_mouse_state_handles =
+            org_denylist.iter().map(|_| Default::default()).collect();
 
         self.command_allowlist_mouse_state_handles = blocklist_permissions
             .get_execute_commands_allowlist(ctx, None)
@@ -4496,7 +4494,7 @@ impl AgentsWidget {
         appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
-        let ai_disabled = !ai_settings.is_command_denylist_editable(app);
+        let ai_disabled = !ai_settings.is_any_ai_enabled(app);
         let org_denylist = BlocklistAIPermissions::get_org_execute_commands_denylist(app);
         let mut tooltip_idx = 0usize;
         let list = render_input_list(

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -1903,6 +1903,12 @@ impl AISettingsPageView {
             .map(|_| Default::default())
             .collect();
 
+        let org_denylist = BlocklistAIPermissions::get_org_execute_commands_denylist(ctx);
+        self.command_denylist_tooltip_mouse_state_handles = org_denylist
+            .iter()
+            .map(|_| Default::default())
+            .collect();
+
         self.command_allowlist_mouse_state_handles = blocklist_permissions
             .get_execute_commands_allowlist(ctx, None)
             .iter()
@@ -4490,6 +4496,7 @@ impl AgentsWidget {
         appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
+        let ai_disabled = !ai_settings.is_command_denylist_editable(app);
         let org_denylist = BlocklistAIPermissions::get_org_execute_commands_denylist(app);
         let mut tooltip_idx = 0usize;
         let list = render_input_list(
@@ -4516,7 +4523,7 @@ impl AgentsWidget {
                         on_remove_action: AISettingsPageAction::RemoveFromProfileCommandDenylist(
                             cmd,
                         ),
-                        is_disabled: is_org,
+                        is_disabled: is_org || ai_disabled,
                         tooltip_mouse_state,
                     }
                 }),

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -432,6 +432,7 @@ pub struct AISettingsPageView {
 
     // Denylisting commands (default profile)
     command_denylist_mouse_state_handles: Vec<MouseStateHandle>,
+    command_denylist_tooltip_mouse_state_handles: Vec<MouseStateHandle>,
     command_denylist_editor: ViewHandle<SubmittableTextInput>,
 
     mcp_allowlist_mouse_state_handles: Vec<MouseStateHandle>,
@@ -472,8 +473,7 @@ impl AISettingsPageView {
 
                 Self::update_editor_interaction_state(
                     me.command_denylist_editor.as_ref(ctx).editor().clone(),
-                    is_any_ai_enabled
-                        && !ai_autonomy_settings.has_override_for_execute_commands_denylist(),
+                    is_any_ai_enabled,
                     ctx,
                 );
 
@@ -876,6 +876,8 @@ impl AISettingsPageView {
                         is_enabled,
                         ctx,
                     );
+                    // Denylist editor is always enabled when AI is on,
+                    // regardless of org override.
                     Self::update_editor_interaction_state(
                         me.code_read_allowlist_editor.as_ref(ctx).editor().clone(),
                         is_enabled,
@@ -890,8 +892,7 @@ impl AISettingsPageView {
 
                     Self::update_editor_interaction_state(
                         me.command_denylist_editor.as_ref(ctx).editor().clone(),
-                        is_enabled
-                            && !ai_autonomy_settings.has_override_for_execute_commands_denylist(),
+                        is_enabled,
                         ctx,
                     );
 
@@ -1245,11 +1246,14 @@ impl AISettingsPageView {
             }
         });
 
+        let org_denylist = BlocklistAIPermissions::get_org_execute_commands_denylist(ctx);
         let command_denylist_mouse_state_handles = current_permission
             .command_denylist
             .iter()
             .map(|_| Default::default())
             .collect();
+        let command_denylist_tooltip_mouse_state_handles: Vec<MouseStateHandle> =
+            org_denylist.iter().map(|_| Default::default()).collect();
 
         let command_denylist_editor = ctx.add_typed_action_view(|ctx| {
             let mut input =
@@ -1418,6 +1422,7 @@ impl AISettingsPageView {
             directory_allowlist_mouse_state_handles,
             directory_allowlist_editor,
             command_denylist_mouse_state_handles,
+            command_denylist_tooltip_mouse_state_handles,
             command_denylist_editor,
             command_allowlist_mouse_state_handles,
             command_allowlist_editor,
@@ -4487,19 +4492,37 @@ impl AgentsWidget {
         appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
+        let org_denylist = BlocklistAIPermissions::get_org_execute_commands_denylist(app);
+        let mut tooltip_idx = 0usize;
         let list = render_input_list(
             None,
             command_denylist
                 .into_iter()
                 .zip(view.command_denylist_mouse_state_handles.clone())
                 .rev()
-                .map(|(cmd, mouse_state_handle)| InputListItem {
-                    item: cmd.to_string(),
-                    mouse_state_handle,
-                    on_remove_action: AISettingsPageAction::RemoveFromProfileCommandDenylist(cmd),
+                .map(|(cmd, mouse_state_handle)| {
+                    let is_org = org_denylist.contains(&cmd);
+                    let tooltip_mouse_state = if is_org {
+                        let handle = view
+                            .command_denylist_tooltip_mouse_state_handles
+                            .get(tooltip_idx)
+                            .cloned();
+                        tooltip_idx += 1;
+                        handle
+                    } else {
+                        None
+                    };
+                    InputListItem {
+                        item: cmd.to_string(),
+                        mouse_state_handle,
+                        on_remove_action: AISettingsPageAction::RemoveFromProfileCommandDenylist(
+                            cmd,
+                        ),
+                        is_disabled: is_org,
+                        tooltip_mouse_state,
+                    }
                 }),
             Some(&view.command_denylist_editor),
-            !ai_settings.is_command_denylist_editable(app),
             appearance,
         );
         render_ai_list(
@@ -4519,19 +4542,21 @@ impl AgentsWidget {
         appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
+        let disabled = !ai_settings.is_command_allowlist_editable(app);
         let list = render_input_list(
             None,
             command_allowlist
                 .into_iter()
                 .zip(view.command_allowlist_mouse_state_handles.clone())
                 .rev()
-                .map(|(cmd, mouse_state_handle)| InputListItem {
+                .map(move |(cmd, mouse_state_handle)| InputListItem {
                     item: cmd.to_string(),
                     mouse_state_handle,
                     on_remove_action: AISettingsPageAction::RemoveFromProfileCommandAllowlist(cmd),
+                    is_disabled: disabled,
+                    tooltip_mouse_state: None,
                 }),
             Some(&view.command_allowlist_editor),
-            !ai_settings.is_command_allowlist_editable(app),
             appearance,
         );
 
@@ -4552,6 +4577,7 @@ impl AgentsWidget {
         appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
+        let disabled = !ai_settings.is_directory_allowlist_editable(app);
         let list = render_input_list(
             None,
             directory_allowlist
@@ -4559,15 +4585,16 @@ impl AgentsWidget {
                 .into_iter()
                 .zip(view.directory_allowlist_mouse_state_handles.clone())
                 .rev()
-                .map(|(path, mouse_state_handle)| InputListItem {
+                .map(move |(path, mouse_state_handle)| InputListItem {
                     item: path.display().to_string(),
                     mouse_state_handle,
                     on_remove_action: AISettingsPageAction::RemoveFromProfileDirectoryAllowlist(
                         path,
                     ),
+                    is_disabled: disabled,
+                    tooltip_mouse_state: None,
                 }),
             Some(&view.directory_allowlist_editor),
-            !ai_settings.is_directory_allowlist_editable(app),
             appearance,
         );
 
@@ -4894,22 +4921,24 @@ impl AgentsWidget {
         .with_margin_bottom(2.)
         .finish();
 
+        let disabled = !ai_settings.is_any_ai_enabled(app);
         let items = render_input_list(
             None,
             items
                 .into_iter()
                 .rev()
                 .zip(mouse_state_handles.clone())
-                .filter_map(|(uuid, mouse_state_handle)| {
+                .filter_map(move |(uuid, mouse_state_handle)| {
                     let server_name = TemplatableMCPServerManager::get_mcp_name(&uuid, app);
                     server_name.map(|server_name| InputListItem {
                         item: server_name,
                         mouse_state_handle,
                         on_remove_action: action(uuid),
+                        is_disabled: disabled,
+                        tooltip_mouse_state: None,
                     })
                 }),
             None,
-            !ai_settings.is_any_ai_enabled(app),
             appearance,
         );
 

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -876,8 +876,6 @@ impl AISettingsPageView {
                         is_enabled,
                         ctx,
                     );
-                    // Denylist editor is always enabled when AI is on,
-                    // regardless of org override.
                     Self::update_editor_interaction_state(
                         me.code_read_allowlist_editor.as_ref(ctx).editor().clone(),
                         is_enabled,

--- a/app/src/settings_view/settings_page.rs
+++ b/app/src/settings_view/settings_page.rs
@@ -1009,9 +1009,7 @@ pub struct InputListItem<SettingsPageAction: Action + Clone> {
     pub item: String,
     pub mouse_state_handle: MouseStateHandle,
     pub on_remove_action: SettingsPageAction,
-    /// When true, the remove button is disabled and text uses the disabled color.
     pub is_disabled: bool,
-    /// When `Some`, the row is wrapped in a workspace-override tooltip on hover.
     /// Must be pre-created (not inline during render) to preserve mouse tracking.
     pub tooltip_mouse_state: Option<MouseStateHandle>,
 }
@@ -1104,8 +1102,6 @@ pub fn render_alternating_color_list<
     }
 }
 
-/// Wraps a single row element in a hoverable tooltip that shows the
-/// workspace-override message on hover.
 fn render_workspace_override_row_tooltip(
     child: Box<dyn Element>,
     mouse_state: MouseStateHandle,

--- a/app/src/settings_view/settings_page.rs
+++ b/app/src/settings_view/settings_page.rs
@@ -31,6 +31,7 @@ use crate::{
     ui_components::icons::Icon,
     view_components::{Dropdown, SubmittableTextInput},
 };
+use pathfinder_geometry::vector::vec2f;
 use settings::Setting;
 use warp_core::{
     settings::SyncToCloud,
@@ -39,11 +40,12 @@ use warp_core::{
 use warpui::{
     elements::{
         new_scrollable::{ClippedAxisConfiguration, DualAxisConfig, SingleAxisConfig},
-        Align, Border, ChildView, ClippedScrollStateHandle, ConstrainedBox, Container,
+        Align, Border, ChildAnchor, ChildView, ClippedScrollStateHandle, ConstrainedBox, Container,
         CornerRadius, CrossAxisAlignment, Element, Empty, Expanded, Flex, Hoverable,
-        MainAxisAlignment, MainAxisSize, MouseStateHandle, NewScrollable, ParentElement, Radius,
-        SavePosition, ScrollTarget, ScrollToPositionMode, Shrinkable, SizeConstraintCondition,
-        SizeConstraintSwitch, Text,
+        MainAxisAlignment, MainAxisSize, MouseStateHandle, NewScrollable, OffsetPositioning,
+        ParentAnchor, ParentElement, ParentOffsetBounds, Radius, SavePosition, ScrollTarget,
+        ScrollToPositionMode, Shrinkable, SizeConstraintCondition, SizeConstraintSwitch, Stack,
+        Text,
     },
     fonts::{Properties, Weight},
     platform::Cursor,
@@ -1000,12 +1002,19 @@ pub(crate) fn render_settings_info_banner(
     .finish()
 }
 
+const WORKSPACE_OVERRIDE_TOOLTIP_TEXT: &str =
+    "This option is enforced by your organization's settings and cannot be customized.";
+
 pub struct InputListItem<SettingsPageAction: Action + Clone> {
     pub item: String,
     pub mouse_state_handle: MouseStateHandle,
     pub on_remove_action: SettingsPageAction,
+    /// When true, the remove button is disabled and text uses the disabled color.
+    pub is_disabled: bool,
+    /// When `Some`, the row is wrapped in a workspace-override tooltip on hover.
+    /// Must be pre-created (not inline during render) to preserve mouse tracking.
+    pub tooltip_mouse_state: Option<MouseStateHandle>,
 }
-
 /// Renders a title, an input field to add new items and a list of already
 /// added items.
 ///
@@ -1014,7 +1023,6 @@ pub fn render_input_list<SettingsPageAction: Action + Clone>(
     title: Option<&str>,
     items: impl IntoIterator<Item = InputListItem<SettingsPageAction>>,
     handle: Option<&ViewHandle<SubmittableTextInput>>,
-    disabled: bool,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let mut column = Flex::column();
@@ -1040,15 +1048,21 @@ pub fn render_input_list<SettingsPageAction: Action + Clone>(
     let background = appearance.theme().surface_1();
     let peekable = items.into_iter().peekable();
     for item in peekable {
-        let mut container = Container::new(render_alternating_color_list_item(
+        let disabled = item.is_disabled;
+        let row_element = render_alternating_color_list_item(
             background,
             item.item,
             item.mouse_state_handle,
             item.on_remove_action,
             disabled,
             appearance,
-        ));
-        container = container.with_margin_bottom(4.);
+        );
+        let row_element = if let Some(tooltip_mouse_state) = item.tooltip_mouse_state {
+            render_workspace_override_row_tooltip(row_element, tooltip_mouse_state, appearance)
+        } else {
+            row_element
+        };
+        let container = Container::new(row_element).with_margin_bottom(4.);
         column.add_child(container.finish());
     }
 
@@ -1090,6 +1104,36 @@ pub fn render_alternating_color_list<
     }
 }
 
+/// Wraps a single row element in a hoverable tooltip that shows the
+/// workspace-override message on hover.
+fn render_workspace_override_row_tooltip(
+    child: Box<dyn Element>,
+    mouse_state: MouseStateHandle,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    Hoverable::new(mouse_state, |state| {
+        let mut stack = Stack::new().with_child(child);
+        if state.is_hovered() {
+            let tooltip = appearance
+                .ui_builder()
+                .tool_tip(WORKSPACE_OVERRIDE_TOOLTIP_TEXT.to_string())
+                .build()
+                .finish();
+            stack.add_positioned_child(
+                tooltip,
+                OffsetPositioning::offset_from_parent(
+                    vec2f(0., -4.),
+                    ParentOffsetBounds::Unbounded,
+                    ParentAnchor::TopLeft,
+                    ChildAnchor::BottomLeft,
+                ),
+            );
+        }
+        stack.finish()
+    })
+    .finish()
+}
+
 fn render_alternating_color_list_item<SettingsPageAction: Action + Clone>(
     background: impl Into<Fill>,
     item_label: String,
@@ -1106,10 +1150,12 @@ fn render_alternating_color_list_item<SettingsPageAction: Action + Clone>(
         remove_button = remove_button.disabled();
     }
 
-    let remove_button = remove_button
-        .build()
-        .on_click(move |ctx, _, _| ctx.dispatch_typed_action(action.clone()))
-        .finish();
+    let mut remove_button = remove_button.build();
+    if !disabled {
+        remove_button =
+            remove_button.on_click(move |ctx, _, _| ctx.dispatch_typed_action(action.clone()));
+    }
+    let remove_button = remove_button.finish();
 
     let background = background.into();
     let font_color = if disabled {

--- a/app/src/settings_view/update_environment_form.rs
+++ b/app/src/settings_view/update_environment_form.rs
@@ -1759,6 +1759,8 @@ impl UpdateEnvironmentForm {
                     .cloned()
                     .unwrap_or_default(),
                 on_remove_action: UpdateEnvironmentFormAction::RemoveSetupCommand(index),
+                is_disabled: false,
+                tooltip_mouse_state: None,
             });
 
         let helper_text = Text::new(
@@ -1779,7 +1781,7 @@ impl UpdateEnvironmentForm {
             .with_child(helper_text)
             .finish();
 
-        let list_items = render_input_list(None, items, None, false, appearance);
+        let list_items = render_input_list(None, items, None, appearance);
 
         let list = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)

--- a/specs/REMOTE-1318/PRODUCT.md
+++ b/specs/REMOTE-1318/PRODUCT.md
@@ -1,0 +1,57 @@
+# REMOTE-1318: Merge org and user command denylists
+
+## Summary
+
+When an organization enforces a command denylist, users should still be able to add their own entries to make the denylist more restrictive. The org and user denylists merge into one list, where org-provided rows are non-removable and user-provided rows are fully editable. This applies everywhere the denylist appears: the settings page, the execution profile editor, and at command-execution time.
+
+Figma: none provided
+
+## Behavior
+
+### Merged denylist
+
+1. When the org (workspace) sets a command denylist override, the effective denylist is the **union** of the org denylist and the user's profile denylist, with duplicates removed. Org entries appear first in the list, followed by user entries.
+
+2. Duplicate detection compares the string representation of each `AgentModeCommandExecutionPredicate`. If a user entry has the same regex string as an org entry, only the org entry appears in the merged list. The user's copy is still persisted in their profile — it is simply not displayed twice.
+
+3. The merged denylist is used for command execution checks. A command that matches any entry in the merged list is denied (requires user confirmation), regardless of whether the matching entry came from the org or the user.
+
+4. The org denylist applies identically across all execution profiles. There is no per-profile override of org entries.
+
+5. When no org denylist override exists, behavior is unchanged — the user's profile denylist is the only source and all entries are user-editable.
+
+### Settings UI — denylist editor (text input)
+
+6. The denylist text input editor is enabled whenever AI mode is enabled, regardless of whether the org has a denylist override. The user can always type and submit new regex entries.
+
+7. When the user submits a new entry, it is added to the user's profile denylist (not the org list). If the entry duplicates an existing org entry, it is still persisted in the user's profile but does not appear as a separate row (per invariant 2).
+
+### Settings UI — per-row behavior
+
+8. Each row in the denylist has an independent disabled/enabled state, determined by whether the entry came from the org denylist.
+
+9. **Org rows**: the remove (×) button is disabled. Hovering the row shows a tooltip: "This option is enforced by your organization's settings and cannot be customized." The row text renders in the disabled text color.
+
+10. **User rows**: the remove (×) button is enabled. No tooltip on hover. The row text renders in the normal foreground color. Clicking the remove button removes the entry from the user's profile denylist.
+
+11. The denylist section is **not** wrapped in a single tooltip as a whole. Only individual org rows show the tooltip.
+
+12. When the org removes an entry from their override that the user had also added independently, the user's copy becomes the sole source for that entry. It transitions to a user row (removable, no tooltip) on the next settings refresh.
+
+### Settings UI — other lists (allowlist, directory allowlist, MCP lists)
+
+13. Lists other than the command denylist retain their current behavior: when the org has an override, the entire list is disabled with the global tooltip. This spec does not change their behavior.
+
+### Scope
+
+14. The per-row merge and editability applies in both surfaces that render the command denylist:
+    - The legacy AI settings page (default profile denylist section).
+    - The execution profile editor view (per-profile denylist section).
+
+### Edge cases
+
+15. If the org denylist is set to an empty list (`Some([])`), the org override is considered active (the org has explicitly chosen "no org entries"), but the user's profile entries are still shown as user rows. The editor remains enabled.
+
+16. If the user's profile denylist is empty and the org provides entries, only org rows appear. The editor is still enabled for the user to add entries.
+
+17. When a user removes a user row, the row disappears immediately. The mouse state handles for remaining rows are recreated to stay in sync with the list.

--- a/specs/REMOTE-1318/TECH.md
+++ b/specs/REMOTE-1318/TECH.md
@@ -1,0 +1,109 @@
+# REMOTE-1318: Tech spec
+
+See `PRODUCT.md` for user-facing behavior.
+
+## Context
+
+The command denylist controls which commands the agent must ask permission to execute. Two sources can contribute entries: the organization (workspace) and the user's execution profile.
+
+**Current data flow:**
+- `AiAutonomySettings.execute_commands_denylist: Option<Vec<AgentModeCommandExecutionPredicate>>` — org override, from `workspace.rs (663-670)`.
+- `AIExecutionProfile.command_denylist: Vec<AgentModeCommandExecutionPredicate>` — per-profile user list, from `execution_profiles/mod.rs (233)`.
+- `get_execute_commands_denylist_for_profile()` in `permissions.rs (395-413)` — resolves the effective list. Currently `unwrap_or_else`: org **replaces** user.
+- `is_command_denylist_editable()` in `ai.rs (1730-1736)` — returns `false` when org override exists, disabling both the editor and all row remove buttons.
+
+**Current UI rendering:**
+- `render_list_section()` in `ui_helpers.rs (640-691)` — generic list renderer for the profile editor. Passes a single `is_editable` bool; when false, wraps the **entire** section in a workspace tooltip via `wrap_disabled_with_workspace_override_tooltip`.
+- `render_command_denylist()` in `ai_page.rs (4483-4513)` — legacy settings page denylist. Same pattern: passes `!is_command_denylist_editable(app)` as a single `disabled` flag.
+- `render_input_list()` in `settings_page.rs (1013-1056)` — renders the editor + item rows. Takes a single `disabled: bool` for all rows.
+- `InputListItem` in `settings_page.rs (1003-1007)` — `{ item, mouse_state_handle, on_remove_action }`. No per-item disabled state.
+- Mouse state handles are stored as `Vec<MouseStateHandle>` per list (one per row, for close buttons). Recreated when the list changes.
+
+**Other callers of `render_input_list`** (must stay backward-compatible): `ai_page.rs` (allowlist, directory allowlist, MCP lists), `ui_helpers.rs` (all list types via `render_list_section`), `update_environment_form.rs` (environment setup commands).
+
+## Proposed changes
+
+### 1. Merge denylist in `permissions.rs`
+
+Change `get_execute_commands_denylist_for_profile()`:
+```
+When org override is Some(org_list):
+  merged = org_list
+  for each item in user_profile.command_denylist:
+    if merged does not contain item:
+      merged.push(item)
+  return merged
+When org override is None:
+  return user_profile.command_denylist (unchanged)
+```
+
+Add `pub fn get_org_execute_commands_denylist(ctx: &AppContext) -> Vec<AgentModeCommandExecutionPredicate>` — returns just the org entries (or empty vec). Used by rendering code to determine which rows are org-owned.
+
+### 2. Per-item disabled state in `InputListItem` (`settings_page.rs`)
+
+Add one field:
+- `is_disabled: bool` — whether the remove button is disabled and text uses disabled color.
+
+Remove the `disabled: bool` parameter from `render_input_list`. Each row uses `item.is_disabled` instead.
+
+Keep `wrap_disabled_with_workspace_override_tooltip` in `ui_helpers.rs` — it is not needed by `render_input_list`. Tooltip wrapping is handled at the call site (see sections 4 and 5 below).
+
+Update all 6 callers of `render_input_list`:
+- Non-denylist callers: set `is_disabled` uniformly based on the existing global disabled logic.
+- Denylist callers: set per-item `is_disabled` based on org membership.
+
+### 3. Always enable denylist editor
+
+`is_command_denylist_editable()` in `ai.rs`: remove the `has_override_for_execute_commands_denylist()` check. Return `self.is_any_ai_enabled(app)` only.
+
+In `editor/mod.rs`, `update_all_editor_interaction_states()` (line 1269): change the denylist editor line to enable whenever AI is on (drop the `&& !ai_autonomy_settings.has_override_for_execute_commands_denylist()` condition).
+
+In `ai_page.rs`, two handlers update the denylist editor state:
+- `TeamsChanged` handler (line 474): same change.
+- `IsAnyAIEnabled` handler (line 891): same change.
+
+### 4. Profile editor denylist rendering (`ui_helpers.rs` + `editor/mod.rs`)
+
+Add `command_denylist_tooltip_mouse_state_handles: Vec<MouseStateHandle>` to `ExecutionProfileEditorView`. Create alongside existing `command_denylist_mouse_state_handles` in `update_mouse_state_handles()`, one per merged-list item (used only for org rows).
+
+Update `render_command_denylist_section()` in `ui_helpers.rs`:
+- Get org denylist via `BlocklistAIPermissions::get_org_execute_commands_denylist(app)`
+- Build rows directly using `render_alternating_color_list_item` (not via `render_list_section`) so each disabled org row can be individually wrapped with `wrap_disabled_with_workspace_override_tooltip`, which stays in `ui_helpers.rs`
+- Always show the editor (regardless of org override)
+
+`render_list_section()` is unchanged — non-denylist lists still use its existing `is_editable` + whole-list tooltip pattern.
+
+### 5. Legacy settings page denylist rendering (`ai_page.rs`)
+
+Add `command_denylist_tooltip_mouse_state_handles: Vec<MouseStateHandle>` to `AISettingsPageView`.
+
+Update `render_command_denylist()`:
+- Get org denylist
+- Build `InputListItem`s with per-item `is_disabled` based on org membership
+- Wrap each disabled row in `wrap_disabled_with_workspace_override_tooltip` (imported from `crate::ai::execution_profiles::editor::ui_helpers`)
+- Always pass the editor
+
+Update mouse state handle creation in `new()` and `AISettingsChangedEvent::AgentModeCommandExecutionDenylist` handler to size both handle Vecs to the merged list.
+
+### 6. Profile data event handling
+
+In `ExecutionProfileEditorView`, subscribe to `UserWorkspacesEvent::TeamsChanged` to refresh mouse state handles and denylist rendering when the org override changes at runtime.
+
+## Testing and validation
+
+**Unit tests** — extend `permissions_test.rs`:
+- Test that `get_execute_commands_denylist_for_profile` returns the union when org override is set (PRODUCT.md invariant 1).
+- Test deduplication: user entry matching org entry appears once (invariant 2).
+- Test merged list is used for execution checks (invariant 3).
+- Test cross-profile: org denylist applies to all profiles (invariant 4).
+- Test no-override path is unchanged (invariant 5).
+- Test empty org override (`Some([])`) still allows user entries (invariant 15).
+- Test `get_org_execute_commands_denylist` returns the right entries.
+
+**Manual verification:**
+- With an org denylist override active: verify the editor is enabled, org rows show disabled × and tooltip, user rows are removable.
+- Without an org override: verify unchanged behavior.
+- Add a user entry that duplicates an org entry: verify it doesn't appear twice.
+- Remove a user entry: verify it disappears and remaining rows render correctly.
+
+**Presubmit:** `cargo fmt` + `cargo clippy` must pass.


### PR DESCRIPTION
## Description

When an org enforces a command denylist override, the entire denylist UI was previously disabled — users couldn't add their own entries. This PR merges the org and user denylists into a single list where:

- **Org rows**: remove button disabled, tooltip on hover ("This option is enforced by your organization's settings and cannot be customized."), text in disabled color
- **User rows**: fully editable — remove button works, no tooltip
- **Editor**: always enabled when AI is on, so users can always add new entries
- **Deduplication**: if a user entry matches an org entry, only the org entry appears (user's copy persists in their profile)
- **Execution**: the merged list is used for command execution checks — both org and user entries deny commands

Applies to both the legacy AI settings page and the execution profile editor.

https://www.loom.com/share/93ff56e922724394b6c64d9511626a6a


## Linear

REMOTE-1318

## Test plan

- 4 unit tests in `permissions_test.rs`: merge behavior, deduplication, org helper, empty org override
- Manual testing confirmed: org rows grayed out with tooltip, button not clickable, user rows removable, editor always enabled, dedup works
- All presubmit checks pass (fmt, clippy, 5779 tests)

## Specs

- `specs/REMOTE-1318/PRODUCT.md` — 17 behavioral invariants
- `specs/REMOTE-1318/TECH.md` — implementation plan

---

[Conversation](https://staging.warp.dev/conversation/11216c5d-ac43-4de7-9ec4-ad2523b0f9c0)

Co-Authored-By: Oz <oz-agent@warp.dev>