### PR TITLE
Fix slash command skills bypassing cloud mode in old UI

### DIFF
--- a/app/src/terminal/input/agent.rs
+++ b/app/src/terminal/input/agent.rs
@@ -65,8 +65,15 @@ const CLOUD_MODE_V2_CHIPS_ROW_TOP_PADDING: f32 = 4.;
 
 impl Input {
     pub fn is_cloud_mode_input_v2_composing(&self, app: &AppContext) -> bool {
-        FeatureFlag::CloudModeInputV2.is_enabled()
-            && FeatureFlag::CloudMode.is_enabled()
+        FeatureFlag::CloudModeInputV2.is_enabled() && self.is_composing_cloud_mode_prompt(app)
+    }
+
+    /// Returns true when the user is composing a cloud-mode prompt (i.e. configuring an
+    /// ambient agent before submitting the first request).
+    /// Unlike `is_cloud_mode_input_v2_composing`, this is not gated on the V2 input flag
+    /// so it covers both the old and new cloud-mode UIs.
+    pub(super) fn is_composing_cloud_mode_prompt(&self, app: &AppContext) -> bool {
+        FeatureFlag::CloudMode.is_enabled()
             && self
                 .ambient_agent_view_model()
                 .is_some_and(|model| model.as_ref(app).is_configuring_ambient_agent())

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1127,9 +1127,7 @@ impl Input {
                     ctx,
                 )
             }
-            SlashCommandEntryState::SkillCommand(_)
-                if self.is_cloud_mode_input_v2_composing(ctx) =>
-            {
+            SlashCommandEntryState::SkillCommand(_) if self.is_composing_cloud_mode_prompt(ctx) => {
                 false
             }
             SlashCommandEntryState::SkillCommand(detected_skill) => {
@@ -1225,9 +1223,7 @@ impl Input {
                     ctx,
                 )
             }
-            SlashCommandEntryState::SkillCommand(_)
-                if self.is_cloud_mode_input_v2_composing(ctx) =>
-            {
+            SlashCommandEntryState::SkillCommand(_) if self.is_composing_cloud_mode_prompt(ctx) => {
                 false
             }
             SlashCommandEntryState::SkillCommand(detected_skill) => {


### PR DESCRIPTION
## Description
Fix slash command skills bypassing cloud mode in the old cloud mode UI.

When a user typed a skill command (e.g. `/some-skill`) in the old cloud mode UI (i.e., when the `CloudModeInputV2` feature flag is disabled), the command was routed through `execute_skill_command` which enters the local agent view and sends the request locally—bypassing cloud mode entirely.

The V2 UI already handled this correctly by returning `false` from `maybe_handle_enter_for_slash_command` when `is_cloud_mode_input_v2_composing` was true, letting the flow fall through to `submit_ai_query` → `spawn_agent` (the cloud mode path).

The fix introduces `is_composing_cloud_mode_prompt`, which checks `CloudMode` + `is_configuring_ambient_agent` without requiring the V2 flag. The `SkillCommand` guards in both `maybe_handle_enter_for_slash_command` and `maybe_handle_cmd_or_ctrl_shift_enter_for_slash_command` now use this broader check, so skill commands in cloud mode setup are correctly submitted through the cloud agent spawn path regardless of which input UI is active.

## Linked Issue
Resolves [REMOTE-1544](https://linear.app/anthropic/issue/REMOTE-1544)

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Verified compilation passes with `cargo check -p warp`.
- Verified `cargo fmt` passes.
- The change is minimal and follows the exact pattern already used by the V2 UI for the same scenario.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed slash command skills not starting cloud mode in the old cloud mode UI
-->

_Conversation: https://staging.warp.dev/conversation/fada95ad-b0b0-4153-a682-747e44e28a0a_
_Run: https://oz.staging.warp.dev/runs/019dee48-2851-73a7-923f-1c4da590b296_
_This PR was generated with [Oz](https://warp.dev/oz)._
