### PR TITLE
fix(deb): respect apt Deb822 source files

### DIFF
--- a/resources/linux/debian/common/postinst.repo.template
+++ b/resources/linux/debian/common/postinst.repo.template
@@ -82,7 +82,12 @@ SIGNINGKEY
 # If our package repository hasn't been configured yet, set it up.
 if [ -d "$APT_SOURCE_LIST_DIR" ]; then
 	APT_SOURCE_LIST="${APT_SOURCE_LIST_DIR}@@REPO_NAME@@.list"
-	if [ ! -f "$APT_SOURCE_LIST" ]; then
+	APT_SOURCE_DEB822="${APT_SOURCE_LIST_DIR}@@REPO_NAME@@.sources"
+	if [ -f "$APT_SOURCE_DEB822" ]; then
+		# Prefer an existing Deb822 source created by apt modernize-sources.
+		# Keeping both files produces duplicate-source warnings on apt update.
+		rm -f "$APT_SOURCE_LIST"
+	elif [ ! -f "$APT_SOURCE_LIST" ]; then
 		# If the source list directory exists but our repository isn't
 		# configured within it, install our repo.
 		cat > "$APT_SOURCE_LIST" <<EOF
@@ -93,4 +98,3 @@ deb [arch=@@ARCH@@ signed-by=$SIGNING_KEY_PATH] https://releases.warp.dev/linux/
 EOF
 	fi
 fi
-

--- a/resources/linux/debian/common/postrm.repo.template
+++ b/resources/linux/debian/common/postrm.repo.template
@@ -17,3 +17,4 @@ rm -f "${APT_TRUSTED_KEYRING_DIR}@@REPO_NAME@@.gpg"
 # then delete our entry.
 eval $("$APT_CONFIG" shell APT_SOURCE_LIST_DIR 'Dir::Etc::sourceparts/d')
 rm -f "${APT_SOURCE_LIST_DIR}@@REPO_NAME@@.list"
+rm -f "${APT_SOURCE_LIST_DIR}@@REPO_NAME@@.sources"


### PR DESCRIPTION
## Description
Fixes #10011.

When Ubuntu's `apt modernize-sources` converts `warpdotdev.list` to the Deb822 `warpdotdev.sources` format, a later package `postinst` run sees that `warpdotdev.list` is missing and recreates it. That leaves both files configured for the same repo and causes duplicate-source warnings during `apt update`.

This change treats an existing `@@REPO_NAME@@.sources` file as an already-configured repo source. If a stale legacy `.list` file is present alongside it, `postinst` removes the `.list` file so the Deb822 source remains the single source of truth. On purge, `postrm` now removes both `.list` and `.sources` formats.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes). N/A; packaging script change.

## Testing
- `sh -n resources/linux/debian/common/postinst.repo.template`
- `sh -n resources/linux/debian/common/postrm.repo.template`
- `bash -n script/linux/bundle_deb`
- `git diff --check`
- Simulated `postinst` with fake `apt-config`: existing `warpdotdev.sources` plus stale `warpdotdev.list` keeps `.sources` and removes `.list`; fresh state with neither source creates `.list` as before.
- Simulated generated `postrm purge` with fake `apt-config`: removes signing key, `.list`, and `.sources`.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Debian package post-install scripts now respect existing Deb822 `.sources` apt source files and remove stale duplicate `.list` files created after `apt modernize-sources`.
-->
