### PR TITLE
fix(cli):Support Pi CLI agent notifications

### DIFF
--- a/app/src/terminal/cli_agent_sessions/listener/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod.rs
@@ -1,10 +1,10 @@
 use warpui::{EntityId, ModelContext, ModelHandle, SingletonEntity};
 
 use super::{CLIAgentEvent, CLIAgentSessionsModel};
+use crate::terminal::CLIAgent;
 use crate::terminal::cli_agent_sessions::event::parse_event;
 use crate::terminal::cli_agent_sessions::event::{CLIAgentEventPayload, CLIAgentEventType};
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
-use crate::terminal::CLIAgent;
 
 /// Per-agent handler that filters and transforms parsed CLI agent events.
 /// Each CLI agent can have a different implementation depending on which events
@@ -46,6 +46,7 @@ pub fn is_agent_supported(agent: &CLIAgent) -> bool {
             | CLIAgent::Codex
             | CLIAgent::Gemini
             | CLIAgent::Auggie
+            | CLIAgent::Pi
     )
 }
 
@@ -56,14 +57,15 @@ fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
         // (https://github.com/augmentmoogi/auggie-warp), which emits the same
         // structured OSC 777 events as the first-party Claude/OpenCode/Gemini
         // plugins. We don't ship an install flow for it — we just listen.
-        CLIAgent::Claude | CLIAgent::OpenCode | CLIAgent::Gemini | CLIAgent::Auggie => {
-            Some(Box::new(DefaultSessionListener))
-        }
+        CLIAgent::Claude
+        | CLIAgent::OpenCode
+        | CLIAgent::Gemini
+        | CLIAgent::Auggie
+        | CLIAgent::Pi => Some(Box::new(DefaultSessionListener)),
         CLIAgent::Codex => Some(Box::new(CodexSessionHandler)),
         CLIAgent::Amp
         | CLIAgent::Droid
         | CLIAgent::Copilot
-        | CLIAgent::Pi
         | CLIAgent::CursorCli
         | CLIAgent::Unknown => None,
     }
@@ -235,9 +237,11 @@ mod tests {
     #[test]
     fn codex_try_parse_ignores_titled_notifications() {
         let handler = CodexSessionHandler;
-        assert!(handler
-            .try_parse(Some("some-title"), "Agent turn complete")
-            .is_none());
+        assert!(
+            handler
+                .try_parse(Some("some-title"), "Agent turn complete")
+                .is_none()
+        );
     }
 
     #[test]
@@ -278,6 +282,46 @@ mod tests {
         let event = CLIAgentEvent {
             v: 1,
             agent: CLIAgent::Auggie,
+            event: CLIAgentEventType::Stop,
+            session_id: None,
+            cwd: None,
+            project: None,
+            payload: CLIAgentEventPayload::default(),
+        };
+        assert!(handler.handle_event(event).is_some());
+    }
+
+    #[test]
+    fn pi_is_supported() {
+        assert!(is_agent_supported(&CLIAgent::Pi));
+    }
+
+    #[test]
+    fn pi_uses_default_handler_with_rich_status() {
+        assert!(agent_supports_rich_status(&CLIAgent::Pi));
+    }
+
+    #[test]
+    fn pi_default_handler_skips_session_start() {
+        let mut handler = DefaultSessionListener;
+        let event = CLIAgentEvent {
+            v: 1,
+            agent: CLIAgent::Pi,
+            event: CLIAgentEventType::SessionStart,
+            session_id: None,
+            cwd: None,
+            project: None,
+            payload: CLIAgentEventPayload::default(),
+        };
+        assert!(handler.handle_event(event).is_none());
+    }
+
+    #[test]
+    fn pi_default_handler_forwards_stop() {
+        let mut handler = DefaultSessionListener;
+        let event = CLIAgentEvent {
+            v: 1,
+            agent: CLIAgent::Pi,
             event: CLIAgentEventType::Stop,
             session_id: None,
             cwd: None,


### PR DESCRIPTION
## Description
Added support for `CLIAgent::Pi` in the CLI agent session listener so Pi notifications are handled by the default structured event listener instead of being dropped. This makes Pi behave like the other supported structured OSC 777 agents and ensures its session events can surface in the UI.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Closes #9663

## Screenshots / Videos
Not applicable. This is a backend/session-listener behavior change with no direct UI surface.

## Testing
Added unit tests in `app/src/terminal/cli_agent_sessions/listener/mod.rs` covering:
- Pi is reported as supported
- Pi uses the default listener with rich status
- Pi default listener skips `SessionStart`
- Pi default listener forwards `Stop`

Verified with:
```sh
cargo test -p warp cli_agent_sessions::listener::tests::
