### PR TITLE
enable tab dragging between windows for internal warp users

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -923,6 +923,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,
     FeatureFlag::CloudModeInputV2,
+    FeatureFlag::DragTabsToWindows,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
This just flips the feature flag gating tab dragging between windows. Dogfood only.

Original PR: https://github.com/warpdotdev/warp/pull/9275