### PR TITLE
fix(cli) Add Mistral Vibe to recognized CLI agents

### DIFF
--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -498,6 +498,7 @@ pub enum CLIAgentType {
     Copilot,
     Pi,
     Auggie,
+    Vibe,
     Cursor,
     Unknown,
 }

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -39,6 +39,14 @@ pub(crate) const GEMINI_BLUE: ColorU = ColorU {
     a: 255,
 };
 
+/// Mistral brand orange (#FA520F)
+pub(crate) const MISTRAL_ORANGE: ColorU = ColorU {
+    r: 250,
+    g: 82,
+    b: 15,
+    a: 255,
+};
+
 /// OpenAI brand color (dark gray/black)
 const OPENAI_COLOR: ColorU = ColorU {
     r: 0,
@@ -116,6 +124,7 @@ pub enum CLIAgent {
     Pi,
     Auggie,
     CursorCli,
+    Vibe,
     /// Represents an unknown/custom CLI agent matched by user-configured regex patterns.
     Unknown,
 }
@@ -134,6 +143,7 @@ impl CLIAgent {
             CLIAgent::Pi => "pi",
             CLIAgent::Auggie => "auggie",
             CLIAgent::CursorCli => "agent",
+            CLIAgent::Vibe => "vibe",
             CLIAgent::Unknown => "",
         }
     }
@@ -164,6 +174,7 @@ impl CLIAgent {
             CLIAgent::Pi => "Pi",
             CLIAgent::Auggie => "Auggie",
             CLIAgent::CursorCli => "Cursor",
+            CLIAgent::Vibe => "Mistral Vibe",
             CLIAgent::Unknown => "CLI Agent",
         }
     }
@@ -181,6 +192,7 @@ impl CLIAgent {
             CLIAgent::Pi => Some(Icon::PiLogo),
             CLIAgent::Auggie => Some(Icon::AuggieLogo),
             CLIAgent::CursorCli => Some(Icon::CursorLogo),
+            CLIAgent::Vibe => None,
             CLIAgent::Unknown => None,
         }
     }
@@ -206,6 +218,7 @@ impl CLIAgent {
             CLIAgent::Copilot => &[SkillProvider::Agents, SkillProvider::Copilot],
             CLIAgent::Droid => &[SkillProvider::Droid, SkillProvider::Agents],
             CLIAgent::Pi => &[SkillProvider::Agents],
+            CLIAgent::Vibe => &[SkillProvider::Agents],
             CLIAgent::Auggie => &[SkillProvider::Agents],
             CLIAgent::CursorCli => &[SkillProvider::Agents],
             CLIAgent::Unknown => &[],
@@ -247,6 +260,7 @@ impl CLIAgent {
             CLIAgent::Pi => Some(PI_COLOR),
             CLIAgent::Auggie => Some(AUGGIE_COLOR),
             CLIAgent::CursorCli => Some(CURSOR_COLOR),
+            CLIAgent::Vibe => Some(MISTRAL_ORANGE),
             CLIAgent::Unknown => None,
         }
     }
@@ -506,6 +520,7 @@ impl From<CLIAgent> for CLIAgentType {
             CLIAgent::Copilot => CLIAgentType::Copilot,
             CLIAgent::Pi => CLIAgentType::Pi,
             CLIAgent::Auggie => CLIAgentType::Auggie,
+            CLIAgent::Vibe => CLIAgentType::Vibe,
             CLIAgent::CursorCli => CLIAgentType::Cursor,
             CLIAgent::Unknown => CLIAgentType::Unknown,
         }

--- a/app/src/terminal/cli_agent_sessions/listener/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod.rs
@@ -1,10 +1,10 @@
 use warpui::{EntityId, ModelContext, ModelHandle, SingletonEntity};
 
 use super::{CLIAgentEvent, CLIAgentSessionsModel};
+use crate::terminal::CLIAgent;
 use crate::terminal::cli_agent_sessions::event::parse_event;
 use crate::terminal::cli_agent_sessions::event::{CLIAgentEventPayload, CLIAgentEventType};
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
-use crate::terminal::CLIAgent;
 
 /// Per-agent handler that filters and transforms parsed CLI agent events.
 /// Each CLI agent can have a different implementation depending on which events
@@ -46,6 +46,7 @@ pub fn is_agent_supported(agent: &CLIAgent) -> bool {
             | CLIAgent::Codex
             | CLIAgent::Gemini
             | CLIAgent::Auggie
+            | CLIAgent::Vibe
     )
 }
 
@@ -56,9 +57,11 @@ fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
         // (https://github.com/augmentmoogi/auggie-warp), which emits the same
         // structured OSC 777 events as the first-party Claude/OpenCode/Gemini
         // plugins. We don't ship an install flow for it — we just listen.
-        CLIAgent::Claude | CLIAgent::OpenCode | CLIAgent::Gemini | CLIAgent::Auggie => {
-            Some(Box::new(DefaultSessionListener))
-        }
+        CLIAgent::Claude
+        | CLIAgent::OpenCode
+        | CLIAgent::Gemini
+        | CLIAgent::Auggie
+        | CLIAgent::Vibe => Some(Box::new(DefaultSessionListener)),
         CLIAgent::Codex => Some(Box::new(CodexSessionHandler)),
         CLIAgent::Amp
         | CLIAgent::Droid
@@ -235,9 +238,11 @@ mod tests {
     #[test]
     fn codex_try_parse_ignores_titled_notifications() {
         let handler = CodexSessionHandler;
-        assert!(handler
-            .try_parse(Some("some-title"), "Agent turn complete")
-            .is_none());
+        assert!(
+            handler
+                .try_parse(Some("some-title"), "Agent turn complete")
+                .is_none()
+        );
     }
 
     #[test]
@@ -255,6 +260,16 @@ mod tests {
     #[test]
     fn auggie_uses_default_handler_with_rich_status() {
         assert!(agent_supports_rich_status(&CLIAgent::Auggie));
+    }
+
+    #[test]
+    fn vibe_is_supported() {
+        assert!(is_agent_supported(&CLIAgent::Vibe));
+    }
+
+    #[test]
+    fn vibe_uses_default_handler_with_rich_status() {
+        assert!(agent_supports_rich_status(&CLIAgent::Vibe));
     }
 
     #[test]

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
@@ -263,6 +263,7 @@ pub(crate) fn plugin_manager_for_with_shell(
         | CLIAgent::Pi
         | CLIAgent::Auggie
         | CLIAgent::CursorCli
+        | CLIAgent::Vibe
         | CLIAgent::Unknown => None,
     }
 }

--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -3,14 +3,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::Local;
+use pathfinder_color::ColorU;
 use smol_str::SmolStr;
 use warp_editor::render::model::LineCount;
 use warp_util::path::EscapeChar;
 use warpui::App;
 
 use super::{
-    build_diff_hunk_prompt, build_review_prompt, build_selection_line_range_prompt,
-    build_selection_substring_prompt, CLIAgent, UBER_TEAM_UID,
+    CLIAgent, UBER_TEAM_UID, build_diff_hunk_prompt, build_review_prompt,
+    build_selection_line_range_prompt, build_selection_substring_prompt,
 };
 use crate::ai::agent::{AgentReviewCommentBatch, DiffSetHunk};
 use crate::code::editor::line::EditorLineLocation;
@@ -257,6 +258,7 @@ fn test_detect_known_agents() {
                 ("droid", CLIAgent::Droid),
                 ("opencode", CLIAgent::OpenCode),
                 ("copilot", CLIAgent::Copilot),
+                ("vibe", CLIAgent::Vibe),
                 ("agent", CLIAgent::CursorCli),
             ] {
                 assert_eq!(
@@ -265,6 +267,18 @@ fn test_detect_known_agents() {
                     "failed to detect {command}",
                 );
             }
+        });
+    });
+}
+
+#[test]
+fn test_vibe_brand_color() {
+    App::test((), |mut app| async move {
+        app.update(|_| {
+            assert_eq!(
+                CLIAgent::Vibe.brand_color(),
+                Some(ColorU::new(250, 82, 15, 255)),
+            );
         });
     });
 }

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -126,7 +126,8 @@ fn rich_input_submit_strategy(agent: CLIAgent) -> RichInputSubmitStrategy {
         | CLIAgent::OpenCode
         | CLIAgent::Gemini
         | CLIAgent::Auggie
-        | CLIAgent::CursorCli => RichInputSubmitStrategy::DelayedEnter,
+        | CLIAgent::CursorCli
+        | CLIAgent::Vibe => RichInputSubmitStrategy::DelayedEnter,
         CLIAgent::Amp | CLIAgent::Droid | CLIAgent::Pi | CLIAgent::Unknown => {
             RichInputSubmitStrategy::Inline
         }


### PR DESCRIPTION
## Description
Adds Mistral Vibe as a recognized CLI agent so Warp can detect `vibe`, display the correct agent name and brand color, route telemetry with a dedicated CLI agent type, and handle structured CLI agent session events.

Also adds focused test coverage for Vibe command detection, brand color, and session listener support.

## Linked Issue
Closes #9607

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
N/A

## Testing
- `cargo test -p warp vibe`
- `cargo test -p warp test_detect_known_agents`

`cargo nextest` was not installed locally, so focused coverage was verified with `cargo test`.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
