### PR TITLE
feat: recognize Mistral Vibe CLI agent

### DIFF
--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -283,6 +283,10 @@ fn test_detect_with_arguments() {
                 CLIAgent::detect("gemini chat", None, None, ctx),
                 Some(CLIAgent::Gemini),
             );
+            assert_eq!(
+                CLIAgent::detect("vibe --model devstral", None, None, ctx),
+                Some(CLIAgent::Vibe),
+            );
         });
     });
 }


### PR DESCRIPTION
## Summary
- Add Mistral Vibe as a recognized CLI agent for `vibe` and `vibe-acp` commands
- Add Mistral brand color, Agents skill-provider support, and telemetry mapping
- Cover detection in CLI agent tests

Fixes #9607

## Testing
- Not run. Rust toolchain is not installed in this environment (`cargo: command not found`).