### PR TITLE
feat: add Mistral Vibe to recognized CLI agents

### DIFF
--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -500,6 +500,7 @@ pub enum CLIAgentType {
     Auggie,
     Cursor,
     Goose,
+    Vibe,
     Unknown,
 }
 

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -159,6 +159,15 @@ impl CLIAgent {
         }
     }
 
+    /// Alternative command prefixes that also resolve to this CLI agent.
+    /// For example, `vibe-acp` is an alternative entry point for Mistral Vibe.
+    pub fn command_aliases(&self) -> &'static [&'static str] {
+        match self {
+            CLIAgent::Vibe => &["vibe-acp"],
+            _ => &[],
+        }
+    }
+
     /// Serialized version of the CLIAgent name (e.g. "Claude", "Gemini"). Used for the
     /// session-sharing protocol's opaque `cli_agent` string field.
     pub fn to_serialized_name(&self) -> String {
@@ -356,6 +365,7 @@ impl CLIAgent {
             .filter(|agent| !matches!(agent, CLIAgent::Unknown))
             .find(|agent| {
                 resolved_first_word == agent.command_prefix()
+                    || agent.command_aliases().contains(&resolved_first_word.as_str())
                     || (matches!(agent, CLIAgent::Claude)
                         && Self::is_aifx_agent_run_claude(&resolved_command, ctx))
             })

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -112,7 +112,15 @@ const GOOSE_COLOR: ColorU = ColorU {
     a: 255,
 };
 
-/// Represents a CLI agent (e.g., Claude Code, Gemini CLI, Codex, Amp, Droid, OpenCode, Copilot, Pi, Auggie, Cursor, Goose)
+/// Mistral brand color (#FA520F, from Mistral AI brand assets)
+const MISTRAL_ORANGE: ColorU = ColorU {
+    r: 250,
+    g: 82,
+    b: 15,
+    a: 255,
+};
+
+/// Represents a CLI agent (e.g., Claude Code, Gemini CLI, Codex, Amp, Droid, OpenCode, Copilot, Pi, Auggie, Cursor, Goose, Vibe)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Sequence, Serialize, Deserialize)]
 pub enum CLIAgent {
     Claude,
@@ -126,6 +134,7 @@ pub enum CLIAgent {
     Auggie,
     CursorCli,
     Goose,
+    Vibe,
     /// Represents an unknown/custom CLI agent matched by user-configured regex patterns.
     Unknown,
 }
@@ -145,6 +154,7 @@ impl CLIAgent {
             CLIAgent::Auggie => "auggie",
             CLIAgent::CursorCli => "agent",
             CLIAgent::Goose => "goose",
+            CLIAgent::Vibe => "vibe",
             CLIAgent::Unknown => "",
         }
     }
@@ -190,6 +200,7 @@ impl CLIAgent {
             CLIAgent::Auggie => "Auggie",
             CLIAgent::CursorCli => "Cursor",
             CLIAgent::Goose => "Goose",
+            CLIAgent::Vibe => "Mistral Vibe",
             CLIAgent::Unknown => "CLI Agent",
         }
     }
@@ -208,6 +219,7 @@ impl CLIAgent {
             CLIAgent::Auggie => Some(Icon::AuggieLogo),
             CLIAgent::CursorCli => Some(Icon::CursorLogo),
             CLIAgent::Goose => Some(Icon::GooseLogo),
+            CLIAgent::Vibe => None,
             CLIAgent::Unknown => None,
         }
     }
@@ -236,6 +248,7 @@ impl CLIAgent {
             CLIAgent::Auggie => &[SkillProvider::Agents],
             CLIAgent::CursorCli => &[SkillProvider::Agents],
             CLIAgent::Goose => &[SkillProvider::Agents],
+            CLIAgent::Vibe => &[SkillProvider::Agents],
             CLIAgent::Unknown => &[],
         }
     }
@@ -276,6 +289,7 @@ impl CLIAgent {
             CLIAgent::Auggie => Some(AUGGIE_COLOR),
             CLIAgent::CursorCli => Some(CURSOR_COLOR),
             CLIAgent::Goose => Some(GOOSE_COLOR),
+            CLIAgent::Vibe => Some(MISTRAL_ORANGE),
             CLIAgent::Unknown => None,
         }
     }
@@ -537,6 +551,7 @@ impl From<CLIAgent> for CLIAgentType {
             CLIAgent::Auggie => CLIAgentType::Auggie,
             CLIAgent::CursorCli => CLIAgentType::Cursor,
             CLIAgent::Goose => CLIAgentType::Goose,
+            CLIAgent::Vibe => CLIAgentType::Vibe,
             CLIAgent::Unknown => CLIAgentType::Unknown,
         }
     }

--- a/app/src/terminal/cli_agent_sessions/listener/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod.rs
@@ -69,6 +69,7 @@ fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
         | CLIAgent::Copilot
         | CLIAgent::CursorCli
         | CLIAgent::Goose
+        | CLIAgent::Vibe
         | CLIAgent::Unknown => None,
     }
 }

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
@@ -264,6 +264,7 @@ pub(crate) fn plugin_manager_for_with_shell(
         | CLIAgent::Auggie
         | CLIAgent::CursorCli
         | CLIAgent::Goose
+        | CLIAgent::Vibe
         | CLIAgent::Unknown => None,
     }
 }

--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -259,6 +259,8 @@ fn test_detect_known_agents() {
                 ("copilot", CLIAgent::Copilot),
                 ("agent", CLIAgent::CursorCli),
                 ("goose", CLIAgent::Goose),
+                ("vibe", CLIAgent::Vibe),
+                ("vibe-acp", CLIAgent::Vibe),
             ] {
                 assert_eq!(
                     CLIAgent::detect(command, None, None, ctx),

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -127,7 +127,7 @@ fn rich_input_submit_strategy(agent: CLIAgent) -> RichInputSubmitStrategy {
         | CLIAgent::Gemini
         | CLIAgent::Auggie
         | CLIAgent::CursorCli => RichInputSubmitStrategy::DelayedEnter,
-        CLIAgent::Amp | CLIAgent::Droid | CLIAgent::Pi | CLIAgent::Goose | CLIAgent::Unknown => {
+        CLIAgent::Amp | CLIAgent::Droid | CLIAgent::Pi | CLIAgent::Goose | CLIAgent::Vibe | CLIAgent::Unknown => {
             RichInputSubmitStrategy::Inline
         }
     }


### PR DESCRIPTION
## Summary

Fixes #9607

Adds Mistral Vibe (`vibe` / `vibe-acp`) to Warp's list of recognized CLI agents so that running it in a Warp pane gets full agent detection, brand-colored toolbar, and skill-provider integration.

### Changes

| File | Change |
|---|---|
| `app/src/terminal/cli_agent.rs` | `Vibe` variant + `MISTRAL_ORANGE` color + all match arms |
| `app/src/server/telemetry/events.rs` | `Vibe` in `CLIAgentType` telemetry enum |
| `app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs` | Added to catch-all `None` match |
| `app/src/terminal/cli_agent_sessions/listener/mod.rs` | Added to catch-all `None` match |
| `app/src/terminal/view/use_agent_footer/mod.rs` | Added to `Inline` submit strategy arm |

### Design decisions

- **`icon` → `None`**: No dedicated Mistral SVG asset in the bundle yet. Can be added in a follow-up when the asset is available.
- **`brand_color` → `#FA520F`**: Mistral's official orange from brand assets.
- **`brand_icon_color` → white (default)**: Orange is a dark/bright background, white provides good contrast.
- **`supported_skill_providers` → `&[SkillProvider::Agents]`**: Follows the same pattern as Amp, Goose, Copilot, etc.
- **`supports_bash_mode` → `false`**: Default; can be enabled in a follow-up if Vibe adds `!` support.
- **`rich_input_submit_strategy` → `Inline`**: Same as other agents without special PTY handling.

### Testing

- All exhaustive match arms are completed (the codebase uses `#![deny(wildcard_enum_match)]` via `WARP.md`).
- No new protocol or transport code needed — `vibe-acp` speaks ACP natively.