### PR TITLE
[fix/3505] Chinese character rendering problem

### DIFF
--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -300,12 +300,16 @@ impl Default for TextLayoutSystem {
 
 impl TextLayoutSystem {
     pub fn new() -> Self {
+        let locale = std::env::var("LANG")
+            .ok()
+            .filter(|lang| !lang.is_empty())
+            .map(cosmic_text::Locale::new)
+            .unwrap_or_else(|| cosmic_text::Locale::new("en").expect("en is a valid locale"));
+
         Self {
             families: Default::default(),
             font_store: RwLock::new(cosmic_text::FontSystem::new_with_locale_and_db(
-                // Locale is needed for font fallback. For now, we hardcode this to "en" to match
-                // our mac implementation https://github.com/warpdotdev/warp-internal/blob/bf33d651a9fcece70df8eac35f89b0393ca5189a/ui/src/platform/mac/fonts.rs#L383.
-                "en".into(),
+                locale,
                 Default::default(),
             )),
             font_id_map: Default::default(),


### PR DESCRIPTION
## Problem
Chinese characters do not render correctly on first display. After any button press, they display correctly.

## Root Cause
On Linux/FreeBSD, the cosmic_text FontSystem was initialized with a hardcoded 'en' locale. The locale is used by cosmic_text to determine which fallback fonts to use for non-Latin characters like CJK.

## Fix
Read the LANG environment variable at TextLayoutSystem initialization and use it to configure the FontSystem locale. This ensures CJK characters display correctly on first render.

Fixes #3505