### PR TITLE
fix: prevent misclassification of single-dash tokens as shorthand flag bundles

### DIFF
--- a/crates/warp_completer/src/completer/describe_test.rs
+++ b/crates/warp_completer/src/completer/describe_test.rs
@@ -13,7 +13,10 @@ use crate::completer::{
 use crate::completer::{suggest::SuggestionType, TopLevelCommandCaseSensitivity};
 use crate::meta::{Span, SpannedItem};
 use crate::signatures::{
-    testing::{add_content_signature, create_test_command_registry, git_signature, test_signature},
+    testing::{
+        add_content_signature, cmake_like_signature, create_test_command_registry,
+        git_signature, test_signature,
+    },
     CommandRegistry,
 };
 
@@ -532,5 +535,31 @@ fn test_describe_case_insensitive_option() {
     assert_eq!(
         describe_at_cursor("Add-Content -e ASCII", ByteOffset::from(14), &ctx),
         None
+    );
+}
+
+#[test]
+fn test_describe_does_not_misclassify_non_bundle_single_dash_tokens() {
+    let registry = create_test_command_registry([cmake_like_signature()]);
+    let ctx = FakeCompletionContext::new(registry);
+
+    // -DWITH_TESTS contains chars not in the known shorthand set, so it should
+    // NOT be described as an option via the shorthand bundle path.
+    assert_eq!(
+        describe_at_cursor("cmake_test -DWITH_TESTS", ByteOffset::from(11), &ctx),
+        None
+    );
+
+    // -DS with only shorthand chars (D, S) IS a valid bundle — this should still work.
+    assert_eq!(
+        describe_at_cursor("cmake_test -DS", ByteOffset::from(11), &ctx),
+        Some(Description {
+            token: "-DS".to_string().spanned(Span::new(11, 14)),
+            description_text: Some("source directory".to_string()),
+            suggestion_type: SuggestionType::Option(
+                MatchRequirement::EntireName,
+                OptionCaseSensitivity::CaseSensitive
+            )
+        })
     );
 }

--- a/crates/warp_completer/src/completer/engine/flag/legacy.rs
+++ b/crates/warp_completer/src/completer/engine/flag/legacy.rs
@@ -28,8 +28,8 @@ fn short_hand_flag_suggestions(
         .flatten()
         .collect();
 
-    let is_valid_shorthand_bundle = !partial_without_dashes.is_empty()
-        && partial_without_dashes
+    let is_valid_shorthand_bundle = partial_without_dashes.is_empty()
+        || partial_without_dashes
             .chars()
             .all(|c| known_shorthand_chars.contains(&c));
 

--- a/crates/warp_completer/src/completer/engine/flag/legacy.rs
+++ b/crates/warp_completer/src/completer/engine/flag/legacy.rs
@@ -1,5 +1,7 @@
 //! Contains the legacy implementation of flag suggestion generation that depends on the legacy
 //! command signature struct (`warp_command_signatures::Signature`).
+use std::collections::HashSet;
+
 use itertools::Itertools;
 use warp_command_signatures::{FlagStyle, Signature as SpecSignature};
 
@@ -20,6 +22,17 @@ fn short_hand_flag_suggestions(
     signature: &SpecSignature,
     partial_without_dashes: &str,
 ) -> impl Iterator<Item = MatchedSuggestion> {
+    let known_shorthand_chars: HashSet<char> = signature
+        .short_hand_flags()
+        .map(|flag| flag.name.chars().next())
+        .flatten()
+        .collect();
+
+    let is_valid_shorthand_bundle = !partial_without_dashes.is_empty()
+        && partial_without_dashes
+            .chars()
+            .all(|c| known_shorthand_chars.contains(&c));
+
     signature
         .short_hand_flags()
         .filter_map(|flag| {
@@ -38,7 +51,8 @@ fn short_hand_flag_suggestions(
                 .chars()
                 .last()
                 .is_some_and(|c| c.to_string() == flag.name);
-            let should_include_flag = !is_flag_already_included || is_current_flag;
+            let should_include_flag = is_valid_shorthand_bundle
+                && (!is_flag_already_included || is_current_flag);
             should_include_flag.then(|| {
                 let replacement_text = if is_current_flag {
                     // The replacement text should be exactly the existing flags.

--- a/crates/warp_completer/src/completer/engine/flag/v2.rs
+++ b/crates/warp_completer/src/completer/engine/flag/v2.rs
@@ -1,6 +1,7 @@
 //! Contains the v2 implementation of flag suggestion generation that depends on the JS-compatible
 //! command signature struct (`crate::signatures::CommandSignature`).
 use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::iter;
 
 use itertools::Itertools;
@@ -92,6 +93,19 @@ fn short_hand_flag_suggestions(
             return Box::new(iter::empty());
         };
 
+    let known_shorthand_chars: HashSet<char> = command_signature
+        .options
+        .iter()
+        .flat_map(|option| option.name.iter())
+        .filter(|name| is_short_hand_flag_name(name))
+        .filter_map(|name| name.trim_start_matches('-').chars().next())
+        .collect();
+
+    let is_valid_shorthand_bundle = !partial_flag_name.is_empty()
+        && partial_flag_name
+            .chars()
+            .all(|c| known_shorthand_chars.contains(&c));
+
     Box::new(
         command_signature
             .options
@@ -110,7 +124,9 @@ fn short_hand_flag_suggestions(
                         .chars()
                         .last()
                         .is_some_and(|c| c.to_string() == name_without_prefix);
-                    (!is_flag_already_included || is_current_flag).then(|| {
+                    (is_valid_shorthand_bundle
+                        && (!is_flag_already_included || is_current_flag))
+                    .then(|| {
                         let replacement_text = if is_current_flag {
                             // The replacement text should be exactly the existing flags.
                             format!("-{partial_flag_name}")

--- a/crates/warp_completer/src/completer/engine/flag/v2.rs
+++ b/crates/warp_completer/src/completer/engine/flag/v2.rs
@@ -101,8 +101,8 @@ fn short_hand_flag_suggestions(
         .filter_map(|name| name.trim_start_matches('-').chars().next())
         .collect();
 
-    let is_valid_shorthand_bundle = !partial_flag_name.is_empty()
-        && partial_flag_name
+    let is_valid_shorthand_bundle = partial_flag_name.is_empty()
+        || partial_flag_name
             .chars()
             .all(|c| known_shorthand_chars.contains(&c));
 

--- a/crates/warp_completer/src/signatures/testing/legacy.rs
+++ b/crates/warp_completer/src/signatures/testing/legacy.rs
@@ -1052,3 +1052,50 @@ fn create_hidden_argument_suggestion(name: impl Into<String>) -> ArgumentType {
         display_name: None,
     })
 }
+
+pub fn cmake_like_signature() -> Signature {
+    Signature {
+        name: "cmake_test".to_string(),
+        alias_generator: None,
+        description: None,
+        priority: Priority::default(),
+        arguments: None,
+        subcommands: None,
+        options: Some(vec![
+            Opt {
+                exact_string: vec!["-D".to_string()],
+                description: None,
+                arguments: Some(vec![Argument {
+                    display_name: Some("define".to_string()),
+                    description: None,
+                    is_variadic: false,
+                    is_command: false,
+                    argument_types: vec![],
+                    optional: IsArgumentOptional::Required,
+                    skip_generator_validation: false,
+                }]),
+                required: false,
+                priority: Priority::Default,
+            },
+            Opt {
+                exact_string: vec!["-S".to_string()],
+                description: Some("source directory".to_string()),
+                arguments: None,
+                required: false,
+                priority: Priority::Default,
+            },
+            Opt {
+                exact_string: vec!["-B".to_string()],
+                description: Some("build directory".to_string()),
+                arguments: None,
+                required: false,
+                priority: Priority::Default,
+            },
+        ]),
+        parser_directives: ParserDirectives {
+            flags_are_posix_noncompliant: false,
+            flags_match_unique_prefix: false,
+            always_case_insensitive: false,
+        },
+    }
+}

--- a/crates/warp_completer/src/signatures/testing/v2.rs
+++ b/crates/warp_completer/src/signatures/testing/v2.rs
@@ -664,3 +664,32 @@ pub fn npm_signature() -> CommandSignature {
         },
     }
 }
+
+pub fn cmake_like_signature() -> CommandSignature {
+    CommandSignature {
+        command: Command {
+            name: "cmake_test".to_owned(),
+            options: vec![
+                Opt {
+                    name: vec!["-D".to_owned()],
+                    arguments: vec![Argument {
+                        name: "define".to_owned(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                Opt {
+                    name: vec!["-S".to_owned()],
+                    description: Some("source directory".to_owned()),
+                    ..Default::default()
+                },
+                Opt {
+                    name: vec!["-B".to_owned()],
+                    description: Some("build directory".to_owned()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        },
+    }
+}


### PR DESCRIPTION
## Description

Single-dash tokens like `-DWITH_TESTS=OFF` were inconsistently highlighted as options because the shorthand bundle logic treated them as a series of short flags if the last character happened to match a known shorthand flag (e.g., `-S`).

The fix validates that **all** characters in the token (after stripping the leading dash) are known shorthand flag characters before applying the bundle logic. Tokens like `-DWITH_TESTS` that contain non-flag characters are no longer misclassified.

### Changes

- **`crates/warp_completer/src/completer/engine/flag/v2.rs`**: Pre-compute the set of known shorthand flag characters and validate that `partial_flag_name` is a valid shorthand bundle before applying the bundle matching logic.
- **`crates/warp_completer/src/completer/engine/flag/legacy.rs`**: Same fix for the legacy flag suggestion path.
- **`crates/warp_completer/src/signatures/testing/v2.rs`** + **`legacy.rs`**: Add `cmake_like_signature()` test helper with `-D`, `-S`, `-B` shorthand flags.
- **`crates/warp_completer/src/completer/describe_test.rs`**: Add regression test `test_describe_does_not_misclassify_non_bundle_single_dash_tokens` that verifies `-DWITH_TESTS` is not described as an option while `-DS` (a valid bundle) still works.

## Linked Issue

- [x] The linked issue is labeled `ready-to-implement`.
- Fixes #9820

## Testing

Added regression test that:
1. Asserts `-DWITH_TESTS` (contains non-shorthand chars) is NOT classified as an option
2. Asserts `-DS` (valid shorthand bundle of `-D` + `-S`) IS still correctly classified as an option

Test passes: `test_describe_does_not_misclassify_non_bundle_single_dash_tokens ... ok`

Co-Authored-By: Warp <agent@warp.dev>