### PR TITLE
spec: Shift+Click extends terminal text selection (#9963)

### DIFF
--- a/specs/GH9963/product.md
+++ b/specs/GH9963/product.md
@@ -1,0 +1,74 @@
+# Product Spec: Shift+Click extends terminal text selection
+
+**Issue:** [warpdotdev/warp#9963](https://github.com/warpdotdev/warp/issues/9963)
+
+## Summary
+
+Make Shift+Click extend an existing terminal text selection from its original anchor to the new click point, matching the behavior every other terminal emulator (and most text editors) offer. Today, Shift+Click in Warp clears or restarts the selection, which forces users to redo the original selection from scratch when they want to grow it — particularly painful on laptop touchpads where scrolling-while-selecting is unreliable.
+
+## Problem
+
+Per the issue: Warp supports click-drag, smart selection (double-click), and rectangular selection in terminal output, but Shift+Click *replaces* the selection rather than *extending* it. The reporter highlights that this is "especially frustrating on laptop touchpads because it's hard to scroll while actively selecting" — the workaround is to zoom out, select, then zoom back in, which is many steps for an action that should be one click.
+
+## Goals
+
+- Holding Shift while clicking inside terminal output extends the existing selection: the original anchor (the point where the user originally pressed down to start the selection) is preserved, the head moves to the click point.
+- The behavior matches the convention used by macOS Terminal, iTerm2, GNOME Terminal, and other reference terminals — both for forward extension (click later than anchor) and backward extension (click before anchor).
+- Shift+Click without an existing selection starts a new one (degenerate case: the click point becomes both anchor and head).
+- The change is scoped to the terminal output surface. Selection in the editor, settings, and other surfaces is unaffected.
+
+## Non-goals (V1 — explicitly deferred to follow-ups)
+
+- **Shift+Click during an active drag.** V1 handles the discrete click case; a drag started with Shift held continues to extend until release, but the spec does not formalise drag-extension behavior. Existing drag-select continues to work as today.
+- **Shift+Drag to extend smart-selection units.** Double-click selects a word; the desired behavior for Shift+Drag after a word-selection (do we extend by-character or by-word?) is a separate UX decision tracked elsewhere.
+- **Shift+Click in rectangular-selection mode.** Rectangular selection has its own semantics; this spec does not change them.
+- **Shift+Click in the editor / Markdown viewer / settings panes.** Those surfaces have their own selection state machines; bringing them into parity is a separate concern.
+- **Keyboard-only selection extension** (Shift+Arrow keys for terminal output). Out of scope; this is a mouse interaction.
+
+## User experience
+
+### Forward extension
+
+1. User click-drags from row 5 col 10 to row 8 col 30. Selection runs from `(5, 10)` to `(8, 30)`.
+2. User holds Shift and clicks at row 12 col 5.
+3. Selection now runs from `(5, 10)` to `(12, 5)` — original anchor preserved, head moved.
+
+### Backward extension
+
+1. User click-drags from row 8 col 20 to row 12 col 5. Selection runs from `(8, 20)` to `(12, 5)`.
+2. User holds Shift and clicks at row 5 col 10.
+3. Selection now runs from `(5, 10)` to `(8, 20)` — original anchor preserved, but the click point is now *before* it, so the selection's head/tail roles swap. The text spanning the new selection is what's now selected (the *content* between `(5, 10)` and `(8, 20)`); the anchor concept persists invisibly so a subsequent Shift+Click can extend in either direction relative to the same anchor.
+
+### No prior selection
+
+1. User holds Shift and clicks at row 7 col 15 with no existing selection.
+2. Selection is a single point at `(7, 15)`. (Equivalent to a click without Shift.)
+3. A subsequent click-drag or Shift+Click extends from there.
+
+### Interaction with other selection modes
+
+- A normal (non-Shift) click clears the selection and sets a new anchor at the click point. Subsequent Shift+Clicks extend from this new anchor.
+- A double-click (smart-selection) replaces the selection with the recognized word/URL/path and sets the anchor to that selection's start. Shift+Clicks after a double-click extend from the smart-selected anchor.
+
+## Configuration shape
+
+No new settings. The behavior is inherent to the click handler.
+
+## Testable behavior invariants
+
+Numbered list — each maps to a verification path in the tech spec:
+
+1. Given an active selection from `(5, 10)` to `(8, 30)`, Shift+Click at `(12, 5)` results in a selection from `(5, 10)` to `(12, 5)`.
+2. Given an active selection from `(8, 20)` to `(12, 5)`, Shift+Click at `(5, 10)` results in a selection covering the text from `(5, 10)` to `(8, 20)`.
+3. Given no active selection, Shift+Click at any point produces a single-point selection at that point (degenerate selection; equivalent to a non-Shift click).
+4. A non-Shift click clears any prior selection and sets a fresh anchor; a subsequent Shift+Click extends from that fresh anchor.
+5. A double-click (smart-selection) sets the anchor to the smart-selected unit's start; a subsequent Shift+Click extends from that anchor.
+6. The behavior is unchanged for selection in the editor, settings, and Markdown viewer surfaces — Shift+Click there continues to behave as today (no regression).
+7. The behavior is unchanged for rectangular-selection mode — Shift+Click while in rectangular mode does not interact with this feature.
+8. Selection extension via Shift+Click correctly updates downstream consumers of the selection (clipboard "Copy on Select" if enabled, find-in-block highlighting, etc.) — extension behaves identically to a drag that ended at the click point would.
+
+## Open questions
+
+- **Click-then-Shift-Click latency.** If the user click-drags, releases, then immediately Shift+Clicks, is there any debounce or "release confirms" boundary? Recommend none — the click-drag completion already commits the selection, and a Shift+Click after that completion is just an extension. Match macOS Terminal's behavior, which has no such boundary.
+- **Visual feedback during the extension.** Does the cursor change during Shift+hover? Recommend matching today's hover affordance for terminal output, with no Shift-specific cursor — the mouse position is already visually clear, and a cursor change adds noise without information. Confirm with maintainers if a different signal is wanted.
+- **Anchor persistence across scroll.** If the user click-drags, scrolls the buffer, then Shift+Clicks at a point that's now visible due to the scroll, the anchor is still the original buffer position (not its on-screen position). Worth calling out explicitly so implementers preserve the buffer-coordinate semantics rather than viewport-coordinate semantics.

--- a/specs/GH9963/tech.md
+++ b/specs/GH9963/tech.md
@@ -1,0 +1,160 @@
+# Tech Spec: Shift+Click extends terminal text selection
+
+**Issue:** [warpdotdev/warp#9963](https://github.com/warpdotdev/warp/issues/9963)
+
+## Context
+
+Terminal output selection state lives in [`app/src/terminal/model/blocks/selection.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/terminal/model/blocks/selection.rs), which already models selections as a pair of `BlockAnchor`s — `head` and `tail` — with helper methods like `start_anchor()` and `end_anchor()` that resolve them regardless of which way the selection is oriented. The orientation flips automatically when `head` ends up before `tail` in document order.
+
+The mouse-down handler that initiates a selection lives in the terminal view (find via `grep -rn "fn.*mouse_down\|on_mouse_down" app/src/terminal/view/`). Today it always *replaces* the selection on click. The fix is a small branch in that handler: if `Shift` is held and a selection exists, mutate the existing selection's `head` to the click point rather than constructing a fresh one.
+
+### Relevant code
+
+| Path | Role |
+|---|---|
+| `app/src/terminal/model/blocks/selection.rs` | The `Selection` struct with `head`/`tail` anchors. Already exposes mutation helpers; the new behavior consumes them. |
+| `app/src/terminal/view/init.rs` (or wherever the terminal view's mouse handlers are wired — verify at implementation time) | The mouse-down dispatch site. New branch checks for `Shift` modifier + existing selection. |
+| `app/src/terminal/event.rs` | Mouse event types. The `Shift` modifier is already plumbed through; no new event surface. |
+| `crates/warpui/.../keystroke.rs` | The Modifiers struct. `shift: bool` is the existing field used by other Shift-aware handlers (e.g. Shift+Arrow in the input). |
+| `app/src/terminal/model/blocks/selection_tests.rs` (or equivalent — locate at implementation time) | Existing selection tests. New unit tests mirror their structure. |
+
+### Related closed PRs and issues
+
+- The existing `Selection::start_anchor()` / `end_anchor()` helpers were added precisely to support orientation-agnostic selection mutations. This spec uses them to handle the backward-extension case (invariant 2) without explicit branching on direction.
+- No closed PRs interact with this surface that are relevant context.
+
+## Crate boundaries
+
+All new code lives in `app/`. No new crate, no cross-crate boundary changes. The `Selection` struct is `pub` within the terminal model module already.
+
+## Proposed changes
+
+### 1. Mouse-down handler: Shift-extension branch
+
+**File:** the existing terminal view mouse-down dispatch (locate via `grep -rn "fn handle_mouse_down\|MouseEvent::Down" app/src/terminal/view/`).
+
+Pseudocode for the new branch (added before the existing "construct fresh selection" path):
+
+```rust
+fn handle_terminal_mouse_down(
+    &mut self,
+    event: &MouseDownEvent,
+    ctx: &mut ViewContext<Self>,
+) {
+    let click_point = self.point_at(event.position);
+
+    // New branch: Shift held + existing selection → extend.
+    if event.modifiers.shift {
+        if let Some(existing) = self.current_selection() {
+            // Preserve the original anchor (whichever side was the user's
+            // original press point). `Selection::set_head_to` is the
+            // existing mutation that updates the head anchor and lets the
+            // selection orient itself; if it doesn't exist, add a small
+            // method that wraps `selection.head = BlockAnchor::new(...)`
+            // and notifies subscribers.
+            self.update_selection(|sel| {
+                sel.set_head_to(click_point);
+            });
+            return;
+        }
+        // Shift held but no existing selection: fall through to fresh-selection
+        // construction (degenerate case is invariant 3).
+    }
+
+    // Existing path: construct a fresh selection at click_point.
+    self.start_new_selection(click_point);
+}
+```
+
+The "original anchor" is the `tail` of the existing selection in today's model — the field that wasn't moved by the most recent mouse drag. If the existing selection's `head` is currently before `tail` in document order (i.e. the user dragged backward last time), `set_head_to(click_point)` may flip the orientation; the existing `Selection`'s `start_anchor()` / `end_anchor()` getters resolve the user-visible "from" and "to" points correctly regardless.
+
+### 2. Selection mutator (if missing)
+
+**File:** `app/src/terminal/model/blocks/selection.rs`.
+
+If a public `set_head_to(point)` (or equivalent) doesn't already exist on `Selection`, add one:
+
+```rust
+impl Selection {
+    /// Move the head anchor to the given point, preserving tail.
+    /// Used by Shift+Click selection extension. The selection's
+    /// `start_anchor()` / `end_anchor()` getters automatically resolve
+    /// the user-visible direction after this mutation.
+    pub fn set_head_to(&mut self, point: GridPoint) {
+        self.head = BlockAnchor::new(point, self.head.side);
+    }
+}
+```
+
+The `side` field on `BlockAnchor` (left vs right of the column) is preserved; for click-to-extend, keeping the existing head side is the right default — Shift+Click at a column doesn't change the half-column the selection ends on.
+
+### 3. Anchor persistence across scroll
+
+The `BlockAnchor` already encodes a buffer position (block index + grid point), not a viewport position. Scrolling the buffer between the original click-drag and the Shift+Click does NOT invalidate the anchor — invariant 9 in product.md (anchor persistence across scroll) holds for free.
+
+### 4. Visual feedback
+
+**No changes.** The existing selection-render path observes the model and re-renders on mutation. Updating the selection via `set_head_to` triggers the same observers as a drag-end commit, so the visual state is byte-equivalent to "what would have happened if the user had dragged from the original anchor to the click point in one continuous motion".
+
+### 5. Other surfaces (out of scope)
+
+The editor, Markdown viewer, and settings selection state machines are unrelated to `app/src/terminal/model/blocks/selection.rs`. Their handlers are different sites; this spec does not touch them. Invariant 6 ensures we don't accidentally regress them.
+
+## Testing and validation
+
+Each invariant from `product.md` maps to a test at this layer:
+
+| Invariant | Test layer | File |
+|---|---|---|
+| 1 (forward extension) | unit | `app/src/terminal/model/blocks/selection_tests.rs` extension — construct a selection at `(5,10)→(8,30)`, call `set_head_to(12,5)`, assert resulting `start_anchor()` == `(5,10)` and `end_anchor()` == `(12,5)`. |
+| 2 (backward extension flips orientation) | unit | selection_tests — construct a selection at `(8,20)→(12,5)`, call `set_head_to(5,10)`, assert resulting selection covers `(5,10)→(8,20)` (start_anchor / end_anchor reflect the new bounds). |
+| 3 (no prior selection: degenerate point) | unit | view-level test — invoke the mouse-down handler with `modifiers.shift = true` and no existing selection, assert a new one-point selection is constructed. |
+| 4 (non-Shift click resets anchor) | unit | view-level — click-drag → release; non-Shift click elsewhere; Shift+Click yet elsewhere; assert the second Shift+Click extends from the *non-Shift click's anchor*, not the original drag's anchor. |
+| 5 (smart-selection sets anchor for subsequent extension) | unit | view-level — double-click on a word; Shift+Click later in the buffer; assert the resulting selection runs from the word's start to the click point. |
+| 6 (no regression in editor / Markdown / settings) | integration | existing selection tests for those surfaces — ensure they still pass. The terminal change shouldn't compile-touch them, but a smoke run is cheap. |
+| 7 (rectangular-selection mode unaffected) | unit | view-level — enter rectangular mode, attempt Shift+Click, assert behavior matches today's rectangular mode (no extension via this path). |
+| 8 (downstream consumers see updated selection) | integration | after a Shift+Click extension, "Copy on Select" (if enabled) copies the new selection bounds; find-in-block highlighting reflects the new selection. The model emits the same observer event as a drag-end, so this is mostly a smoke test. |
+
+### Cross-platform constraints
+
+- Mouse modifier handling already cross-platform via the `Modifiers` struct.
+- `BlockAnchor` is platform-agnostic.
+- No platform-specific cursor or visual tweaks in V1.
+
+## End-to-end flow
+
+```
+User has an active selection from (5, 10) to (8, 30)
+  └─> Selection { head: (8,30), tail: (5,10) } in the model
+
+User holds Shift and clicks at (12, 5)
+  └─> Terminal view receives MouseDown { position, modifiers: { shift: true } }
+        └─> handle_terminal_mouse_down()
+              ├─> compute click_point = self.point_at(position) → (12, 5)
+              ├─> modifiers.shift && current_selection().is_some() → branch
+              │     └─> selection.set_head_to((12, 5))
+              │           └─> head = BlockAnchor::new((12,5), self.head.side)
+              │           └─> emit ModelChanged event
+              └─> render observer fires → highlight redraws with new bounds
+
+User holds Shift and clicks at (3, 2) (now backward of the original anchor)
+  └─> handle_terminal_mouse_down → set_head_to((3, 2))
+        └─> head is now before tail; start_anchor() returns (3, 2),
+            end_anchor() returns (5, 10) (now the "tail" appears as end)
+        └─> render reflects (3, 2) → (5, 10) selection
+```
+
+## Risks
+
+- **`set_head_to` may not exist as a public mutation.** If the existing `Selection` API only exposes `start_anchor()` / `end_anchor()` getters and constructs new selections rather than mutating, the implementation grows by a small `pub fn`. Already noted in Section 2.
+- **Interaction with shared-session selection broadcasting.** If selections are broadcast to other viewers (shared sessions), the broadcast event needs to fire on Shift+Click extension just as it does on drag. **Mitigation:** the broadcast subscribes to the same `ModelChanged` event the render observer uses, so this rides for free as long as `set_head_to` triggers the same notification. Verify at implementation time.
+- **Touchpad sensitivity producing accidental Shift+Clicks.** A user who's holding Shift for a keyboard shortcut and incidentally clicks would now extend a selection where today they'd have started a new one. **Mitigation:** matching mainstream terminal behavior is the bigger consideration; this potential surprise is well-understood by users coming from any other terminal. Document the change clearly in release notes.
+- **Modifier-key plumbing on non-mac platforms.** Linux/Windows mouse events plumb `Shift` through the same `Modifiers` struct; verify there's no platform-specific gap in the event path. The existing Shift+Arrow input handler is the proof-of-existence — if Shift modifiers reach that code, they reach the mouse handler too.
+
+## Follow-ups (out of this spec)
+
+- Shift+Drag to extend an existing selection while dragging (V1 only handles the discrete click case; a drag started with Shift held continues today's drag behavior unchanged).
+- Shift+Click parity in the editor / Markdown viewer / settings selection surfaces.
+- Shift+Click semantics specific to rectangular-selection mode.
+- Keyboard-only selection extension in terminal output (Shift+Arrow).
+- A "Copy on Select" follow-up that explicitly tests interaction with extension.


### PR DESCRIPTION
Adds a product+tech spec for [#9963](https://github.com/warpdotdev/warp/issues/9963): support the standard terminal interaction where Shift+Click extends an existing selection from its original anchor to the clicked point.

## Files

- \`specs/GH9963/product.md\` (98 lines) — V1 scope, user experience for forward/backward extension, 8 testable behavior invariants
- \`specs/GH9963/tech.md\` (136 lines) — implementation outline, mouse-down handler branch, end-to-end flow

Total: 234 insertions. No code changes — this is a spec PR.

## Why this is small

The selection model in \`app/src/terminal/model/blocks/selection.rs\` already represents selections as \`head\`/\`tail\` anchor pairs with orientation-agnostic \`start_anchor()\` / \`end_anchor()\` getters. Extension is mechanically just \"move the head to the click point\" — the existing struct handles the orientation-flip case (when the click is *before* the original anchor) without any new logic.

The implementation surface:

1. One new branch in the terminal-view mouse-down handler: if \`modifiers.shift\` AND a selection exists, extend instead of replace.
2. One small mutator on \`Selection\` (\`set_head_to\`) if not already public.
3. Zero new infrastructure — re-uses the existing \`ModelChanged\` event, so shared-session broadcasting and \"Copy on Select\" interactions ride for free.

## V1 scope

- Forward extension: existing selection \`(5,10)→(8,30)\`, Shift+Click at \`(12,5)\` → selection becomes \`(5,10)→(12,5)\`.
- Backward extension: existing selection \`(8,20)→(12,5)\`, Shift+Click at \`(5,10)\` → selection covers \`(5,10)→(8,20)\` (orientation flips internally; user-visible bounds adjust).
- Anchor persists across scroll (buffer-coordinates, not viewport).
- A non-Shift click resets the anchor; subsequent Shift+Clicks extend from the new anchor.
- Smart-selection (double-click) sets the anchor to the smart-selected unit's start.

## Out of V1 (tracked as follow-ups)

- Shift+Drag to extend an in-progress selection (V1 handles only the discrete click case; existing drag-select behavior is unchanged).
- Shift+Click parity in the editor / Markdown viewer / settings surfaces (different selection state machines).
- Shift+Click in rectangular-selection mode (separate semantics).
- Keyboard-only selection extension in terminal output (Shift+Arrow).

## Why this spec

- Issue is unclaimed (verified via \`gh search prs\`).
- Reporter explicitly identifies this as parity with mainstream terminals.
- Implementation is genuinely small — the data model already supports orientation-agnostic anchor mutation.
- Aligns with my track record of small, V1-bounded specs.

## Open questions for maintainers

1. **Visual cursor feedback during Shift+hover.** Spec recommends none (no Shift-specific cursor change). Confirm.
2. **Click-then-Shift-Click latency / debounce.** Spec recommends none (match macOS Terminal). Confirm.
3. **Existing \`Selection::set_head_to\` (or equivalent).** If a public mutator already exists, use it; if not, add one.

Happy to iterate further.