### PR TITLE
Use a PAT for pushing new release branches and tags.

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -111,6 +111,9 @@ jobs:
         shell: bash
         env:
           CHANNEL: ${{ steps.get-config.outputs.channel }}
+          # See https://github.com/orgs/community/discussions/151442 for why we need to use
+          # a PAT here.
+          GITHUB_TOKEN: ${{ secrets.CREATE_RELEASE_TAG_PUSH_PAT }}
 
       - name: Create GitHub release
         if: ${{ steps.set_publish.outputs.should_publish == 'true' }}


### PR DESCRIPTION
## Description

This is intended to fix issues with creating new release branches/tags when the release branch `.github/workflows` directory doesn't match the `master` branch directory.

The PAT here is owned by our machine user, and has the `contents:write` and `workflows:write` permissions.