### PR TITLE
Preserve agent status in vertical tab summaries

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -902,6 +902,37 @@ fn summary_pane_kinds_share_icon(a: &SummaryPaneKind, b: &SummaryPaneKind) -> bo
     }
 }
 
+fn merge_summary_pane_kind_icon_status(
+    existing: &mut SummaryPaneKind,
+    candidate: &SummaryPaneKind,
+) {
+    match (existing, candidate) {
+        (
+            SummaryPaneKind::OzAgent {
+                status: existing_status,
+                ..
+            },
+            SummaryPaneKind::OzAgent {
+                status: candidate_status,
+                ..
+            },
+        )
+        | (
+            SummaryPaneKind::CLIAgent {
+                status: existing_status,
+                ..
+            },
+            SummaryPaneKind::CLIAgent {
+                status: candidate_status,
+                ..
+            },
+        ) if existing_status != candidate_status => {
+            *existing_status = None;
+        }
+        _ => {}
+    }
+}
+
 fn format_summary_primary_labels(labels: &[String], visible_limit: usize) -> Option<String> {
     const SEPARATOR: &str = " • ";
     if labels.is_empty() {
@@ -947,24 +978,25 @@ fn select_summary_pane_kind_icons(
 
     let mut unique_kinds = Vec::new();
     for (_, pane_kind) in pane_kinds {
-        if !unique_kinds
-            .iter()
-            .any(|kind| summary_pane_kinds_share_icon(kind, &pane_kind))
+        if let Some(existing) = unique_kinds
+            .iter_mut()
+            .find(|kind| summary_pane_kinds_share_icon(kind, &pane_kind))
         {
+            merge_summary_pane_kind_icon_status(existing, &pane_kind);
+        } else if unique_kinds.len() < 2 {
             unique_kinds.push(pane_kind);
-        }
-        if unique_kinds.len() == 2 {
-            return Some(SummaryPaneKindIcons::Pair {
-                primary: unique_kinds[0].clone(),
-                secondary: unique_kinds[1].clone(),
-            });
         }
     }
 
-    unique_kinds
-        .first()
-        .cloned()
-        .map(SummaryPaneKindIcons::Single)
+    match unique_kinds.as_slice() {
+        [primary, secondary] => Some(SummaryPaneKindIcons::Pair {
+            primary: primary.clone(),
+            secondary: secondary.clone(),
+        }),
+        [single] => Some(SummaryPaneKindIcons::Single(single.clone())),
+        [] => None,
+        _ => unreachable!("summary mode keeps at most two icon kinds"),
+    }
 }
 
 fn resolve_summary_pane_kind_icons(

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -729,13 +729,26 @@ enum VerticalTabsResolvedMode {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum SummaryPaneKind {
     Terminal,
-    OzAgent { is_ambient: bool },
-    CLIAgent { agent: CLIAgent, is_ambient: bool },
-    Code { title: String },
+    OzAgent {
+        status: Option<ConversationStatus>,
+        is_ambient: bool,
+    },
+    CLIAgent {
+        agent: CLIAgent,
+        status: Option<ConversationStatus>,
+        is_ambient: bool,
+    },
+    Code {
+        title: String,
+    },
     CodeDiff,
     File,
-    Notebook { is_plan: bool },
-    Workflow { is_ai_prompt: bool },
+    Notebook {
+        is_plan: bool,
+    },
+    Workflow {
+        is_ai_prompt: bool,
+    },
     Settings,
     EnvVarCollection,
     EnvironmentManagement,
@@ -2411,12 +2424,18 @@ impl TypedPane<'_> {
                 // Route through the shared helper so summary mode agrees with
                 // `resolve_icon_with_status_variant` on what the tab represents.
                 match terminal_view_agent_icon_variant(terminal_view, app) {
-                    Some(IconWithStatusVariant::OzAgent { is_ambient, .. }) => {
-                        SummaryPaneKind::OzAgent { is_ambient }
+                    Some(IconWithStatusVariant::OzAgent { status, is_ambient }) => {
+                        SummaryPaneKind::OzAgent { status, is_ambient }
                     }
                     Some(IconWithStatusVariant::CLIAgent {
-                        agent, is_ambient, ..
-                    }) => SummaryPaneKind::CLIAgent { agent, is_ambient },
+                        agent,
+                        status,
+                        is_ambient,
+                    }) => SummaryPaneKind::CLIAgent {
+                        agent,
+                        status,
+                        is_ambient,
+                    },
                     Some(_) | None => SummaryPaneKind::Terminal,
                 }
             }
@@ -3562,11 +3581,8 @@ fn render_summary_pane_kind_icon_circle(
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
-    // For ambient Oz / CLI agent kinds, delegate to `render_icon_with_status` so the
-    // brand-color circle is overlaid with the white cloud badge (status-less in summary
-    // mode). Non-ambient agent kinds and all other pane kinds fall through to the inline
-    // circle rendering below.
-    if let Some(variant) = ambient_agent_variant(&kind) {
+    // Agent summary icons use the same status-aware renderer as focused-session rows.
+    if let Some(variant) = summary_agent_variant(&kind) {
         return render_icon_with_status(variant, total_size, 0., theme, theme.background());
     }
     let icon_size = total_size * SUMMARY_INLINE_ICON_RATIO;
@@ -3640,22 +3656,20 @@ fn render_summary_pane_kind_icon_circle(
     .finish()
 }
 
-/// Maps an ambient Oz / CLI agent summary-pane kind to the `IconWithStatusVariant` used to
-/// render the brand-color circle with the white cloud badge. Non-ambient kinds (and all
-/// other pane kinds) return `None` so the caller falls back to its inline rendering.
-fn ambient_agent_variant(kind: &SummaryPaneKind) -> Option<IconWithStatusVariant> {
+fn summary_agent_variant(kind: &SummaryPaneKind) -> Option<IconWithStatusVariant> {
     match kind {
-        SummaryPaneKind::OzAgent { is_ambient: true } => Some(IconWithStatusVariant::OzAgent {
-            status: None,
-            is_ambient: true,
+        SummaryPaneKind::OzAgent { status, is_ambient } => Some(IconWithStatusVariant::OzAgent {
+            status: status.clone(),
+            is_ambient: *is_ambient,
         }),
         SummaryPaneKind::CLIAgent {
             agent,
-            is_ambient: true,
+            status,
+            is_ambient,
         } => Some(IconWithStatusVariant::CLIAgent {
             agent: *agent,
-            status: None,
-            is_ambient: true,
+            status: status.clone(),
+            is_ambient: *is_ambient,
         }),
         _ => None,
     }

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -880,6 +880,28 @@ fn summary_overflow_count(total_count: usize, visible_limit: usize) -> usize {
     total_count.saturating_sub(visible_limit)
 }
 
+fn summary_pane_kinds_share_icon(a: &SummaryPaneKind, b: &SummaryPaneKind) -> bool {
+    match (a, b) {
+        (
+            SummaryPaneKind::OzAgent { is_ambient: a, .. },
+            SummaryPaneKind::OzAgent { is_ambient: b, .. },
+        ) => a == b,
+        (
+            SummaryPaneKind::CLIAgent {
+                agent: agent_a,
+                is_ambient: ambient_a,
+                ..
+            },
+            SummaryPaneKind::CLIAgent {
+                agent: agent_b,
+                is_ambient: ambient_b,
+                ..
+            },
+        ) => agent_a == agent_b && ambient_a == ambient_b,
+        _ => a == b,
+    }
+}
+
 fn format_summary_primary_labels(labels: &[String], visible_limit: usize) -> Option<String> {
     const SEPARATOR: &str = " • ";
     if labels.is_empty() {
@@ -925,7 +947,10 @@ fn select_summary_pane_kind_icons(
 
     let mut unique_kinds = Vec::new();
     for (_, pane_kind) in pane_kinds {
-        if !unique_kinds.contains(&pane_kind) {
+        if !unique_kinds
+            .iter()
+            .any(|kind| summary_pane_kinds_share_icon(kind, &pane_kind))
+        {
             unique_kinds.push(pane_kind);
         }
         if unique_kinds.len() == 2 {

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -195,6 +195,43 @@ fn summary_agent_variant_preserves_oz_agent_status() {
 }
 
 #[test]
+fn summary_pane_kind_icons_deduplicate_agents_by_stable_kind_not_status() {
+    let icons = select_summary_pane_kind_icons([
+        (
+            EntityId::from_usize(10),
+            SummaryPaneKind::CLIAgent {
+                agent: CLIAgent::Claude,
+                status: Some(ConversationStatus::InProgress),
+                is_ambient: false,
+            },
+        ),
+        (
+            EntityId::from_usize(20),
+            SummaryPaneKind::CLIAgent {
+                agent: CLIAgent::Claude,
+                status: Some(ConversationStatus::Blocked {
+                    blocked_action: "Approve command".to_string(),
+                }),
+                is_ambient: false,
+            },
+        ),
+    ]);
+
+    match icons {
+        Some(SummaryPaneKindIcons::Single(SummaryPaneKind::CLIAgent {
+            agent,
+            status,
+            is_ambient,
+        })) => {
+            assert_eq!(agent, CLIAgent::Claude);
+            assert_eq!(status, Some(ConversationStatus::InProgress));
+            assert!(!is_ambient);
+        }
+        _ => panic!("same agent kind with different statuses should render one summary icon"),
+    }
+}
+
+#[test]
 fn preferred_agent_tab_titles_default_to_title_like_text() {
     let agent_text = TerminalAgentText {
         conversation_display_title: Some("Generated Oz title".to_string()),

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -1,8 +1,10 @@
+use crate::ai::agent::conversation::ConversationStatus;
 use crate::context_chips::display_chip::GitLineChanges;
 use crate::pane_group::pane::IPaneType;
 use crate::pane_group::{PaneId, TerminalPaneId};
 use crate::safe_triangle::SafeTriangle;
 use crate::terminal::CLIAgent;
+use crate::ui_components::icon_with_status::IconWithStatusVariant;
 use crate::workspace::tab_settings::VerticalTabsDisplayGranularity;
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::Vector2F;
@@ -17,12 +19,13 @@ use super::{
     non_terminal_search_text_fragments, pane_ids_for_display_granularity,
     pane_search_text_fragments, preferred_agent_tab_titles, search_fragments_contain_query,
     select_summary_pane_kind_icons, should_keep_detail_sidecar_visible_for_mouse_position,
-    summary_overflow_count, summary_search_text_fragments, terminal_kind_badge_label,
-    terminal_primary_line_data, terminal_pull_request_badge_label, terminal_search_text_fragments,
-    terminal_title_fallback_font, uses_outer_group_container, visible_pane_ids_for_detail_target,
-    vtab_diff_stats_text, AgentTabTextPreference, SummaryPaneKind, SummaryPaneKindIcons,
-    TerminalAgentText, TerminalPrimaryLineData, TerminalPrimaryLineFont, VerticalTabsDetailTarget,
-    VerticalTabsDetailTargetKind, VerticalTabsSummaryBranchEntry, VerticalTabsSummaryData,
+    summary_agent_variant, summary_overflow_count, summary_search_text_fragments,
+    terminal_kind_badge_label, terminal_primary_line_data, terminal_pull_request_badge_label,
+    terminal_search_text_fragments, terminal_title_fallback_font, uses_outer_group_container,
+    visible_pane_ids_for_detail_target, vtab_diff_stats_text, AgentTabTextPreference,
+    SummaryPaneKind, SummaryPaneKindIcons, TerminalAgentText, TerminalPrimaryLineData,
+    TerminalPrimaryLineFont, VerticalTabsDetailTarget, VerticalTabsDetailTargetKind,
+    VerticalTabsSummaryBranchEntry, VerticalTabsSummaryData,
 };
 
 fn pane_id() -> PaneId {
@@ -87,18 +90,23 @@ fn summary_pane_kind_icons_distinguish_agent_terminals_from_plain_terminals() {
                 EntityId::from_usize(20),
                 SummaryPaneKind::CLIAgent {
                     agent: CLIAgent::Claude,
+                    status: None,
                     is_ambient: false,
                 },
             ),
             (
                 EntityId::from_usize(30),
-                SummaryPaneKind::OzAgent { is_ambient: false },
+                SummaryPaneKind::OzAgent {
+                    status: None,
+                    is_ambient: false,
+                },
             ),
         ]),
         Some(SummaryPaneKindIcons::Pair {
             primary: SummaryPaneKind::Terminal,
             secondary: SummaryPaneKind::CLIAgent {
                 agent: CLIAgent::Claude,
+                status: None,
                 is_ambient: false,
             },
         })
@@ -115,6 +123,7 @@ fn summary_pane_kind_icons_distinguish_ambient_claude_from_local_claude() {
                 EntityId::from_usize(10),
                 SummaryPaneKind::CLIAgent {
                     agent: CLIAgent::Claude,
+                    status: None,
                     is_ambient: false,
                 },
             ),
@@ -122,6 +131,7 @@ fn summary_pane_kind_icons_distinguish_ambient_claude_from_local_claude() {
                 EntityId::from_usize(20),
                 SummaryPaneKind::CLIAgent {
                     agent: CLIAgent::Claude,
+                    status: None,
                     is_ambient: true,
                 },
             ),
@@ -129,14 +139,59 @@ fn summary_pane_kind_icons_distinguish_ambient_claude_from_local_claude() {
         Some(SummaryPaneKindIcons::Pair {
             primary: SummaryPaneKind::CLIAgent {
                 agent: CLIAgent::Claude,
+                status: None,
                 is_ambient: false,
             },
             secondary: SummaryPaneKind::CLIAgent {
                 agent: CLIAgent::Claude,
+                status: None,
                 is_ambient: true,
             },
         })
     );
+}
+
+#[test]
+fn summary_agent_variant_preserves_cli_agent_status() {
+    let variant = summary_agent_variant(&SummaryPaneKind::CLIAgent {
+        agent: CLIAgent::Claude,
+        status: Some(ConversationStatus::InProgress),
+        is_ambient: false,
+    })
+    .expect("agent summary kind should produce status-aware icon variant");
+
+    match variant {
+        IconWithStatusVariant::CLIAgent {
+            agent,
+            status,
+            is_ambient,
+        } => {
+            assert_eq!(agent, CLIAgent::Claude);
+            assert_eq!(status, Some(ConversationStatus::InProgress));
+            assert!(!is_ambient);
+        }
+        _ => panic!("expected CLI agent icon variant"),
+    }
+}
+
+#[test]
+fn summary_agent_variant_preserves_oz_agent_status() {
+    let blocked_status = ConversationStatus::Blocked {
+        blocked_action: "Approve command".to_string(),
+    };
+    let variant = summary_agent_variant(&SummaryPaneKind::OzAgent {
+        status: Some(blocked_status.clone()),
+        is_ambient: true,
+    })
+    .expect("oz summary kind should produce status-aware icon variant");
+
+    match variant {
+        IconWithStatusVariant::OzAgent { status, is_ambient } => {
+            assert_eq!(status, Some(blocked_status));
+            assert!(is_ambient);
+        }
+        _ => panic!("expected Oz agent icon variant"),
+    }
 }
 
 #[test]

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -195,7 +195,7 @@ fn summary_agent_variant_preserves_oz_agent_status() {
 }
 
 #[test]
-fn summary_pane_kind_icons_deduplicate_agents_by_stable_kind_not_status() {
+fn summary_pane_kind_icons_suppress_status_when_duplicate_agents_disagree() {
     let icons = select_summary_pane_kind_icons([
         (
             EntityId::from_usize(10),
@@ -224,10 +224,52 @@ fn summary_pane_kind_icons_deduplicate_agents_by_stable_kind_not_status() {
             is_ambient,
         })) => {
             assert_eq!(agent, CLIAgent::Claude);
-            assert_eq!(status, Some(ConversationStatus::InProgress));
+            assert_eq!(status, None);
             assert!(!is_ambient);
         }
         _ => panic!("same agent kind with different statuses should render one summary icon"),
+    }
+}
+
+#[test]
+fn summary_pane_kind_icons_merge_later_duplicate_agent_statuses_after_pair_selected() {
+    let icons = select_summary_pane_kind_icons([
+        (
+            EntityId::from_usize(10),
+            SummaryPaneKind::CLIAgent {
+                agent: CLIAgent::Claude,
+                status: Some(ConversationStatus::InProgress),
+                is_ambient: false,
+            },
+        ),
+        (EntityId::from_usize(20), SummaryPaneKind::Terminal),
+        (
+            EntityId::from_usize(30),
+            SummaryPaneKind::CLIAgent {
+                agent: CLIAgent::Claude,
+                status: Some(ConversationStatus::Blocked {
+                    blocked_action: "Approve command".to_string(),
+                }),
+                is_ambient: false,
+            },
+        ),
+    ]);
+
+    match icons {
+        Some(SummaryPaneKindIcons::Pair {
+            primary:
+                SummaryPaneKind::CLIAgent {
+                    agent,
+                    status,
+                    is_ambient,
+                },
+            secondary: SummaryPaneKind::Terminal,
+        }) => {
+            assert_eq!(agent, CLIAgent::Claude);
+            assert_eq!(status, None);
+            assert!(!is_ambient);
+        }
+        _ => panic!("later duplicate agent statuses should be merged after pair selection"),
     }
 }
 


### PR DESCRIPTION
## Description
Preserve agent status when vertical tabs render tab summaries. Summary icons now use the same status-aware agent icon variant as focused-session rows.

## Linked Issue
Fixes #9868

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
<img width="396" height="321" alt="image" src="https://github.com/user-attachments/assets/784dacfd-bec0-4599-9bc3-0182ebd4e9a2" />


## Testing
- `cargo fmt -- --check`
- `cargo check -p warp --bin warp-oss --features gui,vertical_tabs_summary_mode`
- `cargo test -p warp vertical_tabs`
- `cargo clippy -p warp --bin warp-oss --features gui,vertical_tabs_summary_mode -- -D warnings`

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Preserve agent status badges in vertical tabs Summary mode.

Co-Authored-By: Warp <agent@warp.dev>

## Note
I am new to contributing so please let me know if there are any mistakes or I am going against any styling / warp specifications 😁 