### PR TITLE
Remove blocklist markdown images from preview flags

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -930,7 +930,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
 pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::Orchestration,
     FeatureFlag::BlocklistMarkdownTableRendering,
-    FeatureFlag::BlocklistMarkdownImages,
     FeatureFlag::MarkdownTables,
     FeatureFlag::OzIdentityFederation,
     FeatureFlag::GitOperationsInCodeReview,


### PR DESCRIPTION
## Description
This removes `FeatureFlag::BlocklistMarkdownImages` from `PREVIEW_FLAGS`.

We accidentally promoted inline Markdown image rendering in the AI block list to Stable in the latest release because `blocklist_markdown_images` is already enabled in the default Cargo feature list. This PR aligns the runtime flag lists with that Stable enablement path so the feature is no longer treated as Preview-exclusive.

Mermaid rendering is also already enabled for Stable via the default `markdown_mermaid` Cargo feature. Together, these defaults allow Stable builds to render inline Markdown images and Mermaid diagrams in agent block output.

## Linked Issue
N/A

## Screenshots / Videos
N/A — flag-list cleanup only.

## Testing
- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`

Note: the first clippy attempt failed before Rust checks because `command-signatures-v2` required Yarn 4 via Corepack while the shell had Yarn 1.22. I ran `corepack enable` and reran clippy successfully.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Warp now renders inline local images and Mermaid diagrams in agent block output.

Co-Authored-By: Oz <oz-agent@warp.dev>

Agent artifacts:
- Conversation: https://staging.warp.dev/conversation/7967da60-8ae2-4747-9db4-3bb49f727a32
