### PR TITLE
fix(ui): Prevent stale Git branch and working directory in agent sessions

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4610,29 +4610,16 @@ impl TerminalView {
     }
 
     /// Returns whether this terminal view should subscribe to git status
-    /// updates. We subscribe when:
-    /// 1. Agent mode is active and its chip list includes `GitDiffStats`, or
-    /// 2. Terminal mode with the Warp prompt enabled and the git stats chip
-    ///    configured.
+    /// updates.
+    ///
+    /// Always returns `true` when the local_fs feature is available — the
+    /// caller guards on `current_repo_path` being `Some`, so we only actually
+    /// subscribe when there is a git repository. The vertical tabs, status bar,
+    /// and code review panel all need accurate per-session branch and diff
+    /// metadata regardless of the toolbar chip selection.
     #[cfg(feature = "local_fs")]
-    fn should_subscribe_to_git_status(&self, ctx: &AppContext) -> bool {
-        // Agent view: subscribe only when the configured agent footer includes git stats.
-        if self.agent_view_controller.as_ref(ctx).is_active() {
-            return SessionSettings::as_ref(ctx)
-                .agent_footer_chip_selection
-                .all_chips()
-                .contains(&ContextChipKind::GitDiffStats);
-        }
-
-        // Terminal prompt path: the Warp prompt is active when honor_ps1 is
-        // off, or when UDI overrides PS1. GitDiffStats must also be in the
-        // configured chip list.
-        let is_using_warp_prompt = !*SessionSettings::as_ref(ctx).honor_ps1
-            || InputSettings::as_ref(ctx).is_universal_developer_input_enabled(ctx);
-        is_using_warp_prompt
-            && Prompt::as_ref(ctx)
-                .chip_kinds()
-                .contains(&ContextChipKind::GitDiffStats)
+    fn should_subscribe_to_git_status(&self, _ctx: &AppContext) -> bool {
+        true
     }
 
     /// No-op when the `local_fs` feature is disabled – git status is not

--- a/app/src/terminal/view/tab_metadata.rs
+++ b/app/src/terminal/view/tab_metadata.rs
@@ -14,8 +14,8 @@ impl TerminalView {
 
     pub fn display_working_directory(&self, ctx: &AppContext) -> Option<String> {
         let raw = self
-            .prompt_chip_value(&ContextChipKind::WorkingDirectory, ctx)
-            .or_else(|| self.pwd())?;
+            .pwd()
+            .or_else(|| self.prompt_chip_value(&ContextChipKind::WorkingDirectory, ctx))?;
         let home_dir = self
             .active_block_session_id()
             .and_then(|session_id| self.sessions.as_ref(ctx).get(session_id))
@@ -32,21 +32,18 @@ impl TerminalView {
             .unwrap_or(fallback_title)
     }
 
-    #[cfg_attr(not(feature = "local_fs"), allow(clippy::unnecessary_lazy_evaluations))]
     pub fn current_git_branch(&self, ctx: &AppContext) -> Option<String> {
+        #[cfg(feature = "local_fs")]
+        {
+            if let Some(branch) = self
+                .git_status_metadata(ctx)
+                .map(|metadata| metadata.current_branch_name.clone())
+                .filter(|branch| !branch.trim().is_empty())
+            {
+                return Some(branch);
+            }
+        }
         self.prompt_chip_value(&ContextChipKind::ShellGitBranch, ctx)
-            .or_else(|| {
-                #[cfg(feature = "local_fs")]
-                {
-                    self.git_status_metadata(ctx)
-                        .map(|metadata| metadata.current_branch_name.clone())
-                        .filter(|branch| !branch.trim().is_empty())
-                }
-                #[cfg(not(feature = "local_fs"))]
-                {
-                    None
-                }
-            })
     }
 
     pub fn last_completed_command_text(&self) -> Option<String> {


### PR DESCRIPTION
## Description
This PR addresses **Bug 1** from issue #9958. It ensures that the Git branch and working directory displayed in the vertical tabs and status bar remain fresh during active CLI agent sessions.

### Key Changes
*   **Data Preference:** Updated `current_git_branch()` and `display_working_directory()` to prioritize live filesystem/process data over potentially stale shell prompt chips.
*   **Subscription Logic:** Modified `should_subscribe_to_git_status()` in `view.rs` to be unconditional when a repository is detected. This ensures that `git_status_metadata()` is actually populated even if the `GitDiffStats` toolbar chip is disabled.
*   **Resource Safety:** Subscriptions remain safe as they are gated by the existence of a valid `repo_path` and are managed by `GitStatusUpdateModel` which handles deduplication and automatic teardown.

## Linked Issue
Addresses Bug 1 in #9958

## Screenshots / Videos

https://github.com/user-attachments/assets/a298c81e-8200-42ba-b2a6-3bff385fdecf

<img width="1896" height="1008" alt="screenshot-2026-05-03_16-02-17" src="https://github.com/user-attachments/assets/f5a973bd-74e5-4070-80f8-bec16ddd1c20" />

## Testing
Verified that branch and CWD updates are reflected immediately in the UI even when the CLI agent is active and prompt chips are not refreshing. Verified that disabling toolbar chips no longer breaks the live branch update.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed an issue where the terminal sidebar and status bar could show stale Git branch and working directory information during an active CLI agent session.