### PR TITLE
Remove redundant comments from #9683

### DIFF
--- a/app/src/ai/blocklist/permissions_test.rs
+++ b/app/src/ai/blocklist/permissions_test.rs
@@ -642,7 +642,6 @@ fn test_can_autoexecute_command_denylist_precedence() {
 
         // Org + user denylists are merged: both should be active
         permissions.read(&app, |model, ctx| {
-            // git commands should be denied (from workspace/org denylist)
             let result = model.can_autoexecute_command(
                 &convo_id,
                 "git status",
@@ -660,7 +659,6 @@ fn test_can_autoexecute_command_denylist_precedence() {
                 )
             ));
 
-            // rm commands should ALSO still be denied (from user profile, merged in)
             let result = model.can_autoexecute_command(
                 &convo_id,
                 "rm file.txt",
@@ -1326,7 +1324,6 @@ fn test_merged_denylist_deduplication() {
 
         let rm_predicate = AgentModeCommandExecutionPredicate::new_regex("rm .*").unwrap();
 
-        // Add "rm .*" to user profile denylist
         profile_model.update(&mut app, |model, ctx| {
             model.add_to_command_denylist(
                 *model.active_profile(Some(terminal_view_id), ctx).id(),
@@ -1335,7 +1332,6 @@ fn test_merged_denylist_deduplication() {
             );
         });
 
-        // Also set workspace denylist with "rm .*" (duplicate) + "git .*"
         user_workspaces.update(&mut app, |model, ctx| {
             model.setup_test_workspace(ctx);
             model.update_ai_autonomy_settings(
@@ -1349,13 +1345,10 @@ fn test_merged_denylist_deduplication() {
             );
         });
 
-        // Merged list should have "rm .*" only once + "git .*"
         permissions.read(&app, |model, ctx| {
             let denylist = model.get_execute_commands_denylist(ctx, Some(terminal_view_id));
-            // "rm .*" should appear exactly once (deduplicated)
             let rm_count = denylist.iter().filter(|p| p.to_string() == "rm .*").count();
             assert_eq!(rm_count, 1, "duplicate entries should be deduplicated");
-            // "git .*" should also be present
             assert!(
                 denylist.iter().any(|p| p.to_string() == "git .*"),
                 "org entry 'git .*' should be in merged list"
@@ -1373,13 +1366,11 @@ fn test_get_org_execute_commands_denylist() {
             ..
         } = initialize_permissions_test(&mut app);
 
-        // No org override: should return empty
         permissions.read(&app, |_, ctx| {
             let org_list = BlocklistAIPermissions::get_org_execute_commands_denylist(ctx);
             assert!(org_list.is_empty());
         });
 
-        // Set org denylist
         user_workspaces.update(&mut app, |model, ctx| {
             model.setup_test_workspace(ctx);
             model.update_ai_autonomy_settings(
@@ -1414,7 +1405,6 @@ fn test_empty_org_denylist_allows_user_entries() {
             ..
         } = initialize_permissions_test(&mut app);
 
-        // Add user denylist entry
         profile_model.update(&mut app, |model, ctx| {
             model.add_to_command_denylist(
                 *model.active_profile(Some(terminal_view_id), ctx).id(),
@@ -1423,7 +1413,6 @@ fn test_empty_org_denylist_allows_user_entries() {
             );
         });
 
-        // Set org denylist to empty (Some([]))
         user_workspaces.update(&mut app, |model, ctx| {
             model.setup_test_workspace(ctx);
             model.update_ai_autonomy_settings(
@@ -1434,7 +1423,6 @@ fn test_empty_org_denylist_allows_user_entries() {
             );
         });
 
-        // User entry should still be active despite empty org override
         permissions.read(&app, |model, ctx| {
             let result = model.can_autoexecute_command(
                 &convo_id,

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1728,9 +1728,6 @@ impl AISettings {
     }
 
     pub fn is_command_denylist_editable(&self, app: &AppContext) -> bool {
-        // The denylist editor is always enabled when AI is on. Users can always
-        // add entries to make the denylist more restrictive, even when the org
-        // sets an override. Per-item removal is controlled at the row level.
         self.is_any_ai_enabled(app)
     }
 

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -876,8 +876,6 @@ impl AISettingsPageView {
                         is_enabled,
                         ctx,
                     );
-                    // Denylist editor is always enabled when AI is on,
-                    // regardless of org override.
                     Self::update_editor_interaction_state(
                         me.code_read_allowlist_editor.as_ref(ctx).editor().clone(),
                         is_enabled,

--- a/app/src/settings_view/settings_page.rs
+++ b/app/src/settings_view/settings_page.rs
@@ -1009,9 +1009,7 @@ pub struct InputListItem<SettingsPageAction: Action + Clone> {
     pub item: String,
     pub mouse_state_handle: MouseStateHandle,
     pub on_remove_action: SettingsPageAction,
-    /// When true, the remove button is disabled and text uses the disabled color.
     pub is_disabled: bool,
-    /// When `Some`, the row is wrapped in a workspace-override tooltip on hover.
     /// Must be pre-created (not inline during render) to preserve mouse tracking.
     pub tooltip_mouse_state: Option<MouseStateHandle>,
 }
@@ -1104,8 +1102,6 @@ pub fn render_alternating_color_list<
     }
 }
 
-/// Wraps a single row element in a hoverable tooltip that shows the
-/// workspace-override message on hover.
 fn render_workspace_override_row_tooltip(
     child: Box<dyn Element>,
     mouse_state: MouseStateHandle,


### PR DESCRIPTION
## Description

Reduce unneeded comments in #9683. Removes comments that:
- Duplicate assert messages (e.g. `// "rm .*" should appear exactly once` next to `assert_eq!(rm_count, 1, "duplicate entries should be deduplicated")`)
- Restate obvious code (e.g. `// Add user denylist entry` above `model.add_to_command_denylist(...)`)
- Add unnecessary narration to test setup steps
- Were misplaced (denylist comment above code_read_allowlist_editor code)
- Were excessively wordy for simple one-liners (3-line comment on `is_command_denylist_editable` that just returns `self.is_any_ai_enabled(app)`)

Kept comments that provide genuine value the code can't express: the MouseStateHandle pre-creation warning, and test section headers like `// Org + user denylists are merged: both should be active`.

## Linked Issue

- [x] N/A — follow-up cleanup on #9683

## Testing

No behavioral changes — comment-only deletions.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

---

_Conversation: https://staging.warp.dev/conversation/ff3c03c1-69f7-4d19-a110-229b73035bf1_
_Run: https://oz.staging.warp.dev/runs/019de099-11c0-756f-acc2-98949ee503d7_
_This PR was generated with [Oz](https://warp.dev/oz)._
