### PR TITLE
fix(linux): Correct force_x11 default to enable Wayland autodetection (Fixes #9718)

### DIFF
--- a/app/src/settings/linux.rs
+++ b/app/src/settings/linux.rs
@@ -6,7 +6,7 @@ define_settings_group!(LinuxAppConfiguration,
         force_x11: ForceX11 {
             type: bool,
             // Default to true on WSL and false on all other platforms.
-            default: !linux::is_wsl(),
+            default: linux::is_wsl(),
             supported_platforms: SupportedPlatforms::LINUX,
             sync_to_cloud: SyncToCloud::Never,
             private: false,


### PR DESCRIPTION
## Description
This PR fixes the Wayland autodetection issue on Linux. The previous implementation inverted the WSL check (`!linux::is_wsl()`), causing X11 to be forced on native Linux environments instead of just WSL. This PR removes the negation so `force_x11` correctly defaults to `true` *only* on WSL. 

*Note: The launch hang reported in the issue was confirmed to be a separate upstream KDE Wallet bug (KDE Bug 519638), so this PR specifically addresses the Wayland environment selection.*

## Linked Issue
Fixes #9718

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
*N/A - Backend configuration logic change.*

## Testing
Verified the logic change conceptually. By removing the negation, native Linux systems (like Ubuntu/KDE) will no longer have `force_x11` set to true by default, allowing the existing `WARP_ENABLE_WAYLAND` fallback logic to cleanly select Wayland without requiring the user to explicitly pass `WARP_ENABLE_WAYLAND=1`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode / CLI Agent

CHANGELOG-BUG-FIX: Fixed an issue where X11 was incorrectly forced on native Linux Wayland sessions.