### PR TITLE
Add Hermes CLI-agent notification support

### DIFF
--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -500,6 +500,7 @@ pub enum CLIAgentType {
     Auggie,
     Cursor,
     Goose,
+    Hermes,
     Unknown,
 }
 

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -112,7 +112,15 @@ const GOOSE_COLOR: ColorU = ColorU {
     a: 255,
 };
 
-/// Represents a CLI agent (e.g., Claude Code, Gemini CLI, Codex, Amp, Droid, OpenCode, Copilot, Pi, Auggie, Cursor, Goose)
+/// Hermes Agent brand color (Nous Research purple #7C3AED)
+const HERMES_COLOR: ColorU = ColorU {
+    r: 124,
+    g: 58,
+    b: 237,
+    a: 255,
+};
+
+/// Represents a CLI agent (e.g., Claude Code, Gemini CLI, Codex, Amp, Droid, OpenCode, Copilot, Pi, Auggie, Cursor, Goose, Hermes)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Sequence, Serialize, Deserialize)]
 pub enum CLIAgent {
     Claude,
@@ -126,6 +134,7 @@ pub enum CLIAgent {
     Auggie,
     CursorCli,
     Goose,
+    Hermes,
     /// Represents an unknown/custom CLI agent matched by user-configured regex patterns.
     Unknown,
 }
@@ -145,6 +154,7 @@ impl CLIAgent {
             CLIAgent::Auggie => "auggie",
             CLIAgent::CursorCli => "agent",
             CLIAgent::Goose => "goose",
+            CLIAgent::Hermes => "hermes",
             CLIAgent::Unknown => "",
         }
     }
@@ -190,6 +200,7 @@ impl CLIAgent {
             CLIAgent::Auggie => "Auggie",
             CLIAgent::CursorCli => "Cursor",
             CLIAgent::Goose => "Goose",
+            CLIAgent::Hermes => "Hermes Agent",
             CLIAgent::Unknown => "CLI Agent",
         }
     }
@@ -208,6 +219,7 @@ impl CLIAgent {
             CLIAgent::Auggie => Some(Icon::AuggieLogo),
             CLIAgent::CursorCli => Some(Icon::CursorLogo),
             CLIAgent::Goose => Some(Icon::GooseLogo),
+            CLIAgent::Hermes => None,
             CLIAgent::Unknown => None,
         }
     }
@@ -236,6 +248,7 @@ impl CLIAgent {
             CLIAgent::Auggie => &[SkillProvider::Agents],
             CLIAgent::CursorCli => &[SkillProvider::Agents],
             CLIAgent::Goose => &[SkillProvider::Agents],
+            CLIAgent::Hermes => &[SkillProvider::Agents],
             CLIAgent::Unknown => &[],
         }
     }
@@ -276,6 +289,7 @@ impl CLIAgent {
             CLIAgent::Auggie => Some(AUGGIE_COLOR),
             CLIAgent::CursorCli => Some(CURSOR_COLOR),
             CLIAgent::Goose => Some(GOOSE_COLOR),
+            CLIAgent::Hermes => Some(HERMES_COLOR),
             CLIAgent::Unknown => None,
         }
     }
@@ -537,6 +551,7 @@ impl From<CLIAgent> for CLIAgentType {
             CLIAgent::Auggie => CLIAgentType::Auggie,
             CLIAgent::CursorCli => CLIAgentType::Cursor,
             CLIAgent::Goose => CLIAgentType::Goose,
+            CLIAgent::Hermes => CLIAgentType::Hermes,
             CLIAgent::Unknown => CLIAgentType::Unknown,
         }
     }

--- a/app/src/terminal/cli_agent_sessions/event/v1.rs
+++ b/app/src/terminal/cli_agent_sessions/event/v1.rs
@@ -74,3 +74,27 @@ struct RawEvent {
     tool_input: Option<serde_json::Value>,
     plugin_version: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_hermes_agent_from_command_prefix() {
+        let event = parse(
+            r#"{
+                "v": 1,
+                "agent": "hermes",
+                "event": "stop",
+                "session_id": "session-1",
+                "summary": "Done"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(event.agent, CLIAgent::Hermes);
+        assert_eq!(event.event, CLIAgentEventType::Stop);
+        assert_eq!(event.session_id.as_deref(), Some("session-1"));
+        assert_eq!(event.payload.summary.as_deref(), Some("Done"));
+    }
+}

--- a/app/src/terminal/cli_agent_sessions/listener/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/listener/mod.rs
@@ -47,22 +47,25 @@ pub fn is_agent_supported(agent: &CLIAgent) -> bool {
             | CLIAgent::Gemini
             | CLIAgent::Auggie
             | CLIAgent::Pi
+            | CLIAgent::Hermes
     )
 }
 
 /// Creates the appropriate handler for the given CLI agent.
 fn create_handler(agent: &CLIAgent) -> Option<Box<dyn CLIAgentSessionHandler>> {
     match agent {
-        // Auggie and Pi are supported via community-maintained plugins
+        // Auggie, Pi, and Hermes are supported via external/community-maintained plugins
         // (https://github.com/augmentmoogi/auggie-warp,
-        // https://github.com/badlogic/pi-mono), which emit the same
+        // https://github.com/badlogic/pi-mono, and
+        // https://github.com/NousResearch/hermes-agent), which emit the same
         // structured OSC 777 events as the first-party Claude/OpenCode/Gemini
         // plugins. We don't ship install flows for them — we just listen.
         CLIAgent::Claude
         | CLIAgent::OpenCode
         | CLIAgent::Gemini
         | CLIAgent::Auggie
-        | CLIAgent::Pi => Some(Box::new(DefaultSessionListener)),
+        | CLIAgent::Pi
+        | CLIAgent::Hermes => Some(Box::new(DefaultSessionListener)),
         CLIAgent::Codex => Some(Box::new(CodexSessionHandler)),
         CLIAgent::Amp
         | CLIAgent::Droid
@@ -299,6 +302,46 @@ mod tests {
     #[test]
     fn pi_uses_default_handler_with_rich_status() {
         assert!(agent_supports_rich_status(&CLIAgent::Pi));
+    }
+
+    #[test]
+    fn hermes_is_supported() {
+        assert!(is_agent_supported(&CLIAgent::Hermes));
+    }
+
+    #[test]
+    fn hermes_uses_default_handler_with_rich_status() {
+        assert!(agent_supports_rich_status(&CLIAgent::Hermes));
+    }
+
+    #[test]
+    fn hermes_default_handler_skips_session_start() {
+        let mut handler = DefaultSessionListener;
+        let event = CLIAgentEvent {
+            v: 1,
+            agent: CLIAgent::Hermes,
+            event: CLIAgentEventType::SessionStart,
+            session_id: None,
+            cwd: None,
+            project: None,
+            payload: CLIAgentEventPayload::default(),
+        };
+        assert!(handler.handle_event(event).is_none());
+    }
+
+    #[test]
+    fn hermes_default_handler_forwards_stop() {
+        let mut handler = DefaultSessionListener;
+        let event = CLIAgentEvent {
+            v: 1,
+            agent: CLIAgent::Hermes,
+            event: CLIAgentEventType::Stop,
+            session_id: None,
+            cwd: None,
+            project: None,
+            payload: CLIAgentEventPayload::default(),
+        };
+        assert!(handler.handle_event(event).is_some());
     }
 
     #[test]

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
@@ -264,6 +264,7 @@ pub(crate) fn plugin_manager_for_with_shell(
         | CLIAgent::Auggie
         | CLIAgent::CursorCli
         | CLIAgent::Goose
+        | CLIAgent::Hermes
         | CLIAgent::Unknown => None,
     }
 }

--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -259,6 +259,7 @@ fn test_detect_known_agents() {
                 ("copilot", CLIAgent::Copilot),
                 ("agent", CLIAgent::CursorCli),
                 ("goose", CLIAgent::Goose),
+                ("hermes", CLIAgent::Hermes),
             ] {
                 assert_eq!(
                     CLIAgent::detect(command, None, None, ctx),

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -126,7 +126,8 @@ fn rich_input_submit_strategy(agent: CLIAgent) -> RichInputSubmitStrategy {
         | CLIAgent::OpenCode
         | CLIAgent::Gemini
         | CLIAgent::Auggie
-        | CLIAgent::CursorCli => RichInputSubmitStrategy::DelayedEnter,
+        | CLIAgent::CursorCli
+        | CLIAgent::Hermes => RichInputSubmitStrategy::DelayedEnter,
         CLIAgent::Amp | CLIAgent::Droid | CLIAgent::Pi | CLIAgent::Goose | CLIAgent::Unknown => {
             RichInputSubmitStrategy::Inline
         }


### PR DESCRIPTION
## Summary

Adds Hermes Agent as a recognized Warp CLI agent for structured CLI-agent notification events.

Changes:
- add `CLIAgent::Hermes` with command prefix `hermes`, display name, brand color, skill provider, and telemetry mapping
- parse `agent: "hermes"` in structured `warp://cli-agent` OSC payloads via the normal command-prefix resolver
- route Hermes through the default CLI-agent session listener/rich-status path
- keep Hermes out of bundled plugin install flows (Hermes emits events itself)
- include Hermes in rich-input delayed-enter handling
- add focused tests for command detection, event parsing, support, and default listener forwarding

This is the Warp-side half of Hermes Warp Agent Notifications support. The matching Hermes-side PR emits `ESC ] 777 ; notify ; warp://cli-agent ; <json> BEL` events with `agent: "hermes"`.

Related:
- Fixes/addresses #9745
- Related to #9833 and #9255

## Verification

- `cargo fmt --check` passed
- `git diff --check` passed
- Independent review passed with no blocking issues
- Tried `cargo test -p warp parses_hermes_agent_from_command_prefix --lib`, but local verification is blocked by the environment: `crates/warpui/build.rs` requires Xcode's `metal` utility, and this machine only has CommandLineTools without `metal`.

