### PR TITLE
feat: surface Claude tool calls as inline text annotations (Slice B)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Local-AI bypass for the warpdotdev/warp fork.
+#
+# Loaded by `dotenvy::from_filename(".env")` at the very top of `run()` in app/src/lib.rs.
+# Copy to `.env` (gitignored) and uncomment the lines you want active.
+
+# Boot straight into a logged-in fake-user state. Skips the browser-check / paywall modal.
+# Implied (auto-on) whenever WARP_LOCAL_AI is set.
+# WARP_BYPASS_AUTH=1
+
+# Route agent runs to a local provider. One of: ollama | claude | codex.
+# - claude: shell out to the `claude` CLI (must be on PATH and authenticated).
+# - codex:  shell out to the `codex` CLI (must be on PATH and authenticated).
+# - ollama: NOT YET IMPLEMENTED (chat-only HTTP harness, planned for phase 2).
+# WARP_LOCAL_AI=claude
+
+# Prepended to every system prompt sent to the local agent. Inject ilo-lang context here.
+# Plain text only for now; path-loading not yet supported.
+# WARP_ILO_SYSTEM_PROMPT="You are an ilo-lang expert. Prefer ilo for token-minimal AI agent code."
+
+# Ollama settings (for phase 2, currently no-op):
+# OLLAMA_HOST=http://localhost:11434
+# OLLAMA_MODEL=qwen2.5-coder:7b

--- a/.env.example
+++ b/.env.example
@@ -4,15 +4,21 @@
 # Copy to `.env` (gitignored) and uncomment the lines you want active.
 
 # Boot straight into a logged-in fake-user state. Skips the browser-check / paywall modal.
+# This is the recommended way to run the local-model fork. The model-selector menu will
+# show the local model list (Claude, GPT-5.5 variants) and route to the matching CLI.
 # Implied (auto-on) whenever WARP_LOCAL_AI is set.
 # WARP_BYPASS_AUTH=1
 
-# Route agent runs to a local provider. One of: ollama | claude | codex.
-# - claude: shell out to the `claude` CLI (must be on PATH and authenticated).
-# - codex:  shell out to the `codex` CLI (must be on PATH and authenticated).
-# - ollama: NOT YET IMPLEMENTED (chat-only HTTP harness, planned for phase 2).
+# Legacy provider override (backwards compat). When set, overrides the default model
+# selection to the matching provider. The full model list still appears in the menu.
+# One of: claude | codex
+# (ollama: NOT YET IMPLEMENTED - planned for a future PR)
 # WARP_LOCAL_AI=claude
 
-# Ollama settings (for phase 2, currently no-op):
+# --- Provider credentials (not stored in code) ---
+
+# OpenRouter API key (required for OpenRouter models, planned for a future PR).
+# OPENROUTER_API_KEY=sk-or-...
+
+# Ollama base URL (defaults to http://localhost:11434 if not set, planned for a future PR).
 # OLLAMA_HOST=http://localhost:11434
-# OLLAMA_MODEL=qwen2.5-coder:7b

--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,6 @@
 # - ollama: NOT YET IMPLEMENTED (chat-only HTTP harness, planned for phase 2).
 # WARP_LOCAL_AI=claude
 
-# Prepended to every system prompt sent to the local agent. Inject ilo-lang context here.
-# Plain text only for now; path-loading not yet supported.
-# WARP_ILO_SYSTEM_PROMPT="You are an ilo-lang expert. Prefer ilo for token-minimal AI agent code."
-
 # Ollama settings (for phase 2, currently no-op):
 # OLLAMA_HOST=http://localhost:11434
 # OLLAMA_MODEL=qwen2.5-coder:7b

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ app/src/server/graphql/schema/generated
 crates/command-signatures-v2/js/build
 crates/command-signatures-v2/js/node_modules
 
+# Local-AI bypass: developer-local config (see .env.example)
+.env
+
 # For testing changes to the channel versions file
 channel_versions_test.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,6 +4158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14208,6 +14214,7 @@ dependencies = [
  "difflib 0.4.0 (git+https://github.com/warpdotdev/difflib.git?rev=114177e7d8e1f8017baca397f943e11644b14d63)",
  "directories",
  "dirs 6.0.0",
+ "dotenvy",
  "dunce",
  "email_address 0.2.3",
  "embed-resource",

--- a/README.md
+++ b/README.md
@@ -7,21 +7,11 @@ My personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). 
 
 ## Why this fork exists
 
-### 1. A local-AI version of Warp with cloud features stripped
+### A local-AI version of Warp with cloud features stripped
 
 I want to run Warp's terminal and agent UI without signing into Warp's cloud and without paying for Warp's hosted models. The fork swaps Warp's server-mediated AI path for direct calls to local CLIs I already have authenticated (`claude`, `codex`). It removes the auth gate. It hides cloud-only UI: the notifications inbox, the upgrade-required model badges, the "free AI disabled" modal.
 
 This is useful if you already pay for Claude or Codex and don't want a second AI subscription, if you want to keep agent traffic off a third-party server, or if you want to remix Warp's UI without the live cloud dependency.
-
-### 2. A testbench for ilo-lang
-
-I'm using this fork to test how my agent-optimised programming language, [**ilo-lang**](https://ilo-lang.ai), behaves when wired into a working developer tool. Ilo is token-minimal: programs are written and read primarily by LLMs, so every saved token compounds across millions of agent turns.
-
-This is iteration 3 of integrating ilo into a real agent loop. v1 was Claude Code with the ilo spec pasted manually into the system message. v2 was a Claude skill that loaded the ilo spec on demand. v3 is this fork: ilo context injected at the harness layer of a terminal that runs an agent loop on every keystroke, against whatever codebase I'm in. If ilo expresses agent prompts, tool definitions, and workflows in fewer tokens than Markdown, YAML, or JSON, the difference shows up in day-to-day work, not in a benchmark.
-
-Purpose 1 helps purpose 2: the local-AI bypass lets me run the same ilo system prompt against different LLMs (Claude, Codex, eventually Ollama) and compare token usage and output quality across them.
-
-`WARP_ILO_SYSTEM_PROMPT` is the first hook. It prepends ilo context to every agent turn. Later experiments will cover tool definitions in ilo, ilo-syntax slash commands, and ilo-encoded conversation summaries. What I learn lands back in [ilo-lang](https://github.com/danieljohnmorris/ilo-lang).
 
 **Forked from**: [`warpdotdev/warp@00df35b`](https://github.com/warpdotdev/warp/commit/00df35b5dc951b9ed9ac57f873ea0b0484f42ad6), May 2026.
 **Sync upstream**: `git fetch upstream master && git merge upstream/master`.
@@ -37,16 +27,12 @@ WARP_BYPASS_AUTH=1
 # Route agent runs to a local CLI. Currently supported: claude, codex.
 # Ollama is wired but not yet implemented.
 WARP_LOCAL_AI=claude
-
-# Optional: prepended to the system prompt of every local-AI run.
-WARP_ILO_SYSTEM_PROMPT="You are an ilo-lang expert."
 ```
 
 ## What's changed vs upstream
 
 - **Auth bypass**. `WARP_BYPASS_AUTH=1` short-circuits `AuthState::initialize` to a Test user, drops the `cfg(skip_login)` gates so `Credentials::Test` is available in OSS builds, and forces `is_any_ai_enabled` so the AI menu, Cmd+I binding, and agent-mode predicate light up.
 - **Local-AI harness override**. When `WARP_LOCAL_AI` is set, `harness_kind()` overrides the user's selection to the matching `ThirdParty` harness. A new `CodexHarness` shells `codex --full-auto`. The agent driver synthesises the `ResolvedHarnessPrompt` locally, so it never calls `ServerApi::resolve_prompt()`.
-- **ilo-lang context injection**. `WARP_ILO_SYSTEM_PROMPT` is prepended to every system prompt before the harness writes it to the temp file passed to the CLI subprocess.
 - **Notifications inbox hidden**. `HeaderToolbarItemKind::NotificationsMailbox::is_supported()` returns `false`, removing the inbox icon and dropdown from the header toolbar.
 - **`.env` loading**. dotenvy loads `.env` at the top of `run()`, from the cwd and from `~/.warp/.env`, so launching via `open WarpOss.app` (cwd = `/`) still picks up env vars.
 
@@ -54,7 +40,6 @@ WARP_ILO_SYSTEM_PROMPT="You are an ilo-lang expert."
 
 - The interactive agent panel still dispatches via `generate_multi_agent_output()` to Warp's GraphQL server. Under bypass this returns 401. The `WARP_LOCAL_AI` harness override only intercepts the `agent_sdk` CLI path. Routing the interactive UI to a local CLI requires synthesising a `warp_multi_agent_api::ResponseEvent` stream. Tracked as follow-up.
 - `WARP_LOCAL_AI=ollama` logs a warning and is not yet implemented.
-- `WARP_ILO_SYSTEM_PROMPT` accepts plain text only. Loading from a file path is a follow-up.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,25 @@ My personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). 
 > Not affiliated with or endorsed by Warp Inc. The upstream README (Warp's product description, contribution flow, support links) lives at [UPSTREAM_README.md](UPSTREAM_README.md).
 
 > [!NOTE]
-> This is the `main` branch: generic local-AI bypass. There's also an [`ilo`](https://github.com/danieljohnmorris/warp/tree/ilo) branch that extends this with ilo-lang context injection for agent runs. Use `main` if you want a vanilla local-AI Warp.
+> This is the `main` branch: purpose 1 only (local-AI bypass). Purpose 2 (ilo-lang testbench) lives on the [`ilo`](https://github.com/danieljohnmorris/warp/tree/ilo) branch.
 
 ## Why this fork exists
 
-### A local-AI version of Warp with cloud features stripped
+### 1. A local-AI version of Warp with cloud features stripped
 
 I want to run Warp's terminal and agent UI without signing into Warp's cloud and without paying for Warp's hosted models. The fork swaps Warp's server-mediated AI path for direct calls to local CLIs I already have authenticated (`claude`, `codex`). It removes the auth gate. It hides cloud-only UI: the notifications inbox, the upgrade-required model badges, the "free AI disabled" modal.
 
 This is useful if you already pay for Claude or Codex and don't want a second AI subscription, if you want to keep agent traffic off a third-party server, or if you want to remix Warp's UI without the live cloud dependency.
+
+### 2. A testbench for ilo-lang
+
+Implemented on the [`ilo`](https://github.com/danieljohnmorris/warp/tree/ilo) branch. This branch (`main`) does not include the ilo-lang context injection.
+
+I'm using this fork to test how my agent-optimised programming language, [**ilo-lang**](https://ilo-lang.ai), behaves when wired into a working developer tool. Ilo is token-minimal: programs are written and read primarily by LLMs, so every saved token compounds across millions of agent turns.
+
+This is iteration 3 of integrating ilo into a real agent loop. v1 was Claude Code with the ilo spec pasted manually into the system message. v2 was a Claude skill that loaded the ilo spec on demand. v3 is this fork: ilo context injected at the harness layer of a terminal that runs an agent loop on every keystroke, against whatever codebase I'm in. If ilo expresses agent prompts, tool definitions, and workflows in fewer tokens than Markdown, YAML, or JSON, the difference shows up in day-to-day work, not in a benchmark.
+
+Purpose 1 helps purpose 2: the local-AI bypass lets me run the same ilo system prompt against different LLMs (Claude, Codex, eventually Ollama) and compare token usage and output quality across them. See the [`ilo` branch](https://github.com/danieljohnmorris/warp/tree/ilo) for the implementation.
 
 **Forked from**: [`warpdotdev/warp@00df35b`](https://github.com/warpdotdev/warp/commit/00df35b5dc951b9ed9ac57f873ea0b0484f42ad6), May 2026.
 **Sync upstream**: `git fetch upstream master && git merge upstream/master`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ WARP_BYPASS_AUTH=1
 
 ## Known limitations
 
-- The interactive agent panel routes through a local CLI subprocess (`claude -p` / `codex exec`). Tool calls the CLI emits (file edits, shell commands) are not forwarded back to the Warp panel UI - only the assistant text reply is shown. Full tool-loop support requires a richer protocol bridge and is left as follow-up.
+- **Tool visibility (Slice B)**: The panel now shows inline text annotations for Claude tool calls: `[tool: Bash] echo hello` when the agent invokes a tool, and `[result] output` when the tool returns. Claude is invoked with `--output-format stream-json --verbose` so tool activity is visible in real-time. What's still missing: Warp's native tool-block UI (the rich block rendering you'd see in a cloud agent run). That requires mapping each `tool_use` event to an `api::message::ToolCall` protobuf message (Slice C), which is left as follow-up work.
+- **Codex tool visibility**: Codex events are still parsed from `codex exec --json`, which only surfaces `item.completed / agent_message` lines. Tool calls from Codex are not annotated.
 - **Ollama and OpenRouter models** are listed as planned entries in `.env.example` but not yet implemented. The menu currently shows only Claude and GPT-5.5 (codex) entries. Adding HTTP-based providers requires a new harness type and is deferred to a follow-up PR.
 - `WARP_LOCAL_AI=ollama` logs a warning and falls through to the cloud Oz path (a no-op in bypass mode).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ WARP_LOCAL_AI=claude
 
 ## Known limitations
 
-- The interactive agent panel still dispatches via `generate_multi_agent_output()` to Warp's GraphQL server. Under bypass this returns 401. The `WARP_LOCAL_AI` harness override only intercepts the `agent_sdk` CLI path. Routing the interactive UI to a local CLI requires synthesising a `warp_multi_agent_api::ResponseEvent` stream. Tracked as follow-up.
+- The interactive agent panel under `WARP_LOCAL_AI` routes through a local CLI subprocess (`claude -p` / `codex exec`). Tool calls the CLI emits (file edits, shell commands) are not forwarded back to the Warp panel UI - only the assistant text reply is shown. Full tool-loop support requires a richer protocol bridge and is left as follow-up.
 - `WARP_LOCAL_AI=ollama` logs a warning and is not yet implemented.
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ A personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). B
 > [!IMPORTANT]
 > Not affiliated with or endorsed by Warp Inc. The upstream README (Warp's product description, contribution flow, support links) lives at [UPSTREAM_README.md](UPSTREAM_README.md).
 
+## Why this fork exists
+
+This is a testbench for integrating [**ilo-lang**](https://ilo-lang.ai) — my agent-optimised, token-minimal programming language designed to be written and read by LLMs — into real developer tools. Warp is a useful first target because:
+
+- It's a *terminal* with a deeply embedded coding agent. If ilo can express agent prompts, tool definitions, and workflows in fewer tokens than Markdown / YAML / JSON, that should show up first in an environment that runs an agent loop on every keystroke.
+- The OSS codebase is large, idiomatic Rust with a clean entity-handle UI framework — a realistic test of how an "ilo-aware" agent navigates and modifies a non-trivial codebase, not a toy.
+- The local-AI bypass (`WARP_LOCAL_AI=claude|codex`) lets me swap providers without touching Warp's billing, so I can A/B different agents reading the same ilo system prompt and compare token usage / quality on a level playing field.
+
+The current `WARP_ILO_SYSTEM_PROMPT` env var is the seed of this experiment: a single hook for prepending ilo context to every agent turn. Future work in this fork will explore tool definitions in ilo, ilo-syntax slash commands, ilo-encoded conversation summaries, and similar bench tests. Findings will feed back into [ilo-lang](https://github.com/danieljohnmorris/ilo-lang).
+
 **Forked from**: [`warpdotdev/warp@00df35b`](https://github.com/warpdotdev/warp/commit/00df35b5dc951b9ed9ac57f873ea0b0484f42ad6) (2026-05-01).
 **Sync upstream**: `git fetch upstream master && git merge upstream/master`.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,46 @@
 
 <h1></h1>
 
+## Personal fork — danieljohnmorris/warp
+
+This is a personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). It removes the cloud-auth requirement so the OSS build boots straight into a local terminal, hides the notifications inbox, and adds plumbing to route AI agent runs to local CLIs (`claude`, `codex`) instead of Warp's cloud server.
+
+### Configuration (`.env`)
+
+The OSS build reads `~/.warp/.env` (or `./.env` from the cwd) at startup. See `.env.example` for the full list. Common usage:
+
+```env
+# Boot directly into a logged-in fake-user state. Skips the browser-check / paywall.
+WARP_BYPASS_AUTH=1
+
+# Route agent runs to a local CLI. Currently supported: claude, codex.
+# Ollama is wired but not yet implemented.
+WARP_LOCAL_AI=claude
+
+# Optional: prepended to the system prompt of every local-AI run.
+WARP_ILO_SYSTEM_PROMPT="You are an ilo-lang expert."
+```
+
+### What's changed vs upstream
+
+- **Auth bypass**: `WARP_BYPASS_AUTH=1` short-circuits `AuthState::initialize` to a Test user, drops the `cfg(skip_login)` gates so `Credentials::Test` is available in OSS builds, and forces `is_any_ai_enabled` so the AI menu, Cmd+I binding, and agent-mode predicate all light up.
+- **Local-AI harness override**: when `WARP_LOCAL_AI` is set, `harness_kind()` overrides the user's selection to the matching `ThirdParty` harness. New `CodexHarness` shells `codex --full-auto`. The agent driver synthesizes the `ResolvedHarnessPrompt` locally so it never calls `ServerApi::resolve_prompt()`.
+- **ilo-lang context injection**: `WARP_ILO_SYSTEM_PROMPT` is prepended to every system prompt before the harness writes it to the temp file passed to the CLI subprocess.
+- **Notifications inbox hidden**: `HeaderToolbarItemKind::NotificationsMailbox::is_supported()` returns `false`, removing the inbox icon and dropdown from the header toolbar.
+- **dotenvy** loads `.env` at the top of `run()` from cwd and `~/.warp/.env`, so launching via `open WarpOss.app` (cwd = `/`) still picks up env vars.
+
+### Known limitations
+
+- The interactive agent panel still dispatches via `generate_multi_agent_output()` → Warp's GraphQL server. Under bypass this returns 401. The `WARP_LOCAL_AI` harness override only intercepts the `agent_sdk` CLI path. Full interactive-UI routing to a local CLI requires synthesizing a `warp_multi_agent_api::ResponseEvent` stream, which is a tracked follow-up.
+- `WARP_LOCAL_AI=ollama` logs a warning and is not yet implemented.
+- `WARP_ILO_SYSTEM_PROMPT` accepts plain text only; loading from a file path is a follow-up.
+
+### Build
+
+Same as upstream: `./script/run` from this directory builds and bundles `WarpOss.app` to `target/debug/bundle/osx/`. See [Building the Repo Locally](#building-the-repo-locally) below.
+
+<h1></h1>
+
 ## About
 
 [Warp](https://www.warp.dev) is an agentic development environment, born out of the terminal. Use Warp's built-in coding agent, or bring your own CLI agent (Claude Code, Codex, Gemini CLI, and others).

--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@
 
 <h1></h1>
 
-## Personal fork — danieljohnmorris/warp
+## This fork
 
-This is a personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). It removes the cloud-auth requirement so the OSS build boots straight into a local terminal, hides the notifications inbox, and adds plumbing to route AI agent runs to local CLIs (`claude`, `codex`) instead of Warp's cloud server.
+This is my personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). It boots without server auth, hides the notifications inbox, and adds plumbing to route AI agent runs to local CLIs (`claude`, `codex`) instead of Warp's cloud. Not affiliated with or endorsed by Warp Inc.
+
+**Forked from**: [`warpdotdev/warp@00df35b`](https://github.com/warpdotdev/warp/commit/00df35b5dc951b9ed9ac57f873ea0b0484f42ad6) (2026-05-01).
+**Sync**: pull the latest upstream with `git fetch upstream master && git merge upstream/master`.
 
 ### Configuration (`.env`)
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ WARP_BYPASS_AUTH=1
 - **Local-AI harness override**. When `WARP_LOCAL_AI` is set, `harness_kind_with_model()` overrides the harness selection to the matching `ThirdParty` harness. A new `CodexHarness` shells `codex --full-auto`. The agent driver synthesises the `ResolvedHarnessPrompt` locally, so it never calls `ServerApi::resolve_prompt()`.
 - **Notifications inbox hidden**. `HeaderToolbarItemKind::NotificationsMailbox::is_supported()` returns `false`, removing the inbox icon and dropdown from the header toolbar.
 - **`.env` loading**. dotenvy loads `.env` at the top of `run()`, from the cwd and from `~/.warp/.env`, so launching via `open WarpOss.app` (cwd = `/`) still picks up env vars.
+- **`/init` cloud-only chips hidden**. The "create cloud-agent environment" prompt in the `/init` project-setup flow is suppressed when `WARP_BYPASS_AUTH` is active. The codebase indexing chip is also suppressed: the indexing pipeline sends code fragments to Warp's GraphQL backend for server-side embedding generation (OpenAI text-small-3 / Voyage models), so without a valid session token every `StoreClient` call would fail silently. Language-support installation still appears as normal.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ This is useful if you already pay for Claude or Codex and don't want a second AI
 
 I'm using this fork to test how my agent-optimised programming language, [**ilo-lang**](https://ilo-lang.ai), behaves when wired into a working developer tool. Ilo is token-minimal: programs are written and read primarily by LLMs, so every saved token compounds across millions of agent turns.
 
-Warp is a useful first target. It's a terminal with an embedded coding agent, so an agent loop runs on every keystroke. If ilo expresses agent prompts, tool definitions, and workflows in fewer tokens than Markdown, YAML, or JSON, the difference shows up here first.
-
-The codebase is also a real test for ilo. Around half a million lines of Rust, idiomatic, with a custom entity-handle UI framework. An "ilo-aware" agent has to navigate and modify production-shaped code, not a fixture.
+Warp is a useful first target. It's a terminal with an embedded coding agent, so an agent loop runs on every keystroke against whatever codebase I'm in. If ilo expresses agent prompts, tool definitions, and workflows in fewer tokens than Markdown, YAML, or JSON, the difference shows up in day-to-day work, not in a benchmark.
 
 Purpose 1 helps purpose 2: the local-AI bypass lets me run the same ilo system prompt against different LLMs (Claude, Codex, eventually Ollama) and compare token usage and output quality across them.
 

--- a/README.md
+++ b/README.md
@@ -35,24 +35,27 @@ The OSS build reads `~/.warp/.env`, then `./.env` from the cwd, at startup. See 
 
 ```env
 # Boot directly into a logged-in fake-user state. Skips the browser-check / paywall.
+# The model-selector menu (footer button) will show the local model list.
 WARP_BYPASS_AUTH=1
 
-# Route agent runs to a local CLI. Currently supported: claude, codex.
-# Ollama is wired but not yet implemented.
-WARP_LOCAL_AI=claude
+# Optional: override the default menu selection to a specific provider.
+# Supported: claude, codex. (Ollama planned - see Known limitations.)
+# WARP_LOCAL_AI=claude
 ```
 
 ## What's changed vs upstream
 
 - **Auth bypass**. `WARP_BYPASS_AUTH=1` short-circuits `AuthState::initialize` to a Test user, drops the `cfg(skip_login)` gates so `Credentials::Test` is available in OSS builds, and forces `is_any_ai_enabled` so the AI menu, Cmd+I binding, and agent-mode predicate light up.
-- **Local-AI harness override**. When `WARP_LOCAL_AI` is set, `harness_kind()` overrides the user's selection to the matching `ThirdParty` harness. A new `CodexHarness` shells `codex --full-auto`. The agent driver synthesises the `ResolvedHarnessPrompt` locally, so it never calls `ServerApi::resolve_prompt()`.
+- **Local-model selector**. When `WARP_BYPASS_AUTH=1` is set, the model-selector menu (footer button) replaces Warp's server-fetched model list with a local set: Claude Sonnet 4.7, Opus 4.7, Haiku 4.5, and GPT-5.5 at low/medium/high reasoning effort. Selecting a model routes the panel agent to the corresponding CLI (`claude -p --model ...` or `codex exec -m ...`). The selection persists across restarts via Warp's existing profile persistence.
+- **Local-AI harness override**. When `WARP_LOCAL_AI` is set, `harness_kind_with_model()` overrides the harness selection to the matching `ThirdParty` harness. A new `CodexHarness` shells `codex --full-auto`. The agent driver synthesises the `ResolvedHarnessPrompt` locally, so it never calls `ServerApi::resolve_prompt()`.
 - **Notifications inbox hidden**. `HeaderToolbarItemKind::NotificationsMailbox::is_supported()` returns `false`, removing the inbox icon and dropdown from the header toolbar.
 - **`.env` loading**. dotenvy loads `.env` at the top of `run()`, from the cwd and from `~/.warp/.env`, so launching via `open WarpOss.app` (cwd = `/`) still picks up env vars.
 
 ## Known limitations
 
-- The interactive agent panel under `WARP_LOCAL_AI` routes through a local CLI subprocess (`claude -p` / `codex exec`). Tool calls the CLI emits (file edits, shell commands) are not forwarded back to the Warp panel UI - only the assistant text reply is shown. Full tool-loop support requires a richer protocol bridge and is left as follow-up.
-- `WARP_LOCAL_AI=ollama` logs a warning and is not yet implemented.
+- The interactive agent panel routes through a local CLI subprocess (`claude -p` / `codex exec`). Tool calls the CLI emits (file edits, shell commands) are not forwarded back to the Warp panel UI - only the assistant text reply is shown. Full tool-loop support requires a richer protocol bridge and is left as follow-up.
+- **Ollama and OpenRouter models** are listed as planned entries in `.env.example` but not yet implemented. The menu currently shows only Claude and GPT-5.5 (codex) entries. Adding HTTP-based providers requires a new harness type and is deferred to a follow-up PR.
+- `WARP_LOCAL_AI=ollama` logs a warning and falls through to the cloud Oz path (a no-op in bypass mode).
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,16 @@
-<a href="https://www.warp.dev">
-    <img width="1024" alt="Warp Agentic Development Environment product preview" src="https://github.com/user-attachments/assets/9976b2da-2edd-4604-a36c-8fd53719c6d4" />
-</a>
+# danieljohnmorris/warp · personal fork
 
-<p align="center">
-  <a href="https://www.warp.dev">Website</a>
-  ·
-  <a href="https://www.warp.dev/code">Code</a>
-  ·
-  <a href="https://www.warp.dev/agents">Agents</a>
-  ·
-  <a href="https://www.warp.dev/terminal">Terminal</a>
-  ·
-  <a href="https://www.warp.dev/drive">Drive</a>
-  ·
-  <a href="https://docs.warp.dev">Docs</a>
-  ·
-  <a href="https://www.warp.dev/blog/how-warp-works">How Warp Works</a>
-</p>
+A personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). Boots the OSS build without server auth, hides the notifications inbox, and adds plumbing to route AI agent runs to local CLIs (`claude`, `codex`) instead of Warp's cloud.
 
-> [!NOTE]
-> OpenAI is the founding sponsor of the new, open-source Warp repository, and the new agentic management workflows are powered by GPT models.
-
-<h1></h1>
-
-## This fork
-
-This is my personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). It boots without server auth, hides the notifications inbox, and adds plumbing to route AI agent runs to local CLIs (`claude`, `codex`) instead of Warp's cloud. Not affiliated with or endorsed by Warp Inc.
+> [!IMPORTANT]
+> Not affiliated with or endorsed by Warp Inc. The upstream README (Warp's product description, contribution flow, support links) lives at [UPSTREAM_README.md](UPSTREAM_README.md).
 
 **Forked from**: [`warpdotdev/warp@00df35b`](https://github.com/warpdotdev/warp/commit/00df35b5dc951b9ed9ac57f873ea0b0484f42ad6) (2026-05-01).
-**Sync**: pull the latest upstream with `git fetch upstream master && git merge upstream/master`.
+**Sync upstream**: `git fetch upstream master && git merge upstream/master`.
 
-### Configuration (`.env`)
+## Configuration (`.env`)
 
-The OSS build reads `~/.warp/.env` (or `./.env` from the cwd) at startup. See `.env.example` for the full list. Common usage:
+The OSS build reads `~/.warp/.env` (or `./.env` from the cwd) at startup. See [`.env.example`](.env.example) for the full list. Common usage:
 
 ```env
 # Boot directly into a logged-in fake-user state. Skips the browser-check / paywall.
@@ -46,87 +24,33 @@ WARP_LOCAL_AI=claude
 WARP_ILO_SYSTEM_PROMPT="You are an ilo-lang expert."
 ```
 
-### What's changed vs upstream
+## What's changed vs upstream
 
 - **Auth bypass**: `WARP_BYPASS_AUTH=1` short-circuits `AuthState::initialize` to a Test user, drops the `cfg(skip_login)` gates so `Credentials::Test` is available in OSS builds, and forces `is_any_ai_enabled` so the AI menu, Cmd+I binding, and agent-mode predicate all light up.
 - **Local-AI harness override**: when `WARP_LOCAL_AI` is set, `harness_kind()` overrides the user's selection to the matching `ThirdParty` harness. New `CodexHarness` shells `codex --full-auto`. The agent driver synthesizes the `ResolvedHarnessPrompt` locally so it never calls `ServerApi::resolve_prompt()`.
 - **ilo-lang context injection**: `WARP_ILO_SYSTEM_PROMPT` is prepended to every system prompt before the harness writes it to the temp file passed to the CLI subprocess.
 - **Notifications inbox hidden**: `HeaderToolbarItemKind::NotificationsMailbox::is_supported()` returns `false`, removing the inbox icon and dropdown from the header toolbar.
-- **dotenvy** loads `.env` at the top of `run()` from cwd and `~/.warp/.env`, so launching via `open WarpOss.app` (cwd = `/`) still picks up env vars.
+- **`.env` loading**: dotenvy loads `.env` at the top of `run()` from cwd and `~/.warp/.env`, so launching via `open WarpOss.app` (cwd = `/`) still picks up env vars.
 
-### Known limitations
+## Known limitations
 
-- The interactive agent panel still dispatches via `generate_multi_agent_output()` → Warp's GraphQL server. Under bypass this returns 401. The `WARP_LOCAL_AI` harness override only intercepts the `agent_sdk` CLI path. Full interactive-UI routing to a local CLI requires synthesizing a `warp_multi_agent_api::ResponseEvent` stream, which is a tracked follow-up.
+- The interactive agent panel still dispatches via `generate_multi_agent_output()` → Warp's GraphQL server. Under bypass this returns 401. The `WARP_LOCAL_AI` harness override only intercepts the `agent_sdk` CLI path. Full interactive-UI routing to a local CLI requires synthesizing a `warp_multi_agent_api::ResponseEvent` stream — tracked follow-up.
 - `WARP_LOCAL_AI=ollama` logs a warning and is not yet implemented.
 - `WARP_ILO_SYSTEM_PROMPT` accepts plain text only; loading from a file path is a follow-up.
 
-### Build
+## Build
 
-Same as upstream: `./script/run` from this directory builds and bundles `WarpOss.app` to `target/debug/bundle/osx/`. See [Building the Repo Locally](#building-the-repo-locally) below.
+```bash
+./script/bootstrap   # one-time platform setup (Xcode tools, brew, rustup)
+./script/run         # build + bundle + launch WarpOss.app
+```
 
-<h1></h1>
-
-## About
-
-[Warp](https://www.warp.dev) is an agentic development environment, born out of the terminal. Use Warp's built-in coding agent, or bring your own CLI agent (Claude Code, Codex, Gemini CLI, and others).
-
-## Installation
-
-You can [download Warp](https://www.warp.dev/download) and [read our docs](https://docs.warp.dev/) for platform-specific instructions.
+For everything else (engineering guide, coding style, testing, platform notes), see [WARP.md](WARP.md).
 
 ## Licensing
 
-Warp's UI framework (the `warpui_core` and `warpui` crates) are licensed under the [MIT license](LICENSE-MIT).
+Same as upstream: `warpui_core` and `warpui` crates are [MIT](LICENSE-MIT); everything else is [AGPL v3](LICENSE-AGPL). My changes inherit the AGPL of the files they edit.
 
-The rest of the code in this repository is licensed under the [AGPL v3](LICENSE-AGPL).
+---
 
-## Open Source & Contributing
-
-Warp's client codebase is open source and lives in this repository. We welcome community contributions and have designed a lightweight workflow to help new contributors get started. For the full contribution flow, read our [CONTRIBUTING.md](CONTRIBUTING.md) guide.
-
-### Issue to PR
-
-Before filing, [search existing issues](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) for your bug or feature request. If nothing exists, [file an issue](https://github.com/warpdotdev/warp/issues/new/choose) using our templates. Security vulnerabilities should be reported privately as described in [CONTRIBUTING.md](CONTRIBUTING.md#reporting-security-issues).
-
-Once filed, a Warp maintainer reviews the issue and may apply a readiness label: [`ready-to-spec`](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+label%3Aready-to-spec) signals the design is open for contributors to spec out, and [`ready-to-implement`](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+label%3Aready-to-implement) signals the design is settled and code PRs are welcome. Anyone can pick up a labeled issue — mention **@oss-maintainers** on an issue if you'd like it considered for a readiness label.
-
-### Building the Repo Locally
-
-To build and run Warp from source:
-
-```bash
-./script/bootstrap   # platform-specific setup
-./script/run         # build and run Warp
-./script/presubmit   # fmt, clippy, and tests
-```
-
-See [WARP.md](WARP.md) for the full engineering guide, including coding style, testing, and platform-specific notes.
-
-## Joining the Team
-
-Interested in joining the team? See our [open roles](https://www.warp.dev/careers).
-
-## Support and Questions
-
-1. See our [docs](https://docs.warp.dev/) for a comprehensive guide to Warp's features.
-2. Join our [Slack Community](https://go.warp.dev/join-preview) to connect with other users and get help from the Warp team.
-3. Try our [Preview build](https://www.warp.dev/download-preview) to test the latest experimental features.
-4. Mention **@oss-maintainers** on any issue to escalate to the team — for example, if you encounter problems with the automated agents.
-
-## Code of Conduct
-
-We ask everyone to be respectful and empathetic. Warp follows the [Code of Conduct](CODE_OF_CONDUCT.md). To report violations, email warp-coc at warp.dev.
-
-## Open Source Dependencies
-
-We'd like to call out a few of the [open source dependencies](https://docs.warp.dev/help/licenses) that have helped Warp to get off the ground:
-
-* [Tokio](https://github.com/tokio-rs/tokio)
-* [NuShell](https://github.com/nushell/nushell)
-* [Fig Completion Specs](https://github.com/withfig/autocomplete)
-* [Warp Server Framework](https://github.com/seanmonstar/warp)
-* [Alacritty](https://github.com/alacritty/alacritty)
-* [Hyper HTTP library](https://github.com/hyperium/hyper)
-* [FontKit](https://github.com/servo/font-kit)
-* [Core-foundation](https://github.com/servo/core-foundation-rs)
-* [Smol](https://github.com/smol-rs/smol)
+→ Looking for the original project? Read [the upstream Warp README](UPSTREAM_README.md).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Two reasons, in priority order.
 
 I want to run Warp's terminal and agent UI without signing into Warp's cloud and without paying for Warp's hosted models. The fork swaps Warp's server-mediated AI path for direct calls to local CLIs I already have authenticated (`claude`, `codex`). It removes the auth gate. It hides cloud-only UI: the notifications inbox, the upgrade-required model badges, the "free AI disabled" modal.
 
-This is useful if you already pay for Claude or Codex and don't want a second AI subscription, if you want to keep agent traffic off a third-party server, or if you want to hack on Warp's UI without the live cloud dependency.
+This is useful if you already pay for Claude or Codex and don't want a second AI subscription, if you want to keep agent traffic off a third-party server, or if you want to remix Warp's UI without the live cloud dependency.
 
 ### 2. A testbench for ilo-lang
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is useful if you already pay for Claude or Codex and don't want a second AI
 
 I'm using this fork to test how my agent-optimised programming language, [**ilo-lang**](https://ilo-lang.ai), behaves when wired into a working developer tool. Ilo is token-minimal: programs are written and read primarily by LLMs, so every saved token compounds across millions of agent turns.
 
-Warp is a useful first target. It's a terminal with an embedded coding agent, so an agent loop runs on every keystroke against whatever codebase I'm in. If ilo expresses agent prompts, tool definitions, and workflows in fewer tokens than Markdown, YAML, or JSON, the difference shows up in day-to-day work, not in a benchmark.
+This is iteration 3 of integrating ilo into a real agent loop. v1 was Claude Code with the ilo spec pasted manually into the system message. v2 was a Claude skill that loaded the ilo spec on demand. v3 is this fork: ilo context injected at the harness layer of a terminal that runs an agent loop on every keystroke, against whatever codebase I'm in. If ilo expresses agent prompts, tool definitions, and workflows in fewer tokens than Markdown, YAML, or JSON, the difference shows up in day-to-day work, not in a benchmark.
 
 Purpose 1 helps purpose 2: the local-AI bypass lets me run the same ilo system prompt against different LLMs (Claude, Codex, eventually Ollama) and compare token usage and output quality across them.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ My personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). 
 > [!IMPORTANT]
 > Not affiliated with or endorsed by Warp Inc. The upstream README (Warp's product description, contribution flow, support links) lives at [UPSTREAM_README.md](UPSTREAM_README.md).
 
+> [!NOTE]
+> This is the `main` branch: generic local-AI bypass. There's also an [`ilo`](https://github.com/danieljohnmorris/warp/tree/ilo) branch that extends this with ilo-lang context injection for agent runs. Use `main` if you want a vanilla local-AI Warp.
+
 ## Why this fork exists
 
 ### A local-AI version of Warp with cloud features stripped

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ WARP_LOCAL_AI=claude
 
 For everything else (engineering guide, coding style, testing, platform notes), see [WARP.md](WARP.md).
 
+## Related work
+
+[`regismesquita/warp-with-local-server`](https://github.com/regismesquita/warp-with-local-server) takes a different route to the same goal. It runs a local OpenAI-compatible shim server that intercepts Warp's GraphQL/WebSocket calls and translates them to any OpenAI-compatible upstream (Anthropic, OpenAI, Ollama, LiteLLM). Network-layer interception, vs this fork's harness-layer override that shells out to local CLIs.
+
 ## Licensing
 
 Same as upstream. `warpui_core` and `warpui` crates are [MIT](LICENSE-MIT). The rest of the repo is [AGPL v3](LICENSE-AGPL). My changes inherit the AGPL of the files they edit.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,38 @@
 # danieljohnmorris/warp · personal fork
 
-A personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). Boots the OSS build without server auth, hides the notifications inbox, and adds plumbing to route AI agent runs to local CLIs (`claude`, `codex`) instead of Warp's cloud.
+My personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). The OSS build boots without server auth, the notifications inbox is gone, and agent runs route to local CLIs (`claude`, `codex`) instead of Warp's cloud.
 
 > [!IMPORTANT]
 > Not affiliated with or endorsed by Warp Inc. The upstream README (Warp's product description, contribution flow, support links) lives at [UPSTREAM_README.md](UPSTREAM_README.md).
 
 ## Why this fork exists
 
-This is a testbench for integrating [**ilo-lang**](https://ilo-lang.ai) — my agent-optimised, token-minimal programming language designed to be written and read by LLMs — into real developer tools. Warp is a useful first target because:
+Two reasons, in priority order.
 
-- It's a *terminal* with a deeply embedded coding agent. If ilo can express agent prompts, tool definitions, and workflows in fewer tokens than Markdown / YAML / JSON, that should show up first in an environment that runs an agent loop on every keystroke.
-- The OSS codebase is large, idiomatic Rust with a clean entity-handle UI framework — a realistic test of how an "ilo-aware" agent navigates and modifies a non-trivial codebase, not a toy.
-- The local-AI bypass (`WARP_LOCAL_AI=claude|codex`) lets me swap providers without touching Warp's billing, so I can A/B different agents reading the same ilo system prompt and compare token usage / quality on a level playing field.
+### 1. A local-AI version of Warp with cloud features stripped
 
-The current `WARP_ILO_SYSTEM_PROMPT` env var is the seed of this experiment: a single hook for prepending ilo context to every agent turn. Future work in this fork will explore tool definitions in ilo, ilo-syntax slash commands, ilo-encoded conversation summaries, and similar bench tests. Findings will feed back into [ilo-lang](https://github.com/danieljohnmorris/ilo-lang).
+I want to run Warp's terminal and agent UI without signing into Warp's cloud and without paying for Warp's hosted models. The fork swaps Warp's server-mediated AI path for direct calls to local CLIs I already have authenticated (`claude`, `codex`). It removes the auth gate. It hides cloud-only UI: the notifications inbox, the upgrade-required model badges, the "free AI disabled" modal.
 
-**Forked from**: [`warpdotdev/warp@00df35b`](https://github.com/warpdotdev/warp/commit/00df35b5dc951b9ed9ac57f873ea0b0484f42ad6) (2026-05-01).
+This is useful if you already pay for Claude or Codex and don't want a second AI subscription, if you want to keep agent traffic off a third-party server, or if you want to hack on Warp's UI without the live cloud dependency.
+
+### 2. A testbench for ilo-lang
+
+I'm using this fork to test how my agent-optimised programming language, [**ilo-lang**](https://ilo-lang.ai), behaves when wired into a working developer tool. Ilo is token-minimal: programs are written and read primarily by LLMs, so every saved token compounds across millions of agent turns.
+
+Warp is a useful first target. It's a terminal with an embedded coding agent, so an agent loop runs on every keystroke. If ilo expresses agent prompts, tool definitions, and workflows in fewer tokens than Markdown, YAML, or JSON, the difference shows up here first.
+
+The codebase is also a real test for ilo. Around half a million lines of Rust, idiomatic, with a custom entity-handle UI framework. An "ilo-aware" agent has to navigate and modify production-shaped code, not a fixture.
+
+Purpose 1 helps purpose 2: the local-AI bypass lets me run the same ilo system prompt against different LLMs (Claude, Codex, eventually Ollama) and compare token usage and output quality across them.
+
+`WARP_ILO_SYSTEM_PROMPT` is the first hook. It prepends ilo context to every agent turn. Later experiments will cover tool definitions in ilo, ilo-syntax slash commands, and ilo-encoded conversation summaries. What I learn lands back in [ilo-lang](https://github.com/danieljohnmorris/ilo-lang).
+
+**Forked from**: [`warpdotdev/warp@00df35b`](https://github.com/warpdotdev/warp/commit/00df35b5dc951b9ed9ac57f873ea0b0484f42ad6), May 2026.
 **Sync upstream**: `git fetch upstream master && git merge upstream/master`.
 
 ## Configuration (`.env`)
 
-The OSS build reads `~/.warp/.env` (or `./.env` from the cwd) at startup. See [`.env.example`](.env.example) for the full list. Common usage:
+The OSS build reads `~/.warp/.env`, then `./.env` from the cwd, at startup. See [`.env.example`](.env.example) for the full list.
 
 ```env
 # Boot directly into a logged-in fake-user state. Skips the browser-check / paywall.
@@ -36,31 +48,31 @@ WARP_ILO_SYSTEM_PROMPT="You are an ilo-lang expert."
 
 ## What's changed vs upstream
 
-- **Auth bypass**: `WARP_BYPASS_AUTH=1` short-circuits `AuthState::initialize` to a Test user, drops the `cfg(skip_login)` gates so `Credentials::Test` is available in OSS builds, and forces `is_any_ai_enabled` so the AI menu, Cmd+I binding, and agent-mode predicate all light up.
-- **Local-AI harness override**: when `WARP_LOCAL_AI` is set, `harness_kind()` overrides the user's selection to the matching `ThirdParty` harness. New `CodexHarness` shells `codex --full-auto`. The agent driver synthesizes the `ResolvedHarnessPrompt` locally so it never calls `ServerApi::resolve_prompt()`.
-- **ilo-lang context injection**: `WARP_ILO_SYSTEM_PROMPT` is prepended to every system prompt before the harness writes it to the temp file passed to the CLI subprocess.
-- **Notifications inbox hidden**: `HeaderToolbarItemKind::NotificationsMailbox::is_supported()` returns `false`, removing the inbox icon and dropdown from the header toolbar.
-- **`.env` loading**: dotenvy loads `.env` at the top of `run()` from cwd and `~/.warp/.env`, so launching via `open WarpOss.app` (cwd = `/`) still picks up env vars.
+- **Auth bypass**. `WARP_BYPASS_AUTH=1` short-circuits `AuthState::initialize` to a Test user, drops the `cfg(skip_login)` gates so `Credentials::Test` is available in OSS builds, and forces `is_any_ai_enabled` so the AI menu, Cmd+I binding, and agent-mode predicate light up.
+- **Local-AI harness override**. When `WARP_LOCAL_AI` is set, `harness_kind()` overrides the user's selection to the matching `ThirdParty` harness. A new `CodexHarness` shells `codex --full-auto`. The agent driver synthesises the `ResolvedHarnessPrompt` locally, so it never calls `ServerApi::resolve_prompt()`.
+- **ilo-lang context injection**. `WARP_ILO_SYSTEM_PROMPT` is prepended to every system prompt before the harness writes it to the temp file passed to the CLI subprocess.
+- **Notifications inbox hidden**. `HeaderToolbarItemKind::NotificationsMailbox::is_supported()` returns `false`, removing the inbox icon and dropdown from the header toolbar.
+- **`.env` loading**. dotenvy loads `.env` at the top of `run()`, from the cwd and from `~/.warp/.env`, so launching via `open WarpOss.app` (cwd = `/`) still picks up env vars.
 
 ## Known limitations
 
-- The interactive agent panel still dispatches via `generate_multi_agent_output()` → Warp's GraphQL server. Under bypass this returns 401. The `WARP_LOCAL_AI` harness override only intercepts the `agent_sdk` CLI path. Full interactive-UI routing to a local CLI requires synthesizing a `warp_multi_agent_api::ResponseEvent` stream — tracked follow-up.
+- The interactive agent panel still dispatches via `generate_multi_agent_output()` to Warp's GraphQL server. Under bypass this returns 401. The `WARP_LOCAL_AI` harness override only intercepts the `agent_sdk` CLI path. Routing the interactive UI to a local CLI requires synthesising a `warp_multi_agent_api::ResponseEvent` stream. Tracked as follow-up.
 - `WARP_LOCAL_AI=ollama` logs a warning and is not yet implemented.
-- `WARP_ILO_SYSTEM_PROMPT` accepts plain text only; loading from a file path is a follow-up.
+- `WARP_ILO_SYSTEM_PROMPT` accepts plain text only. Loading from a file path is a follow-up.
 
 ## Build
 
 ```bash
 ./script/bootstrap   # one-time platform setup (Xcode tools, brew, rustup)
-./script/run         # build + bundle + launch WarpOss.app
+./script/run         # build, bundle, launch WarpOss.app
 ```
 
 For everything else (engineering guide, coding style, testing, platform notes), see [WARP.md](WARP.md).
 
 ## Licensing
 
-Same as upstream: `warpui_core` and `warpui` crates are [MIT](LICENSE-MIT); everything else is [AGPL v3](LICENSE-AGPL). My changes inherit the AGPL of the files they edit.
+Same as upstream. `warpui_core` and `warpui` crates are [MIT](LICENSE-MIT). The rest of the repo is [AGPL v3](LICENSE-AGPL). My changes inherit the AGPL of the files they edit.
 
 ---
 
-→ Looking for the original project? Read [the upstream Warp README](UPSTREAM_README.md).
+Looking for the original project? Read [the upstream Warp README](UPSTREAM_README.md).

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ My personal AGPL fork of [warpdotdev/warp](https://github.com/warpdotdev/warp). 
 
 ## Why this fork exists
 
-Two reasons, in priority order.
-
 ### 1. A local-AI version of Warp with cloud features stripped
 
 I want to run Warp's terminal and agent UI without signing into Warp's cloud and without paying for Warp's hosted models. The fork swaps Warp's server-mediated AI path for direct calls to local CLIs I already have authenticated (`claude`, `codex`). It removes the auth gate. It hides cloud-only UI: the notifications inbox, the upgrade-required model badges, the "free AI disabled" modal.

--- a/UPSTREAM_README.md
+++ b/UPSTREAM_README.md
@@ -1,0 +1,94 @@
+<!--
+This is an unmodified copy of the upstream warpdotdev/warp README, preserved
+verbatim under AGPL v3. The fork-specific README lives at ./README.md.
+-->
+
+<a href="https://www.warp.dev">
+    <img width="1024" alt="Warp Agentic Development Environment product preview" src="https://github.com/user-attachments/assets/9976b2da-2edd-4604-a36c-8fd53719c6d4" />
+</a>
+
+<p align="center">
+  <a href="https://www.warp.dev">Website</a>
+  ·
+  <a href="https://www.warp.dev/code">Code</a>
+  ·
+  <a href="https://www.warp.dev/agents">Agents</a>
+  ·
+  <a href="https://www.warp.dev/terminal">Terminal</a>
+  ·
+  <a href="https://www.warp.dev/drive">Drive</a>
+  ·
+  <a href="https://docs.warp.dev">Docs</a>
+  ·
+  <a href="https://www.warp.dev/blog/how-warp-works">How Warp Works</a>
+</p>
+
+> [!NOTE]
+> OpenAI is the founding sponsor of the new, open-source Warp repository, and the new agentic management workflows are powered by GPT models.
+
+<h1></h1>
+
+## About
+
+[Warp](https://www.warp.dev) is an agentic development environment, born out of the terminal. Use Warp's built-in coding agent, or bring your own CLI agent (Claude Code, Codex, Gemini CLI, and others).
+
+## Installation
+
+You can [download Warp](https://www.warp.dev/download) and [read our docs](https://docs.warp.dev/) for platform-specific instructions.
+
+## Licensing
+
+Warp's UI framework (the `warpui_core` and `warpui` crates) are licensed under the [MIT license](LICENSE-MIT).
+
+The rest of the code in this repository is licensed under the [AGPL v3](LICENSE-AGPL).
+
+## Open Source & Contributing
+
+Warp's client codebase is open source and lives in this repository. We welcome community contributions and have designed a lightweight workflow to help new contributors get started. For the full contribution flow, read our [CONTRIBUTING.md](CONTRIBUTING.md) guide.
+
+### Issue to PR
+
+Before filing, [search existing issues](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) for your bug or feature request. If nothing exists, [file an issue](https://github.com/warpdotdev/warp/issues/new/choose) using our templates. Security vulnerabilities should be reported privately as described in [CONTRIBUTING.md](CONTRIBUTING.md#reporting-security-issues).
+
+Once filed, a Warp maintainer reviews the issue and may apply a readiness label: [`ready-to-spec`](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+label%3Aready-to-spec) signals the design is open for contributors to spec out, and [`ready-to-implement`](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+is%3Aopen+label%3Aready-to-implement) signals the design is settled and code PRs are welcome. Anyone can pick up a labeled issue — mention **@oss-maintainers** on an issue if you'd like it considered for a readiness label.
+
+### Building the Repo Locally
+
+To build and run Warp from source:
+
+```bash
+./script/bootstrap   # platform-specific setup
+./script/run         # build and run Warp
+./script/presubmit   # fmt, clippy, and tests
+```
+
+See [WARP.md](WARP.md) for the full engineering guide, including coding style, testing, and platform-specific notes.
+
+## Joining the Team
+
+Interested in joining the team? See our [open roles](https://www.warp.dev/careers).
+
+## Support and Questions
+
+1. See our [docs](https://docs.warp.dev/) for a comprehensive guide to Warp's features.
+2. Join our [Slack Community](https://go.warp.dev/join-preview) to connect with other users and get help from the Warp team.
+3. Try our [Preview build](https://www.warp.dev/download-preview) to test the latest experimental features.
+4. Mention **@oss-maintainers** on any issue to escalate to the team — for example, if you encounter problems with the automated agents.
+
+## Code of Conduct
+
+We ask everyone to be respectful and empathetic. Warp follows the [Code of Conduct](CODE_OF_CONDUCT.md). To report violations, email warp-coc at warp.dev.
+
+## Open Source Dependencies
+
+We'd like to call out a few of the [open source dependencies](https://docs.warp.dev/help/licenses) that have helped Warp to get off the ground:
+
+* [Tokio](https://github.com/tokio-rs/tokio)
+* [NuShell](https://github.com/nushell/nushell)
+* [Fig Completion Specs](https://github.com/withfig/autocomplete)
+* [Warp Server Framework](https://github.com/seanmonstar/warp)
+* [Alacritty](https://github.com/alacritty/alacritty)
+* [Hyper HTTP library](https://github.com/hyperium/hyper)
+* [FontKit](https://github.com/servo/font-kit)
+* [Core-foundation](https://github.com/servo/core-foundation-rs)
+* [Smol](https://github.com/smol-rs/smol)

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -93,6 +93,7 @@ diesel.workspace = true
 difflib = { git = "https://github.com/warpdotdev/difflib.git", rev = "114177e7d8e1f8017baca397f943e11644b14d63" }
 directories.workspace = true
 dirs.workspace = true
+dotenvy = "0.15"
 dunce.workspace = true
 email_address = { git = "https://github.com/warpdotdev/rust-email_address", branch = "main" }
 embed_plist = "1.2"

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -9,11 +9,21 @@ use crate::server::server_api::ServerApi;
 
 use super::{convert_to::convert_input, ConvertToAPITypeError, RequestParams, ResponseStream};
 
+#[path = "local_cli.rs"]
+mod local_cli;
+
 pub async fn generate_multi_agent_output(
     server_api: Arc<ServerApi>,
     mut params: RequestParams,
     cancellation_rx: futures::channel::oneshot::Receiver<()>,
 ) -> Result<ResponseStream, ConvertToAPITypeError> {
+    // Local-AI bypass: when WARP_LOCAL_AI is set, route the interactive panel
+    // through the CLI subprocess instead of Warp's authenticated server.
+    // This avoids the 401 "User not in context" error from generate_multi_agent_output.
+    if crate::local_ai::is_active() {
+        let stream = local_cli::generate_local_output(params, cancellation_rx).await;
+        return Ok(stream);
+    }
     let supported_tools = params
         .supported_tools_override
         .take()

--- a/app/src/ai/agent/api/local_cli.rs
+++ b/app/src/ai/agent/api/local_cli.rs
@@ -14,10 +14,25 @@
 //! If the ID is not a local model ID, the legacy `WARP_LOCAL_AI` env var is
 //! used as a fallback so existing configurations keep working.
 //!
-//! Only the user-visible text path is implemented here.  Tool calls emitted by
-//! the underlying CLI (file edits, shell commands, etc.) are not yet forwarded
-//! back to the panel - that requires a richer protocol bridge and is left as
-//! follow-up work.
+//! # Tool-call visibility (Slice B)
+//!
+//! Claude is invoked with `--output-format stream-json --verbose`, which emits
+//! one JSON object per line.  This module parses those events and renders them
+//! as inline text annotations in the panel:
+//!
+//! - `assistant` content blocks of type `text` are forwarded verbatim.
+//! - `assistant` content blocks of type `tool_use` produce a `[tool: Name]`
+//!   line so the user sees which tool the agent is calling.
+//! - `user` events carrying `tool_result` produce a `[result]` line with a
+//!   short stdout/stderr excerpt so the user sees what the tool returned.
+//! - `result`/`system` events are silently dropped.
+//!
+//! This is Slice B of the full tool-loop bridge.  Warp native tool-block UI
+//! (Slice C) is deferred - that requires mapping each CLI tool event to a
+//! proper `api::message::ToolCall` protobuf message.
+//!
+//! Codex `--json` events are unchanged from the previous implementation: only
+//! `item.completed / agent_message` lines are surfaced as text.
 
 use std::process::Stdio;
 
@@ -38,7 +53,16 @@ type ResponseStream = crate::ai::agent::api::ResponseStream;
 /// Which output format the CLI subprocess uses.
 enum OutputMode {
     /// Raw text: each stdout line is displayed verbatim.
+    ///
+    /// Kept for future harnesses (e.g. Ollama) that don't emit structured JSON.
+    #[allow(dead_code)]
     RawText,
+    /// Claude `--output-format stream-json --verbose` events.
+    ///
+    /// Each line is a JSON object with a `type` discriminator.  Text content
+    /// from `assistant` events is forwarded; `tool_use` and `tool_result`
+    /// events are rendered as inline annotations.
+    ClaudeStreamJson,
     /// Codex `--json` events: each stdout line is a JSON object; only
     /// `{"type":"item.completed","item":{"type":"agent_message","text":"..."}}` is shown.
     CodexJson,
@@ -122,7 +146,7 @@ async fn run_local_cli(
     let (output_mode, cli_label, mut cmd) = match maybe_spec {
         Some(ref spec) => match spec {
             LocalModelSpec::Claude { .. } => (
-                OutputMode::RawText,
+                OutputMode::ClaudeStreamJson,
                 "claude",
                 build_command_from_spec(spec, &query, cwd.as_deref()),
             ),
@@ -136,7 +160,7 @@ async fn run_local_cli(
             // Legacy WARP_LOCAL_AI env var path.
             match crate::local_ai::current() {
                 LocalAiMode::Claude => (
-                    OutputMode::RawText,
+                    OutputMode::ClaudeStreamJson,
                     "claude",
                     build_legacy_command("claude", &query, cwd.as_deref()),
                 ),
@@ -200,6 +224,12 @@ async fn run_local_cli(
                                     format!("{raw_line}\n")
                                 }
                             }
+                            OutputMode::ClaudeStreamJson => {
+                                match extract_claude_stream_json_text(&raw_line) {
+                                    Some(t) => t,
+                                    None => continue,
+                                }
+                            }
                             OutputMode::CodexJson => {
                                 match extract_codex_json_text(&raw_line) {
                                     Some(t) => t,
@@ -251,7 +281,7 @@ async fn run_local_cli(
 
 /// Build a `tokio::process::Command` from a parsed [`LocalModelSpec`].
 ///
-/// - `Claude`: `claude -p --model <name> --output-format text --dangerously-skip-permissions <query>`
+/// - `Claude`: `claude -p --model <name> --output-format stream-json --verbose --dangerously-skip-permissions <query>`
 /// - `Codex`: `codex exec -m <name> [-c reasoning_effort=<effort>] --dangerously-bypass-approvals-and-sandbox --json --color never <query>`
 fn build_command_from_spec(spec: &LocalModelSpec, query: &str, cwd: Option<&str>) -> Command {
     let mut cmd = match spec {
@@ -262,7 +292,8 @@ fn build_command_from_spec(spec: &LocalModelSpec, query: &str, cwd: Option<&str>
                 "--model",
                 model_name,
                 "--output-format",
-                "text",
+                "stream-json",
+                "--verbose",
                 "--dangerously-skip-permissions",
             ]);
             c.arg(query);
@@ -302,8 +333,14 @@ fn build_legacy_command(cli: &str, query: &str, cwd: Option<&str>) -> Command {
 
     match cli {
         "claude" => {
-            // -p / --print: non-interactive; output-format text: plain text to stdout.
-            cmd.args(["-p", "--output-format", "text", "--dangerously-skip-permissions"]);
+            // -p / --print: non-interactive; stream-json for tool-call visibility.
+            cmd.args([
+                "-p",
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--dangerously-skip-permissions",
+            ]);
             cmd.arg(query);
         }
         "codex" => {
@@ -329,6 +366,167 @@ fn build_legacy_command(cli: &str, query: &str, cwd: Option<&str>) -> Command {
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::null());
     cmd
+}
+
+/// Parse one line from `claude -p --output-format stream-json --verbose` and
+/// return the text that should appear in the panel, or `None` to skip the line.
+///
+/// Handled event types:
+/// - `assistant` with `content[].type == "text"` -> forward the text verbatim.
+/// - `assistant` with `content[].type == "tool_use"` -> emit `[tool: Name] summary`.
+/// - `user` with `content[].type == "tool_result"` (tool finished) -> emit `[result] excerpt`.
+/// - Everything else (`system`, `result`, `rate_limit_event`, …) -> `None`.
+fn extract_claude_stream_json_text(line: &str) -> Option<String> {
+    // Fast-path: skip lines that can't carry user-visible content.
+    if line.is_empty() {
+        return None;
+    }
+
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    let event_type = v.get("type")?.as_str()?;
+
+    match event_type {
+        "assistant" => {
+            let message = v.get("message")?;
+            let content = message.get("content")?.as_array()?;
+            let mut out = String::new();
+            for block in content {
+                match block.get("type")?.as_str()? {
+                    "text" => {
+                        if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                            if !text.is_empty() {
+                                out.push_str(text);
+                                // Ensure the text ends with a newline so subsequent
+                                // chunks stay visually separated.
+                                if !out.ends_with('\n') {
+                                    out.push('\n');
+                                }
+                            }
+                        }
+                    }
+                    "tool_use" => {
+                        let name = block
+                            .get("name")
+                            .and_then(|n| n.as_str())
+                            .unwrap_or("unknown");
+                        // Build a short human-readable summary of the input.
+                        let summary = tool_use_summary(name, block.get("input"));
+                        out.push_str(&format!("[tool: {name}] {summary}\n"));
+                    }
+                    _ => {}
+                }
+            }
+            if out.is_empty() {
+                None
+            } else {
+                Some(out)
+            }
+        }
+        "user" => {
+            // Tool results come back as `user` events with tool_result content blocks.
+            let message = v.get("message")?;
+            let content = message.get("content")?.as_array()?;
+            let mut out = String::new();
+            for block in content {
+                if block.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
+                    // Prefer the top-level `tool_use_result` field (richer).
+                    let excerpt = if let Some(tur) = v.get("tool_use_result") {
+                        tool_result_excerpt(tur)
+                    } else {
+                        // Fall back to content string payload.
+                        block
+                            .get("content")
+                            .and_then(|c| c.as_str())
+                            .map(|s| truncate(s, 120).to_string())
+                            .unwrap_or_default()
+                    };
+                    if !excerpt.is_empty() {
+                        out.push_str(&format!("[result] {excerpt}\n"));
+                    }
+                }
+            }
+            if out.is_empty() {
+                None
+            } else {
+                Some(out)
+            }
+        }
+        // `system`, `result`, `rate_limit_event`, and any future event types
+        // are intentionally dropped - they carry no user-visible content for
+        // the panel.
+        _ => None,
+    }
+}
+
+/// Build a short summary string for a `tool_use` content block.
+///
+/// For well-known tool names (Bash, Read, Write, Edit, Grep, Glob) we surface
+/// the most relevant field.  For everything else we fall back to a compact JSON
+/// representation of the input (truncated to 120 chars).
+fn tool_use_summary(name: &str, input: Option<&serde_json::Value>) -> String {
+    let Some(inp) = input else {
+        return String::new();
+    };
+
+    // Helper: get a string field from the input object.
+    let field = |key: &str| -> Option<&str> { inp.get(key)?.as_str() };
+
+    match name {
+        "Bash" => field("command")
+            .map(|s| truncate(s, 120).to_string())
+            .unwrap_or_default(),
+        "Read" => field("file_path")
+            .or_else(|| field("path"))
+            .map(|s| s.to_string())
+            .unwrap_or_default(),
+        "Write" | "Edit" => field("file_path")
+            .or_else(|| field("path"))
+            .map(|s| s.to_string())
+            .unwrap_or_default(),
+        "Grep" => {
+            let pattern = field("pattern").unwrap_or("");
+            let path = field("path").unwrap_or("");
+            if path.is_empty() {
+                pattern.to_string()
+            } else {
+                format!("{pattern} in {path}")
+            }
+        }
+        "Glob" => field("pattern").unwrap_or("").to_string(),
+        _ => {
+            // Generic fallback: compact JSON, truncated.
+            let compact = inp.to_string();
+            truncate(&compact, 120).to_string()
+        }
+    }
+}
+
+/// Extract a short excerpt from a `tool_use_result` JSON value.
+fn tool_result_excerpt(tur: &serde_json::Value) -> String {
+    // `stdout` is the primary output; fall back to `output` for older schemas.
+    let raw = tur
+        .get("stdout")
+        .and_then(|s| s.as_str())
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            tur.get("output")
+                .and_then(|s| s.as_str())
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or("");
+    truncate(raw, 120).to_string()
+}
+
+/// Return a string slice of at most `max_chars` UTF-8 characters.
+fn truncate(s: &str, max_chars: usize) -> &str {
+    if s.chars().count() <= max_chars {
+        return s;
+    }
+    // Find the byte offset of the `max_chars`-th character boundary.
+    match s.char_indices().nth(max_chars) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
 }
 
 /// For codex `--json` output, extract the agent reply text from an

--- a/app/src/ai/agent/api/local_cli.rs
+++ b/app/src/ai/agent/api/local_cli.rs
@@ -1,10 +1,18 @@
 //! Local-CLI bypass for the interactive agent panel.
 //!
-//! When `WARP_LOCAL_AI=claude` or `WARP_LOCAL_AI=codex` is set, the panel
-//! ordinarily fails with a 401 because `generate_multi_agent_output` routes to
-//! Warp's authenticated GraphQL server.  This module short-circuits that path:
-//! instead of hitting the server, it shells out to the local CLI and synthesises
-//! a `ResponseEvent` stream that Warp's controller can consume normally.
+//! When `WARP_BYPASS_AUTH=1` is set (with or without `WARP_LOCAL_AI`), the
+//! panel ordinarily fails with a 401 because `generate_multi_agent_output`
+//! routes to Warp's authenticated GraphQL server.  This module short-circuits
+//! that path: instead of hitting the server, it shells out to the local CLI
+//! indicated by the user's model-selector choice, and synthesises a
+//! `ResponseEvent` stream that Warp's controller can consume normally.
+//!
+//! # Model routing
+//!
+//! The model is taken from `params.model`.  Local model IDs are structured
+//! strings like `"local:claude:claude-sonnet-4-7"` (see `local_ai` module).
+//! If the ID is not a local model ID, the legacy `WARP_LOCAL_AI` env var is
+//! used as a fallback so existing configurations keep working.
 //!
 //! Only the user-visible text path is implemented here.  Tool calls emitted by
 //! the underlying CLI (file edits, shell commands, etc.) are not yet forwarded
@@ -21,6 +29,7 @@ use warp_multi_agent_api as api;
 
 use crate::ai::agent::api::RequestParams;
 use crate::ai::agent::{AIAgentContext, AIAgentInput};
+use crate::local_ai::{LocalAiMode, LocalModelSpec};
 
 // Re-use the type aliases from the parent api module.
 type Event = crate::ai::agent::api::Event;
@@ -101,24 +110,57 @@ async fn run_local_cli(
 
     let message_id = format!("local-msg-{}", Uuid::new_v4());
 
-    // Determine CLI command and output mode.
-    let (cli, output_mode) = match crate::local_ai::current() {
-        crate::local_ai::LocalAiMode::Claude => ("claude", OutputMode::RawText),
-        crate::local_ai::LocalAiMode::Codex => ("codex", OutputMode::CodexJson),
-        _ => {
-            let _ =
-                send_internal_error(&tx, "WARP_LOCAL_AI mode not supported in panel bypass").await;
-            return;
+    // Determine which local CLI to invoke.
+    //
+    // Priority:
+    //   1. If the selected model is a local-model ID (e.g. "local:claude:…"),
+    //      parse it and use its provider + parameters.
+    //   2. Fall back to the legacy WARP_LOCAL_AI env var for backward compat.
+    let model_id_str = params.model.to_string();
+    let maybe_spec = LocalModelSpec::parse(&model_id_str);
+
+    let (output_mode, cli_label, mut cmd) = match maybe_spec {
+        Some(ref spec) => match spec {
+            LocalModelSpec::Claude { .. } => (
+                OutputMode::RawText,
+                "claude",
+                build_command_from_spec(spec, &query, cwd.as_deref()),
+            ),
+            LocalModelSpec::Codex { .. } => (
+                OutputMode::CodexJson,
+                "codex",
+                build_command_from_spec(spec, &query, cwd.as_deref()),
+            ),
+        },
+        None => {
+            // Legacy WARP_LOCAL_AI env var path.
+            match crate::local_ai::current() {
+                LocalAiMode::Claude => (
+                    OutputMode::RawText,
+                    "claude",
+                    build_legacy_command("claude", &query, cwd.as_deref()),
+                ),
+                LocalAiMode::Codex => (
+                    OutputMode::CodexJson,
+                    "codex",
+                    build_legacy_command("codex", &query, cwd.as_deref()),
+                ),
+                _ => {
+                    let _ = send_internal_error(
+                        &tx,
+                        "No local model selected; set WARP_LOCAL_AI or select a model from the menu",
+                    )
+                    .await;
+                    return;
+                }
+            }
         }
     };
-
-    // Build the subprocess.
-    let mut cmd = build_command(cli, &query, cwd.as_deref());
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            let msg = format!("Failed to launch `{cli}`: {e}");
+            let msg = format!("Failed to launch `{cli_label}`: {e}");
             log::error!("{msg}");
             let _ = send_internal_error(&tx, msg).await;
             return;
@@ -207,8 +249,55 @@ async fn run_local_cli(
     }
 }
 
-/// Build the `tokio::process::Command` for the local CLI.
-fn build_command(cli: &str, query: &str, cwd: Option<&str>) -> Command {
+/// Build a `tokio::process::Command` from a parsed [`LocalModelSpec`].
+///
+/// - `Claude`: `claude -p --model <name> --output-format text --dangerously-skip-permissions <query>`
+/// - `Codex`: `codex exec -m <name> [-c reasoning_effort=<effort>] --dangerously-bypass-approvals-and-sandbox --json --color never <query>`
+fn build_command_from_spec(spec: &LocalModelSpec, query: &str, cwd: Option<&str>) -> Command {
+    let mut cmd = match spec {
+        LocalModelSpec::Claude { model_name } => {
+            let mut c = Command::new("claude");
+            c.args([
+                "-p",
+                "--model",
+                model_name,
+                "--output-format",
+                "text",
+                "--dangerously-skip-permissions",
+            ]);
+            c.arg(query);
+            c
+        }
+        LocalModelSpec::Codex {
+            model_name,
+            reasoning_effort,
+        } => {
+            let mut c = Command::new("codex");
+            c.args(["exec", "-m", model_name]);
+            if let Some(effort) = reasoning_effort {
+                c.args(["-c", &format!("reasoning_effort={effort}")]);
+            }
+            c.args([
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--json",
+                "--color",
+                "never",
+            ]);
+            c.arg(query);
+            c
+        }
+    };
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::null());
+    cmd
+}
+
+/// Build a `tokio::process::Command` using the legacy provider name string
+/// (no model flag, uses the CLI's own default model).
+fn build_legacy_command(cli: &str, query: &str, cwd: Option<&str>) -> Command {
     let mut cmd = Command::new(cli);
 
     match cli {

--- a/app/src/ai/agent/api/local_cli.rs
+++ b/app/src/ai/agent/api/local_cli.rs
@@ -1,0 +1,402 @@
+//! Local-CLI bypass for the interactive agent panel.
+//!
+//! When `WARP_LOCAL_AI=claude` or `WARP_LOCAL_AI=codex` is set, the panel
+//! ordinarily fails with a 401 because `generate_multi_agent_output` routes to
+//! Warp's authenticated GraphQL server.  This module short-circuits that path:
+//! instead of hitting the server, it shells out to the local CLI and synthesises
+//! a `ResponseEvent` stream that Warp's controller can consume normally.
+//!
+//! Only the user-visible text path is implemented here.  Tool calls emitted by
+//! the underlying CLI (file edits, shell commands, etc.) are not yet forwarded
+//! back to the panel - that requires a richer protocol bridge and is left as
+//! follow-up work.
+
+use std::process::Stdio;
+
+use async_channel::{Sender, unbounded};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use uuid::Uuid;
+use warp_multi_agent_api as api;
+
+use crate::ai::agent::api::RequestParams;
+use crate::ai::agent::{AIAgentContext, AIAgentInput};
+
+// Re-use the type aliases from the parent api module.
+type Event = crate::ai::agent::api::Event;
+type ResponseStream = crate::ai::agent::api::ResponseStream;
+
+/// Which output format the CLI subprocess uses.
+enum OutputMode {
+    /// Raw text: each stdout line is displayed verbatim.
+    RawText,
+    /// Codex `--json` events: each stdout line is a JSON object; only
+    /// `{"type":"item.completed","item":{"type":"agent_message","text":"..."}}` is shown.
+    CodexJson,
+}
+
+/// Build and return a local-CLI `ResponseStream` for the given `params`.
+///
+/// On success the stream emits:
+///   1. `StreamInit`
+///   2. One or more `ClientActions(AddMessagesToTask / AppendToMessageContent)`
+///      carrying the CLI stdout as agent-output text
+///   3. `StreamFinished(Done)` or `StreamFinished(InternalError)` on failure
+///
+/// The `cancellation_rx` channel is monitored: when it fires the stream ends
+/// early with a `Done` finish event (consistent with user-cancel behaviour in
+/// the non-bypass path).
+pub(super) async fn generate_local_output(
+    params: RequestParams,
+    cancellation_rx: futures::channel::oneshot::Receiver<()>,
+) -> ResponseStream {
+    let (tx, rx) = unbounded::<Event>();
+    tokio::spawn(run_local_cli(params, tx, cancellation_rx));
+    Box::pin(rx)
+}
+
+async fn run_local_cli(
+    params: RequestParams,
+    tx: Sender<Event>,
+    cancellation_rx: futures::channel::oneshot::Receiver<()>,
+) {
+    let conversation_id = params
+        .conversation_token
+        .as_ref()
+        .map(|t| t.as_str().to_string())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+    let request_id = Uuid::new_v4().to_string();
+    let run_id = Uuid::new_v4().to_string();
+
+    // Emit StreamInit.
+    let _ = tx
+        .send(Ok(api::ResponseEvent {
+            r#type: Some(api::response_event::Type::Init(
+                api::response_event::StreamInit {
+                    conversation_id: conversation_id.clone(),
+                    request_id: request_id.clone(),
+                    run_id: run_id.clone(),
+                },
+            )),
+        }))
+        .await;
+
+    // Extract user query and working directory from params.
+    let query = extract_query(&params.input);
+    let cwd = extract_cwd(&params.input);
+
+    // Resolve task id.
+    let task_id = params
+        .tasks
+        .first()
+        .and_then(|t| {
+            let id = t.id.trim();
+            if id.is_empty() {
+                None
+            } else {
+                Some(id.to_string())
+            }
+        })
+        .unwrap_or_else(|| format!("local-task-{}", Uuid::new_v4()));
+
+    let message_id = format!("local-msg-{}", Uuid::new_v4());
+
+    // Determine CLI command and output mode.
+    let (cli, output_mode) = match crate::local_ai::current() {
+        crate::local_ai::LocalAiMode::Claude => ("claude", OutputMode::RawText),
+        crate::local_ai::LocalAiMode::Codex => ("codex", OutputMode::CodexJson),
+        _ => {
+            let _ =
+                send_internal_error(&tx, "WARP_LOCAL_AI mode not supported in panel bypass").await;
+            return;
+        }
+    };
+
+    // Build the subprocess.
+    let mut cmd = build_command(cli, &query, cwd.as_deref());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            let msg = format!("Failed to launch `{cli}`: {e}");
+            log::error!("{msg}");
+            let _ = send_internal_error(&tx, msg).await;
+            return;
+        }
+    };
+
+    let stdout = match child.stdout.take() {
+        Some(s) => s,
+        None => {
+            let _ = send_internal_error(&tx, "CLI subprocess has no stdout").await;
+            return;
+        }
+    };
+
+    let mut lines = BufReader::new(stdout).lines();
+    let mut first_chunk = true;
+    let mut cancellation_rx = cancellation_rx;
+
+    loop {
+        tokio::select! {
+            // Cancellation: user pressed stop.
+            _ = &mut cancellation_rx => {
+                let _ = child.kill().await;
+                let _ = send_done(&tx).await;
+                return;
+            }
+            line = lines.next_line() => {
+                match line {
+                    Ok(Some(raw_line)) => {
+                        // Extract text to display (may be empty for non-text lines).
+                        let text = match output_mode {
+                            OutputMode::RawText => {
+                                if raw_line.is_empty() {
+                                    // Preserve blank lines.
+                                    "\n".to_string()
+                                } else {
+                                    format!("{raw_line}\n")
+                                }
+                            }
+                            OutputMode::CodexJson => {
+                                match extract_codex_json_text(&raw_line) {
+                                    Some(t) => t,
+                                    None => continue,
+                                }
+                            }
+                        };
+
+                        let event = if first_chunk {
+                            first_chunk = false;
+                            add_agent_output_event(&request_id, &task_id, &message_id, &text)
+                        } else {
+                            append_agent_output_event(&request_id, &task_id, &message_id, &text)
+                        };
+                        if tx.send(Ok(event)).await.is_err() {
+                            // Receiver dropped; clean up.
+                            let _ = child.kill().await;
+                            return;
+                        }
+                    }
+                    Ok(None) => {
+                        // EOF: stream finished.
+                        break;
+                    }
+                    Err(e) => {
+                        log::warn!("Error reading CLI stdout: {e}");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Wait for exit and check status.
+    match child.wait().await {
+        Ok(status) if status.success() => {
+            let _ = send_done(&tx).await;
+        }
+        Ok(status) => {
+            log::warn!("CLI exited with non-zero status: {status}");
+            // Finish with Done so the panel renders whatever text was already emitted.
+            let _ = send_done(&tx).await;
+        }
+        Err(e) => {
+            let _ = send_internal_error(&tx, format!("CLI wait failed: {e}")).await;
+        }
+    }
+}
+
+/// Build the `tokio::process::Command` for the local CLI.
+fn build_command(cli: &str, query: &str, cwd: Option<&str>) -> Command {
+    let mut cmd = Command::new(cli);
+
+    match cli {
+        "claude" => {
+            // -p / --print: non-interactive; output-format text: plain text to stdout.
+            cmd.args(["-p", "--output-format", "text", "--dangerously-skip-permissions"]);
+            cmd.arg(query);
+        }
+        "codex" => {
+            // exec subcommand: non-interactive run; --json: structured JSON events on stdout.
+            cmd.args([
+                "exec",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--json",
+                "--color",
+                "never",
+            ]);
+            cmd.arg(query);
+        }
+        _ => {
+            cmd.arg(query);
+        }
+    }
+
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::null());
+    cmd
+}
+
+/// For codex `--json` output, extract the agent reply text from an
+/// `item.completed` / `agent_message` line.  Returns `None` for all other
+/// event types.
+fn extract_codex_json_text(line: &str) -> Option<String> {
+    // Fast path: skip lines that definitely aren't the right event.
+    if !line.contains("item.completed") {
+        return None;
+    }
+    // Parse just enough JSON to get item.type and item.text.
+    // Example: {"type":"item.completed","item":{"id":"…","type":"agent_message","text":"Hello."}}
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    if v.get("type")?.as_str()? != "item.completed" {
+        return None;
+    }
+    let item = v.get("item")?;
+    if item.get("type")?.as_str()? != "agent_message" {
+        return None;
+    }
+    let text = item.get("text")?.as_str()?;
+    Some(text.to_string())
+}
+
+/// Extract the human-readable query text from the input list.
+fn extract_query(inputs: &[AIAgentInput]) -> String {
+    for input in inputs.iter().rev() {
+        let text = match input {
+            AIAgentInput::UserQuery { query, .. } => query.as_str(),
+            AIAgentInput::AutoCodeDiffQuery { query, .. } => query.as_str(),
+            AIAgentInput::CreateNewProject { query, .. } => query.as_str(),
+            _ => continue,
+        };
+        if !text.is_empty() {
+            return text.to_string();
+        }
+    }
+    String::new()
+}
+
+/// Extract the working directory from the input list.
+fn extract_cwd(inputs: &[AIAgentInput]) -> Option<String> {
+    for input in inputs {
+        if let Some(context) = input.context() {
+            for ctx in context {
+                if let AIAgentContext::Directory {
+                    pwd: Some(pwd), ..
+                } = ctx
+                {
+                    if !pwd.is_empty() {
+                        return Some(pwd.clone());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+// --- ResponseEvent helpers ---
+
+fn add_agent_output_event(
+    request_id: &str,
+    task_id: &str,
+    message_id: &str,
+    text: &str,
+) -> api::ResponseEvent {
+    api::ResponseEvent {
+        r#type: Some(api::response_event::Type::ClientActions(
+            api::response_event::ClientActions {
+                actions: vec![api::ClientAction {
+                    action: Some(api::client_action::Action::AddMessagesToTask(
+                        api::client_action::AddMessagesToTask {
+                            task_id: task_id.to_string(),
+                            messages: vec![api::Message {
+                                id: message_id.to_string(),
+                                task_id: task_id.to_string(),
+                                request_id: request_id.to_string(),
+                                message: Some(api::message::Message::AgentOutput(
+                                    api::message::AgentOutput {
+                                        text: text.to_string(),
+                                    },
+                                )),
+                                ..Default::default()
+                            }],
+                        },
+                    )),
+                }],
+            },
+        )),
+    }
+}
+
+fn append_agent_output_event(
+    request_id: &str,
+    task_id: &str,
+    message_id: &str,
+    text: &str,
+) -> api::ResponseEvent {
+    api::ResponseEvent {
+        r#type: Some(api::response_event::Type::ClientActions(
+            api::response_event::ClientActions {
+                actions: vec![api::ClientAction {
+                    action: Some(api::client_action::Action::AppendToMessageContent(
+                        api::client_action::AppendToMessageContent {
+                            task_id: task_id.to_string(),
+                            message: Some(api::Message {
+                                id: message_id.to_string(),
+                                task_id: task_id.to_string(),
+                                request_id: request_id.to_string(),
+                                message: Some(api::message::Message::AgentOutput(
+                                    api::message::AgentOutput {
+                                        text: text.to_string(),
+                                    },
+                                )),
+                                ..Default::default()
+                            }),
+                            mask: Some(prost_types::FieldMask {
+                                paths: vec!["agent_output.text".to_string()],
+                            }),
+                        },
+                    )),
+                }],
+            },
+        )),
+    }
+}
+
+async fn send_done(tx: &Sender<Event>) -> Result<(), async_channel::SendError<Event>> {
+    tx.send(Ok(api::ResponseEvent {
+        r#type: Some(api::response_event::Type::Finished(
+            api::response_event::StreamFinished {
+                reason: Some(api::response_event::stream_finished::Reason::Done(
+                    api::response_event::stream_finished::Done {},
+                )),
+                ..Default::default()
+            },
+        )),
+    }))
+    .await
+}
+
+async fn send_internal_error(
+    tx: &Sender<Event>,
+    msg: impl Into<String>,
+) -> Result<(), async_channel::SendError<Event>> {
+    tx.send(Ok(api::ResponseEvent {
+        r#type: Some(api::response_event::Type::Finished(
+            api::response_event::StreamFinished {
+                reason: Some(api::response_event::stream_finished::Reason::InternalError(
+                    api::response_event::stream_finished::InternalError {
+                        message: msg.into(),
+                    },
+                )),
+                ..Default::default()
+            },
+        )),
+    }))
+    .await
+}

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1490,6 +1490,23 @@ impl AgentDriver {
             AgentRunPrompt::ServerSide {
                 skill,
                 attachments_dir,
+            } if crate::local_ai::is_active() => {
+                // Bypass `server_api.resolve_prompt()` (requires auth, makes a network round-trip).
+                // Synthesize a minimal prompt locally from the skill content if any was attached.
+                let prompt = skill
+                    .as_ref()
+                    .map(|s| s.content.clone())
+                    .unwrap_or_default();
+                if attachments_dir.is_some() {
+                    log::warn!(
+                        "Local-AI mode: ignoring server-side attachments_dir; only skill content is forwarded."
+                    );
+                }
+                (Cow::Owned(prompt), None, None)
+            }
+            AgentRunPrompt::ServerSide {
+                skill,
+                attachments_dir,
             } => {
                 let skill = skill
                     .as_ref()
@@ -1512,6 +1529,14 @@ impl AgentDriver {
                     resolved.resumption_prompt,
                 )
             }
+        };
+
+        // Prepend the ilo-lang context (WARP_ILO_SYSTEM_PROMPT) to the system prompt for any
+        // local-AI run. Combines with whatever the harness already builds in.
+        let system_prompt = match (system_prompt, crate::local_ai::ilo_system_prompt()) {
+            (Some(existing), Some(ilo)) => Some(format!("{ilo}\n\n{existing}")),
+            (None, Some(ilo)) => Some(ilo.to_owned()),
+            (existing, None) => existing,
         };
 
         // Prepare harness config files (onboarding, trust dialog, API-key approval, etc.).

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1531,14 +1531,6 @@ impl AgentDriver {
             }
         };
 
-        // Prepend the ilo-lang context (WARP_ILO_SYSTEM_PROMPT) to the system prompt for any
-        // local-AI run. Combines with whatever the harness already builds in.
-        let system_prompt = match (system_prompt, crate::local_ai::ilo_system_prompt()) {
-            (Some(existing), Some(ilo)) => Some(format!("{ilo}\n\n{existing}")),
-            (None, Some(ilo)) => Some(ilo.to_owned()),
-            (existing, None) => existing,
-        };
-
         // Prepare harness config files (onboarding, trust dialog, API-key approval, etc.).
         let secrets = foreground
             .spawn(|me, _| Arc::clone(&me.secrets))

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -1,0 +1,213 @@
+//! Third-party harness for the OpenAI `codex` CLI.
+//!
+//! Modeled on [`super::gemini::GeminiHarness`]: the harness writes the seed prompt to a
+//! tempfile and shells out to `codex` in interactive mode. Codex maintains its own
+//! conversation/session state, so we don't store transcripts client-side beyond what the
+//! base `HarnessRunner` already does.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use warp_cli::agent::Harness;
+use warpui::{ModelHandle, ModelSpawner};
+
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::server::server_api::harness_support::HarnessSupportClient;
+use crate::server::server_api::ServerApi;
+use crate::terminal::model::block::BlockId;
+use crate::terminal::CLIAgent;
+
+use super::super::terminal::{CommandHandle, TerminalDriver};
+use super::super::{AgentDriver, AgentDriverError};
+use super::{write_temp_file, HarnessRunner, ResumePayload, SavePoint, ThirdPartyHarness};
+
+pub(crate) struct CodexHarness;
+
+const CODEX_CLI_FORMAT: &str = "codex_cli";
+const CODEX_EXIT_COMMAND: &str = "/quit";
+
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+impl ThirdPartyHarness for CodexHarness {
+    fn harness(&self) -> Harness {
+        // Reuse `Harness::Unknown` rather than threading a new variant through every match
+        // statement in `warp_cli`. The harness is selected here via env var, not the CLI flag,
+        // so the enum value is only used for telemetry/logging.
+        Harness::Unknown
+    }
+
+    fn cli_agent(&self) -> CLIAgent {
+        CLIAgent::Codex
+    }
+
+    fn install_docs_url(&self) -> Option<&'static str> {
+        Some("https://github.com/openai/codex")
+    }
+
+    fn build_runner(
+        &self,
+        prompt: &str,
+        system_prompt: Option<&str>,
+        _resumption_prompt: Option<&str>,
+        _working_dir: &Path,
+        _task_id: Option<AmbientAgentTaskId>,
+        server_api: Arc<ServerApi>,
+        terminal_driver: ModelHandle<TerminalDriver>,
+        _resume: Option<ResumePayload>,
+    ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
+        let client: Arc<dyn HarnessSupportClient> = server_api;
+        Ok(Box::new(CodexHarnessRunner::new(
+            self.cli_agent().command_prefix(),
+            prompt,
+            system_prompt,
+            client,
+            terminal_driver,
+        )?))
+    }
+}
+
+/// Build the shell command that launches the codex TUI.
+///
+/// `--full-auto` runs without per-action confirmation; the prompt is piped via cat so codex
+/// reads it as the first user turn before continuing in interactive mode.
+fn codex_command(cli_name: &str, prompt_path: &str, system_prompt_path: Option<&str>) -> String {
+    let mut cmd = format!("{cli_name} --full-auto");
+    if let Some(sys_path) = system_prompt_path {
+        cmd.push_str(&format!(" --instructions \"$(cat '{sys_path}')\""));
+    }
+    cmd.push_str(&format!(" \"$(cat '{prompt_path}')\""));
+    cmd
+}
+
+enum CodexRunnerState {
+    Preexec,
+    Running {
+        conversation_id: AIConversationId,
+        block_id: BlockId,
+    },
+}
+
+struct CodexHarnessRunner {
+    command: String,
+    _temp_prompt_file: tempfile::NamedTempFile,
+    _temp_system_prompt_file: Option<tempfile::NamedTempFile>,
+    client: Arc<dyn HarnessSupportClient>,
+    terminal_driver: ModelHandle<TerminalDriver>,
+    state: Mutex<CodexRunnerState>,
+}
+
+impl CodexHarnessRunner {
+    fn new(
+        cli_command: &str,
+        prompt: &str,
+        system_prompt: Option<&str>,
+        client: Arc<dyn HarnessSupportClient>,
+        terminal_driver: ModelHandle<TerminalDriver>,
+    ) -> Result<Self, AgentDriverError> {
+        let prompt_file = write_temp_file("oz_prompt_", prompt)?;
+        let prompt_path = prompt_file.path().display().to_string();
+
+        let system_prompt_file = system_prompt
+            .map(|sp| write_temp_file("oz_system_", sp))
+            .transpose()?;
+        let system_prompt_path = system_prompt_file
+            .as_ref()
+            .map(|f| f.path().display().to_string());
+
+        let command = codex_command(cli_command, &prompt_path, system_prompt_path.as_deref());
+
+        Ok(Self {
+            command,
+            _temp_prompt_file: prompt_file,
+            _temp_system_prompt_file: system_prompt_file,
+            client,
+            terminal_driver,
+            state: Mutex::new(CodexRunnerState::Preexec),
+        })
+    }
+}
+
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+impl HarnessRunner for CodexHarnessRunner {
+    async fn start(
+        &self,
+        foreground: &ModelSpawner<AgentDriver>,
+    ) -> Result<CommandHandle, AgentDriverError> {
+        let conversation_id = self
+            .client
+            .create_external_conversation(CODEX_CLI_FORMAT)
+            .await
+            .map_err(|e| {
+                log::error!("Failed to create external conversation: {e}");
+                AgentDriverError::ConfigBuildFailed(e)
+            })?;
+        log::info!("Created external conversation {conversation_id}");
+
+        let command = self.command.clone();
+        let terminal_driver = self.terminal_driver.clone();
+        let command_handle = foreground
+            .spawn(move |_, ctx| {
+                terminal_driver.update(ctx, |driver, ctx| driver.execute_command(&command, ctx))
+            })
+            .await??
+            .await?;
+
+        *self.state.lock() = CodexRunnerState::Running {
+            conversation_id,
+            block_id: command_handle.block_id().clone(),
+        };
+
+        Ok(command_handle)
+    }
+
+    async fn exit(&self, foreground: &ModelSpawner<AgentDriver>) -> Result<()> {
+        log::info!("Sending /quit to Codex CLI");
+        let terminal_driver = self.terminal_driver.clone();
+        foreground
+            .spawn(move |_, ctx| {
+                terminal_driver.update(ctx, |driver, ctx| {
+                    driver.send_text_to_cli(CODEX_EXIT_COMMAND.to_string(), ctx);
+                });
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("Agent driver dropped while sending /quit"))
+    }
+
+    async fn save_conversation(
+        &self,
+        save_point: SavePoint,
+        foreground: &ModelSpawner<AgentDriver>,
+    ) -> Result<()> {
+        if matches!(save_point, SavePoint::Periodic)
+            && !super::has_running_cli_agent(&self.terminal_driver, foreground).await
+        {
+            log::debug!("Will not save conversation, Codex not in progress");
+            return Ok(());
+        }
+
+        let (conversation_id, block_id) = match &*self.state.lock() {
+            CodexRunnerState::Preexec => {
+                log::warn!("save_conversation called before start");
+                return Ok(());
+            }
+            CodexRunnerState::Running {
+                conversation_id,
+                block_id,
+            } => (*conversation_id, block_id.clone()),
+        };
+
+        super::upload_current_block_snapshot(
+            foreground,
+            &self.terminal_driver,
+            self.client.as_ref(),
+            conversation_id,
+            block_id,
+        )
+        .await
+    }
+}

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -36,11 +36,13 @@ use super::{
 
 mod claude_code;
 pub(crate) mod claude_transcript;
+mod codex;
 mod gemini;
 mod json_utils;
 
 pub(crate) use claude_code::ClaudeHarness;
 use claude_transcript::ClaudeResumeInfo;
+use codex::CodexHarness;
 use gemini::GeminiHarness;
 
 /// Harness-agnostic payload describing how to resume an existing conversation.
@@ -162,6 +164,23 @@ impl fmt::Debug for HarnessKind {
 /// We shouldn't ever get a `--harness unknown` here because clap should handle
 /// it.
 pub(crate) fn harness_kind(harness: Harness) -> Result<HarnessKind, AgentDriverError> {
+    // When `WARP_LOCAL_AI` is set, override the requested harness regardless of UI selection.
+    // The local-AI bypass requires routing to a CLI subprocess, not Warp's server.
+    match crate::local_ai::current() {
+        crate::local_ai::LocalAiMode::Claude => {
+            return Ok(HarnessKind::ThirdParty(Box::new(ClaudeHarness)));
+        }
+        crate::local_ai::LocalAiMode::Codex => {
+            return Ok(HarnessKind::ThirdParty(Box::new(CodexHarness)));
+        }
+        crate::local_ai::LocalAiMode::Ollama => {
+            // Phase 2: implement OllamaHarness. For now, fall through with a clear error so
+            // setting WARP_LOCAL_AI=ollama doesn't silently route to the cloud Oz path.
+            log::warn!("WARP_LOCAL_AI=ollama is not yet implemented; falling back to selected harness");
+        }
+        crate::local_ai::LocalAiMode::Off => {}
+    }
+
     match harness {
         Harness::Oz => Ok(HarnessKind::Oz),
         Harness::Claude => Ok(HarnessKind::ThirdParty(Box::new(ClaudeHarness))),

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -159,13 +159,34 @@ impl fmt::Debug for HarnessKind {
     }
 }
 
-/// Build a [`HarnessKind`] for the given [`Harness`].
+/// Build a [`HarnessKind`] for the given [`Harness`], optionally using
+/// `model_id` to pick the local provider when auth-bypass is active.
 ///
-/// We shouldn't ever get a `--harness unknown` here because clap should handle
-/// it.
-pub(crate) fn harness_kind(harness: Harness) -> Result<HarnessKind, AgentDriverError> {
-    // When `WARP_LOCAL_AI` is set, override the requested harness regardless of UI selection.
-    // The local-AI bypass requires routing to a CLI subprocess, not Warp's server.
+/// Priority:
+///   1. If `model_id` is a local model ID (e.g. `"local:claude:…"`), use
+///      the matching harness regardless of the `harness` flag.
+///   2. If `WARP_LOCAL_AI` is set, use that provider.
+///   3. Otherwise, honour the `harness` flag as before.
+pub(crate) fn harness_kind_with_model(
+    harness: Harness,
+    model_id: Option<&str>,
+) -> Result<HarnessKind, AgentDriverError> {
+    // When local-model routing is active, prefer the spec from the model ID.
+    if crate::local_ai::local_model_routing_active() {
+        if let Some(id) = model_id {
+            match crate::local_ai::LocalModelSpec::parse(id) {
+                Some(crate::local_ai::LocalModelSpec::Claude { .. }) => {
+                    return Ok(HarnessKind::ThirdParty(Box::new(ClaudeHarness)));
+                }
+                Some(crate::local_ai::LocalModelSpec::Codex { .. }) => {
+                    return Ok(HarnessKind::ThirdParty(Box::new(CodexHarness)));
+                }
+                None => {}
+            }
+        }
+    }
+
+    // Fall back to the legacy WARP_LOCAL_AI env var override.
     match crate::local_ai::current() {
         crate::local_ai::LocalAiMode::Claude => {
             return Ok(HarnessKind::ThirdParty(Box::new(ClaudeHarness)));
@@ -189,6 +210,7 @@ pub(crate) fn harness_kind(harness: Harness) -> Result<HarnessKind, AgentDriverE
         Harness::Unknown => Err(AgentDriverError::InvalidRuntimeState),
     }
 }
+
 
 /// Check that `cli` is installed and on PATH, returning a `HarnessSetupFailed`
 /// error with an optional install-docs link when it isn't.

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -12,7 +12,7 @@ use crate::ai::agent::api::convert_conversation::{
 };
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::AIConversationId;
-use crate::ai::agent_sdk::driver::harness::{harness_kind, HarnessKind};
+use crate::ai::agent_sdk::driver::harness::{harness_kind_with_model, HarnessKind};
 use crate::ai::agent_sdk::driver::{AgentDriverOptions, AgentRunPrompt, Task};
 use crate::ai::agent_sdk::mcp_config::build_mcp_servers_from_specs;
 #[cfg(not(target_family = "wasm"))]
@@ -397,10 +397,13 @@ fn build_merged_config_and_task(
 
     let task = Task {
         prompt: AgentRunPrompt::Local(resolve_prompt(&local_prompt, ctx)?),
-        model: model_override,
+        model: model_override.clone(),
         profile: args.profile.clone(),
         mcp_specs: runtime_mcp_specs,
-        harness: harness_kind(args.harness)?,
+        harness: harness_kind_with_model(
+            args.harness,
+            model_override.as_ref().map(|id| id.as_str()),
+        )?,
     };
 
     Ok((merged_config, task))
@@ -457,10 +460,13 @@ fn build_server_side_task(
             skill,
             attachments_dir: None,
         },
-        model: model_override,
+        model: model_override.clone(),
         profile,
         mcp_specs: runtime_mcp_specs,
-        harness: harness_kind(args.harness)?,
+        harness: harness_kind_with_model(
+            args.harness,
+            model_override.as_ref().map(|id| id.as_str()),
+        )?,
     };
 
     Ok((config, task))

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -507,32 +507,42 @@ pub struct LLMPreferences {
 
 impl LLMPreferences {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
-        let models_by_feature = get_cached_models(ctx).unwrap_or_default();
+        // When running with auth bypass / local-AI, use the hardcoded local
+        // model list instead of whatever was cached from the server.  The
+        // server is unavailable in bypass mode so the cache is stale anyway.
+        let models_by_feature = if crate::local_ai::local_model_routing_active() {
+            crate::local_ai::local_model_list()
+        } else {
+            get_cached_models(ctx).unwrap_or_default()
+        };
 
-        ctx.subscribe_to_model(&NetworkStatus::handle(ctx), |me, event, ctx| {
-            if let NetworkStatusEvent::NetworkStatusChanged {
-                new_status: NetworkStatusKind::Online,
-            } = event
-            {
-                me.refresh_authed_models(ctx);
-            }
-        });
+        // Only subscribe to server-side refresh events when not in bypass mode.
+        if !crate::local_ai::local_model_routing_active() {
+            ctx.subscribe_to_model(&NetworkStatus::handle(ctx), |me, event, ctx| {
+                if let NetworkStatusEvent::NetworkStatusChanged {
+                    new_status: NetworkStatusKind::Online,
+                } = event
+                {
+                    me.refresh_authed_models(ctx);
+                }
+            });
 
-        // TODO: Instead of querying this ad-hoc upon a successful log in, we should add the
-        // available LLMs query to the general workspace metadata query which is polled
-        // and hooked up to workspace changes. For that to work, each user would need to
-        // have a personal workspace. This is a stop-gap.
-        ctx.subscribe_to_model(&AuthManager::handle(ctx), |me, event, ctx| {
-            if let AuthManagerEvent::AuthComplete = event {
-                me.refresh_authed_models(ctx);
-            }
-        });
+            // TODO: Instead of querying this ad-hoc upon a successful log in, we should add the
+            // available LLMs query to the general workspace metadata query which is polled
+            // and hooked up to workspace changes. For that to work, each user would need to
+            // have a personal workspace. This is a stop-gap.
+            ctx.subscribe_to_model(&AuthManager::handle(ctx), |me, event, ctx| {
+                if let AuthManagerEvent::AuthComplete = event {
+                    me.refresh_authed_models(ctx);
+                }
+            });
 
-        ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), |me, event, ctx| {
-            if let UserWorkspacesEvent::TeamsChanged = event {
-                me.refresh_authed_models(ctx);
-            }
-        });
+            ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), |me, event, ctx| {
+                if let UserWorkspacesEvent::TeamsChanged = event {
+                    me.refresh_authed_models(ctx);
+                }
+            });
+        }
 
         let base_llm_for_terminal_view = HashMap::new();
 
@@ -848,6 +858,11 @@ impl LLMPreferences {
 
     /// Fetches the latest set of models from the server for the currently logged in user, and updates the model.
     pub fn refresh_authed_models(&self, ctx: &mut ModelContext<Self>) {
+        // In bypass / local-AI mode the server is unavailable; keep the
+        // hardcoded local model list and skip the network request.
+        if crate::local_ai::local_model_routing_active() {
+            return;
+        }
         // Don't try to fetch auth'd models if the user is not logged in yet.
         if !AuthStateProvider::as_ref(ctx).get().is_logged_in() {
             return;
@@ -871,6 +886,9 @@ impl LLMPreferences {
 
     /// No auth required (i.e. to populate the pre-login onboarding picker).
     fn refresh_public_models(&self, ctx: &mut ModelContext<Self>) {
+        if crate::local_ai::local_model_routing_active() {
+            return;
+        }
         let ai_api_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         ctx.spawn(
             async move { ai_api_client.get_free_available_models(None).await },

--- a/app/src/auth/auth_state.rs
+++ b/app/src/auth/auth_state.rs
@@ -84,7 +84,6 @@ impl AuthState {
 
         if Self::should_use_test_user() {
             state.set_user(Some(User::test()));
-            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             state.set_credentials(Some(Credentials::Test));
             return state;
         }
@@ -134,7 +133,9 @@ impl AuthState {
     }
 
     fn should_use_test_user() -> bool {
-        cfg!(any(test, feature = "skip_login")) || ChannelState::channel() == Channel::Integration
+        cfg!(any(test, feature = "skip_login"))
+            || ChannelState::channel() == Channel::Integration
+            || crate::local_ai::auth_bypass_enabled()
     }
 
     /// Determines the appropriate persistence action based on the current auth state.
@@ -168,7 +169,6 @@ impl AuthState {
             // Do not persist if using API keys, session cookies, or test credentials.
             (Some(_), Some(Credentials::ApiKey { .. })) => PersistAction::DoNothing,
             (Some(_), Some(Credentials::SessionCookie)) => PersistAction::DoNothing,
-            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             (Some(_), Some(Credentials::Test)) => PersistAction::DoNothing,
             // Credentials without a user, or user without credentials - transient states
             // during initialization or refresh; no persistence action needed.

--- a/app/src/auth/credentials.rs
+++ b/app/src/auth/credentials.rs
@@ -25,8 +25,8 @@ pub enum Credentials {
     },
     /// Authentication derived from an ambient browser session cookie.
     SessionCookie,
-    /// Test credentials used in unit tests, integration tests, and skip_login builds.
-    #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
+    /// Test credentials used in unit tests, integration tests, skip_login builds, and the
+    /// runtime `WARP_BYPASS_AUTH=1` local-AI bypass path.
     Test,
 }
 
@@ -37,7 +37,6 @@ impl Credentials {
             Credentials::Firebase(tokens) => Some(tokens),
             Credentials::ApiKey { .. } => None,
             Credentials::SessionCookie => None,
-            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => None,
         }
     }
@@ -48,7 +47,6 @@ impl Credentials {
             Credentials::ApiKey { key, .. } => Some(key),
             Credentials::Firebase(_) => None,
             Credentials::SessionCookie => None,
-            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => None,
         }
     }
@@ -59,7 +57,6 @@ impl Credentials {
             Credentials::ApiKey { owner_type, .. } => *owner_type,
             Credentials::Firebase(_) => None,
             Credentials::SessionCookie => None,
-            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => None,
         }
     }
@@ -70,7 +67,6 @@ impl Credentials {
             Credentials::Firebase(tokens) => Some(&tokens.refresh_token),
             Credentials::ApiKey { .. } => None,
             Credentials::SessionCookie => None,
-            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => None,
         }
     }
@@ -81,7 +77,6 @@ impl Credentials {
             Credentials::Firebase(tokens) => AuthToken::Firebase(tokens.id_token.clone()),
             Credentials::ApiKey { key, .. } => AuthToken::ApiKey(key.clone()),
             Credentials::SessionCookie => AuthToken::NoAuth,
-            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => AuthToken::NoAuth,
         }
     }
@@ -94,7 +89,6 @@ impl Credentials {
             ))),
             Credentials::ApiKey { key, .. } => Some(LoginToken::ApiKey(key.clone())),
             Credentials::SessionCookie => Some(LoginToken::SessionCookie),
-            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => None,
         }
     }
@@ -108,10 +102,6 @@ pub enum AuthToken {
     /// API key for direct server authentication.
     ApiKey(String),
     /// No authentication token available (e.g. session cookie auth or test credentials).
-    #[cfg_attr(
-        not(any(test, feature = "integration_tests", feature = "skip_login")),
-        allow(dead_code)
-    )]
     NoAuth,
 }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -44,6 +44,7 @@ mod gpu_state;
 mod input_classifier;
 mod interval_timer;
 mod linear;
+mod local_ai;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 mod login_item;
 mod menu;
@@ -493,6 +494,10 @@ fn apply_scroll_multiplier(event: &mut Event, app: &AppContext) {
 
 /// Runs the app. If a subcommand was requested, it'll be run instead of the main application.
 pub fn run() -> Result<()> {
+    // Load `.env` from the current working directory before anything reads env vars.
+    // Used by the local-AI bypass feature (WARP_BYPASS_AUTH, WARP_LOCAL_AI, WARP_ILO_SYSTEM_PROMPT).
+    let _ = dotenvy::from_filename(".env");
+
     // Perform any necessary platform-specific initialization.
     platform::init();
 
@@ -2305,6 +2310,19 @@ fn init_logging_for_unit_tests_glue() {
 pub fn init_feature_flags() {
     for flag in enabled_features() {
         flag.set_enabled(true);
+    }
+    // Local-AI bypass: force-enable feature flags that are gated behind cargo features in
+    // OSS builds but are required for the agent UI (Cmd+I to enter agent mode, etc).
+    if local_ai::auth_bypass_enabled() {
+        for flag in [
+            FeatureFlag::AgentView,
+            FeatureFlag::AgentViewBlockContext,
+            FeatureFlag::AgentTips,
+            FeatureFlag::AgentManagementView,
+            FeatureFlag::AgentHarness,
+        ] {
+            flag.set_enabled(true);
+        }
     }
     features::mark_initialized();
 }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -494,9 +494,15 @@ fn apply_scroll_multiplier(event: &mut Event, app: &AppContext) {
 
 /// Runs the app. If a subcommand was requested, it'll be run instead of the main application.
 pub fn run() -> Result<()> {
-    // Load `.env` from the current working directory before anything reads env vars.
-    // Used by the local-AI bypass feature (WARP_BYPASS_AUTH, WARP_LOCAL_AI, WARP_ILO_SYSTEM_PROMPT).
+    // Load `.env` for the local-AI bypass feature (WARP_BYPASS_AUTH, WARP_LOCAL_AI,
+    // WARP_ILO_SYSTEM_PROMPT). Try the cwd first (works for `cargo run` from the repo) and
+    // fall back to `~/.warp/.env` so launching via `open WarpOss.app` (cwd = `/`) also works.
+    // `dotenvy::from_filename` does not overwrite vars already present in the process env,
+    // so anything pre-set in the shell still wins over either file.
     let _ = dotenvy::from_filename(".env");
+    if let Some(home) = dirs::home_dir() {
+        let _ = dotenvy::from_filename(home.join(".warp").join(".env"));
+    }
 
     // Perform any necessary platform-specific initialization.
     platform::init();

--- a/app/src/local_ai.rs
+++ b/app/src/local_ai.rs
@@ -49,15 +49,3 @@ pub fn auth_bypass_enabled() -> bool {
             || LocalAiMode::from_env() != LocalAiMode::Off
     })
 }
-
-pub fn ilo_system_prompt() -> Option<&'static str> {
-    static CACHE: OnceLock<Option<String>> = OnceLock::new();
-    CACHE
-        .get_or_init(|| {
-            std::env::var("WARP_ILO_SYSTEM_PROMPT")
-                .ok()
-                .map(|s| s.trim().to_owned())
-                .filter(|s| !s.is_empty())
-        })
-        .as_deref()
-}

--- a/app/src/local_ai.rs
+++ b/app/src/local_ai.rs
@@ -1,8 +1,38 @@
 //! Local-AI bypass plumbing. Reads `.env`/process env to route agent runs to a
 //! local provider (Ollama / Claude CLI / Codex CLI) and to skip Warp's online
 //! auth gate. All state is read once at startup and cached.
+//!
+//! # Local model IDs
+//!
+//! When local-AI is active the model selector shows a custom list of models
+//! instead of Warp's server-fetched list.  Each entry uses a structured ID
+//! that encodes the provider and its parameters:
+//!
+//! | ID string                                   | CLI invoked                                   |
+//! |---------------------------------------------|-----------------------------------------------|
+//! | `local:claude:claude-sonnet-4-7`             | `claude -p --model claude-sonnet-4-7 ...`     |
+//! | `local:claude:claude-opus-4-7`               | `claude -p --model claude-opus-4-7 ...`       |
+//! | `local:claude:claude-haiku-4-5`              | `claude -p --model claude-haiku-4-5 ...`      |
+//! | `local:codex:gpt-5.5:low`                   | `codex exec -m gpt-5.5 -c reasoning_effort=low ...`  |
+//! | `local:codex:gpt-5.5:medium`                | `codex exec -m gpt-5.5 -c reasoning_effort=medium ...` |
+//! | `local:codex:gpt-5.5:high`                  | `codex exec -m gpt-5.5 -c reasoning_effort=high ...`  |
+//!
+//! The `WARP_LOCAL_AI` env var overrides which provider is used (for
+//! backwards compatibility) but does NOT restrict which models appear in the
+//! menu.  The menu selection is the primary control when `WARP_BYPASS_AUTH=1`
+//! is set without `WARP_LOCAL_AI`.
 
+use std::collections::HashMap;
 use std::sync::OnceLock;
+
+// Re-export only what callers need; the full model definitions live here.
+use crate::ai::llms::{
+    AvailableLLMs, LLMId, LLMInfo, LLMProvider, LLMSpec, LLMUsageMetadata, ModelsByFeature,
+};
+
+// ---------------------------------------------------------------------------
+// LocalAiMode – legacy env-var override
+// ---------------------------------------------------------------------------
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LocalAiMode {
@@ -38,6 +68,9 @@ pub fn is_active() -> bool {
     current() != LocalAiMode::Off
 }
 
+/// Returns true if the full auth bypass (no server, no credentials) is active.
+/// This is also true when `WARP_BYPASS_AUTH=1` without `WARP_LOCAL_AI`, so
+/// the model selector and harness both activate the local path.
 pub fn auth_bypass_enabled() -> bool {
     static CACHE: OnceLock<bool> = OnceLock::new();
     *CACHE.get_or_init(|| {
@@ -48,4 +81,188 @@ pub fn auth_bypass_enabled() -> bool {
             // Local-AI mode implies auth bypass: the server-mediated path requires auth.
             || LocalAiMode::from_env() != LocalAiMode::Off
     })
+}
+
+/// Returns true when local-model routing should be used.  This is true when
+/// either `WARP_LOCAL_AI` is set OR `WARP_BYPASS_AUTH=1` is set (in bypass
+/// mode the server is unavailable, so we always want local models).
+pub fn local_model_routing_active() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(|| auth_bypass_enabled())
+}
+
+// ---------------------------------------------------------------------------
+// Local model ID helpers
+// ---------------------------------------------------------------------------
+
+/// Well-known local model ID prefix.
+pub const LOCAL_MODEL_PREFIX: &str = "local:";
+
+/// Returns true if `id` is a local-model ID managed by this module.
+#[allow(dead_code)]
+pub fn is_local_model_id(id: &str) -> bool {
+    id.starts_with(LOCAL_MODEL_PREFIX)
+}
+
+/// Parsed representation of a local model ID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalModelSpec {
+    /// `claude -p --model <model_name>`
+    Claude { model_name: String },
+    /// `codex exec -m <model_name> -c reasoning_effort=<effort>`
+    Codex {
+        model_name: String,
+        reasoning_effort: Option<String>,
+    },
+}
+
+impl LocalModelSpec {
+    /// Parse a local model ID string (e.g. `"local:claude:claude-sonnet-4-7"`).
+    /// Returns `None` for unrecognised or non-local IDs.
+    pub fn parse(id: &str) -> Option<Self> {
+        let rest = id.strip_prefix(LOCAL_MODEL_PREFIX)?;
+        let mut parts = rest.splitn(3, ':');
+        let provider = parts.next()?;
+        let model_name = parts.next()?.to_string();
+
+        match provider {
+            "claude" => Some(LocalModelSpec::Claude { model_name }),
+            "codex" => {
+                let reasoning_effort = parts.next().map(str::to_string);
+                Some(LocalModelSpec::Codex {
+                    model_name,
+                    reasoning_effort,
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Local model list
+// ---------------------------------------------------------------------------
+
+fn make_claude_model(
+    display_name: &str,
+    model_name: &str,
+    spec: Option<LLMSpec>,
+) -> LLMInfo {
+    LLMInfo {
+        display_name: display_name.to_string(),
+        base_model_name: display_name.to_string(),
+        id: format!("local:claude:{model_name}").into(),
+        reasoning_level: None,
+        usage_metadata: LLMUsageMetadata {
+            request_multiplier: 1,
+            credit_multiplier: None,
+        },
+        description: None,
+        disable_reason: None,
+        vision_supported: true,
+        spec,
+        provider: LLMProvider::Anthropic,
+        host_configs: HashMap::new(),
+        discount_percentage: None,
+    }
+}
+
+fn make_codex_model(
+    display_name: &str,
+    model_name: &str,
+    reasoning_effort: Option<&str>,
+    spec: Option<LLMSpec>,
+) -> LLMInfo {
+    let id = match reasoning_effort {
+        Some(effort) => format!("local:codex:{model_name}:{effort}"),
+        None => format!("local:codex:{model_name}"),
+    };
+    LLMInfo {
+        display_name: display_name.to_string(),
+        base_model_name: display_name.to_string(),
+        id: id.into(),
+        reasoning_level: reasoning_effort.map(str::to_string),
+        usage_metadata: LLMUsageMetadata {
+            request_multiplier: 1,
+            credit_multiplier: None,
+        },
+        description: None,
+        disable_reason: None,
+        vision_supported: false,
+        spec,
+        provider: LLMProvider::OpenAI,
+        host_configs: HashMap::new(),
+        discount_percentage: None,
+    }
+}
+
+/// Build the `ModelsByFeature` for the local-model menu.
+///
+/// The default selection is Claude Sonnet 4.7 (good balance of quality and speed
+/// for users who already have `claude` CLI authenticated).
+///
+/// The `WARP_LOCAL_AI` env var does NOT restrict which models appear; it only
+/// provides a backwards-compatible default provider choice.  Specifically:
+/// - If `WARP_LOCAL_AI=codex`, the default selection becomes GPT-5.5 (medium).
+/// - Otherwise, Claude Sonnet 4.7 is the default.
+pub fn local_model_list() -> ModelsByFeature {
+    let claude_sonnet = make_claude_model(
+        "Claude Sonnet 4.7",
+        "claude-sonnet-4-7",
+        Some(LLMSpec { cost: 0.5, quality: 0.85, speed: 0.8 }),
+    );
+    let claude_opus = make_claude_model(
+        "Claude Opus 4.7",
+        "claude-opus-4-7",
+        Some(LLMSpec { cost: 0.9, quality: 1.0, speed: 0.5 }),
+    );
+    let claude_haiku = make_claude_model(
+        "Claude Haiku 4.5",
+        "claude-haiku-4-5",
+        Some(LLMSpec { cost: 0.2, quality: 0.6, speed: 1.0 }),
+    );
+    let gpt55_low = make_codex_model(
+        "GPT-5.5 (low)",
+        "gpt-5.5",
+        Some("low"),
+        Some(LLMSpec { cost: 0.3, quality: 0.65, speed: 0.9 }),
+    );
+    let gpt55_medium = make_codex_model(
+        "GPT-5.5 (medium)",
+        "gpt-5.5",
+        Some("medium"),
+        Some(LLMSpec { cost: 0.55, quality: 0.80, speed: 0.7 }),
+    );
+    let gpt55_high = make_codex_model(
+        "GPT-5.5 (high)",
+        "gpt-5.5",
+        Some("high"),
+        Some(LLMSpec { cost: 0.85, quality: 0.95, speed: 0.45 }),
+    );
+
+    let all_choices = vec![
+        claude_sonnet.clone(),
+        claude_opus,
+        claude_haiku,
+        gpt55_low.clone(),
+        gpt55_medium.clone(),
+        gpt55_high,
+    ];
+
+    // The default ID depends on the legacy WARP_LOCAL_AI env var so that
+    // existing configurations keep working without re-selecting a model.
+    let default_id: LLMId = match current() {
+        LocalAiMode::Codex => gpt55_medium.id.clone(),
+        _ => claude_sonnet.id.clone(),
+    };
+
+    let available = AvailableLLMs::new(default_id, all_choices, None)
+        .expect("local model list is non-empty and default is present");
+
+    ModelsByFeature {
+        agent_mode: available.clone(),
+        coding: available.clone(),
+        cli_agent: Some(available.clone()),
+        computer_use: None,
+    }
 }

--- a/app/src/local_ai.rs
+++ b/app/src/local_ai.rs
@@ -1,0 +1,63 @@
+//! Local-AI bypass plumbing. Reads `.env`/process env to route agent runs to a
+//! local provider (Ollama / Claude CLI / Codex CLI) and to skip Warp's online
+//! auth gate. All state is read once at startup and cached.
+
+use std::sync::OnceLock;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LocalAiMode {
+    Off,
+    Ollama,
+    Claude,
+    Codex,
+}
+
+impl LocalAiMode {
+    fn from_env() -> Self {
+        match std::env::var("WARP_LOCAL_AI")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("ollama") => LocalAiMode::Ollama,
+            Some("claude") | Some("claude-code") => LocalAiMode::Claude,
+            Some("codex") => LocalAiMode::Codex,
+            _ => LocalAiMode::Off,
+        }
+    }
+}
+
+pub fn current() -> LocalAiMode {
+    static CACHE: OnceLock<LocalAiMode> = OnceLock::new();
+    *CACHE.get_or_init(LocalAiMode::from_env)
+}
+
+pub fn is_active() -> bool {
+    current() != LocalAiMode::Off
+}
+
+pub fn auth_bypass_enabled() -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("WARP_BYPASS_AUTH")
+            .ok()
+            .map(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"))
+            .unwrap_or(false)
+            // Local-AI mode implies auth bypass: the server-mediated path requires auth.
+            || LocalAiMode::from_env() != LocalAiMode::Off
+    })
+}
+
+pub fn ilo_system_prompt() -> Option<&'static str> {
+    static CACHE: OnceLock<Option<String>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            std::env::var("WARP_ILO_SYSTEM_PROMPT")
+                .ok()
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+        .as_deref()
+}

--- a/app/src/server/server_api/auth.rs
+++ b/app/src/server/server_api/auth.rs
@@ -274,7 +274,6 @@ impl AuthClient for ServerApi {
                 Ok(AuthToken::Firebase(auth_tokens.id_token))
             }
             Credentials::SessionCookie => Ok(AuthToken::NoAuth),
-            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => Ok(AuthToken::NoAuth),
         }
     }

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1483,6 +1483,12 @@ impl AISettings {
     }
 
     pub fn is_any_ai_enabled(&self, app: &AppContext) -> bool {
+        // Local-AI bypass: force-enable AI gating so the agent UI, menu items,
+        // and Cmd+I binding predicate all light up.
+        if crate::local_ai::auth_bypass_enabled() {
+            return true;
+        }
+
         // Disable AI for anonymous and logged-out users.
         let is_anonymous_or_logged_out = AuthStateProvider::as_ref(app)
             .get()

--- a/app/src/terminal/input/models/data_source.rs
+++ b/app/src/terminal/input/models/data_source.rs
@@ -225,8 +225,10 @@ impl ModelSearchItem {
     fn new(llm: &LLMInfo, active_llm_id: &LLMId, app: &AppContext) -> Self {
         // If the model requires an upgrade but the user already has a BYOK key
         // for this provider, treat it as enabled by clearing the disable reason.
+        // Also clear it when the local-AI bypass is active, so all models appear usable.
         let disable_reason = if llm.disable_reason == Some(DisableReason::RequiresUpgrade)
-            && is_using_api_key_for_provider(&llm.provider, app)
+            && (is_using_api_key_for_provider(&llm.provider, app)
+                || crate::local_ai::auth_bypass_enabled())
         {
             None
         } else {

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -1274,6 +1274,14 @@ impl TerminalManager {
         sharer_remote_update_guard: RemoteUpdateGuard,
         ctx: &mut AppContext,
     ) {
+        // Session sharing requires Warp server auth. Under auth bypass the server
+        // would reject the request with UserNotFound, producing a spurious toast.
+        // Skip the init entirely; session sharing is not functional in this mode.
+        if crate::local_ai::auth_bypass_enabled() {
+            log::debug!("Skipping session sharing init: auth bypass is active");
+            return;
+        }
+
         let mut session_sharer = shared_session_model.borrow_mut();
 
         // If it's already being shared, then this should no-op.

--- a/app/src/terminal/view/init.rs
+++ b/app/src/terminal/view/init.rs
@@ -1156,6 +1156,20 @@ fn register_input_mode_bindings(app: &mut AppContext) {
     )
     .with_enabled(|| FeatureFlag::AgentView.is_enabled())]);
 
+    // Local-AI bypass: cmd-i / ctrl-i toggles agent mode unconditionally when WARP_BYPASS_AUTH=1.
+    // The default is an EditableBinding that depends on the user's keybindings.json; in fresh
+    // OSS builds it doesn't fire reliably, so we add a FixedBinding with a Workspace-only
+    // predicate to guarantee the keystroke registers.
+    app.register_fixed_bindings([FixedBinding::new_per_platform(
+        PerPlatformKeystroke {
+            mac: "cmd-i",
+            linux_and_windows: "ctrl-i",
+        },
+        TerminalAction::SetInputModeAgent,
+        id!("Workspace"),
+    )
+    .with_enabled(|| crate::local_ai::auth_bypass_enabled())]);
+
     app.register_editable_bindings([
         EditableBinding::new(
             SET_INPUT_MODE_AGENT_ACTION_NAME,

--- a/app/src/terminal/view/init_project/model.rs
+++ b/app/src/terminal/view/init_project/model.rs
@@ -161,14 +161,17 @@ impl InitProjectModel {
         }
         self.compute_project_scoped_rules_step(&pwd_path, ctx);
 
-        // CreateEnvironment step is always Ready (no async computation)
-        self.set_step(
-            InitStepKind::CreateEnvironment,
-            Some(InitStep::new_ready(
+        // CreateEnvironment step is always Ready (no async computation).
+        // Hidden under local-AI bypass: cloud agents can't run without Warp auth.
+        if !crate::local_ai::auth_bypass_enabled() {
+            self.set_step(
                 InitStepKind::CreateEnvironment,
-                InitStepData::CreateEnvironment,
-            )),
-        );
+                Some(InitStep::new_ready(
+                    InitStepKind::CreateEnvironment,
+                    InitStepData::CreateEnvironment,
+                )),
+            );
+        }
 
         // Emit welcome step immediately, then progress to next
         ctx.emit(InitProjectModelEvent::InsertStep(InitStepKind::Welcome));
@@ -366,6 +369,14 @@ impl InitProjectModel {
     fn compute_codebase_context_step(&mut self, pwd_path: &Path, ctx: &mut ModelContext<Self>) {
         if !UserWorkspaces::as_ref(ctx).is_codebase_context_enabled(ctx) {
             // Feature disabled, leave as None
+            return;
+        }
+
+        // Codebase indexing sends code fragments to Warp's GraphQL backend for
+        // server-side embedding generation and retrieval. Under local-AI bypass
+        // there is no valid session token, so every StoreClient call would fail.
+        // Leave the step as None so the prompt is never shown.
+        if crate::local_ai::auth_bypass_enabled() {
             return;
         }
 

--- a/app/src/workspace/header_toolbar_item.rs
+++ b/app/src/workspace/header_toolbar_item.rs
@@ -75,7 +75,10 @@ impl HeaderToolbarItemKind {
                     && !is_web_anonymous_user
             }
             Self::CodeReview => cfg!(feature = "local_fs"),
-            Self::NotificationsMailbox => FeatureFlag::HOANotifications.is_enabled(),
+            // Notifications inbox is intentionally disabled in this build:
+            // the entry point (icon button + popup) has been removed from the tab bar.
+            // The underlying notifications model is left intact.
+            Self::NotificationsMailbox => false,
         }
     }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -21670,11 +21670,15 @@ impl View for Workspace {
             context.set.insert("IsOnline");
         }
 
-        if AISettings::as_ref(app).is_any_ai_enabled(app) {
+        if AISettings::as_ref(app).is_any_ai_enabled(app)
+            || crate::local_ai::auth_bypass_enabled()
+        {
             context.set.insert(flags::IS_ANY_AI_ENABLED);
         }
 
-        if AISettings::as_ref(app).is_active_ai_enabled(app) {
+        if AISettings::as_ref(app).is_active_ai_enabled(app)
+            || crate::local_ai::auth_bypass_enabled()
+        {
             context.set.insert(flags::IS_ACTIVE_AI_ENABLED);
         }
         if AISettings::as_ref(app).is_voice_input_enabled(app)


### PR DESCRIPTION
## Summary

- Switches `claude -p` from `--output-format text` to `--output-format stream-json --verbose`, enabling structured event parsing
- Parses NDJSON stream events and renders tool activity as inline text annotations in the agent panel:
  - `[tool: Bash] echo hello` when Claude invokes a tool
  - `[result] hello` when the tool returns output
- Assistant text blocks are forwarded verbatim as before
- System, rate_limit, and result events are silently dropped
- Codex `--json` parsing is unchanged

## What's new vs the previous text-only path

Before: only the final assistant text reply appeared in the panel. Tool calls (file edits, shell commands, searches) were invisible.

After: each tool invocation and its result appear as a line in the panel as Claude works. Users see the agent's tool loop in real time.

## Scope

This is Slice B of the tool-loop bridge. The previous state was effectively Slice 0 (text-only).

Deferred (Slice C): Warp's native tool-block UI - the rich block rendering in cloud agent runs. That requires mapping each `tool_use` event to an `api::message::ToolCall` protobuf message, which is a larger protocol surface change.

## Event types handled

| Claude stream-json type | Panel output |
|---|---|
| `assistant` / `text` block | text forwarded verbatim |
| `assistant` / `tool_use` block | `[tool: Name] input-summary` |
| `user` / `tool_result` block | `[result] stdout-excerpt` |
| `system`, `result`, `rate_limit_event` | dropped |

Tool input summaries are tailored for common tools (Bash shows command, Read/Write/Edit show path, Grep shows pattern + path) and fall back to truncated JSON for everything else.

## Test plan

- Build with `./script/run` and set `WARP_BYPASS_AUTH=1`
- Open the agent panel (Cmd+I), ask a question that causes Claude to run a shell command, e.g. "what files are in the current directory?"
- Verify `[tool: Bash] ls ...` and `[result] file1 file2 ...` lines appear as Claude works
- Verify assistant text is still shown correctly after the tool loop completes
- Verify a text-only prompt (no tool use) still works correctly