### PR TITLE
[DRAFT] feat: add starter flake.nix for nix users (#9296)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,97 @@
+{
+  description = "Development shell for warpdotdev/warp (the open-source Warp terminal).";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+
+        # Pin the same toolchain rust-toolchain.toml requests so
+        # `cargo build` doesn't try to download a different stable
+        # underneath rustup. Keep this in sync with rust-toolchain.toml.
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        # System packages mirroring the Linux build/test deps installed
+        # by `script/linux/install_build_deps` and
+        # `script/linux/install_runtime_deps`. The mapping is approximate;
+        # nix package names diverge from apt names. Maintainers should
+        # treat this list as a starting point and refine for their
+        # preferred pinning strategy (e.g. swap rust-overlay for fenix).
+        nativeBuildInputs = with pkgs; [
+          rustToolchain
+          pkg-config
+          cmake
+          protobuf
+          jq
+          brotli
+          # Matches `clang-format` from install_build_deps.
+          clang-tools
+        ];
+
+        # Linux-only runtime libraries. On macOS these come from the
+        # system SDK and shouldn't be in the dev shell.
+        linuxRuntimeInputs = with pkgs; lib.optionals stdenv.isLinux [
+          openssl
+          freetype
+          expat
+          libgit2
+          fontconfig
+          alsa-lib
+          libclang.lib
+          # X11 stack
+          xorg.libX11
+          xorg.libxcb
+          xorg.libXi
+          xorg.libXcursor
+          libxkbcommon
+          # Wayland
+          wayland
+          libGL
+          # Vulkan / EGL
+          mesa
+          vulkan-loader
+        ];
+
+        # macOS frameworks the Rust crates link against.
+        darwinFrameworks = with pkgs; lib.optionals stdenv.isDarwin [
+          # Framework set used by warpui — Metal, AppKit, etc. Rely on the
+          # darwin xcrun toolchain rather than nix-built frameworks for
+          # the actual compilation; this is documented as a known sharp
+          # edge for nix users on macOS.
+        ];
+      in
+      {
+        # Dev shell only. We deliberately do not provide a `packages.default`
+        # build of Warp: the cargo build wraps platform-specific shader
+        # compilation (Metal on macOS, Vulkan on Linux) that nix would
+        # need a more involved derivation to handle correctly. Adding a
+        # derivation is a clean follow-up.
+        devShells.default = pkgs.mkShell {
+          inherit nativeBuildInputs;
+          buildInputs = linuxRuntimeInputs ++ darwinFrameworks;
+
+          # Prevent the wrapped clang/gcc from loading the nix-store
+          # libclang while bindgen-using crates expect a system one.
+          LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+
+          shellHook = ''
+            echo "warp dev shell"
+            echo "rust: $(rustc --version 2>/dev/null || echo "(rustc not found — toolchain failed to load)")"
+            echo "node + yarn need to be on PATH (see WARP.md \"Node.js setup\")."
+          '';
+        };
+
+        # Convenience: `nix fmt` runs nixpkgs-fmt on the flake itself.
+        formatter = pkgs.nixpkgs-fmt;
+      });
+}


### PR DESCRIPTION
## ⚠️ Draft — runtime untested

I cannot run \`nix flake check\` or \`nix develop\` in this build environment, so the flake is **inspection-only verified** and parses by static read. A maintainer with nix installed should validate before merging.

## Description

Resolves #9296 (dev shell scope only).

Provides a starter \`flake.nix\` that gives nix users a buildable dev shell against the same Rust toolchain (1.92.0) the rest of the repo already pins via \`rust-toolchain.toml\`. Scope is deliberately narrow — dev shell only — to keep the maintenance surface this PR carries small.

## Linked Issue

- [x] The linked issue is labeled \`ready-to-spec\` or \`ready-to-implement\`. (#9296 is \`ready-to-implement\`.)

Resolves #9296.

## Changes

| File | Change |
|---|---|
| \`flake.nix\` (new) | flake-utils + rust-overlay + nixpkgs unstable. \`devShells.default\` includes rust toolchain (read from \`rust-toolchain.toml\`), build deps mirroring \`script/linux/install_build_deps\`, Linux runtime libs from \`install_runtime_deps\`, and \`LIBCLANG_PATH\` so bindgen finds libclang. \`formatter = nixpkgs-fmt\`. |

## Explicitly out of scope

- A \`packages.default\` derivation that actually builds Warp via nix. The cargo build wraps platform-specific shader compilation (Metal/Vulkan); that needs a deeper derivation. Clean follow-up PR.
- \`nixosModule\` / \`homeManagerModule\` outputs. The original issue only asked for flake inputs, not a NixOS module.

## Style choices to confirm with maintainers

If maintainers prefer different conventions, this PR is happy to be the starting point — these are routine refactors once shape is agreed:

- **rust-overlay vs fenix** for toolchain pinning. I picked rust-overlay because \`fromRustupToolchainFile\` reads \`rust-toolchain.toml\` directly, but fenix is fine if preferred.
- **flake-utils vs explicit \`systems\` enumeration**. I used flake-utils for brevity.
- **devShell-only vs full package output**. Same reasoning as above.

## Testing — honest status

| What | Status |
|---|---|
| Static parse (file is valid Nix syntax) | ✅ |
| \`nix flake check\` | ❌ Not run — no nix in this env |
| \`nix develop\` then \`cargo build\` | ❌ Not run |
| Verified \`rust-toolchain.toml\` exists at the path the flake reads | ✅ |
| Verified the deb→nix package mapping by reading \`install_build_deps\` and \`install_runtime_deps\` | ✅ (best-effort; package-name divergence is real) |

**Maintainer verification needed before merge:**

```bash
nix flake check
nix develop
# inside the shell:
cargo build
```

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added a starter \`flake.nix\` that nix users can reference to get a working dev shell with a pinned Rust toolchain. Thanks @lonexreb!