### PR TITLE
docs: standardize bullet style to hyphens (GH9742)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,11 +24,11 @@ How did you test this change? What automated tests did you add? If you didn't ad
 
 The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:
 
-* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
-* IMPROVEMENT: for new functionality of existing features.
-* BUG-FIX: for fixes related to known bugs or regressions.
-* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
-* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
+- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
+- IMPROVEMENT: for new functionality of existing features.
+- BUG-FIX: for fixes related to known bugs or regressions.
+- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
+- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
 
 CHANGELOG-NEW-FEATURE: {{text goes here...}}
 CHANGELOG-IMPROVEMENT: {{text goes here...}}

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ We ask everyone to be respectful and empathetic. Warp follows the [Code of Condu
 
 We'd like to call out a few of the [open source dependencies](https://docs.warp.dev/help/licenses) that have helped Warp to get off the ground:
 
-* [Tokio](https://github.com/tokio-rs/tokio)
-* [NuShell](https://github.com/nushell/nushell)
-* [Fig Completion Specs](https://github.com/withfig/autocomplete)
-* [Warp Server Framework](https://github.com/seanmonstar/warp)
-* [Alacritty](https://github.com/alacritty/alacritty)
-* [Hyper HTTP library](https://github.com/hyperium/hyper)
-* [FontKit](https://github.com/servo/font-kit)
-* [Core-foundation](https://github.com/servo/core-foundation-rs)
-* [Smol](https://github.com/smol-rs/smol)
+- [Tokio](https://github.com/tokio-rs/tokio)
+- [NuShell](https://github.com/nushell/nushell)
+- [Fig Completion Specs](https://github.com/withfig/autocomplete)
+- [Warp Server Framework](https://github.com/seanmonstar/warp)
+- [Alacritty](https://github.com/alacritty/alacritty)
+- [Hyper HTTP library](https://github.com/hyperium/hyper)
+- [FontKit](https://github.com/servo/font-kit)
+- [Core-foundation](https://github.com/servo/core-foundation-rs)
+- [Smol](https://github.com/smol-rs/smol)


### PR DESCRIPTION
  ## Summary                              
                                                                                                                                     
  Resolves the inconsistent bullet styling called out in #9742. Two files in the core docs were mixing asterisk (`*`) and hyphen     
  (`-`) bullets within themselves, while every other top-level Markdown file in the repo already uses hyphens uniformly:             
   
  - **`README.md`** — the nine *Open Source Dependencies* entries used `*` while the rest of the file used `-`.                      
  - **`.github/pull_request_template.md`** — the five `CHANGELOG-*` suffix descriptions in the commented-out instruction block used
  `*` while the visible *Linked Issue* checkboxes used `-`.                                                                          
                                                                                                                                     
  Both are now hyphens. After this PR every `.md` file in the seven core docs (`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `FAQ.md`,
  `README.md`, `SECURITY.md`, `WARP.md`, `.github/pull_request_template.md`) uses the hyphen style consistently.                     
                                                                                          
  The other items mentioned in #9742 (header spacing, section dividers) were spot-checked and are already consistent across these    
  files; no further changes were necessary. If a maintainer wants stricter project-wide enforcement (e.g. a `markdownlint` config or
  `prettier --parser markdown` run over the whole tree), that is a tooling decision that warrants its own discussion and a much      
  larger diff — happy to follow up on a separate PR if there is interest.                                                            
                                         
  ## Linked Issue                                                                                                                    
                                                                                          
  Closes #9742.                          

  - [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
  - [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI
  changes).                                   
                                          
  N/A — docs-only change; no UI or behavior impact.
                                                                                                                                     
  ## Screenshots / Videos                     
                                                                                                                                     
  N/A — docs-only.                                                                        
                                                                                                                                     
  ## Testing
                                                                                                                                     
  Verified post-edit with `grep -c '^\* \|^  \* \|^   \* '` over the seven core `.md` files; all return `0` asterisk-bulleted lines.
  No code changes; no test-suite impact.  

  ## Agent Mode                                                                                                                      
   
  - [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode   