### PR TITLE
Treat numpad Enter like Enter in keybindings

### DIFF
--- a/crates/warpui_core/src/elements/hoverable.rs
+++ b/crates/warpui_core/src/elements/hoverable.rs
@@ -657,16 +657,17 @@ impl Element for Hoverable {
 
                 // The double-clicked handler takes precendence. However, we should still fall back to the single-click handler
                 // on a double-click if there's no double-click handler set.
-                if matches!(click_count, Some(2)) && self.double_click_handler.is_some() {
-                    let handler = self
-                        .double_click_handler
-                        .as_mut()
-                        .expect("handler should exist");
-                    handler(ctx, app, *position);
-                    ctx.notify();
-                    return true;
-                } else if click_count.is_some() && self.click_handler.is_some() {
-                    let handler = self.click_handler.as_mut().expect("handler should exist");
+                if matches!(click_count, Some(2)) {
+                    if let Some(handler) = self.double_click_handler.as_mut() {
+                        handler(ctx, app, *position);
+                        ctx.notify();
+                        return true;
+                    }
+                }
+                if click_count.is_some() {
+                    let Some(handler) = self.click_handler.as_mut() else {
+                        return handled;
+                    };
                     handler(ctx, app, *position);
                     ctx.notify();
                     return true;

--- a/crates/warpui_core/src/keymap/matcher.rs
+++ b/crates/warpui_core/src/keymap/matcher.rs
@@ -31,6 +31,36 @@ struct Pending {
     context: Option<Context>,
 }
 
+fn keystroke_matches_binding(
+    binding_keystroke: &Keystroke,
+    pressed_keystroke: &Keystroke,
+    allow_enter_equivalence: bool,
+) -> bool {
+    binding_keystroke == pressed_keystroke
+        || (allow_enter_equivalence
+            && binding_keystroke.key == "enter"
+            && pressed_keystroke.key == "numpadenter"
+            && binding_keystroke.ctrl == pressed_keystroke.ctrl
+            && binding_keystroke.alt == pressed_keystroke.alt
+            && binding_keystroke.shift == pressed_keystroke.shift
+            && binding_keystroke.cmd == pressed_keystroke.cmd
+            && binding_keystroke.meta == pressed_keystroke.meta)
+}
+
+fn keystrokes_start_with(
+    binding_keystrokes: &[Keystroke],
+    pressed_keystrokes: &[Keystroke],
+    allow_enter_equivalence: bool,
+) -> bool {
+    binding_keystrokes.len() >= pressed_keystrokes.len()
+        && binding_keystrokes
+            .iter()
+            .zip(pressed_keystrokes)
+            .all(|(binding, pressed)| {
+                keystroke_matches_binding(binding, pressed, allow_enter_equivalence)
+            })
+}
+
 type BindingValidatorFn = Box<dyn Fn(BindingLens) -> IsBindingValid>;
 
 /// Enum indicating the results of validating a binding.
@@ -315,30 +345,35 @@ impl Matcher {
         }
 
         pending.keystrokes.push(keystroke);
+        for allow_enter_equivalence in [false, true] {
+            let mut retain_pending = false;
 
-        let mut retain_pending = false;
-        for binding in self.keymap.bindings() {
-            if let Trigger::Keystrokes(keystrokes) = &binding.trigger {
-                if keystrokes.starts_with(&pending.keystrokes)
-                    && binding.context_predicate.eval(ctx)
-                {
-                    if keystrokes.len() == pending.keystrokes.len() {
-                        self.pending.remove(&view_id);
-                        return MatchResult::Action(binding.action.clone());
-                    } else {
-                        retain_pending = true;
-                        pending.context = Some(ctx.clone());
+            for binding in self.keymap.bindings() {
+                if let Trigger::Keystrokes(keystrokes) = &binding.trigger {
+                    if keystrokes_start_with(
+                        keystrokes,
+                        &pending.keystrokes,
+                        allow_enter_equivalence,
+                    ) && binding.context_predicate.eval(ctx)
+                    {
+                        if keystrokes.len() == pending.keystrokes.len() {
+                            self.pending.remove(&view_id);
+                            return MatchResult::Action(binding.action.clone());
+                        } else {
+                            retain_pending = true;
+                            pending.context = Some(ctx.clone());
+                        }
                     }
                 }
             }
+
+            if retain_pending {
+                return MatchResult::Pending;
+            }
         }
 
-        if retain_pending {
-            MatchResult::Pending
-        } else {
-            self.pending.remove(&view_id);
-            MatchResult::None
-        }
+        self.pending.remove(&view_id);
+        MatchResult::None
     }
 
     // Attempt to match with a StandardAction.

--- a/crates/warpui_core/src/keymap/matcher_test.rs
+++ b/crates/warpui_core/src/keymap/matcher_test.rs
@@ -227,6 +227,86 @@ fn test_bindings_for_context() {
     assert_eq!(ctx_b_bindings, vec!["c", "b"]);
 }
 
+#[test]
+fn test_numpad_enter_matches_enter_bindings() {
+    #[derive(Debug, PartialEq)]
+    enum Action {
+        Enter,
+        ShiftEnter,
+        CtrlShiftEnter,
+        AltEnter,
+    }
+
+    let keymap = Keymap::new(vec![
+        FixedBinding::new("enter", Action::Enter, always!()),
+        FixedBinding::new("shift-enter", Action::ShiftEnter, always!()),
+        FixedBinding::new("ctrl-shift-enter", Action::CtrlShiftEnter, always!()),
+        FixedBinding::new("alt-enter", Action::AltEnter, always!()),
+    ]);
+    let mut matcher = Matcher::new(keymap);
+    let ctx = Context::default();
+
+    assert_eq!(
+        matcher
+            .test_keystroke("numpadenter", EntityId::new(), &ctx)
+            .unwrap()
+            .as_action::<Action>(),
+        &Action::Enter
+    );
+    assert_eq!(
+        matcher
+            .test_keystroke("shift-numpadenter", EntityId::new(), &ctx)
+            .unwrap()
+            .as_action::<Action>(),
+        &Action::ShiftEnter
+    );
+    assert_eq!(
+        matcher
+            .test_keystroke("ctrl-shift-numpadenter", EntityId::new(), &ctx)
+            .unwrap()
+            .as_action::<Action>(),
+        &Action::CtrlShiftEnter
+    );
+    assert_eq!(
+        matcher
+            .test_keystroke("alt-numpadenter", EntityId::new(), &ctx)
+            .unwrap()
+            .as_action::<Action>(),
+        &Action::AltEnter
+    );
+}
+
+#[test]
+fn test_exact_numpad_enter_binding_takes_precedence() {
+    #[derive(Debug, PartialEq)]
+    enum Action {
+        Enter,
+        NumpadEnter,
+    }
+
+    let keymap = Keymap::new(vec![
+        FixedBinding::new("enter", Action::Enter, always!()),
+        FixedBinding::new("numpadenter", Action::NumpadEnter, always!()),
+    ]);
+    let mut matcher = Matcher::new(keymap);
+    let ctx = Context::default();
+
+    assert_eq!(
+        matcher
+            .test_keystroke("enter", EntityId::new(), &ctx)
+            .unwrap()
+            .as_action::<Action>(),
+        &Action::Enter
+    );
+    assert_eq!(
+        matcher
+            .test_keystroke("numpadenter", EntityId::new(), &ctx)
+            .unwrap()
+            .as_action::<Action>(),
+        &Action::NumpadEnter
+    );
+}
+
 impl Matcher {
     fn test_keystroke(
         &mut self,


### PR DESCRIPTION
## Description
Treat `numpadenter` as equivalent to regular `enter` when matching keybindings, including modifier combinations like `shift-numpadenter`, while preserving exact `numpadenter` binding precedence.

This fixes Shift+NumpadEnter not following Shift+Enter behavior in input editors and applies the same parity across keybinding contexts. I also fixed an existing clippy lint in `Hoverable` click handling so `warpui_core` clippy passes.

## Linked Issue
None.

## Screenshots / Videos
Not applicable; keybinding-only behavior.

## Testing
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --package warpui_core -- --check`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warpui_core --all-targets -- -D warnings`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warpui_core numpad_enter`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warpui_core`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/aa8bd547-1e03-41fc-89c2-fe69c363c633_
_Run: https://oz.staging.warp.dev/runs/019df40f-9ce9-785b-8abc-9c86405ccef2_
_This PR was generated with [Oz](https://warp.dev/oz)._
