### PR TITLE
Fix: validate pacman signing key before allowing update

### DIFF
--- a/app/src/autoupdate/linux.rs
+++ b/app/src/autoupdate/linux.rs
@@ -626,6 +626,20 @@ fn is_pacman_signing_key_installed() -> bool {
         return false;
     };
 
+    // After parsing the pub: line, also check validity field (index 1 = validity)
+    let fields: Vec<&str> = stdout
+        .lines()
+        .find(|line| line.starts_with("pub:"))
+        .map(|line| line.split(':').collect())
+        .unwrap_or_default();
+
+    // Field index 1 = validity: 'f' (full), 'u' (ultimate) are valid;
+    // 'e' (expired), 'r' (revoked), '-', 'q' = invalid
+    let validity = fields.get(1).copied().unwrap_or("");
+    if !matches!(validity, "f" | "u") {
+        return false; // Force key reconfiguration
+    }
+
     // Parse the expiry timestamp from the pub: line (field 7, 1-indexed).
     let Some(expiry_field) = stdout
         .lines()

--- a/app/src/autoupdate/linux.rs
+++ b/app/src/autoupdate/linux.rs
@@ -642,6 +642,9 @@ fn is_pacman_signing_key_installed() -> bool {
     if !matches!(validity, 'f' | 'u') {
         return false; // Force key reconfiguration
     }
+    if !matches!(validity, 'f' | 'u') {
+        return false; // Force key reconfiguration
+    }
 
     // Parse the expiry timestamp from the pub: line (field 7, 1-indexed).
     let Some(expiry_field) = stdout

--- a/app/src/autoupdate/linux.rs
+++ b/app/src/autoupdate/linux.rs
@@ -635,8 +635,11 @@ fn is_pacman_signing_key_installed() -> bool {
 
     // Field index 1 = validity: 'f' (full), 'u' (ultimate) are valid;
     // 'e' (expired), 'r' (revoked), '-', 'q' = invalid
-    let validity = fields.get(1).copied().unwrap_or("");
-    if !matches!(validity, "f" | "u") {
+    let validity = fields
+        .get(1)
+        .and_then(|field| field.chars().next())
+        .unwrap_or('\0');
+    if !matches!(validity, 'f' | 'u') {
         return false; // Force key reconfiguration
     }
 

--- a/app/src/autoupdate/linux.rs
+++ b/app/src/autoupdate/linux.rs
@@ -642,9 +642,6 @@ fn is_pacman_signing_key_installed() -> bool {
     if !matches!(validity, 'f' | 'u') {
         return false; // Force key reconfiguration
     }
-    if !matches!(validity, 'f' | 'u') {
-        return false; // Force key reconfiguration
-    }
 
     // Parse the expiry timestamp from the pub: line (field 7, 1-indexed).
     let Some(expiry_field) = stdout


### PR DESCRIPTION
## Description
## Summary
This PR improves the pacman update flow by validating the signing key before proceeding with the update.

Currently, Warp checks for the presence and expiration of the pacman signing key, but does not verify whether the key is valid at the trust level (e.g., revoked, expired, or otherwise unusable). This can lead to update failures during package installation due to signature verification errors.

## Changes
- Added parsing of the `pub:` line from GPG output to extract the validity field
- Ensured only valid keys (`f` = full, `u` = ultimate) are accepted
- Return false for invalid states (`e`, `r`, `-`, `q`) to trigger key reconfiguration
- Preserved existing expiry checks and overall logic flow

## Impact
Prevents update attempts with invalid or misconfigured pacman signing keys, improving reliability and user experience on pacman-based systems.

Happy to make further changes if needed.


## Linked Issue
N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).


## Screenshots / Videos
N/A


## Testing
- Verified correctness of GPG output parsing logic
- Ensured compatibility with existing expiry validation
- Confirmed no changes to external interfaces or update flow beyond validation

No new tests were added as this is a small internal validation improvement.


## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode