### PR TITLE
Fix computer use rejections

### DIFF
--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -633,7 +633,6 @@ impl BlocklistAIController {
         let mut inputs = if should_prepend_finished_action_results {
             completed_action_results
                 .into_iter()
-                .filter(|result| !result.result.is_cancelled())
                 .map(|result| AIAgentInput::ActionResult {
                     result,
                     context: context.clone(),


### PR DESCRIPTION
## Description

Previously, if you rejected a computer use request, you'd get stuck in the computer use subagent. This is because of a line in https://github.com/warpdotdev/warp-internal/pull/24463 that prevented cancelled actions from being sent in the next request.

I synced with @vkodithala and verified that this line isn't needed for the original fix, so I'm removing.

<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue

<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos

https://www.loom.com/share/ea23a90e5db445b0863e993612f817e2

<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Testing

Tested that:

- The code review ctrl-c flow still works.
- Rejecting a computer use request works