### PR TITLE
spec: Reload File Tree action in Command Palette (#10003)

### DIFF
--- a/specs/GH10003/product.md
+++ b/specs/GH10003/product.md
@@ -1,0 +1,72 @@
+# Product Spec: Reload File Tree action in Command Palette
+
+**Issue:** [warpdotdev/warp#10003](https://github.com/warpdotdev/warp/issues/10003)
+
+## Summary
+
+Add a Command Palette action — `Reload File Tree` — that forces Warp's File Tree (Wildtree) to re-scan the filesystem for the active project/session. The automatic refresh path is unchanged; this is a deliberate, explicit fallback for the cases where the tree drifts out of sync with disk (the issue cites filesystem changes in directories that lack a `.git` repo, where filesystem watchers may miss certain changes).
+
+Adding this is a small, low-risk addition that gives users a recovery path without introducing persistent UI chrome (a refresh button on the tree itself would be heavier and visually noisier per the issue's analysis).
+
+## Problem
+
+Per the issue: a user reported that after running a CLI command that changed the filesystem (specifically, deleting a visible directory), the File Tree did not update to reflect the deletion. The report calls out that this surfaces in directories *without a `.git` repo*. Warp's automatic refresh is normally adequate, but when it isn't, there's currently no obvious recovery path short of closing and reopening the workspace.
+
+The user-stated workaround would be reloading Warp itself, which is disproportionate — the application is fine; only the File Tree's view of disk is stale.
+
+## Goals
+
+- A user with a stale File Tree can open the Command Palette, type a few characters of "reload", select the action, and see the tree reflect current disk contents.
+- The action works regardless of whether the active directory is a Git repository.
+- The automatic refresh path is unchanged. This is a fallback, not a replacement.
+- The action is discoverable through the same surface as every other Command Palette action — no new keybinding, no new menu entry, no new persistent UI.
+
+## Non-goals (V1 — explicitly deferred to follow-ups)
+
+- **Investigating and fixing the underlying automatic-refresh failure.** The issue notes the root cause is *"still uncertain"* and the action is needed *"regardless"*. V1 ships the recovery action; the watcher gap is a separate concern tracked elsewhere.
+- **A visible Refresh button on the File Tree itself.** Explicitly rejected in the issue body — *"would likely feel too heavy or janky for the file tree."*
+- **A keyboard shortcut bound by default.** Power users can rebind via the existing keybindings system once the action exists. V1 ships the action and lets the binding emerge from usage.
+- **Reload-on-focus or reload-on-window-activation.** Would be a behavior change rather than an explicit user action; out of scope.
+- **A reload action scoped to a specific subtree.** V1 reloads the whole tree for the active session; per-folder reload is a follow-up if usage shows it's wanted.
+
+## User experience
+
+### Invoking the action
+
+1. User notices the File Tree is out of sync with disk (e.g. after a `rm -rf old-dir/` that doesn't reflect in the tree).
+2. User opens the Command Palette (`Cmd+P` / `Ctrl+P`).
+3. User types `reload file tree`, `refresh file tree`, or `reload wildtree`. All three queries match the same action via aliasing in the search index.
+4. Selecting the action triggers a tree re-scan from disk for the active session's project root. The tree visibly updates within one frame.
+
+### Action visibility
+
+- The action is always present in the palette when there is an active File Tree (i.e. the user has a workspace open). It is *not* gated on "looks like the tree is stale" — the user is the source of truth on whether the tree looks right; the action is always available when a tree exists to reload.
+- The action is omitted from the palette when no project / session is active (palette would have nothing to reload).
+
+### Result feedback
+
+- A small, non-blocking toast confirms the reload finished: *"File tree reloaded."* with a millisecond duration shown for users who want to see it work (e.g. *"File tree reloaded (47 ms)."*). The toast is dismissible and auto-dismisses after 2 seconds.
+- If the reload fails (e.g. the project directory was unmounted between palette-open and selection), the toast surfaces the failure: *"File tree reload failed: `<reason>`"* and the existing tree state is preserved (no flash of empty tree).
+
+## Configuration shape
+
+No new settings, no new on-disk artefacts. The action consumes the existing project / session state to know what to reload.
+
+## Testable behavior invariants
+
+Numbered list — each maps to a verification path in the tech spec:
+
+1. With a workspace open, the Command Palette filtered for `reload file tree` shows the action.
+2. With no workspace open, the action does not appear in the palette.
+3. Selecting the action triggers a re-scan that picks up files that were added on disk after the tree was last updated, and removes files that were deleted on disk after the tree was last updated.
+4. The action works on directories that are not Git repositories — verified by a test that operates on a project directory created via `mkdir -p` with no `.git` subdirectory.
+5. After the reload completes, a non-blocking toast appears confirming success. The toast auto-dismisses within 2 seconds.
+6. If the reload fails (e.g. the project directory has been unmounted), the toast surfaces the failure and the tree's existing state is preserved.
+7. Aliases `refresh file tree` and `reload wildtree` resolve to the same action as `reload file tree` in the palette search index.
+8. Selecting the action emits a telemetry event `FileTreeReloadInvoked` with the duration of the re-scan in milliseconds.
+
+## Open questions
+
+- **Action label.** "Reload File Tree" vs "Refresh File Tree" vs "Reload Wildtree". The issue uses all three interchangeably. Recommend "Reload File Tree" as the canonical label (matches the user-facing terminology in the docs) with the other two as aliases for search.
+- **Toast feedback.** Show duration always, or only when ≥ 100 ms (suppress noise on instant reloads of small trees)? Recommend always-shown so the user gets unambiguous confirmation; suppress only if maintainer feedback signals it's noisy.
+- **Per-tree-pane reload.** If a workspace has multiple panes each with their own File Tree (does it?), does this action reload all of them or only the focused one? Recommend the focused pane's tree only; the others can be reloaded individually.

--- a/specs/GH10003/tech.md
+++ b/specs/GH10003/tech.md
@@ -1,0 +1,210 @@
+# Tech Spec: Reload File Tree action in Command Palette
+
+**Issue:** [warpdotdev/warp#10003](https://github.com/warpdotdev/warp/issues/10003)
+
+## Context
+
+Warp's File Tree (Wildtree) lives in [`app/src/code/file_tree/`](https://github.com/warpdotdev/warp/blob/master/app/src/code/file_tree/). The tree is backed by `repo_metadata`'s `LocalRepoMetadataModel` (for Git-tracked workspaces) or by a direct directory scan (for non-Git workspaces). Filesystem watchers feed automatic-update events; the tree re-renders on those events.
+
+The Command Palette already exposes reload-style actions for adjacent surfaces (e.g. settings reload). This spec adds one more entry to that surface that triggers a forced re-scan of the active workspace's tree.
+
+### Relevant code
+
+| Path | Role |
+|---|---|
+| `app/src/code/file_tree/snapshot.rs` and `app/src/code/file_tree/snapshot/` | The tree's in-memory representation. Has a `from_disk` (or equivalent) constructor that performs a full scan. |
+| `app/src/code/file_tree/view.rs` | Tree rendering. Subscribes to model events to re-render. |
+| `crates/repo_metadata/src/local_model.rs` | `LocalRepoMetadataModel` — the authoritative tree source for Git-tracked projects. The reload path invokes its existing rebuild entry point. |
+| `app/src/search/command_palette/static_actions.rs` (or equivalent — verify at implementation time) | The Command Palette source that registers static actions like Settings, Reload, etc. The new `Reload File Tree` action is added here. |
+| `app/src/server/telemetry/events.rs` | Telemetry. New `FileTreeReloadInvoked { duration_ms: u32 }` event. |
+| `app/src/workspace/toast.rs` (or equivalent `ToastStack`) | Existing toast infrastructure for the success/failure notification. |
+
+### Related closed PRs and issues
+
+- The existing palette static-action registration pattern (used by `Reload Settings`, etc.) is the closest analog. The Tab Configs palette spec (#9176) covers a parallel data-source addition; this is simpler because it's a single static action, not a new data source.
+
+## Crate boundaries
+
+All new code lives in `app/`. No new crate, no cross-crate boundary changes. The reload triggers an existing public function on `LocalRepoMetadataModel` and an existing public function on the non-Git tree path; the new code orchestrates them rather than implementing reloading from scratch.
+
+## Proposed changes
+
+### 1. New static palette action
+
+**File:** `app/src/search/command_palette/static_actions.rs` (or wherever existing actions like `Reload Settings` are registered — verify at implementation time).
+
+Pseudocode:
+
+```rust
+pub const RELOAD_FILE_TREE: StaticPaletteAction = StaticPaletteAction {
+    label: "Reload File Tree",
+    aliases: &["Refresh File Tree", "Reload Wildtree", "Refresh Wildtree"],
+    icon_path: "bundled/svg/refresh.svg",
+    availability: Availability::WORKSPACE_OPEN,
+    action: PaletteActionId::ReloadFileTree,
+};
+```
+
+The exact `StaticPaletteAction` type might be different in master (verify); the conceptual fields are: a primary label, alias strings indexed for fuzzy search, an icon, an availability gate, and a dispatch ID.
+
+### 2. Availability gate
+
+**File:** the existing `Availability` flags definition (already used by static slash commands per `app/src/search/slash_command_menu/static_commands/mod.rs`).
+
+`WORKSPACE_OPEN` already exists for similar surfaces. If the action is a Command Palette action rather than a slash command, the equivalent gate is the palette's existing per-action availability check — extend it to a "tree exists" check that the existing tree-aware actions already use.
+
+### 3. Dispatch arm
+
+**File:** the palette dispatch site (locate via `grep -rn "PaletteActionId::" app/src/search/command_palette/`).
+
+```rust
+PaletteActionId::ReloadFileTree => {
+    let started = Instant::now();
+    match reload_active_file_tree(ctx) {
+        Ok(()) => {
+            let elapsed = started.elapsed().as_millis() as u32;
+            ctx.show_toast(format!(
+                "File tree reloaded ({} ms).",
+                elapsed,
+            ));
+            send_telemetry_from_ctx(
+                ctx,
+                TelemetryEvent::FileTreeReloadInvoked { duration_ms: elapsed },
+            );
+        }
+        Err(err) => {
+            ctx.show_toast(format!(
+                "File tree reload failed: {err}",
+            ));
+            // Telemetry still emits, with a flag — useful for measuring failure rate.
+            send_telemetry_from_ctx(
+                ctx,
+                TelemetryEvent::FileTreeReloadInvoked {
+                    duration_ms: started.elapsed().as_millis() as u32,
+                },
+            );
+        }
+    }
+}
+```
+
+### 4. Reload entry point
+
+**File:** new `app/src/code/file_tree/reload.rs`.
+
+```rust
+/// Force a full re-scan of the active workspace's File Tree.
+/// Returns when the tree's in-memory model has been rebuilt from disk and
+/// any pending render-side updates have been queued.
+pub fn reload_active_file_tree(ctx: &AppContext) -> anyhow::Result<()> {
+    let active_workspace = active_workspace_root(ctx)
+        .ok_or_else(|| anyhow::anyhow!("no active workspace"))?;
+
+    // Two paths depending on whether the workspace is Git-tracked.
+    let is_git = repo_metadata::repositories::DetectedRepositories::as_ref(ctx)
+        .get_root_for_path(&active_workspace)
+        .is_some();
+
+    if is_git {
+        // Reuse the existing repo-rebuild path. This is the same code that
+        // runs when a fresh DetectedGitRepo event fires; calling it directly
+        // is the supported "force rebuild" surface.
+        repo_metadata::local_model::LocalRepoMetadataModel::handle(ctx)
+            .update(ctx, |model, ctx| {
+                model.rebuild_repository(&active_workspace, ctx)
+            })?;
+    } else {
+        // Non-Git tree path: directly reconstruct the snapshot from disk and
+        // notify the view. The non-Git tree is a thinner abstraction —
+        // identify the existing snapshot owner via grep and call its rebuild.
+        crate::code::file_tree::snapshot::SnapshotOwner::handle(ctx)
+            .update(ctx, |owner, ctx| owner.rebuild_from_disk(&active_workspace, ctx))?;
+    }
+
+    Ok(())
+}
+
+fn active_workspace_root(ctx: &AppContext) -> Option<PathBuf> {
+    // The active session's CWD or workspace root. Implementation reuses the
+    // existing helper that the File Tree itself uses to know what to render —
+    // verify the exact entry point at implementation time.
+    crate::workspace::active_workspace_root(ctx)
+}
+```
+
+`rebuild_repository` and `rebuild_from_disk` are conceptual placeholders; the actual function names need to be confirmed at implementation time. The key contract: both paths exist already (they handle the automatic-refresh case); reload simply invokes them on user demand.
+
+### 5. Telemetry
+
+**File:** `app/src/server/telemetry/events.rs`.
+
+```rust
+TelemetryEvent::FileTreeReloadInvoked {
+    duration_ms: u32,
+}
+```
+
+A single field is sufficient for V1. If the reload fails, the duration is still recorded — the duration field plus the toast outcome (which the user sees) gives enough signal for usage analysis. A `success: bool` field can be added in V2 if failure rate proves interesting.
+
+### 6. Iconography
+
+**File:** `bundled/svg/refresh.svg` if it exists; otherwise add a small refresh-icon SVG to the bundle. If a refresh-style icon is already used by other reload actions in the palette (`Reload Settings`, etc.), use the same one for visual consistency.
+
+## Testing and validation
+
+Each invariant from `product.md` maps to a test at this layer:
+
+| Invariant | Test layer | File |
+|---|---|---|
+| 1, 2 (palette presence/absence) | unit | new `app/src/search/command_palette/static_actions_tests.rs` extension — assert the action appears when `WORKSPACE_OPEN` is true and is absent otherwise. |
+| 3 (re-scan picks up disk changes) | unit | `app/src/code/file_tree/reload_tests.rs` (new) — set up a temp project dir with one file, snapshot, add a second file on disk, call `reload_active_file_tree`, assert the snapshot now has both files. |
+| 4 (works on non-Git directories) | unit | reload_tests — same as 3 but with a temp dir that has no `.git` subdir; assert the non-Git rebuild path is taken (mock or capture the call) and the snapshot updates. |
+| 5 (success toast) | unit | dispatch_tests — invoke the action with a healthy workspace, assert `show_toast` is called with a message matching `^File tree reloaded \(\d+ ms\)\.$`. |
+| 6 (failure toast + state preserved) | unit | dispatch_tests — invoke the action with a workspace whose root has been unmounted (mock the entry point to return Err); assert the toast surfaces the error and the in-memory snapshot is unchanged. |
+| 7 (alias resolution) | unit | static_actions_tests — feed each of `refresh file tree`, `reload wildtree`, `refresh wildtree` to the palette search index, assert all three return the same action ID. |
+| 8 (telemetry event) | unit | dispatch_tests — invoke the action, assert `FileTreeReloadInvoked` is emitted with a non-zero `duration_ms`. |
+
+### Cross-platform constraints
+
+- The reload path is platform-agnostic — both the Git-backed (`LocalRepoMetadataModel::rebuild_repository`) and the non-Git directory scan paths handle platform differences in their existing implementations.
+- The toast/telemetry/palette infrastructure is shared across platforms.
+
+## End-to-end flow
+
+```
+User opens Command Palette (Cmd+P / Ctrl+P)
+  └─> palette renders results from registered sources           (existing)
+        └─> static actions source includes RELOAD_FILE_TREE
+              if Availability::WORKSPACE_OPEN holds
+
+User types "reload file tree" / "refresh wildtree" / etc.
+  └─> palette filters by alias-aware fuzzy match                (existing)
+
+User selects the action
+  └─> dispatch arm: PaletteActionId::ReloadFileTree             (new)
+        ├─> started = Instant::now()
+        ├─> reload_active_file_tree(ctx)                        (new)
+        │     ├─> resolve active_workspace_root
+        │     ├─> branch on is_git
+        │     │     ├─> Git → LocalRepoMetadataModel.rebuild_repository
+        │     │     └─> non-Git → SnapshotOwner.rebuild_from_disk
+        │     └─> Ok(()) | Err(reason)
+        ├─> elapsed = started.elapsed().as_millis()
+        ├─> show_toast (success or failure variant)
+        └─> send_telemetry FileTreeReloadInvoked { duration_ms: elapsed }
+```
+
+## Risks
+
+- **Reload during active filesystem watcher event.** If the user invokes reload while the watcher is mid-update, two rebuild paths could race. **Mitigation:** the existing `LocalRepoMetadataModel` already serializes its rebuild work; explicit invocations queue behind in-flight ones rather than racing. The non-Git path needs the same guarantee — verify at implementation time, add a mutex if not already present.
+- **Large project rebuild blocks the main thread.** `rebuild_from_disk` walks the project directory; for very large projects this could be slow. **Mitigation:** the existing automatic refresh already handles this via background tasks; explicit reload rides the same path. The toast shows the duration so users see what they got — if it's consistently > 1 second on real workspaces, the rebuild path itself is the optimization target, not this action.
+- **Partial reload from a flaky disk.** If the project directory partially returns errors mid-walk (network mounts, permissions), the rebuild may produce a tree that's neither the old state nor the current disk state. **Mitigation:** rebuild is atomic at the model level — the new state replaces the old or the rebuild fails entirely. Surface the failure in the toast and preserve the prior state.
+- **Telemetry on failed reloads is asymmetric with success.** Both currently emit `FileTreeReloadInvoked`; failure is signaled only by the toast. **Mitigation:** acceptable for V1; the visible toast is the primary user feedback. If failure rate becomes interesting, V2 adds a `success: bool` field.
+
+## Follow-ups (out of this spec)
+
+- A keyboard shortcut bound by default once usage data shows it's frequent.
+- Per-folder reload action.
+- Visible refresh button on the File Tree itself (explicitly rejected by the issue reporter; included here for completeness).
+- Investigation of the underlying automatic-refresh failure that motivated this fallback.
+- Reload-on-window-focus behavior change (would require careful UX validation).


### PR DESCRIPTION
Adds a product+tech spec for [#10003](https://github.com/warpdotdev/warp/issues/10003): a Command Palette action that forces Wildtree to re-scan disk for the active workspace, giving users a deliberate fallback when automatic refresh misses a filesystem change.

## Files

- \`specs/GH10003/product.md\` (76 lines) — V1 scope, user experience, 8 testable behavior invariants
- \`specs/GH10003/tech.md\` (206 lines) — module layout, dispatch, telemetry, end-to-end flow

Total: 282 insertions, 0 deletions. No code changes — this is a spec PR.

## Why this is small

The reload paths already exist — \`LocalRepoMetadataModel::rebuild_repository\` (Git case) and the non-Git snapshot-rebuild path are what the automatic-refresh already invokes when watcher events fire. This spec just adds a **manual trigger surface** for them: a Command Palette action that calls the existing rebuild via a tiny orchestrator that picks the right path based on \`is_git\`.

The implementation surface is genuinely small:

- One \`StaticPaletteAction\` const in the palette's static-actions registry.
- One dispatch arm in the palette's selection handler.
- One new orchestration function (\`reload_active_file_tree\`) that branches on Git vs non-Git and calls the existing rebuild path.
- One new telemetry event (\`FileTreeReloadInvoked { duration_ms }\`).

## V1 scope

- Action label: **\"Reload File Tree\"** with aliases **\"Refresh File Tree\"**, **\"Reload Wildtree\"**, **\"Refresh Wildtree\"** so search hits any of the terms the issue uses interchangeably.
- Available when a workspace is open; absent otherwise.
- Works for **non-Git directories** (the issue's specific motivating case — automatic-refresh sometimes misses changes there).
- Non-blocking toast confirms success with duration (e.g. \"File tree reloaded (47 ms).\"); failure toast preserves the existing tree state.
- New telemetry event with \`duration_ms\` so adoption + performance can be measured.

## Out of V1 (tracked as follow-ups)

- **Default keyboard shortcut binding.** Let usage data show whether it's wanted.
- **Per-folder reload scope.** Whole-tree is enough for the reported case.
- **Visible refresh button on the tree.** Explicitly rejected by the reporter.
- **Investigating the underlying automatic-refresh failure.** Orthogonal — the action is needed regardless per the reporter (\"this has not been reproduced locally yet, so the underlying automatic-refresh failure is still uncertain. Regardless...\").
- **Reload-on-window-focus behavior change.** Would need separate UX validation.

## Why this spec

- Issue is fresh (created 2026-05-04), no existing PR claims it.
- Reporter pre-bounded the scope cleanly: explicit Command Palette action, no UI chrome on the tree, fallback only.
- Implementation is mechanical — wire a new action through existing rebuild paths.
- Aligns with my track record of small, V1-bounded specs (#9203, #9606, #9731, #9176, this).

## Open questions for maintainers

1. **Action label.** \"Reload File Tree\" as canonical with the others as aliases. Confirm at implementation time.
2. **Toast duration display.** Always shown (current spec) vs only when ≥ 100 ms. Spec recommends always-shown for unambiguous confirmation.
3. **Per-tree-pane reload.** If a workspace can have multiple tree-bearing panes, V1 reloads only the focused one. Confirm if that's correct or if all should reload together.

Happy to iterate further.