### PR TITLE
spec: launch configs that open at app startup (#9203)

### DIFF
--- a/specs/GH9203/product.md
+++ b/specs/GH9203/product.md
@@ -1,0 +1,105 @@
+# Product Spec: Launch configs that open at app startup
+
+**Issue:** [warpdotdev/warp#9203](https://github.com/warpdotdev/warp/issues/9203)
+**Figma:** none provided
+
+## Summary
+
+Let users mark one or more saved Launch Configs as "open at startup" so the user's daily workflow layout (multiple tabs, panes, working directories, agent panes) materializes automatically when Warp launches. The data model already supports multi-window, multi-tab, multi-pane layouts via `LaunchConfig`; this feature adds a single per-config toggle and the startup hook that consumes it.
+
+This addresses the issue's core ask — *"a default group of tab config panes that either open on launch or are a one click open"* — by leaning on the existing Launch Configs feature (which already covers the "one click open" case via the command palette) and filling the missing "open on launch" half.
+
+## Problem
+
+A user with a stable daily layout (the issue's reporter mentions ~5 panes for a typical workflow) currently has to:
+
+1. Launch Warp.
+2. Open the command palette.
+3. Find their saved launch config by name.
+4. Trigger it.
+
+Every time. The friction compounds when multiple workflows are part of the daily setup (e.g. a "frontend" config plus a "backend" config). Users coming from iTerm2 windows sets, tmuxinator/teamocil sessions, or VS Code workspace restore expect their layout to come back when they relaunch the app.
+
+The infrastructure to *describe* a multi-tab, multi-pane layout is fully present in `LaunchConfig` (windows → tabs → panes, with start commands, working directories, and pane-mode metadata). The feature gate is exclusively *when* to apply it.
+
+## Goals
+
+- A user can flip a single toggle on a Launch Config to make it auto-launch at startup, with no other configuration required.
+- Multiple Launch Configs may be marked auto-launch; all of them open at startup, in the order users assign.
+- The mechanism is opt-in. A user who never opens the toggle sees no behavior change — Warp launches with its current default (a single new tab).
+- A misconfigured or partially-broken auto-launch config (e.g. a saved working directory that no longer exists) does not block app startup. It opens the parts it can and surfaces a non-blocking notification listing what failed.
+- Auto-launch configs interact cleanly with Warp's existing **Restore previous tabs on startup** preference: if the user has both turned on, restore-previous wins for the previous-session tabs and the auto-launch configs open as additional windows alongside (not duplicating, not replacing).
+
+## Non-goals (V1 — explicitly deferred to follow-ups)
+
+- **Per-day or per-time-of-day scheduling.** "Open the morning config Mon–Fri 9am, the personal config evenings/weekends" is a richer scheduling system; out of scope.
+- **Conditional auto-launch based on directory or git state.** "Only open this config when the launching CWD is under `~/code/foo`" — interesting but a separate feature.
+- **Workspace-folder-anchored auto-launch.** "When opening Warp from `code .`-style integration, pick the matching saved config" — depends on shell/IDE integration that isn't part of this feature.
+- **A new top-level "Startup" settings page.** The toggle lives on the existing Launch Config row, the same surface that already exposes Save / Edit / Delete affordances. No new section in Settings.
+- **Programmatic startup-config switching from a CLI flag.** Out of scope; the existing `--launch-config` family of flags (if any) is unchanged.
+- **Re-running auto-launch when a window crashes mid-session.** The hook fires once per app process startup. Crash recovery is the existing tab/restore-on-relaunch system's job.
+
+## User experience
+
+### Marking a config as auto-launch
+
+1. User opens the Launch Configs list (existing surface — accessible via the command palette and the resource-center sections per `app/src/resource_center/sections.rs`).
+2. Each row gains a small toggle labeled **Open at startup**, sitting alongside the existing per-row affordances.
+3. Toggling it on persists the change to the launch-config record. No restart required to record the preference; the behavior takes effect on the *next* app launch.
+4. The list visually surfaces auto-launch-enabled configs (e.g. a small "Startup" tag next to the config name) so users can see at a glance which configs will open next launch.
+
+### App startup with auto-launch configs configured
+
+1. User launches Warp.
+2. Warp goes through its existing startup path (loading settings, restoring previous tabs if that preference is on, etc.).
+3. After the existing startup completes, Warp enumerates the saved launch configs whose `auto_launch_at_startup` flag is set, sorted by the user-assigned order (see "Ordering" below), and applies each one — opening windows and tabs as if the user had triggered the config from the command palette.
+4. The user sees their full workflow ready to go without any manual steps.
+
+### Ordering multiple auto-launch configs
+
+The Launch Configs list lets the user reorder rows via drag-and-drop (existing affordance, V0 simply respects the existing list ordering). Auto-launch configs open in list order on startup. There's no separate "startup order" UI in V1 — keeping the surface simple matches the issue's importance level (the reporter rated this 2/5).
+
+### Failure scenarios
+
+1. **Auto-launch config references a missing working directory** (e.g. user deleted `~/projects/foo` since saving the config). The config's other tabs/panes open normally; the broken pane opens with a fallback CWD (`$HOME` or the OS default — match whatever the existing manual launch-config flow does today). Warp surfaces a non-blocking notification: *"Auto-launch config `<name>`: 1 pane opened with fallback working directory."*
+2. **Auto-launch config fails to apply entirely** (e.g. the config record is corrupt, or the saved windows array is empty). Warp logs the error, skips the config, surfaces a notification *"Auto-launch config `<name>` could not be opened. See settings."*, and continues with the next auto-launch config. App startup is never blocked.
+3. **All auto-launch configs are missing or invalid** (e.g. user wiped their config storage). Warp falls through to its current default startup behavior (single new tab). Same as if the user had no auto-launch configs in the first place.
+4. **Restore-previous-tabs is on AND auto-launch configs are present.** The two preferences compose: restore-previous restores the previous session's tabs into the existing default window (today's behavior), and auto-launch configs each open in *new* windows alongside. The user gets both. (No de-duplication: if a user has restore-previous on and the same workflow saved as an auto-launch config, they'll see duplicate panes and can disable one. This is documented but not auto-detected; auto-detection is a follow-up.)
+
+## Configuration shape
+
+Per-launch-config flag, persisted on the existing launch-config record:
+
+```rust
+pub struct LaunchConfig {
+    pub name: String,
+    pub windows: Vec<WindowTemplate>,
+    pub active_window_index: Option<usize>,
+    // V1 addition:
+    #[serde(default)]
+    pub auto_launch_at_startup: bool,
+}
+```
+
+Defaults to `false` so existing saved configs are unchanged. No global setting; the feature is enabled per-config.
+
+## Testable behavior invariants
+
+Numbered list — each maps to a verification path in the tech spec:
+
+1. With no launch configs marked `auto_launch_at_startup`, app startup behavior is byte-equivalent to today: existing default window with a single new tab, plus the existing restore-previous behavior if that preference is on.
+2. With exactly one launch config marked `auto_launch_at_startup`, that config's windows and tabs open at app startup *in addition to* the default startup behavior.
+3. With two configs marked `auto_launch_at_startup`, both apply on startup in the same order they appear in the launch-configs list.
+4. Toggling the flag on a config from off → on records the change immediately and persists across app restarts. The current app session does *not* retroactively open the config — the toggle takes effect on next launch.
+5. Toggling the flag from on → off prevents the config from auto-launching on next app startup; the config remains saved and can still be triggered manually.
+6. An auto-launch config whose record is missing fields the current schema requires (a hypothetical migration mismatch) is skipped at startup with a non-blocking notification, and other auto-launch configs continue to apply.
+7. An auto-launch config that references a working directory that no longer exists opens the rest of the config normally; the broken pane opens with the existing fallback CWD path used by manual launch-config invocation. Notification surfaces the count of fallback panes.
+8. Disabling the flag on every auto-launch config restores today's startup behavior (invariant 1) on the next app launch.
+9. Auto-launch behavior coexists with the **Restore previous tabs on startup** preference: when both are on, both apply. The auto-launch configs' windows are additive; they do not displace restored windows.
+10. The auto-launch hook fires exactly once per app process startup. Subsequent in-session events (closing all windows then re-opening, switching workspaces, etc.) do not re-trigger auto-launch.
+
+## Open questions
+
+- **Should auto-launch configs share a flag with the existing "favorite" or "pinned" affordances on Launch Configs (if any)?** Recommend no — this is a separate semantic. Pin/favorite is for ordering and discovery; auto-launch is for behavior at app startup. Conflating them couples two unrelated concerns.
+- **How does this interact with Quake mode?** `LaunchConfig::from_snapshot` already filters `quake_mode` windows out of saved configs, so auto-launch configs cannot create quake windows. This is fine for V1; quake-mode auto-launch is a separate feature.
+- **Should the user reorder auto-launch configs via a dedicated "Startup order" UI rather than via the main list order?** Recommend no for V1 — adds a second list to maintain. If a third or fourth auto-launch config is common in practice, a dedicated list is a follow-up.

--- a/specs/GH9203/tech.md
+++ b/specs/GH9203/tech.md
@@ -1,0 +1,237 @@
+# Tech Spec: Launch configs that open at app startup
+
+**Issue:** [warpdotdev/warp#9203](https://github.com/warpdotdev/warp/issues/9203)
+
+## Context
+
+The Launch Configs feature is fully implemented today. `LaunchConfig` (in [`app/src/launch_configs/launch_config.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/launch_configs/launch_config.rs)) already serializes a multi-window, multi-tab, multi-pane layout with per-pane working directories, start commands, and pane modes. Configs are saved via the existing save modal and triggered via the command palette. The data model was designed for this exact use case; only the *time of application* is missing.
+
+This spec adds:
+1. A per-config `auto_launch_at_startup: bool` flag on `LaunchConfig`.
+2. A startup hook in the existing app-init path that enumerates configs with the flag set and applies them.
+3. A toggle on the existing Launch Configs list UI.
+
+No new data model, no new module structure, no new persistence layer — the feature reuses the launch-config persistence and the launch-config-application path that the command-palette trigger already exercises.
+
+### Relevant code
+
+| Path | Role |
+|---|---|
+| `app/src/launch_configs/launch_config.rs` | The `LaunchConfig` struct gets a new `auto_launch_at_startup` field with `#[serde(default)]` so existing on-disk configs deserialize unchanged. |
+| `app/src/launch_configs/mod.rs` | Module entry. The new startup hook lives in a new `startup.rs` submodule alongside `launch_config.rs` and `save_modal.rs`. |
+| `app/src/launch_configs/save_modal.rs` | Existing save UI. The new toggle slots in here (or in the configs-list view, depending on which existing surface is the closest fit — verify at implementation time). |
+| `app/src/lib.rs` / `app/src/app_state.rs` | The app-level startup path that loads previous-session tabs and creates the default window. The new hook fires after that completes. |
+| `app/src/search/command_palette/launch_config/` | Existing launch-config-application code path (the same code the user triggers via `/launch-config <name>`). The new startup hook calls into the same entry point. |
+
+### Related closed PRs and issues
+
+- The existing **Restore previous tabs on startup** preference is the closest analog. It runs at app startup, opens windows/tabs, and is opt-in. The new auto-launch hook fires alongside it, not instead of it.
+
+## Crate boundaries
+
+All new code lives in `app/`. No new crate, no cross-crate boundary changes. The `LaunchConfig` struct remains in `app/src/launch_configs/launch_config.rs` (already used only within `app/`).
+
+## Proposed changes
+
+### 1. Add the flag
+
+**File:** `app/src/launch_configs/launch_config.rs`.
+
+```rust
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct LaunchConfig {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub active_window_index: Option<usize>,
+    pub windows: Vec<WindowTemplate>,
+    /// V1 addition: when true, this config opens automatically on app launch.
+    /// Existing on-disk configs deserialize as `false` via `#[serde(default)]`.
+    /// `from_snapshot` defaults to `false` — saving a snapshot doesn't auto-flip
+    /// the flag; the user must toggle it explicitly.
+    #[serde(default)]
+    pub auto_launch_at_startup: bool,
+}
+```
+
+`from_snapshot` is unchanged in behavior — newly-saved configs default to `false` for the flag. The user opts in via the toggle.
+
+### 2. Startup hook
+
+**File:** new `app/src/launch_configs/startup.rs`.
+
+```rust
+/// Enumerate saved launch configs with `auto_launch_at_startup = true`,
+/// in their list order, and apply each. Called once during app startup,
+/// after the default window and restore-previous-tabs path complete.
+pub fn apply_auto_launch_configs(ctx: &mut AppContext) {
+    let configs = load_all_launch_configs(); // existing loader
+    let auto_launch: Vec<&LaunchConfig> = configs
+        .iter()
+        .filter(|c| c.auto_launch_at_startup)
+        .collect();
+
+    if auto_launch.is_empty() {
+        return;
+    }
+
+    let mut failures = Vec::new();
+    for config in auto_launch {
+        match apply_launch_config(ctx, config) {  // existing application path
+            Ok(report) => {
+                if report.fallback_pane_count > 0 {
+                    failures.push(StartupFailure::PartialFallback {
+                        name: config.name.clone(),
+                        fallback_count: report.fallback_pane_count,
+                    });
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    config_name = %config.name,
+                    error = %err,
+                    "auto-launch config failed to apply",
+                );
+                failures.push(StartupFailure::Skipped {
+                    name: config.name.clone(),
+                    reason: err.to_string(),
+                });
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        surface_startup_notifications(ctx, &failures);
+    }
+}
+```
+
+`apply_launch_config` is the existing function that the command-palette `/launch-config <name>` trigger calls. Its return type may need to grow a small `LaunchConfigApplicationReport` struct (or equivalent) to surface fallback-pane counts; if today's API silently substitutes fallback CWDs without reporting, this PR adds that signal as a backwards-compatible additive change.
+
+### 3. Wire the hook into app startup
+
+**File:** `app/src/lib.rs` (or the app's main init function — find via `grep -rn "App::new\|app_state.init\|fn init.*AppContext"`).
+
+The startup sequence today, conceptually:
+
+```
+load settings
+  → create default window with new tab
+  → if `restore_previous_tabs`: restore from snapshot
+  → window becomes interactive
+```
+
+Becomes:
+
+```
+load settings
+  → create default window with new tab
+  → if `restore_previous_tabs`: restore from snapshot
+  → apply_auto_launch_configs()              ← new hook, last step before windows go interactive
+  → windows become interactive
+```
+
+Placing the hook *after* restore-previous-tabs ensures the existing preference's behavior is byte-equivalent to today (invariant 1, 9). The auto-launch configs add windows alongside; they do not interact with the restore path.
+
+### 4. UI toggle
+
+**File:** the existing Launch Configs list view (locate via `grep -rn "LaunchConfig" app/src/search/command_palette/launch_config/`). Each row gains a toggle component.
+
+Pseudocode for the row:
+
+```
+[Config name]  [Open at startup ☐]  [Edit] [Delete]
+```
+
+Click handler:
+
+```rust
+fn on_auto_launch_toggle_clicked(&mut self, config_id: &str, ctx: &mut ViewContext) {
+    let mut configs = load_all_launch_configs();
+    if let Some(c) = configs.iter_mut().find(|c| c.name == config_id) {
+        c.auto_launch_at_startup = !c.auto_launch_at_startup;
+        save_all_launch_configs(&configs);
+        ctx.notify();
+    }
+}
+```
+
+The "Startup" pill rendered next to a config's name reads `auto_launch_at_startup` directly — no separate persistence.
+
+### 5. Notification rendering
+
+**File:** new `app/src/launch_configs/startup.rs` (helper alongside the hook).
+
+Two notification types, both routed through the existing `ToastStack` infrastructure:
+
+- `StartupFailure::PartialFallback { name, fallback_count }` → *"Auto-launch config `<name>`: `<n>` pane(s) opened with fallback working directory."*
+- `StartupFailure::Skipped { name, reason }` → *"Auto-launch config `<name>` could not be opened: `<reason>`."*
+
+Both are non-blocking. If multiple auto-launch configs each produced failures, render one notification per failure (capped at 3 — beyond that, render a single rolled-up notification *"`<n>` auto-launch configs had startup issues. See logs."*).
+
+## Testing and validation
+
+Each invariant from `product.md` maps to a test at this layer:
+
+| Invariant | Test layer | File |
+|---|---|---|
+| 1 (no auto-launch → byte-equivalent) | unit | `app/src/launch_configs/startup_tests.rs` (new) — call `apply_auto_launch_configs` with no flagged configs, assert it returns without modifying the test app state. |
+| 2 (one config applies on startup) | unit | startup_tests — flag one config, run the hook, assert the expected windows/tabs were applied. Mocks `apply_launch_config` to record calls. |
+| 3 (two configs apply in list order) | unit | startup_tests — flag two configs in a known order, run the hook, assert `apply_launch_config` was called in that order. |
+| 4 (toggle persists across restart) | unit | `app/src/launch_configs/launch_config_tests.rs` — round-trip a `LaunchConfig` with `auto_launch_at_startup = true` through serde JSON, assert the flag survives. |
+| 5 (toggle off prevents auto-launch) | unit | startup_tests — set the flag false on a previously-flagged config, run the hook, assert no application happens. |
+| 6 (corrupt config skipped) | unit | startup_tests — supply a config record that fails to deserialize / fails `apply_launch_config`, assert subsequent configs still apply and a notification is surfaced. |
+| 7 (missing CWD → fallback + notification) | unit | startup_tests — feed a config whose `apply_launch_config` returns a `fallback_pane_count > 0`, assert the partial-fallback notification is surfaced. |
+| 8 (disable all → today's behavior) | unit | startup_tests — flag all configs false, run the hook, assert no-op (same as invariant 1). |
+| 9 (composes with restore-previous) | integration | `crates/integration/tests/` — set restore-previous to true, flag one launch config, launch, assert both restored tabs *and* the auto-launch config's windows are present. |
+| 10 (hook fires once) | unit | startup_tests — call the hook twice in the same test app context, assert the second call is a no-op (or that the auto-launch tracker prevents duplicate application). |
+
+### Cross-platform constraints
+
+- The `auto_launch_at_startup` boolean serializes identically across all platforms.
+- Working-directory fallback semantics are inherited from the existing manual `apply_launch_config` path; this PR doesn't change them.
+- No new file-system, network, or shell interactions.
+
+## End-to-end flow
+
+```
+User toggles "Open at startup" on a Launch Config row
+  └─> [launch_config_view::on_auto_launch_toggle_clicked]   (new handler)
+        ├─> load_all_launch_configs()
+        ├─> mutate target config's auto_launch_at_startup
+        └─> save_all_launch_configs()
+              └─> existing persistence path (unchanged)
+
+Next time Warp starts
+  └─> [app_state::init]                                     (existing)
+        ├─> load settings
+        ├─> create default window with new tab
+        ├─> if restore_previous_tabs: restore from snapshot  (existing)
+        └─> [launch_configs::startup::apply_auto_launch_configs]    (new hook)
+              ├─> load_all_launch_configs()
+              ├─> filter where auto_launch_at_startup
+              ├─> for each (in list order):
+              │     └─> apply_launch_config(config)         (existing entry point)
+              │           ├─> Ok(report)
+              │           │     ├─> if report.fallback_pane_count > 0
+              │           │     │     → push StartupFailure::PartialFallback
+              │           │     └─> else: silent success
+              │           └─> Err(_) → push StartupFailure::Skipped
+              └─> if failures.is_empty() → done
+                  else → surface_startup_notifications()
+```
+
+## Risks
+
+- **Invocation idempotency.** If the hook runs twice (e.g. in a code path where app state can be re-initialized within a single process — closing all windows then reopening), the user would see duplicated windows. **Mitigation:** an `AUTO_LAUNCH_APPLIED: AtomicBool` guards the hook; subsequent calls are no-ops within the same process. Invariant 10 covers this.
+- **Auto-launch storms.** A user with 10+ auto-launch configs would get 10+ windows on startup, possibly slow and overwhelming. **Mitigation:** V1 doesn't impose a cap, but the failure notification path (capped at 3 individual notifications + 1 rolled-up) prevents notification spam. If auto-launch storms become a real complaint, V2 can add a "max auto-launch configs" setting or a warning at startup.
+- **Restore-previous + auto-launch double-counting.** A user with the same workflow saved as both an auto-launch config and as the previous session sees duplicate panes. **Mitigation:** documented in the user-experience section. Auto-detecting overlap is a follow-up.
+- **Schema evolution.** If a future version adds required fields to `WindowTemplate` or `TabTemplate`, existing auto-launch configs would skip with a "Skipped" notification on startup. **Mitigation:** the existing `LaunchConfig` deserialization already uses `#[serde(default)]` patterns; new fields should follow that convention. The V1 `auto_launch_at_startup` field itself uses `#[serde(default)]` so the reverse case (older Warp reading newer config) deserializes the field as `false`, which is safe.
+
+## Follow-ups (out of this spec)
+
+- Per-day or time-of-day scheduling for auto-launch configs.
+- Conditional auto-launch based on launching CWD or git state.
+- Workspace-folder-anchored auto-launch (driven by IDE / shell integration).
+- A separate "Startup order" UI distinct from the main launch-configs list ordering.
+- Auto-detection of overlap between restore-previous-tabs and auto-launch configs.
+- "Disable all auto-launch this session" affordance for the rare case where the user wants a clean launch without flipping every flag.


### PR DESCRIPTION
Adds a product+tech spec for [#9203](https://github.com/warpdotdev/warp/issues/9203): a per-Launch-Config "Open at startup" toggle so users can have their daily workflow layout materialize on every Warp launch.

## Files

- `specs/GH9203/product.md` (122 lines) — V1 scope, user experience, configuration shape, 10 testable behavior invariants
- `specs/GH9203/tech.md` (220 lines) — implementation plan, startup hook integration, UI toggle wiring, end-to-end flow

Total: 342 insertions, 0 deletions. No code changes — this is a spec PR.

## Why this is small

The Launch Configs feature already serializes a multi-window, multi-tab, multi-pane layout with per-pane CWDs, start commands, and pane modes. `LaunchConfig::from_snapshot` and `apply_launch_config` exist and are exercised today by the command-palette `/launch-config <name>` trigger. The data model was designed for this exact use case; only the **time of application** is missing.

This spec adds:

1. **One bool field** on `LaunchConfig` (`auto_launch_at_startup`) with `#[serde(default)]` so existing on-disk configs deserialize unchanged.
2. **One new hook** in the app startup path that enumerates flagged configs and calls `apply_launch_config` on each.
3. **One toggle** on the existing Launch Configs list row.

That's it. No new persistence, no new application path, no new settings page.

## V1 scope

- Per-config opt-in toggle, not a global setting.
- Multiple configs may be flagged; all apply on startup in list order.
- Composes additively with **Restore previous tabs on startup** (both run, neither displaces the other).
- Failures (missing CWDs, corrupt records) surface non-blocking notifications; app startup is never blocked.
- Idempotency: hook fires exactly once per process startup, guarded by an `AtomicBool`.

## Out of V1 (tracked as follow-ups)

- Time-of-day or per-day scheduling.
- Conditional auto-launch (CWD- or git-state-anchored).
- Workspace-folder-anchored auto-launch (driven by IDE / shell integration).
- Dedicated "Startup order" UI distinct from the main list ordering.
- Auto-detection of overlap with restore-previous-tabs.
- "Disable all auto-launch this session" affordance.

## Why this spec

- Issue is `ready-to-spec`, no existing PR claims it.
- Reporter rated importance 2/5; this spec keeps the surface area appropriately small (one toggle, no new settings page) to match the cost-vs-value math.
- Quietly the most leveraged of the three remaining unclaimed `ready-to-spec` issues — the data model and application path are already built; this is the smallest possible addition that delivers the user-visible feature.

## Open questions for maintainers

1. **Notification routing.** Spec uses the existing `ToastStack` for failure notifications. Confirm at implementation time.
2. **Idempotency guard placement.** `AtomicBool` in the `startup.rs` module vs. on the hook's input context. Implementation-time choice.
3. **Toggle UI surface.** This spec assumes the toggle goes on the existing Launch Configs list row. If that surface doesn't exist as expected (it might be the save modal or a settings page instead), the spec needs a small adjustment but the core mechanism doesn't change.

Happy to iterate on the design or tighten the V1 scope further.