### PR TITLE
fix: close cli rich input with ctrl-g from editor

### DIFF
--- a/app/src/terminal/view/init.rs
+++ b/app/src/terminal/view/init.rs
@@ -325,7 +325,10 @@ pub fn init(app: &mut AppContext) {
     ]);
 
     app.register_editable_bindings([
-        // Ctrl-G: open rich input for CLI agents before the keystroke reaches the PTY.
+        // Ctrl-G: toggle CLI agent rich input.
+        // Two contexts match this binding:
+        // 1. Terminal context when CLI agent footer is visible (opens rich input)
+        // 2. EditorView context when rich input is already open (closes rich input, fix for #9286)
         EditableBinding::new(
             OPEN_CLI_AGENT_RICH_INPUT_KEYBINDING,
             "Toggle CLI Agent Rich Input",
@@ -333,11 +336,14 @@ pub fn init(app: &mut AppContext) {
         )
         .with_key_binding("ctrl-g")
         .with_context_predicate(
-            id!("Terminal")
+            // Case 1: Open from terminal during CLI agent session
+            (id!("Terminal")
                 & !id!("IMEOpen")
                 & (id!("LongRunningCommand") | id!("AltScreen"))
                 & id!(flags::CLI_AGENT_FOOTER_ENABLED)
-                & id!(flags::CLI_AGENT_RICH_INPUT_CHIP_ENABLED),
+                & id!(flags::CLI_AGENT_RICH_INPUT_CHIP_ENABLED))
+            // Case 2: Close from focused editor when rich input is open
+            | (id!("EditorView") & !id!("IMEOpen") & id!(flags::CLI_AGENT_RICH_INPUT_OPEN)),
         ),
         EditableBinding::new(
             "terminal:warpify_subshell",

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -3714,7 +3714,14 @@ fn submit_rich_input_and_collect_pty_writes(
 }
 
 fn open_cli_agent_rich_input_for_agent(app: &mut App, agent: CLIAgent) -> ViewHandle<TerminalView> {
-    let terminal = add_window_with_terminal(app, None);
+    open_cli_agent_rich_input_for_agent_with_window_id(app, agent).1
+}
+
+fn open_cli_agent_rich_input_for_agent_with_window_id(
+    app: &mut App,
+    agent: CLIAgent,
+) -> (WindowId, ViewHandle<TerminalView>) {
+    let (window_id, terminal) = add_window_with_id_and_terminal(app, None);
     terminal.update(app, |view, ctx| {
         CLIAgentSessionsModel::handle(ctx).update(ctx, |sessions, ctx| {
             sessions.set_session(
@@ -3738,7 +3745,50 @@ fn open_cli_agent_rich_input_for_agent(app: &mut App, agent: CLIAgent) -> ViewHa
         view.open_cli_agent_rich_input(CLIAgentInputEntrypoint::FooterButton, ctx);
         assert!(view.has_active_cli_agent_input_session(ctx));
     });
-    terminal
+    (window_id, terminal)
+}
+
+/// Verifies that Ctrl-G closes CLI agent rich input when dispatched from the
+/// focused editor context. This is a regression test for #9286 where the
+/// keybinding only matched the terminal context, not the embedded editor.
+#[test]
+fn ctrl_g_closes_cli_agent_rich_input_when_editor_is_focused() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        // Register keybindings so keystroke dispatch can match the Ctrl-G binding.
+        app.update(|ctx| {
+            crate::terminal::init(ctx);
+            crate::editor::init(ctx);
+        });
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cli_rich = FeatureFlag::CLIAgentRichInput.override_enabled(true);
+
+        let (window_id, terminal) =
+            open_cli_agent_rich_input_for_agent_with_window_id(&mut app, CLIAgent::OpenCode);
+
+        // Dispatch Ctrl-G through the focused editor's responder chain.
+        let (input_id, editor_id) = terminal.read(&app, |view, ctx| {
+            let input = view.input.clone();
+            let editor = input.as_ref(ctx).editor().clone();
+            (input.id(), editor.id())
+        });
+        let handled = app
+            .dispatch_keystroke(
+                window_id,
+                &[terminal.id(), input_id, editor_id],
+                &warpui::keymap::Keystroke::parse("ctrl-g").expect("valid keystroke"),
+                false,
+            )
+            .expect("dispatch should succeed");
+
+        assert!(handled, "ctrl-g should be handled from the focused editor");
+        terminal.read(&app, |view, ctx| {
+            assert!(
+                !view.has_active_cli_agent_input_session(ctx),
+                "rich input should be closed after Ctrl-G"
+            );
+        });
+    })
 }
 
 #[test]

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -3755,6 +3755,7 @@ fn open_cli_agent_rich_input_for_agent_with_window_id(
 fn ctrl_g_closes_cli_agent_rich_input_when_editor_is_focused() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
+        app.add_singleton_model(ImportedConfigModel::new);
         // Register keybindings so keystroke dispatch can match the Ctrl-G binding.
         app.update(|ctx| {
             crate::terminal::init(ctx);


### PR DESCRIPTION
## Description
Fixes #9286 - Ctrl-G now closes CLI agent rich input when dispatched from the focused editor context. Previously the keybinding only matched the terminal context, so rich input couldn't be closed with Ctrl-G when the editor was focused.

This issue was reproduced on Arch Linux based system. The issue wasn't reproducible on MacOS.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos

Before:

https://github.com/user-attachments/assets/0fa76723-1a6d-4122-ae63-c639d1164b24

After:

[warp-ctrlg-fix.webm](https://github.com/user-attachments/assets/76cca669-17e2-43eb-847f-cedee89da09a)

## Testing

Added regression test `ctrl_g_closes_cli_agent_rich_input_when_editor_is_focused()` that verifies Ctrl-G closes rich input when dispatched from the focused editor context.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->

CHANGELOG-BUG-FIX: Fixed Ctrl-G not closing CLI agent rich input on linux when editor is focused (fixes #9286)