### PR TITLE
fix(ime): preserve Korean IME last syllable across commits (#8919)

### DIFF
--- a/crates/warpui/src/platform/mac/objc/host_view.m
+++ b/crates/warpui/src/platform/mac/objc/host_view.m
@@ -59,6 +59,13 @@ void warp_marked_text_cleared(WarpHostView *);
     // The selectedRange of the most recent setMarkedText: call, kept so we
     // can re-dispatch the marked text after a commit (see keyDownImpl:).
     NSRange lastMarkedSelectedRange;
+
+    // True if setMarkedText: was actually called during the current
+    // interpretKeyEvents:. Used to distinguish a freshly-started composition
+    // from stale markedText that survived a commit-only flow — insertText:
+    // deliberately skips unmarkText while interpretingKeyEvents is true, so
+    // hasMarkedText alone cannot tell the two apart.
+    BOOL setMarkedTextDuringInterpret;
 }
 
 - (BOOL)acceptsFirstResponder {
@@ -157,6 +164,7 @@ void warp_marked_text_cleared(WarpHostView *);
 - (BOOL)keyDownImpl:(NSEvent *)event {
     BOOL wasComposing = [self hasMarkedText];
     [textToInsert setString:@""];
+    setMarkedTextDuringInterpret = NO;
 
     // Interpret the key events here so we could check whether user is composing
     // text within the IME and pass the state down to the KeyDown events.
@@ -197,7 +205,13 @@ void warp_marked_text_cleared(WarpHostView *);
         // text would then overwrite that selection (losing the next
         // character). Workaround: temporarily clear the marked text,
         // dispatch the commit, then re-apply the marked text.
-        BOOL hasNewMarked = [self hasMarkedText];
+        //
+        // We can only treat hasMarkedText as a "freshly-started composition"
+        // when setMarkedText: was actually called during this keyDown.
+        // insertText: leaves stale markedText untouched while
+        // interpretingKeyEvents, so commit-only flows (e.g. dead-key + char)
+        // would otherwise see stale marked text and incorrectly re-emit it.
+        BOOL hasNewMarked = setMarkedTextDuringInterpret && [self hasMarkedText];
         if (hasNewMarked) {
             warp_marked_text_cleared(self);
             warp_update_ime_state(self, NO);
@@ -206,6 +220,14 @@ void warp_marked_text_cleared(WarpHostView *);
         if (hasNewMarked) {
             warp_marked_text_updated(self, markedText.string, lastMarkedSelectedRange);
             warp_update_ime_state(self, YES);
+        } else {
+            // Commit-only flow (no new composition started). End IME state
+            // explicitly — insertText: deliberately skipped unmarkText while
+            // interpretingKeyEvents was true, so the stale markedText object
+            // and ime_active flag would otherwise survive into the next
+            // keyDown and break downstream input (e.g. Backspace would be
+            // treated as composing-state input and not delete the character).
+            [self unmarkText];
         }
     }
 
@@ -496,6 +518,9 @@ void warp_marked_text_cleared(WarpHostView *);
         markedText = [[NSMutableAttributedString alloc] initWithString:string];
 
     lastMarkedSelectedRange = selectedRange;
+    if (interpretingKeyEvents) {
+        setMarkedTextDuringInterpret = YES;
+    }
 
     if (self.readyForWarp) {
         warp_marked_text_updated(self, markedText.string, selectedRange);

--- a/crates/warpui/src/platform/mac/objc/host_view.m
+++ b/crates/warpui/src/platform/mac/objc/host_view.m
@@ -55,6 +55,10 @@ void warp_marked_text_cleared(WarpHostView *);
 
     // Whether we're in the middle of a call to interpretKeyEvents.
     BOOL interpretingKeyEvents;
+
+    // The selectedRange of the most recent setMarkedText: call, kept so we
+    // can re-dispatch the marked text after a commit (see keyDownImpl:).
+    NSRange lastMarkedSelectedRange;
 }
 
 - (BOOL)acceptsFirstResponder {
@@ -180,9 +184,29 @@ void warp_marked_text_cleared(WarpHostView *);
     }
 
     // Dispatch TypedCharacter event after KeyDown has been dispatched.
-    if ([textToInsert length] > 0 && !handled) {
+    // If the key event committed previously-composed marked text (wasComposing),
+    // dispatch the committed text even when `handled` is true — it represents
+    // the user's already-typed input (e.g. the last Korean syllable being
+    // committed by an Arrow/Enter key), not text produced by the keybinding.
+    if ([textToInsert length] > 0 && (!handled || wasComposing)) {
+        // Korean (and other CJK) IMEs can both commit the previous syllable
+        // AND start a new composition in the same keyDown — e.g. typing 'ㅏ'
+        // after '간' produces commit '가' + new marked '나'. By the time we
+        // get here, setMarkedText: has already placed the new marked text as
+        // a selection in the input field's buffer. Inserting the committed
+        // text would then overwrite that selection (losing the next
+        // character). Workaround: temporarily clear the marked text,
+        // dispatch the commit, then re-apply the marked text.
+        BOOL hasNewMarked = [self hasMarkedText];
+        if (hasNewMarked) {
+            warp_marked_text_cleared(self);
+            warp_update_ime_state(self, NO);
+        }
         warp_handle_insert_text(self, (NSString *)textToInsert);
-        [self unmarkText];
+        if (hasNewMarked) {
+            warp_marked_text_updated(self, markedText.string, lastMarkedSelectedRange);
+            warp_update_ime_state(self, YES);
+        }
     }
 
     return handled;
@@ -470,6 +494,8 @@ void warp_marked_text_cleared(WarpHostView *);
         markedText = [[NSMutableAttributedString alloc] initWithAttributedString:string];
     else
         markedText = [[NSMutableAttributedString alloc] initWithString:string];
+
+    lastMarkedSelectedRange = selectedRange;
 
     if (self.readyForWarp) {
         warp_marked_text_updated(self, markedText.string, selectedRange);


### PR DESCRIPTION
## Description

Fixes a long-standing Korean (and broader CJK) IME bug on macOS where the last composing character could be silently dropped — both when terminating composition with Enter/Arrow keys and during ongoing composition that bridges syllables.

## Linked Issue

Fixes #8919.

- [x] The linked issue is labeled `triaged` (implicitly `ready-to-implement` per CONTRIBUTING.md).
- [x] Screenshots / video

## Root cause

Two bugs in `crates/warpui/src/platform/mac/objc/host_view.m`'s `keyDownImpl:` interacted with the way Korean (and other CJK) IMEs commit pre-edit text:

1. **`!handled` guard discarded committed text on Arrow/Enter.**
   When the user pressed Enter/Arrow to terminate composition, the macOS Korean IME committed the trailing syllable via `insertText:`, but the existing guard `if ([textToInsert length] > 0 && !handled)` then discarded it because the input field had handled the key. So the very last syllable (e.g. the '요' in '안녕하세요') was lost.
2. **Commit overwrote the next marked-text selection.**
   Korean IMEs can both commit a previous syllable AND start a new composition within the same keyDown — typing 'ㅏ' after '간' produces commit '가' + new marked '나'. By the time we dispatched the commit, `setMarkedText:` had already placed the new marked text as a selection in the input field's buffer, and `insert_internal` (called by `user_insert`) overwrote that selection with the committed text — losing the new syllable.

## Fix

In `keyDownImpl:`:

1. Loosen the guard to `(!handled || wasComposing)` so a key that was both consumed by the input field AND committed previously-composed text still dispatches the committed text (it represents the user's already-typed input, not text produced by the keybinding).
2. When dispatching a commit while a new marked-text composition is already in place, temporarily clear marked text, dispatch the commit, then re-apply the marked text. The new selectedRange is captured at `setMarkedText:` time into a new instance variable `lastMarkedSelectedRange` so we can re-emit the same range afterwards.

## Testing

Manual repro on macOS with `cargo run --features ime_marked_text` (release/dogfood builds enable this flag automatically — see `crates/warp_features/src/lib.rs`):

1. Switch to macOS Korean IME.
2. Type `안녕하세요` and press **Enter** → before: `안녕하세` is sent, `요` lost. After: full `안녕하세요` is sent.
3. Type `안녕하세요` and press **→ / ↓** → before: trailing `요` dropped. After: preserved.
4. Type `가나다` slowly and watch composition during typing → before: the last syllable being composed (e.g. `다`) wasn't shown until the next syllable bumped it. After: each composing syllable is visible as marked text in real time.
5. Sanity check: dead-key flow (Option-E + g → ´g) still works; English input unaffected.

No automated tests added — `host_view.m` is Objective-C and not directly unit-testable; the `marked_text_tests.rs` suite exercises the editor model layer below this fix and continues to pass. Happy to add an integration test if reviewers want one.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed Korean IME on macOS dropping the last composing character when pressing Enter/Arrow keys, and not displaying the trailing syllable while typing across syllable boundaries.
-->

https://github.com/user-attachments/assets/402f2c81-e5a9-4cc3-b1d6-e9955425e3ec


https://github.com/user-attachments/assets/6d68c0f3-52c4-4721-aa43-13979646367e


