### PR TITLE
spec: built-in /review slash command (#9606)

### DIFF
--- a/specs/GH9606/product.md
+++ b/specs/GH9606/product.md
@@ -1,0 +1,124 @@
+# Product Spec: Built-in `/review` slash command
+
+**Issue:** [warpdotdev/warp#9606](https://github.com/warpdotdev/warp/issues/9606)
+**Figma:** none provided
+
+## Summary
+
+Add a built-in `/review` slash command in Agent input that gathers the current working tree's uncommitted changes and asks the Agent for a concise code review focused on logic bugs, security concerns, performance, simplicity, reuse, and maintainability. The command becomes available whenever the user is in a Git repository with at least one tracked-file change (staged or unstaged) and the agent is enabled.
+
+This complements — does not replace — Warp's existing **Code Review** panel and the existing `/open-code-review` slash command, which are oriented toward inspecting and managing diffs rather than generating AI feedback. `/review` is the proactive, agent-facing entry point users currently improvise with hand-written prompts and ad-hoc diff attachment.
+
+## Problem
+
+Per the issue: users who want AI feedback on their uncommitted changes today have to:
+
+1. Manually prompt the Agent ("can you review my changes?") and rely on the agent inferring how to gather the diff, OR
+2. Paste a diff into the conversation, OR
+3. Build their own reusable skill or saved prompt.
+
+This makes a high-value, frequently-repeated workflow undiscoverable. The `/agent`, `/fork`, `/open-code-review`, `/index`, `/init`, and `/pr-comments` commands all already live as built-in static commands. A `/review` command sits naturally in this set and short-circuits the manual-prompt pattern.
+
+## Goals
+
+- A user in a Git repo with uncommitted changes types `/review` in Agent input and gets a focused code review back as the next agent turn — no manual diff gathering, no template prompt to memorize.
+- The command surfaces in the existing static-command palette (`/`-prefix dropdown) when the conditions are met, with an icon and short description matching today's `/open-code-review` UX.
+- The command is discoverable from the same surface as every other built-in agent command (no new menu, no new keybinding required for V1).
+- The diff payload is bounded — a runaway 100k-line refactor doesn't blow the agent's context window or the user's token budget.
+- The command is gracefully unavailable when the preconditions (Git repo, AI enabled, has changes) aren't met, with a clear reason instead of a silent failure.
+
+## Non-goals (V1 — explicitly deferred to follow-ups)
+
+- **Reviewing committed changes / specific commits / branches.** V1 covers uncommitted changes (working tree + index). Commit-range review (`/review HEAD~3..HEAD`, `/review main..feature`) is a follow-up gated on the V1 prompt template proving useful.
+- **Reviewing PRs from GitHub.** The existing `/pr-comments` command pulls PR review comments; `/review` is local-changes-focused. No overlap.
+- **User-customizable review prompt template.** V1 ships a fixed prompt focusing on the issue's stated priorities (logic bugs, security, performance, simplicity, reuse, maintainability). A per-project override file is a follow-up.
+- **Auto-applying suggested fixes.** `/review` produces feedback; applying it is the existing agent edit flow. No new auto-apply affordance.
+- **Per-file review filtering** (`/review src/foo.rs`). V1 reviews the entire diff. File scoping is a follow-up.
+- **Streaming / incremental review.** V1 sends the full diff in one agent turn. Streaming summary→deep-dive is a follow-up.
+
+## User experience
+
+### Invoking the command
+
+1. User is in a Warp tab whose CWD is inside a Git repository, AI is enabled, and there is at least one uncommitted change (staged or unstaged) to a tracked file.
+2. User types `/r` in Agent input. The static-command palette shows `/review` alongside other matching commands.
+3. User hits Enter (or clicks). Warp:
+   - Synchronously runs `git diff HEAD --no-color` (or equivalent) to gather staged + unstaged changes against `HEAD`.
+   - If the diff is over the configured size cap (default 50k bytes ≈ 1k lines), Warp truncates per-file (longest files first) and includes a note in the prompt: *"This diff was truncated from `<n>` files / `<n>` bytes to fit the review budget."*
+   - Constructs an agent prompt containing the (possibly truncated) diff and a fixed review template (see "Prompt template" below).
+   - Submits the prompt as a normal agent turn, opening or reusing the agent conversation per existing convention.
+
+### Subsequent turns
+
+1. The agent's response renders inline in the conversation as it streams back, with the same affordances as any other agent turn (apply suggestions, copy snippets, follow-up questions).
+2. The user can type a follow-up turn (`"focus on the changes in src/auth/"`) and the agent has the diff in conversation context — no need to re-run `/review`.
+
+### Unavailability scenarios
+
+The command should fail loudly and predictably, not silently:
+
+1. **Not in a Git repository.** The command does not appear in the slash-command palette. Same surface today's `/open-code-review` already uses (`Availability::REPOSITORY`).
+2. **In a Git repo but no uncommitted changes.** The command appears in the palette but is disabled with a tooltip *"`/review` needs at least one uncommitted change."* Selecting it (e.g. via keyboard) shows the same tooltip toast and does not submit a turn.
+3. **AI disabled** (the user has turned AI off, or is offline / unauthenticated). Command does not appear; same surface today's `/index` and `/init` already use (`Availability::AI_ENABLED`).
+4. **Diff exceeds the truncation cap by an order of magnitude** (e.g. ≥ 500k bytes, indicating a vendored-blob commit or generated-code dump). The command runs but the prompt notes truncation explicitly. Users can re-narrow scope with a follow-up; the V1 command does not pre-emptively refuse.
+
+## Configuration shape
+
+The setting lives under the existing **AI** group. Default values keep V1 ergonomics defensible without exposing the user to runaway cost:
+
+```toml
+[ai]
+review_command_max_diff_bytes = 51200    # ~50k bytes, ~1k lines of diff
+```
+
+| Field | Default | Notes |
+|---|---|---|
+| `review_command_max_diff_bytes` | 51200 | Truncation cap. When the gathered diff exceeds this, Warp prefers shorter files and notes truncation in the prompt. Tunable so users on unusually large refactors can opt up; minimum 1024, maximum 1048576. |
+
+V1 deliberately ships **no other knobs** — review focus list, prompt template, included file globs are all hardcoded. Each is a follow-up if the V1 command proves popular.
+
+## Prompt template (fixed in V1)
+
+The agent prompt assembled by `/review` is, byte-for-byte:
+
+```
+Please review the following uncommitted changes in this Git repository.
+
+Focus on, in priority order:
+1. Logic bugs (off-by-one, null/empty handling, race conditions, incorrect state transitions)
+2. Security concerns (injection, missing input validation, secrets in code, unsafe deserialization)
+3. Performance issues (obvious O(n²) hot paths, unbounded queries, sync I/O on hot paths)
+4. Simplicity and reuse (existing helpers being re-implemented, dead branches, code that can be deleted)
+5. Maintainability (poor naming, missing tests for new logic, public API drift)
+
+Skip stylistic nits unless they materially hurt readability. Group findings by file and severity. If a finding is uncertain, say so.
+
+If the diff is short, also briefly note what looks correct.
+
+[BEGIN DIFF]
+{diff_content}
+[END DIFF]
+```
+
+Justification: the priority list mirrors the issue's stated focus (*"logic bugs, security concerns, performance problems, simplicity, reuse, and maintainability"*). The "skip nits" line keeps the V1 review tight enough to be useful in a single agent turn. The "if uncertain, say so" line avoids the most common AI-review failure mode (confidently-wrong feedback).
+
+## Testable behavior invariants
+
+Numbered list — each maps to a verification path in the tech spec:
+
+1. With a Git repo open, AI enabled, and at least one tracked-file change (staged OR unstaged), `/review` is present and selectable in the slash-command palette.
+2. With no Git repo OR no AI OR a Git repo with zero tracked-file changes, `/review` is either absent from the palette (no repo / no AI) or visibly disabled with a tooltip (no changes).
+3. Selecting `/review` from the palette gathers diff via `git diff HEAD --no-color` (against `HEAD`, including staged and unstaged), constructs the fixed V1 prompt with the diff inlined, and submits it as a single agent turn.
+4. When the gathered diff exceeds `ai.review_command_max_diff_bytes`, the prompt's diff content is truncated (longest files first), and the prompt body contains the literal substring `"This diff was truncated"`.
+5. The diff content is wrapped between the literal markers `[BEGIN DIFF]` and `[END DIFF]` exactly once each.
+6. The command's `Availability` flags include `REPOSITORY | AI_ENABLED` (matching the pattern set by `/init`).
+7. If the user has uncommitted changes only in untracked (new) files — i.e. files Git does not yet know about — the command still gathers them (via `git diff HEAD --no-color --binary` plus the file contents for new files via the existing change-detection path).
+8. Submitting `/review` records a telemetry event of the existing slash-command type with `command_name = "/review"`.
+9. After the V1 turn completes, follow-up agent turns in the same conversation have the diff in conversation context (no special handling — this falls out of the existing agent turn flow).
+10. The V1 command does not silently re-invoke or re-attach the diff on follow-up turns; it is a one-shot invocation that opens the conversation. Follow-ups are normal agent turns.
+
+## Open questions
+
+- **Untracked-file handling.** `git diff HEAD` does not include untracked (new) files. Does the V1 command include them? Recommend yes — they are part of "uncommitted changes" colloquially, and excluding them would silently drop new-file changes from review. Tech spec details the gathering path.
+- **Conversation-routing semantics.** Does `/review` always start a *new* conversation (like `/agent`) or use the active conversation if one exists (like the bare prompt path)? Recommend reuse-active-or-create-new, matching the default agent prompt path. This keeps follow-ups attached without proliferating conversations.
+- **Should the command surface a "Re-review" affordance** after diff changes? Recommend no for V1 — users can re-type `/review` if they want a fresh pass with new diff state. Avoids over-design for a feature whose usage we don't yet have data on.

--- a/specs/GH9606/tech.md
+++ b/specs/GH9606/tech.md
@@ -1,0 +1,259 @@
+# Tech Spec: Built-in `/review` slash command
+
+**Issue:** [warpdotdev/warp#9606](https://github.com/warpdotdev/warp/issues/9606)
+
+## Context
+
+Warp's static slash commands are declared as `StaticCommand` constants/lazies in [`app/src/search/slash_command_menu/static_commands/commands.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/search/slash_command_menu/static_commands/commands.rs) and routed through the dispatch logic in `app/src/terminal/input/slash_commands/mod.rs`. The pattern for an agent-facing command (one that submits a turn rather than opening a panel) is well established by `/init`, `/index`, and `/fork`.
+
+This spec adds a single new entry to that registry plus a focused diff-gathering helper. No new infrastructure, no new modules.
+
+### Relevant code
+
+| Path | Role |
+|---|---|
+| `app/src/search/slash_command_menu/static_commands/commands.rs` | The `StaticCommand` registry. The new `REVIEW` constant goes here, alongside `OPEN_CODE_REVIEW` and `INIT`. |
+| `app/src/search/slash_command_menu/static_commands/mod.rs` | `Availability` bitflags (`REPOSITORY`, `AI_ENABLED`, etc.) and the `COMMAND_REGISTRY` aggregator. The new constant is added to the registry. |
+| `app/src/terminal/input/slash_commands/mod.rs` | Dispatch site for selected slash commands. The new arm builds the agent prompt and calls into the existing agent-turn submission path. |
+| `app/src/code_review/` | Existing code-review surface that knows how to read the working tree's diff against `HEAD`. The diff-gathering helper introduced here reuses any helpers it exposes; if none are public, a small `git diff` shellout lives alongside the dispatch. |
+| `app/src/settings/ai.rs` | The `AISettings` group. The new `ReviewCommandMaxDiffBytes` setting lands here. |
+| `app/src/server/telemetry/events.rs` | Telemetry. `/review` is recorded via the existing slash-command telemetry path; no new event type needed. |
+
+### Related closed PRs and issues
+
+- `/open-code-review` and `/pr-comments` are the closest existing analogs. Neither submits an agent turn; both open panels. `/review` is closer in shape to `/init`, which constructs an agent prompt and submits it.
+- No closed PRs interact with this surface that are relevant context.
+
+## Crate boundaries
+
+The new code lives entirely in `app/`. Diff gathering happens in the same process via either an existing `code_review` helper or a `tokio::process::Command` shell out to `git`. No new crate, no new shared type, no cross-crate boundary changes.
+
+## Proposed changes
+
+### 1. New `StaticCommand` constant
+
+**File:** `app/src/search/slash_command_menu/static_commands/commands.rs`.
+
+```rust
+pub const REVIEW: StaticCommand = StaticCommand {
+    name: "/review",
+    description: "AI review of local uncommitted changes",
+    icon_path: "bundled/svg/diff.svg",
+    availability: Availability::REPOSITORY
+        .union(Availability::AI_ENABLED)
+        .union(Availability::HAS_UNCOMMITTED_CHANGES),
+    auto_enter_ai_mode: true,
+    argument: None,
+};
+```
+
+`HAS_UNCOMMITTED_CHANGES` is a new flag; see Section 3.
+
+`auto_enter_ai_mode: true` matches `/agent` and `/fork` — selecting the command should land the user in an agent turn, not the terminal-input default.
+
+The constant is exported from `mod.rs`'s `COMMAND_REGISTRY` (find the existing aggregator macro/list and append).
+
+### 2. Dispatch arm
+
+**File:** `app/src/terminal/input/slash_commands/mod.rs`.
+
+The dispatch path that consumes `SlashCommandId` already has a switch over the registry's identifiers. Add an arm:
+
+```rust
+SlashCommandId::Review => {
+    let workspace_root = ctx.current_session_cwd()
+        .and_then(|p| find_git_root(&p)); // existing helper
+
+    let Some(repo_root) = workspace_root else {
+        // Defensive — Availability::REPOSITORY should have prevented this
+        ctx.show_toast("Run /review from a Git repository.");
+        return;
+    };
+
+    let max_bytes = AISettings::handle()
+        .review_command_max_diff_bytes()
+        .clamp(1024, 1_048_576);
+
+    let diff = match gather_uncommitted_diff(&repo_root, max_bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            ctx.show_toast(format!("/review failed to gather diff: {e}"));
+            return;
+        }
+    };
+
+    if diff.payload.is_empty() {
+        ctx.show_toast("/review found no uncommitted changes.");
+        return;
+    }
+
+    let prompt = build_review_prompt(&diff);
+    submit_agent_turn(ctx, prompt);  // existing entry point used by /init etc.
+    send_telemetry_from_ctx(
+        ctx,
+        TelemetryEvent::SlashCommandAccepted(SlashCommandAcceptedDetails {
+            command_name: "/review".to_owned(),
+            ..
+        }),
+    );
+}
+```
+
+### 3. New `Availability` flag: `HAS_UNCOMMITTED_CHANGES`
+
+**File:** `app/src/search/slash_command_menu/static_commands/mod.rs`.
+
+The existing `Availability` bitflags struct gets one more flag. The condition is true when the active session's CWD is inside a Git repo *and* `git status --porcelain` returns at least one entry. Existing `Availability` flags are checked at palette-render time via cached `WorkspaceState` flags (find the cache via `grep -rn "Availability::REPOSITORY" app/src/`). The new flag rides the same cache; the cache is invalidated when the working tree changes (which the file-tree observer already tracks for the existing Code Review panel).
+
+If the cache infrastructure already tracks "has uncommitted changes" — likely, since `/open-code-review` is enabled per-repo regardless of state but the panel itself shows a "no changes" empty state — V1 reuses that signal directly. If not, the cache acquires one new boolean populated by the same file-tree observer.
+
+### 4. Diff gathering helper
+
+**File:** new `app/src/terminal/input/slash_commands/review.rs`.
+
+```rust
+pub struct ReviewDiff {
+    pub payload: String,           // The diff text inlined into the prompt
+    pub truncated: Option<TruncationNote>,
+}
+
+pub struct TruncationNote {
+    pub original_files: usize,
+    pub original_bytes: usize,
+    pub kept_files: usize,
+    pub kept_bytes: usize,
+}
+
+pub fn gather_uncommitted_diff(repo_root: &Path, max_bytes: usize) -> anyhow::Result<ReviewDiff> {
+    // 1. Run `git diff HEAD --no-color` for tracked-file changes (staged + unstaged).
+    let tracked = run_git(repo_root, &["diff", "HEAD", "--no-color"])?;
+
+    // 2. Detect untracked files via `git ls-files --others --exclude-standard`
+    //    and synthesize a /dev/null → file diff for each so they appear in the
+    //    review just like new-file diffs would after `git add`. Bounded by max_bytes
+    //    along with the rest.
+    let untracked_paths = run_git(
+        repo_root,
+        &["ls-files", "--others", "--exclude-standard"],
+    )?;
+    let untracked_diff = synthesize_new_file_diffs(repo_root, &untracked_paths)?;
+
+    let combined = format!("{tracked}\n{untracked_diff}");
+
+    // 3. If under the cap, return as-is. Otherwise split into per-file diffs,
+    //    sort shortest-first, keep adding until we'd exceed the cap, and report.
+    if combined.len() <= max_bytes {
+        return Ok(ReviewDiff { payload: combined, truncated: None });
+    }
+    Ok(truncate_diff(combined, max_bytes))
+}
+
+fn build_review_prompt(diff: &ReviewDiff) -> String {
+    // Fixed V1 template per product.md. Diff content inlined between
+    // [BEGIN DIFF] / [END DIFF] markers exactly once.
+    ...
+}
+```
+
+`run_git` is a thin `tokio::process::Command` wrapper. The existing `code_review` module may already expose an equivalent helper (find via `grep -rn "fn.*git.*diff\|fn.*diff.*git" app/src/code_review/`). Prefer reusing if present, to keep diff-gathering behavior consistent across the two entry points.
+
+`truncate_diff` splits on the per-file `diff --git a/... b/...` headers (well-known stable format), sorts files ascending by per-file diff length, accumulates until adding the next file would exceed the cap, and returns the kept set with a `TruncationNote`. The note is interpolated into the prompt template's truncation line.
+
+### 5. Settings entry
+
+**File:** `app/src/settings/ai.rs`.
+
+Add via the existing `define_settings_group!` macro:
+
+```rust
+review_command_max_diff_bytes: ReviewCommandMaxDiffBytes {
+    type: u32,
+    default: 51200,
+    supported_platforms: SupportedPlatforms::ALL,
+    sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+    private: false,
+    toml_path: "ai.review_command_max_diff_bytes",
+    description: "Maximum diff size (bytes) the /review command sends to the agent. Larger diffs are truncated longest-files-first.",
+},
+```
+
+The dispatch arm clamps the read value to `[1024, 1_048_576]` defensively; the macro itself doesn't currently support range constraints (verify at implementation time).
+
+### 6. Documentation
+
+The static command's `description` field (`"AI review of local uncommitted changes"`) is what surfaces in the palette and is the only user-facing text that ships in the command itself. A docs page at `docs/slash-commands.md` (or wherever the existing `/init` and `/index` are documented) gets a short paragraph. Out of scope for the spec's core gate; recommend shipping in the same release.
+
+## Testing and validation
+
+Each invariant from `product.md` maps to a test at this layer:
+
+| Invariant | Test layer | File |
+|---|---|---|
+| 1, 2 (palette presence/absence) | unit | `app/src/search/slash_command_menu/static_commands/mod_test.rs` extension — for each combination of (in-repo, AI-enabled, has-changes), assert presence/absence/disabled state. |
+| 3 (gather diff + submit turn) | unit | `app/src/terminal/input/slash_commands/review_tests.rs` (new) — mock `run_git` to return a small diff, assert the constructed prompt contains the diff and the marker text, assert `submit_agent_turn` is invoked exactly once. |
+| 4 (truncation when over cap) | unit | review_tests — feed a diff with 5 files of varying lengths totaling 100k bytes, cap at 30k, assert kept-files-set is the shortest N that fit and the prompt contains "This diff was truncated". |
+| 5 (BEGIN/END markers exactly once) | unit | review_tests — assert prompt body contains `[BEGIN DIFF]` exactly once and `[END DIFF]` exactly once. |
+| 6 (Availability flags) | unit | command_tests — assert `REVIEW.availability` includes `REPOSITORY`, `AI_ENABLED`, `HAS_UNCOMMITTED_CHANGES`. |
+| 7 (untracked files included) | unit | review_tests — set up a temp repo with one untracked new file, assert the gathered diff includes a `/dev/null → b/<path>` synthetic diff for it. |
+| 8 (telemetry event) | unit | review_tests — assert `send_telemetry_from_ctx` is called with `command_name = "/review"`. |
+| 9 (follow-up turns have diff context) | integration | UI integration test — invoke `/review`, agent responds; user submits a follow-up "focus on auth/"; assert the agent's prompt context includes the original diff. (This falls out of the existing turn flow; the test is a regression guard.) |
+| 10 (no auto re-invoke on follow-ups) | unit | review_tests — assert no second call to `gather_uncommitted_diff` is triggered when a follow-up turn is submitted. |
+
+### Cross-platform constraints
+
+- `git diff HEAD --no-color` is portable across Git versions Warp supports today.
+- `git ls-files --others --exclude-standard` is also portable.
+- The `tokio::process::Command` wrapper handles Windows path quoting via the same convention used elsewhere for git invocations.
+- The diff is UTF-8; binary-file diffs are coerced via `--no-color` (binary diffs collapse to a "Binary files differ" line, which is fine for review purposes — the agent can ask follow-up questions if it needs the binary itself).
+
+## End-to-end flow
+
+```
+User types `/review` in Agent input
+  └─> [slash_command_palette]                                (existing)
+        └─> filter by Availability flags
+              ├─> REPOSITORY: cached at session-cwd-change
+              ├─> AI_ENABLED: cached at AI-settings-change
+              └─> HAS_UNCOMMITTED_CHANGES: cached at file-tree-change
+        └─> render `/review` if all flags set; disabled-with-tooltip if HAS_UNCOMMITTED_CHANGES is false
+        └─> on selection → SlashCommandId::Review
+
+User accepts the command
+  └─> [slash_commands::dispatch::Review arm]                 (new)
+        ├─> resolve repo_root from session cwd
+        ├─> read max_bytes from AISettings (clamped)
+        ├─> [gather_uncommitted_diff]                        (new helper)
+        │     ├─> run `git diff HEAD --no-color`             (tracked)
+        │     ├─> run `git ls-files --others --exclude-standard` (untracked names)
+        │     ├─> synthesize new-file diffs for untracked
+        │     ├─> if combined ≤ max_bytes → return as-is
+        │     └─> else truncate_diff (shortest-files-first, return TruncationNote)
+        ├─> [build_review_prompt]                            (V1 fixed template)
+        │     └─> interpolate diff between [BEGIN DIFF] / [END DIFF]
+        ├─> [submit_agent_turn]                              (existing entry point)
+        │     └─> agent processes prompt, streams response into conversation
+        └─> [send_telemetry_from_ctx]                        (existing)
+              └─> SlashCommandAccepted { command_name: "/review", ... }
+
+Agent response renders inline in the conversation
+  └─> User submits a follow-up turn (normal agent flow)
+        └─> conversation context includes the original `/review` prompt + diff;
+            no special re-invocation of the slash command.
+```
+
+## Risks
+
+- **Diff payload as a security surface.** The diff is sent to the agent provider verbatim, including any secrets a developer accidentally committed locally (`.env` files, tokens in fixtures, etc.). **Mitigation:** the V1 prompt is silent about this; the existing AI privacy posture applies. Long-term, the existing redaction infrastructure (used for command output) could be applied to diffs — tracked as a follow-up. Document the risk in the docs page.
+- **Truncation hides important changes.** Sorting shortest-files-first preserves the most files but may drop a large, security-critical change. **Mitigation:** the `[truncated]` marker in the prompt makes the truncation visible to the user, who can re-invoke with a higher `max_diff_bytes` or re-narrow scope manually. A follow-up could let the user opt into a "longest files first" mode or per-file selection.
+- **Untracked-file inclusion may surprise users.** A developer who runs `/review` after `git status` showing only modified files might not expect the untracked files in their workspace to be reviewed too. **Mitigation:** the prompt's diff content visibly contains the new-file diffs; the user can see what was included. If user feedback suggests this is too aggressive, V2 can gate untracked inclusion behind a setting.
+- **`Availability::HAS_UNCOMMITTED_CHANGES` cache staleness.** If the file-tree observer is debounced, the palette might briefly show `/review` enabled when it should be disabled (or vice versa). **Mitigation:** the dispatch arm re-checks `gather_uncommitted_diff` and shows a graceful toast if there are no changes — invariant 4's "found no uncommitted changes" path handles the race.
+- **Large repos with many untracked vendored files.** A user who hasn't `git ignore`d their `node_modules` or `target/` would see a 1GB "diff" gathered. **Mitigation:** `git ls-files --others --exclude-standard` already respects `.gitignore`; the `--exclude-standard` flag excludes default ignores. The truncation cap is the second line of defense.
+
+## Follow-ups (out of this spec)
+
+- Commit-range review: `/review HEAD~3..HEAD`, `/review main..feature`. Argument syntax + Availability flag updates.
+- User-customizable review prompt template (per-repo `.warp/review-template.md`).
+- Per-file scope: `/review src/auth/`.
+- Streaming summary→deep-dive (multi-turn agent dialogue rather than one big turn).
+- Redaction layer for diff payloads sent to the agent provider, mirroring the existing command-output redaction for shell output.
+- "Re-review" affordance in the conversation header that re-runs `/review` with the *current* working tree state without retyping.


### PR DESCRIPTION
Adds a product+tech spec for [#9606](https://github.com/warpdotdev/warp/issues/9606): a built-in `/review` slash command in Agent input that gathers local uncommitted changes and asks the Agent for a focused code review.

## Files

- `specs/GH9606/product.md` (108 lines) — V1 scope, user experience, fixed prompt template, 10 testable behavior invariants
- `specs/GH9606/tech.md` (160 lines) — module layout, dispatch arm, diff-gathering helper, settings entry, end-to-end flow

Total: 383 insertions, 0 deletions. No code changes — this is a spec PR.

## Why this command

Per the issue: users today get AI feedback on uncommitted changes by improvising — manual prompts (\"can you review my changes?\"), pasting diffs into the conversation, or building reusable skills. `/review` makes this discoverable as a built-in command that sits naturally next to the existing `/init`, `/index`, `/fork`, `/open-code-review`, and `/pr-comments` static commands.

## V1 scope

- **New `StaticCommand` entry** in `app/src/search/slash_command_menu/static_commands/commands.rs` alongside the existing crew.
- **Diff source:** `git diff HEAD --no-color` (tracked, staged + unstaged) + synthesized `/dev/null` diffs for untracked files (respecting `.gitignore` via `git ls-files --others --exclude-standard`).
- **Truncation cap:** default 50 KB (configurable 1 KB – 1 MB via `ai.review_command_max_diff_bytes`); over-cap diffs preserve shortest files first and the prompt notes the truncation explicitly.
- **Fixed V1 prompt template** prioritizing the issue's stated focus (logic bugs → security → performance → simplicity → maintainability), with a \"skip nits unless they hurt readability\" line and an \"if uncertain, say so\" line to keep the V1 review tight.
- **Availability gate:** `REPOSITORY | AI_ENABLED | HAS_UNCOMMITTED_CHANGES` (new flag, riding the existing file-tree-change cache that already powers the Code Review panel's empty state).

## Out of V1 (tracked as follow-ups)

- Commit-range review (`/review HEAD~3..HEAD`)
- User-customizable prompt template (per-repo `.warp/review-template.md`)
- Per-file scope (`/review src/auth/`)
- Streaming summary→deep-dive multi-turn pattern
- Diff redaction layer for sensitive content (mirrors existing command-output redaction)
- \"Re-review\" affordance after follow-ups

## Why this spec

- Issue is `ready-to-spec`, no existing PR claims it.
- Implementation surface is genuinely small: one new `StaticCommand` const, one dispatch arm, one diff-gathering helper module, one settings entry, one new `Availability` flag. Reuses existing agent-turn submission, telemetry, and `Availability` cache.
- The pattern is already well-established by `/init` (also constructs an agent prompt and submits it).
- Aligns with Warp's positioning as an *agentic development environment* — the issue calls this out explicitly, and the Project Explorer is on the critical path for navigation, but proactive AI review is also a high-frequency workflow.

## Open questions for maintainers

1. **Untracked-file inclusion.** V1 includes them via synthesized new-file diffs (matches colloquial \"uncommitted changes\"); excluding would silently drop new-file changes from review. Confirm this is the right default.
2. **Conversation routing.** `/review` is specced as reuse-active-or-create-new (matches the default agent prompt path), so follow-ups attach without proliferating conversations.
3. **Settings group.** This spec uses `ai.review_command_max_diff_bytes`. Confirm `AISettings` is the right Rust group at implementation time.

Happy to iterate on the design or tighten the V1 scope further.