### PR TITLE
fix(macos/ime): don't submit form when Enter confirms Japanese IME conversion

### DIFF
--- a/crates/warpui/src/platform/mac/objc/host_view.m
+++ b/crates/warpui/src/platform/mac/objc/host_view.m
@@ -55,6 +55,14 @@ void warp_marked_text_cleared(WarpHostView *);
 
     // Whether we're in the middle of a call to interpretKeyEvents.
     BOOL interpretingKeyEvents;
+
+    // Whether the IME modified marked text (via setMarkedText: or unmarkText)
+    // during the current interpretKeyEvents: pass. Used to avoid wiping a
+    // freshly-set marked text in the split-commit scenario where an IME
+    // calls insertText: (committing some text) and then setMarkedText: (with
+    // new in-progress text) in the same keystroke. Without this, the trailing
+    // unmarkText in keyDownImpl would clobber that new marked text.
+    BOOL imeTouchedMarkedTextDuringInterpret;
 }
 
 - (BOOL)acceptsFirstResponder {
@@ -153,6 +161,7 @@ void warp_marked_text_cleared(WarpHostView *);
 - (BOOL)keyDownImpl:(NSEvent *)event {
     BOOL wasComposing = [self hasMarkedText];
     [textToInsert setString:@""];
+    imeTouchedMarkedTextDuringInterpret = NO;
 
     // Interpret the key events here so we could check whether user is composing
     // text within the IME and pass the state down to the KeyDown events.
@@ -182,7 +191,14 @@ void warp_marked_text_cleared(WarpHostView *);
     // Dispatch TypedCharacter event after KeyDown has been dispatched.
     if ([textToInsert length] > 0 && !handled) {
         warp_handle_insert_text(self, (NSString *)textToInsert);
-        [self unmarkText];
+        // Only clear marked text if the IME did not touch it during this
+        // interpretKeyEvents pass. Otherwise we'd either fire a redundant
+        // ClearMarkedText (if IME already cleared) or, worse, wipe the new
+        // marked text the IME just set in a split-commit (e.g. Japanese IME
+        // committing a phrase and queuing the next character as marked text).
+        if (!imeTouchedMarkedTextDuringInterpret) {
+            [self unmarkText];
+        }
     }
 
     return handled;
@@ -465,6 +481,10 @@ void warp_marked_text_cleared(WarpHostView *);
 - (void)setMarkedText:(id)string
         selectedRange:(NSRange)selectedRange
      replacementRange:(NSRange)replacementRange {
+    if (interpretingKeyEvents) {
+        imeTouchedMarkedTextDuringInterpret = YES;
+    }
+
     [markedText release];
     if ([string isKindOfClass:[NSAttributedString class]])
         markedText = [[NSMutableAttributedString alloc] initWithAttributedString:string];
@@ -482,6 +502,9 @@ void warp_marked_text_cleared(WarpHostView *);
 }
 
 - (void)unmarkText {
+    if (interpretingKeyEvents) {
+        imeTouchedMarkedTextDuringInterpret = YES;
+    }
     [[markedText mutableString] setString:@""];
     if (self.readyForWarp) {
         warp_update_ime_state(self, NO);


### PR DESCRIPTION
## Description                                                                                                                                                                                               
                                                              
On macOS, some Japanese IMEs (built-in macOS Japanese, Google Japanese Input, etc.) commit a phrase mid-typing via a single `interpretKeyEvents:` pass that fires `insertText:` (the just-committed phrase) and then `setMarkedText:` (the next in-progress character). The trailing `[self unmarkText]` in `keyDownImpl` was unconditionally clobbering that freshly-set marked text in our state.
                                                                                                                                                                                                           
After that, the IME's internal state still held the queued character but `WarpHostView`'s `markedText` was empty and `warp_marked_text_cleared` had been dispatched. On the next keystroke (typically Enter  
to commit), `wasComposing` was therefore `false`, so `warp_handle_view_event` ran without the composing flag and the keybinding system handled Enter as a command submission. The IME's `insertText:` of the queued character arrived at the post-dispatch insert path with `handled=YES` and was silently dropped.                                                                                                       
                                                              
The fix tracks whether the IME modified marked text via `setMarkedText:` or `unmarkText` during the current `interpretKeyEvents:` pass, and skips the trailing `unmarkText` if the IME has already touched   
marked text in that pass — the IME has either cleared it (so our call would have been a redundant `ClearMarkedText`) or replaced it with new in-progress text we must preserve.
                                                                                                                                                                                                           
This change is contained to the macOS Objective-C IME plumbing in `host_view.m`. The Linux/Windows IME path (winit `Ime::Preedit` / `Ime::Commit` in `crates/warpui/src/windowing/winit/event_loop/mod.rs`) is structurally different and not affected by this PR.
                                                                                                                                                                                                           
## Linked Issue                                                 

Fixes #7261

> Note: the issue body explicitly reports `Operating system (OS): macOS` (`15.6（24G84）`), so the `os:linux` label appears to have been applied in error during automated triage. This PR addresses the     
macOS path only; please drop the `os:linux` label or relabel as `os:mac` during review.
                                                                                                                                                                                                           
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).
                                                                                                                                                                                                           
## Screenshots / Videos
                                                                                                                                                                                                           
          
### Before Fix
https://github.com/user-attachments/assets/f3acf468-2860-4326-b8ab-f8ff4990d5a0

### After Fix
https://github.com/user-attachments/assets/a45d9c18-8619-4422-9406-e3cb66cc380e
                                             
## Testing                                                                                                                                                                                                   
                                                              
Manual verification on macOS 15.x with the macOS built-in Japanese IME (Hiragana / Romaji mode):                                                                                                             

1. Reproduced the bug on `master` with the steps from #7261 — typing `漢字の入力（変換）が、` and pressing Enter dropped the trailing `、` and submitted the buffer immediately.                             
2. Verified the fix on this branch with `cargo run --bin warp-oss` (with `FeatureFlag::ImeMarkedText` enabled locally so inline preedit could be observed). After the fix the queued `、` is preserved across
the split-commit, the next Enter commits it via the IME, and a subsequent Enter submits the buffer as expected.                                                                                             
3. Sanity-checked dead-key composition (`⌥e` then `a` → `á`) on a US keyboard layout to confirm the dead-key suppression branch in `keyDownImpl` is unaffected.
4. Ran the presubmit checks locally:                                                                                                                                                                         
 - `cargo fmt --check` — pass                                 
 - `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` — pass                                                                                                         
 - `cargo clippy -p warp_completer --all-targets --tests -- -D warnings` — pass                                                                                                                            
 - `./script/run-clang-format.py -r --extensions 'c,h,cpp,m' ./crates/warpui/src/ ./app/src/` — pass
 - `cargo nextest run --no-fail-fast --workspace --exclude command-signatures-v2` — passes for the IME-relevant suites; the only failures observed locally                                                 
(`settings::init::tests::test_migration_does_not_rerun_when_marker_present` and the SSH-IAP integration suite) reproduce identically on `master` and are unrelated to this change.                           
 - `cargo test --doc` — pass                                                                                                                                                                                                                                                                                
                                                              
## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
                                                                                                                                                                                                           
<!--
CHANGELOG-BUG-FIX: Fix Japanese IME losing the last character of a phrase that ends right before a punctuation mark on macOS.                                                                                
-->