### PR TITLE
Cache settings schema between Linux builds

### DIFF
--- a/.github/actions/bundle_arch_package/action.yml
+++ b/.github/actions/bundle_arch_package/action.yml
@@ -37,5 +37,6 @@ runs:
           -e GIT_RELEASE_TAG="$GIT_RELEASE_TAG" \
           -e GITHUB_ACTIONS="$GITHUB_ACTIONS" \
           -e GITHUB_OUTPUT="/dev/null" \
+          ${SETTINGS_SCHEMA_CACHE:+-e SETTINGS_SCHEMA_CACHE=/github/workspace/.settings_schema_cache.json} \
           arch-bundle-builder \
           ${{ inputs.channel }} ${{ inputs.release-tag }} ${{ inputs.arch }} ${{ inputs.artifact }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -519,6 +519,9 @@ jobs:
       # them with FUSE, which isn't available on GitHub runners (and this is
       # easier and less error-prone than trying to install it).
       APPIMAGE_EXTRACT_AND_RUN: "1"
+      # Cache the generated settings schema so prepare_bundled_resources only
+      # compiles and runs the generator once per job instead of per-package.
+      SETTINGS_SCHEMA_CACHE: ${{ github.workspace }}/.settings_schema_cache.json
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -669,6 +672,10 @@ jobs:
     needs: prepare_release
     if: ${{ inputs.build_linux != false }}
     timeout-minutes: 90
+    env:
+      # Cache the generated settings schema so prepare_bundled_resources only
+      # compiles and runs the generator once per job instead of per-package.
+      SETTINGS_SCHEMA_CACHE: ${{ github.workspace }}/.settings_schema_cache.json
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -845,6 +852,9 @@ jobs:
       # them with FUSE, which isn't available on GitHub runners (and this is
       # easier and less error-prone than trying to install it).
       APPIMAGE_EXTRACT_AND_RUN: "1"
+      # Cache the generated settings schema so prepare_bundled_resources only
+      # compiles and runs the generator once per job instead of per-package.
+      SETTINGS_SCHEMA_CACHE: ${{ github.workspace }}/.settings_schema_cache.json
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -1011,6 +1021,10 @@ jobs:
     needs: [ prepare_release, build_linux_arm_binaries, build_linux_cli_arm_binaries ]
     if: ${{ inputs.build_linux != false }}
     timeout-minutes: 60
+    env:
+      # Cache the generated settings schema so prepare_bundled_resources only
+      # compiles and runs the generator once per job instead of per-package.
+      SETTINGS_SCHEMA_CACHE: ${{ github.workspace }}/.settings_schema_cache.json
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/script/prepare_bundled_resources
+++ b/script/prepare_bundled_resources
@@ -22,6 +22,12 @@
 #   SKIP_SETTINGS_SCHEMA: Set to "1" to skip generating the JSON settings
 #                         schema. By default the schema is always generated
 #                         so that production bundles never accidentally omit it.
+#   SETTINGS_SCHEMA_CACHE: Path to a cache file for the generated schema.
+#                          When set, the first invocation generates the schema
+#                          and saves a copy to this path; subsequent invocations
+#                          copy from the cache instead of regenerating. This
+#                          avoids redundant compilations when bundling multiple
+#                          package formats for the same channel.
 
 set -e
 
@@ -124,19 +130,30 @@ fi
 # Generate settings JSON schema unless explicitly skipped.
 if [ "${SKIP_SETTINGS_SCHEMA:-}" != "1" ]; then
   SCHEMA_OUTPUT="$DEST_DIR/settings_schema.json"
-  echo "Generating settings schema at $SCHEMA_OUTPUT"
 
-  SCHEMA_CMD=(cargo run)
-  if [ -n "$CARGO_PROFILE" ]; then
-    SCHEMA_CMD+=(--profile "$CARGO_PROFILE")
-  fi
-  SCHEMA_CMD+=(--manifest-path "$REPO_ROOT/Cargo.toml" --bin generate_settings_schema --)
-  if [ -n "$CHANNEL" ]; then
-    SCHEMA_CMD+=(--channel "$CHANNEL")
-  fi
-  SCHEMA_CMD+=("$SCHEMA_OUTPUT")
+  if [ -n "${SETTINGS_SCHEMA_CACHE:-}" ] && [ -f "$SETTINGS_SCHEMA_CACHE" ]; then
+    echo "Copying cached settings schema to $SCHEMA_OUTPUT"
+    cp "$SETTINGS_SCHEMA_CACHE" "$SCHEMA_OUTPUT"
+  else
+    echo "Generating settings schema at $SCHEMA_OUTPUT"
 
-  "${SCHEMA_CMD[@]}"
+    SCHEMA_CMD=(cargo run)
+    if [ -n "$CARGO_PROFILE" ]; then
+      SCHEMA_CMD+=(--profile "$CARGO_PROFILE")
+    fi
+    SCHEMA_CMD+=(--manifest-path "$REPO_ROOT/Cargo.toml" --bin generate_settings_schema --)
+    if [ -n "$CHANNEL" ]; then
+      SCHEMA_CMD+=(--channel "$CHANNEL")
+    fi
+    SCHEMA_CMD+=("$SCHEMA_OUTPUT")
+
+    "${SCHEMA_CMD[@]}"
+
+    if [ -n "${SETTINGS_SCHEMA_CACHE:-}" ]; then
+      echo "Caching settings schema at $SETTINGS_SCHEMA_CACHE"
+      cp "$SCHEMA_OUTPUT" "$SETTINGS_SCHEMA_CACHE"
+    fi
+  fi
 fi
 
 echo "Successfully prepared bundled resources in $DEST_DIR"


### PR DESCRIPTION
## Description

**Assumptions**
- The setting schema does not vary between linux builds.
- The separate builds share the same filesystem.

Cache the generated settings schema between Linux builds to avoid redundant compilations.

During Linux release builds, `prepare_bundled_resources` is invoked multiple times (once per package format: `.deb`, `.rpm`, AppImage, Arch, etc.) within the same CI job. Each invocation currently runs `cargo run --bin generate_settings_schema`, which triggers a full compilation and execution of the generator binary — even though the output is identical across formats for the same channel.

This PR adds a `SETTINGS_SCHEMA_CACHE` environment variable to `prepare_bundled_resources`. When set:
- The **first** invocation generates the schema normally and saves a copy to the cache path.
- **Subsequent** invocations copy from the cache instead of regenerating.

The CI workflows (`create_release.yml`) and the Arch Docker action are updated to set this variable in all Linux packaging jobs.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- Verified the script logic handles all edge cases: cache not set (no-op), cache set but file doesn't exist yet (generate + save), cache set and file exists (copy).
- No user-visible changes; this is a CI-only optimization.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
