### PR TITLE
fix: add horizontal scroll to rendered markdown code blocks

### DIFF
--- a/crates/editor/src/content/edit.rs
+++ b/crates/editor/src/content/edit.rs
@@ -952,6 +952,7 @@ fn layout_text_block(
                 BlockItem::RunnableCodeBlock {
                     paragraph_block,
                     code_block_type,
+                    scroll_left: Cell::new(Pixels::zero()),
                 }
             })
             .ok_or_else(|| anyhow!("Code block should have at least one paragraph")),

--- a/crates/editor/src/content/edit.rs
+++ b/crates/editor/src/content/edit.rs
@@ -953,6 +953,7 @@ fn layout_text_block(
                     paragraph_block,
                     code_block_type,
                     scroll_left: Cell::new(Pixels::zero()),
+                    scrollbar_interaction_state: Default::default(),
                 }
             })
             .ok_or_else(|| anyhow!("Code block should have at least one paragraph")),

--- a/crates/editor/src/render/element/paint.rs
+++ b/crates/editor/src/render/element/paint.rs
@@ -76,6 +76,10 @@ pub struct RenderContext<'a, 'b> {
     /// Underlying paint context for rendering.
     pub paint: &'a mut PaintContext<'b>,
     saved_positions: &'a SavedPositions,
+    /// Extra content-space X amount subtracted in [`Self::content_to_screen`] (and thus in
+    /// paragraph text, selection, and decorations). Used for nested horizontal scroll inside a
+    /// block (e.g. markdown code fences) so all painting shares one transform.
+    pub nested_horizontal_scroll: f32,
     pub viewport_size: Vector2F,
     /// Current VimMode of the rich text element, if there is one.
     pub vim_mode: Option<VimMode>,
@@ -112,6 +116,7 @@ impl<'a, 'b> RenderContext<'a, 'b> {
             text_decorations,
             paint,
             saved_positions: model.saved_positions(),
+            nested_horizontal_scroll: 0.0,
             viewport_size,
             vim_mode,
             vim_visual_tails,
@@ -132,7 +137,8 @@ impl<'a, 'b> RenderContext<'a, 'b> {
     /// Note that the returned location may be out of viewport. The caller is responsible for
     /// bounds checking.
     pub fn content_to_screen(&self, position: Vector2F) -> Vector2F {
-        let viewport_relative = position - self.content_offset;
+        let viewport_relative =
+            position - self.content_offset - vec2f(self.nested_horizontal_scroll, 0.0);
         self.bounds.origin() + viewport_relative
     }
 
@@ -162,6 +168,22 @@ impl<'a, 'b> RenderContext<'a, 'b> {
 
         paragraph.draw_selection(state, self);
         self.draw_text_decorations(paragraph, state.decorations().text(), state);
+    }
+
+    /// Like [`draw_paragraph`] but applies horizontal scroll `x_scroll` for nested overflow (e.g.
+    /// a clipped markdown code block). Temporarily increases [`Self::nested_horizontal_scroll`]
+    /// so text, selection, cursors, and decorations stay aligned.
+    pub fn draw_paragraph_scrolled(
+        &mut self,
+        paragraph: &Positioned<Paragraph>,
+        style: &ParagraphStyles,
+        state: &RenderState,
+        x_scroll: f32,
+    ) {
+        let prev = self.nested_horizontal_scroll;
+        self.nested_horizontal_scroll = prev + x_scroll;
+        self.draw_paragraph(paragraph, style, state);
+        self.nested_horizontal_scroll = prev;
     }
 
     /// Helper to draw text decorations over a paragraph. The decorations must be sorted by **end**

--- a/crates/editor/src/render/element/runnable_command.rs
+++ b/crates/editor/src/render/element/runnable_command.rs
@@ -1,7 +1,17 @@
 use warpui::{
-    AppContext, Element, SizeConstraint,
-    elements::{Border, CornerRadius, Empty, Radius},
-    geometry::vector::vec2f,
+    AppContext, ClipBounds, Element, Event, EventContext, SizeConstraint,
+    elements::{
+        Axis, Border, CornerRadius, DEFAULT_SCROLL_WHEEL_PIXELS_PER_LINE, Empty, Radius,
+        ScrollData, ScrollbarAppearance, ScrollbarGeometry, ScrollbarWidth,
+        compute_scrollbar_geometry, project_scroll_delta_by_sensitivity,
+        scroll_delta_for_pointer_movement,
+    },
+    event::DispatchedEvent,
+    geometry::{
+        rect::RectF,
+        vector::{Vector2F, vec2f},
+    },
+    units::{IntoPixels, Pixels},
 };
 
 use crate::{
@@ -15,11 +25,29 @@ use crate::{
 
 use super::{RenderContext, RenderableBlock};
 
+const CODE_SCROLL_SENSITIVITY: f32 = 1.0;
+
+struct CodeBlockScrollDrag {
+    start_position_x: Pixels,
+    start_scroll_left: f32,
+    scroll_data: ScrollData,
+}
+
 /// [`RenderableBlock`] implementation for runnable command blocks.
 pub struct RenderableRunnableCommand {
     viewport_item: ViewportItem,
     footer: Box<dyn Element>,
     border: Option<Border>,
+    /// Current horizontal scroll offset in pixels.
+    scroll_left: f32,
+    /// Natural (intrinsic) width of the code content, updated each paint.
+    natural_width: f32,
+    /// Clip/viewport bounds set during paint and reused in dispatch_event.
+    viewport_bounds: Option<RectF>,
+    /// Scrollbar geometry computed during paint.
+    scrollbar: Option<ScrollbarGeometry>,
+    scrollbar_hovered: bool,
+    scrollbar_drag: Option<CodeBlockScrollDrag>,
 }
 
 impl RenderableRunnableCommand {
@@ -39,8 +67,57 @@ impl RenderableRunnableCommand {
             viewport_item,
             footer,
             border,
+            scroll_left: 0.0,
+            natural_width: 0.0,
+            viewport_bounds: None,
+            scrollbar: None,
+            scrollbar_hovered: false,
+            scrollbar_drag: None,
         }
     }
+}
+
+/// Maximum reachable scroll position for a code block.
+pub(crate) fn code_block_max_scroll(natural_width: f32, container_width: f32) -> f32 {
+    (natural_width - container_width).max(0.0)
+}
+
+/// Scroll data describing the current scroll state for scrollbar geometry calculations.
+pub(crate) fn code_block_scroll_data(
+    natural_width: f32,
+    container_width: f32,
+    scroll_left: f32,
+) -> ScrollData {
+    ScrollData {
+        scroll_start: scroll_left.into_pixels(),
+        visible_px: container_width.into_pixels(),
+        total_size: natural_width.into_pixels(),
+    }
+}
+
+/// Extracts a horizontal scroll delta from a scroll-wheel event, matching the table behaviour:
+/// fires only when the user explicitly scrolls horizontally (shift-scroll or a horizontal
+/// trackpad gesture).
+pub(crate) fn code_block_horizontal_scroll_delta(
+    delta: Vector2F,
+    precise: bool,
+    shift: bool,
+) -> Option<f32> {
+    let delta = if shift && delta.x().abs() <= f32::EPSILON {
+        vec2f(delta.y(), 0.0)
+    } else {
+        delta
+    };
+    let projected_delta = project_scroll_delta_by_sensitivity(delta, CODE_SCROLL_SENSITIVITY);
+    let horizontal = projected_delta.x();
+    if horizontal.abs() <= f32::EPSILON {
+        return None;
+    }
+    Some(if precise {
+        horizontal
+    } else {
+        horizontal * DEFAULT_SCROLL_WHEEL_PIXELS_PER_LINE
+    })
 }
 
 impl RenderableBlock for RenderableRunnableCommand {
@@ -61,7 +138,11 @@ impl RenderableBlock for RenderableRunnableCommand {
 
     fn paint(&mut self, model: &RenderState, ctx: &mut RenderContext, app: &AppContext) {
         let content = model.content();
-        let code_block = extract_block!(self.viewport_item, content, (block, BlockItem::RunnableCodeBlock{code_block_type: _, paragraph_block}) => block.code_block(paragraph_block));
+        let code_block = extract_block!(
+            self.viewport_item,
+            content,
+            (block, BlockItem::RunnableCodeBlock { paragraph_block, .. }) => block.code_block(paragraph_block)
+        );
 
         let styles = model.styles();
         let code_style = &styles.code_text;
@@ -72,8 +153,8 @@ impl RenderableBlock for RenderableRunnableCommand {
             styles.code_border
         };
 
+        // Background is drawn before the clip layer so rounded corners aren't clipped.
         let background_rect = self.viewport_item.visible_bounds(ctx);
-
         ctx.paint
             .scene
             .draw_rect_without_hit_recording(background_rect)
@@ -81,16 +162,65 @@ impl RenderableBlock for RenderableRunnableCommand {
             .with_border(border)
             .with_background(model.styles().code_background);
 
+        // Compute natural vs container widths for horizontal scrolling.
+        let container_width = self.viewport_item.content_size.x();
+        let natural_width = code_block.item.content_size().x();
+        self.natural_width = natural_width;
+
+        let max_scroll = code_block_max_scroll(natural_width, container_width);
+        self.scroll_left = self.scroll_left.clamp(0.0, max_scroll);
+
+        // Viewport bounds used for clipping text content and the scrollbar.
+        let content_origin_screen = ctx.content_to_screen(code_block.content_origin());
+        let viewport_size = vec2f(container_width, code_block.item.height().as_f32());
+        let viewport_bounds = RectF::new(content_origin_screen, viewport_size);
+        self.viewport_bounds = Some(viewport_bounds);
+
+        // Compute scrollbar geometry when there is content to scroll.
+        self.scrollbar = if max_scroll > 0.0 {
+            let scroll_data =
+                code_block_scroll_data(natural_width, container_width, self.scroll_left);
+            let scrollbar = compute_scrollbar_geometry(
+                Axis::Horizontal,
+                viewport_bounds.origin(),
+                viewport_bounds.size(),
+                scroll_data,
+                ScrollbarAppearance::new(ScrollbarWidth::Auto, true),
+            );
+            scrollbar.has_thumb().then_some(scrollbar)
+        } else {
+            self.scrollbar_drag = None;
+            self.scrollbar_hovered = false;
+            None
+        };
+
+        // Clip text content to the container width and paint with scroll offset.
+        ctx.paint
+            .scene
+            .start_layer(ClipBounds::BoundedByActiveLayerAnd(viewport_bounds));
+
         for paragraph in code_block.paragraphs() {
-            ctx.draw_paragraph(&paragraph, code_style, model);
+            ctx.draw_paragraph_scrolled(&paragraph, code_style, model, self.scroll_left);
         }
 
-        // Place the button at a higher z-index for event handling. See the comment on
-        // `RichTextElement::content_z_index` for context.
-        ctx.paint.scene.start_layer(warpui::ClipBounds::ActiveLayer);
+        // Paint scrollbar thumb inside the clip layer.
+        if let Some(scrollbar) = self.scrollbar {
+            let active = self.scrollbar_hovered || self.scrollbar_drag.is_some();
+            ctx.paint
+                .scene
+                .draw_rect_without_hit_recording(scrollbar.thumb_bounds)
+                .with_background(if active {
+                    styles.table_style.scrollbar_active_thumb_color
+                } else {
+                    styles.table_style.scrollbar_nonactive_thumb_color
+                })
+                .with_corner_radius(CornerRadius::with_all(Radius::Percentage(50.0)));
+        }
 
-        // Position the block footer right below the content area, flush with its right-hand edge.
-        // This gives the footer some padding relative to the visible area with a background.
+        ctx.paint.scene.stop_layer();
+
+        // Place the footer at a higher z-index outside the clip layer.
+        ctx.paint.scene.start_layer(ClipBounds::ActiveLayer);
         let content_rect = self.viewport_item.content_bounds(ctx);
         let button_origin = content_rect.lower_right()
             - vec2f(
@@ -98,7 +228,6 @@ impl RenderableBlock for RenderableRunnableCommand {
                 0.,
             );
         self.footer.paint(button_origin, ctx.paint, app);
-
         ctx.paint.scene.stop_layer();
     }
 
@@ -108,11 +237,212 @@ impl RenderableBlock for RenderableRunnableCommand {
 
     fn dispatch_event(
         &mut self,
-        _model: &crate::render::model::RenderState,
-        event: &warpui::event::DispatchedEvent,
-        ctx: &mut warpui::EventContext,
+        _model: &RenderState,
+        event: &DispatchedEvent,
+        ctx: &mut EventContext,
         app: &AppContext,
     ) -> bool {
-        self.footer.dispatch_event(event, ctx, app)
+        if self.footer.dispatch_event(event, ctx, app) {
+            return true;
+        }
+
+        let container_width = self.viewport_item.content_size.x();
+
+        match event.raw_event() {
+            Event::LeftMouseDown { position, .. } => {
+                let Some(scrollbar) = self.scrollbar else {
+                    return false;
+                };
+                let thumb_hit = scrollbar.thumb_bounds.contains_point(*position);
+                let track_hit = scrollbar.track_bounds.contains_point(*position);
+
+                if thumb_hit {
+                    let scroll_data = code_block_scroll_data(
+                        self.natural_width,
+                        container_width,
+                        self.scroll_left,
+                    );
+                    self.scrollbar_drag = Some(CodeBlockScrollDrag {
+                        start_position_x: position.x().into_pixels(),
+                        start_scroll_left: self.scroll_left,
+                        scroll_data,
+                    });
+                    ctx.notify();
+                    return true;
+                }
+
+                if track_hit {
+                    let scroll_data = code_block_scroll_data(
+                        self.natural_width,
+                        container_width,
+                        self.scroll_left,
+                    );
+                    let delta = scroll_delta_for_pointer_movement(
+                        scrollbar.thumb_center_along(Axis::Horizontal),
+                        position.x().into_pixels(),
+                        scroll_data,
+                    );
+                    let new_scroll = (self.scroll_left - delta.as_f32()).clamp(
+                        0.0,
+                        code_block_max_scroll(self.natural_width, container_width),
+                    );
+                    if (new_scroll - self.scroll_left).abs() > f32::EPSILON {
+                        self.scroll_left = new_scroll;
+                        ctx.notify();
+                    }
+                    return true;
+                }
+
+                false
+            }
+            Event::LeftMouseDragged { position, .. } => {
+                let Some(drag) = &self.scrollbar_drag else {
+                    return false;
+                };
+                let delta = scroll_delta_for_pointer_movement(
+                    drag.start_position_x,
+                    position.x().into_pixels(),
+                    drag.scroll_data,
+                );
+                let new_scroll = (drag.start_scroll_left - delta.as_f32()).clamp(
+                    0.0,
+                    code_block_max_scroll(self.natural_width, container_width),
+                );
+                if (new_scroll - self.scroll_left).abs() > f32::EPSILON {
+                    self.scroll_left = new_scroll;
+                    ctx.notify();
+                }
+                true
+            }
+            Event::LeftMouseUp { .. } => {
+                let had_drag = self.scrollbar_drag.take().is_some();
+                if had_drag {
+                    ctx.notify();
+                }
+                had_drag
+            }
+            Event::MouseMoved { position, .. } => {
+                let hovered = self
+                    .scrollbar
+                    .is_some_and(|sb| sb.thumb_bounds.contains_point(*position));
+                if hovered != self.scrollbar_hovered {
+                    self.scrollbar_hovered = hovered;
+                    ctx.notify();
+                }
+                // Never consume MouseMoved so downstream handlers (hover-link, cursor) still fire.
+                false
+            }
+            Event::ScrollWheel {
+                position,
+                delta,
+                precise,
+                modifiers,
+            } if !modifiers.ctrl => {
+                let Some(bounds) = self.viewport_bounds else {
+                    return false;
+                };
+                if !bounds.contains_point(*position)
+                    || code_block_max_scroll(self.natural_width, container_width) <= 0.0
+                {
+                    return false;
+                }
+                let Some(horizontal_delta) =
+                    code_block_horizontal_scroll_delta(*delta, *precise, modifiers.shift)
+                else {
+                    return false;
+                };
+                let new_scroll = (self.scroll_left - horizontal_delta).clamp(
+                    0.0,
+                    code_block_max_scroll(self.natural_width, container_width),
+                );
+                let changed = (new_scroll - self.scroll_left).abs() > f32::EPSILON;
+                if changed {
+                    self.scroll_left = new_scroll;
+                    ctx.notify();
+                }
+                changed
+            }
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod code_block_scroll_tests {
+    use warpui::geometry::vector::vec2f;
+
+    use super::*;
+
+    #[test]
+    fn max_scroll_zero_when_content_fits() {
+        assert_eq!(code_block_max_scroll(100.0, 200.0), 0.0);
+    }
+
+    #[test]
+    fn max_scroll_zero_when_content_exactly_fits() {
+        assert_eq!(code_block_max_scroll(200.0, 200.0), 0.0);
+    }
+
+    #[test]
+    fn max_scroll_positive_when_content_overflows() {
+        assert_eq!(code_block_max_scroll(350.0, 200.0), 150.0);
+    }
+
+    #[test]
+    fn scroll_data_reflects_current_state() {
+        let data = code_block_scroll_data(400.0, 200.0, 50.0);
+        assert_eq!(data.scroll_start, 50.0.into_pixels());
+        assert_eq!(data.visible_px, 200.0.into_pixels());
+        assert_eq!(data.total_size, 400.0.into_pixels());
+    }
+
+    #[test]
+    fn horizontal_delta_returns_none_for_plain_vertical_scroll() {
+        let delta = vec2f(0.0, -3.0);
+        assert!(code_block_horizontal_scroll_delta(delta, false, false).is_none());
+    }
+
+    #[test]
+    fn horizontal_delta_fires_on_shift_scroll() {
+        let delta = vec2f(0.0, -3.0);
+        let result = code_block_horizontal_scroll_delta(delta, false, true);
+        assert!(result.is_some());
+        // shift maps y → x, so negative y (scroll down) = positive horizontal delta
+        assert!(result.unwrap() < 0.0);
+    }
+
+    #[test]
+    fn horizontal_delta_fires_on_horizontal_trackpad_gesture() {
+        let delta = vec2f(-5.0, 0.0);
+        let result = code_block_horizontal_scroll_delta(delta, true, false);
+        assert!(result.is_some());
+        assert!(result.unwrap() < 0.0);
+    }
+
+    #[test]
+    fn horizontal_delta_precise_skips_line_multiplier() {
+        let delta = vec2f(-1.0, 0.0);
+        let precise = code_block_horizontal_scroll_delta(delta, true, false).unwrap();
+        let imprecise = code_block_horizontal_scroll_delta(delta, false, false).unwrap();
+        assert!(imprecise.abs() > precise.abs());
+    }
+
+    #[test]
+    fn scroll_left_clamps_to_zero() {
+        // Simulate clamping logic used in paint().
+        let natural = 300.0_f32;
+        let container = 200.0_f32;
+        let raw = -50.0_f32;
+        let clamped = raw.clamp(0.0, code_block_max_scroll(natural, container));
+        assert_eq!(clamped, 0.0);
+    }
+
+    #[test]
+    fn scroll_left_clamps_to_max_scroll() {
+        let natural = 300.0_f32;
+        let container = 200.0_f32;
+        let raw = 500.0_f32;
+        let clamped = raw.clamp(0.0, code_block_max_scroll(natural, container));
+        assert_eq!(clamped, 100.0);
     }
 }

--- a/crates/editor/src/render/element/runnable_command.rs
+++ b/crates/editor/src/render/element/runnable_command.rs
@@ -221,6 +221,7 @@ impl RenderableBlock for RenderableRunnableCommand {
         ctx.paint
             .scene
             .start_layer(ClipBounds::BoundedByActiveLayerAnd(viewport_bounds));
+        ctx.paint.scene.set_active_layer_click_through();
 
         for paragraph in code_block.paragraphs() {
             ctx.draw_paragraph_scrolled(&paragraph, code_style, model, scroll_left_f);

--- a/crates/editor/src/render/element/runnable_command.rs
+++ b/crates/editor/src/render/element/runnable_command.rs
@@ -1,3 +1,4 @@
+use float_cmp::ApproxEq;
 use warpui::{
     AppContext, ClipBounds, Element, Event, EventContext, SizeConstraint,
     elements::{
@@ -16,10 +17,9 @@ use warpui::{
 
 use crate::{
     editor::RunnableCommandModel,
-    extract_block,
     render::{
         BLOCK_FOOTER_HEIGHT,
-        model::{BlockItem, RenderState, viewport::ViewportItem},
+        model::{BlockItem, RenderState, UNIT_MARGIN, viewport::ViewportItem},
     },
 };
 
@@ -29,7 +29,7 @@ const CODE_SCROLL_SENSITIVITY: f32 = 1.0;
 
 struct CodeBlockScrollDrag {
     start_position_x: Pixels,
-    start_scroll_left: f32,
+    start_scroll_left: Pixels,
     scroll_data: ScrollData,
 }
 
@@ -38,10 +38,6 @@ pub struct RenderableRunnableCommand {
     viewport_item: ViewportItem,
     footer: Box<dyn Element>,
     border: Option<Border>,
-    /// Current horizontal scroll offset in pixels.
-    scroll_left: f32,
-    /// Natural (intrinsic) width of the code content, updated each paint.
-    natural_width: f32,
     /// Clip/viewport bounds set during paint and reused in dispatch_event.
     viewport_bounds: Option<RectF>,
     /// Scrollbar geometry computed during paint.
@@ -67,8 +63,6 @@ impl RenderableRunnableCommand {
             viewport_item,
             footer,
             border,
-            scroll_left: 0.0,
-            natural_width: 0.0,
             viewport_bounds: None,
             scrollbar: None,
             scrollbar_hovered: false,
@@ -86,10 +80,10 @@ pub(crate) fn code_block_max_scroll(natural_width: f32, container_width: f32) ->
 pub(crate) fn code_block_scroll_data(
     natural_width: f32,
     container_width: f32,
-    scroll_left: f32,
+    scroll_left: Pixels,
 ) -> ScrollData {
     ScrollData {
-        scroll_start: scroll_left.into_pixels(),
+        scroll_start: scroll_left,
         visible_px: container_width.into_pixels(),
         total_size: natural_width.into_pixels(),
     }
@@ -102,7 +96,7 @@ pub(crate) fn code_block_horizontal_scroll_delta(
     delta: Vector2F,
     precise: bool,
     shift: bool,
-) -> Option<f32> {
+) -> Option<Pixels> {
     let delta = if shift && delta.x().abs() <= f32::EPSILON {
         vec2f(delta.y(), 0.0)
     } else {
@@ -113,11 +107,11 @@ pub(crate) fn code_block_horizontal_scroll_delta(
     if horizontal.abs() <= f32::EPSILON {
         return None;
     }
-    Some(if precise {
+    Some(Pixels::new(if precise {
         horizontal
     } else {
         horizontal * DEFAULT_SCROLL_WHEEL_PIXELS_PER_LINE
-    })
+    }))
 }
 
 impl RenderableBlock for RenderableRunnableCommand {
@@ -125,7 +119,7 @@ impl RenderableBlock for RenderableRunnableCommand {
         &self.viewport_item
     }
 
-    fn layout(&mut self, _model: &RenderState, ctx: &mut warpui::LayoutContext, app: &AppContext) {
+    fn layout(&mut self, model: &RenderState, ctx: &mut warpui::LayoutContext, app: &AppContext) {
         self.footer.layout(
             SizeConstraint::strict(vec2f(
                 self.viewport_item.content_size.x(),
@@ -134,15 +128,45 @@ impl RenderableBlock for RenderableRunnableCommand {
             ctx,
             app,
         );
+
+        // Clamp horizontal scroll when layout width changes (do this in layout, not paint).
+        let content = model.content();
+        if let Some(block) = content.block_at_offset(self.viewport_item.block_offset())
+            && let BlockItem::RunnableCodeBlock {
+                paragraph_block,
+                scroll_left,
+                ..
+            } = block.item
+        {
+            let container_width = self.viewport_item.content_size.x();
+            let natural_width = paragraph_block.content_size().x();
+            let max_scroll_px = Pixels::new(code_block_max_scroll(natural_width, container_width));
+            let current = scroll_left.get();
+            let capped = current.max(Pixels::zero()).min(max_scroll_px);
+            if !capped.approx_eq(current, UNIT_MARGIN) {
+                scroll_left.set(capped);
+            }
+        }
     }
 
     fn paint(&mut self, model: &RenderState, ctx: &mut RenderContext, app: &AppContext) {
         let content = model.content();
-        let code_block = extract_block!(
-            self.viewport_item,
-            content,
-            (block, BlockItem::RunnableCodeBlock { paragraph_block, .. }) => block.code_block(paragraph_block)
-        );
+        let Some(block) = content.block_at_offset(self.viewport_item.block_offset()) else {
+            return;
+        };
+        let BlockItem::RunnableCodeBlock {
+            paragraph_block,
+            scroll_left,
+            ..
+        } = block.item
+        else {
+            log::trace!(
+                "Expected RunnableCodeBlock at block offset {:?}",
+                self.viewport_item.block_offset()
+            );
+            return;
+        };
+        let code_block = block.code_block(paragraph_block);
 
         let styles = model.styles();
         let code_style = &styles.code_text;
@@ -165,10 +189,10 @@ impl RenderableBlock for RenderableRunnableCommand {
         // Compute natural vs container widths for horizontal scrolling.
         let container_width = self.viewport_item.content_size.x();
         let natural_width = code_block.item.content_size().x();
-        self.natural_width = natural_width;
-
         let max_scroll = code_block_max_scroll(natural_width, container_width);
-        self.scroll_left = self.scroll_left.clamp(0.0, max_scroll);
+        let max_scroll_px = Pixels::new(max_scroll);
+        let scroll_px = scroll_left.get().max(Pixels::zero()).min(max_scroll_px);
+        let scroll_left_f = scroll_px.as_f32();
 
         // Viewport bounds used for clipping text content and the scrollbar.
         let content_origin_screen = ctx.content_to_screen(code_block.content_origin());
@@ -178,8 +202,7 @@ impl RenderableBlock for RenderableRunnableCommand {
 
         // Compute scrollbar geometry when there is content to scroll.
         self.scrollbar = if max_scroll > 0.0 {
-            let scroll_data =
-                code_block_scroll_data(natural_width, container_width, self.scroll_left);
+            let scroll_data = code_block_scroll_data(natural_width, container_width, scroll_px);
             let scrollbar = compute_scrollbar_geometry(
                 Axis::Horizontal,
                 viewport_bounds.origin(),
@@ -200,7 +223,7 @@ impl RenderableBlock for RenderableRunnableCommand {
             .start_layer(ClipBounds::BoundedByActiveLayerAnd(viewport_bounds));
 
         for paragraph in code_block.paragraphs() {
-            ctx.draw_paragraph_scrolled(&paragraph, code_style, model, self.scroll_left);
+            ctx.draw_paragraph_scrolled(&paragraph, code_style, model, scroll_left_f);
         }
 
         // Paint scrollbar thumb inside the clip layer.
@@ -237,7 +260,7 @@ impl RenderableBlock for RenderableRunnableCommand {
 
     fn dispatch_event(
         &mut self,
-        _model: &RenderState,
+        model: &RenderState,
         event: &DispatchedEvent,
         ctx: &mut EventContext,
         app: &AppContext,
@@ -246,7 +269,22 @@ impl RenderableBlock for RenderableRunnableCommand {
             return true;
         }
 
+        let content = model.content();
+        let Some(block) = content.block_at_offset(self.viewport_item.block_offset()) else {
+            return false;
+        };
+        let BlockItem::RunnableCodeBlock {
+            paragraph_block,
+            scroll_left,
+            ..
+        } = block.item
+        else {
+            return false;
+        };
+        let code_block = block.code_block(paragraph_block);
+        let natural_width = code_block.item.content_size().x();
         let container_width = self.viewport_item.content_size.x();
+        let max_scroll_px = Pixels::new(code_block_max_scroll(natural_width, container_width));
 
         match event.raw_event() {
             Event::LeftMouseDown { position, .. } => {
@@ -257,14 +295,11 @@ impl RenderableBlock for RenderableRunnableCommand {
                 let track_hit = scrollbar.track_bounds.contains_point(*position);
 
                 if thumb_hit {
-                    let scroll_data = code_block_scroll_data(
-                        self.natural_width,
-                        container_width,
-                        self.scroll_left,
-                    );
+                    let scroll_data =
+                        code_block_scroll_data(natural_width, container_width, scroll_left.get());
                     self.scrollbar_drag = Some(CodeBlockScrollDrag {
                         start_position_x: position.x().into_pixels(),
-                        start_scroll_left: self.scroll_left,
+                        start_scroll_left: scroll_left.get(),
                         scroll_data,
                     });
                     ctx.notify();
@@ -272,22 +307,18 @@ impl RenderableBlock for RenderableRunnableCommand {
                 }
 
                 if track_hit {
-                    let scroll_data = code_block_scroll_data(
-                        self.natural_width,
-                        container_width,
-                        self.scroll_left,
-                    );
+                    let scroll_data =
+                        code_block_scroll_data(natural_width, container_width, scroll_left.get());
                     let delta = scroll_delta_for_pointer_movement(
                         scrollbar.thumb_center_along(Axis::Horizontal),
                         position.x().into_pixels(),
                         scroll_data,
                     );
-                    let new_scroll = (self.scroll_left - delta.as_f32()).clamp(
-                        0.0,
-                        code_block_max_scroll(self.natural_width, container_width),
-                    );
-                    if (new_scroll - self.scroll_left).abs() > f32::EPSILON {
-                        self.scroll_left = new_scroll;
+                    let new_scroll = (scroll_left.get() - delta)
+                        .max(Pixels::zero())
+                        .min(max_scroll_px);
+                    if !new_scroll.approx_eq(scroll_left.get(), UNIT_MARGIN) {
+                        scroll_left.set(new_scroll);
                         ctx.notify();
                     }
                     return true;
@@ -304,12 +335,11 @@ impl RenderableBlock for RenderableRunnableCommand {
                     position.x().into_pixels(),
                     drag.scroll_data,
                 );
-                let new_scroll = (drag.start_scroll_left - delta.as_f32()).clamp(
-                    0.0,
-                    code_block_max_scroll(self.natural_width, container_width),
-                );
-                if (new_scroll - self.scroll_left).abs() > f32::EPSILON {
-                    self.scroll_left = new_scroll;
+                let new_scroll = (drag.start_scroll_left - delta)
+                    .max(Pixels::zero())
+                    .min(max_scroll_px);
+                if !new_scroll.approx_eq(scroll_left.get(), UNIT_MARGIN) {
+                    scroll_left.set(new_scroll);
                     ctx.notify();
                 }
                 true
@@ -341,9 +371,7 @@ impl RenderableBlock for RenderableRunnableCommand {
                 let Some(bounds) = self.viewport_bounds else {
                     return false;
                 };
-                if !bounds.contains_point(*position)
-                    || code_block_max_scroll(self.natural_width, container_width) <= 0.0
-                {
+                if !bounds.contains_point(*position) || max_scroll_px <= Pixels::zero() {
                     return false;
                 }
                 let Some(horizontal_delta) =
@@ -351,13 +379,12 @@ impl RenderableBlock for RenderableRunnableCommand {
                 else {
                     return false;
                 };
-                let new_scroll = (self.scroll_left - horizontal_delta).clamp(
-                    0.0,
-                    code_block_max_scroll(self.natural_width, container_width),
-                );
-                let changed = (new_scroll - self.scroll_left).abs() > f32::EPSILON;
+                let new_scroll = (scroll_left.get() - horizontal_delta)
+                    .max(Pixels::zero())
+                    .min(max_scroll_px);
+                let changed = !new_scroll.approx_eq(scroll_left.get(), UNIT_MARGIN);
                 if changed {
-                    self.scroll_left = new_scroll;
+                    scroll_left.set(new_scroll);
                     ctx.notify();
                 }
                 changed
@@ -390,7 +417,7 @@ mod code_block_scroll_tests {
 
     #[test]
     fn scroll_data_reflects_current_state() {
-        let data = code_block_scroll_data(400.0, 200.0, 50.0);
+        let data = code_block_scroll_data(400.0, 200.0, 50.0.into_pixels());
         assert_eq!(data.scroll_start, 50.0.into_pixels());
         assert_eq!(data.visible_px, 200.0.into_pixels());
         assert_eq!(data.total_size, 400.0.into_pixels());
@@ -408,7 +435,7 @@ mod code_block_scroll_tests {
         let result = code_block_horizontal_scroll_delta(delta, false, true);
         assert!(result.is_some());
         // shift maps y → x, so negative y (scroll down) = positive horizontal delta
-        assert!(result.unwrap() < 0.0);
+        assert!(result.unwrap().as_f32() < 0.0);
     }
 
     #[test]
@@ -416,14 +443,18 @@ mod code_block_scroll_tests {
         let delta = vec2f(-5.0, 0.0);
         let result = code_block_horizontal_scroll_delta(delta, true, false);
         assert!(result.is_some());
-        assert!(result.unwrap() < 0.0);
+        assert!(result.unwrap().as_f32() < 0.0);
     }
 
     #[test]
     fn horizontal_delta_precise_skips_line_multiplier() {
         let delta = vec2f(-1.0, 0.0);
-        let precise = code_block_horizontal_scroll_delta(delta, true, false).unwrap();
-        let imprecise = code_block_horizontal_scroll_delta(delta, false, false).unwrap();
+        let precise = code_block_horizontal_scroll_delta(delta, true, false)
+            .unwrap()
+            .as_f32();
+        let imprecise = code_block_horizontal_scroll_delta(delta, false, false)
+            .unwrap()
+            .as_f32();
         assert!(imprecise.abs() > precise.abs());
     }
 

--- a/crates/editor/src/render/element/runnable_command.rs
+++ b/crates/editor/src/render/element/runnable_command.rs
@@ -27,12 +27,6 @@ use super::{RenderContext, RenderableBlock};
 
 const CODE_SCROLL_SENSITIVITY: f32 = 1.0;
 
-struct CodeBlockScrollDrag {
-    start_position_x: Pixels,
-    start_scroll_left: Pixels,
-    scroll_data: ScrollData,
-}
-
 /// [`RenderableBlock`] implementation for runnable command blocks.
 pub struct RenderableRunnableCommand {
     viewport_item: ViewportItem,
@@ -42,8 +36,6 @@ pub struct RenderableRunnableCommand {
     viewport_bounds: Option<RectF>,
     /// Scrollbar geometry computed during paint.
     scrollbar: Option<ScrollbarGeometry>,
-    scrollbar_hovered: bool,
-    scrollbar_drag: Option<CodeBlockScrollDrag>,
 }
 
 impl RenderableRunnableCommand {
@@ -65,8 +57,6 @@ impl RenderableRunnableCommand {
             border,
             viewport_bounds: None,
             scrollbar: None,
-            scrollbar_hovered: false,
-            scrollbar_drag: None,
         }
     }
 }
@@ -157,6 +147,7 @@ impl RenderableBlock for RenderableRunnableCommand {
         let BlockItem::RunnableCodeBlock {
             paragraph_block,
             scroll_left,
+            scrollbar_interaction_state,
             ..
         } = block.item
         else {
@@ -212,8 +203,7 @@ impl RenderableBlock for RenderableRunnableCommand {
             );
             scrollbar.has_thumb().then_some(scrollbar)
         } else {
-            self.scrollbar_drag = None;
-            self.scrollbar_hovered = false;
+            scrollbar_interaction_state.clear();
             None
         };
 
@@ -229,7 +219,8 @@ impl RenderableBlock for RenderableRunnableCommand {
 
         // Paint scrollbar thumb inside the clip layer.
         if let Some(scrollbar) = self.scrollbar {
-            let active = self.scrollbar_hovered || self.scrollbar_drag.is_some();
+            let active = scrollbar_interaction_state.hovered()
+                || scrollbar_interaction_state.drag_state().is_some();
             ctx.paint
                 .scene
                 .draw_rect_without_hit_recording(scrollbar.thumb_bounds)
@@ -277,6 +268,7 @@ impl RenderableBlock for RenderableRunnableCommand {
         let BlockItem::RunnableCodeBlock {
             paragraph_block,
             scroll_left,
+            scrollbar_interaction_state,
             ..
         } = block.item
         else {
@@ -298,11 +290,11 @@ impl RenderableBlock for RenderableRunnableCommand {
                 if thumb_hit {
                     let scroll_data =
                         code_block_scroll_data(natural_width, container_width, scroll_left.get());
-                    self.scrollbar_drag = Some(CodeBlockScrollDrag {
-                        start_position_x: position.x().into_pixels(),
-                        start_scroll_left: scroll_left.get(),
+                    scrollbar_interaction_state.start_drag(
+                        position.x().into_pixels(),
+                        scroll_left.get(),
                         scroll_data,
-                    });
+                    );
                     ctx.notify();
                     return true;
                 }
@@ -328,7 +320,7 @@ impl RenderableBlock for RenderableRunnableCommand {
                 false
             }
             Event::LeftMouseDragged { position, .. } => {
-                let Some(drag) = &self.scrollbar_drag else {
+                let Some(drag) = scrollbar_interaction_state.drag_state() else {
                     return false;
                 };
                 let delta = scroll_delta_for_pointer_movement(
@@ -346,7 +338,7 @@ impl RenderableBlock for RenderableRunnableCommand {
                 true
             }
             Event::LeftMouseUp { .. } => {
-                let had_drag = self.scrollbar_drag.take().is_some();
+                let had_drag = scrollbar_interaction_state.end_drag();
                 if had_drag {
                     ctx.notify();
                 }
@@ -356,8 +348,7 @@ impl RenderableBlock for RenderableRunnableCommand {
                 let hovered = self
                     .scrollbar
                     .is_some_and(|sb| sb.thumb_bounds.contains_point(*position));
-                if hovered != self.scrollbar_hovered {
-                    self.scrollbar_hovered = hovered;
+                if scrollbar_interaction_state.set_hovered(hovered) {
                     ctx.notify();
                 }
                 // Never consume MouseMoved so downstream handlers (hover-link, cursor) still fire.

--- a/crates/editor/src/render/model/location.rs
+++ b/crates/editor/src/render/model/location.rs
@@ -147,9 +147,12 @@ impl<'a> Positioned<'a, BlockItem> {
             BlockItem::Paragraph(paragraph) => self
                 .paragraph(paragraph)
                 .coordinate_to_location(self.unpad_x(x), y),
-            BlockItem::TextBlock { paragraph_block } => {
-                self.location_in_paragraph_block(x, y, self.text_block(paragraph_block))
-            }
+            BlockItem::TextBlock { paragraph_block } => self.location_in_paragraph_block(
+                x,
+                y,
+                self.text_block(paragraph_block),
+                Pixels::zero(),
+            ),
             BlockItem::TaskList { paragraph, .. } => self
                 .task_list(paragraph)
                 .coordinate_to_location(self.unpad_x(x), y),
@@ -160,7 +163,9 @@ impl<'a> Positioned<'a, BlockItem> {
                 .ordered_list(paragraph)
                 .coordinate_to_location(self.unpad_x(x), y),
             BlockItem::RunnableCodeBlock {
-                paragraph_block, ..
+                paragraph_block,
+                scroll_left,
+                ..
             } => {
                 // To make text selection more ergonomic, any point on a line with text is
                 // considered part of the block's text area, including padding. Points within the
@@ -172,8 +177,13 @@ impl<'a> Positioned<'a, BlockItem> {
                     text_origin.y()..=text_origin.y() + paragraph_block.height().as_f32();
 
                 if options.force_text_selection || text_height_range.contains(&y.as_f32()) {
-                    // Note: we don't unpad `x` here because it's handled by `location_in_paragraph_block`.
-                    self.location_in_paragraph_block(x, y, self.code_block(paragraph_block))
+                    // Horizontal scroll shifts visible text; add scroll so hits map to layout coords.
+                    self.location_in_paragraph_block(
+                        x,
+                        y,
+                        self.code_block(paragraph_block),
+                        scroll_left.get(),
+                    )
                 } else {
                     Location::Block {
                         start_offset: self.start_char_offset,
@@ -234,10 +244,13 @@ impl<'a> Positioned<'a, BlockItem> {
         x: Pixels,
         y: Pixels,
         paragraph_block: Positioned<'a, ParagraphBlock>,
+        // Added to unpad'd x before resolving to a character (e.g. code-block horizontal scroll).
+        content_x_scroll: Pixels,
     ) -> Location {
         for paragraph in paragraph_block.paragraphs() {
             if paragraph.end_y_offset() > y {
-                let mut location = paragraph.coordinate_to_location(self.unpad_x(x), y);
+                let mut location =
+                    paragraph.coordinate_to_location(self.unpad_x(x) + content_x_scroll, y);
                 // Adjust the paragraph-relative start offset to be the start of this block.
                 if let Location::Text { block_start, .. } = &mut location {
                     *block_start = self.start_char_offset;

--- a/crates/editor/src/render/model/location_tests.rs
+++ b/crates/editor/src/render/model/location_tests.rs
@@ -19,7 +19,7 @@ use sum_tree::SumTree;
 use warpui::assets::asset_cache::AssetSource;
 use warpui::fonts::FamilyId;
 use warpui::text_layout::{CaretPosition, TextFrame};
-use warpui::units::IntoPixels;
+use warpui::units::{IntoPixels, Pixels};
 
 fn test_table_layout() -> LaidOutTable {
     let source = "aaa\tbbb\nccc\tddd\n";
@@ -580,6 +580,7 @@ fn test_hit_code_block() {
                 width - COMMAND_SPACING.x_axis_offset().as_f32(),
             )),
             code_block_type: Default::default(),
+            scroll_left: Cell::new(Pixels::zero()),
         },
     ]);
     model.set_content(tree);

--- a/crates/editor/src/render/model/location_tests.rs
+++ b/crates/editor/src/render/model/location_tests.rs
@@ -581,6 +581,7 @@ fn test_hit_code_block() {
             )),
             code_block_type: Default::default(),
             scroll_left: Cell::new(Pixels::zero()),
+            scrollbar_interaction_state: Default::default(),
         },
     ]);
     model.set_content(tree);

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -774,6 +774,8 @@ pub enum BlockItem {
     RunnableCodeBlock {
         paragraph_block: ParagraphBlock,
         code_block_type: CodeBlockType,
+        /// Horizontal scroll for overflow (render + hit-testing); see [`LaidOutTable::scroll_left`].
+        scroll_left: Cell<Pixels>,
     },
     MermaidDiagram {
         content_length: CharOffset,
@@ -3810,13 +3812,21 @@ impl Positioned<'_, BlockItem> {
             }
             BlockItem::Header { paragraph, .. } => self.header(paragraph).character_bounds(offset),
             BlockItem::RunnableCodeBlock {
-                paragraph_block, ..
+                paragraph_block,
+                scroll_left,
+                ..
             } => {
                 let code_block = self.code_block(paragraph_block);
                 code_block
                     .paragraphs()
                     .find_or_last(|paragraph| paragraph.end_char_offset() > offset)
                     .and_then(|paragraph| paragraph.character_bounds(offset))
+                    .map(|bounds| {
+                        RectF::new(
+                            bounds.origin() - vec2f(scroll_left.get().as_f32(), 0.0),
+                            bounds.size(),
+                        )
+                    })
             }
             BlockItem::MermaidDiagram { config, .. } => {
                 let origin = self.content_origin();

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -776,6 +776,8 @@ pub enum BlockItem {
         code_block_type: CodeBlockType,
         /// Horizontal scroll for overflow (render + hit-testing); see [`LaidOutTable::scroll_left`].
         scroll_left: Cell<Pixels>,
+        /// Scrollbar drag/hover state; survives layout rebuilds. See [`LaidOutTable::scrollbar_interaction_state`].
+        scrollbar_interaction_state: CodeBlockScrollbarInteractionState,
     },
     MermaidDiagram {
         content_length: CharOffset,
@@ -1243,6 +1245,55 @@ pub(crate) struct TableScrollbarDragState {
 pub(crate) struct TableScrollbarInteractionState {
     drag_state: Cell<Option<TableScrollbarDragState>>,
     hovered: Cell<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CodeBlockScrollbarDragState {
+    pub start_position_x: Pixels,
+    pub start_scroll_left: Pixels,
+    pub scroll_data: ScrollData,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CodeBlockScrollbarInteractionState {
+    drag_state: Cell<Option<CodeBlockScrollbarDragState>>,
+    hovered: Cell<bool>,
+}
+
+impl CodeBlockScrollbarInteractionState {
+    pub(crate) fn start_drag(
+        &self,
+        start_position_x: Pixels,
+        start_scroll_left: Pixels,
+        scroll_data: ScrollData,
+    ) {
+        self.drag_state.set(Some(CodeBlockScrollbarDragState {
+            start_position_x,
+            start_scroll_left,
+            scroll_data,
+        }));
+    }
+
+    pub(crate) fn end_drag(&self) -> bool {
+        self.drag_state.take().is_some()
+    }
+
+    pub(crate) fn drag_state(&self) -> Option<CodeBlockScrollbarDragState> {
+        self.drag_state.get()
+    }
+
+    pub(crate) fn hovered(&self) -> bool {
+        self.hovered.get()
+    }
+
+    pub(crate) fn set_hovered(&self, hovered: bool) -> bool {
+        self.hovered.replace(hovered) != hovered
+    }
+
+    pub(crate) fn clear(&self) {
+        self.drag_state.set(None);
+        self.hovered.set(false);
+    }
 }
 
 impl LaidOutTable {

--- a/crates/editor/src/render/model/mod_tests.rs
+++ b/crates/editor/src/render/model/mod_tests.rs
@@ -336,6 +336,7 @@ fn test_non_empty_content_can_hide_final_trailing_newline() {
             model.viewport.width().as_f32(),
         )),
         code_block_type: Default::default(),
+        scroll_left: Cell::new(Pixels::zero()),
     });
     model.set_content(content);
 
@@ -612,6 +613,7 @@ fn test_first_line_bounds() {
             model.viewport.width().as_f32(),
         )),
         code_block_type: Default::default(),
+        scroll_left: Cell::new(Pixels::zero()),
     });
     model.set_content(content);
 

--- a/crates/editor/src/render/model/mod_tests.rs
+++ b/crates/editor/src/render/model/mod_tests.rs
@@ -337,6 +337,7 @@ fn test_non_empty_content_can_hide_final_trailing_newline() {
         )),
         code_block_type: Default::default(),
         scroll_left: Cell::new(Pixels::zero()),
+        scrollbar_interaction_state: Default::default(),
     });
     model.set_content(content);
 
@@ -614,6 +615,7 @@ fn test_first_line_bounds() {
         )),
         code_block_type: Default::default(),
         scroll_left: Cell::new(Pixels::zero()),
+        scrollbar_interaction_state: Default::default(),
     });
     model.set_content(content);
 


### PR DESCRIPTION
## Description

Rendered markdown code blocks in the notebook file view were silently clipped at the pane edge with no affordance to reach overflowing content. Switching to Raw mode showed a horizontal scrollbar; Rendered mode had none.

**Root cause:** `RenderableRunnableCommand` drew paragraphs directly to the scene with no clip layer and no scroll state. Monospace code lines wider than the container extended past the right edge and were swallowed by the outer editor clip. (`RenderableTable` already has a full horizontal-scroll implementation; this brings code blocks to parity.)

**Changes:**

- `crates/editor/src/render/element/paint.rs` — adds `draw_paragraph_scrolled`, which temporarily increments `RenderContext::nested_horizontal_scroll` so that `content_to_screen` shifts text, selection highlights, cursors, and syntax-highlight decorations together under the scroll offset.
- `crates/editor/src/render/element/runnable_command.rs` — tracks `scroll_left`, `natural_width`, `viewport_bounds`, `scrollbar`, `scrollbar_hovered`, and `scrollbar_drag`; wraps code content in a `BoundedByActiveLayerAnd` clip layer; renders a horizontal scrollbar thumb (reusing the table scrollbar colours from the active theme); handles shift-scroll / horizontal trackpad and scrollbar drag in `dispatch_event`, mirroring `RenderableTable`.
- 10 unit tests covering: max-scroll arithmetic (fits / exact / overflow), `ScrollData` construction, delta gating (plain vertical → `None`, shift-scroll and horizontal trackpad → `Some`), line-multiplier scaling for imprecise scroll, and `scroll_left` clamping at both edges.

## Linked Issue

Fixes #9089

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos



https://github.com/user-attachments/assets/512a14ed-a273-4164-a4f8-a9f709a2ada6



## Testing

- Added 10 unit tests in `runnable_command.rs` (see `code_block_scroll_tests` module); all pass with `cargo nextest run -p warp_editor`.
- Full `warp_editor` suite: 422/422 pass, zero regressions.
- **Note on presubmit:** 6 tests were already failing on `master` before this branch was created (verified by checking out `master` without these changes). These failures are pre-existing and unrelated to this PR.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Rendered markdown code blocks now scroll horizontally when content overflows the pane width, matching Raw mode behaviour.