### PR TITLE
fix: improve network log readability and copying

### DIFF
--- a/app/src/server/network_log_view.rs
+++ b/app/src/server/network_log_view.rs
@@ -12,7 +12,8 @@ use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::render::element::VerticalExpansionBehavior;
 use warp_util::path::LineAndColumnArg;
 use warpui::{
-    elements::{ChildView, MouseStateHandle},
+    clipboard::ClipboardContent,
+    elements::{ChildView, Flex, Length, MouseStateHandle},
     text_layout::ClipConfig,
     ui_components::components::UiComponent,
     AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
@@ -54,6 +55,7 @@ pub enum NetworkLogViewAction {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NetworkLogViewCustomAction {
     Refresh,
+    CopyAll,
 }
 
 /// A pane view backed by a read-only [`CodeEditorView`] displaying a snapshot
@@ -63,6 +65,8 @@ pub struct NetworkLogView {
     pane_configuration: ModelHandle<PaneConfiguration>,
     focus_handle: Option<PaneFocusHandle>,
     refresh_button_mouse_state: MouseStateHandle,
+    copy_button_mouse_state: MouseStateHandle,
+    latest_plain_text: String,
 }
 
 impl NetworkLogView {
@@ -74,7 +78,7 @@ impl NetworkLogView {
         // subscribe to the model: new items that arrive after the pane is
         // opened are not reflected until the pane is explicitly reopened
         // (see `reload_snapshot`).
-        let snapshot = NetworkLogModel::as_ref(ctx).snapshot_text();
+        let snapshot = NetworkLogModel::as_ref(ctx).snapshot();
 
         let editor = ctx.add_typed_action_view(|ctx| {
             let mut view = CodeEditorView::new(
@@ -83,7 +87,7 @@ impl NetworkLogView {
                 CodeEditorRenderOptions::new(VerticalExpansionBehavior::FillMaxHeight),
                 ctx,
             );
-            Self::apply_snapshot_to_editor(&mut view, &snapshot, ctx);
+            Self::apply_snapshot_to_editor(&mut view, &snapshot.display_text, ctx);
             // Read-only pane: disallow editing but keep selection/copy/find
             // available.
             view.set_interaction_state(InteractionState::Selectable, ctx);
@@ -95,6 +99,8 @@ impl NetworkLogView {
             pane_configuration,
             focus_handle: None,
             refresh_button_mouse_state: MouseStateHandle::default(),
+            copy_button_mouse_state: MouseStateHandle::default(),
+            latest_plain_text: snapshot.plain_text,
         }
     }
 
@@ -111,10 +117,11 @@ impl NetworkLogView {
     /// open-network-log-pane action while the pane is already open, or when
     /// the user clicks the refresh icon in the pane header, so they can see
     /// items captured since the pane was opened.
-    pub fn reload_snapshot(&self, ctx: &mut ViewContext<Self>) {
-        let snapshot = NetworkLogModel::as_ref(ctx).snapshot_text();
+    pub fn reload_snapshot(&mut self, ctx: &mut ViewContext<Self>) {
+        let snapshot = NetworkLogModel::as_ref(ctx).snapshot();
+        self.latest_plain_text = snapshot.plain_text;
         self.editor.update(ctx, |view, ctx| {
-            Self::apply_snapshot_to_editor(view, &snapshot, ctx);
+            Self::apply_snapshot_to_editor(view, &snapshot.display_text, ctx);
         });
     }
 
@@ -137,6 +144,10 @@ impl NetworkLogView {
             }),
             version,
         ));
+    }
+
+    fn snapshot_is_empty(&self) -> bool {
+        self.latest_plain_text.is_empty()
     }
 
     /// Renders the refresh icon button for the pane header. Clicking the
@@ -167,6 +178,31 @@ impl NetworkLogView {
                 NetworkLogViewCustomAction,
             >>(PaneHeaderAction::CustomAction(
                 NetworkLogViewCustomAction::Refresh,
+            ));
+        })
+        .finish()
+    }
+
+    fn render_copy_button(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let ui_builder = appearance.ui_builder().clone();
+
+        icon_button_with_color(
+            appearance,
+            icons::Icon::Copy,
+            false,
+            self.copy_button_mouse_state.clone(),
+            blended_colors::text_sub(theme, theme.background()).into(),
+        )
+        .with_tooltip(move || ui_builder.tool_tip("Copy all".to_string()).build().finish())
+        .build()
+        .on_click(|ctx, _, _| {
+            ctx.dispatch_typed_action::<PaneHeaderAction<
+                NetworkLogViewAction,
+                NetworkLogViewCustomAction,
+            >>(PaneHeaderAction::CustomAction(
+                NetworkLogViewCustomAction::CopyAll,
             ));
         })
         .finish()
@@ -215,6 +251,10 @@ impl BackingView for NetworkLogView {
     ) {
         match custom_action {
             NetworkLogViewCustomAction::Refresh => self.reload_snapshot(ctx),
+            NetworkLogViewCustomAction::CopyAll => {
+                ctx.clipboard()
+                    .write(ClipboardContent::plain_text(self.latest_plain_text.clone()));
+            }
         }
     }
 
@@ -239,7 +279,13 @@ impl BackingView for NetworkLogView {
             title_max_width: None,
             left_of_title: None,
             right_of_title: None,
-            left_of_overflow: Some(self.render_refresh_button(app)),
+            left_of_overflow: Some(if self.snapshot_is_empty() {
+                self.render_refresh_button(app)
+            } else {
+                Flex::new(vec![self.render_copy_button(app), self.render_refresh_button(app)])
+                    .gap(Length::new(4.0))
+                    .finish()
+            }),
             // Keep the close button always visible so hovering the header
             // doesn't cause the refresh button to shift horizontally as the
             // close button appears.

--- a/app/src/server/network_log_view.rs
+++ b/app/src/server/network_log_view.rs
@@ -120,6 +120,7 @@ impl NetworkLogView {
         self.editor.update(ctx, |view, ctx| {
             Self::apply_snapshot_to_editor(view, &snapshot.display_text, ctx);
         });
+        ctx.notify();
     }
 
     /// Resets the editor buffer with the given snapshot text and queues a
@@ -279,8 +280,10 @@ impl BackingView for NetworkLogView {
             left_of_overflow: Some(if self.snapshot_is_empty() {
                 self.render_refresh_button(app)
             } else {
-                Flex::new(vec![self.render_copy_button(app), self.render_refresh_button(app)])
-                    .gap(Length::new(4.0))
+                Flex::row()
+                    .with_spacing(4.0)
+                    .with_child(self.render_copy_button(app))
+                    .with_child(self.render_refresh_button(app))
                     .finish()
             }),
             // Keep the close button always visible so hovering the header

--- a/app/src/server/network_log_view.rs
+++ b/app/src/server/network_log_view.rs
@@ -11,7 +11,8 @@
 use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::render::element::VerticalExpansionBehavior;
 use warp_util::path::LineAndColumnArg;
-use warpui::elements::{ChildView, MouseStateHandle};
+use warpui::clipboard::ClipboardContent;
+use warpui::elements::{ChildView, Flex, MouseStateHandle};
 use warpui::text_layout::ClipConfig;
 use warpui::ui_components::components::UiComponent;
 use warpui::{
@@ -51,6 +52,7 @@ pub enum NetworkLogViewAction {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NetworkLogViewCustomAction {
     Refresh,
+    CopyAll,
 }
 
 /// A pane view backed by a read-only [`CodeEditorView`] displaying a snapshot
@@ -60,6 +62,8 @@ pub struct NetworkLogView {
     pane_configuration: ModelHandle<PaneConfiguration>,
     focus_handle: Option<PaneFocusHandle>,
     refresh_button_mouse_state: MouseStateHandle,
+    copy_button_mouse_state: MouseStateHandle,
+    latest_plain_text: String,
 }
 
 impl NetworkLogView {
@@ -71,7 +75,7 @@ impl NetworkLogView {
         // subscribe to the model: new items that arrive after the pane is
         // opened are not reflected until the pane is explicitly reopened
         // (see `reload_snapshot`).
-        let snapshot = NetworkLogModel::as_ref(ctx).snapshot_text();
+        let snapshot = NetworkLogModel::as_ref(ctx).snapshot();
 
         let editor = ctx.add_typed_action_view(|ctx| {
             let mut view = CodeEditorView::new(
@@ -80,7 +84,7 @@ impl NetworkLogView {
                 CodeEditorRenderOptions::new(VerticalExpansionBehavior::FillMaxHeight),
                 ctx,
             );
-            Self::apply_snapshot_to_editor(&mut view, &snapshot, ctx);
+            Self::apply_snapshot_to_editor(&mut view, &snapshot.display_text, ctx);
             // Read-only pane: disallow editing but keep selection/copy/find
             // available.
             view.set_interaction_state(InteractionState::Selectable, ctx);
@@ -92,6 +96,8 @@ impl NetworkLogView {
             pane_configuration,
             focus_handle: None,
             refresh_button_mouse_state: MouseStateHandle::default(),
+            copy_button_mouse_state: MouseStateHandle::default(),
+            latest_plain_text: snapshot.plain_text,
         }
     }
 
@@ -108,10 +114,11 @@ impl NetworkLogView {
     /// open-network-log-pane action while the pane is already open, or when
     /// the user clicks the refresh icon in the pane header, so they can see
     /// items captured since the pane was opened.
-    pub fn reload_snapshot(&self, ctx: &mut ViewContext<Self>) {
-        let snapshot = NetworkLogModel::as_ref(ctx).snapshot_text();
+    pub fn reload_snapshot(&mut self, ctx: &mut ViewContext<Self>) {
+        let snapshot = NetworkLogModel::as_ref(ctx).snapshot();
+        self.latest_plain_text = snapshot.plain_text;
         self.editor.update(ctx, |view, ctx| {
-            Self::apply_snapshot_to_editor(view, &snapshot, ctx);
+            Self::apply_snapshot_to_editor(view, &snapshot.display_text, ctx);
         });
     }
 
@@ -134,6 +141,10 @@ impl NetworkLogView {
             }),
             version,
         ));
+    }
+
+    fn snapshot_is_empty(&self) -> bool {
+        self.latest_plain_text.is_empty()
     }
 
     /// Renders the refresh icon button for the pane header. Clicking the
@@ -164,6 +175,31 @@ impl NetworkLogView {
                 NetworkLogViewCustomAction,
             >>(PaneHeaderAction::CustomAction(
                 NetworkLogViewCustomAction::Refresh,
+            ));
+        })
+        .finish()
+    }
+
+    fn render_copy_button(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let ui_builder = appearance.ui_builder().clone();
+
+        icon_button_with_color(
+            appearance,
+            icons::Icon::Copy,
+            false,
+            self.copy_button_mouse_state.clone(),
+            blended_colors::text_sub(theme, theme.background()).into(),
+        )
+        .with_tooltip(move || ui_builder.tool_tip("Copy all".to_string()).build().finish())
+        .build()
+        .on_click(|ctx, _, _| {
+            ctx.dispatch_typed_action::<PaneHeaderAction<
+                NetworkLogViewAction,
+                NetworkLogViewCustomAction,
+            >>(PaneHeaderAction::CustomAction(
+                NetworkLogViewCustomAction::CopyAll,
             ));
         })
         .finish()
@@ -212,6 +248,10 @@ impl BackingView for NetworkLogView {
     ) {
         match custom_action {
             NetworkLogViewCustomAction::Refresh => self.reload_snapshot(ctx),
+            NetworkLogViewCustomAction::CopyAll => {
+                ctx.clipboard()
+                    .write(ClipboardContent::plain_text(self.latest_plain_text.clone()));
+            }
         }
     }
 
@@ -236,7 +276,13 @@ impl BackingView for NetworkLogView {
             title_max_width: None,
             left_of_title: None,
             right_of_title: None,
-            left_of_overflow: Some(self.render_refresh_button(app)),
+            left_of_overflow: Some(if self.snapshot_is_empty() {
+                self.render_refresh_button(app)
+            } else {
+                Flex::new(vec![self.render_copy_button(app), self.render_refresh_button(app)])
+                    .gap(Length::new(4.0))
+                    .finish()
+            }),
             // Keep the close button always visible so hovering the header
             // doesn't cause the refresh button to shift horizontally as the
             // close button appears.

--- a/app/src/server/network_log_view.rs
+++ b/app/src/server/network_log_view.rs
@@ -13,7 +13,7 @@ use warp_editor::render::element::VerticalExpansionBehavior;
 use warp_util::path::LineAndColumnArg;
 use warpui::{
     clipboard::ClipboardContent,
-    elements::{ChildView, Flex, Length, MouseStateHandle},
+    elements::{ChildView, Flex, MouseStateHandle},
     text_layout::ClipConfig,
     ui_components::components::UiComponent,
     AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
@@ -123,6 +123,7 @@ impl NetworkLogView {
         self.editor.update(ctx, |view, ctx| {
             Self::apply_snapshot_to_editor(view, &snapshot.display_text, ctx);
         });
+        ctx.notify();
     }
 
     /// Resets the editor buffer with the given snapshot text and queues a
@@ -282,8 +283,10 @@ impl BackingView for NetworkLogView {
             left_of_overflow: Some(if self.snapshot_is_empty() {
                 self.render_refresh_button(app)
             } else {
-                Flex::new(vec![self.render_copy_button(app), self.render_refresh_button(app)])
-                    .gap(Length::new(4.0))
+                Flex::row()
+                    .with_spacing(4.0)
+                    .with_child(self.render_copy_button(app))
+                    .with_child(self.render_refresh_button(app))
                     .finish()
             }),
             // Keep the close button always visible so hovering the header

--- a/app/src/server/network_logging.rs
+++ b/app/src/server/network_logging.rs
@@ -26,6 +26,13 @@ pub struct NetworkLogModel {
     items: BoundedVecDeque<NetworkLogItem>,
 }
 
+/// Human-friendly snapshot plus a plain-text export for copying/sharing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkLogSnapshot {
+    pub display_text: String,
+    pub plain_text: String,
+}
+
 impl Default for NetworkLogModel {
     fn default() -> Self {
         Self {
@@ -44,18 +51,37 @@ impl NetworkLogModel {
         ctx.notify();
     }
 
-    /// Returns the current snapshot as a single string with one item per line,
-    /// in chronological order. Returns an empty string when no items have been
-    /// captured.
-    pub fn snapshot_text(&self) -> String {
-        let mut out = String::new();
+    /// Returns both a human-friendly snapshot for the pane and a plain-text
+    /// export suitable for copying into another editor.
+    pub fn snapshot(&self) -> NetworkLogSnapshot {
+        if self.items.is_empty() {
+            return NetworkLogSnapshot {
+                display_text: String::new(),
+                plain_text: String::new(),
+            };
+        }
+
+        let mut display_text = String::new();
+        let mut plain_text = String::new();
+
         for (i, item) in self.items.iter().enumerate() {
             if i > 0 {
-                out.push('\n');
+                display_text.push_str("\n\n");
+                plain_text.push_str("\n\n");
             }
-            out.push_str(&item.0);
+            display_text.push_str(&item.display_text);
+            plain_text.push_str(&item.plain_text);
         }
-        out
+
+        NetworkLogSnapshot {
+            display_text,
+            plain_text,
+        }
+    }
+
+    /// Returns the current display snapshot as a single string.
+    pub fn snapshot_text(&self) -> String {
+        self.snapshot().display_text
     }
 
     /// Number of items currently retained. Exposed for tests.
@@ -121,11 +147,12 @@ pub(super) fn init<'a>(
 }
 
 /// Represents an item (either a request or response) captured for the network
-/// activity log. The inner string contains a timestamp and the
-/// [`Debug`]-formatted representation of the request or response, matching the
-/// format previously written to `warp_network.log`.
+/// activity log.
 #[derive(Clone, Debug)]
-pub struct NetworkLogItem(String);
+pub struct NetworkLogItem {
+    display_text: String,
+    plain_text: String,
+}
 
 impl NetworkLogItem {
     pub fn request(
@@ -133,34 +160,87 @@ impl NetworkLogItem {
         serialized_payload: Option<String>,
         timestamp: DateTime<FixedOffset>,
     ) -> Self {
-        Self(format!(
-            "[{}]: {:?}{}",
-            timestamp.format("%Y-%m-%d %H:%M:%S,%3f"),
-            request,
-            serialized_payload.map_or("".to_owned(), |payload| format!("\nBody {payload}"))
-        ))
+        let timestamp = timestamp.format("%Y-%m-%d %H:%M:%S,%3f").to_string();
+        let request_debug = format!("{:?}", request);
+        let body_suffix = serialized_payload
+            .as_ref()
+            .map_or(String::new(), |payload| format!("\nBody {payload}"));
+        let plain_text = format!("[{timestamp}]: {request_debug}{body_suffix}");
+        let display_text = format_request_for_display(&timestamp, request, serialized_payload.as_deref());
+        Self {
+            display_text,
+            plain_text,
+        }
     }
 
     pub fn response(response: &reqwest::Response, timestamp: DateTime<FixedOffset>) -> Self {
-        Self(format!(
-            "[{}]: {:?}",
-            timestamp.format("%Y-%m-%d %H:%M:%S,%3f"),
-            response
-        ))
+        let timestamp = timestamp.format("%Y-%m-%d %H:%M:%S,%3f").to_string();
+        let response_debug = format!("{:?}", response);
+        let plain_text = format!("[{timestamp}]: {response_debug}");
+        let display_text = format_response_for_display(&timestamp, response);
+        Self {
+            display_text,
+            plain_text,
+        }
     }
 
     /// Constructs a log item directly from a pre-formatted string. Used in
     /// tests where we don't have a real `reqwest` request/response handy.
     #[cfg(test)]
     pub fn from_string(s: impl Into<String>) -> Self {
-        Self(s.into())
+        let s = s.into();
+        Self {
+            display_text: s.clone(),
+            plain_text: s,
+        }
     }
 }
 
 impl fmt::Display for NetworkLogItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.plain_text)
     }
+}
+
+fn format_request_for_display(
+    timestamp: &str,
+    request: &reqwest::Request,
+    serialized_payload: Option<&str>,
+) -> String {
+    let method = request.method();
+    let url = request.url();
+    let path = if url.path().is_empty() { "/" } else { url.path() };
+    let query = url.query().map_or(String::new(), |query| format!("?{query}"));
+
+    let mut lines = vec![
+        format!("[{timestamp}] Request"),
+        format!("Method: {method}"),
+        format!("Host: {}", url.host_str().unwrap_or("")),
+        format!("Path: {path}{query}"),
+        format!("URL: {url}"),
+    ];
+
+    if let Some(payload) = serialized_payload {
+        lines.push(format!("Body: {payload}"));
+    }
+
+    lines.join("\n")
+}
+
+fn format_response_for_display(timestamp: &str, response: &reqwest::Response) -> String {
+    let status = response.status();
+    let url = response.url();
+    let path = if url.path().is_empty() { "/" } else { url.path() };
+    let query = url.query().map_or(String::new(), |query| format!("?{query}"));
+
+    [
+        format!("[{timestamp}] Response"),
+        format!("Status: {status}"),
+        format!("Host: {}", url.host_str().unwrap_or("")),
+        format!("Path: {path}{query}"),
+        format!("URL: {url}"),
+    ]
+    .join("\n")
 }
 
 #[cfg(test)]

--- a/app/src/server/network_logging.rs
+++ b/app/src/server/network_logging.rs
@@ -165,7 +165,8 @@ impl NetworkLogItem {
             .as_ref()
             .map_or(String::new(), |payload| format!("\nBody {payload}"));
         let plain_text = format!("[{timestamp}]: {request_debug}{body_suffix}");
-        let display_text = format_request_for_display(&timestamp, request, serialized_payload.as_deref());
+        let display_text =
+            format_request_for_display(&timestamp, request, serialized_payload.as_deref());
         Self {
             display_text,
             plain_text,
@@ -208,8 +209,14 @@ fn format_request_for_display(
 ) -> String {
     let method = request.method();
     let url = request.url();
-    let path = if url.path().is_empty() { "/" } else { url.path() };
-    let query = url.query().map_or(String::new(), |query| format!("?{query}"));
+    let path = if url.path().is_empty() {
+        "/"
+    } else {
+        url.path()
+    };
+    let query = url
+        .query()
+        .map_or(String::new(), |query| format!("?{query}"));
 
     let mut lines = vec![
         format!("[{timestamp}] Request"),
@@ -229,8 +236,14 @@ fn format_request_for_display(
 fn format_response_for_display(timestamp: &str, response: &reqwest::Response) -> String {
     let status = response.status();
     let url = response.url();
-    let path = if url.path().is_empty() { "/" } else { url.path() };
-    let query = url.query().map_or(String::new(), |query| format!("?{query}"));
+    let path = if url.path().is_empty() {
+        "/"
+    } else {
+        url.path()
+    };
+    let query = url
+        .query()
+        .map_or(String::new(), |query| format!("?{query}"));
 
     [
         format!("[{timestamp}] Response"),

--- a/app/src/server/network_logging.rs
+++ b/app/src/server/network_logging.rs
@@ -25,6 +25,13 @@ pub struct NetworkLogModel {
     items: BoundedVecDeque<NetworkLogItem>,
 }
 
+/// Human-friendly snapshot plus a plain-text export for copying/sharing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkLogSnapshot {
+    pub display_text: String,
+    pub plain_text: String,
+}
+
 impl Default for NetworkLogModel {
     fn default() -> Self {
         Self {
@@ -43,18 +50,37 @@ impl NetworkLogModel {
         ctx.notify();
     }
 
-    /// Returns the current snapshot as a single string with one item per line,
-    /// in chronological order. Returns an empty string when no items have been
-    /// captured.
-    pub fn snapshot_text(&self) -> String {
-        let mut out = String::new();
+    /// Returns both a human-friendly snapshot for the pane and a plain-text
+    /// export suitable for copying into another editor.
+    pub fn snapshot(&self) -> NetworkLogSnapshot {
+        if self.items.is_empty() {
+            return NetworkLogSnapshot {
+                display_text: String::new(),
+                plain_text: String::new(),
+            };
+        }
+
+        let mut display_text = String::new();
+        let mut plain_text = String::new();
+
         for (i, item) in self.items.iter().enumerate() {
             if i > 0 {
-                out.push('\n');
+                display_text.push_str("\n\n");
+                plain_text.push_str("\n\n");
             }
-            out.push_str(&item.0);
+            display_text.push_str(&item.display_text);
+            plain_text.push_str(&item.plain_text);
         }
-        out
+
+        NetworkLogSnapshot {
+            display_text,
+            plain_text,
+        }
+    }
+
+    /// Returns the current display snapshot as a single string.
+    pub fn snapshot_text(&self) -> String {
+        self.snapshot().display_text
     }
 
     /// Number of items currently retained. Exposed for tests.
@@ -120,11 +146,12 @@ pub(super) fn init<'a>(
 }
 
 /// Represents an item (either a request or response) captured for the network
-/// activity log. The inner string contains a timestamp and the
-/// [`Debug`]-formatted representation of the request or response, matching the
-/// format previously written to `warp_network.log`.
+/// activity log.
 #[derive(Clone, Debug)]
-pub struct NetworkLogItem(String);
+pub struct NetworkLogItem {
+    display_text: String,
+    plain_text: String,
+}
 
 impl NetworkLogItem {
     pub fn request(
@@ -132,34 +159,87 @@ impl NetworkLogItem {
         serialized_payload: Option<String>,
         timestamp: DateTime<FixedOffset>,
     ) -> Self {
-        Self(format!(
-            "[{}]: {:?}{}",
-            timestamp.format("%Y-%m-%d %H:%M:%S,%3f"),
-            request,
-            serialized_payload.map_or("".to_owned(), |payload| format!("\nBody {payload}"))
-        ))
+        let timestamp = timestamp.format("%Y-%m-%d %H:%M:%S,%3f").to_string();
+        let request_debug = format!("{:?}", request);
+        let body_suffix = serialized_payload
+            .as_ref()
+            .map_or(String::new(), |payload| format!("\nBody {payload}"));
+        let plain_text = format!("[{timestamp}]: {request_debug}{body_suffix}");
+        let display_text = format_request_for_display(&timestamp, request, serialized_payload.as_deref());
+        Self {
+            display_text,
+            plain_text,
+        }
     }
 
     pub fn response(response: &reqwest::Response, timestamp: DateTime<FixedOffset>) -> Self {
-        Self(format!(
-            "[{}]: {:?}",
-            timestamp.format("%Y-%m-%d %H:%M:%S,%3f"),
-            response
-        ))
+        let timestamp = timestamp.format("%Y-%m-%d %H:%M:%S,%3f").to_string();
+        let response_debug = format!("{:?}", response);
+        let plain_text = format!("[{timestamp}]: {response_debug}");
+        let display_text = format_response_for_display(&timestamp, response);
+        Self {
+            display_text,
+            plain_text,
+        }
     }
 
     /// Constructs a log item directly from a pre-formatted string. Used in
     /// tests where we don't have a real `reqwest` request/response handy.
     #[cfg(test)]
     pub fn from_string(s: impl Into<String>) -> Self {
-        Self(s.into())
+        let s = s.into();
+        Self {
+            display_text: s.clone(),
+            plain_text: s,
+        }
     }
 }
 
 impl fmt::Display for NetworkLogItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.plain_text)
     }
+}
+
+fn format_request_for_display(
+    timestamp: &str,
+    request: &reqwest::Request,
+    serialized_payload: Option<&str>,
+) -> String {
+    let method = request.method();
+    let url = request.url();
+    let path = if url.path().is_empty() { "/" } else { url.path() };
+    let query = url.query().map_or(String::new(), |query| format!("?{query}"));
+
+    let mut lines = vec![
+        format!("[{timestamp}] Request"),
+        format!("Method: {method}"),
+        format!("Host: {}", url.host_str().unwrap_or("")),
+        format!("Path: {path}{query}"),
+        format!("URL: {url}"),
+    ];
+
+    if let Some(payload) = serialized_payload {
+        lines.push(format!("Body: {payload}"));
+    }
+
+    lines.join("\n")
+}
+
+fn format_response_for_display(timestamp: &str, response: &reqwest::Response) -> String {
+    let status = response.status();
+    let url = response.url();
+    let path = if url.path().is_empty() { "/" } else { url.path() };
+    let query = url.query().map_or(String::new(), |query| format!("?{query}"));
+
+    [
+        format!("[{timestamp}] Response"),
+        format!("Status: {status}"),
+        format!("Host: {}", url.host_str().unwrap_or("")),
+        format!("Path: {path}{query}"),
+        format!("URL: {url}"),
+    ]
+    .join("\n")
 }
 
 #[cfg(test)]

--- a/app/src/server/network_logging.rs
+++ b/app/src/server/network_logging.rs
@@ -226,6 +226,11 @@ fn format_request_for_display(
         format!("URL: {url}"),
     ];
 
+    for (name, value) in request.headers() {
+        let value_str = value.to_str().unwrap_or("<binary>");
+        lines.push(format!("{name}: {value_str}"));
+    }
+
     if let Some(payload) = serialized_payload {
         lines.push(format!("Body: {payload}"));
     }
@@ -245,14 +250,20 @@ fn format_response_for_display(timestamp: &str, response: &reqwest::Response) ->
         .query()
         .map_or(String::new(), |query| format!("?{query}"));
 
-    [
+    let mut lines = vec![
         format!("[{timestamp}] Response"),
         format!("Status: {status}"),
         format!("Host: {}", url.host_str().unwrap_or("")),
         format!("Path: {path}{query}"),
         format!("URL: {url}"),
-    ]
-    .join("\n")
+    ];
+
+    for (name, value) in response.headers() {
+        let value_str = value.to_str().unwrap_or("<binary>");
+        lines.push(format!("{name}: {value_str}"));
+    }
+
+    lines.join("\n")
 }
 
 #[cfg(test)]

--- a/app/src/server/network_logging.rs
+++ b/app/src/server/network_logging.rs
@@ -166,7 +166,8 @@ impl NetworkLogItem {
             .as_ref()
             .map_or(String::new(), |payload| format!("\nBody {payload}"));
         let plain_text = format!("[{timestamp}]: {request_debug}{body_suffix}");
-        let display_text = format_request_for_display(&timestamp, request, serialized_payload.as_deref());
+        let display_text =
+            format_request_for_display(&timestamp, request, serialized_payload.as_deref());
         Self {
             display_text,
             plain_text,
@@ -209,8 +210,14 @@ fn format_request_for_display(
 ) -> String {
     let method = request.method();
     let url = request.url();
-    let path = if url.path().is_empty() { "/" } else { url.path() };
-    let query = url.query().map_or(String::new(), |query| format!("?{query}"));
+    let path = if url.path().is_empty() {
+        "/"
+    } else {
+        url.path()
+    };
+    let query = url
+        .query()
+        .map_or(String::new(), |query| format!("?{query}"));
 
     let mut lines = vec![
         format!("[{timestamp}] Request"),
@@ -230,8 +237,14 @@ fn format_request_for_display(
 fn format_response_for_display(timestamp: &str, response: &reqwest::Response) -> String {
     let status = response.status();
     let url = response.url();
-    let path = if url.path().is_empty() { "/" } else { url.path() };
-    let query = url.query().map_or(String::new(), |query| format!("?{query}"));
+    let path = if url.path().is_empty() {
+        "/"
+    } else {
+        url.path()
+    };
+    let query = url
+        .query()
+        .map_or(String::new(), |query| format!("?{query}"));
 
     [
         format!("[{timestamp}] Response"),

--- a/app/src/server/network_logging_tests.rs
+++ b/app/src/server/network_logging_tests.rs
@@ -13,7 +13,7 @@ fn empty_snapshot_is_empty_string() {
 }
 
 #[test]
-fn snapshot_joins_items_with_newlines() {
+fn snapshot_joins_items_with_blank_lines() {
     App::test((), |mut app| async move {
         let model = app.add_singleton_model(|_| NetworkLogModel::default());
         model.update(&mut app, |model, ctx| {
@@ -22,7 +22,10 @@ fn snapshot_joins_items_with_newlines() {
             model.push(NetworkLogItem::from_string("third"), ctx);
         });
         model.read(&app, |model, _| {
-            assert_eq!(model.snapshot_text(), "first\nsecond\nthird");
+            let snapshot = model.snapshot();
+            assert_eq!(snapshot.display_text, "first\n\nsecond\n\nthird");
+            assert_eq!(snapshot.plain_text, "first\n\nsecond\n\nthird");
+            assert_eq!(model.snapshot_text(), "first\n\nsecond\n\nthird");
             assert_eq!(model.len(), 3);
         });
     });
@@ -32,8 +35,6 @@ fn snapshot_joins_items_with_newlines() {
 fn push_beyond_capacity_drops_oldest() {
     App::test((), |mut app| async move {
         let model = app.add_singleton_model(|_| NetworkLogModel::default());
-        // Push exactly the capacity; the snapshot should contain all items
-        // and the count should equal the capacity.
         model.update(&mut app, |model, ctx| {
             for i in 0..NETWORK_LOGGING_MAX_ITEMS {
                 model.push(NetworkLogItem::from_string(format!("item-{i}")), ctx);
@@ -41,23 +42,19 @@ fn push_beyond_capacity_drops_oldest() {
         });
         model.read(&app, |model, _| {
             assert_eq!(model.len(), NETWORK_LOGGING_MAX_ITEMS);
-            // Oldest is still present when we're exactly at capacity.
-            assert!(model.snapshot_text().starts_with("item-0\n"));
+            assert!(model.snapshot_text().starts_with("item-0\n\n"));
         });
 
-        // Push one more: the oldest item should be evicted so the store stays
-        // at capacity, and the snapshot should start at item-1 now.
         model.update(&mut app, |model, ctx| {
             model.push(NetworkLogItem::from_string("overflow"), ctx);
         });
         model.read(&app, |model, _| {
             assert_eq!(model.len(), NETWORK_LOGGING_MAX_ITEMS);
-            assert!(!model.snapshot_text().contains("item-0\n"));
-            assert!(model.snapshot_text().starts_with("item-1\n"));
-            assert!(model.snapshot_text().ends_with("\noverflow"));
+            assert!(!model.snapshot_text().contains("item-0\n\n"));
+            assert!(model.snapshot_text().starts_with("item-1\n\n"));
+            assert!(model.snapshot_text().ends_with("\n\noverflow"));
         });
 
-        // Pushing many additional items keeps the store at capacity.
         model.update(&mut app, |model, ctx| {
             for i in 0..10 {
                 model.push(NetworkLogItem::from_string(format!("extra-{i}")), ctx);
@@ -65,6 +62,21 @@ fn push_beyond_capacity_drops_oldest() {
         });
         model.read(&app, |model, _| {
             assert_eq!(model.len(), NETWORK_LOGGING_MAX_ITEMS);
+        });
+    });
+}
+
+#[test]
+fn snapshot_preserves_plain_text_for_copying() {
+    App::test((), |mut app| async move {
+        let model = app.add_singleton_model(|_| NetworkLogModel::default());
+        model.update(&mut app, |model, ctx| {
+            model.push(NetworkLogItem::from_string("line one\nline two"), ctx);
+        });
+        model.read(&app, |model, _| {
+            let snapshot = model.snapshot();
+            assert_eq!(snapshot.display_text, "line one\nline two");
+            assert_eq!(snapshot.plain_text, "line one\nline two");
         });
     });
 }

--- a/app/src/server/network_logging_tests.rs
+++ b/app/src/server/network_logging_tests.rs
@@ -14,7 +14,7 @@ fn empty_snapshot_is_empty_string() {
 }
 
 #[test]
-fn snapshot_joins_items_with_newlines() {
+fn snapshot_joins_items_with_blank_lines() {
     App::test((), |mut app| async move {
         let model = app.add_singleton_model(|_| NetworkLogModel::default());
         model.update(&mut app, |model, ctx| {
@@ -23,7 +23,10 @@ fn snapshot_joins_items_with_newlines() {
             model.push(NetworkLogItem::from_string("third"), ctx);
         });
         model.read(&app, |model, _| {
-            assert_eq!(model.snapshot_text(), "first\nsecond\nthird");
+            let snapshot = model.snapshot();
+            assert_eq!(snapshot.display_text, "first\n\nsecond\n\nthird");
+            assert_eq!(snapshot.plain_text, "first\n\nsecond\n\nthird");
+            assert_eq!(model.snapshot_text(), "first\n\nsecond\n\nthird");
             assert_eq!(model.len(), 3);
         });
     });
@@ -33,8 +36,6 @@ fn snapshot_joins_items_with_newlines() {
 fn push_beyond_capacity_drops_oldest() {
     App::test((), |mut app| async move {
         let model = app.add_singleton_model(|_| NetworkLogModel::default());
-        // Push exactly the capacity; the snapshot should contain all items
-        // and the count should equal the capacity.
         model.update(&mut app, |model, ctx| {
             for i in 0..NETWORK_LOGGING_MAX_ITEMS {
                 model.push(NetworkLogItem::from_string(format!("item-{i}")), ctx);
@@ -42,23 +43,19 @@ fn push_beyond_capacity_drops_oldest() {
         });
         model.read(&app, |model, _| {
             assert_eq!(model.len(), NETWORK_LOGGING_MAX_ITEMS);
-            // Oldest is still present when we're exactly at capacity.
-            assert!(model.snapshot_text().starts_with("item-0\n"));
+            assert!(model.snapshot_text().starts_with("item-0\n\n"));
         });
 
-        // Push one more: the oldest item should be evicted so the store stays
-        // at capacity, and the snapshot should start at item-1 now.
         model.update(&mut app, |model, ctx| {
             model.push(NetworkLogItem::from_string("overflow"), ctx);
         });
         model.read(&app, |model, _| {
             assert_eq!(model.len(), NETWORK_LOGGING_MAX_ITEMS);
-            assert!(!model.snapshot_text().contains("item-0\n"));
-            assert!(model.snapshot_text().starts_with("item-1\n"));
-            assert!(model.snapshot_text().ends_with("\noverflow"));
+            assert!(!model.snapshot_text().contains("item-0\n\n"));
+            assert!(model.snapshot_text().starts_with("item-1\n\n"));
+            assert!(model.snapshot_text().ends_with("\n\noverflow"));
         });
 
-        // Pushing many additional items keeps the store at capacity.
         model.update(&mut app, |model, ctx| {
             for i in 0..10 {
                 model.push(NetworkLogItem::from_string(format!("extra-{i}")), ctx);
@@ -66,6 +63,21 @@ fn push_beyond_capacity_drops_oldest() {
         });
         model.read(&app, |model, _| {
             assert_eq!(model.len(), NETWORK_LOGGING_MAX_ITEMS);
+        });
+    });
+}
+
+#[test]
+fn snapshot_preserves_plain_text_for_copying() {
+    App::test((), |mut app| async move {
+        let model = app.add_singleton_model(|_| NetworkLogModel::default());
+        model.update(&mut app, |model, ctx| {
+            model.push(NetworkLogItem::from_string("line one\nline two"), ctx);
+        });
+        model.read(&app, |model, _| {
+            let snapshot = model.snapshot();
+            assert_eq!(snapshot.display_text, "line one\nline two");
+            assert_eq!(snapshot.plain_text, "line one\nline two");
         });
     });
 }


### PR DESCRIPTION
## Summary
- Format network log request/response entries into readable fields instead of raw debug blobs.
- Preserve raw/plain-text snapshots for copying and add a Copy all header action.
- Separate entries with blank lines and cover snapshot behavior in tests.
- Address review feedback by using the existing `Flex::row().with_spacing(...).with_child(...)` API and notifying the view after snapshot refresh.

Fixes #9716

## Testing
- `git diff --check`
- Attempted `cargo test -p warp network_logging`, but this machine ran out of disk while compiling dependencies.
