### PR TITLE
Combine detect platform with check binary

### DIFF
--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -117,6 +117,43 @@ impl RemoteTransport for SshTransport {
         })
     }
 
+    fn detect_platform_and_check_binary(
+        &self,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = (Result<RemotePlatform, String>, Result<bool, String>)> + Send,
+        >,
+    > {
+        let socket_path = self.socket_path.clone();
+        Box::pin(async move {
+            log::info!(
+                "Checking platform and remote server binary at {}",
+                setup::remote_server_binary()
+            );
+            match run_ssh_command(
+                &socket_path,
+                &setup::platform_and_binary_check_command(),
+                CHECK_TIMEOUT,
+            )
+            .await
+            {
+                Ok(output) => {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    let (platform, binary) =
+                        setup::parse_platform_and_binary_check_output(&stdout);
+                    (
+                        platform.map_err(|e| format!("{e:#}")),
+                        binary.map_err(|e| format!("{e:#}")),
+                    )
+                }
+                Err(e) => {
+                    let error = format!("{e:#}");
+                    (Err(error.clone()), Err(error))
+                }
+            }
+        })
+    }
+
     fn install_binary(&self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -76,47 +76,6 @@ impl SshTransport {
 }
 
 impl RemoteTransport for SshTransport {
-    fn detect_platform(
-        &self,
-    ) -> Pin<Box<dyn Future<Output = Result<RemotePlatform, String>> + Send>> {
-        let socket_path = self.socket_path.clone();
-        Box::pin(async move {
-            match run_ssh_command(&socket_path, "uname -sm", CHECK_TIMEOUT).await {
-                Ok(output) if output.status.success() => {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    setup::parse_uname_output(&stdout).map_err(|e| format!("{e:#}"))
-                }
-                Ok(output) => {
-                    let code = output.status.code().unwrap_or(-1);
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    Err(format!("uname -sm exited with code {code}: {stderr}"))
-                }
-                Err(e) => Err(format!("{e:#}")),
-            }
-        })
-    }
-
-    fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, String>> + Send>> {
-        let socket_path = self.socket_path.clone();
-        Box::pin(async move {
-            let bin_path = setup::remote_server_binary();
-            log::info!("Checking for remote server binary at {bin_path}");
-            match run_ssh_command(&socket_path, &setup::binary_check_command(), CHECK_TIMEOUT).await
-            {
-                Ok(output) => match output.status.code() {
-                    Some(0) => Ok(true),
-                    Some(1) => Ok(false),
-                    Some(code) => {
-                        let stderr = String::from_utf8_lossy(&output.stderr);
-                        Err(format!("binary check exited with code {code}: {stderr}"))
-                    }
-                    None => Err("binary check terminated by signal".into()),
-                },
-                Err(e) => Err(format!("{e:#}")),
-            }
-        })
-    }
-
     fn detect_platform_and_check_binary(
         &self,
     ) -> Pin<

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -438,9 +438,11 @@ impl RemoteServerManager {
             let spawner = self.spawner.clone();
             ctx.background_executor()
                 .spawn(async move {
-                    // Run platform detection and binary check concurrently.
+                    // Combined into a single transport round-trip to avoid
+                    // opening multiple SSH channels, which can hit the remote
+                    // host's MaxSessions limit.
                     let (platform_result, check_result) =
-                        futures::join!(transport.detect_platform(), transport.check_binary(),);
+                        transport.detect_platform_and_check_binary().await;
                     let platform = match platform_result {
                         Ok(p) => Some(p),
                         Err(e) => {

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -184,6 +184,45 @@ pub fn binary_check_command() -> String {
     format!("test -x {bin}")
 }
 
+/// Sentinel line separating `uname -sm` output from the binary-check result
+/// in [`platform_and_binary_check_command`].
+const PLATFORM_CHECK_DELIM: &str = "__WARP_PLATFORM_CHECK_DELIM__";
+
+/// Returns a single shell command that detects the remote platform via
+/// `uname -sm` **and** checks whether the remote server binary is installed,
+/// producing structured stdout that [`parse_platform_and_binary_check_output`]
+/// can parse.
+///
+/// Using one command avoids opening multiple SSH channels, which can hit
+/// the remote host's `MaxSessions` limit.
+pub fn platform_and_binary_check_command() -> String {
+    let bin = remote_server_binary();
+    format!(
+        "uname -sm; printf '{PLATFORM_CHECK_DELIM}\\n'; test -x {bin} && echo INSTALLED || echo NOT_INSTALLED"
+    )
+}
+
+/// Parse the stdout of [`platform_and_binary_check_command`] into a
+/// platform result and a binary-installed result.
+pub fn parse_platform_and_binary_check_output(
+    stdout: &str,
+) -> (Result<RemotePlatform>, Result<bool>) {
+    let Some((uname_section, check_section)) = stdout.split_once(PLATFORM_CHECK_DELIM) else {
+        let err = "missing delimiter in combined platform/binary check output";
+        return (Err(anyhow!(err)), Err(anyhow!(err)));
+    };
+
+    let platform_result = parse_uname_output(uname_section);
+
+    let binary_result = match check_section.trim() {
+        "INSTALLED" => Ok(true),
+        "NOT_INSTALLED" => Ok(false),
+        other => Err(anyhow!("unexpected binary check result: {other}")),
+    };
+
+    (platform_result, binary_result)
+}
+
 /// The install script template, loaded from a standalone `.sh` file for
 /// readability. Placeholders like `{download_base_url}` are substituted by
 /// [`install_script`].

--- a/crates/remote_server/src/setup_tests.rs
+++ b/crates/remote_server/src/setup_tests.rs
@@ -77,6 +77,45 @@ fn parse_uname_missing_arch() {
 }
 
 #[test]
+fn parse_combined_linux_installed() {
+    let stdout = "Linux x86_64\n__WARP_PLATFORM_CHECK_DELIM__\nINSTALLED\n";
+    let (platform, binary) = parse_platform_and_binary_check_output(stdout);
+    let platform = platform.unwrap();
+    assert_eq!(platform.os, RemoteOs::Linux);
+    assert_eq!(platform.arch, RemoteArch::X86_64);
+    assert_eq!(binary.unwrap(), true);
+}
+
+#[test]
+fn parse_combined_darwin_not_installed() {
+    let stdout = "Darwin arm64\n__WARP_PLATFORM_CHECK_DELIM__\nNOT_INSTALLED\n";
+    let (platform, binary) = parse_platform_and_binary_check_output(stdout);
+    let platform = platform.unwrap();
+    assert_eq!(platform.os, RemoteOs::MacOs);
+    assert_eq!(platform.arch, RemoteArch::Aarch64);
+    assert_eq!(binary.unwrap(), false);
+}
+
+#[test]
+fn parse_combined_with_shell_init_output() {
+    let stdout =
+        "Welcome to server\nLinux aarch64\n__WARP_PLATFORM_CHECK_DELIM__\nINSTALLED\n";
+    let (platform, binary) = parse_platform_and_binary_check_output(stdout);
+    let platform = platform.unwrap();
+    assert_eq!(platform.os, RemoteOs::Linux);
+    assert_eq!(platform.arch, RemoteArch::Aarch64);
+    assert_eq!(binary.unwrap(), true);
+}
+
+#[test]
+fn parse_combined_missing_delimiter() {
+    let stdout = "Linux x86_64\n";
+    let (platform, binary) = parse_platform_and_binary_check_output(stdout);
+    assert!(platform.is_err());
+    assert!(binary.is_err());
+}
+
+#[test]
 fn state_is_ready() {
     assert!(RemoteServerSetupState::Ready.is_ready());
     assert!(!RemoteServerSetupState::Checking.is_ready());

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -82,6 +82,21 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
         &self,
     ) -> Pin<Box<dyn std::future::Future<Output = Result<bool, String>> + Send>>;
 
+    /// Combined platform detection and binary check in a single transport
+    /// round-trip. Returns `(platform_result, binary_check_result)`.
+    ///
+    /// Implementations should combine both checks into a single command
+    /// to avoid opening multiple channels (e.g. hitting the remote
+    /// host's `MaxSessions` limit over SSH).
+    fn detect_platform_and_check_binary(
+        &self,
+    ) -> Pin<
+        Box<
+            dyn std::future::Future<Output = (Result<RemotePlatform, String>, Result<bool, String>)>
+                + Send,
+        >,
+    >;
+
     /// Installs the remote server binary on the remote host.
     ///
     /// Pure I/O — does not emit any events. The caller

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -61,27 +61,6 @@ pub struct Connection {
 /// Object-safe: returns boxed futures so implementations can be stored
 /// as `Arc<dyn RemoteTransport>` for reconnection.
 pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
-    /// Detects the remote host's OS and architecture by running `uname -sm`.
-    ///
-    /// Returns the parsed [`RemotePlatform`] on success, or an error string
-    /// if the command fails or the output cannot be parsed.
-    fn detect_platform(
-        &self,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<RemotePlatform, String>> + Send>>;
-
-    /// Checks whether the remote server binary is present on the remote host.
-    ///
-    /// Pure I/O — does not emit any events. The caller
-    /// ([`RemoteServerManager::check_binary`]) is responsible for emitting
-    /// [`SetupStateChanged`] and [`BinaryCheckComplete`].
-    ///
-    /// Returns `Ok(true)` if the binary is installed and executable,
-    /// `Ok(false)` if it is definitively not installed, and
-    /// `Err(_)` if the check failed (e.g. SSH timeout/unreachable).
-    fn check_binary(
-        &self,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<bool, String>> + Send>>;
-
     /// Combined platform detection and binary check in a single transport
     /// round-trip. Returns `(platform_result, binary_check_result)`.
     ///


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Testing
<!--
How did you test this change?  What automated tests did you add?  If you didn't add any new tests, what's your justification for not adding any?

If you're not sure whether you should add a test, check our testing policy: https://www.notion.so/warpdev/How-We-Code-at-Warp-257fe43d556e4b3c8dfd42f70004cc72#1f97825450504baa9c5fd87a737daa09
-->

## Server API dependencies
<!-- You may remove this section if your PR does not have any server dependencies. -->
- [ ] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4?pvs=4#d55ecf8aea3449949d3c33b0e67f6800)?
- [ ] Does this change rely on a [new server API](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#04da1e6a493542d68b3e998c7d339640)?
  - [ ] If so, is the use of this API restricted to client channels that rely on the staging server (e.g. WarpDev)?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server (e.g. WarpStable)?
  - [ ] If so, has the new server API been stable on production for at least one server release cycle? See [here](https://www.notion.so/warpdev/How-to-add-a-new-full-stack-feature-8412cede405a4ec194b32bdd4b951035?pvs=4#73b202f939834b97ab1fbdf7fc82cd53) for more details.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
-->

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
