### PR TITLE
fix(user_defaults): return canonical JSON for NSNumber(BOOL) values (#9041)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15072,6 +15072,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "cocoa 0.26.0",
+ "core-foundation 0.10.1",
  "gloo-storage",
  "log",
  "objc",

--- a/crates/warpui_extras/Cargo.toml
+++ b/crates/warpui_extras/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 default = ["secure_storage", "user_preferences", "user_preferences-file"]
 secure_storage = ["dep:security-framework", "dep:secret-service", "dep:ouroboros"]
 test-util = []
-user_preferences = ["dep:cocoa", "dep:objc", "dep:gloo-storage"]
+user_preferences = ["dep:cocoa", "dep:objc", "dep:gloo-storage", "dep:core-foundation"]
 user_preferences-file = ["user_preferences", "dep:serde", "dep:serde_json"]
 user_preferences-toml = ["user_preferences", "dep:serde", "dep:serde_json", "dep:toml_edit"]
 
@@ -32,6 +32,7 @@ tempfile.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = { workspace = true, optional = true }
+core-foundation = { workspace = true, optional = true }
 objc = { workspace = true, optional = true }
 security-framework = { version = "2.0.0", optional = true }
 

--- a/crates/warpui_extras/src/user_preferences/user_defaults.rs
+++ b/crates/warpui_extras/src/user_preferences/user_defaults.rs
@@ -3,6 +3,8 @@
 #![allow(deprecated)]
 
 use cocoa::base::{id, nil};
+use core_foundation::base::{CFGetTypeID, CFTypeRef, TCFType};
+use core_foundation::boolean::CFBoolean;
 use objc::{class, msg_send, rc::StrongPtr, sel, sel_impl};
 
 /// A user preferences store backed by macOS user defaults (`NSUserDefaults`).
@@ -66,18 +68,15 @@ impl super::UserPreferences for UserDefaultsPreferencesStorage {
             // is written via `defaults write -bool false`, it is stored as NSNumber(BOOL).
             // stringForKey: coerces that to "0"/"1", which serde_json cannot parse as bool
             // and silently falls back to the setting's default. Return canonical JSON instead.
+            //
+            // BOOL is toll-free bridged with the kCFBooleanTrue/kCFBooleanFalse singletons,
+            // so CFGetTypeID is the only safe way to discriminate a real BOOL from a
+            // char-valued NSNumber (which shares ObjC encoding "c" on x86_64). Char-valued
+            // and other numeric NSNumbers carry CFNumber's type ID and fall through.
             let raw: id = msg_send![*self.user_defaults, objectForKey: *key];
-            if raw != nil {
-                let is_number: bool = msg_send![raw, isKindOfClass: class!(NSNumber)];
-                if is_number {
-                    let obj_c_type: *const std::os::raw::c_char = msg_send![raw, objCType];
-                    let encoding = std::ffi::CStr::from_ptr(obj_c_type).to_bytes();
-                    // 'c' = signed char (BOOL on x86_64); 'B' = C++ bool (BOOL on arm64).
-                    if encoding == b"c" || encoding == b"B" {
-                        let b: bool = msg_send![raw, boolValue];
-                        return Ok(Some(b.to_string()));
-                    }
-                }
+            if raw != nil && CFGetTypeID(raw as CFTypeRef) == CFBoolean::type_id() {
+                let b: bool = msg_send![raw, boolValue];
+                return Ok(Some(b.to_string()));
             }
 
             let value: id = msg_send![*self.user_defaults, stringForKey: *key];

--- a/crates/warpui_extras/src/user_preferences/user_defaults.rs
+++ b/crates/warpui_extras/src/user_preferences/user_defaults.rs
@@ -75,11 +75,7 @@ impl super::UserPreferences for UserDefaultsPreferencesStorage {
                     // 'c' = signed char (BOOL on x86_64); 'B' = C++ bool (BOOL on arm64).
                     if encoding == b"c" || encoding == b"B" {
                         let b: bool = msg_send![raw, boolValue];
-                        return Ok(Some(if b {
-                            "true".to_owned()
-                        } else {
-                            "false".to_owned()
-                        }));
+                        return Ok(Some(b.to_string()));
                     }
                 }
             }

--- a/crates/warpui_extras/src/user_preferences/user_defaults.rs
+++ b/crates/warpui_extras/src/user_preferences/user_defaults.rs
@@ -61,6 +61,29 @@ impl super::UserPreferences for UserDefaultsPreferencesStorage {
     fn read_value(&self, key: &str) -> Result<Option<String>, super::Error> {
         unsafe {
             let key = util::make_nsstring(key);
+
+            // Check for NSNumber-typed booleans before calling stringForKey:. When a value
+            // is written via `defaults write -bool false`, it is stored as NSNumber(BOOL).
+            // stringForKey: coerces that to "0"/"1", which serde_json cannot parse as bool
+            // and silently falls back to the setting's default. Return canonical JSON instead.
+            let raw: id = msg_send![*self.user_defaults, objectForKey: *key];
+            if raw != nil {
+                let is_number: bool = msg_send![raw, isKindOfClass: class!(NSNumber)];
+                if is_number {
+                    let obj_c_type: *const std::os::raw::c_char = msg_send![raw, objCType];
+                    let encoding = std::ffi::CStr::from_ptr(obj_c_type).to_bytes();
+                    // 'c' = signed char (BOOL on x86_64); 'B' = C++ bool (BOOL on arm64).
+                    if encoding == b"c" || encoding == b"B" {
+                        let b: bool = msg_send![raw, boolValue];
+                        return Ok(Some(if b {
+                            "true".to_owned()
+                        } else {
+                            "false".to_owned()
+                        }));
+                    }
+                }
+            }
+
             let value: id = msg_send![*self.user_defaults, stringForKey: *key];
             if value != nil {
                 Ok(Some(


### PR DESCRIPTION
## Description

Refs #9041.

`CopyOnSelect=false` set via `defaults write -bool false` is silently ignored. Root cause: `UserDefaultsPreferencesStorage::read_value` uses `stringForKey:`, which coerces an `NSNumber(BOOL)` to `"0"` or `"1"`. `serde_json::from_str::<bool>("0")` returns `Err`; the setting falls back to its default `true`; drag-to-select copies regardless of the user's preference.

Fix: call `objectForKey:` first. If the stored value is an `NSNumber` with a boolean ObjC type encoding (`c` on x86_64, `B` on arm64), return `"true"` or `"false"` directly. All other value types (NSString, non-boolean NSNumber) fall through to the original `stringForKey:` path — no behavior change for values written without `-bool`.

A second conditional path where post-migration `defaults write` edits are stranded when `FeatureFlag::SettingsFile` is enabled was also identified during the audit of this issue. That scenario has design tradeoffs and is tracked separately.

## Linked Issue

- [x] The linked issue is labeled `ready-to-implement`.

## Screenshots / Videos

Not applicable — no user-visible UI change; the fix restores an existing preference to having effect.

## Testing

- `cargo clippy -p warpui_extras --all-targets -- -D warnings` clean
- Manual: set `defaults write dev.warp.Warp-Stable CopyOnSelect -bool false`, launch Warp, drag-select text — clipboard should not be written. Toggle back with `-bool true`, verify drag-select copies again.

## Agent Mode
- [ ] Warp Agent Mode

CHANGELOG-BUG-FIX: Fix CopyOnSelect=false being ignored when the preference was set via `defaults write -bool false`