### PR TITLE
Respect Markdown Viewer setting for .md links in AI rules/facts panel

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5624,18 +5624,27 @@ impl Workspace {
             #[allow(unused_variables)]
             AIFactViewEvent::OpenFile(path) => {
                 #[cfg(feature = "local_fs")]
-                self.open_code(
-                    CodeSource::Link {
-                        path: path.clone(),
-                        range_start: None,
-                        range_end: None,
-                    },
-                    *EditorSettings::as_ref(ctx).open_file_layout.value(),
-                    None,  // no line/column specified
-                    false, // preview
-                    &[],
-                    ctx,
-                );
+                {
+                    let settings = EditorSettings::as_ref(ctx);
+                    let target = resolve_file_target_with_editor_choice(
+                        path,
+                        *settings.open_file_editor,
+                        *settings.prefer_markdown_viewer,
+                        *settings.open_file_layout,
+                        None,
+                    );
+                    self.open_file_with_target(
+                        path.clone(),
+                        target,
+                        None,
+                        CodeSource::Link {
+                            path: path.clone(),
+                            range_start: None,
+                            range_end: None,
+                        },
+                        ctx,
+                    );
+                }
             }
             AIFactViewEvent::InitializeProject(path) => {
                 let active_terminal_view = self


### PR DESCRIPTION
Closes #8998.

### Description

Clicking a `.md` file link in the agent conversation / AI rules / AI facts panel was opening the Warp Code Editor (or a new terminal at the parent directory) even when the user had enabled **Settings → Features → General → Open Markdown files in Warp's Markdown viewer by default**. The same setting was already respected for `.md` links inside terminal output blocks.

### Root cause

`Workspace::handle_ai_fact_view_event` (`app/src/workspace/view.rs:5618`) handled `AIFactViewEvent::OpenFile` by calling `self.open_code(CodeSource::Link { … })` directly. `open_code` always routes the file into the Warp Code Editor — it never consults `EditorSettings::prefer_markdown_viewer` or `open_file_editor`. The buggy path is also reachable from `RuleViewEvent::OpenFile`, which `app/src/ai/facts/view/mod.rs:132-133` re-emits as `AIFactViewEvent::OpenFile`, so the rules and facts panels share the regression.

The terminal-block path uses a different (correct) routing chain: `Terminal::open_file_path` (`app/src/terminal/view.rs:17061`) calls `resolve_file_target` and emits `Event::OpenFileWithTarget`, which the workspace then dispatches through `Workspace::open_file_with_target` — that helper has explicit branches for `MarkdownViewer`, `EnvEditor`, `CodeEditor`, `SystemGeneric`, and `ExternalEditor`. The AI panels were skipping all of that.

### Fix

In the `AIFactViewEvent::OpenFile` arm:

1. Compute the appropriate `FileTarget` via `resolve_file_target_with_editor_choice` (already imported in the file at `view.rs:111`), feeding in `open_file_editor`, `prefer_markdown_viewer`, and `open_file_layout` from `EditorSettings`.
2. Dispatch through `Workspace::open_file_with_target` with `CodeSource::Link { … }` as the source — same shape used by the existing `view.rs:6424` (tab-config-template open) and `view.rs:19882` (toast file-open) call sites.

That single change covers both `RuleViewEvent::OpenFile` and `AIFactViewEvent::OpenFile` because they converge on the same handler.

### Testing

- `cargo fmt -p warp -- --check` — passes.
- `cargo check --features=gui --bin=warp-oss` — passes (full re-check after edit).
- `cargo nextest run --features=gui -p warp -E 'test(test_resolve_file_target_markdown_viewer_precedence) | test(test_resolve_file_target_warp_uses_default_layout) | test(test_resolve_file_target_binary_is_system_generic) | test(test_resolve_file_target_binary_uses_env_editor)'` — **4 tests run: 4 passed**, including `test_resolve_file_target_markdown_viewer_precedence` which directly covers the `.md + prefer_markdown_viewer = true → FileTarget::MarkdownViewer` decision this fix relies on.

### Server API

- [ ] Yes
- [x] No

### Agent Mode

- [ ] Yes
- [x] No

### Changelog Entries

`CHANGELOG-BUG-FIX`: Clicking a `.md` file link from the AI rules/facts panel now opens it in Warp's Markdown Viewer when "Open Markdown files in Warp's Markdown viewer by default" is enabled, matching the behaviour for terminal output block links.