### PR TITLE
Spec: per-tab theme overrides driven by directory and launch configurations (GH478)

### DIFF
--- a/specs/GH478/product.md
+++ b/specs/GH478/product.md
@@ -195,10 +195,11 @@ bit-for-bit identical to today.
     so that reopening the saved configuration produces the same effective
     themes (modulo cwd matching, which re-runs against the current
     `directory_overrides`). Specifically, for each tab the *preserved
-    override* is the tab's manual pin if any, otherwise the tab's
-    window-level default if any; tabs whose effective theme came only
-    from directory matching have no preserved override. The save rule
-    is then:
+    override* is the first non-empty value of, in priority order: the
+    tab's menu pin (layer #1), the tab's launch-configuration manual
+    pin (layer #2), or the tab's window-level default (layer #4). Tabs
+    whose effective theme came only from directory matching (layer #3)
+    have no preserved override. The save rule is then:
 
     - If every tab in the window has the same preserved override
       `Some(X)` and no tab has a manual pin different from the others,
@@ -317,18 +318,24 @@ bit-for-bit identical to today.
 
 ### Accessibility
 
-21. The override does not change any text content, accessible labels, or
-    focus order. Screen readers continue to report tab titles and
-    contents identically. The new menu entries have accessible labels
-    "Pin theme" (with a submenu) and "Reset theme".
+21. The override does not change any text content, accessible labels,
+    or focus order. Screen readers continue to report tab titles and
+    contents identically. The three new right-click menu entries have
+    accessible labels "Pin theme" (with a submenu of theme names),
+    "Reset theme", and "Forget launch config theme"; each is announced
+    as a menu item, and each follows the menu's existing visibility
+    rules (Reset theme appears only when the tab has a menu pin;
+    Forget launch config theme appears only when the tab has a
+    launch-config manual pin).
 
 ## User-visible failure modes
 
 - **Unknown theme name** — anywhere it appears, the entry is skipped at
   apply time, a one-line warning is written to the Warp log identifying
-  the source (launch configuration filename + tab title or index;
-  `directory_overrides` key), and the rest of the configuration loads
-  normally.
+  the source (launch configuration filename + tab title or index for
+  launch-config sources; **redacted entry identifier** for
+  `directory_overrides` sources, never the raw path key — see #7b),
+  and the rest of the configuration loads normally.
 - **Custom theme file missing** — same fallback the global theme uses
   today: tab opens with the next-layer theme, warning logged.
 - **Two `directory_overrides` keys are equivalent after tilde expansion**

--- a/specs/GH478/product.md
+++ b/specs/GH478/product.md
@@ -1,0 +1,184 @@
+# PRODUCT.md — Per-tab theme override via launch configurations
+
+Issue: https://github.com/warpdotdev/warp/issues/478
+Related: https://github.com/warpdotdev/warp/issues/2618 (set warp theme in launch configuration)
+
+## Summary
+
+Today the Warp theme is a single global value (`appearance.themes.theme` in
+`settings.toml`). Switching themes affects every open window and tab at once.
+Users who keep many tabs open across distinct contexts — different projects,
+local vs. remote machines, production vs. development environments — have asked
+for years (`#478`, 55+ upvotes; `#2618`) for a way to give specific tabs a
+different theme so context is visible at a glance.
+
+This spec covers a focused first cut of that capability: a tab can carry a
+**theme override** that comes from the launch configuration that opened it (or
+from a tab restored from a previous session). The override scopes the theme to
+that single tab; the global theme setting is unchanged and continues to apply
+to every tab that does not have an override. A window-level default override is
+also defined so a launch configuration can theme all of its tabs at once.
+
+This spec deliberately scopes out automatic theme switching (SSH host
+detection, agent conversation type, escape-code-driven runtime changes). Those
+appear in `#478` discussion and warrant their own product spec once the
+override mechanism this spec defines exists to build on.
+
+Figma: none provided.
+
+## Goals / Non-goals
+
+In-scope surfaces:
+
+- The launch configuration YAML schema (`~/.warp/launch_configurations/*.yaml`)
+  gains an optional theme field at the tab level and at the window level. The
+  values are theme identifiers — the same names users already see in the theme
+  picker (`"Dark"`, `"Solarized Dark"`, `"Dracula"`, `"Dark City"`, etc.) and
+  the same custom-theme references the rest of the theme system already
+  accepts.
+- Tabs opened from a launch configuration that specifies a theme render with
+  that theme: terminal background, foreground, ANSI palette, and any
+  theme-derived UI surfaces inside the tab follow the override.
+- The override persists with the tab so that on restart / session restore the
+  tab continues to render with the same theme without depending on the user
+  re-running the launch configuration.
+- A user can clear a tab-level override (returning the tab to the global theme)
+  through the same right-click tab menu that already exposes per-tab
+  attributes.
+
+Out of scope (explicitly **not** part of this spec):
+
+- Automatic theming based on SSH host, hostname, working directory, or
+  `whoami` (raised in `#478` comments). These require separate detection and
+  policy mechanisms and are tracked as follow-ups.
+- A new escape-code or shell-side protocol for setting a tab's theme at
+  runtime (raised in `#478` comments by users wanting hooks to color Claude
+  Code sessions). Once a per-tab override field exists internally a runtime
+  setter is a small follow-up; defining the protocol is its own surface.
+- Per-pane theming. Panes inside a tab continue to share one theme; the
+  override is a tab-level concept.
+- Changes to the global theme storage path
+  (`appearance.themes.theme` in `settings.toml`), the theme picker UI, or
+  custom-theme loading. The override reuses the existing theme identifier type
+  unchanged.
+- Onboarding or settings-page surfacing of the new field. Discoverability lives
+  in the launch configuration docs and the right-click tab menu only.
+
+## Behavior
+
+1. A launch configuration YAML file may include a `theme:` field on any tab
+   entry. The accepted value is a theme identifier exactly as it appears in
+   `settings.toml` today (e.g. `theme: "Dark City"`, `theme: "Solarized Dark"`,
+   `theme: "Dracula"`). Custom theme references use the same form the global
+   theme setting accepts. Omitting the field leaves the tab using whatever
+   theme would otherwise apply (per behavior #3).
+
+2. A launch configuration YAML file may include a `theme:` field on any window
+   entry. When present, every tab in that window with no tab-level `theme:`
+   inherits this window-level value. A tab-level `theme:` always wins over a
+   window-level one.
+
+3. Theme resolution for a tab is, in order: (a) the tab's own override, if
+   any; (b) the window-level override of the window that opened the tab, if
+   any and inherited at open time; (c) the global theme as derived from
+   `ThemeSettings` and the system theme, exactly as today. If none of the
+   override sources apply the tab's behavior is bit-for-bit identical to a
+   tab opened without this feature.
+
+4. When a tab has an override the override applies to: the terminal cell
+   foreground/background, the ANSI 16-color palette used by the terminal grid,
+   and any in-tab UI surfaces whose colors are derived from the active theme
+   (block backgrounds, command output styling, accent colors). The window
+   chrome (title bar, sidebar, settings views, the tab strip itself) continues
+   to follow the global theme so that windows holding mixed-theme tabs remain
+   visually coherent at the window level.
+
+5. Switching tabs is instant: there is no flash, no progressive paint, and no
+   redraw of unrelated tabs. The previously-active tab's content does not
+   change appearance because of the switch — only the rendering of the
+   newly-active tab reflects its (possibly different) theme. A user
+   alt-tabbing through ten tabs with different overrides sees each tab in its
+   own theme as it becomes active.
+
+6. Changing the global theme (via the theme picker, settings page, or system
+   light/dark switch) updates every tab that does **not** have an override.
+   Tabs with overrides are unaffected by the global change; their rendering
+   stays on the override value.
+
+7. The existing per-tab `color:` field on a tab template (the small colored
+   indicator next to the tab title) is independent of the new `theme:` field.
+   Both can be set on the same tab; both are honored. Neither implies the
+   other.
+
+8. A tab opened with a theme override surfaces a "Reset theme" entry in the
+   right-click tab context menu, alongside the existing per-tab attributes
+   (color, title, etc.). Choosing "Reset theme" clears the tab's override; the
+   tab immediately re-renders using whatever theme falls out of the resolution
+   order in #3 (typically the global theme). The menu entry is hidden for
+   tabs that have no override.
+
+9. Tab overrides survive session restore. A tab that had an override when the
+   user last quit Warp opens with the same override on relaunch. A tab with
+   no override opens with no override (i.e. it tracks the current global
+   theme).
+
+10. Saving a window's current state to a launch configuration (`File → Save
+    Layout as Launch Configuration` and equivalents) emits `theme:` entries on
+    each tab that has an override. Tabs without overrides emit no `theme:`
+    field. Window-level `theme:` is emitted only when every tab in the window
+    shared the same explicit override at save time, in which case the per-tab
+    fields are coalesced up to the window. (This keeps round-trip save/load
+    clean for the common "themed launch config" case.)
+
+11. An unknown theme identifier in a launch configuration (e.g. a theme that
+    has been deleted, or a typo) is treated the same way an unknown global
+    theme is treated today: the tab falls back to the global resolved theme,
+    a warning is logged, and opening the launch configuration does not fail.
+    Other tabs in the same launch configuration are unaffected.
+
+12. Custom themes referenced by an override behave identically to custom
+    themes used as the global theme — they are loaded from the user's themes
+    directory, fail-soft to the global theme if the file is missing, and
+    obey the same trust/validation rules already in the theme loader.
+
+13. The override persists per-tab, not per-launch-configuration. If a user
+    edits a launch configuration's theme after first opening it, already-open
+    tabs that came from that launch configuration keep their original
+    override; new tabs opened by re-running the launch configuration get the
+    new value. This matches how the existing per-tab `color:` field behaves.
+
+14. Accessibility: the theme override does not change any text content,
+    accessible labels, or focus order. Screen readers continue to report tab
+    titles and contents identically. The "Reset theme" menu entry has the
+    accessible label "Reset theme" and is announced as a menu item.
+
+15. The feature applies on every supported platform (macOS, Linux, Windows).
+    It is gated behind no feature flag and is on by default once shipped.
+
+## User-visible failure modes
+
+- **Unknown theme name in YAML** — tab opens with the global theme; a one-line
+  warning is written to the Warp log identifying the launch configuration
+  filename, the tab title (or index, if untitled), and the unrecognized theme
+  string. The launch configuration as a whole still opens.
+- **Custom theme file missing** — same fallback as the global theme exhibits
+  today: tab opens with the global theme, warning logged.
+- **Window-level theme set, tab-level not set, tab opens with override
+  inherited; user later edits the YAML to remove the window-level value** —
+  already-open tabs keep their existing override (per #13). New tabs opened
+  from the edited launch configuration get no override.
+
+## Open questions
+
+- Should the right-click "Reset theme" entry also offer a submenu of theme
+  names so a user can change a tab's override without editing YAML? This spec
+  takes the more conservative position of "reset only" so the launch
+  configuration file remains the single source of truth for setting overrides;
+  a richer in-app picker is a candidate follow-up.
+- Should saving a launch configuration record the *resolved* theme of each
+  tab, or only the explicit override the tab carries? This spec records only
+  explicit overrides (#10) so a saved launch configuration that contains no
+  `theme:` fields continues to track the global theme on every machine it is
+  loaded on. The alternative (record resolved theme always) would lock the
+  saved configuration to a snapshot of the user's current global theme, which
+  is rarely the desired behavior for a portable launch configuration.

--- a/specs/GH478/product.md
+++ b/specs/GH478/product.md
@@ -131,6 +131,16 @@ bit-for-bit identical to today.
    skipped for matching purposes, and the rest of the map continues to
    work.
 
+7a. **`directory_overrides` is stored locally and never synced to Warp's
+    cloud.** Directory paths can encode employer, customer, and project
+    names (`~/Work/<client>/<engagement>/...`); cloud-syncing the keys
+    would push that organizational context off-machine. Users on
+    multiple machines who want shared themes today set them per-machine.
+    An opt-in cloud-sync mode is a candidate follow-up. The global
+    theme setting (`appearance.themes.theme`) and per-tab pins set via
+    the right-click menu remain user-controllable surfaces; only this
+    map is local-only.
+
 ### Launch-configuration overrides
 
 8. A launch configuration YAML may include `theme:` on any tab entry.
@@ -165,11 +175,15 @@ bit-for-bit identical to today.
     directory, fail-soft to the next layer if the file is missing, same
     trust/validation rules as the global theme loader.
 
-13. The override persists per-tab through session restore. A tab whose
-    effective theme came from a manual pin keeps that pin on relaunch. A
-    tab whose effective theme came from directory matching is restored
-    with no manual pin; on relaunch its theme is recomputed from the
-    current `directory_overrides` and the restored cwd.
+13. Overrides persist per-tab through session restore, by source:
+    - **Manual pin** — kept on relaunch.
+    - **Launch-configuration window-level default** — kept on relaunch.
+      The launch configuration that opened the tab is not necessarily
+      reopened on restore, so the value travels with the tab.
+    - **Directory match** — not stored; recomputed on relaunch from the
+      current `directory_overrides` and the restored cwd. Editing
+      `directory_overrides` between sessions therefore takes effect on
+      the next launch.
 
 14. The accepted form for any theme reference (in
     `directory_overrides`, in launch-config tab `theme:`, in launch-config

--- a/specs/GH478/product.md
+++ b/specs/GH478/product.md
@@ -101,9 +101,27 @@ bit-for-bit identical to today.
    `appearance.themes.theme` (the parser tolerates both display names like
    `"Dark City"` and snake-case like `"dark_city"`; see #14 below).
 
-2. Keys are tilde-expanded to absolute paths at match time. Trailing slashes
-   are normalized away. Symlinks are not resolved — the cwd as the shell
-   reports it is what's matched.
+2. Keys are tilde-expanded to absolute paths at match time. Trailing
+   slashes are normalized away. Symlinks are not resolved — the cwd as
+   the shell reports it is what's matched. Path normalization rules,
+   per platform:
+
+    - **Linux:** matching is case-sensitive (matches the filesystem
+      semantics on standard ext4/xfs). Path separators are `/`.
+    - **macOS:** matching is case-insensitive (matches the default
+      HFS+/APFS case-insensitive setting). Path separators are `/`.
+    - **Windows:** matching is case-insensitive. Both `/` and `\` are
+      accepted as separators in `directory_overrides` keys and are
+      normalized internally to a single canonical form before
+      comparison. Drive letters are normalized to uppercase (`c:\Work`
+      and `C:\Work` are equivalent keys; the second-written one wins
+      per TOML duplicate-key semantics). Tilde expands to
+      `%USERPROFILE%`.
+
+   Component-boundary matching (the rule in the previous paragraph
+   that prevents `~/Work/medone` from matching `~/Work/medone-archive`)
+   uses the platform's path-component definition — on Windows that
+   means the boundary follows either `\` or `/` after normalization.
 
 3. Match resolution: a key matches if it is a prefix of the active pane's
    cwd at a path-component boundary. `~/Work/medone` matches both
@@ -141,6 +159,20 @@ bit-for-bit identical to today.
     the right-click menu remain user-controllable surfaces; only this
     map is local-only.
 
+7b. **Diagnostic output never contains raw `directory_overrides` keys.**
+    Local logs are routinely shared with Warp support and copied into
+    bug reports, so even local diagnostics can leak path keys. The
+    invariant is: any warning or telemetry emitted by the
+    `directory_overrides` machinery refers to an offending entry by a
+    short non-cryptographic hash of its key plus the offending value
+    (the theme name, which is non-sensitive). For example, a warning
+    that today might say `directory_overrides: "~/Work/AcmeCorp/2026":
+    unknown theme "Drakula"` instead reads
+    `directory_overrides[hash=8a3f9c]: unknown theme "Drakula"`. The
+    user can grep their `settings.toml` for the bad theme name to find
+    the offending row. Hashes are stable for the same key but contain
+    no path information.
+
 ### Launch-configuration overrides
 
 8. A launch configuration YAML may include `theme:` on any tab entry.
@@ -152,13 +184,31 @@ bit-for-bit identical to today.
    inherit this window-level value (per the resolution order: #3 sits
    below #2).
 
-10. Saving a window's current state to a launch configuration emits
-    `theme:` entries on each tab whose effective theme came from a manual
-    override. Tabs themed only by directory matching emit no `theme:`
-    field — directory matching is config-level, not tab-level, so a saved
-    launch configuration that relies on it stays portable. Window-level
-    `theme:` is emitted only when every tab in the window shared the same
-    explicit manual override at save time.
+10. Saving a window's current state to a launch configuration preserves
+    every theme override that was *not* derived from directory matching,
+    so that reopening the saved configuration produces the same effective
+    themes (modulo cwd matching, which re-runs against the current
+    `directory_overrides`). Specifically, for each tab the *preserved
+    override* is the tab's manual pin if any, otherwise the tab's
+    window-level default if any; tabs whose effective theme came only
+    from directory matching have no preserved override. The save rule
+    is then:
+
+    - If every tab in the window has the same preserved override
+      `Some(X)` and no tab has a manual pin different from the others,
+      the saved YAML emits a single window-level `theme: X` and no
+      per-tab `theme:` fields.
+    - Otherwise, each tab whose preserved override is `Some(Y)` emits a
+      per-tab `theme: Y`; tabs with no preserved override emit no
+      `theme:` field; window-level `theme:` is omitted.
+    - Directory-matched themes never appear in saved YAML — directory
+      matching is settings-level and re-applies on next open.
+
+    This means a launch configuration that originally opened with a
+    window-level `theme:` round-trips correctly: every tab inherited
+    the value into its `window_default` slot, the save rule sees a
+    shared preserved override, and emits the same window-level
+    `theme:` again.
 
 ### YAML / settings format
 

--- a/specs/GH478/product.md
+++ b/specs/GH478/product.md
@@ -1,28 +1,39 @@
-# PRODUCT.md — Per-tab theme override via launch configurations
+# PRODUCT.md — Per-tab theme overrides driven by directory and launch configurations
 
 Issue: https://github.com/warpdotdev/warp/issues/478
 Related: https://github.com/warpdotdev/warp/issues/2618 (set warp theme in launch configuration)
 
 ## Summary
 
-Today the Warp theme is a single global value (`appearance.themes.theme` in
-`settings.toml`). Switching themes affects every open window and tab at once.
-Users who keep many tabs open across distinct contexts — different projects,
-local vs. remote machines, production vs. development environments — have asked
-for years (`#478`, 55+ upvotes; `#2618`) for a way to give specific tabs a
-different theme so context is visible at a glance.
+The Warp theme is a single global value today (`appearance.themes.theme` in
+`settings.toml`); switching it affects every open tab at once. Users have asked
+for years (`#478`, 55+ upvotes; `#2618`) for tabs to render with different
+themes when they represent different contexts — different projects, local vs.
+remote machines, production vs. development.
 
-This spec covers a focused first cut of that capability: a tab can carry a
-**theme override** that comes from the launch configuration that opened it (or
-from a tab restored from a previous session). The override scopes the theme to
-that single tab; the global theme setting is unchanged and continues to apply
-to every tab that does not have an override. A window-level default override is
-also defined so a launch configuration can theme all of its tabs at once.
+This spec covers a focused first cut of per-tab theme overrides driven by
+**three** sources, in priority order:
 
-This spec deliberately scopes out automatic theme switching (SSH host
-detection, agent conversation type, escape-code-driven runtime changes). Those
-appear in `#478` discussion and warrant their own product spec once the
-override mechanism this spec defines exists to build on.
+1. A user-visible **manual** override on a tab (set via the launch
+   configuration YAML or via a right-click menu).
+2. A **directory-pattern** auto-match: the user maps directory paths to
+   themes in `settings.toml`, and tabs whose active pane's cwd matches a
+   pattern render with the mapped theme. This is the path most users in the
+   issue thread describe (`pyronaur`, `janderegg`, `milopersic`): "I `cd`
+   into project A, my theme should change."
+3. A **launch-configuration window-level default** that themes every tab a
+   given launch configuration opens unless the tab itself has another
+   override.
+
+The global theme remains the fallback when none of the three sources apply.
+Window chrome (title bar, sidebar, settings views, the tab strip) continues
+to follow the global theme so windows holding mixed-theme tabs remain
+visually coherent at the window level.
+
+This spec deliberately scopes out automatic theming triggered by SSH host,
+hostname, runtime escape codes, or shell hooks. Those appear in `#478`
+discussion and are listed as follow-ups that consume the override field this
+spec introduces.
 
 Figma: none provided.
 
@@ -30,155 +41,225 @@ Figma: none provided.
 
 In-scope surfaces:
 
-- The launch configuration YAML schema (`~/.warp/launch_configurations/*.yaml`)
-  gains an optional theme field at the tab level and at the window level. The
-  values are theme identifiers — the same names users already see in the theme
-  picker (`"Dark"`, `"Solarized Dark"`, `"Dracula"`, `"Dark City"`, etc.) and
-  the same custom-theme references the rest of the theme system already
-  accepts.
-- Tabs opened from a launch configuration that specifies a theme render with
-  that theme: terminal background, foreground, ANSI palette, and any
-  theme-derived UI surfaces inside the tab follow the override.
-- The override persists with the tab so that on restart / session restore the
-  tab continues to render with the same theme without depending on the user
-  re-running the launch configuration.
-- A user can clear a tab-level override (returning the tab to the global theme)
-  through the same right-click tab menu that already exposes per-tab
-  attributes.
+- A new settings map `appearance.themes.directory_overrides` whose keys are
+  directory paths (tilde-expanded) and whose values are theme identifiers.
+  Matching uses longest-prefix-wins.
+- The launch-configuration YAML schema gains an optional `theme:` field at
+  the tab level and at the window level.
+- A persisted per-tab override that survives session restore.
+- A right-click tab menu entry for **Pin theme** (manually override the
+  active tab's theme to a chosen theme) and **Reset theme** (clear a
+  manual override; cwd-pattern matching may then reapply).
 
-Out of scope (explicitly **not** part of this spec):
+Out of scope:
 
-- Automatic theming based on SSH host, hostname, working directory, or
-  `whoami` (raised in `#478` comments). These require separate detection and
-  policy mechanisms and are tracked as follow-ups.
-- A new escape-code or shell-side protocol for setting a tab's theme at
-  runtime (raised in `#478` comments by users wanting hooks to color Claude
-  Code sessions). Once a per-tab override field exists internally a runtime
-  setter is a small follow-up; defining the protocol is its own surface.
-- Per-pane theming. Panes inside a tab continue to share one theme; the
-  override is a tab-level concept.
+- SSH-host-driven, hostname-driven, or `whoami`-driven theming
+  (`stevenchanin`, `pyronaur`, `zethon`, `janderegg`).
+- Escape-code or shell-hook protocols for runtime theme switching
+  (`yatharth`, for Claude-Code session signaling).
+- Per-pane theming. Panes inside a tab continue to share one theme.
+- Per-tab wallpaper or graphics (`scottaw66`, `SheepDomination`).
 - Changes to the global theme storage path
-  (`appearance.themes.theme` in `settings.toml`), the theme picker UI, or
-  custom-theme loading. The override reuses the existing theme identifier type
-  unchanged.
-- Onboarding or settings-page surfacing of the new field. Discoverability lives
-  in the launch configuration docs and the right-click tab menu only.
+  (`appearance.themes.theme`), the theme picker UI, or custom-theme loading.
+  Overrides reuse the existing theme identifier type.
+
+## Resolution order
+
+A tab's effective theme is determined by walking these layers and returning
+the first hit:
+
+1. **Manual override**, if any. Sources: a tab-level `theme:` in a launch
+   configuration; the right-click "Pin theme" menu.
+2. **Directory match**, if any. The active pane's current working directory
+   is matched against `appearance.themes.directory_overrides`; if a key is
+   a prefix of the cwd, the longest such key wins.
+3. **Launch-configuration window-level default**, if the tab was opened from
+   a launch configuration with a window-level `theme:` and no closer
+   override applies.
+4. **Global theme** as derived from `ThemeSettings` and the system theme,
+   exactly as today.
+
+If none of the override sources resolve to a known theme, behavior is
+bit-for-bit identical to today.
 
 ## Behavior
 
-1. A launch configuration YAML file may include a `theme:` field on any tab
-   entry. The accepted value is a theme identifier exactly as it appears in
-   `settings.toml` today (e.g. `theme: "Dark City"`, `theme: "Solarized Dark"`,
-   `theme: "Dracula"`). Custom theme references use the same form the global
-   theme setting accepts. Omitting the field leaves the tab using whatever
-   theme would otherwise apply (per behavior #3).
+### Directory-pattern overrides
 
-2. A launch configuration YAML file may include a `theme:` field on any window
-   entry. When present, every tab in that window with no tab-level `theme:`
-   inherits this window-level value. A tab-level `theme:` always wins over a
-   window-level one.
+1. `settings.toml` accepts a new section
+   `[appearance.themes.directory_overrides]` whose entries map a directory
+   path to a theme identifier. Example:
 
-3. Theme resolution for a tab is, in order: (a) the tab's own override, if
-   any; (b) the window-level override of the window that opened the tab, if
-   any and inherited at open time; (c) the global theme as derived from
-   `ThemeSettings` and the system theme, exactly as today. If none of the
-   override sources apply the tab's behavior is bit-for-bit identical to a
-   tab opened without this feature.
+   ```toml
+   [appearance.themes.directory_overrides]
+   "~/Work/medone"   = "Dark City"
+   "~/Work/bondwise" = "Solarized Dark"
+   "~/Work/checkpt"  = "Dracula"
+   ```
 
-4. When a tab has an override the override applies to: the terminal cell
-   foreground/background, the ANSI 16-color palette used by the terminal grid,
-   and any in-tab UI surfaces whose colors are derived from the active theme
-   (block backgrounds, command output styling, accent colors). The window
-   chrome (title bar, sidebar, settings views, the tab strip itself) continues
-   to follow the global theme so that windows holding mixed-theme tabs remain
-   visually coherent at the window level.
+   Theme values are the same string form accepted by the global
+   `appearance.themes.theme` (the parser tolerates both display names like
+   `"Dark City"` and snake-case like `"dark_city"`; see #14 below).
 
-5. Switching tabs is instant: there is no flash, no progressive paint, and no
-   redraw of unrelated tabs. The previously-active tab's content does not
-   change appearance because of the switch — only the rendering of the
-   newly-active tab reflects its (possibly different) theme. A user
-   alt-tabbing through ten tabs with different overrides sees each tab in its
-   own theme as it becomes active.
+2. Keys are tilde-expanded to absolute paths at match time. Trailing slashes
+   are normalized away. Symlinks are not resolved — the cwd as the shell
+   reports it is what's matched.
 
-6. Changing the global theme (via the theme picker, settings page, or system
-   light/dark switch) updates every tab that does **not** have an override.
-   Tabs with overrides are unaffected by the global change; their rendering
-   stays on the override value.
+3. Match resolution: a key matches if it is a prefix of the active pane's
+   cwd at a path-component boundary. `~/Work/medone` matches both
+   `~/Work/medone` and `~/Work/medone/apps/admin-api`, but does **not**
+   match `~/Work/medone-archive` (no component boundary). When multiple
+   keys match, the longest one wins (most specific).
 
-7. The existing per-tab `color:` field on a tab template (the small colored
-   indicator next to the tab title) is independent of the new `theme:` field.
-   Both can be set on the same tab; both are honored. Neither implies the
-   other.
+4. The cwd evaluated for a tab is the cwd of the **focused pane** in that
+   tab. A tab whose focused pane is in a non-shell context (notebook,
+   settings view, etc.) has no cwd and falls through directory matching.
 
-8. A tab opened with a theme override surfaces a "Reset theme" entry in the
-   right-click tab context menu, alongside the existing per-tab attributes
-   (color, title, etc.). Choosing "Reset theme" clears the tab's override; the
-   tab immediately re-renders using whatever theme falls out of the resolution
-   order in #3 (typically the global theme). The menu entry is hidden for
-   tabs that have no override.
+5. When a tab's active pane changes cwd (because the user ran `cd`, opened
+   a subdirectory, or moved focus to a pane in a different cwd), directory
+   matching re-runs. If the new cwd matches a different key, the tab
+   immediately re-renders with the new theme. If it matches no key, the
+   tab falls through to the next layer in the resolution order.
 
-9. Tab overrides survive session restore. A tab that had an override when the
-   user last quit Warp opens with the same override on relaunch. A tab with
-   no override opens with no override (i.e. it tracks the current global
-   theme).
+6. Adding, editing, or removing entries in `directory_overrides` while
+   Warp is running re-evaluates every open tab. Tabs whose effective theme
+   changes redraw; tabs whose effective theme is unchanged do not.
 
-10. Saving a window's current state to a launch configuration (`File → Save
-    Layout as Launch Configuration` and equivalents) emits `theme:` entries on
-    each tab that has an override. Tabs without overrides emit no `theme:`
-    field. Window-level `theme:` is emitted only when every tab in the window
-    shared the same explicit override at save time, in which case the per-tab
-    fields are coalesced up to the window. (This keeps round-trip save/load
-    clean for the common "themed launch config" case.)
+7. A theme name in `directory_overrides` that does not resolve to a known
+   theme is treated the same way an unknown launch-configuration theme is
+   (#11): a warning is logged identifying the offending key, the entry is
+   skipped for matching purposes, and the rest of the map continues to
+   work.
 
-11. An unknown theme identifier in a launch configuration (e.g. a theme that
-    has been deleted, or a typo) is treated the same way an unknown global
-    theme is treated today: the tab falls back to the global resolved theme,
-    a warning is logged, and opening the launch configuration does not fail.
-    Other tabs in the same launch configuration are unaffected.
+### Launch-configuration overrides
+
+8. A launch configuration YAML may include `theme:` on any tab entry.
+   Accepted values are theme identifiers in the form documented in #14.
+   Omitting the field leaves the tab to fall through the resolution order.
+
+9. A launch configuration YAML may include `theme:` on any window entry.
+   Tabs in that window with no tab-level `theme:` and no directory match
+   inherit this window-level value (per the resolution order: #3 sits
+   below #2).
+
+10. Saving a window's current state to a launch configuration emits
+    `theme:` entries on each tab whose effective theme came from a manual
+    override. Tabs themed only by directory matching emit no `theme:`
+    field — directory matching is config-level, not tab-level, so a saved
+    launch configuration that relies on it stays portable. Window-level
+    `theme:` is emitted only when every tab in the window shared the same
+    explicit manual override at save time.
+
+### YAML / settings format
+
+11. An unknown theme identifier — anywhere it appears — never causes a
+    file-level load failure. The deserializer accepts any string; the
+    resolver runs at apply time and falls back to the next resolution
+    layer for the affected entry only. Other tabs in the same launch
+    configuration, and other entries in the same `directory_overrides`
+    map, are unaffected. Each unknown name produces exactly one logged
+    warning per load.
 
 12. Custom themes referenced by an override behave identically to custom
-    themes used as the global theme — they are loaded from the user's themes
-    directory, fail-soft to the global theme if the file is missing, and
-    obey the same trust/validation rules already in the theme loader.
+    themes used as the global theme — loaded from the user's themes
+    directory, fail-soft to the next layer if the file is missing, same
+    trust/validation rules as the global theme loader.
 
-13. The override persists per-tab, not per-launch-configuration. If a user
-    edits a launch configuration's theme after first opening it, already-open
-    tabs that came from that launch configuration keep their original
-    override; new tabs opened by re-running the launch configuration get the
-    new value. This matches how the existing per-tab `color:` field behaves.
+13. The override persists per-tab through session restore. A tab whose
+    effective theme came from a manual pin keeps that pin on relaunch. A
+    tab whose effective theme came from directory matching is restored
+    with no manual pin; on relaunch its theme is recomputed from the
+    current `directory_overrides` and the restored cwd.
 
-14. Accessibility: the theme override does not change any text content,
-    accessible labels, or focus order. Screen readers continue to report tab
-    titles and contents identically. The "Reset theme" menu entry has the
-    accessible label "Reset theme" and is announced as a menu item.
+14. The accepted form for any theme reference (in
+    `directory_overrides`, in launch-config tab `theme:`, in launch-config
+    window `theme:`) is a single string. Both the human-readable display
+    form (`"Dark City"`, `"Solarized Dark"`, `"Dracula"`) and the
+    snake-case form (`"dark_city"`, `"solarized_dark"`, `"dracula"`) are
+    accepted. Matching is case-insensitive on whitespace-stripped input.
+    Custom themes are referenced by their custom-theme name, same as
+    today's global setting.
 
-15. The feature applies on every supported platform (macOS, Linux, Windows).
-    It is gated behind no feature flag and is on by default once shipped.
+### Rendering scope
+
+15. When a tab has an effective override (from any layer), the override
+    applies to: the terminal cell foreground/background, the ANSI 16-color
+    palette used by the terminal grid, and any in-tab UI surfaces whose
+    colors are derived from the active theme (block backgrounds, command
+    output styling, accent colors). The window chrome (title bar, sidebar,
+    settings views, the tab strip itself) continues to follow the global
+    theme.
+
+16. Switching tabs is instant — no flash, no progressive paint. Only the
+    rendering of the newly-active tab reflects its (possibly different)
+    theme; inactive tabs do not redraw on switch.
+
+17. Changing the global theme updates every tab whose effective theme
+    falls through to the global layer. Tabs with overrides at any
+    higher-priority layer are unaffected.
+
+### User affordances
+
+18. The right-click tab context menu gains two entries, alongside the
+    existing per-tab attributes:
+    - **Pin theme...** — opens a submenu listing available themes.
+      Choosing one sets a manual override on the tab, which wins over
+      directory matching and the global theme. Visible at all times.
+    - **Reset theme** — clears the tab's manual override. Visible only
+      when the tab has a manual override. After reset, the tab falls
+      through to the directory-match / window-default / global layers in
+      that order; if a directory match applies, the tab redraws with the
+      directory-matched theme.
+
+19. The existing per-tab `color:` field on a tab template (the small
+    colored indicator next to the tab title) is independent of the new
+    theme override. Both can be set; both are honored.
+
+20. The feature applies on every supported platform (macOS, Linux,
+    Windows). It is gated behind no feature flag and is on by default once
+    shipped. An empty `directory_overrides` map (the default) plus no
+    launch-config theme fields plus no pinned themes is bit-for-bit
+    identical to current behavior.
+
+### Accessibility
+
+21. The override does not change any text content, accessible labels, or
+    focus order. Screen readers continue to report tab titles and
+    contents identically. The new menu entries have accessible labels
+    "Pin theme" (with a submenu) and "Reset theme".
 
 ## User-visible failure modes
 
-- **Unknown theme name in YAML** — tab opens with the global theme; a one-line
-  warning is written to the Warp log identifying the launch configuration
-  filename, the tab title (or index, if untitled), and the unrecognized theme
-  string. The launch configuration as a whole still opens.
-- **Custom theme file missing** — same fallback as the global theme exhibits
-  today: tab opens with the global theme, warning logged.
-- **Window-level theme set, tab-level not set, tab opens with override
-  inherited; user later edits the YAML to remove the window-level value** —
-  already-open tabs keep their existing override (per #13). New tabs opened
-  from the edited launch configuration get no override.
+- **Unknown theme name** — anywhere it appears, the entry is skipped at
+  apply time, a one-line warning is written to the Warp log identifying
+  the source (launch configuration filename + tab title or index;
+  `directory_overrides` key), and the rest of the configuration loads
+  normally.
+- **Custom theme file missing** — same fallback the global theme uses
+  today: tab opens with the next-layer theme, warning logged.
+- **Two `directory_overrides` keys are equivalent after tilde expansion**
+  — last-write-wins per TOML semantics; a warning is logged identifying
+  the duplicate.
+- **A pane's cwd is unavailable** (non-shell pane content) — that pane
+  contributes no cwd to directory matching; if it is the focused pane the
+  tab falls through to the window/global layers.
 
 ## Open questions
 
-- Should the right-click "Reset theme" entry also offer a submenu of theme
-  names so a user can change a tab's override without editing YAML? This spec
-  takes the more conservative position of "reset only" so the launch
-  configuration file remains the single source of truth for setting overrides;
-  a richer in-app picker is a candidate follow-up.
-- Should saving a launch configuration record the *resolved* theme of each
-  tab, or only the explicit override the tab carries? This spec records only
-  explicit overrides (#10) so a saved launch configuration that contains no
-  `theme:` fields continues to track the global theme on every machine it is
-  loaded on. The alternative (record resolved theme always) would lock the
-  saved configuration to a snapshot of the user's current global theme, which
-  is rarely the desired behavior for a portable launch configuration.
+- Should `directory_overrides` keys support glob patterns (`~/Work/*`)?
+  This spec proposes prefix-matching only because that covers the
+  most-requested use case ("a folder of projects, each in a subfolder")
+  and avoids the edge cases of glob semantics on Windows paths. Globs are
+  a candidate follow-up.
+- Should "Reset theme" also clear a launch-config-set manual override
+  (#18 says it does)? An alternative is "Reset theme" only clears
+  pin-from-menu overrides and a separate "Forget launch config theme"
+  entry handles YAML-set overrides. This spec takes the simpler
+  one-entry-clears-all-manual position and lists the alternative as a
+  follow-up.
+- Should saving a launch configuration emit `directory_overrides`
+  entries (so themes travel with the launch config)? This spec keeps the
+  two surfaces independent: launch configs carry only manual overrides;
+  directory matching is a settings-level concept that does not roundtrip
+  through saved launch configs. A future "shareable theme bundle" feature
+  could compose them.

--- a/specs/GH478/product.md
+++ b/specs/GH478/product.md
@@ -68,15 +68,21 @@ Out of scope:
 A tab's effective theme is determined by walking these layers and returning
 the first hit:
 
-1. **Manual override**, if any. Sources: a tab-level `theme:` in a launch
-   configuration; the right-click "Pin theme" menu.
-2. **Directory match**, if any. The active pane's current working directory
-   is matched against `appearance.themes.directory_overrides`; if a key is
-   a prefix of the cwd, the longest such key wins.
-3. **Launch-configuration window-level default**, if the tab was opened from
-   a launch configuration with a window-level `theme:` and no closer
-   override applies.
-4. **Global theme** as derived from `ThemeSettings` and the system theme,
+1. **Menu pin**, if any. Set by the right-click "Pin theme" menu and
+   cleared by the right-click "Reset theme" menu. Persists across
+   sessions.
+2. **Launch-configuration manual pin**, if any. Set by a tab-level
+   `theme:` in the launch configuration that opened (or restored) the
+   tab. Cleared only by an explicit "Forget launch config theme" menu
+   entry — `Reset theme` does **not** clear this layer (per Zach's v4
+   review). Persists across sessions.
+3. **Directory match**, if any. The active pane's current working
+   directory is matched against `appearance.themes.directory_overrides`;
+   if a key is a prefix of the cwd, the longest such key wins.
+4. **Launch-configuration window-level default**, if the tab was opened
+   from a launch configuration with a window-level `theme:` and no
+   closer override applies. Persists across sessions.
+5. **Global theme** as derived from `ThemeSettings` and the system theme,
    exactly as today.
 
 If none of the override sources resolve to a known theme, behavior is
@@ -226,14 +232,16 @@ bit-for-bit identical to today.
     trust/validation rules as the global theme loader.
 
 13. Overrides persist per-tab through session restore, by source:
-    - **Manual pin** — kept on relaunch.
-    - **Launch-configuration window-level default** — kept on relaunch.
-      The launch configuration that opened the tab is not necessarily
+    - **Menu pin** (layer #1) — kept on relaunch.
+    - **Launch-configuration manual pin** (layer #2) — kept on
+      relaunch. The launch configuration that set it is not necessarily
       reopened on restore, so the value travels with the tab.
-    - **Directory match** — not stored; recomputed on relaunch from the
-      current `directory_overrides` and the restored cwd. Editing
-      `directory_overrides` between sessions therefore takes effect on
-      the next launch.
+    - **Launch-configuration window-level default** (layer #4) — kept
+      on relaunch, same reason as #2.
+    - **Directory match** (layer #3) — not stored; recomputed on
+      relaunch from the current `directory_overrides` and the restored
+      cwd. Editing `directory_overrides` between sessions therefore
+      takes effect on the next launch.
 
 14. The accepted form for any theme reference (in
     `directory_overrides`, in launch-config tab `theme:`, in launch-config
@@ -264,26 +272,48 @@ bit-for-bit identical to today.
 
 ### User affordances
 
-18. The right-click tab context menu gains two entries, alongside the
+18. The right-click tab context menu gains three entries, alongside the
     existing per-tab attributes:
     - **Pin theme...** — opens a submenu listing available themes.
-      Choosing one sets a manual override on the tab, which wins over
-      directory matching and the global theme. Visible at all times.
-    - **Reset theme** — clears the tab's manual override. Visible only
-      when the tab has a manual override. After reset, the tab falls
-      through to the directory-match / window-default / global layers in
-      that order; if a directory match applies, the tab redraws with the
-      directory-matched theme.
+      Choosing one sets a *menu pin* on the tab (resolution layer #1),
+      which wins over every other layer including a launch-config
+      manual pin. Visible at all times.
+    - **Reset theme** — clears only the menu pin (layer #1). The tab
+      falls through to the launch-config manual pin / directory match /
+      window default / global layers in that order. Visible only when
+      the tab has a menu pin.
+    - **Forget launch config theme** — clears only the launch-config
+      manual pin (layer #2). The tab falls through to the directory
+      match / window default / global layers. Visible only when the
+      tab has a launch-config manual pin.
+
+    Splitting "Reset theme" from "Forget launch config theme" means a
+    user who pinned a different theme via the menu can clear that pin
+    without unintentionally also discarding what their launch
+    configuration originally set. (Per Zach's v4 review.)
 
 19. The existing per-tab `color:` field on a tab template (the small
     colored indicator next to the tab title) is independent of the new
     theme override. Both can be set; both are honored.
 
 20. The feature applies on every supported platform (macOS, Linux,
-    Windows). It is gated behind no feature flag and is on by default once
-    shipped. An empty `directory_overrides` map (the default) plus no
-    launch-config theme fields plus no pinned themes is bit-for-bit
-    identical to current behavior.
+    Windows). It is **gated behind a feature flag** named
+    `appearance.themes.per_tab_overrides` (per Zach's v4 review):
+    - Initial release ships with the flag **off** in stable and **on**
+      in dev/preview, so the rollout can soak with internal users
+      before reaching the broader install base.
+    - When the flag is off the feature is invisible: the right-click
+      menu entries are hidden, `directory_overrides` matching does not
+      run (the settings group is still parseable so users who set up
+      the map under preview do not lose data), and launch-configuration
+      `theme:` fields are deserialized but ignored. The user-visible
+      behavior is bit-for-bit identical to today.
+    - The default flips to on in stable in a follow-up release, after
+      telemetry on the preview/dev cohort confirms no regressions in
+      render performance, settings parsing, or session restore.
+    - An empty `directory_overrides` map (the default) plus no
+      launch-config theme fields plus no pinned themes — even with the
+      flag on — is bit-for-bit identical to current behavior.
 
 ### Accessibility
 
@@ -310,20 +340,20 @@ bit-for-bit identical to today.
 
 ## Open questions
 
-- Should `directory_overrides` keys support glob patterns (`~/Work/*`)?
-  This spec proposes prefix-matching only because that covers the
-  most-requested use case ("a folder of projects, each in a subfolder")
-  and avoids the edge cases of glob semantics on Windows paths. Globs are
-  a candidate follow-up.
-- Should "Reset theme" also clear a launch-config-set manual override
-  (#18 says it does)? An alternative is "Reset theme" only clears
-  pin-from-menu overrides and a separate "Forget launch config theme"
-  entry handles YAML-set overrides. This spec takes the simpler
-  one-entry-clears-all-manual position and lists the alternative as a
-  follow-up.
+(Resolved in v4 review and folded into the spec — kept here as a record
+of the design choices made.)
+
+- ~~`directory_overrides` keys: glob vs. prefix matching.~~ Resolved:
+  prefix matching only (Zach v4: "i think prefix-match is fine to
+  start"). Globs are a follow-up.
+- ~~"Reset theme" scope: clear all manual layers, or only menu pins.~~
+  Resolved: only menu pins (Zach v4: "i don't think it should" clear
+  launch-config pins). A separate "Forget launch config theme" entry
+  exists for the launch-config layer. Reflected in behaviors #18 and
+  in the resolution order.
 - Should saving a launch configuration emit `directory_overrides`
-  entries (so themes travel with the launch config)? This spec keeps the
-  two surfaces independent: launch configs carry only manual overrides;
-  directory matching is a settings-level concept that does not roundtrip
-  through saved launch configs. A future "shareable theme bundle" feature
-  could compose them.
+  entries so themes travel with the launch config? Spec keeps the two
+  surfaces independent — launch configs carry only manual pins;
+  directory matching is settings-level and does not round-trip through
+  saved launch configs. A future "shareable theme bundle" could
+  compose them. Open for product-team input.

--- a/specs/GH478/tech.md
+++ b/specs/GH478/tech.md
@@ -159,40 +159,85 @@ Implementation:
 This satisfies Oz concerns 1 and 2 by making YAML-format coupling
 explicit and keeping unknown-theme handling field-level.
 
-### 3. `ThemeOverride` source enum on `TabSnapshot` and `TabData`
+### 3. `TabThemeState` on `TabSnapshot` and `TabData`
 
 File: `app/src/app_state.rs` and `app/src/tab.rs`.
 
-Add a new type:
+A tab can have up to three independent theme inputs at once — a manual
+pin, a cwd-pattern match, and a launch-configuration window-level
+default — and the product spec defines a strict priority order between
+them (manual > cwd > window default > global). A single `Option<enum>`
+cannot represent "manual cleared, cwd applies, window default also
+exists as a deeper fallback" because the three sources are not mutually
+exclusive at storage time, only at render time. Replace the single
+field with a struct holding all three slots, plus a resolver:
 
 ```rust
-/// The source of a tab's theme override. The enum exists so "Reset
-/// theme" can clear a manual override without also dismissing a
-/// directory match that the tab would otherwise still receive.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ThemeOverride {
-    /// Set explicitly: launch-configuration tab-level `theme:`,
-    /// "Pin theme" menu, or saved-and-restored manual pin.
-    Manual(ThemeKind),
-    /// Set automatically by `directory_overrides` matching against the
-    /// focused pane's cwd. Not persisted across sessions; recomputed on
-    /// startup from the current settings + cwd.
-    Cwd(ThemeKind),
+/// Per-tab theme state. Each slot is independent storage for one
+/// resolution layer; the resolver in `effective()` enforces the
+/// priority order from `product.md` (Resolution order #1–#4).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TabThemeState {
+    /// User-set pin: launch-config tab-level `theme:`, "Pin theme"
+    /// menu, or a restored pin from a previous session.
+    /// **Persisted across sessions.**
+    pub manual: Option<ThemeKind>,
+
+    /// Set at open time when the tab was created from a launch
+    /// configuration whose window had a window-level `theme:`.
+    /// **Persisted across sessions** (the launch config that opened
+    /// the tab is not necessarily reopened on restore, so the value
+    /// must travel with the tab).
+    pub window_default: Option<ThemeKind>,
+
+    /// Computed by directory-pattern matching against the focused
+    /// pane's cwd. Recomputed on tab creation, on focused-pane cwd
+    /// change, and on `directory_overrides` settings change.
+    /// **Not persisted** — recomputed on startup from current
+    /// settings + restored cwd.
+    pub cwd_resolved: Option<ThemeKind>,
+}
+
+impl TabThemeState {
+    /// Resolution order: manual > cwd > window default > caller's
+    /// global fallback. Mirrors product.md §"Resolution order".
+    pub fn effective<'a>(&'a self, global: &'a ThemeKind) -> &'a ThemeKind {
+        self.manual.as_ref()
+            .or(self.cwd_resolved.as_ref())
+            .or(self.window_default.as_ref())
+            .unwrap_or(global)
+    }
+
+    pub fn has_any_override(&self) -> bool {
+        self.manual.is_some() || self.cwd_resolved.is_some()
+            || self.window_default.is_some()
+    }
 }
 ```
 
-Add `pub theme_override: Option<ThemeOverride>` to:
+Add `pub theme_state: TabThemeState` to:
 
 - `TabSnapshot` (`app_state.rs:61–69`), placed next to `selected_color`.
 - `TabData` (`tab.rs:134`), same.
 
-Snapshot ↔ runtime conversion copies the field unchanged. Session
-serialization persists only `Manual(_)` overrides; `Cwd(_)` overrides are
-re-derived on startup (per product spec behavior #13).
+Session serialization writes only `manual` and `window_default`;
+`cwd_resolved` is recomputed on startup. The serializer omits the
+field entirely when all three slots are `None`, so existing sessions
+with no overrides round-trip with no schema cost.
 
-`WindowSnapshot` does not gain a theme field — window-level launch-config
-theme is expanded to per-tab `Manual` overrides at open time and not
-persisted at the window level.
+`WindowSnapshot` does not gain a theme field; the window-level
+launch-config theme lives only on the *tabs* it opened (in their
+`window_default` slot). This is what Oz's first v2 review correctly
+flagged: expanding the window default into the *manual* slot would
+have made it incorrectly outrank cwd matches. The dedicated slot fixes
+that — `effective()` consults `manual` first, then `cwd_resolved`, and
+falls through to `window_default` only when neither of the higher
+layers applies.
+
+The right-click "Reset theme" entry (§6) only clears `manual`. The
+other two slots are unaffected, so a tab whose manual pin sat on top
+of a still-applicable cwd match falls back to the cwd theme on reset
+rather than to the global theme — matching product behavior #18.
 
 ### 4. Directory-pattern overrides settings group
 
@@ -207,17 +252,55 @@ define_settings_group!(DirectoryThemeOverrides, settings: [
         type: BTreeMap<String, String>,
         default: BTreeMap::new(),
         supported_platforms: SupportedPlatforms::ALL,
-        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
-        private: false,
+        // **Local-only.** Directory paths can encode employer, customer,
+        // and project names (e.g. `~/Work/<client>/<engagement>/...`).
+        // Cloud-syncing the keys would leak that organizational context
+        // off-machine; cloud-syncing the values without the keys is
+        // useless. The setting is therefore not synced. Per-tab themes
+        // remain user-controllable through the right-click "Pin theme"
+        // menu, which writes to the (non-synced) tab snapshot, not to
+        // this map. See *Privacy model* below.
+        sync_to_cloud: SyncToCloud::Locally,
+        private: true,
         toml_path: "appearance.themes.directory_overrides",
         max_table_depth: 1,
-        description: "Map of directory paths to theme names. The active \
-                      pane's cwd is matched against keys (longest prefix \
-                      wins); the matched theme overrides the global theme \
-                      for that tab.",
+        description: "Local map of directory paths to theme names. The \
+                      active pane's cwd is matched against keys (longest \
+                      prefix wins); the matched theme overrides the global \
+                      theme for that tab. Stored locally; never synced to \
+                      Warp's cloud because path keys can leak employer or \
+                      project names.",
     },
 ]);
 ```
+
+#### Privacy model (responding to Oz's [SECURITY] finding on v2)
+
+Directory paths are not just configuration — they encode information
+about the user's employer, clients, and projects. A key like
+`~/Work/AcmeCorp/redesign-2026` reveals all three. The settings system
+already distinguishes synced from local settings via `sync_to_cloud`
+and `private`; the design rule applied here is:
+
+- **Keys are locally-stored, never synced.** `sync_to_cloud:
+  Locally` and `private: true`. The map is written only to the user's
+  local `settings.toml` and is not transmitted off-machine by the
+  settings sync path.
+- **No telemetry on the contents.** The match function emits at most a
+  count metric ("a directory match applied to N tabs this minute"); it
+  never logs path keys or theme names to remote telemetry pipelines.
+  The local Warp log (which already contains plenty of cwd-bearing
+  information from existing features) may include a key in a
+  warning when a value fails to resolve, but that surface is local.
+- **No round-tripping into shareable artifacts.** A saved launch
+  configuration does not emit `directory_overrides` entries (product
+  spec #10). Launch configurations are explicitly designed to be
+  shared between machines and users; the directory map is not.
+- **Opt-in cloud sync is a follow-up.** A future `cloud_sync_directory_overrides`
+  setting could let users with enterprise sync needs share the map
+  *to themselves* across machines. That requires a separate spec
+  covering opt-in UI, encryption-at-rest of keys, and admin-policy
+  controls; it is deliberately not pre-paid for here.
 
 Resolution helper, alongside the group:
 
@@ -241,18 +324,36 @@ Match semantics (per product spec #2, #3):
   skipped and a warning is logged once at settings-change time, not
   per-match.
 
-Matching is invoked from two places:
+Matching is invoked from **three** places (responding to Oz's v2
+finding that settings edits were not handled):
 
-- **Tab creation** — when a tab is added (from a launch configuration or
-  from "new tab"), if the tab has no `Manual` override the focused
-  pane's cwd is matched. On hit, the tab's `theme_override` is set to
-  `Cwd(...)`.
-- **Cwd-change events** — the existing pane-cwd tracker emits a
-  "focused pane cwd changed" event used for tab title updates. Add a
-  subscriber that re-runs directory matching for the affected tab when
-  the new cwd differs from the previous match key. The runtime tab
-  retains the last-matched key so re-matching is `O(1)` in the no-change
-  case.
+- **Tab creation** — when a tab is added (from a launch configuration
+  or from "new tab"), the focused pane's cwd is matched and
+  `tab.theme_state.cwd_resolved` is set to the result (`None` on no
+  match). The `manual` slot is set independently from the launch
+  config or from a saved pin; it is *not* gated on `cwd_resolved`
+  being absent.
+- **Focused-pane cwd-change events** — the existing pane-cwd tracker
+  emits a "focused pane cwd changed" event used today for tab title
+  updates. A new subscriber re-runs `directory_theme_for` for the
+  affected tab when the cwd differs from the last-matched key. The
+  runtime tab retains the last-matched key so re-matching is `O(1)`
+  in the no-change case. Result is written to `cwd_resolved`; if
+  the effective theme (per `TabThemeState::effective`) changes, the
+  tab re-renders.
+- **Settings-change events on `DirectoryThemeOverrides`** — the
+  `define_settings_group!` macro emits change events the same way
+  `ThemeSettings` does (`app/src/appearance.rs:51` is the existing
+  pattern). A new subscription on `DirectoryThemeOverrides::handle(ctx)`
+  walks every open tab in every window, recomputes
+  `cwd_resolved` from the new map and the tab's current cwd, and
+  re-renders each tab whose effective theme changed. Implements
+  product behavior #6.
+
+The same subscription handles validation: any value in the new map
+that fails `resolve_theme_ref` is logged once (with its key) and
+treated as absent for matching purposes. Subsequent edits that fix
+the value re-trigger this validation.
 
 ### 5. Renderer: `Appearance` gains a theme catalog
 
@@ -283,8 +384,9 @@ impl Appearance {
         self.global_theme.clone()
     }
 
-    /// Per-tab theme lookup. `override` is taken straight from
-    /// `TabData::theme_override.as_ref().map(ThemeOverride::kind)`.
+    /// Per-tab theme lookup. The caller passes
+    /// `tab.theme_state.effective(global_kind)` (or `None` for the
+    /// global theme).
     /// Returns the global theme when `override` is `None`.
     pub fn theme_for(&self, override_kind: Option<&ThemeKind>) -> Arc<WarpTheme> {
         match override_kind {
@@ -322,7 +424,12 @@ Cache-invalidation rules:
 
 Renderer call-site update: every place that today reads
 `Appearance::as_ref(ctx).theme()` and is **inside a tab's render path**
-becomes `Appearance::as_ref(ctx).theme_for(tab.theme_override.as_ref().map(ThemeOverride::kind))`.
+becomes
+`Appearance::as_ref(ctx).theme_for(Some(tab.theme_state.effective(&global_kind)))`,
+where `global_kind` is the active global `ThemeKind` from
+`active_theme_kind(theme_settings, app)`. Render paths that already have
+no per-tab context (window chrome) keep calling `Appearance::theme()`
+unchanged.
 The exact list of call sites (terminal cell renderer in
 `app/src/terminal/view.rs`, color derivation in
 `app/src/terminal/color.rs`, any block-styling consumers) is enumerated
@@ -338,12 +445,13 @@ The existing tab context menu gains two entries:
 
 - **Pin theme...** — opens a submenu listing built-in themes plus any
   loaded custom themes (the same list the theme picker shows). On
-  click, sets the tab's `theme_override` to `Manual(chosen)`. Always
+  click, sets `tab.theme_state.manual = Some(chosen)`. Always
   visible.
-- **Reset theme** — clears any `Manual(_)` override on the tab; if the
-  focused pane's cwd matches a `directory_overrides` key the override
-  is set to `Cwd(_)` immediately, otherwise it becomes `None`. Visible
-  only when the tab has a `Manual` override.
+- **Reset theme** — sets `tab.theme_state.manual = None`. The other
+  two slots (`cwd_resolved`, `window_default`) are unaffected; if
+  either still has a value the tab immediately re-renders with the
+  next-priority theme per `effective()`. Visible only when
+  `theme_state.manual.is_some()`.
 
 Both entries trigger the existing theme-changed redraw path used today
 when the global theme changes (no new render-invalidation work).
@@ -390,13 +498,22 @@ conventions. No new event schema.
 
 `app/src/app_state.rs` (or test module):
 
-- `TabSnapshot { theme_override: Some(Manual(Dracula)) }` round-trips
-  through session-restore serialization.
-- `TabSnapshot { theme_override: Some(Cwd(Dracula)) }` does **not**
-  persist — the Cwd variant is re-derived on startup from current
-  settings + cwd. (This pins behavior #13.)
+- `TabThemeState { manual: Some(Dracula), .. }` round-trips through
+  session-restore serialization.
+- `TabThemeState { window_default: Some(Light), .. }` round-trips —
+  window defaults travel with the tab because the launch config that
+  set them is not necessarily reopened on restore.
+- `TabThemeState { cwd_resolved: Some(Dracula), .. }` does **not**
+  persist; on deserialization the slot is `None` regardless of what
+  was written. (Pins product behavior #13.)
+- `TabThemeState::effective()` priority: `manual=Some(A) cwd=Some(B)
+  window=Some(C)` resolves to `A`; `manual=None cwd=Some(B) window=Some(C)`
+  resolves to `B`; `manual=None cwd=None window=Some(C)` resolves to
+  `C`; all `None` resolves to the global fallback. (Pins the
+  resolution order from product.md and directly addresses Oz's v2
+  CRITICAL finding — window defaults must not outrank cwd.)
 - `TabSnapshot::color()` returns the same value with and without
-  `theme_override` set (color and theme are independent — #19).
+  `theme_state` populated (color and theme are independent — #19).
 
 `app/src/appearance.rs` (or `warp_core` tests):
 
@@ -428,13 +545,40 @@ conventions. No new event schema.
   that maps to `Solarized Dark`. Assert Dracula wins (manual > cwd).
   Right-click → Reset theme. Assert the tab redraws with Solarized
   Dark (the cwd match takes over).
-- Edit `directory_overrides` while Warp is running. Assert all tabs
-  whose effective theme changes redraw, others do not.
+- **Settings-change recompute.** With three tabs open in three
+  different cwds, edit `directory_overrides` to add a new key that
+  matches one of them. Assert that one tab redraws with the new
+  theme; the other two are unchanged. Then edit the same key's value
+  to a different theme name. Assert the matched tab redraws again.
+  Then delete the key. Assert the tab falls through to its
+  next-priority theme. (Pins product behavior #6 and addresses Oz's
+  v2 IMPORTANT finding that this path was missing from the design.)
+- Open a launch configuration with a window-level `theme:` and three
+  tabs, one of which sits in a `directory_overrides`-matched cwd.
+  Assert the matched tab uses the cwd theme (cwd > window default);
+  the other two use the window default. (Pins the priority order and
+  addresses Oz's v2 CRITICAL finding.)
 - Quit and relaunch. Assert manually-pinned tabs restore their pin;
-  cwd-matched tabs re-derive their theme from current settings + cwd.
+  tabs that had only a `cwd_resolved` theme have `cwd_resolved` set
+  to `None` after deserialization but are recomputed on startup from
+  current settings + cwd.
 - Unknown theme name in a launch configuration: the file opens,
   exactly that one tab falls through, the warning appears in the log,
   other tabs render correctly.
+
+### Privacy invariant tests
+
+- `DirectoryThemeOverrides` settings group has `private == true` and
+  `sync_to_cloud == SyncToCloud::Locally`. Pinned by a settings-system
+  test analogous to the existing tests that gate which settings sync.
+- The settings sync serializer, when run over a populated
+  `DirectoryThemeOverrides`, emits no entry containing a path key in
+  the cloud-sync payload. Test by populating the map, running the
+  serializer, and asserting the resulting payload does not contain
+  the literal key string.
+- Saving a window's state as a launch configuration with a populated
+  `directory_overrides` map produces YAML with no
+  `directory_overrides` field.
 
 ### Manual verification
 
@@ -480,24 +624,36 @@ conventions. No new event schema.
   documented in the product spec; integration tests cover the common
   cases.
 
-- **`Cwd(_)` override mistakenly persists across sessions.** Session
-  serialization explicitly emits only `Manual(_)`; the integration test
-  for restart behavior pins this.
+- **`cwd_resolved` mistakenly persists across sessions.** The slot's
+  serde derives skip it on serialization and default it to `None` on
+  deserialization; the integration test for restart behavior pins this.
 
-- **Concern 1 / Concern 2 / Concern 3 from Oz's first review.**
+- **Path keys leaking off-machine.** Addressed in *Privacy model* (§4):
+  `private: true`, `sync_to_cloud: Locally`, no telemetry on contents,
+  no roundtrip into shareable launch-config YAML. Privacy invariant
+  tests pin each rule.
+
+- **Window-default outranking cwd matches.** Addressed by giving
+  window-default its own slot in `TabThemeState` (§3) rather than
+  expanding it into the manual slot. `effective()` walks slots in the
+  product spec's resolution order; the integration test for the
+  launch-config-with-window-default scenario pins the priority.
+
+- **Concern 1 / Concern 2 / Concern 3 from Oz's first-pass review.**
   Addressed in §1 (Option<String> + apply-time resolver), §2
   (`resolve_theme_ref` returns `Option<ThemeKind>`), and §5 (theme
   catalog, `Arc<WarpTheme>` ownership) respectively. Each concern has
   a corresponding unit test above.
 
-- **Per-pane theme creep.** The override field lives on the tab, not
-  the pane, and the resolver consults the focused pane's cwd. A future
+- **Per-pane theme creep.** Override slots live on the tab, not the
+  pane; the resolver consults the focused pane's cwd. A future
   per-pane theming feature would need its own data path; this spec
   does not lock that out but does not pre-pay for it either.
 
-- **Persistence schema collision with future per-window theming.** The
-  field is named `theme_override` (not `theme`) so a separate resolved
-  theme can live elsewhere if added later.
+- **Persistence schema collision with future per-window theming.**
+  The field is named `theme_state` (a struct of slots) rather than
+  `theme`, so a separate resolved theme can live elsewhere if added
+  later.
 
 ## Follow-ups (deliberately not in this PR)
 
@@ -505,7 +661,8 @@ conventions. No new event schema.
   product.md) — extends key matching from prefix to glob.
 - **Auto-theme by SSH host or hostname** (`stevenchanin`, `pyronaur`,
   `zethon`, `janderegg` in #478). Requires detection inside the tab's
-  shell; consumes the `Manual` / new `Ssh` variant of `ThemeOverride`.
+  shell; would add a fourth slot (`ssh_resolved`) to `TabThemeState`
+  and a corresponding rung in `effective()`'s priority order.
 - **Runtime escape-code or shell-hook protocol for setting a tab's
   theme** (`yatharth`, for Claude-Code session signaling). Defines a
   wire format and a security model; consumes the override field.

--- a/specs/GH478/tech.md
+++ b/specs/GH478/tech.md
@@ -1,0 +1,383 @@
+# TECH.md — Per-tab theme override via launch configurations
+
+Issue: https://github.com/warpdotdev/warp/issues/478
+Related: https://github.com/warpdotdev/warp/issues/2618
+Product spec: `specs/GH478/product.md`
+
+## Context
+
+The Warp theme is currently a single global value derived from
+`ThemeSettings`. The renderer reads it through the global `Appearance`
+singleton; nothing in the rendering pipeline today accepts a per-tab theme
+parameter. Adding per-tab overrides therefore touches three layers — the
+launch configuration schema, the persisted tab snapshot, and the renderer's
+theme lookup — but does not require changing the theme storage format or
+adding any new theme types.
+
+The rest of this section enumerates the existing surfaces the implementation
+will modify or read from. All file references are at HEAD on `master`.
+
+### Launch configuration schema
+
+`app/src/launch_configs/launch_config.rs` defines the YAML data model:
+
+- `LaunchConfig` (lines 14–20) — top-level: `name`, `active_window_index`,
+  `windows: Vec<WindowTemplate>`.
+- `WindowTemplate` (lines 36–41) — `active_tab_index`, `tabs:
+  Vec<TabTemplate>`. **No theme field today.**
+- `TabTemplate` (lines 180–187) — `title`, `layout: PaneTemplateType`,
+  `color: Option<AnsiColorIdentifier>`. The `color` field (line 186) is the
+  closest precedent for the new `theme` field: same `Option<…>` shape, same
+  serde skip-if-none treatment, deserialized into the same struct, and
+  forwarded into the runtime tab. Importantly the file already imports
+  `crate::themes::theme::AnsiColorIdentifier` (line 7), so importing
+  `ThemeKind` from the same module is a one-line addition.
+- `PaneTemplateType` (lines 92–113) — pane-level layout. Not modified by this
+  spec; per-pane theming is explicitly out of scope per `product.md`.
+
+### Theme model
+
+`app/src/themes/theme.rs` defines:
+
+- `ThemeKind` enum (lines 42–100) — the canonical theme identifier. Includes
+  built-in themes (`Dark`, `Light`, `Dracula`, `DarkCity`, …) plus
+  `Custom(CustomTheme)` and `CustomBase16(CustomTheme)` variants for
+  user-supplied themes. Already derives `Serialize`, `Deserialize`,
+  `JsonSchema`, and `settings_value::SettingsValue`, so it round-trips through
+  serde with no additional work.
+- `Display for ThemeKind` (lines 112+) — the canonical user-facing string for
+  each variant. Used for both the global theme setting and the theme picker;
+  reusable as-is for launch configuration YAML.
+
+### Theme settings and resolution
+
+`app/src/settings/theme.rs` defines:
+
+- `ThemeSettings` group (lines 14–48) — three fields: `theme_kind`,
+  `use_system_theme`, `selected_system_themes`. The `theme_kind` field's
+  `toml_path` is `"appearance.themes.theme"` (line 23).
+- `derived_theme_kind(theme_settings, system_theme) -> ThemeKind`
+  (lines 69–78) — applies the system-light/dark logic. **This is the function
+  the per-tab override must wrap**: when an override is present we want to
+  return it directly; when absent we want this function's existing answer.
+- `active_theme_kind(theme_settings, app) -> ThemeKind` (lines 81–83) — calls
+  `derived_theme_kind` with `app.system_theme()`. Currently the only entry
+  point for "what theme should we show?" outside the appearance manager.
+
+### Renderer entry point
+
+`app/src/appearance.rs` re-exports the singleton `Appearance` from
+`warp_core::ui::appearance` (line 34) and defines `AppearanceManager`
+(lines 40–47) that subscribes to `ThemeSettings` (line 51) and pushes theme,
+font, and icon changes into `Appearance`. `Appearance::handle(ctx)` is the
+canonical "give me the active theme" handle used by the terminal view, the
+theme picker, and other UI surfaces.
+
+`Appearance` today holds **one** theme. It does not have a notion of "the
+theme for tab X". Plumbing per-tab overrides will therefore introduce a
+*resolved theme* lookup that consults the active tab's override before
+falling back to `Appearance`'s global value (see *Proposed changes* below).
+
+### Tab and window state
+
+`app/src/app_state.rs`:
+
+- `WindowSnapshot` (lines 43–59) — persisted window state. **No theme field.**
+- `TabSnapshot` (lines 61–69) — persisted per-tab state. Carries
+  `default_directory_color` and `selected_color: SelectedTabColor` (the
+  per-tab indicator color from `#7` in `product.md`). **No theme field.**
+  This is where the persisted override is added.
+- `TabSnapshot::color()` (lines 71–75) — resolves the indicator color. The
+  per-tab theme override resolution will live next to this method and follow
+  the same shape.
+
+### Existing precedent — per-tab color flow
+
+The path that loads `TabTemplate.color` into a runtime tab is the closest
+analog to what this spec adds, and the implementation should mirror it
+exactly. The flow today:
+
+1. `TabTemplate.color: Option<AnsiColorIdentifier>` parsed from YAML
+   (`launch_config.rs:186`).
+2. On launch-config open, `app/src/workspace/view.rs:3517–3519` writes
+   `tab_template.color` into `self.tabs[…].selected_color` via
+   `SelectedTabColor::Color`. Tabs without `color` get `SelectedTabColor::Unset`.
+3. `TabSnapshot.selected_color` persists this through session save/restore.
+4. `TabSnapshot::color()` resolves `selected_color` against
+   `default_directory_color` and the resulting `Option<AnsiColorIdentifier>`
+   is rendered as the tab indicator.
+
+The new theme override follows the same four steps, replacing
+`AnsiColorIdentifier` with `ThemeKind` and routing the resolved value into
+the renderer instead of the indicator widget.
+
+## Proposed changes
+
+The implementation is broken into four areas, in dependency order. Each step
+compiles and passes tests on its own.
+
+### 1. Schema: add `theme` to `TabTemplate` and `WindowTemplate`
+
+File: `app/src/launch_configs/launch_config.rs`.
+
+- Add `use crate::themes::theme::ThemeKind;` next to the existing
+  `AnsiColorIdentifier` import on line 7.
+- Add a new field to `TabTemplate` (lines 180–187):
+
+  ```rust
+  #[serde(skip_serializing_if = "Option::is_none", default)]
+  pub theme: Option<ThemeKind>,
+  ```
+
+- Add the same field to `WindowTemplate` (lines 36–41) so a launch
+  configuration can theme an entire window without repeating the value on
+  every tab. Window-level inheritance is resolved at open time
+  (`workspace/view.rs`, step 3 below); the runtime never needs to consult
+  `WindowTemplate` after that.
+- Update `impl TryFrom<TabSnapshot> for TabTemplate` (lines 189–200) to copy
+  the override out of the snapshot. This keeps "save layout as launch
+  configuration" round-tripping symmetric, satisfying behavior #10 of
+  `product.md`.
+- Update `impl From<WindowSnapshot> for WindowTemplate` (lines 43–70) to
+  emit the window-level `theme` when every tab in the window has the same
+  explicit override (the coalescing rule in behavior #10). When emitted at
+  the window level the per-tab fields are dropped; otherwise per-tab
+  fields are emitted and the window field is `None`.
+
+`ThemeKind` already derives `Serialize` and `Deserialize`, so YAML support
+comes for free. Round-trip and serde tests live in
+`launch_configs/launch_config_tests.rs` (referenced by the `#[path]`
+attribute on line 11) and gain coverage in step 5 below.
+
+### 2. Persisted state: add `theme_override` to `TabSnapshot`
+
+File: `app/src/app_state.rs`.
+
+- Add `pub theme_override: Option<ThemeKind>` to `TabSnapshot` (lines 61–69).
+  Place it next to `selected_color` so the "what's been overridden on this
+  tab" fields stay grouped.
+- Mirror this in the runtime tab type (`app/src/tab.rs`, `TabData` around
+  line 134, alongside the existing `selected_color` field).
+- Wire snapshot ↔ runtime conversion. The codebase has bidirectional
+  conversions between `TabSnapshot` and the runtime tab; both directions
+  copy the new field unchanged.
+- `WindowSnapshot` does **not** gain a theme field. Window-level themes are a
+  pure launch-configuration convenience: at open time we expand them into
+  per-tab overrides (step 3) and never persist the window-level form. This
+  keeps session restore unambiguous — every tab's effective override is
+  stored on the tab itself.
+
+### 3. Apply on open: window/tab template → runtime tab
+
+File: `app/src/workspace/view.rs`, the `for_each` block at lines 3506–3520
+that already applies `tab_template.color`.
+
+- After the existing `selected_color` assignment (lines 3517–3519), assign
+  `theme_override`:
+
+  ```rust
+  let resolved_theme = tab_template
+      .theme
+      .clone()
+      .or_else(|| window.theme.clone());
+  self.tabs[start_index + tab_index].theme_override = resolved_theme;
+  ```
+
+  This implements behavior #2 of `product.md` — tab-level wins, window-level
+  is the fallback. It also closes over `window` exactly the way
+  `tab_template` already does.
+- No other code path in this function changes. Tabs without `theme` (and
+  without a window-level value) get `theme_override = None`, which is
+  identical to the pre-feature behavior.
+
+### 4. Renderer: theme resolution in `Appearance` lookup
+
+This is the architecturally interesting step. Two options were considered:
+
+**Option A — Resolved-theme accessor on `Appearance`**: extend `Appearance`
+with `pub fn theme_for_tab(&self, override: Option<&ThemeKind>) -> &WarpTheme`
+that returns the override's resolved theme when `Some`, or
+`self.theme()` when `None`. Every consumer that reads the active theme is
+updated to call `theme_for_tab(active_tab.theme_override.as_ref())`.
+
+**Option B — Per-tab `Appearance` instances**: clone `Appearance` per
+overridden tab and swap which one is consulted on tab activation.
+
+Option A is recommended. It localizes the change (one new method on
+`Appearance`, one new lookup point per consumer), keeps font / icon /
+non-theme appearance state shared (those are still global today), and fits
+the existing "Appearance is one global thing, but the value it returns can
+depend on context" pattern that already governs system-light/dark resolution.
+Option B duplicates state, complicates change propagation
+(`AppearanceManager`'s subscription would have to fan out to every
+overridden tab), and tempts later code into per-tab font or icon overrides
+that this spec explicitly does not promise.
+
+Concretely:
+
+- Add `pub fn theme_for(&self, override: Option<&ThemeKind>) -> &WarpTheme`
+  to `warp_core::ui::appearance::Appearance` (the canonical type re-exported
+  from `app/src/appearance.rs:34`). When `override` is `Some`, look the theme
+  up via the same loader the global theme already uses; when `None`, return
+  the existing `self.theme()`. Loader fallbacks (unknown theme name,
+  missing custom theme file) reuse the existing global-theme fallback path,
+  satisfying behaviors #11 and #12 of `product.md`.
+- Update the terminal cell renderer (`app/src/terminal/view.rs` and
+  `app/src/terminal/color.rs`, the consumers identified in the codebase
+  map) to consult `theme_for(tab.theme_override.as_ref())` rather than the
+  global `Appearance::theme`. The exact call sites will be enumerated when
+  the implementation PR is opened — they all flow through the existing
+  `Appearance::as_ref(ctx).theme()` lookup, so the change is a mechanical
+  swap with the new accessor at each site.
+- Window chrome (title bar, sidebar, settings views, tab strip) continues to
+  consult `Appearance::theme()` directly with no override argument,
+  satisfying behavior #4 of `product.md`.
+
+### 5. Right-click menu: "Reset theme"
+
+The existing tab context menu already exposes per-tab attributes. Add a
+"Reset theme" entry that:
+
+- Is shown only when the active tab's `theme_override` is `Some`.
+- On click, sets `theme_override` to `None` on the tab and triggers the
+  renderer's existing theme-changed redraw path (the one used today when the
+  global theme changes).
+
+This menu entry is the only in-app surface for clearing an override; setting
+overrides remains the launch-configuration file's job per `product.md`.
+Telemetry: emit a single counter on click using the existing tab-menu
+telemetry conventions; no new event schema is required.
+
+## Testing and validation
+
+### Unit tests
+
+- `app/src/launch_configs/launch_config_tests.rs`:
+  - YAML round-trip for `TabTemplate` with `theme: "Solarized Dark"`.
+  - YAML round-trip for `TabTemplate` with `theme: { custom: { … } }` to
+    cover the `Custom` variant.
+  - Round-trip for `WindowTemplate.theme` set with all tabs un-themed,
+    asserting tabs inherit the window value at open time.
+  - Round-trip for a launch configuration mixing some themed tabs and some
+    un-themed tabs in the same window.
+  - Negative test: an unknown theme string deserializes successfully into
+    `Some(ThemeKind::…)`-fallback or surfaces a deserialization error that
+    the launch-config loader catches and converts to a logged warning. The
+    behavior here matches whatever path `ThemeKind` already uses for
+    `appearance.themes.theme`; the test pins it.
+
+- `app/src/app_state.rs` (or its test module):
+  - `TabSnapshot` with `theme_override: Some(ThemeKind::Dracula)` round-trips
+    through whatever serializer session-restore uses.
+  - `TabSnapshot::color()` continues to return the same value with and
+    without `theme_override` set (the indicator color and the theme override
+    are independent — behavior #7 of `product.md`).
+
+- `app/src/themes/theme.rs` or `app/src/appearance.rs`:
+  - `Appearance::theme_for(None)` returns the same reference as
+    `Appearance::theme()`.
+  - `Appearance::theme_for(Some(&ThemeKind::Light))` resolves to the Light
+    theme regardless of the global setting.
+  - `Appearance::theme_for(Some(&ThemeKind::Custom(missing)))` returns the
+    global theme (fallback path) and increments whatever warning counter the
+    global custom-theme loader uses today.
+
+### Integration tests
+
+`crates/integration/` is the home for user-flow tests per `CONTRIBUTING.md`.
+Add coverage for:
+
+- Open a launch configuration with three tabs — one with `theme: "Dracula"`,
+  one with `theme: "Solarized Light"`, one un-themed. Assert each tab
+  renders with the expected theme and that switching the active tab does not
+  change the rendering of the inactive tabs.
+- Change the global theme via settings while the above launch configuration
+  is open. Assert the un-themed tab redraws to match the new global theme;
+  the two themed tabs do not redraw (behavior #6 of `product.md`).
+- Right-click the Dracula-themed tab → "Reset theme". Assert the tab
+  redraws to match the global theme and that the menu entry disappears.
+- Quit and relaunch with session restore enabled. Assert the Dracula and
+  Solarized Light overrides persist; the previously-reset tab continues to
+  follow the global theme.
+
+### Manual verification
+
+- macOS, Linux, Windows: open the test launch configuration above and visually
+  confirm each tab's terminal background and ANSI palette match the chosen
+  theme. Confirm the window chrome and tab strip continue to follow the
+  global theme.
+- Toggle system light/dark: confirm un-themed tabs follow the system, themed
+  tabs do not.
+- Save layout as launch configuration with mixed overrides; reopen the saved
+  YAML and confirm the per-tab `theme:` fields match what was set.
+- Save layout as launch configuration with every tab on the same explicit
+  override; confirm the YAML coalesces to a window-level `theme:` per
+  behavior #10 of `product.md`.
+- Edit a launch configuration's `theme:` value; reopen Warp; confirm
+  already-open tabs from a previous run keep their original override, new
+  tabs from the edited launch configuration get the new value (behavior #13).
+
+### Tooling
+
+- `cargo fmt` and
+  `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
+  must pass per `CONTRIBUTING.md` style rules.
+- `cargo nextest run` for unit tests; `crates/integration` for end-to-end.
+- `./script/presubmit` before pushing.
+
+## Risks and mitigations
+
+- **Risk: rendering pipeline is hotter than expected and an extra
+  `Option<&ThemeKind>` argument shows up in profiling.** Mitigation: the
+  override is a small enum and the `theme_for` lookup is one branch and one
+  `HashMap` hit at most. The existing per-tab indicator color path executes
+  on the same render frame and has not been a bottleneck. If profiling
+  flags it post-merge, cache the resolved `&WarpTheme` on the runtime tab.
+
+- **Risk: subtle visual mismatch where a UI surface today reads from
+  `Appearance::theme()` but logically belongs *inside* a tab (e.g. block
+  output styling) and we miss it during the consumer-update sweep.**
+  Mitigation: the integration tests above visually exercise terminal
+  background, ANSI palette, and block output; the manual verification step
+  walks across the in-tab UI surfaces explicitly. Any miss surfaces as "this
+  bit didn't change theme" rather than as a crash, and is fixable with a
+  follow-up call-site update.
+
+- **Risk: round-trip save/load asymmetry produces a launch configuration that
+  no longer reproduces the user's tabs.** Mitigation: behavior #10 in
+  `product.md` is precise about when `theme:` is emitted at the tab vs.
+  window level, and the launch-configuration round-trip tests pin both
+  directions.
+
+- **Risk: an unknown theme string in a launch configuration shipped between
+  Warp versions silently downgrades a user's tab.** Mitigation: behavior #11
+  of `product.md` mandates a logged warning identifying the offending
+  launch configuration, tab, and theme name. The fallback is the same
+  one global-theme uses today, so the tab still opens.
+
+- **Risk: persisted `theme_override` collides with a future per-window or
+  per-pane theme feature.** Mitigation: the field is named
+  `theme_override` (not `theme`) precisely to leave room for a separate
+  resolved theme to live elsewhere later. Per-pane theming is explicitly
+  out of scope; per-window theming, if added, would also produce a
+  per-tab override at open time and reuse this same field.
+
+## Follow-ups (deliberately not in this PR)
+
+Tracked separately so that this spec stays scoped:
+
+- **Auto-theme by SSH host or hostname** (raised by `stevenchanin`,
+  `pyronaur`, `zethon`, `janderegg` in `#478`). Requires a detection layer
+  that observes process state inside the tab. Would consume the
+  `theme_override` field this spec adds.
+- **Auto-theme by cwd** (`pyronaur`). Same shape as the SSH case; consumes
+  the field.
+- **Runtime escape-code or shell-hook protocol for setting a tab's theme**
+  (raised by `yatharth` for Claude Code session signaling). Defines a wire
+  format and a security model; consumes the field.
+- **In-app per-tab theme picker submenu in the right-click menu** (open
+  question in `product.md`). Strictly additive to this spec.
+- **Wallpaper-per-tab** (`scottaw66`, `SheepDomination`). Different surface
+  area entirely (asset loading, layering); does not conflict with this
+  spec.
+- **Closing `#2618` as a duplicate** of `#478` once this spec lands.

--- a/specs/GH478/tech.md
+++ b/specs/GH478/tech.md
@@ -119,10 +119,42 @@ reasons that directly address Oz's first-pass concerns:
   product spec's behavior #11.
 
 The `From<WindowSnapshot> for WindowTemplate` (lines 43–70) and
-`TryFrom<TabSnapshot> for TabTemplate` (lines 189–200) impls are updated
-to copy *manual* overrides out of the snapshot. Directory-matched
-overrides are not emitted into saved launch configurations (per product
-spec behavior #10).
+`TryFrom<TabSnapshot> for TabTemplate` (lines 189–200) impls implement
+the save rule from product behavior #10. The "preserved override" for a
+tab is computed as:
+
+```rust
+fn preserved_override(state: &TabThemeState) -> Option<&ThemeKind> {
+    state.manual.as_ref().or(state.window_default.as_ref())
+}
+```
+
+(Directory-matched themes are deliberately not part of `preserved_override`
+— they round-trip through `directory_overrides`, not through the saved
+launch configuration.)
+
+`From<WindowSnapshot> for WindowTemplate` then:
+
+1. Computes the preserved override for every tab.
+2. If every tab's preserved override is the same `Some(X)` *and* no tab
+   has a manual pin different from the others, emits the saved
+   `WindowTemplate` with `theme: Some(X.to_string())` and clears the
+   per-tab `theme:` on every `TabTemplate`. This is the common case —
+   a window opened from a launch configuration with a window-level
+   `theme:` and no per-tab pinning round-trips losslessly.
+3. Otherwise, emits no window-level `theme:` and writes each tab's
+   preserved override (if any) into the corresponding `TabTemplate.theme`.
+4. Tabs whose preserved override is `None` (all sources empty, or only
+   `cwd_resolved` populated) emit no `theme:` field. Their effective
+   theme on reopen will be either a fresh directory match or the
+   global theme.
+
+This is what Oz's v3 review correctly flagged: a window opened with a
+window-level `theme:` would otherwise drop the theme on save, because
+v2's "only emit manual" rule treated `window_default` as not preserved.
+The `preserved_override` helper makes the logic symmetric with
+resolution and adds an integration test (in §6) that exercises the
+full round-trip.
 
 Round-trip and serde tests live in
 `launch_configs/launch_config_tests.rs` (referenced by the `#[path]`
@@ -289,9 +321,10 @@ and `private`; the design rule applied here is:
 - **No telemetry on the contents.** The match function emits at most a
   count metric ("a directory match applied to N tabs this minute"); it
   never logs path keys or theme names to remote telemetry pipelines.
-  The local Warp log (which already contains plenty of cwd-bearing
-  information from existing features) may include a key in a
-  warning when a value fails to resolve, but that surface is local.
+- **Local logs are also redacted.** Diagnostic output is routinely
+  shared in bug reports and support sessions, so even the local
+  Warp log must not contain raw `directory_overrides` keys. The
+  redaction rule and helper are specced in *Diagnostic redaction* below.
 - **No round-tripping into shareable artifacts.** A saved launch
   configuration does not emit `directory_overrides` entries (product
   spec #10). Launch configurations are explicitly designed to be
@@ -301,6 +334,40 @@ and `private`; the design rule applied here is:
   *to themselves* across machines. That requires a separate spec
   covering opt-in UI, encryption-at-rest of keys, and admin-policy
   controls; it is deliberately not pre-paid for here.
+
+#### Diagnostic redaction
+
+Helper, alongside the settings group:
+
+```rust
+/// Stable short hash of a `directory_overrides` key suitable for
+/// inclusion in user-facing warnings. **Not cryptographic.** Purpose
+/// is identification of an entry across runs without including the
+/// raw path. 6 hex chars (24 bits) is enough to disambiguate the
+/// O(10) entries a typical user will have.
+pub fn redacted_key_id(raw_key: &str) -> String {
+    let mut hasher = rustc_hash::FxHasher::default();
+    raw_key.hash(&mut hasher);
+    format!("{:06x}", hasher.finish() & 0xffff_ff)
+}
+```
+
+Usage rule (enforced by code review and by the tests in *Privacy
+invariant tests*): every log/warn/error line emitted by the
+`directory_overrides` matcher, settings subscriber, or value validator
+must reference offending entries by `redacted_key_id` only.
+
+Warnings include the offending **value** (the theme name) verbatim
+because theme names are not sensitive and are needed for the user to
+locate the entry in their `settings.toml`. Example warning text:
+
+```
+directory_overrides[hash=8a3f9c]: unknown theme "Drakula" — matching this entry will be skipped until the value is corrected
+```
+
+The hash is stable for a given key, so the same warning recurs with
+the same hash across Warp restarts and helps the user correlate
+multiple diagnostics about the same entry.
 
 Resolution helper, alongside the group:
 
@@ -316,13 +383,30 @@ pub fn directory_theme_for(
 
 Match semantics (per product spec #2, #3):
 
-- Keys are tilde-expanded once at evaluation time.
-- A key matches a cwd if it is a prefix at a path-component boundary
-  (use `Path::starts_with` after normalization, not `str::starts_with`).
-- The longest matching key wins.
+- Keys are tilde-expanded once at evaluation time. On Linux/macOS tilde
+  expands to `$HOME`; on Windows to `%USERPROFILE%`.
+- Both `/` and `\` are accepted as separators in keys; normalization
+  rewrites them to the platform's canonical form via
+  `Path::components()` before comparison.
+- On Windows, drive-letter prefixes are normalized to uppercase
+  (`c:\…` → `C:\…`).
+- A key matches a cwd if it is a prefix at a path-component boundary.
+  Implementation: walk both paths' `Path::components()` after
+  normalization and require the key's components to be an exact prefix
+  of the cwd's. Using `str::starts_with` would let `~/Work/medone`
+  spuriously match `~/Work/medone-archive` and is forbidden.
+- Case sensitivity follows the platform's filesystem default:
+  case-sensitive on Linux, case-insensitive on macOS, case-insensitive
+  on Windows. Implementation uses
+  `unicase::eq(key_component, cwd_component)` on Windows and macOS,
+  `key_component == cwd_component` on Linux. Tests cover each platform.
+- The longest matching key wins (most components after normalization,
+  not most bytes — `~/Work` is shorter than `~/Work/medone` regardless
+  of how the user typed them).
 - Each value is resolved via `resolve_theme_ref`; unresolved values are
   skipped and a warning is logged once at settings-change time, not
-  per-match.
+  per-match. **Warnings refer to the offending entry by a short hash of
+  its key, never by the key itself, per *Diagnostic redaction* below.**
 
 Matching is invoked from **three** places (responding to Oz's v2
 finding that settings edits were not handled):
@@ -422,22 +506,64 @@ Cache-invalidation rules:
 - Custom-theme file changes (which already invalidate the global theme
   via the existing watcher) trigger the same cache clear.
 
-Renderer call-site update: every place that today reads
-`Appearance::as_ref(ctx).theme()` and is **inside a tab's render path**
-becomes
-`Appearance::as_ref(ctx).theme_for(Some(tab.theme_state.effective(&global_kind)))`,
-where `global_kind` is the active global `ThemeKind` from
-`active_theme_kind(theme_settings, app)`. Render paths that already have
-no per-tab context (window chrome) keep calling `Appearance::theme()`
-unchanged.
-The exact list of call sites (terminal cell renderer in
-`app/src/terminal/view.rs`, color derivation in
-`app/src/terminal/color.rs`, any block-styling consumers) is enumerated
-during implementation; the change is mechanical at each site.
+#### Renderer call-site migration
 
-Window-chrome consumers (title bar, sidebar, settings views, tab strip)
-continue to call `Appearance::theme()` with no override argument, per
-product spec #15.
+`Appearance::as_ref(ctx).theme()` is consumed in 862 call sites across
+the workspace as of HEAD. An exhaustive line-by-line enumeration in this
+spec would be unreviewable and would also rot the moment any caller
+moves; the design instead defines a categorical rule plus a custom lint
+that mechanically enforces it.
+
+**Categorical rule** (matches product spec #15):
+
+A call to `Appearance::*::theme()` becomes
+`Appearance::as_ref(ctx).theme_for(Some(tab.theme_state.effective(&global_kind)))`
+**if and only if** the call is reached during the rendering of content
+that lives inside a single tab. All other calls keep the existing
+global `theme()` form. Concretely:
+
+| Area | Per-tab? | Notes |
+| --- | --- | --- |
+| `app/src/terminal/view/**` | per-tab | terminal grid, blocks, in-tab modals over the grid |
+| `app/src/terminal/input/**` | per-tab | input bar, inline menus, slash commands inside the tab |
+| `app/src/terminal/{view.rs, block_filter.rs, rich_history.rs, terminal_manager.rs, universal_developer_input.rs, ssh/**, warpify/**, shared_session/**}` | per-tab | terminal-pane content |
+| `app/src/terminal/{share_block_modal.rs, profile_model_selector.rs}` | per-tab | scoped to a specific tab's content |
+| `app/src/{tab.rs, root_view.rs, voltron.rs, modal.rs, menu.rs, search_bar.rs, input_suggestions.rs}` | global | window chrome, command palette, top-level modals |
+| `app/src/settings/**` | global | settings UI |
+| `app/src/reward_view.rs`, `wasm_nux_dialog.rs`, `word_block_editor.rs` | global | full-window modals/views |
+| `crates/onboarding/**` | global | onboarding flow runs outside a tab |
+| `crates/ui_components/**` | global | generic widgets — they do not know about tabs |
+| `crates/editor/**` | global by default; per-tab when invoked from `terminal/view/**` (the call site, not the crate, decides) | editor is reusable |
+| `crates/integration/**` | tests; updated to assert both forms |
+
+**Migration enforcement — custom lint**
+
+To make the migration mechanical, exhaustive, and durable across future
+additions, the implementation adds a small `clippy_lints`-style check
+(or a `dylint` lint, depending on the existing tooling Warp uses)
+named `appearance_theme_in_tab_path`. The lint:
+
+- Flags any call to `Appearance::*::theme()` (the global accessor)
+  whose enclosing module is under a *per-tab* path per the table
+  above. Path classification is hard-coded in the lint config.
+- Fails CI when triggered.
+- Is silenced at a call site only by replacing the call with
+  `theme_for(...)`, or — for a deliberate exception — by
+  `#[allow(appearance_theme_in_tab_path = "...")]` with a written
+  rationale (e.g. "this surface intentionally renders in window
+  chrome even though it lives under terminal/view/").
+
+The lint is the deliverable that gives this spec a feasibility
+guarantee: the migration is correct *by construction* across all 862
+sites, and any future call site added in a per-tab path is caught by
+CI before merge. The PR opens with the lint enabled and zero
+warnings; subsequent reviewers can read the diff knowing every flagged
+site was either migrated or explicitly justified.
+
+Window-chrome consumers (per the table) keep
+`Appearance::as_ref(ctx).theme()` unchanged. The custom lint is the
+single source of truth for which sites are which; reviewers verify the
+table by reading the lint config, not by re-walking 862 call sites.
 
 ### 6. Right-click menu: Pin theme / Reset theme
 
@@ -553,6 +679,38 @@ conventions. No new event schema.
   Then delete the key. Assert the tab falls through to its
   next-priority theme. (Pins product behavior #6 and addresses Oz's
   v2 IMPORTANT finding that this path was missing from the design.)
+- **Save-from-snapshot for window-level theme.** Open a launch config
+  whose window has `theme: "Dark City"` and three tabs (no per-tab
+  pins, no directory matches). Save the resulting layout to a new
+  launch config. Assert the saved YAML contains a window-level
+  `theme: "Dark City"` and no per-tab `theme:` fields. Reopen it.
+  Assert all three tabs render Dark City. (Addresses Oz v3 IMPORTANT
+  finding on save-rule dropping window defaults.)
+- **Save-from-snapshot for mixed pinning.** Open a layout with a mix
+  of manually pinned tabs (different themes), tabs with only a window
+  default, and tabs whose effective theme came from cwd. Save.
+  Assert: window-level `theme:` is omitted (mixed manual pins make
+  coalescing impossible); each manually pinned tab emits its own
+  `theme:`; tabs with only `window_default` emit their default; tabs
+  themed only by cwd emit no `theme:`. Reopen and assert the
+  effective theme of every tab matches what it was pre-save.
+- **Windows path normalization.** Cross-platform integration test
+  matrix:
+  - Linux: keys `~/Work/medone` (case-sensitive) — assert
+    `~/Work/MEDONE` does **not** match.
+  - macOS: same key — assert `~/Work/MEDONE` **does** match
+    (case-insensitive default).
+  - Windows: keys `C:\Work\medone` and `c:\Work\medone` collapse to
+    one entry (drive-letter normalization). Cwd `C:/Work/medone/app`
+    matches (separator normalization). Cwd
+    `C:\Work\medone-archive` does not match (component boundary).
+- **Diagnostic redaction.** Configure `directory_overrides` with a
+  key `~/Work/AcmeCorp/2026` mapped to a bad theme name `"Drakula"`.
+  Trigger validation. Capture the warning string. Assert it
+  contains `"Drakula"` and `redacted_key_id("~/Work/AcmeCorp/2026")`,
+  and does **not** contain `"AcmeCorp"`, `"Work"`, `"2026"`, or any
+  substring of the raw key. Assert the same key produces the same
+  hash on a second run within the test process.
 - Open a launch configuration with a window-level `theme:` and three
   tabs, one of which sits in a `directory_overrides`-matched cwd.
   Assert the matched tab uses the cwd theme (cwd > window default);
@@ -638,6 +796,31 @@ conventions. No new event schema.
   expanding it into the manual slot. `effective()` walks slots in the
   product spec's resolution order; the integration test for the
   launch-config-with-window-default scenario pins the priority.
+
+- **Save layout dropping window-level theme.** Addressed by the
+  `preserved_override` helper in §1. Both save tests above pin the
+  round-trip.
+
+- **Windows path matching ambiguity.** Component-boundary matching
+  uses `Path::components()` rather than string operations, separator
+  and drive-letter normalization happens before comparison, and case
+  semantics are platform-conditional. Pinned by the cross-platform
+  test matrix above. The lint `appearance_theme_in_tab_path` does not
+  cover this — these are runtime correctness tests.
+
+- **Path keys leaking through diagnostics.** Addressed by
+  `redacted_key_id` and the *Diagnostic redaction* contract in §4.
+  Pinned by the redaction test above plus a code-review checklist
+  item; we considered a custom lint but the surface is small enough
+  (one helper function, one logger call site) that a unit-test
+  enforcement is sufficient.
+
+- **Renderer call-site drift.** The
+  `appearance_theme_in_tab_path` lint catches both the initial
+  migration and any future call site added in a per-tab path. This
+  replaces a one-time enumeration that would have rotted on the next
+  PR. The trade-off is the small cost of maintaining the lint config
+  (one entry per top-level area).
 
 - **Concern 1 / Concern 2 / Concern 3 from Oz's first-pass review.**
   Addressed in §1 (Option<String> + apply-time resolver), §2

--- a/specs/GH478/tech.md
+++ b/specs/GH478/tech.md
@@ -1,4 +1,4 @@
-# TECH.md — Per-tab theme override via launch configurations
+# TECH.md — Per-tab theme overrides driven by directory and launch configurations
 
 Issue: https://github.com/warpdotdev/warp/issues/478
 Related: https://github.com/warpdotdev/warp/issues/2618
@@ -8,376 +8,509 @@ Product spec: `specs/GH478/product.md`
 
 The Warp theme is currently a single global value derived from
 `ThemeSettings`. The renderer reads it through the global `Appearance`
-singleton; nothing in the rendering pipeline today accepts a per-tab theme
-parameter. Adding per-tab overrides therefore touches three layers — the
-launch configuration schema, the persisted tab snapshot, and the renderer's
-theme lookup — but does not require changing the theme storage format or
-adding any new theme types.
+singleton, which today owns exactly one resolved `WarpTheme`. Per-tab
+overrides therefore require changes in four layers — the launch
+configuration schema, a new directory-pattern settings group, the
+persisted tab snapshot (with override-source semantics), and the
+renderer's theme lookup (with a theme catalog so non-active themes can be
+borrowed by reference). None of this requires changing the theme storage
+format or adding new theme types.
 
-The rest of this section enumerates the existing surfaces the implementation
-will modify or read from. All file references are at HEAD on `master`.
+All file references are at HEAD on `master`.
 
 ### Launch configuration schema
 
 `app/src/launch_configs/launch_config.rs` defines the YAML data model:
 
-- `LaunchConfig` (lines 14–20) — top-level: `name`, `active_window_index`,
-  `windows: Vec<WindowTemplate>`.
-- `WindowTemplate` (lines 36–41) — `active_tab_index`, `tabs:
-  Vec<TabTemplate>`. **No theme field today.**
-- `TabTemplate` (lines 180–187) — `title`, `layout: PaneTemplateType`,
-  `color: Option<AnsiColorIdentifier>`. The `color` field (line 186) is the
-  closest precedent for the new `theme` field: same `Option<…>` shape, same
-  serde skip-if-none treatment, deserialized into the same struct, and
-  forwarded into the runtime tab. Importantly the file already imports
-  `crate::themes::theme::AnsiColorIdentifier` (line 7), so importing
-  `ThemeKind` from the same module is a one-line addition.
-- `PaneTemplateType` (lines 92–113) — pane-level layout. Not modified by this
-  spec; per-pane theming is explicitly out of scope per `product.md`.
+- `LaunchConfig` (lines 14–20) — `name`, `active_window_index`, `windows`.
+- `WindowTemplate` (lines 36–41) — `active_tab_index`, `tabs`. **No theme
+  field today.**
+- `TabTemplate` (lines 180–187) — `title`, `layout`, `color:
+  Option<AnsiColorIdentifier>`. The `color` field (line 186) is the
+  closest precedent for a per-tab theme field.
+- The file already imports `crate::themes::theme::AnsiColorIdentifier`
+  (line 7).
 
-### Theme model
+### Theme model and global theme settings
 
-`app/src/themes/theme.rs` defines:
-
-- `ThemeKind` enum (lines 42–100) — the canonical theme identifier. Includes
-  built-in themes (`Dark`, `Light`, `Dracula`, `DarkCity`, …) plus
-  `Custom(CustomTheme)` and `CustomBase16(CustomTheme)` variants for
-  user-supplied themes. Already derives `Serialize`, `Deserialize`,
-  `JsonSchema`, and `settings_value::SettingsValue`, so it round-trips through
-  serde with no additional work.
-- `Display for ThemeKind` (lines 112+) — the canonical user-facing string for
-  each variant. Used for both the global theme setting and the theme picker;
-  reusable as-is for launch configuration YAML.
-
-### Theme settings and resolution
-
-`app/src/settings/theme.rs` defines:
-
-- `ThemeSettings` group (lines 14–48) — three fields: `theme_kind`,
-  `use_system_theme`, `selected_system_themes`. The `theme_kind` field's
-  `toml_path` is `"appearance.themes.theme"` (line 23).
-- `derived_theme_kind(theme_settings, system_theme) -> ThemeKind`
-  (lines 69–78) — applies the system-light/dark logic. **This is the function
-  the per-tab override must wrap**: when an override is present we want to
-  return it directly; when absent we want this function's existing answer.
-- `active_theme_kind(theme_settings, app) -> ThemeKind` (lines 81–83) — calls
-  `derived_theme_kind` with `app.system_theme()`. Currently the only entry
-  point for "what theme should we show?" outside the appearance manager.
+- `app/src/themes/theme.rs:42–100` — `ThemeKind` enum, the canonical
+  theme identifier. Built-in variants plus `Custom(CustomTheme)` and
+  `CustomBase16(CustomTheme)`. Derives `Serialize`, `Deserialize`,
+  `JsonSchema`, `settings_value::SettingsValue`.
+- `app/src/themes/theme.rs:112+` — `Display for ThemeKind` returns the
+  canonical user-facing string (`"Dark City"`, `"Solarized Dark"`, etc.).
+- `app/src/settings/theme.rs:14–48` — `ThemeSettings` group; `theme_kind`
+  field with `toml_path: "appearance.themes.theme"` (line 23).
+- `app/src/settings/theme.rs:69–78` — `derived_theme_kind`, applies
+  system-light/dark logic. Wrapped by per-tab resolution.
+- `app/src/settings/theme.rs:81–83` — `active_theme_kind`, current entry
+  point for "what theme should we show?".
 
 ### Renderer entry point
 
-`app/src/appearance.rs` re-exports the singleton `Appearance` from
-`warp_core::ui::appearance` (line 34) and defines `AppearanceManager`
-(lines 40–47) that subscribes to `ThemeSettings` (line 51) and pushes theme,
-font, and icon changes into `Appearance`. `Appearance::handle(ctx)` is the
-canonical "give me the active theme" handle used by the terminal view, the
-theme picker, and other UI surfaces.
-
-`Appearance` today holds **one** theme. It does not have a notion of "the
-theme for tab X". Plumbing per-tab overrides will therefore introduce a
-*resolved theme* lookup that consults the active tab's override before
-falling back to `Appearance`'s global value (see *Proposed changes* below).
+- `app/src/appearance.rs:34` re-exports `Appearance` from
+  `warp_core::ui::appearance`.
+- `app/src/appearance.rs:40–47` — `AppearanceManager`; subscribes to
+  `ThemeSettings` (line 51) and pushes changes into `Appearance`.
+- `Appearance` today owns one `WarpTheme`. Per-tab overrides require
+  it to own a *catalog* (see *Proposed changes* §5).
 
 ### Tab and window state
 
-`app/src/app_state.rs`:
-
-- `WindowSnapshot` (lines 43–59) — persisted window state. **No theme field.**
-- `TabSnapshot` (lines 61–69) — persisted per-tab state. Carries
+- `app/src/app_state.rs:43–59` — `WindowSnapshot`. **No theme field.**
+- `app/src/app_state.rs:61–69` — `TabSnapshot`. Carries
   `default_directory_color` and `selected_color: SelectedTabColor` (the
-  per-tab indicator color from `#7` in `product.md`). **No theme field.**
-  This is where the persisted override is added.
-- `TabSnapshot::color()` (lines 71–75) — resolves the indicator color. The
-  per-tab theme override resolution will live next to this method and follow
-  the same shape.
+  per-tab indicator color).
+- `app/src/app_state.rs:71–75` — `TabSnapshot::color()`, the resolution
+  helper for the indicator.
+- `app/src/tab.rs:134–143` — `TabData` (runtime), holds `selected_color`.
 
-### Existing precedent — per-tab color flow
+### Existing precedent — per-tab color
 
-The path that loads `TabTemplate.color` into a runtime tab is the closest
-analog to what this spec adds, and the implementation should mirror it
-exactly. The flow today:
+The path that loads `TabTemplate.color` into a runtime tab is the
+closest analog. Today:
 
 1. `TabTemplate.color: Option<AnsiColorIdentifier>` parsed from YAML
    (`launch_config.rs:186`).
 2. On launch-config open, `app/src/workspace/view.rs:3517–3519` writes
    `tab_template.color` into `self.tabs[…].selected_color` via
-   `SelectedTabColor::Color`. Tabs without `color` get `SelectedTabColor::Unset`.
+   `SelectedTabColor::Color`.
 3. `TabSnapshot.selected_color` persists this through session save/restore.
-4. `TabSnapshot::color()` resolves `selected_color` against
-   `default_directory_color` and the resulting `Option<AnsiColorIdentifier>`
-   is rendered as the tab indicator.
 
-The new theme override follows the same four steps, replacing
-`AnsiColorIdentifier` with `ThemeKind` and routing the resolved value into
-the renderer instead of the indicator widget.
+The new override follows the same path but with richer types (an
+override-source enum, see §3) and an apply-time resolver (§2) instead of
+direct serde (which is what Oz's first-pass review correctly flagged).
+
+### Existing pane cwd tracking
+
+The active pane's cwd is already tracked for tab title generation and
+breadcrumbs. The directory-pattern feature (§4) hooks into the existing
+"focused pane cwd changed" event rather than introducing new shell-side
+plumbing.
 
 ## Proposed changes
 
-The implementation is broken into four areas, in dependency order. Each step
-compiles and passes tests on its own.
+Six steps in dependency order. Each compiles standalone.
 
-### 1. Schema: add `theme` to `TabTemplate` and `WindowTemplate`
+### 1. Schema: `theme: Option<String>` on `TabTemplate` and `WindowTemplate`
 
 File: `app/src/launch_configs/launch_config.rs`.
 
-- Add `use crate::themes::theme::ThemeKind;` next to the existing
-  `AnsiColorIdentifier` import on line 7.
-- Add a new field to `TabTemplate` (lines 180–187):
+Add a new field to both structs:
 
-  ```rust
-  #[serde(skip_serializing_if = "Option::is_none", default)]
-  pub theme: Option<ThemeKind>,
-  ```
+```rust
+#[serde(skip_serializing_if = "Option::is_none", default)]
+pub theme: Option<String>,
+```
 
-- Add the same field to `WindowTemplate` (lines 36–41) so a launch
-  configuration can theme an entire window without repeating the value on
-  every tab. Window-level inheritance is resolved at open time
-  (`workspace/view.rs`, step 3 below); the runtime never needs to consult
-  `WindowTemplate` after that.
-- Update `impl TryFrom<TabSnapshot> for TabTemplate` (lines 189–200) to copy
-  the override out of the snapshot. This keeps "save layout as launch
-  configuration" round-tripping symmetric, satisfying behavior #10 of
-  `product.md`.
-- Update `impl From<WindowSnapshot> for WindowTemplate` (lines 43–70) to
-  emit the window-level `theme` when every tab in the window has the same
-  explicit override (the coalescing rule in behavior #10). When emitted at
-  the window level the per-tab fields are dropped; otherwise per-tab
-  fields are emitted and the window field is `None`.
+The field is `Option<String>` rather than `Option<ThemeKind>` for two
+reasons that directly address Oz's first-pass concerns:
 
-`ThemeKind` already derives `Serialize` and `Deserialize`, so YAML support
-comes for free. Round-trip and serde tests live in
+- **Serde-compat (Oz concern 1).** `ThemeKind` derives `Deserialize`,
+  but its accepted string form (variant names / snake-case) is not
+  guaranteed to match the human-readable display strings the product
+  spec promises (`"Dark City"`, `"Solarized Dark"`). Going through
+  `String` decouples the YAML surface from the enum's internal
+  representation.
+- **Field-level fallback (Oz concern 2).** A direct `ThemeKind`
+  deserialization on an unknown string would fail the entire YAML load
+  and reject every tab in the file. With `Option<String>` the load
+  always succeeds; resolution and fallback happen at apply time per the
+  product spec's behavior #11.
+
+The `From<WindowSnapshot> for WindowTemplate` (lines 43–70) and
+`TryFrom<TabSnapshot> for TabTemplate` (lines 189–200) impls are updated
+to copy *manual* overrides out of the snapshot. Directory-matched
+overrides are not emitted into saved launch configurations (per product
+spec behavior #10).
+
+Round-trip and serde tests live in
 `launch_configs/launch_config_tests.rs` (referenced by the `#[path]`
-attribute on line 11) and gain coverage in step 5 below.
+attribute on line 11) and gain coverage in §6.
 
-### 2. Persisted state: add `theme_override` to `TabSnapshot`
+### 2. Theme-name resolver
 
-File: `app/src/app_state.rs`.
+A new helper, alongside `ThemeKind` in `app/src/themes/theme.rs`:
 
-- Add `pub theme_override: Option<ThemeKind>` to `TabSnapshot` (lines 61–69).
-  Place it next to `selected_color` so the "what's been overridden on this
-  tab" fields stay grouped.
-- Mirror this in the runtime tab type (`app/src/tab.rs`, `TabData` around
-  line 134, alongside the existing `selected_color` field).
-- Wire snapshot ↔ runtime conversion. The codebase has bidirectional
-  conversions between `TabSnapshot` and the runtime tab; both directions
-  copy the new field unchanged.
-- `WindowSnapshot` does **not** gain a theme field. Window-level themes are a
-  pure launch-configuration convenience: at open time we expand them into
-  per-tab overrides (step 3) and never persist the window-level form. This
-  keeps session restore unambiguous — every tab's effective override is
-  stored on the tab itself.
+```rust
+/// Resolve a free-form theme reference (from a launch configuration or
+/// from `directory_overrides`) to a `ThemeKind`.
+///
+/// Accepts:
+///   * Display strings: "Dark City", "Solarized Dark", "Dracula"
+///   * Snake-case strings: "dark_city", "solarized_dark", "dracula"
+///   * Custom theme names registered via the theme loader
+///
+/// Matching is case-insensitive on whitespace-stripped input.
+/// Returns `None` for unknown names; callers log a warning and fall
+/// through to the next resolution layer.
+pub fn resolve_theme_ref(raw: &str) -> Option<ThemeKind> { ... }
+```
 
-### 3. Apply on open: window/tab template → runtime tab
+Implementation:
 
-File: `app/src/workspace/view.rs`, the `for_each` block at lines 3506–3520
-that already applies `tab_template.color`.
+1. Trim and case-fold the input.
+2. Walk built-in `ThemeKind` variants; return the first whose `Display`
+   string or snake-case form matches.
+3. Consult the custom-theme registry the existing loader maintains
+   (the same registry that powers the theme picker).
+4. Return `None` on no match.
 
-- After the existing `selected_color` assignment (lines 3517–3519), assign
-  `theme_override`:
+This satisfies Oz concerns 1 and 2 by making YAML-format coupling
+explicit and keeping unknown-theme handling field-level.
 
-  ```rust
-  let resolved_theme = tab_template
-      .theme
-      .clone()
-      .or_else(|| window.theme.clone());
-  self.tabs[start_index + tab_index].theme_override = resolved_theme;
-  ```
+### 3. `ThemeOverride` source enum on `TabSnapshot` and `TabData`
 
-  This implements behavior #2 of `product.md` — tab-level wins, window-level
-  is the fallback. It also closes over `window` exactly the way
-  `tab_template` already does.
-- No other code path in this function changes. Tabs without `theme` (and
-  without a window-level value) get `theme_override = None`, which is
-  identical to the pre-feature behavior.
+File: `app/src/app_state.rs` and `app/src/tab.rs`.
 
-### 4. Renderer: theme resolution in `Appearance` lookup
+Add a new type:
 
-This is the architecturally interesting step. Two options were considered:
+```rust
+/// The source of a tab's theme override. The enum exists so "Reset
+/// theme" can clear a manual override without also dismissing a
+/// directory match that the tab would otherwise still receive.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ThemeOverride {
+    /// Set explicitly: launch-configuration tab-level `theme:`,
+    /// "Pin theme" menu, or saved-and-restored manual pin.
+    Manual(ThemeKind),
+    /// Set automatically by `directory_overrides` matching against the
+    /// focused pane's cwd. Not persisted across sessions; recomputed on
+    /// startup from the current settings + cwd.
+    Cwd(ThemeKind),
+}
+```
 
-**Option A — Resolved-theme accessor on `Appearance`**: extend `Appearance`
-with `pub fn theme_for_tab(&self, override: Option<&ThemeKind>) -> &WarpTheme`
-that returns the override's resolved theme when `Some`, or
-`self.theme()` when `None`. Every consumer that reads the active theme is
-updated to call `theme_for_tab(active_tab.theme_override.as_ref())`.
+Add `pub theme_override: Option<ThemeOverride>` to:
 
-**Option B — Per-tab `Appearance` instances**: clone `Appearance` per
-overridden tab and swap which one is consulted on tab activation.
+- `TabSnapshot` (`app_state.rs:61–69`), placed next to `selected_color`.
+- `TabData` (`tab.rs:134`), same.
 
-Option A is recommended. It localizes the change (one new method on
-`Appearance`, one new lookup point per consumer), keeps font / icon /
-non-theme appearance state shared (those are still global today), and fits
-the existing "Appearance is one global thing, but the value it returns can
-depend on context" pattern that already governs system-light/dark resolution.
-Option B duplicates state, complicates change propagation
-(`AppearanceManager`'s subscription would have to fan out to every
-overridden tab), and tempts later code into per-tab font or icon overrides
-that this spec explicitly does not promise.
+Snapshot ↔ runtime conversion copies the field unchanged. Session
+serialization persists only `Manual(_)` overrides; `Cwd(_)` overrides are
+re-derived on startup (per product spec behavior #13).
 
-Concretely:
+`WindowSnapshot` does not gain a theme field — window-level launch-config
+theme is expanded to per-tab `Manual` overrides at open time and not
+persisted at the window level.
 
-- Add `pub fn theme_for(&self, override: Option<&ThemeKind>) -> &WarpTheme`
-  to `warp_core::ui::appearance::Appearance` (the canonical type re-exported
-  from `app/src/appearance.rs:34`). When `override` is `Some`, look the theme
-  up via the same loader the global theme already uses; when `None`, return
-  the existing `self.theme()`. Loader fallbacks (unknown theme name,
-  missing custom theme file) reuse the existing global-theme fallback path,
-  satisfying behaviors #11 and #12 of `product.md`.
-- Update the terminal cell renderer (`app/src/terminal/view.rs` and
-  `app/src/terminal/color.rs`, the consumers identified in the codebase
-  map) to consult `theme_for(tab.theme_override.as_ref())` rather than the
-  global `Appearance::theme`. The exact call sites will be enumerated when
-  the implementation PR is opened — they all flow through the existing
-  `Appearance::as_ref(ctx).theme()` lookup, so the change is a mechanical
-  swap with the new accessor at each site.
-- Window chrome (title bar, sidebar, settings views, tab strip) continues to
-  consult `Appearance::theme()` directly with no override argument,
-  satisfying behavior #4 of `product.md`.
+### 4. Directory-pattern overrides settings group
 
-### 5. Right-click menu: "Reset theme"
+A new settings group, defined in a new file
+`app/src/settings/directory_overrides.rs` and exported from
+`app/src/settings/mod.rs`:
 
-The existing tab context menu already exposes per-tab attributes. Add a
-"Reset theme" entry that:
+```rust
+define_settings_group!(DirectoryThemeOverrides, settings: [
+    overrides: Map {
+        // Stored as TOML table: keys = directory paths, values = theme refs.
+        type: BTreeMap<String, String>,
+        default: BTreeMap::new(),
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "appearance.themes.directory_overrides",
+        max_table_depth: 1,
+        description: "Map of directory paths to theme names. The active \
+                      pane's cwd is matched against keys (longest prefix \
+                      wins); the matched theme overrides the global theme \
+                      for that tab.",
+    },
+]);
+```
 
-- Is shown only when the active tab's `theme_override` is `Some`.
-- On click, sets `theme_override` to `None` on the tab and triggers the
-  renderer's existing theme-changed redraw path (the one used today when the
-  global theme changes).
+Resolution helper, alongside the group:
 
-This menu entry is the only in-app surface for clearing an override; setting
-overrides remains the launch-configuration file's job per `product.md`.
-Telemetry: emit a single counter on click using the existing tab-menu
-telemetry conventions; no new event schema is required.
+```rust
+/// Returns the theme to use for `cwd`, walking the directory-overrides
+/// map by longest-prefix match. Returns `None` when no key matches.
+/// Tilde expansion and trailing-slash normalization happen here.
+pub fn directory_theme_for(
+    overrides: &BTreeMap<String, String>,
+    cwd: &Path,
+) -> Option<ThemeKind> { ... }
+```
+
+Match semantics (per product spec #2, #3):
+
+- Keys are tilde-expanded once at evaluation time.
+- A key matches a cwd if it is a prefix at a path-component boundary
+  (use `Path::starts_with` after normalization, not `str::starts_with`).
+- The longest matching key wins.
+- Each value is resolved via `resolve_theme_ref`; unresolved values are
+  skipped and a warning is logged once at settings-change time, not
+  per-match.
+
+Matching is invoked from two places:
+
+- **Tab creation** — when a tab is added (from a launch configuration or
+  from "new tab"), if the tab has no `Manual` override the focused
+  pane's cwd is matched. On hit, the tab's `theme_override` is set to
+  `Cwd(...)`.
+- **Cwd-change events** — the existing pane-cwd tracker emits a
+  "focused pane cwd changed" event used for tab title updates. Add a
+  subscriber that re-runs directory matching for the affected tab when
+  the new cwd differs from the previous match key. The runtime tab
+  retains the last-matched key so re-matching is `O(1)` in the no-change
+  case.
+
+### 5. Renderer: `Appearance` gains a theme catalog
+
+This addresses Oz concern 3 (`Appearance::theme_for` cannot return
+`&WarpTheme` for arbitrary overrides because `Appearance` only owns the
+global `WarpTheme` today).
+
+`Appearance` is extended in `warp_core::ui::appearance`:
+
+```rust
+pub struct Appearance {
+    // existing fields...
+
+    /// Currently-active global theme. Always present in the catalog
+    /// below, but tracked separately so `theme()` is O(1).
+    global_theme: Arc<WarpTheme>,
+
+    /// Lazy cache of all themes referenced by per-tab overrides.
+    /// Keyed by `ThemeKind` so custom themes get their own entries.
+    /// Wrapped in `RwLock` because lookup is on the hot rendering path
+    /// while population happens on the (much rarer) settings-change path.
+    theme_cache: parking_lot::RwLock<HashMap<ThemeKind, Arc<WarpTheme>>>,
+}
+
+impl Appearance {
+    /// Active global theme. Unchanged contract.
+    pub fn theme(&self) -> Arc<WarpTheme> {
+        self.global_theme.clone()
+    }
+
+    /// Per-tab theme lookup. `override` is taken straight from
+    /// `TabData::theme_override.as_ref().map(ThemeOverride::kind)`.
+    /// Returns the global theme when `override` is `None`.
+    pub fn theme_for(&self, override_kind: Option<&ThemeKind>) -> Arc<WarpTheme> {
+        match override_kind {
+            None => self.global_theme.clone(),
+            Some(kind) if *kind == self.global_theme.kind() => {
+                self.global_theme.clone()
+            }
+            Some(kind) => {
+                if let Some(t) = self.theme_cache.read().get(kind).cloned() {
+                    return t;
+                }
+                self.load_and_cache(kind)
+            }
+        }
+    }
+
+    fn load_and_cache(&self, kind: &ThemeKind) -> Arc<WarpTheme> {
+        // Load via the same path the global theme loader uses.
+        // On failure, log warning and return self.global_theme.clone()
+        // (callers see a fall-through to global theme; per behavior #11).
+    }
+}
+```
+
+Cache-invalidation rules:
+
+- `AppearanceManager` already subscribes to `ThemeSettings` change events
+  (`app/src/appearance.rs:51`). On every change it (a) updates
+  `global_theme` and (b) calls a new `theme_cache.clear()` so any
+  previously-cached entries are reloaded next time they are looked up.
+  The hit-rate cost is bounded by the number of distinct overridden
+  themes open at once (typically ≤ 5).
+- Custom-theme file changes (which already invalidate the global theme
+  via the existing watcher) trigger the same cache clear.
+
+Renderer call-site update: every place that today reads
+`Appearance::as_ref(ctx).theme()` and is **inside a tab's render path**
+becomes `Appearance::as_ref(ctx).theme_for(tab.theme_override.as_ref().map(ThemeOverride::kind))`.
+The exact list of call sites (terminal cell renderer in
+`app/src/terminal/view.rs`, color derivation in
+`app/src/terminal/color.rs`, any block-styling consumers) is enumerated
+during implementation; the change is mechanical at each site.
+
+Window-chrome consumers (title bar, sidebar, settings views, tab strip)
+continue to call `Appearance::theme()` with no override argument, per
+product spec #15.
+
+### 6. Right-click menu: Pin theme / Reset theme
+
+The existing tab context menu gains two entries:
+
+- **Pin theme...** — opens a submenu listing built-in themes plus any
+  loaded custom themes (the same list the theme picker shows). On
+  click, sets the tab's `theme_override` to `Manual(chosen)`. Always
+  visible.
+- **Reset theme** — clears any `Manual(_)` override on the tab; if the
+  focused pane's cwd matches a `directory_overrides` key the override
+  is set to `Cwd(_)` immediately, otherwise it becomes `None`. Visible
+  only when the tab has a `Manual` override.
+
+Both entries trigger the existing theme-changed redraw path used today
+when the global theme changes (no new render-invalidation work).
+
+Telemetry: one counter per click, using the existing tab-menu telemetry
+conventions. No new event schema.
 
 ## Testing and validation
 
 ### Unit tests
 
-- `app/src/launch_configs/launch_config_tests.rs`:
-  - YAML round-trip for `TabTemplate` with `theme: "Solarized Dark"`.
-  - YAML round-trip for `TabTemplate` with `theme: { custom: { … } }` to
-    cover the `Custom` variant.
-  - Round-trip for `WindowTemplate.theme` set with all tabs un-themed,
-    asserting tabs inherit the window value at open time.
-  - Round-trip for a launch configuration mixing some themed tabs and some
-    un-themed tabs in the same window.
-  - Negative test: an unknown theme string deserializes successfully into
-    `Some(ThemeKind::…)`-fallback or surfaces a deserialization error that
-    the launch-config loader catches and converts to a logged warning. The
-    behavior here matches whatever path `ThemeKind` already uses for
-    `appearance.themes.theme`; the test pins it.
+`app/src/themes/theme.rs` (or sibling test module):
 
-- `app/src/app_state.rs` (or its test module):
-  - `TabSnapshot` with `theme_override: Some(ThemeKind::Dracula)` round-trips
-    through whatever serializer session-restore uses.
-  - `TabSnapshot::color()` continues to return the same value with and
-    without `theme_override` set (the indicator color and the theme override
-    are independent — behavior #7 of `product.md`).
+- `resolve_theme_ref("Dark City")` → `Some(ThemeKind::DarkCity)`.
+- `resolve_theme_ref("dark_city")` → `Some(ThemeKind::DarkCity)`.
+- `resolve_theme_ref("  DARK CITY  ")` → `Some(ThemeKind::DarkCity)`
+  (case-insensitive, whitespace-tolerant).
+- `resolve_theme_ref("My Custom Theme")` → `Some(ThemeKind::Custom(...))`
+  when registered; `None` otherwise.
+- `resolve_theme_ref("Definitely Not A Theme")` → `None`.
 
-- `app/src/themes/theme.rs` or `app/src/appearance.rs`:
-  - `Appearance::theme_for(None)` returns the same reference as
-    `Appearance::theme()`.
-  - `Appearance::theme_for(Some(&ThemeKind::Light))` resolves to the Light
-    theme regardless of the global setting.
-  - `Appearance::theme_for(Some(&ThemeKind::Custom(missing)))` returns the
-    global theme (fallback path) and increments whatever warning counter the
-    global custom-theme loader uses today.
+`app/src/launch_configs/launch_config_tests.rs`:
+
+- YAML round-trip of `TabTemplate { theme: Some("Solarized Dark") }`.
+- A YAML file with one valid and one unknown `theme:` value loads
+  successfully; resolution applied at apply time, only the unknown tab
+  falls through, the file is **not** rejected.
+- `WindowTemplate.theme` set with all tabs un-themed: round-trip
+  preserves the window-level value.
+- Saving a snapshot whose tabs have only `Cwd(_)` overrides emits no
+  `theme:` fields in the resulting YAML.
+
+`app/src/settings/directory_overrides.rs` (new):
+
+- `directory_theme_for(map, "~/Work/medone/apps/admin-api")` returns
+  the theme mapped to `"~/Work/medone"`.
+- `directory_theme_for(map, "~/Work/medone-archive")` returns `None`
+  when only `"~/Work/medone"` is mapped (component-boundary match).
+- Two overlapping keys `"~/Work"` and `"~/Work/medone"`: longer wins
+  for paths under `medone`, shorter wins elsewhere under `~/Work`.
+- Unresolved theme value: that entry is skipped, `directory_theme_for`
+  on a path that would have matched it returns `None` (or the next
+  match), and one warning is logged.
+
+`app/src/app_state.rs` (or test module):
+
+- `TabSnapshot { theme_override: Some(Manual(Dracula)) }` round-trips
+  through session-restore serialization.
+- `TabSnapshot { theme_override: Some(Cwd(Dracula)) }` does **not**
+  persist — the Cwd variant is re-derived on startup from current
+  settings + cwd. (This pins behavior #13.)
+- `TabSnapshot::color()` returns the same value with and without
+  `theme_override` set (color and theme are independent — #19).
+
+`app/src/appearance.rs` (or `warp_core` tests):
+
+- `Appearance::theme_for(None)` returns the same `Arc` as
+  `Appearance::theme()`.
+- `Appearance::theme_for(Some(&ThemeKind::Light))` returns a `WarpTheme`
+  whose kind is `Light` regardless of the active global theme.
+- `Appearance::theme_for(Some(&ThemeKind::Custom(missing)))` falls back
+  to the global theme and increments the existing missing-custom-theme
+  warning counter.
+- After `ThemeSettings` changes, the cache is cleared: a subsequent
+  `theme_for(Some(&kind))` reloads from disk rather than returning
+  stale custom-theme content.
 
 ### Integration tests
 
-`crates/integration/` is the home for user-flow tests per `CONTRIBUTING.md`.
-Add coverage for:
+`crates/integration/`:
 
-- Open a launch configuration with three tabs — one with `theme: "Dracula"`,
-  one with `theme: "Solarized Light"`, one un-themed. Assert each tab
-  renders with the expected theme and that switching the active tab does not
-  change the rendering of the inactive tabs.
-- Change the global theme via settings while the above launch configuration
-  is open. Assert the un-themed tab redraws to match the new global theme;
-  the two themed tabs do not redraw (behavior #6 of `product.md`).
-- Right-click the Dracula-themed tab → "Reset theme". Assert the tab
-  redraws to match the global theme and that the menu entry disappears.
-- Quit and relaunch with session restore enabled. Assert the Dracula and
-  Solarized Light overrides persist; the previously-reset tab continues to
-  follow the global theme.
+- Open a launch configuration with three tabs — `theme: "Dracula"`,
+  `theme: "Solarized Light"`, no `theme:`. Assert each tab renders the
+  expected theme and that switching tabs does not redraw inactive tabs.
+- Configure `[appearance.themes.directory_overrides]` with two entries.
+  Open one tab in each matched directory and one in an unmatched
+  directory. Assert each tab renders the expected theme. `cd` the
+  unmatched tab into a matched directory; assert the tab redraws with
+  the matched theme. `cd` it back out; assert it redraws with the
+  global theme.
+- Tab with `Manual(Dracula)` from a launch config sits in a directory
+  that maps to `Solarized Dark`. Assert Dracula wins (manual > cwd).
+  Right-click → Reset theme. Assert the tab redraws with Solarized
+  Dark (the cwd match takes over).
+- Edit `directory_overrides` while Warp is running. Assert all tabs
+  whose effective theme changes redraw, others do not.
+- Quit and relaunch. Assert manually-pinned tabs restore their pin;
+  cwd-matched tabs re-derive their theme from current settings + cwd.
+- Unknown theme name in a launch configuration: the file opens,
+  exactly that one tab falls through, the warning appears in the log,
+  other tabs render correctly.
 
 ### Manual verification
 
-- macOS, Linux, Windows: open the test launch configuration above and visually
-  confirm each tab's terminal background and ANSI palette match the chosen
-  theme. Confirm the window chrome and tab strip continue to follow the
-  global theme.
-- Toggle system light/dark: confirm un-themed tabs follow the system, themed
-  tabs do not.
-- Save layout as launch configuration with mixed overrides; reopen the saved
-  YAML and confirm the per-tab `theme:` fields match what was set.
-- Save layout as launch configuration with every tab on the same explicit
-  override; confirm the YAML coalesces to a window-level `theme:` per
-  behavior #10 of `product.md`.
-- Edit a launch configuration's `theme:` value; reopen Warp; confirm
-  already-open tabs from a previous run keep their original override, new
-  tabs from the edited launch configuration get the new value (behavior #13).
+- macOS, Linux, Windows: visually confirm terminal background and ANSI
+  palette match the expected theme for each tab in the test scenarios.
+- Confirm window chrome (title bar, sidebar, tab strip) follows the
+  global theme in all scenarios.
+- Toggle system light/dark while a mix of themed/unthemed tabs is open;
+  confirm only unthemed tabs follow the system.
+- Save layout as launch configuration; confirm tabs with manual pins
+  emit `theme:`, tabs themed only by directory matching do not.
+- After implementation, invoke the `verify-ui-change-in-cloud` skill
+  per the repository rule for user-facing client changes.
 
 ### Tooling
 
 - `cargo fmt` and
   `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
-  must pass per `CONTRIBUTING.md` style rules.
-- `cargo nextest run` for unit tests; `crates/integration` for end-to-end.
+  must pass.
+- `cargo nextest run` for unit tests; `crates/integration` for
+  end-to-end.
 - `./script/presubmit` before pushing.
 
 ## Risks and mitigations
 
-- **Risk: rendering pipeline is hotter than expected and an extra
-  `Option<&ThemeKind>` argument shows up in profiling.** Mitigation: the
-  override is a small enum and the `theme_for` lookup is one branch and one
-  `HashMap` hit at most. The existing per-tab indicator color path executes
-  on the same render frame and has not been a bottleneck. If profiling
-  flags it post-merge, cache the resolved `&WarpTheme` on the runtime tab.
+- **Render hot-path cost of the per-tab lookup.** The added work per
+  frame is one `Option` deref, one `Arc` clone in the common case (no
+  override or override == global), or one `RwLock::read` + `HashMap`
+  hit when the override resolves to a non-global cached theme. The
+  existing per-tab indicator color path runs on the same frame and has
+  not been a bottleneck. If profiling flags it post-merge, cache the
+  `Arc<WarpTheme>` directly on `TabData` and invalidate on
+  override-change; the change is local.
 
-- **Risk: subtle visual mismatch where a UI surface today reads from
-  `Appearance::theme()` but logically belongs *inside* a tab (e.g. block
-  output styling) and we miss it during the consumer-update sweep.**
-  Mitigation: the integration tests above visually exercise terminal
-  background, ANSI palette, and block output; the manual verification step
-  walks across the in-tab UI surfaces explicitly. Any miss surfaces as "this
-  bit didn't change theme" rather than as a crash, and is fixable with a
-  follow-up call-site update.
+- **Cache stampedes when the user changes the global theme with many
+  overridden tabs open.** `theme_cache.clear()` followed by lazy
+  reload means each unique overridden theme reloads once. Bounded by
+  open-tab cardinality.
 
-- **Risk: round-trip save/load asymmetry produces a launch configuration that
-  no longer reproduces the user's tabs.** Mitigation: behavior #10 in
-  `product.md` is precise about when `theme:` is emitted at the tab vs.
-  window level, and the launch-configuration round-trip tests pin both
-  directions.
+- **Mismatch between `directory_overrides` keys and how the OS reports
+  paths.** Tilde expansion happens in the resolver; symlinks are not
+  followed (matching whatever the shell's `pwd` reports). This is
+  documented in the product spec; integration tests cover the common
+  cases.
 
-- **Risk: an unknown theme string in a launch configuration shipped between
-  Warp versions silently downgrades a user's tab.** Mitigation: behavior #11
-  of `product.md` mandates a logged warning identifying the offending
-  launch configuration, tab, and theme name. The fallback is the same
-  one global-theme uses today, so the tab still opens.
+- **`Cwd(_)` override mistakenly persists across sessions.** Session
+  serialization explicitly emits only `Manual(_)`; the integration test
+  for restart behavior pins this.
 
-- **Risk: persisted `theme_override` collides with a future per-window or
-  per-pane theme feature.** Mitigation: the field is named
-  `theme_override` (not `theme`) precisely to leave room for a separate
-  resolved theme to live elsewhere later. Per-pane theming is explicitly
-  out of scope; per-window theming, if added, would also produce a
-  per-tab override at open time and reuse this same field.
+- **Concern 1 / Concern 2 / Concern 3 from Oz's first review.**
+  Addressed in §1 (Option<String> + apply-time resolver), §2
+  (`resolve_theme_ref` returns `Option<ThemeKind>`), and §5 (theme
+  catalog, `Arc<WarpTheme>` ownership) respectively. Each concern has
+  a corresponding unit test above.
+
+- **Per-pane theme creep.** The override field lives on the tab, not
+  the pane, and the resolver consults the focused pane's cwd. A future
+  per-pane theming feature would need its own data path; this spec
+  does not lock that out but does not pre-pay for it either.
+
+- **Persistence schema collision with future per-window theming.** The
+  field is named `theme_override` (not `theme`) so a separate resolved
+  theme can live elsewhere if added later.
 
 ## Follow-ups (deliberately not in this PR)
 
-Tracked separately so that this spec stays scoped:
-
-- **Auto-theme by SSH host or hostname** (raised by `stevenchanin`,
-  `pyronaur`, `zethon`, `janderegg` in `#478`). Requires a detection layer
-  that observes process state inside the tab. Would consume the
-  `theme_override` field this spec adds.
-- **Auto-theme by cwd** (`pyronaur`). Same shape as the SSH case; consumes
-  the field.
-- **Runtime escape-code or shell-hook protocol for setting a tab's theme**
-  (raised by `yatharth` for Claude Code session signaling). Defines a wire
-  format and a security model; consumes the field.
-- **In-app per-tab theme picker submenu in the right-click menu** (open
-  question in `product.md`). Strictly additive to this spec.
-- **Wallpaper-per-tab** (`scottaw66`, `SheepDomination`). Different surface
-  area entirely (asset loading, layering); does not conflict with this
-  spec.
-- **Closing `#2618` as a duplicate** of `#478` once this spec lands.
+- **Glob pattern support in `directory_overrides`** (open question in
+  product.md) — extends key matching from prefix to glob.
+- **Auto-theme by SSH host or hostname** (`stevenchanin`, `pyronaur`,
+  `zethon`, `janderegg` in #478). Requires detection inside the tab's
+  shell; consumes the `Manual` / new `Ssh` variant of `ThemeOverride`.
+- **Runtime escape-code or shell-hook protocol for setting a tab's
+  theme** (`yatharth`, for Claude-Code session signaling). Defines a
+  wire format and a security model; consumes the override field.
+- **In-tab "Pin theme" command in the command palette** (so users can
+  pin without right-clicking). Strictly additive.
+- **Wallpaper-per-tab** (`scottaw66`, `SheepDomination`). Different
+  surface area entirely; does not conflict.
+- **Closing #2618 as a duplicate** of #478 once this spec lands.

--- a/specs/GH478/tech.md
+++ b/specs/GH478/tech.md
@@ -367,21 +367,66 @@ and `private`; the design rule applied here is:
 
 Helper, alongside the settings group:
 
+Per Oz's v5 [SECURITY] review: a stable unsalted 24-bit FxHash over
+the raw key is dictionary-guessable — an adversary with a shared log
+can hash a list of plausible candidate paths and recover the key by
+collision. The fix is a **per-installation keyed hash**: a 32-byte
+random salt is generated on first launch, stored in a local-only,
+non-synced file (`~/.warp/redaction_salt`, mode `0600`), and never
+leaves the machine.
+
 ```rust
-/// Stable short hash of a `directory_overrides` key suitable for
-/// inclusion in user-facing warnings. **Not cryptographic.** Purpose
-/// is identification of an entry across runs without including the
-/// raw path. 6 hex chars (24 bits) is enough to disambiguate the
-/// O(10) entries a typical user will have.
-pub fn redacted_key_id(raw_key: &str) -> String {
-    let mut hasher = rustc_hash::FxHasher::default();
-    raw_key.hash(&mut hasher);
-    format!("{:06x}", hasher.finish() & 0xffff_ff)
+/// Stable, **non-reversible** short identifier for a
+/// `directory_overrides` key. Suitable for inclusion in user-facing
+/// warnings and locally-shared diagnostic logs.
+///
+/// Implementation: HMAC-SHA256(installation_salt, raw_key), truncated
+/// to 6 hex chars (24 bits). The installation salt is read from
+/// `~/.warp/redaction_salt` (generated on first launch, mode 0600,
+/// never synced). Because the salt is per-installation and never
+/// shared, an identifier leaked in a log file cannot be reversed by
+/// a dictionary attack against candidate paths — the attacker would
+/// need the salt, which only ever exists on the originating machine.
+///
+/// Truncation to 24 bits keeps the identifier short enough for
+/// readable log lines; with O(10) entries per typical user the
+/// collision probability inside a single installation is negligible,
+/// and cross-installation collisions are irrelevant because each
+/// installation has its own salt.
+pub fn redacted_key_id(raw_key: &str, salt: &InstallationSalt) -> String {
+    let tag = hmac_sha256::HMAC::mac(raw_key.as_bytes(), salt.as_bytes());
+    let truncated = u32::from_be_bytes([tag[0], tag[1], tag[2], tag[3]])
+        & 0x00ff_ffff;
+    format!("{truncated:06x}")
 }
 ```
 
+`InstallationSalt` is a thin newtype around `[u8; 32]` whose
+constructor reads the salt file, generating it (with `rand::OsRng`,
+mode `0600` write) if missing. It is loaded once into the settings
+subsystem at startup and passed into `redacted_key_id` as a borrow;
+no global static is required.
+
+If the salt file is missing or unreadable at runtime — for example
+the user deleted it, or Warp is running in a container without write
+access — the redaction helper emits `directory_overrides[unsalted]:
+...` with no derived identifier from the path at all, which is the
+safest fallback and surfaces the configuration error to the user.
+
+**Even-stronger alternative considered and rejected**: storing an
+opaque local ID alongside each entry (e.g. a sidecar file mapping
+`key → uuid`). That removes the hash entirely but requires every
+settings edit to round-trip through Warp's runtime to allocate IDs
+for new keys; users editing `settings.toml` directly in a text
+editor would not get an ID until next launch, so the diagnostic for
+a freshly-typed bad theme value would be
+`directory_overrides[unidentified]`. The salted-HMAC scheme is
+deterministic from the key alone and preserves "edit settings.toml,
+get an immediate identifying warning" — the property that makes the
+diagnostics actually useful for the user.
+
 Usage rule (enforced by code review and by the tests in *Privacy
-invariant tests*): every log/warn/error line emitted by the
+invariant tests*): every log / warn / error line emitted by the
 `directory_overrides` matcher, settings subscriber, or value validator
 must reference offending entries by `redacted_key_id` only.
 
@@ -390,12 +435,15 @@ because theme names are not sensitive and are needed for the user to
 locate the entry in their `settings.toml`. Example warning text:
 
 ```
-directory_overrides[hash=8a3f9c]: unknown theme "Drakula" — matching this entry will be skipped until the value is corrected
+directory_overrides[id=8a3f9c]: unknown theme "Drakula" — matching this entry will be skipped until the value is corrected
 ```
 
-The hash is stable for a given key, so the same warning recurs with
-the same hash across Warp restarts and helps the user correlate
-multiple diagnostics about the same entry.
+The identifier is stable for a given key on a given machine, so the
+same warning recurs with the same id across Warp restarts and helps
+the user correlate multiple diagnostics about the same entry. The
+identifier does **not** match between machines (different salts), so
+correlation across users in a shared bug-report channel is impossible
+— which is the point.
 
 Resolution helper, alongside the group:
 
@@ -466,8 +514,10 @@ finding that settings edits were not handled):
   product behavior #6.
 
 The same subscription handles validation: any value in the new map
-that fails `resolve_theme_ref` is logged once (with its key) and
-treated as absent for matching purposes. Subsequent edits that fix
+that fails `resolve_theme_ref` is logged once via the
+`redacted_key_id` helper (the raw key is **never** included in the
+warning, per *Diagnostic redaction* below) and treated as absent for
+matching purposes. Subsequent edits that fix
 the value re-trigger this validation.
 
 ### 5. Renderer: `Appearance` gains a theme catalog
@@ -567,22 +617,41 @@ global `theme()` form. Concretely:
 | `crates/editor/**` | global by default; per-tab when invoked from `terminal/view/**` (the call site, not the crate, decides) | editor is reusable |
 | `crates/integration/**` | tests; updated to assert both forms |
 
-**Migration enforcement — custom lint**
+**Migration enforcement — concrete tooling**
 
-To make the migration mechanical, exhaustive, and durable across future
-additions, the implementation adds a small `clippy_lints`-style check
-(or a `dylint` lint, depending on the existing tooling Warp uses)
-named `appearance_theme_in_tab_path`. The lint:
+Per Oz's v5 suggestion, the spec commits to a specific mechanism
+rather than leaving it open between tooling families. The
+implementation adds the lint as a **`dylint`** library named
+`appearance_theme_in_tab_path` under a new top-level `tools/lints/`
+directory. `dylint` is the standard for project-specific Rust lints
+(used by `rust-fuzz`, `solana`, and others), runs against a normal
+`cargo` build, and does not require forking clippy or modifying the
+toolchain. The lint:
 
 - Flags any call to `Appearance::*::theme()` (the global accessor)
   whose enclosing module is under a *per-tab* path per the table
-  above. Path classification is hard-coded in the lint config.
+  above. Path classification is hard-coded in the lint source.
 - Fails CI when triggered.
 - Is silenced at a call site only by replacing the call with
   `theme_for(...)`, or — for a deliberate exception — by
   `#[allow(appearance_theme_in_tab_path = "...")]` with a written
   rationale (e.g. "this surface intentionally renders in window
   chrome even though it lives under terminal/view/").
+
+CI hook: `./script/presubmit` gains
+`cargo dylint --lib appearance_theme_in_tab_path -- -D warnings`
+after the existing `cargo clippy` step. The lint runs in parallel
+with clippy and adds well under a minute to presubmit time.
+
+**Fallback** if the Warp team would rather not introduce `dylint` as
+a new dependency: replace the lint library with a `ripgrep` check in
+`./script/presubmit` that matches `Appearance::*::theme()` calls
+under per-tab paths and exits non-zero on hit. This gives 90% of the
+guarantee with no new tooling; the trade-off is no per-call-site
+`#[allow]` syntax (deliberate exceptions need a known-marker comment
+that the script greps and skips). The implementation PR opens with
+`dylint`; if review prefers ripgrep, that switch is one file change
+and one CI-script change.
 
 The lint is the deliverable that gives this spec a feasibility
 guarantee: the migration is correct *by construction* across all 862
@@ -642,9 +711,47 @@ in-development features like `OpenWarpNewSettingsModes`).
 | `directory_overrides` matching | Skipped entirely. The settings group is still parsed (so users who set up the map under preview do not lose data on stable) but `directory_theme_for` is never invoked. |
 | Launch-config `theme:` fields | Deserialized as today (`Option<String>`) but ignored — `launch_config_pin` and `window_default` are not populated when applying templates. |
 | Right-click menu entries | "Pin theme...", "Reset theme", and "Forget launch config theme" are hidden. |
-| Theme catalog (§5) | `theme_for(None)` always returns the global theme; `theme_for(Some(_))` is unreachable because no slot is ever populated. The catalog cache stays empty. |
+| Theme catalog (§5) | `theme_for(None)` always returns the global theme. `theme_for(Some(_))` is reachable only if a render path bypasses the flag check — see *Flag check at the resolver* below — and falls back to the global theme via the catalog's existing missing-theme path. The catalog cache stays empty in normal flag-off operation. |
 | Settings-change subscription on `DirectoryThemeOverrides` | Subscribed but the handler short-circuits when the flag is off. |
-| `appearance_theme_in_tab_path` lint (§5) | Still enforced — the call sites need to be migrated regardless of runtime behavior because the flag must be flippable without recompiling. The migrated call sites pass `theme_state.effective(&global)` which falls through to `global` when every slot is `None`, which is exactly what the flag-off state guarantees. |
+| `appearance_theme_in_tab_path` lint (§5) | Still enforced. Migrated call sites pass not `theme_state.effective(&global)` directly but the wrapper described below, so the flag toggle is the single place that controls runtime behavior. |
+
+**Flag check at the resolver (single source of truth)**
+
+Per Oz's v5 [IMPORTANT] finding: the table above implied populated
+slots could not exist when the flag is off, but the persistence
+section preserves them so flipping the flag back on is non-lossy.
+Both must be true. The resolution is to put the flag check inside the
+resolver itself, so populated slots **on disk** are independent from
+populated slots **at render time**:
+
+```rust
+/// The single function the renderer should call. When the flag is
+/// off, `effective()`'s slot walk is skipped entirely and the global
+/// theme is returned. When on, `effective()` runs normally.
+///
+/// Putting the check here (not at the call site) means:
+///   * Flipping the flag has no per-frame cost: still one branch.
+///   * Persisted slot data is never consulted at render time when
+///     off, so "did the migration miss a call site?" defects can't
+///     leak themed pixels into a flag-off install.
+///   * The 862 migrated call sites all look identical and don't
+///     each need their own flag check.
+pub fn theme_state_effective<'a>(
+    state: &'a TabThemeState,
+    global: &'a ThemeKind,
+    ctx: &AppContext,
+) -> &'a ThemeKind {
+    if !per_tab_overrides_enabled(ctx) {
+        return global;
+    }
+    state.effective(global)
+}
+```
+
+The renderer-call-site migration in §5 calls `theme_state_effective`,
+not `state.effective` directly. The lint flags both the bare
+`Appearance::*::theme()` form and any direct `state.effective()` call
+inside a per-tab module — both are migration mistakes.
 
 **Persisted state with flag off:**
 
@@ -663,9 +770,10 @@ fn per_tab_overrides_enabled(ctx: &AppContext) -> bool {
 }
 ```
 
-Each gated surface above guards entry with this single call. The
-implementation PR introduces a constant for the flag name to avoid
-typos.
+Each gated surface above (matching, launch-config application, menu
+visibility, settings-change subscription) guards entry with this
+single call. The implementation PR introduces a constant for the flag
+name to avoid typos.
 
 ## Testing and validation
 
@@ -804,11 +912,20 @@ typos.
     `C:\Work\medone-archive` does not match (component boundary).
 - **Diagnostic redaction.** Configure `directory_overrides` with a
   key `~/Work/AcmeCorp/2026` mapped to a bad theme name `"Drakula"`.
-  Trigger validation. Capture the warning string. Assert it
-  contains `"Drakula"` and `redacted_key_id("~/Work/AcmeCorp/2026")`,
+  Trigger validation. Capture the warning string. Assert it contains
+  `"Drakula"` and `redacted_key_id("~/Work/AcmeCorp/2026", &salt)`,
   and does **not** contain `"AcmeCorp"`, `"Work"`, `"2026"`, or any
-  substring of the raw key. Assert the same key produces the same
-  hash on a second run within the test process.
+  substring of the raw key.
+- **Per-installation salt.** Two test runs with different generated
+  salts on the same key produce **different** identifiers (asserts
+  the salt is actually keyed in). Two runs with the same salt
+  produce the **same** identifier (asserts determinism within an
+  installation).
+- **Salt file mode.** On a Unix platform, after first-launch salt
+  generation, `stat` the file and assert mode bits == `0600`.
+- **Salt missing fallback.** Delete the salt file mid-test, trigger a
+  fresh validation. Assert the warning string contains
+  `[unsalted]` and does not contain any derived identifier.
 - Open a launch configuration with a window-level `theme:` and three
   tabs, one of which sits in a `directory_overrides`-matched cwd.
   Assert the matched tab uses the cwd theme (cwd > window default);
@@ -839,15 +956,22 @@ typos.
   their effects without losing data, and `cwd_resolved` is recomputed
   from current settings.
 - Toggle the flag from **on** to **off** mid-session. Assert all
-  themed tabs redraw with the global theme (or the cwd-stripped
-  fallback chain — but with the flag off, `effective()` collapses to
-  global). Persisted slot data is not cleared.
+  themed tabs redraw with the global theme (because
+  `theme_state_effective` short-circuits when the flag is off, even
+  though slot data remains populated in memory and on disk).
+  Persisted slot data is not cleared. Toggle back **on**: assert
+  every tab redraws with its prior effective theme without any
+  reload.
 
 ### Privacy invariant tests
 
 - `DirectoryThemeOverrides` settings group has `private == true` and
-  `sync_to_cloud == SyncToCloud::Locally`. Pinned by a settings-system
+  `sync_to_cloud == SyncToCloud::Never`. Pinned by a settings-system
   test analogous to the existing tests that gate which settings sync.
+- The redaction-salt file (`~/.warp/redaction_salt`) is created with
+  mode `0600` on first launch and is **not** included in any
+  cloud-synced settings payload (verified by the same serializer test
+  that asserts no path keys leak).
 - The settings sync serializer, when run over a populated
   `DirectoryThemeOverrides`, emits no entry containing a path key in
   the cloud-sync payload. Test by populating the map, running the

--- a/specs/GH478/tech.md
+++ b/specs/GH478/tech.md
@@ -125,13 +125,21 @@ tab is computed as:
 
 ```rust
 fn preserved_override(state: &TabThemeState) -> Option<&ThemeKind> {
-    state.manual.as_ref().or(state.window_default.as_ref())
+    // menu_pin and launch_config_pin both round-trip through saved
+    // launch configs as tab-level `theme:`. menu_pin wins on
+    // resolution (layer #1 > #2), so we save the higher-priority slot
+    // when both are set; on reopen the field reseeds launch_config_pin
+    // and the user's prior menu_pin (if any) is restored from session
+    // state independently.
+    state.menu_pin.as_ref()
+        .or(state.launch_config_pin.as_ref())
+        .or(state.window_default.as_ref())
 }
 ```
 
-(Directory-matched themes are deliberately not part of `preserved_override`
-— they round-trip through `directory_overrides`, not through the saved
-launch configuration.)
+(Directory-matched themes are deliberately not part of
+`preserved_override` — they round-trip through `directory_overrides`,
+not through the saved launch configuration.)
 
 `From<WindowSnapshot> for WindowTemplate` then:
 
@@ -195,53 +203,64 @@ explicit and keeping unknown-theme handling field-level.
 
 File: `app/src/app_state.rs` and `app/src/tab.rs`.
 
-A tab can have up to three independent theme inputs at once — a manual
-pin, a cwd-pattern match, and a launch-configuration window-level
-default — and the product spec defines a strict priority order between
-them (manual > cwd > window default > global). A single `Option<enum>`
-cannot represent "manual cleared, cwd applies, window default also
-exists as a deeper fallback" because the three sources are not mutually
+A tab can have up to four independent theme inputs at once — a menu
+pin, a launch-config manual pin, a cwd-pattern match, and a
+launch-config window-level default — and the product spec defines a
+strict priority order between them (menu > launch-config-manual > cwd >
+window default > global). A single `Option<enum>` cannot represent the
+state "menu pin cleared, launch-config-manual still applies, cwd also
+exists as a deeper fallback" because the sources are not mutually
 exclusive at storage time, only at render time. Replace the single
-field with a struct holding all three slots, plus a resolver:
+field with a struct holding all four slots, plus a resolver:
 
 ```rust
 /// Per-tab theme state. Each slot is independent storage for one
 /// resolution layer; the resolver in `effective()` enforces the
-/// priority order from `product.md` (Resolution order #1–#4).
+/// priority order from `product.md` §Resolution order.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TabThemeState {
-    /// User-set pin: launch-config tab-level `theme:`, "Pin theme"
-    /// menu, or a restored pin from a previous session.
+    /// Layer #1. Set by the right-click "Pin theme" menu; cleared by
+    /// the right-click "Reset theme" menu.
     /// **Persisted across sessions.**
-    pub manual: Option<ThemeKind>,
+    pub menu_pin: Option<ThemeKind>,
 
-    /// Set at open time when the tab was created from a launch
-    /// configuration whose window had a window-level `theme:`.
-    /// **Persisted across sessions** (the launch config that opened
-    /// the tab is not necessarily reopened on restore, so the value
-    /// must travel with the tab).
-    pub window_default: Option<ThemeKind>,
+    /// Layer #2. Set by a tab-level `theme:` in the launch
+    /// configuration that opened (or restored) the tab. Cleared only
+    /// by the right-click "Forget launch config theme" menu, never by
+    /// "Reset theme" — see Zach's v4 review.
+    /// **Persisted across sessions.**
+    pub launch_config_pin: Option<ThemeKind>,
 
-    /// Computed by directory-pattern matching against the focused
-    /// pane's cwd. Recomputed on tab creation, on focused-pane cwd
-    /// change, and on `directory_overrides` settings change.
-    /// **Not persisted** — recomputed on startup from current
-    /// settings + restored cwd.
+    /// Layer #3. Computed by directory-pattern matching against the
+    /// focused pane's cwd. Recomputed on tab creation, on focused-pane
+    /// cwd change, and on `directory_overrides` settings change.
+    /// **Not persisted** — recomputed on startup from current settings
+    /// + restored cwd.
     pub cwd_resolved: Option<ThemeKind>,
+
+    /// Layer #4. Set at open time when the tab was created from a
+    /// launch configuration whose window had a window-level `theme:`.
+    /// **Persisted across sessions** (the launch config that opened
+    /// the tab is not necessarily reopened on restore).
+    pub window_default: Option<ThemeKind>,
 }
 
 impl TabThemeState {
-    /// Resolution order: manual > cwd > window default > caller's
-    /// global fallback. Mirrors product.md §"Resolution order".
+    /// Resolution order: menu_pin > launch_config_pin > cwd_resolved
+    /// > window_default > caller's global fallback. Mirrors
+    /// product.md §"Resolution order" exactly.
     pub fn effective<'a>(&'a self, global: &'a ThemeKind) -> &'a ThemeKind {
-        self.manual.as_ref()
+        self.menu_pin.as_ref()
+            .or(self.launch_config_pin.as_ref())
             .or(self.cwd_resolved.as_ref())
             .or(self.window_default.as_ref())
             .unwrap_or(global)
     }
 
     pub fn has_any_override(&self) -> bool {
-        self.manual.is_some() || self.cwd_resolved.is_some()
+        self.menu_pin.is_some()
+            || self.launch_config_pin.is_some()
+            || self.cwd_resolved.is_some()
             || self.window_default.is_some()
     }
 }
@@ -252,24 +271,30 @@ Add `pub theme_state: TabThemeState` to:
 - `TabSnapshot` (`app_state.rs:61–69`), placed next to `selected_color`.
 - `TabData` (`tab.rs:134`), same.
 
-Session serialization writes only `manual` and `window_default`;
-`cwd_resolved` is recomputed on startup. The serializer omits the
-field entirely when all three slots are `None`, so existing sessions
-with no overrides round-trip with no schema cost.
+Session serialization writes `menu_pin`, `launch_config_pin`, and
+`window_default`; `cwd_resolved` is recomputed on startup. The
+serializer omits the field entirely when all four slots are `None`, so
+existing sessions with no overrides round-trip with no schema cost.
 
 `WindowSnapshot` does not gain a theme field; the window-level
 launch-config theme lives only on the *tabs* it opened (in their
-`window_default` slot). This is what Oz's first v2 review correctly
-flagged: expanding the window default into the *manual* slot would
-have made it incorrectly outrank cwd matches. The dedicated slot fixes
-that — `effective()` consults `manual` first, then `cwd_resolved`, and
-falls through to `window_default` only when neither of the higher
-layers applies.
+`window_default` slot). The dedicated slot is what makes
+`effective()`'s priority order honor the product spec without
+collapsing into an enum that could mis-rank window defaults — the
+finding Oz raised in the v2 review.
 
-The right-click "Reset theme" entry (§6) only clears `manual`. The
-other two slots are unaffected, so a tab whose manual pin sat on top
-of a still-applicable cwd match falls back to the cwd theme on reset
-rather than to the global theme — matching product behavior #18.
+Menu actions (§6) target individual slots:
+
+- **Reset theme** clears `menu_pin` only. `launch_config_pin`,
+  `cwd_resolved`, and `window_default` are unaffected — the tab falls
+  through to the next non-empty layer per `effective()`.
+- **Forget launch config theme** clears `launch_config_pin` only.
+- "Pin theme..." sets `menu_pin`.
+
+A tab can have a menu pin AND a launch-config pin simultaneously: the
+menu pin wins for rendering (layer #1 > layer #2), and clearing the
+menu pin reveals the launch-config pin underneath. This is exactly the
+behavior Zach's v4 review asked for.
 
 ### 4. Directory-pattern overrides settings group
 
@@ -292,7 +317,10 @@ define_settings_group!(DirectoryThemeOverrides, settings: [
         // remain user-controllable through the right-click "Pin theme"
         // menu, which writes to the (non-synced) tab snapshot, not to
         // this map. See *Privacy model* below.
-        sync_to_cloud: SyncToCloud::Locally,
+        // (Per Zach's v4 review: `Never` is the correct variant here.
+        // The settings system uses `Globally`, `Never`, `PerPlatform`;
+        // there is no `Locally` variant.)
+        sync_to_cloud: SyncToCloud::Never,
         private: true,
         toml_path: "appearance.themes.directory_overrides",
         max_table_depth: 1,
@@ -314,10 +342,10 @@ about the user's employer, clients, and projects. A key like
 already distinguishes synced from local settings via `sync_to_cloud`
 and `private`; the design rule applied here is:
 
-- **Keys are locally-stored, never synced.** `sync_to_cloud:
-  Locally` and `private: true`. The map is written only to the user's
-  local `settings.toml` and is not transmitted off-machine by the
-  settings sync path.
+- **Keys are locally-stored, never synced.** `sync_to_cloud: Never`
+  and `private: true`. The map is written only to the user's local
+  `settings.toml` and is not transmitted off-machine by the settings
+  sync path.
 - **No telemetry on the contents.** The match function emits at most a
   count metric ("a directory match applied to N tabs this minute"); it
   never logs path keys or theme names to remote telemetry pipelines.
@@ -414,9 +442,12 @@ finding that settings edits were not handled):
 - **Tab creation** — when a tab is added (from a launch configuration
   or from "new tab"), the focused pane's cwd is matched and
   `tab.theme_state.cwd_resolved` is set to the result (`None` on no
-  match). The `manual` slot is set independently from the launch
-  config or from a saved pin; it is *not* gated on `cwd_resolved`
-  being absent.
+  match). The `launch_config_pin` slot is set independently from the
+  launch config (`tab_template.theme` resolved through
+  `resolve_theme_ref`); the `window_default` slot is set similarly
+  from the window-level `theme:`. None of these is gated on
+  `cwd_resolved` being absent — every applicable slot is filled, and
+  `effective()` chooses the winner.
 - **Focused-pane cwd-change events** — the existing pane-cwd tracker
   emits a "focused pane cwd changed" event used today for tab title
   updates. A new subscriber re-runs `directory_theme_for` for the
@@ -565,25 +596,76 @@ Window-chrome consumers (per the table) keep
 single source of truth for which sites are which; reviewers verify the
 table by reading the lint config, not by re-walking 862 call sites.
 
-### 6. Right-click menu: Pin theme / Reset theme
+### 6. Right-click menu: Pin theme / Reset theme / Forget launch config theme
 
-The existing tab context menu gains two entries:
+The existing tab context menu gains three entries:
 
 - **Pin theme...** — opens a submenu listing built-in themes plus any
   loaded custom themes (the same list the theme picker shows). On
-  click, sets `tab.theme_state.manual = Some(chosen)`. Always
-  visible.
-- **Reset theme** — sets `tab.theme_state.manual = None`. The other
-  two slots (`cwd_resolved`, `window_default`) are unaffected; if
-  either still has a value the tab immediately re-renders with the
-  next-priority theme per `effective()`. Visible only when
-  `theme_state.manual.is_some()`.
+  click, sets `tab.theme_state.menu_pin = Some(chosen)`. Always
+  visible (when the feature flag is on, see §7).
+- **Reset theme** — sets `tab.theme_state.menu_pin = None`. The other
+  three slots (`launch_config_pin`, `cwd_resolved`, `window_default`)
+  are unaffected; if any still has a value the tab immediately
+  re-renders with the next-priority theme per `effective()`. Visible
+  only when `theme_state.menu_pin.is_some()`.
+- **Forget launch config theme** — sets `tab.theme_state.launch_config_pin
+  = None`. Visible only when `theme_state.launch_config_pin.is_some()`.
+  This entry exists per Zach's v4 review: a user pinning a different
+  theme via the menu should not also discard what their launch
+  configuration originally set.
 
-Both entries trigger the existing theme-changed redraw path used today
-when the global theme changes (no new render-invalidation work).
+All three entries trigger the existing theme-changed redraw path used
+today when the global theme changes (no new render-invalidation work).
 
-Telemetry: one counter per click, using the existing tab-menu telemetry
-conventions. No new event schema.
+Telemetry: one counter per click for each of the three entries (using
+existing tab-menu telemetry conventions). No new event schema.
+
+### 7. Feature flag wiring
+
+Per Zach's v4 review, the entire feature ships behind a feature flag
+`appearance.themes.per_tab_overrides`. The flag is added through the
+existing feature-flag system (the same mechanism that gates other
+in-development features like `OpenWarpNewSettingsModes`).
+
+**Default values:**
+
+- `dev` and `preview` channels: flag defaults to **on**.
+- `stable` channel: flag defaults to **off** in the initial release.
+  A follow-up changelog entry flips it on once preview telemetry
+  confirms no regressions.
+
+**Surfaces gated by the flag (when off):**
+
+| Surface | Behavior with flag off |
+| --- | --- |
+| `directory_overrides` matching | Skipped entirely. The settings group is still parsed (so users who set up the map under preview do not lose data on stable) but `directory_theme_for` is never invoked. |
+| Launch-config `theme:` fields | Deserialized as today (`Option<String>`) but ignored — `launch_config_pin` and `window_default` are not populated when applying templates. |
+| Right-click menu entries | "Pin theme...", "Reset theme", and "Forget launch config theme" are hidden. |
+| Theme catalog (§5) | `theme_for(None)` always returns the global theme; `theme_for(Some(_))` is unreachable because no slot is ever populated. The catalog cache stays empty. |
+| Settings-change subscription on `DirectoryThemeOverrides` | Subscribed but the handler short-circuits when the flag is off. |
+| `appearance_theme_in_tab_path` lint (§5) | Still enforced — the call sites need to be migrated regardless of runtime behavior because the flag must be flippable without recompiling. The migrated call sites pass `theme_state.effective(&global)` which falls through to `global` when every slot is `None`, which is exactly what the flag-off state guarantees. |
+
+**Persisted state with flag off:**
+
+The `theme_state` field is still serialized and deserialized through
+session restore. A user who pinned themes under preview, then opens
+stable with the flag off, has their pins preserved on disk; flipping
+the flag back on (or upgrading to a stable release that turns it on)
+restores the visible behavior exactly as they left it. This avoids
+any "I lost my themes when I downgraded" regression.
+
+The settings-system feature-flag check is one call:
+
+```rust
+fn per_tab_overrides_enabled(ctx: &AppContext) -> bool {
+    FeatureFlags::as_ref(ctx).per_tab_overrides.value()
+}
+```
+
+Each gated surface above guards entry with this single call. The
+implementation PR introduces a constant for the flag name to avoid
+typos.
 
 ## Testing and validation
 
@@ -624,20 +706,28 @@ conventions. No new event schema.
 
 `app/src/app_state.rs` (or test module):
 
-- `TabThemeState { manual: Some(Dracula), .. }` round-trips through
-  session-restore serialization.
-- `TabThemeState { window_default: Some(Light), .. }` round-trips —
-  window defaults travel with the tab because the launch config that
-  set them is not necessarily reopened on restore.
-- `TabThemeState { cwd_resolved: Some(Dracula), .. }` does **not**
-  persist; on deserialization the slot is `None` regardless of what
-  was written. (Pins product behavior #13.)
-- `TabThemeState::effective()` priority: `manual=Some(A) cwd=Some(B)
-  window=Some(C)` resolves to `A`; `manual=None cwd=Some(B) window=Some(C)`
-  resolves to `B`; `manual=None cwd=None window=Some(C)` resolves to
-  `C`; all `None` resolves to the global fallback. (Pins the
-  resolution order from product.md and directly addresses Oz's v2
-  CRITICAL finding — window defaults must not outrank cwd.)
+- Each persisted slot round-trips through session-restore
+  serialization: `menu_pin`, `launch_config_pin`, `window_default`.
+- `cwd_resolved` does **not** persist; on deserialization the slot is
+  `None` regardless of what was written. (Pins product behavior #13.)
+- `TabThemeState::effective()` walks the priority order exactly:
+  - `menu=A launch=B cwd=C window=D` → `A`.
+  - `menu=None launch=B cwd=C window=D` → `B`.
+  - `menu=None launch=None cwd=C window=D` → `C`.
+  - `menu=None launch=None cwd=None window=D` → `D`.
+  - All `None` → global fallback.
+  Pins the 5-layer resolution order from product.md and addresses
+  the CRITICAL finding from Oz's v2 review (window defaults must
+  not outrank cwd) plus Zach's v4 split (menu pin must outrank
+  launch-config pin).
+- "Reset theme" semantics: a tab with `menu=A launch=B` resolves to
+  `A`. After clearing `menu_pin`, it resolves to `B`. A tab with
+  `menu=A` only resolves to `A`; after clear, falls through to
+  global. Pins product behavior #18.
+- "Forget launch config theme" semantics: a tab with `menu=A launch=B`
+  resolves to `A`. After clearing `launch_config_pin`, it still
+  resolves to `A` (menu wins). After also clearing `menu_pin`, it
+  falls through to global.
 - `TabSnapshot::color()` returns the same value with and without
   `theme_state` populated (color and theme are independent — #19).
 
@@ -667,10 +757,18 @@ conventions. No new event schema.
   unmatched tab into a matched directory; assert the tab redraws with
   the matched theme. `cd` it back out; assert it redraws with the
   global theme.
-- Tab with `Manual(Dracula)` from a launch config sits in a directory
-  that maps to `Solarized Dark`. Assert Dracula wins (manual > cwd).
-  Right-click → Reset theme. Assert the tab redraws with Solarized
-  Dark (the cwd match takes over).
+- Tab with `launch_config_pin = Some(Dracula)` (set via launch-config
+  tab-level `theme:`) sits in a directory that maps to
+  `Solarized Dark`. Assert Dracula wins (launch_config_pin > cwd).
+  Right-click → "Forget launch config theme". Assert the tab redraws
+  with Solarized Dark.
+- Tab with both `menu_pin = Some(Light)` and `launch_config_pin =
+  Some(Dracula)`. Assert Light wins (menu_pin > launch_config_pin).
+  Right-click → "Reset theme" (clears menu_pin only). Assert the tab
+  redraws with Dracula. Right-click → "Forget launch config theme".
+  Assert the tab redraws with the next-priority theme. (Addresses
+  Zach's v4 review — menu and launch-config pins must be
+  independently clearable.)
 - **Settings-change recompute.** With three tabs open in three
   different cwds, edit `directory_overrides` to add a new key that
   matches one of them. Assert that one tab redraws with the new
@@ -723,6 +821,27 @@ conventions. No new event schema.
 - Unknown theme name in a launch configuration: the file opens,
   exactly that one tab falls through, the warning appears in the log,
   other tabs render correctly.
+
+### Feature-flag tests
+
+- With `appearance.themes.per_tab_overrides` **off**, open a launch
+  configuration containing both window-level and tab-level `theme:`
+  fields. Assert no tab carries any populated slot in `theme_state`
+  (effective() falls through to global) and no warning is logged for
+  the launch-config theme references.
+- With the flag **off**, configure `directory_overrides` and `cd` into
+  a matched directory. Assert no theme change occurs.
+- With the flag **off**, the right-click tab menu does not include
+  "Pin theme...", "Reset theme", or "Forget launch config theme".
+- Toggle the flag from **off** to **on** while a session is restored
+  with persisted slots from a prior preview run. Assert the persisted
+  `menu_pin`, `launch_config_pin`, and `window_default` slots resume
+  their effects without losing data, and `cwd_resolved` is recomputed
+  from current settings.
+- Toggle the flag from **on** to **off** mid-session. Assert all
+  themed tabs redraw with the global theme (or the cwd-stripped
+  fallback chain — but with the flag off, `effective()` collapses to
+  global). Persisted slot data is not cleared.
 
 ### Privacy invariant tests
 


### PR DESCRIPTION
## Description

Spec PR for [#478](https://github.com/warpdotdev/warp/issues/478) — *Allow for different theme per session, agent conversation, ssh, etc.* — which is labeled `ready-to-spec`. Per [`CONTRIBUTING.md`](https://github.com/warpdotdev/warp/blob/master/CONTRIBUTING.md), feature requests at this stage need a product + tech spec under `specs/GH<issue>/` before any code change.

This PR adds:

- `specs/GH478/product.md` — product spec with 15 numbered testable invariants, scope/non-scope, user-visible failure modes, and two open questions.
- `specs/GH478/tech.md` — tech spec grounded in real file:line references, structured per `CONTRIBUTING.md` (Context → Proposed changes → Testing and validation → Risks → Follow-ups).

### Scope of the proposal

Adds an optional `theme:` field to launch-configuration tab and window templates, persisted on `TabSnapshot`, and resolved at render time through a new `Appearance::theme_for(Option<&ThemeKind>)` accessor that falls back to the global theme when no override is present. Window chrome stays on the global theme; terminal cells and in-tab UI follow the override. Saving a layout round-trips overrides, with window-level coalescing when every tab in a window shares the same override.

### What this spec deliberately does **not** propose

These items are raised in the `#478` thread but are scoped out so this spec stays focused; each is listed as a follow-up that *consumes* the override field this spec introduces:

- Auto-theme by SSH host / hostname / cwd (`stevenchanin`, `pyronaur`, `zethon`, `janderegg`).
- Runtime escape-code or shell-hook protocol for setting a tab's theme (`yatharth`, for Claude Code session signaling).
- In-app per-tab theme picker submenu (open question in the product spec).
- Per-pane theming and per-tab wallpapers (`scottaw66`, `SheepDomination`).

### Relationship to #2618

[#2618](https://github.com/warpdotdev/warp/issues/2618) (*Set warp theme in launch configuration*) describes the same feature at a narrower scope and would close as a duplicate of #478 once this spec lands.

## Linked Issue

Closes #478 (spec-only — implementation will follow on this PR or a linked code PR per `CONTRIBUTING.md`).

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

> Spec-only PR: no implementation yet, so no screenshots. Visual verification is enumerated in `tech.md` under *Manual verification* and will be attached on the implementation PR.

## Screenshots / Videos

N/A — spec-only PR.

## Testing

No code changes in this PR. The tech spec's *Testing and validation* section enumerates the unit tests (launch-config YAML round-trip, `TabSnapshot` persistence, `Appearance::theme_for` fallback semantics), integration tests under `crates/integration/` (multi-tab launch configuration, global-theme change scoping, "Reset theme" menu, session-restore), and manual verification artifacts that the implementation PR will need to satisfy.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

Spec-only PR; no changelog entry per CONTRIBUTING.md ("omit only for docs-only or refactoring-only changes").
-->