### PR TITLE
Add editable keybinding for toggling the conversation details panel.

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -26467,6 +26467,12 @@ impl View for TerminalView {
             context.set.insert("InsideRepository");
         }
 
+        if self.can_show_conversation_details_ui_from_model(&model_lock, app) {
+            context
+                .set
+                .insert(init::CAN_SHOW_CONVERSATION_DETAILS_KEY);
+        }
+
         let active_conversation = if FeatureFlag::AgentView.is_enabled() {
             self.agent_view_controller
                 .as_ref(app)

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -26467,10 +26467,9 @@ impl View for TerminalView {
             context.set.insert("InsideRepository");
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
         if self.can_show_conversation_details_ui_from_model(&model_lock, app) {
-            context
-                .set
-                .insert(init::CAN_SHOW_CONVERSATION_DETAILS_KEY);
+            context.set.insert(init::CAN_SHOW_CONVERSATION_DETAILS_KEY);
         }
 
         let active_conversation = if FeatureFlag::AgentView.is_enabled() {

--- a/app/src/terminal/view/init.rs
+++ b/app/src/terminal/view/init.rs
@@ -60,6 +60,7 @@ pub const INPUT_BOX_VISIBLE_KEY: &str = "InputVisible";
 pub const KEYBOARD_PROTOCOL_ENABLED_KEY: &str = "KeyboardProtocolEnabled";
 pub const CLI_AGENT_SESSION_ACTIVE_KEY: &str = "CLIAgentSessionActive";
 pub const ROOT_CLOUD_MODE_PANE_KEY: &str = "RootCloudModePane";
+pub const CAN_SHOW_CONVERSATION_DETAILS_KEY: &str = "CanShowConversationDetails";
 
 /// Some keybindings will do different things in different contexts. We break
 /// these into their own function to ensure we pay special attention to
@@ -1085,6 +1086,14 @@ pub fn init(app: &mut AppContext) {
     )
     .with_enabled(|| FeatureFlag::Projects.is_enabled())
     .with_context_predicate(id!("Workspace") & id!(flags::IS_ANY_AI_ENABLED))]);
+
+    app.register_editable_bindings([EditableBinding::new(
+        "terminal:toggle_conversation_details_panel",
+        "Toggle Conversation Details Panel",
+        TerminalAction::ToggleConversationDetailsPanel,
+    )
+    .with_group(bindings::BindingGroup::WarpAi.as_str())
+    .with_context_predicate(id!("Terminal") & id!(CAN_SHOW_CONVERSATION_DETAILS_KEY))]);
 
     // Register bindings for starting a new cloud agent conversation.
     {

--- a/app/src/terminal/view/init.rs
+++ b/app/src/terminal/view/init.rs
@@ -1087,6 +1087,7 @@ pub fn init(app: &mut AppContext) {
     .with_enabled(|| FeatureFlag::Projects.is_enabled())
     .with_context_predicate(id!("Workspace") & id!(flags::IS_ANY_AI_ENABLED))]);
 
+    #[cfg(not(target_arch = "wasm32"))]
     app.register_editable_bindings([EditableBinding::new(
         "terminal:toggle_conversation_details_panel",
         "Toggle Conversation Details Panel",


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
WISOTT. Follows precedent for defining keys in the keymap context and uses existing function for determining whether this keybinding should be active.

Defaults to unset - I wasn't sure of a good keybind for this and don't think it warrants a default.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?
-->
Ran locally, set a keybinding (cmd + alt + I), and then observed toggle behavior.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode


## Changelog Entries for Stable
<!--
The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->
CHANGELOG-IMPROVEMENT: The conversation details panelcan now be opened and closed with a configurable keyboard shortcut.
