### PR TITLE
feat: register Rename Active Pane as a keyboard-bindable action (#9351)

### DIFF
--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -112,6 +112,10 @@ pub enum WorkspaceAction {
     RenamePane(PaneViewLocator),
     ResetPaneName(PaneViewLocator),
     RenameActiveTab,
+    /// Renames the focused pane in the active tab. Mirrors `RenameActiveTab`
+    /// so the action is reachable from the binding registry / Command Palette
+    /// (see #9351). The context-menu path keeps using `RenamePane(locator)`.
+    RenameActivePane,
     SetActiveTabName(String),
     /// Sets the manual color override for the active tab.
     ///
@@ -726,6 +730,7 @@ impl WorkspaceAction {
             | RenamePane(_)
             | ResetPaneName(_)
             | RenameActiveTab
+            | RenameActivePane
             | SetActiveTabName(_)
             | SetActiveTabColor(_)
             | CloseTab(_)

--- a/app/src/workspace/action_tests.rs
+++ b/app/src/workspace/action_tests.rs
@@ -74,4 +74,8 @@ fn pane_name_actions_save_workspace_state() {
 
     assert!(WorkspaceAction::RenamePane(locator).should_save_app_state_on_action());
     assert!(WorkspaceAction::ResetPaneName(locator).should_save_app_state_on_action());
+    // GH-9351: the keyboard-bindable variant must persist app state on the
+    // same conditions as the locator-based one, since both ultimately drive
+    // `rename_pane` which mutates `pane_configuration`.
+    assert!(WorkspaceAction::RenameActivePane.should_save_app_state_on_action());
 }

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -912,6 +912,19 @@ pub fn init(app: &mut AppContext) {
     .with_custom_action(CustomAction::RenameTab)
     .with_context_predicate(id!("Workspace"))]);
 
+    // Pane rename — same shape as RenameActiveTab but acts on the focused pane
+    // in the active tab. Ships with no default keybinding so it surfaces in
+    // Settings → Keyboard shortcuts as remappable; resolves issue #9351, where
+    // the action existed only in the right-click context menu and was not
+    // reachable via the binding registry.
+    app.register_editable_bindings([EditableBinding::new(
+        "workspace:rename_active_pane",
+        "Rename the current pane",
+        WorkspaceAction::RenameActivePane,
+    )
+    .with_group(bindings::BindingGroup::Settings.as_str())
+    .with_context_predicate(id!("Workspace"))]);
+
     app.register_editable_bindings([
         EditableBinding::new(
             "workspace:terminate_app",

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19764,6 +19764,18 @@ impl TypedActionView for Workspace {
             RenamePane(locator) => self.rename_pane(*locator, ctx),
             ResetPaneName(locator) => self.clear_pane_name(*locator, ctx),
             RenameActiveTab => self.rename_tab(self.active_tab_index, ctx),
+            RenameActivePane => {
+                let pane_group = self.active_tab_pane_group().clone();
+                let pane_group_id = pane_group.id();
+                let pane_id = pane_group.as_ref(ctx).focused_pane_id(ctx);
+                self.rename_pane(
+                    PaneViewLocator {
+                        pane_group_id,
+                        pane_id,
+                    },
+                    ctx,
+                );
+            }
             SetActiveTabName(name) => self.set_active_tab_name(name, ctx),
             SetActiveTabColor(color) => self.set_tab_color(self.active_tab_index, *color, ctx),
             ToggleTabRightClickMenu { tab_index, anchor } => {


### PR DESCRIPTION
## Description

Resolves the keyboard-binding portion of #9351.

The Rename Pane action shipped only via the right-click context menu on a pane title bar (\`WorkspaceAction::RenamePane(PaneViewLocator)\`). Because that variant requires an explicit locator, it can't be wired into the keybinding registry, the Command Palette, or Settings → Keyboard shortcuts — keyboard-driven users had no path to the action.

This PR mirrors the existing \`RenameActiveTab\` pattern by adding a parameterless \`RenameActivePane\` variant that resolves the active pane at dispatch time and delegates to the existing \`rename_pane\` infrastructure.

## Linked Issue

- [x] The linked issue is labeled \`ready-to-spec\` or \`ready-to-implement\`. (#9351 is \`ready-to-implement\`.)

Resolves #9351 (binding-registry portion).

## Changes

| File | Change |
|---|---|
| \`app/src/workspace/action.rs\` | New \`RenameActivePane\` variant on \`WorkspaceAction\`; added to \`should_save_app_state_on_action\` (mutates \`pane_configuration\`, parallel to \`RenamePane(locator)\`). |
| \`app/src/workspace/view.rs\` | Handler resolves the active tab's pane group, looks up its focused pane id, builds a \`PaneViewLocator\`, and delegates to the existing \`self.rename_pane(locator, ctx)\` path. No new render or persistence code. |
| \`app/src/workspace/mod.rs\` | Register \`workspace:rename_active_pane\` (\"Rename the current pane\") as an \`EditableBinding\` under the Settings group, with no default keystroke. Surfaces the action in Settings → Keyboard shortcuts as remappable. |
| \`app/src/workspace/action_tests.rs\` | Unit test confirms the new variant participates in \`should_save_app_state_on_action\` alongside \`RenamePane(locator)\`. |

## Scope

The issue's three asks are:
1. **Binding registry / Settings → Keyboard shortcuts** — addressed here. ✅
2. **Command Palette** — out of scope for this PR; \`EditableBinding\` registration alone may already surface it via the existing \`from_editable_lens\` path, but I haven't verified.
3. **Optional \`/rename-pane\` slash command** — out of scope for this PR.

(2) and (3) can be follow-ups once (1) lands; keeps the PR atomic.

## Testing

- \`action_tests.rs\` covers the persistence contract for the new variant.
- I have **not** exercised the binding through Settings → Keyboard shortcuts on a running Warp — this build environment cannot run Warp (no Metal toolchain). CI's MacOS/Linux/Windows lanes will validate compilation, and a maintainer with a working dev build can confirm the new \`workspace:rename_active_pane\` row appears in Settings → Keyboard shortcuts when searching \"rename\". Flagging this honestly so it doesn't get assumed.

Once verified, follow-up keysets-manifest registration in [warpdotdev/keysets](https://github.com/warpdotdev/keysets) (out of scope for this repo) would let the action also surface as a default-keyset entry.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Rename Pane is now reachable from Settings → Keyboard shortcuts as a remappable binding (\`workspace:rename_active_pane\`), in addition to the existing right-click context menu. Thanks @lonexreb!