### PR TITLE
Sidebar file tree: ancestor refresh fix + VS Code-style git decorations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10607,6 +10607,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-lite 1.13.0",
+ "git2",
  "ignore",
  "itertools 0.14.0",
  "log",

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -1,11 +1,13 @@
 use editing::sort_entries_for_file_tree;
 use itertools::Itertools;
+use pathfinder_color::ColorU;
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::Vector2F;
 use render::RenderState;
 use repo_metadata::file_tree_store::{
     FileTreeDirectoryEntryState, FileTreeEntryState, FileTreeFileMetadata,
 };
+use repo_metadata::git_status::GitStatus;
 use repo_metadata::local_model::IndexedRepoState;
 use repo_metadata::FileTreeEntry;
 use repo_metadata::RepoMetadataModel;
@@ -20,8 +22,8 @@ use repo_metadata::repositories::DetectedRepositories;
 use warp_core::send_telemetry_from_ctx;
 use warpui::elements::{
     AcceptedByDropTarget, Align, Clipped, ConstrainedBox, Container, Dismiss, Draggable,
-    DraggableState, Empty, FormattedTextElement, MainAxisAlignment, Percentage, Rect, SavePosition,
-    Scrollable, Shrinkable,
+    DraggableState, Empty, Expanded, FormattedTextElement, MainAxisAlignment, Percentage, Rect,
+    SavePosition, Scrollable, Shrinkable,
 };
 use warpui::fonts::Style;
 use warpui::keymap::FixedBinding;
@@ -200,6 +202,17 @@ enum FileTreeItem {
         depth: usize,
         mouse_state_handle: MouseStateHandle,
         draggable_state: DraggableState,
+    },
+}
+
+#[derive(Clone)]
+enum FileTreeGitDecoration {
+    File {
+        color: ColorU,
+        badge: Option<&'static str>,
+    },
+    DirtyDirectory {
+        color: ColorU,
     },
 }
 
@@ -536,15 +549,16 @@ impl FileTreeView {
             RepoMetadataEvent::FileTreeEntryUpdated {
                 id: RepositoryIdentifier::Local(std_path),
             } => {
-                // Find root directories whose backing model entry matches this path.
-                let root_paths: Vec<StandardizedPath> = self
-                    .root_directories
-                    .iter()
-                    .filter_map(|(root_path, root_dir)| {
-                        (**root_dir.entry.root_directory() == *std_path)
-                            .then_some(root_path.clone())
-                    })
-                    .collect();
+                let mut root_paths = Vec::new();
+                let mut should_rebuild = false;
+                for (root_path, root_dir) in &self.root_directories {
+                    let root_directory = root_dir.entry.root_directory().as_ref();
+                    if root_directory == std_path {
+                        root_paths.push(root_path.clone());
+                    } else if std_path.starts_with(root_directory) {
+                        should_rebuild = true;
+                    }
+                }
 
                 if !root_paths.is_empty() {
                     let id = RepositoryIdentifier::Local(std_path.clone());
@@ -555,10 +569,14 @@ impl FileTreeView {
                             }
                         }
 
-                        self.rebuild_flattened_items();
-                        self.apply_pending_focus_target();
-                        ctx.notify();
+                        should_rebuild = true;
                     }
+                }
+
+                if should_rebuild {
+                    self.rebuild_flattened_items();
+                    self.apply_pending_focus_target();
+                    ctx.notify();
                 }
             }
             RepoMetadataEvent::UpdatingRepositoryFailed {
@@ -1750,12 +1768,94 @@ impl FileTreeView {
         (selected_item_index, removed_item)
     }
 
+    fn git_decoration_for_item(
+        item: &FileTreeItem,
+        root_dir: &RootDirectory,
+        appearance: &Appearance,
+        ctx: &AppContext,
+    ) -> Option<FileTreeGitDecoration> {
+        if root_dir.is_remote() {
+            return None;
+        }
+
+        let repo_metadata = RepoMetadataModel::as_ref(ctx);
+        match item {
+            FileTreeItem::File { .. } => {
+                let status = repo_metadata.git_status_for(item.path(), ctx)?;
+                Self::file_git_decoration(status, appearance)
+            }
+            FileTreeItem::DirectoryHeader { .. } => repo_metadata
+                .dirty_dir_status_for(item.path(), ctx)
+                .map(|status| FileTreeGitDecoration::DirtyDirectory {
+                    color: Self::git_status_color(status, appearance),
+                }),
+        }
+    }
+
+    fn file_git_decoration(
+        status: GitStatus,
+        appearance: &Appearance,
+    ) -> Option<FileTreeGitDecoration> {
+        let badge = match status {
+            GitStatus::Modified => Some("M"),
+            GitStatus::Added => Some("A"),
+            GitStatus::Untracked => Some("U"),
+            GitStatus::Conflict => Some("C"),
+            GitStatus::Renamed => Some("R"),
+            GitStatus::Ignored => None,
+            // Deleted files have no tree row in v1; deletions are surfaced by the parent dirty dot.
+            GitStatus::Deleted => return None,
+        };
+
+        Some(FileTreeGitDecoration::File {
+            color: Self::git_status_color(status, appearance),
+            badge,
+        })
+    }
+
+    fn git_status_color(status: GitStatus, appearance: &Appearance) -> ColorU {
+        match status {
+            GitStatus::Modified => appearance.theme().ui_yellow_color(),
+            GitStatus::Added | GitStatus::Untracked | GitStatus::Renamed => {
+                crate::code::editor::add_color(appearance)
+            }
+            GitStatus::Conflict => appearance.theme().ansi_fg_red(),
+            GitStatus::Ignored => {
+                internal_colors::text_disabled(appearance.theme(), appearance.theme().background())
+            }
+            GitStatus::Deleted => crate::code::editor::remove_color(appearance),
+        }
+    }
+
+    fn render_git_decoration_marker(
+        text: &'static str,
+        color: ColorU,
+        appearance: &Appearance,
+    ) -> Box<dyn Element> {
+        Container::new(
+            ConstrainedBox::new(
+                Align::new(
+                    Text::new_inline(text, appearance.ui_font_family(), ITEM_FONT_SIZE)
+                        .with_color(color)
+                        .finish(),
+                )
+                .right()
+                .finish(),
+            )
+            .with_width(FOLDER_INDENT)
+            .finish(),
+        )
+        .with_margin_left(ITEM_PADDING)
+        .finish()
+    }
+
     /// Renders a file item with proper indentation and optional hover/selected styling
     fn render_item_with_hover(
         render_state: RenderState,
         appearance: &Appearance,
         item_highlight_state: ItemHighlightState,
         editor_view: Option<&ViewHandle<EditorView>>,
+        git_decoration: Option<FileTreeGitDecoration>,
     ) -> Box<dyn Element> {
         // Create the folder header row
         let mut header_row = Flex::row()
@@ -1802,8 +1902,14 @@ impl FileTreeView {
             .finish(),
         );
 
+        let decoration_color = git_decoration.as_ref().map(|decoration| match decoration {
+            FileTreeGitDecoration::File { color, .. }
+            | FileTreeGitDecoration::DirtyDirectory { color } => *color,
+        });
+
         // Add the icon for the item.
-        let icon_color = item_highlight_state.text_and_icon_color(appearance);
+        let icon_color = decoration_color
+            .unwrap_or_else(|| item_highlight_state.text_and_icon_color(appearance));
         let icon = match render_state.icon {
             ImageOrIcon::Icon(icon) => icon.to_warpui_icon(icon_color.into()).finish(),
             ImageOrIcon::Image(image) => image,
@@ -1819,7 +1925,8 @@ impl FileTreeView {
             .finish(),
         );
 
-        let text_color = item_highlight_state.text_and_icon_color(appearance);
+        let text_color = decoration_color
+            .unwrap_or_else(|| item_highlight_state.text_and_icon_color(appearance));
         let text_style = if render_state.is_ignored {
             Properties::default()
                 .style(Style::Italic)
@@ -1830,7 +1937,7 @@ impl FileTreeView {
         match editor_view {
             Some(editor_view) => {
                 header_row.add_child(
-                    Shrinkable::new(
+                    Expanded::new(
                         1.,
                         Dismiss::new(Clipped::new(ChildView::new(editor_view).finish()).finish())
                             .on_dismiss(|ctx, _app| {
@@ -1843,19 +1950,42 @@ impl FileTreeView {
             }
             None => {
                 header_row.add_child(
-                    Shrinkable::new(
+                    Expanded::new(
                         1.,
-                        Text::new_inline(
-                            render_state.display_name,
-                            appearance.ui_font_family(),
-                            ITEM_FONT_SIZE,
+                        Align::new(
+                            Clipped::new(
+                                Text::new_inline(
+                                    render_state.display_name,
+                                    appearance.ui_font_family(),
+                                    ITEM_FONT_SIZE,
+                                )
+                                .with_color(text_color)
+                                .with_style(text_style)
+                                .finish(),
+                            )
+                            .finish(),
                         )
-                        .with_color(text_color)
-                        .with_style(text_style)
+                        .left()
                         .finish(),
                     )
                     .finish(),
                 );
+            }
+        }
+
+        if let Some(git_decoration) = git_decoration {
+            match git_decoration {
+                FileTreeGitDecoration::File { color, badge } => {
+                    if let Some(badge) = badge {
+                        header_row.add_child(Self::render_git_decoration_marker(
+                            badge, color, appearance,
+                        ));
+                    }
+                }
+                FileTreeGitDecoration::DirtyDirectory { color } => {
+                    header_row
+                        .add_child(Self::render_git_decoration_marker("●", color, appearance));
+                }
             }
         }
 
@@ -1924,7 +2054,12 @@ impl FileTreeView {
     }
 
     /// Renders a clickable tree item with mouse state handle
-    fn render_item(&self, id: &FileTreeIdentifier, appearance: &Appearance) -> Box<dyn Element> {
+    fn render_item(
+        &self,
+        id: &FileTreeIdentifier,
+        appearance: &Appearance,
+        ctx: &AppContext,
+    ) -> Box<dyn Element> {
         let Some(root_dir) = self.root_directories.get(&id.root) else {
             return Empty::new().finish();
         };
@@ -1936,6 +2071,7 @@ impl FileTreeView {
         let is_expanded = self.is_item_expanded(&id.root, item);
         let render_state = item.to_render_state(is_expanded, appearance);
         let is_remote_file = root_dir.is_remote() && matches!(item, FileTreeItem::File { .. });
+        let git_decoration = Self::git_decoration_for_item(item, root_dir, appearance, ctx);
 
         let item_display_name = render_state.display_name.clone();
         let item_position_id = format!("file_tree_item:{item_display_name}");
@@ -1962,6 +2098,7 @@ impl FileTreeView {
                 appearance,
                 item_highlight_state,
                 editor_view,
+                git_decoration.clone(),
             );
 
             if is_remote_file && mouse_state.is_hovered() {
@@ -2619,7 +2756,7 @@ impl FileTreeView {
                 range
                     .filter_map(|global_index| {
                         let item_id = view.identifier_from_global_index(global_index)?;
-                        Some(view.render_item(&item_id, appearance))
+                        Some(view.render_item(&item_id, appearance, app))
                     })
                     .collect::<Vec<_>>()
                     .into_iter()

--- a/app/src/code/file_tree/view/view_tests.rs
+++ b/app/src/code/file_tree/view/view_tests.rs
@@ -1,14 +1,15 @@
-use std::sync::Arc;
+use std::{fs, path::Path, sync::Arc};
 
 use repo_metadata::entry::{DirectoryEntry, Entry, FileMetadata};
 use repo_metadata::file_tree_store::FileTreeState;
+use repo_metadata::git_status::GitStatus;
 use repo_metadata::local_model::IndexedRepoState;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::watcher::DirectoryWatcher;
 use repo_metadata::RepoMetadataModel;
 use virtual_fs::{Stub, VirtualFS};
 use warp_core::ui::appearance::Appearance;
-use warpui::{platform::WindowStyle, App, ModelHandle};
+use warpui::{platform::WindowStyle, App, ModelHandle, SingletonEntity as _};
 
 use crate::auth::AuthStateProvider;
 use crate::server::server_api::{team::MockTeamClient, workspace::MockWorkspaceClient};
@@ -19,7 +20,7 @@ use crate::workspace::sync_inputs::SyncedInputState;
 use crate::workspace::ToastStack;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
-use super::FileTreeView;
+use super::{FileTreeGitDecoration, FileTreeView};
 
 fn std_path(path: &std::path::Path) -> warp_util::standardized_path::StandardizedPath {
     warp_util::standardized_path::StandardizedPath::try_from_local(path).unwrap()
@@ -91,6 +92,28 @@ fn build_repo_state(repo_root: &std::path::Path) -> FileTreeState {
         loaded: true,
     });
     FileTreeState::new(root, vec![], None)
+}
+
+fn commit_paths(repo: &git2::Repository, paths: &[&Path]) -> anyhow::Result<()> {
+    let mut index = repo.index()?;
+    for path in paths {
+        index.add_path(path)?;
+    }
+    index.write()?;
+
+    let tree_id = index.write_tree()?;
+    let tree = repo.find_tree(tree_id)?;
+    let signature = git2::Signature::now("Warp Test", "test@example.com")?;
+    repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        "initial commit",
+        &tree,
+        &[],
+    )?;
+
+    Ok(())
 }
 
 fn build_repo_state_with_unloaded_directory(repo_root: &std::path::Path) -> FileTreeState {
@@ -469,6 +492,140 @@ fn failed_lazy_loaded_path_registration_is_retried() {
                     .unwrap(),
                     ctx
                 ));
+            });
+        });
+    });
+}
+
+#[test]
+fn file_tree_entry_updated_rebuilds_ancestor_root_without_replacing_entry() {
+    VirtualFS::test(
+        "file_tree_ancestor_metadata_event_rebuild",
+        |dirs, mut vfs| {
+            vfs.mkdir("tree/repo")
+                .with_files(vec![Stub::FileWithContent(
+                    "tree/repo/main.rs",
+                    "fn main() {}\n",
+                )]);
+            let tree = dirs.tests().join("tree");
+            let repo = tree.join("repo");
+
+            App::test((), |mut app| async move {
+                let _ = initialize_app(&mut app);
+                let (_, file_tree_view) =
+                    app.add_window(WindowStyle::NotStealFocus, FileTreeView::new);
+
+                file_tree_view.update(&mut app, |view, ctx| {
+                    view.set_is_active(true, ctx);
+                    view.set_root_directories(vec![tree.clone()], ctx);
+
+                    let tree_std = std_path(&tree);
+                    let root_dir = view.root_directories.get_mut(&tree_std).unwrap();
+                    root_dir.items.clear();
+
+                    view.handle_repository_metadata_event(
+                        &repo_metadata::RepoMetadataEvent::FileTreeEntryUpdated {
+                            id: repo_metadata::RepositoryIdentifier::local(std_path(&repo)),
+                        },
+                        ctx,
+                    );
+                });
+
+                file_tree_view.read(&app, |view, _ctx| {
+                    let tree_std = std_path(&tree);
+                    let root_dir = view.root_directories.get(&tree_std).unwrap();
+                    assert_eq!(root_dir.entry.root_directory().as_ref(), &tree_std);
+                    assert!(
+                        !root_dir.items.is_empty(),
+                        "ancestor FileTreeEntryUpdated event should rebuild flattened items"
+                    );
+                });
+            });
+        },
+    );
+}
+
+#[test]
+fn git_status_decorations_update_for_ancestor_displayed_root() {
+    VirtualFS::test("file_tree_git_status_decorations", |dirs, mut vfs| {
+        vfs.mkdir("tree/repo/packages/app/src").with_files(vec![
+            Stub::FileWithContent("tree/repo/packages/app/src/main.rs", "fn main() {}\n"),
+            Stub::FileWithContent("tree/repo/.gitignore", ""),
+        ]);
+
+        let tree = dirs.tests().join("tree");
+        let repo = tree.join("repo");
+        let modified_file = repo.join("packages/app/src/main.rs");
+        let git_repo = git2::Repository::init(&repo).unwrap();
+        commit_paths(&git_repo, &[Path::new("packages/app/src/main.rs")]).unwrap();
+        fs::write(&modified_file, "fn main() { println!(\"modified\"); }\n").unwrap();
+        let canonical_repo_root =
+            warp_util::standardized_path::StandardizedPath::from_local_canonicalized(&repo)
+                .unwrap();
+
+        App::test((), |mut app| async move {
+            let (detected_repositories, repository_metadata_model) = initialize_app(&mut app);
+            let (_, file_tree_view) = app.add_window(WindowStyle::NotStealFocus, FileTreeView::new);
+
+            detected_repositories.update(&mut app, |repositories, _ctx| {
+                repositories.insert_test_repo_root(canonical_repo_root.clone());
+            });
+
+            file_tree_view.update(&mut app, |view, ctx| {
+                view.set_is_active(true, ctx);
+                view.set_root_directories(vec![tree.clone()], ctx);
+            });
+
+            repository_metadata_model.update(&mut app, |model, ctx| {
+                model.insert_test_state(canonical_repo_root.clone(), build_repo_state(&repo), ctx);
+                model.recompute_git_statuses_for_test(
+                    canonical_repo_root.clone(),
+                    vec![modified_file.clone()],
+                    ctx,
+                );
+            });
+
+            file_tree_view.update(&mut app, |view, ctx| {
+                view.handle_repository_metadata_event(
+                    &repo_metadata::RepoMetadataEvent::FileTreeEntryUpdated {
+                        id: repo_metadata::RepositoryIdentifier::local(canonical_repo_root.clone()),
+                    },
+                    ctx,
+                );
+            });
+
+            repository_metadata_model.read(&app, |model, ctx| {
+                assert_eq!(
+                    model.git_status_for(&std_path(&modified_file), ctx),
+                    Some(GitStatus::Modified)
+                );
+                assert!(model.is_dirty_dir(&canonical_repo_root, ctx));
+                assert!(model.is_dirty_dir(&std_path(&repo.join("packages/app/src")), ctx));
+                assert_eq!(
+                    model.dirty_dir_status_for(&std_path(&repo.join("packages/app/src")), ctx),
+                    Some(GitStatus::Modified)
+                );
+            });
+
+            file_tree_view.read(&app, |view, _ctx| {
+                let tree_std = std_path(&tree);
+                let root_dir = view.root_directories.get(&tree_std).unwrap();
+                assert!(
+                    !root_dir.items.is_empty(),
+                    "ancestor FileTreeEntryUpdated event should rebuild items after status changes"
+                );
+            });
+
+            file_tree_view.read(&app, |_view, ctx| {
+                let appearance = Appearance::as_ref(ctx);
+                let decoration = FileTreeView::file_git_decoration(GitStatus::Modified, appearance);
+                match decoration {
+                    Some(FileTreeGitDecoration::File { color, badge }) => {
+                        assert_eq!(badge, Some("M"));
+                        assert_eq!(color, appearance.theme().ui_yellow_color());
+                    }
+                    _ => panic!("modified files should render an M badge with modified color"),
+                }
             });
         });
     });

--- a/crates/repo_metadata/Cargo.toml
+++ b/crates/repo_metadata/Cargo.toml
@@ -39,6 +39,9 @@ strum.workspace = true
 notify-debouncer-full.workspace = true
 async-fs.workspace = true
 watcher.workspace = true
+git2 = { version = "0.20.4", default-features = false, features = [
+    "vendored-libgit2",
+] }
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/repo_metadata/src/git_status.rs
+++ b/crates/repo_metadata/src/git_status.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GitStatus {
+    Modified,
+    Added,
+    Untracked,
+    Deleted,
+    Conflict,
+    Renamed,
+    Ignored,
+}
+
+#[cfg(not(target_family = "wasm"))]
+mod native {
+    use std::path::{Path, PathBuf};
+
+    use git2::{Repository, Status, StatusEntry, StatusOptions};
+    use thiserror::Error;
+    use warp_util::standardized_path::{InvalidPathError, StandardizedPath};
+
+    use super::{GitStatus, HashMap};
+
+    #[derive(Debug, Error)]
+    pub enum GitStatusError {
+        #[error("failed to read git status: {0}")]
+        Git(#[from] git2::Error),
+        #[error("failed to standardize status path: {0}")]
+        InvalidPath(#[from] InvalidPathError),
+        #[error("git status entry had no path")]
+        MissingPath,
+    }
+
+    pub fn statuses_for_repo(
+        repo_root: &Path,
+        pathspec: Option<&[&Path]>,
+    ) -> Result<HashMap<StandardizedPath, GitStatus>, GitStatusError> {
+        let repository = Repository::open(repo_root)?;
+        let mut options = StatusOptions::new();
+        options
+            .include_untracked(true)
+            .include_ignored(true)
+            .recurse_untracked_dirs(true)
+            .recurse_ignored_dirs(true)
+            .disable_pathspec_match(true)
+            .renames_head_to_index(true)
+            .renames_index_to_workdir(true);
+
+        let pathspecs = pathspec
+            .unwrap_or_default()
+            .iter()
+            .map(|path| repo_relative_path(repo_root, path))
+            .collect::<Vec<_>>();
+
+        for path in &pathspecs {
+            options.pathspec(path.as_path());
+        }
+
+        let statuses = repository.statuses(Some(&mut options))?;
+        let mut result = HashMap::new();
+
+        for entry in statuses.iter() {
+            let status = entry.status();
+            let Some(git_status) = map_status(status) else {
+                continue;
+            };
+            let path = status_path(&entry, status).ok_or(GitStatusError::MissingPath)?;
+            let standardized = StandardizedPath::try_from_local(&repo_root.join(path))?;
+            result.insert(standardized, git_status);
+        }
+
+        Ok(result)
+    }
+
+    fn repo_relative_path(repo_root: &Path, path: &Path) -> PathBuf {
+        path.strip_prefix(repo_root)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|_| path.to_path_buf())
+    }
+
+    fn status_path<'entry>(
+        entry: &'entry StatusEntry<'entry>,
+        status: Status,
+    ) -> Option<&'entry Path> {
+        if status.is_index_renamed() {
+            entry
+                .head_to_index()
+                .and_then(|delta| delta.new_file().path())
+        } else if status.is_wt_renamed() {
+            entry
+                .index_to_workdir()
+                .and_then(|delta| delta.new_file().path())
+        } else {
+            entry.path().map(Path::new)
+        }
+    }
+
+    fn map_status(status: Status) -> Option<GitStatus> {
+        if status.is_conflicted() {
+            Some(GitStatus::Conflict)
+        } else if status.is_ignored() {
+            Some(GitStatus::Ignored)
+        } else if status.is_index_renamed() || status.is_wt_renamed() {
+            Some(GitStatus::Renamed)
+        } else if status.is_index_new() {
+            Some(GitStatus::Added)
+        } else if status.is_wt_new() {
+            Some(GitStatus::Untracked)
+        } else if status.is_index_deleted() || status.is_wt_deleted() {
+            Some(GitStatus::Deleted)
+        } else if status.is_index_modified()
+            || status.is_wt_modified()
+            || status.is_index_typechange()
+            || status.is_wt_typechange()
+        {
+            Some(GitStatus::Modified)
+        } else {
+            None
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::{fs, path::Path};
+
+        use git2::Signature;
+        use tempfile::TempDir;
+
+        use super::*;
+
+        #[test]
+        fn statuses_for_repo_maps_modified_untracked_added_and_ignored() -> anyhow::Result<()> {
+            let temp_dir = TempDir::new()?;
+            let repo = Repository::init(temp_dir.path())?;
+
+            fs::write(temp_dir.path().join(".gitignore"), "*.log\n")?;
+            fs::write(temp_dir.path().join("tracked.txt"), "baseline\n")?;
+            commit_all(&repo)?;
+
+            fs::write(temp_dir.path().join("tracked.txt"), "modified\n")?;
+            fs::write(temp_dir.path().join("untracked.txt"), "new\n")?;
+            fs::write(temp_dir.path().join("ignored.log"), "ignored\n")?;
+            fs::write(temp_dir.path().join("staged.txt"), "staged\n")?;
+            let mut index = repo.index()?;
+            index.add_path(Path::new("staged.txt"))?;
+            index.write()?;
+
+            let statuses = statuses_for_repo(temp_dir.path(), None)?;
+
+            assert_eq!(
+                statuses.get(&StandardizedPath::try_from_local(
+                    &temp_dir.path().join("tracked.txt")
+                )?),
+                Some(&GitStatus::Modified)
+            );
+            assert_eq!(
+                statuses.get(&StandardizedPath::try_from_local(
+                    &temp_dir.path().join("untracked.txt")
+                )?),
+                Some(&GitStatus::Untracked)
+            );
+            assert_eq!(
+                statuses.get(&StandardizedPath::try_from_local(
+                    &temp_dir.path().join("ignored.log")
+                )?),
+                Some(&GitStatus::Ignored)
+            );
+            assert_eq!(
+                statuses.get(&StandardizedPath::try_from_local(
+                    &temp_dir.path().join("staged.txt")
+                )?),
+                Some(&GitStatus::Added)
+            );
+
+            let tracked_path = temp_dir.path().join("tracked.txt");
+            let pathspecs = [tracked_path.as_path()];
+            let scoped_statuses = statuses_for_repo(temp_dir.path(), Some(&pathspecs))?;
+            assert_eq!(scoped_statuses.len(), 1);
+            assert_eq!(
+                scoped_statuses.get(&StandardizedPath::try_from_local(&tracked_path)?),
+                Some(&GitStatus::Modified)
+            );
+
+            Ok(())
+        }
+
+        fn commit_all(repo: &Repository) -> anyhow::Result<()> {
+            let mut index = repo.index()?;
+            index.add_path(Path::new(".gitignore"))?;
+            index.add_path(Path::new("tracked.txt"))?;
+            index.write()?;
+
+            let tree_id = index.write_tree()?;
+            let tree = repo.find_tree(tree_id)?;
+            let signature = Signature::now("Warp Test", "test@example.com")?;
+            repo.commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                "initial commit",
+                &tree,
+                &[],
+            )?;
+
+            Ok(())
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub use native::{statuses_for_repo, GitStatusError};

--- a/crates/repo_metadata/src/lib.rs
+++ b/crates/repo_metadata/src/lib.rs
@@ -33,6 +33,7 @@ pub enum RepoMetadataError {
 pub mod entry;
 pub mod file_tree_store;
 pub mod file_tree_update;
+pub mod git_status;
 pub mod local_model;
 pub mod remote_model;
 pub mod repositories;

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -5,7 +5,7 @@
 //! all repositories tracked by Warp.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -21,8 +21,11 @@ pub enum RepoContent<'a> {
 
 use warp_util::standardized_path::StandardizedPath;
 
+#[cfg(not(target_family = "wasm"))]
+use crate::{entry::is_git_internal_path, git_status::statuses_for_repo};
 use crate::{
     entry::{Entry, FileId, IgnoredPathStrategy},
+    git_status::GitStatus,
     gitignores_for_directory, matches_gitignores,
     repository::Repository,
     telemetry::RepoMetadataTelemetryEvent,
@@ -110,6 +113,10 @@ pub enum IndexedRepoState {
 pub struct LocalRepoMetadataModel {
     /// Mapping from repository path to its indexed state.
     repositories: HashMap<StandardizedPath, IndexedRepoState>,
+    /// Per-file git status, keyed by repository root.
+    git_statuses: HashMap<StandardizedPath, HashMap<StandardizedPath, GitStatus>>,
+    /// Directory rollups for repositories with dirty descendants.
+    dirty_dirs: HashMap<StandardizedPath, HashSet<StandardizedPath>>,
     /// Refcounts for lazily-loaded standalone paths tracked in the model.
     lazy_loaded_paths: HashMap<StandardizedPath, usize>,
     /// File system watcher for monitoring changes.
@@ -126,6 +133,13 @@ struct RepoUpdate {
     added: Vec<PathBuf>,
     deleted: Vec<PathBuf>,
     moved: HashMap<PathBuf, PathBuf>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[derive(Debug)]
+struct GitStatusComputation {
+    changed_paths: Option<Vec<PathBuf>>,
+    statuses: Result<HashMap<StandardizedPath, GitStatus>, String>,
 }
 
 /// Describes a single file-tree mutation computed on a background thread.
@@ -199,6 +213,8 @@ impl LocalRepoMetadataModel {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
         let mut model = Self {
             repositories: HashMap::new(),
+            git_statuses: HashMap::new(),
+            dirty_dirs: HashMap::new(),
             lazy_loaded_paths: HashMap::new(),
             #[cfg(feature = "local_fs")]
             watcher: None,
@@ -297,9 +313,18 @@ impl LocalRepoMetadataModel {
                             &gitignores_clone,
                         )
                         .await;
-                        (mutations, repo_path_clone, lazy_load)
+                        let git_status_computation = Self::compute_git_status_computation(
+                            &repo_path_clone,
+                            &repo_scoped_update,
+                        );
+                        (
+                            mutations,
+                            repo_path_clone,
+                            lazy_load,
+                            git_status_computation,
+                        )
                     },
-                    |model, (mutations, repo_path, lazy_load), ctx| {
+                    |model, (mutations, repo_path, lazy_load, git_status_computation), ctx| {
                         if let Some(IndexedRepoState::Indexed(state)) =
                             model.repositories.get_mut(&repo_path)
                         {
@@ -309,6 +334,7 @@ impl LocalRepoMetadataModel {
                                 lazy_load,
                                 model.emit_incremental_updates,
                             );
+                            model.recompute_git_statuses(&repo_path, git_status_computation);
                             ctx.emit(RepositoryMetadataEvent::FileTreeEntryUpdated {
                                 path: repo_path,
                             });
@@ -405,6 +431,9 @@ impl LocalRepoMetadataModel {
         ctx: &mut ModelContext<Self>,
     ) -> Result<(), RepoMetadataError> {
         if self.repositories.remove(repo_path).is_some() {
+            self.git_statuses.remove(repo_path);
+            self.dirty_dirs.remove(repo_path);
+
             // Unregister from watcher
             #[cfg(feature = "local_fs")]
             {
@@ -452,6 +481,25 @@ impl LocalRepoMetadataModel {
     /// Returns whether the given path is tracked as a lazily-loaded standalone path.
     pub fn is_lazy_loaded_path(&self, path: &StandardizedPath) -> bool {
         self.lazy_loaded_paths.contains_key(path)
+    }
+
+    pub fn git_status_for(&self, path: &StandardizedPath) -> Option<GitStatus> {
+        self.git_statuses
+            .values()
+            .find_map(|statuses| statuses.get(path).copied())
+    }
+
+    pub fn is_dirty_dir(&self, path: &StandardizedPath) -> bool {
+        self.dirty_dirs.values().any(|dirs| dirs.contains(path))
+    }
+
+    pub fn dirty_dir_status_for(&self, path: &StandardizedPath) -> Option<GitStatus> {
+        self.git_statuses
+            .values()
+            .flat_map(HashMap::iter)
+            .filter(|(status_path, _status)| status_path.starts_with(path))
+            .map(|(_status_path, status)| *status)
+            .min_by_key(|status| Self::git_status_rollup_priority(*status))
     }
 
     /// Lazily indexes a standalone path with only the first level of children.
@@ -626,6 +674,148 @@ impl LocalRepoMetadataModel {
         }
 
         mutations
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn compute_git_status_computation(
+        repo_path: &StandardizedPath,
+        update: &RepoUpdate,
+    ) -> GitStatusComputation {
+        let changed_paths = Self::git_status_changed_paths(update);
+        let statuses = match repo_path.to_local_path() {
+            Some(_) if changed_paths.as_ref().is_some_and(Vec::is_empty) => Ok(HashMap::new()),
+            Some(repo_root) => {
+                let pathspecs = changed_paths
+                    .as_ref()
+                    .map(|paths| paths.iter().map(PathBuf::as_path).collect::<Vec<&Path>>());
+                statuses_for_repo(&repo_root, pathspecs.as_deref()).map_err(|e| e.to_string())
+            }
+            None => Err(RepoMetadataError::PathEncodingMismatch(repo_path.clone()).to_string()),
+        };
+
+        GitStatusComputation {
+            changed_paths,
+            statuses,
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn git_status_changed_paths(update: &RepoUpdate) -> Option<Vec<PathBuf>> {
+        let mut changed_paths = Vec::new();
+        for path in update
+            .added
+            .iter()
+            .chain(update.deleted.iter())
+            .chain(update.moved.keys())
+            .chain(update.moved.values())
+        {
+            if is_git_internal_path(path) {
+                return None;
+            }
+            if !changed_paths.contains(path) {
+                changed_paths.push(path.clone());
+            }
+        }
+
+        Some(changed_paths)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn recompute_git_statuses(
+        &mut self,
+        repo_path: &StandardizedPath,
+        computation: GitStatusComputation,
+    ) {
+        let statuses = match computation.statuses {
+            Ok(statuses) => statuses,
+            Err(error) => {
+                log::warn!("Failed to refresh git statuses for {repo_path}: {error}");
+                return;
+            }
+        };
+
+        match computation.changed_paths {
+            Some(changed_paths) => {
+                let repo_statuses = self.git_statuses.entry(repo_path.clone()).or_default();
+                for path in changed_paths {
+                    let Some(std_path) = StandardizedPath::try_from_local(&path).ok() else {
+                        continue;
+                    };
+                    repo_statuses.remove(&std_path);
+                }
+                repo_statuses.extend(statuses);
+            }
+            None => {
+                self.git_statuses.insert(repo_path.clone(), statuses);
+            }
+        }
+
+        self.recompute_dirty_dirs(repo_path);
+    }
+
+    fn recompute_dirty_dirs(&mut self, repo_path: &StandardizedPath) {
+        let Some(statuses) = self.git_statuses.get(repo_path) else {
+            self.dirty_dirs.remove(repo_path);
+            return;
+        };
+
+        let mut dirty_dirs = HashSet::new();
+        for path in statuses.keys() {
+            for ancestor in path.ancestors().skip(1) {
+                if !ancestor.starts_with(repo_path) {
+                    break;
+                }
+                dirty_dirs.insert(ancestor);
+            }
+        }
+
+        if dirty_dirs.is_empty() {
+            self.dirty_dirs.remove(repo_path);
+        } else {
+            self.dirty_dirs.insert(repo_path.clone(), dirty_dirs);
+        }
+    }
+
+    fn git_status_rollup_priority(status: GitStatus) -> u8 {
+        match status {
+            GitStatus::Conflict => 0,
+            GitStatus::Deleted => 1,
+            GitStatus::Modified => 2,
+            GitStatus::Added | GitStatus::Untracked | GitStatus::Renamed => 3,
+            GitStatus::Ignored => 4,
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn spawn_full_git_status_refresh(
+        repo_path: StandardizedPath,
+        ctx: &mut ModelContext<'_, Self>,
+    ) {
+        ctx.spawn(
+            async move {
+                let statuses = match repo_path.to_local_path() {
+                    Some(repo_root) => {
+                        statuses_for_repo(&repo_root, None).map_err(|e| e.to_string())
+                    }
+                    None => {
+                        Err(RepoMetadataError::PathEncodingMismatch(repo_path.clone()).to_string())
+                    }
+                };
+                (
+                    repo_path,
+                    GitStatusComputation {
+                        changed_paths: None,
+                        statuses,
+                    },
+                )
+            },
+            |model, (repo_path, git_status_computation), ctx| {
+                if model.repositories.contains_key(&repo_path) {
+                    model.recompute_git_statuses(&repo_path, git_status_computation);
+                    ctx.emit(RepositoryMetadataEvent::FileTreeEntryUpdated { path: repo_path });
+                }
+            },
+        );
     }
 
     /// Phase 2: Applies pre-computed mutations to the file tree on the main thread.
@@ -936,6 +1126,8 @@ impl LocalRepoMetadataModel {
                                 repo_path_str,
                                 files.len()
                             );
+                            #[cfg(not(target_family = "wasm"))]
+                            Self::spawn_full_git_status_refresh(std_repo_path, ctx);
                         }
                     }
                     Err(e) => {
@@ -1024,6 +1216,21 @@ impl LocalRepoMetadataModel {
     pub fn insert_test_state(&mut self, repo_path: StandardizedPath, state: FileTreeState) {
         self.repositories
             .insert(repo_path, IndexedRepoState::Indexed(state));
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    pub fn recompute_git_statuses_for_test(
+        &mut self,
+        repo_path: &StandardizedPath,
+        changed_paths: Vec<PathBuf>,
+    ) {
+        let update = RepoUpdate {
+            added: changed_paths,
+            deleted: vec![],
+            moved: HashMap::new(),
+        };
+        let computation = Self::compute_git_status_computation(repo_path, &update);
+        self.recompute_git_statuses(repo_path, computation);
     }
 }
 

--- a/crates/repo_metadata/src/local_model_test.rs
+++ b/crates/repo_metadata/src/local_model_test.rs
@@ -5,6 +5,7 @@
 mod tests {
     use crate::entry::{DirectoryEntry, Entry, FileMetadata};
     use crate::file_tree_store::{FileTreeEntry, FileTreeEntryState, FileTreeState};
+    use crate::git_status::GitStatus;
     use crate::local_model::{
         GetContentsArgs, IndexedRepoState, LocalRepoMetadataModel, RepoUpdate,
         RepositoryMetadataEvent,
@@ -16,7 +17,8 @@ mod tests {
     use ignore::gitignore::Gitignore;
     use std::cell::RefCell;
     use std::collections::HashMap;
-    use std::path::PathBuf;
+    use std::fs;
+    use std::path::{Path, PathBuf};
     use std::rc::Rc;
     use std::time::Duration;
     use virtual_fs::{Stub, VirtualFS};
@@ -28,6 +30,8 @@ mod tests {
         fn new_for_test() -> Self {
             Self {
                 repositories: HashMap::new(),
+                git_statuses: HashMap::new(),
+                dirty_dirs: HashMap::new(),
                 lazy_loaded_paths: Default::default(),
                 #[cfg(feature = "local_fs")]
                 watcher: Default::default(),
@@ -608,6 +612,91 @@ mod tests {
                 .unwrap()
                 .loaded());
         });
+    }
+
+    #[test]
+    fn git_status_recompute_marks_modified_file_and_dirty_ancestors() -> anyhow::Result<()> {
+        let temp_dir = tempfile::TempDir::new()?;
+        let repo = git2::Repository::init(temp_dir.path())?;
+        let nested_dir = temp_dir.path().join("src/nested");
+        fs::create_dir_all(&nested_dir)?;
+        let modified_file = nested_dir.join("main.rs");
+        fs::write(&modified_file, "baseline\n")?;
+        commit_paths(&repo, &[Path::new("src/nested/main.rs")])?;
+        fs::write(&modified_file, "modified\n")?;
+
+        let repo_root = StandardizedPath::try_from_local(temp_dir.path())?;
+        let src_dir = StandardizedPath::try_from_local(&temp_dir.path().join("src"))?;
+        let nested_dir_std = StandardizedPath::try_from_local(&nested_dir)?;
+        let modified_file_std = StandardizedPath::try_from_local(&modified_file)?;
+
+        let root = Entry::Directory(DirectoryEntry {
+            path: repo_root.clone(),
+            children: vec![Entry::Directory(DirectoryEntry {
+                path: src_dir.clone(),
+                children: vec![Entry::Directory(DirectoryEntry {
+                    path: nested_dir_std.clone(),
+                    children: vec![Entry::File(FileMetadata::new(modified_file.clone(), false))],
+                    ignored: false,
+                    loaded: true,
+                })],
+                ignored: false,
+                loaded: true,
+            })],
+            ignored: false,
+            loaded: true,
+        });
+
+        let mut model = LocalRepoMetadataModel::new_for_test();
+        model.repositories.insert(
+            repo_root.clone(),
+            IndexedRepoState::Indexed(FileTreeState::new_lazy_loaded(root)),
+        );
+
+        let update = RepoUpdate {
+            added: vec![modified_file.clone()],
+            deleted: vec![],
+            moved: HashMap::new(),
+        };
+        let computation =
+            LocalRepoMetadataModel::compute_git_status_computation(&repo_root, &update);
+        model.recompute_git_statuses(&repo_root, computation);
+
+        assert_eq!(
+            model.git_status_for(&modified_file_std),
+            Some(GitStatus::Modified)
+        );
+        assert!(model.is_dirty_dir(&nested_dir_std));
+        assert!(model.is_dirty_dir(&src_dir));
+        assert!(model.is_dirty_dir(&repo_root));
+        assert_eq!(
+            model.dirty_dir_status_for(&src_dir),
+            Some(GitStatus::Modified)
+        );
+
+        Ok(())
+    }
+
+    fn commit_paths(repo: &git2::Repository, paths: &[&Path]) -> anyhow::Result<()> {
+        let mut index = repo.index()?;
+        for path in paths {
+            index.add_path(path)?;
+        }
+        index.write()?;
+
+        let tree_id = index.write_tree()?;
+        let tree = repo.find_tree(tree_id)?;
+        let signature = git2::Signature::now("Warp Test", "test@example.com")?;
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            "initial commit",
+            &tree,
+            &[],
+        )?;
+
+        Ok(())
     }
 
     #[test]

--- a/crates/repo_metadata/src/wrapper_model.rs
+++ b/crates/repo_metadata/src/wrapper_model.rs
@@ -7,6 +7,8 @@
 
 #[cfg(feature = "local_fs")]
 use std::path::Path;
+#[cfg(any(test, feature = "test-util"))]
+use std::path::PathBuf;
 
 use warp_core::HostId;
 use warp_util::standardized_path::StandardizedPath;
@@ -14,6 +16,7 @@ use warpui::{AppContext, ModelContext, ModelHandle, SingletonEntity};
 
 use crate::file_tree_store::FileTreeState;
 use crate::file_tree_update::RepoMetadataUpdate;
+use crate::git_status::GitStatus;
 use crate::local_model::{
     GetContentsArgs, IndexedRepoState, LocalRepoMetadataModel, RepoContent, RepositoryMetadataEvent,
 };
@@ -354,6 +357,22 @@ impl RepoMetadataModel {
     pub fn is_lazy_loaded_path(&self, path: &StandardizedPath, ctx: &AppContext) -> bool {
         self.local.as_ref(ctx).is_lazy_loaded_path(path)
     }
+
+    pub fn git_status_for(&self, path: &StandardizedPath, ctx: &AppContext) -> Option<GitStatus> {
+        self.local.as_ref(ctx).git_status_for(path)
+    }
+
+    pub fn is_dirty_dir(&self, path: &StandardizedPath, ctx: &AppContext) -> bool {
+        self.local.as_ref(ctx).is_dirty_dir(path)
+    }
+
+    pub fn dirty_dir_status_for(
+        &self,
+        path: &StandardizedPath,
+        ctx: &AppContext,
+    ) -> Option<GitStatus> {
+        self.local.as_ref(ctx).dirty_dir_status_for(path)
+    }
 }
 
 impl warpui::Entity for RepoMetadataModel {
@@ -373,6 +392,18 @@ impl RepoMetadataModel {
     ) {
         self.local.update(ctx, |local, _ctx| {
             local.insert_test_state(repo_path, state);
+        });
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    pub fn recompute_git_statuses_for_test(
+        &self,
+        repo_path: StandardizedPath,
+        changed_paths: Vec<PathBuf>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.local.update(ctx, |local, _ctx| {
+            local.recompute_git_statuses_for_test(&repo_path, changed_paths);
         });
     }
 }


### PR DESCRIPTION
## Summary

- **Bug fix:** sidebar file tree silently no-ops when an ancestor-displayed root contains a nested indexed repo. The exact-path filter in `FileTreeView::handle_repository_metadata_event` drops `FileTreeEntryUpdated` events routed to the longest-matching repo path (via `LocalRepoMetadataModel::find_repository_for_path_string`), so the tree never rebuilds. Fix matches roots whose `entry.root_directory()` is a strict ancestor of the updated path; preserves existing exact-match behavior.
- **Feature:** VS Code-style git status decorations in the sidebar — letter badge (M/A/U/C/R) + filename color tint + dim parent-directory rollup dot. Live updates via the existing fs watcher; reuses `FileTreeEntryUpdated`.

## Why

The bug fix is small (~30 lines) and catches a real correctness gap. The decoration feature is independent but lands cleanly on top of the same update path.

## Implementation notes

- New `repo_metadata::git_status` module (uses the existing vendored `libgit2` already in `app/Cargo.toml`; added `git2` dep to `repo_metadata/Cargo.toml`).
- `LocalRepoMetadataModel` gets `git_statuses` and `dirty_dirs` caches; recomputes off-thread inside the existing `ctx.spawn` block in `handle_watcher_event`. `.git/` internal events trigger a full-repo refresh, normal events use scoped pathspecs.
- `RepoMetadataModel` (wrapper) exposes `git_status_for` and `is_dirty_dir` for consumers.
- View renders status via a new `FileTreeGitDecoration` enum; `render_item` was extended to receive `&AppContext`.
- Colors use existing theme methods (`ui_yellow_color`, `ansi_fg_red`) and editor diff helpers (`add_color`) — no raw RGB.
- `Deleted` status is mapped by the reader but skipped in the view in this version: deleted files are removed from the tree by `FileTreeMutation::Remove`, so there's no row to decorate. Matches VS Code Explorer behavior (deletions surface in the SCM panel).
- Watcher debounce is unchanged at 1s.

## Tests

- `git_status::tests::statuses_for_repo_maps_modified_untracked_added_and_ignored` — uses a real temp git repo (init, commit baseline, modify/untrack/ignore/stage), asserts the enum mapping.
- `local_model::tests::git_status_recompute_marks_modified_file_and_dirty_ancestors` — model-level cache + rollup test.
- `view_tests::git_status_decorations_update_for_ancestor_displayed_root` — view-level: ancestor-displayed root with a nested modified file, asserts decoration mapping (badge `M`, modified color). The existing harness has no precedent for asserting rendered `Text` color directly; falls back to model-state + decoration assertions.

## Test plan

- [x] `cargo check -p repo_metadata`
- [x] `cargo check -p warp`
- [x] `cargo test -p repo_metadata git_status`
- [x] `cargo test -p warp git_status_decorations_update_for_ancestor_displayed_root`
- [x] Release build (`./script/run --release`) launches successfully

CHANGELOG-IMPROVEMENT: File tree shows VS Code-style git status decorations and refreshes ancestor-displayed roots when nested repos change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)