### PR TITLE
fix: warp-terminal --help shows Warp Terminal CLI, not Oz (#9726)

### DIFF
--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -369,6 +369,13 @@ impl Args {
 "#
         ));
 
+        // When invoked as the Warp Terminal binary (e.g. `warp-terminal` on Linux),
+        // override the Oz-flavored CLI identity so that `--help` reflects the terminal app
+        // the user actually launched. See https://github.com/warpdotdev/warp/issues/9726.
+        if is_warp_terminal_binary(&bin_name) {
+            command = customize_for_warp_terminal(command);
+        }
+
         command
     }
 
@@ -699,6 +706,27 @@ pub fn binary_name() -> Option<String> {
 /// untagged builds (e.g. local `cargo run`).
 pub fn version_string() -> &'static str {
     ChannelState::app_version().unwrap_or("<unknown>")
+}
+
+/// Whether the binary name (`argv[0]`'s file name) corresponds to the Warp Terminal
+/// installed binary on Linux. Matches all channels: `warp-terminal`,
+/// `warp-terminal-preview`, `warp-terminal-dev`, `warp-terminal-local`,
+/// `warp-terminal-integration`, and `warp-terminal-oss`.
+fn is_warp_terminal_binary(bin_name: &str) -> bool {
+    bin_name.starts_with("warp-terminal")
+}
+
+/// Override the Oz-flavored CLI metadata (display name, about) so that the help text
+/// reflects the Warp Terminal app the user invoked.
+fn customize_for_warp_terminal(command: clap::Command) -> clap::Command {
+    command.display_name("Warp Terminal CLI").about(
+        r#"The Warp Terminal command-line interface.
+
+Use this CLI to interact with Warp from your shell:
+* Run agents and inspect their output
+* Manage MCP servers and integrations
+* Sign in, generate completions, and inspect debug info"#,
+    )
 }
 
 #[cfg(test)]

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -1867,3 +1867,38 @@ fn finish_task_rejects_missing_status() {
     ]);
     assert!(result.is_err());
 }
+
+#[test]
+fn warp_terminal_binary_detection() {
+    assert!(is_warp_terminal_binary("warp-terminal"));
+    assert!(is_warp_terminal_binary("warp-terminal-preview"));
+    assert!(is_warp_terminal_binary("warp-terminal-dev"));
+    assert!(is_warp_terminal_binary("warp-terminal-local"));
+    assert!(is_warp_terminal_binary("warp-terminal-integration"));
+    assert!(is_warp_terminal_binary("warp-terminal-oss"));
+
+    assert!(!is_warp_terminal_binary("oz"));
+    assert!(!is_warp_terminal_binary("oz-dev"));
+    assert!(!is_warp_terminal_binary("warp"));
+    assert!(!is_warp_terminal_binary("warp-oss"));
+}
+
+#[test]
+fn warp_terminal_help_does_not_mention_oz() {
+    // Regression test for https://github.com/warpdotdev/warp/issues/9726.
+    // When the binary is invoked as `warp-terminal`, the rendered help text
+    // must not describe itself as the Oz orchestration platform.
+    use clap::CommandFactory;
+
+    let mut command = customize_for_warp_terminal(<Args as CommandFactory>::command());
+    let help = command.render_long_help().to_string();
+
+    assert!(
+        !help.contains("orchestration platform for cloud agents"),
+        "help should not include the Oz tagline; got:\n{help}"
+    );
+    assert!(
+        !help.contains("Oz CLI is a tool"),
+        "help should not describe itself as the Oz CLI; got:\n{help}"
+    );
+}


### PR DESCRIPTION
## Description
Fixes #9726.

When the `warp` binary is installed on Linux as `warp-terminal*`, the user invokes a terminal app — but `--help` was describing the Oz cloud-agent CLI ("The orchestration platform for cloud agents…"), which is confusing for users who aren't using Oz/cloud agents.

This change detects the `warp-terminal*` binary name in `Args::clap_command()` and overrides `display_name` and `about` so the help text reflects the Warp Terminal CLI. Subcommands are unchanged (they're shared with `oz`).

## Linked Issue
- [x] The linked issue is labeled `ready-to-implement` (triaged bug).

## Testing
Two unit tests added in `crates/warp_cli/src/lib_tests.rs`:
- `warp_terminal_binary_detection` — covers all six channel names (`warp-terminal`, `-preview`, `-dev`, `-local`, `-integration`, `-oss`) plus negative cases (`oz`, `warp`, `warp-oss`).
- `warp_terminal_help_does_not_mention_oz` — regression test that asserts the rendered long help no longer contains "orchestration platform for cloud agents" or "Oz CLI is a tool".

Verified locally on WSL Ubuntu (Rust 1.92.0):
- `cargo test -p warp_cli --lib` → 143 passed, 0 failed
- `cargo clippy -p warp_cli --all-targets --tests -- -D warnings` → clean
- `cargo fmt --check` (workspace) → clean

Full-workspace `clippy --workspace` and `nextest run --workspace` were skipped locally due to time, but the change is private (private fns inside `warp_cli`) with no public API impact, so cross-crate breakage is not possible.

## Agent Mode
- [ ] Warp Agent Mode

CHANGELOG-BUG-FIX: Fixed `warp-terminal --help` showing the Oz CLI description instead of the Warp Terminal CLI description.
