### PR TITLE
Fix find focus drifting when output streams into active block

### DIFF
--- a/app/src/terminal/find/model/block_list.rs
+++ b/app/src/terminal/find/model/block_list.rs
@@ -288,6 +288,40 @@ impl BlockListMatch {
             _ => false,
         }
     }
+
+    /// Returns `true` if `self` and `other` refer to the same matched span, ignoring transient
+    /// state like `is_filtered`.
+    fn same_span(&self, other: &BlockListMatch) -> bool {
+        match (self, other) {
+            (
+                BlockListMatch::CommandBlock(BlockGridMatch {
+                    grid_type: g1,
+                    range: r1,
+                    block_index: b1,
+                    ..
+                }),
+                BlockListMatch::CommandBlock(BlockGridMatch {
+                    grid_type: g2,
+                    range: r2,
+                    block_index: b2,
+                    ..
+                }),
+            ) => g1 == g2 && r1 == r2 && b1 == b2,
+            (
+                BlockListMatch::RichContent {
+                    match_id: id1,
+                    view_id: v1,
+                    index: i1,
+                },
+                BlockListMatch::RichContent {
+                    match_id: id2,
+                    view_id: v2,
+                    index: i2,
+                },
+            ) => id1 == id2 && v1 == v2 && i1 == i2,
+            _ => false,
+        }
+    }
 }
 
 /// Represents the result of a find "run" on the blocklist.
@@ -471,11 +505,17 @@ impl BlockListFindRun {
             return self;
         };
 
+        // Remember the currently focused match so we can relocate it after splicing.
+        let old_focused_match = self
+            .raw_focused_match_index
+            .and_then(|i| self.matches.get(i).cloned());
+
         let old_block_matches_start_index = self
             .matches
             .iter()
             .position(|find_match| find_match.matches_block(block_index));
-        let mut new_matches = run_find_on_block(dfas, block, block_index, block_sort_direction);
+        let new_matches = run_find_on_block(dfas, block, block_index, block_sort_direction);
+        let new_block_match_count = new_matches.len();
         if let Some(start_index) = old_block_matches_start_index {
             let end_index = old_block_matches_start_index
                 .and_then(|i| {
@@ -486,21 +526,60 @@ impl BlockListFindRun {
                 })
                 .unwrap_or(self.matches.len());
 
+            let old_block_match_count = end_index - start_index;
+
             // Splice in the new matches where the old block matches used to exist.
             self.matches.splice(start_index..end_index, new_matches);
+
+            // Adjust the focused match index so it still points to the same match.
+            if let Some(focused_index) = self.raw_focused_match_index {
+                if focused_index >= start_index && focused_index < end_index {
+                    // The focused match was inside the rerun block. Try to find the same
+                    // match (by span identity) in the new results.
+                    self.raw_focused_match_index = old_focused_match
+                        .as_ref()
+                        .and_then(|old_match| {
+                            self.matches[start_index..(start_index + new_block_match_count)]
+                                .iter()
+                                .position(|m| m.same_span(old_match))
+                                .map(|p| start_index + p)
+                        })
+                        .or_else(|| {
+                            // The old match no longer exists; clamp to a valid index.
+                            if self.matches.is_empty() {
+                                None
+                            } else {
+                                Some(focused_index.min(self.matches.len() - 1))
+                            }
+                        });
+                } else if focused_index >= end_index {
+                    // The focused match was after the rerun block. Shift by the change in
+                    // match count so it continues to point at the same match.
+                    let new_index = focused_index + new_block_match_count - old_block_match_count;
+                    self.raw_focused_match_index =
+                        Some(new_index.min(self.matches.len().saturating_sub(1)));
+                }
+                // If focused_index < start_index the match is before the rerun block and
+                // needs no adjustment.
+            }
         } else {
+            let mut new_matches = new_matches;
             new_matches.append(&mut self.matches);
             self.matches = new_matches;
+
+            // All previous indices shifted forward by the number of newly prepended matches.
+            if let Some(focused_index) = self.raw_focused_match_index {
+                self.raw_focused_match_index = Some(focused_index + new_block_match_count);
+            }
         }
 
         if self.matches.is_empty() {
             self.raw_focused_match_index = None;
-        } else if let Some(mut focused_match_index) = self.raw_focused_match_index {
-            // Ensure the focused match index is still valid.
-            while focused_match_index >= self.matches.len() {
-                focused_match_index = focused_match_index.saturating_sub(1);
+        } else if let Some(focused_match_index) = self.raw_focused_match_index {
+            // Final bounds check.
+            if focused_match_index >= self.matches.len() {
+                self.raw_focused_match_index = Some(self.matches.len() - 1);
             }
-            self.raw_focused_match_index = Some(focused_match_index);
         }
 
         self

--- a/app/src/terminal/find/model/block_list_test.rs
+++ b/app/src/terminal/find/model/block_list_test.rs
@@ -9,11 +9,15 @@ use crate::terminal::{
         model::{block_list::run_find_on_block_list, FindOptions},
         BlockGridMatch,
     },
-    model::{index::Point, terminal_model::BlockSortDirection},
+    model::{
+        index::Point,
+        terminal_model::{BlockIndex, BlockSortDirection},
+    },
     GridType, TerminalModel,
 };
 
 use super::{BlockListFindRun, BlockListMatch};
+use crate::view_components::find::FindDirection;
 
 impl BlockListFindRun {
     fn all_matches(&self) -> &[BlockListMatch] {
@@ -350,6 +354,145 @@ fn test_run_find_on_block_list_with_filtered_block() {
                     is_filtered: false,
                 }),
             ]
+        );
+    });
+}
+
+/// Regression test for https://github.com/warpdotdev/warp/issues/9542
+///
+/// When the active block's output is still streaming and the find results are refreshed,
+/// the focused match must remain on the same text span even though new matches are
+/// inserted before it in the match vector.
+#[test]
+fn test_rerun_on_block_preserves_focused_match_in_active_block() {
+    App::test((), |mut app| async move {
+        let mut mock_terminal_model = TerminalModel::mock(None, None);
+        // Block 1: a finished block.
+        mock_terminal_model.simulate_block("echo bar", "bar\r\n");
+        // Block 2: a long-running block whose command also matches so there are both
+        // output and prompt matches.  This lets us navigate to the prompt match and then
+        // verify it stays focused after new output matches are spliced in before it.
+        mock_terminal_model.simulate_long_running_block("barserver", "request bar\r\n");
+
+        let last_block_index: BlockIndex = 2.into();
+
+        let mut run = app.update(|ctx| {
+            run_find_on_block_list(
+                FindOptions {
+                    query: Some("bar".to_owned().into()),
+                    is_regex_enabled: false,
+                    is_case_sensitive: false,
+                    ..Default::default()
+                },
+                mock_terminal_model.block_list(),
+                &HashMap::new(),
+                BlockSortDirection::MostRecentLast,
+                ctx,
+            )
+        });
+
+        // In MostRecentLast the match order for block 2 is:
+        //   [0] Output  row 0, col 8..=10   ("bar" in "request bar")
+        //   [1] Prompt  row 0, col 0..=2    ("bar" in "barserver")
+        // Navigate "Up" once to move from the output match to the prompt match.
+        run.focus_next_match(FindDirection::Up, BlockSortDirection::MostRecentLast);
+        let focused_before = run.focused_match().cloned();
+        assert_eq!(
+            focused_before,
+            Some(BlockListMatch::CommandBlock(BlockGridMatch {
+                grid_type: GridType::PromptAndCommand,
+                range: Point { row: 0, col: 0 }..=Point { row: 0, col: 2 },
+                block_index: last_block_index,
+                is_filtered: false,
+            }))
+        );
+
+        // Simulate more streaming output that introduces new output matches before the
+        // prompt match in the match vector.
+        mock_terminal_model.process_bytes("request bar\r\nrequest bar\r\n");
+
+        let block = mock_terminal_model
+            .block_list()
+            .block_at(last_block_index)
+            .unwrap();
+        let run = run.rerun_on_block(block, last_block_index, BlockSortDirection::MostRecentLast);
+
+        // The focused match must still be the same prompt span, even though new output
+        // matches were inserted before it in the active block's match slice.
+        assert_eq!(run.focused_match().cloned(), focused_before);
+    });
+}
+
+/// Regression test for https://github.com/warpdotdev/warp/issues/9542
+///
+/// When the user is focused on a match in an older (finished) block and the active block
+/// receives new streaming output, the focus must not drift to a different match.
+#[test]
+fn test_rerun_on_block_preserves_focused_match_in_older_block() {
+    App::test((), |mut app| async move {
+        let mut mock_terminal_model = TerminalModel::mock(None, None);
+        mock_terminal_model.simulate_block("echo bar", "bar\r\n");
+        mock_terminal_model.simulate_long_running_block("server", "request bar\r\n");
+
+        let last_block_index: BlockIndex = 2.into();
+        let older_block_index: BlockIndex = 1.into();
+
+        let mut run = app.update(|ctx| {
+            run_find_on_block_list(
+                FindOptions {
+                    query: Some("bar".to_owned().into()),
+                    is_regex_enabled: false,
+                    is_case_sensitive: false,
+                    ..Default::default()
+                },
+                mock_terminal_model.block_list(),
+                &HashMap::new(),
+                BlockSortDirection::MostRecentLast,
+                ctx,
+            )
+        });
+
+        // Navigate past the active block's matches to reach block 1's output match.
+        // Matches order (MostRecentLast): block 2 output, block 2 prompt ("server" has no
+        // match), block 1 output, block 1 prompt.
+        // Initial focus is at index 0 (block 2 output row 0).
+        // "Up" in MostRecentLast moves toward older blocks (higher index).
+        let match_count = run.all_matches().len();
+        for _ in 0..match_count {
+            if run
+                .focused_match()
+                .is_some_and(|m| m.matches_block(older_block_index))
+            {
+                break;
+            }
+            run.focus_next_match(FindDirection::Up, BlockSortDirection::MostRecentLast);
+        }
+
+        let focused_before = run.focused_match().cloned();
+        assert!(
+            focused_before
+                .as_ref()
+                .is_some_and(|m| m.matches_block(older_block_index)),
+            "expected focus on block 1, got {focused_before:?}"
+        );
+        let ui_index_before = run.focused_match_index();
+
+        // Simulate new streaming output in the active block.
+        mock_terminal_model.process_bytes("request bar\r\nrequest bar\r\n");
+
+        let block = mock_terminal_model
+            .block_list()
+            .block_at(last_block_index)
+            .unwrap();
+        let run = run.rerun_on_block(block, last_block_index, BlockSortDirection::MostRecentLast);
+
+        // The focused match must still be the same span in block 1.
+        assert_eq!(run.focused_match().cloned(), focused_before);
+        // The UI index should have shifted to account for the newly inserted matches.
+        assert_ne!(
+            run.focused_match_index(),
+            ui_index_before,
+            "UI index should change when new matches are inserted before the focused match"
         );
     });
 }


### PR DESCRIPTION
## Description

When using cmd+f to search a block whose output is still streaming, the currently selected match jumps to a different piece of text as new matches are appended. This happens because `BlockListFindRun::rerun_on_block()` preserves the raw focused-match index when splicing updated matches for the active block — as new matches stream in, the same numeric index points to a different span.

**Fix:** Before splicing, snapshot the currently focused `BlockListMatch`. After splicing, relocate it in the updated vector by comparing span identity (`block_index`, `grid_type`, `range`) via a new `same_span()` helper. If the focused match was outside the rerun block's slice, shift the index by the delta in match count. Also handles the "no old matches" (new block) case by shifting the index forward.

## Linked Issue

Closes #9542

- [x] The linked issue is labeled `ready-to-implement` (triaged bug — implicitly ready-to-implement per CONTRIBUTING.md).
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Added two regression tests in `block_list_test.rs`:
- `test_rerun_on_block_preserves_focused_match_in_active_block` — focuses the prompt match inside a streaming block, appends new output with additional matches, verifies focus stays on the same span.
- `test_rerun_on_block_preserves_focused_match_in_older_block` — focuses a match in an older finished block, appends output to the active block, verifies the focused match and its UI index shift correctly.

All 10 terminal find tests pass. `cargo fmt` and `cargo clippy -p warp --tests` pass clean.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation link](https://app.warp.dev/conversation/1129ea71-41d4-4f5c-a0c7-771b3bc714e4)

CHANGELOG-BUG-FIX: Fixed find (cmd+f) selection jumping to a different match when new output streams into the active block.
-->

Co-Authored-By: Oz <oz-agent@warp.dev>