### PR TITLE
Add Left/Right position toggle to vertical tabs panel settings popup

### DIFF
--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -40,8 +40,8 @@ use warpui::{EntityId, WeakViewHandle, WindowId};
 
 use super::global_actions::{ForkFromExchange, ForkedConversationDestination};
 use super::tab_settings::{
-    VerticalTabsCompactSubtitle, VerticalTabsDisplayGranularity, VerticalTabsPrimaryInfo,
-    VerticalTabsTabItemMode, VerticalTabsViewMode,
+    VerticalTabsCompactSubtitle, VerticalTabsDisplayGranularity, VerticalTabsPanelSide,
+    VerticalTabsPrimaryInfo, VerticalTabsTabItemMode, VerticalTabsViewMode,
 };
 use super::view::{OnboardingTutorial, WorkspaceBanner};
 
@@ -278,6 +278,8 @@ pub enum WorkspaceAction {
     SetVerticalTabsViewMode(VerticalTabsViewMode),
     SetVerticalTabsPrimaryInfo(VerticalTabsPrimaryInfo),
     SetVerticalTabsCompactSubtitle(VerticalTabsCompactSubtitle),
+    /// Moves the vertical tabs panel to the specified side of the terminal.
+    SetVerticalTabsPanelSide(VerticalTabsPanelSide),
     ToggleVerticalTabsShowPrLink,
     ToggleVerticalTabsShowDiffStats,
     ToggleVerticalTabsShowDetailsOnHover,
@@ -843,6 +845,7 @@ impl WorkspaceAction {
             | SetVerticalTabsViewMode(_)
             | SetVerticalTabsPrimaryInfo(_)
             | SetVerticalTabsCompactSubtitle(_)
+            | SetVerticalTabsPanelSide(_)
             | ToggleVerticalTabsShowPrLink
             | ToggleVerticalTabsShowDiffStats
             | ToggleVerticalTabsShowDetailsOnHover

--- a/app/src/workspace/action_tests.rs
+++ b/app/src/workspace/action_tests.rs
@@ -1,8 +1,8 @@
 use super::WorkspaceAction;
 use crate::pane_group::TerminalPaneId;
 use crate::workspace::tab_settings::{
-    VerticalTabsDisplayGranularity, VerticalTabsPrimaryInfo, VerticalTabsTabItemMode,
-    VerticalTabsViewMode,
+    VerticalTabsDisplayGranularity, VerticalTabsPanelSide, VerticalTabsPrimaryInfo,
+    VerticalTabsTabItemMode, VerticalTabsViewMode,
 };
 use crate::workspace::PaneViewLocator;
 use warpui::EntityId;
@@ -61,6 +61,18 @@ fn primary_info_change_does_not_save_workspace_state() {
     .should_save_app_state_on_action());
     assert!(
         !WorkspaceAction::SetVerticalTabsPrimaryInfo(VerticalTabsPrimaryInfo::Branch)
+            .should_save_app_state_on_action()
+    );
+}
+
+#[test]
+fn panel_side_change_does_not_save_workspace_state() {
+    assert!(
+        !WorkspaceAction::SetVerticalTabsPanelSide(VerticalTabsPanelSide::Left)
+            .should_save_app_state_on_action()
+    );
+    assert!(
+        !WorkspaceAction::SetVerticalTabsPanelSide(VerticalTabsPanelSide::Right)
             .should_save_app_state_on_action()
     );
 }

--- a/app/src/workspace/tab_settings.rs
+++ b/app/src/workspace/tab_settings.rs
@@ -541,6 +541,14 @@ define_settings_group!(TabSettings, settings: [
     directory_tab_colors: DirectoryTabColors,
 ]);
 
+/// Which side of the terminal the vertical tabs panel is displayed on.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum VerticalTabsPanelSide {
+    #[default]
+    Left,
+    Right,
+}
+
 #[cfg(test)]
 #[path = "tab_settings_tests.rs"]
 mod tests;

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -22073,21 +22073,33 @@ impl View for Workspace {
             && self.vertical_tabs_panel_open
             && self.vertical_tabs_panel.show_settings_popup
         {
-            stack.add_positioned_overlay_child(
-                Dismiss::new(render_settings_popup(&self.vertical_tabs_panel, app))
-                    .prevent_interaction_with_other_elements()
-                    .on_dismiss(|ctx, _| {
-                        ctx.dispatch_typed_action(WorkspaceAction::ToggleVerticalTabsSettingsPopup);
-                    })
-                    .finish(),
-                OffsetPositioning::offset_from_save_position_element(
-                    VERTICAL_TABS_SETTINGS_BUTTON_POSITION_ID,
-                    vec2f(0., 4.),
-                    PositionedElementOffsetBounds::WindowByPosition,
-                    PositionedElementAnchor::BottomLeft,
-                    ChildAnchor::TopLeft,
-                ),
-            );
+            {
+                let tabs_side = Self::tabs_panel_side(
+                    &TabSettings::as_ref(app).header_toolbar_chip_selection,
+                );
+                let (popup_anchor, popup_child_anchor) = if tabs_side == PanelPosition::Left {
+                    (PositionedElementAnchor::BottomLeft, ChildAnchor::TopLeft)
+                } else {
+                    (PositionedElementAnchor::BottomRight, ChildAnchor::TopRight)
+                };
+                stack.add_positioned_overlay_child(
+                    Dismiss::new(render_settings_popup(&self.vertical_tabs_panel, app))
+                        .prevent_interaction_with_other_elements()
+                        .on_dismiss(|ctx, _| {
+                            ctx.dispatch_typed_action(
+                                WorkspaceAction::ToggleVerticalTabsSettingsPopup,
+                            );
+                        })
+                        .finish(),
+                    OffsetPositioning::offset_from_save_position_element(
+                        VERTICAL_TABS_SETTINGS_BUTTON_POSITION_ID,
+                        vec2f(0., 4.),
+                        PositionedElementOffsetBounds::WindowByPosition,
+                        popup_anchor,
+                        popup_child_anchor,
+                    ),
+                );
+            }
         }
 
         if FeatureFlag::VerticalTabs.is_enabled()

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -20490,6 +20490,17 @@ impl TypedActionView for Workspace {
                 let config = TabSettings::as_ref(ctx)
                     .header_toolbar_chip_selection
                     .clone();
+                let already_on_side = match side {
+                    VerticalTabsPanelSide::Left => {
+                        config.left_items().contains(&HeaderToolbarItemKind::TabsPanel)
+                    }
+                    VerticalTabsPanelSide::Right => {
+                        config.right_items().contains(&HeaderToolbarItemKind::TabsPanel)
+                    }
+                };
+                if already_on_side {
+                    return;
+                }
                 let mut left_items = config.left_items();
                 let mut right_items = config.right_items();
                 left_items.retain(|i| i != &HeaderToolbarItemKind::TabsPanel);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -433,7 +433,7 @@ use super::{ActiveSession, TabBarDropTargetData, TabBarLocation};
 
 use super::tab_settings::{
     HeaderToolbarChipSelection, NewTabPlacement, TabSettings, TabSettingsChangedEvent,
-    VerticalTabsDisplayGranularity, WorkspaceDecorationVisibility,
+    VerticalTabsDisplayGranularity, VerticalTabsPanelSide, WorkspaceDecorationVisibility,
 };
 use super::util::{
     PaneViewLocator, TabMovement, TerminalSessionFallbackBehavior, WelcomeTipsViewState,
@@ -20483,6 +20483,40 @@ impl TypedActionView for Workspace {
                     ),
                     ctx
                 );
+                ctx.notify();
+            }
+            SetVerticalTabsPanelSide(side) => {
+                let side = *side;
+                let config = TabSettings::as_ref(ctx)
+                    .header_toolbar_chip_selection
+                    .clone();
+                let mut left_items = config.left_items();
+                let mut right_items = config.right_items();
+                left_items.retain(|i| i != &HeaderToolbarItemKind::TabsPanel);
+                right_items.retain(|i| i != &HeaderToolbarItemKind::TabsPanel);
+                match side {
+                    VerticalTabsPanelSide::Left => {
+                        left_items.insert(0, HeaderToolbarItemKind::TabsPanel);
+                    }
+                    VerticalTabsPanelSide::Right => {
+                        right_items.insert(0, HeaderToolbarItemKind::TabsPanel);
+                    }
+                }
+                let selection = if left_items == HeaderToolbarItemKind::default_left()
+                    && right_items == HeaderToolbarItemKind::default_right()
+                {
+                    HeaderToolbarChipSelection::Default
+                } else {
+                    HeaderToolbarChipSelection::Custom {
+                        left: left_items,
+                        right: right_items,
+                    }
+                };
+                TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings
+                        .header_toolbar_chip_selection
+                        .set_value(selection, ctx));
+                });
                 ctx.notify();
             }
             ToggleVerticalTabsShowPrLink => {

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -41,9 +41,10 @@ use crate::util::bindings::keybinding_name_to_display_string;
 use crate::util::color::Opacity;
 use crate::workspace::action::WorkspaceAction;
 use crate::workspace::hoa_onboarding::HoaOnboardingStep;
+use crate::workspace::header_toolbar_item::HeaderToolbarItemKind;
 use crate::workspace::tab_settings::{
     TabSettings, VerticalTabsCompactSubtitle, VerticalTabsDisplayGranularity,
-    VerticalTabsPrimaryInfo, VerticalTabsTabItemMode, VerticalTabsViewMode,
+    VerticalTabsPanelSide, VerticalTabsPrimaryInfo, VerticalTabsTabItemMode, VerticalTabsViewMode,
 };
 use crate::workspace::{
     PaneViewLocator, TabBarLocation, TabContextMenuAnchor, VerticalTabsPaneContextMenuTarget,
@@ -594,6 +595,8 @@ pub(super) struct VerticalTabsPanelState {
     show_pr_link_info_tooltip_mouse_state: MouseStateHandle,
     show_diff_stats_mouse_state: MouseStateHandle,
     show_details_on_hover_mouse_state: MouseStateHandle,
+    panel_side_left_mouse_state: MouseStateHandle,
+    panel_side_right_mouse_state: MouseStateHandle,
     pub(super) show_settings_popup: bool,
 }
 
@@ -629,6 +632,8 @@ impl Default for VerticalTabsPanelState {
             show_pr_link_info_tooltip_mouse_state: Default::default(),
             show_diff_stats_mouse_state: Default::default(),
             show_details_on_hover_mouse_state: Default::default(),
+            panel_side_left_mouse_state: Default::default(),
+            panel_side_right_mouse_state: Default::default(),
             show_settings_popup: false,
         }
     }
@@ -4669,6 +4674,81 @@ pub(super) fn render_settings_popup(
         appearance,
         theme,
     ));
+
+    let current_panel_side =
+        if TabSettings::as_ref(app)
+            .header_toolbar_chip_selection
+            .left_items()
+            .contains(&HeaderToolbarItemKind::TabsPanel)
+        {
+            VerticalTabsPanelSide::Left
+        } else {
+            VerticalTabsPanelSide::Right
+        };
+
+    let position_header = Container::new(
+        Text::new_inline(
+            "Position".to_string(),
+            appearance.ui_font_family(),
+            SETTINGS_POPUP_MENU_ITEM_FONT_SIZE,
+        )
+        .with_color(sub_text.into())
+        .finish(),
+    )
+    .with_horizontal_padding(16.)
+    .with_margin_bottom(4.)
+    .finish();
+
+    let position_segmented_control = Container::new(
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(
+                Expanded::new(
+                    1.,
+                    render_popup_panel_side_segment(
+                        "Left",
+                        matches!(current_panel_side, VerticalTabsPanelSide::Left),
+                        state.panel_side_left_mouse_state.clone(),
+                        VerticalTabsPanelSide::Left,
+                        appearance,
+                        theme,
+                    ),
+                )
+                .finish(),
+            )
+            .with_child(
+                Expanded::new(
+                    1.,
+                    render_popup_panel_side_segment(
+                        "Right",
+                        matches!(current_panel_side, VerticalTabsPanelSide::Right),
+                        state.panel_side_right_mouse_state.clone(),
+                        VerticalTabsPanelSide::Right,
+                        appearance,
+                        theme,
+                    ),
+                )
+                .finish(),
+            )
+            .finish(),
+    )
+    .with_uniform_padding(4.)
+    .with_background(internal_colors::fg_overlay_2(theme))
+    .with_corner_radius(CornerRadius::with_all(Radius::Pixels(
+        SETTINGS_POPUP_CORNER_RADIUS,
+    )))
+    .finish();
+
+    popup_col.add_child(make_divider(theme));
+    popup_col.add_child(position_header);
+    popup_col.add_child(
+        Container::new(position_segmented_control)
+            .with_horizontal_padding(16.)
+            .with_padding_bottom(4.)
+            .finish(),
+    );
+
     EventHandler::new(
         ConstrainedBox::new(
             Container::new(popup_col.finish())
@@ -5021,6 +5101,46 @@ fn render_popup_text_segment(
         ctx.dispatch_typed_action(WorkspaceAction::SetVerticalTabsDisplayGranularity(
             granularity,
         ));
+    })
+    .with_cursor(Cursor::PointingHand)
+    .finish()
+}
+
+fn render_popup_panel_side_segment(
+    label: &str,
+    is_selected: bool,
+    mouse_state: MouseStateHandle,
+    side: VerticalTabsPanelSide,
+    appearance: &Appearance,
+    theme: &WarpTheme,
+) -> Box<dyn Element> {
+    let label = label.to_string();
+    let main_text = theme.main_text_color(theme.background());
+    let sub_text = theme.sub_text_color(theme.background());
+    Hoverable::new(mouse_state, move |hover_state| {
+        let background = if is_selected {
+            internal_colors::fg_overlay_3(theme)
+        } else if hover_state.is_hovered() {
+            internal_colors::fg_overlay_1(theme)
+        } else {
+            ThemeFill::Solid(ColorU::transparent_black())
+        };
+
+        Container::new(
+            Align::new(
+                Text::new_inline(label.clone(), appearance.ui_font_family(), 14.)
+                    .with_color(if is_selected { main_text } else { sub_text }.into())
+                    .finish(),
+            )
+            .finish(),
+        )
+        .with_background(background)
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+        .with_vertical_padding(2.)
+        .finish()
+    })
+    .on_click(move |ctx, _, _| {
+        ctx.dispatch_typed_action(WorkspaceAction::SetVerticalTabsPanelSide(side));
     })
     .with_cursor(Cursor::PointingHand)
     .finish()


### PR DESCRIPTION
## Summary

  - Adds a "Position" section (Left / Right segmented control) to the
  vertical tabs panel "View options" popup
  - Clicking "Right" moves the tabs panel to the right side of the
  terminal; clicking "Left" restores it to the default left position
  - Reuses the existing `HeaderToolbarChipSelection` infrastructure — no
   new settings storage needed

  ## Changes

  - `tab_settings.rs` — new `VerticalTabsPanelSide { Left, Right }` enum
  - `action.rs` — new `SetVerticalTabsPanelSide(VerticalTabsPanelSide)`
  action
  - `action_tests.rs` — test for `should_save_app_state_on_action`
  - `view.rs` — action handler that moves `TabsPanel` between left/right
   items
  - `vertical_tabs.rs` — mouse states, helper render function, and
  "Position" UI section
 ## Demo

https://github.com/user-attachments/assets/cf3e6408-64c9-4992-afe3-2d0fb19c3e0a

<img width="1363" height="860" alt="right-position-tabs panel" src="https://github.com/user-attachments/assets/b03e77ac-0d89-4833-b1dc-850fe33eaf25" />

<img width="277" height="111" alt="Position-example" src="https://github.com/user-attachments/assets/a68e82fc-fd2a-402c-986b-52e3a3a235fb" />




  Closes #9825 