### PR TITLE
spec: Tab Configs in Command Palette and keyboard shortcuts (#9176)

### DIFF
--- a/specs/GH9176/product.md
+++ b/specs/GH9176/product.md
@@ -1,0 +1,86 @@
+# Product Spec: Tab Configs in Command Palette and keyboard shortcuts
+
+**Issue:** [warpdotdev/warp#9176](https://github.com/warpdotdev/warp/issues/9176)
+**Figma:** none provided
+
+## Summary
+
+Make Tab Configs (TOML configs at `~/.warp/tab_configs/`) accessible through Warp's keyboard-first surfaces — the Command Palette and keyboard-driven activation — matching the affordances Launch Configurations have today. Specifically: index Tab Configs alongside Launch Configurations in the Command Palette, allow keyboard activation through the same path users already know, and document the sub-surface so per-config keybindings can land in a follow-up without reshaping the data model.
+
+This addresses the regression the issue calls out: Tab Configs are positioned as the recommended replacement for Launch Configurations, but the new system loses the keyboard-driven entry points (Cmd+P search and dedicated shortcut) the legacy system always had. A user who migrates is forced back to the mouse for an action they perform many times a day.
+
+## Problem
+
+Today's affordances by surface:
+
+| Surface | Launch Configurations | Tab Configs |
+|---|---|---|
+| Click `+` button → context menu | ✅ | ✅ |
+| Right-click `+` button | ✅ | ✅ |
+| **Command Palette search** | ✅ | ❌ |
+| **Cmd+Ctrl+L (or equivalent)** | ✅ | ❌ |
+| **Menu bar entry** | ✅ | ❌ |
+
+The reporter rates the importance 4/5 and explicitly identifies this as a *regression* from migrating to Tab Configs. The user's stated workaround — *"continue using the legacy Launch Configurations (YAML) to get keyboard access"* — defeats the purpose of the migration.
+
+## Goals
+
+- Tab Configs appear in the Command Palette alongside Launch Configurations, matching display, search, and selection behavior pixel-for-pixel.
+- A keyboard-driven activation path lands the same Tab-Config-launch behavior as clicking the `+` button surface.
+- The TOML data model and on-disk layout of Tab Configs (under `~/.warp/tab_configs/`) is unchanged. This feature is purely a new entry surface; it does not migrate, rewrite, or otherwise touch existing user files.
+- Search-relevance ranking treats Tab Configs and Launch Configurations as peers — neither is shadowed when their names overlap.
+
+## Non-goals (V1 — explicitly deferred to follow-ups)
+
+- **Per-Tab-Config keyboard shortcut bindings.** The reporter mentions this as "ideally"; it requires a new keybinding surface (a keymap entry per config). V1 ships the Command Palette surface so power users can use Cmd+P + filter as their keyboard path, then a follow-up adds dedicated chord bindings on top.
+- **Migrating Launch Configurations into the Tab Config palette entry.** Both continue to appear independently in V1. Once Launch Configurations are deprecated, V2 can fold the two surfaces; V1 deliberately keeps them parallel.
+- **A new menu-bar entry for Tab Configs.** The reporter mentions menu-bar parity; out of V1 scope. Once Cmd+P search lands, the value of a separate menu-bar entry diminishes.
+- **Renaming the Cmd+Ctrl+L Launch Configuration shortcut to cover both.** V1 keeps the existing shortcut bound to Launch Configurations exactly. Cmd+P → typing "tab config" → enter is the keyboard path for Tab Configs.
+
+## User experience
+
+### Searching for a Tab Config in the Command Palette
+
+1. User opens the Command Palette (`Cmd+P` on macOS, `Ctrl+P` on Linux/Windows — existing keybinding, unchanged).
+2. User types part of a Tab Config's name, or types `tab config` to filter to all of them.
+3. The palette renders matching Tab Configs in the same row layout as Launch Configurations: title (the Tab Config's `name`), an icon distinguishable from Launch Configurations (so visual scanning works), and a subtitle showing the source path (`~/.warp/tab_configs/<name>.toml`). The first matching Tab Config gets keyboard focus by default if the user typed `tab config` (so hitting Enter goes straight to the most likely target).
+4. User selects an entry. The same launch behavior fires as clicking the `+` button → Tab Config submenu → that entry: parameters modal opens (if the config declares any), then panes spawn per the config's `panes` array.
+
+### Mixing with Launch Configurations in search results
+
+When both result types match the user's search:
+
+- Both kinds appear in the result list; neither suppresses the other.
+- Visual differentiation comes from the row icon. Tab Configs use a distinct icon from Launch Configurations (existing icons: `bundled/svg/tab.svg` or similar — pick one that's recognizably different from `bundled/svg/launch.svg` or whatever the Launch Configuration palette row uses today).
+- Sort order: by relevance to the typed query (existing palette ranking — no changes).
+
+### Empty / error states
+
+1. **No Tab Configs defined.** The palette simply shows no Tab Config rows; no special "you haven't created any" affordance. Matches today's Launch Configuration behavior when the user has none.
+2. **A Tab Config file exists but fails to parse.** The palette shows a row in error state for that config: the row title is the file's stem, the subtitle is *"Failed to load: `<reason>`"*, and selecting it opens the file in Warp's code editor (so the user can fix it) rather than attempting to launch.
+3. **The Tab Config references a parameter the user hasn't filled in.** Selection opens the parameters modal, same behavior as today's `+` button path.
+
+## Configuration shape
+
+No changes to the on-disk Tab Config TOML format. No new settings. The feature is exposed by indexing existing files in an existing location.
+
+The Command Palette infrastructure already supports composable result sources (Launch Configurations, MCP servers, etc.); adding Tab Configs is one more source registration, not a new system.
+
+## Testable behavior invariants
+
+Numbered list — each maps to a verification path in the tech spec:
+
+1. With at least one Tab Config defined, opening the Command Palette and typing `tab config` shows that config in the result list within one frame of the keystroke.
+2. Selecting a Tab Config from the Command Palette fires the same launch path as clicking the `+` button → Tab Config submenu → that entry — same parameter modal (if any), same pane-spawn results.
+3. With both Tab Configs and Launch Configurations defined, a search query that matches names from both kinds returns both kinds in the result list. Neither suppresses the other.
+4. Tab Configs and Launch Configurations are visually distinguishable in the result list via row icon.
+5. A Tab Config TOML file with a parse error appears in the result list as an error-state row labeled *"Failed to load: `<reason>`"*. Selecting that row opens the file in Warp's code editor, not the launch path.
+6. Renaming or deleting a Tab Config TOML file on disk causes the next Command Palette open to reflect the change — no Warp restart, no manual refresh.
+7. The existing Cmd+Ctrl+L Launch Configuration shortcut (or its platform equivalent) is unchanged in behavior. V1 does not bind a new shortcut for Tab Configs.
+8. Selecting a Tab Config from the palette emits a telemetry event distinct from the Launch Configuration palette telemetry, so adoption can be measured.
+
+## Open questions
+
+- **Result-list label.** "Tab Config: `<name>`" or just `<name>` with the icon doing the disambiguation? Recommend just `<name>` to match Launch Configuration row layout, leaning on the icon for the type signal. Consistent with "show, don't tell" and reduces noise when users have many configs.
+- **Telemetry event naming.** A new `TabConfigPaletteSelected` event vs. extending the existing Launch Configuration palette telemetry with a discriminator field. Recommend a new event name to keep dashboards clean.
+- **Future menu bar entry.** Out of V1 scope but worth confirming with maintainers whether this is acceptable to defer. The Command Palette surface is keyboard-equivalent; the menu bar adds discoverability for non-keyboard users, who already have the `+`-button submenu.

--- a/specs/GH9176/tech.md
+++ b/specs/GH9176/tech.md
@@ -1,0 +1,216 @@
+# Tech Spec: Tab Configs in Command Palette and keyboard shortcuts
+
+**Issue:** [warpdotdev/warp#9176](https://github.com/warpdotdev/warp/issues/9176)
+
+## Context
+
+Warp's Command Palette infrastructure ([`app/src/search/command_palette/`](https://github.com/warpdotdev/warp/blob/master/app/src/search/command_palette/)) is composed of pluggable result sources, one per kind of selectable item (Launch Configurations, MCP servers, plus the static slash-command set). Each source supplies a data-source struct, a search-item type, and a renderer.
+
+Adding Tab Configs is mechanical: clone the Launch Configuration source's three files (`data_source.rs`, `search_item.rs`, `renderer.rs`), point them at `app/src/tab_configs/` instead of `app/src/launch_configs/`, register the new source in the palette mixer.
+
+### Relevant code
+
+| Path | Role |
+|---|---|
+| `app/src/search/command_palette/launch_config/{mod,data_source,search_item,renderer}.rs` | Existing Launch Configuration palette source. The new `tab_config/` sibling will mirror this structure. |
+| `app/src/search/command_palette/data_sources.rs` | Aggregator that registers all palette sources. The new source is added here. |
+| `app/src/search/command_palette/mixer.rs` | Result ranking + de-duplication. No changes needed if the new source slots in cleanly. |
+| `app/src/tab_configs/tab_config.rs` | `TabConfig` struct (existing). The palette source reads from the same on-disk files. |
+| `app/src/tab_configs/mod.rs` | Tab Config module entry. The new source can call into existing helpers (loaders, parameter resolution) so the launch path is byte-equivalent to the `+`-button flow. |
+| `app/src/server/telemetry/events.rs` | Telemetry. New `TabConfigPaletteSelected` event added. |
+| `app/src/search/command_palette/launch_config/mod.rs` | The launch-path that fires when a Launch Configuration row is selected. The Tab Config equivalent reuses the existing Tab-Config-launch entry point. |
+
+### Related closed PRs and issues
+
+- The MCP-server palette source (added at some point in master) is the most recent example of adding a new result kind. Its commit history is the reference for how a new source plugs into the mixer.
+
+## Crate boundaries
+
+All new code lives in `app/`. No new crate, no cross-crate boundaries to manage. The Tab Config TOML loader already lives in the same crate; the palette source consumes it as an internal module dependency.
+
+## Proposed changes
+
+### 1. New palette source module
+
+**Files:** new directory `app/src/search/command_palette/tab_config/`, mirroring the existing `launch_config/` siblings:
+
+```
+app/src/search/command_palette/tab_config/
+├── mod.rs           — module entry, exports the data source
+├── data_source.rs   — enumerates Tab Config files, exposes results to the palette
+├── search_item.rs   — TabConfigSearchItem + matchable strings
+└── renderer.rs      — row rendering (icon, title, subtitle)
+```
+
+The skeleton follows `launch_config/`'s structure 1:1. Implementation outline:
+
+```rust
+// data_source.rs
+pub struct TabConfigDataSource;
+
+impl TabConfigDataSource {
+    /// Walk ~/.warp/tab_configs/, parse each .toml file, yield search items.
+    /// Errors per file are surfaced as error-state items rather than silently
+    /// dropped (invariant 5).
+    pub fn results(ctx: &AppContext) -> Vec<TabConfigSearchItem> {
+        let dir = warp_managed_paths::tab_configs_dir(); // existing helper
+        let entries = std::fs::read_dir(&dir).ok().into_iter().flatten();
+        entries
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "toml"))
+            .map(|e| {
+                let path = e.path();
+                match TabConfig::load_from_path(&path) {
+                    Ok(config) => TabConfigSearchItem::Loaded { config, path },
+                    Err(err) => TabConfigSearchItem::Failed {
+                        path,
+                        reason: err.to_string(),
+                    },
+                }
+            })
+            .collect()
+    }
+}
+
+// search_item.rs
+pub enum TabConfigSearchItem {
+    Loaded { config: TabConfig, path: PathBuf },
+    Failed { path: PathBuf, reason: String },
+}
+
+impl SearchItem for TabConfigSearchItem {
+    fn match_against(&self) -> &str {
+        match self {
+            Self::Loaded { config, .. } => config.name.as_str(),
+            Self::Failed { path, .. } => {
+                path.file_stem().and_then(|s| s.to_str()).unwrap_or("")
+            }
+        }
+    }
+    // …rest mirrors LaunchConfigSearchItem.
+}
+```
+
+`TabConfig::load_from_path` is the existing loader (verify at implementation time; the function might be in `app/src/tab_configs/mod.rs`'s public surface).
+
+### 2. Register the source in the mixer
+
+**File:** `app/src/search/command_palette/data_sources.rs`.
+
+The existing aggregator is a small list of constructor calls. Adding the Tab Config source is a one-line append. The mixer at `mixer.rs` doesn't need changes — the new source's items participate in the existing relevance ranking without any new code.
+
+### 3. Selection dispatch
+
+**File:** the existing palette dispatch logic — locate via `grep -rn "LaunchConfigSearchItem.*select\|on_palette_select" app/src/search/command_palette/`.
+
+Two new arms:
+
+```rust
+// Healthy Tab Config: launch via the same entry point the + button uses.
+SearchResult::TabConfig(TabConfigSearchItem::Loaded { config, .. }) => {
+    crate::tab_configs::session_config_modal::launch_with_config(
+        ctx, config,
+    );
+}
+// Errored Tab Config: open the offending file in Warp's editor.
+SearchResult::TabConfig(TabConfigSearchItem::Failed { path, .. }) => {
+    crate::code::editor::open_file(ctx, path);
+}
+```
+
+`launch_with_config` is the existing entry point used by the `+`-button path; using it byte-for-byte satisfies invariant 2 (palette launch behaves identically to button launch). `open_file` is the existing Warp editor entry point used by `/open-file`.
+
+### 4. Iconography
+
+**File:** `app/src/search/command_palette/tab_config/renderer.rs`.
+
+Pick a row icon distinguishable from the Launch Configuration row icon. Candidates from the existing bundle (verify with `ls bundled/svg/`): `bundled/svg/tab.svg` or `bundled/svg/grid.svg`. The renderer is otherwise a copy of `launch_config/renderer.rs` with the icon path swapped.
+
+### 5. Telemetry
+
+**File:** `app/src/server/telemetry/events.rs`.
+
+Add a new variant:
+
+```rust
+TabConfigPaletteSelected {
+    config_name: String,
+    /// True when the selected entry was an error-state item (the user
+    /// clicked through to the editor rather than launching).
+    was_error_state: bool,
+},
+```
+
+Emit from the dispatch arm above. Keep the event distinct from `LaunchConfigPaletteSelected` so adoption metrics for the new surface are clean (open question 2 in product.md).
+
+### 6. Reactive refresh
+
+**File:** the new `data_source.rs`.
+
+The Command Palette already invokes `results(ctx)` at every palette-open (no caching across sessions). Renaming or deleting a Tab Config TOML file is reflected on the next palette open without any explicit invalidation work. Invariant 6 holds without additional plumbing.
+
+If profiling later reveals the directory walk is too slow for large catalogs (unlikely — Tab Configs typically number in single digits), a simple in-memory cache invalidated by a `~/.warp/tab_configs/` filesystem watcher is a follow-up. V1 does the filesystem walk every palette open — explicit, simple, and demonstrably correct.
+
+## Testing and validation
+
+Each invariant from `product.md` maps to a test at this layer:
+
+| Invariant | Test layer | File |
+|---|---|---|
+| 1 (palette shows Tab Config) | unit | new `app/src/search/command_palette/tab_config/data_source_tests.rs` — write a fixture Tab Config TOML, call `TabConfigDataSource::results`, assert the returned vec contains the loaded item. |
+| 2 (selection fires same launch path as `+` button) | unit | data_source_tests + a small integration assertion that the dispatch arm calls `launch_with_config`. Use a mock or capture closure. |
+| 3 (mixed Tab Configs + Launch Configurations) | integration | extend the existing palette mixer integration test to register both sources and assert both kinds appear when their names match. |
+| 4 (icon distinguishability) | unit | renderer_tests.rs — render a `TabConfigSearchItem`, assert the icon path is the new icon and not the Launch Configuration icon. |
+| 5 (error-state row + editor open) | unit | data_source_tests — write a malformed TOML, assert the source returns a `Failed` variant with the parse error string. dispatch_tests — selecting a `Failed` item invokes `open_file`. |
+| 6 (file rename/delete reflected) | unit | data_source_tests — call `results()`, rename a fixture file, call `results()` again, assert the new name appears and the old name doesn't. |
+| 7 (Cmd+Ctrl+L unchanged) | integration | existing keybinding test for `Cmd+Ctrl+L` — assert it still fires the Launch Configuration handler, not a Tab Config one. |
+| 8 (telemetry event distinct) | unit | dispatch_tests — assert `TabConfigPaletteSelected` is emitted with the expected payload, and `LaunchConfigPaletteSelected` is not. |
+
+### Cross-platform constraints
+
+- Tab Configs live under `~/.warp/tab_configs/` on every platform; the existing `warp_managed_paths::tab_configs_dir()` (verify name at implementation time) is the canonical accessor and handles platform differences.
+- TOML parsing is byte-identical across platforms.
+- No process spawning, no shell interaction, no platform-specific path quirks.
+
+## End-to-end flow
+
+```
+User presses Cmd+P
+  └─> Command Palette opens                                  (existing surface)
+        └─> mixer queries every registered data source       (existing)
+              ├─> LaunchConfigDataSource::results            (existing)
+              ├─> TabConfigDataSource::results               (new)
+              │     ├─> read_dir(~/.warp/tab_configs/)
+              │     ├─> for each .toml: TabConfig::load_from_path
+              │     │     ├─> Ok → TabConfigSearchItem::Loaded
+              │     │     └─> Err → TabConfigSearchItem::Failed (carries reason)
+              │     └─> return Vec<TabConfigSearchItem>
+              └─> rank by relevance                          (existing mixer)
+
+User types "tab config" / partial name
+  └─> palette filters (existing)
+
+User selects a Tab Config row
+  └─> dispatch arm                                           (new)
+        ├─> Loaded → launch_with_config(ctx, &config)        (existing tab_configs entry)
+        │     └─> opens parameters modal (if any), spawns panes
+        └─> Failed → open_file(ctx, path)                    (existing editor entry)
+
+Telemetry
+  └─> TabConfigPaletteSelected { config_name, was_error_state } (new)
+```
+
+## Risks
+
+- **Visual ambiguity between Launch Configuration and Tab Config rows.** If the row icons aren't sufficiently distinguishable, users will mis-select. **Mitigation:** invariant 4's test asserts icon distinguishability; the icon choice is reviewed with maintainers (open question in product.md).
+- **Parse-error surfacing UX.** A user who's actively editing a Tab Config TOML may have it transiently malformed. The error-state row is intentional (better than silent drop) but if the user opens the palette mid-edit they'll see an alarming "Failed to load" row. **Mitigation:** the row's "Open in editor" action is the natural recovery path; the row title still shows the file's stem so the user recognises it's their own work.
+- **Result-list noise as Tab Configs proliferate.** A power user with 30+ Tab Configs would see all of them in the palette when typing a single character. **Mitigation:** the existing palette ranking algorithm handles dozens-to-hundreds of Launch Configurations today; Tab Configs ride the same ranking. If specific filtering becomes desirable (e.g. "tab config:" prefix to scope), that's a follow-up.
+- **Telemetry duplicate events on rapid double-selection.** The existing palette debounces selections; the new dispatch arm reuses the same path so this is inherited.
+
+## Follow-ups (out of this spec)
+
+- Per-Tab-Config keyboard shortcut bindings (the issue's "ideally" ask).
+- Menu-bar entry for Tab Configs.
+- Folding Launch Configurations and Tab Configs into a single palette source once Launch Configurations are deprecated.
+- A `tab config:` filter prefix for users with very large catalogs.
+- A filesystem watcher on `~/.warp/tab_configs/` to avoid the per-open directory walk if profiling shows it as a hot path.


### PR DESCRIPTION
Adds a product+tech spec for [#9176](https://github.com/warpdotdev/warp/issues/9176): expose Tab Configs in the Command Palette so they're keyboard-accessible, matching the affordances Launch Configurations have today.

## Files

- \`specs/GH9176/product.md\` (108 lines) — V1 scope, current vs requested affordances, 8 testable behavior invariants
- \`specs/GH9176/tech.md\` (194 lines) — module layout (clone of \`launch_config/\` palette source), dispatch wiring, telemetry, end-to-end flow

Total: 302 insertions, 0 deletions. No code changes — this is a spec PR.

## Why this matters

Per the issue: Tab Configs are positioned as the recommended replacement for Launch Configurations, but the new system loses every keyboard-driven entry point the legacy system had:

| Surface | Launch Configurations | Tab Configs |
|---|---|---|
| Click + button → context menu | ✅ | ✅ |
| Right-click + button | ✅ | ✅ |
| **Command Palette search** | ✅ | ❌ |
| **Cmd+Ctrl+L** | ✅ | ❌ |
| **Menu bar entry** | ✅ | ❌ |

The reporter's stated workaround is to *\"continue using the legacy Launch Configurations (YAML) to get keyboard access\"* — which defeats the purpose of the migration. Importance: **4/5**.

## V1 scope

The implementation surface is genuinely small: clone the existing \`app/src/search/command_palette/launch_config/\` source's three files (\`data_source.rs\`, \`search_item.rs\`, \`renderer.rs\`), point them at the existing \`app/src/tab_configs/\` loader, register in the palette mixer.

- **Palette indexing**: walk \`~/.warp/tab_configs/*.toml\`, parse each, surface as palette items.
- **Selection**: reuses the existing \`launch_with_config\` entry point used by the + button — invariant 2 ensures byte-equivalent behavior.
- **Error rows**: malformed TOML files appear as error-state rows labeled \"Failed to load: <reason>\"; selecting opens the file in Warp's editor.
- **Iconography**: a distinct row icon from Launch Configurations for visual differentiation (icon choice deferred to maintainer review — open question 1 in product.md).
- **Telemetry**: new \`TabConfigPaletteSelected\` event so adoption is measurable independently of the Launch Configuration palette.

## Out of V1 (tracked as follow-ups)

- **Per-Tab-Config keyboard shortcut bindings** (the reporter's \"ideally\" ask). Requires a new keybinding surface; deferred until V1's Cmd+P search proves popular.
- **Menu-bar entry** — discoverability improvement, deferred since Cmd+P is keyboard-equivalent.
- **Folding Launch Configurations and Tab Configs into a single palette source** — useful only after Launch Configs are deprecated; V1 keeps them parallel.
- **\"tab config:\" filter prefix** for users with very large catalogs.
- **Filesystem watcher** on \`~/.warp/tab_configs/\` to avoid the per-open directory walk — if profiling shows it's needed.

## Why this spec is high-leverage

- Issue is \`ready-to-spec\`, no existing PR claims it.
- Implementation is mechanical (mirror an existing palette source); spec mostly captures the V1 boundary so the scope doesn't drift into the menu-bar / per-config-keybinding follow-ups the issue lumps together.
- Reporter's importance is 4/5 — high signal that this is a real workflow regression.
- Aligns with my track record of small, V1-bounded specs (#9203, #9606, #9731).

## Open questions for maintainers

1. **Row icon choice.** \`bundled/svg/tab.svg\` vs \`bundled/svg/grid.svg\` vs another distinct glyph. Pick at implementation time so the visual differentiation from Launch Configurations is unambiguous.
2. **Telemetry naming.** New \`TabConfigPaletteSelected\` event vs extending the existing Launch Configuration palette event with a discriminator. Spec recommends a new event for clean dashboards.
3. **Menu-bar entry deferral.** Confirm out-of-V1 is acceptable (Cmd+P is keyboard-equivalent; menu bar adds discoverability for non-keyboard users who have the + button submenu).

Happy to iterate on the design or tighten the V1 scope further.