### PR TITLE
Skip reconnect for unrecoverable transport disconnects

### DIFF
--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -14,6 +14,7 @@ use warpui::r#async::executor;
 
 use remote_server::auth::RemoteServerAuthContext;
 use remote_server::client::RemoteServerClient;
+use remote_server::manager::RemoteServerExitStatus;
 use remote_server::setup::{
     parse_uname_output, remote_server_daemon_dir, PreinstallCheckResult, RemotePlatform,
 };
@@ -283,6 +284,19 @@ impl RemoteTransport for SshTransport {
                 Err(anyhow::anyhow!("Failed to remove binary: {stderr}"))
             }
         })
+    }
+
+    /// SSH exit code 255 indicates a connection-level error (broken pipe,
+    /// connection reset, host unreachable) — the ControlMaster's TCP
+    /// connection is dead. A signal kill also suggests the transport was
+    /// torn down. In either case, reconnecting through the same
+    /// ControlMaster is futile.
+    fn is_reconnectable(&self, exit_status: Option<&RemoteServerExitStatus>) -> bool {
+        match exit_status {
+            Some(s) => s.code != Some(255) && !s.signal_killed,
+            // No exit status available — optimistically allow reconnect.
+            None => true,
+        }
     }
 }
 

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -1355,22 +1355,26 @@ impl RemoteServerManager {
             let exit_status = Self::capture_exit_status(&mut _child, session_id);
             // Drop the old child process explicitly before reconnecting.
             drop(_child);
+
+            // Ask the transport whether a reconnect is viable given the
+            // exit status. For example, SSH returns false when exit code
+            // 255 indicates the ControlMaster's TCP connection is dead.
+            if !transport.is_reconnectable(exit_status.as_ref()) {
+                log::warn!(
+                    "Transport reports disconnect is not reconnectable for \
+                     session {session_id:?} (exit_status={exit_status:?}), \
+                     skipping reconnect"
+                );
+                self.finalize_disconnect(session_id, host_id, exit_status, ctx);
+                return;
+            }
+
             let Some(auth_context) = self.auth_context.clone() else {
                 log::warn!(
                     "Spontaneous disconnect for session {session_id:?}, \
                      but no auth context is available for reconnect"
                 );
-                self.sessions
-                    .insert(session_id, RemoteSessionState::Disconnected);
-                self.remove_from_host_index(&host_id, session_id);
-                ctx.emit(RemoteServerManagerEvent::SessionDisconnected {
-                    session_id,
-                    host_id: host_id.clone(),
-                    exit_status,
-                });
-                if !self.host_to_sessions.contains_key(&host_id) {
-                    ctx.emit(RemoteServerManagerEvent::HostDisconnected { host_id });
-                }
+                self.finalize_disconnect(session_id, host_id, exit_status, ctx);
                 return;
             };
             log::info!(
@@ -1573,6 +1577,35 @@ impl RemoteServerManager {
             });
             // Note: HostDisconnected was already emitted by
             // mark_session_disconnected when entering the reconnect flow.
+        }
+    }
+
+    /// Marks a session as `Disconnected`, cleans up the host index, and
+    /// emits the appropriate disconnect events. Used by
+    /// `mark_session_disconnected` when reconnection is not possible
+    /// (SSH transport failure, missing auth context).
+    ///
+    /// Not used by `handle_reconnect_failure` because that path enters
+    /// from `attempt_reconnect`, which already cleared the host index
+    /// and emitted `HostDisconnected` when entering the reconnect flow.
+    #[cfg(not(target_family = "wasm"))]
+    fn finalize_disconnect(
+        &mut self,
+        session_id: SessionId,
+        host_id: HostId,
+        exit_status: Option<RemoteServerExitStatus>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.sessions
+            .insert(session_id, RemoteSessionState::Disconnected);
+        self.remove_from_host_index(&host_id, session_id);
+        ctx.emit(RemoteServerManagerEvent::SessionDisconnected {
+            session_id,
+            host_id: host_id.clone(),
+            exit_status,
+        });
+        if !self.host_to_sessions.contains_key(&host_id) {
+            ctx.emit(RemoteServerManagerEvent::HostDisconnected { host_id });
         }
     }
 

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -18,6 +18,7 @@ use async_channel::Receiver;
 use warpui::r#async::executor;
 
 use crate::client::{ClientEvent, RemoteServerClient};
+use crate::manager::RemoteServerExitStatus;
 use crate::setup::{PreinstallCheckResult, RemotePlatform};
 
 /// A successful return from [`RemoteTransport::connect`].
@@ -153,4 +154,13 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     fn remove_remote_server_binary(
         &self,
     ) -> Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>>;
+
+    /// Returns `true` if the transport considers a reconnect viable after
+    /// a spontaneous disconnect with the given exit status.
+    ///
+    /// Transports that can determine the underlying connection is
+    /// unrecoverable (e.g. SSH detecting a dead ControlMaster via exit
+    /// code 255) should return `false`, which tells the manager to skip
+    /// the reconnect loop entirely.
+    fn is_reconnectable(&self, exit_status: Option<&RemoteServerExitStatus>) -> bool;
 }


### PR DESCRIPTION
## Description

We are seeing ~850 Sentry errors in 2 days ([WARP-CLIENT-BETA-STABLE-7JNH](https://warpdotdev.sentry.io/issues/7456268110/)) from doomed reconnect attempts after SSH disconnects caused by system sleep / network loss.

When the Mac sleeps, the SSH TCP connection dies but the ControlMaster process stays alive locally (no keepalives configured). The `remote-server-proxy` reader task detects EOF and triggers reconnect, but reconnecting through the same ControlMaster is futile since its TCP connection is dead. Both attempts fail with "Response channel closed before receiving a reply" and the errors get reported to Sentry.

**Root cause**: the reconnect flow had no way to distinguish a recoverable disconnect (remote server process crashed, SSH connection still alive) from an unrecoverable one (SSH connection itself is dead).

**Fix**: Add `is_reconnectable(exit_status)` to the `RemoteTransport` trait so each transport can decide whether a reconnect is viable. `SshTransport` returns `false` when the exit code is 255 (SSH connection-level error) or the process was signal-killed, indicating the ControlMaster connection is dead. `mark_session_disconnected` consults the transport before entering the reconnect loop.

This is a required trait method (no default impl) so future transports must explicitly consider reconnectability.

### Changes
- **`RemoteTransport` trait** (`transport.rs`): Added required `is_reconnectable` method
- **`SshTransport`** (`ssh_transport.rs`): Implements `is_reconnectable` — returns `false` for exit code 255 / signal kill
- **`RemoteServerManager`** (`manager.rs`): `mark_session_disconnected` calls `transport.is_reconnectable()` before attempting reconnect; extracted `finalize_disconnect` helper to deduplicate the disconnect-and-emit pattern

## Linked Issue
- Sentry: [WARP-CLIENT-BETA-STABLE-7JNH](https://warpdotdev.sentry.io/issues/7456268110/)

## Testing
- `cargo clippy` passes on both `remote_server` and `warp` crates
- All 48 `remote_server` tests pass

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/ead2a14e-5ddd-4fe6-9a04-5ce7f48ec84f)

<!--
CHANGELOG-BUG-FIX: Fixed unnecessary reconnect attempts for remote SSH sessions after system sleep, reducing error noise
-->