### PR TITLE
docs: replace Becoming a Collaborator with Code Review section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,13 +117,14 @@ You can use **any coding agent** to implement a contribution — for example, Wa
 
 If you'd rather have an **Oz cloud agent** implement a ready issue for you, mention **@oss-maintainers** on the issue to request it. Approved requests run **for free** on complimentary Oz credits — you don't need to set up your own Oz account or pay for compute.
 
-## Becoming a Collaborator
+## Code Review
 
-Contributors with several merged PRs may be invited to become collaborators. Collaborators receive expanded permissions including the ability to:
+All pull requests go through a two-stage review process:
 
-- Assign [Oz](https://warp.dev/oz) to work on issues by mentioning `@oz` in a comment on any issue that has a readiness label.
-- Use complimentary Oz credits for contributions to this repository.
-- Apply and manage issue labels.
+1. **Oz review** — When you open a PR, [Oz](https://warp.dev/oz) is automatically assigned and produces the first review. Oz checks for correctness, style, test coverage, and alignment with the linked issue and any associated specs.
+2. **Warp team review** — Only after Oz has **approved** the PR is it routed to a Warp team subject-matter expert for a final human review. PRs that have not yet been approved by Oz will not be assigned to a team member.
+
+You do not need to manually request reviewers at any stage. After pushing changes that address Oz's feedback, comment `/oz-review` on the PR to request a re-review — you can do this up to **three times** per PR. If something looks stuck or you need additional reviews, mention **@oss-maintainers** on the PR to escalate to the team.
 
 ## Development Setup
 


### PR DESCRIPTION
## Description
Remove the "Becoming a Collaborator" section from CONTRIBUTING.md and replace it with a new "Code Review" section that clearly documents the two-stage review process:

1. **Oz review** — Oz is automatically assigned and produces the first review on every PR.
2. **Warp team review** — Only after Oz has approved the PR is it routed to a Warp team subject-matter expert for final human review. PRs not yet approved by Oz will not be assigned to a team member.

## Linked Issue
N/A — documentation-only change requested internally.

## Testing
Docs-only change; no code or tests affected.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/cd3469da-7b12-46ea-84e4-fd639252308b_
_Run: https://oz.staging.warp.dev/runs/019deec0-9ca9-701d-8043-05c7027c73ba_

_This PR was generated with [Oz](https://warp.dev/oz)._
