### PR TITLE
Remove alt-screen sampling

### DIFF
--- a/app/src/terminal/alt_screen/alt_screen_element.rs
+++ b/app/src/terminal/alt_screen/alt_screen_element.rs
@@ -721,6 +721,9 @@ impl Element for AltScreenElement {
         let obfuscate_secrets =
             get_secret_obfuscation_mode(app).and(&grid.get_secret_obfuscation());
 
+        let mut sampler = model.alt_screen().bg_color_sampler.lock();
+        sampler.reset();
+
         // Render grid cells. Since the alt screen has no scrollback we can always start at index 0.
         record_trace_event!("alt_screen_element:paint:preparing_to_render_grid");
         let start_row = self.scroll_top.as_f64();
@@ -759,7 +762,7 @@ impl Element for AltScreenElement {
             cursor_visible.then(|| model.alt_screen().cursor_style().shape),
             RespectDisplayedOutput::Yes,
             &model.image_id_to_metadata,
-            None,
+            Some(&mut sampler),
             self.grid_render_params.hide_cursor_cell,
             ctx,
             app,

--- a/app/src/terminal/alt_screen/alt_screen_element.rs
+++ b/app/src/terminal/alt_screen/alt_screen_element.rs
@@ -38,7 +38,7 @@ use warpui::text::SelectionType;
 use super::{should_intercept_mouse, should_intercept_scroll};
 use std::ops::{Deref as _, Range};
 use std::sync::Arc;
-use warpui::elements::{Axis, Fill, Point as UiPoint, ScrollData, ScrollableElement};
+use warpui::elements::{Axis, Point as UiPoint, ScrollData, ScrollableElement};
 use warpui::fonts::Properties;
 use warpui::geometry::rect::RectF;
 use warpui::geometry::vector::Vector2F;
@@ -721,18 +721,6 @@ impl Element for AltScreenElement {
         let obfuscate_secrets =
             get_secret_obfuscation_mode(app).and(&grid.get_secret_obfuscation());
 
-        let mut sampler = model.alt_screen().bg_color_sampler.lock();
-        if let Some(bg_color) = sampler.most_common() {
-            if !bg_color.is_fully_transparent() {
-                if let Some(bounds) = self.bounds {
-                    ctx.scene
-                        .draw_rect_without_hit_recording(bounds)
-                        .with_background(Fill::Solid(bg_color));
-                }
-            }
-        }
-        sampler.reset();
-
         // Render grid cells. Since the alt screen has no scrollback we can always start at index 0.
         record_trace_event!("alt_screen_element:paint:preparing_to_render_grid");
         let start_row = self.scroll_top.as_f64();
@@ -771,7 +759,7 @@ impl Element for AltScreenElement {
             cursor_visible.then(|| model.alt_screen().cursor_style().shape),
             RespectDisplayedOutput::Yes,
             &model.image_id_to_metadata,
-            Some(&mut sampler),
+            None,
             self.grid_render_params.hide_cursor_cell,
             ctx,
             app,


### PR DESCRIPTION
## Description

Fix background colour bleed in the alt screen when programs use coloured backgrounds for content highlighting (e.g. `delta`, `diff-so-fancy`).

Before rendering grid cells, `AltScreenElement::paint()` samples cell background colours via `ColorSampler`, finds the most common colour, and paints a full-viewport rect with it. This is intended to infer the background of programs like vim/htop, but it breaks when content uses mixed background colours for syntax highlighting.

When a coloured region (e.g. green addition lines in a diff) dominates >50% of visible cells, the sampler picks that colour as the "background" and fills the entire viewport — bleeding through cells that have transparent backgrounds (context lines, uncoloured text).

The fix removes the pre-render background fill rect. Per-cell background rendering already handles all cases correctly — opaque cells draw their own backgrounds, and transparent cells show the terminal's theme background.

The `ColorSampler` infrastructure is preserved as it's still used by CLI agent and agent footer code via `inferred_bg_color()`.

## Linked Issue

Fixes #8393

## Screenshots

### Before

Bug as seen in my production build.
<img width="1242" height="531" alt="warp_pager_bug_erroneous" src="https://github.com/user-attachments/assets/c9baba69-b1d5-42b5-b517-48dc2c39f9c2" />

When scrolling two lines down, lines render as expected.
<img width="1242" height="531" alt="warp_pager_bug_two_lines_scrolled" src="https://github.com/user-attachments/assets/66996f2f-5255-4c4a-b6cd-cfda4efeca89" />

Before shot to compare to after using my current build. Everything is green where it should not be.
<img width="1242" height="948" alt="image" src="https://github.com/user-attachments/assets/928a38da-106d-4355-8181-3305a85080f3" />

### After

After shot using the patched debug build. Latter lines do not show as highlighted as expected.
<img width="1242" height="948" alt="image" src="https://github.com/user-attachments/assets/00f9cd11-7209-4c3b-8107-8d2c70575602" />

## Testing

- Reproduced with `cat file.diff | delta` — scrolling through a large addition block caused green to fill the entire viewport
- Added debug logging to confirm `ColorSampler.most_common()` returns `(0, 40, 0, 255)` (delta's green) when the bug triggers
- Disabled the fill rect and confirmed the bleed is eliminated
- Tested `vim` — background renders correctly without the fill rect
- `cargo fmt` and `cargo clippy -p warp --all-targets -- -D warnings` pass clean

CHANGELOG-BUG-FIX: Fixed background colour bleeding in alt screen programs (e.g. delta, diff-so-fancy) where coloured regions would incorrectly fill the entire viewport when they dominated the visible area.

