### PR TITLE
docs: replace warp-external with warp in local agent skills

### DIFF
--- a/.agents/skills/dedupe-issue-local/SKILL.md
+++ b/.agents/skills/dedupe-issue-local/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: dedupe-issue-local
 specializes: dedupe-issue
-description: Repo-specific dedupe guidance for warp-external. Only the categories declared overridable by the core dedupe-issue skill may be specialized here.
+description: Repo-specific dedupe guidance for warp. Only the categories declared overridable by the core dedupe-issue skill may be specialized here.
 ---
 
-# Repo-specific dedupe guidance for `warp-external`
+# Repo-specific dedupe guidance for `warp`
 
 This file is a companion to the core `dedupe-issue` skill. It does not
 redefine the duplicate-detection algorithm, the similarity thresholds,

--- a/.agents/skills/triage-issue-local/SKILL.md
+++ b/.agents/skills/triage-issue-local/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: triage-issue-local
 specializes: triage-issue
-description: Repo-specific triage guidance for warp-external. Only the categories declared overridable by the core triage-issue skill may be specialized here.
+description: Repo-specific triage guidance for warp. Only the categories declared overridable by the core triage-issue skill may be specialized here.
 ---
 
-# Repo-specific triage guidance for `warp-external`
+# Repo-specific triage guidance for `warp`
 
 This file is a companion to the core `triage-issue` skill. It does not
 redefine the triage output schema, safety rules, or follow-up-question
@@ -13,7 +13,7 @@ marks as overridable.
 
 ## Heuristics
 
-- `warp-external` is the public-facing Warp desktop client repository. Treat public issue reports as potentially incomplete and avoid asking for secrets, tokens, private workspace names, private repository names, or account identifiers in the public issue thread.
+- `warp` is the public-facing Warp desktop client repository. Treat public issue reports as potentially incomplete and avoid asking for secrets, tokens, private workspace names, private repository names, or account identifiers in the public issue thread.
 - Distinguish the user's observed Warp behavior from their guesses about Rust modules, UI components, server behavior, feature flags, or product intent.
 - For issue reports that mention another terminal, editor, shell, or CLI tool, identify whether the problem is Warp-specific or generally reproducible outside Warp before assigning Warp ownership.
 - When the issue includes screenshots, videos, logs, stack traces, or command output, use them as primary evidence and ask follow-up questions only for missing details that cannot be inferred from that evidence.


### PR DESCRIPTION
## Description
Replace all references to `warp-external` with `warp` in the local agent skills to reflect the current repository name.

Updated files:
- `.agents/skills/triage-issue-local/SKILL.md` — frontmatter description, section heading, first heuristic bullet
- `.agents/skills/dedupe-issue-local/SKILL.md` — frontmatter description, section heading

## Linked Issue
N/A — housekeeping rename.

- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Verified the updated files read correctly and contain no remaining `warp-external` references.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/0f4d123a-8765-48ca-b0c4-7a3044a39f91_
_Run: https://oz.staging.warp.dev/runs/019defa2-0e5f-786b-b0da-dea1278e8e2f_
_This PR was generated with [Oz](https://warp.dev/oz)._
