### PR TITLE
fix(mcp): show file-based MCP servers to the agent in fresh conversations (#9111)

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -177,15 +177,26 @@ impl RequestParams {
                 .copied()
                 .collect();
 
-            // If file-based MCP servers are enabled, add active servers in scope of
-            // the user's current working directory
-            if let Some(cwd) = session_context.current_working_directory() {
-                active_servers.extend(
-                    templatable_manager
-                        .get_active_file_based_servers(Path::new(cwd), app)
-                        .values(),
-                );
-            }
+            // Add file-based MCP servers in scope.
+            //
+            // We always include home-rooted (global) servers, regardless of whether
+            // a cwd is available. This matters for fresh conversations whose
+            // `current_working_directory()` returns `None` because no exchange has
+            // populated one yet — without this, globally-configured servers in
+            // `~/.warp/.mcp.json` would be invisible to the agent even though they
+            // appear connected in Settings (#9111).
+            //
+            // Repo-scoped servers in `<repo>/.warp/.mcp.json` are still gated on
+            // `cwd` since they have no meaning without one.
+            let cwd_path = session_context
+                .current_working_directory()
+                .as_deref()
+                .map(Path::new);
+            active_servers.extend(
+                templatable_manager
+                    .get_active_file_based_servers(cwd_path, app)
+                    .values(),
+            );
 
             // Include any ephemeral MCP servers started via the Oz CLI.
             active_servers.extend(

--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -180,15 +180,26 @@ impl RequestParams {
                 .copied()
                 .collect();
 
-            // If file-based MCP servers are enabled, add active servers in scope of
-            // the user's current working directory
-            if let Some(cwd) = session_context.current_working_directory() {
-                active_servers.extend(
-                    templatable_manager
-                        .get_active_file_based_servers(Path::new(cwd), app)
-                        .values(),
-                );
-            }
+            // Add file-based MCP servers in scope.
+            //
+            // We always include home-rooted (global) servers, regardless of whether
+            // a cwd is available. This matters for fresh conversations whose
+            // `current_working_directory()` returns `None` because no exchange has
+            // populated one yet — without this, globally-configured servers in
+            // `~/.warp/.mcp.json` would be invisible to the agent even though they
+            // appear connected in Settings (#9111).
+            //
+            // Repo-scoped servers in `<repo>/.warp/.mcp.json` are still gated on
+            // `cwd` since they have no meaning without one.
+            let cwd_path = session_context
+                .current_working_directory()
+                .as_deref()
+                .map(Path::new);
+            active_servers.extend(
+                templatable_manager
+                    .get_active_file_based_servers(cwd_path, app)
+                    .values(),
+            );
 
             // Include any ephemeral MCP servers started via the Oz CLI.
             active_servers.extend(

--- a/app/src/ai/mcp/dummy_file_based_manager.rs
+++ b/app/src/ai/mcp/dummy_file_based_manager.rs
@@ -14,7 +14,7 @@ impl FileBasedMCPManager {
 
     pub fn get_servers_for_working_directory(
         &self,
-        _cwd: &Path,
+        _cwd: Option<&Path>,
         _app: &AppContext,
     ) -> Vec<&TemplatableMCPServerInstallation> {
         vec![]

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -70,12 +70,21 @@ impl FileBasedMCPManager {
     }
 
     /// Get file-based MCP servers in scope for the given current working directory.
+    ///
+    /// When `cwd` is `Some`, returns servers rooted at either the user's home
+    /// directory (global servers in `~/.warp/.mcp.json`) or the repo containing
+    /// `cwd` (project-scoped servers in `<repo>/.warp/.mcp.json`).
+    ///
+    /// When `cwd` is `None`, returns only the home-rooted servers. This matters
+    /// for callers that need to enumerate available MCP servers before any
+    /// concrete cwd is known — for example, the agent in a brand-new
+    /// conversation that has no exchanges yet (#9111).
     pub fn get_servers_for_working_directory(
         &self,
-        cwd: &Path,
+        cwd: Option<&Path>,
         app: &AppContext,
     ) -> Vec<&TemplatableMCPServerInstallation> {
-        let repo_root = DetectedRepositories::as_ref(app).get_root_for_path(cwd);
+        let repo_root = cwd.and_then(|c| DetectedRepositories::as_ref(app).get_root_for_path(c));
         let candidate_roots = [dirs::home_dir(), repo_root];
 
         let mut servers = Vec::new();

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -76,13 +76,25 @@ impl FileBasedMCPManager {
     }
 
     /// Get file-based MCP servers in scope for the given current working directory.
+    ///
+    /// When `cwd` is `Some`, returns servers rooted at either the user's home
+    /// directory (global servers in `~/.warp/.mcp.json`) or the repo containing
+    /// `cwd` (project-scoped servers in `<repo>/.warp/.mcp.json`).
+    ///
+    /// When `cwd` is `None`, returns only the home-rooted servers. This matters
+    /// for callers that need to enumerate available MCP servers before any
+    /// concrete cwd is known — for example, the agent in a brand-new
+    /// conversation that has no exchanges yet (#9111).
     pub fn get_servers_for_working_directory(
         &self,
-        cwd: &Path,
+        cwd: Option<&Path>,
         app: &AppContext,
     ) -> Vec<&TemplatableMCPServerInstallation> {
-        let repo_root = DetectedRepositories::as_ref(app)
-            .get_root_for_path(&LocalOrRemotePath::Local(cwd.to_path_buf()))
+        let repo_root = cwd
+            .and_then(|c| {
+                DetectedRepositories::as_ref(app)
+                    .get_root_for_path(&LocalOrRemotePath::Local(c.to_path_buf()))
+            })
             .and_then(|r| PathBuf::try_from(r).ok());
         let candidate_roots = [dirs::home_dir(), repo_root];
 

--- a/app/src/ai/mcp/file_based_manager_tests.rs
+++ b/app/src/ai/mcp/file_based_manager_tests.rs
@@ -511,3 +511,105 @@ fn test_update_file_based_servers_removes_server_only_when_no_refs() {
         });
     });
 }
+
+/// Regression test for warpdotdev/warp#9111. When the agent enumerates MCP
+/// servers in a fresh conversation that has no exchanges yet,
+/// `current_working_directory()` returns `None`. Before the fix, the entire
+/// file-based-servers branch was gated behind `if let Some(cwd) = ...`, which
+/// excluded global servers in `~/.warp/.mcp.json` even though the home dir is
+/// already a candidate root inside `get_servers_for_working_directory`.
+///
+/// With `cwd: Option<&Path>`, passing `None` should still return home-rooted
+/// servers — that's the agent-context-with-no-cwd path.
+#[test]
+fn test_get_servers_for_working_directory_returns_home_servers_when_cwd_is_none() {
+    let Some(home) = dirs::home_dir() else {
+        // CI runner without a home dir would skip the home-rooted candidate
+        // entirely; the test isn't meaningful there.
+        return;
+    };
+    let parsed = parse_mcp_json(
+        r#"{"global-server": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-example"]}}"#,
+    );
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+
+        manager_handle.update(&mut app, |manager, ctx| {
+            // Seed a global server rooted at the home directory.
+            manager.apply_parsed_servers(home.clone(), MCPProvider::Claude, parsed, ctx);
+            assert_eq!(manager.file_based_servers.len(), 1);
+        });
+
+        manager_handle.read(&app, |manager, app_ctx| {
+            let servers = manager.get_servers_for_working_directory(None, app_ctx);
+            assert_eq!(
+                servers.len(),
+                1,
+                "global (home-rooted) server must be returned even when cwd is None"
+            );
+        });
+    });
+}
+
+/// When `cwd` is `None`, repo-scoped servers (rooted at a project directory,
+/// not the home dir) must NOT be returned — without a cwd there is no project
+/// to anchor them to. This guards against a future refactor that accidentally
+/// always returns every file-based server regardless of scope.
+#[test]
+fn test_get_servers_for_working_directory_excludes_repo_servers_when_cwd_is_none() {
+    let repo_path = PathBuf::from("/tmp/test-9111-repo-only");
+    let parsed = parse_mcp_json(
+        r#"{"project-server": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-example"]}}"#,
+    );
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+
+        manager_handle.update(&mut app, |manager, ctx| {
+            // Seed a project-scoped server rooted at a repo path (not home).
+            manager.apply_parsed_servers(repo_path.clone(), MCPProvider::Claude, parsed, ctx);
+            assert_eq!(manager.file_based_servers.len(), 1);
+        });
+
+        manager_handle.read(&app, |manager, app_ctx| {
+            let servers = manager.get_servers_for_working_directory(None, app_ctx);
+            assert!(
+                servers.is_empty(),
+                "repo-rooted server must not be returned when cwd is None: {servers:?}"
+            );
+        });
+    });
+}
+
+/// Pre-existing behavior preserved: when `cwd` is `Some`, home-rooted (global)
+/// servers are still returned. This is the path that already worked before the
+/// fix; the test guards against a regression in the cwd-Some branch while we
+/// add the cwd-None branch.
+#[test]
+fn test_get_servers_for_working_directory_returns_home_servers_when_cwd_is_some() {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    let parsed = parse_mcp_json(
+        r#"{"global-server": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-example"]}}"#,
+    );
+    let cwd = PathBuf::from("/tmp/test-9111-some-cwd");
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+
+        manager_handle.update(&mut app, |manager, ctx| {
+            manager.apply_parsed_servers(home.clone(), MCPProvider::Claude, parsed, ctx);
+        });
+
+        manager_handle.read(&app, |manager, app_ctx| {
+            let servers = manager.get_servers_for_working_directory(Some(&cwd), app_ctx);
+            assert_eq!(
+                servers.len(),
+                1,
+                "global (home-rooted) server must still be returned when cwd is Some"
+            );
+        });
+    });
+}

--- a/app/src/ai/mcp/file_based_manager_tests.rs
+++ b/app/src/ai/mcp/file_based_manager_tests.rs
@@ -608,3 +608,105 @@ fn test_update_file_based_servers_removes_server_only_when_no_refs() {
         });
     });
 }
+
+/// Regression test for warpdotdev/warp#9111. When the agent enumerates MCP
+/// servers in a fresh conversation that has no exchanges yet,
+/// `current_working_directory()` returns `None`. Before the fix, the entire
+/// file-based-servers branch was gated behind `if let Some(cwd) = ...`, which
+/// excluded global servers in `~/.warp/.mcp.json` even though the home dir is
+/// already a candidate root inside `get_servers_for_working_directory`.
+///
+/// With `cwd: Option<&Path>`, passing `None` should still return home-rooted
+/// servers — that's the agent-context-with-no-cwd path.
+#[test]
+fn test_get_servers_for_working_directory_returns_home_servers_when_cwd_is_none() {
+    let Some(home) = dirs::home_dir() else {
+        // CI runner without a home dir would skip the home-rooted candidate
+        // entirely; the test isn't meaningful there.
+        return;
+    };
+    let parsed = parse_mcp_json(
+        r#"{"global-server": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-example"]}}"#,
+    );
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+
+        manager_handle.update(&mut app, |manager, ctx| {
+            // Seed a global server rooted at the home directory.
+            manager.apply_parsed_servers(home.clone(), MCPProvider::Claude, parsed, ctx);
+            assert_eq!(manager.file_based_servers.len(), 1);
+        });
+
+        manager_handle.read(&app, |manager, app_ctx| {
+            let servers = manager.get_servers_for_working_directory(None, app_ctx);
+            assert_eq!(
+                servers.len(),
+                1,
+                "global (home-rooted) server must be returned even when cwd is None"
+            );
+        });
+    });
+}
+
+/// When `cwd` is `None`, repo-scoped servers (rooted at a project directory,
+/// not the home dir) must NOT be returned — without a cwd there is no project
+/// to anchor them to. This guards against a future refactor that accidentally
+/// always returns every file-based server regardless of scope.
+#[test]
+fn test_get_servers_for_working_directory_excludes_repo_servers_when_cwd_is_none() {
+    let repo_path = PathBuf::from("/tmp/test-9111-repo-only");
+    let parsed = parse_mcp_json(
+        r#"{"project-server": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-example"]}}"#,
+    );
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+
+        manager_handle.update(&mut app, |manager, ctx| {
+            // Seed a project-scoped server rooted at a repo path (not home).
+            manager.apply_parsed_servers(repo_path.clone(), MCPProvider::Claude, parsed, ctx);
+            assert_eq!(manager.file_based_servers.len(), 1);
+        });
+
+        manager_handle.read(&app, |manager, app_ctx| {
+            let servers = manager.get_servers_for_working_directory(None, app_ctx);
+            assert!(
+                servers.is_empty(),
+                "repo-rooted server must not be returned when cwd is None: {servers:?}"
+            );
+        });
+    });
+}
+
+/// Pre-existing behavior preserved: when `cwd` is `Some`, home-rooted (global)
+/// servers are still returned. This is the path that already worked before the
+/// fix; the test guards against a regression in the cwd-Some branch while we
+/// add the cwd-None branch.
+#[test]
+fn test_get_servers_for_working_directory_returns_home_servers_when_cwd_is_some() {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    let parsed = parse_mcp_json(
+        r#"{"global-server": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-example"]}}"#,
+    );
+    let cwd = PathBuf::from("/tmp/test-9111-some-cwd");
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+
+        manager_handle.update(&mut app, |manager, ctx| {
+            manager.apply_parsed_servers(home.clone(), MCPProvider::Claude, parsed, ctx);
+        });
+
+        manager_handle.read(&app, |manager, app_ctx| {
+            let servers = manager.get_servers_for_working_directory(Some(&cwd), app_ctx);
+            assert_eq!(
+                servers.len(),
+                1,
+                "global (home-rooted) server must still be returned when cwd is Some"
+            );
+        });
+    });
+}

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -315,10 +315,16 @@ impl TemplatableMCPServerManager {
             .collect()
     }
 
-    /// Returns file-based MCP servers that are currently active and in scope for the given working directory.
+    /// Returns file-based MCP servers that are currently active and in scope.
+    ///
+    /// When `cwd` is `Some`, includes both home-rooted (global) servers and
+    /// servers rooted at the repo containing `cwd`. When `cwd` is `None` (e.g.,
+    /// a fresh agent conversation with no exchanges yet — #9111), includes only
+    /// home-rooted servers; project-scoped servers are excluded since there's
+    /// no cwd to anchor them.
     pub fn get_active_file_based_servers(
         &self,
-        cwd: &std::path::Path,
+        cwd: Option<&std::path::Path>,
         app: &warpui::AppContext,
     ) -> HashMap<Uuid, &TemplatableMCPServerInfo> {
         FileBasedMCPManager::as_ref(app)

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -320,10 +320,16 @@ impl TemplatableMCPServerManager {
             .collect()
     }
 
-    /// Returns file-based MCP servers that are currently active and in scope for the given working directory.
+    /// Returns file-based MCP servers that are currently active and in scope.
+    ///
+    /// When `cwd` is `Some`, includes both home-rooted (global) servers and
+    /// servers rooted at the repo containing `cwd`. When `cwd` is `None` (e.g.,
+    /// a fresh agent conversation with no exchanges yet — #9111), includes only
+    /// home-rooted servers; project-scoped servers are excluded since there's
+    /// no cwd to anchor them.
     pub fn get_active_file_based_servers(
         &self,
-        cwd: &std::path::Path,
+        cwd: Option<&std::path::Path>,
         app: &warpui::AppContext,
     ) -> HashMap<Uuid, &TemplatableMCPServerInfo> {
         FileBasedMCPManager::as_ref(app)


### PR DESCRIPTION
## Description

Fixes #9111.

When an MCP server configured globally in `~/.warp/.mcp.json` was connected — green dot in Settings, tools listed — the Oz agent in a brand-new conversation could not see it. `list_relevant_mcp_context` returned no context.

### Root cause

In [`make_request_input`](app/src/ai/agent/api.rs), the file-based-MCP-servers branch was gated behind `if let Some(cwd) = session_context.current_working_directory()`. That accessor:

```rust
pub fn current_working_directory(&self) -> &Option<String> {
    self.task_store.all_exchanges_rev().find_map(|exchange| exchange.working_directory.clone())
}
```

walks prior exchanges to find a working directory. A fresh conversation has no exchanges, so cwd is `None`, the gate skips the entire file-based branch, and `get_active_file_based_servers` is never called. Globally-configured servers — which are already home-rooted candidates inside `get_servers_for_working_directory` — never make it into the agent's context.

The Settings UI uses a different read path with no cwd gate, which is why the same server shows as connected there. Two readers, divergent filtering — that's why the symptom looked like "agent ignores a server that's clearly connected."

### Fix

Thread `Option<&Path>` through `FileBasedMCPManager::get_servers_for_working_directory` and `TemplatableMCPServerManager::get_active_file_based_servers`. When `cwd` is `None`, return home-rooted (global) servers only; repo-scoped servers are still gated since they have no meaning without a cwd. The home-rooted candidate was already in `candidate_roots` inside the function — the change just lets the call go through.

Touches 4 production files (`api.rs`, `templatable_manager.rs`, `file_based_manager.rs`, `dummy_file_based_manager.rs`) and 1 test file. No other callers, no API breakage.

## Testing

### Unit regression coverage

Three new tests in `app/src/ai/mcp/file_based_manager_tests.rs`:

- **`test_get_servers_for_working_directory_returns_home_servers_when_cwd_is_none`** — direct regression test for #9111. Seeds a global server at `dirs::home_dir()`, calls `get_servers_for_working_directory(None, app)`, asserts the global server is returned.
- **`test_get_servers_for_working_directory_excludes_repo_servers_when_cwd_is_none`** — guard. Seeds a server at a repo path (not home), asserts that path-rooted servers are NOT returned when cwd is `None`.
- **`test_get_servers_for_working_directory_returns_home_servers_when_cwd_is_some`** — preserves pre-existing behavior so the cwd-`Some` branch can't silently regress alongside this fix.

### End-to-end agent UX confirmation

Recorded against this branch with [warp-taper](https://github.com/david-engelmann/warp-taper) + the fixture MCP server at [proof-mcp](https://github.com/david-engelmann/proof-mcp):

![9853-evidence](https://github.com/david-engelmann/warp-taper/raw/main/docs/sample-tape/9853.gif)

No terminal command is run anywhere in the session, so `current_working_directory()` is `None` throughout — this is the failure precondition. The recording shows:

1. Fresh agent input clicked.
2. Prompt typed: `use the whoami tool from proof-mcp`.
3. Agent recognizes `proof-mcp` and the `whoami` tool, renders the standard tool-call approval gate.
4. Return pressed to approve.
5. Tool runs; agent renders `whoami result from proof-mcp: proof-mcp:warp#9853:david-engelmann`.

The unique identifier in the response is what makes this evidence: no built-in tool can produce that string, so the agent definitely invoked the file-based server from `~/.warp-oss/.mcp.json`.

Pre-fix on `master`, step 3 doesn't happen: `RequestParams::new` gates global-server inclusion on `cwd.is_some()`, so `MCPContext` for fresh-conversation requests has zero file-based servers and the agent has no `whoami` to call.

Reproducibility:
- MCP fixture: https://github.com/david-engelmann/proof-mcp (12-line `server.py`, `pip install mcp`).
- Capture pipeline: [`scripts/warp-driver.swift`](https://github.com/david-engelmann/warp-taper/blob/main/scripts/warp-driver.swift) — JSON-recipe interpreter that uses Vision OCR to anchor every typing/clicking step against expected UI text. Recipe: [`scripts/recipes/9853-mcp-fresh-conversation.json`](https://github.com/david-engelmann/warp-taper/blob/main/scripts/recipes/9853-mcp-fresh-conversation.json).

### Local presubmit

Full `script/presubmit` sequence run locally (Xcode + protoc + nextest installed):

| Step | Result |
|---|---|
| `cargo check --workspace --exclude command-signatures-v2 --all-targets --tests` | ✅ 1m 55s clean |
| `cargo clippy --workspace --exclude warp_completer --exclude command-signatures-v2 --all-targets --tests -- -D warnings` | ✅ 2m 31s clean |
| `cargo nextest run --no-fail-fast --workspace --exclude command-signatures-v2` | ✅ 5809/5814 pass |
| `cargo fmt -- --check` | ✅ clean |
| `cargo test --doc -p warp` | ✅ 4 passed, 0 failed |
| MCP-scoped tests | ✅ 57/57 (3 new + 54 existing) |

The 5 nextest failures are all in `crates/integration::ssh*` and require GCP IAP tunnel credentials; they fail identically on master (verified by `git stash && cargo nextest run -p integration -E '<same tests>'`). Not related to this change.

## Server API dependencies

N/A — client-only change.

- [x] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4): **No**

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fix MCP servers configured in `~/.warp/.mcp.json` not appearing in the Oz agent's context in brand-new conversations (#9111).
