### PR TITLE
fix: update rand to 0.9.4 to resolve GHSA-cq8v-f236-94qc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.1",
+ "rand 0.9.4",
  "sha1",
  "smallvec 1.15.1",
  "tokio",
@@ -1113,7 +1113,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.1",
+ "rand 0.9.4",
  "serde",
  "serde_repr",
  "url",
@@ -2476,7 +2476,7 @@ dependencies = [
  "memmap2 0.9.7",
  "num-traits",
  "num_cpus",
- "rand 0.9.1",
+ "rand 0.9.4",
  "rand_distr",
  "rayon",
  "safetensors",
@@ -4725,7 +4725,7 @@ checksum = "8f463a8a37ede13dac13316d1a1eeafa992300906a0c4c7fa1177f366d10bcbf"
 dependencies = [
  "half",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.4",
  "rand_distr",
 ]
 
@@ -5784,7 +5784,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.4",
  "rand_distr",
 ]
 
@@ -7983,7 +7983,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.1",
+ "rand 0.9.4",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -10121,7 +10121,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.1",
  "rustls 0.23.39",
@@ -10205,9 +10205,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -10259,7 +10259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -10310,7 +10310,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.1",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.17",
@@ -11488,7 +11488,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e9bd2cadaeda3af41e9fa5d14645127d6f6a4aec73da3ae38e477ecafd3682"
 dependencies = [
- "rand 0.9.1",
+ "rand 0.9.4",
  "sentry-types",
  "serde",
  "serde_json",
@@ -11545,7 +11545,7 @@ checksum = "a08e7154abe2cd557f26fd70038452810748aefdf39bc973f674421224b147c1"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.9.1",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -13134,7 +13134,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.1",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",
@@ -14751,7 +14751,7 @@ dependencies = [
  "getrandom 0.3.4",
  "hpke",
  "log",
- "rand 0.9.1",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "tempfile",


### PR DESCRIPTION
## Summary

Updates the transitive dependency `rand` from 0.9.1 to 0.9.4 to resolve [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) (RUSTSEC-2026-0097).

## Vulnerability Details

- **Advisory:** [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) — Rand is unsound with a custom logger using `rand::rng()`
- **Dependabot alert:** https://github.com/warpdotdev/warp/security/dependabot/4
- **Severity:** Low (CVSS 0.0)
- **Vulnerable range:** >= 0.9.0, < 0.9.3
- **Patched version:** 0.9.3 (updated to 0.9.4)

## What Changed

- `Cargo.lock`: `rand` 0.9.1 → 0.9.4 (transitive dependency, pulled in by `actix-http`, `quinn-proto`, `sentry-core`, `tokenizers`, `candle-core`, and others)
- The workspace's direct `rand` dependency remains at 0.8.6 (unaffected by this advisory)

## Dependabot Error

Dependabot reported `security_update_not_possible` claiming the max installable version was 0.9.1. However, `cargo update -p rand@0.9.1` successfully resolved to 0.9.4 without any conflicts.

## Verification

- `cargo audit` confirms GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097 no longer appears

---

_Conversation: https://staging.warp.dev/conversation/1e0f1592-cbd6-4750-8423-7f910f6e48ae_
_Run: https://oz.staging.warp.dev/runs/019df3b7-d9a0-7c25-9c32-022e308172b4_

_This PR was generated with [Oz](https://warp.dev/oz)._
