### PR TITLE
fix(shared-session): hide "Copy session sharing link" when no link exists (GH9736)

### DIFF
--- a/app/src/terminal/shared_session/mod.rs
+++ b/app/src/terminal/shared_session/mod.rs
@@ -149,6 +149,19 @@ impl SharedSessionStatus {
         !matches!(self, Self::NotShared)
     }
 
+    /// Returns `true` when the session currently has a usable sharing
+    /// link the user can copy — i.e. when the share has fully
+    /// established (sharer side) or been joined (viewer side). Pending
+    /// and finished states return `false` so the right-click "Copy
+    /// session sharing link" menu item is not offered when the link
+    /// would either not exist yet or no longer be valid (GH#9736).
+    pub fn has_active_share_link(&self) -> bool {
+        matches!(
+            self,
+            Self::ActiveSharer | Self::ActiveViewer { .. }
+        )
+    }
+
     pub fn as_keymap_context(&self) -> &'static str {
         match self {
             Self::NotShared => "SharedSessionStatus_NotShared",

--- a/app/src/terminal/shared_session/mod_test.rs
+++ b/app/src/terminal/shared_session/mod_test.rs
@@ -1,4 +1,6 @@
-use super::{decode_scrollback, SharedSessionScrollbackType};
+use super::{decode_scrollback, SharedSessionScrollbackType, SharedSessionStatus};
+use session_sharing_protocol::common::Role;
+use session_sharing_protocol::sharer::SessionSourceType;
 
 use crate::ai::blocklist::agent_view::AgentViewState;
 use crate::assert_lines_approx_eq;
@@ -346,4 +348,41 @@ fn test_loading_scrollback_in_alt_screen() {
 
     // Make sure we're in the alt screen.
     assert!(model.is_alt_screen_active());
+}
+
+/// Regression test for GH#9736: the right-click "Copy session sharing link"
+/// menu item must only be offered when a sharing URL actually exists. Pending
+/// shares (which can include shares that failed to establish) and finished
+/// viewer states leave no link to copy and previously surfaced the menu item
+/// anyway, writing a stale or empty value to the clipboard.
+#[test]
+fn has_active_share_link_only_true_for_active_states() {
+    // States with a usable link.
+    assert!(SharedSessionStatus::ActiveSharer.has_active_share_link());
+    assert!(
+        SharedSessionStatus::ActiveViewer { role: Role::Reader }.has_active_share_link(),
+        "ActiveViewer (reader) must offer copy link"
+    );
+    assert!(
+        SharedSessionStatus::ActiveViewer {
+            role: Role::Executor,
+        }
+        .has_active_share_link(),
+        "ActiveViewer (executor) must offer copy link"
+    );
+
+    // States without a usable link — these are the ones that produced
+    // the GH#9736 regression.
+    assert!(!SharedSessionStatus::NotShared.has_active_share_link());
+    assert!(!SharedSessionStatus::SharePending.has_active_share_link());
+    assert!(
+        !SharedSessionStatus::SharePendingPreBootstrap {
+            source_type: SessionSourceType::default(),
+        }
+        .has_active_share_link(),
+        "SharePendingPreBootstrap must not offer copy link — \
+         this is the state a failed-to-share session sits in"
+    );
+    assert!(!SharedSessionStatus::ViewPending.has_active_share_link());
+    assert!(!SharedSessionStatus::FinishedViewer.has_active_share_link());
 }

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -652,7 +652,14 @@ impl BackingView for TerminalView {
         let shared_session_status = model.shared_session_status();
         let is_ambient_agent = self.is_ambient_agent_session(ctx);
         if shared_session_status.is_sharer_or_viewer() {
-            if !is_ambient_agent {
+            // "Copy link" is gated on `has_active_share_link()` rather than
+            // the outer `is_sharer_or_viewer()` so that pending and failed
+            // states (which leave no usable URL) do not surface a copy
+            // entry — see GH#9736. The neighbouring "Stop sharing session"
+            // entry deliberately stays under `is_sharer_or_viewer()` /
+            // `is_sharer()` so the user can still cancel a stuck pending
+            // share.
+            if !is_ambient_agent && shared_session_status.has_active_share_link() {
                 items.push(
                     MenuItemFields::new("Copy link")
                         .with_on_select_action(TerminalAction::CopySharedSessionLink { source })

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -1630,7 +1630,13 @@ impl TerminalView {
             );
         }
 
-        if model.shared_session_status().is_sharer_or_viewer() {
+        // Only offer "Copy session sharing link" when a link actually
+        // exists. Pending shares (SharePending / SharePendingPreBootstrap)
+        // have not yet produced a URL, and a session that finished or
+        // failed to share leaves no link to copy. Surfacing the menu
+        // entry in those states writes a stale or empty value to the
+        // clipboard — see GH#9736.
+        if model.shared_session_status().has_active_share_link() {
             items.push(
                 MenuItemFields::new("Copy session sharing link")
                     .with_on_select_action(TerminalAction::CopySharedSessionLink {


### PR DESCRIPTION
## Description

Fixes #9736. The right-click *Copy session sharing link* menu item was offered whenever the session's `SharedSessionStatus` was anything other than `NotShared`. That set includes the pending states (`SharePending`, `SharePendingPreBootstrap`) and the post-end `FinishedViewer` state — none of which have an actual sharing URL. After a session fails to share (the reproduction described in #9735), the status remains in `SharePending*` and the menu still offers the copy entry; selecting it writes a stale or empty value to the clipboard.

### Fix

Introduce a new predicate `SharedSessionStatus::has_active_share_link()` that returns `true` only for `ActiveSharer` and `ActiveViewer { .. }` and use it to gate the menu entry in `session_sharing_context_menu_items` (`app/src/terminal/view/shared_session/view_impl.rs:1633`):

```rust
pub fn has_active_share_link(&self) -> bool {
    matches!(self, Self::ActiveSharer | Self::ActiveViewer { .. })
}
```

Pending and finished states no longer surface the copy entry, so a session that failed to share simply leaves the right-click menu showing only the unrelated entries (`Share session...` / `Stop sharing`) — which matches the expected behavior in #9736 ("I should not be offered to duplicate a non-existent URI into my clipboard").

### What is **not** changed

The existing `is_sharer_or_viewer` helper is kept unchanged because other call sites — most notably the reconnection-banner guard at `app/src/terminal/view/shared_session/view_impl.rs:1571–1582` — intentionally include pending states. Adding a separate, narrower predicate (rather than tightening the existing one) avoids touching those sites.

`#9735` (the underlying "share fails" reproduction) is a separate root-cause that is out of scope for this PR; this change makes the secondary symptom (stale menu entry) safe regardless of whether #9735 is fixed.

## Linked Issue

Closes #9736.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

> No new visual UI is added; the change hides an existing menu entry in states where it should not appear. The reproduction video on the linked issue (the menu showing *Copy session sharing link* after a failed share) demonstrates the pre-fix behavior; with this PR the entry is absent in that state.

## Testing

Regression test added in `app/src/terminal/shared_session/mod_test.rs` (`has_active_share_link_only_true_for_active_states`). It asserts:

- `ActiveSharer` and both `ActiveViewer` role variants (`Reader`, `Executor`) return `true`.
- `NotShared`, `SharePending`, `SharePendingPreBootstrap`, `ViewPending`, and `FinishedViewer` all return `false`.

The `SharePendingPreBootstrap` assertion is the one that pins the GH#9736 regression specifically — that's the state a failed-to-share session sits in.

Manual verification on macOS (`SharedSession` flows): right-click during a `SharePending` session shows only `Stop sharing` (no *Copy session sharing link*); after the share fully establishes (`ActiveSharer`), the entry returns. After `Stop sharing`, the menu reverts to `Share session...` only.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Hide "Copy session sharing link" right-click entry when the session has no usable share link (e.g. when the share is still pending or has failed to establish).
-->