### PR TITLE
open local->cloud mode conversation in the same pane

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -3173,12 +3173,16 @@ impl TerminalView {
                     original_exchange_count,
                     final_exchange_count,
                     was_ambient_agent,
+                    is_exit_before_new_entrance,
                     ..
                 } => {
                     // Prompt suggestions should not follow the user back to terminal view.
                     me.clear_prompt_suggestions(ctx);
                     // For ambient agent sessions, pop the pane stack to return to the parent terminal.
-                    if *was_ambient_agent {
+                    // Skip the pop when this exit is immediately followed by re-entering agent view
+                    // for a different conversation (e.g. a restored conversation taking over the
+                    // pane).
+                    if *was_ambient_agent && !*is_exit_before_new_entrance {
                         if let Some(pane_stack) =
                             me.pane_stack.as_ref().and_then(|h| h.upgrade(ctx))
                         {

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -11,6 +11,7 @@ use crate::ai::AIRequestUsageModel;
 use warp_core::features::FeatureFlag;
 use warp_core::send_telemetry_from_ctx;
 use warpui::prelude::{Empty, Vector2F};
+use warpui::{ModelHandle, ViewHandle};
 
 use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEntryPoint};
 use crate::ai::blocklist::{agent_view::AgentViewEntryOrigin, BlocklistAIHistoryModel};
@@ -30,10 +31,24 @@ use super::loading_screen::{
     render_cloud_mode_cancelled_screen, render_cloud_mode_error_screen,
     render_cloud_mode_github_auth_required_screen, render_cloud_mode_loading_screen,
 };
-use super::{AmbientAgentEntryBlock, AmbientAgentViewModelEvent};
+use super::{AmbientAgentEntryBlock, AmbientAgentViewModel, AmbientAgentViewModelEvent};
 use crate::terminal::view::Event as TerminalViewEvent;
+
 const CHILD_AGENT_GITHUB_AUTH_REQUIRED_BLOCKED_ACTION: &str =
     "GitHub authentication required before starting the child agent.";
+
+/// How a freshly-pushed cloud-mode pane should be initialized after creation.
+enum CloudModeStartMode {
+    /// Enter setup mode for composing a prompt; optional initial prompt to pre-fill.
+    EnterSetup { initial_prompt: Option<String> },
+    /// Spawn an agent immediately with the given request. Boxed because
+    /// `SpawnAgentRequest` is large and this variant is rarely-used today.
+    #[allow(dead_code)]
+    SpawnRequest(Box<SpawnAgentRequest>),
+    /// Skip both setup and spawn. Used by the local-to-cloud handoff path which restores
+    /// a forked conversation onto the new pane and waits for the user to commit later.
+    Bare,
+}
 
 impl TerminalView {
     fn active_ambient_agent_conversation_id(&self, ctx: &AppContext) -> Option<AIConversationId> {
@@ -619,7 +634,12 @@ impl TerminalView {
             let prompt = initial_prompt.clone();
             self.set_pending_cloud_mode_start_callback(
                 Box::new(move |view, ctx| {
-                    view.start_cloud_mode(None, prompt, ctx);
+                    view.start_cloud_mode(
+                        CloudModeStartMode::EnterSetup {
+                            initial_prompt: prompt,
+                        },
+                        ctx,
+                    );
                 }),
                 ctx,
             );
@@ -633,19 +653,32 @@ impl TerminalView {
             return;
         }
 
-        self.start_cloud_mode(None, initial_prompt, ctx);
+        self.start_cloud_mode(CloudModeStartMode::EnterSetup { initial_prompt }, ctx);
     }
 
-    /// Start a cloud mode session nested under this one.
+    /// Push a fresh cloud-mode pane onto this view's pane_stack for a local-to-cloud handoff.
+    /// Returns the pushed view and its `AmbientAgentViewModel` so the caller can restore the
+    /// forked conversation, bind it to the cloud-side conversation id, and seed `PendingHandoff`.
     ///
-    /// If `spawn_request` is `Some`, the agent is immediately started. Otherwise, it can
-    /// further configured in the cloud mode session.
+    /// Mirrors `start_cloud_mode` but skips entering setup mode and dispatching an agent — the
+    /// handoff path restores an existing forked conversation onto the new pane and waits for
+    /// the user to commit the handoff later.
+    pub(crate) fn start_local_to_cloud_handoff_pane(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<(ViewHandle<TerminalView>, ModelHandle<AmbientAgentViewModel>)> {
+        self.start_cloud_mode(CloudModeStartMode::Bare, ctx)
+    }
+
+    /// Start a cloud mode session nested under this one, pushing a new pane onto this view's
+    /// pane_stack and returning the pushed view + model handle.
+    ///
+    /// `mode` controls how the new pane is initialized after creation; see [`CloudModeStartMode`].
     fn start_cloud_mode(
         &mut self,
-        spawn_request: Option<SpawnAgentRequest>,
-        initial_prompt: Option<String>,
+        mode: CloudModeStartMode,
         ctx: &mut ViewContext<Self>,
-    ) {
+    ) -> Option<(ViewHandle<TerminalView>, ModelHandle<AmbientAgentViewModel>)> {
         let resources = TerminalViewResources {
             tips_completed: self.tips_completed.clone(),
             server_api: self.server_api.clone(),
@@ -665,7 +698,7 @@ impl TerminalView {
             .cloned()
         else {
             log::warn!("Cloud mode view was created without an ambient agent view model");
-            return;
+            return None;
         };
         let terminal_view_weak = terminal_view.downgrade();
         let terminal_manager_weak = terminal_manager.downgrade();
@@ -723,33 +756,41 @@ impl TerminalView {
         terminal_view.update(ctx, |view, ctx| {
             view.set_pane_configuration(pane_config);
 
-            if let Some(request) = spawn_request {
-                // Spawn the agent immediately with the provided request.
-                view.enter_agent_view_for_new_conversation(
-                    None,
-                    AgentViewEntryOrigin::CloudAgent,
-                    ctx,
-                );
-                ambient_agent_view_model_for_update.update(ctx, |model, ctx| {
-                    model.spawn_agent_with_request(request, ctx);
-                });
-            } else {
-                // Enter setup mode for composing a prompt
-                view.enter_ambient_agent_setup(initial_prompt, ctx);
+            match mode {
+                CloudModeStartMode::SpawnRequest(request) => {
+                    // Spawn the agent immediately with the provided request.
+                    view.enter_agent_view_for_new_conversation(
+                        None,
+                        AgentViewEntryOrigin::CloudAgent,
+                        ctx,
+                    );
+                    ambient_agent_view_model_for_update.update(ctx, |model, ctx| {
+                        model.spawn_agent_with_request(*request, ctx);
+                    });
+                }
+                CloudModeStartMode::EnterSetup { initial_prompt } => {
+                    // Enter setup mode for composing a prompt.
+                    view.enter_ambient_agent_setup(initial_prompt, ctx);
+                }
+                CloudModeStartMode::Bare => {
+                    // No setup or spawn — caller (e.g. local-to-cloud handoff) restores
+                    // the forked conversation and seeds handoff state itself.
+                }
             }
         });
 
-        if let Some(pane_stack) = self.pane_stack.clone() {
-            if let Some(stack) = pane_stack.upgrade(ctx) {
-                stack.update(ctx, |stack, ctx| {
-                    stack.push(terminal_manager, terminal_view, ctx);
-                });
-            } else {
-                log::warn!("Pane stack deallocated, cannot enter cloud mode");
-            }
-        } else {
+        let Some(pane_stack) = self.pane_stack.clone() else {
             log::warn!("Pane stack not available, cannot enter cloud mode");
-        }
+            return None;
+        };
+        let Some(stack) = pane_stack.upgrade(ctx) else {
+            log::warn!("Pane stack deallocated, cannot enter cloud mode");
+            return None;
+        };
+        let pushed_view = terminal_view.clone();
+        stack.update(ctx, |stack, ctx| {
+            stack.push(terminal_manager, pushed_view, ctx);
+        });
 
         send_telemetry_from_ctx!(
             CloudAgentTelemetryEvent::EnteredCloudMode {
@@ -757,6 +798,8 @@ impl TerminalView {
             },
             ctx
         );
+
+        Some((terminal_view, ambient_agent_view_model))
     }
 
     /// Renders the ambient agent progress view based on agent progress.

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -17,7 +17,6 @@ use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEn
 use crate::ai::blocklist::{agent_view::AgentViewEntryOrigin, BlocklistAIHistoryModel};
 use crate::ai::conversation_details_panel::ConversationDetailsData;
 use crate::pane_group::TerminalViewResources;
-use crate::server::server_api::ai::SpawnAgentRequest;
 use crate::terminal::view::rich_content::{RichContentInsertionPosition, RichContentMetadata};
 use crate::terminal::view::TerminalView;
 use crate::terminal::CLIAgent;
@@ -36,19 +35,6 @@ use crate::terminal::view::Event as TerminalViewEvent;
 
 const CHILD_AGENT_GITHUB_AUTH_REQUIRED_BLOCKED_ACTION: &str =
     "GitHub authentication required before starting the child agent.";
-
-/// How a freshly-pushed cloud-mode pane should be initialized after creation.
-enum CloudModeStartMode {
-    /// Enter setup mode for composing a prompt; optional initial prompt to pre-fill.
-    EnterSetup { initial_prompt: Option<String> },
-    /// Spawn an agent immediately with the given request. Boxed because
-    /// `SpawnAgentRequest` is large and this variant is rarely-used today.
-    #[allow(dead_code)]
-    SpawnRequest(Box<SpawnAgentRequest>),
-    /// Skip both setup and spawn. Used by the local-to-cloud handoff path which restores
-    /// a forked conversation onto the new pane and waits for the user to commit later.
-    Bare,
-}
 
 impl TerminalView {
     fn active_ambient_agent_conversation_id(&self, ctx: &AppContext) -> Option<AIConversationId> {
@@ -634,12 +620,7 @@ impl TerminalView {
             let prompt = initial_prompt.clone();
             self.set_pending_cloud_mode_start_callback(
                 Box::new(move |view, ctx| {
-                    view.start_cloud_mode(
-                        CloudModeStartMode::EnterSetup {
-                            initial_prompt: prompt,
-                        },
-                        ctx,
-                    );
+                    view.start_cloud_mode(prompt, ctx);
                 }),
                 ctx,
             );
@@ -653,30 +634,33 @@ impl TerminalView {
             return;
         }
 
-        self.start_cloud_mode(CloudModeStartMode::EnterSetup { initial_prompt }, ctx);
+        self.start_cloud_mode(initial_prompt, ctx);
     }
 
     /// Push a fresh cloud-mode pane onto this view's pane_stack for a local-to-cloud handoff.
     /// Returns the pushed view and its `AmbientAgentViewModel` so the caller can restore the
     /// forked conversation, bind it to the cloud-side conversation id, and seed `PendingHandoff`.
     ///
-    /// Mirrors `start_cloud_mode` but skips entering setup mode and dispatching an agent — the
-    /// handoff path restores an existing forked conversation onto the new pane and waits for
-    /// the user to commit the handoff later.
+    /// Uses the same setup-mode initialization path as fresh cloud-mode runs (which calls
+    /// `enter_ambient_agent_setup` → `enter_agent_view_for_new_conversation` and focuses the
+    /// input) so the new pane's cloud-mode input is editable and focused immediately. The
+    /// caller then layers the forked conversation's blocks on top via
+    /// `restore_conversation_after_view_creation` and seeds `PendingHandoff`; submission uses
+    /// the cached `forked_conversation_id` from `PendingHandoff`, not the new pane's local
+    /// agent-view conversation id.
     pub(crate) fn start_local_to_cloud_handoff_pane(
         &mut self,
         ctx: &mut ViewContext<Self>,
     ) -> Option<(ViewHandle<TerminalView>, ModelHandle<AmbientAgentViewModel>)> {
-        self.start_cloud_mode(CloudModeStartMode::Bare, ctx)
+        self.start_cloud_mode(None, ctx)
     }
 
     /// Start a cloud mode session nested under this one, pushing a new pane onto this view's
-    /// pane_stack and returning the pushed view + model handle.
-    ///
-    /// `mode` controls how the new pane is initialized after creation; see [`CloudModeStartMode`].
+    /// pane_stack and returning the pushed view + model handle. The new pane enters setup mode
+    /// with `initial_prompt` (if any) pre-filled in the input.
     fn start_cloud_mode(
         &mut self,
-        mode: CloudModeStartMode,
+        initial_prompt: Option<String>,
         ctx: &mut ViewContext<Self>,
     ) -> Option<(ViewHandle<TerminalView>, ModelHandle<AmbientAgentViewModel>)> {
         let resources = TerminalViewResources {
@@ -752,31 +736,9 @@ impl TerminalView {
         });
 
         let pane_config = self.pane_configuration.clone();
-        let ambient_agent_view_model_for_update = ambient_agent_view_model.clone();
         terminal_view.update(ctx, |view, ctx| {
             view.set_pane_configuration(pane_config);
-
-            match mode {
-                CloudModeStartMode::SpawnRequest(request) => {
-                    // Spawn the agent immediately with the provided request.
-                    view.enter_agent_view_for_new_conversation(
-                        None,
-                        AgentViewEntryOrigin::CloudAgent,
-                        ctx,
-                    );
-                    ambient_agent_view_model_for_update.update(ctx, |model, ctx| {
-                        model.spawn_agent_with_request(*request, ctx);
-                    });
-                }
-                CloudModeStartMode::EnterSetup { initial_prompt } => {
-                    // Enter setup mode for composing a prompt.
-                    view.enter_ambient_agent_setup(initial_prompt, ctx);
-                }
-                CloudModeStartMode::Bare => {
-                    // No setup or spawn — caller (e.g. local-to-cloud handoff) restores
-                    // the forked conversation and seeds handoff state itself.
-                }
-            }
+            view.enter_ambient_agent_setup(initial_prompt, ctx);
         });
 
         let Some(pane_stack) = self.pane_stack.clone() else {

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -648,6 +648,7 @@ impl TerminalView {
     /// `restore_conversation_after_view_creation` and seeds `PendingHandoff`; submission uses
     /// the cached `forked_conversation_id` from `PendingHandoff`, not the new pane's local
     /// agent-view conversation id.
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     pub(crate) fn start_local_to_cloud_handoff_pane(
         &mut self,
         ctx: &mut ViewContext<Self>,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -12877,14 +12877,16 @@ impl Workspace {
         });
     }
 
-    /// Open a local-to-cloud handoff pane next to the active local pane. Triggered
-    /// by the `/move-to-cloud` slash command and the "Hand off to cloud" footer
-    /// chip.
+    /// Open a local-to-cloud handoff pane in place over the active local pane.
+    /// Triggered by the `/move-to-cloud` slash command and the "Hand off to
+    /// cloud" footer chip.
     ///
     /// When the active conversation is non-empty and has a server token, mints a
-    /// server-side fork via `POST /agent/conversations/{conversation_id}/fork`, then
-    /// splits a fresh cloud-mode pane next to the local pane and pre-populates it
-    /// with the forked conversation.
+    /// server-side fork via `POST /agent/conversations/{conversation_id}/fork`,
+    /// then pushes a fresh cloud-mode view onto the active pane's navigation stack
+    /// and pre-populates it with the forked conversation. Pressing Escape in the
+    /// cloud-mode view pops back to the original local pane (the same pattern used
+    /// by Cmd-Alt-Enter / Ctrl-Alt-Enter to enter cloud mode from a local session).
     ///
     /// All failure modes — ineligibility, fork RPC failure, and local fork
     /// materialization failure — surface an error toast and **do not open** any
@@ -12914,11 +12916,11 @@ impl Workspace {
                         conversation
                             .server_conversation_token()
                             .cloned()
-                            .map(|token| (conversation.clone(), token))
+                            .map(|token| (view.clone(), conversation.clone(), token))
                     })
             });
 
-        let Some((source_conversation, source_token)) = source else {
+        let Some((source_view, source_conversation, source_token)) = source else {
             // Ineligible: don't open a fresh unrelated pane — the chip is a
             // hand-off-this-conversation action.
             let window_id = ctx.window_id();
@@ -12931,6 +12933,22 @@ impl Workspace {
             return;
         };
 
+        // Exit the source pane's fullscreen agent view (if active) before kicking off the
+        // prepare-fork RPC. Mirrors the cmd-alt-enter pattern in `enter_cloud_mode_from_session`:
+        // starting cloud mode from agent view is analogous to starting a new agent
+        // conversation, and the source pane should be left in terminal mode so Esc from the
+        // pushed cloud-mode pane returns the user to a clean local terminal.
+        let source_agent_view_controller = source_view.as_ref(ctx).agent_view_controller().clone();
+        if source_agent_view_controller
+            .as_ref(ctx)
+            .agent_view_state()
+            .is_fullscreen()
+        {
+            source_agent_view_controller.update(ctx, |controller, ctx| {
+                controller.exit_agent_view_without_confirmation(ctx);
+            });
+        }
+
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let source_conversation_id = source_token.as_str().to_string();
         ctx.spawn(
@@ -12938,6 +12956,7 @@ impl Workspace {
             move |me, result, ctx| match result {
                 Ok(response) => {
                     me.complete_local_to_cloud_handoff_open(
+                        source_view,
                         source_conversation,
                         response.forked_conversation_id,
                         initial_prompt,
@@ -12960,11 +12979,13 @@ impl Workspace {
 
     /// Finishes the local-to-cloud handoff open after the fork RPC returns.
     /// Materializes a local fork bound to the server's forked conversation id,
-    /// splits a fresh cloud-mode pane, restores the forked conversation into it,
-    /// seeds `PendingHandoff`, and kicks off async derivation + snapshot upload.
+    /// pushes a fresh cloud-mode view onto `source_view`'s navigation stack,
+    /// restores the forked conversation into it, seeds `PendingHandoff`, and
+    /// kicks off async derivation + snapshot upload.
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn complete_local_to_cloud_handoff_open(
         &mut self,
+        source_view: ViewHandle<TerminalView>,
         source_conversation: AIConversation,
         forked_conversation_id: String,
         initial_prompt: Option<String>,
@@ -12997,25 +13018,22 @@ impl Workspace {
         };
         let local_fork_id = local_fork.id();
 
-        self.active_tab_pane_group().update(ctx, |pane_group, ctx| {
-            pane_group.add_ambient_agent_pane(ctx);
-        });
-        let Some(new_pane_view) = self
-            .active_tab_pane_group()
-            .as_ref(ctx)
-            .active_session_view(ctx)
-        else {
+        // Push a fresh cloud-mode view onto the source pane's navigation stack instead
+        // of splitting a sibling pane. Pressing Escape in the new view pops back to the
+        // local pane via the existing pane-stack escape handling.
+        let Some((new_pane_view, model_handle)) = source_view.update(ctx, |view, view_ctx| {
+            view.start_local_to_cloud_handoff_pane(view_ctx)
+        }) else {
             log::warn!(
-                "start_local_to_cloud_handoff: no active session view after add_ambient_agent_pane"
+                "start_local_to_cloud_handoff: failed to push handoff cloud-mode pane onto source pane stack"
             );
-            return;
-        };
-        let Some(model_handle) = new_pane_view
-            .as_ref(ctx)
-            .ambient_agent_view_model()
-            .cloned()
-        else {
-            log::warn!("start_local_to_cloud_handoff: new ambient agent pane has no view model");
+            let window_id = ctx.window_id();
+            WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                let toast = DismissibleToast::error(
+                    "Failed to prepare handoff. Please try again.".to_owned(),
+                );
+                toast_stack.add_ephemeral_toast(toast, window_id, ctx);
+            });
             return;
         };
 
@@ -13034,6 +13052,22 @@ impl Workspace {
             terminal_view.restore_conversation_after_view_creation(
                 RestoredAIConversation::new(local_fork_for_restore),
                 /* use_live_appearance */ true,
+                view_ctx,
+            );
+        });
+
+        // Enter fullscreen agent view for the restored fork in the new pane. Without this the
+        // pane sits in shared-session-viewer-pending mode and the input renders read-only;
+        // entering agent view activates the editable cloud-mode input flow. Use
+        // `RestoreExistingConversation` to indicate the conversation is restored (not new) —
+        // the `is_local_to_cloud_handoff` flag set via `set_pending_handoff` below is the
+        // authoritative "this is a cloud agent pane" signal for downstream gating
+        // (`is_cloud_agent_pre_first_exchange`, etc.).
+        new_pane_view.update(ctx, |terminal_view, view_ctx| {
+            terminal_view.enter_agent_view_for_conversation(
+                None,
+                AgentViewEntryOrigin::RestoreExistingConversation,
+                local_fork_id,
                 view_ctx,
             );
         });

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -12933,22 +12933,6 @@ impl Workspace {
             return;
         };
 
-        // Exit the source pane's fullscreen agent view (if active) before kicking off the
-        // prepare-fork RPC. Mirrors the cmd-alt-enter pattern in `enter_cloud_mode_from_session`:
-        // starting cloud mode from agent view is analogous to starting a new agent
-        // conversation, and the source pane should be left in terminal mode so Esc from the
-        // pushed cloud-mode pane returns the user to a clean local terminal.
-        let source_agent_view_controller = source_view.as_ref(ctx).agent_view_controller().clone();
-        if source_agent_view_controller
-            .as_ref(ctx)
-            .agent_view_state()
-            .is_fullscreen()
-        {
-            source_agent_view_controller.update(ctx, |controller, ctx| {
-                controller.exit_agent_view_without_confirmation(ctx);
-            });
-        }
-
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let source_conversation_id = source_token.as_str().to_string();
         ctx.spawn(
@@ -12980,8 +12964,18 @@ impl Workspace {
     /// Finishes the local-to-cloud handoff open after the fork RPC returns.
     /// Materializes a local fork bound to the server's forked conversation id,
     /// pushes a fresh cloud-mode view onto `source_view`'s navigation stack,
-    /// restores the forked conversation into it, seeds `PendingHandoff`, and
+    /// restores the forked conversation into it, exits the source pane's agent
+    /// view (so Esc returns to a clean terminal), seeds `PendingHandoff`, and
     /// kicks off async derivation + snapshot upload.
+    ///
+    /// The source's agent-view exit happens AFTER the new pane is pushed, so the
+    /// source pane is hidden behind the cloud-mode view when its chrome flips
+    /// from agent mode to terminal mode — the user never sees the transition.
+    /// The pane-stack pop logic in `terminal/view.rs` skips popping when the
+    /// `ExitedAgentView` event has `is_exit_before_new_entrance: true`, which
+    /// prevents the bookkeeping exit triggered by `restore_conversation_after_view_creation`
+    /// (re-entering agent view for the forked conversation) from tearing down
+    /// the just-pushed pane.
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn complete_local_to_cloud_handoff_open(
         &mut self,
@@ -13018,15 +13012,11 @@ impl Workspace {
         };
         let local_fork_id = local_fork.id();
 
-        // Push a fresh cloud-mode view onto the source pane's navigation stack instead
-        // of splitting a sibling pane. Pressing Escape in the new view pops back to the
-        // local pane via the existing pane-stack escape handling.
+        // Push the cloud-mode pane onto the source's nav stack.
         let Some((new_pane_view, model_handle)) = source_view.update(ctx, |view, view_ctx| {
             view.start_local_to_cloud_handoff_pane(view_ctx)
         }) else {
-            log::warn!(
-                "start_local_to_cloud_handoff: failed to push handoff cloud-mode pane onto source pane stack"
-            );
+            log::warn!("start_local_to_cloud_handoff: failed to push cloud-mode pane");
             let window_id = ctx.window_id();
             WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
                 let toast = DismissibleToast::error(
@@ -13046,11 +13036,12 @@ impl Workspace {
         }
 
         // Restore the forked conversation into the new pane so its AI exchanges are
-        // visible immediately. Mirrors the `/fork` in-current-pane flow.
-        let local_fork_for_restore = local_fork.clone();
+        // visible immediately. This re-enters agent view for the forked conversation,
+        // which emits an internal `ExitedAgentView { is_exit_before_new_entrance: true }`
+        // for the cloud-mode placeholder; the pane-stack pop is skipped for that flag.
         new_pane_view.update(ctx, |terminal_view, view_ctx| {
             terminal_view.restore_conversation_after_view_creation(
-                RestoredAIConversation::new(local_fork_for_restore),
+                RestoredAIConversation::new(local_fork.clone()),
                 /* use_live_appearance */ true,
                 view_ctx,
             );
@@ -13080,6 +13071,22 @@ impl Workspace {
             );
             history_model.set_viewing_shared_session_for_conversation(local_fork_id, true);
         });
+
+        // Exit the source pane's fullscreen agent view (if active) so pressing Esc in the
+        // cloud-mode pane returns to a terminal-mode source. This runs AFTER the push, so
+        // the source pane is hidden behind the cloud-mode view and the transition is
+        // invisible to the user. `was_ambient_agent` is false for a local source, so this
+        // exit doesn't pop the pane stack.
+        let source_agent_view_controller = source_view.as_ref(ctx).agent_view_controller().clone();
+        if source_agent_view_controller
+            .as_ref(ctx)
+            .agent_view_state()
+            .is_fullscreen()
+        {
+            source_agent_view_controller.update(ctx, |controller, ctx| {
+                controller.exit_agent_view_without_confirmation(ctx);
+            });
+        }
 
         let pending = PendingHandoff {
             forked_conversation_id: forked_conversation_id.clone(),

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -940,6 +940,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,
     FeatureFlag::CloudModeInputV2,
+    FeatureFlag::HandoffLocalCloud,
     FeatureFlag::DragTabsToWindows,
 ];
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

After posting a demo of local -> cloud handoff, I get some feedback (from peter, varoon, and ZL) that it would be better to just open the cloud mode session in the same pane as the local conversation. This makes sense to me, and we're still forking the conversation and opening up a new cloud mode pane so it's not like this is a destructive action (someone can just close the cloud mode view and re-open the local conversation view).

Implements REMOTE-1557

## Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

demo: https://www.loom.com/share/d2f67ee4e15245959210ef41d1dfe7c6

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode