### PR TITLE
fix(branch-picker): strip linked-worktree '+' marker from branch names

### DIFF
--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -354,7 +354,7 @@ impl CurrentPrompt {
     fn update_on_click_value(&mut self, chip_kind: &ContextChipKind, value: Option<Vec<String>>) {
         log::debug!("Updating prompt on_click value of {chip_kind:?} to {value:?}");
         let filter_values = match chip_kind {
-            ContextChipKind::ShellGitBranch => self.filter_git_branch_on_click_values(value),
+            ContextChipKind::ShellGitBranch => Self::filter_git_branch_on_click_values(value),
             _ => value,
         };
         if let Some(state) = self.states.get_mut(chip_kind) {
@@ -615,10 +615,7 @@ impl CurrentPrompt {
         }
     }
 
-    fn filter_git_branch_on_click_values(
-        &self,
-        values_opt: Option<Vec<String>>,
-    ) -> Option<Vec<String>> {
+    fn filter_git_branch_on_click_values(values_opt: Option<Vec<String>>) -> Option<Vec<String>> {
         values_opt.map(|values| {
             let mut trimmed: Vec<String> = values
                 .into_iter()
@@ -634,9 +631,13 @@ impl CurrentPrompt {
                 b_starts_with_star.cmp(&a_starts_with_star)
             });
 
+            // `git branch` prefixes lines with `* ` for the current branch and
+            // `+ ` for branches checked out in another linked worktree; strip
+            // both so the picker dispatches `git checkout <name>` and not
+            // `git checkout + <name>`.
             trimmed
                 .into_iter()
-                .map(|s| s.trim_start_matches('*').trim().to_string())
+                .map(|s| s.trim_start_matches(['*', '+']).trim().to_string())
                 .collect()
         })
     }

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -637,7 +637,13 @@ impl CurrentPrompt {
             // `git checkout + <name>`.
             trimmed
                 .into_iter()
-                .map(|s| s.trim_start_matches(['*', '+']).trim().to_string())
+                .map(|s| {
+                    s.strip_prefix("* ")
+                        .or_else(|| s.strip_prefix("+ "))
+                        .unwrap_or(s.as_str())
+                        .trim()
+                        .to_string()
+                })
                 .collect()
         })
     }

--- a/app/src/context_chips/current_prompt_test.rs
+++ b/app/src/context_chips/current_prompt_test.rs
@@ -1360,3 +1360,37 @@ impl CommandExecutor for RecordingCommandExecutor {
         false
     }
 }
+
+#[test]
+fn test_filter_git_branch_on_click_values_strips_worktree_and_current_markers() {
+    // Output from `git branch --no-color` includes `* ` for the current branch
+    // and `+ ` for a branch checked out in another linked worktree. Both
+    // prefixes must be stripped before the value is fed to `git checkout`,
+    // otherwise selecting a worktree-linked branch produces commands like
+    // `git checkout + my-branch` which fail (issue #9170).
+    let raw = vec![
+        "  feature-a".to_string(),
+        "+ 273-improvement-suggestion-agent".to_string(),
+        "* master".to_string(),
+        "  feature-b".to_string(),
+    ];
+
+    let filtered = CurrentPrompt::filter_git_branch_on_click_values(Some(raw))
+        .expect("filter should pass through Some");
+
+    // Current branch is sorted to the top, all marker prefixes are gone.
+    assert_eq!(
+        filtered,
+        vec![
+            "master".to_string(),
+            "feature-a".to_string(),
+            "273-improvement-suggestion-agent".to_string(),
+            "feature-b".to_string(),
+        ],
+    );
+}
+
+#[test]
+fn test_filter_git_branch_on_click_values_passes_through_none() {
+    assert_eq!(CurrentPrompt::filter_git_branch_on_click_values(None), None);
+}

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -1466,9 +1466,13 @@ impl Session {
                     );
                     return vec![];
                 };
+                // `git branch` prefixes lines with `* ` for the current branch
+                // and `+ ` for branches checked out in another linked worktree;
+                // strip both so command corrections operate on the bare names.
                 let res = output_string
                     .lines()
-                    .map(|s| s.trim().to_string())
+                    .map(|s| s.trim().trim_start_matches(['*', '+']).trim().to_string())
+                    .filter(|s| !s.is_empty())
                     .collect();
                 res
             }

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -1471,7 +1471,14 @@ impl Session {
                 // strip both so command corrections operate on the bare names.
                 let res = output_string
                     .lines()
-                    .map(|s| s.trim().trim_start_matches(['*', '+']).trim().to_string())
+                    .map(|s| {
+                        let s = s.trim();
+                        s.strip_prefix("* ")
+                            .or_else(|| s.strip_prefix("+ "))
+                            .unwrap_or(s)
+                            .trim()
+                            .to_string()
+                    })
                     .filter(|s| !s.is_empty())
                     .collect();
                 res


### PR DESCRIPTION
## Description

The prompt branch picker tries to check out the selected branch by running `git checkout <branch>`. When the branch is the one displayed with `git branch`'s `+ ` prefix — i.e. checked out in another linked worktree — Warp keeps the `+` glued to the name and dispatches:

```
git checkout + 273-improvement-suggestion-agent
```

which fails with `error: pathspec '+' did not match any file(s) known to git`.

The same `git branch` output is parsed in two places. Both stripped only `*` and left `+` attached:

- `app/src/context_chips/current_prompt.rs` — `filter_git_branch_on_click_values`, the path that drives the prompt picker (the user-facing failure in #9170).
- `app/src/terminal/model/session.rs` — `git_branches_for_command_corrections`, which feeds the command-corrections engine. Worktree-linked branches were previously fed in as `"+ branch"` strings, so corrections would never match them.

Per `man git-branch`, `+ ` is an officially documented two-character marker for linked worktrees, the symmetric counterpart of `* ` for the current branch. The fix is to strip both. Branch names cannot start with `*` (forbidden in refnames) or `+ ` (the prefix is always exactly two chars), so widening the strip is safe.

A small refactor was needed to make the helper unit-testable: `filter_git_branch_on_click_values` did not use `&self`, so it became an associated function and the single call site was updated to `Self::filter_git_branch_on_click_values(...)`.

## Linked Issue

Fixes #9170

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (`ready-to-implement`, bug)

## Screenshots / Videos

Not applicable — no UI changes; the picker UI is unchanged, only the dispatched command argument.

## Testing

Added two unit tests in `app/src/context_chips/current_prompt_test.rs`:

- `test_filter_git_branch_on_click_values_strips_worktree_and_current_markers` — feeds the parser the exact marker mix from the issue (`* master`, `+ <worktree branch>`, plain branches) and asserts the `+` and `*` are stripped and the current branch is sorted to the top.
- `test_filter_git_branch_on_click_values_passes_through_none` — guards the `None` short-circuit.

Without the fix, the first test fails on the `+ 273-improvement-suggestion-agent` entry (`+` survives the strip).

The `session.rs` change mirrors the same one-line strip; it has no public boundary worth a separate dedicated test, but its parser now produces the same shape (bare branch names, no empty lines) that the rest of the engine already expects.

I did not run `./script/presubmit` end-to-end on this machine — full clippy/test on the workspace was too heavy to complete locally — but the change is self-contained: a `trim_start_matches` widening, a `&self` removal, and two unit tests in an existing file. Happy to chase any CI failure that surfaces.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fix branch picker passing the linked-worktree `+` marker to `git checkout`, which made selecting a branch checked out in another worktree fail with `pathspec '+' did not match`.