### PR TITLE
spec: voice input hotkey picker — Caps Lock, F-keys, custom (#9869)

### DIFF
--- a/specs/GH9869/product.md
+++ b/specs/GH9869/product.md
@@ -131,9 +131,15 @@ replace or rename any existing variant.
 The press-to-capture flow rejects (with an inline error message and
 no save) any key that would brick the user's keyboard:
 - The currently-bound app-quit shortcut.
-- The currently-bound voice-input shortcut itself (no infinite loop).
 - Enter, Escape, Tab, Backspace, Space (would block the agent input).
 - Modifier-only without the >800ms held-modifier rule (B3 carve-out).
+
+> **Correction (re-review #10127):** the previous draft included
+> "the currently-bound voice-input shortcut itself" as a reject-list
+> entry. That would have prevented users from changing an existing
+> custom hotkey — the literal opposite of the modal's purpose. The
+> tech spec already removed the rule (capture is accepted; same-key
+> re-confirm is a no-op short-circuit). Product B5 now matches.
 
 ### B6 — "None" remains the disable option
 

--- a/specs/GH9869/product.md
+++ b/specs/GH9869/product.md
@@ -56,18 +56,40 @@ escape hatch for everything else.
 
 ## Behavior contract (V1)
 
-### B1 — Caps Lock as a first-class option
+### B1 — Caps Lock as a first-class option (platform-specific semantics)
+
+> **Correction (review #10127):** earlier drafts described Caps Lock
+> as hold-to-talk on every platform while tech.md required macOS
+> press-to-toggle. Resolved to a single source of truth below.
 
 Caps Lock appears in the dropdown on all platforms (macOS, Windows,
-Linux). When selected, holding Caps Lock activates voice input and
-releasing it deactivates it, identical to the current modifier-key
-behavior. The OS-level Caps Lock toggle (the LED, the
-uppercase-letters effect) is NOT consumed: holding Caps Lock for
-voice input still toggles the OS Caps Lock state. (Suppressing the OS
-behavior would require platform-specific event interception which is
-out of V1 scope; users who want the suppression can remap Caps Lock
-to F19 at the OS level and bind that, which is the current best
-practice in Discord/Krisp.)
+Linux). The activation semantics are **platform-specific** and
+documented to the user in the dropdown's tooltip:
+
+- **macOS — press-to-toggle:** macOS reports Caps Lock as a single
+  key event when the lock state changes, not as a sustained press.
+  Holding-to-talk is impossible without OS-level event interception
+  (out of V1 scope). One tap starts voice input recording; the next
+  tap stops it. The dropdown tooltip on macOS reads
+  *"Tap to start, tap again to stop."* This matches Discord and
+  Krisp.
+- **Windows — hold-to-talk:** standard behavior. Holding Caps Lock
+  activates voice input; releasing it deactivates. The OS-level Caps
+  Lock toggle (the LED, the uppercase-letters effect) still fires —
+  V1 does not suppress it. The dropdown tooltip on Windows reads
+  *"Hold to talk."*
+- **Linux — hold-to-talk:** same as Windows. Tooltip reads
+  *"Hold to talk."*
+
+Acceptance criteria A4 is split accordingly:
+- A4-mac: tap, then tap again, on macOS — voice activates then
+  deactivates.
+- A4-win-lin: hold and release on Windows or Linux — voice activates
+  while held, deactivates on release.
+
+Users on macOS who want hold-to-talk semantics can remap Caps Lock
+to F19 at the OS level and bind F19; this is the current best
+practice in Discord/Krisp.
 
 ### B2 — F1 through F12 as first-class options
 
@@ -137,6 +159,20 @@ settings-change telemetry event with the new value (enum variant name
 for known variants, `"custom:<KeyCode>"` for press-to-capture
 variants). This lets the team see whether the new options actually
 solve the user demand or whether further additions are needed.
+
+**Privacy guardrails (security review #10127):**
+- The event fires **only after Confirm/save** in the press-to-capture
+  modal, never during capture.
+- Raw key events captured during the modal session are not logged or
+  emitted — they exist only in the modal's local state.
+- Rejected captures (B5 reject-list hits) are NOT emitted. The user
+  pressing keys that fail validation is the user's private interaction
+  with the modal.
+- Cancelled captures (Escape, Cancel button) are NOT emitted.
+- The emitted payload is `{ setting:
+  "agents.voice.voice_input_toggle_key", new_value: <enum-name-or-custom-keycode> }`.
+  No timestamps, no sequence of attempted keys, no modal session id.
+- The event respects Warp's existing global telemetry opt-out.
 
 ## Acceptance criteria
 

--- a/specs/GH9869/product.md
+++ b/specs/GH9869/product.md
@@ -1,0 +1,218 @@
+# Product spec: Voice input hotkey picker — Caps Lock, F-keys, custom keys (GH-9869)
+
+## Problem
+
+The voice input hotkey picker in **Settings → Agents → Warp Agent →
+Voice** offers a fixed list of ten modifier/function keys:
+
+```
+None | Fn | Option (Left/Right) | Control (Left/Right) | Command (Left/Right) | Shift (Left/Right)
+```
+
+The list is missing the two most common keys users repurpose for
+push-to-talk in real-world setups:
+
+- **Caps Lock** — the canonical "I never use this for typing" key,
+  remapped to push-to-talk in Discord, Krisp, Whisper, and most
+  VoIP/voice apps. macOS even surfaces "remap Caps Lock" as a
+  first-class system setting.
+- **Individual F-keys (F1–F12, and F13+ on extended keyboards)** —
+  isolated from the typing flow, naturally hold-to-record. A common
+  ergonomic choice on streamdecks, ortholinear keyboards, and
+  external programmable keypads where users dedicate F13–F19 to app
+  shortcuts.
+
+There is also no escape hatch: if a user has an ergonomic key Warp's
+fixed list does not name (e.g. an extra mouse button mapped to a key,
+a Hyper key, an unused punctuation key), they cannot bind voice input
+to it. The only workaround today is to give up on Warp's voice input
+hotkey and use the OS-wide voice input shortcut instead, which loses
+the in-app integration.
+
+## Goal
+
+Users can bind voice input to any single physical key Warp's
+underlying `KeyCode` enum can identify, with first-class UI for the
+two most-requested additions (Caps Lock, F-keys) and a press-to-capture
+escape hatch for everything else.
+
+## Non-goals (V1)
+
+- **Modifier-combination hotkeys** (Cmd+Shift+V etc.). The current
+  semantics are "hold one physical key"; introducing chord support
+  changes the press/release tracking and the dropdown's
+  expressiveness substantially. Track separately.
+- **Per-tab or per-profile voice hotkeys.** The setting stays global
+  per device.
+- **Cloud sync.** The setting is intentionally `SyncToCloud::Never`
+  ([app/src/settings/ai.rs:146](app/src/settings/ai.rs)) because the
+  same person uses different keyboards on different devices. V1
+  preserves this.
+- **Re-binding the system-wide voice input hotkey.** This spec is
+  scoped to Warp's in-app voice input only.
+- **Custom display names for captured keys.** A captured F19 displays
+  as "F19", a captured Backslash displays as "Backslash". Pretty
+  per-keyboard labeling (e.g. "Right Mouse Button 4") is a follow-up.
+
+## Behavior contract (V1)
+
+### B1 — Caps Lock as a first-class option
+
+Caps Lock appears in the dropdown on all platforms (macOS, Windows,
+Linux). When selected, holding Caps Lock activates voice input and
+releasing it deactivates it, identical to the current modifier-key
+behavior. The OS-level Caps Lock toggle (the LED, the
+uppercase-letters effect) is NOT consumed: holding Caps Lock for
+voice input still toggles the OS Caps Lock state. (Suppressing the OS
+behavior would require platform-specific event interception which is
+out of V1 scope; users who want the suppression can remap Caps Lock
+to F19 at the OS level and bind that, which is the current best
+practice in Discord/Krisp.)
+
+### B2 — F1 through F12 as first-class options
+
+F1–F12 each appear as their own dropdown entry on all platforms.
+F13–F24 (and beyond, up to whatever `KeyCode` supports) are reachable
+via the press-to-capture flow (B3) but are not pre-listed in the
+dropdown to keep it scannable. The dropdown groups F-keys under a
+single "Function key…" sub-section so the list does not balloon.
+
+### B3 — Press-to-capture escape hatch
+
+A new dropdown entry "Custom key…" opens a modal that prompts
+"Press the key you want to use for voice input." The user presses
+any single key. The modal:
+- Confirms the captured key by name and `KeyCode` (e.g.
+  "Selected: F19 (KeyCode::F19)").
+- Has Cancel and Confirm buttons.
+- On Confirm, persists the captured `KeyCode` to the setting.
+- On Escape during capture, closes without saving.
+
+The modal blocks the rest of the settings UI while open. It does not
+record modifier-only chords; it captures the first non-modifier key
+press, OR if only modifiers are held for >800ms before release, it
+captures the held modifier (so the user can still capture a bare
+Shift via this flow if for some reason the dropdown options are
+hidden).
+
+### B4 — Backwards compatibility for existing settings
+
+Users who have already set their voice toggle key to one of the
+existing 10 enum variants see no change. The TOML key
+`agents.voice.voice_input_toggle_key`
+([app/src/settings/ai.rs:148](app/src/settings/ai.rs)) preserves
+its existing values. The new variants extend the enum; they do not
+replace or rename any existing variant.
+
+### B5 — Keys not safely bindable are rejected
+
+The press-to-capture flow rejects (with an inline error message and
+no save) any key that would brick the user's keyboard:
+- The currently-bound app-quit shortcut.
+- The currently-bound voice-input shortcut itself (no infinite loop).
+- Enter, Escape, Tab, Backspace, Space (would block the agent input).
+- Modifier-only without the >800ms held-modifier rule (B3 carve-out).
+
+### B6 — "None" remains the disable option
+
+The existing `VoiceInputToggleKey::None` variant remains the
+"disable voice toggle" entry. The press-to-capture flow does not
+offer a way to bind to "no key"; users must select "None" from the
+dropdown. This keeps the disable path obvious.
+
+### B7 — Display name reflects user perception, not the protocol
+
+Captured keys display by their user-visible label, not their `KeyCode`
+spelling. E.g. `KeyCode::Backquote` displays as "` (Backquote)" or
+"\\\\` (Tilde key on US layout)" — whichever string already exists in
+Warp's keymap display layer. Falls back to `KeyCode::Debug` only if
+no display string is available; in that case a `log::warn!` fires (a
+key the user successfully pressed should always have a display
+string).
+
+### B8 — Telemetry: which key was bound
+
+When the user changes the voice input hotkey, fire the existing
+settings-change telemetry event with the new value (enum variant name
+for known variants, `"custom:<KeyCode>"` for press-to-capture
+variants). This lets the team see whether the new options actually
+solve the user demand or whether further additions are needed.
+
+## Acceptance criteria
+
+A1. Caps Lock appears in the voice hotkey dropdown on macOS, Windows,
+    and Linux.
+
+A2. F1–F12 appear in the dropdown as individual entries, grouped
+    under a "Function keys" sub-section.
+
+A3. Selecting "Custom key…" opens a press-to-capture modal; pressing
+    F19 binds F19; pressing the app-quit shortcut shows an inline
+    error and does not save.
+
+A4. Holding the bound key activates voice input; releasing
+    deactivates it. Pixel-equivalent to today's behavior for the
+    existing modifier keys.
+
+A5. A user upgrading from the current build with
+    `agents.voice.voice_input_toggle_key = "alt_left"` in their
+    settings file sees no change in behavior. The dropdown shows
+    "Option (Left)" selected (macOS) / "Alt (Left)" (Windows/Linux).
+
+A6. With an unbindable key bound from a corrupted settings file
+    (e.g. someone hand-edited TOML to set `voice_input_toggle_key =
+    "enter"`), the dropdown shows "None" and a one-time toast
+    explains the setting was reset for safety. The TOML is left
+    unchanged so the user can fix it themselves.
+
+## Risks and decisions for tech.md
+
+1. **Enum vs. `KeyCode`.** The current setting is a Rust enum with
+   `SettingsValue`-derived TOML serialization. Adding F1–F12 as
+   variants is fine. But "Custom key" must persist a `KeyCode` value
+   that is not in the curated enum. Choices:
+   (a) Make `VoiceInputToggleKey` carry a `Custom(KeyCode)` variant.
+   (b) Keep the curated enum for the dropdown and add a separate
+       `voice_input_toggle_keycode_override: Option<KeyCode>` setting
+       that, if set, overrides the enum.
+   The TECH spec must pick one and justify; (b) is less invasive but
+   splits the source of truth.
+
+2. **TOML serialization stability.** `SettingsValue` derive uses
+   `rename_all = "snake_case"`. New variants `CapsLock` → `caps_lock`,
+   `F1` → `f1`. For (a) above, `Custom(KeyCode)` needs custom
+   serialization; the natural choice is `{ custom = "f19" }` matching
+   `KeyCode`'s lowercase serialization.
+
+3. **macOS Caps Lock special-case.** On macOS, Caps Lock generates a
+   single keydown event when toggled on and a single keyup when
+   toggled off, NOT a press-and-hold stream. This is OS-level. Our
+   "hold to talk" semantics break for Caps Lock unless we either:
+   (a) Use Caps Lock as a press-to-toggle (one tap = recording on,
+       next tap = off);
+   (b) Document the difference in the dropdown tooltip and let users
+       decide whether to remap Caps Lock at the OS level first.
+   The TECH spec must pick one and justify. Recommendation: (a),
+   with a tooltip explaining the difference. Discord and Krisp both
+   take approach (a).
+
+4. **Dropdown UX with 20+ entries.** Adding Caps Lock + 12 F-keys +
+   "Custom…" pushes the dropdown to 22 entries. The TECH spec must
+   address whether to use a sub-menu, a search filter, or sectioned
+   headings. Recommendation: sectioned headings ("Modifier keys" /
+   "Function keys" / "Other") with the current modifiers at the top
+   so existing users see no reorder.
+
+5. **Press-to-capture cancellation.** What happens if the user
+   presses Escape (which is on the B5 reject-list)? The TECH spec
+   must define: Escape ALWAYS dismisses the modal without saving
+   (not "rejected with error"), because Escape is the universal
+   "cancel modal" key.
+
+## Reporter-supplied detail (preserved)
+
+The reporter explicitly cited Caps Lock and F1–F12 as the most-wanted
+additions, with F-keys justified by ergonomic isolation from the
+typing flow and Caps Lock justified by its commonness as a
+push-to-talk key in voice/video apps. The reporter also requested
+"any other bindable key" which B3 satisfies.

--- a/specs/GH9869/product.md
+++ b/specs/GH9869/product.md
@@ -186,9 +186,24 @@ A3. Selecting "Custom key…" opens a press-to-capture modal; pressing
     F19 binds F19; pressing the app-quit shortcut shows an inline
     error and does not save.
 
-A4. Holding the bound key activates voice input; releasing
-    deactivates it. Pixel-equivalent to today's behavior for the
-    existing modifier keys.
+A4 is split per platform per B1's split semantics:
+
+- **A4-win-lin (hold-to-talk).** On Windows and Linux, holding the
+  bound key activates voice input; releasing deactivates it.
+  Pixel-equivalent to today's behavior for the existing modifier
+  keys.
+- **A4-mac (press-to-toggle).** On macOS, when the bound key is
+  Caps Lock, tapping starts voice input recording and tapping
+  again stops it. For all other macOS-bound keys (F-keys, modifier
+  keys, custom non-CapsLock), behavior is hold-to-talk identical
+  to Windows/Linux. Caps Lock is the only key that uses press-to-
+  toggle, because macOS reports it as a toggle event rather than a
+  sustained press.
+
+> **Correction (re-review #10127):** the previous A4 still said
+> "holding the bound key … releasing deactivates" for every key,
+> which contradicted B1's macOS Caps Lock tap-to-toggle. Resolved
+> by splitting A4 above.
 
 A5. A user upgrading from the current build with
     `agents.voice.voice_input_toggle_key = "alt_left"` in their
@@ -198,8 +213,14 @@ A5. A user upgrading from the current build with
 A6. With an unbindable key bound from a corrupted settings file
     (e.g. someone hand-edited TOML to set `voice_input_toggle_key =
     "enter"`), the dropdown shows "None" and a one-time toast
-    explains the setting was reset for safety. The TOML is left
-    unchanged so the user can fix it themselves.
+    explains the setting was reset for safety. The TOML is
+    rewritten with the corrected value so the user is not stuck in
+    a permanent toast loop on subsequent launches.
+
+> **Correction (re-review #10127):** the previous A6 said the TOML
+> was left unchanged. tech.md's reset path rewrites the TOML so
+> the user-facing toast fires once, not every launch. Updated A6
+> here to match.
 
 ## Risks and decisions for tech.md
 

--- a/specs/GH9869/tech.md
+++ b/specs/GH9869/tech.md
@@ -232,8 +232,19 @@ New module `app/src/settings_view/voice_hotkey_capture_modal.rs`.
 
 - Triggered when the user clicks "Custom key…".
 - Renders a focused modal: title "Press the key for voice input",
-  body with the captured key (initially empty), Cancel + Confirm
-  buttons, an inline error area.
+  body with the captured key shown by **friendly display name**
+  (e.g. "F19", "Caps Lock", "Backslash") and a hover tooltip
+  showing the protocol-level `KeyCode` spelling (e.g.
+  `KeyCode::F19`); initially empty, Cancel + Confirm buttons,
+  an inline error area.
+
+  > **Correction (re-review #10127):** the previous draft showed
+  > "Selected: F19 (KeyCode::F19)" inline in the body — that
+  > inlines the protocol spelling. The resolved decision (Open
+  > Question 4 in the previous round) is friendly-name-only
+  > inline, with `KeyCode` spelling only in the hover tooltip.
+  > Both surfaces (modal body and dropdown "Custom: ..." row)
+  > use the same friendly name.
 - Listens for raw key events at the top level (using whatever modal
   key-event hook the existing settings modals use — verify by
   inspecting one existing modal first).
@@ -385,11 +396,40 @@ enum VoiceInputTomlValue {
     /// for diagnostic surfacing.
     Invalid(toml::Value),
 }
-
-// AISettings::voice_input_toggle_key is internally
-// VoiceInputTomlValue, with a public accessor that returns
-// VoiceInputToggleKey (mapping Invalid -> None on read).
 ```
+
+> **Correction (re-review #10127):** the previous draft introduced
+> the wrapper but didn't reconcile it with the rest of the spec
+> (which still treats `voice_input_toggle_key` as if it had the
+> bare `VoiceInputToggleKey` type — `set_value`, dropdown reads,
+> tests, etc.). The reconciliation below makes the wrapper an
+> internal implementation detail; all external surfaces continue
+> to see the unwrapped type.
+
+**API reconciliation:**
+
+- The `AISettings` struct holds the field internally typed as
+  `VoiceInputTomlValue`, deserialized directly from TOML.
+- Immediately after `AISettings::initialize()` (the post-init pass
+  described below), the field is normalized: any `Invalid` value
+  is logged, the toast is fired, the TOML is rewritten with
+  `VoiceInputToggleKey::None`, and the field is replaced with
+  `Valid(VoiceInputToggleKey::None)`.
+- After post-init, **the field is always `Valid(...)`**. All
+  external accessors are typed as `VoiceInputToggleKey`:
+  - `voice_input_toggle_key.value() -> VoiceInputToggleKey`
+    unwraps the always-`Valid` variant.
+  - `voice_input_toggle_key.set_value(VoiceInputToggleKey, ctx)`
+    wraps in `Valid` before storing.
+- Existing tests, dropdown rendering, and dispatch all continue
+  to use `VoiceInputToggleKey` exactly as documented elsewhere in
+  this spec. The wrapper is a 30-line implementation detail in
+  the field's `Serialize`/`Deserialize` impls + the post-init
+  pass, not a leak into the settings public API.
+
+T1, T2, IT1–IT3 in the test plan continue to assert against
+`VoiceInputToggleKey` values directly — they don't see the
+wrapper.
 
 This works with stock Serde (`#[serde(untagged)]` falls through to
 `Invalid` when none of the `Valid` shapes match) and does not
@@ -487,9 +527,13 @@ disk file is consistent and subsequent launches are quiet.
 
 ## Open questions for maintainer review
 
-1. Does the `SettingsValue` derive macro support enum variants with
-   payloads (`Custom(KeyCode)`), or do we need a manual
-   `Serialize`/`Deserialize` impl?
+1. ~~Does the `SettingsValue` derive macro support enum variants
+   with payloads (`Custom(KeyCode)`), or do we need a manual
+   `Serialize`/`Deserialize` impl?~~ **Resolved (re-review
+   #10127):** committed to the manual impl path in the "Settings
+   serialization" section above (option 2). The `VoiceInputTomlValue`
+   wrapper enum and post-init pass on `AISettings::initialize`
+   are the implementation. No macro extension needed.
 2. For the dropdown sectioning, is there an existing
    `DropdownItem::heading()` constructor, or should we add one?
 3. Confirm the macOS Caps Lock press-to-toggle decision (vs

--- a/specs/GH9869/tech.md
+++ b/specs/GH9869/tech.md
@@ -44,7 +44,7 @@ pub enum VoiceInputToggleKey {
     CapsLock,                          // NEW
     F1, F2, F3, F4, F5, F6,            // NEW
     F7, F8, F9, F10, F11, F12,         // NEW
-    Custom(KeyCode),                   // NEW
+    Custom(KeyCode),                   // NEW — non-iter variant
 }
 ```
 
@@ -54,30 +54,100 @@ Why (a) over (b) (separate `Option<KeyCode>` override field):
 - Avoids a "two settings disagree" failure mode where a user changes
   the dropdown but the override is stale.
 
-Cost of (a):
-- `SettingsValue` derive macro must support enum variants with
-  payloads. If it does not (verify before implementing), we have two
-  options: extend the macro, or use a manual `serde::Deserialize` /
-  `serde::Serialize` impl with a tagged form
-  (`{ kind = "custom", key = "f19" }`).
+### Replacing the EnumIter / `all_possible_values()` flow
 
-### TOML format
+> **Correction (review #10127):** the existing
+> `VoiceInputToggleKey::all_possible_values()`
+> ([app/src/settings/ai.rs:153](app/src/settings/ai.rs)) calls
+> `Self::iter().collect()` from `strum::EnumIter`. Adding a payload
+> variant like `Custom(KeyCode)` makes the enum non-iterable: there is
+> no finite list of `KeyCode` payloads.
 
-For known variants: existing snake_case (no change).
+Replace `all_possible_values()` with a curated `predefined_options()`
+that returns the unit variants for the dropdown:
+
+```rust
+impl VoiceInputToggleKey {
+    pub fn predefined_options() -> Vec<VoiceInputToggleKey> {
+        let mut out = vec![
+            VoiceInputToggleKey::None,
+            VoiceInputToggleKey::AltLeft, VoiceInputToggleKey::AltRight,
+            VoiceInputToggleKey::ControlLeft, VoiceInputToggleKey::ControlRight,
+            VoiceInputToggleKey::SuperLeft, VoiceInputToggleKey::SuperRight,
+            VoiceInputToggleKey::ShiftLeft, VoiceInputToggleKey::ShiftRight,
+            VoiceInputToggleKey::CapsLock,
+            VoiceInputToggleKey::F1,  VoiceInputToggleKey::F2,
+            VoiceInputToggleKey::F3,  VoiceInputToggleKey::F4,
+            VoiceInputToggleKey::F5,  VoiceInputToggleKey::F6,
+            VoiceInputToggleKey::F7,  VoiceInputToggleKey::F8,
+            VoiceInputToggleKey::F9,  VoiceInputToggleKey::F10,
+            VoiceInputToggleKey::F11, VoiceInputToggleKey::F12,
+        ];
+        if matches!(OperatingSystem::get(), OperatingSystem::Mac) {
+            // Fn was macOS-only in the original list; preserve that.
+            out.insert(1, VoiceInputToggleKey::Fn);
+        }
+        out
+    }
+}
+```
+
+`Custom(KeyCode)` is **not** part of `predefined_options()` — it is
+constructed by the press-to-capture modal at runtime. The dropdown
+shows a synthetic "Custom key…" entry that opens the modal; once a
+key is captured, the resulting `Custom(KeyCode)` is set as the
+current value but does not appear in the predefined list.
+
+Drop the `EnumIter` derive (it would now be wrong for the payload
+variant). Existing call sites of `iter()` are limited to
+`all_possible_values()` itself, so this is a one-line removal.
+
+### Settings serialization
+
+The existing `implement_setting_for_enum!` macro
+([app/src/settings/ai.rs:140](app/src/settings/ai.rs)) does **not**
+support payload variants. Two options:
+
+1. **Extend the macro** to allow a `Custom(T)` arm with a custom
+   tag/serialize hook.
+2. **Hand-write `Serialize`/`Deserialize` for `VoiceInputToggleKey`**
+   and use the simpler `implement_setting!` (non-enum) macro for
+   persistence.
+
+Recommendation: **option 2.** The macro extension would be a one-off
+for this single enum and the manual impl is ~30 lines of
+straightforward code, fully testable.
+
+### Canonical TOML format
+
+> **Correction (review #10127):** earlier drafts mentioned both
+> `{ custom = "F19" }` and `{ kind = "custom", key = "f19" }`. The
+> canonical form is below; the tests assert it bit-for-bit.
+
+For unit variants — existing snake_case format, no change:
 ```toml
 voice_input_toggle_key = "alt_left"
 voice_input_toggle_key = "caps_lock"
 voice_input_toggle_key = "f1"
+voice_input_toggle_key = "f12"
 ```
-For `Custom`:
+
+For `Custom(KeyCode)` — TOML inline-table with one key, `custom`,
+and the `KeyCode` value as its lowercased Serde-default
+representation:
 ```toml
-voice_input_toggle_key = { custom = "F19" }
-# or
-voice_input_toggle_key = { custom = "Backslash" }
+voice_input_toggle_key = { custom = "f19" }
+voice_input_toggle_key = { custom = "backslash" }
+voice_input_toggle_key = { custom = "intl_yen" }   # snake_case for multi-word
 ```
-The `Custom` payload is the `KeyCode` `Debug` representation
-(matches Serde's default for the existing `KeyCode` `Serialize`
-derive).
+
+The `KeyCode` payload uses `serde_with`-style snake_case lowercasing
+to match the existing settings TOML convention. Round-trip:
+- Serialize: `KeyCode::F19` → `"f19"`, `KeyCode::IntlYen` → `"intl_yen"`.
+- Deserialize: case-insensitive match against the snake_case form.
+The hand-written `Serialize`/`Deserialize` impl is the single
+source of truth for this mapping; T2 in the test plan asserts the
+exact strings.
 
 ### Migration
 
@@ -134,11 +204,45 @@ New module `app/src/settings_view/voice_hotkey_capture_modal.rs`.
 - On Confirm, dispatches
   `AISettingsPageAction::SetVoiceInputToggleKey(VoiceInputToggleKey::Custom(key_code))`.
 - On Cancel or Escape, closes without dispatch.
-- The modal's reject-list (B5) is constructed at open time from:
-  - The currently-bound app-quit shortcut (read from key bindings).
-  - The currently-bound voice-input shortcut (the value being
-    replaced — but allow re-confirming the same key).
-  - A static list: `[Enter, Escape, Tab, Backspace, Space]`.
+- The modal's reject-list (B5) operates on **full keystrokes** (key
+  + modifiers), not bare `KeyCode`s.
+
+> **Correction (review #10127):** earlier drafts described the
+> reject-list as a `KeyCode` set. App-quit (`Cmd+Q` on macOS,
+> `Alt+F4` on Windows) is a chord — comparing only `KeyCode::KeyQ`
+> would either ban a bare `Q` (wrong) or fail to reject Cmd+Q. The
+> reject-list must compare full `Keystroke`s.
+
+  Reject-list construction (at modal open time):
+
+  - **Currently-bound app-quit shortcut:** read the full
+    `Keystroke` from the key-binding registry (e.g. `Cmd+Q` on
+    macOS, `Alt+F4` on Windows). The captured input is rejected
+    only if its full `Keystroke` (key + modifiers) matches.
+  - **Currently-bound voice-input shortcut:** allow re-confirming
+    the same key (so the user can re-open and confirm without
+    error), but reject if the user picks a different value than
+    the existing one for any reason. Same `Keystroke` comparison.
+  - **Static structural rejects:** these are bare-key rejects (no
+    modifier needed) because they would brick the input flow:
+    `[Enter, Escape, Tab, Backspace, Space]`. The modifier
+    state is ignored for these specifically. (Pressing
+    `Cmd+Enter` is also rejected — Cmd+Enter is just as broken as
+    bare Enter for our use case.)
+  - **Bare modifier rule:** a press whose `KeyCode` is a modifier
+    AND no other key is pressed can still be captured via the
+    >800ms held-modifier rule (B3). The captured value is the
+    bare modifier (`KeyCode::ShiftLeft`), not the
+    chord, since voice activation tracks press/release of a
+    single physical key.
+
+  Because the captured value persisted into the setting is a
+  single `KeyCode` (or one of the predefined enum variants), not a
+  full `Keystroke`, the reject-list comparison happens **at
+  capture time only**, before the value is saved. Once saved, the
+  dispatch-side (`block_list_element.rs:3072` /
+  `alt_screen_element.rs:620`) only sees the bare `KeyCode` and
+  matches a single key event.
 
 ### Caps Lock toggle vs. hold semantics
 
@@ -198,16 +302,55 @@ keycode_string(key_code).to_string(), .. Default::default() }`.
 
 ## Settings reset on corrupted TOML (A6)
 
-When `VoiceInputToggleKey` deserialization fails (user hand-edited
-TOML with `voice_input_toggle_key = "enter"`), the `SettingsValue`
-deserializer falls back to `Default` today. We need to additionally
-fire a one-time toast.
+> **Correction (review #10127):** earlier drafts said the validation
+> hook fires when "deserialization successfully produces an
+> unbindable `KeyCode`." But TOML like `voice_input_toggle_key =
+> "enter"` does NOT deserialize successfully into the curated unit-
+> variant set — it fails parsing. A `validate()` hook running on the
+> deserialized value never sees the bad value. Below is the corrected
+> design that intercepts the raw parse failure.
 
-Implementation: add a `validate()` method on `VoiceInputToggleKey`
-called during `AISettings::initialize()`. If the loaded value
-deserializes successfully but the resulting `KeyCode` is in B5's
-reject list, reset to `None`, fire the toast via the existing
-toast/notification channel, and log a warn.
+There are two distinct A6 paths:
+
+### Path 1: raw parse failure (e.g. `"enter"`, `"foo"`, malformed TOML)
+
+The hand-written `Deserialize` impl on `VoiceInputToggleKey` (see
+"Settings serialization" above) is the single entry point. It is
+modified to:
+
+1. Attempt the normal parse against the curated unit-variant set
+   plus the `{ custom = "..." }` form.
+2. **On parse failure, return a special `Default` value tagged with
+   the original raw string** instead of erroring out. The tag is
+   stored in a side-channel: a `parking_lot::Mutex<Option<String>>`
+   on `AISettings` named `voice_input_toggle_key_raw_parse_failure`.
+3. Do NOT propagate the parse error — that would prevent the rest
+   of `AISettings` from loading.
+
+After `AISettings::initialize()` completes, a one-shot consumer in
+the AI page's mount hook drains the side-channel:
+- If `Some(raw)`: fire the toast *"Voice input hotkey reset — could
+  not parse `<raw>`"*, log
+  `log::warn!(raw = ?raw, "voice_input_toggle_key parse failed,
+  reset to None")`. Drain to `None` so the toast never re-fires.
+- If `None`: no-op.
+
+### Path 2: parsed-but-unbindable value (e.g. captured from an old
+build that allowed it)
+
+After deserialization succeeds, an additional `validate()` method on
+`VoiceInputToggleKey` checks the resulting `KeyCode` against the
+runtime reject list (modifier-only-but-not-curated, etc.). If the
+check fails:
+- Reset the in-memory value to `None`.
+- Re-write the TOML on disk with the corrected value.
+- Fire the same toast and warn-log as Path 1.
+- The toast text is the same; the side-channel is reused for the
+  raw value (set to the `Debug` representation).
+
+This split — parse failure as one path, post-parse validation as
+another — guarantees A6's toast fires regardless of how the bad
+value got into the file.
 
 ## Test plan
 

--- a/specs/GH9869/tech.md
+++ b/specs/GH9869/tech.md
@@ -1,0 +1,283 @@
+# Technical spec: Voice input hotkey picker (GH-9869)
+
+This spec is the implementation companion to `product.md`. It picks
+the data-model approach, the UI changes, and the testable invariants.
+
+## Current implementation
+
+- **Setting enum:** `VoiceInputToggleKey` at
+  [app/src/settings/ai.rs:110-138](app/src/settings/ai.rs). 10
+  variants. Derives `SettingsValue` (TOML `snake_case`).
+- **Persistence:** `agents.voice.voice_input_toggle_key` TOML path,
+  `SyncToCloud::Never` (intentional — see product spec §non-goals).
+- **Display:** `VoiceInputToggleKey::display_name`
+  ([app/src/settings/ai.rs:169-198](app/src/settings/ai.rs)) returns
+  platform-aware strings ("Option (Left)" on macOS,
+  "Alt (Left)" on Windows/Linux).
+- **Mapping to `KeyCode`:** `VoiceInputToggleKey::to_key_code`
+  ([app/src/settings/ai.rs:200-213](app/src/settings/ai.rs)) maps
+  variants to `warpui_core::platform::KeyCode`.
+- **Dropdown UI:** [app/src/settings_view/ai_page.rs:498-532](app/src/settings_view/ai_page.rs)
+  builds a `Dropdown<AISettingsPageAction>` from
+  `VoiceInputToggleKey::all_possible_values()`.
+- **Underlying `KeyCode` enum:** [crates/warpui_core/src/platform/keyboard.rs:85](crates/warpui_core/src/platform/keyboard.rs)
+  already supports `CapsLock` (line 210), `F1`–`F35` (lines 437+),
+  and the long tail.
+- **Action dispatch:** `block_list_element.rs:3072` and
+  `alt_screen_element.rs:620` compare incoming `key_code` to the
+  configured one. No code changes needed there for new variants —
+  they speak `KeyCode`, not the enum.
+
+## Data model: `Custom(KeyCode)` variant on the existing enum
+
+Choice (a) from product.md §risks: extend `VoiceInputToggleKey` with
+a `Custom(KeyCode)` variant.
+
+```rust
+pub enum VoiceInputToggleKey {
+    None,
+    Fn,
+    AltLeft, AltRight,
+    ControlLeft, ControlRight,
+    SuperLeft, SuperRight,
+    ShiftLeft, ShiftRight,
+    CapsLock,                          // NEW
+    F1, F2, F3, F4, F5, F6,            // NEW
+    F7, F8, F9, F10, F11, F12,         // NEW
+    Custom(KeyCode),                   // NEW
+}
+```
+
+Why (a) over (b) (separate `Option<KeyCode>` override field):
+- Single source of truth for "what key fires voice input."
+- The dropdown selection state cleanly maps to one enum value.
+- Avoids a "two settings disagree" failure mode where a user changes
+  the dropdown but the override is stale.
+
+Cost of (a):
+- `SettingsValue` derive macro must support enum variants with
+  payloads. If it does not (verify before implementing), we have two
+  options: extend the macro, or use a manual `serde::Deserialize` /
+  `serde::Serialize` impl with a tagged form
+  (`{ kind = "custom", key = "f19" }`).
+
+### TOML format
+
+For known variants: existing snake_case (no change).
+```toml
+voice_input_toggle_key = "alt_left"
+voice_input_toggle_key = "caps_lock"
+voice_input_toggle_key = "f1"
+```
+For `Custom`:
+```toml
+voice_input_toggle_key = { custom = "F19" }
+# or
+voice_input_toggle_key = { custom = "Backslash" }
+```
+The `Custom` payload is the `KeyCode` `Debug` representation
+(matches Serde's default for the existing `KeyCode` `Serialize`
+derive).
+
+### Migration
+
+No migration needed. Existing TOML values continue to deserialize.
+New variants only appear in TOML if the user picks them in the UI.
+
+## UI changes (ai_page.rs)
+
+### Dropdown sectioning
+
+Replace the flat `dropdown.add_items(values.into_iter().map(...))`
+loop at
+[app/src/settings_view/ai_page.rs:517-528](app/src/settings_view/ai_page.rs)
+with a sectioned builder:
+
+```text
+[Disabled]
+  None
+
+[Modifier keys]
+  Fn (macOS only)
+  Option (Left), Option (Right)
+  Control (Left), Control (Right)
+  Command (Left), Command (Right)
+  Shift (Left), Shift (Right)
+  Caps Lock                ← NEW
+
+[Function keys]            ← NEW SECTION
+  F1, F2, F3, F4, F5, F6,
+  F7, F8, F9, F10, F11, F12
+
+[Other]                    ← NEW SECTION
+  Custom key…              ← opens press-to-capture modal
+```
+
+If `Dropdown` does not support section headings today, add a
+non-clickable `DropdownItem` constructor (or use a thin separator
+`DropdownItem`). The TECH spec recommends adding the heading
+support; it is small and reusable.
+
+### Press-to-capture modal
+
+New module `app/src/settings_view/voice_hotkey_capture_modal.rs`.
+
+- Triggered when the user clicks "Custom key…".
+- Renders a focused modal: title "Press the key for voice input",
+  body with the captured key (initially empty), Cancel + Confirm
+  buttons, an inline error area.
+- Listens for raw key events at the top level (using whatever modal
+  key-event hook the existing settings modals use — verify by
+  inspecting one existing modal first).
+- Filters per B5 (product.md): rejects unbindable keys with an
+  inline error; accepts any other single key.
+- On Confirm, dispatches
+  `AISettingsPageAction::SetVoiceInputToggleKey(VoiceInputToggleKey::Custom(key_code))`.
+- On Cancel or Escape, closes without dispatch.
+- The modal's reject-list (B5) is constructed at open time from:
+  - The currently-bound app-quit shortcut (read from key bindings).
+  - The currently-bound voice-input shortcut (the value being
+    replaced — but allow re-confirming the same key).
+  - A static list: `[Enter, Escape, Tab, Backspace, Space]`.
+
+### Caps Lock toggle vs. hold semantics
+
+Per product.md §risk 3, on macOS Caps Lock fires only on
+toggle-on/toggle-off, not on press/release. The handler in
+`block_list_element.rs:3072` uses press-and-release tracking. For
+the `CapsLock` variant on macOS, switch the handler to
+press-to-toggle: first event starts recording, second event stops.
+
+Implementation: a new helper `VoiceInputToggleKey::is_toggle_mode()`
+returns `true` for `CapsLock` on macOS, `false` otherwise. The
+handler branches on this. The dropdown tooltip for the `CapsLock`
+entry on macOS displays "Tap to start, tap again to stop" instead
+of "Hold to talk."
+
+## Display name for new variants
+
+Extend `VoiceInputToggleKey::display_name`
+([app/src/settings/ai.rs:169](app/src/settings/ai.rs)):
+
+```rust
+match self {
+    // existing arms unchanged
+    VoiceInputToggleKey::CapsLock => "Caps Lock",
+    VoiceInputToggleKey::F1 => "F1",
+    // ... F2..F12
+    VoiceInputToggleKey::Custom(key_code) => {
+        // Use a new helper that mirrors what the keymap layer shows
+        // for this KeyCode, falling back to {key_code:?}.
+        Box::leak(format_keycode_display(key_code).into_boxed_str())
+    }
+}
+```
+
+Note: `display_name` currently uses `Box::leak` for runtime-formatted
+strings. The pattern is unchanged for `Custom`.
+
+`tooltip_message` ([app/src/settings/ai.rs:247](app/src/settings/ai.rs))
+gets matching arms.
+
+## Mapping to `KeyCode`
+
+Extend `VoiceInputToggleKey::to_key_code`
+([app/src/settings/ai.rs:200](app/src/settings/ai.rs)):
+
+```rust
+VoiceInputToggleKey::CapsLock => Some(KeyCode::CapsLock),
+VoiceInputToggleKey::F1 => Some(KeyCode::F1),
+// ... F2..F12
+VoiceInputToggleKey::Custom(key_code) => Some(*key_code),
+```
+
+`keystroke()` at line 218: the existing modifier-only path returns
+a `Keystroke` with the modifier flag set. For non-modifier keys
+(F-keys, CapsLock, custom), construct a `Keystroke { key:
+keycode_string(key_code).to_string(), .. Default::default() }`.
+
+## Settings reset on corrupted TOML (A6)
+
+When `VoiceInputToggleKey` deserialization fails (user hand-edited
+TOML with `voice_input_toggle_key = "enter"`), the `SettingsValue`
+deserializer falls back to `Default` today. We need to additionally
+fire a one-time toast.
+
+Implementation: add a `validate()` method on `VoiceInputToggleKey`
+called during `AISettings::initialize()`. If the loaded value
+deserializes successfully but the resulting `KeyCode` is in B5's
+reject list, reset to `None`, fire the toast via the existing
+toast/notification channel, and log a warn.
+
+## Test plan
+
+### Unit tests (`app/src/settings/ai.rs::tests`)
+
+- T1: TOML round-trip for each new variant (`caps_lock`, `f1`–`f12`).
+- T2: TOML round-trip for `Custom(KeyCode::F19)` and
+  `Custom(KeyCode::Backslash)`.
+- T3: `display_name` returns expected strings on each platform.
+- T4: `to_key_code` returns the correct `KeyCode` for each variant.
+- T5: `is_toggle_mode()` returns true for `CapsLock` on macOS,
+  false otherwise.
+- T6: A TOML file with an invalid `voice_input_toggle_key = "enter"`
+  loads as `None` and triggers the validation reset path.
+
+### Unit tests (`app/src/settings_view/voice_hotkey_capture_modal_test.rs`)
+
+- T7: Pressing F19 in the modal captures `KeyCode::F19`.
+- T8: Pressing the app-quit shortcut shows an inline error and does
+  not dispatch.
+- T9: Pressing Escape closes without dispatch.
+- T10: Holding only Shift for >800ms then releasing captures
+  `KeyCode::ShiftLeft` (B3 carve-out).
+
+### Integration test (`app/src/integration_testing/`)
+
+- IT1: Open the AI settings page, click "Custom key…", press F19,
+  click Confirm. Verify `AISettings.voice_input_toggle_key.value() ==
+  Custom(KeyCode::F19)`.
+- IT2: Set the setting to `CapsLock` on macOS, press CapsLock once,
+  verify voice input starts; press CapsLock again, verify it stops.
+- IT3: Set the setting to `F5`, hold F5, verify voice input is
+  active; release, verify it stops.
+
+## Files touched
+
+- `app/src/settings/ai.rs` — extend enum, `display_name`,
+  `to_key_code`, `keystroke`, `tooltip_message`, add
+  `is_toggle_mode()` and `validate()`.
+- `app/src/settings_view/ai_page.rs` — sectioned dropdown,
+  "Custom key…" entry, modal trigger.
+- `app/src/settings_view/voice_hotkey_capture_modal.rs` (new) —
+  press-to-capture modal.
+- `app/src/terminal/block_list_element.rs:3072` — branch on
+  `is_toggle_mode()` for press-to-toggle vs hold-to-talk.
+- `app/src/terminal/alt_screen/alt_screen_element.rs:620` — same.
+- `app/src/settings_view/voice_hotkey_capture_modal_test.rs` (new) —
+  T7–T10.
+- `app/src/integration_testing/settings/voice_hotkey_test.rs` (new)
+  — IT1–IT3.
+
+## Out-of-scope follow-ups
+
+- Modifier-combination hotkeys (Cmd+Shift+V).
+- Per-tab or per-profile voice hotkey.
+- Cloud sync for voice hotkey (would conflict with cross-device
+  keyboard variation).
+- Remapping the OS-wide voice input shortcut.
+
+## Open questions for maintainer review
+
+1. Does the `SettingsValue` derive macro support enum variants with
+   payloads (`Custom(KeyCode)`), or do we need a manual
+   `Serialize`/`Deserialize` impl?
+2. For the dropdown sectioning, is there an existing
+   `DropdownItem::heading()` constructor, or should we add one?
+3. Confirm the macOS Caps Lock press-to-toggle decision (vs
+   "document the difference and don't fix"). Discord and Krisp
+   both go press-to-toggle.
+4. Should the press-to-capture modal expose the captured `KeyCode`
+   spelling to the user (debug aid), or only the friendly display
+   name? Recommendation: friendly name with a hover tooltip
+   showing `KeyCode::F19` for users who care.

--- a/specs/GH9869/tech.md
+++ b/specs/GH9869/tech.md
@@ -219,10 +219,21 @@ New module `app/src/settings_view/voice_hotkey_capture_modal.rs`.
     `Keystroke` from the key-binding registry (e.g. `Cmd+Q` on
     macOS, `Alt+F4` on Windows). The captured input is rejected
     only if its full `Keystroke` (key + modifiers) matches.
-  - **Currently-bound voice-input shortcut:** allow re-confirming
-    the same key (so the user can re-open and confirm without
-    error), but reject if the user picks a different value than
-    the existing one for any reason. Same `Keystroke` comparison.
+  - **Currently-bound voice-input shortcut:** the modal does NOT
+    add the existing voice-input value to the reject list. The
+    capture flow exists precisely to *change* the binding; rejecting
+    the existing value would only matter for the "same key already"
+    no-op confirm case, which we instead handle by accepting the
+    capture and short-circuiting the dispatch when the captured
+    `KeyCode` equals the current one. There is no infinite loop
+    risk because the dispatch handler at `block_list_element.rs:3072`
+    only fires voice activation, never re-binds the hotkey.
+
+> **Correction (re-review #10127):** the previous draft said the
+> reject-list "rejects if the user picks a different value than the
+> existing one for any reason" — which would have prevented users
+> from changing an existing custom hotkey. That was the literal
+> opposite of the intended behavior. Resolved as above.
   - **Static structural rejects:** these are bare-key rejects (no
     modifier needed) because they would brick the input flow:
     `[Enter, Escape, Tab, Backspace, Space]`. The modifier
@@ -310,47 +321,73 @@ keycode_string(key_code).to_string(), .. Default::default() }`.
 > deserialized value never sees the bad value. Below is the corrected
 > design that intercepts the raw parse failure.
 
-There are two distinct A6 paths:
+> **Correction (re-review #10127):** the previous draft proposed
+> mutating a `Mutex<Option<String>>` on `AISettings` *from inside*
+> the `Deserialize` impl of `VoiceInputToggleKey`. A field
+> deserializer doesn't have a reference to the containing settings
+> struct — that design isn't feasible Serde. The corrected design
+> below uses a wrapper-enum field type, which IS standard Serde,
+> and post-processes after deserialization completes.
+>
+> Also corrected: product.md A6 said the TOML was left unchanged
+> while tech.md said it was rewritten. Resolved to **rewrite** so
+> the toast fires once, not on every launch.
 
-### Path 1: raw parse failure (e.g. `"enter"`, `"foo"`, malformed TOML)
+The TOML field uses a wrapper enum that captures both successful
+and failed parses without erroring out:
 
-The hand-written `Deserialize` impl on `VoiceInputToggleKey` (see
-"Settings serialization" above) is the single entry point. It is
-modified to:
+```rust
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum VoiceInputTomlValue {
+    /// The TOML value parsed cleanly into one of the predefined
+    /// variants OR the `{ custom = "..." }` form.
+    Valid(VoiceInputToggleKey),
+    /// Anything else — string, table, integer — is captured raw
+    /// for diagnostic surfacing.
+    Invalid(toml::Value),
+}
 
-1. Attempt the normal parse against the curated unit-variant set
-   plus the `{ custom = "..." }` form.
-2. **On parse failure, return a special `Default` value tagged with
-   the original raw string** instead of erroring out. The tag is
-   stored in a side-channel: a `parking_lot::Mutex<Option<String>>`
-   on `AISettings` named `voice_input_toggle_key_raw_parse_failure`.
-3. Do NOT propagate the parse error — that would prevent the rest
-   of `AISettings` from loading.
+// AISettings::voice_input_toggle_key is internally
+// VoiceInputTomlValue, with a public accessor that returns
+// VoiceInputToggleKey (mapping Invalid -> None on read).
+```
 
-After `AISettings::initialize()` completes, a one-shot consumer in
-the AI page's mount hook drains the side-channel:
-- If `Some(raw)`: fire the toast *"Voice input hotkey reset — could
-  not parse `<raw>`"*, log
-  `log::warn!(raw = ?raw, "voice_input_toggle_key parse failed,
-  reset to None")`. Drain to `None` so the toast never re-fires.
-- If `None`: no-op.
+This works with stock Serde (`#[serde(untagged)]` falls through to
+`Invalid` when none of the `Valid` shapes match) and does not
+require any side-channel mutation from inside a deserializer.
 
-### Path 2: parsed-but-unbindable value (e.g. captured from an old
-build that allowed it)
+After `AISettings::initialize()` completes, a single post-init pass
+walks the deserialized struct:
 
-After deserialization succeeds, an additional `validate()` method on
-`VoiceInputToggleKey` checks the resulting `KeyCode` against the
-runtime reject list (modifier-only-but-not-curated, etc.). If the
-check fails:
-- Reset the in-memory value to `None`.
-- Re-write the TOML on disk with the corrected value.
-- Fire the same toast and warn-log as Path 1.
-- The toast text is the same; the side-channel is reused for the
-  raw value (set to the `Debug` representation).
+```rust
+fn post_init_voice_input_toggle_key(settings: &mut AISettings, ctx: &mut AppContext) {
+    let Some(invalid) = settings.voice_input_toggle_key.take_if_invalid() else {
+        // Either Valid (no action) or already drained on a previous launch.
+        return;
+    };
 
-This split — parse failure as one path, post-parse validation as
-another — guarantees A6's toast fires regardless of how the bad
-value got into the file.
+    // Path 1 (raw parse failure) — `invalid` is the rejected toml::Value.
+    let raw_repr = invalid.to_string();
+    log::warn!(raw = ?raw_repr,
+        "voice_input_toggle_key did not deserialize, resetting to None");
+    settings.voice_input_toggle_key.set_value(VoiceInputToggleKey::None, ctx);
+    settings.persist_to_disk(ctx);  // rewrite TOML so the toast fires once
+    fire_toast(ctx, format!(
+        "Voice input hotkey reset — could not parse `{raw_repr}`"
+    ));
+}
+```
+
+Path 2 (parsed-but-unbindable: e.g. a `Valid` value that fails the
+runtime reject-list check) is folded into the same routine: after
+unwrapping `Valid`, run `validate()`; if it fails, log + rewrite +
+toast with the same code path as Path 1, but with the rejected
+`KeyCode`'s display name as the raw representation.
+
+This guarantees A6's toast fires **once** for any combination of
+TOML-parse-failure and post-parse-validation-failure, then the
+disk file is consistent and subsequent launches are quiet.
 
 ## Test plan
 

--- a/specs/GH9869/tech.md
+++ b/specs/GH9869/tech.md
@@ -102,6 +102,44 @@ Drop the `EnumIter` derive (it would now be wrong for the payload
 variant). Existing call sites of `iter()` are limited to
 `all_possible_values()` itself, so this is a one-line removal.
 
+### Displaying a persisted `Custom(KeyCode)` in the dropdown
+
+> **Correction (re-review #10127):** the previous draft did not
+> specify how the dropdown shows the *currently selected* value
+> when that value is a `Custom(KeyCode)` outside
+> `predefined_options()`. Resolved below.
+
+When the user has previously bound a `Custom(KeyCode::F19)` (or
+similar), the dropdown still uses `predefined_options()` for the
+**list of choices**, but the **selected-row label** is rendered
+from the live setting value:
+
+1. The dropdown's `set_selected_by_index` call at
+   [app/src/settings_view/ai_page.rs:529](app/src/settings_view/ai_page.rs)
+   currently looks up the index of the current value in
+   `predefined_options()`. For a `Custom` value this lookup
+   returns `None`.
+2. On `None`, instead of falling back to index 0 (which would
+   *change* the persisted value to the first predefined option on
+   render — a silent data-loss bug), the dropdown gets a virtual
+   "current row" prepended to the list with the label
+   `format!("Custom: {}", custom_display(key_code))` and gets
+   selected.
+3. The virtual row is **read-only as a list entry** — clicking it
+   re-opens the press-to-capture modal pre-populated with the
+   current `KeyCode` (so the user sees what they have and can
+   confirm or change). It is removed from the list as soon as a
+   different option is selected.
+
+This keeps `predefined_options()` finite and small while
+correctly displaying any `Custom(...)` already in the user's
+TOML, including values from a future build that captured a key
+the current build's predefined list doesn't surface.
+
+`custom_display(KeyCode)` is the same friendly-name helper used
+in the modal display (see "Display name for new variants" below)
+so both surfaces show the same string for the same `KeyCode`.
+
 ### Settings serialization
 
 The existing `implement_setting_for_enum!` macro
@@ -457,7 +495,12 @@ disk file is consistent and subsequent launches are quiet.
 3. Confirm the macOS Caps Lock press-to-toggle decision (vs
    "document the difference and don't fix"). Discord and Krisp
    both go press-to-toggle.
-4. Should the press-to-capture modal expose the captured `KeyCode`
-   spelling to the user (debug aid), or only the friendly display
-   name? Recommendation: friendly name with a hover tooltip
-   showing `KeyCode::F19` for users who care.
+4. ~~Should the press-to-capture modal expose the captured
+   `KeyCode` spelling to the user?~~ **Resolved (re-review
+   #10127):** the modal shows the friendly display name primarily
+   (e.g. "F19", "Caps Lock"), with the protocol-level `KeyCode`
+   spelling (e.g. `KeyCode::F19`) shown only in a hover tooltip
+   on the captured-key label. This matches the dropdown's
+   "Custom: F19" rendering above and keeps the same friendly name
+   on both surfaces. Power users get the protocol spelling without
+   noise for everyone else.


### PR DESCRIPTION
## Summary

Spec for issue #9869 — the voice input hotkey picker in **Settings → Agents → Voice** offers a fixed list of 10 modifier/function keys, missing **Caps Lock** and **individual F-keys (F1–F12)**, and providing no escape hatch for any other key.

## Investigation

- Setting is `VoiceInputToggleKey` enum at [`app/src/settings/ai.rs:110`](app/src/settings/ai.rs). Closed enum with hand-written `display_name`, `to_key_code`, `keystroke`, and `tooltip_message`.
- Underlying [`KeyCode` at `crates/warpui_core/src/platform/keyboard.rs`](crates/warpui_core/src/platform/keyboard.rs) already exposes `CapsLock` and `F1`–`F35`; the enum is artificially narrower than what the platform layer can identify.
- Persistence is `SyncToCloud::Never` (intentional — same person uses different keyboards on different devices). Preserved.
- Action dispatch at [`block_list_element.rs:3072`](app/src/terminal/block_list_element.rs) and [`alt_screen_element.rs:620`](app/src/terminal/alt_screen/alt_screen_element.rs) already compares incoming `key_code: KeyCode` to the configured one, so new variants don't require dispatch-layer changes.

## What's in the spec

**`product.md`** — 8 testable behavior invariants (B1–B8), 6 acceptance criteria (A1–A6), explicit non-goals (chord hotkeys, per-tab/profile, cloud sync), and 5 risks with concrete TECH decisions to make.

**`tech.md`** — picks the data-model approach with explicit reasoning, names every file and line range touched, and lays out 6 unit tests + 4 modal tests + 3 integration tests.

## Architectural choices

- **`Custom(KeyCode)` variant on the existing enum, not a separate override field.** Single source of truth for "what key fires voice input"; avoids a "two settings disagree" failure mode.
- **Sectioned dropdown** ("Modifier keys" / "Function keys" / "Other") to keep 22 entries scannable. Existing modifiers stay at the top so existing users see no reorder.
- **Press-to-capture modal** for the "Custom key…" entry, with a reject-list (app-quit shortcut, Enter/Escape/Tab/Backspace/Space) and an >800ms held-modifier carve-out so users can still bind a bare modifier through this path.
- **macOS Caps Lock uses press-to-toggle** semantics (one tap on, next tap off) because macOS Caps Lock fires only on toggle events, not press/release. Discord and Krisp both take this approach.
- **Validation reset** for hand-edited TOML with unbindable values, with a one-time toast.

## Test plan

- [ ] Unit T1–T6 (TOML round-trip, display name, key mapping, toggle-mode, validation reset)
- [ ] Modal T7–T10 (capture flow, reject-list, Escape, held-modifier carve-out)
- [ ] Integration IT1–IT3 (full modal flow, Caps Lock toggle on macOS, F-key hold-to-talk)
- [ ] Manual: existing user with `voice_input_toggle_key = "alt_left"` in TOML sees no behavior change after upgrade
- [ ] Manual: hand-edited `voice_input_toggle_key = "enter"` shows toast and resets to None

## Open questions for maintainer review

1. Does the `SettingsValue` derive macro support enum variants with payloads (`Custom(KeyCode)`), or do we need a manual `Serialize`/`Deserialize` impl?
2. Is there an existing `DropdownItem::heading()` constructor for sectioning, or should this PR add one?
3. Confirm the macOS Caps Lock press-to-toggle decision (vs documenting the difference and not handling).
4. Should the press-to-capture modal expose the captured `KeyCode` spelling (debug aid) or only the friendly display name?

Closes (spec-only) #9869 — implementation PR will follow once spec direction is confirmed.