### PR TITLE
Remove ready-to-implement from bug report template

### DIFF
--- a/.agents/skills/triage-issue-local/SKILL.md
+++ b/.agents/skills/triage-issue-local/SKILL.md
@@ -28,6 +28,8 @@ Ask **at most 2 follow-up questions** per triage response. Each question must be
 
 The label taxonomy for this repository is managed in `.github/issue-triage/config.json`. Prefer labels from that configuration, especially the `area:*`, `os:*`, `repro:*`, `accessibility`, `needs-info`, `duplicate`, and primary issue-type labels. Do not invent new labels unless the prompt explicitly allows it.
 
+Evaluate `ready-to-implement` during triage instead of relying on issue-template defaults. For bug reports, apply `ready-to-implement` only when the issue is reproducible from the provided evidence or straightforward local verification and the likely fix appears narrow enough to implement without a product spec, design mocks, or substantial investigation. If the bug is not reproducible, lacks a clear fix path, requires product/design decisions, or needs deeper technical discovery, omit `ready-to-implement` and prefer `needs-info`, `ready-to-spec`, `needs-mocks`, or the appropriate `repro:*` label.
+
 Use area labels based on the user's reported surface:
 
 - `area:shell-terminal` for terminal output, block rendering, shell integration, prompt rendering, command execution display, and terminal-emulation behavior.

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: "Found a bug? Please search through our open issues and docs, to make sure it isn't already submitted. If you have an SSH related issue, please use the SSH Template below"
-labels: ["bug", "ready-to-implement"]
+labels: ["bug"]
 body:
   - type: checkboxes
     attributes:
@@ -134,4 +134,3 @@ body:
         - Ignore
     validations:
       required: false
-


### PR DESCRIPTION
## Description
Removes the `ready-to-implement` default label from the bug report issue template while keeping the `bug` label. Also updates the `triage-issue-local` skill so the triage agent determines whether `ready-to-implement` should be applied based on reproducibility and fix scope.

## Linked Issue
N/A - requested from Slack.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
N/A - issue template and skill guidance changes only.

## Testing
- `python3` assertion that `.github/ISSUE_TEMPLATE/01_bug_report.yml` now uses only `labels: ["bug"]` and no longer includes `ready-to-implement` in the template metadata.
- `python3` assertion that `.agents/skills/triage-issue-local/SKILL.md` includes the new `ready-to-implement` triage guidance for reproducible, narrow-scope bugs.
- `git diff --check`

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._