### PR TITLE
Implement full-frame clear for active block for CLI Agents.

### DIFF
--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -1102,9 +1102,8 @@ impl Block {
         self.output_grid.set_trim_trailing_blank_rows(trim);
     }
 
-    pub fn set_clear_screen_in_place_for_frame_redraws(&mut self, clear_in_place: bool) {
-        self.output_grid
-            .set_clear_screen_in_place_for_frame_redraws(clear_in_place);
+    pub(in crate::terminal) fn enable_full_grid_clear_behavior(&mut self) {
+        self.output_grid.enable_full_grid_clear_behavior();
     }
 
     pub fn set_restored_block_was_local(&mut self, was_local: bool) {

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -1102,6 +1102,11 @@ impl Block {
         self.output_grid.set_trim_trailing_blank_rows(trim);
     }
 
+    pub fn set_clear_screen_in_place_for_frame_redraws(&mut self, clear_in_place: bool) {
+        self.output_grid
+            .set_clear_screen_in_place_for_frame_redraws(clear_in_place);
+    }
+
     pub fn set_restored_block_was_local(&mut self, was_local: bool) {
         debug_assert!(
             self.bootstrap_stage == BootstrapStage::RestoreBlocks,

--- a/app/src/terminal/model/blockgrid.rs
+++ b/app/src/terminal/model/blockgrid.rs
@@ -290,6 +290,7 @@ impl BlockGrid {
         self.started = true;
         self.finished = true;
         self.trim_trailing_blank_rows = false;
+        self.set_clear_screen_in_place_for_frame_redraws(false);
 
         self.grid_handler_mut().finish();
     }
@@ -297,6 +298,13 @@ impl BlockGrid {
     pub fn set_trim_trailing_blank_rows(&mut self, trim: bool) {
         self.trim_trailing_blank_rows = trim;
         self.grid_handler.set_track_content_length(trim);
+    }
+
+    /// Controls whether primary-screen frame redraw operations should mutate the
+    /// visible grid instead of preserving the current frame in scrollback.
+    pub fn set_clear_screen_in_place_for_frame_redraws(&mut self, clear_in_place: bool) {
+        self.grid_handler
+            .set_clear_screen_in_place_for_frame_redraws(clear_in_place);
     }
 
     /// Returns a freshly-computed value of rightmost_nonempty_cell if this grid isn't

--- a/app/src/terminal/model/blockgrid.rs
+++ b/app/src/terminal/model/blockgrid.rs
@@ -290,7 +290,6 @@ impl BlockGrid {
         self.started = true;
         self.finished = true;
         self.trim_trailing_blank_rows = false;
-        self.set_clear_screen_in_place_for_frame_redraws(false);
 
         self.grid_handler_mut().finish();
     }
@@ -300,11 +299,8 @@ impl BlockGrid {
         self.grid_handler.set_track_content_length(trim);
     }
 
-    /// Controls whether primary-screen frame redraw operations should mutate the
-    /// visible grid instead of preserving the current frame in scrollback.
-    pub fn set_clear_screen_in_place_for_frame_redraws(&mut self, clear_in_place: bool) {
-        self.grid_handler
-            .set_clear_screen_in_place_for_frame_redraws(clear_in_place);
+    pub(in crate::terminal) fn enable_full_grid_clear_behavior(&mut self) {
+        self.grid_handler.enable_full_grid_clear_behavior();
     }
 
     /// Returns a freshly-computed value of rightmost_nonempty_cell if this grid isn't

--- a/app/src/terminal/model/blockgrid_test.rs
+++ b/app/src/terminal/model/blockgrid_test.rs
@@ -31,6 +31,29 @@ pub fn test_finish_truncates_grid_basic() {
 }
 
 #[test]
+pub fn test_finish_clears_frame_redraw_clear_mode() {
+    let size = SizeInfo::new_without_font_metrics(10, 7);
+    let mut block_grid = BlockGrid::new(
+        size,
+        1000, /* max_scroll_limit */
+        ChannelEventListener::new_for_test(),
+        ObfuscateSecrets::No,
+        PerformResetGridChecks::default(),
+    );
+
+    block_grid.set_clear_screen_in_place_for_frame_redraws(true);
+    assert!(block_grid
+        .grid_handler()
+        .clear_screen_in_place_for_frame_redraws());
+
+    block_grid.finish();
+
+    assert!(!block_grid
+        .grid_handler()
+        .clear_screen_in_place_for_frame_redraws());
+}
+
+#[test]
 pub fn test_finish_truncates_grid_cursor_at_bottom() {
     let size = SizeInfo::new_without_font_metrics(10, 7);
     let mut block_grid = BlockGrid::new(

--- a/app/src/terminal/model/blockgrid_test.rs
+++ b/app/src/terminal/model/blockgrid_test.rs
@@ -31,29 +31,6 @@ pub fn test_finish_truncates_grid_basic() {
 }
 
 #[test]
-pub fn test_finish_clears_frame_redraw_clear_mode() {
-    let size = SizeInfo::new_without_font_metrics(10, 7);
-    let mut block_grid = BlockGrid::new(
-        size,
-        1000, /* max_scroll_limit */
-        ChannelEventListener::new_for_test(),
-        ObfuscateSecrets::No,
-        PerformResetGridChecks::default(),
-    );
-
-    block_grid.set_clear_screen_in_place_for_frame_redraws(true);
-    assert!(block_grid
-        .grid_handler()
-        .clear_screen_in_place_for_frame_redraws());
-
-    block_grid.finish();
-
-    assert!(!block_grid
-        .grid_handler()
-        .clear_screen_in_place_for_frame_redraws());
-}
-
-#[test]
 pub fn test_finish_truncates_grid_cursor_at_bottom() {
     let size = SizeInfo::new_without_font_metrics(10, 7);
     let mut block_grid = BlockGrid::new(

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -848,6 +848,8 @@ impl ansi::Handler for GridHandler {
             ansi::ClearMode::All => {
                 if self.ansi_handler_state.is_alt_screen {
                     self.grid.region_mut(..).each(|cell| *cell = bg.into());
+                } else if self.clear_screen_in_place_for_frame_redraws {
+                    self.clear_visible_rows_in_place(bg);
                 } else {
                     self.clear_viewport();
                 }
@@ -1699,6 +1701,31 @@ impl GridHandler {
         for i in positions..self.visible_rows() {
             self.grid[i].reset(&template);
         }
+    }
+
+    fn clear_visible_rows_in_place(&mut self, bg: Color) {
+        self.grid.region_mut(..).each(|cell| *cell = bg.into());
+        let visible_start_row = self.history_size();
+        let visible_end_row = visible_start_row + self.visible_rows();
+        if visible_start_row < visible_end_row {
+            self.images.evict_image_ids_between_points_with_type(
+                AbsolutePoint::from_point(Point::new(visible_start_row, 0), self),
+                AbsolutePoint::from_point(Point::new(visible_end_row - 1, usize::MAX), self),
+                vec![ImageType::ITerm, ImageType::Kitty],
+            );
+            if self.columns() > 0 {
+                self.clear_secrets_in_range(
+                    Point::new(visible_start_row, 0)
+                        ..=Point::new(visible_end_row - 1, self.columns() - 1),
+                );
+            }
+        }
+        self.clear_displayed_rows_and_filter_matches();
+        if self.track_content_length {
+            self.bottommost_visible_content_row = self.bottommost_visible_content_row_backward();
+        }
+        self.ansi_handler_state.dirty_cells_range =
+            Point::new(visible_start_row, 0)..Point::new(visible_end_row, 0);
     }
 
     pub(in crate::terminal::model) fn disable_reset_grid_checks(&mut self) {

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -44,7 +44,7 @@ use crate::terminal::model::selection::ScrollDelta;
 use crate::terminal::model::ObfuscateSecrets;
 use crate::terminal::{ClipboardType, SizeInfo};
 
-use super::{AbsolutePoint, GridHandler, PerformResetGridChecks, TermMode};
+use super::{AbsolutePoint, FullGridClearBehavior, GridHandler, PerformResetGridChecks, TermMode};
 
 use tab_stops::TabStops;
 
@@ -848,7 +848,7 @@ impl ansi::Handler for GridHandler {
             ansi::ClearMode::All => {
                 if self.ansi_handler_state.is_alt_screen {
                     self.grid.region_mut(..).each(|cell| *cell = bg.into());
-                } else if self.clear_screen_in_place_for_frame_redraws {
+                } else if self.full_grid_clear_behavior == FullGridClearBehavior::Clear {
                     self.clear_visible_rows_in_place(bg);
                 } else {
                     self.clear_viewport();

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -343,6 +343,10 @@ pub struct GridHandler {
     /// `bottommost_visible_content_row` via backward scan. Set by the owning
     /// `BlockGrid` when `trim_trailing_blank_rows` is active.
     track_content_length: bool,
+
+    /// Treat primary-screen full clears and resizes as live frame updates
+    /// instead of preserving the current visible rows into scrollback.
+    clear_screen_in_place_for_frame_redraws: bool,
 }
 
 impl GridHandler {
@@ -391,6 +395,7 @@ impl GridHandler {
             marked_text: None,
             bottommost_visible_content_row: None,
             track_content_length: false,
+            clear_screen_in_place_for_frame_redraws: false,
         }
     }
 
@@ -439,6 +444,15 @@ impl GridHandler {
             // back to the full max_cursor_point-based height.
             self.bottommost_visible_content_row = self.bottommost_visible_content_row_backward();
         }
+    }
+
+    pub fn set_clear_screen_in_place_for_frame_redraws(&mut self, clear_in_place: bool) {
+        self.clear_screen_in_place_for_frame_redraws = clear_in_place;
+    }
+
+    #[cfg(test)]
+    pub fn clear_screen_in_place_for_frame_redraws(&self) -> bool {
+        self.clear_screen_in_place_for_frame_redraws
     }
 
     pub(crate) fn set_supports_emoji_presentation_selector(
@@ -517,6 +531,7 @@ impl GridHandler {
             marked_text: None,
             bottommost_visible_content_row: None,
             track_content_length: false,
+            clear_screen_in_place_for_frame_redraws: false,
         };
 
         // Scan the full grid for secrets.  This is less performant than

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -305,6 +305,18 @@ enum StorageRow {
     FlatStorage(usize),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Controls whether full-grid operations on a primary-screen grid preserve the old visible rows as
+/// scrollback or treat them as a mutable redraw surface.
+pub(in crate::terminal) enum FullGridClearBehavior {
+    /// Reset visible cells in place for full-grid clears and resizes, avoiding scrollback growth
+    /// during TUI-style redraws on the primary grid.
+    Clear,
+    /// Preserve normal primary-grid behavior where full-grid clears and resizes move visible rows
+    /// into scrollback.
+    Scroll,
+}
+
 /// An implementation of `ansi::Handler` that writes to a `Grid`.
 #[derive(Clone)]
 pub struct GridHandler {
@@ -344,9 +356,7 @@ pub struct GridHandler {
     /// `BlockGrid` when `trim_trailing_blank_rows` is active.
     track_content_length: bool,
 
-    /// Treat primary-screen full clears and resizes as live frame updates
-    /// instead of preserving the current visible rows into scrollback.
-    clear_screen_in_place_for_frame_redraws: bool,
+    full_grid_clear_behavior: FullGridClearBehavior,
 }
 
 impl GridHandler {
@@ -395,7 +405,7 @@ impl GridHandler {
             marked_text: None,
             bottommost_visible_content_row: None,
             track_content_length: false,
-            clear_screen_in_place_for_frame_redraws: false,
+            full_grid_clear_behavior: FullGridClearBehavior::Scroll,
         }
     }
 
@@ -446,13 +456,8 @@ impl GridHandler {
         }
     }
 
-    pub fn set_clear_screen_in_place_for_frame_redraws(&mut self, clear_in_place: bool) {
-        self.clear_screen_in_place_for_frame_redraws = clear_in_place;
-    }
-
-    #[cfg(test)]
-    pub fn clear_screen_in_place_for_frame_redraws(&self) -> bool {
-        self.clear_screen_in_place_for_frame_redraws
+    pub(in crate::terminal) fn enable_full_grid_clear_behavior(&mut self) {
+        self.full_grid_clear_behavior = FullGridClearBehavior::Clear;
     }
 
     pub(crate) fn set_supports_emoji_presentation_selector(
@@ -531,7 +536,7 @@ impl GridHandler {
             marked_text: None,
             bottommost_visible_content_row: None,
             track_content_length: false,
-            clear_screen_in_place_for_frame_redraws: false,
+            full_grid_clear_behavior: FullGridClearBehavior::Scroll,
         };
 
         // Scan the full grid for secrets.  This is less performant than

--- a/app/src/terminal/model/grid/grid_handler_test.rs
+++ b/app/src/terminal/model/grid/grid_handler_test.rs
@@ -1724,10 +1724,10 @@ fn test_clear_screen_all_primary_preserves_visible_rows_in_history_by_default() 
 }
 
 #[test]
-fn test_clear_screen_all_primary_with_frame_redraw_flag_clears_in_place() {
+fn test_clear_screen_all_primary_with_full_grid_clear_behavior_clears_in_place() {
     let mut grid = GridHandler::new_for_test_with_scroll_limit(3, 5, MAX_SCROLL_LIMIT);
     write_two_visible_rows(&mut grid);
-    grid.set_clear_screen_in_place_for_frame_redraws(true);
+    grid.enable_full_grid_clear_behavior();
 
     grid.clear_screen(ansi::ClearMode::All);
 
@@ -1757,13 +1757,25 @@ fn test_resize_primary_preserves_visible_rows_in_history_by_default() {
 }
 
 #[test]
-fn test_resize_primary_with_frame_redraw_flag_keeps_visible_rows_in_place() {
+fn test_resize_primary_with_full_grid_clear_behavior_keeps_visible_rows_in_place() {
     let mut grid = GridHandler::new_for_test_with_scroll_limit(1, 5, MAX_SCROLL_LIMIT);
     grid.input_at_cursor("12345");
-    grid.set_clear_screen_in_place_for_frame_redraws(true);
+    grid.enable_full_grid_clear_behavior();
     grid.resize(SizeInfo::new_without_font_metrics(1, 2));
 
     assert_eq!(grid.history_size(), 0);
+}
+
+#[test]
+fn test_resize_finished_primary_with_full_grid_clear_behavior_uses_scrollback() {
+    let mut grid = GridHandler::new_for_test_with_scroll_limit(1, 5, MAX_SCROLL_LIMIT);
+    grid.input_at_cursor("12345");
+    grid.finish();
+    grid.enable_full_grid_clear_behavior();
+
+    grid.resize(SizeInfo::new_without_font_metrics(1, 2));
+
+    assert!(grid.history_size() > 0);
 }
 
 #[test]

--- a/app/src/terminal/model/grid/grid_handler_test.rs
+++ b/app/src/terminal/model/grid/grid_handler_test.rs
@@ -1697,6 +1697,75 @@ fn test_clear_screen_above_at_wide_char() {
         .contains(Flags::WIDE_CHAR_SPACER));
 }
 
+fn assert_visible_grid_blank(grid: &GridHandler) {
+    for row in 0..grid.visible_rows() {
+        for col in 0..grid.columns() {
+            assert_eq!(grid.grid_storage()[VisibleRow(row)][col].c, '\0');
+        }
+    }
+}
+
+fn write_two_visible_rows(grid: &mut GridHandler) {
+    grid.input_at_cursor("abc");
+    grid.carriage_return();
+    grid.linefeed();
+    grid.input_at_cursor("def");
+}
+
+#[test]
+fn test_clear_screen_all_primary_preserves_visible_rows_in_history_by_default() {
+    let mut grid = GridHandler::new_for_test_with_scroll_limit(3, 5, MAX_SCROLL_LIMIT);
+    write_two_visible_rows(&mut grid);
+
+    grid.clear_screen(ansi::ClearMode::All);
+
+    assert!(grid.history_size() > 0);
+    assert_visible_grid_blank(&grid);
+}
+
+#[test]
+fn test_clear_screen_all_primary_with_frame_redraw_flag_clears_in_place() {
+    let mut grid = GridHandler::new_for_test_with_scroll_limit(3, 5, MAX_SCROLL_LIMIT);
+    write_two_visible_rows(&mut grid);
+    grid.set_clear_screen_in_place_for_frame_redraws(true);
+
+    grid.clear_screen(ansi::ClearMode::All);
+
+    assert_eq!(grid.history_size(), 0);
+    assert_visible_grid_blank(&grid);
+}
+
+#[test]
+fn test_clear_screen_all_alt_screen_clears_in_place() {
+    let mut grid = GridHandler::new_for_alt_screen_test(3, 5);
+    write_two_visible_rows(&mut grid);
+
+    grid.clear_screen(ansi::ClearMode::All);
+
+    assert_eq!(grid.history_size(), 0);
+    assert_visible_grid_blank(&grid);
+}
+
+#[test]
+fn test_resize_primary_preserves_visible_rows_in_history_by_default() {
+    let mut grid = GridHandler::new_for_test_with_scroll_limit(1, 5, MAX_SCROLL_LIMIT);
+    grid.input_at_cursor("12345");
+
+    grid.resize(SizeInfo::new_without_font_metrics(1, 2));
+
+    assert!(grid.history_size() > 0);
+}
+
+#[test]
+fn test_resize_primary_with_frame_redraw_flag_keeps_visible_rows_in_place() {
+    let mut grid = GridHandler::new_for_test_with_scroll_limit(1, 5, MAX_SCROLL_LIMIT);
+    grid.input_at_cursor("12345");
+    grid.set_clear_screen_in_place_for_frame_redraws(true);
+    grid.resize(SizeInfo::new_without_font_metrics(1, 2));
+
+    assert_eq!(grid.history_size(), 0);
+}
+
 #[test]
 fn test_clear_line_left_preserves_adjacent_wide_char() {
     // Wide char at cols 2-3, cursor at col 1.  Clearing left should only

--- a/app/src/terminal/model/grid/resize.rs
+++ b/app/src/terminal/model/grid/resize.rs
@@ -12,7 +12,7 @@ use warp_terminal::model::{
 
 use crate::terminal::{model::grid::Cursor, SizeInfo};
 
-use super::GridHandler;
+use super::{FullGridClearBehavior, GridHandler};
 
 impl GridHandler {
     /// Resize terminal to new dimensions.
@@ -62,10 +62,12 @@ impl GridHandler {
         use std::cmp::min;
 
         // If this is the alt screen, we can skip reflowing the grid and simply
-        // adjust the size of rows. We also do this for frame redraws for CLI
-        // agent TUIs so pane resizes don't append old frames into block scrollback
-        // before the app redraws (GH #9838).
-        if self.ansi_handler_state.is_alt_screen || self.clear_screen_in_place_for_frame_redraws {
+        // adjust the size of rows. We also do this for CLI agent TUIs so pane
+        // resizes don't append old frames into block scrollback before the app
+        // redraws (GH #9838).
+        if self.ansi_handler_state.is_alt_screen
+            || (self.full_grid_clear_behavior == FullGridClearBehavior::Clear && !self.finished)
+        {
             // We should never finish the alt screen grid.
             debug_assert!(!self.ansi_handler_state.is_alt_screen || !self.finished);
             // We can delegate to the old grid resizing logic, as there's no

--- a/app/src/terminal/model/grid/resize.rs
+++ b/app/src/terminal/model/grid/resize.rs
@@ -62,10 +62,12 @@ impl GridHandler {
         use std::cmp::min;
 
         // If this is the alt screen, we can skip reflowing the grid and simply
-        // adjust the size of rows.
-        if self.ansi_handler_state.is_alt_screen {
+        // adjust the size of rows. We also do this for frame redraws for CLI
+        // agent TUIs so pane resizes don't append old frames into block scrollback
+        // before the app redraws (GH #9838).
+        if self.ansi_handler_state.is_alt_screen || self.clear_screen_in_place_for_frame_redraws {
             // We should never finish the alt screen grid.
-            debug_assert!(!self.finished);
+            debug_assert!(!self.ansi_handler_state.is_alt_screen || !self.finished);
             // We can delegate to the old grid resizing logic, as there's no
             // flat storage for the alt screen.
             self.grid.resize(false, num_rows, num_cols, self.finished);

--- a/app/src/terminal/model/grid/secrets.rs
+++ b/app/src/terminal/model/grid/secrets.rs
@@ -117,7 +117,7 @@ impl GridHandler {
 
     /// Clears the secrets that are encompassed in the given range. Returns a range of the minimum
     /// and maximum point of all of the secrets that were removed.
-    fn clear_secrets_in_range(
+    pub(super) fn clear_secrets_in_range(
         &mut self,
         range: RangeInclusive<Point>,
     ) -> Option<RangeInclusive<Point>> {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -11809,23 +11809,21 @@ impl TerminalView {
             CLIAgentSessionsModelEvent::Started {
                 terminal_view_id, ..
             } if *terminal_view_id == self.view_id => {
+                let mut model = self.model.lock();
+                let active_block = model.block_list_mut().active_block_mut();
+                active_block.set_clear_screen_in_place_for_frame_redraws(true);
                 if FeatureFlag::TrimTrailingBlankLines.is_enabled() {
-                    self.model
-                        .lock()
-                        .block_list_mut()
-                        .active_block_mut()
-                        .set_trim_trailing_blank_rows(true);
+                    active_block.set_trim_trailing_blank_rows(true);
                 }
             }
             CLIAgentSessionsModelEvent::Ended {
                 terminal_view_id, ..
             } if *terminal_view_id == self.view_id => {
+                let mut model = self.model.lock();
+                let active_block = model.block_list_mut().active_block_mut();
+                active_block.set_clear_screen_in_place_for_frame_redraws(false);
                 if FeatureFlag::TrimTrailingBlankLines.is_enabled() {
-                    self.model
-                        .lock()
-                        .block_list_mut()
-                        .active_block_mut()
-                        .set_trim_trailing_blank_rows(false);
+                    active_block.set_trim_trailing_blank_rows(false);
                 }
             }
             _ => {}

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -11811,7 +11811,7 @@ impl TerminalView {
             } if *terminal_view_id == self.view_id => {
                 let mut model = self.model.lock();
                 let active_block = model.block_list_mut().active_block_mut();
-                active_block.set_clear_screen_in_place_for_frame_redraws(true);
+                active_block.enable_full_grid_clear_behavior();
                 if FeatureFlag::TrimTrailingBlankLines.is_enabled() {
                     active_block.set_trim_trailing_blank_rows(true);
                 }
@@ -11821,7 +11821,6 @@ impl TerminalView {
             } if *terminal_view_id == self.view_id => {
                 let mut model = self.model.lock();
                 let active_block = model.block_list_mut().active_block_mut();
-                active_block.set_clear_screen_in_place_for_frame_redraws(false);
                 if FeatureFlag::TrimTrailingBlankLines.is_enabled() {
                     active_block.set_trim_trailing_blank_rows(false);
                 }

--- a/specs/tui-output-redraw/TECH.md
+++ b/specs/tui-output-redraw/TECH.md
@@ -20,16 +20,15 @@ The target model is that CLI-agent frame redraws should treat primary-screen fra
 ## Proposed changes
 Add an explicit “primary-screen frame redraws happen in place” mode to the active CLI-agent output grid.
 Implementation shape:
-- Add a boolean field to `GridHandler`, for example `clear_screen_in_place_for_frame_redraws: bool`, defaulting to `false` in `GridHandler::new` and preserved/reset intentionally in split/finish paths. The name can mention “clear screen” because full clear is the most direct ANSI trigger, but the behavior should also gate primary-screen resize reflow for frame-redraw grids.
-- Add a setter on `GridHandler`, then thread it through `BlockGrid` and `Block` with names that make the scope clear, for example:
-  - `GridHandler::set_clear_screen_in_place_for_frame_redraws(bool)`
-  - `BlockGrid::set_clear_screen_in_place_for_frame_redraws(bool)`
-  - `Block::set_clear_screen_in_place_for_frame_redraws(bool)`
-- In `GridHandler::clear_screen(ClearMode::All)`, clear in place when either the grid is alt-screen or `clear_screen_in_place_for_frame_redraws` is true. Otherwise keep the existing `clear_viewport()` path. This preserves existing primary-screen/block semantics outside the scoped CLI-agent case.
+- Add a `FullGridClearBehavior` field to `GridHandler`, defaulting to `FullGridClearBehavior::Scroll` in `GridHandler::new`. `FullGridClearBehavior::Clear` gates both primary-screen full clears and primary-screen resize reflow for active CLI-agent grids.
+- Add a one-way enable method on `GridHandler`, then thread it through `BlockGrid` and `Block`:
+  - `GridHandler::enable_full_grid_clear_behavior()`
+  - `BlockGrid::enable_full_grid_clear_behavior()`
+  - `Block::enable_full_grid_clear_behavior()`
+- In `GridHandler::clear_screen(ClearMode::All)`, clear in place when either the grid is alt-screen or `full_grid_clear_behavior` is `FullGridClearBehavior::Clear`. Otherwise keep the existing `clear_viewport()` path. This preserves existing primary-screen/block semantics outside the scoped CLI-agent case.
 - Factor the in-place branch into a small helper so alt-screen and CLI-agent primary-screen clears share the same behavior. The helper should reset the active grid cells using the current cursor background template, mark the affected region dirty through the existing dirty-cell machinery, and evict visible image placements/secrets that no longer have backing cells if the current scroll-clear path does that indirectly.
-- In `GridHandler::resize_storage`, treat primary-screen grids with `clear_screen_in_place_for_frame_redraws` like alt-screen grids for resize purposes: resize visible `GridStorage` in place instead of pushing visible rows into `flat_storage`, resizing `flat_storage`, and popping rows back. This prevents the current frame from becoming block scrollback before the CLI agent receives SIGWINCH and redraws.
-- Set the mode to `true` in `TerminalView::handle_cli_agent_sessions_event` when a matching `CLIAgentSessionsModelEvent::Started` arrives. Set it to `false` when the matching session ends.
-- Clear the mode when the output grid/block finishes, mirroring the existing `trim_trailing_blank_rows` cleanup in `BlockGrid::finish()`. This protects against delayed `Ended` events targeting a block that has already completed or advanced.
+- In `GridHandler::resize_storage`, treat unfinished primary-screen grids with `FullGridClearBehavior::Clear` like alt-screen grids for resize purposes: resize visible `GridStorage` in place instead of pushing visible rows into `flat_storage`, resizing `flat_storage`, and popping rows back. This prevents the current frame from becoming block scrollback before the CLI agent receives SIGWINCH and redraws.
+- Enable `FullGridClearBehavior::Clear` in `TerminalView::handle_cli_agent_sessions_event` when a matching `CLIAgentSessionsModelEvent::Started` arrives. The behavior is one-way for that block; once the block is finished, resize ignores the clear behavior because the output is immutable.
 - Do not reuse `FeatureFlag::TrimTrailingBlankLines` for this behavior. If rollback is desired, add a distinct feature flag; otherwise rely on the CLI-agent-only session scope. The two behaviors address related symptoms but have different terminal semantics.
 Expected data flow:
 1. Pane resize updates Warp’s model and sends a PTY resize to the running process.
@@ -55,8 +54,7 @@ Recommended unit tests in `app/src/terminal/model/grid/grid_handler_test.rs`:
 - `ClearMode::Saved`, `ResetAndClear`, and `ActiveBlock` still clear history/state through their existing paths.
 Recommended wiring tests:
 - A started CLI-agent session marks the active block output grid for in-place frame redraw clears.
-- An ended CLI-agent session unmarks it.
-- Finishing a block clears the mode even if the session end event is delayed.
+- A finished block no longer relies on reverting this behavior; finished-grid resize follows the normal scrollback path even if the behavior remains set.
 Manual validation:
 - Capture raw PTY output while resizing Claude Code, if possible, and confirm the redraw contains a full-screen clear such as `ESC[H ESC[2J`.
 - Run Claude Code in Warp, resize the pane narrower several times, and verify the active block overwrites the current frame instead of accumulating prior frames.
@@ -68,7 +66,7 @@ Suggested commands:
 - If implementation touches broader terminal-model behavior, run the relevant terminal model tests before manual verification.
 ## Risks and mitigations
 - Primary-screen full clear and resize reflow have user-visible history semantics in Warp. Mitigation: scope the in-place behavior only to active CLI-agent sessions, and only for `ClearMode::All` plus primary-screen resize while the frame-redraw mode is active.
-- Some CLI agents might intentionally use primary-screen clears to preserve previous output. Mitigation: the behavior applies only while Warp has detected an active CLI-agent session, where full-screen clears are overwhelmingly frame redraws; completed blocks revert to normal.
+- Some CLI agents might intentionally use primary-screen clears to preserve previous output. Mitigation: the behavior applies only while Warp has detected an active CLI-agent session, where full-screen clears are overwhelmingly frame redraws; completed blocks no longer use the in-place resize path.
 - Images and secret metadata may outlive in-place-cleared cells if only grid cells are reset. Mitigation: reuse or extend existing clear/eviction helpers so ancillary grid state matches the cleared visible region.
-- Delayed lifecycle events can target the wrong active block. Mitigation: clear the flag on `BlockGrid::finish()` in addition to handling `Ended`.
+- Delayed lifecycle events can target the wrong active block. Mitigation: only enable the behavior on session start and do not rely on a later disable event for correctness.
 - Resize ordering may still produce edge cases if a process writes during the gap between model resize and PTY resize delivery. Mitigation: the scoped resize path prevents the main old-frame preservation mechanism; treat backend-before-model resizing as a follow-up only if manual verification still shows accumulation.

--- a/specs/tui-output-redraw/TECH.md
+++ b/specs/tui-output-redraw/TECH.md
@@ -1,0 +1,74 @@
+# Prevent CLI Agent Frame Redraws from Accumulating on Resize
+## Context
+Claude Code and similar CLI agents run pseudo-TUI interfaces in the primary screen. When the terminal is resized narrower, the process receives a PTY resize event, redraws its frame, and commonly clears the screen before writing the new frame. In Warp, those old frames can become block output instead of being overwritten, so repeated resizes append multiple historical frames to the active block.
+This does not appear to be caused by the CLI-agent trailing-blank-line trimming work in `specs/APP-4004/TECH.md` or `specs/APP-4006/TECH.md`. That work changes displayed height and cursor visibility for active CLI-agent blocks. It does not send resize events, change alt-screen state, or append PTY output. The accumulation mechanism is in primary-screen operations that preserve visible rows into scrollback, specifically full-screen clears and primary-screen resize reflow.
+Relevant code:
+- `app/src/terminal/view.rs:14654` — `TerminalView::resize_internal` updates the terminal model before the resize event is emitted to the PTY controller.
+- `app/src/terminal/writeable_pty/terminal_manager_util.rs:69` — view resize events are forwarded to `PtyController::resize_pty`.
+- `app/src/terminal/writeable_pty/pty_controller.rs:604` — `resize_pty` sends `Message::Resize(size_update.new_size)` when rows, columns, pane size, or refresh changes.
+- `app/src/terminal/local_tty/event_loop.rs:173` and `app/src/terminal/local_tty/unix.rs:642` — the local PTY event loop handles `Message::Resize` by calling `ioctl(TIOCSWINSZ)`.
+- `app/src/terminal/model/terminal_model.rs:1957` and `app/src/terminal/model/blocks.rs:1988` — the model and active block are reflowed on size changes.
+- `app/src/terminal/model/grid/resize.rs:61` — primary-screen resize pushes visible rows into `flat_storage`, resizes `flat_storage`, then pulls rows back into visible grid storage.
+- `app/src/terminal/model/grid/resize.rs:71` — alt-screen resize skips that reflow path and resizes the visible grid in place.
+- `app/src/terminal/model/terminal_model.rs:2620` and `app/src/terminal/model/blocks.rs:3563` — ANSI `clear_screen` is delegated from the terminal model through the active block list.
+- `app/src/terminal/model/grid/ansi_handler.rs:798` — `GridHandler::clear_screen` is where `ansi::ClearMode` is applied to the active grid.
+- `app/src/terminal/model/grid/ansi_handler.rs:848` — `ClearMode::All` clears alt-screen grids in place, but primary-screen grids call `clear_viewport()`.
+- `app/src/terminal/model/grid/ansi_handler.rs:1645` and `app/src/terminal/model/grid/ansi_handler.rs:1674` — `clear_viewport()` computes the visible rows to clear, then calls `scroll_region_up`, which pushes those rows into `flat_storage` before resetting the visible grid.
+- `app/src/terminal/model/grid/grid_handler.rs:310` and `app/src/terminal/model/grid/grid_handler.rs:393` — `GridHandler` already owns display-only state toggled by higher-level block features.
+- `app/src/terminal/model/blockgrid.rs:297`, `app/src/terminal/model/block.rs:1101`, and `app/src/terminal/view.rs:11778` — active CLI-agent state already propagates from `CLIAgentSessionsModelEvent::Started/Ended` into active-block output-grid behavior for trailing blank row trimming.
+The target model is that CLI-agent frame redraws should treat primary-screen frame replacement operations as mutations of the live visible grid, not as scrollback-producing history. That includes primary-screen full erases and primary-screen resize reflow. Warp should not globally adopt this for all primary-screen blocks because Warp’s block model intentionally preserves `clear`-style shell output and ordinary command output in scrollback. The fix should be scoped to active CLI-agent frame redraws.
+## Proposed changes
+Add an explicit “primary-screen frame redraws happen in place” mode to the active CLI-agent output grid.
+Implementation shape:
+- Add a boolean field to `GridHandler`, for example `clear_screen_in_place_for_frame_redraws: bool`, defaulting to `false` in `GridHandler::new` and preserved/reset intentionally in split/finish paths. The name can mention “clear screen” because full clear is the most direct ANSI trigger, but the behavior should also gate primary-screen resize reflow for frame-redraw grids.
+- Add a setter on `GridHandler`, then thread it through `BlockGrid` and `Block` with names that make the scope clear, for example:
+  - `GridHandler::set_clear_screen_in_place_for_frame_redraws(bool)`
+  - `BlockGrid::set_clear_screen_in_place_for_frame_redraws(bool)`
+  - `Block::set_clear_screen_in_place_for_frame_redraws(bool)`
+- In `GridHandler::clear_screen(ClearMode::All)`, clear in place when either the grid is alt-screen or `clear_screen_in_place_for_frame_redraws` is true. Otherwise keep the existing `clear_viewport()` path. This preserves existing primary-screen/block semantics outside the scoped CLI-agent case.
+- Factor the in-place branch into a small helper so alt-screen and CLI-agent primary-screen clears share the same behavior. The helper should reset the active grid cells using the current cursor background template, mark the affected region dirty through the existing dirty-cell machinery, and evict visible image placements/secrets that no longer have backing cells if the current scroll-clear path does that indirectly.
+- In `GridHandler::resize_storage`, treat primary-screen grids with `clear_screen_in_place_for_frame_redraws` like alt-screen grids for resize purposes: resize visible `GridStorage` in place instead of pushing visible rows into `flat_storage`, resizing `flat_storage`, and popping rows back. This prevents the current frame from becoming block scrollback before the CLI agent receives SIGWINCH and redraws.
+- Set the mode to `true` in `TerminalView::handle_cli_agent_sessions_event` when a matching `CLIAgentSessionsModelEvent::Started` arrives. Set it to `false` when the matching session ends.
+- Clear the mode when the output grid/block finishes, mirroring the existing `trim_trailing_blank_rows` cleanup in `BlockGrid::finish()`. This protects against delayed `Ended` events targeting a block that has already completed or advanced.
+- Do not reuse `FeatureFlag::TrimTrailingBlankLines` for this behavior. If rollback is desired, add a distinct feature flag; otherwise rely on the CLI-agent-only session scope. The two behaviors address related symptoms but have different terminal semantics.
+Expected data flow:
+1. Pane resize updates Warp’s model and sends a PTY resize to the running process.
+2. Because the active block is marked as a CLI-agent frame-redraw grid, primary-screen resize updates visible grid storage in place instead of first pushing the old visible frame into `flat_storage`.
+3. Claude Code receives the resize and emits a primary-screen full clear plus a new frame.
+4. Because the same mode is enabled, `ClearMode::All` clears the current visible frame in place instead of pushing it into `flat_storage`.
+5. Claude’s new frame is written into the same active grid area, so the block shows the latest frame rather than an accumulated stack of old frames.
+The fix intentionally does not change:
+- `ClearMode::Above`, `Below`, `Saved`, `ResetAndClear`, or `ActiveBlock`.
+- Alt-screen behavior, which already clears full-screen frames in place.
+- Non-agent primary-screen `ESC[2J` behavior, including shell prompt `clear`/Ctrl-L-style history preservation.
+- Non-agent primary-screen resize reflow and history preservation.
+- The trailing blank row trimming predicate or cursor-hiding behavior from APP-4004/APP-4006.
+The important invariant is that visible rows should enter `flat_storage` only when they represent historical block output. During active CLI-agent frame redraws, the visible rows are the mutable frame surface; preserving them into `flat_storage` turns ephemeral frames into accumulated output.
+## Testing and validation
+Add targeted model tests first, then manually verify against Claude Code.
+Recommended unit tests in `app/src/terminal/model/grid/grid_handler_test.rs`:
+- Primary-screen `ClearMode::All` with the new flag disabled keeps existing behavior: visible rows are moved into `flat_storage` by `clear_viewport()`.
+- Primary-screen `ClearMode::All` with the new flag enabled clears active rows in place: `history_size()` does not grow, old frame text is gone, and text written after the clear appears as the only current frame.
+- Alt-screen `ClearMode::All` remains in-place and unchanged.
+- Primary-screen resize with the new flag disabled keeps existing behavior: resize reflow may move visible rows into `flat_storage`.
+- Primary-screen resize with the new flag enabled resizes visible storage in place: `history_size()` does not grow during resize.
+- `ClearMode::Saved`, `ResetAndClear`, and `ActiveBlock` still clear history/state through their existing paths.
+Recommended wiring tests:
+- A started CLI-agent session marks the active block output grid for in-place frame redraw clears.
+- An ended CLI-agent session unmarks it.
+- Finishing a block clears the mode even if the session end event is delayed.
+Manual validation:
+- Capture raw PTY output while resizing Claude Code, if possible, and confirm the redraw contains a full-screen clear such as `ESC[H ESC[2J`.
+- Run Claude Code in Warp, resize the pane narrower several times, and verify the active block overwrites the current frame instead of accumulating prior frames.
+- Repeat a normal shell `clear`/Ctrl-L flow outside a CLI-agent session and verify Warp still preserves the prior primary-screen contents according to existing block semantics.
+- Resize ordinary primary-screen command output outside a CLI-agent session and verify existing reflow/scrollback behavior is unchanged.
+- Smoke-test Codex/OpenCode CLI-agent sessions to ensure trailing blank trimming and cursor behavior from APP-4004/APP-4006 are unchanged.
+Suggested commands:
+- `cargo test -p app terminal::model::grid::grid_handler_test -- --nocapture` or the narrowest package/test invocation that matches this repo’s current test target names.
+- If implementation touches broader terminal-model behavior, run the relevant terminal model tests before manual verification.
+## Risks and mitigations
+- Primary-screen full clear and resize reflow have user-visible history semantics in Warp. Mitigation: scope the in-place behavior only to active CLI-agent sessions, and only for `ClearMode::All` plus primary-screen resize while the frame-redraw mode is active.
+- Some CLI agents might intentionally use primary-screen clears to preserve previous output. Mitigation: the behavior applies only while Warp has detected an active CLI-agent session, where full-screen clears are overwhelmingly frame redraws; completed blocks revert to normal.
+- Images and secret metadata may outlive in-place-cleared cells if only grid cells are reset. Mitigation: reuse or extend existing clear/eviction helpers so ancillary grid state matches the cleared visible region.
+- Delayed lifecycle events can target the wrong active block. Mitigation: clear the flag on `BlockGrid::finish()` in addition to handling `Ended`.
+- Resize ordering may still produce edge cases if a process writes during the gap between model resize and PTY resize delivery. Mitigation: the scoped resize path prevents the main old-frame preservation mechanism; treat backend-before-model resizing as a follow-up only if manual verification still shows accumulation.


### PR DESCRIPTION
## Description
Fixes #9838 and fixes REMOTE-1423

Add a block-level flag for conditionally clearing output grid contents in-place on ansi::ClearMode::All (`esc[2j`) rather than clearing by 'scrolling' + appending to block-level scrollback.

In a traditional terminal the sequence clears the entire screen - in ghostty we see that frame-redrawing resizes for claude code, for instance, clear the entire terminal display (not appending to scrollback). This implements that behavior at a block-level for CLI agent TUIs that Warp is 'aware' of.

Preserves existing behavior for other cases to limit blast radius of the change - I think there are cases where the current block-level clear-by-scrolling behavior might be preferable/intended

CHANGELOG-BUG-FIX: Fixes issue with repeated TUI redraws for CLI agents on terminal pane resize.
