### PR TITLE
fix: narrow feedback skill trigger and add SKIP conditions

### DIFF
--- a/resources/bundled/skills/feedback/SKILL.md
+++ b/resources/bundled/skills/feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feedback
-description: Turn rough feedback about the Warp app into a filed GitHub issue or duplicate-issue response for `warpdotdev/warp`. Use ONLY when the user explicitly wants to report a problem with the Warp terminal/IDE/app itself—not when they're working on their own code, managing their own GitHub repos, or doing general software development tasks. SKIP when: the user is creating/managing GitHub issues or PRs for their own projects, reviewing PRs, diagnosing CI failures, using `gh` CLI for repo management, or performing any GitHub workflow not specifically about reporting a problem with the Warp application itself.
+description: "Turn rough feedback about the Warp app into a filed GitHub issue or duplicate-issue response for `warpdotdev/warp`. Use ONLY when the user explicitly wants to report a problem with the Warp terminal/IDE/app itself—not when they're working on their own code, managing their own GitHub repos, or doing general software development tasks. SKIP when: the user is creating/managing GitHub issues or PRs for their own projects, reviewing PRs, diagnosing CI failures, using `gh` CLI for repo management, or performing any GitHub workflow not specifically about reporting a problem with the Warp application itself."
 ---
 
 # Feedback

--- a/resources/bundled/skills/feedback/SKILL.md
+++ b/resources/bundled/skills/feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feedback
-description: Turn rough feedback about the Warp app into a filed GitHub issue or duplicate-issue response for `warpdotdev/warp`. Use when the user shares a Warp bug report, regression, confusing UX note, feature gap, or short complaint and wants it clarified into reproduction steps, expected vs actual behavior, concrete impact, and grounded source references from local Warp repos when available.
+description: Turn rough feedback about the Warp app into a filed GitHub issue or duplicate-issue response for `warpdotdev/warp`. Use ONLY when the user explicitly wants to report a problem with the Warp terminal/IDE/app itself—not when they're working on their own code, managing their own GitHub repos, or doing general software development tasks. SKIP when: the user is creating/managing GitHub issues or PRs for their own projects, reviewing PRs, diagnosing CI failures, using `gh` CLI for repo management, or performing any GitHub workflow not specifically about reporting a problem with the Warp application itself.
 ---
 
 # Feedback


### PR DESCRIPTION
## Description

Update the feedback skill's frontmatter description to reduce false-positive triggering by:

1. **Narrowing the positive trigger language** — Changed from the broad "Use when the user shares a Warp bug report, regression, confusing UX note, feature gap, or short complaint..." to "Use ONLY when the user explicitly wants to report a problem with the Warp terminal/IDE/app itself—not when they're working on their own code, managing their own GitHub repos, or doing general software development tasks."

2. **Adding explicit SKIP conditions** — Following the TRIGGER/SKIP pattern already used by the `claude-api` bundled skill, added: "SKIP when: the user is creating/managing GitHub issues or PRs for their own projects, reviewing PRs, diagnosing CI failures, using `gh` CLI for repo management, or performing any GitHub workflow not specifically about reporting a problem with the Warp application itself."

These changes target the skill description (the primary triggering mechanism) to prevent the feedback skill from activating during general GitHub/development workflows that happen to mention issues, PRs, or bugs.

## Linked Issue

N/A — this is a direct improvement to skill triggering accuracy.

## Testing

- Verified the SKILL.md file parses correctly with the updated frontmatter.
- No code changes; only the skill description field was modified.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/81c50255-b149-457e-8de8-197b7c5f93a3_
_Run: https://oz.staging.warp.dev/runs/019df3f6-a530-76a4-9229-0c248a627ee1_

_This PR was generated with [Oz](https://warp.dev/oz)._
