### PR TITLE
Update remote server logs

### DIFF
--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -577,7 +577,7 @@ impl ServerModel {
 
         let Some(shell_type) = ShellType::from_name(&msg.shell_type) else {
             safe_error!(
-                safe: ("Received unknown shell_type in SessionBootstrapped"),
+                safe: ("Received unknown shell_type in SessionBootstrapped: shell_type={:?}", msg.shell_type),
                 full: ("Received unknown shell_type in SessionBootstrapped: shell_type={:?} session={session_id:?}", msg.shell_type)
             );
             return;

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -6,6 +6,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use warp_core::channel::ChannelState;
+use warp_core::safe_error;
 use warp_core::SessionId;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::platform::TerminationMode;
@@ -575,9 +576,9 @@ impl ServerModel {
         );
 
         let Some(shell_type) = ShellType::from_name(&msg.shell_type) else {
-            log::error!(
-                "Unknown shell_type {:?} in SessionBootstrapped for session {session_id:?}",
-                msg.shell_type,
+            safe_error!(
+                safe: ("Received unknown shell_type in SessionBootstrapped"),
+                full: ("Received unknown shell_type in SessionBootstrapped: shell_type={:?} session={session_id:?}", msg.shell_type)
             );
             return;
         };
@@ -628,7 +629,10 @@ impl ServerModel {
         };
 
         let Some(executor) = self.executors.get(&session_id).cloned() else {
-            log::error!("No executor for session {session_id:?}, session was never initialized");
+            safe_error!(
+                safe: ("No executor for RunCommand, session was never initialized"),
+                full: ("No executor for RunCommand, session was never initialized: session={session_id:?}")
+            );
             return HandlerOutcome::Sync(server_message::Message::RunCommandResponse(
                 RunCommandResponse {
                     result: Some(run_command_response::Result::Error(RunCommandError {

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -167,7 +167,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 pty.initialize_shell(&session_info, ctx);
             });
         } else {
-            log::warn!("PtyController dropped before bootstrap could be flushed");
+            log::warn!("Remote server PtyController dropped before bootstrap could be flushed");
         }
     }
 
@@ -253,8 +253,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             });
         if let Some((check, reason)) = unsupported {
             log::info!(
-                "Preinstall check classified {session_id:?} as unsupported \
-                 ({:?}); falling back to legacy SSH",
+                "Remote server preinstall check classified as unsupported, falling back to legacy SSH: session={session_id:?} status={:?}",
                 check.status
             );
             send_unsupported_telemetry(self.remote_platform.as_ref(), check, ctx);
@@ -324,7 +323,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 }
             }
             Err(err) => {
-                log::error!("Binary check failed for {session_id:?}: {err}");
+                log::warn!("Remote server binary check failed: session={session_id:?} error={err}");
                 self.flush_stashed_bootstrap(session_info, ctx);
             }
         }
@@ -336,7 +335,9 @@ impl<T: EventLoopSender> RemoteServerController<T> {
         ctx: &mut ModelContext<Self>,
     ) {
         let SshInitState::AwaitingUserChoice { .. } = self.state else {
-            log::warn!("Install clicked but state is not AwaitingUserChoice for {session_id:?}");
+            log::warn!(
+                "Remote server install requested in unexpected state: session={session_id:?}"
+            );
             return;
         };
 
@@ -448,10 +449,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
         else {
             unreachable!("just matched AwaitingConnect above");
         };
-        log::warn!(
-            "Remote server connection failed for session {session_id:?}; \
-             flushing bootstrap to unblock SSH session"
-        );
+        log::warn!("Remote server connection failed: session={session_id:?}");
         self.flush_stashed_bootstrap(session_info, ctx);
     }
 
@@ -463,7 +461,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
         let SshInitState::AwaitingUserChoice { session_info, .. } =
             std::mem::replace(&mut self.state, SshInitState::Idle)
         else {
-            log::warn!("Skip clicked but state is not AwaitingUserChoice for {session_id:?}");
+            log::warn!("Remote server skip requested in unexpected state: session={session_id:?}");
             return;
         };
         self.flush_stashed_bootstrap(session_info, ctx);
@@ -504,7 +502,9 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 self.connect_session_for_current_identity(session_id, socket_path, ctx);
             }
             Err(err) => {
-                log::error!("Binary install failed for {session_id:?}: {err}");
+                log::warn!(
+                    "Remote server binary install failed: session={session_id:?} error={err}"
+                );
                 self.flush_stashed_bootstrap(session_info, ctx);
             }
         }

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -19,6 +19,7 @@ use crate::proto::{
 use crate::protocol::{self, ProtocolError, RequestId};
 
 use warp_core::SessionId;
+use warp_core::{safe_error, safe_warn};
 use warpui::r#async::TransportStream;
 
 /// Default request timeout (2 minutes).
@@ -199,7 +200,10 @@ impl RemoteServerClient {
         match response.message {
             Some(server_message::Message::InitializeResponse(resp)) => Ok(resp),
             other => {
-                log::error!("Unexpected response variant for Initialize: {other:?}");
+                safe_error!(
+                    safe: ("Remote server unexpected response for Initialize"),
+                    full: ("Remote server unexpected response for Initialize: response={other:?}")
+                );
                 Err(ClientError::UnexpectedResponse)
             }
         }
@@ -256,7 +260,10 @@ impl RemoteServerClient {
         match response.message {
             Some(server_message::Message::NavigatedToDirectoryResponse(resp)) => Ok(resp),
             other => {
-                log::error!("Unexpected response variant for NavigatedToDirectory: {other:?}");
+                safe_error!(
+                    safe: ("Remote server unexpected response for NavigatedToDirectory"),
+                    full: ("Remote server unexpected response for NavigatedToDirectory: response={other:?}")
+                );
                 Err(ClientError::UnexpectedResponse)
             }
         }
@@ -284,7 +291,10 @@ impl RemoteServerClient {
         match response.message {
             Some(server_message::Message::LoadRepoMetadataDirectoryResponse(resp)) => Ok(resp),
             other => {
-                log::error!("Unexpected response variant for LoadRepoMetadataDirectory: {other:?}");
+                safe_error!(
+                    safe: ("Remote server unexpected response for LoadRepoMetadataDirectory"),
+                    full: ("Remote server unexpected response for LoadRepoMetadataDirectory: response={other:?}")
+                );
                 Err(ClientError::UnexpectedResponse)
             }
         }
@@ -310,7 +320,10 @@ impl RemoteServerClient {
                 }
             },
             other => {
-                log::error!("Unexpected response variant for WriteFile: {other:?}");
+                safe_error!(
+                    safe: ("Remote server unexpected response for WriteFile"),
+                    full: ("Remote server unexpected response for WriteFile: response={other:?}")
+                );
                 Err(ClientError::UnexpectedResponse)
             }
         }
@@ -335,7 +348,10 @@ impl RemoteServerClient {
         match response.message {
             Some(server_message::Message::ReadFileContextResponse(resp)) => Ok(resp),
             other => {
-                log::error!("Unexpected response variant for ReadFileContext: {other:?}");
+                safe_error!(
+                    safe: ("Remote server unexpected response for ReadFileContext"),
+                    full: ("Remote server unexpected response for ReadFileContext: response={other:?}")
+                );
                 Err(ClientError::UnexpectedResponse)
             }
         }
@@ -357,7 +373,10 @@ impl RemoteServerClient {
                 }
             },
             other => {
-                log::error!("Unexpected response variant for DeleteFile: {other:?}");
+                safe_error!(
+                    safe: ("Remote server unexpected response for DeleteFile"),
+                    full: ("Remote server unexpected response for DeleteFile: response={other:?}")
+                );
                 Err(ClientError::UnexpectedResponse)
             }
         }
@@ -375,7 +394,10 @@ impl RemoteServerClient {
                 Some(ClientEvent::RepoMetadataUpdated { update })
             }
             other => {
-                log::warn!("Unhandled push message variant: {other:?}");
+                safe_warn!(
+                    safe: ("Unhandled push message variant"),
+                    full: ("Unhandled push message variant: {other:?}")
+                );
                 None
             }
         }
@@ -405,7 +427,10 @@ impl RemoteServerClient {
         match response.message {
             Some(server_message::Message::RunCommandResponse(resp)) => Ok(resp),
             other => {
-                log::error!("Unexpected response variant for RunCommand: {other:?}");
+                safe_error!(
+                    safe: ("Remote server unexpected response for RunCommand"),
+                    full: ("Remote server unexpected response for RunCommand: response={other:?}")
+                );
                 Err(ClientError::UnexpectedResponse)
             }
         }
@@ -497,11 +522,11 @@ impl RemoteServerClient {
             if let Err(e) = protocol::write_client_message(&mut writer, &msg).await {
                 let request_id = RequestId::from(msg.request_id);
                 if !e.is_write_recoverable() {
-                    log::error!("Writer task fatal error: request_id={request_id}: {e}");
+                    log::error!("Writer task fatal error: request_id={request_id} error={e}");
                     pending_requests.clear();
                     break;
                 }
-                log::error!("Writer task: request_id={request_id}: {e}");
+                log::warn!("Remote server writer task error: request_id={request_id} error={e}");
                 // Drop the sender so the caller receives ResponseChannelClosed.
                 pending_requests.remove(&request_id);
             }

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -469,7 +469,7 @@ impl RemoteServerManager {
     {
         #[cfg(target_family = "wasm")]
         {
-            log::warn!("check_binary is a no-op on WASM");
+            log::warn!("Remote server check_binary is a no-op on WASM");
         }
 
         #[cfg(not(target_family = "wasm"))]
@@ -495,7 +495,7 @@ impl RemoteServerManager {
                     let platform = match platform_result {
                         Ok(p) => Some(p),
                         Err(e) => {
-                            log::warn!("Platform detection failed for session {session_id:?}: {e}");
+                            log::warn!("Remote server platform detection failed: session={session_id:?} error={e}");
                             None
                         }
                     };
@@ -503,8 +503,7 @@ impl RemoteServerManager {
                         Ok(has) => has,
                         Err(e) => {
                             log::warn!(
-                                "Old-binary detection failed for session {session_id:?}: {e}. \
-                                 Treating as fresh install."
+                                "Remote server old-binary detection failed, treating as fresh install: session={session_id:?} error={e}"
                             );
                             false
                         }
@@ -520,7 +519,7 @@ impl RemoteServerManager {
                                 Ok(r) => Some(r),
                                 Err(e) => {
                                     log::warn!(
-                                        "Preinstall check failed for session {session_id:?}: {e}"
+                                        "Remote server preinstall check failed: session={session_id:?} error={e}"
                                     );
                                     None
                                 }
@@ -568,7 +567,7 @@ impl RemoteServerManager {
         _reason: UnsupportedReason,
         _ctx: &mut ModelContext<Self>,
     ) {
-        log::warn!("mark_setup_unsupported is a no-op on WASM");
+        log::warn!("Remote server mark_setup_unsupported is a no-op on WASM");
     }
 
     /// Marks a session as unsupported by the prebuilt remote-server
@@ -605,7 +604,7 @@ impl RemoteServerManager {
     {
         #[cfg(target_family = "wasm")]
         {
-            log::warn!("install_binary is a no-op on WASM");
+            log::warn!("Remote server install_binary is a no-op on WASM");
         }
 
         #[cfg(not(target_family = "wasm"))]
@@ -669,12 +668,12 @@ impl RemoteServerManager {
     {
         #[cfg(target_family = "wasm")]
         {
-            log::warn!("connect_session is a no-op on WASM");
+            log::warn!("Remote server connect_session is a no-op on WASM");
         }
 
         #[cfg(not(target_family = "wasm"))]
         {
-            log::info!("Starting remote server connection for session {session_id:?}");
+            log::info!("Starting remote server connection: session={session_id:?}");
 
             // Advance the user-visible setup pipeline.
             ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
@@ -722,7 +721,9 @@ impl RemoteServerManager {
                                 .await;
                         }
                         Err(e) => {
-                            log::error!("Connection failed for session {session_id:?}: {e}");
+                            log::warn!(
+                                "Remote server connection failed: session={session_id:?} error={e}"
+                            );
                             let phase = e.phase();
                             let error = format!("{e}");
                             let _ = spawner
@@ -829,8 +830,8 @@ impl RemoteServerManager {
         let client_version = ChannelState::app_version();
         if !version_is_compatible(client_version, &resp.server_version) {
             log::warn!(
-                "Remote server version mismatch for session {session_id:?}: \
-                 client={client_version:?}, server={:?}. Removing stale binary.",
+                "Remote server version mismatch, removing stale binary: session={session_id:?} \
+                 client={client_version:?} server={:?}",
                 resp.server_version
             );
 
@@ -842,7 +843,9 @@ impl RemoteServerManager {
                 .await
                 .unwrap_or_else(|_| Err(anyhow::anyhow!("timed out after {REMOVAL_TIMEOUT:?}")))
             {
-                log::warn!("Failed to remove stale remote binary for session {session_id:?}: {e}");
+                log::warn!(
+                    "Remote server stale binary removal failed: session={session_id:?} error={e}"
+                );
             }
             return Err(ConnectAndHandshakeError::Initialize(anyhow::anyhow!(
                 "remote server version mismatch (client: {client_version:?}, \
@@ -967,7 +970,7 @@ impl RemoteServerManager {
     /// notification per connected host is sufficient.
     pub fn rotate_auth_token(&self, token: String) {
         let Some(ref auth_context) = self.auth_context else {
-            log::warn!("rotate_auth_token: no auth_context available, skipping");
+            log::warn!("Remote server rotate_auth_token: no auth_context available, skipping");
             return;
         };
         let current_identity_key = auth_context.remote_server_identity_key();
@@ -1051,11 +1054,13 @@ impl RemoteServerManager {
         }
 
         let Some(client) = self.client_for_session(session_id).cloned() else {
-            log::warn!("navigate_to_directory: no connected client for session {session_id:?}");
+            log::warn!(
+                "Remote server navigate_to_directory: no connected client session={session_id:?}"
+            );
             return;
         };
         let Some(host_id) = self.host_id_for_session(session_id).cloned() else {
-            log::warn!("navigate_to_directory: no host_id for session {session_id:?}");
+            log::warn!("Remote server navigate_to_directory: no host_id session={session_id:?}");
             return;
         };
 
@@ -1080,7 +1085,7 @@ impl RemoteServerManager {
                             .await;
                     }
                     Err(e) => {
-                        log::error!("navigate_to_directory failed for session {session_id:?}: {e}");
+                        log::warn!("Remote server navigate_to_directory failed: session={session_id:?} error={e}");
                         let error_kind = RemoteServerErrorKind::from_client_error(&e);
                         let _ = spawner
                             .spawn(move |_me, ctx| {
@@ -1137,15 +1142,11 @@ impl RemoteServerManager {
         ctx: &mut ModelContext<Self>,
     ) {
         let Some(client) = self.client_for_session(session_id).cloned() else {
-            log::warn!(
-                "load_remote_repo_metadata_directory: no connected client for session {session_id:?}"
-            );
+            log::warn!("Remote server load_remote_repo_metadata_directory: no connected client session={session_id:?}");
             return;
         };
         let Some(host_id) = self.host_id_for_session(session_id).cloned() else {
-            log::warn!(
-                "load_remote_repo_metadata_directory: no host_id for session {session_id:?}"
-            );
+            log::warn!("Remote server load_remote_repo_metadata_directory: no host_id session={session_id:?}");
             return;
         };
 
@@ -1173,8 +1174,8 @@ impl RemoteServerManager {
                         }
                     }
                     Err(e) => {
-                        log::error!(
-                            "load_repo_metadata_directory failed for session {session_id:?}: {e}"
+                        log::warn!(
+                            "Remote server load_repo_metadata_directory failed: session={session_id:?} error={e}"
                         );
                         let error_kind = RemoteServerErrorKind::from_client_error(&e);
                         let _ = spawner
@@ -1235,7 +1236,7 @@ impl RemoteServerManager {
         transport: Arc<dyn RemoteTransport>,
         ctx: &mut ModelContext<Self>,
     ) {
-        log::info!("Remote server connected for session {session_id:?}, host {host_id}");
+        log::info!("Remote server connected: session={session_id:?} host={host_id}");
 
         // Only transition if the session is still in Initializing state.
         let Some(RemoteSessionState::Initializing {
@@ -1282,7 +1283,7 @@ impl RemoteServerManager {
         // initial connect and every reconnect.
         if let Some(info) = self.session_bootstrap_info.get(&session_id) {
             if let Some(client) = self.client_for_session(session_id) {
-                log::info!("Sending SessionBootstrapped notification for session {session_id:?}");
+                log::info!("Remote server sending SessionBootstrapped notification: session={session_id:?}");
                 client.notify_session_bootstrapped(
                     session_id,
                     &info.shell_type,
@@ -1309,8 +1310,7 @@ impl RemoteServerManager {
                 #[cfg(not(unix))]
                 let signal_killed = false;
                 log::warn!(
-                    "Remote server process exited for session {session_id:?}: \
-                     code={code:?}, signal_killed={signal_killed}"
+                    "Remote server process exited: session={session_id:?} code={code:?} signal_killed={signal_killed}"
                 );
                 Some(RemoteServerExitStatus {
                     code,
@@ -1319,13 +1319,14 @@ impl RemoteServerManager {
             }
             Ok(None) => {
                 log::warn!(
-                    "Remote server process still running for session {session_id:?} \
-                     despite EOF on reader task"
+                    "Remote server process still running despite EOF on reader task: session={session_id:?}"
                 );
                 None
             }
             Err(e) => {
-                log::warn!("Failed to read exit status for session {session_id:?}: {e}");
+                log::warn!(
+                    "Remote server exit status read failed: session={session_id:?} error={e}"
+                );
                 None
             }
         }
@@ -1360,27 +1361,17 @@ impl RemoteServerManager {
             // exit status. For example, SSH returns false when exit code
             // 255 indicates the ControlMaster's TCP connection is dead.
             if !transport.is_reconnectable(exit_status.as_ref()) {
-                log::warn!(
-                    "Transport reports disconnect is not reconnectable for \
-                     session {session_id:?} (exit_status={exit_status:?}), \
-                     skipping reconnect"
-                );
+                log::warn!("Transport reports disconnect is not reconnectable, skipping reconnect: session={session_id:?} exit_status={exit_status:?}");
                 self.finalize_disconnect(session_id, host_id, exit_status, ctx);
                 return;
             }
 
             let Some(auth_context) = self.auth_context.clone() else {
-                log::warn!(
-                    "Spontaneous disconnect for session {session_id:?}, \
-                     but no auth context is available for reconnect"
-                );
+                log::warn!("Remote server spontaneous disconnect without auth context: session={session_id:?}");
                 self.finalize_disconnect(session_id, host_id, exit_status, ctx);
                 return;
             };
-            log::info!(
-                "Spontaneous disconnect for session {session_id:?}, \
-                 will attempt reconnect (transport={transport:?})"
-            );
+            log::info!("Remote server spontaneous disconnect, will attempt reconnect: session={session_id:?} host={host_id:?}");
 
             // Clear stale repo metadata and host index so downstream
             // models don't hold onto data from the dead server process.
@@ -1437,8 +1428,7 @@ impl RemoteServerManager {
         } = params;
 
         log::info!(
-            "Attempting reconnect for session {session_id:?} \
-             (attempt {attempt}/{MAX_RECONNECT_ATTEMPTS})"
+            "Attempting reconnect: session={session_id:?} attempt={attempt}/{MAX_RECONNECT_ATTEMPTS}"
         );
 
         self.sessions.insert(
@@ -1466,7 +1456,7 @@ impl RemoteServerManager {
                     .await
                     .unwrap_or(true);
                 if was_removed {
-                    log::info!("Session {session_id:?} removed during reconnect delay, aborting");
+                    log::info!("Remote server session removed during reconnect delay: session={session_id:?}");
                     return;
                 }
 
@@ -1486,8 +1476,7 @@ impl RemoteServerManager {
                                 // handshake, don't resurrect it.
                                 if !me.sessions.contains_key(&session_id) {
                                     log::info!(
-                                        "Session {session_id:?} deregistered during \
-                                         reconnect handshake, aborting"
+                                        "Remote server session deregistered during reconnect handshake, aborting: session={session_id:?}"
                                     );
                                     return;
                                 }
@@ -1510,9 +1499,8 @@ impl RemoteServerManager {
                             .await;
                     }
                     Err(e) => {
-                        log::error!(
-                            "Reconnect failed for session {session_id:?} \
-                             (attempt {attempt}): {e}"
+                        log::warn!(
+                            "Remote server reconnect failed: session={session_id:?} attempt={attempt} error={e}"
                         );
                         let _ = spawner
                             .spawn(move |me, ctx| {
@@ -1520,8 +1508,7 @@ impl RemoteServerManager {
                                 // handshake, don't retry or insert Disconnected.
                                 if !me.sessions.contains_key(&session_id) {
                                     log::info!(
-                                        "Session {session_id:?} deregistered during \
-                                         reconnect handshake, aborting"
+                                        "Remote server session deregistered during reconnect handshake, aborting: session={session_id:?}"
                                     );
                                     return;
                                 }
@@ -1565,7 +1552,7 @@ impl RemoteServerManager {
             );
         } else {
             log::warn!(
-                "Reconnect exhausted for session {session_id:?} after {} attempt(s)",
+                "Remote server reconnect exhausted: session={session_id:?} attempts={}",
                 params.attempt
             );
             self.sessions


### PR DESCRIPTION
## Description
* Demotes various logs from `error` to `warn` to not flood our sentry reporting 
* Updates formatting of logs such that all conversation specific parts are at the end 
* Uses `safe_error` instead of `log::error`

## Linked Issue
Context: https://warpdev.slack.com/archives/C06MT1NRBFV/p1777920384522969?thread_ts=1777919599.697909&cid=C06MT1NRBFV and https://warpdev.slack.com/archives/C0AMRA82ZKL/p1777920563254069

## Testing
No-op

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
