### PR TITLE
Don't panic in RowIterator when stored grapheme runs overflow the row

### DIFF
--- a/crates/warp_terminal/src/model/grid/flat_storage/mod_tests.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/mod_tests.rs
@@ -55,6 +55,47 @@ fn test_row_with_double_width_char() {
     assert!(rows.next().is_none());
 }
 
+#[test]
+fn test_row_iterator_handles_wide_char_at_row_boundary_without_panicking() {
+    // Regression for #9161: stored rows whose grapheme runs imply more
+    // cells than the row holds — typically a wide CJK character placed at
+    // the last column of a row, leaving no room for its trailing spacer —
+    // used to abort the process via `panic!` inside `RowIterator::next`.
+    // The iterator must instead degrade gracefully so the user can keep
+    // using the terminal.
+    let mut storage = FlatStorage::new(7, None, Some(2));
+
+    let mut wide_cell = Cell::default();
+    wide_cell.c = '日';
+    wide_cell.flags.insert(Flags::WIDE_CHAR);
+    let row = Row::from_vec(
+        vec![
+            cell_with('a'),
+            cell_with('b'),
+            cell_with('c'),
+            cell_with('d'),
+            cell_with('e'),
+            cell_with('f'),
+            wide_cell,
+        ],
+        7,
+    );
+    storage.push_rows([&row]);
+
+    let mut rows = storage.rows_from(0);
+    let row = rows
+        .next()
+        .expect("should be able to get the row from storage");
+    assert_eq!(row[0].c, 'a');
+    assert_eq!(row[5].c, 'f');
+}
+
+fn cell_with(c: char) -> Cell {
+    let mut cell = Cell::default();
+    cell.c = c;
+    cell
+}
+
 /// This test validates our handling of complex emoji sequences.
 ///
 /// The three graphemes here are comprised of a number of Unicode characters.

--- a/crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs
@@ -97,7 +97,7 @@ impl Iterator for RowIterator<'_> {
                     row.len(),
                     self.storage.index.grapheme_runs_for_row(self.row_index)?
                 );
-                panic!("Tried to mutate cell past the end of a row in RowIterator::next!")
+                break;
             };
 
             let mut chars = grapheme.chars();
@@ -127,10 +127,14 @@ impl Iterator for RowIterator<'_> {
             }
 
             // If the grapheme takes up two cells, mark the following cell as
-            // a spacer.
+            // a spacer (only when there is a following cell to mark — a wide
+            // char written into the last column has no room for its spacer
+            // and would otherwise panic via `IndexMut`).
             if cell_width == 2 {
                 row[idx].flags.insert(Flags::WIDE_CHAR);
-                row[idx + 1].flags.insert(Flags::WIDE_CHAR_SPACER);
+                if idx + 1 < row.len() {
+                    row[idx + 1].flags.insert(Flags::WIDE_CHAR_SPACER);
+                }
             }
 
             current_offset += grapheme.len();


### PR DESCRIPTION
Closes #9161.

### Description

`RowIterator::next` aborts the process via `panic!` when a stored row's grapheme runs imply more cells than the row actually holds. The reporter's panic log captures the canonical case:

```
idx: 142
len: 142
grapheme runs: [
  GraphemeRun { count: 6, info: GraphemeInfo { cell_width: 1, utf8_bytes: 1 } },
  GraphemeRun { count: 1, info: GraphemeInfo { cell_width: 2, utf8_bytes: 6 } },
  GraphemeRun { count: 135, info: GraphemeInfo { cell_width: 1, utf8_bytes: 1 } },
]
```

The grapheme runs claim `6 * 1 + 1 * 2 + 135 * 1 = 143` cell positions in a row whose length is `142`, so once the iterator advances `row.occ` past the wide character's spacer the next `row.get_mut(row.occ)` returns `None` and we unconditionally `panic!` (`row_iterator.rs:100`). This is the same panic site reported in the auto-closed #8515 (same file, same line) and is reproducible whenever any CJK / emoji grapheme sits at a row boundary on a row whose grapheme bookkeeping has gone out of sync with its allocated length (which the issue reporter hits daily on Windows).

### Fix

Two changes in `crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs`:

1. **Replace the `panic!` after the diagnostic `log::warn!` with a `break`.** The partially-filled row is still returned, so the terminal keeps running. The pre-existing warning preserves the diagnostic context for tracking the underlying writer-side inconsistency separately — without aborting the user's session.

2. **Bounds-check the `WIDE_CHAR_SPACER` write at `row[idx + 1]`.** When a wide grapheme is the last cell of a row, `idx + 1 == row.len()` and the existing `row[idx + 1].flags.insert(...)` would panic via the `Row::index_mut` impl regardless of the change above. The `WIDE_CHAR` flag is still set on the wide cell itself; we just skip the unreachable spacer cell.

The reporter's specific row layout (6 ASCII + 1 wide + 135 ASCII overflowing a 142-cell row) is hit by both code paths. The combined fix means neither one aborts.

### Testing

- Added `test_row_iterator_handles_wide_char_at_row_boundary_without_panicking` (`mod_tests.rs`). It constructs a 7-cell row whose final cell holds the wide CJK character `日`, pushes it through `FlatStorage`, and asserts that `RowIterator::next` returns the row instead of panicking. The test fails on the pre-fix code via the `IndexMut` panic at the `row[idx + 1]` spacer write.
- Confirmed the existing wide-char tests still pass (`test_row_with_double_width_char`, `test_row_iteration`):

```
Starting 3 tests across 1 binary (83 tests skipped)
    PASS [0.020s] test_row_iteration
    PASS [0.021s] test_row_with_double_width_char
    PASS [0.020s] test_row_iterator_handles_wide_char_at_row_boundary_without_panicking
────────────
     Summary [0.021s] 3 tests run: 3 passed, 83 skipped
```

- `cargo fmt -p warp_terminal -- --check` passes.
- `cargo check --tests -p warp_terminal` passes.

### Server API

- [ ] Yes
- [x] No

### Agent Mode

- [ ] Yes
- [x] No

### Changelog Entries

`CHANGELOG-BUG-FIX`: Fixed a crash on Windows when terminal output containing CJK characters or emoji landed at a row boundary (regression of #8515).
