### PR TITLE
fix(macos/ime): skip key-equivalent priority path while IME is composing (#9709)

### DIFF
--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -432,6 +432,23 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     // We need to bypass the default performKeyEquivalent implementation which, in the case of
     // having keybinding conflicts with MacOS itself, yields priority to the OS.
     if ([event type] == NSEventTypeKeyDown) {
+        // While the IME is composing (e.g. selecting candidates in a Bopomofo / Pinyin / Kana
+        // input method), skip the priority path entirely. AppKit will then route the event
+        // through the standard keyDown: chain exactly once, which calls interpretKeyEvents
+        // and lets the IME consume the keystroke.
+        //
+        // Without this guard, navigation keys with the function-key flag (e.g. arrow keys,
+        // 0xa00100) reach this method first because they qualify as key equivalents. We then
+        // call keyDownImpl, which invokes interpretKeyEvents and forwards to Rust. Rust
+        // suppresses keystrokes during composition, so keyDownImpl returns NO. We fall
+        // through to [super performKeyEquivalent:], AppKit fires keyDown: on the host view,
+        // and interpretKeyEvents runs a second time. IMEs that listen to every keystroke on
+        // the input context — for example 超注音 (Yahoo Bopomofo) — observe both deliveries
+        // and advance their candidate selection by 2 per arrow press. See #9709.
+        if ([(WarpHostView *)self.contentView hasMarkedText]) {
+            return [super performKeyEquivalent:event];
+        }
+
         NSApplication *application = [NSApplication sharedApplication];
 
         // If we are recording a keystroke for an EditableBinding.

--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -432,19 +432,11 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     // We need to bypass the default performKeyEquivalent implementation which, in the case of
     // having keybinding conflicts with MacOS itself, yields priority to the OS.
     if ([event type] == NSEventTypeKeyDown) {
-        // While the IME is composing (e.g. selecting candidates in a Bopomofo / Pinyin / Kana
-        // input method), skip the priority path entirely. AppKit will then route the event
-        // through the standard keyDown: chain exactly once, which calls interpretKeyEvents
-        // and lets the IME consume the keystroke.
-        //
-        // Without this guard, navigation keys with the function-key flag (e.g. arrow keys,
-        // 0xa00100) reach this method first because they qualify as key equivalents. We then
-        // call keyDownImpl, which invokes interpretKeyEvents and forwards to Rust. Rust
-        // suppresses keystrokes during composition, so keyDownImpl returns NO. We fall
-        // through to [super performKeyEquivalent:], AppKit fires keyDown: on the host view,
-        // and interpretKeyEvents runs a second time. IMEs that listen to every keystroke on
-        // the input context — for example 超注音 (Yahoo Bopomofo) — observe both deliveries
-        // and advance their candidate selection by 2 per arrow press. See #9709.
+        // Skip the key-equivalent priority path while the IME has marked text. Arrow keys carry
+        // NSEventModifierFlagFunction, so AppKit delivers them here before keyDown:. If we call
+        // keyDownImpl and Rust suppresses the keystroke (composing mode), we return NO, and AppKit
+        // proceeds to call keyDown: — running interpretKeyEvents a second time for the same event.
+        // See #9709.
         if ([(WarpHostView *)self.contentView hasMarkedText]) {
             return [super performKeyEquivalent:event];
         }


### PR DESCRIPTION
## Description

Fixes #9709 — on macOS, third-party IMEs that listen on the input context (e.g. 超注音 / Yahoo Bopomofo) observed every arrow keystroke twice during candidate selection, advancing the highlight by 2 instead of 1.

### Root cause

Arrow keys carry the function-key flag (`modifierFlags=0xa00100`), so they qualify as key equivalents and AppKit dispatches them through `performKeyEquivalent:` before `keyDown:`. In `crates/warpui/src/platform/mac/objc/window.m::performKeyEquivalent:`, the previous implementation:

1. Called `[self.contentView keyDownImpl:event]` — which invokes `interpretKeyEvents:` and forwards to Rust
2. Rust suppresses keystrokes during composition (`is_composing=true`), so `keyDownImpl` returned `NO`
3. Fell through to `[super performKeyEquivalent:event]`
4. AppKit then dispatched `keyDown:` on the host view → `keyDownImpl` again → **`interpretKeyEvents` ran a second time**

Apple's built-in IME uses `IMKCandidates` (a separate `NSPanel`) for candidate selection, so the second delivery doesn't reach its candidate index. 超注音 draws its candidate panel itself and listens on the input context directly — it observes both deliveries and advances by 2.

### Fix

Skip the priority path in `performKeyEquivalent:` while `hasMarkedText` is `YES`. AppKit then routes the event through the standard `keyDown:` chain exactly once.

## Testing

### NSLog instrumentation (before/after)

I added per-call instrumentation around `keyDownImpl`, `interpretKeyEvents`, `setMarkedText:`, `insertText:`, `unmarkText`, `doCommandBySelector:`, and `performKeyEquivalent:` and reproduced with 超注音 (Yahoo Bopomofo) on macOS 26.4.1.

**Before the fix** — single right-arrow press during candidate selection:
```
performKeyEquivalent: keyCode=124 modifiers=0xa00100
performKeyEquivalent: keystrokeIsAssigned=1
keyDownImpl#8 ENTER keyCode=124 wasComposing=1
  interpretKeyEvents BEGIN                    ← IME +1
  setMarkedText: '...' (interpretingKeyEvents=1)
  setMarkedText: '...' (interpretingKeyEvents=1)
  interpretKeyEvents END (hasMarkedText=1)
warp_handle_view_event(composing=1) handled=0
performKeyEquivalent: keyDownImpl returned NO, falling through to super
keyDown: keyCode=124                          ← AppKit fires again
keyDownImpl#9 ENTER keyCode=124 wasComposing=1
  interpretKeyEvents BEGIN                    ← IME +1 again → total +2
  ...
```

**After the fix**:
```
performKeyEquivalent: keyCode=124 modifiers=0xa00100
performKeyEquivalent: IME composing, skipping priority path
keyDown: keyCode=124
keyDownImpl#22 ENTER keyCode=124 wasComposing=1
  interpretKeyEvents BEGIN                    ← single delivery
  interpretKeyEvents END (hasMarkedText=1)
```

### Manual verification (macOS)

- 超注音 (Yahoo Bopomofo): right/left arrow now advances candidate by exactly 1 per press (was 2). ✅
- Apple built-in 注音 (Bopomofo): no regression — candidate window behaves identically. ✅
- Apple Pinyin: no regression. ✅
- Cmd-shortcut keys without IME composition (e.g. Cmd-T new tab): no regression — the `hasMarkedText` guard only triggers during active composition, so the priority path still executes for ordinary key equivalents. ✅
- Plain typing without an IME: no regression. ✅

No automated tests were added: the bug requires running an IME on macOS and observing AppKit's two-stage event delivery (`performKeyEquivalent:` → `keyDown:`), which is impractical to simulate in the existing unit/integration test harnesses. The change is small, well-scoped (`performKeyEquivalent:` only), and the guard short-circuits to `[super performKeyEquivalent:]` on the same path AppKit would fall back to anyway.

## Server API dependencies

- [ ] Is this change necessary to make the client compatible with a desired server API breaking change?
- [ ] Does this change rely on a new server API?
- [ ] Is this change enabling the use of a server API on client channels that rely on the production server?

None — this is a pure native-input-handling change.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: macOS: fix third-party IMEs (e.g. 超注音 / Yahoo Bopomofo) advancing candidate selection by 2 per arrow press during composition.
