### PR TITLE
fix(bootstrap): install Xcode Metal Toolchain on macOS (#9996)

### DIFF
--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -23,10 +23,12 @@ xcodebuild -runFirstLaunch
 if ! xcrun --find metal >/dev/null 2>&1; then
     echo "Metal Toolchain not installed. Running: xcodebuild -downloadComponent MetalToolchain"
     echo "(this can take several minutes on first run; xcodebuild streams progress below)"
-    xcodebuild -downloadComponent MetalToolchain
+    # Allow non-zero exit from xcodebuild without aborting the script under `set -e`.
+    # `xcodebuild -downloadComponent` can fail (or exit 0 without actually downloading,
+    # e.g. when App Store credentials are missing); we let the `xcrun --find metal`
+    # re-probe below be the source of truth on whether the toolchain is now usable.
+    xcodebuild -downloadComponent MetalToolchain || true
 
-    # `xcodebuild -downloadComponent` can exit 0 without actually downloading the
-    # component (e.g. when the App Store credentials are missing). Re-check.
     if ! xcrun --find metal >/dev/null 2>&1; then
         echo
         echo "Error: Metal Toolchain still not installed after xcodebuild -downloadComponent."

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -15,6 +15,27 @@ sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 # development environment.
 xcodebuild -runFirstLaunch
 
+# Xcode 16+ ships the Metal Toolchain as a separately-downloadable component.
+# `crates/warpui/build.rs` invokes `metal` to compile shaders to .air, so a
+# missing toolchain produces a confusing build-script panic deep in the cargo
+# output (see #9996). Detect it up front and download via xcodebuild so the
+# user gets a clear progress indicator instead of failing later.
+if ! xcrun --find metal >/dev/null 2>&1; then
+    echo "Metal Toolchain not installed. Running: xcodebuild -downloadComponent MetalToolchain"
+    echo "(this can take several minutes on first run; xcodebuild streams progress below)"
+    xcodebuild -downloadComponent MetalToolchain
+
+    # `xcodebuild -downloadComponent` can exit 0 without actually downloading the
+    # component (e.g. when the App Store credentials are missing). Re-check.
+    if ! xcrun --find metal >/dev/null 2>&1; then
+        echo
+        echo "Error: Metal Toolchain still not installed after xcodebuild -downloadComponent."
+        echo "Open Xcode -> Settings -> Components and install \"Metal Toolchain\" manually,"
+        echo "then re-run ./script/bootstrap."
+        exit 1
+    fi
+fi
+
 if ! command -v brew; then
     echo "Installing brew..."
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"


### PR DESCRIPTION
Fixes [#9996](https://github.com/warpdotdev/warp/issues/9996).

`crates/warpui/build.rs` invokes the `metal` compiler to translate shader sources to `.air` at cargo-build time. Xcode 16 split the Metal Toolchain into a separately-downloadable component that is **not** installed by Xcode's default first-launch setup, so a fresh macOS dev box following \`./script/bootstrap\` then \`./script/run\` fails partway through cargo with a confusing build-script panic deep in the output:

```
error compiling metal shaders to .air; error: error: cannot execute tool 'metal' due to missing Metal Toolchain;
use: xcodebuild -downloadComponent MetalToolchain
```

This is the macOS counterpart to #9544 (Node.js / yarn check on Linux / Windows, fixed in #9669) — same pattern, different platform: catch a missing build-time tool during bootstrap rather than during cargo build, where the user is least equipped to diagnose it.

## What's in the diff

- `xcrun --find metal` probes for the toolchain (fast, no network).
- If missing, `xcodebuild -downloadComponent MetalToolchain` triggers Apple's downloader. xcodebuild streams progress output so the user can see what's happening on the multi-GB download.
- After the download attempt, re-probe `xcrun --find metal` and fail loudly with manual-install instructions if the tool is still missing. **The re-probe is load-bearing**: `xcodebuild -downloadComponent` can exit 0 without actually downloading the component (e.g. when App Store credentials are missing). Without the re-probe the bug just resurfaces later in cargo build.

## Placement

Placed between `xcodebuild -runFirstLaunch` and the brew installs so the Apple-side environment setup happens together. The script structure stays linear and matches the convention `./script/macos/bootstrap` already uses (probe → install → continue).

## Scope

- Single file (`script/macos/bootstrap`), 21 insertions, 0 deletions.
- No change to Linux or Windows bootstrap scripts.
- The reporter also noted a separate `cargo-bundle` gap; that's tracked under #9996 as a sibling concern but is out of scope for this PR (line 37 of the script does already install `cargo-bundle` from a specific commit; if there's still a gap it deserves its own focused fix).

## Test plan

- [ ] On a fresh macOS dev box without Metal Toolchain installed, `./script/bootstrap` detects the gap, runs `xcodebuild -downloadComponent MetalToolchain`, and produces a working `xcrun --find metal` after the download completes.
- [ ] On a macOS box where Metal Toolchain is already installed, `./script/bootstrap` no-ops the new probe (`xcrun --find metal` succeeds, no `xcodebuild` invocation).
- [ ] If `xcodebuild -downloadComponent` exits 0 without installing (e.g. App Store creds missing), the script fails with the manual-install message rather than letting cargo fail later.
- [ ] No regression on the existing `xcodebuild -runFirstLaunch` step or the brew/rust/gcloud installs that follow.