### PR TITLE
fix: replace confusing Oz CLI references in warp-terminal --help output

### DIFF
--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -92,15 +92,15 @@ pub struct GlobalOptions {
 #[derive(Debug, Default, Parser, Clone)]
 #[command(
     name = "oz",
-    display_name = "Oz",
-    about = r#"The orchestration platform for cloud agents
+    display_name = "Warp",
+    about = r#"The intelligent terminal for developers
 
-The Oz CLI is a tool for running, managing, and orchestrating coding agents at scale.
+The Warp CLI is a tool for managing agents, MCP servers, and cloud environments.
 Use the CLI to:
-* Launch and inspect cloud agents
-* Schedule cloud agents to run in the future
-* Manage the environments that cloud agents run in
-* Upload secrets to Oz's secure storage"#
+* Launch and inspect coding agents
+* Manage MCP servers and integrations
+* Manage cloud environments
+* Manage secrets and artifacts"#
 )]
 #[clap(args_conflicts_with_subcommands = true)]
 pub struct Args {

--- a/resources/linux/arch/cli/PKGBUILD.template
+++ b/resources/linux/arch/cli/PKGBUILD.template
@@ -1,7 +1,7 @@
 pkgname=oz@@CHANNEL_SUFFIX@@
 pkgver=@@VERSION@@
 pkgrel=@@RELEASE@@
-pkgdesc="The orchestration platform for cloud agents"
+pkgdesc="The intelligent terminal for developers"
 arch=('@@ARCH@@')
 url="https://warp.dev"
 license=('custom')

--- a/resources/linux/debian/cli/control.template
+++ b/resources/linux/debian/cli/control.template
@@ -8,10 +8,10 @@ Maintainer: Warp Linux Maintainers <linux-maintainers@warp.dev>
 Homepage: https://warp.dev/
 Replaces: warp-cli@@CHANNEL_SUFFIX@@ (<< @@VERSION@@), oz (= 0.2026.02.09.06.06.stable.00), oz (= 0.2026.02.09.06.06.stable.02), oz (= 0.2026.02.10.11.37.stable.00), oz (= 0.2026.02.10.11.37.stable.01), oz (= 0.2026.02.11.08.23.stable.00)
 Conflicts: warp-cli@@CHANNEL_SUFFIX@@ (<< @@VERSION@@), oz (= 0.2026.02.09.06.06.stable.00), oz (= 0.2026.02.09.06.06.stable.02), oz (= 0.2026.02.10.11.37.stable.00), oz (= 0.2026.02.10.11.37.stable.01), oz (= 0.2026.02.11.08.23.stable.00)
-Description: The orchestration platform for cloud agents
- The Oz CLI is a tool for running, managing, and orchestrating coding agents at scale.
+Description: The intelligent terminal for developers
+ The Warp CLI is a tool for managing agents, MCP servers, and cloud environments.
  Use the CLI to:
- * Launch and inspect cloud agents
- * Schedule cloud agents to run in the future
- * Manage the environments that cloud agents run in
- * Upload secrets to Oz's secure storage
+ * Launch and inspect coding agents
+ * Manage MCP servers and integrations
+ * Manage cloud environments
+ * Manage secrets and artifacts

--- a/resources/linux/rpm/cli/warp.spec.template
+++ b/resources/linux/rpm/cli/warp.spec.template
@@ -2,7 +2,7 @@
 # Package Spec
 ###############################################################################
 
-Summary:     The orchestration platform for cloud agents.
+Summary:     The intelligent terminal for developers.
 Name:        oz@@CHANNEL_SUFFIX@@
 Version:     @@VERSION@@
 Release:     @@RELEASE@@
@@ -31,12 +31,12 @@ prefix:      /opt
 ###############################################################################
 
 %description
-The Oz CLI is a tool for running, managing, and orchestrating coding agents at scale.
+The Warp CLI is a tool for managing agents, MCP servers, and cloud environments.
 Use the CLI to:
-* Launch and inspect cloud agents
-* Schedule cloud agents to run in the future
-* Manage the environments that cloud agents run in
-* Upload secrets to Oz's secure storage
+* Launch and inspect coding agents
+* Manage MCP servers and integrations
+* Manage cloud environments
+* Manage secrets and artifacts
 
 ###############################################################################
 # Build rule - how does the package get built?


### PR DESCRIPTION
## Summary

Fixes #9726

When running `warp-terminal --help`, users see confusing internal "Oz" branding instead of Warp branding:

```
$ warp-terminal --help
The orchestration platform for cloud agents

The Oz CLI is a tool for running, managing, and orchestrating coding agents at scale.
```

This PR replaces all user-facing "Oz" references with "Warp" in:

- **CLI help text** (`crates/warp_cli/src/lib.rs`) - Updated `display_name` and `about` text
- **RPM package spec** (`resources/linux/rpm/cli/warp.spec.template`) - Updated Summary and description
- **Debian package control** (`resources/linux/debian/cli/control.template`) - Updated Description
- **Arch PKGBUILD** (`resources/linux/arch/cli/PKGBUILD.template`) - Updated pkgdesc

## Testing

- Verified the diff updates only user-facing description strings
- Internal `name = "oz"` is preserved since it may be referenced by internal tooling
- Package metadata fields (Name, Version, Replaces, Conflicts, etc.) are unchanged