### PR TITLE
[DRAFT] docs(bootstrap): explain what the dispatcher script does (#9421)

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,35 @@
 #!/usr/bin/env bash
+#
+# Bootstraps a development environment for Warp on the current platform.
+#
+# What this script does (high level):
+#
+#   * Installs the platform's system-level build/runtime dependencies via
+#     the host package manager (`brew` on macOS, `apt` on Debian/Ubuntu,
+#     `winget` on Windows).
+#   * Installs the Rust toolchain pinned by `rust-toolchain.toml` and the
+#     Cargo helper binaries the build/test pipeline expects.
+#   * Verifies that Node.js and yarn are available, since
+#     `crates/command-signatures-v2` runs a TypeScript build at
+#     `cargo build` time. (No auto-install — see the "Node.js setup"
+#     section in WARP.md.)
+#   * On macOS, downloads the Metal toolchain via `xcodebuild`.
+#
+# What this script may do that requires `sudo` / Administrator rights
+# you may not have expected:
+#
+#   * Switch the active Xcode developer directory on macOS.
+#   * Install system packages via `apt-get install` on Linux.
+#   * Install brew casks (e.g. Docker) on macOS.
+#   * Authenticate with `gcloud` so SSH integration tests can run.
+#
+# Each platform-specific script under `script/<platform>/bootstrap`
+# carries the actual installation logic. Read it before running if you
+# prefer to install dependencies through your own package manager
+# (Volta, asdf, mise, OrbStack instead of Docker, etc.) — the goal of
+# this top-level script is just to dispatch by platform.
+#
+# Tracked at #9421.
 
 OS_TYPE="$(uname -s)"
 


### PR DESCRIPTION
## ⚠️ Draft — minimal slice of #9421

#9421 raised eight separate concerns about the bootstrap process. **This PR addresses only the first one** — the up-front explanation of what the script does — by adding a comment block at the top of \`script/bootstrap\`. The other seven (cargo-bundle git pin, brew casks, Docker default, gcloud auth, etc.) are real but each their own design debate; happy to follow up on those individually if maintainers want them split that way.

## Description

Resolves the documentation portion of #9421.

The dispatcher \`script/bootstrap\` is what \`README.md\` tells new contributors to run. Before this PR it was a 14-line conditional with no preamble. After this PR it carries a ~30-line comment block summarising what each platform script will do, what operations require \`sudo\`, and where to find the actual installation logic if you want to install deps your own way (Volta over corepack, OrbStack over Docker, etc.).

## Linked Issue

- [x] The linked issue is labeled \`ready-to-spec\` or \`ready-to-implement\`. (#9421 is \`ready-to-implement\`.)

Partially resolves #9421.

## Changes

| File | Change |
|---|---|
| \`script/bootstrap\` | Comment-only addition. Explains what each platform branch does at a high level, calls out sudo/admin operations, and points readers at the per-platform scripts for the actual logic. No behavior change. |

## Honest test status

| What | Status |
|---|---|
| \`bash -n script/bootstrap\` (syntax check) | ✅ |
| Runtime behavior change | None — comment-only |
| Wording reviewed against the issue's specific complaints | ✅ |

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: \`script/bootstrap\` now opens with an up-front summary of what each platform script will install and which operations require sudo. Thanks @lonexreb!