### PR TITLE
Client support for HTTP POST form upload targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10801,6 +10801,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10712,6 +10712,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,6 +217,7 @@ reqwest = { version = "0.13", features = [
   "gzip",
   "form",
   "json",
+  "multipart",
   "query",
   "stream",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,6 +221,7 @@ reqwest = { version = "0.12.28", default-features = false, features = [
   "http2",
   "json",
   "macos-system-configuration",
+  "multipart",
   "rustls-tls-native-roots-no-provider",
   "stream",
   "system-proxy",

--- a/app/src/ai/agent_sdk/artifact_upload.rs
+++ b/app/src/ai/agent_sdk/artifact_upload.rs
@@ -16,6 +16,7 @@ use crate::server::server_api::ai::{
     AIClient, CreateFileArtifactUploadRequest, CreateFileArtifactUploadResponse,
     FileArtifactRecord, FileArtifactUploadTargetInfo,
 };
+use crate::server::server_api::harness_support::FileUploadBody;
 use crate::server::server_api::presigned_upload::upload_file_to_target;
 use crate::server::server_api::ServerApi;
 use crate::util::image::{infer_mime_type, MIME_SNIFF_BYTES};
@@ -164,8 +165,7 @@ impl FileArtifactUploader {
         upload_file_to_target(
             self.server_api.http_client(),
             target,
-            &artifact.path,
-            artifact.file_size,
+            FileUploadBody::new(artifact.path.clone()),
         )
         .await
     }

--- a/app/src/ai/agent_sdk/driver/snapshot.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot.rs
@@ -1388,6 +1388,7 @@ fn merge_content_type(target: &UploadTarget, mime_type: &str) -> UploadTarget {
         url: target.url.clone(),
         method: target.method.clone(),
         headers,
+        fields: target.fields.clone(),
     }
 }
 

--- a/app/src/ai/agent_sdk/driver/snapshot_tests.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot_tests.rs
@@ -147,6 +147,7 @@ impl HarnessSupportClient for TestClient {
                 url: format!("{}/upload/{}", self.server_base_url, f.filename),
                 method: "PUT".to_string(),
                 headers: HashMap::new(),
+                fields: Vec::new(),
             })
             .collect();
         let keep = targets.len().saturating_sub(self.drop_trailing_targets);

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -16,7 +16,7 @@ use warp_core::{features::FeatureFlag, report_error};
 use warp_multi_agent_api::ConversationData;
 
 use super::auth::AuthClient;
-use super::harness_support::UploadTarget;
+use super::harness_support::{UploadField, UploadFieldValue, UploadTarget};
 use super::ServerApi;
 use crate::ai::agent::conversation::{
     AIAgentConversationFormat, AIAgentHarness, AIAgentSerializedBlockFormat,
@@ -584,6 +584,8 @@ pub struct FileArtifactUploadTargetInfo {
     pub url: String,
     pub method: String,
     pub headers: Vec<FileArtifactUploadHeaderInfo>,
+    /// Ordered multipart form fields for presigned POST uploads.
+    pub fields: Vec<UploadField>,
 }
 
 #[derive(Debug, Clone)]
@@ -1191,6 +1193,34 @@ impl ServerApi {
         let response = response.json::<ReadAgentMessageResponse>().await?;
         Ok(response)
     }
+}
+
+/// Convert a cynic `FileArtifactUploadField` into the shared [`UploadField`]
+/// domain type. Unknown variants bubble as an error rather than being silently
+/// dropped, because a server-provided field we can't represent will almost certainly
+/// cause the upload to fail.
+fn convert_upload_field(
+    field: warp_graphql::mutations::create_file_artifact_upload_target::FileArtifactUploadField,
+) -> anyhow::Result<UploadField> {
+    use warp_graphql::mutations::create_file_artifact_upload_target::FileArtifactUploadFieldValue;
+
+    let value = match field.value {
+        FileArtifactUploadFieldValue::StaticUploadFieldValue(v) => {
+            UploadFieldValue::Static { value: v.value }
+        }
+        FileArtifactUploadFieldValue::ContentCRC32CFieldValue(_) => UploadFieldValue::ContentCrc32C,
+        FileArtifactUploadFieldValue::ContentDataFieldValue(_) => UploadFieldValue::ContentData,
+        FileArtifactUploadFieldValue::Unknown => {
+            return Err(anyhow!(
+                "Unknown UploadFieldValue variant for field '{}'; update client GraphQL types",
+                field.name
+            ));
+        }
+    };
+    Ok(UploadField {
+        name: field.name,
+        value,
+    })
 }
 
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
@@ -2048,20 +2078,28 @@ impl AIClient for ServerApi {
 
         match response.create_file_artifact_upload_target {
             CreateFileArtifactUploadTargetResult::CreateFileArtifactUploadTargetOutput(output) => {
+                let headers = output
+                    .upload_target
+                    .headers
+                    .into_iter()
+                    .map(|header| FileArtifactUploadHeaderInfo {
+                        name: header.name,
+                        value: header.value,
+                    })
+                    .collect();
+                let fields = output
+                    .upload_target
+                    .fields
+                    .into_iter()
+                    .map(convert_upload_field)
+                    .collect::<anyhow::Result<Vec<_>>>()?;
                 Ok(CreateFileArtifactUploadResponse {
                     artifact: into_file_artifact_record(output.artifact),
                     upload_target: FileArtifactUploadTargetInfo {
                         url: output.upload_target.url,
                         method: output.upload_target.method,
-                        headers: output
-                            .upload_target
-                            .headers
-                            .into_iter()
-                            .map(|header| FileArtifactUploadHeaderInfo {
-                                name: header.name,
-                                value: header.value,
-                            })
-                            .collect(),
+                        headers,
+                        fields,
                     },
                 })
             }

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -16,7 +16,7 @@ use warp_core::{features::FeatureFlag, report_error};
 use warp_multi_agent_api::ConversationData;
 
 use super::auth::AuthClient;
-use super::harness_support::UploadTarget;
+use super::harness_support::{UploadField, UploadFieldValue, UploadTarget};
 use super::ServerApi;
 use crate::ai::agent::conversation::{
     AIAgentConversationFormat, AIAgentHarness, AIAgentSerializedBlockFormat,
@@ -580,6 +580,8 @@ pub struct FileArtifactUploadTargetInfo {
     pub url: String,
     pub method: String,
     pub headers: Vec<FileArtifactUploadHeaderInfo>,
+    /// Ordered multipart form fields for presigned POST uploads.
+    pub fields: Vec<UploadField>,
 }
 
 #[derive(Debug, Clone)]
@@ -1187,6 +1189,34 @@ impl ServerApi {
         let response = response.json::<ReadAgentMessageResponse>().await?;
         Ok(response)
     }
+}
+
+/// Convert a cynic `FileArtifactUploadField` into the shared [`UploadField`]
+/// domain type. Unknown variants bubble as an error rather than being silently
+/// dropped, because a server-provided field we can't represent will almost certainly
+/// cause the upload to fail.
+fn convert_upload_field(
+    field: warp_graphql::mutations::create_file_artifact_upload_target::FileArtifactUploadField,
+) -> anyhow::Result<UploadField> {
+    use warp_graphql::mutations::create_file_artifact_upload_target::FileArtifactUploadFieldValue;
+
+    let value = match field.value {
+        FileArtifactUploadFieldValue::StaticUploadFieldValue(v) => {
+            UploadFieldValue::Static { value: v.value }
+        }
+        FileArtifactUploadFieldValue::ContentCRC32CFieldValue(_) => UploadFieldValue::ContentCrc32C,
+        FileArtifactUploadFieldValue::ContentDataFieldValue(_) => UploadFieldValue::ContentData,
+        FileArtifactUploadFieldValue::Unknown => {
+            return Err(anyhow!(
+                "Unknown UploadFieldValue variant for field '{}'; update client GraphQL types",
+                field.name
+            ));
+        }
+    };
+    Ok(UploadField {
+        name: field.name,
+        value,
+    })
 }
 
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
@@ -2044,20 +2074,28 @@ impl AIClient for ServerApi {
 
         match response.create_file_artifact_upload_target {
             CreateFileArtifactUploadTargetResult::CreateFileArtifactUploadTargetOutput(output) => {
+                let headers = output
+                    .upload_target
+                    .headers
+                    .into_iter()
+                    .map(|header| FileArtifactUploadHeaderInfo {
+                        name: header.name,
+                        value: header.value,
+                    })
+                    .collect();
+                let fields = output
+                    .upload_target
+                    .fields
+                    .into_iter()
+                    .map(convert_upload_field)
+                    .collect::<anyhow::Result<Vec<_>>>()?;
                 Ok(CreateFileArtifactUploadResponse {
                     artifact: into_file_artifact_record(output.artifact),
                     upload_target: FileArtifactUploadTargetInfo {
                         url: output.upload_target.url,
                         method: output.upload_target.method,
-                        headers: output
-                            .upload_target
-                            .headers
-                            .into_iter()
-                            .map(|header| FileArtifactUploadHeaderInfo {
-                                name: header.name,
-                                value: header.value,
-                            })
-                            .collect(),
+                        headers,
+                        fields,
                     },
                 })
             }

--- a/app/src/server/server_api/harness_support.rs
+++ b/app/src/server/server_api/harness_support.rs
@@ -16,12 +16,41 @@ use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::artifacts::Artifact;
 use crate::server::server_api::auth::AuthClient;
 
+#[cfg(feature = "local_fs")]
+pub use super::presigned_upload::FileUploadBody;
+pub use super::presigned_upload::UploadBody;
+
 /// A presigned upload target returned by the server.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct UploadTarget {
     pub url: String,
     pub method: String,
     pub headers: HashMap<String, String>,
+    /// Ordered multipart form fields for POST uploads.
+    #[serde(default)]
+    pub fields: Vec<UploadField>,
+}
+
+/// A single multipart form field on a POST upload target.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct UploadField {
+    pub name: String,
+    pub value: UploadFieldValue,
+}
+
+/// Descriptor for a field value when uploading to an [`UploadTarget`].
+/// This is currently only used for `POST` requests, but may be supported
+/// for HTTP headers in the future.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UploadFieldValue {
+    /// Literal string value known at URL-generation time.
+    Static { value: String },
+    /// Client should compute CRC32C of the upload, base64-encode the 4-byte
+    /// big-endian result, and send it as this field's value.
+    ContentCrc32C,
+    /// Client should use the raw upload bytes as this field's value.
+    ContentData,
 }
 
 /// Request body for upload-snapshot upload targets.
@@ -459,7 +488,7 @@ impl HarnessSupportClient for ServerApi {
 pub async fn upload_to_target(
     http_client: &http_client::Client,
     target: &UploadTarget,
-    body: impl Into<reqwest::Body>,
+    body: impl UploadBody,
 ) -> Result<()> {
     super::presigned_upload::upload_to_target(http_client, target, body).await
 }

--- a/app/src/server/server_api/presigned_upload.rs
+++ b/app/src/server/server_api/presigned_upload.rs
@@ -1,24 +1,17 @@
-#[cfg(not(target_family = "wasm"))]
-use std::path::{Path, PathBuf};
-#[cfg(not(target_family = "wasm"))]
-use std::sync::{Arc, Mutex};
+#[cfg(feature = "local_fs")]
+use std::path::PathBuf;
 
 use anyhow::{anyhow, Context, Result};
 #[cfg(not(target_family = "wasm"))]
-use async_stream::try_stream;
-#[cfg(not(target_family = "wasm"))]
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 #[cfg(not(target_family = "wasm"))]
-use bytes::Bytes;
-#[cfg(not(target_family = "wasm"))]
 use crc::{Crc, CRC_32_ISCSI};
-#[cfg(not(target_family = "wasm"))]
-use futures_lite::io::AsyncReadExt as _;
+use std::future::Future;
 use thiserror::Error;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "local_fs")]
 use super::ai::FileArtifactUploadTargetInfo;
-use super::harness_support::UploadTarget;
+use super::harness_support::{UploadFieldValue, UploadTarget};
 
 /// Typed error for HTTP-backed operations so downstream classifiers (e.g. the agent-SDK
 /// retry helper) can decide transient vs permanent failures without string-parsing the
@@ -34,15 +27,31 @@ pub struct HttpStatusError {
 }
 
 #[cfg(not(target_family = "wasm"))]
-static CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
+pub(crate) static CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 const CONTENT_LENGTH_HEADER_NAME: &str = "content-length";
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "local_fs")]
 const FILE_UPLOAD_CHUNK_SIZE: usize = 64 * 1024;
 
 struct NormalizedUploadTarget<'a> {
     url: &'a str,
     method: &'a str,
     headers: Vec<(&'a str, &'a str)>,
+    fields: Vec<NormalizedField<'a>>,
+}
+
+/// Borrowed view of a single multipart form field.
+#[derive(Debug, PartialEq, Eq)]
+struct NormalizedField<'a> {
+    name: &'a str,
+    value: NormalizedFieldValue<'a>,
+}
+
+/// Borrowed view of a single multipart form field value.
+#[derive(Debug, PartialEq, Eq)]
+enum NormalizedFieldValue<'a> {
+    Static(&'a str),
+    ContentCrc32C,
+    ContentData,
 }
 
 impl<'a> From<&'a UploadTarget> for NormalizedUploadTarget<'a> {
@@ -55,11 +64,25 @@ impl<'a> From<&'a UploadTarget> for NormalizedUploadTarget<'a> {
                 .iter()
                 .map(|(name, value)| (name.as_str(), value.as_str()))
                 .collect(),
+            fields: target
+                .fields
+                .iter()
+                .map(|field| NormalizedField {
+                    name: field.name.as_str(),
+                    value: match &field.value {
+                        UploadFieldValue::Static { value } => {
+                            NormalizedFieldValue::Static(value.as_str())
+                        }
+                        UploadFieldValue::ContentCrc32C => NormalizedFieldValue::ContentCrc32C,
+                        UploadFieldValue::ContentData => NormalizedFieldValue::ContentData,
+                    },
+                })
+                .collect(),
         }
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "local_fs")]
 impl<'a> From<&'a FileArtifactUploadTargetInfo> for NormalizedUploadTarget<'a> {
     fn from(target: &'a FileArtifactUploadTargetInfo) -> Self {
         Self {
@@ -70,13 +93,124 @@ impl<'a> From<&'a FileArtifactUploadTargetInfo> for NormalizedUploadTarget<'a> {
                 .iter()
                 .map(|header| (header.name.as_str(), header.value.as_str()))
                 .collect(),
+            fields: target
+                .fields
+                .iter()
+                .map(|field| NormalizedField {
+                    name: field.name.as_str(),
+                    value: match &field.value {
+                        UploadFieldValue::Static { value } => {
+                            NormalizedFieldValue::Static(value.as_str())
+                        }
+                        UploadFieldValue::ContentCrc32C => NormalizedFieldValue::ContentCrc32C,
+                        UploadFieldValue::ContentData => NormalizedFieldValue::ContentData,
+                    },
+                })
+                .collect(),
         }
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
-#[derive(Clone)]
-struct SharedChecksumState(Arc<Mutex<Option<crc::Digest<'static, u32>>>>);
+/// A source of bytes to upload to a presigned upload target.
+///
+/// This abstracts over the requirements for file uploads, such as knowing
+/// the payload size, so that we can avoid loading entire files into memory
+/// wherever possible.
+///
+/// It also allows the upload target implementation to skip work that's
+/// not needed for a particular target. For example, AWS S3 requires that
+/// the client provide a checksum ahead of time, while GCS does not.
+pub trait UploadBody {
+    /// Total length of the body in bytes. Used for the `Content-Length`
+    /// header on PUT uploads and for the multipart `ContentData` part length.
+    fn length(&self) -> u64;
+
+    /// Base64-encoded big-endian CRC32C of the body content.
+    #[cfg(not(target_family = "wasm"))]
+    fn compute_crc32c_base64(&self) -> impl Future<Output = Result<String>> + Send;
+
+    /// Consume this body and produce a `reqwest::Body` for the upload
+    /// request.
+    fn into_reqwest_body(self) -> impl Future<Output = Result<reqwest::Body>> + Send;
+}
+
+/// In-memory implementation of [`UploadBody`].
+impl UploadBody for Vec<u8> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    async fn compute_crc32c_base64(&self) -> Result<String> {
+        Ok(encode_crc32c_base64(CRC32C.checksum(self)))
+    }
+
+    async fn into_reqwest_body(self) -> Result<reqwest::Body> {
+        Ok(reqwest::Body::from(self))
+    }
+}
+
+/// `UploadBody` implementation backed by a file on disk. Used for streaming
+/// artifact uploads without buffering the file content in memory.
+#[cfg(feature = "local_fs")]
+#[derive(Debug, Clone)]
+pub struct FileUploadBody {
+    path: PathBuf,
+}
+
+#[cfg(feature = "local_fs")]
+impl FileUploadBody {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+#[cfg(feature = "local_fs")]
+impl UploadBody for FileUploadBody {
+    fn length(&self) -> u64 {
+        // Read metadata on demand so callers don't have to keep a pre-computed
+        // size in sync with the file on disk. Returning 0 on a stat failure is
+        // safe: reqwest will still stream the actual bytes, and any PUT paths
+        // that use this for `Content-Length` already tolerate unknown lengths.
+        std::fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0)
+    }
+
+    async fn compute_crc32c_base64(&self) -> Result<String> {
+        use std::io::Read as _;
+        let path = self.path.clone();
+
+        // Compute the checksum as a blocking task for 2 reasons:
+        // - Filesystem operations generally aren't natively async to begin with
+        // - Checksum calculation is CPU-bound, and shouldn't tie up an async worker thread
+        tokio::task::spawn_blocking(move || -> Result<String> {
+            let mut file = std::fs::File::open(&path)
+                .with_context(|| format!("Failed to open artifact file '{}'", path.display()))?;
+            let mut digest = CRC32C.digest();
+            let mut buf = vec![0u8; FILE_UPLOAD_CHUNK_SIZE];
+            loop {
+                let n = file.read(&mut buf).with_context(|| {
+                    format!("Failed to read artifact file '{}'", path.display())
+                })?;
+                if n == 0 {
+                    break;
+                }
+                digest.update(&buf[..n]);
+            }
+            Ok(encode_crc32c_base64(digest.finalize()))
+        })
+        .await
+        .context("CRC32C computation task failed to join")?
+    }
+
+    async fn into_reqwest_body(self) -> Result<reqwest::Body> {
+        let file = tokio::fs::File::open(&self.path)
+            .await
+            .with_context(|| format!("Failed to open artifact file '{}'", self.path.display()))?;
+        Ok(reqwest::Body::wrap_stream(
+            tokio_util::io::ReaderStream::new(file),
+        ))
+    }
+}
 
 #[derive(Copy, Clone)]
 struct UploadErrorContext {
@@ -84,38 +218,9 @@ struct UploadErrorContext {
     failure: &'static str,
 }
 
-#[cfg(not(target_family = "wasm"))]
-impl SharedChecksumState {
-    fn new() -> Self {
-        Self(Arc::new(Mutex::new(Some(CRC32C.digest()))))
-    }
-
-    fn update(&self, bytes: &[u8]) {
-        if bytes.is_empty() {
-            return;
-        }
-
-        let mut digest = self.0.lock().expect("checksum state mutex poisoned");
-        digest
-            .as_mut()
-            .expect("checksum already finalized")
-            .update(bytes);
-    }
-
-    fn finalize(&self) -> Result<String> {
-        let digest = self
-            .0
-            .lock()
-            .map_err(|_| anyhow!("checksum state mutex poisoned"))?
-            .take()
-            .ok_or_else(|| anyhow!("checksum already finalized"))?;
-        Ok(encode_crc32c_base64(digest.finalize()))
-    }
-}
-
 fn build_upload_request<'a>(
     http_client: &'a http_client::Client,
-    target: NormalizedUploadTarget<'_>,
+    target: &NormalizedUploadTarget<'_>,
     content_length: Option<u64>,
 ) -> Result<http_client::RequestBuilder<'a>> {
     let method = target.method.to_ascii_uppercase();
@@ -132,8 +237,8 @@ fn build_upload_request<'a>(
         other => return Err(anyhow!("Unsupported HTTP method: {other}")),
     };
 
-    for (name, value) in target.headers {
-        request = request.header(name, value);
+    for (name, value) in &target.headers {
+        request = request.header(*name, *value);
     }
 
     if let Some(content_length) = content_length.filter(|_| !has_content_length) {
@@ -165,12 +270,12 @@ async fn ensure_upload_succeeded(
 
 async fn send_upload_request(
     http_client: &http_client::Client,
-    target: NormalizedUploadTarget<'_>,
+    target: &NormalizedUploadTarget<'_>,
     body: impl Into<reqwest::Body>,
-    content_length: Option<u64>,
+    content_length: u64,
     error_context: UploadErrorContext,
 ) -> Result<()> {
-    let response = build_upload_request(http_client, target, content_length)?
+    let response = build_upload_request(http_client, target, Some(content_length))?
         .body(body)
         .send()
         .await
@@ -182,19 +287,116 @@ async fn send_upload_request(
 pub(crate) async fn upload_to_target(
     http_client: &http_client::Client,
     target: &UploadTarget,
-    body: impl Into<reqwest::Body>,
+    body: impl UploadBody,
 ) -> Result<()> {
-    send_upload_request(
-        http_client,
-        target.into(),
-        body,
-        None,
-        UploadErrorContext {
-            transport: "Failed to upload to presigned URL",
-            failure: "Upload",
-        },
-    )
-    .await
+    let normalized = NormalizedUploadTarget::from(target);
+    let error_context = UploadErrorContext {
+        transport: "Failed to upload to presigned URL",
+        failure: "Upload",
+    };
+    send_upload(http_client, &normalized, body, None, error_context).await
+}
+
+/// Internal dispatcher shared between [`upload_to_target`] and
+/// [`upload_file_to_target`]. Routes the request to either a plain body upload
+/// or a multipart form upload based on whether the target has form fields.
+async fn send_upload(
+    http_client: &http_client::Client,
+    target: &NormalizedUploadTarget<'_>,
+    body: impl UploadBody,
+    precomputed_crc32c: Option<String>,
+    error_context: UploadErrorContext,
+) -> Result<()> {
+    if target.fields.is_empty() {
+        let length = body.length();
+        let reqwest_body = body.into_reqwest_body().await?;
+        send_upload_request(http_client, target, reqwest_body, length, error_context).await
+    } else {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            send_multipart_upload(http_client, target, body, precomputed_crc32c, error_context)
+                .await
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            let _ = (http_client, body, precomputed_crc32c, error_context);
+            Err(anyhow!(
+                "Multipart upload targets are not supported on wasm"
+            ))
+        }
+    }
+}
+
+/// Send a `multipart/form-data` request.
+///
+/// Callers that already computed the CRC32C (for example `upload_file_to_target`,
+/// which needs it for `confirmFileArtifactUpload`) pass it through via
+/// `precomputed_crc32c` so we don't hash the body twice. Otherwise we only
+/// compute the checksum when requested by the upload target.
+#[cfg(not(target_family = "wasm"))]
+async fn send_multipart_upload(
+    http_client: &http_client::Client,
+    target: &NormalizedUploadTarget<'_>,
+    body: impl UploadBody,
+    precomputed_crc32c: Option<String>,
+    error_context: UploadErrorContext,
+) -> Result<()> {
+    let form = build_multipart_form(target, body, precomputed_crc32c).await?;
+    let request = build_upload_request(http_client, target, None)?;
+    let response = request
+        .multipart(form)
+        .send()
+        .await
+        .context(error_context.transport)?;
+    ensure_upload_succeeded(response, error_context).await
+}
+
+#[cfg(not(target_family = "wasm"))]
+async fn build_multipart_form(
+    target: &NormalizedUploadTarget<'_>,
+    body: impl UploadBody,
+    precomputed_crc32c: Option<String>,
+) -> Result<reqwest::multipart::Form> {
+    use reqwest::multipart::{Form, Part};
+
+    let needs_crc32c = target
+        .fields
+        .iter()
+        .any(|field| matches!(field.value, NormalizedFieldValue::ContentCrc32C));
+    let crc32c_base64 = match (precomputed_crc32c, needs_crc32c) {
+        (Some(crc), _) => Some(crc),
+        (None, true) => Some(body.compute_crc32c_base64().await?),
+        (None, false) => None,
+    };
+    let content_length = body.length();
+    let content_body = body.into_reqwest_body().await?;
+
+    let mut form = Form::new();
+    let mut content_body_cell = Some((content_body, content_length));
+    for field in &target.fields {
+        let name = field.name.to_string();
+        match &field.value {
+            NormalizedFieldValue::Static(value) => {
+                form = form.text(name, value.to_string());
+            }
+            NormalizedFieldValue::ContentCrc32C => {
+                let crc = crc32c_base64.as_deref().ok_or_else(|| {
+                    anyhow!(
+                        "Internal error: ContentCrc32C field '{}' requires a computed checksum",
+                        field.name
+                    )
+                })?;
+                form = form.text(name, crc.to_string());
+            }
+            NormalizedFieldValue::ContentData => {
+                let (body, length) = content_body_cell.take().ok_or_else(|| {
+                    anyhow!("Multipart upload must contain exactly one ContentData field")
+                })?;
+                form = form.part(name, Part::stream_with_length(body, length));
+            }
+        }
+    }
+    Ok(form)
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -204,63 +406,33 @@ fn encode_crc32c_base64(crc32c: u32) -> String {
     STANDARD.encode(crc32c.to_be_bytes())
 }
 
-#[cfg(not(target_family = "wasm"))]
-fn file_upload_stream(
-    mut file: async_fs::File,
-    path: PathBuf,
-    checksum: SharedChecksumState,
-) -> impl futures::Stream<Item = std::io::Result<Bytes>> + Send + 'static {
-    try_stream! {
-        loop {
-            let mut chunk = vec![0; FILE_UPLOAD_CHUNK_SIZE];
-            let bytes_read = file.read(&mut chunk).await.map_err(|err| {
-                std::io::Error::other(format!(
-                    "Failed to read artifact file '{}': {err}",
-                    path.display()
-                ))
-            })?;
-
-            if bytes_read == 0 {
-                break;
-            }
-
-            chunk.truncate(bytes_read);
-            checksum.update(&chunk);
-            yield Bytes::from(chunk);
-        }
-    }
-}
-
-#[cfg(not(target_family = "wasm"))]
+/// Upload a file artifact. Always computes the base64 CRC32C so callers can
+/// pass it to `confirmFileArtifactUpload`.
+#[cfg(feature = "local_fs")]
 pub(crate) async fn upload_file_to_target(
     http_client: &http_client::Client,
     target: &FileArtifactUploadTargetInfo,
-    path: &Path,
-    file_size: u64,
+    body: impl UploadBody,
 ) -> Result<String> {
-    let file = async_fs::File::open(path)
-        .await
-        .with_context(|| format!("Failed to open artifact file '{}'", path.display()))?;
-    let checksum = SharedChecksumState::new();
-    let body = reqwest::Body::wrap_stream(file_upload_stream(
-        file,
-        path.to_path_buf(),
-        checksum.clone(),
-    ));
+    let normalized = NormalizedUploadTarget::from(target);
+    let error_context = UploadErrorContext {
+        transport: "Failed to upload artifact bytes",
+        failure: "Artifact upload",
+    };
 
-    send_upload_request(
+    // `confirmFileArtifactUpload` always needs the CRC32C, so we always compute
+    // it up front and then hand it to the dispatcher so the multipart path
+    // doesn't recompute it.
+    let crc32c_base64 = body.compute_crc32c_base64().await?;
+    send_upload(
         http_client,
-        target.into(),
+        &normalized,
         body,
-        Some(file_size),
-        UploadErrorContext {
-            transport: "Failed to upload artifact bytes",
-            failure: "Artifact upload",
-        },
+        Some(crc32c_base64.clone()),
+        error_context,
     )
     .await?;
-
-    checksum.finalize()
+    Ok(crc32c_base64)
 }
 
 #[cfg(test)]

--- a/app/src/server/server_api/presigned_upload.rs
+++ b/app/src/server/server_api/presigned_upload.rs
@@ -1,24 +1,17 @@
-#[cfg(not(target_family = "wasm"))]
-use std::path::{Path, PathBuf};
-#[cfg(not(target_family = "wasm"))]
-use std::sync::{Arc, Mutex};
+#[cfg(feature = "local_fs")]
+use std::path::PathBuf;
 
 use anyhow::{anyhow, Context, Result};
 #[cfg(not(target_family = "wasm"))]
-use async_stream::try_stream;
-#[cfg(not(target_family = "wasm"))]
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 #[cfg(not(target_family = "wasm"))]
-use bytes::Bytes;
-#[cfg(not(target_family = "wasm"))]
 use crc::{Crc, CRC_32_ISCSI};
-#[cfg(not(target_family = "wasm"))]
-use futures_lite::io::AsyncReadExt as _;
+use std::future::Future;
 use thiserror::Error;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "local_fs")]
 use super::ai::FileArtifactUploadTargetInfo;
-use super::harness_support::UploadTarget;
+use super::harness_support::{UploadFieldValue, UploadTarget};
 
 /// Typed error for HTTP-backed operations so downstream classifiers (e.g. the agent-SDK
 /// retry helper) can decide transient vs permanent failures without string-parsing the
@@ -34,15 +27,31 @@ pub struct HttpStatusError {
 }
 
 #[cfg(not(target_family = "wasm"))]
-static CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
+pub(crate) static CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 const CONTENT_LENGTH_HEADER_NAME: &str = "content-length";
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "local_fs")]
 const FILE_UPLOAD_CHUNK_SIZE: usize = 64 * 1024;
 
 struct NormalizedUploadTarget<'a> {
     url: &'a str,
     method: &'a str,
     headers: Vec<(&'a str, &'a str)>,
+    fields: Vec<NormalizedField<'a>>,
+}
+
+/// Borrowed view of a single multipart form field.
+#[derive(Debug, PartialEq, Eq)]
+struct NormalizedField<'a> {
+    name: &'a str,
+    value: NormalizedFieldValue<'a>,
+}
+
+/// Borrowed view of a single multipart form field value.
+#[derive(Debug, PartialEq, Eq)]
+enum NormalizedFieldValue<'a> {
+    Static(&'a str),
+    ContentCrc32C,
+    ContentData,
 }
 
 impl<'a> From<&'a UploadTarget> for NormalizedUploadTarget<'a> {
@@ -55,11 +64,25 @@ impl<'a> From<&'a UploadTarget> for NormalizedUploadTarget<'a> {
                 .iter()
                 .map(|(name, value)| (name.as_str(), value.as_str()))
                 .collect(),
+            fields: target
+                .fields
+                .iter()
+                .map(|field| NormalizedField {
+                    name: field.name.as_str(),
+                    value: match &field.value {
+                        UploadFieldValue::Static { value } => {
+                            NormalizedFieldValue::Static(value.as_str())
+                        }
+                        UploadFieldValue::ContentCrc32C => NormalizedFieldValue::ContentCrc32C,
+                        UploadFieldValue::ContentData => NormalizedFieldValue::ContentData,
+                    },
+                })
+                .collect(),
         }
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "local_fs")]
 impl<'a> From<&'a FileArtifactUploadTargetInfo> for NormalizedUploadTarget<'a> {
     fn from(target: &'a FileArtifactUploadTargetInfo) -> Self {
         Self {
@@ -70,13 +93,124 @@ impl<'a> From<&'a FileArtifactUploadTargetInfo> for NormalizedUploadTarget<'a> {
                 .iter()
                 .map(|header| (header.name.as_str(), header.value.as_str()))
                 .collect(),
+            fields: target
+                .fields
+                .iter()
+                .map(|field| NormalizedField {
+                    name: field.name.as_str(),
+                    value: match &field.value {
+                        UploadFieldValue::Static { value } => {
+                            NormalizedFieldValue::Static(value.as_str())
+                        }
+                        UploadFieldValue::ContentCrc32C => NormalizedFieldValue::ContentCrc32C,
+                        UploadFieldValue::ContentData => NormalizedFieldValue::ContentData,
+                    },
+                })
+                .collect(),
         }
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
-#[derive(Clone)]
-struct SharedChecksumState(Arc<Mutex<Option<crc::Digest<'static, u32>>>>);
+/// A source of bytes to upload to a presigned upload target.
+///
+/// This abstracts over the requirements for file uploads, such as knowing
+/// the payload size, so that we can avoid loading entire files into memory
+/// wherever possible.
+///
+/// It also allows the upload target implementation to skip work that's
+/// not needed for a particular target. For example, AWS S3 requires that
+/// the client provide a checksum ahead of time, while GCS does not.
+pub trait UploadBody {
+    /// Total length of the body in bytes. Used for the `Content-Length`
+    /// header on PUT uploads and for the multipart `ContentData` part length.
+    fn length(&self) -> u64;
+
+    /// Base64-encoded big-endian CRC32C of the body content.
+    #[cfg(not(target_family = "wasm"))]
+    fn compute_crc32c_base64(&self) -> impl Future<Output = Result<String>> + Send;
+
+    /// Consume this body and produce a `reqwest::Body` for the upload
+    /// request.
+    fn into_reqwest_body(self) -> impl Future<Output = Result<reqwest::Body>> + Send;
+}
+
+/// In-memory implementation of [`UploadBody`].
+impl UploadBody for Vec<u8> {
+    fn length(&self) -> u64 {
+        self.len() as u64
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    async fn compute_crc32c_base64(&self) -> Result<String> {
+        Ok(encode_crc32c_base64(CRC32C.checksum(self)))
+    }
+
+    async fn into_reqwest_body(self) -> Result<reqwest::Body> {
+        Ok(reqwest::Body::from(self))
+    }
+}
+
+/// `UploadBody` implementation backed by a file on disk. Used for streaming
+/// artifact uploads without buffering the file content in memory.
+#[cfg(feature = "local_fs")]
+#[derive(Debug, Clone)]
+pub struct FileUploadBody {
+    path: PathBuf,
+}
+
+#[cfg(feature = "local_fs")]
+impl FileUploadBody {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+#[cfg(feature = "local_fs")]
+impl UploadBody for FileUploadBody {
+    fn length(&self) -> u64 {
+        // Read metadata on demand so callers don't have to keep a pre-computed
+        // size in sync with the file on disk. Returning 0 on a stat failure is
+        // safe: reqwest will still stream the actual bytes, and any PUT paths
+        // that use this for `Content-Length` already tolerate unknown lengths.
+        std::fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0)
+    }
+
+    async fn compute_crc32c_base64(&self) -> Result<String> {
+        use std::io::Read as _;
+        let path = self.path.clone();
+
+        // Compute the checksum as a blocking task for 2 reasons:
+        // - Filesystem operations generally aren't natively async to begin with
+        // - Checksum calculation is CPU-bound, and shouldn't tie up an async worker thread
+        tokio::task::spawn_blocking(move || -> Result<String> {
+            let mut file = std::fs::File::open(&path)
+                .with_context(|| format!("Failed to open artifact file '{}'", path.display()))?;
+            let mut digest = CRC32C.digest();
+            let mut buf = vec![0u8; FILE_UPLOAD_CHUNK_SIZE];
+            loop {
+                let n = file.read(&mut buf).with_context(|| {
+                    format!("Failed to read artifact file '{}'", path.display())
+                })?;
+                if n == 0 {
+                    break;
+                }
+                digest.update(&buf[..n]);
+            }
+            Ok(encode_crc32c_base64(digest.finalize()))
+        })
+        .await
+        .context("CRC32C computation task failed to join")?
+    }
+
+    async fn into_reqwest_body(self) -> Result<reqwest::Body> {
+        let file = tokio::fs::File::open(&self.path)
+            .await
+            .with_context(|| format!("Failed to open artifact file '{}'", self.path.display()))?;
+        Ok(reqwest::Body::wrap_stream(
+            tokio_util::io::ReaderStream::new(file),
+        ))
+    }
+}
 
 #[derive(Copy, Clone)]
 struct UploadErrorContext {
@@ -84,38 +218,9 @@ struct UploadErrorContext {
     failure: &'static str,
 }
 
-#[cfg(not(target_family = "wasm"))]
-impl SharedChecksumState {
-    fn new() -> Self {
-        Self(Arc::new(Mutex::new(Some(CRC32C.digest()))))
-    }
-
-    fn update(&self, bytes: &[u8]) {
-        if bytes.is_empty() {
-            return;
-        }
-
-        let mut digest = self.0.lock().expect("checksum state mutex poisoned");
-        digest
-            .as_mut()
-            .expect("checksum already finalized")
-            .update(bytes);
-    }
-
-    fn finalize(&self) -> Result<String> {
-        let digest = self
-            .0
-            .lock()
-            .map_err(|_| anyhow!("checksum state mutex poisoned"))?
-            .take()
-            .ok_or_else(|| anyhow!("checksum already finalized"))?;
-        Ok(encode_crc32c_base64(digest.finalize()))
-    }
-}
-
 fn build_upload_request<'a>(
     http_client: &'a http_client::Client,
-    target: NormalizedUploadTarget<'_>,
+    target: &NormalizedUploadTarget<'_>,
     content_length: Option<u64>,
 ) -> Result<http_client::RequestBuilder<'a>> {
     let method = target.method.to_ascii_uppercase();
@@ -132,8 +237,8 @@ fn build_upload_request<'a>(
         other => return Err(anyhow!("Unsupported HTTP method: {other}")),
     };
 
-    for (name, value) in target.headers {
-        request = request.header(name, value);
+    for (name, value) in &target.headers {
+        request = request.header(*name, *value);
     }
 
     if let Some(content_length) = content_length.filter(|_| !has_content_length) {
@@ -165,12 +270,12 @@ async fn ensure_upload_succeeded(
 
 async fn send_upload_request(
     http_client: &http_client::Client,
-    target: NormalizedUploadTarget<'_>,
+    target: &NormalizedUploadTarget<'_>,
     body: impl Into<reqwest::Body>,
-    content_length: Option<u64>,
+    content_length: u64,
     error_context: UploadErrorContext,
 ) -> Result<()> {
-    let response = build_upload_request(http_client, target, content_length)?
+    let response = build_upload_request(http_client, target, Some(content_length))?
         .body(body)
         .send()
         .await
@@ -182,19 +287,121 @@ async fn send_upload_request(
 pub(crate) async fn upload_to_target(
     http_client: &http_client::Client,
     target: &UploadTarget,
-    body: impl Into<reqwest::Body>,
+    body: impl UploadBody,
 ) -> Result<()> {
-    send_upload_request(
-        http_client,
-        target.into(),
-        body,
-        None,
-        UploadErrorContext {
-            transport: "Failed to upload to presigned URL",
-            failure: "Upload",
-        },
-    )
-    .await
+    let normalized = NormalizedUploadTarget::from(target);
+    let error_context = UploadErrorContext {
+        transport: "Failed to upload to presigned URL",
+        failure: "Upload",
+    };
+    send_upload(http_client, &normalized, body, None, error_context).await
+}
+
+/// Internal dispatcher shared between [`upload_to_target`] and
+/// [`upload_file_to_target`]. Routes the request to either a plain body upload
+/// or a multipart form upload based on whether the target has form fields.
+async fn send_upload(
+    http_client: &http_client::Client,
+    target: &NormalizedUploadTarget<'_>,
+    body: impl UploadBody,
+    precomputed_crc32c: Option<String>,
+    error_context: UploadErrorContext,
+) -> Result<()> {
+    if target.fields.is_empty() {
+        let length = body.length();
+        let reqwest_body = body.into_reqwest_body().await?;
+        send_upload_request(http_client, target, reqwest_body, length, error_context).await
+    } else {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            send_multipart_upload(http_client, target, body, precomputed_crc32c, error_context)
+                .await
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            let _ = (http_client, body, precomputed_crc32c, error_context);
+            Err(anyhow!(
+                "Multipart upload targets are not supported on wasm"
+            ))
+        }
+    }
+}
+
+/// Send a `multipart/form-data` request.
+///
+/// Callers that already computed the CRC32C (for example `upload_file_to_target`,
+/// which needs it for `confirmFileArtifactUpload`) pass it through via
+/// `precomputed_crc32c` so we don't hash the body twice. Otherwise we only
+/// compute the checksum when requested by the upload target.
+#[cfg(not(target_family = "wasm"))]
+async fn send_multipart_upload(
+    http_client: &http_client::Client,
+    target: &NormalizedUploadTarget<'_>,
+    body: impl UploadBody,
+    precomputed_crc32c: Option<String>,
+    error_context: UploadErrorContext,
+) -> Result<()> {
+    let form = build_multipart_form(target, body, precomputed_crc32c).await?;
+    let request = build_upload_request(http_client, target, None)?;
+    let response = request
+        .multipart(form)
+        .send()
+        .await
+        .context(error_context.transport)?;
+    ensure_upload_succeeded(response, error_context).await
+}
+
+#[cfg(not(target_family = "wasm"))]
+async fn build_multipart_form(
+    target: &NormalizedUploadTarget<'_>,
+    body: impl UploadBody,
+    precomputed_crc32c: Option<String>,
+) -> Result<reqwest::multipart::Form> {
+    use reqwest::multipart::{Form, Part};
+
+    let needs_crc32c = target
+        .fields
+        .iter()
+        .any(|field| matches!(field.value, NormalizedFieldValue::ContentCrc32C));
+    let crc32c_base64 = match (precomputed_crc32c, needs_crc32c) {
+        (Some(crc), _) => Some(crc),
+        (None, true) => Some(body.compute_crc32c_base64().await?),
+        (None, false) => None,
+    };
+    let content_length = body.length();
+    let content_body = body.into_reqwest_body().await?;
+
+    let mut form = Form::new();
+    let mut content_body_cell = Some((content_body, content_length));
+    for field in &target.fields {
+        let name = field.name.to_string();
+        match &field.value {
+            NormalizedFieldValue::Static(value) => {
+                form = form.text(name, value.to_string());
+            }
+            NormalizedFieldValue::ContentCrc32C => {
+                let crc = crc32c_base64.as_deref().ok_or_else(|| {
+                    anyhow!(
+                        "Internal error: ContentCrc32C field '{}' requires a computed checksum",
+                        field.name
+                    )
+                })?;
+                form = form.text(name, crc.to_string());
+            }
+            NormalizedFieldValue::ContentData => {
+                let (body, length) = content_body_cell.take().ok_or_else(|| {
+                    anyhow!("Multipart upload must contain exactly one ContentData field")
+                })?;
+                form = form.part(name, Part::stream_with_length(body, length));
+            }
+        }
+    }
+    if content_body_cell.is_some() {
+        return Err(anyhow!(
+            "Multipart upload must contain exactly one ContentData field"
+        ));
+    }
+    Ok(form)
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -204,63 +411,33 @@ fn encode_crc32c_base64(crc32c: u32) -> String {
     STANDARD.encode(crc32c.to_be_bytes())
 }
 
-#[cfg(not(target_family = "wasm"))]
-fn file_upload_stream(
-    mut file: async_fs::File,
-    path: PathBuf,
-    checksum: SharedChecksumState,
-) -> impl futures::Stream<Item = std::io::Result<Bytes>> + Send + 'static {
-    try_stream! {
-        loop {
-            let mut chunk = vec![0; FILE_UPLOAD_CHUNK_SIZE];
-            let bytes_read = file.read(&mut chunk).await.map_err(|err| {
-                std::io::Error::other(format!(
-                    "Failed to read artifact file '{}': {err}",
-                    path.display()
-                ))
-            })?;
-
-            if bytes_read == 0 {
-                break;
-            }
-
-            chunk.truncate(bytes_read);
-            checksum.update(&chunk);
-            yield Bytes::from(chunk);
-        }
-    }
-}
-
-#[cfg(not(target_family = "wasm"))]
+/// Upload a file artifact. Always computes the base64 CRC32C so callers can
+/// pass it to `confirmFileArtifactUpload`.
+#[cfg(feature = "local_fs")]
 pub(crate) async fn upload_file_to_target(
     http_client: &http_client::Client,
     target: &FileArtifactUploadTargetInfo,
-    path: &Path,
-    file_size: u64,
+    body: impl UploadBody,
 ) -> Result<String> {
-    let file = async_fs::File::open(path)
-        .await
-        .with_context(|| format!("Failed to open artifact file '{}'", path.display()))?;
-    let checksum = SharedChecksumState::new();
-    let body = reqwest::Body::wrap_stream(file_upload_stream(
-        file,
-        path.to_path_buf(),
-        checksum.clone(),
-    ));
+    let normalized = NormalizedUploadTarget::from(target);
+    let error_context = UploadErrorContext {
+        transport: "Failed to upload artifact bytes",
+        failure: "Artifact upload",
+    };
 
-    send_upload_request(
+    // `confirmFileArtifactUpload` always needs the CRC32C, so we always compute
+    // it up front and then hand it to the dispatcher so the multipart path
+    // doesn't recompute it.
+    let crc32c_base64 = body.compute_crc32c_base64().await?;
+    send_upload(
         http_client,
-        target.into(),
+        &normalized,
         body,
-        Some(file_size),
-        UploadErrorContext {
-            transport: "Failed to upload artifact bytes",
-            failure: "Artifact upload",
-        },
+        Some(crc32c_base64.clone()),
+        error_context,
     )
     .await?;
-
-    checksum.finalize()
+    Ok(crc32c_base64)
 }
 
 #[cfg(test)]

--- a/app/src/server/server_api/presigned_upload_tests.rs
+++ b/app/src/server/server_api/presigned_upload_tests.rs
@@ -2,11 +2,21 @@ use std::collections::HashMap;
 use std::fs;
 
 use futures::executor::block_on;
-use mockito::Server;
+use mockito::{Matcher, Server};
 use tempfile::tempdir;
 
 use super::*;
 use crate::server::server_api::ai::{FileArtifactUploadHeaderInfo, FileArtifactUploadTargetInfo};
+use crate::server::server_api::harness_support::{UploadField, UploadFieldValue};
+
+/// Drive a future to completion on a fresh Tokio runtime. Required for tests
+/// that exercise `FileUploadBody`, which hashes the file via `spawn_blocking`
+/// and therefore needs an actual Tokio reactor - `futures::executor::block_on`
+/// works for the other tests because they never touch Tokio's blocking pool.
+#[cfg(feature = "local_fs")]
+fn block_on_tokio<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Runtime::new().unwrap().block_on(fut)
+}
 
 #[test]
 fn encode_crc32c_base64_matches_spec_example() {
@@ -14,18 +24,29 @@ fn encode_crc32c_base64_matches_spec_example() {
 }
 
 #[test]
-fn shared_checksum_state_finalize_returns_error_when_called_twice() {
-    let checksum = SharedChecksumState::new();
-    checksum.update(b"artifact payload");
+fn vec_upload_body_hashes_its_buffer() {
+    block_on(async {
+        let body: Vec<u8> = b"artifact payload".to_vec();
+        let checksum = body.compute_crc32c_base64().await.unwrap();
+        assert_eq!(
+            checksum,
+            encode_crc32c_base64(CRC32C.checksum(b"artifact payload"))
+        );
+    });
+}
 
-    let finalized = checksum.finalize().unwrap();
-    let err = checksum.finalize().unwrap_err();
-
-    assert_eq!(
-        finalized,
-        encode_crc32c_base64(CRC32C.checksum(b"artifact payload"))
-    );
-    assert!(err.to_string().contains("checksum already finalized"));
+#[cfg(feature = "local_fs")]
+#[test]
+fn file_upload_body_hashes_without_buffering() {
+    block_on_tokio(async {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("artifact.bin");
+        let payload = b"streamed artifact payload";
+        fs::write(&path, payload).unwrap();
+        let body = FileUploadBody::new(path);
+        let checksum = body.compute_crc32c_base64().await.unwrap();
+        assert_eq!(checksum, encode_crc32c_base64(CRC32C.checksum(payload)));
+    });
 }
 
 #[test]
@@ -44,9 +65,10 @@ fn upload_to_target_replays_headers_for_byte_uploads() {
             url: format!("{}/upload", server.url()),
             method: "POST".to_string(),
             headers: HashMap::from([("x-test-header".to_string(), "expected-header".to_string())]),
+            fields: Vec::new(),
         };
 
-        upload_to_target(&client, &target, "serialized body".to_string())
+        upload_to_target(&client, &target, b"serialized body".to_vec())
             .await
             .unwrap();
 
@@ -54,72 +76,217 @@ fn upload_to_target_replays_headers_for_byte_uploads() {
     });
 }
 
+#[cfg(feature = "local_fs")]
 #[test]
 fn upload_file_to_target_replays_headers_sets_content_length_and_returns_checksum() {
-    block_on(async {
-        let tempdir = tempdir().unwrap();
-        let path = tempdir.path().join("artifact.bin");
-        let body = b"artifact payload";
-        let content_length = body.len().to_string();
-        fs::write(&path, body).unwrap();
+    // mockito::Server spins its own Tokio runtime, so we build it here (on the
+    // thread's current runtime-less state) and only enter our Tokio runtime
+    // when we're ready to drive the async upload.
+    let tempdir = tempdir().unwrap();
+    let path = tempdir.path().join("artifact.bin");
+    let body = b"artifact payload";
+    let content_length = body.len().to_string();
+    fs::write(&path, body).unwrap();
 
+    let mut server = Server::new();
+    let mock = server
+        .mock("POST", "/upload")
+        .match_header("x-test-header", "expected-header")
+        .match_header("content-length", content_length.as_str())
+        .match_body(body.to_vec())
+        .with_status(200)
+        .create();
+
+    let client = http_client::Client::new_for_test();
+    let target = FileArtifactUploadTargetInfo {
+        url: format!("{}/upload", server.url()),
+        method: "POST".to_string(),
+        headers: vec![FileArtifactUploadHeaderInfo {
+            name: "x-test-header".to_string(),
+            value: "expected-header".to_string(),
+        }],
+        fields: Vec::new(),
+    };
+
+    let checksum = block_on_tokio(upload_file_to_target(
+        &client,
+        &target,
+        FileUploadBody::new(path),
+    ))
+    .unwrap();
+
+    mock.assert();
+    assert_eq!(checksum, encode_crc32c_base64(CRC32C.checksum(body)));
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn upload_file_to_target_returns_status_and_body_for_failed_uploads() {
+    let tempdir = tempdir().unwrap();
+    let path = tempdir.path().join("artifact.bin");
+    fs::write(&path, b"artifact payload").unwrap();
+
+    let mut server = Server::new();
+    let mock = server
+        .mock("PUT", "/upload")
+        .with_status(403)
+        .with_body("denied")
+        .create();
+
+    let client = http_client::Client::new_for_test();
+    let target = FileArtifactUploadTargetInfo {
+        url: format!("{}/upload", server.url()),
+        method: "PUT".to_string(),
+        headers: Vec::new(),
+        fields: Vec::new(),
+    };
+
+    let err = block_on_tokio(upload_file_to_target(
+        &client,
+        &target,
+        FileUploadBody::new(path),
+    ))
+    .unwrap_err();
+
+    mock.assert();
+    assert!(err
+        .to_string()
+        .contains("Artifact upload failed with status 403 Forbidden: denied"));
+}
+
+/// Mockito matcher that captures the raw request body so individual fields of
+/// a multipart payload can be asserted without depending on reqwest's boundary.
+fn matches_multipart_field(name: &'static str, expected: &'static str) -> Matcher {
+    // mockito matches on the body as a raw byte slice; we look for the form-data
+    // disposition header and the expected value within the same part.
+    Matcher::Regex(format!(
+        "name=\"{name}\"\r\n\r\n{expected}\r\n",
+        name = regex::escape(name),
+        expected = regex::escape(expected)
+    ))
+}
+
+#[test]
+fn upload_to_target_builds_multipart_post_with_static_crc_and_data_fields() {
+    block_on(async {
         let mut server = Server::new();
+        let body = b"multipart artifact payload";
+        let expected_crc32c = encode_crc32c_base64(CRC32C.checksum(body));
+        let expected_crc32c_escaped = expected_crc32c.clone();
+
         let mock = server
             .mock("POST", "/upload")
-            .match_header("x-test-header", "expected-header")
-            .match_header("content-length", content_length.as_str())
-            .match_body(body.to_vec())
-            .with_status(200)
+            .match_header(
+                "content-type",
+                Matcher::Regex("^multipart/form-data; boundary=.+".to_string()),
+            )
+            .match_body(Matcher::AllOf(vec![
+                matches_multipart_field("key", "presigned/object/key"),
+                matches_multipart_field("Content-Type", "application/octet-stream"),
+                Matcher::Regex(format!(
+                    r#"name="x-amz-checksum-crc32c"\r\n\r\n{crc}\r\n"#,
+                    crc = regex::escape(&expected_crc32c_escaped)
+                )),
+                Matcher::Regex(r#"name="file"[\s\S]*multipart artifact payload"#.to_string()),
+            ]))
+            .with_status(204)
             .create();
 
         let client = http_client::Client::new_for_test();
-        let target = FileArtifactUploadTargetInfo {
+        let target = UploadTarget {
             url: format!("{}/upload", server.url()),
             method: "POST".to_string(),
-            headers: vec![FileArtifactUploadHeaderInfo {
-                name: "x-test-header".to_string(),
-                value: "expected-header".to_string(),
-            }],
+            headers: HashMap::new(),
+            fields: vec![
+                UploadField {
+                    name: "key".to_string(),
+                    value: UploadFieldValue::Static {
+                        value: "presigned/object/key".to_string(),
+                    },
+                },
+                UploadField {
+                    name: "Content-Type".to_string(),
+                    value: UploadFieldValue::Static {
+                        value: "application/octet-stream".to_string(),
+                    },
+                },
+                UploadField {
+                    name: "x-amz-checksum-crc32c".to_string(),
+                    value: UploadFieldValue::ContentCrc32C,
+                },
+                UploadField {
+                    name: "file".to_string(),
+                    value: UploadFieldValue::ContentData,
+                },
+            ],
         };
 
-        let checksum = upload_file_to_target(&client, &target, &path, body.len() as u64)
+        upload_to_target(&client, &target, body.to_vec())
             .await
             .unwrap();
 
         mock.assert();
-        assert_eq!(checksum, encode_crc32c_base64(CRC32C.checksum(body)));
     });
 }
 
+#[cfg(feature = "local_fs")]
 #[test]
-fn upload_file_to_target_returns_status_and_body_for_failed_uploads() {
-    block_on(async {
-        let tempdir = tempdir().unwrap();
-        let path = tempdir.path().join("artifact.bin");
-        fs::write(&path, b"artifact payload").unwrap();
+fn upload_file_to_target_builds_multipart_post_and_returns_computed_crc32c() {
+    let tempdir = tempdir().unwrap();
+    let path = tempdir.path().join("artifact.bin");
+    let body = b"file-backed multipart payload";
+    fs::write(&path, body).unwrap();
+    let expected_crc32c = encode_crc32c_base64(CRC32C.checksum(body));
+    let expected_crc32c_escaped = expected_crc32c.clone();
 
-        let mut server = Server::new();
-        let mock = server
-            .mock("PUT", "/upload")
-            .with_status(403)
-            .with_body("denied")
-            .create();
+    let mut server = Server::new();
+    let mock = server
+        .mock("POST", "/upload")
+        .match_header(
+            "content-type",
+            Matcher::Regex("^multipart/form-data; boundary=.+".to_string()),
+        )
+        .match_body(Matcher::AllOf(vec![
+            matches_multipart_field("key", "artifact/key"),
+            Matcher::Regex(format!(
+                r#"name="x-amz-checksum-crc32c"\r\n\r\n{crc}\r\n"#,
+                crc = regex::escape(&expected_crc32c_escaped)
+            )),
+            Matcher::Regex(r#"name="file"[\s\S]*file-backed multipart payload"#.to_string()),
+        ]))
+        .with_status(204)
+        .create();
 
-        let client = http_client::Client::new_for_test();
-        let target = FileArtifactUploadTargetInfo {
-            url: format!("{}/upload", server.url()),
-            method: "PUT".to_string(),
-            headers: Vec::new(),
-        };
+    let client = http_client::Client::new_for_test();
+    let target = FileArtifactUploadTargetInfo {
+        url: format!("{}/upload", server.url()),
+        method: "POST".to_string(),
+        headers: Vec::new(),
+        fields: vec![
+            UploadField {
+                name: "key".to_string(),
+                value: UploadFieldValue::Static {
+                    value: "artifact/key".to_string(),
+                },
+            },
+            UploadField {
+                name: "x-amz-checksum-crc32c".to_string(),
+                value: UploadFieldValue::ContentCrc32C,
+            },
+            UploadField {
+                name: "file".to_string(),
+                value: UploadFieldValue::ContentData,
+            },
+        ],
+    };
 
-        let err =
-            upload_file_to_target(&client, &target, &path, fs::metadata(&path).unwrap().len())
-                .await
-                .unwrap_err();
+    let checksum = block_on_tokio(upload_file_to_target(
+        &client,
+        &target,
+        FileUploadBody::new(path),
+    ))
+    .unwrap();
 
-        mock.assert();
-        assert!(err
-            .to_string()
-            .contains("Artifact upload failed with status 403 Forbidden: denied"));
-    });
+    mock.assert();
+    assert_eq!(checksum, expected_crc32c);
 }

--- a/app/src/server/server_api/presigned_upload_tests.rs
+++ b/app/src/server/server_api/presigned_upload_tests.rs
@@ -2,11 +2,21 @@ use std::collections::HashMap;
 use std::fs;
 
 use futures::executor::block_on;
-use mockito::Server;
+use mockito::{Matcher, Server};
 use tempfile::tempdir;
 
 use super::*;
 use crate::server::server_api::ai::{FileArtifactUploadHeaderInfo, FileArtifactUploadTargetInfo};
+use crate::server::server_api::harness_support::{UploadField, UploadFieldValue};
+
+/// Drive a future to completion on a fresh Tokio runtime. Required for tests
+/// that exercise `FileUploadBody`, which hashes the file via `spawn_blocking`
+/// and therefore needs an actual Tokio reactor - `futures::executor::block_on`
+/// works for the other tests because they never touch Tokio's blocking pool.
+#[cfg(feature = "local_fs")]
+fn block_on_tokio<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Runtime::new().unwrap().block_on(fut)
+}
 
 #[test]
 fn encode_crc32c_base64_matches_spec_example() {
@@ -14,18 +24,29 @@ fn encode_crc32c_base64_matches_spec_example() {
 }
 
 #[test]
-fn shared_checksum_state_finalize_returns_error_when_called_twice() {
-    let checksum = SharedChecksumState::new();
-    checksum.update(b"artifact payload");
+fn vec_upload_body_hashes_its_buffer() {
+    block_on(async {
+        let body: Vec<u8> = b"artifact payload".to_vec();
+        let checksum = body.compute_crc32c_base64().await.unwrap();
+        assert_eq!(
+            checksum,
+            encode_crc32c_base64(CRC32C.checksum(b"artifact payload"))
+        );
+    });
+}
 
-    let finalized = checksum.finalize().unwrap();
-    let err = checksum.finalize().unwrap_err();
-
-    assert_eq!(
-        finalized,
-        encode_crc32c_base64(CRC32C.checksum(b"artifact payload"))
-    );
-    assert!(err.to_string().contains("checksum already finalized"));
+#[cfg(feature = "local_fs")]
+#[test]
+fn file_upload_body_hashes_without_buffering() {
+    block_on_tokio(async {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("artifact.bin");
+        let payload = b"streamed artifact payload";
+        fs::write(&path, payload).unwrap();
+        let body = FileUploadBody::new(path);
+        let checksum = body.compute_crc32c_base64().await.unwrap();
+        assert_eq!(checksum, encode_crc32c_base64(CRC32C.checksum(payload)));
+    });
 }
 
 #[test]
@@ -44,9 +65,10 @@ fn upload_to_target_replays_headers_for_byte_uploads() {
             url: format!("{}/upload", server.url()),
             method: "POST".to_string(),
             headers: HashMap::from([("x-test-header".to_string(), "expected-header".to_string())]),
+            fields: Vec::new(),
         };
 
-        upload_to_target(&client, &target, "serialized body".to_string())
+        upload_to_target(&client, &target, b"serialized body".to_vec())
             .await
             .unwrap();
 
@@ -54,72 +76,243 @@ fn upload_to_target_replays_headers_for_byte_uploads() {
     });
 }
 
+#[cfg(feature = "local_fs")]
 #[test]
 fn upload_file_to_target_replays_headers_sets_content_length_and_returns_checksum() {
-    block_on(async {
-        let tempdir = tempdir().unwrap();
-        let path = tempdir.path().join("artifact.bin");
-        let body = b"artifact payload";
-        let content_length = body.len().to_string();
-        fs::write(&path, body).unwrap();
+    // mockito::Server spins its own Tokio runtime, so we build it here (on the
+    // thread's current runtime-less state) and only enter our Tokio runtime
+    // when we're ready to drive the async upload.
+    let tempdir = tempdir().unwrap();
+    let path = tempdir.path().join("artifact.bin");
+    let body = b"artifact payload";
+    let content_length = body.len().to_string();
+    fs::write(&path, body).unwrap();
 
+    let mut server = Server::new();
+    let mock = server
+        .mock("POST", "/upload")
+        .match_header("x-test-header", "expected-header")
+        .match_header("content-length", content_length.as_str())
+        .match_body(body.to_vec())
+        .with_status(200)
+        .create();
+
+    let client = http_client::Client::new_for_test();
+    let target = FileArtifactUploadTargetInfo {
+        url: format!("{}/upload", server.url()),
+        method: "POST".to_string(),
+        headers: vec![FileArtifactUploadHeaderInfo {
+            name: "x-test-header".to_string(),
+            value: "expected-header".to_string(),
+        }],
+        fields: Vec::new(),
+    };
+
+    let checksum = block_on_tokio(upload_file_to_target(
+        &client,
+        &target,
+        FileUploadBody::new(path),
+    ))
+    .unwrap();
+
+    mock.assert();
+    assert_eq!(checksum, encode_crc32c_base64(CRC32C.checksum(body)));
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn upload_file_to_target_returns_status_and_body_for_failed_uploads() {
+    let tempdir = tempdir().unwrap();
+    let path = tempdir.path().join("artifact.bin");
+    fs::write(&path, b"artifact payload").unwrap();
+
+    let mut server = Server::new();
+    let mock = server
+        .mock("PUT", "/upload")
+        .with_status(403)
+        .with_body("denied")
+        .create();
+
+    let client = http_client::Client::new_for_test();
+    let target = FileArtifactUploadTargetInfo {
+        url: format!("{}/upload", server.url()),
+        method: "PUT".to_string(),
+        headers: Vec::new(),
+        fields: Vec::new(),
+    };
+
+    let err = block_on_tokio(upload_file_to_target(
+        &client,
+        &target,
+        FileUploadBody::new(path),
+    ))
+    .unwrap_err();
+
+    mock.assert();
+    assert!(err
+        .to_string()
+        .contains("Artifact upload failed with status 403 Forbidden: denied"));
+}
+
+/// Mockito matcher that captures the raw request body so individual fields of
+/// a multipart payload can be asserted without depending on reqwest's boundary.
+fn matches_multipart_field(name: &'static str, expected: &'static str) -> Matcher {
+    // mockito matches on the body as a raw byte slice; we look for the form-data
+    // disposition header and the expected value within the same part.
+    Matcher::Regex(format!(
+        "name=\"{name}\"\r\n\r\n{expected}\r\n",
+        name = regex::escape(name),
+        expected = regex::escape(expected)
+    ))
+}
+
+#[test]
+fn upload_to_target_builds_multipart_post_with_static_crc_and_data_fields() {
+    block_on(async {
         let mut server = Server::new();
+        let body = b"multipart artifact payload";
+        let expected_crc32c = encode_crc32c_base64(CRC32C.checksum(body));
+        let expected_crc32c_escaped = expected_crc32c.clone();
+
         let mock = server
             .mock("POST", "/upload")
-            .match_header("x-test-header", "expected-header")
-            .match_header("content-length", content_length.as_str())
-            .match_body(body.to_vec())
-            .with_status(200)
+            .match_header(
+                "content-type",
+                Matcher::Regex("^multipart/form-data; boundary=.+".to_string()),
+            )
+            .match_body(Matcher::AllOf(vec![
+                matches_multipart_field("key", "presigned/object/key"),
+                matches_multipart_field("Content-Type", "application/octet-stream"),
+                Matcher::Regex(format!(
+                    r#"name="x-amz-checksum-crc32c"\r\n\r\n{crc}\r\n"#,
+                    crc = regex::escape(&expected_crc32c_escaped)
+                )),
+                Matcher::Regex(r#"name="file"[\s\S]*multipart artifact payload"#.to_string()),
+            ]))
+            .with_status(204)
             .create();
 
         let client = http_client::Client::new_for_test();
-        let target = FileArtifactUploadTargetInfo {
+        let target = UploadTarget {
             url: format!("{}/upload", server.url()),
             method: "POST".to_string(),
-            headers: vec![FileArtifactUploadHeaderInfo {
-                name: "x-test-header".to_string(),
-                value: "expected-header".to_string(),
-            }],
+            headers: HashMap::new(),
+            fields: vec![
+                UploadField {
+                    name: "key".to_string(),
+                    value: UploadFieldValue::Static {
+                        value: "presigned/object/key".to_string(),
+                    },
+                },
+                UploadField {
+                    name: "Content-Type".to_string(),
+                    value: UploadFieldValue::Static {
+                        value: "application/octet-stream".to_string(),
+                    },
+                },
+                UploadField {
+                    name: "x-amz-checksum-crc32c".to_string(),
+                    value: UploadFieldValue::ContentCrc32C,
+                },
+                UploadField {
+                    name: "file".to_string(),
+                    value: UploadFieldValue::ContentData,
+                },
+            ],
         };
 
-        let checksum = upload_file_to_target(&client, &target, &path, body.len() as u64)
+        upload_to_target(&client, &target, body.to_vec())
             .await
             .unwrap();
 
         mock.assert();
-        assert_eq!(checksum, encode_crc32c_base64(CRC32C.checksum(body)));
     });
 }
 
 #[test]
-fn upload_file_to_target_returns_status_and_body_for_failed_uploads() {
+fn multipart_post_requires_content_data_field() {
     block_on(async {
-        let tempdir = tempdir().unwrap();
-        let path = tempdir.path().join("artifact.bin");
-        fs::write(&path, b"artifact payload").unwrap();
-
-        let mut server = Server::new();
-        let mock = server
-            .mock("PUT", "/upload")
-            .with_status(403)
-            .with_body("denied")
-            .create();
-
-        let client = http_client::Client::new_for_test();
-        let target = FileArtifactUploadTargetInfo {
-            url: format!("{}/upload", server.url()),
-            method: "PUT".to_string(),
-            headers: Vec::new(),
+        let target = UploadTarget {
+            url: "https://example.com/upload".to_string(),
+            method: "POST".to_string(),
+            headers: HashMap::new(),
+            fields: vec![UploadField {
+                name: "key".to_string(),
+                value: UploadFieldValue::Static {
+                    value: "presigned/object/key".to_string(),
+                },
+            }],
         };
+        let normalized = NormalizedUploadTarget::from(&target);
 
-        let err =
-            upload_file_to_target(&client, &target, &path, fs::metadata(&path).unwrap().len())
-                .await
-                .unwrap_err();
+        let err = build_multipart_form(&normalized, b"missing content data".to_vec(), None)
+            .await
+            .unwrap_err();
 
-        mock.assert();
         assert!(err
             .to_string()
-            .contains("Artifact upload failed with status 403 Forbidden: denied"));
+            .contains("Multipart upload must contain exactly one ContentData field"));
     });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn upload_file_to_target_builds_multipart_post_and_returns_computed_crc32c() {
+    let tempdir = tempdir().unwrap();
+    let path = tempdir.path().join("artifact.bin");
+    let body = b"file-backed multipart payload";
+    fs::write(&path, body).unwrap();
+    let expected_crc32c = encode_crc32c_base64(CRC32C.checksum(body));
+    let expected_crc32c_escaped = expected_crc32c.clone();
+
+    let mut server = Server::new();
+    let mock = server
+        .mock("POST", "/upload")
+        .match_header(
+            "content-type",
+            Matcher::Regex("^multipart/form-data; boundary=.+".to_string()),
+        )
+        .match_body(Matcher::AllOf(vec![
+            matches_multipart_field("key", "artifact/key"),
+            Matcher::Regex(format!(
+                r#"name="x-amz-checksum-crc32c"\r\n\r\n{crc}\r\n"#,
+                crc = regex::escape(&expected_crc32c_escaped)
+            )),
+            Matcher::Regex(r#"name="file"[\s\S]*file-backed multipart payload"#.to_string()),
+        ]))
+        .with_status(204)
+        .create();
+
+    let client = http_client::Client::new_for_test();
+    let target = FileArtifactUploadTargetInfo {
+        url: format!("{}/upload", server.url()),
+        method: "POST".to_string(),
+        headers: Vec::new(),
+        fields: vec![
+            UploadField {
+                name: "key".to_string(),
+                value: UploadFieldValue::Static {
+                    value: "artifact/key".to_string(),
+                },
+            },
+            UploadField {
+                name: "x-amz-checksum-crc32c".to_string(),
+                value: UploadFieldValue::ContentCrc32C,
+            },
+            UploadField {
+                name: "file".to_string(),
+                value: UploadFieldValue::ContentData,
+            },
+        ],
+    };
+
+    let checksum = block_on_tokio(upload_file_to_target(
+        &client,
+        &target,
+        FileUploadBody::new(path),
+    ))
+    .unwrap();
+
+    mock.assert();
+    assert_eq!(checksum, expected_crc32c);
 }

--- a/crates/graphql/src/api/mutations/create_file_artifact_upload_target.rs
+++ b/crates/graphql/src/api/mutations/create_file_artifact_upload_target.rs
@@ -53,6 +53,7 @@ pub struct FileArtifactUploadTarget {
     pub url: String,
     pub method: String,
     pub headers: Vec<FileArtifactUploadHeader>,
+    pub fields: Vec<FileArtifactUploadField>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -60,6 +61,51 @@ pub struct FileArtifactUploadTarget {
 pub struct FileArtifactUploadHeader {
     pub name: String,
     pub value: String,
+}
+
+/// A single multipart form field for a presigned POST upload target.
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "UploadField")]
+pub struct FileArtifactUploadField {
+    pub name: String,
+    pub value: FileArtifactUploadFieldValue,
+}
+
+/// The value of a multipart form field on a presigned POST upload target.
+#[derive(cynic::InlineFragments, Debug)]
+#[cynic(graphql_type = "UploadFieldValue")]
+pub enum FileArtifactUploadFieldValue {
+    StaticUploadFieldValue(StaticUploadFieldValue),
+    ContentCRC32CFieldValue(ContentCRC32CFieldValue),
+    ContentDataFieldValue(ContentDataFieldValue),
+    #[cynic(fallback)]
+    Unknown,
+}
+
+/// Literal string value known at URL-generation time.
+#[derive(cynic::QueryFragment, Debug)]
+pub struct StaticUploadFieldValue {
+    pub value: String,
+}
+
+/// Signals the client to compute CRC32C of the upload, base64-encode the 4-byte
+/// big-endian result, and send it as the field's value. The GraphQL type
+/// carries no payload beyond a placeholder `_: Boolean`; the client only cares
+/// about the variant tag, but cynic's `QueryFragment` derive requires at least
+/// one field to select.
+#[derive(cynic::QueryFragment, Debug, Default)]
+pub struct ContentCRC32CFieldValue {
+    #[cynic(rename = "_")]
+    _placeholder: Option<bool>,
+}
+
+/// Signals the client to use the raw upload bytes as the field's value. Must
+/// be the final entry in `fields`. See [`ContentCRC32CFieldValue`] for why we
+/// select a placeholder `_: Boolean`.
+#[derive(cynic::QueryFragment, Debug, Default)]
+pub struct ContentDataFieldValue {
+    #[cynic(rename = "_")]
+    _placeholder: Option<bool>,
 }
 
 #[derive(cynic::InputObject, Debug)]

--- a/crates/http_client/src/lib.rs
+++ b/crates/http_client/src/lib.rs
@@ -555,6 +555,16 @@ impl<'a> RequestBuilder<'a> {
         }
     }
 
+    /// Attach a `multipart/form-data` body.
+    /// Not available on wasm because reqwest's multipart builder API is native-only.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn multipart(self, form: reqwest::multipart::Form) -> RequestBuilder<'a> {
+        Self {
+            wrapped: self.wrapped.multipart(form),
+            ..self
+        }
+    }
+
     /// Prevents the system from sleeping due to idle while this request is in progress.
     ///
     /// The provided reason will be used in user-visible logging, so make sure it is

--- a/crates/http_client/src/lib.rs
+++ b/crates/http_client/src/lib.rs
@@ -553,6 +553,16 @@ impl<'a> RequestBuilder<'a> {
         }
     }
 
+    /// Attach a `multipart/form-data` body.
+    /// Not available on wasm because reqwest's multipart builder API is native-only.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn multipart(self, form: reqwest::multipart::Form) -> RequestBuilder<'a> {
+        Self {
+            wrapped: self.wrapped.multipart(form),
+            ..self
+        }
+    }
+
     /// Prevents the system from sleeping due to idle while this request is in progress.
     ///
     /// The provided reason will be used in user-visible logging, so make sure it is

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -923,7 +923,16 @@ type CreateTeamOutput implements Response {
 
 union CreateTeamResult = CreateTeamOutput | UserFacingError
 
+type ContentCRC32CFieldValue {
+  _: Boolean
+}
+
+type ContentDataFieldValue {
+  _: Boolean
+}
+
 type CreateUploadTarget {
+  fields: [UploadField!]!
   headers: [CreateUploadTargetHeader!]!
   method: String!
   url: String!
@@ -3115,6 +3124,10 @@ enum SpaceType {
   User
 }
 
+type StaticUploadFieldValue {
+  value: String!
+}
+
 input StripeBillingPortalInput {
   teamUid: ID!
 }
@@ -3818,6 +3831,13 @@ input UpdatedObjectInput {
   revisionTs: Time!
   uid: ID!
 }
+
+type UploadField {
+  name: String!
+  value: UploadFieldValue!
+}
+
+union UploadFieldValue = ContentCRC32CFieldValue | ContentDataFieldValue | StaticUploadFieldValue
 
 type UsageBasedPricingPolicy {
   toggleable: Boolean!

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -923,7 +923,16 @@ type CreateTeamOutput implements Response {
 
 union CreateTeamResult = CreateTeamOutput | UserFacingError
 
+type ContentCRC32CFieldValue {
+  _: Boolean
+}
+
+type ContentDataFieldValue {
+  _: Boolean
+}
+
 type CreateUploadTarget {
+  fields: [UploadField!]!
   headers: [CreateUploadTargetHeader!]!
   method: String!
   url: String!
@@ -3114,6 +3123,10 @@ enum SpaceType {
   User
 }
 
+type StaticUploadFieldValue {
+  value: String!
+}
+
 input StripeBillingPortalInput {
   teamUid: ID!
 }
@@ -3817,6 +3830,13 @@ input UpdatedObjectInput {
   revisionTs: Time!
   uid: ID!
 }
+
+type UploadField {
+  name: String!
+  value: UploadFieldValue!
+}
+
+union UploadFieldValue = ContentCRC32CFieldValue | ContentDataFieldValue | StaticUploadFieldValue
 
 type UsageBasedPricingPolicy {
   toggleable: Boolean!


### PR DESCRIPTION
## Description

This adds client-side support for HTTP POST multipart forms in the `UploadTarget` abstraction. Currently, only HTTP PUT uploads are supported (via GCS), but S3 requires a form upload instead.

Multipart form support is added to both the REST-based `UploadTarget` client used for harness support and the GraphQL-based version used for file artifact uploads.

To support form construction, callers must provide an `UploadBody`, rather than a direct `reqwest::Body`. This allows:
* Calculating the CRC32C checksum to include as a form field (required by S3)
* Retrieving the contents as either the direct body or as a multipart form `Part`

## Testing

* Tested e2e with WIP server-side S3 storage
* Added unit tests against a mock server

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

