### PR TITLE
docs: attribute two more Alacritty-derived files (#9522)

### DIFF
--- a/app/src/terminal/model/grid/grid_storage/resize.rs
+++ b/app/src/terminal/model/grid/grid_storage/resize.rs
@@ -1,3 +1,6 @@
+// The code in this file is adapted from the alacritty_terminal crate under the
+// Apache license; see: crates/warp_terminal/src/model/LICENSE-ALACRITTY.
+
 //! Grid resize and reflow.
 
 use std::cmp::{min, Ordering};

--- a/app/src/terminal/ref_tests/mod.rs
+++ b/app/src/terminal/ref_tests/mod.rs
@@ -1,3 +1,6 @@
+// The test harness in this file is adapted from the alacritty_terminal crate
+// under the Apache license; see: crates/warp_terminal/src/model/LICENSE-ALACRITTY.
+
 use std::fs::{self, File};
 use std::io::{self, Read};
 use std::path::Path;


### PR DESCRIPTION
## Description

Refs #9522.

After #9513 and #9563 added attribution headers to the original set of derivative files, two more files remain unattributed:

| File | Upstream origin |
| --- | --- |
| `app/src/terminal/model/grid/grid_storage/resize.rs` | `alacritty_terminal/src/grid/resize.rs` — grid resize/reflow logic. The parent `grid_storage.rs` was attributed in #9513; this child module was missed. |
| `app/src/terminal/ref_tests/mod.rs` | `alacritty_terminal/tests/ref.rs` — test harness, including the `ref_tests!` macro, JSON fixture loading, and the `.alacritty.recording` data format. |

Both files now carry the same two-line attribution comment that #9513 and #9563 introduced, pointing to the existing `crates/warp_terminal/src/model/LICENSE-ALACRITTY` (Apache-2.0).

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Screenshots / Videos

Not applicable — documentation/comments only.

## Testing

No code paths changed. `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` clean.

Note: `cargo fmt --check` reports pre-existing import-ordering failures in both files that are present on `master` before this change (confirmed by checking `git stash` baseline). These are not introduced by this PR.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode