### PR TITLE
Fix linked-worktree branch checkout

### DIFF
--- a/app/src/context_chips/builtins.rs
+++ b/app/src/context_chips/builtins.rs
@@ -147,10 +147,17 @@ pub fn shell_git_branch() -> ShellCommandGenerator {
 }
 
 pub fn shell_other_git_branches() -> ShellCommandGenerator {
-    const SH_COMMAND: &str = "git --no-optional-locks branch --no-color --sort=-committerdate";
+    const SH_COMMAND: &str = "git --no-optional-locks branch --no-color --sort=-committerdate; \
+        printf '\\036\\n'; \
+        git --no-optional-locks worktree list --porcelain";
+    let pwsh_command = safe_git_powershell(
+        "git --no-optional-locks branch --no-color --sort=-committerdate; \
+        [char]30; \
+        git --no-optional-locks worktree list --porcelain",
+    );
 
     let command = ShellCommand::shell_specific([
-        (ShellType::PowerShell, SH_COMMAND.to_string()),
+        (ShellType::PowerShell, pwsh_command),
         (ShellType::Bash, SH_COMMAND.to_string()),
         (ShellType::Zsh, SH_COMMAND.to_string()),
         (ShellType::Fish, SH_COMMAND.to_string()),

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -201,6 +201,65 @@ struct ShellCommandExecutionContext {
     shell_type: crate::terminal::shell::ShellType,
 }
 
+fn trimmed_git_branch_on_click_value(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn git_branch_on_click_value_is_current(value: &str) -> bool {
+    value
+        .trim()
+        .strip_prefix('*')
+        .is_some_and(|rest| rest.chars().next().is_some_and(|c| c.is_whitespace()))
+}
+
+fn strip_git_branch_status_marker(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    let branch = ['*', '+']
+        .into_iter()
+        .find_map(|marker| {
+            trimmed.strip_prefix(marker).and_then(|rest| {
+                rest.chars()
+                    .next()
+                    .filter(|c| c.is_whitespace())
+                    .map(|_| rest.trim())
+            })
+        })
+        .unwrap_or(trimmed);
+
+    if branch.is_empty() {
+        None
+    } else {
+        Some(branch)
+    }
+}
+
+fn filter_git_branch_on_click_values(values_opt: Option<Vec<String>>) -> Option<Vec<String>> {
+    values_opt.map(|values| {
+        let mut trimmed: Vec<String> = values
+            .into_iter()
+            .filter_map(|s| trimmed_git_branch_on_click_value(&s))
+            .collect();
+
+        // We want to sort the branches so the current branch is first (denoted by *).
+        // The rest of the branches maintain their relative order.
+        trimmed.sort_by(|a, b| {
+            let a_starts_with_star = git_branch_on_click_value_is_current(a);
+            let b_starts_with_star = git_branch_on_click_value_is_current(b);
+            b_starts_with_star.cmp(&a_starts_with_star)
+        });
+
+        trimmed
+            .into_iter()
+            .filter_map(|s| strip_git_branch_status_marker(&s).map(str::to_string))
+            .collect()
+    })
+}
+
 impl CurrentPrompt {
     pub fn new(sessions: ModelHandle<Sessions>, ctx: &mut ModelContext<Self>) -> Self {
         Self::new_with_model_events(sessions, None, ctx)
@@ -619,26 +678,7 @@ impl CurrentPrompt {
         &self,
         values_opt: Option<Vec<String>>,
     ) -> Option<Vec<String>> {
-        values_opt.map(|values| {
-            let mut trimmed: Vec<String> = values
-                .into_iter()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-
-            // We want to sort the branches so the current branch is first (denoted by *).
-            // The rest of the branches maintain their relative order.
-            trimmed.sort_by(|a, b| {
-                let a_starts_with_star = a.starts_with('*');
-                let b_starts_with_star = b.starts_with('*');
-                b_starts_with_star.cmp(&a_starts_with_star)
-            });
-
-            trimmed
-                .into_iter()
-                .map(|s| s.trim_start_matches('*').trim().to_string())
-                .collect()
-        })
+        filter_git_branch_on_click_values(values_opt)
     }
 
     /// Perform a single update of the given chip.

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -201,65 +201,6 @@ struct ShellCommandExecutionContext {
     shell_type: crate::terminal::shell::ShellType,
 }
 
-fn trimmed_git_branch_on_click_value(value: &str) -> Option<String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
-
-fn git_branch_on_click_value_is_current(value: &str) -> bool {
-    value
-        .trim()
-        .strip_prefix('*')
-        .is_some_and(|rest| rest.chars().next().is_some_and(|c| c.is_whitespace()))
-}
-
-fn strip_git_branch_status_marker(value: &str) -> Option<&str> {
-    let trimmed = value.trim();
-    let branch = ['*', '+']
-        .into_iter()
-        .find_map(|marker| {
-            trimmed.strip_prefix(marker).and_then(|rest| {
-                rest.chars()
-                    .next()
-                    .filter(|c| c.is_whitespace())
-                    .map(|_| rest.trim())
-            })
-        })
-        .unwrap_or(trimmed);
-
-    if branch.is_empty() {
-        None
-    } else {
-        Some(branch)
-    }
-}
-
-fn filter_git_branch_on_click_values(values_opt: Option<Vec<String>>) -> Option<Vec<String>> {
-    values_opt.map(|values| {
-        let mut trimmed: Vec<String> = values
-            .into_iter()
-            .filter_map(|s| trimmed_git_branch_on_click_value(&s))
-            .collect();
-
-        // We want to sort the branches so the current branch is first (denoted by *).
-        // The rest of the branches maintain their relative order.
-        trimmed.sort_by(|a, b| {
-            let a_starts_with_star = git_branch_on_click_value_is_current(a);
-            let b_starts_with_star = git_branch_on_click_value_is_current(b);
-            b_starts_with_star.cmp(&a_starts_with_star)
-        });
-
-        trimmed
-            .into_iter()
-            .filter_map(|s| strip_git_branch_status_marker(&s).map(str::to_string))
-            .collect()
-    })
-}
-
 impl CurrentPrompt {
     pub fn new(sessions: ModelHandle<Sessions>, ctx: &mut ModelContext<Self>) -> Self {
         Self::new_with_model_events(sessions, None, ctx)
@@ -678,7 +619,7 @@ impl CurrentPrompt {
         &self,
         values_opt: Option<Vec<String>>,
     ) -> Option<Vec<String>> {
-        filter_git_branch_on_click_values(values_opt)
+        super::git_branch_on_click::filter_git_branch_on_click_values(values_opt)
     }
 
     /// Perform a single update of the given chip.

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -166,27 +166,6 @@ fn test_prompt_to_string() {
 }
 
 #[test]
-fn test_git_branch_on_click_values_strip_git_branch_markers() {
-    let values = Some(vec![
-        "  feature-a".to_string(),
-        "+ linked-worktree".to_string(),
-        "* main".to_string(),
-        "".to_string(),
-        "  +literal-plus".to_string(),
-    ]);
-
-    assert_eq!(
-        super::filter_git_branch_on_click_values(values),
-        Some(vec![
-            "main".to_string(),
-            "feature-a".to_string(),
-            "linked-worktree".to_string(),
-            "+literal-plus".to_string(),
-        ])
-    );
-}
-
-#[test]
 fn test_fingerprint_skips_contextual_chip_recompute_when_context_is_unchanged() {
     App::test((), |mut app| async move {
         let session_id = SessionId::from(777);

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -166,6 +166,27 @@ fn test_prompt_to_string() {
 }
 
 #[test]
+fn test_git_branch_on_click_values_strip_git_branch_markers() {
+    let values = Some(vec![
+        "  feature-a".to_string(),
+        "+ linked-worktree".to_string(),
+        "* main".to_string(),
+        "".to_string(),
+        "  +literal-plus".to_string(),
+    ]);
+
+    assert_eq!(
+        super::filter_git_branch_on_click_values(values),
+        Some(vec![
+            "main".to_string(),
+            "feature-a".to_string(),
+            "linked-worktree".to_string(),
+            "+literal-plus".to_string(),
+        ])
+    );
+}
+
+#[test]
 fn test_fingerprint_skips_contextual_chip_recompute_when_context_is_unchanged() {
     App::test((), |mut app| async move {
         let session_id = SessionId::from(777);

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -1789,8 +1789,8 @@ fn format_change_directory_command(dir_name: &str) -> String {
     format!("cd {}", shell_single_quote(dir_name))
 }
 
-pub fn format_git_branch_command(value: &str) -> String {
-    let branch = GitBranchOnClickValue::decode(value);
+pub fn format_git_branch_command(encoded_git_branch_on_click_value: &str) -> String {
+    let branch = GitBranchOnClickValue::decode(encoded_git_branch_on_click_value);
     if let Some(worktree_path) = branch.worktree_path {
         return format_change_directory_command(&worktree_path);
     }
@@ -1805,7 +1805,7 @@ pub fn format_git_branch_command(value: &str) -> String {
         );
     }
 
-    format!("git checkout {}", branch.branch_name)
+    format!("git checkout {}", shell_single_quote(&branch.branch_name))
 }
 
 pub(crate) fn chip_container(

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -448,6 +448,15 @@ impl GitBranch {
     fn command(&self) -> String {
         format_git_branch_command(&self.0)
     }
+
+    fn icon_for_menu(&self) -> Icon {
+        let branch = GitBranchOnClickValue::decode(&self.0);
+        if branch.is_linked_worktree {
+            Icon::Dataflow02
+        } else {
+            Icon::GitBranch
+        }
+    }
 }
 
 impl GenericMenuItem for GitBranch {
@@ -460,7 +469,7 @@ impl GenericMenuItem for GitBranch {
     }
 
     fn icon(&self, _app: &AppContext) -> Option<Icon> {
-        Some(Icon::GitBranch)
+        Some(self.icon_for_menu())
     }
 
     fn action_data(&self) -> String {

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -1782,7 +1782,7 @@ impl ActionButtonTheme for EnterAgentViewButton {
 }
 
 fn shell_single_quote(value: &str) -> String {
-    format!("'{}'", value.replace("'", "'\\'''"))
+    format!("'{}'", value.replace("'", "'\\''"))
 }
 
 fn format_change_directory_command(dir_name: &str) -> String {

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -10,6 +10,7 @@ use crate::ai::{
 use crate::code::editor::{add_color, remove_color};
 use crate::code_review::code_review_view::CODE_REVIEW_TOOLTIP_TEXT;
 use crate::code_review::diff_state::DiffStats;
+use crate::context_chips::git_branch_on_click::GitBranchOnClickValue;
 use crate::context_chips::node_version_popup::{NodeVersionPopupEvent, NodeVersionPopupView};
 use crate::context_chips::spacing;
 use crate::settings::{AISettings, AISettingsChangedEvent, InputSettings};
@@ -443,13 +444,19 @@ pub struct DisplayChipConfig {
 #[derive(Debug, Clone)]
 pub struct GitBranch(String);
 
+impl GitBranch {
+    fn command(&self) -> String {
+        format_git_branch_command(&self.0)
+    }
+}
+
 impl GenericMenuItem for GitBranch {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 
     fn name(&self) -> String {
-        self.0.clone()
+        GitBranchOnClickValue::decode(&self.0).branch_name
     }
 
     fn icon(&self, _app: &AppContext) -> Option<Icon> {
@@ -557,7 +564,7 @@ impl DisplayChip {
                         };
 
                         ctx.emit(PromptDisplayChipEvent::TryExecuteCommand(
-                            format_git_branch_command(&git_branch.name()),
+                            git_branch.command(),
                         ));
                         me.close_git_branch_menu(ctx);
                         ctx.notify();
@@ -1774,12 +1781,31 @@ impl ActionButtonTheme for EnterAgentViewButton {
     }
 }
 
-fn format_change_directory_command(dir_name: &str) -> String {
-    format!("cd '{}'", dir_name.replace("'", "'\\'''"))
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace("'", "'\\'''"))
 }
 
-pub fn format_git_branch_command(branch_name: &str) -> String {
-    format!("git checkout {branch_name}")
+fn format_change_directory_command(dir_name: &str) -> String {
+    format!("cd {}", shell_single_quote(dir_name))
+}
+
+pub fn format_git_branch_command(value: &str) -> String {
+    let branch = GitBranchOnClickValue::decode(value);
+    if let Some(worktree_path) = branch.worktree_path {
+        return format_change_directory_command(&worktree_path);
+    }
+
+    if branch.is_linked_worktree {
+        return format!(
+            "echo {}",
+            shell_single_quote(&format!(
+                "Branch '{}' is already checked out in another worktree, but Warp couldn't find its path.",
+                branch.branch_name
+            ))
+        );
+    }
+
+    format!("git checkout {}", branch.branch_name)
 }
 
 pub(crate) fn chip_container(

--- a/app/src/context_chips/display_chip_tests.rs
+++ b/app/src/context_chips/display_chip_tests.rs
@@ -43,6 +43,16 @@ fn test_github_pr_chip_display_value_falls_back_to_raw_value() {
 }
 
 #[test]
+fn test_format_git_branch_command_checks_out_normal_branch() {
+    let value = GitBranchOnClickValue::new("feature/alice's-work".to_string()).encode();
+
+    assert_eq!(
+        format_git_branch_command(&value),
+        "git checkout 'feature/alice'\\''s-work'"
+    );
+}
+
+#[test]
 fn test_format_git_branch_command_changes_to_linked_worktree_path() {
     let value = GitBranchOnClickValue {
         branch_name: "feature-a".to_string(),

--- a/app/src/context_chips/display_chip_tests.rs
+++ b/app/src/context_chips/display_chip_tests.rs
@@ -1,7 +1,8 @@
-use super::{format_git_branch_command, truncate_from_beginning, GitLineChanges};
+use super::{format_git_branch_command, truncate_from_beginning, GitBranch, GitLineChanges};
 use crate::context_chips::{
     git_branch_on_click::GitBranchOnClickValue, github_pr_display_text_from_url, ContextChipKind,
 };
+use crate::ui_components::icons::Icon;
 
 #[test]
 fn test_github_pr_display_text_from_url() {
@@ -80,6 +81,25 @@ fn test_format_git_branch_command_reports_missing_linked_worktree_path() {
         format_git_branch_command(&value),
         "echo 'Branch '\\''feature-a'\\'' is already checked out in another worktree, but Warp couldn'\\''t find its path.'"
     );
+}
+
+#[test]
+fn test_git_branch_menu_icon_uses_branch_icon_for_normal_branch() {
+    let value = GitBranchOnClickValue::new("feature-a".to_string()).encode();
+
+    assert_eq!(GitBranch(value).icon_for_menu(), Icon::GitBranch);
+}
+
+#[test]
+fn test_git_branch_menu_icon_uses_worktree_icon_for_linked_worktree() {
+    let value = GitBranchOnClickValue {
+        branch_name: "feature-a".to_string(),
+        worktree_path: Some("/tmp/repo-feature-a".to_string()),
+        is_linked_worktree: true,
+    }
+    .encode();
+
+    assert_eq!(GitBranch(value).icon_for_menu(), Icon::Dataflow02);
 }
 
 #[test]

--- a/app/src/context_chips/display_chip_tests.rs
+++ b/app/src/context_chips/display_chip_tests.rs
@@ -1,5 +1,7 @@
-use super::{truncate_from_beginning, GitLineChanges};
-use crate::context_chips::{github_pr_display_text_from_url, ContextChipKind};
+use super::{format_git_branch_command, truncate_from_beginning, GitLineChanges};
+use crate::context_chips::{
+    git_branch_on_click::GitBranchOnClickValue, github_pr_display_text_from_url, ContextChipKind,
+};
 
 #[test]
 fn test_github_pr_display_text_from_url() {
@@ -37,6 +39,36 @@ fn test_github_pr_chip_display_value_falls_back_to_raw_value() {
     assert_eq!(
         ContextChipKind::GithubPullRequest.display_value(&value),
         "https://example.com/not-a-pr"
+    );
+}
+
+#[test]
+fn test_format_git_branch_command_changes_to_linked_worktree_path() {
+    let value = GitBranchOnClickValue {
+        branch_name: "feature-a".to_string(),
+        worktree_path: Some("/tmp/repo feature-a".to_string()),
+        is_linked_worktree: true,
+    }
+    .encode();
+
+    assert_eq!(
+        format_git_branch_command(&value),
+        "cd '/tmp/repo feature-a'"
+    );
+}
+
+#[test]
+fn test_format_git_branch_command_reports_missing_linked_worktree_path() {
+    let value = GitBranchOnClickValue {
+        branch_name: "feature-a".to_string(),
+        worktree_path: None,
+        is_linked_worktree: true,
+    }
+    .encode();
+
+    assert_eq!(
+        format_git_branch_command(&value),
+        "echo 'Branch '\\''feature-a'\\'' is already checked out in another worktree, but Warp couldn'\\''t find its path.'"
     );
 }
 

--- a/app/src/context_chips/git_branch_on_click.rs
+++ b/app/src/context_chips/git_branch_on_click.rs
@@ -1,0 +1,232 @@
+use std::collections::HashMap;
+
+pub(crate) const WORKTREE_LIST_SEPARATOR: &str = "\u{1e}";
+
+const ENCODED_VALUE_SEPARATOR: char = '\u{1f}';
+const WORKTREE_TAG: &str = "worktree";
+const GIT_BRANCH_REF_PREFIX: &str = "refs/heads/";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct GitBranchOnClickValue {
+    pub(crate) branch_name: String,
+    pub(crate) worktree_path: Option<String>,
+    pub(crate) is_linked_worktree: bool,
+}
+
+impl GitBranchOnClickValue {
+    pub(crate) fn new(branch_name: String) -> Self {
+        Self {
+            branch_name,
+            worktree_path: None,
+            is_linked_worktree: false,
+        }
+    }
+
+    fn linked_worktree(branch_name: String, worktree_path: Option<String>) -> Self {
+        Self {
+            branch_name,
+            worktree_path,
+            is_linked_worktree: true,
+        }
+    }
+
+    pub(crate) fn encode(&self) -> String {
+        if self.is_linked_worktree {
+            match &self.worktree_path {
+                Some(path) => format!(
+                    "{}{ENCODED_VALUE_SEPARATOR}{WORKTREE_TAG}{ENCODED_VALUE_SEPARATOR}{path}",
+                    self.branch_name
+                ),
+                None => format!(
+                    "{}{ENCODED_VALUE_SEPARATOR}{WORKTREE_TAG}",
+                    self.branch_name
+                ),
+            }
+        } else {
+            self.branch_name.clone()
+        }
+    }
+
+    pub(crate) fn decode(value: &str) -> Self {
+        let mut parts = value.splitn(3, ENCODED_VALUE_SEPARATOR);
+        let branch_name = parts.next().unwrap_or_default().to_string();
+
+        match parts.next() {
+            Some(WORKTREE_TAG) => {
+                let worktree_path = parts
+                    .next()
+                    .filter(|path| !path.is_empty())
+                    .map(str::to_string);
+                Self::linked_worktree(branch_name, worktree_path)
+            }
+            _ => Self::new(value.to_string()),
+        }
+    }
+}
+
+struct ParsedGitBranchLine {
+    branch_name: String,
+    is_current: bool,
+    is_linked_worktree: bool,
+}
+
+pub(crate) fn filter_git_branch_on_click_values(
+    values_opt: Option<Vec<String>>,
+) -> Option<Vec<String>> {
+    values_opt.map(|values| {
+        let worktree_list_separator_index = values
+            .iter()
+            .position(|value| value.trim() == WORKTREE_LIST_SEPARATOR);
+
+        let (branch_lines, worktree_lines) = match worktree_list_separator_index {
+            Some(index) => (&values[..index], &values[index + 1..]),
+            None => (&values[..], &[][..]),
+        };
+
+        let branch_to_worktree_path = parse_git_worktree_paths(worktree_lines);
+        let branches: Vec<ParsedGitBranchLine> = branch_lines
+            .iter()
+            .filter_map(|line| parse_git_branch_line(line))
+            .collect();
+
+        // Keep the current branch first (denoted by *), preserving relative order
+        // for the remaining branches.
+        let (current_branches, other_branches): (Vec<_>, Vec<_>) =
+            branches.into_iter().partition(|branch| branch.is_current);
+
+        current_branches
+            .into_iter()
+            .chain(other_branches)
+            .map(|branch| {
+                if branch.is_linked_worktree {
+                    GitBranchOnClickValue::linked_worktree(
+                        branch.branch_name.clone(),
+                        branch_to_worktree_path.get(&branch.branch_name).cloned(),
+                    )
+                } else {
+                    GitBranchOnClickValue::new(branch.branch_name)
+                }
+                .encode()
+            })
+            .collect()
+    })
+}
+
+fn parse_git_branch_line(line: &str) -> Option<ParsedGitBranchLine> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let status_marker = ['*', '+'].into_iter().find_map(|marker| {
+        trimmed.strip_prefix(marker).and_then(|rest| {
+            rest.chars()
+                .next()
+                .filter(|c| c.is_whitespace())
+                .map(|_| marker)
+        })
+    });
+
+    let branch_name = match status_marker {
+        Some(marker) => trimmed
+            .strip_prefix(marker)
+            .map(str::trim)
+            .unwrap_or(trimmed),
+        None => trimmed,
+    };
+
+    if branch_name.is_empty() {
+        return None;
+    }
+
+    Some(ParsedGitBranchLine {
+        branch_name: branch_name.to_string(),
+        is_current: status_marker == Some('*'),
+        is_linked_worktree: status_marker == Some('+'),
+    })
+}
+
+fn parse_git_worktree_paths(lines: &[String]) -> HashMap<String, String> {
+    let mut branch_to_worktree_path = HashMap::new();
+    let mut current_worktree_path: Option<String> = None;
+
+    for line in lines {
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() {
+            current_worktree_path = None;
+            continue;
+        }
+
+        if let Some(path) = trimmed.strip_prefix("worktree ") {
+            current_worktree_path = Some(path.to_string());
+            continue;
+        }
+
+        let Some(branch_ref) = trimmed.strip_prefix("branch ") else {
+            continue;
+        };
+        let Some(branch_name) = branch_ref.strip_prefix(GIT_BRANCH_REF_PREFIX) else {
+            continue;
+        };
+        let Some(path) = current_worktree_path.as_ref() else {
+            continue;
+        };
+
+        branch_to_worktree_path.insert(branch_name.to_string(), path.clone());
+    }
+
+    branch_to_worktree_path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_git_branch_on_click_values_resolve_linked_worktree_paths() {
+        let values = Some(vec![
+            "  feature-a".to_string(),
+            "+ linked-worktree".to_string(),
+            "* main".to_string(),
+            "".to_string(),
+            "  +literal-plus".to_string(),
+            WORKTREE_LIST_SEPARATOR.to_string(),
+            "worktree /repo".to_string(),
+            "branch refs/heads/main".to_string(),
+            "".to_string(),
+            "worktree /repo-linked".to_string(),
+            "branch refs/heads/linked-worktree".to_string(),
+        ]);
+
+        let values = filter_git_branch_on_click_values(values).unwrap();
+        let values: Vec<_> = values
+            .iter()
+            .map(|value| GitBranchOnClickValue::decode(value))
+            .collect();
+
+        assert_eq!(
+            values,
+            vec![
+                GitBranchOnClickValue::new("main".to_string()),
+                GitBranchOnClickValue::new("feature-a".to_string()),
+                GitBranchOnClickValue::linked_worktree(
+                    "linked-worktree".to_string(),
+                    Some("/repo-linked".to_string()),
+                ),
+                GitBranchOnClickValue::new("+literal-plus".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_git_branch_on_click_values_keep_linked_marker_without_path() {
+        let values = filter_git_branch_on_click_values(Some(vec!["+ feature".to_string()]))
+            .expect("expected parsed branch values");
+        let value = GitBranchOnClickValue::decode(&values[0]);
+
+        assert_eq!(value.branch_name, "feature");
+        assert_eq!(value.worktree_path, None);
+        assert!(value.is_linked_worktree);
+    }
+}

--- a/app/src/context_chips/git_branch_on_click.rs
+++ b/app/src/context_chips/git_branch_on_click.rs
@@ -184,6 +184,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_git_branch_on_click_value_round_trips_through_encode_decode() {
+        let values = [
+            GitBranchOnClickValue::new("feature-a".to_string()),
+            GitBranchOnClickValue::linked_worktree(
+                "feature-b".to_string(),
+                Some("/repo/feature-b".to_string()),
+            ),
+            GitBranchOnClickValue::linked_worktree("feature-c".to_string(), None),
+        ];
+
+        for value in values {
+            assert_eq!(GitBranchOnClickValue::decode(&value.encode()), value);
+        }
+    }
+
+    #[test]
     fn test_git_branch_on_click_values_resolve_linked_worktree_paths() {
         let values = Some(vec![
             "  feature-a".to_string(),

--- a/app/src/context_chips/mod.rs
+++ b/app/src/context_chips/mod.rs
@@ -6,6 +6,7 @@ pub mod directory_fetcher;
 pub mod display;
 pub mod display_chip;
 pub mod display_menu;
+pub(crate) mod git_branch_on_click;
 pub(crate) mod logging;
 pub mod node_version_popup;
 pub mod prompt;


### PR DESCRIPTION
## Description

Teach the prompt branch picker to treat Git's `+` branch marker as a linked-worktree action, not a checkout target. `git branch` marks the current branch with `*` and branches checked out in another worktree with `+`; clicking a `+` branch should move the user into that worktree instead of running `git checkout <branch>`, which Git rejects.

The branch list command now also fetches `git worktree list --porcelain`, and Warp keeps the worktree path as hidden action data for `+` branches. Normal branches still run `git checkout '<branch>'`, quoted for shell safety. Linked-worktree branches run `cd '<worktree-path>'`; if the path cannot be resolved, Warp prints a clear message instead of attempting a checkout that is expected to fail.

## Linked Issue

Fixes #9170

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos

Demo showing the git chip with a linked worktree branch and selecting it to move into that worktree:

https://github.com/user-attachments/assets/5b31d204-9e13-4855-8977-cbd5bc0ad1bd

## Testing

- `cargo fmt -- --check`
- `git diff --check`
- `env TOOLCHAINS=com.apple.dt.toolchain.Metal.32023.864 cargo test -p warp test_format_git_branch_command_checks_out_normal_branch --lib`
- `env TOOLCHAINS=com.apple.dt.toolchain.Metal.32023.864 cargo test -p warp test_git_branch_on_click_value_round_trips_through_encode_decode --lib`
- Added parser coverage for resolving `+` branches to worktree paths
- Added `GitBranchOnClickValue` encode/decode round-trip coverage
- Added command formatting coverage for normal branch checkout quoting, linked-worktree branch clicks, and the missing-path fallback
- GitHub CI is passing

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed prompt branch picker clicks for branches checked out in linked worktrees. Thanks to @JasonLovesDoggo (#9264), @tkshsbcue (#9440), and @lonexreb (#9560) for earlier fixes and investigation.

Co-Authored-By: Warp <agent@warp.dev>