### PR TITLE
fix(ui): Correct context chip styling during active CLI agent sessions 

### DIFF
--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -1452,7 +1452,7 @@ impl DisplayChip {
         };
 
         let mut stack = Stack::new().with_child(hoverable);
-        if popup_open {
+        if popup_open && !is_cli_agent_active {
             let positioning = self.menu_positioning_provider.menu_position(app);
             let (parent_anchor, child_anchor) = Self::positioning_to_anchors(positioning);
             let offset = match positioning {

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -1047,7 +1047,7 @@ impl DisplayChip {
 
         let mut stack = Stack::new().with_child(hover);
 
-        if menu_open {
+        if menu_open && !is_cli_agent_active {
             let positioning = self.menu_positioning_provider.menu_position(app);
             let (parent_anchor, child_anchor) = Self::positioning_to_anchors(positioning);
             let offset = match positioning {
@@ -1283,8 +1283,9 @@ impl DisplayChip {
         } else {
             // Non-interactive chip (either show_menu is false or in active ambient agent)
             let font_color = if self.is_in_agent_view {
-                // Use disabled text color when in active ambient agent or CLI agent session
-                if is_in_active_ambient_agent || is_cli_agent_active {
+                if is_cli_agent_active {
+                    internal_colors::neutral_6(theme)
+                } else if is_in_active_ambient_agent {
                     theme
                         .disabled_text_color(blended_colors::neutral_1(theme).into())
                         .into_solid()
@@ -1330,7 +1331,7 @@ impl DisplayChip {
 
         stack.add_child(button);
 
-        if menu_open {
+        if menu_open && !is_cli_agent_active {
             let positioning = self.menu_positioning_provider.menu_position(app);
             let (parent_anchor, child_anchor) = Self::positioning_to_anchors(positioning);
 

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -999,14 +999,17 @@ impl DisplayChip {
         app: &AppContext,
     ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
-        let font_color = if self.is_in_agent_view {
+        let is_cli_agent_active = self.is_cli_agent_session_active(app);
+
+        let font_color = if is_cli_agent_active {
+            internal_colors::neutral_6(appearance.theme())
+        } else if self.is_in_agent_view {
             agent_view_chip_color(appearance)
         } else {
             appearance.theme().ansi_fg_green()
         };
 
-        let is_interactive =
-            !self.is_shared_session_viewer && !self.is_cli_agent_session_active(app);
+        let is_interactive = !self.is_shared_session_viewer && !is_cli_agent_active;
         let is_in_agent_view = self.is_in_agent_view;
         let chip_text = self.text.clone();
         let hover = Hoverable::new(self.mouse_state.clone(), move |state| {
@@ -1280,18 +1283,20 @@ impl DisplayChip {
         } else {
             // Non-interactive chip (either show_menu is false or in active ambient agent)
             let font_color = if self.is_in_agent_view {
-                // Use disabled text color when in active ambient agent
-                if is_in_active_ambient_agent {
+                // Use disabled text color when in active ambient agent or CLI agent session
+                if is_in_active_ambient_agent || is_cli_agent_active {
                     theme
                         .disabled_text_color(blended_colors::neutral_1(theme).into())
                         .into_solid()
                 } else {
-                    // In agent view but the chip is non-interactive for reasons other than an active
-                    // ambient agent session. Keep the normal agent-view subtext styling (not disabled).
                     agent_view_chip_color(appearance)
                 }
             } else {
-                theme.ansi_fg_cyan()
+                if is_cli_agent_active {
+                    internal_colors::neutral_6(theme)
+                } else {
+                    theme.ansi_fg_cyan()
+                }
             };
 
             let chip_text = self.text.clone();
@@ -1414,28 +1419,37 @@ impl DisplayChip {
         app: &AppContext,
     ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
+        let is_cli_agent_active = self.is_cli_agent_session_active(app);
 
         let chip_text = self.text.clone();
         let is_in_agent_view = self.is_in_agent_view;
         let hoverable = Hoverable::new(self.mouse_state.clone(), move |state| {
-            let color = if is_in_agent_view {
+            let color = if is_cli_agent_active {
+                internal_colors::neutral_6(appearance.theme())
+            } else if is_in_agent_view {
                 agent_view_chip_color(appearance)
             } else {
                 appearance.theme().ansi_fg_green()
             };
-            let hovered = state.is_hovered() && !popup_open;
+            let hovered = state.is_hovered() && !popup_open && !is_cli_agent_active;
             let mut config = UdiChipConfig::new_with_icon(Icon::NodeJS, color, chip_text.clone())
                 .with_hovered(hovered);
             if is_in_agent_view {
                 config = config.for_agent_view();
             }
             render_udi_chip(config, appearance)
-        })
-        .on_click(|ctx, _app, _pos| {
-            ctx.dispatch_typed_action(DisplayChipAction::ToggleMenu);
-        })
-        .with_cursor(Cursor::PointingHand)
-        .finish();
+        });
+
+        let hoverable = if is_cli_agent_active {
+            hoverable.finish()
+        } else {
+            hoverable
+                .on_click(|ctx, _app, _pos| {
+                    ctx.dispatch_typed_action(DisplayChipAction::ToggleMenu);
+                })
+                .with_cursor(Cursor::PointingHand)
+                .finish()
+        };
 
         let mut stack = Stack::new().with_child(hoverable);
         if popup_open {


### PR DESCRIPTION
# fix(ui): Correct context chip styling during active CLI agent sessions

## Description
This PR addresses **Bug 3** from issue #9958, where context chips (badges) in the CLI agent toolbar appeared interactive despite their click actions being suppressed. 

The fix ensures that the UI correctly reflects the disabled state when a CLI agent session is active by:
*   Removing hover background effects and tooltips.
*   Reverting the cursor from a `PointingHand` to a default `Arrow`.
*   Applying `internal_colors::neutral_6` to provide a muted, "disabled" visual style for the text and icons.
*   Explicitly skipping click handler registration for the affected chips.

These changes were applied to the **Git Branch**, **Working Directory**, and **Node Version** chips in `app/src/context_chips/display_chip.rs`.

## Linked Issue
Addresses Bug 3 in #9958

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Screenshots / Videos

<img width="1896" height="1008" alt="screenshot-2026-05-06_20-04-27" src="https://github.com/user-attachments/assets/77533f9a-76d4-4b96-81ac-00902d340e57" />


## Testing
Verified the implementation by checking the rendering logic in `display_chip.rs`. Confirmed that `is_cli_agent_active` now gates all interactive UI properties (hover, cursor, click) and triggers the muted color palette.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed a UI mismatch where certain toolbar context chips (Git Branch, Working Directory, Node Version) appeared falsely clickable during active CLI agent sessions.