### PR TITLE
Add BYOK support for MiniMax, Moonshot, and Z.ai

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14770,7 +14770,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=aa2f9cde164a5b48ac01087d417d1188771f9b6d#aa2f9cde164a5b48ac01087d417d1188771f9b6d"
+source = "git+https://github.com/bloodf/warp-proto-apis.git?rev=4602238edc1dd2cb7f39361a8c3841fc1eb22bb7#4602238edc1dd2cb7f39361a8c3841fc1eb22bb7"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "aa2f9cde164a5b48ac01087d417d1188771f9b6d" }
+warp_multi_agent_api = { git = "https://github.com/bloodf/warp-proto-apis.git", rev = "4602238edc1dd2cb7f39361a8c3841fc1eb22bb7" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -1,5 +1,5 @@
 use parking_lot::FairMutex;
-use serde::{de, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, OnceLock},
@@ -10,8 +10,8 @@ use warpui::{AppContext, Entity, EntityId, ModelContext, SingletonEntity};
 
 use crate::{
     auth::{
-        auth_manager::{AuthManager, AuthManagerEvent},
         AuthStateProvider,
+        auth_manager::{AuthManager, AuthManagerEvent},
     },
     network::{NetworkStatus, NetworkStatusEvent, NetworkStatusKind},
     report_error,
@@ -36,6 +36,9 @@ pub fn is_using_api_key_for_provider(provider: &LLMProvider, app: &AppContext) -
         LLMProvider::OpenAI => api_keys.is_some_and(|keys| keys.openai.is_some()),
         LLMProvider::Anthropic => api_keys.is_some_and(|keys| keys.anthropic.is_some()),
         LLMProvider::Google => api_keys.is_some_and(|keys| keys.google.is_some()),
+        LLMProvider::MiniMax => api_keys.is_some_and(|keys| keys.minimax.is_some()),
+        LLMProvider::Moonshot => api_keys.is_some_and(|keys| keys.moonshot.is_some()),
+        LLMProvider::Zai => api_keys.is_some_and(|keys| keys.zai.is_some()),
         _ => false,
     }
 }
@@ -89,6 +92,9 @@ pub enum LLMProvider {
     Anthropic,
     Google,
     Xai,
+    MiniMax,
+    Moonshot,
+    Zai,
     Unknown,
 }
 
@@ -100,6 +106,9 @@ impl LLMProvider {
             LLMProvider::Anthropic => Some(Icon::ClaudeLogo),
             LLMProvider::Google => Some(Icon::GeminiLogo),
             LLMProvider::Xai => None,
+            LLMProvider::MiniMax => None,
+            LLMProvider::Moonshot => None,
+            LLMProvider::Zai => None,
             LLMProvider::Unknown => None,
         }
     }

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -2193,10 +2193,17 @@ impl From<warp_graphql::queries::get_feature_model_choices::LlmProvider> for LLM
                 LLMProvider::Unknown
             }
             warp_graphql::queries::get_feature_model_choices::LlmProvider::Other(value) => {
-                report_error!(anyhow!(
-                    "Invalid LlmProvider '{value}'. Make sure to update client GraphQL types!"
-                ));
-                LLMProvider::Unknown
+                match value.as_str() {
+                    "minimax" => LLMProvider::MiniMax,
+                    "moonshot" => LLMProvider::Moonshot,
+                    "zai" => LLMProvider::Zai,
+                    _ => {
+                        report_error!(anyhow!(
+                            "Invalid LlmProvider '{value}'. Make sure to update client GraphQL types!"
+                        ));
+                        LLMProvider::Unknown
+                    }
+                }
             }
         }
     }
@@ -2211,10 +2218,17 @@ impl From<warp_graphql::workspace::LlmProvider> for LLMProvider {
             warp_graphql::workspace::LlmProvider::Xai => LLMProvider::Xai,
             warp_graphql::workspace::LlmProvider::Unknown => LLMProvider::Unknown,
             warp_graphql::workspace::LlmProvider::Other(value) => {
-                report_error!(anyhow!(
-                    "Invalid LlmProvider '{value}'. Make sure to update client GraphQL types!"
-                ));
-                LLMProvider::Unknown
+                match value.as_str() {
+                    "minimax" => LLMProvider::MiniMax,
+                    "moonshot" => LLMProvider::Moonshot,
+                    "zai" => LLMProvider::Zai,
+                    _ => {
+                        report_error!(anyhow!(
+                            "Invalid LlmProvider '{value}'. Make sure to update client GraphQL types!"
+                        ));
+                        LLMProvider::Unknown
+                    }
+                }
             }
         }
     }

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -2193,7 +2193,7 @@ impl From<warp_graphql::queries::get_feature_model_choices::LlmProvider> for LLM
                 LLMProvider::Unknown
             }
             warp_graphql::queries::get_feature_model_choices::LlmProvider::Other(value) => {
-                match value.as_str() {
+                match value.to_lowercase().as_str() {
                     "minimax" => LLMProvider::MiniMax,
                     "moonshot" => LLMProvider::Moonshot,
                     "zai" => LLMProvider::Zai,
@@ -2218,7 +2218,7 @@ impl From<warp_graphql::workspace::LlmProvider> for LLMProvider {
             warp_graphql::workspace::LlmProvider::Xai => LLMProvider::Xai,
             warp_graphql::workspace::LlmProvider::Unknown => LLMProvider::Unknown,
             warp_graphql::workspace::LlmProvider::Other(value) => {
-                match value.as_str() {
+                match value.to_lowercase().as_str() {
                     "minimax" => LLMProvider::MiniMax,
                     "moonshot" => LLMProvider::Moonshot,
                     "zai" => LLMProvider::Zai,

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -6275,6 +6275,10 @@ struct ApiKeysWidget {
     openai_api_key_editor: ViewHandle<EditorView>,
     anthropic_api_key_editor: ViewHandle<EditorView>,
     google_api_key_editor: ViewHandle<EditorView>,
+    open_router_api_key_editor: ViewHandle<EditorView>,
+    minimax_api_key_editor: ViewHandle<EditorView>,
+    moonshot_api_key_editor: ViewHandle<EditorView>,
+    zai_api_key_editor: ViewHandle<EditorView>,
 
     can_use_warp_credits_with_byok: SwitchStateHandle,
     upgrade_highlight_index: HighlightedHyperlink,
@@ -6291,7 +6295,10 @@ impl ApiKeysWidget {
             openai: openai_key,
             anthropic: anthropic_key,
             google: google_key,
-            ..
+            open_router: open_router_key,
+            minimax: minimax_key,
+            moonshot: moonshot_key,
+            zai: zai_key,
         } = ApiKeyManager::as_ref(ctx).keys().clone();
 
         // A helper macro to create and configure an API key editor.  This avoids a lot
@@ -6378,11 +6385,39 @@ impl ApiKeysWidget {
             set_google_key,
             "AIzaSy..."
         );
+        create_api_key_editor!(
+            open_router_api_key_editor,
+            open_router_key,
+            set_open_router_key,
+            "sk-or-..."
+        );
+        create_api_key_editor!(
+            minimax_api_key_editor,
+            minimax_key,
+            set_minimax_key,
+            "..."
+        );
+        create_api_key_editor!(
+            moonshot_api_key_editor,
+            moonshot_key,
+            set_moonshot_key,
+            "..."
+        );
+        create_api_key_editor!(
+            zai_api_key_editor,
+            zai_key,
+            set_zai_key,
+            "..."
+        );
 
         Self {
             openai_api_key_editor,
             anthropic_api_key_editor,
             google_api_key_editor,
+            open_router_api_key_editor,
+            minimax_api_key_editor,
+            moonshot_api_key_editor,
+            zai_api_key_editor,
 
             can_use_warp_credits_with_byok: Default::default(),
             upgrade_highlight_index: Default::default(),
@@ -6469,6 +6504,34 @@ impl ApiKeysWidget {
             appearance,
             "Google API Key",
             self.google_api_key_editor.clone(),
+            is_enabled,
+            app,
+        ));
+        column.add_child(render_api_key_input(
+            appearance,
+            "OpenRouter API Key",
+            self.open_router_api_key_editor.clone(),
+            is_enabled,
+            app,
+        ));
+        column.add_child(render_api_key_input(
+            appearance,
+            "MiniMax API Key",
+            self.minimax_api_key_editor.clone(),
+            is_enabled,
+            app,
+        ));
+        column.add_child(render_api_key_input(
+            appearance,
+            "Moonshot API Key",
+            self.moonshot_api_key_editor.clone(),
+            is_enabled,
+            app,
+        ));
+        column.add_child(render_api_key_input(
+            appearance,
+            "Z.ai API Key",
+            self.zai_api_key_editor.clone(),
             is_enabled,
             app,
         ));
@@ -6568,7 +6631,7 @@ impl SettingsWidget for ApiKeysWidget {
     type View = AISettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "api keys bring your own byo openai anthropic google claude gemini gpt"
+        "api keys bring your own byo openai anthropic google claude gemini gpt openrouter minimax moonshot zai zhipu"
     }
 
     fn render(

--- a/app/src/terminal/input/models/data_source.rs
+++ b/app/src/terminal/input/models/data_source.rs
@@ -496,7 +496,12 @@ impl SearchItem for ModelSearchItem {
             let byok_available = UserWorkspaces::as_ref(app).is_byo_api_key_enabled()
                 && matches!(
                     self.provider,
-                    LLMProvider::OpenAI | LLMProvider::Anthropic | LLMProvider::Google
+                    LLMProvider::OpenAI
+                        | LLMProvider::Anthropic
+                        | LLMProvider::Google
+                        | LLMProvider::MiniMax
+                        | LLMProvider::Moonshot
+                        | LLMProvider::Zai
                 );
 
             let mut text_fragments = vec![

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -162,17 +162,15 @@ impl ApiKeyManager {
             .then(|| self.keys.open_router.clone())
             .flatten()
             .unwrap_or_default();
-        // TODO: Wire minimax, moonshot, and zai keys into the protobuf request
-        // once warp-proto-apis adds support for these providers.
-        let _minimax = include_byo_keys
+        let minimax = include_byo_keys
             .then(|| self.keys.minimax.clone())
             .flatten()
             .unwrap_or_default();
-        let _moonshot = include_byo_keys
+        let moonshot = include_byo_keys
             .then(|| self.keys.moonshot.clone())
             .flatten()
             .unwrap_or_default();
-        let _zai = include_byo_keys
+        let zai = include_byo_keys
             .then(|| self.keys.zai.clone())
             .flatten()
             .unwrap_or_default();
@@ -196,6 +194,9 @@ impl ApiKeyManager {
             && openai.is_empty()
             && google.is_empty()
             && open_router.is_empty()
+            && minimax.is_empty()
+            && moonshot.is_empty()
+            && zai.is_empty()
             && aws_credentials.is_none()
         {
             None
@@ -205,6 +206,9 @@ impl ApiKeyManager {
                 openai,
                 google,
                 open_router,
+                minimax,
+                moonshot,
+                zai,
                 allow_use_of_warp_credits: false,
                 aws_credentials,
             })

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -22,6 +22,9 @@ pub struct ApiKeys {
     pub anthropic: Option<String>,
     pub openai: Option<String>,
     pub open_router: Option<String>,
+    pub minimax: Option<String>,
+    pub moonshot: Option<String>,
+    pub zai: Option<String>,
 }
 
 impl ApiKeys {
@@ -30,6 +33,9 @@ impl ApiKeys {
             || self.anthropic.is_some()
             || self.google.is_some()
             || self.open_router.is_some()
+            || self.minimax.is_some()
+            || self.moonshot.is_some()
+            || self.zai.is_some()
     }
 }
 
@@ -93,6 +99,24 @@ impl ApiKeyManager {
         self.write_keys_to_secure_storage(ctx);
     }
 
+    pub fn set_minimax_key(&mut self, key: Option<String>, ctx: &mut ModelContext<Self>) {
+        self.keys.minimax = key;
+        ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+        self.write_keys_to_secure_storage(ctx);
+    }
+
+    pub fn set_moonshot_key(&mut self, key: Option<String>, ctx: &mut ModelContext<Self>) {
+        self.keys.moonshot = key;
+        ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+        self.write_keys_to_secure_storage(ctx);
+    }
+
+    pub fn set_zai_key(&mut self, key: Option<String>, ctx: &mut ModelContext<Self>) {
+        self.keys.zai = key;
+        ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+        self.write_keys_to_secure_storage(ctx);
+    }
+
     pub fn set_aws_credentials_state(
         &mut self,
         state: AwsCredentialsState,
@@ -136,6 +160,20 @@ impl ApiKeyManager {
             .unwrap_or_default();
         let open_router = include_byo_keys
             .then(|| self.keys.open_router.clone())
+            .flatten()
+            .unwrap_or_default();
+        // TODO: Wire minimax, moonshot, and zai keys into the protobuf request
+        // once warp-proto-apis adds support for these providers.
+        let _minimax = include_byo_keys
+            .then(|| self.keys.minimax.clone())
+            .flatten()
+            .unwrap_or_default();
+        let _moonshot = include_byo_keys
+            .then(|| self.keys.moonshot.clone())
+            .flatten()
+            .unwrap_or_default();
+        let _zai = include_byo_keys
+            .then(|| self.keys.zai.clone())
             .flatten()
             .unwrap_or_default();
         // Also include credentials when running with OIDC-managed Bedrock inference, regardless


### PR DESCRIPTION
## Description

This PR adds three new bring-your-own-key (BYOK) AI providers to Warp: **MiniMax**, **Moonshot**, and **Z.ai** (Zhipu). It also wires the existing OpenRouter API key field into the Settings > AI UI.

### What changed

- **New LLM providers**: Added `MiniMax`, `Moonshot`, and `Zai` variants to the client-side `LLMProvider` enum.
- **API key storage**: Added `minimax`, `moonshot`, and `zai` fields to the `ApiKeys` struct with read/write to secure local storage.
- **Settings UI**: Added API key input fields for OpenRouter, MiniMax, Moonshot, and Z.ai in Settings > AI > API Keys.
- **GraphQL mapping**: Updated `From<LlmProvider>` implementations to gracefully map `Other("minimax")` / `Other("moonshot")` / `Other("zai")` strings from the server schema. This avoids requiring client-side GraphQL schema changes.
- **BYOK eligibility**: Added the new providers to the upgrade prompt's "bring your own key" match arms so users see the BYOK option when these models are selected.
- **Protobuf wiring**: The three new keys are now included in the `api_keys_for_request()` protobuf construction.

### Review feedback addressed

1. **Protobuf wiring** — MiniMax, Moonshot, and Z.ai keys are now wired into the multi-agent API request (`api_keys_for_request` in `crates/ai/src/api_keys.rs`).
2. **GraphQL uppercase normalization** — The fallback mapping now normalizes the received string to lowercase (`value.to_lowercase().as_str()`) before matching, so both uppercase (`MINIMAX`) and lowercase (`minimax`) wire values from the server are handled correctly.

### Proto dependency

This PR updates `Cargo.toml` to point to a fork of `warp-proto-apis` that adds the `minimax`, `moonshot`, and `zai` fields to `Request.Settings.ApiKeys`:

- **Proto PR**: _(to be created from https://github.com/bloodf/warp-proto-apis/compare/main...add-minimax-moonshot-zai-api-keys)_
- **Fork commit**: https://github.com/bloodf/warp-proto-apis/commit/4602238edc1dd2cb7f39361a8c3841fc1eb22bb7
- **Proto change**: `apis/multi_agent/v1/request.proto`

Before this PR can be merged upstream, the Warp team will need to either:
1. Apply the equivalent proto change to `warpdotdev/warp-proto-apis`, or
2. Merge the forked branch and update this PR's `Cargo.toml`/`Cargo.lock` to point to the new upstream rev.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos

N/A — the new provider inputs follow the existing API key editor pattern. Manual testing was performed by verifying the inputs render correctly in Settings > AI.

## Testing

- `cargo check -p warp --lib` – passes
- `cargo check -p ai --lib` – passes
- Built and tested locally on macOS ARM64 (`target/aarch64-apple-darwin/debug/bundle/osx/WarpLocal.app`)
- Verified that the new API key fields appear in Settings > AI and accept input
- Verified that existing OpenAI, Anthropic, and Google key fields remain unaffected

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
