### PR TITLE
Conversation resuming for codex

### DIFF
--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -86,28 +86,9 @@ impl ThirdPartyHarness for ClaudeHarness {
         conversation_id: &AIConversationId,
         harness_support_client: Arc<dyn HarnessSupportClient>,
     ) -> Result<Option<ResumePayload>, AgentDriverError> {
-        let conversation_id_str = conversation_id.to_string();
-        let bytes = harness_support_client
-            .fetch_transcript()
-            .await
-            .map_err(|err| {
-                // A 404 from the server maps to "no stored transcript" so the CLI can tell
-                // the user the prior run never saved state.
-                let message = format!("{err:#}").to_lowercase();
-                if message.contains("status 404") {
-                    AgentDriverError::ConversationResumeStateMissing {
-                        harness: "claude".to_string(),
-                        conversation_id: conversation_id_str.clone(),
-                    }
-                } else {
-                    AgentDriverError::ConversationLoadFailed(format!("{err:#}"))
-                }
-            })?;
-        let envelope: ClaudeTranscriptEnvelope = serde_json::from_slice(&bytes).map_err(|err| {
-            AgentDriverError::ConversationLoadFailed(format!(
-                "Failed to deserialize Claude transcript for {conversation_id_str}: {err:#}"
-            ))
-        })?;
+        let envelope: ClaudeTranscriptEnvelope =
+            super::fetch_transcript_envelope("claude", conversation_id, harness_support_client)
+                .await?;
         let session_id = envelope.uuid;
         Ok(Some(ResumePayload::Claude(ClaudeResumeInfo {
             conversation_id: *conversation_id,
@@ -127,12 +108,8 @@ impl ThirdPartyHarness for ClaudeHarness {
         terminal_driver: ModelHandle<TerminalDriver>,
         resume: Option<ResumePayload>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
-        // Extract the Claude variant; any other variant is ignored since it belongs to a
-        // different harness. Today there are no other variants, but this keeps the shape
-        // ready for future CLI-specific payloads.
-        let claude_resume = resume.map(|payload| match payload {
-            ResumePayload::Claude(info) => info,
-        });
+        // The ResumePayload shouldn't contain non-Claude information, error if it does.
+        let claude_resume = resume.map(ClaudeResumeInfo::try_from).transpose()?;
         // Claude treats the user-turn message as immediate intent, so the resumption preamble
         // is most reliable when prepended directly to the prompt that gets piped into the CLI.
         let owned_prompt = match resumption_prompt {
@@ -230,7 +207,7 @@ impl ClaudeHarnessRunner {
         let temp_file = write_temp_file("oz_prompt_", prompt)?;
         let prompt_path = temp_file.path().display().to_string();
 
-        let (session_id, preexisting_conversation_id, resuming) = match resume {
+        let (session_id, preexisting_conversation_id) = match resume {
             Some(ClaudeResumeInfo {
                 conversation_id,
                 session_id,
@@ -256,9 +233,9 @@ impl ClaudeHarnessRunner {
                 if let Err(e) = write_session_index_entry(session_id, working_dir, &config_root) {
                     log::warn!("Failed to update Claude sessions-index.json: {e:#}");
                 }
-                (session_id, Some(conversation_id), true)
+                (session_id, Some(conversation_id))
             }
-            None => (Uuid::new_v4(), None, false),
+            None => (Uuid::new_v4(), None),
         };
 
         let temp_system_prompt_file = system_prompt
@@ -279,7 +256,7 @@ impl ClaudeHarnessRunner {
                 &session_id,
                 &prompt_path,
                 system_prompt_path.as_deref(),
-                resuming,
+                preexisting_conversation_id.is_some(),
             ),
             cli_name: cli_command.to_string(),
             _temp_prompt_file: temp_file,

--- a/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
@@ -26,6 +26,8 @@ use warp_core::safe_warn;
 
 use crate::ai::agent::conversation::AIConversationId;
 
+use super::json_utils::entries_to_jsonl;
+
 /// JSON envelope sent to the server representing a complete Claude Code session.
 ///
 /// Bundles the main session transcript, any subagent transcripts, and
@@ -291,16 +293,6 @@ pub(crate) fn write_session_index_entry(
     )
     .with_context(|| format!("Failed to write {}", index_path.display()))?;
     Ok(())
-}
-
-/// Serialize a slice of JSON values as a JSONL byte string (one value per line).
-fn entries_to_jsonl(entries: &[Value]) -> Result<Vec<u8>> {
-    let mut buf = Vec::new();
-    for entry in entries {
-        serde_json::to_writer(&mut buf, entry)?;
-        buf.push(b'\n');
-    }
-    Ok(buf)
 }
 
 /// Read a JSONL file, returning one parsed [`Value`] per non-blank line.

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -26,7 +26,8 @@ use super::super::terminal::{CommandHandle, TerminalDriver};
 use super::super::{AgentDriver, AgentDriverError};
 use super::claude_transcript::read_jsonl;
 use super::codex_transcript::{
-    codex_sessions_root, find_session_file, parse_session_meta, CodexTranscriptEnvelope,
+    codex_sessions_root, find_session_file, parse_session_meta, write_envelope, CodexResumeInfo,
+    CodexTranscriptEnvelope,
 };
 use super::json_utils::read_json_file_or_default;
 use super::{write_temp_file, HarnessRunner, ResumePayload, SavePoint, ThirdPartyHarness};
@@ -67,26 +68,53 @@ impl ThirdPartyHarness for CodexHarness {
         })
     }
 
+    /// Fetch the codex transcript for the current task's conversation and wrap it into a
+    /// [`ResumePayload::Codex`].
+    async fn fetch_resume_payload(
+        &self,
+        conversation_id: &AIConversationId,
+        harness_support_client: Arc<dyn HarnessSupportClient>,
+    ) -> Result<Option<ResumePayload>, AgentDriverError> {
+        let envelope: CodexTranscriptEnvelope =
+            super::fetch_transcript_envelope("codex", conversation_id, harness_support_client)
+                .await?;
+        let session_id = envelope.session_id;
+        Ok(Some(ResumePayload::Codex(CodexResumeInfo {
+            conversation_id: *conversation_id,
+            session_id,
+            envelope,
+        })))
+    }
+
     fn build_runner(
         &self,
         prompt: &str,
         system_prompt: Option<&str>,
-        _resumption_prompt: Option<&str>,
+        resumption_prompt: Option<&str>,
         working_dir: &Path,
         _task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
-        _resume: Option<ResumePayload>,
+        resume: Option<ResumePayload>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
-        // TODO(REMOTE-1503): support resume for Codex.
+        // The ResumePayload shouldn't contain non-Codex information, error if it does.
+        let codex_resume = resume.map(CodexResumeInfo::try_from).transpose()?;
+
+        // Mirror Claude harness behavior: prepend the resumption preamble to
+        // the user-turn prompt so codex treats it as immediate intent.
+        let owned_prompt = match resumption_prompt {
+            Some(preamble) if !preamble.is_empty() => format!("{preamble}\n\n{prompt}"),
+            _ => prompt.to_string(),
+        };
         let client: Arc<dyn HarnessSupportClient> = server_api;
         Ok(Box::new(CodexHarnessRunner::new(
             self.cli_agent().command_prefix(),
-            prompt,
+            &owned_prompt,
             system_prompt,
             working_dir,
             client,
             terminal_driver,
+            codex_resume,
         )?))
     }
 }
@@ -95,8 +123,20 @@ impl ThirdPartyHarness for CodexHarness {
 ///
 /// `--dangerously-bypass-approvals-and-sandbox` disables both the sandbox and approval
 /// prompts so the agent can run autonomously.
-fn codex_command(cli_name: &str, prompt_path: &str) -> String {
-    format!("{cli_name} --dangerously-bypass-approvals-and-sandbox \"$(cat '{prompt_path}')\"")
+/// `Some(session_id)` indicates that we want to resume that prior session. Unlike claude,
+/// codex does not support assigning a session_id to a new conversation.
+fn codex_command(cli_name: &str, session_id: Option<&Uuid>, prompt_path: &str) -> String {
+    match session_id {
+        Some(session_id) => format!(
+            "{cli_name} resume --dangerously-bypass-approvals-and-sandbox {session_id} \
+             \"$(cat '{prompt_path}')\""
+        ),
+        None => {
+            format!(
+                "{cli_name} --dangerously-bypass-approvals-and-sandbox \"$(cat '{prompt_path}')\""
+            )
+        }
+    }
 }
 
 enum CodexRunnerState {
@@ -121,9 +161,12 @@ struct CodexHarnessRunner {
     /// successful [`find_session_file`] walk so that subsequent saves skip the YYYY/MM/DD
     /// directory walk and read the JSONL file directly.
     transcript_path: OnceLock<PathBuf>,
+    /// Optionally supply an existing conversation ID.
+    preexisting_conversation_id: Option<AIConversationId>,
 }
 
 impl CodexHarnessRunner {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         cli_command: &str,
         prompt: &str,
@@ -131,18 +174,52 @@ impl CodexHarnessRunner {
         _working_dir: &Path,
         client: Arc<dyn HarnessSupportClient>,
         terminal_driver: ModelHandle<TerminalDriver>,
+        resume: Option<CodexResumeInfo>,
     ) -> Result<Self, AgentDriverError> {
         let temp_file = write_temp_file("oz_prompt_", prompt)?;
         let prompt_path = temp_file.path().display().to_string();
 
+        let (session_id, preexisting_conversation_id, transcript_path) = match resume {
+            Some(CodexResumeInfo {
+                conversation_id,
+                session_id,
+                envelope,
+            }) => {
+                let sessions_root = codex_sessions_root().map_err(|e| {
+                    AgentDriverError::ConfigBuildFailed(
+                        e.context("Failed to resolve codex sessions root"),
+                    )
+                })?;
+                let path = write_envelope(&envelope, &sessions_root).map_err(|e| {
+                    AgentDriverError::ConfigBuildFailed(
+                        e.context("Failed to rehydrate codex transcript"),
+                    )
+                })?;
+                (Some(session_id), Some(conversation_id), Some(path))
+            }
+            None => (None, None, None),
+        };
+
+        let command = codex_command(cli_command, session_id.as_ref(), &prompt_path);
+
+        let session_id_cell: OnceLock<Uuid> = OnceLock::new();
+        if let Some(id) = session_id {
+            let _ = session_id_cell.set(id);
+        }
+        let transcript_path_cell: OnceLock<PathBuf> = OnceLock::new();
+        if let Some(p) = transcript_path {
+            let _ = transcript_path_cell.set(p);
+        }
+
         Ok(Self {
-            command: codex_command(cli_command, &prompt_path),
+            command,
             _temp_prompt_file: temp_file,
             client,
             terminal_driver,
             state: Mutex::new(CodexRunnerState::Preexec),
-            session_id: OnceLock::new(),
-            transcript_path: OnceLock::new(),
+            session_id: session_id_cell,
+            transcript_path: transcript_path_cell,
+            preexisting_conversation_id,
         })
     }
 
@@ -172,15 +249,25 @@ impl HarnessRunner for CodexHarnessRunner {
         &self,
         foreground: &ModelSpawner<AgentDriver>,
     ) -> Result<CommandHandle, AgentDriverError> {
-        let conversation_id = self
-            .client
-            .create_external_conversation(CODEX_CLI_FORMAT)
-            .await
-            .map_err(|e| {
-                log::error!("Failed to create external conversation: {e}");
-                AgentDriverError::ConfigBuildFailed(e)
-            })?;
-        log::info!("Created external conversation {conversation_id}");
+        // Resume runs reuse the prior server conversation id; fresh runs mint a new one.
+        let conversation_id = match self.preexisting_conversation_id {
+            Some(id) => {
+                log::info!("Resuming external conversation {id}");
+                id
+            }
+            None => {
+                let id = self
+                    .client
+                    .create_external_conversation(CODEX_CLI_FORMAT)
+                    .await
+                    .map_err(|e| {
+                        log::error!("Failed to create external conversation: {e}");
+                        AgentDriverError::ConfigBuildFailed(e)
+                    })?;
+                log::info!("Created external conversation {id}");
+                id
+            }
+        };
 
         let command = self.command.clone();
         let terminal_driver = self.terminal_driver.clone();

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -1,10 +1,15 @@
 use std::collections::HashMap;
 use std::fs;
+use std::sync::Arc;
 
 use serde_json::Value;
 use tempfile::TempDir;
+use uuid::Uuid;
 
+use super::super::codex_transcript::CodexTranscriptEnvelope;
 use super::*;
+use crate::ai::agent::conversation::AIConversationId;
+use crate::server::server_api::harness_support::MockHarnessSupportClient;
 
 #[test]
 fn prepare_codex_auth_writes_fresh_file_with_api_key_mode() {
@@ -323,4 +328,89 @@ fn find_child_git_repos_returns_empty_when_dir_missing() {
     let tmp = TempDir::new().unwrap();
     let missing = tmp.path().join("does-not-exist");
     assert!(find_child_git_repos(&missing).is_empty());
+}
+
+#[test]
+fn codex_command_with_session_id_invokes_resume_subcommand() {
+    let uuid = Uuid::new_v4();
+    let cmd = codex_command("codex", Some(&uuid), "/tmp/prompt.txt");
+    assert!(
+        cmd.contains(&format!(
+            "resume --dangerously-bypass-approvals-and-sandbox {uuid}"
+        )),
+        "resume command should pass UUID to `resume`: {cmd}"
+    );
+    assert!(
+        cmd.contains("\"$(cat '/tmp/prompt.txt')\""),
+        "resume command should pipe prompt: {cmd}"
+    );
+}
+
+#[tokio::test]
+async fn fetch_resume_payload_maps_404_to_resume_state_missing() {
+    let mut mock = MockHarnessSupportClient::new();
+    mock.expect_fetch_transcript()
+        .returning(|| Err(anyhow::anyhow!("upstream returned status 404")));
+    let conversation_id = AIConversationId::new();
+
+    let result = CodexHarness
+        .fetch_resume_payload(&conversation_id, Arc::new(mock))
+        .await;
+
+    match result {
+        Err(AgentDriverError::ConversationResumeStateMissing { harness, .. }) => {
+            assert_eq!(harness, "codex");
+        }
+        other => panic!("expected ConversationResumeStateMissing, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn fetch_resume_payload_maps_other_errors_to_load_failed() {
+    let mut mock = MockHarnessSupportClient::new();
+    mock.expect_fetch_transcript()
+        .returning(|| Err(anyhow::anyhow!("connection reset")));
+    let conversation_id = AIConversationId::new();
+
+    let result = CodexHarness
+        .fetch_resume_payload(&conversation_id, Arc::new(mock))
+        .await;
+
+    assert!(
+        matches!(result, Err(AgentDriverError::ConversationLoadFailed(_))),
+        "expected ConversationLoadFailed, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn fetch_resume_payload_returns_codex_variant_on_success() {
+    let uuid = Uuid::new_v4();
+    let envelope = CodexTranscriptEnvelope {
+        cwd: "/cloud/work".into(),
+        session_id: uuid,
+        codex_version: Some("0.55.0".to_string()),
+        session_start_timestamp: None,
+        entries: vec![serde_json::json!({"type": "event_msg"})],
+    };
+    let bytes = serde_json::to_vec(&envelope).unwrap();
+
+    let mut mock = MockHarnessSupportClient::new();
+    mock.expect_fetch_transcript()
+        .returning(move || Ok(bytes::Bytes::from(bytes.clone())));
+    let conversation_id = AIConversationId::new();
+
+    let payload = CodexHarness
+        .fetch_resume_payload(&conversation_id, Arc::new(mock))
+        .await
+        .unwrap()
+        .unwrap();
+
+    match payload {
+        ResumePayload::Codex(info) => {
+            assert_eq!(info.session_id, uuid);
+            assert_eq!(info.conversation_id, conversation_id);
+            assert_eq!(info.envelope.codex_version.as_deref(), Some("0.55.0"));
+        }
+        other => panic!("expected ResumePayload::Codex, got {other:?}"),
+    }
 }

--- a/app/src/ai/agent_sdk/driver/harness/codex_transcript.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_transcript.rs
@@ -1,16 +1,26 @@
-//! Codex session transcript envelope + read helpers.
+//! Codex session transcript envelope + rehydration helpers.
 //!
 //! Owns:
 //! - [`CodexTranscriptEnvelope`] — the on-wire/on-GCS shape of a saved Codex rollout
-//!   (parsed JSONL entries plus session-level metadata). Reader functions interoperate
-//!   with Codex's own `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` layout
-//!   (codex `rollout/src/recorder.rs`).
+//!   (parsed JSONL entries plus session-level metadata). Reader/writer functions
+//!   interoperate with Codex's own `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`
+//!   layout (codex `rollout/src/recorder.rs`).
+//! - [`CodexResumeInfo`] — everything the harness runner needs to resume an existing
+//!   Codex conversation: the Warp server conversation id to reuse, the codex session
+//!   uuid (`ThreadId`) to pass to `codex resume`, and the decoded envelope to rehydrate
+//!   onto disk.
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use anyhow::{Context, Result};
+use chrono::{DateTime, Datelike, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
+
+use super::json_utils::entries_to_jsonl;
+
+use crate::ai::agent::conversation::AIConversationId;
 
 /// Env var codex honors to override `~/.codex` (see codex `core/src/config/mod.rs`).
 const CODEX_HOME_ENV: &str = "CODEX_HOME";
@@ -31,6 +41,10 @@ pub(crate) struct CodexTranscriptEnvelope {
     /// `cli_version` from `SessionMeta`, surfaced separately for the server.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) codex_version: Option<String>,
+    /// Timestamp from the `SessionMeta` line, used to derive the YYYY/MM/DD directory
+    /// path when writing the rollout file back to disk.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) session_start_timestamp: Option<DateTime<Utc>>,
     /// Parsed JSONL entries.
     pub(crate) entries: Vec<Value>,
 }
@@ -41,6 +55,7 @@ impl CodexTranscriptEnvelope {
             cwd: meta.cwd,
             session_id,
             codex_version: meta.codex_version,
+            session_start_timestamp: meta.session_start_timestamp,
             entries,
         }
     }
@@ -51,6 +66,23 @@ impl CodexTranscriptEnvelope {
 pub(crate) struct CodexSessionMetadata {
     pub(crate) cwd: PathBuf,
     pub(crate) codex_version: Option<String>,
+    pub(crate) session_start_timestamp: Option<DateTime<Utc>>,
+}
+
+/// Everything needed to resume an existing Codex conversation.
+///
+/// Built from a `--conversation` id after the client fetches the stored envelope from
+/// the server. Passed into `CodexHarnessRunner::new` so the runner reuses the existing
+/// session and server conversation ids instead of minting fresh ones.
+#[derive(Debug)]
+pub(crate) struct CodexResumeInfo {
+    /// Warp server-side conversation id. Reused so subsequent transcript/block-snapshot
+    /// uploads overwrite the same GCS objects.
+    pub(crate) conversation_id: AIConversationId,
+    /// Codex session uuid passed to `codex resume <session_id>`. Matches `envelope.session_id`.
+    pub(crate) session_id: Uuid,
+    /// Envelope fetched from the server, written back to disk before launching codex.
+    pub(crate) envelope: CodexTranscriptEnvelope,
 }
 
 /// Resolve the codex sessions root, honoring `$CODEX_HOME` then falling back to `~/.codex`.
@@ -117,7 +149,44 @@ pub(crate) fn parse_session_meta(first: Option<&Value>) -> Option<CodexSessionMe
         .get("cli_version")
         .and_then(|v| v.as_str())
         .map(str::to_owned);
-    Some(CodexSessionMetadata { cwd, codex_version })
+    let session_start_timestamp = payload
+        .get("timestamp")
+        .and_then(|v| v.as_str())
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+    Some(CodexSessionMetadata {
+        cwd,
+        codex_version,
+        session_start_timestamp,
+    })
+}
+
+/// Write `envelope` back under `<sessions_root>/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`.
+///
+/// YYYY/MM/DD and `<ts>` come from `envelope.session_start_timestamp`. Falls back to
+/// today's UTC date if absent — codex's lookup is by UUID so the precise path doesn't
+/// matter for resume to work.
+pub(crate) fn write_envelope(
+    envelope: &CodexTranscriptEnvelope,
+    sessions_root: &Path,
+) -> Result<PathBuf> {
+    let timestamp = envelope.session_start_timestamp.unwrap_or_else(Utc::now);
+    let day_dir = sessions_root
+        .join(format!("{:04}", timestamp.year()))
+        .join(format!("{:02}", timestamp.month()))
+        .join(format!("{:02}", timestamp.day()));
+    fs::create_dir_all(&day_dir)
+        .with_context(|| format!("Failed to create {}", day_dir.display()))?;
+    // Codex's filename format: `[year]-[month]-[day]T[hour]-[minute]-[second]`
+    // (codex `rollout/src/recorder.rs::precompute_log_file_info`).
+    let date_str = timestamp.format("%Y-%m-%dT%H-%M-%S").to_string();
+    let file_path = day_dir.join(format!(
+        "rollout-{date_str}-{session_id}.jsonl",
+        session_id = envelope.session_id
+    ));
+    fs::write(&file_path, entries_to_jsonl(&envelope.entries)?)
+        .with_context(|| format!("Failed to write {}", file_path.display()))?;
+    Ok(file_path)
 }
 
 #[cfg(test)]

--- a/app/src/ai/agent_sdk/driver/harness/codex_transcript_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_transcript_tests.rs
@@ -110,3 +110,96 @@ fn read_envelope_returns_none_when_missing() {
     let tmp = TempDir::new().unwrap();
     assert!(read_envelope(Uuid::new_v4(), tmp.path()).unwrap().is_none());
 }
+
+#[test]
+fn write_envelope_uses_session_meta_timestamp_for_path() {
+    let tmp = TempDir::new().unwrap();
+    let uuid = Uuid::new_v4();
+    let envelope = CodexTranscriptEnvelope {
+        cwd: "/work".into(),
+        session_id: uuid,
+        codex_version: Some("0.55.0".to_string()),
+        session_start_timestamp: Some(
+            chrono::DateTime::parse_from_rfc3339("2026-04-30T01:54:20.000Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        ),
+        entries: vec![
+            serde_json::from_str::<serde_json::Value>(&session_meta_line(
+                uuid,
+                "/work",
+                "2026-04-30T01:54:20.000Z",
+                "0.55.0",
+            ))
+            .unwrap(),
+        ],
+    };
+
+    let path = write_envelope(&envelope, tmp.path()).unwrap();
+
+    let expected = tmp
+        .path()
+        .join("2026")
+        .join("04")
+        .join("30")
+        .join(format!("rollout-2026-04-30T01-54-20-{uuid}.jsonl"));
+    assert_eq!(path, expected);
+    assert!(path.exists());
+}
+
+#[test]
+fn write_envelope_round_trip_preserves_entries() {
+    let tmp = TempDir::new().unwrap();
+    let uuid = Uuid::new_v4();
+    let entries = vec![
+        serde_json::from_str::<serde_json::Value>(&session_meta_line(
+            uuid,
+            "/work",
+            "2026-04-30T01:54:20.000Z",
+            "0.55.0",
+        ))
+        .unwrap(),
+        serde_json::json!({"type": "event_msg", "payload": {"x": 1}}),
+    ];
+    let original = CodexTranscriptEnvelope {
+        cwd: "/work".into(),
+        session_id: uuid,
+        codex_version: Some("0.55.0".to_string()),
+        session_start_timestamp: Some(
+            chrono::DateTime::parse_from_rfc3339("2026-04-30T01:54:20.000Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        ),
+        entries: entries.clone(),
+    };
+
+    write_envelope(&original, tmp.path()).unwrap();
+    let decoded = read_envelope(uuid, tmp.path()).unwrap().unwrap();
+
+    assert_eq!(decoded.session_id, uuid);
+    assert_eq!(decoded.entries, entries);
+    // `cwd` and `codex_version` are recovered from the SessionMeta line.
+    assert_eq!(decoded.cwd, std::path::PathBuf::from("/work"));
+    assert_eq!(decoded.codex_version.as_deref(), Some("0.55.0"));
+}
+
+#[test]
+fn write_envelope_falls_back_to_today_when_timestamp_missing() {
+    let tmp = TempDir::new().unwrap();
+    let uuid = Uuid::new_v4();
+    // No SessionMeta first line — just one event entry.
+    let envelope = CodexTranscriptEnvelope {
+        cwd: "/work".into(),
+        session_id: uuid,
+        codex_version: None,
+        session_start_timestamp: None,
+        entries: vec![serde_json::json!({"type": "event_msg"})],
+    };
+
+    let path = write_envelope(&envelope, tmp.path()).unwrap();
+
+    // Path should still be under sessions_root and findable by uuid.
+    assert!(path.starts_with(tmp.path()));
+    let found = find_session_file(tmp.path(), uuid).unwrap();
+    assert_eq!(found, Some(path));
+}

--- a/app/src/ai/agent_sdk/driver/harness/codex_transcript_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_transcript_tests.rs
@@ -200,6 +200,6 @@ fn write_envelope_falls_back_to_today_when_timestamp_missing() {
 
     // Path should still be under sessions_root and findable by uuid.
     assert!(path.starts_with(tmp.path()));
-    let found = find_session_file(tmp.path(), uuid).unwrap();
+    let found = find_session_file(tmp.path(), uuid);
     assert_eq!(found, Some(path));
 }

--- a/app/src/ai/agent_sdk/driver/harness/json_utils.rs
+++ b/app/src/ai/agent_sdk/driver/harness/json_utils.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Read a JSON file as `T`, or return `T::default()` if the file does not exist.
 ///
@@ -53,4 +54,14 @@ where
         serde_json::to_vec_pretty(value).context(serialize_error)?,
     )
     .with_context(|| format!("Failed to write {}", path.display()))
+}
+
+/// Serialize a slice of JSON values as a JSONL byte string (one value per line).
+pub(super) fn entries_to_jsonl(entries: &[Value]) -> Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    for entry in entries {
+        serde_json::to_writer(&mut buf, entry)?;
+        buf.push(b'\n');
+    }
+    Ok(buf)
 }

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -44,6 +44,7 @@ mod json_utils;
 pub(crate) use claude_code::ClaudeHarness;
 use claude_transcript::ClaudeResumeInfo;
 use codex::CodexHarness;
+use codex_transcript::CodexResumeInfo;
 use gemini::GeminiHarness;
 
 /// Harness-agnostic payload describing how to resume an existing conversation.
@@ -54,6 +55,62 @@ use gemini::GeminiHarness;
 pub(crate) enum ResumePayload {
     /// Claude Code session state fetched from the server's transcript endpoint.
     Claude(ClaudeResumeInfo),
+    /// Codex session state fetched from the server's transcript endpoint.
+    Codex(CodexResumeInfo),
+}
+
+impl TryFrom<ResumePayload> for ClaudeResumeInfo {
+    type Error = AgentDriverError;
+
+    fn try_from(payload: ResumePayload) -> Result<Self, Self::Error> {
+        match payload {
+            ResumePayload::Claude(info) => Ok(info),
+            _ => {
+                log::error!("ClaudeHarness given non-Claude ResumePayload variant");
+                Err(AgentDriverError::InvalidRuntimeState)
+            }
+        }
+    }
+}
+
+impl TryFrom<ResumePayload> for CodexResumeInfo {
+    type Error = AgentDriverError;
+
+    fn try_from(payload: ResumePayload) -> Result<Self, Self::Error> {
+        match payload {
+            ResumePayload::Codex(info) => Ok(info),
+            _ => {
+                log::error!("CodexHarness given non-Codex ResumePayload variant");
+                Err(AgentDriverError::InvalidRuntimeState)
+            }
+        }
+    }
+}
+
+/// Fetch the harness transcript for `conversation_id` and deserialize it into `E`.
+pub(super) async fn fetch_transcript_envelope<E: serde::de::DeserializeOwned>(
+    harness_label: &str,
+    conversation_id: &AIConversationId,
+    client: Arc<dyn HarnessSupportClient>,
+) -> Result<E, AgentDriverError> {
+    let bytes = client.fetch_transcript().await.map_err(|err| {
+        // A 404 from the server maps to "no stored transcript" so the CLI can tell
+        // the user the prior run never saved state.
+        let message = format!("{err:#}").to_lowercase();
+        if message.contains("status 404") {
+            AgentDriverError::ConversationResumeStateMissing {
+                harness: harness_label.to_string(),
+                conversation_id: conversation_id.to_string(),
+            }
+        } else {
+            AgentDriverError::ConversationLoadFailed(format!("{err:#}"))
+        }
+    })?;
+    serde_json::from_slice(&bytes).map_err(|err| {
+        AgentDriverError::ConversationLoadFailed(format!(
+            "Failed to deserialize {harness_label} transcript for {conversation_id}: {err:#}"
+        ))
+    })
 }
 
 /// Trait for third-party agent harnesses that execute prompts via their own CLIs.

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -52,6 +52,7 @@ use gemini::GeminiHarness;
 /// Each variant carries the data a specific harness needs to rehydrate state before its CLI
 /// launches. Harnesses match on the variant they produce and ignore others; new CLIs that
 /// want resume support add a new variant and override [`ThirdPartyHarness::fetch_resume_payload`].
+#[derive(Debug)]
 pub(crate) enum ResumePayload {
     /// Claude Code session state fetched from the server's transcript endpoint.
     Claude(ClaudeResumeInfo),

--- a/specs/REMOTE-1503/TECH.md
+++ b/specs/REMOTE-1503/TECH.md
@@ -1,0 +1,66 @@
+# REMOTE-1503: Conversation Resumption for Codex
+
+## Context
+Cloud agent runs using the Codex harness need conversation resumption, matching what already exists for Claude Code. The Claude resumption flow — `fetch_resume_payload` → `build_runner` with `ResumePayload` → rehydrate transcript to disk → launch CLI with resume flag — is the template.
+
+Key differences from Claude:
+- Codex resumes via `codex resume <session_id> <prompt>`, not `--resume <uuid>`. There is no `--session-id` equivalent for fresh sessions; codex assigns its own UUID on first run.
+- Codex's session files live under `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` (vs Claude's `~/.claude/projects/<encoded_cwd>/`). The YYYY/MM/DD path is derived from the `SessionMeta` timestamp.
+- Codex doesn't have a `sessions-index.json` equivalent.
+
+Relevant files:
+- `app/src/ai/agent_sdk/driver/harness/mod.rs` — `ResumePayload` enum, `ThirdPartyHarness` trait, shared `fetch_transcript_envelope`
+- `app/src/ai/agent_sdk/driver/harness/codex.rs` — `CodexHarness`, `CodexHarnessRunner`, `codex_command()`
+- `app/src/ai/agent_sdk/driver/harness/codex_transcript.rs` — `CodexTranscriptEnvelope`, `CodexSessionMetadata`, session file I/O
+- `app/src/ai/agent_sdk/driver/harness/claude_code.rs` — reference implementation for resume flow
+- `app/src/ai/agent_sdk/driver/harness/json_utils.rs` — shared `entries_to_jsonl`
+- `app/src/ai/agent_sdk/driver/harness/claude_transcript.rs` — previously owned `entries_to_jsonl`
+
+## Proposed Changes
+
+### 1. Shared `fetch_transcript_envelope<E>` (mod.rs)
+Extract the fetch-and-deserialize logic from `ClaudeHarness::fetch_resume_payload` into a generic `fetch_transcript_envelope<E: DeserializeOwned>(harness_label, conversation_id, client)` in `mod.rs`. Both harnesses call it with their envelope type; the 404→`ConversationResumeStateMissing` and parse-error→`ConversationLoadFailed` mapping lives once.
+
+### 2. Shared `entries_to_jsonl` (json_utils.rs)
+Move `entries_to_jsonl` from `claude_transcript.rs` into `json_utils.rs` so both the Claude and Codex transcript modules can use it without duplication.
+
+### 3. `ResumePayload::Codex` variant + type-safe extraction (mod.rs)
+Add `Codex(CodexResumeInfo)` to `ResumePayload`. Add `TryFrom<ResumePayload>` impls for both `ClaudeResumeInfo` and `CodexResumeInfo` that return `AgentDriverError::InvalidRuntimeState` on variant mismatch — replaces the inline `match` in `ClaudeHarness::build_runner`.
+
+### 4. `CodexResumeInfo` + `session_start_timestamp` (codex_transcript.rs)
+New `CodexResumeInfo` struct: `{ conversation_id, session_id, envelope }`. Add `session_start_timestamp: Option<DateTime<Utc>>` to `CodexTranscriptEnvelope` and `CodexSessionMetadata`, parsed from the `SessionMeta` line's `timestamp` field. Used to reconstruct the YYYY/MM/DD directory path when writing back to disk.
+
+### 5. `write_envelope` (codex_transcript.rs)
+New function that writes the envelope's JSONL entries back to `<sessions_root>/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`. Timestamp comes from `session_start_timestamp`; falls back to `Utc::now()` if absent (codex's lookup is by UUID so the path doesn't need to be exact).
+
+### 6. `CodexHarness::fetch_resume_payload` (codex.rs)
+Override `fetch_resume_payload` on `CodexHarness` using the shared `fetch_transcript_envelope::<CodexTranscriptEnvelope>`, wrapping the result into `ResumePayload::Codex`.
+
+### 7. `CodexHarnessRunner` resume path (codex.rs)
+In `build_runner`:
+- Extract `CodexResumeInfo` via `TryFrom`
+- Prepend `resumption_prompt` to the user prompt (mirrors Claude)
+
+In `CodexHarnessRunner::new`, when `resume` is `Some`:
+- Write envelope to disk via `write_envelope`
+- Pre-populate `session_id`, `transcript_path`, and `session_metadata` `OnceLock`s from the envelope
+- Store `preexisting_conversation_id`
+
+### 8. `codex_command` resume subcommand (codex.rs)
+`codex_command` gains `session_id: Option<&Uuid>`. When `Some`, emits `codex resume --dangerously-bypass-approvals-and-sandbox <uuid> "$(cat '<prompt>')"`. When `None`, same as before.
+
+### 9. `HarnessRunner::start` reuses conversation ID (codex.rs)
+If `preexisting_conversation_id` is set, skip `create_external_conversation` and reuse it. Matches the Claude runner pattern.
+
+## Testing and Validation
+
+### Unit tests (codex_tests.rs)
+- `codex_command_with_session_id_invokes_resume_subcommand` — verifies `resume` subcommand format
+- `fetch_resume_payload_maps_404_to_resume_state_missing` — mock returns 404, assert `ConversationResumeStateMissing` with harness `"codex"`
+- `fetch_resume_payload_maps_other_errors_to_load_failed` — mock returns generic error, assert `ConversationLoadFailed`
+- `fetch_resume_payload_returns_codex_variant_on_success` — round-trip envelope through mock, assert `ResumePayload::Codex` fields
+
+### Unit tests (codex_transcript_tests.rs)
+- `write_envelope_uses_session_meta_timestamp_for_path` — writes to `2026/04/30/rollout-…-<uuid>.jsonl`
+- `write_envelope_round_trip_preserves_entries` — write then `read_envelope`, assert entries match
+- `write_envelope_falls_back_to_today_when_timestamp_missing` — no timestamp → still findable by UUID via `find_session_file`


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
Following the pattern for resuming claude conversations, we add support for codex conversations. 

These changes are pretty straightforward:
- Pull out `fetch_transcript_envelope` and `entries_to_jsonl` from the claude implementation and reuse
- Write the codex transcript to disk using either the stored timestamp on the envelope or the current time to write the directories (`/.codex/sessions/YYYY/MM/DD/...-<session_id>.jsonl`)

## Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->
Demo: https://www.loom.com/share/fc40514af96649a9b35d3c85f2888627

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?
-->
Tested locally by running a codex cloud agent, closing it, and then using Safia's resume conversation script to trigger a followup message in that conversation.  

Also added unit tests for writing the envelope.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
