### PR TITLE
Remove stray backticks from Windows installer README code blocks

### DIFF
--- a/script/windows/README.md
+++ b/script/windows/README.md
@@ -35,11 +35,11 @@ First, ensure you've set up your environment.
 By default, it is located at `C:\Program Files (x86)\Inno Setup 6\ISCC.exe`.
 2. Compile the installer:
 ```shell
-iscc .\script\windows\windows-installer.iss`.
+iscc .\script\windows\windows-installer.iss
 ```
 3. Run the generated executable:
 ```shell
-.\script\windows\Output\Warp-Windows-Setup.exe`.
+.\script\windows\Output\Warp-Windows-Setup.exe
 ```
 
 The script begins with a series of preprocessor definitions.


### PR DESCRIPTION
## Description

Fixes a copy-paste hazard in `script/windows/README.md`. Two `iscc` / `.exe` examples each ended with a trailing `` `. `` inside their ```` ```shell ```` fenced blocks:

```diff
 ```shell
-iscc .\script\windows\windows-installer.iss`.
+iscc .\script\windows\windows-installer.iss
 ```
```
```diff
 ```shell
-.\script\windows\Output\Warp-Windows-Setup.exe`.
+.\script\windows\Output\Warp-Windows-Setup.exe
 ```
```

Inside a fenced code block those characters render literally, so anyone copying the example commands into cmd.exe or PowerShell hits a syntax error from the trailing `` ` ``. Most likely a leftover from when the lines were in prose form (inline code closing a sentence) before being wrapped in code fences.

Verified the pattern is isolated to these two lines: `grep -rn '\`\.$'` across all repo Markdown files inside ```` ```shell ```` blocks returns zero other instances.

## Testing

Docs-only change; no test impact. The diff is purely the removal of two stray characters per line.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode