### PR TITLE
Fix rendered Markdown anchor links

### DIFF
--- a/app/src/notebooks/editor/model.rs
+++ b/app/src/notebooks/editor/model.rs
@@ -1,5 +1,11 @@
 use base64::{prelude::BASE64_STANDARD, Engine as _};
-use std::{any::Any, borrow::Cow, collections::HashMap, ops::Range, time::Duration};
+use std::{
+    any::Any,
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    ops::Range,
+    time::Duration,
+};
 
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -29,11 +35,6 @@ use string_offset::CharOffset;
 use warp_core::features::FeatureFlag;
 use warp_core::semantic_selection::SemanticSelection;
 use warp_editor::{
-    content::{buffer::ShouldAutoscroll, selection_model::BufferSelectionModel},
-    model::BufferUpdateWrapper,
-    render::model::{BlockItem, StyleUpdateAction},
-};
-use warp_editor::{
     content::{
         buffer::{
             AutoScrollBehavior, Buffer, BufferEditAction, BufferEvent, BufferSelectAction,
@@ -41,7 +42,8 @@ use warp_editor::{
         },
         text::{
             BlockHeaderSize, BlockType, BufferBlockItem, BufferBlockStyle, BufferTextStyle,
-            CodeBlockType, IndentBehavior, IndentUnit, TextStyles, TextStylesWithMetadata,
+            CodeBlockType, IndentBehavior, IndentUnit, LineCount, TextStyles,
+            TextStylesWithMetadata,
         },
     },
     model::{CoreEditorModel, RichTextEditorModel},
@@ -49,7 +51,16 @@ use warp_editor::{
     search::Searcher,
     selection::{SelectionMode, SelectionModel, TextDirection, TextUnit},
 };
+use warp_editor::{
+    content::{
+        buffer::{ShouldAutoscroll, ToBufferCharOffset},
+        selection_model::BufferSelectionModel,
+    },
+    model::BufferUpdateWrapper,
+    render::model::{BlockItem, StyleUpdateAction},
+};
 use warpui::elements::ListIndentLevel;
+use warpui::{text::point::Point, units::Pixels};
 
 use super::{
     super::telemetry::SelectionMode as TelemetrySelectionMode, embedding_model::NotebookEmbed,
@@ -1257,6 +1268,58 @@ impl NotebooksEditorModel {
         self.content.as_ref(app).link_url_at_offset(offset)
     }
 
+    pub fn markdown_anchor_offset(
+        &self,
+        anchor_slug: &str,
+        app: &AppContext,
+    ) -> Option<CharOffset> {
+        let content = self.content.as_ref(app);
+        let mut generated_slugs = HashSet::new();
+
+        for row in 0..=content.max_point().row {
+            let line_start = Point::new(row, 0).to_buffer_char_offset(content);
+            if !matches!(
+                content.block_type_at_point(line_start),
+                BlockType::Text(BufferBlockStyle::Header { .. })
+            ) {
+                continue;
+            }
+
+            let line_end = content.line_end(LineCount::from(row as usize));
+            let heading_text = content.text_in_range(line_start..line_end).to_string();
+            let base_slug = markdown_heading_slug(&heading_text);
+            if base_slug.is_empty() {
+                continue;
+            }
+
+            let mut heading_slug = base_slug.clone();
+            let mut suffix = 1;
+            while !generated_slugs.insert(heading_slug.clone()) {
+                heading_slug = format!("{base_slug}-{suffix}");
+                suffix += 1;
+            }
+
+            if heading_slug == anchor_slug {
+                return Some(line_start);
+            }
+        }
+
+        None
+    }
+
+    pub fn jump_to_markdown_anchor(
+        &mut self,
+        anchor_slug: &str,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<bool> {
+        let offset = self.markdown_anchor_offset(anchor_slug, ctx)?;
+        let had_command_selection = self.select_at(offset, false, ctx);
+        self.render_state.update(ctx, |render_state, _| {
+            render_state.request_autoscroll_to_exact_vertical(offset, Pixels::zero());
+        });
+        Some(had_command_selection)
+    }
+
     /// Whether or not there's an active command block selection.
     pub fn has_command_selection(&self, ctx: &AppContext) -> bool {
         self.child_models
@@ -2161,6 +2224,34 @@ fn is_valid_url(content: &str) -> Option<String> {
         Ok(_) => Some(content.to_string()),
         Err(_) => None,
     }
+}
+
+pub(super) fn markdown_anchor_slug_from_url(url: &str) -> Option<String> {
+    let anchor = url.strip_prefix('#')?;
+    let decoded = urlencoding::decode(anchor).ok()?;
+    let slug = markdown_heading_slug(decoded.as_ref());
+    (!slug.is_empty()).then_some(slug)
+}
+
+fn markdown_heading_slug(text: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_hyphen = false;
+
+    for char in text.trim().chars() {
+        if char.is_alphanumeric() {
+            if pending_hyphen && !slug.is_empty() {
+                slug.push('-');
+            }
+            for lower in char.to_lowercase() {
+                slug.push(lower);
+            }
+            pending_hyphen = false;
+        } else if char.is_whitespace() || char == '-' {
+            pending_hyphen = true;
+        }
+    }
+
+    slug
 }
 
 fn notebook_tab_indentation(block_style: &BufferBlockStyle, shift: bool) -> IndentBehavior {

--- a/app/src/notebooks/editor/model_tests.rs
+++ b/app/src/notebooks/editor/model_tests.rs
@@ -207,6 +207,97 @@ async fn finish_highlighting(
 }
 
 #[test]
+fn markdown_heading_slug_normalizes_heading_text() {
+    assert_eq!(super::markdown_heading_slug("Goal"), "goal");
+    assert_eq!(
+        super::markdown_heading_slug("  Goal & Launch Plan!  "),
+        "goal-launch-plan"
+    );
+    assert_eq!(
+        super::markdown_heading_slug("Repeated---Heading"),
+        "repeated-heading"
+    );
+}
+
+#[test]
+fn markdown_anchor_slug_from_url_only_accepts_same_document_anchors() {
+    assert_eq!(
+        super::markdown_anchor_slug_from_url("#Goal%20%26%20Launch%20Plan!").as_deref(),
+        Some("goal-launch-plan")
+    );
+    assert_eq!(super::markdown_anchor_slug_from_url("#").as_deref(), None);
+    assert_eq!(
+        super::markdown_anchor_slug_from_url("https://warp.dev/#goal").as_deref(),
+        None
+    );
+}
+
+#[test]
+fn markdown_anchor_offset_resolves_headings_and_duplicates() {
+    App::test((), |mut app| async move {
+        initialize_deps(&mut app);
+        let model = model_from_markdown(
+            "# Goal\n\n## Goal & Launch Plan!\n\n## Goal 1\n\n## Goal\n\nParagraph",
+            &mut app,
+            true,
+        );
+
+        let first_goal = model
+            .read(&app, |model, ctx| model.markdown_anchor_offset("goal", ctx))
+            .expect("first heading should resolve");
+        let launch_plan = model
+            .read(&app, |model, ctx| {
+                model.markdown_anchor_offset("goal-launch-plan", ctx)
+            })
+            .expect("punctuated heading should resolve");
+        let goal_one = model
+            .read(&app, |model, ctx| {
+                model.markdown_anchor_offset("goal-1", ctx)
+            })
+            .expect("colliding heading slug should resolve");
+        let second_goal = model
+            .read(&app, |model, ctx| {
+                model.markdown_anchor_offset("goal-2", ctx)
+            })
+            .expect("duplicate heading should skip colliding slug");
+
+        assert!(first_goal < launch_plan);
+        assert!(launch_plan < goal_one);
+        assert!(goal_one < second_goal);
+        assert_eq!(
+            model.read(&app, |model, ctx| model
+                .markdown_anchor_offset("missing", ctx)),
+            None
+        );
+    });
+}
+
+#[test]
+fn jump_to_markdown_anchor_selects_heading_offset() {
+    App::test((), |mut app| async move {
+        initialize_deps(&mut app);
+        let model = model_from_markdown("# Intro\n\n## Goal\n", &mut app, true);
+        let goal_offset = model
+            .read(&app, |model, ctx| model.markdown_anchor_offset("goal", ctx))
+            .expect("heading should resolve");
+
+        let jumped = model
+            .update(&mut app, |model, ctx| {
+                model.jump_to_markdown_anchor("goal", ctx)
+            })
+            .is_some();
+
+        assert!(jumped);
+        assert_eq!(
+            model.read(&app, |model, ctx| {
+                model.selection_model.as_ref(ctx).first_selection_head()
+            }),
+            goal_offset
+        );
+    });
+}
+
+#[test]
 fn test_edit_command_submodel() {
     App::test((), |mut app| async move {
         initialize_deps(&mut app);

--- a/app/src/notebooks/editor/view.rs
+++ b/app/src/notebooks/editor/view.rs
@@ -61,7 +61,7 @@ use crate::{
     editor::InteractionState,
     features::FeatureFlag,
     notebooks::{
-        editor::{find_bar::FindBarAction, model::word_unit},
+        editor::{find_bar::FindBarAction, model::markdown_anchor_slug_from_url, model::word_unit},
         link::{LinkTarget, NotebookLinks, ResolveError},
         telemetry::{ActionEntrypoint, BlockInfo, EmbeddedObjectInfo, SelectionMode},
     },
@@ -1880,9 +1880,15 @@ impl RichTextEditorView {
         };
 
         if let Some(url) = url {
+            let open_directly =
+                cmd || matches!(self.interaction_state(ctx), InteractionState::Selectable);
+            if self.maybe_open_markdown_anchor(&url, editable, open_directly, ctx) {
+                return;
+            }
+
             // In read-only comment chips (Selectable), open the link directly on
             // click instead of showing a tooltip.
-            if cmd || matches!(self.interaction_state(ctx), InteractionState::Selectable) {
+            if open_directly {
                 self.links
                     .update(ctx, |links, ctx| links.resolve_and_open(&url, ctx));
             } else {
@@ -1907,6 +1913,41 @@ impl RichTextEditorView {
                 ctx.notify();
             }
         }
+    }
+
+    pub(super) fn maybe_open_markdown_anchor(
+        &mut self,
+        url: &str,
+        editable: bool,
+        open_directly: bool,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        let Some(anchor_slug) = markdown_anchor_slug_from_url(url) else {
+            return false;
+        };
+
+        if let Some(had_command_selection) = self.model.update(ctx, |model, ctx| {
+            model.jump_to_markdown_anchor(&anchor_slug, ctx)
+        }) {
+            self.focus(ctx);
+            self.open_link = None;
+            if had_command_selection {
+                ctx.emit(EditorViewEvent::ChangedSelectionMode(SelectionMode::Text));
+            }
+            ctx.notify();
+            return true;
+        }
+
+        if !open_directly {
+            self.open_link = Some(LinkToolTipConfig {
+                url: url.to_string(),
+                editable,
+                state: LinkState::Broken(ResolveError::FileNotFound),
+            });
+            ctx.notify();
+        }
+
+        true
     }
 
     /// Make this editor the focused view.

--- a/app/src/notebooks/editor/view_tests.rs
+++ b/app/src/notebooks/editor/view_tests.rs
@@ -2,6 +2,7 @@ use crate::features::FeatureFlag;
 use async_channel::TryRecvError;
 use std::sync::Arc;
 use string_offset::CharOffset;
+use warp_editor::model::CoreEditorModel;
 use warp_editor::render::{
     element::RichTextAction,
     model::{HitTestBlockType, Location, RenderEvent},
@@ -519,6 +520,42 @@ fn test_link_editing() {
                 "<text>Some <a_https://warp.dev>text<a><a_https://example.com>new link<a>"
             );
         });
+    });
+}
+
+#[test]
+fn markdown_anchor_link_jumps_locally_without_link_resolution() {
+    App::test((), |mut app| async move {
+        let (_, editor_view, _) = initialize_editor(&mut app);
+        reset_editor_with_markdown(
+            &mut app,
+            &editor_view,
+            "# Intro\n\n[Go](#goal)\n\n## Goal\n",
+        )
+        .await;
+
+        let goal_offset = editor_view
+            .read(&app, |editor, ctx| {
+                editor.model.as_ref(ctx).markdown_anchor_offset("goal", ctx)
+            })
+            .expect("heading should resolve");
+
+        editor_view.update(&mut app, |editor, ctx| {
+            assert!(editor.maybe_open_markdown_anchor("#goal", false, false, ctx));
+            assert!(editor.open_link.is_none());
+        });
+
+        assert_eq!(
+            editor_view.read(&app, |editor, ctx| {
+                editor
+                    .model
+                    .as_ref(ctx)
+                    .buffer_selection_model()
+                    .as_ref(ctx)
+                    .first_selection_head()
+            }),
+            goal_offset
+        );
     });
 }
 


### PR DESCRIPTION
## Summary
- resolve same-document Markdown anchors before generic notebook link resolution
- derive anchor targets from rendered heading blocks and support normalized duplicate heading slugs
- jump the rendered editor to the matching heading and keep missing anchors as broken local links

## Issue
Fixes #10058

## Test plan
- cargo fmt --check
- cargo test -p warp anchor

CHANGELOG-BUG-FIX: Fixed rendered Markdown table-of-contents anchors so same-document heading links jump to the target heading.