### PR TITLE
Mark focused-pane notifications as read when the warp window is re-focused

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -16041,13 +16041,18 @@ impl Workspace {
             StateEvent::ValueChanged { current, previous } => {
                 let did_window_change_focus =
                     WindowManager::did_window_change_focus(self.window_id, current, previous);
+                let cached_window_is_active = current.active_window == Some(self.window_id);
+                let app_became_active = previous.stage != ApplicationStage::Active
+                    && current.stage == ApplicationStage::Active;
+                let platform_window_is_active =
+                    ctx.windows().active_window() == Some(self.window_id);
 
                 // Notify focus listeners when this window is active after either a window focus
                 // change or app reactivation while the active window stayed the same.
-                if current.active_window == Some(self.window_id)
-                    && (did_window_change_focus
-                        || (previous.stage != ApplicationStage::Active
-                            && current.stage == ApplicationStage::Active))
+                // On macOS, app activation can beat the deferred key-window update, so
+                // reactivation also verifies the live platform window.
+                if cached_window_is_active
+                    && (did_window_change_focus || (app_became_active && platform_window_is_active))
                 {
                     if let Some(terminal_view) = self
                         .active_tab_pane_group()

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -420,7 +420,7 @@ use warpui::elements::{
     MouseInBehavior, Rect,
 };
 use warpui::ui_components::button::{Button, ButtonVariant};
-use warpui::windowing::{StateEvent, WindowManager};
+use warpui::windowing::{state::ApplicationStage, StateEvent, WindowManager};
 use warpui::{elements::MouseStateHandle, fonts::Properties};
 
 use crate::{autoupdate, channel::ChannelState};
@@ -16039,11 +16039,36 @@ impl Workspace {
     fn handle_window_state_change(&mut self, event: &StateEvent, ctx: &mut ViewContext<Self>) {
         match &event {
             StateEvent::ValueChanged { current, previous } => {
+                let did_window_change_focus =
+                    WindowManager::did_window_change_focus(self.window_id, current, previous);
+
+                // Notify focus listeners when this window is active after either a window focus
+                // change or app reactivation while the active window stayed the same.
+                if current.active_window == Some(self.window_id)
+                    && (did_window_change_focus
+                        || (previous.stage != ApplicationStage::Active
+                            && current.stage == ApplicationStage::Active))
+                {
+                    if let Some(terminal_view) = self
+                        .active_tab_pane_group()
+                        .as_ref(ctx)
+                        .focused_session_view(ctx)
+                    {
+                        let ambient_agent_task_id = terminal_view
+                            .as_ref(ctx)
+                            .ambient_agent_task_id_for_details_panel(ctx);
+                        self.notify_terminal_focus_change(
+                            Some(terminal_view.id()),
+                            ambient_agent_task_id,
+                            ctx,
+                        );
+                    }
+                }
+
                 // Re-render if fullscreen state for active window has changed.
                 if current.is_active_window_fullscreen != previous.is_active_window_fullscreen {
                     ctx.notify();
-                } else if WindowManager::did_window_change_focus(self.window_id, current, previous)
-                {
+                } else if did_window_change_focus {
                     // Re-render if this window's focus state has changed.
                     ctx.notify();
                 } else if current.stage != previous.stage {


### PR DESCRIPTION
## Summary

When the user shifts focus from one pane to another pane, we mark the notifications in that pane as read. We should do the same when a user shifts focus from a different app back into warp (for the pane that is then focused).

## Demo

https://www.loom.com/share/343ab3ee8358495686e0dc30c4d4ba2a

Linear: WAR-7383

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._