### PR TITLE
`Input::maybe_backspace_ai_icon` no longer resets convesation on backspace in the agent view

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -10302,6 +10302,13 @@ impl Input {
             return;
         }
 
+        // When the agent view is active, the classic-mode AI icon toggling and follow-up clearing
+        // logic below does not apply.
+        if FeatureFlag::AgentView.is_enabled() && self.agent_view_controller.as_ref(ctx).is_active()
+        {
+            return;
+        }
+
         // If we have an AI follow up icon, backspace should clear that icon.
         if self
             .ai_context_model


### PR DESCRIPTION
## Description

This PR fixes #9692

To repro the bug:

1. Select classic input (not UDI).
2. Start a conversation
3. fork the conversation
4. In the new forked conversation, press backspace
5. the conversation is cleared

I fixed this by simply having `Input::maybe_backspace_ai_icon` simply bail if the agent view feature flag is on since agent view got rid of the sparkle icon.

## Testing

WarpDev (left) and this branch (right)


https://github.com/user-attachments/assets/eaf3f360-ca19-466c-a06c-dae52c719b8b



## Changelog Entries for Stable


CHANGELOG-BUG-FIX: Pressing backspace in the agent view when the buffer is empty no longer resets the conversation.

