### PR TITLE
[REMOTE-1486] Add cloud handoff snapshot upload

### DIFF
--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -489,6 +489,8 @@ impl AmbientAgentRunner {
                 parent_run_id: None,
                 runtime_skills: vec![],
                 referenced_attachments: vec![],
+                fork_from_conversation_id: None,
+                initial_snapshot_token: None,
             };
 
             let should_open = args.open;

--- a/app/src/ai/agent_sdk/driver/snapshot.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot.rs
@@ -43,6 +43,10 @@ use warpui::r#async::FutureExt as _;
 
 use crate::ai::agent_sdk::retry::with_bounded_retry;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::server::server_api::ai::{
+    AIClient, InitialSnapshotToken, SnapshotUploadFileInfo as AiSnapshotUploadFileInfo,
+    UploadLocalHandoffSnapshotRequest,
+};
 use crate::server::server_api::harness_support::{
     upload_to_target, HarnessSupportClient, SnapshotFileInfo, SnapshotUploadRequest, UploadTarget,
 };
@@ -212,7 +216,7 @@ fn resolve_declarations_path(task_id: Option<&AmbientAgentTaskId>) -> PathBuf {
 /// 3. `{DEFAULT_DECLARATIONS_DIR}/{DEFAULT_DECLARATIONS_FILENAME}` as a final fallback.
 fn resolve_declarations_path_with_override(
     task_id: Option<&AmbientAgentTaskId>,
-    override_path: Option<std::ffi::OsString>,
+    override_path: Option<OsString>,
 ) -> PathBuf {
     if let Some(override_path) = override_path {
         return PathBuf::from(override_path);
@@ -229,31 +233,28 @@ fn resolve_declarations_path_with_override(
 ///
 /// Returns `None` when the file is missing, unreadable, or yields no valid entries; logs a
 /// WARN describing why in each case. A returned `Some(entries)` is guaranteed non-empty.
-fn read_and_parse_declarations(
-    path: &Path,
-    task_id: &AmbientAgentTaskId,
-) -> Option<Vec<DeclarationEntry>> {
+fn read_and_parse_declarations(path: &Path) -> Option<Vec<DeclarationEntry>> {
     let contents = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             log::warn!(
-                "Snapshot declarations file not found at '{}'; skipping upload (task {task_id})",
+                "Snapshot declarations file not found at '{}'; skipping upload",
                 path.display()
             );
             return None;
         }
         Err(e) => {
             log::warn!(
-                "Failed to read snapshot declarations file '{}': {e:#}; skipping upload (task {task_id})",
+                "Failed to read snapshot declarations file '{}': {e:#}; skipping upload",
                 path.display()
             );
             return None;
         }
     };
-    let entries = parse_declarations(&contents, task_id);
+    let entries = parse_declarations(&contents);
     if entries.is_empty() {
         log::warn!(
-            "Snapshot declarations file '{}' has no valid entries; skipping upload (task {task_id})",
+            "Snapshot declarations file '{}' has no valid entries; skipping upload",
             path.display()
         );
         return None;
@@ -267,7 +268,7 @@ fn read_and_parse_declarations(
 /// and `path` (absolute path). Blank lines are ignored. Malformed lines (invalid JSON, missing
 /// fields, unsupported versions, unknown kind, non-absolute path) are logged at WARN and skipped;
 /// they never abort parsing.
-fn parse_declarations(contents: &str, task_id: &AmbientAgentTaskId) -> Vec<DeclarationEntry> {
+fn parse_declarations(contents: &str) -> Vec<DeclarationEntry> {
     let mut entries = Vec::new();
     let mut seen = HashSet::new();
     for (index, raw) in contents.lines().enumerate() {
@@ -280,26 +281,26 @@ fn parse_declarations(contents: &str, task_id: &AmbientAgentTaskId) -> Vec<Decla
             Ok(declaration) => declaration,
             Err(e) => {
                 log::warn!(
-                    "Malformed snapshot declarations JSONL line {line_number}: {e:#}: {raw:?} (task {task_id})"
+                    "Malformed snapshot declarations JSONL line {line_number}: {e:#}: {raw:?}"
                 );
                 continue;
             }
         };
         if declaration.version != Some(DECLARATION_VERSION) {
             log::warn!(
-                "Malformed snapshot declarations line {line_number} (missing or unsupported version): {raw:?} (task {task_id})"
+                "Malformed snapshot declarations line {line_number} (missing or unsupported version): {raw:?}"
             );
             continue;
         }
         if declaration.path.is_empty() {
             log::warn!(
-                "Malformed snapshot declarations line {line_number} (missing path): {raw:?} (task {task_id})"
+                "Malformed snapshot declarations line {line_number} (missing path): {raw:?}"
             );
             continue;
         }
         if !Path::new(&declaration.path).is_absolute() {
             log::warn!(
-                "Malformed snapshot declarations line {line_number} (non-absolute path): {raw:?} (task {task_id})"
+                "Malformed snapshot declarations line {line_number} (non-absolute path): {raw:?}"
             );
             continue;
         }
@@ -308,7 +309,7 @@ fn parse_declarations(contents: &str, task_id: &AmbientAgentTaskId) -> Vec<Decla
             "file" => EntryKind::File,
             other => {
                 log::warn!(
-                    "Malformed snapshot declarations line {line_number} (unknown kind '{other}'): {raw:?} (task {task_id})"
+                    "Malformed snapshot declarations line {line_number} (unknown kind '{other}'): {raw:?}"
                 );
                 continue;
             }
@@ -697,7 +698,7 @@ pub(super) async fn upload_snapshot_from_declarations(
     task_id: &AmbientAgentTaskId,
 ) {
     let declarations_path = resolve_declarations_path(Some(task_id));
-    let _ = upload_snapshot_from_declarations_file(&declarations_path, client, task_id).await;
+    let _ = upload_snapshot_from_declarations_file(&declarations_path, client).await;
 }
 
 /// Internal entry that reads from an explicit path and returns the structured outcome so tests
@@ -706,13 +707,9 @@ pub(super) async fn upload_snapshot_from_declarations(
 async fn upload_snapshot_from_declarations_file(
     path: &Path,
     client: Arc<dyn HarnessSupportClient>,
-    task_id: &AmbientAgentTaskId,
 ) -> Option<SnapshotOutcome> {
-    log::info!(
-        "Snapshot upload starting from {} (task {task_id})",
-        path.display()
-    );
-    let declarations = read_and_parse_declarations(path, task_id)?;
+    log::info!("Snapshot upload starting from {}", path.display());
+    let declarations = read_and_parse_declarations(path)?;
     let declarations = drop_files_covered_by_repos(declarations);
     let (repo_count, file_count) = declarations
         .iter()
@@ -721,12 +718,149 @@ async fn upload_snapshot_from_declarations_file(
             EntryKind::File => (r, f + 1),
         });
     log::info!(
-        "Snapshot declarations: {} entries ({repo_count} repo, {file_count} file) (task {task_id})",
+        "Snapshot declarations: {} entries ({repo_count} repo, {file_count} file)",
         declarations.len(),
     );
-    let outcome = run_pipeline(declarations, client, task_id).await?;
-    log_snapshot_outcome(&outcome, task_id);
+    let outcome = run_pipeline(declarations, client).await?;
+    log_snapshot_outcome(&outcome);
     Some(outcome)
+}
+
+/// Build the snapshot for a local-to-cloud handoff: gather repo patches and orphan file
+/// contents, allocate an initial snapshot token plus presigned upload URLs via
+/// `AIClient::upload_local_handoff_snapshot`, and upload the artifacts.
+///
+/// Returns:
+/// - `Ok(Some(initial_snapshot_token))` when a token was minted **and the manifest landed in GCS**.
+///   Individual blob uploads may still have failed; the manifest catalogues their status so the
+///   cloud agent rehydrates against whatever did land, matching the cloud→cloud best-effort
+///   posture.
+/// - `Ok(None)` when the workspace was empty (no repos, no orphan files) **or** when the
+///   manifest itself failed to upload. Without the manifest the snapshot is unusable, so
+///   callers should spawn the cloud agent without an initial snapshot token instead of pointing
+///   it at an incomplete prefix. Manifest-upload failures are also routed through
+///   `report_error!` so on-call alerting catches the silent regression.
+/// - `Err(_)` only for hard failures of `upload_local_handoff_snapshot` itself (auth, etc.).
+// TODO(REMOTE-1486): drop once the handoff UI in the parent stack branch wires this up.
+#[allow(dead_code)]
+pub(crate) async fn upload_snapshot_for_handoff(
+    repo_paths: Vec<PathBuf>,
+    orphan_file_paths: Vec<PathBuf>,
+    client: Arc<dyn AIClient>,
+    http: &http_client::Client,
+) -> Result<Option<InitialSnapshotToken>> {
+    if repo_paths.is_empty() && orphan_file_paths.is_empty() {
+        log::info!("Handoff snapshot has no declarations; skipping upload");
+        return Ok(None);
+    }
+
+    let declarations: Vec<DeclarationEntry> = repo_paths
+        .into_iter()
+        .map(|path| DeclarationEntry {
+            kind: EntryKind::Repo,
+            path: path.display().to_string(),
+        })
+        .chain(orphan_file_paths.into_iter().map(|path| DeclarationEntry {
+            kind: EntryKind::File,
+            path: path.display().to_string(),
+        }))
+        .collect();
+
+    let GatheredSnapshot {
+        manifest_filename,
+        mut upload_files,
+        mut repos,
+        mut files,
+        mut pre_upload_entries,
+    } = gather_snapshot_entries(declarations).await;
+
+    apply_per_run_cap(
+        &mut upload_files,
+        &mut repos,
+        &mut files,
+        &mut pre_upload_entries,
+    );
+
+    let mut file_infos: Vec<SnapshotFileInfo> = upload_files
+        .iter()
+        .map(|file| SnapshotFileInfo {
+            filename: file.filename.clone(),
+            mime_type: file.mime_type.clone(),
+        })
+        .collect();
+    file_infos.push(SnapshotFileInfo {
+        filename: manifest_filename.clone(),
+        mime_type: "application/json".to_string(),
+    });
+
+    let upload_request = UploadLocalHandoffSnapshotRequest {
+        files: file_infos
+            .iter()
+            .map(|file| AiSnapshotUploadFileInfo {
+                filename: file.filename.clone(),
+                mime_type: file.mime_type.clone(),
+            })
+            .collect(),
+    };
+    let response = client
+        .upload_local_handoff_snapshot(upload_request)
+        .await
+        .context("failed to allocate initial snapshot token")?;
+    log::info!(
+        "Initial snapshot token allocated; expires_at={}, uploads={}",
+        response.expires_at,
+        response.uploads.len(),
+    );
+    let initial_snapshot_token = response.initial_snapshot_token;
+
+    // Server returns `uploads` aligned by index with the request `files` array (and does
+    // not echo per-entry filenames), so we zip them positionally into a filename-keyed map.
+    // Any request file the server omits lands in `upload_entry` with no target and is
+    // marked `skipped` downstream.
+    if response.uploads.len() != file_infos.len() {
+        log::warn!(
+            "Handoff snapshot upload-target response length {} does not match request length {}; \
+             extras will be marked skipped",
+            response.uploads.len(),
+            file_infos.len(),
+        );
+    }
+    let mut target_map: HashMap<String, UploadTarget> = HashMap::new();
+    for (file, target) in file_infos.iter().zip(response.uploads.into_iter()) {
+        target_map.insert(file.filename.clone(), target);
+    }
+
+    let Some(outcome) = upload_prepared_snapshot_files(
+        http,
+        manifest_filename,
+        upload_files,
+        repos,
+        files,
+        pre_upload_entries,
+        target_map,
+    )
+    .await
+    else {
+        // Manifest serialization failed (already reported via `report_error!` inside
+        // the helper). Without a manifest the snapshot is unusable, so refuse the token.
+        return Ok(None);
+    };
+
+    let summary = SnapshotSummary::from_entries(&outcome.entries, outcome.manifest_uploaded);
+    log_snapshot_outcome(&outcome);
+    if !summary.manifest_uploaded {
+        // Without the manifest the cloud agent has no catalogue to rehydrate from, even
+        // when individual blobs landed. Alert on-call and refuse the token so we don't
+        // silently spawn a cloud agent with no recoverable state.
+        report_error!(anyhow::anyhow!(
+            "Handoff snapshot manifest failed to upload (blobs: {}/{}); cloud agent will start with no rehydration content",
+            summary.uploaded,
+            summary.total,
+        ));
+        return Ok(None);
+    }
+
+    Ok(Some(initial_snapshot_token))
 }
 
 /// Core upload pipeline.
@@ -737,7 +871,6 @@ async fn upload_snapshot_from_declarations_file(
 async fn run_pipeline(
     declarations: Vec<DeclarationEntry>,
     client: Arc<dyn HarnessSupportClient>,
-    task_id: &AmbientAgentTaskId,
 ) -> Option<SnapshotOutcome> {
     let GatheredSnapshot {
         manifest_filename,
@@ -745,11 +878,10 @@ async fn run_pipeline(
         repos,
         files,
         pre_upload_entries,
-    } = gather_snapshot_entries(declarations, task_id).await;
+    } = gather_snapshot_entries(declarations).await;
 
     upload_gathered_snapshot(
         client,
-        task_id,
         manifest_filename,
         upload_files,
         repos,
@@ -767,10 +899,7 @@ struct GatheredSnapshot {
     pre_upload_entries: Vec<EntryResult>,
 }
 
-async fn gather_snapshot_entries(
-    declarations: Vec<DeclarationEntry>,
-    task_id: &AmbientAgentTaskId,
-) -> GatheredSnapshot {
+async fn gather_snapshot_entries(declarations: Vec<DeclarationEntry>) -> GatheredSnapshot {
     let mut used_filenames = HashSet::new();
     let manifest_filename = unique_filename("snapshot_state.json", &mut used_filenames);
 
@@ -793,7 +922,6 @@ async fn gather_snapshot_entries(
                     &mut upload_files,
                     &mut repos,
                     &mut pre_upload_entries,
-                    task_id,
                 )
                 .await;
             }
@@ -804,7 +932,6 @@ async fn gather_snapshot_entries(
                     &mut upload_files,
                     &mut files,
                     &mut pre_upload_entries,
-                    task_id,
                 )
                 .await;
             }
@@ -822,7 +949,6 @@ async fn gather_snapshot_entries(
 
 async fn upload_gathered_snapshot(
     client: Arc<dyn HarnessSupportClient>,
-    task_id: &AmbientAgentTaskId,
     manifest_filename: String,
     mut upload_files: Vec<SnapshotUploadFile>,
     mut repos: Vec<RepoManifestEntry>,
@@ -838,7 +964,6 @@ async fn upload_gathered_snapshot(
         &mut repos,
         &mut files,
         &mut pre_upload_entries,
-        task_id,
     );
 
     // Ask the server for presigned URLs for every filename we intend to upload —
@@ -870,16 +995,14 @@ async fn upload_gathered_snapshot(
             Err(e) => {
                 // Pipeline-abort: route through report_error! so Sentry captures the structured
                 // error chain and on-call alerting can fire.
-                report_error!(e.context(format!(
-                    "Failed to get snapshot upload targets; skipping upload (task {task_id})"
-                )));
+                report_error!(e.context("Failed to get snapshot upload targets; skipping upload"));
                 return None;
             }
         };
         if targets.len() != chunk.len() {
             log::warn!(
                 "Snapshot upload-target response length {} does not match request length {}; \
-                 extras will be marked skipped (task {task_id})",
+                 extras will be marked skipped",
                 targets.len(),
                 chunk.len(),
             );
@@ -888,14 +1011,33 @@ async fn upload_gathered_snapshot(
             target_map.insert(file.filename.clone(), target);
         }
     }
+    upload_prepared_snapshot_files(
+        client.http_client(),
+        manifest_filename,
+        upload_files,
+        repos,
+        files,
+        pre_upload_entries,
+        target_map,
+    )
+    .await
+}
 
+async fn upload_prepared_snapshot_files(
+    http: &http_client::Client,
+    manifest_filename: String,
+    upload_files: Vec<SnapshotUploadFile>,
+    mut repos: Vec<RepoManifestEntry>,
+    mut files: Vec<FileManifestEntry>,
+    pre_upload_entries: Vec<EntryResult>,
+    target_map: HashMap<String, UploadTarget>,
+) -> Option<SnapshotOutcome> {
     // Upload non-manifest blobs concurrently, each with bounded retries on transient errors.
-    let http = client.http_client();
     let upload_futures = upload_files
         .iter()
-        .map(|file| upload_entry(http, file, &target_map, task_id));
+        .map(|file| upload_entry(http, file, &target_map));
     let upload_entries: Vec<EntryResult> = join_all(upload_futures).await;
-    fold_upload_results(&mut repos, &mut files, &upload_entries, task_id);
+    fold_upload_results(&mut repos, &mut files, &upload_entries);
 
     // Build and upload the manifest last, with the real outcomes baked in.
     let manifest = SnapshotManifest {
@@ -907,9 +1049,8 @@ async fn upload_gathered_snapshot(
         Ok(b) => b,
         Err(e) => {
             // Pipeline-abort: route through report_error! so Sentry captures it.
-            report_error!(anyhow::Error::from(e).context(format!(
-                "Failed to serialize snapshot manifest; skipping upload (task {task_id})"
-            )));
+            report_error!(anyhow::Error::from(e)
+                .context("Failed to serialize snapshot manifest; skipping upload"));
             return None;
         }
     };
@@ -922,9 +1063,7 @@ async fn upload_gathered_snapshot(
                 Err(e) => {
                     // Capture the full chain for the manifest's `error` field, then surface it
                     // to Sentry via report_error!.
-                    let e = e.context(format!(
-                        "Failed to upload manifest '{manifest_filename}' (task {task_id})"
-                    ));
+                    let e = e.context(format!("Failed to upload manifest '{manifest_filename}'"));
                     let msg = format!("{e:#}");
                     report_error!(e);
                     (false, Some(msg))
@@ -965,7 +1104,6 @@ async fn gather_repo(
     upload_files: &mut Vec<SnapshotUploadFile>,
     repos: &mut Vec<RepoManifestEntry>,
     pre_upload_entries: &mut Vec<EntryResult>,
-    task_id: &AmbientAgentTaskId,
 ) {
     let repo = Path::new(repo_path);
     let metadata = repo_metadata(repo).await;
@@ -1007,7 +1145,7 @@ async fn gather_repo(
         }
         Err(e) => {
             let err_str = format!("{e:#}");
-            log::warn!("Failed to snapshot repo '{repo_path}': {err_str} (task {task_id})");
+            log::warn!("Failed to snapshot repo '{repo_path}': {err_str}");
             repos.push(RepoManifestEntry {
                 path: repo_path.to_string(),
                 repo_name: metadata.repo_name,
@@ -1034,7 +1172,6 @@ async fn gather_file(
     upload_files: &mut Vec<SnapshotUploadFile>,
     files: &mut Vec<FileManifestEntry>,
     pre_upload_entries: &mut Vec<EntryResult>,
-    task_id: &AmbientAgentTaskId,
 ) {
     let path = Path::new(file_path);
     match tokio::fs::read(path).await {
@@ -1063,7 +1200,7 @@ async fn gather_file(
         }
         Err(e) => {
             let err_str = format!("Failed to read file '{file_path}': {e:#}");
-            log::warn!("{err_str} (task {task_id})");
+            log::warn!("{err_str}");
             files.push(FileManifestEntry {
                 path: file_path.to_string(),
                 snapshot_file: None,
@@ -1087,13 +1224,9 @@ async fn upload_entry(
     http: &http_client::Client,
     file: &SnapshotUploadFile,
     target_map: &HashMap<String, UploadTarget>,
-    task_id: &AmbientAgentTaskId,
 ) -> EntryResult {
     let Some(target) = target_map.get(&file.filename) else {
-        log::warn!(
-            "No upload target for file '{}', skipping (task {task_id})",
-            file.filename
-        );
+        log::warn!("No upload target for file '{}', skipping", file.filename);
         return EntryResult {
             label: file.filename.clone(),
             status: EntryStatus::Skipped,
@@ -1111,10 +1244,7 @@ async fn upload_entry(
         },
         Err(e) => {
             let msg = format!("{e:#}");
-            log::warn!(
-                "Failed to upload '{}': {msg} (task {task_id})",
-                file.filename
-            );
+            log::warn!("Failed to upload '{}': {msg}", file.filename);
             EntryResult {
                 label: file.filename.clone(),
                 status: EntryStatus::Failed,
@@ -1130,7 +1260,6 @@ fn fold_upload_results(
     repos: &mut [RepoManifestEntry],
     files: &mut [FileManifestEntry],
     upload_entries: &[EntryResult],
-    task_id: &AmbientAgentTaskId,
 ) {
     for entry in upload_entries {
         if let Some(repo_entry) = repos
@@ -1154,7 +1283,7 @@ fn fold_upload_results(
                 }
                 EntryStatus::GatherFailed | EntryStatus::ReadFailed => {
                     log::error!(
-                        "fold_upload_results: unexpected pre-upload status {:?} for repo patch '{}' (task {task_id})",
+                        "fold_upload_results: unexpected pre-upload status {:?} for repo patch '{}'",
                         entry.status,
                         entry.label
                     );
@@ -1181,7 +1310,7 @@ fn fold_upload_results(
                 }
                 EntryStatus::GatherFailed | EntryStatus::ReadFailed => {
                     log::error!(
-                        "fold_upload_results: unexpected pre-upload status {:?} for file '{}' (task {task_id})",
+                        "fold_upload_results: unexpected pre-upload status {:?} for file '{}'",
                         entry.status,
                         entry.label
                     );
@@ -1200,7 +1329,6 @@ fn apply_per_run_cap(
     repos: &mut [RepoManifestEntry],
     files: &mut [FileManifestEntry],
     pre_upload_entries: &mut Vec<EntryResult>,
-    task_id: &AmbientAgentTaskId,
 ) {
     let blob_limit = MAX_SNAPSHOT_FILES_PER_RUN.saturating_sub(1);
     if upload_files.len() <= blob_limit {
@@ -1209,7 +1337,7 @@ fn apply_per_run_cap(
     let total_including_manifest = upload_files.len() + 1;
     let dropped = upload_files.split_off(blob_limit);
     log::warn!(
-        "Snapshot exceeds per-run cap of {MAX_SNAPSHOT_FILES_PER_RUN} files ({total_including_manifest} declared); dropping {} blob(s) from upload (task {task_id})",
+        "Snapshot exceeds per-run cap of {MAX_SNAPSHOT_FILES_PER_RUN} files ({total_including_manifest} declared); dropping {} blob(s) from upload",
         dropped.len(),
     );
     let err_msg = format!("exceeded per-run snapshot cap of {MAX_SNAPSHOT_FILES_PER_RUN} files");
@@ -1268,7 +1396,7 @@ fn merge_content_type(target: &UploadTarget, mime_type: &str) -> UploadTarget {
 /// Log the final outcome at INFO when everything uploaded, WARN otherwise. The log line
 /// includes per-entry statuses so operators can diagnose partial state without parsing any
 /// downstream logs.
-fn log_snapshot_outcome(outcome: &SnapshotOutcome, task_id: &AmbientAgentTaskId) {
+fn log_snapshot_outcome(outcome: &SnapshotOutcome) {
     let summary = SnapshotSummary::from_entries(&outcome.entries, outcome.manifest_uploaded);
     let manifest_bit = if summary.manifest_uploaded {
         "manifest: uploaded"
@@ -1276,7 +1404,7 @@ fn log_snapshot_outcome(outcome: &SnapshotOutcome, task_id: &AmbientAgentTaskId)
         "manifest: failed"
     };
     let header = format!(
-        "Snapshot upload: {}/{} uploaded (failed: {}, skipped: {}, gather_failed: {}, read_failed: {}; {manifest_bit}) (task {task_id})",
+        "Snapshot upload: {}/{} uploaded (failed: {}, skipped: {}, gather_failed: {}, read_failed: {}; {manifest_bit})",
         summary.uploaded,
         summary.total,
         summary.failed,

--- a/app/src/ai/agent_sdk/driver/snapshot_tests.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot_tests.rs
@@ -248,7 +248,6 @@ fn run(
         .block_on(upload_snapshot_from_declarations_file(
             &declarations_path,
             client,
-            &fake_task_id(),
         ))
         .expect("pipeline returned None");
     let summary = SnapshotSummary::from_entries(&outcome.entries, outcome.manifest_uploaded);
@@ -276,7 +275,7 @@ fn parse_declarations_ignores_blank_lines() {
         "{\"version\":1,\"kind\":\"file\",\"path\":\"/abs/file.txt\"}\n",
         "\n",
     );
-    let entries = parse_declarations(contents, &fake_task_id());
+    let entries = parse_declarations(contents);
     assert_eq!(
         entries,
         vec![
@@ -302,7 +301,7 @@ fn parse_declarations_skips_malformed_lines_without_aborting() {
         "{\"version\":1,\"kind\":\"file\"}\n",
         "{\"version\":1,\"kind\":\"file\",\"path\":\"/abs/also-good\",\"extra\":true}\n",
     );
-    let entries = parse_declarations(contents, &fake_task_id());
+    let entries = parse_declarations(contents);
     assert_eq!(
         entries,
         vec![
@@ -325,7 +324,7 @@ fn parse_declarations_skips_missing_or_unsupported_versions() {
         "{\"version\":2,\"kind\":\"repo\",\"path\":\"/abs/unsupported-version\"}\n",
         "{\"version\":1,\"kind\":\"file\",\"path\":\"/abs/good\"}\n",
     );
-    let entries = parse_declarations(contents, &fake_task_id());
+    let entries = parse_declarations(contents);
     assert_eq!(
         entries,
         vec![DeclarationEntry {
@@ -342,7 +341,7 @@ fn parse_declarations_tolerates_crlf_line_endings() {
         "{\"version\":1,\"kind\":\"repo\",\"path\":\"/abs/good\"}\r\n",
         "{\"version\":1,\"kind\":\"file\",\"path\":\"/abs/also-good\"}\r\n",
     );
-    let entries = parse_declarations(contents, &fake_task_id());
+    let entries = parse_declarations(contents);
     assert_eq!(
         entries,
         vec![
@@ -365,7 +364,7 @@ fn parse_declarations_skips_lines_with_empty_path() {
         "{\"version\":1,\"kind\":\"file\",\"path\":\"   \"}\n",
         "{\"version\":1,\"kind\":\"repo\",\"path\":\"/abs/still-good\"}\n",
     );
-    let entries = parse_declarations(contents, &fake_task_id());
+    let entries = parse_declarations(contents);
     assert_eq!(
         entries,
         vec![DeclarationEntry {
@@ -382,7 +381,7 @@ fn parse_declarations_deduplicates_kind_path_pairs() {
         "{\"version\":1,\"kind\":\"repo\",\"path\":\"/abs/repo\"}\n",
         "{\"version\":1,\"kind\":\"file\",\"path\":\"/abs/repo\"}\n",
     );
-    let entries = parse_declarations(contents, &fake_task_id());
+    let entries = parse_declarations(contents);
     assert_eq!(
         entries,
         vec![
@@ -406,11 +405,7 @@ fn upload_skipped_when_declarations_file_missing() {
     let client = TestClient::new(server.url());
     let outcome = Runtime::new()
         .unwrap()
-        .block_on(upload_snapshot_from_declarations_file(
-            &missing,
-            client,
-            &fake_task_id(),
-        ));
+        .block_on(upload_snapshot_from_declarations_file(&missing, client));
     assert!(
         outcome.is_none(),
         "missing declarations file should skip the upload"
@@ -426,11 +421,7 @@ fn upload_skipped_when_declarations_file_empty() {
     let client = TestClient::new(server.url());
     let outcome = Runtime::new()
         .unwrap()
-        .block_on(upload_snapshot_from_declarations_file(
-            &decl,
-            client,
-            &fake_task_id(),
-        ));
+        .block_on(upload_snapshot_from_declarations_file(&decl, client));
     assert!(outcome.is_none(), "empty declarations file should skip");
 }
 
@@ -447,11 +438,7 @@ fn upload_skipped_when_declarations_file_has_no_valid_jsonl_entries() {
     let client = TestClient::new(server.url());
     let outcome = Runtime::new()
         .unwrap()
-        .block_on(upload_snapshot_from_declarations_file(
-            &decl,
-            client,
-            &fake_task_id(),
-        ));
+        .block_on(upload_snapshot_from_declarations_file(&decl, client));
     assert!(
         outcome.is_none(),
         "declarations file with no valid entries should skip"
@@ -980,7 +967,6 @@ fn e2e_get_snapshot_upload_targets_failure_returns_none() {
         .block_on(upload_snapshot_from_declarations_file(
             &declarations_path,
             client,
-            &fake_task_id(),
         ));
     assert!(
         outcome.is_none(),
@@ -1024,7 +1010,6 @@ fn e2e_short_response_leaves_trailing_file_without_target() {
         .block_on(upload_snapshot_from_declarations_file(
             &declarations_path,
             client,
-            &fake_task_id(),
         ))
         .expect("pipeline returned None");
     let summary = SnapshotSummary::from_entries(&outcome.entries, outcome.manifest_uploaded);
@@ -1256,7 +1241,7 @@ fn drop_files_covered_by_repos_handles_nested_repo_paths() {
 /// about for assertions, ignoring any lines the helper tests weren't asked to produce.
 fn parsed_file_paths(path: &Path) -> Vec<String> {
     let contents = fs::read_to_string(path).unwrap_or_default();
-    let entries = parse_declarations(&contents, &fake_task_id());
+    let entries = parse_declarations(&contents);
     entries
         .into_iter()
         .filter(|e| e.kind == EntryKind::File)
@@ -1451,11 +1436,7 @@ fn e2e_repo_plus_inside_and_outside_files_filters_overlap() {
     let client = TestClient::new(server.url());
     let outcome = Runtime::new()
         .unwrap()
-        .block_on(upload_snapshot_from_declarations_file(
-            &decl_path,
-            client,
-            &fake_task_id(),
-        ))
+        .block_on(upload_snapshot_from_declarations_file(&decl_path, client))
         .expect("pipeline returned None");
     let summary = SnapshotSummary::from_entries(&outcome.entries, outcome.manifest_uploaded);
 

--- a/app/src/ai/agent_sdk/mcp_config_tests.rs
+++ b/app/src/ai/agent_sdk/mcp_config_tests.rs
@@ -284,6 +284,8 @@ fn serializes_mcp_servers_as_object_not_string() {
         parent_run_id: None,
         runtime_skills: vec![],
         referenced_attachments: vec![],
+        fork_from_conversation_id: None,
+        initial_snapshot_token: None,
     };
 
     let value = serde_json::to_value(&request).unwrap();

--- a/app/src/ai/ambient_agents/spawn.rs
+++ b/app/src/ai/ambient_agents/spawn.rs
@@ -33,29 +33,21 @@ pub struct SessionJoinInfo {
 impl SessionJoinInfo {
     pub fn from_task(task: &AmbientAgentTask) -> Option<Self> {
         let run_execution = task.active_run_execution();
-        // Prefer the server-provided session_link when available; it is a better signal
-        // that a session-sharing link is ready to be shown to the user.
-        if let Some(link) = run_execution.session_link {
-            let session_id = run_execution
-                .session_id
-                .and_then(|session_id| SessionId::from_str(session_id).ok());
-            return Some(Self {
-                session_id,
-                session_link: link.to_string(),
-            });
-        }
+        // The cloud-mode pane joins on `session_id`; a standalone `session_link` isn't
+        // actionable without it.
+        let session_id_str = run_execution.session_id?;
+        let session_id = SessionId::from_str(session_id_str).ok()?;
 
-        // Fallback to constructing a link from the session_id.
-        if let Some(session_id) = run_execution.session_id {
-            if let Ok(session_id) = SessionId::from_str(session_id) {
-                return Some(Self {
-                    session_id: Some(session_id),
-                    session_link: shared_session::join_link(&session_id),
-                });
-            }
-        }
-
-        None
+        // Prefer the server-provided `session_link`; fall back to constructing one from
+        // `session_id`. `active_run_execution()` already filters out empty links.
+        let session_link = run_execution
+            .session_link
+            .map(String::from)
+            .unwrap_or_else(|| shared_session::join_link(&session_id));
+        Some(Self {
+            session_id: Some(session_id),
+            session_link,
+        })
     }
 }
 

--- a/app/src/ai/ambient_agents/spawn_tests.rs
+++ b/app/src/ai/ambient_agents/spawn_tests.rs
@@ -341,6 +341,8 @@ async fn poll_stops_on_terminal_failure_like_state() {
         parent_run_id: None,
         runtime_skills: vec![],
         referenced_attachments: vec![],
+        fork_from_conversation_id: None,
+        initial_snapshot_token: None,
     };
 
     let mut stream = Box::pin(spawn_task(request, ai_client, None));
@@ -369,16 +371,42 @@ async fn poll_stops_on_terminal_failure_like_state() {
 }
 
 #[test]
-fn session_join_info_prefers_session_link_and_tolerates_missing_session_id() {
+fn session_join_info_requires_session_id() {
+    // session_link without session_id is not actionable for the cloud-mode pane
+    // (the GET task handler may overwrite session_link with a conversation link
+    // for tasks with synced conversation data, e.g. local-to-cloud handoff forks).
     let task = task_with(
         AmbientAgentTaskState::InProgress,
         None,
         Some("https://example.com/session/abc".to_string()),
     );
+    assert!(SessionJoinInfo::from_task(&task).is_none());
+}
+
+#[test]
+fn session_join_info_prefers_server_session_link_when_session_id_is_present() {
+    let task = task_with(
+        AmbientAgentTaskState::InProgress,
+        Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        Some("https://example.com/session/abc".to_string()),
+    );
 
     let join_info = SessionJoinInfo::from_task(&task).expect("expected join info");
     assert_eq!(join_info.session_link, "https://example.com/session/abc");
-    assert!(join_info.session_id.is_none());
+    assert!(join_info.session_id.is_some());
+}
+
+#[test]
+fn session_join_info_constructs_link_from_session_id_when_link_missing() {
+    let task = task_with(
+        AmbientAgentTaskState::InProgress,
+        Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        None,
+    );
+
+    let join_info = SessionJoinInfo::from_task(&task).expect("expected join info");
+    assert!(!join_info.session_link.is_empty());
+    assert!(join_info.session_id.is_some());
 }
 
 #[test]
@@ -435,7 +463,7 @@ async fn poll_for_session_join_info_waits_until_link_is_available() {
             } else {
                 task_with(
                     AmbientAgentTaskState::InProgress,
-                    None,
+                    Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
                     Some("https://example.com/session/ready".to_string()),
                 )
             };
@@ -457,6 +485,8 @@ async fn poll_for_session_join_info_waits_until_link_is_available() {
         parent_run_id: None,
         runtime_skills: vec![],
         referenced_attachments: vec![],
+        fork_from_conversation_id: None,
+        initial_snapshot_token: None,
     };
 
     let mut stream = Box::pin(spawn_task(request, ai_client, None));

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1544,6 +1544,8 @@ fn launch_remote_child(
         parent_run_id: Some(parent_run_id),
         runtime_skills,
         referenced_attachments: vec![],
+        fork_from_conversation_id: None,
+        initial_snapshot_token: None,
     };
 
     new_terminal_view.update(ctx, |terminal_view, ctx| {

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -16,6 +16,7 @@ use warp_core::{features::FeatureFlag, report_error};
 use warp_multi_agent_api::ConversationData;
 
 use super::auth::AuthClient;
+use super::harness_support::UploadTarget;
 use super::ServerApi;
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{
@@ -226,6 +227,55 @@ pub struct SpawnAgentRequest {
     /// Base64-encoded `warp.multi_agent.v1.Attachment` payloads to restore as referenced attachments.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub referenced_attachments: Vec<String>,
+    /// When set, instructs the server to fork the named conversation and use the resulting
+    /// fork id as `task.AgentConversationID`. Used by the local-to-cloud handoff flow.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fork_from_conversation_id: Option<String>,
+    /// References a batch of files previously uploaded to handoff/{token}/
+    /// via `POST /agent/handoff/upload-snapshot`. The server stores the token on the new run's
+    /// queued execution input and resolves the prefix in place at rehydration time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_snapshot_token: Option<InitialSnapshotToken>,
+}
+
+/// Server-minted token returned by `POST /agent/handoff/upload-snapshot` that scopes a batch
+/// of presigned upload URLs to `handoff/{token}/`. The client passes it
+/// back via `SpawnAgentRequest.initial_snapshot_token`; the server stores it on the new run's
+/// queued execution input so rehydration discovery can read the same prefix.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InitialSnapshotToken(String);
+
+impl InitialSnapshotToken {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Request body for `POST /agent/handoff/upload-snapshot`. Used by the local-to-cloud
+/// handoff flow (REMOTE-1486) to allocate a token and presigned upload URLs
+/// scoped to `handoff/{token}/` before any task exists.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct UploadLocalHandoffSnapshotRequest {
+    pub files: Vec<SnapshotUploadFileInfo>,
+}
+
+/// Describes a single file the client wants to upload as part of a handoff snapshot.
+/// Wire-compatible with the server's `SnapshotUploadFileInfo` schema (also used by the
+/// existing harness-side `/harness-support/upload-snapshot` endpoint).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SnapshotUploadFileInfo {
+    pub filename: String,
+    pub mime_type: String,
+}
+
+/// Response body for `POST /agent/handoff/upload-snapshot`. The `uploads` array is aligned
+/// by index with the request `files` array; the client matches each `UploadTarget` back
+/// to the requested filename by index.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct UploadLocalHandoffSnapshotResponse {
+    pub initial_snapshot_token: InitialSnapshotToken,
+    pub expires_at: String,
+    pub uploads: Vec<UploadTarget>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -830,6 +880,13 @@ pub trait AIClient: 'static + Send + Sync {
         &self,
         request: SpawnAgentRequest,
     ) -> anyhow::Result<SpawnAgentResponse, anyhow::Error>;
+
+    /// Allocate an initial snapshot token and presigned upload URLs for staging local-to-cloud
+    /// handoff snapshot files before the corresponding cloud task exists.
+    async fn upload_local_handoff_snapshot(
+        &self,
+        request: UploadLocalHandoffSnapshotRequest,
+    ) -> anyhow::Result<UploadLocalHandoffSnapshotResponse, anyhow::Error>;
 
     async fn list_ambient_agent_tasks(
         &self,
@@ -1514,6 +1571,16 @@ impl AIClient for ServerApi {
         request: SpawnAgentRequest,
     ) -> anyhow::Result<SpawnAgentResponse, anyhow::Error> {
         let response: SpawnAgentResponse = self.post_public_api("agent/run", &request).await?;
+        Ok(response)
+    }
+
+    async fn upload_local_handoff_snapshot(
+        &self,
+        request: UploadLocalHandoffSnapshotRequest,
+    ) -> anyhow::Result<UploadLocalHandoffSnapshotResponse, anyhow::Error> {
+        let response: UploadLocalHandoffSnapshotResponse = self
+            .post_public_api("agent/handoff/upload-snapshot", &request)
+            .await?;
         Ok(response)
     }
 

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -631,6 +631,8 @@ impl AmbientAgentViewModel {
             parent_run_id: None,
             runtime_skills: vec![],
             referenced_attachments: vec![],
+            fork_from_conversation_id: None,
+            initial_snapshot_token: None,
         };
 
         self.spawn_internal(request, ctx);

--- a/app/src/terminal/view_test.rs
+++ b/app/src/terminal/view_test.rs
@@ -724,6 +724,8 @@ fn cloud_mode_dispatched_agent_inserts_queued_user_query() {
                             parent_run_id: None,
                             runtime_skills: vec![],
                             referenced_attachments: vec![],
+                            fork_from_conversation_id: None,
+                            initial_snapshot_token: None,
                         },
                         ctx,
                     );

--- a/specs/REMOTE-1486/SNAPSHOT_UPLOAD_TECH.md
+++ b/specs/REMOTE-1486/SNAPSHOT_UPLOAD_TECH.md
@@ -1,0 +1,54 @@
+# Cloud Handoff Snapshot Upload — Tech Spec
+Part of the local-to-cloud Oz handoff feature ([REMOTE-1486](https://linear.app/warpdotdev/issue/REMOTE-1486)). Full feature behavior in `PRODUCT.md`; the orchestrator that wires this together lives in `TECH.md`.
+## Context
+The handoff flow stages the local agent's workspace into GCS *before* the cloud task exists, so the cloud sandbox can rehydrate from those files on its first turn. There's no `task_id` to scope the upload to at that point — only a server-minted initial snapshot token and a `handoff/{token}/` GCS prefix.
+The existing end-of-run snapshot pipeline (REMOTE-1332) is generic enough to reuse for the gather + upload phase, but the entry point and the URL-allocation step both need new variants that don't depend on a task. The `task_id` parameter that the existing helpers thread through purely for log context becomes a liability in the new entry point, so we drop it and re-extract a `task_id`-free upload helper that both paths share.
+This branch contains only the upload + server-contract pieces; nothing in-tree calls `upload_snapshot_for_handoff` yet, so the function and the unused `InitialSnapshotToken::as_str` accessor are gated with `#[allow(dead_code)]` until the parent stack branch wires them up.
+Relevant code:
+- `app/src/ai/agent_sdk/driver/snapshot.rs` — existing end-of-run pipeline (`run_pipeline`, `gather_snapshot_entries`, `upload_gathered_snapshot`, `apply_per_run_cap`, `upload_entry`, `repo_metadata`, `build_repo_patch`).
+- `app/src/server/server_api/ai.rs` — `AIClient` trait, `SpawnAgentRequest`, the existing `HarnessSupportClient::get_snapshot_upload_targets` URL allocation we don't reuse here.
+- `app/src/ai/ambient_agents/spawn.rs` — `SessionJoinInfo::from_task`, the cloud-mode session join helper we tighten for the new fork-via-handoff server contract.
+## Proposed changes
+### `upload_snapshot_for_handoff`
+A sibling entry point in `app/src/ai/agent_sdk/driver/snapshot.rs` that reuses the existing gather + upload internals but skips the JSONL declarations file and the cloud-side `run_declarations_script`:
+```rust path=null start=null
+pub(crate) async fn upload_snapshot_for_handoff(
+    repo_paths: Vec<PathBuf>,
+    orphan_file_paths: Vec<PathBuf>,
+    client: Arc<dyn AIClient>,
+    http: &http_client::Client,
+) -> Result<Option<InitialSnapshotToken>>;
+```
+Translates the input paths into the same internal `Vec<DeclarationEntry>` that `parse_declarations` produces today (repos → `EntryKind::Repo`, orphan files → `EntryKind::File`), then:
+1. Calls `gather_snapshot_entries` to build the manifest stubs and upload blobs.
+2. Applies the existing per-run cap (`MAX_SNAPSHOT_FILES_PER_RUN = 100`).
+3. Calls `AIClient::upload_local_handoff_snapshot` with the planned filenames + mime types to mint an initial snapshot token and presigned upload URLs scoped to `handoff/{token}/` (rather than going through `HarnessSupportClient::get_snapshot_upload_targets`, which requires a task).
+4. Builds the upload `target_map` by zipping the requested filenames with the positionally-aligned server `uploads` array; missing targets are marked `skipped` downstream.
+5. Routes the actual blob + manifest uploads through the new `upload_prepared_snapshot_files` helper.
+Returns:
+- `Ok(Some(initial_snapshot_token))` when a token was minted **and the `snapshot_state.json` manifest landed in GCS**. Individual blob uploads may still have failed; the manifest catalogues their status so the cloud side rehydrates against whatever did land, matching the cloud→cloud best-effort posture.
+- `Ok(None)` when the workspace was empty **or** when the manifest itself failed to upload. Without the manifest the snapshot prefix is unusable, so callers spawn the cloud agent without an initial snapshot token instead of pointing it at incomplete state.
+- `Err(_)` only for hard failures of `upload_local_handoff_snapshot` itself (auth, etc.).
+Manifest-upload failures (whether the manifest serialization aborted the pipeline or its presigned PUT failed) also route through `report_error!` so on-call alerting catches the silent regression.
+### Refactor: drop `task_id` from the existing helpers, extract `upload_prepared_snapshot_files`
+The existing `upload_snapshot_from_declarations_file`, `run_pipeline`, `gather_snapshot_entries`, `upload_gathered_snapshot`, `gather_repo` / `gather_file`, `apply_per_run_cap`, `fold_upload_results`, `upload_entry`, `parse_declarations`, and `read_and_parse_declarations` previously took `&AmbientAgentTaskId` only for log context. The new handoff entry point has no task at this stage, so each helper drops the parameter and the corresponding log lines lose the `(task X)` suffix. The outer `upload_snapshot_from_declarations` (which `AgentDriver` calls at end-of-run) still has a task id and passes it to `resolve_declarations_path` for the per-run JSONL file path; that's the only remaining task-aware helper.
+`upload_prepared_snapshot_files` is extracted out of `upload_gathered_snapshot` as a private helper. Both the existing `run_pipeline` path (declarations → server `get_snapshot_upload_targets` → upload) and the new `upload_snapshot_for_handoff` path (touched-workspace input → `upload_local_handoff_snapshot` → upload) terminate in the same blob + manifest upload logic.
+### Server contract: `upload_local_handoff_snapshot` + new types
+Adds to `app/src/server/server_api/ai.rs`:
+- `InitialSnapshotToken(String)` — opaque token the server returns from `upload_local_handoff_snapshot` and the client passes back via `SpawnAgentRequest.initial_snapshot_token`.
+- `UploadLocalHandoffSnapshotRequest { files: Vec<SnapshotUploadFileInfo> }` and `SnapshotUploadFileInfo { filename, mime_type }`.
+- `UploadLocalHandoffSnapshotResponse { initial_snapshot_token, expires_at, uploads: Vec<UploadTarget> }`; the response field deserializes from the public wire key `initial_snapshot_token`.
+- `AIClient::upload_local_handoff_snapshot(...)` trait method (POSTs to `agent/handoff/upload-snapshot`) and its `ServerApi` implementation.
+The server-side handler mints a UUID-v4 initial snapshot token, authorizes against the user, and generates URLs scoped to `handoff/{token}/` via the existing presigned-URL helper. No DB writes — discovery happens later by GCS prefix. Server-side details are covered in the parent feature's `TECH.md`.
+### `SpawnAgentRequest` field additions
+Two new optional fields on `SpawnAgentRequest`:
+- `fork_from_conversation_id: Option<String>` — instructs the server to fork the named conversation and use the resulting fork id as `task.AgentConversationID`. The actual fork is server-side; this field is the client's signal.
+- `initial_snapshot_token: Option<InitialSnapshotToken>` — references the GCS prefix uploaded above so the server can bind the token to the new run's queued execution and the cloud sandbox can list / download files from it on first turn. This serializes as the public API wire key `initial_snapshot_token`.
+Both fields use `#[serde(skip_serializing_if = "Option::is_none")]` so they're backwards-compatible against older server builds. Existing constructor sites in `agent_sdk/ambient.rs`, `agent_sdk/mcp_config_tests.rs`, `pane_group/pane/terminal_pane.rs`, `ambient_agents/spawn_tests.rs`, and `view/ambient_agent/model.rs::spawn_agent` set both to `None`; the parent stack branch's `submit_handoff` is the only call site that populates them.
+### `SessionJoinInfo::from_task` strictness
+`SessionJoinInfo::from_task` (`app/src/ai/ambient_agents/spawn.rs`) is rewritten to require a parseable `session_id` and return `None` otherwise. Previously a task with a `session_link` but no `session_id` returned a join info with `session_id: None`; that path is no longer actionable for the cloud-mode pane.
+The new behavior is needed because the GET task handler now overwrites `session_link` with a conversation link for tasks that have synced conversation data (e.g. the local-to-cloud handoff fork) — so a `session_link` alone is no longer a reliable signal that a real session exists. `session_link` falls back to `shared_session::join_link(&session_id)` when the server didn't provide one. Matching `spawn_tests.rs` test updates ship in this branch.
+## Testing and validation
+- `snapshot_tests.rs` is updated to drop the `&fake_task_id()` arguments from every helper call, keeping the existing `run_pipeline` coverage intact under the simplified signature.
+- `spawn_tests.rs` covers the new `SessionJoinInfo::from_task` invariants: `requires_session_id` (no session_id returns `None`), `prefers_server_session_link_when_session_id_is_present`, `constructs_link_from_session_id_when_link_missing`.
+- End-to-end coverage of `upload_snapshot_for_handoff` (mockito for the upload-snapshot endpoint, asserting manifest shape and per-blob upload outcomes) lands on the parent stack branch where the function actually has a caller.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

This is the second step to get local->client snapshotting working.

On the server, we have an endpoint to to prepare a snapshot (see [server PR here](https://github.com/warpdotdev/warp-server/pull/10777), providing pre-signed GCS endpoints to upload snapshot files. The same server PR also adds fields on the `SpawnAgentRequest` to provide the conversation id that we're forking from and the prep token that identifies where we uploaded our snapshot files.

This PR adds the apparatus for us to use those endpoints, which we will then use in the PR above this one to correctly snapshot and create our local->cloud handoff run.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode