### PR TITLE
spec: render inline image protocols at shell startup (#10020)

### DIFF
--- a/specs/GH10020/product.md
+++ b/specs/GH10020/product.md
@@ -1,0 +1,190 @@
+# Product spec: Inline image protocols render at shell startup (GH-10020)
+
+## Problem
+
+Inline image-protocol escape sequences emitted during shell initialization
+(e.g., from `~/.zshrc`, `~/.bashrc`, `~/.config/fish/config.fish`) are
+silently discarded. The same escape sequence, typed manually after the
+prompt is shown in the same tab, renders correctly.
+
+This breaks the most common consumer of inline image protocols on every
+platform: shell-startup banner tools (`fastfetch`, `neofetch`, `macchina`,
+`viu`, `imgcat`, `chafa` in image-protocol mode, custom OSC scripts).
+Other terminals supporting these protocols — iTerm2, WezTerm, Kitty,
+Ghostty — render images at startup as documented in their respective
+specifications. The protocols themselves do not require the parser to be
+in any "post-prompt" or "interactive" state.
+
+The reporter additionally verified that **deferring fastfetch into a
+detached background subshell** (`( sleep 0.2 && fastfetch ... ) &!`) so
+its output arrives **after** the first prompt also fails to render the
+image. Plain text and ANSI color escapes from the same byte stream do
+render. The drop is therefore specific to the inline image-protocol
+parser path under early-session state, not general PTY routing.
+
+## Goal
+
+Inline image-protocol bytes — Kitty graphics protocol, iTerm2 inline
+image protocol, and any future image protocol Warp adds — render
+identically regardless of the session phase in which they arrive,
+provided the relevant feature flag is enabled and the bytes are
+well-formed.
+
+## Affected protocols
+
+- **iTerm2 inline image protocol** — `OSC 1337;File=...:<base64>BEL`
+  (gated by `FeatureFlag::ITermImages`).
+- **Kitty graphics protocol** — `APC G<control_data>;<payload>ST`
+  (gated by `FeatureFlag::KittyGraphicsProtocol` if present, otherwise
+  by the default protocol enablement path).
+- Any subsequent inline image protocol Warp adds (e.g. Sixel, if added).
+  The fix must not be protocol-specific.
+
+## Non-goals (V1)
+
+- Adding support for new image protocols not currently parsed.
+- Changing image-protocol *placement* semantics (z-order, scrolling
+  behavior, cell-vs-pixel sizing). The placement that already works
+  post-prompt is the desired behavior — early-session emissions should
+  reach the same code path with the same outputs.
+- Rendering images that arrive while the alt screen is active and that
+  intentionally use the alt-screen image lifecycle. (Out of scope; this
+  bug is about the main screen / block list.)
+- Backfilling images into restored historical blocks during session
+  restoration. (Restoration replays bytes through the same parser, so
+  if the V1 fix routes them correctly, restoration benefits for free.
+  But session restoration of pre-fix sessions is not a goal.)
+
+## Behavior contract (V1)
+
+### B1 — Renders during ScriptExecution stage
+
+Given a shell init file that emits a well-formed Kitty or iTerm2 image
+escape sequence between `BootstrapStage::WarpInput` and
+`BootstrapStage::PostBootstrapPrecmd`, when the user opens a new tab,
+the image is visible in the same scrollback position where its
+surrounding text appears. The image must not appear above the first
+visible prompt, must not appear below the next user-executed block, and
+must not require a re-render to become visible.
+
+### B2 — Renders for early-output between prompt and first user keystroke
+
+Given the bootstrap is complete (`PostBootstrapPrecmd`) and a background
+job emits an image-protocol sequence after the first prompt is shown but
+before the user submits a command (the `is_early_output()` window), the
+image renders in the same scrollback position as text early-output
+already does today.
+
+### B3 — Renders for output during execution (existing behavior preserved)
+
+The existing post-prompt user-typed-command path (the case that already
+works today) continues to render images identically. No regression in
+the working code path.
+
+### B4 — Renders identically across protocols and across feature-flag
+combinations
+
+For every (protocol, feature-flag-state, session-phase) tuple where the
+feature flag for that protocol is enabled, the image either always
+renders or always drops with the same observable reason. No combination
+silently drops only because of session phase.
+
+### B5 — No render path is gated on `is_bootstrapping_precmd_done()`
+
+The bootstrap-stage gate exists for typeahead disambiguation and for
+height/layout updates that are unsafe before the first real block. It
+must not gate the image-protocol completion handlers. Any future
+addition of new "completed-protocol" handlers must not inherit this
+gate by accident.
+
+### B6 — Telemetry for silent drops
+
+If an image-protocol completion is reached for any reason that prevents
+placement (zero dimensions, feature flag off, decode failure, missing
+target grid), the event is logged at `warn` level with the protocol
+name, the session phase, and the failure reason. Today the silent drop
+in the early-session path is not logged at all, which is what made this
+bug invisible for months. This is the smallest invariant that prevents
+this class of bug from regressing silently again.
+
+### B7 — Feature-flag-off path unchanged
+
+If the feature flag for the relevant protocol is disabled, behavior is
+identical to today: the bytes are consumed by the parser and the image
+is not rendered. No telemetry noise from the feature-flag-off path
+(only from unexpected drops with the flag on).
+
+## Acceptance criteria
+
+A1. With Kitty `--logo-type kitty-direct` fastfetch in `~/.zshrc`, the
+    image renders in the bootstrap output area on a new tab.
+
+A2. With iTerm2 `--logo-type iterm` fastfetch in `~/.zshrc`, same as A1.
+
+A3. With `( sleep 0.2 && fastfetch --logo-type kitty-direct ... ) &!` at
+    the end of `~/.zshrc`, the image renders after the first prompt
+    appears.
+
+A4. Manually typing the same fastfetch invocation after the prompt
+    renders the image (no regression). Pixel-equivalent output to today.
+
+A5. With `FeatureFlag::ITermImages` disabled, no image renders in any of
+    the above cases (no regression in the off-path).
+
+A6. An automated integration test asserts B1, B2, B3, and B5 by feeding
+    a synthetic byte stream through the parser at each session phase
+    and asserting `Event::ImageReceived` is dispatched and the image is
+    placed in the correct grid.
+
+## Risks and decisions to make in tech.md
+
+1. **Where to fix.** Two candidate sites:
+   (a) `BlockList::handle_completed_iterm_image` /
+       `handle_completed_kitty_action` (blocks.rs:3794, 3798) — route to
+       the visible bootstrap block instead of dropping when the active
+       block is a hidden bootstrap block.
+   (b) `Block::delegate!` macro (block.rs:2882) — route image
+       completions to `output_grid` even when `state ==
+       BeforeExecution`, since `header_grid` placement is not rendered
+       in the same way.
+   The TECH spec must pick one and justify against the other.
+
+2. **Background-subshell case (B2).** The `is_early_output()` path
+   (blocks.rs:3088) routes most output to `EarlyOutput::handler`, but
+   image completions skip the early-output check (they use
+   `delegate_to_block!` directly, not `delegate!`). The fix may need to
+   either teach `EarlyOutput` to forward image completions, or change
+   the early-output check to exclude image completions from the
+   typeahead split.
+
+3. **Alt-screen interaction.** A program that switches to the alt
+   screen during shell init (rare but possible — `tput smcup` in a
+   `.profile` is legal) emits images that go to `AltScreen::handle_*`.
+   The fix must not change alt-screen behavior; that path is correct
+   today.
+
+4. **Hidden vs visible bootstrap blocks.** `BootstrapStage::WarpInput`
+   is hidden (`bootstrap.rs::is_hidden`); `ScriptExecution` is not.
+   Images emitted while the active block is the hidden WarpInput block
+   should not render (those bytes belong to Warp's own injected
+   bootstrap script and are not user content). Images emitted while
+   the active block is the ScriptExecution block must render. The TECH
+   spec must make this distinction explicit.
+
+## Reporter-supplied diagnostic facts (preserved)
+
+From the issue, verified by the reporter via stdout capture:
+
+- `\e_Ga=T,f=100,t=f,c=22,r=22;<base64>\e\` (Kitty graphics) is emitted
+  by fastfetch during shell init, identical bytes to the post-prompt
+  case.
+- `--pipe false` forces emission regardless of TTY auto-detection;
+  drops occur even with this flag.
+- `precmd` zsh hook deferral: output is suppressed by Warp's block UI
+  (different failure mode — out of scope for this spec).
+- Pre-rendering with `chafa --format symbols` (text + ANSI color) works
+  in all phases, confirming the parser-state-dependent drop is specific
+  to the inline image-protocol path.
+
+These should be cited verbatim in the integration test fixture so the
+test fails for the same observable reason the user reported.

--- a/specs/GH10020/tech.md
+++ b/specs/GH10020/tech.md
@@ -1,0 +1,217 @@
+# Technical spec: Inline image protocols at shell startup (GH-10020)
+
+This spec is the implementation companion to `product.md`. It picks the
+fix site, names the affected files and line ranges, and defines a
+testable invariant set.
+
+## Current routing of `handle_completed_iterm_image` /
+## `handle_completed_kitty_action`
+
+Trace of an inline image emitted from `~/.zshrc`:
+
+1. PTY bytes reach the ANSI processor.
+2. `TerminalModel::handle_completed_iterm_image` (terminal_model.rs:3354)
+   stores `StoredImageMetadata::ITerm(...)` in `image_id_to_metadata`,
+   then calls the model-level `delegate!` macro
+   (terminal_model.rs:2347), which routes to either `alt_screen` or
+   `block_list` based on `alt_screen_active`. The shell-init case is
+   not on the alt screen, so it routes to `BlockList`.
+3. `BlockList::handle_completed_iterm_image` (blocks.rs:3794) calls
+   the block-list-level `delegate_to_block!` macro (blocks.rs:532),
+   which is `self.active_block_mut().handle_completed_iterm_image(...)`.
+   Note: this is **not** the gated `delegate!` (blocks.rs:519) that
+   routes through `EarlyOutput` — image completions bypass the
+   early-output check.
+4. `Block::handle_completed_iterm_image` (block.rs:3292) calls the
+   block-level `delegate!` macro (block.rs:2882), which routes:
+   - to `header_grid` if a prompt is being received,
+   - to `rprompt_grid` if the right prompt is being received,
+   - **to `header_grid` if `state == BlockState::BeforeExecution`,**
+   - to `output_grid` otherwise.
+5. `GridHandler::handle_completed_iterm_image`
+   (grid/ansi_handler.rs:1266) does the actual work: dispatches
+   `Event::ImageReceived`, calls `self.images.add_image_placement_data`
+   and `self.images.place(...)`, then advances the cursor.
+
+The `BootstrapStage::ScriptExecution` block has not yet executed a
+user command, so it is in `BlockState::BeforeExecution`. Per step 4,
+**the image is placed in `header_grid`**, not `output_grid`. The
+`header_grid` is the prompt area; its image-placement is not rendered
+in the visible bootstrap block content. This is the architectural root
+cause of B1 (init-phase image drop).
+
+For B2 (post-prompt background subshell drop): when output arrives in
+the `is_early_output()` window (blocks.rs:3088), the active block has
+been advanced to a new block in `BlockState::BeforeExecution` waiting
+for the user's first keystroke. Same routing in step 4 sends the image
+to `header_grid` of that block, and it is again invisible.
+
+For the working post-prompt typed-command case: by the time the user
+hits Enter, `BlockState` has progressed past `BeforeExecution` and the
+image lands in `output_grid`, which is rendered in the block body.
+This is why typing the same command works.
+
+## Chosen fix site
+
+**Block-level `delegate!` macro (block.rs:2882) is amended for
+image-protocol completions only.** Image-protocol completions route to
+`output_grid` even when `state == BlockState::BeforeExecution`,
+provided the active block is *not* receiving prompt characters (i.e.
+not in the prompt-receiving branches of the existing match).
+
+Why not the BlockList layer (blocks.rs:3794):
+- The BlockList layer does not know about `header_grid` vs
+  `output_grid`; that distinction lives in `Block`. Pushing the
+  routing decision up would require leaking grid identity into
+  BlockList.
+
+Why not the GridHandler layer (grid/ansi_handler.rs:1266):
+- Once the image reaches a grid, it is placed in *that* grid. The
+  decision of *which* grid must be made above. Moving the fix lower
+  would require a "redirect" message back up, which is more invasive.
+
+Why not change `BlockState::BeforeExecution` semantics:
+- The state machine is correct as a state machine. The invariant we
+  are tightening is "image-protocol output is body output, not prompt
+  output," which is a routing rule, not a state transition.
+
+## Implementation sketch
+
+### Change 1: image-completion-aware `delegate!` in block.rs
+
+Introduce a sibling macro `delegate_image_completion!` (or a
+`is_image_completion: bool` parameter to `delegate!`) that overrides
+the `BeforeExecution → header_grid` arm to use `output_grid` instead.
+The two prompt-receiving arms (`Initial`, `Right`) are unchanged: a
+program emitting an image inside the prompt-string itself is
+sufficiently unusual that preserving today's behavior is correct.
+
+Apply the new macro at the two image-completion sites in `Block`'s
+`ansi::Handler` impl:
+
+- `Block::handle_completed_iterm_image` (block.rs:3292)
+- `Block::handle_completed_kitty_action` (block.rs:3296)
+
+These are the only two methods affected. All other handler methods
+keep the existing `delegate!`.
+
+### Change 2: skip the bootstrap-stage gate verification
+
+The `BlockList::handle_completed_iterm_image` /
+`handle_completed_kitty_action` site (blocks.rs:3794, 3798) does not
+gate on `is_bootstrapping_precmd_done()` and must continue not to.
+Add a one-line comment at both sites referencing this spec to prevent
+a well-meaning future PR from "fixing the missing gate." This is the
+cheapest defense against B5 regression.
+
+### Change 3: drop in the WarpInput stage only
+
+The `WarpInput` block (the hidden block containing Warp's own
+bootstrap script) must not render images, even with Change 1 in
+place. Add a guard in the new `delegate_image_completion!` arm: if
+`self.bootstrap_stage == BootstrapStage::WarpInput`, return without
+placing. This preserves the invariant from product.md §3 (hidden
+bootstrap output is not user content). `Block` already exposes
+`bootstrap_stage()` (used by `bootstrap_block_contents`,
+blocks.rs:3325), so no new accessor is needed.
+
+### Change 4: warn-level telemetry on silent drop
+
+In `GridHandler::handle_completed_iterm_image`
+(grid/ansi_handler.rs:1266) and
+`handle_completed_kitty_action_internal`
+(grid/ansi_handler.rs:1718), every early-return path
+(`!FeatureFlag::ITermImages.is_enabled()`, zero-dimension, decode
+failure) emits a `log::warn!` with:
+- protocol name (`"iterm"` / `"kitty"`),
+- failure reason (`"feature_flag_off"`, `"zero_dimension"`,
+  `"decode_failure"`),
+- the active `BootstrapStage` (passed in via existing handler context
+  or a new optional parameter).
+
+The feature-flag-off case is `log::debug!`, not `warn!` (B7: no noise
+when the user has explicitly disabled the protocol).
+
+## Test plan
+
+### Unit tests
+
+`app/src/terminal/model/block_test.rs` — add cases that:
+
+- T1: With `BlockState::BeforeExecution`, calling
+  `handle_completed_iterm_image` routes to `output_grid`, not
+  `header_grid` (assert by inspecting which grid received the image).
+- T2: With `BlockState::Started`, calling
+  `handle_completed_iterm_image` continues to route to `output_grid`
+  (no regression).
+- T3: With `header_grid.receiving_chars_for_prompt =
+  Some(PromptKind::Initial)`, image completion still routes to
+  `header_grid` (prompt-string image case unchanged).
+- T4: With `bootstrap_stage == BootstrapStage::WarpInput`, image
+  completion is dropped (no placement on either grid).
+
+### Integration test
+
+`app/src/integration_testing/terminal/` — add a new file
+`image_protocol_at_startup_test.rs` that:
+
+- IT1: Creates a session, advances bootstrap to `ScriptExecution`,
+  feeds the exact byte sequence `\x1b_Ga=T,f=100,t=f,c=22,r=22;<b64>\x1b\\`
+  (the Kitty bytes from the issue), then advances to
+  `PostBootstrapPrecmd`. Asserts `Event::ImageReceived` was dispatched
+  exactly once with `image_protocol: ImageProtocol::Kitty`, and the
+  image is `place`d in the bootstrap block's `output_grid`.
+- IT2: Same as IT1 but for iTerm bytes
+  (`\x1b]1337;File=...:<b64>\x07`) and
+  `image_protocol: ImageProtocol::ITerm`.
+- IT3: Advances all the way to `PostBootstrapPrecmd`, then feeds
+  image bytes while `is_early_output()` is true (no preexec yet).
+  Asserts the image is placed in the new active block's `output_grid`.
+- IT4: Existing post-prompt typed-command path continues to render
+  (regression guard).
+- IT5: With `FeatureFlag::ITermImages` disabled, IT2's bytes produce
+  no `Event::ImageReceived` and no `log::warn!` (only `log::debug!`).
+
+### Negative-space test
+
+- IT6: With `bootstrap_stage == BootstrapStage::WarpInput`, image
+  bytes are consumed by the parser (no panic, no error log) and no
+  `Event::ImageReceived` fires. This catches a future "always render"
+  regression that would surface Warp's own bootstrap-script bytes if
+  any happened to look like image protocols.
+
+## Files touched
+
+- `app/src/terminal/model/block.rs` — new
+  `delegate_image_completion!` macro near block.rs:2882; the two
+  image-completion handler sites at block.rs:3292 and 3296 use it.
+- `app/src/terminal/model/blocks.rs` — comment-only change at
+  blocks.rs:3794 and 3798 referencing this spec to prevent a "missing
+  gate" regression.
+- `app/src/terminal/model/grid/ansi_handler.rs` — telemetry
+  `log::warn!` / `log::debug!` calls on early-return paths in
+  `handle_completed_iterm_image` and
+  `handle_completed_kitty_action_internal`.
+- `app/src/terminal/model/block_test.rs` — T1–T4.
+- `app/src/integration_testing/terminal/image_protocol_at_startup_test.rs`
+  — new file, IT1–IT6.
+
+## Out-of-scope follow-ups (linked, not addressed in this PR)
+
+- `precmd` zsh hook deferral failure (issue mentions output being
+  "suppressed by Warp's block UI" — different code path, deserves its
+  own issue).
+- Sixel protocol support if/when added.
+- Backfilling images into restored historical bootstrap blocks.
+- Image-protocol behavior when the alt screen is entered during
+  bootstrap.
+
+## Open questions for maintainer review
+
+1. Is `delegate_image_completion!` an acceptable name, or would the
+   team prefer the boolean parameter form on the existing `delegate!`?
+2. Is `log::warn!` the right level for unexpected silent drops, or is
+   `log::debug!` preferred (and tracked via a separate metric instead)?
+3. The bootstrap-stage gate at blocks.rs:3789 (`on_reset_grid`) and
+   3724/3763 (`precmd`/`preexec`) is left alone. Confirm these gates
+   are intentional and not symptoms of the same family of bug.


### PR DESCRIPTION
## Summary

Spec for issue #10020 — inline image-protocol escape sequences (Kitty graphics, iTerm2 inline image) emitted from shell init files (`~/.zshrc`, `~/.bashrc`, etc.) are silently dropped, while the same bytes typed manually after the prompt render correctly. Other terminals (iTerm2, WezTerm, Kitty, Ghostty) render images at shell startup as documented in their respective protocol specs.

## Investigation

Traced the routing end-to-end:

1. `TerminalModel::handle_completed_iterm_image` ([terminal_model.rs:3354](app/src/terminal/model/terminal_model.rs)) → `delegate!` → `BlockList`.
2. `BlockList::handle_completed_iterm_image` ([blocks.rs:3794](app/src/terminal/model/blocks.rs)) → `delegate_to_block!` → active block (intentionally bypasses the early-output gate).
3. `Block::handle_completed_iterm_image` ([block.rs:3292](app/src/terminal/model/block.rs)) → block-level `delegate!` ([block.rs:2882](app/src/terminal/model/block.rs)).
4. The block-level `delegate!` routes to **`header_grid`** when `state == BlockState::BeforeExecution`. The `header_grid` is the prompt area; its image placement is not rendered in the visible block body.
5. Once the user types a command, the block transitions out of `BeforeExecution` and image bytes land in `output_grid`, which renders. **This is why typing the same command works.**

The reporter's background-subshell case (`( sleep 0.2 && fastfetch ) &!`) hits the same branch via a different session phase: the post-prompt block is itself in `BeforeExecution` waiting for the user's first keystroke, so background output emitted during the `is_early_output()` window is also routed to `header_grid`.

## What's in the spec

**`product.md`** — 7 testable behavior invariants (B1–B7), 6 acceptance criteria (A1–A6), explicit non-goals, and a preserved record of the reporter's diagnostic facts (verified byte sequences, alternative approaches that were tried and ruled out).

**`tech.md`** — picks the fix site with explicit reasoning against the two alternatives, names every file and line range touched, and lays out four unit tests + six integration tests (including a negative-space test for the `WarpInput` hidden bootstrap block and a feature-flag-off regression guard).

## Architectural choices

- **Fix at the block-level `delegate!` macro, not at `BlockList` and not at `GridHandler`.** Rationale: `BlockList` does not know about `header_grid` vs `output_grid`; pushing the routing decision up would leak grid identity. `GridHandler` is downstream of the routing decision; pushing it down would require a redirect message back up. The block-level `delegate!` is exactly where the (state, grid) routing decision belongs.
- **Carve out `BootstrapStage::WarpInput`.** Warp's own injected bootstrap-script bytes must never accidentally render an image even after the fix.
- **Add warn-level telemetry on every silent-drop path.** The whole reason this bug was invisible for months is that drops were unlogged. Tightening this is the cheapest defense against the same family of bug regressing.

## Test plan

- [ ] Unit tests T1–T4 in `block_test.rs` — verify routing per `BlockState` value and per `bootstrap_stage`.
- [ ] Integration tests IT1–IT6 in `image_protocol_at_startup_test.rs` (new file) — feed the exact byte sequences from the issue at each session phase, assert `Event::ImageReceived` dispatch and grid placement.
- [ ] Manual: fastfetch in `~/.zshrc` with `--logo-type kitty-direct` (A1), `--logo-type iterm` (A2), and the background-subshell variant (A3).
- [ ] Manual: post-prompt typed `fastfetch` continues to render (A4 regression guard).
- [ ] Manual: `FeatureFlag::ITermImages` disabled produces no render and no warn-level log noise (A5 + B7).

## Open questions for maintainer review

1. Macro naming: prefer `delegate_image_completion!` (sibling macro) or a boolean parameter on the existing `delegate!`?
2. Telemetry level for unexpected drops: `log::warn!` vs `log::debug!` + a separate metric?
3. The bootstrap-stage gates at `blocks.rs:3789` (`on_reset_grid`), `3724` (`precmd`), and `3763` (`preexec`) are left alone. Confirm they are intentional and not symptoms of the same family.

Closes (spec-only) #10020 — implementation PR will follow once spec direction is confirmed.