### PR TITLE
Fix cloud status badge using themed background instead of white

### DIFF
--- a/app/src/ui_components/icon_with_status.rs
+++ b/app/src/ui_components/icon_with_status.rs
@@ -125,13 +125,13 @@ pub(crate) enum IconWithStatusVariant {
 /// BR (more overhang) and negative values pull it inward toward the circle's center.
 ///
 /// When `is_ambient` is set on an agent variant, the status badge is replaced by a
-/// white cloud containing the status icon.
+/// cloud (filled with `status_container_background`) containing the status icon.
 pub(crate) fn render_icon_with_status(
     variant: IconWithStatusVariant,
     total_size: f32,
     overlay_extra_overhang_ratio: f32,
     theme: &WarpTheme,
-    badge_ring_background: WarpThemeFill,
+    status_container_background: WarpThemeFill,
 ) -> Box<dyn Element> {
     let sub_text = theme.sub_text_color(theme.background());
 
@@ -174,7 +174,7 @@ pub(crate) fn render_icon_with_status(
                 total_size,
                 overlay_extra_overhang_ratio,
                 theme,
-                badge_ring_background,
+                status_container_background,
             )
         }
         IconWithStatusVariant::CLIAgent {
@@ -201,7 +201,7 @@ pub(crate) fn render_icon_with_status(
                 total_size,
                 overlay_extra_overhang_ratio,
                 theme,
-                badge_ring_background,
+                status_container_background,
             )
         }
     }
@@ -263,7 +263,7 @@ fn attach_status_overlay(
     total_size: f32,
     overlay_extra_overhang_ratio: f32,
     theme: &WarpTheme,
-    badge_ring_background: WarpThemeFill,
+    status_container_background: WarpThemeFill,
 ) -> Box<dyn Element> {
     if is_ambient {
         render_with_cloud_status_badge(
@@ -272,6 +272,7 @@ fn attach_status_overlay(
             total_size,
             overlay_extra_overhang_ratio,
             theme,
+            status_container_background,
         )
     } else {
         render_with_optional_status_badge(
@@ -280,12 +281,12 @@ fn attach_status_overlay(
             total_size,
             overlay_extra_overhang_ratio,
             theme,
-            badge_ring_background,
+            status_container_background,
         )
     }
 }
 
-/// Overlays a white cloud (with the conversation status icon centered inside, if any) at
+/// Overlays a cloud (with the conversation status icon centered inside, if any) at
 /// the bottom-right of the base circle. Used for agents running in ambient/cloud mode.
 fn render_with_cloud_status_badge(
     circle: Box<dyn Element>,
@@ -293,11 +294,12 @@ fn render_with_cloud_status_badge(
     total_size: f32,
     overlay_extra_overhang_ratio: f32,
     theme: &WarpTheme,
+    status_container_background: WarpThemeFill,
 ) -> Box<dyn Element> {
     let cloud_diameter = cloud_icon_size(total_size);
     let cloud = ConstrainedBox::new(
         WarpIcon::CloudFilled
-            .to_warpui_icon(WarpThemeFill::Solid(ColorU::white()))
+            .to_warpui_icon(status_container_background)
             .finish(),
     )
     .with_width(cloud_diameter)
@@ -361,7 +363,7 @@ fn render_with_optional_status_badge(
     total_size: f32,
     overlay_extra_overhang_ratio: f32,
     theme: &WarpTheme,
-    badge_ring_background: WarpThemeFill,
+    status_container_background: WarpThemeFill,
 ) -> Box<dyn Element> {
     let Some(status) = status else {
         // No status badge: still occupy the full `total_size` footprint so the agent
@@ -386,7 +388,7 @@ fn render_with_optional_status_badge(
     // Cutout ring that visually separates the badge from the circle.
     let badge_with_ring = Container::new(badge)
         .with_uniform_padding(pad)
-        .with_background(badge_ring_background)
+        .with_background(status_container_background)
         .with_corner_radius(CornerRadius::with_all(Radius::Percentage(50.)))
         .finish();
 


### PR DESCRIPTION
## Description

The cloud status container should use the same themed background as the regular status container (confirmed from Peter's original figma that this was always the intention)

## Linked Issue
Fixes APP-4369

## Testing

![image.png](https://app.graphite.com/user-attachments/assets/470b4ae9-8c03-4598-b9fb-b30fabb18a18.png)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/ebc3b299-10da-4229-8024-2bb3a6e6a9b9_
_Run: https://oz.staging.warp.dev/runs/019dee41-47db-7eb2-b477-1bdd26d8f2b3_
_This PR was generated with [Oz](https://warp.dev/oz)._
