### PR TITLE
Fix duplicate words and grammar in comments

### DIFF
--- a/app/src/editor/view/model/mod.rs
+++ b/app/src/editor/view/model/mod.rs
@@ -693,7 +693,7 @@ impl EditorModel {
         // (whether that's the real buffer or the last ephemeral buffer).
         // This needs to be done _before_ we start the batch below so that
         // 1) we take the snapshot of the correct (regular vs. ephemeral) buffer
-        // 2) we star the the batch on the correct (regular vs. ephemeral) buffer
+        // 2) we star the batch on the correct (regular vs. ephemeral) buffer
         let restore_from_snapshot = if can_edit && edit.is_ephemeral() {
             let snapshot = self.as_snapshot(ctx);
             self.buffer_and_display_map

--- a/app/src/experiments/mod.rs
+++ b/app/src/experiments/mod.rs
@@ -278,8 +278,8 @@ pub trait Experiment<T: Experiment<T>>: FromStr {
     /// Gets the assigned group of the experiment for the current user. Returns None
     /// if the user is not in this experiment.
     ///
-    /// TODO: we should investigate if we can suffice with just a AppContext
-    /// here to allow `get_group` to be used when a AppContext isn't available
+    /// TODO: we should investigate if we can suffice with just an AppContext
+    /// here to allow `get_group` to be used when an AppContext isn't available
     /// (e.g. when rendering a view). We currently need it because `get_group`
     /// might emit telemetry.
     fn get_group(ctx: &mut AppContext) -> Option<T>

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -5190,7 +5190,7 @@ impl PaneGroup {
             return Some(terminal_pane);
         }
 
-        // Finally, fall back to a a session that's to the right/down.
+        // Finally, fall back to a session that's to the right/down.
         pane_ids
             .iter()
             .skip(pane_idx + 1)

--- a/app/src/search/search_bar.rs
+++ b/app/src/search/search_bar.rs
@@ -36,7 +36,7 @@ use crate::{
 use super::mixer::SearchMixerEvent;
 
 /// Function to create a [`QueryResultRenderer`] from a [`QueryResult`]. Used to specify the styles
-/// and click-action of a a rendered query result.
+/// and click-action of a rendered query result.
 pub type CreateQueryResultRendererFn<T> =
     fn(QueryResultIndex, QueryResult<T>) -> QueryResultRenderer<T>;
 

--- a/app/src/terminal/model/ansi/handler.rs
+++ b/app/src/terminal/model/ansi/handler.rs
@@ -279,12 +279,12 @@ pub trait Handler {
     /// input buffer (the reporting is itself triggered by Warp).
     fn input_buffer(&mut self, _data: InputBufferValue) {}
 
-    /// Callback emitted during the initialization process for subshells with where the shell type
-    /// is initiall not known.
+    /// Callback emitted during the initialization process for subshells where the shell type
+    /// is initially not known.
     fn init_subshell(&mut self, _data: InitSubshellValue) {}
 
     /// Callback emitted when executing the user's RC file, which signals a new session is being
-    /// created. If the session is for a subshell, this should triggers Warp's bootstrap process.
+    /// created. If the session is for a subshell, this should trigger Warp's bootstrap process.
     /// Otherwise, it's ignored.
     fn sourced_rc_file(&mut self, _data: SourcedRcFileForWarpValue) {}
 

--- a/app/src/util/bindings.rs
+++ b/app/src/util/bindings.rs
@@ -148,7 +148,7 @@ lazy_static! {
         (action as isize, action)
     }));
 
-    /// Regex that matches whether the the normalized form of a [`Keystroke`] matches a control
+    /// Regex that matches whether the normalized form of a [`Keystroke`] matches a control
     /// character. ASCII control characters constitute the first 31 values of ASCII characters.
     /// Though they have their own ASCII codepoints, they are typed into the keyboard using
     /// `ctrl-XX`, see <https://en.wikipedia.org/wiki/Caret_notation>.

--- a/app/src/util/link_detection.rs
+++ b/app/src/util/link_detection.rs
@@ -305,7 +305,7 @@ fn compute_valid_file_path(
         });
     } else if path.components().count() <= 1 {
         // If the path does not contain a separator and isn't in files_and_folders_in_working_directory,
-        // we know it isn't a valid path. Return immediately to save a a file system call.
+        // we know it isn't a valid path. Return immediately to save a file system call.
         return None;
     }
 


### PR DESCRIPTION
## Description

Fixes typos missed in the recent typo cleanup PR (#9318):
- Remove duplicate words ("a a", "the the", etc.)
- Fix grammatical errors ("a AppContext" -> "an AppContext")
- Correct verb conjugation ("triggers" -> "trigger")
- Remove spurious word ("with where" -> "where")
- Fix misspelling ("initiall" -> "initially")

## Testing

No code changes — comment-only fixes.

## Changelog Entries

CHANGELOG-IMPROVEMENT: Fixed duplicate words and grammar issues in code comments.