### PR TITLE
Fix pane search for custom tab titles

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1012,6 +1012,19 @@ impl VerticalTabsPanelState {
                         )
                     }
                     VerticalTabsResolvedMode::Panes | VerticalTabsResolvedMode::FocusedSession => {
+                        let custom_group_title_matches =
+                            uses_outer_group_container(display_granularity)
+                                && pane_group
+                                    .custom_title(app)
+                                    .as_deref()
+                                    .is_some_and(|title| {
+                                        title.to_lowercase().contains(&query_lower)
+                                    });
+
+                        if custom_group_title_matches {
+                            return true;
+                        }
+
                         pane_ids_for_display_granularity(
                             &visible_pane_ids,
                             pane_group.focused_pane_id(app),
@@ -1019,7 +1032,9 @@ impl VerticalTabsPanelState {
                         )
                         .into_iter()
                         .any(|pane_id| {
-                            let title_override = pane_group.custom_title(app);
+                            let title_override = (!uses_outer_group_container(display_granularity))
+                                .then(|| pane_group.custom_title(app))
+                                .flatten();
                             let ms = MouseStateHandle::default();
                             PaneProps::new(
                                 pane_group,
@@ -1542,7 +1557,15 @@ fn render_groups(
                         .then_some((tab_index, None))
                     }
                     VerticalTabsResolvedMode::Panes | VerticalTabsResolvedMode::FocusedSession => {
-                        let title_override = pane_group.custom_title(app);
+                        let custom_group_title_matches = uses_outer_group_container
+                            && pane_group
+                                .custom_title(app)
+                                .as_deref()
+                                .is_some_and(|title| title.to_lowercase().contains(&query_lower));
+
+                        let title_override = (!uses_outer_group_container)
+                            .then(|| pane_group.custom_title(app))
+                            .flatten();
                         let matching_ids: Vec<PaneId> = pane_ids_for_display_granularity(
                             &visible_pane_ids,
                             pane_group.focused_pane_id(app),
@@ -1608,7 +1631,11 @@ fn render_groups(
                         })
                         .collect();
 
-                        (!matching_ids.is_empty()).then_some((tab_index, Some(matching_ids)))
+                        if custom_group_title_matches {
+                            Some((tab_index, None))
+                        } else {
+                            (!matching_ids.is_empty()).then_some((tab_index, Some(matching_ids)))
+                        }
                     }
                 }
             })

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1019,9 +1019,7 @@ impl VerticalTabsPanelState {
                         )
                         .into_iter()
                         .any(|pane_id| {
-                            let title_override = (!uses_outer_group_container(display_granularity))
-                                .then(|| pane_group.custom_title(app))
-                                .flatten();
+                            let title_override = pane_group.custom_title(app);
                             let ms = MouseStateHandle::default();
                             PaneProps::new(
                                 pane_group,
@@ -1544,9 +1542,7 @@ fn render_groups(
                         .then_some((tab_index, None))
                     }
                     VerticalTabsResolvedMode::Panes | VerticalTabsResolvedMode::FocusedSession => {
-                        let title_override = (!uses_outer_group_container)
-                            .then(|| pane_group.custom_title(app))
-                            .flatten();
+                        let title_override = pane_group.custom_title(app);
                         let matching_ids: Vec<PaneId> = pane_ids_for_display_granularity(
                             &visible_pane_ids,
                             pane_group.focused_pane_id(app),


### PR DESCRIPTION
## Description

Fixes sidebar search in vertical tabs Panes mode so renamed tabs can be found by their custom title.

Previously, the Panes-mode filtering path dropped the tab group's `custom_title` when constructing the temporary `PaneProps` used for search matching. This meant searching for a visible custom tab title, like `deploy`, returned no results even though that title was shown as the group header.

This change includes `pane_group.custom_title(app)` in the two search/filter paths while preserving the existing render-side behavior that prevents the custom tab title from being duplicated on every pane row.

## Linked Issue

Fixes #9666

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos

N/A — this is a search/filtering behavior fix. I manually verified the visible behavior in the vertical tabs sidebar.

## Testing

Manual test performed:

1. Enabled vertical tabs.
2. Switched vertical tabs to Panes mode.
3. Renamed a tab to a unique custom title.
4. Searched for that custom title in the vertical tabs search box.
5. Confirmed the tab group remains visible.
6. Confirmed the custom title is not duplicated on each pane row.
7. Confirmed normal pane search still works.

Also ran:

- `cargo fmt`
- `cargo nextest run`

`cargo nextest run` did not complete successfully due to unrelated GCP cloud-provider tests failing on Windows:

- `ai::agent_sdk::driver::cloud_provider::tests::collect_provider_env_vars_merges_all_providers`
- `ai::agent_sdk::driver::cloud_provider::tests::extract_cloud_providers_creates_gcp_provider`
- `ai::agent_sdk::driver::cloud_provider::tests::gcp_provider_env_vars`

The failure appears unrelated to this vertical-tabs change. The error was:

`Cannot use executable ...\target\debug\deps\warp-...exe for GCP executable-sourced credentials`

No new automated test was added because this change affects UI search/filtering behavior in the vertical tabs sidebar and was verified manually against the reproduction steps from the issue.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed vertical tabs Panes-mode search so renamed tabs can be found by their custom title.