### PR TITLE
add `RedirectionGuard=no` to windows-installer.iss

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -784,6 +784,9 @@ fn init_common(launch_mode: &LaunchMode, timer: Option<&mut IntervalTimer>) -> R
         timer.mark_interval_end("LOG_FILE_SETUP_COMPLETE");
     }
 
+    #[cfg(windows)]
+    platform::windows::check_redirection_guard();
+
     // Adjust resource limits early, before doing other work, to ensure that
     // any children we spawn (like the terminal server) inherit our adjusted
     // rlimits.

--- a/app/src/platform/mod.rs
+++ b/app/src/platform/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(target_family = "wasm")]
 pub mod wasm;
+#[cfg(windows)]
+pub mod windows;
 
 pub fn init() {
     #[cfg(target_family = "wasm")]

--- a/app/src/platform/windows.rs
+++ b/app/src/platform/windows.rs
@@ -16,9 +16,7 @@ pub fn check_redirection_guard() {
     let ok = unsafe {
         Threading::GetProcessMitigationPolicy(
             Threading::GetCurrentProcess(),
-            std::mem::transmute::<i32, Threading::PROCESS_MITIGATION_POLICY>(
-                Threading::ProcessRedirectionTrustPolicy.0,
-            ),
+            Threading::ProcessRedirectionTrustPolicy,
             &mut policy as *mut _ as *mut std::ffi::c_void,
             std::mem::size_of::<RedirectionTrustPolicy>(),
         )

--- a/app/src/platform/windows.rs
+++ b/app/src/platform/windows.rs
@@ -1,0 +1,33 @@
+use windows::Win32::System::Threading;
+
+#[repr(C)]
+#[derive(Default)]
+struct RedirectionTrustPolicy {
+    flags: u32,
+}
+
+/// Warn if the Windows RedirectionGuard process mitigation policy is enforced on this process. When
+/// active, symlink and junction traversal to paths created by non-admin users fails with
+/// ERROR_UNTRUSTED_MOUNT_POINT (448).
+///
+/// See https://github.com/warpdotdev/warp/issues/9044
+pub fn check_redirection_guard() {
+    let mut policy = RedirectionTrustPolicy::default();
+    let ok = unsafe {
+        Threading::GetProcessMitigationPolicy(
+            Threading::GetCurrentProcess(),
+            std::mem::transmute::<i32, Threading::PROCESS_MITIGATION_POLICY>(
+                Threading::ProcessRedirectionTrustPolicy.0,
+            ),
+            &mut policy as *mut _ as *mut std::ffi::c_void,
+            std::mem::size_of::<RedirectionTrustPolicy>(),
+        )
+    };
+
+    if ok.is_ok() && policy.flags & 1 != 0 {
+        log::warn!(
+            "RedirectionGuard is enforced on this process — symlink/junction traversal to paths \
+            created by non-admin users will fail with error 448."
+        );
+    }
+}

--- a/script/windows/windows-installer.iss
+++ b/script/windows/windows-installer.iss
@@ -77,6 +77,7 @@ SetupMutex={#AppMutexName}Setup
 MinVersion=10.0.18362
 ; Tell Windows Explorer to reload the environment so that path changes take effect.
 ChangesEnvironment=true
+RedirectionGuard=no
 ; Sign the setup engine and uninstaller so that the temporary bootstrapper
 ; extracted to %TEMP% is Authenticode-signed.  This prevents Microsoft Defender
 ; ASR rule D4F940AB from blocking the installer in enterprise environments.


### PR DESCRIPTION
## Description

This fixes #9044

As a bonus, we are also getting auto-update failures for our community package in [scoop extras](https://github.com/ScoopInstaller/Extras) and this should fix that #9796

See: https://jrsoftware.org/ishelp/index.php?topic=setup_redirectionguard

Symlink traversal was being blocked by Warp and all child processes. This caused all kinds of failures:

- inability to start in user's configured new session starting dir if that contained a symlink
- bootstrap failures if PROFILE file contained symlink
- unable to show code review if `~/.gitconfig` is a symlink
- other examples in the linked issue.

## Testing

You can test this by building the installer, running the installer, and installing it with the "Run Warp" option checked at the end of the installer.

```pwsh
pwsh -NoProfile script\windows\bundle.ps1 -DEBUG_BUILD -CHANNEL preview
& C:\Users\dev\warp\warp\script\windows\Output\WarpPreviewSetup.exe
```

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: [Windows] Symlink traversal fixed.
