### PR TITLE
fix: disable reset grid checks for restored blocks on Windows

### DIFF
--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -1241,7 +1241,7 @@ impl Block {
         self.wakeup_after_delay();
     }
 
-    fn disable_reset_grid_checks(&mut self) {
+    pub(super) fn disable_reset_grid_checks(&mut self) {
         self.header_grid.disable_reset_grid_checks();
         self.output_grid.disable_reset_grid_checks();
     }

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -2677,6 +2677,7 @@ impl BlockList {
 
         // Start the block and add the command
         self.active_block_mut().start();
+        self.active_block_mut().disable_reset_grid_checks();
         processor.parse_bytes(self, command.as_bytes(), &mut io::sink());
 
         // Simulate preexec to transition to Executing state
@@ -2921,6 +2922,7 @@ impl BlockList {
             self.active_block_mut().start_background(None);
         } else {
             self.active_block_mut().start();
+            self.active_block_mut().disable_reset_grid_checks();
         }
 
         if let Some(serialized_ai_metadata) = block.ai_metadata.as_ref().and_then(|ai_metadata| {


### PR DESCRIPTION
Closes #10068

## Description

Fix a Windows-only debug assert panic ("Grid received input but did not receive Reset Grid OSC") that fires when viewing a conversation on Web is handed off to the native client.

On Windows, ConPTY maintains an internal grid model that must be kept in sync with Warp's grids via a Reset Grid OSC. A `debug_assert!` in `GridHandler::input()` verifies this OSC was received before any character input is processed.

When a conversation is handed off from Web to native, the blocks are created from serialized data rather than from ConPTY output. Since no actual commands execute through ConPTY, the Reset Grid OSC is never sent, causing the assert to fire.

**Fix:** Call `disable_reset_grid_checks()` on restored blocks after `start()`, matching the existing pattern already used for background blocks. This is applied in two code paths:
- `restore_block()` — used for session restoration, shared session scrollback, and web-to-native conversation handoff
- `create_restored_command_block()` — used for AI conversation command blocks

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

This is a targeted fix that disables a debug assert for code paths that don't go through ConPTY. The existing pattern (`start_background` already calls `disable_reset_grid_checks`) validates the approach. The code compiles and passes `cargo fmt` checks.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed a crash on Windows when handing off a Web conversation to the native client ("Grid received input but did not receive Reset Grid OSC").
-->

_Conversation: https://staging.warp.dev/conversation/c1ffab67-45e7-4b0c-8641-ac6508585a21_
_Run: https://oz.staging.warp.dev/runs/019def4c-a123-716d-8018-4c82964c8137_

_This PR was generated with [Oz](https://warp.dev/oz)._