### PR TITLE
Add server conversation ID to computer use telemetry events.

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1047,9 +1047,14 @@ impl BlocklistAIActionModel {
             pending_action.action,
             AIAgentActionType::RequestComputerUse(_)
         ) {
+            let server_conversation_id = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .and_then(|c| c.server_conversation_token())
+                .map(|t| t.as_str().to_string());
             send_telemetry_from_ctx!(
                 TelemetryEvent::ComputerUseCancelled {
-                    conversation_id,
+                    client_conversation_id: conversation_id,
+                    server_conversation_id,
                     ambient_agent_task_id: self.ambient_agent_task_id,
                 },
                 ctx

--- a/app/src/ai/blocklist/action_model/execute/request_computer_use.rs
+++ b/app/src/ai/blocklist/action_model/execute/request_computer_use.rs
@@ -6,6 +6,7 @@ use warpui::{Entity, EntityId, ModelContext, SingletonEntity};
 
 use crate::ai::agent::{AIAgentActionId, AIAgentActionType};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::send_telemetry_from_ctx;
 use crate::server::telemetry::TelemetryEvent;
 
@@ -70,9 +71,14 @@ impl RequestComputerUseExecutor {
 
         // If we're executing, that implies that computer use has been approved.
         let is_autoexecuted = self.autoexecuted_actions.remove(&action.id);
+        let server_conversation_id = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .and_then(|c| c.server_conversation_token())
+            .map(|t| t.as_str().to_string());
         send_telemetry_from_ctx!(
             TelemetryEvent::ComputerUseApproved {
-                conversation_id,
+                client_conversation_id: conversation_id,
+                server_conversation_id,
                 is_autoexecuted,
                 ambient_agent_task_id: self.ambient_agent_task_id,
             },

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -2771,13 +2771,15 @@ pub enum TelemetryEvent {
     CloudAgentCapacityModalUpgradeClicked,
     /// Emitted when a RequestComputerUse action is approved (manually or auto-executed).
     ComputerUseApproved {
-        conversation_id: AIConversationId,
+        client_conversation_id: AIConversationId,
+        server_conversation_id: Option<String>,
         is_autoexecuted: bool,
         ambient_agent_task_id: Option<AmbientAgentTaskId>,
     },
     /// Emitted when a RequestComputerUse action is cancelled/rejected.
     ComputerUseCancelled {
-        conversation_id: AIConversationId,
+        client_conversation_id: AIConversationId,
+        server_conversation_id: Option<String>,
         ambient_agent_task_id: Option<AmbientAgentTaskId>,
     },
     /// Emitted when a warp://linear deeplink is opened.
@@ -4539,19 +4541,23 @@ impl TelemetryEvent {
             TelemetryEvent::CloudAgentCapacityModalDismissed => None,
             TelemetryEvent::CloudAgentCapacityModalUpgradeClicked => None,
             TelemetryEvent::ComputerUseApproved {
-                conversation_id,
+                client_conversation_id,
+                server_conversation_id,
                 is_autoexecuted,
                 ambient_agent_task_id,
             } => Some(json!({
-                "conversation_id": conversation_id,
+                "client_conversation_id": client_conversation_id,
+                "server_conversation_id": server_conversation_id,
                 "is_autoexecuted": is_autoexecuted,
                 "ambient_agent_task_id": ambient_agent_task_id.map(|id| id.to_string()),
             })),
             TelemetryEvent::ComputerUseCancelled {
-                conversation_id,
+                client_conversation_id,
+                server_conversation_id,
                 ambient_agent_task_id,
             } => Some(json!({
-                "conversation_id": conversation_id,
+                "client_conversation_id": client_conversation_id,
+                "server_conversation_id": server_conversation_id,
                 "ambient_agent_task_id": ambient_agent_task_id.map(|id| id.to_string()),
             })),
             TelemetryEvent::FreeTierLimitHitInterstitialDisplayed => None,


### PR DESCRIPTION
## Description
Add `server_conversation_id` to the `ComputerUseApproved` and `ComputerUseCancelled` telemetry events so that these events can be cross-referenced with conversations in the prod debugger (which uses the server/proto conversation ID as its lookup key).

Also rename the existing `conversation_id` field to `client_conversation_id` for clarity, since it was ambiguous which ID was being sent.

## Testing
`cargo check` passes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>