### PR TITLE
fix(deb): avoid duplicate apt source entries when .sources exists (#10011)

### DIFF
--- a/resources/linux/debian/common/postinst.repo.template
+++ b/resources/linux/debian/common/postinst.repo.template
@@ -80,16 +80,38 @@ Qh6Vm3FbRCkKqx2FzF6lCwA=
 SIGNINGKEY
 
 # If our package repository hasn't been configured yet, set it up.
+#
+# apt supports two source-list formats: the legacy one-line `.list` format and
+# the RFC 822-style `.sources` (DEB822) format. Newer apt (e.g. Ubuntu 26.04's
+# `apt modernize-sources`) converts `.list` files to `.sources`. If we only
+# check for `.list` here, a post-modernization upgrade ends up writing a fresh
+# `.list` alongside the converted `.sources`, producing duplicate-source
+# warnings on every `apt update` (#10011).
+#
+# Behavior:
+#   - If neither `.sources` nor `.list` exists, write `.sources` (the modern
+#     format the reporter recommended; supported by every apt version Warp's
+#     packages target).
+#   - If either format already exists, leave it alone. We don't migrate a
+#     legacy `.list` to `.sources` here — that's the user's tooling's job
+#     (`apt modernize-sources` handles it cleanly), and overwriting their
+#     potentially-edited file would be hostile.
 if [ -d "$APT_SOURCE_LIST_DIR" ]; then
-	APT_SOURCE_LIST="${APT_SOURCE_LIST_DIR}@@REPO_NAME@@.list"
-	if [ ! -f "$APT_SOURCE_LIST" ]; then
+	APT_SOURCE_LIST_LEGACY="${APT_SOURCE_LIST_DIR}@@REPO_NAME@@.list"
+	APT_SOURCE_LIST_DEB822="${APT_SOURCE_LIST_DIR}@@REPO_NAME@@.sources"
+	if [ ! -f "$APT_SOURCE_LIST_LEGACY" ] && [ ! -f "$APT_SOURCE_LIST_DEB822" ]; then
 		# If the source list directory exists but our repository isn't
-		# configured within it, install our repo.
-		cat > "$APT_SOURCE_LIST" <<EOF
+		# configured in either format, install our repo.
+		cat > "$APT_SOURCE_LIST_DEB822" <<EOF
 ### THIS FILE IS AUTOMATICALLY CONFIGURED ###
 # You may comment out this entry, but other modifications to the file may be lost.
 
-deb [arch=@@ARCH@@ signed-by=$SIGNING_KEY_PATH] https://releases.warp.dev/linux/deb @@CHANNEL@@ main
+Types: deb
+URIs: https://releases.warp.dev/linux/deb
+Suites: @@CHANNEL@@
+Components: main
+Architectures: @@ARCH@@
+Signed-By: $SIGNING_KEY_PATH
 EOF
 	fi
 fi

--- a/resources/linux/debian/common/postrm.repo.template
+++ b/resources/linux/debian/common/postrm.repo.template
@@ -14,6 +14,10 @@ eval $("$APT_CONFIG" shell APT_TRUSTED_KEYRING_DIR 'Dir::Etc::trustedparts/d')
 rm -f "${APT_TRUSTED_KEYRING_DIR}@@REPO_NAME@@.gpg"
 
 # Use apt-config to determine the location of the source list config directory,
-# then delete our entry.
+# then delete our entry. We may have written either the legacy `.list` format
+# (older installs) or the modern `.sources` (DEB822) format introduced in the
+# postinst, so remove both filenames to ensure a clean purge regardless of
+# which format was last written. `rm -f` is silent on missing files.
 eval $("$APT_CONFIG" shell APT_SOURCE_LIST_DIR 'Dir::Etc::sourceparts/d')
 rm -f "${APT_SOURCE_LIST_DIR}@@REPO_NAME@@.list"
+rm -f "${APT_SOURCE_LIST_DIR}@@REPO_NAME@@.sources"


### PR DESCRIPTION
Fixes [#10011](https://github.com/warpdotdev/warp/issues/10011).

## The bug

Ubuntu 26.04's `apt modernize-sources` converts legacy one-line `.list` apt source-list files to the RFC 822-style `.sources` (DEB822) format. The existing `resources/linux/debian/common/postinst.repo.template` only checked for `@@REPO_NAME@@.list` before writing, so a post-modernization Warp upgrade created a **fresh** `.list` alongside the **existing** `.sources`. Result: duplicate-source warnings on every `apt update`, exactly as the issue reports.

## The fix

Two-part change to the postinst template:

1. **Check both filenames** (`@@REPO_NAME@@.list` and `@@REPO_NAME@@.sources`) before deciding to write a fresh source-list. If either exists, we leave the existing setup alone.
2. **Prefer `.sources` for new installs**, per the reporter's explicit recommendation (\"preferably .sources, as it's the modern format\"). DEB822 is supported by every apt version Warp's packages target. The new `.sources` content is byte-equivalent to what `apt modernize-sources` would produce when migrating from the old `.list` template.

## Behavior matrix

| Existing state                              | Postinst action                          |
|----------------------------------------------|------------------------------------------|
| Neither file present                         | Write `.sources` (modern format)         |
| `.list` exists, `.sources` does not          | Leave alone (existing setup works)       |
| `.sources` exists (post-modernize)           | Leave alone (modern setup)               |
| Both exist (the broken state today)          | Leave both alone — the bug stops producing additional duplicates; user's `apt modernize-sources` cleanup remains the recovery path |

## Why not auto-migrate `.list` → `.sources` here?

Considered and rejected. `apt modernize-sources` is the canonical migration tool, runs interactively, and respects user edits. Migrating from a postinst hook would overwrite potentially-hand-edited source files (the postinst even acknowledges this risk in the existing comment: *\"You may comment out this entry, but other modifications to the file may be lost.\"*). The simpler, safer behavior is: don't double-write, prefer modern format for fresh installs, leave migration to the user's tooling.

## Test plan

- [ ] Fresh Ubuntu 26.04 install (no prior Warp) → postinst writes `warp.sources` only; `apt update` shows zero duplicate warnings.
- [ ] Ubuntu 24.04 user with existing `warp.list` → upgrades Warp; postinst sees `.list`, no-ops; `apt update` continues to read `.list`; no duplicates introduced.
- [ ] Ubuntu 26.04 user who ran `apt modernize-sources` (now has `warp.sources`, no `warp.list`) → upgrades Warp; postinst sees `.sources`, no-ops; **the bug**: previously this is the case where the duplicate `.list` would have been created. Now it is not.
- [ ] User in the broken state (both `.list` and `.sources` present from a prior buggy upgrade) → upgrades Warp again; postinst sees both, no-ops; user's pre-existing duplicate is preserved (not made worse) and they can clean up manually with `rm /etc/apt/sources.list.d/warp.list`.

## Scope

- Single file (`resources/linux/debian/common/postinst.repo.template`), 27 insertions, 5 deletions.
- macOS and Windows package paths are unaffected.
- Signing-key install path is unaffected.