### PR TITLE
ci: simplify external contributor check to fork-only

### DIFF
--- a/.github/workflows/label_external_contributors.yml
+++ b/.github/workflows/label_external_contributors.yml
@@ -3,21 +3,15 @@
 # ======================================================================================
 # Usage:
 #   - Runs whenever a pull request is opened.
-#   - Adds the `external-contributor` label to the PR if either of the following is
-#     true (logical OR), and the PR is not authored by a bot:
-#       1. The PR author is not a member of the `warpdotdev` GitHub organization.
-#       2. The PR head repository is a fork (i.e. it does not belong to the same
-#          repository as the base).
+#   - Adds the `external-contributor` label to the PR if the PR head repository is
+#     a fork (i.e. it does not belong to the same repository as the base), and the
+#     PR is not authored by a bot.
 #
 # Notes:
 #   - The workflow triggers on `pull_request_target` rather than `pull_request` so
 #     that it has the `pull-requests: write` permission needed to apply labels even
 #     when the PR is opened from a fork. Because we never check out the PR's code
 #     and only read the event payload, this trigger is safe.
-#   - Org membership is determined via the GitHub REST API. We fall back to the
-#     PR's `author_association` field when the API call cannot be performed (for
-#     example, when the GITHUB_TOKEN lacks org-membership context for private
-#     members).
 # ======================================================================================
 
 name: Label External Contributors
@@ -55,35 +49,11 @@ jobs:
               !pr.head.repo ||
               pr.head.repo.full_name !== pr.base.repo.full_name;
 
-            // Check whether the author is a member of the warpdotdev org. The
-            // membership API requires the requester to be a member of the org.
-            // When it cannot return a definitive result, fall back to the PR's
-            // author_association field, which GitHub computes based on the
-            // author's relationship to the repository.
-            let isOrgMember =
-              pr.author_association === 'MEMBER' ||
-              pr.author_association === 'OWNER';
-            try {
-              await github.rest.orgs.checkMembershipForUser({
-                org: 'warpdotdev',
-                username: author,
-              });
-              isOrgMember = true;
-            } catch (error) {
-              console.log(
-                `checkMembershipForUser failed (${error.status}); ` +
-                  `falling back to author_association="${pr.author_association}"`,
-              );
-            }
-
-            const isExternal = !isOrgMember || isFork;
             console.log(
-              `PR #${pr.number} by ${author}: ` +
-                `isFork=${isFork}, isOrgMember=${isOrgMember}, ` +
-                `isExternal=${isExternal}`,
+              `PR #${pr.number} by ${author}: isFork=${isFork}`,
             );
 
-            if (!isExternal) {
+            if (!isFork) {
               return;
             }
 


### PR DESCRIPTION
## Description
Simplifies the `label_external_contributors` workflow to strictly determine external contributors by checking if the PR originates from a fork. Removes the org membership API call (`checkMembershipForUser`) and the `author_association` fallback logic.

The workflow now only labels a PR as `external-contributor` when `pr.head.repo.full_name !== pr.base.repo.full_name` (i.e., the PR is from a fork). Bot PRs continue to be skipped.

## Linked Issue
N/A — requested workflow simplification.

## Testing
Reviewed the workflow YAML for correctness. The logic is straightforward: fork check + bot exclusion.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/86ae63f1-b0ae-4f48-a332-381f187ad442_
_Run: https://oz.staging.warp.dev/runs/019de157-0bfc-77bc-830d-bd1bc98a60b0_

_This PR was generated with [Oz](https://warp.dev/oz)._
