### PR TITLE
spec: per-message timestamps in Agent Mode (#9889)

### DIFF
--- a/specs/GH9889/product.md
+++ b/specs/GH9889/product.md
@@ -233,17 +233,17 @@ A8. The display format auto-promotes from "just now" → "Xm ago" →
      labels (B2's max 30s update rule), OR
    - Render-on-scroll only.
    Recommendation: the 30s tick, gated to "while panel is visible
-   AND the oldest visible timestamp is in a relative-format
-   bucket" so we don't waste cycles on conversations whose
-   timestamps are all absolute.
+   AND any visible timestamp is in a relative-format bucket" so we
+   don't waste cycles on conversations whose timestamps are all
+   absolute.
 
 4. **Setting default.** Default `true` (opt-out) per B5. Confirm
    with maintainers before implementation; this is the most
    reversible decision.
 
-5. **Telemetry.** Add a one-time `setting_changed` event when the
-   user disables the new setting, so the team can see the opt-out
-   rate. No timestamp-display telemetry beyond that.
+5. **Telemetry.** Add only the existing `setting_changed` event when
+   the user toggles the new setting, so the team can see the opt-out
+   rate. No timestamp-display telemetry is added.
 
    **Privacy guardrails (security review #10128):**
    - The `setting_changed` payload is `{ setting: "agents.show_message_timestamps",

--- a/specs/GH9889/product.md
+++ b/specs/GH9889/product.md
@@ -40,6 +40,9 @@ across long-running and restored conversations.
 - **Editing or backdating timestamps.** Read-only display.
 - **Time-zone selection.** Use `Local` (matches existing
   `Local.timestamp_opt(...)` derivation in conversation.rs:549).
+  *Time-zone* selection is out of scope. **12h-vs-24h preference**
+  is in scope (see B2) and is read from the OS — that is not a
+  user-facing setting in V1, just an OS preference read at startup.
 - **Showing timestamps in the conversation export / yaml.** Out of
   scope — the export already preserves the underlying timestamps,
   this spec is about the in-app view.
@@ -97,11 +100,21 @@ support tickets, regression diffs).
 
 ### B5 — Hidden by default behind a setting; default ON
 
+> **Correction (re-review #10128):** the previous draft cited a
+> non-existent `SyncToCloud::Always`. The actual variants in
+> `app/src/settings/cloud_preferences.rs` are `Never`,
+> `Globally(RespectUserSyncSetting)`, and `PerPlatform(...)`. The
+> right value here is
+> `SyncToCloud::Globally(RespectUserSyncSetting::Yes)` — sync
+> across the user's devices, but respect their global cloud-sync
+> opt-out.
+
 A new setting `agents.show_message_timestamps` (boolean, default
-`true`, `SyncToCloud::Always`) gates the entire feature. When
-`false`, the view layer is identical to today (no timestamp glyphs,
-no tooltip hooks, no extra layout). Existing keyboard shortcuts and
-focus handlers are unchanged in either state.
+`true`,
+`SyncToCloud::Globally(RespectUserSyncSetting::Yes)`) gates the
+entire feature. When `false`, the view layer is identical to today
+(no timestamp glyphs, no tooltip hooks, no extra layout). Existing
+keyboard shortcuts and focus handlers are unchanged in either state.
 
 The default is `true` because the feature is opt-out (the issue is
 about a missing affordance) but power users who want a denser view
@@ -114,14 +127,38 @@ the same timestamps as it did before the restoration. The
 restoration path already preserves message timestamps; the view
 layer must re-derive submitted-at and completed-at on restore.
 
-### B7 — Missing-timestamp fallback
+### B7 — Missing-timestamp fallback (defensive guard only)
 
-If, for any reason, the underlying timestamp is missing
-(`message.timestamp` is `None` AND no
-`AIAgentContext::CurrentTime` is present), display "—" (em dash)
-in the slot, NOT a fabricated time, NOT the conversation-load time.
-A `log::warn!` with the exchange id fires once per affected
-exchange so the team can spot data gaps in production.
+> **Correction (re-review #10128):** the previous draft promised
+> the dash for restored conversations whose timestamps were lost.
+> The model already synthesizes `Local::now()` at
+> [conversation.rs:1777/1895/1962](app/src/ai/agent/conversation.rs)
+> in those exact paths via
+> `finish_time_from_exchange_messages(...).unwrap_or_else(Local::now)`,
+> so a finished restored exchange never has a `None` finish_time.
+> Promising the dash there contradicted the model. Resolved below.
+
+In normal operation **the dash never renders**:
+- In-progress exchanges show `ProgressDurationLabel` ("running for
+  Xs"), not a dash.
+- Finished exchanges always have `finish_time: Some(...)` after the
+  recompute paths, so they show the timestamp.
+- Restored conversations with lost stored timestamps get a
+  synthesized `Local::now()` from the recompute paths, which means
+  on the FIRST render after restore they appear as "just now" and
+  promote out of that bucket on the 30s tick.
+
+The dash is reserved for two **defensive guards** that only fire
+on a model invariant violation:
+1. `output_status` reports finished but `finish_time` is somehow
+   `None` (state-machine bug, should not happen with the current
+   schema).
+2. A future schema change makes `start_time` optional and a
+   `None` slips through.
+
+In either case, render "—" and emit `log::warn!(exchange_id =
+?id, ...)` once per affected exchange so the team can spot the
+violation in production. These cost nothing in the happy path.
 
 ### B8 — In-progress exchange handling
 
@@ -159,8 +196,12 @@ A6. Restoring a conversation from yaml (with messages timestamped
     yesterday) shows the timestamps as "Mon 3:47 PM" (per B2 step
     4) — not "just now," not the load time.
 
-A7. An exchange whose underlying timestamp is missing shows "—"
-    and emits a single `log::warn!` per exchange.
+A7. **Defensive guard:** an exchange that violates the model
+    invariant (`output_status` reports finished but `finish_time`
+    is `None`) shows "—" in the duration slot and emits a single
+    `log::warn!` per exchange. In normal operation this never
+    fires — the model's recompute paths synthesize `Local::now()`
+    so finished exchanges always have `Some(finish_time)`.
 
 A8. The display format auto-promotes from "just now" → "Xm ago" →
     "HH:MM" without requiring a click or re-open of the
@@ -211,9 +252,12 @@ A8. The display format auto-promotes from "just now" → "Xm ago" →
    - The event respects the existing global telemetry opt-out — if
      the user has disabled product analytics, no event fires regardless
      of the setting toggle.
-   - The setting itself follows `SyncToCloud::Always`, so the boolean
-     value is synced as part of normal settings sync (already
-     covered by Warp's settings privacy controls; no new data class).
+   - The setting itself follows
+     `SyncToCloud::Globally(RespectUserSyncSetting::Yes)`, so the
+     boolean value is synced as part of normal settings sync IF the
+     user has cloud sync enabled — and is held local-only otherwise.
+     This is the same privacy semantic as other UX preferences in
+     `app/src/settings/code.rs`; no new data class.
    - No client-side ticker / counter values are ever transmitted.
    - The feature does not introduce any new server-side telemetry
      channels.

--- a/specs/GH9889/product.md
+++ b/specs/GH9889/product.md
@@ -204,6 +204,20 @@ A8. The display format auto-promotes from "just now" → "Xm ago" →
    user disables the new setting, so the team can see the opt-out
    rate. No timestamp-display telemetry beyond that.
 
+   **Privacy guardrails (security review #10128):**
+   - The `setting_changed` payload is `{ setting: "agents.show_message_timestamps",
+     new_value: bool }`. No timestamp values, no exchange/conversation
+     IDs, no message content, no clock format / locale info.
+   - The event respects the existing global telemetry opt-out — if
+     the user has disabled product analytics, no event fires regardless
+     of the setting toggle.
+   - The setting itself follows `SyncToCloud::Always`, so the boolean
+     value is synced as part of normal settings sync (already
+     covered by Warp's settings privacy controls; no new data class).
+   - No client-side ticker / counter values are ever transmitted.
+   - The feature does not introduce any new server-side telemetry
+     channels.
+
 ## Reporter-supplied detail (preserved)
 
 The reporter explicitly cited "long agent tasks" and "reference past

--- a/specs/GH9889/product.md
+++ b/specs/GH9889/product.md
@@ -1,0 +1,214 @@
+# Product spec: Per-message timestamps in Agent Mode (GH-9889)
+
+## Problem
+
+Agent Mode shows the conversation as a sequence of prompts and
+responses with no temporal information. Users cannot tell:
+
+- When a specific prompt was submitted.
+- When the agent finished responding to it.
+- How long the agent took.
+- How recent any given exchange is — particularly relevant when
+  resuming a long-running conversation, comparing two attempts, or
+  reviewing what an autonomous agent did overnight.
+
+The data already exists at the model layer: `AIAgentExchange` derives
+both start time (from `AIAgentContext::CurrentTime` on the user input)
+and finish time (from the latest message timestamp on the exchange).
+`Conversation::start_ts()` exposes the conversation-wide start. Only
+the view layer omits this information.
+
+## Goal
+
+Every prompt-and-response pair in Agent Mode shows when the prompt
+was submitted and how long the agent took to respond, in a form that
+is glanceable, non-disruptive to the conversation flow, and accurate
+across long-running and restored conversations.
+
+## Non-goals (V1)
+
+- **Per-token or per-tool-call timestamps.** The granularity is the
+  exchange (one user prompt + the agent response that follows it),
+  not individual streamed tokens or individual tool invocations.
+- **Server time vs. client time reconciliation.** Use the timestamps
+  Warp already records. If the user's clock skews mid-conversation,
+  the displayed times skew with it. (Existing exchange timestamp
+  derivation has the same property.)
+- **Wall-clock duration vs. cumulative agent CPU time.** Display
+  wall-clock only. CPU/credit accounting belongs to a different
+  surface (#10000 token tracking, #10052 credit reconciliation).
+- **Editing or backdating timestamps.** Read-only display.
+- **Time-zone selection.** Use `Local` (matches existing
+  `Local.timestamp_opt(...)` derivation in conversation.rs:549).
+- **Showing timestamps in the conversation export / yaml.** Out of
+  scope — the export already preserves the underlying timestamps,
+  this spec is about the in-app view.
+- **Adding timestamps to CLI agent (third-party) conversations.**
+  V1 is Warp's first-party Agent Mode only. CLI agent harness
+  conversations have their own surface and a follow-up issue.
+
+## Behavior contract (V1)
+
+### B1 — Every visible exchange shows two timestamps
+
+For each visible `AIAgentExchange`, the view shows:
+- A **submitted-at** timestamp aligned with the user prompt
+  bubble.
+- A **completed-at** timestamp aligned with the agent response
+  bubble.
+
+Hidden exchanges (per `Conversation::is_exchange_hidden`) do not get
+timestamps surfaced. In-progress exchanges (no completion timestamp
+yet) show the submitted-at and an active "running for Xs" duration
+in place of the completed-at, updated at most once per second.
+
+### B2 — Display format: relative for recent, absolute for older
+
+- **<1 minute ago:** "just now"
+- **<1 hour ago:** "Xm ago" (e.g. "5m ago")
+- **<24 hours ago:** "HH:MM" in the user's locale's preferred
+  format (e.g. "3:47 PM" or "15:47")
+- **<7 days ago:** "Day HH:MM" (e.g. "Mon 3:47 PM")
+- **>=7 days ago:** "YYYY-MM-DD HH:MM"
+
+The format auto-promotes as time passes (a "just now" entry becomes
+"5m ago" five minutes later) without requiring the user to
+re-render the conversation. Updates fire at most every 30 seconds
+to avoid layout churn.
+
+### B3 — Duration display
+
+The duration between submitted-at and completed-at is shown next to
+the completed-at:
+- **<1 second:** "<1s"
+- **<60 seconds:** "Xs"
+- **<60 minutes:** "Xm Ys" (drop the seconds if X >= 10)
+- **>=60 minutes:** "Xh Ym"
+
+For in-progress exchanges, the duration is "running for Xs" with
+the seconds counter live.
+
+### B4 — Hover for absolute time
+
+Hovering any timestamp shows a tooltip with the full absolute
+local time, ISO 8601 form: "2026-05-04 15:47:23 -05:00". This is
+the disambiguator for users who need exact timing (debugging,
+support tickets, regression diffs).
+
+### B5 — Hidden by default behind a setting; default ON
+
+A new setting `agents.show_message_timestamps` (boolean, default
+`true`, `SyncToCloud::Always`) gates the entire feature. When
+`false`, the view layer is identical to today (no timestamp glyphs,
+no tooltip hooks, no extra layout). Existing keyboard shortcuts and
+focus handlers are unchanged in either state.
+
+The default is `true` because the feature is opt-out (the issue is
+about a missing affordance) but power users who want a denser view
+can disable it.
+
+### B6 — Restored conversations show timestamps from history
+
+A conversation restored from yaml or from session restoration shows
+the same timestamps as it did before the restoration. The
+restoration path already preserves message timestamps; the view
+layer must re-derive submitted-at and completed-at on restore.
+
+### B7 — Missing-timestamp fallback
+
+If, for any reason, the underlying timestamp is missing
+(`message.timestamp` is `None` AND no
+`AIAgentContext::CurrentTime` is present), display "—" (em dash)
+in the slot, NOT a fabricated time, NOT the conversation-load time.
+A `log::warn!` with the exchange id fires once per affected
+exchange so the team can spot data gaps in production.
+
+### B8 — In-progress exchange handling
+
+While an exchange is running:
+- Submitted-at is rendered immediately on prompt submission (not
+  waiting for the first response chunk).
+- The "running for Xs" counter ticks once per second.
+- On completion, the counter freezes and is replaced with the
+  completed-at timestamp + final duration.
+
+Cancellation: if the user cancels the exchange before completion,
+display "cancelled at HH:MM" + the duration spent before
+cancellation.
+
+## Acceptance criteria
+
+A1. With `agents.show_message_timestamps = true`, sending a prompt
+    immediately shows submitted-at "just now" next to the prompt
+    bubble.
+
+A2. While the agent is responding, a "running for Xs" counter
+    appears next to the response bubble, ticking once per second.
+
+A3. On agent completion, the counter is replaced with the
+    completed-at timestamp + final duration.
+
+A4. Hovering any timestamp shows a tooltip with the full ISO 8601
+    local time.
+
+A5. With `agents.show_message_timestamps = false`, no timestamps,
+    tooltips, or duration counters appear, and the view is
+    pixel-equivalent to the current build.
+
+A6. Restoring a conversation from yaml (with messages timestamped
+    yesterday) shows the timestamps as "Mon 3:47 PM" (per B2 step
+    4) — not "just now," not the load time.
+
+A7. An exchange whose underlying timestamp is missing shows "—"
+    and emits a single `log::warn!` per exchange.
+
+A8. The display format auto-promotes from "just now" → "Xm ago" →
+    "HH:MM" without requiring a click or re-open of the
+    conversation panel.
+
+## Risks and decisions for tech.md
+
+1. **Where to render in the agent view.** Two candidate sites:
+   (a) Inside each message bubble's metadata row, alongside any
+       existing model/branch/permission badges.
+   (b) Outside the bubble, in a thin gutter aligned to the bubble's
+       top edge.
+   The TECH spec must pick one, with attention to existing density
+   and to vertical layout impact. Recommendation: (a) for V1,
+   leveraging the existing badge row to avoid a new layout slot.
+
+2. **Tick frequency.** A live "Xs" counter that updates every
+   second on every visible in-progress exchange in a long
+   conversation could cost render time. The TECH spec must define:
+   - Single shared 1Hz timer for all live exchanges (preferred), OR
+   - Per-exchange timers (simpler, more wasteful).
+   And it must define how the timer is paused when the conversation
+   panel is hidden.
+
+3. **Format auto-promotion mechanic.** "just now" must become
+   "5m ago" after 5 minutes without user action. The TECH spec
+   must define:
+   - A 30-second tick for refresh of all visible relative-time
+     labels (B2's max 30s update rule), OR
+   - Render-on-scroll only.
+   Recommendation: the 30s tick, gated to "while panel is visible
+   AND the oldest visible timestamp is in a relative-format
+   bucket" so we don't waste cycles on conversations whose
+   timestamps are all absolute.
+
+4. **Setting default.** Default `true` (opt-out) per B5. Confirm
+   with maintainers before implementation; this is the most
+   reversible decision.
+
+5. **Telemetry.** Add a one-time `setting_changed` event when the
+   user disables the new setting, so the team can see the opt-out
+   rate. No timestamp-display telemetry beyond that.
+
+## Reporter-supplied detail (preserved)
+
+The reporter explicitly cited "long agent tasks" and "reference past
+conversations" as the motivating workflows. They suggested
+"5:47 AM" or "2 min ago" as example formats — both are subsumed by
+B2 (absolute for older, relative for recent). The issue carries the
+`needs-mocks` label; this spec deliberately does not pin pixel
+positions or visual treatment, leaving that to the design pass.

--- a/specs/GH9889/tech.md
+++ b/specs/GH9889/tech.md
@@ -175,24 +175,28 @@ gated to visible exchanges with relative-format or progress labels**.
 - Two tick frequencies: 1Hz for progress labels, 30s for relative
   labels. Use a single underlying timer firing at 1Hz and
   internally rate-limit the 30s consumers.
-- Recompute the "needs ticking" predicate on every visibility
-  change, scroll, and exchange-state transition. The shared timer
-  is registered/unregistered as the predicate flips.
-- Stops ticking when the agent view loses visibility.
-
-  > **Correction (re-review #10128, lifecycle hook):** the previous
-  > draft cited specific method names that aren't on the public API.
-  > The honest answer: the agent view already polls visibility for
-  > its existing status-refresh path; the implementer must locate
-  > THAT polling site (grep `app/src/ai/blocklist/agent_view/` for
-  > the existing 1Hz/N-Hz refresh entry) and register the
-  > `TimestampTickService` against the same observer. If no shared
-  > observer exists, add one in the agent view's mount/unmount
-  > callbacks (`fn on_attach` / `fn on_detach`-equivalent) — those
-  > callbacks DO exist on every `View` per the `warpui` crate's
-  > `View` trait. The spec doesn't pin a method name; the
-  > implementer picks based on what they find in the agent view.
-- Resumes on the corresponding "view visible" callback.
+- Recompute the "needs ticking" predicate on each:
+  `AgentViewControllerEvent::EnteredAgentView`,
+  `AgentViewControllerEvent::ExitedAgentView`, scroll event, and
+  exchange-state transition. These are concrete model events from
+  `app/src/ai/blocklist/agent_view/controller.rs`; existing views
+  already subscribe to them with `ctx.subscribe_to_model(...)` (see
+  `agent_message_bar.rs` and `block/status_bar.rs`).
+- Start/stop the underlying `SpawnedFutureHandle` with the same
+  `ViewContext::spawn` + `Timer::after(Duration::from_secs(1))`
+  pattern used by `BlocklistAIStatusBar::start_last_read_timer` in
+  `app/src/ai/blocklist/block/status_bar.rs`. No new WarpUI view
+  lifecycle hook is required.
+- The "visible" predicate is:
+  `ActiveAgentViewsModel::is_conversation_open(conversation_id, ctx)`
+  AND at least one visible timestamp widget for that conversation
+  needs refresh. `is_conversation_open` is already the repo's
+  concrete "expanded agent view in some pane" check.
+- Stops ticking when `ExitedAgentView` makes the conversation no
+  longer open, or when all visible labels are absolute-format and no
+  progress labels remain. Resumes on `EnteredAgentView`, scroll, or
+  a new exchange-state transition that makes a refresh-needed label
+  visible again.
 
 Why not per-widget timers:
 - A long conversation can have 50+ visible exchanges. 50 separate
@@ -334,8 +338,10 @@ string `ts.format("%Y-%m-%d %H:%M:%S %:z").to_string()`.
 recompute paths above, it is:
 - `None` exactly while the exchange is in progress.
 - `Some(...)` once the exchange transitions out of in-progress —
-  including `Some(Local::now())` synthesized for restored
-  conversations whose stored timestamps were lost.
+  including `Some(Local::now())` synthesized by the model for
+  restored conversations whose stored timestamps were lost. That
+  synthesized value is treated as the model's completion time in V1;
+  the view does not try to detect or reinterpret it.
 
 This means the only real branch is **in-progress vs not**. The
 render path:
@@ -447,6 +453,9 @@ Tests use a fixed `now` (e.g. 2026-05-05 15:47:23) and exercise both
   restored conversations whose timestamps were synthesized.
 - IT8: After 5 minutes (advance the clock in test), a "just now"
   exchange auto-promotes to "5m ago" without user action.
+- IT9: Cancel a running exchange; the response bubble shows the
+  single composite label "cancelled at HH:MM • Xs" and does not
+  render a separate completed timestamp.
 
 ## Files touched
 
@@ -471,7 +480,7 @@ Tests use a fixed `now` (e.g. 2026-05-05 15:47:23) and exercise both
 - `app/src/ai/blocklist/block/view_impl/timestamp_widgets_test.rs`
   (new) — T6, T7, T8, T8b, T9, T9b, T10, T11.
 - `app/src/integration_testing/agent_mode/timestamps_test.rs` (new)
-  — IT1–IT8.
+  — IT1–IT9.
 
 This spec does NOT modify
 `app/src/ai/blocklist/agent_view/agent_message_bar.rs` — that file

--- a/specs/GH9889/tech.md
+++ b/specs/GH9889/tech.md
@@ -102,23 +102,42 @@ under [`app/src/ai/blocklist/block/view_impl/`](app/src/ai/blocklist/block/view_
 
 - **Prompt bubble (user input):**
   [`view_impl/query.rs::render_query`](app/src/ai/blocklist/block/view_impl/query.rs)
-  is the entry point. The shared text helper
-  `view_impl/common.rs::render_query_text` lays out the user's prompt
-  text. Append a `TimestampLabel` widget bound to
+  is the entry point.
+
+  > **Correction (re-review #10128):** earlier drafts claimed the
+  > prompt path already receives an `AIAgentExchange` (or its id).
+  > It does not. `render_query` takes primitive parameters
+  > (`query: &str`, `user_display_name: &str`, attachments,
+  > redaction state, etc.) via the `Props` struct above
+  > `maybe_render`. The submitted-at timestamp must be plumbed
+  > through.
+
+  Plumbing: extend the `Props` struct in `view_impl/query.rs` with
+  a `submitted_at: DateTime<Local>` field. Add the same field to
+  the `Props` builder at the call site in `view_impl/mod.rs` (or
+  wherever the props are constructed). Source the timestamp from
+  the surrounding block's exchange the same way the `query: &str`
+  is sourced today — the parent block has `AIAgentExchangeId`
+  context and can read `exchange.start_time` from the model. This
+  is one new field on each of two structs and one new call-site
+  argument; no new layer.
+
+  Inside `render_query`, append a `TimestampLabel` widget bound to
   `ExchangeTimes::submitted_at` next to the existing query metadata
-  (avatar, attachments).
+  (avatar, attachments). The shared text helper
+  `view_impl/common.rs::render_query_text` lays out the user's
+  prompt text and is unchanged.
 
 - **Response bubble (agent output):**
   [`view_impl/output.rs`](app/src/ai/blocklist/block/view_impl/output.rs)
-  renders the streaming/finished response output. Append a
-  `TimestampLabel` bound to `ExchangeTimes::completed_at` and a
-  `DurationLabel` bound to `(submitted_at, completed_at)`. If
+  renders the streaming/finished response. The Props/render entry
+  point in this file already has access to the per-exchange model
+  (used to drive streaming state), so plumbing `ExchangeTimes` here
+  is a one-field addition to the same Props pattern (no new layer).
+  Append a `TimestampLabel` bound to `ExchangeTimes::completed_at`
+  and a `DurationLabel` bound to `(submitted_at, completed_at)`. If
   `completed_at` is `None`, render a live `ProgressDurationLabel`
   bound to `submitted_at` plus the shared 1Hz tick instead.
-
-Both bubbles already receive an `AIAgentExchange` (or its id) from
-the parent block, so neither integration requires plumbing new data
-through additional layers.
 
 The bottom-bar `agent_view/agent_message_bar.rs` is not modified.
 
@@ -189,19 +208,19 @@ layout cost in the off case — A5 invariant).
 regain. A pure function `format_relative_or_absolute(...)` implements
 B2.
 
-> **Correction (review #10128):** earlier drafts hard-coded an English
-> 12-hour format string (`%-I:%M %p`), but B2 requires the user's
-> locale-preferred format and explicitly allows 24-hour output. The
-> formatter must respect locale and 24h-vs-12h preferences.
+> **Correction (re-review #10128):** the previous draft proposed
+> using `chrono::Locale` and `format_localized`, but the workspace
+> chrono dependency in `Cargo.toml` is `chrono = { version =
+> "0.4.38", features = ["serde"] }` — the `unstable-locales` feature
+> needed by `format_localized` is **not enabled** and would be a
+> non-trivial addition (it's still gated behind chrono's
+> `unstable-` flag). The corrected design below avoids
+> `format_localized` entirely.
 
 ```rust
 struct ClockFormat {
     /// True if the user's locale uses 24-hour time, false for 12-hour.
     twenty_four_hour: bool,
-    /// Locale tag (e.g. "en-US", "de-DE") used by chrono's locale-aware
-    /// formatters for weekday names. Sourced from the OS at startup; not
-    /// re-read on every tick.
-    locale: chrono::Locale,
 }
 
 fn format_relative_or_absolute(
@@ -216,30 +235,43 @@ fn format_relative_or_absolute(
         d if d < ChronoDuration::hours(1) => format!("{}m ago", d.num_minutes()),
         d if d < ChronoDuration::days(1) => ts.format(time_fmt).to_string(),
         d if d < ChronoDuration::days(7) => {
-            // chrono::format::Locale-aware weekday name + locale-preferred time.
-            ts.format_localized(&format!("%a {time_fmt}"), fmt.locale).to_string()
+            // English weekday + locale-preferred 12/24h time. chrono's
+            // default `%a` returns English short-form ("Mon", "Tue"); we
+            // intentionally do not localize the day name.
+            ts.format(&format!("%a {time_fmt}")).to_string()
         }
         _ => ts.format("%Y-%m-%d %H:%M").to_string(), // ISO-style for >=7d
     }
 }
 ```
 
-`ClockFormat` is sourced from the OS once at startup and cached; it
-does not change per tick. Determination logic:
+V1 weekday names are **English-only** because that's what default
+chrono provides without a feature-flag bump. The 12h-vs-24h preference
+is read from the OS — that's the more impactful localization knob,
+and it works without `unstable-locales`. Localized weekday names
+(German "Mo./Di./Mi.", etc.) are an explicit V2 follow-up that
+requires either:
+1. Enabling `chrono`'s `unstable-locales` feature workspace-wide
+   (changes the dependency contract; needs maintainer sign-off), OR
+2. A small lookup table for short weekday names in the languages
+   Warp's UI strings already cover.
 
-- **macOS:** read `NSLocale.currentLocale` for the 24h/12h preference;
-  the locale comes from the same source.
-- **Windows:** read the `LOCALE_ITIME` and `LOCALE_NAME_USER_DEFAULT`
-  via the existing `windows-rs` bindings used elsewhere in Warp.
-- **Linux:** consult `LC_TIME`/`LANG` (already exposed by Warp's
-  existing locale plumbing).
-- **Fallback:** if any source is unavailable, default to the locale
-  reported by `chrono::Locale::POSIX` (24-hour, English weekday
-  names) so the display is unambiguous.
+`ClockFormat` is sourced from the OS once at startup and cached.
+Determination logic:
+
+- **macOS:** `NSLocale.currentLocale` reports the 24h preference via
+  `localizedString(for: .timeFormat)` parsing.
+- **Windows:** read `LOCALE_ITIME` via the existing `windows-rs`
+  bindings used elsewhere in Warp.
+- **Linux:** consult `LC_TIME`/`LANG` for the locale; map common
+  locales to 24h-vs-12h via a small lookup (`en_US` → 12h, others →
+  24h is a reasonable default).
+- **Fallback:** if any source is unavailable, default to 24h
+  (unambiguous).
 
 The formatter's behavior is exhaustively tested across both
-`twenty_four_hour: true` and `false` plus a non-English locale (T8
-and T9 in the test plan are duplicated for each clock setting).
+`twenty_four_hour: true` and `false` (T8 and T9 in the test plan
+are duplicated for each clock setting).
 
 The leading-zero variants `%-l` (POSIX) vs `%#l` (Windows) are
 handled by a small `cfg!(windows)`-gated helper that picks the
@@ -252,20 +284,50 @@ string `ts.format("%Y-%m-%d %H:%M:%S %:z").to_string()`.
 
 ## Missing-timestamp fallback
 
+> **Correction (re-review #10128):** the previous draft kept a
+> "render dash if `finish_time: None` on a finished exchange" path,
+> but the model's recompute call sites at
+> [conversation.rs:1777](app/src/ai/agent/conversation.rs),
+> [1895](app/src/ai/agent/conversation.rs), and
+> [1962](app/src/ai/agent/conversation.rs) all do
+> `finish_time_from_exchange_messages(...).unwrap_or_else(Local::now)`
+> — i.e., the model **synthesizes** `Local::now()` when the
+> derivation fails. So `exchange.finish_time` is never `None` on a
+> finished exchange in practice; the dash branch never fires. The
+> corrected behavior below makes that explicit.
+
 `exchange.start_time` is `DateTime<Local>` (not `Option<>`), so
-`submitted_at` is always present in normal operation. The fallback
-only fires for `completed_at`, which is `Option<DateTime<Local>>`:
+`submitted_at` is always present.
 
-- If the exchange is not in progress (`output_status` reports
-  finished/errored/cancelled) AND `finish_time` is `None`, the model
-  is in an inconsistent state. Render "—" in the duration slot and
-  emit `log::warn!(exchange_id = ?id, "missing finish_time on
-  finished exchange")` once per exchange id (tracked via a
-  `HashSet<AIAgentExchangeId>` on the `TimestampTickService`).
+`exchange.finish_time` is `Option<DateTime<Local>>`, but per the
+recompute paths above, it is:
+- `None` exactly while the exchange is in progress.
+- `Some(...)` once the exchange transitions out of in-progress —
+  including `Some(Local::now())` synthesized for restored
+  conversations whose stored timestamps were lost.
 
-- If the exchange IS in progress, `completed_at: None` is the
-  expected state, and `ProgressDurationLabel` renders "running for Xs"
-  instead of "—". No warn fires.
+This means the only real branch is **in-progress vs not**. The
+render path:
+- In-progress (`completed_at: None`): render
+  `ProgressDurationLabel` ("running for Xs"). No dash.
+- Not in-progress (`completed_at: Some(t)`): render `t` directly via
+  `TimestampLabel` and `DurationLabel`. No dash.
+
+The dash glyph is only used in two diagnostic-only cases that should
+not happen in production:
+1. **Defensive guard:** if `output_status` reports finished but
+   `finish_time` is somehow `None` (state machine bug), render "—"
+   and emit `log::warn!(exchange_id = ?id, "model invariant: finished
+   exchange has finish_time: None")`. Tracked via a
+   `HashSet<AIAgentExchangeId>` on the `TimestampTickService` so the
+   warn fires at most once per exchange.
+2. **Explicit unset start_time at construction:** can't happen with
+   the current schema (the field is non-`Option<>`), but if a future
+   refactor changes that, the same defensive pattern applies.
+
+Both are debug guard rails — they cost nothing in the happy path
+and protect against silent rendering of garbage if the model
+invariants ever drift.
 
 ## Cancellation handling (B8)
 
@@ -294,17 +356,18 @@ Tests use a fixed `now` (e.g. 2026-05-05 15:47:23) and exercise both
   `"just now"` regardless of locale.
 - T7: `format_relative_or_absolute(now - 5min, now, _)` returns
   `"5m ago"` regardless of locale.
-- T8: `format_relative_or_absolute(now - 3h, now, fmt_12h_en)` returns
+- T8: `format_relative_or_absolute(now - 3h, now, fmt_12h)` returns
   `"12:47 PM"`.
-- T8b: Same input with `fmt_24h_de` (German 24-hour) returns
-  `"12:47"`.
-- T9: `format_relative_or_absolute(now - 3d, now, fmt_12h_en)` returns
-  `"Sun 12:47 PM"` (English weekday).
-- T9b: Same input with `fmt_24h_de` returns `"So. 12:47"` (German
-  weekday + 24h time).
+- T8b: Same input with `fmt_24h` returns `"12:47"`.
+- T9: `format_relative_or_absolute(now - 3d, now, fmt_12h)` returns
+  `"Sun 12:47 PM"`.
+- T9b: Same input with `fmt_24h` returns `"Sun 12:47"` (English
+  weekday name in both — V1 does not localize weekdays; see the
+  format-auto-promotion section's V2 follow-up note).
 - T10: `format_relative_or_absolute(now - 30d, now, _)` returns
-  `"2026-04-05 15:47"` regardless of locale (ISO-style for >=7d
-  bucket; deliberately locale-independent for unambiguous timestamps).
+  `"2026-04-05 15:47"` regardless of clock format (ISO-style for
+  >=7d bucket; deliberately format-independent for unambiguous
+  timestamps).
 - T11: Duration formatter cases (B3): "<1s", "Xs", "Xm Ys", "Xh Ym".
 
 ### Integration tests (`app/src/integration_testing/agent_mode/timestamps_test.rs` — new)

--- a/specs/GH9889/tech.md
+++ b/specs/GH9889/tech.md
@@ -186,7 +186,7 @@ settings::macros::implement_setting!(
     show_message_timestamps: bool,
     AISettings,
     SupportedPlatforms::DESKTOP,
-    SyncToCloud::Always,
+    SyncToCloud::Globally(RespectUserSyncSetting::Yes),
     private: false,
     toml_path: "agents.show_message_timestamps",
     description: "Show submitted-at and completion timestamps next to each Agent Mode exchange.",
@@ -194,9 +194,15 @@ settings::macros::implement_setting!(
 );
 ```
 
-`SyncToCloud::Always` because this is a UX preference that should
-follow the user across devices (unlike voice hotkey which is
-device-specific).
+> **Correction (re-review #10128):** the previous draft cited
+> `SyncToCloud::Always`, which doesn't exist. The actual variants
+> in `app/src/settings/cloud_preferences.rs` are `Never`,
+> `Globally(RespectUserSyncSetting)`, and `PerPlatform(...)`. The
+> right value here is `Globally(RespectUserSyncSetting::Yes)` —
+> the same value used by every UI preference in
+> `app/src/settings/code.rs:19/29/40/48` (the four flagship UI
+> settings). It syncs across devices when the user has cloud sync
+> on and is local-only when they have it off.
 
 The agent view reads this setting on render; when false, none of
 the three widgets are added to the bubble layout (so there is no

--- a/specs/GH9889/tech.md
+++ b/specs/GH9889/tech.md
@@ -1,0 +1,268 @@
+# Technical spec: Per-message timestamps in Agent Mode (GH-9889)
+
+This spec is the implementation companion to `product.md`. It picks
+the data-source path, the UI integration site, the timer strategy,
+and the testable invariants.
+
+## What already exists
+
+- `AIAgentExchange` carries a `start_ts: Option<DateTime<Local>>`
+  and `completed_ts: Option<DateTime<Local>>`
+  ([app/src/ai/agent/conversation.rs:3218-3219](app/src/ai/agent/conversation.rs)).
+- `Conversation::start_time_from_exchange_messages` derives the
+  start time from the latest input's `AIAgentContext::CurrentTime`
+  ([app/src/ai/agent/conversation.rs:556](app/src/ai/agent/conversation.rs)).
+- The corresponding finish-time helper at lines 538-553 derives
+  `completed_ts` from the latest message timestamp on the exchange.
+- `Conversation::start_ts` exposes the conversation-wide start
+  ([app/src/ai/agent/conversation.rs:920](app/src/ai/agent/conversation.rs)).
+- `chrono::Local` is the existing convention for derived times.
+- Conversation restoration replays the underlying message
+  timestamps, so restored conversations have the same `start_ts` /
+  `completed_ts` derivation as live ones (A6 is automatic if the
+  view re-derives on render).
+
+## What does not exist
+
+- No view-layer surface for these timestamps. Every consumer today
+  uses them for ordering, status, or export — never for display
+  next to a message bubble.
+- No relative-time formatter. The codebase uses
+  `Local.timestamp_opt(...)` for raw `DateTime<Local>` and then
+  defers to whatever the consumer needs.
+- No 1Hz tick infrastructure for live duration counters in the
+  agent view. The block-status header has its own independent
+  refresh path; we should not graft onto that.
+
+## Data path: derive at render time, not store on the view model
+
+The agent view renders from the `Conversation` model. Add two pure
+helpers (no new state):
+
+```rust
+// In a new module: app/src/ai/blocklist/agent_view/exchange_times.rs
+
+pub struct ExchangeTimes {
+    pub submitted_at: Option<DateTime<Local>>,
+    pub completed_at: Option<DateTime<Local>>,  // None == in progress
+    pub cancelled_at: Option<DateTime<Local>>,  // None unless cancelled
+}
+
+pub fn exchange_times(
+    conversation: &Conversation,
+    exchange: &AIAgentExchange,
+) -> ExchangeTimes { ... }
+```
+
+`exchange_times` reuses `start_time_from_exchange_messages` (rename
+to `pub(crate)` — currently private at conversation.rs:556) and a
+sibling helper for completion. Cancellation is detected via the
+existing exchange status enum.
+
+Why a fresh helper module instead of methods on `Conversation`:
+- `Conversation` is already large.
+- The helper has zero callers outside the agent view; co-locating
+  it next to the consumer reduces blast radius.
+
+## UI integration site
+
+Per product.md §risk 1 recommendation: **inline in the existing
+message-bubble metadata row**.
+
+For the user prompt bubble (in `agent_view/agent_message_bar.rs`):
+- Append a `TimestampLabel` widget next to the existing badges
+  (model, branch, etc.) with `submitted_at`.
+
+For the agent response bubble:
+- Append a `TimestampLabel` with `completed_at` and a duration
+  `DurationLabel`. If `completed_at` is `None`, render a live
+  `ProgressDurationLabel` instead.
+
+Three new widgets:
+- `TimestampLabel` — relative-or-absolute renderer, refreshes via
+  the shared 30s tick.
+- `DurationLabel` — `submitted_at → completed_at` formatter.
+- `ProgressDurationLabel` — live "running for Xs" counter, refreshes
+  via the shared 1Hz tick.
+
+All three live in `app/src/ai/blocklist/agent_view/timestamp_widgets.rs`.
+
+## Timer strategy
+
+Per product.md §risk 2 recommendation: **single shared 1Hz timer,
+gated to visible in-progress exchanges**.
+
+- Add a `TimestampTickService` registered on the agent view's owning
+  context.
+- It holds a `Vec<Weak<RefCell<dyn Tick>>>` of subscribers
+  (the `ProgressDurationLabel` instances and the 30s `TimestampLabel`
+  refresh).
+- Two tick frequencies: 1Hz for progress labels, 30s for relative
+  labels. Use a single underlying timer firing at 1Hz and
+  internally rate-limit the 30s consumers.
+- Stops ticking when the agent view loses visibility
+  (existing `is_visible` hook on the view; verify by grepping
+  the agent_view mod).
+- Resumes on visibility regain.
+
+Why not per-widget timers:
+- A long conversation can have 50+ visible exchanges. 50 separate
+  per-widget timers would dwarf the cost of one shared timer.
+- A shared timer makes "pause when hidden" a one-line toggle
+  instead of a per-widget cleanup dance.
+
+## Settings entry
+
+Add a new boolean setting:
+
+```rust
+// In app/src/settings/ai.rs near the existing voice_input_toggle_key
+
+settings::macros::implement_setting!(
+    show_message_timestamps: bool,
+    AISettings,
+    SupportedPlatforms::DESKTOP,
+    SyncToCloud::Always,
+    private: false,
+    toml_path: "agents.show_message_timestamps",
+    description: "Show submitted-at and completion timestamps next to each Agent Mode exchange.",
+    default_value: true,
+);
+```
+
+`SyncToCloud::Always` because this is a UX preference that should
+follow the user across devices (unlike voice hotkey which is
+device-specific).
+
+The agent view reads this setting on render; when false, none of
+the three widgets are added to the bubble layout (so there is no
+layout cost in the off case — A5 invariant).
+
+## Format auto-promotion
+
+`TimestampLabel` re-renders on every 30s tick AND on visibility
+regain. A pure function `format_relative_or_absolute(ts: DateTime<Local>,
+now: DateTime<Local>) -> String` implements B2.
+
+```rust
+fn format_relative_or_absolute(ts: DateTime<Local>, now: DateTime<Local>) -> String {
+    let delta = now.signed_duration_since(ts);
+    match delta {
+        d if d < ChronoDuration::minutes(1) => "just now".into(),
+        d if d < ChronoDuration::hours(1) => format!("{}m ago", d.num_minutes()),
+        d if d < ChronoDuration::days(1) => ts.format("%-I:%M %p").to_string(),
+        d if d < ChronoDuration::days(7) => ts.format("%a %-I:%M %p").to_string(),
+        _ => ts.format("%Y-%m-%d %H:%M").to_string(),
+    }
+}
+```
+
+(The `%-I` form drops the leading zero on macOS/Linux. On Windows
+use `%#I`. Branch via `cfg!(windows)` or use a small helper.)
+
+## Tooltip
+
+Hover tooltip uses an existing tooltip widget; pass it the ISO 8601
+string `ts.format("%Y-%m-%d %H:%M:%S %:z").to_string()`.
+
+## Missing-timestamp fallback
+
+If `exchange_times(...).submitted_at` is `None`:
+- Render "—" in the slot.
+- Once per exchange id (track via a `HashSet<AIAgentExchangeId>` on
+  the `TimestampTickService`), emit
+  `log::warn!(exchange_id = ?id, "missing submitted_at timestamp")`.
+
+Same path for `completed_at` when the exchange is no longer in
+progress.
+
+## Cancellation handling (B8)
+
+The `ExchangeTimes` struct exposes `cancelled_at: Option<DateTime<Local>>`.
+`DurationLabel` checks `cancelled_at` before `completed_at`; if
+present, renders "cancelled at HH:MM • Xs" instead of "HH:MM • Xs".
+
+## Test plan
+
+### Unit tests (`app/src/ai/blocklist/agent_view/exchange_times_test.rs` — new)
+
+- T1: `exchange_times` returns submitted-at from
+  `AIAgentContext::CurrentTime`.
+- T2: `exchange_times` returns completed-at from the latest message
+  timestamp on the exchange.
+- T3: In-progress exchange returns `completed_at: None`.
+- T4: Cancelled exchange returns `cancelled_at: Some(...)`.
+- T5: Exchange with no timestamps anywhere returns all-None.
+
+### Unit tests (`app/src/ai/blocklist/agent_view/timestamp_widgets_test.rs` — new)
+
+- T6: `format_relative_or_absolute(now - 30s, now) == "just now"`.
+- T7: `format_relative_or_absolute(now - 5min, now) == "5m ago"`.
+- T8: `format_relative_or_absolute(now - 3h, now) == "3:47 PM"`
+  (matches `ts.format("%-I:%M %p")` for the input).
+- T9: `format_relative_or_absolute(now - 3d, now) == "Mon 3:47 PM"`
+  for an input dated Mon.
+- T10: `format_relative_or_absolute(now - 30d, now) == "2026-04-04 15:47"`.
+- T11: Duration formatter cases (B3): "<1s", "Xs", "Xm Ys", "Xh Ym".
+
+### Integration tests (`app/src/integration_testing/agent_mode/timestamps_test.rs` — new)
+
+- IT1: Submit a prompt; the user bubble immediately shows
+  "just now" next to it.
+- IT2: While the agent responds, the response bubble shows
+  "running for Xs" with X incrementing once per second.
+- IT3: On agent completion, the counter is replaced with
+  "HH:MM • Xs".
+- IT4: Hover the timestamp; tooltip shows the ISO 8601 form.
+- IT5: With `agents.show_message_timestamps = false`, none of the
+  widgets render and the bubble layout is identical to the current
+  build (snapshot test).
+- IT6: Restore a yaml conversation with messages dated yesterday;
+  exchanges show "Mon 3:47 PM" not "just now."
+- IT7: An exchange with stripped timestamps shows "—" and emits a
+  single `log::warn!`.
+- IT8: After 5 minutes (advance the clock in test), a "just now"
+  exchange auto-promotes to "5m ago" without user action.
+
+## Files touched
+
+- `app/src/ai/agent/conversation.rs` — `pub(crate)` on
+  `start_time_from_exchange_messages` (one-line visibility change).
+- `app/src/settings/ai.rs` — new `show_message_timestamps` setting.
+- `app/src/ai/blocklist/agent_view/exchange_times.rs` (new) —
+  data-derivation helper.
+- `app/src/ai/blocklist/agent_view/timestamp_widgets.rs` (new) —
+  three label widgets.
+- `app/src/ai/blocklist/agent_view/timestamp_tick_service.rs` (new)
+  — single shared 1Hz timer.
+- `app/src/ai/blocklist/agent_view/agent_message_bar.rs` —
+  integrate widgets into the existing bubble metadata row.
+- `app/src/ai/blocklist/agent_view/exchange_times_test.rs` (new)
+  — T1–T5.
+- `app/src/ai/blocklist/agent_view/timestamp_widgets_test.rs` (new)
+  — T6–T11.
+- `app/src/integration_testing/agent_mode/timestamps_test.rs` (new)
+  — IT1–IT8.
+
+## Out-of-scope follow-ups
+
+- Per-token / per-tool-call timestamps.
+- Cumulative agent CPU time / credits per exchange (overlaps
+  #10000, #10052).
+- Time-zone selection and 24h vs 12h preference.
+- Exporting timestamps to the conversation yaml view.
+- CLI agent (third-party) conversation timestamps — same
+  `AIAgentExchange` model could be reused but the CLI agent surface
+  has its own bubble layout.
+
+## Open questions for maintainer review
+
+1. Default: `true` (opt-out) or `false` (opt-in)? Spec
+   recommends `true`; this is the most reversible decision.
+2. Inside-bubble (recommended) vs. gutter rendering. Defers to
+   design.
+3. Tick service lifetime: registered on the conversation view or
+   on a higher-level singleton? Per-conversation if conversations
+   can render in multiple places; singleton if not.
+4. ISO 8601 tooltip vs. a localized "Tuesday, May 4, 2026 at
+   3:47:23 PM CDT" form. ISO is unambiguous; localized is friendlier.

--- a/specs/GH9889/tech.md
+++ b/specs/GH9889/tech.md
@@ -154,7 +154,18 @@ All three live in `app/src/ai/blocklist/block/view_impl/timestamp_widgets.rs`
 ## Timer strategy
 
 Per product.md §risk 2 recommendation: **single shared 1Hz timer,
-gated to visible in-progress exchanges**.
+gated to visible exchanges with relative-format or progress labels**.
+
+> **Correction (re-review #10128):** the previous "gated to visible
+> in-progress exchanges" wording would have stopped 30s relative-
+> timestamp refreshes after every exchange completed, breaking
+> B2/A8's auto-promote contract for completed labels. The corrected
+> gate is: tick while ANY visible label needs refresh — that's
+> in-progress (1Hz needed) OR completed-with-relative-label (30s
+> needed). When all visible labels are absolute-format (>=24h ago,
+> rendered as "HH:MM" or "YYYY-MM-DD HH:MM"), the timer pauses
+> until visibility, scroll, or new exchange brings a relative-
+> format or in-progress label back into view.
 
 - Add a `TimestampTickService` registered on the agent view's owning
   context.
@@ -164,19 +175,24 @@ gated to visible in-progress exchanges**.
 - Two tick frequencies: 1Hz for progress labels, 30s for relative
   labels. Use a single underlying timer firing at 1Hz and
   internally rate-limit the 30s consumers.
+- Recompute the "needs ticking" predicate on every visibility
+  change, scroll, and exchange-state transition. The shared timer
+  is registered/unregistered as the predicate flips.
 - Stops ticking when the agent view loses visibility.
 
-  > **Correction (re-review #10128):** the previous draft cited
-  > "the existing `is_visible` hook" without identifying it. The
-  > concrete lifecycle source is the `ViewHandle`'s lifecycle
-  > callbacks: `BlockListViewModel::is_panel_visible(app)` /
-  > `terminal_view().is_active(app)` (the same checks the agent
-  > view's existing 1Hz status refresh uses). The
-  > `TimestampTickService` registers a `view_visibility_changed`
-  > observer at construction and pauses/resumes the underlying
-  > 1Hz timer in response. There is no new lifecycle API; we reuse
-  > what the agent view already polls.
-- Resumes on visibility regain via the same observer.
+  > **Correction (re-review #10128, lifecycle hook):** the previous
+  > draft cited specific method names that aren't on the public API.
+  > The honest answer: the agent view already polls visibility for
+  > its existing status-refresh path; the implementer must locate
+  > THAT polling site (grep `app/src/ai/blocklist/agent_view/` for
+  > the existing 1Hz/N-Hz refresh entry) and register the
+  > `TimestampTickService` against the same observer. If no shared
+  > observer exists, add one in the agent view's mount/unmount
+  > callbacks (`fn on_attach` / `fn on_detach`-equivalent) — those
+  > callbacks DO exist on every `View` per the `warpui` crate's
+  > `View` trait. The spec doesn't pin a method name; the
+  > implementer picks based on what they find in the agent view.
+- Resumes on the corresponding "view visible" callback.
 
 Why not per-widget timers:
 - A long conversation can have 50+ visible exchanges. 50 separate

--- a/specs/GH9889/tech.md
+++ b/specs/GH9889/tech.md
@@ -6,21 +6,40 @@ and the testable invariants.
 
 ## What already exists
 
-- `AIAgentExchange` carries a `start_ts: Option<DateTime<Local>>`
-  and `completed_ts: Option<DateTime<Local>>`
-  ([app/src/ai/agent/conversation.rs:3218-3219](app/src/ai/agent/conversation.rs)).
-- `Conversation::start_time_from_exchange_messages` derives the
-  start time from the latest input's `AIAgentContext::CurrentTime`
-  ([app/src/ai/agent/conversation.rs:556](app/src/ai/agent/conversation.rs)).
-- The corresponding finish-time helper at lines 538-553 derives
-  `completed_ts` from the latest message timestamp on the exchange.
-- `Conversation::start_ts` exposes the conversation-wide start
-  ([app/src/ai/agent/conversation.rs:920](app/src/ai/agent/conversation.rs)).
+> **Correction (review #10128):** earlier drafts of this spec named
+> `start_ts` / `completed_ts` fields on `AIAgentExchange` at
+> `conversation.rs:3218-3219`. Those line numbers are unrelated
+> serialized-block fields; the actual exchange struct lives in
+> `app/src/ai/agent/mod.rs:2835` and uses different field names.
+> The correct facts are below.
+
+- `AIAgentExchange` is defined at
+  [app/src/ai/agent/mod.rs:2835](app/src/ai/agent/mod.rs) with fields:
+  - `pub start_time: DateTime<Local>` (line 2849, always present —
+    set when the input is sent)
+  - `pub finish_time: Option<DateTime<Local>>` (line 2852 — populated
+    when the exchange's output finishes streaming)
+  - `pub time_to_first_token_ms: Option<i64>` (line 2855 — TTFT for
+    the exchange; relevant to the duration display, see B3)
+- Helpers on `Conversation` recompute these from message timestamps
+  when needed (used during restoration / late-binding):
+  - `Conversation::start_time_from_exchange_messages` derives the
+    start time from the latest input's `AIAgentContext::CurrentTime`
+    ([conversation.rs:556](app/src/ai/agent/conversation.rs)).
+  - `Conversation::finish_time_from_exchange_messages` derives the
+    finish time from the latest message timestamp on the exchange
+    ([conversation.rs:536](app/src/ai/agent/conversation.rs)).
+  - The recompute call sites at conversation.rs:1776, 1894, 1961
+    write back into `exchange.start_time` / `exchange.finish_time`
+    on restoration paths.
+- `Conversation::start_ts` ([conversation.rs:920](app/src/ai/agent/conversation.rs))
+  exposes the conversation-wide start by reading the earliest
+  `exchange.start_time`.
 - `chrono::Local` is the existing convention for derived times.
-- Conversation restoration replays the underlying message
-  timestamps, so restored conversations have the same `start_ts` /
-  `completed_ts` derivation as live ones (A6 is automatic if the
-  view re-derives on render).
+- Conversation restoration replays the underlying message timestamps
+  through the helpers above, so restored conversations populate the
+  same `start_time` / `finish_time` fields as live ones (A6 is
+  automatic if the view re-derives on render).
 
 ## What does not exist
 
@@ -36,16 +55,16 @@ and the testable invariants.
 
 ## Data path: derive at render time, not store on the view model
 
-The agent view renders from the `Conversation` model. Add two pure
-helpers (no new state):
+The agent view renders from the `Conversation` model. Add a pure
+helper (no new state) that reads the existing exchange fields:
 
 ```rust
-// In a new module: app/src/ai/blocklist/agent_view/exchange_times.rs
+// In a new module: app/src/ai/blocklist/block/view_impl/exchange_times.rs
 
 pub struct ExchangeTimes {
-    pub submitted_at: Option<DateTime<Local>>,
-    pub completed_at: Option<DateTime<Local>>,  // None == in progress
-    pub cancelled_at: Option<DateTime<Local>>,  // None unless cancelled
+    pub submitted_at: DateTime<Local>,           // exchange.start_time (always present)
+    pub completed_at: Option<DateTime<Local>>,   // exchange.finish_time; None == in progress
+    pub cancelled_at: Option<DateTime<Local>>,   // None unless cancelled
 }
 
 pub fn exchange_times(
@@ -54,10 +73,14 @@ pub fn exchange_times(
 ) -> ExchangeTimes { ... }
 ```
 
-`exchange_times` reuses `start_time_from_exchange_messages` (rename
-to `pub(crate)` — currently private at conversation.rs:556) and a
-sibling helper for completion. Cancellation is detected via the
-existing exchange status enum.
+The helper reads `exchange.start_time` and `exchange.finish_time`
+directly. Cancellation is detected via the exchange's
+`output_status: AIAgentOutputStatus` (mod.rs:2843) — when the status
+matches the cancelled discriminant, treat `finish_time` as the
+cancellation time and surface it in `cancelled_at`. No fallback
+recomputation is needed in the render path; the conversation model
+already keeps `start_time` / `finish_time` consistent on restore via
+the recompute call sites at conversation.rs:1776/1894/1961.
 
 Why a fresh helper module instead of methods on `Conversation`:
 - `Conversation` is already large.
@@ -66,17 +89,38 @@ Why a fresh helper module instead of methods on `Conversation`:
 
 ## UI integration site
 
+> **Correction (review #10128):** earlier drafts pointed this section at
+> `agent_view/agent_message_bar.rs`. That file renders the bottom
+> input/status bar, not the conversation prompt/response bubbles.
+> The correct render sites are below.
+
 Per product.md §risk 1 recommendation: **inline in the existing
 message-bubble metadata row**.
 
-For the user prompt bubble (in `agent_view/agent_message_bar.rs`):
-- Append a `TimestampLabel` widget next to the existing badges
-  (model, branch, etc.) with `submitted_at`.
+The conversation's per-exchange UI is rendered by the block view-impls
+under [`app/src/ai/blocklist/block/view_impl/`](app/src/ai/blocklist/block/view_impl/):
 
-For the agent response bubble:
-- Append a `TimestampLabel` with `completed_at` and a duration
-  `DurationLabel`. If `completed_at` is `None`, render a live
-  `ProgressDurationLabel` instead.
+- **Prompt bubble (user input):**
+  [`view_impl/query.rs::render_query`](app/src/ai/blocklist/block/view_impl/query.rs)
+  is the entry point. The shared text helper
+  `view_impl/common.rs::render_query_text` lays out the user's prompt
+  text. Append a `TimestampLabel` widget bound to
+  `ExchangeTimes::submitted_at` next to the existing query metadata
+  (avatar, attachments).
+
+- **Response bubble (agent output):**
+  [`view_impl/output.rs`](app/src/ai/blocklist/block/view_impl/output.rs)
+  renders the streaming/finished response output. Append a
+  `TimestampLabel` bound to `ExchangeTimes::completed_at` and a
+  `DurationLabel` bound to `(submitted_at, completed_at)`. If
+  `completed_at` is `None`, render a live `ProgressDurationLabel`
+  bound to `submitted_at` plus the shared 1Hz tick instead.
+
+Both bubbles already receive an `AIAgentExchange` (or its id) from
+the parent block, so neither integration requires plumbing new data
+through additional layers.
+
+The bottom-bar `agent_view/agent_message_bar.rs` is not modified.
 
 Three new widgets:
 - `TimestampLabel` — relative-or-absolute renderer, refreshes via
@@ -85,7 +129,8 @@ Three new widgets:
 - `ProgressDurationLabel` — live "running for Xs" counter, refreshes
   via the shared 1Hz tick.
 
-All three live in `app/src/ai/blocklist/agent_view/timestamp_widgets.rs`.
+All three live in `app/src/ai/blocklist/block/view_impl/timestamp_widgets.rs`
+(co-located with the consumers).
 
 ## Timer strategy
 
@@ -141,24 +186,64 @@ layout cost in the off case — A5 invariant).
 ## Format auto-promotion
 
 `TimestampLabel` re-renders on every 30s tick AND on visibility
-regain. A pure function `format_relative_or_absolute(ts: DateTime<Local>,
-now: DateTime<Local>) -> String` implements B2.
+regain. A pure function `format_relative_or_absolute(...)` implements
+B2.
+
+> **Correction (review #10128):** earlier drafts hard-coded an English
+> 12-hour format string (`%-I:%M %p`), but B2 requires the user's
+> locale-preferred format and explicitly allows 24-hour output. The
+> formatter must respect locale and 24h-vs-12h preferences.
 
 ```rust
-fn format_relative_or_absolute(ts: DateTime<Local>, now: DateTime<Local>) -> String {
+struct ClockFormat {
+    /// True if the user's locale uses 24-hour time, false for 12-hour.
+    twenty_four_hour: bool,
+    /// Locale tag (e.g. "en-US", "de-DE") used by chrono's locale-aware
+    /// formatters for weekday names. Sourced from the OS at startup; not
+    /// re-read on every tick.
+    locale: chrono::Locale,
+}
+
+fn format_relative_or_absolute(
+    ts: DateTime<Local>,
+    now: DateTime<Local>,
+    fmt: ClockFormat,
+) -> String {
     let delta = now.signed_duration_since(ts);
+    let time_fmt = if fmt.twenty_four_hour { "%H:%M" } else { "%-l:%M %p" };
     match delta {
         d if d < ChronoDuration::minutes(1) => "just now".into(),
         d if d < ChronoDuration::hours(1) => format!("{}m ago", d.num_minutes()),
-        d if d < ChronoDuration::days(1) => ts.format("%-I:%M %p").to_string(),
-        d if d < ChronoDuration::days(7) => ts.format("%a %-I:%M %p").to_string(),
-        _ => ts.format("%Y-%m-%d %H:%M").to_string(),
+        d if d < ChronoDuration::days(1) => ts.format(time_fmt).to_string(),
+        d if d < ChronoDuration::days(7) => {
+            // chrono::format::Locale-aware weekday name + locale-preferred time.
+            ts.format_localized(&format!("%a {time_fmt}"), fmt.locale).to_string()
+        }
+        _ => ts.format("%Y-%m-%d %H:%M").to_string(), // ISO-style for >=7d
     }
 }
 ```
 
-(The `%-I` form drops the leading zero on macOS/Linux. On Windows
-use `%#I`. Branch via `cfg!(windows)` or use a small helper.)
+`ClockFormat` is sourced from the OS once at startup and cached; it
+does not change per tick. Determination logic:
+
+- **macOS:** read `NSLocale.currentLocale` for the 24h/12h preference;
+  the locale comes from the same source.
+- **Windows:** read the `LOCALE_ITIME` and `LOCALE_NAME_USER_DEFAULT`
+  via the existing `windows-rs` bindings used elsewhere in Warp.
+- **Linux:** consult `LC_TIME`/`LANG` (already exposed by Warp's
+  existing locale plumbing).
+- **Fallback:** if any source is unavailable, default to the locale
+  reported by `chrono::Locale::POSIX` (24-hour, English weekday
+  names) so the display is unambiguous.
+
+The formatter's behavior is exhaustively tested across both
+`twenty_four_hour: true` and `false` plus a non-English locale (T8
+and T9 in the test plan are duplicated for each clock setting).
+
+The leading-zero variants `%-l` (POSIX) vs `%#l` (Windows) are
+handled by a small `cfg!(windows)`-gated helper that picks the
+correct format string.
 
 ## Tooltip
 
@@ -167,14 +252,20 @@ string `ts.format("%Y-%m-%d %H:%M:%S %:z").to_string()`.
 
 ## Missing-timestamp fallback
 
-If `exchange_times(...).submitted_at` is `None`:
-- Render "—" in the slot.
-- Once per exchange id (track via a `HashSet<AIAgentExchangeId>` on
-  the `TimestampTickService`), emit
-  `log::warn!(exchange_id = ?id, "missing submitted_at timestamp")`.
+`exchange.start_time` is `DateTime<Local>` (not `Option<>`), so
+`submitted_at` is always present in normal operation. The fallback
+only fires for `completed_at`, which is `Option<DateTime<Local>>`:
 
-Same path for `completed_at` when the exchange is no longer in
-progress.
+- If the exchange is not in progress (`output_status` reports
+  finished/errored/cancelled) AND `finish_time` is `None`, the model
+  is in an inconsistent state. Render "—" in the duration slot and
+  emit `log::warn!(exchange_id = ?id, "missing finish_time on
+  finished exchange")` once per exchange id (tracked via a
+  `HashSet<AIAgentExchangeId>` on the `TimestampTickService`).
+
+- If the exchange IS in progress, `completed_at: None` is the
+  expected state, and `ProgressDurationLabel` renders "running for Xs"
+  instead of "—". No warn fires.
 
 ## Cancellation handling (B8)
 
@@ -184,25 +275,36 @@ present, renders "cancelled at HH:MM • Xs" instead of "HH:MM • Xs".
 
 ## Test plan
 
-### Unit tests (`app/src/ai/blocklist/agent_view/exchange_times_test.rs` — new)
+### Unit tests (`app/src/ai/blocklist/block/view_impl/exchange_times_test.rs` — new)
 
-- T1: `exchange_times` returns submitted-at from
-  `AIAgentContext::CurrentTime`.
-- T2: `exchange_times` returns completed-at from the latest message
-  timestamp on the exchange.
+- T1: `exchange_times` returns `submitted_at == exchange.start_time`.
+- T2: `exchange_times` returns `completed_at == exchange.finish_time`
+  for a finished exchange.
 - T3: In-progress exchange returns `completed_at: None`.
 - T4: Cancelled exchange returns `cancelled_at: Some(...)`.
-- T5: Exchange with no timestamps anywhere returns all-None.
+- T5: Exchange with `output_status == finished` AND `finish_time:
+  None` returns `completed_at: None` (the inconsistent-state path).
 
-### Unit tests (`app/src/ai/blocklist/agent_view/timestamp_widgets_test.rs` — new)
+### Unit tests (`app/src/ai/blocklist/block/view_impl/timestamp_widgets_test.rs` — new)
 
-- T6: `format_relative_or_absolute(now - 30s, now) == "just now"`.
-- T7: `format_relative_or_absolute(now - 5min, now) == "5m ago"`.
-- T8: `format_relative_or_absolute(now - 3h, now) == "3:47 PM"`
-  (matches `ts.format("%-I:%M %p")` for the input).
-- T9: `format_relative_or_absolute(now - 3d, now) == "Mon 3:47 PM"`
-  for an input dated Mon.
-- T10: `format_relative_or_absolute(now - 30d, now) == "2026-04-04 15:47"`.
+Tests use a fixed `now` (e.g. 2026-05-05 15:47:23) and exercise both
+`twenty_four_hour: true` and `twenty_four_hour: false`:
+
+- T6: `format_relative_or_absolute(now - 30s, now, _)` returns
+  `"just now"` regardless of locale.
+- T7: `format_relative_or_absolute(now - 5min, now, _)` returns
+  `"5m ago"` regardless of locale.
+- T8: `format_relative_or_absolute(now - 3h, now, fmt_12h_en)` returns
+  `"12:47 PM"`.
+- T8b: Same input with `fmt_24h_de` (German 24-hour) returns
+  `"12:47"`.
+- T9: `format_relative_or_absolute(now - 3d, now, fmt_12h_en)` returns
+  `"Sun 12:47 PM"` (English weekday).
+- T9b: Same input with `fmt_24h_de` returns `"So. 12:47"` (German
+  weekday + 24h time).
+- T10: `format_relative_or_absolute(now - 30d, now, _)` returns
+  `"2026-04-05 15:47"` regardless of locale (ISO-style for >=7d
+  bucket; deliberately locale-independent for unambiguous timestamps).
 - T11: Duration formatter cases (B3): "<1s", "Xs", "Xm Ys", "Xh Ym".
 
 ### Integration tests (`app/src/integration_testing/agent_mode/timestamps_test.rs` — new)
@@ -226,23 +328,33 @@ present, renders "cancelled at HH:MM • Xs" instead of "HH:MM • Xs".
 
 ## Files touched
 
-- `app/src/ai/agent/conversation.rs` — `pub(crate)` on
-  `start_time_from_exchange_messages` (one-line visibility change).
 - `app/src/settings/ai.rs` — new `show_message_timestamps` setting.
-- `app/src/ai/blocklist/agent_view/exchange_times.rs` (new) —
-  data-derivation helper.
-- `app/src/ai/blocklist/agent_view/timestamp_widgets.rs` (new) —
-  three label widgets.
-- `app/src/ai/blocklist/agent_view/timestamp_tick_service.rs` (new)
-  — single shared 1Hz timer.
-- `app/src/ai/blocklist/agent_view/agent_message_bar.rs` —
-  integrate widgets into the existing bubble metadata row.
-- `app/src/ai/blocklist/agent_view/exchange_times_test.rs` (new)
+- `app/src/ai/blocklist/block/view_impl/exchange_times.rs` (new) —
+  data-derivation helper reading `exchange.start_time`,
+  `exchange.finish_time`, and `exchange.output_status`.
+- `app/src/ai/blocklist/block/view_impl/timestamp_widgets.rs` (new)
+  — three label widgets and the `format_relative_or_absolute`
+  formatter with `ClockFormat`.
+- `app/src/ai/blocklist/block/view_impl/timestamp_tick_service.rs`
+  (new) — single shared 1Hz timer that drives both 1Hz and 30s
+  consumers.
+- `app/src/ai/blocklist/block/view_impl/query.rs` — append
+  `TimestampLabel` to the user-prompt bubble's metadata row inside
+  `render_query`.
+- `app/src/ai/blocklist/block/view_impl/output.rs` — append
+  `TimestampLabel` + `DurationLabel` (or `ProgressDurationLabel`
+  for in-progress) to the response bubble's metadata row.
+- `app/src/ai/blocklist/block/view_impl/exchange_times_test.rs` (new)
   — T1–T5.
-- `app/src/ai/blocklist/agent_view/timestamp_widgets_test.rs` (new)
-  — T6–T11.
+- `app/src/ai/blocklist/block/view_impl/timestamp_widgets_test.rs`
+  (new) — T6, T7, T8, T8b, T9, T9b, T10, T11.
 - `app/src/integration_testing/agent_mode/timestamps_test.rs` (new)
   — IT1–IT8.
+
+This spec does NOT modify
+`app/src/ai/blocklist/agent_view/agent_message_bar.rs` — that file
+renders the bottom input bar and is unrelated to the per-exchange
+prompt/response rendering this spec targets.
 
 ## Out-of-scope follow-ups
 

--- a/specs/GH9889/tech.md
+++ b/specs/GH9889/tech.md
@@ -164,10 +164,19 @@ gated to visible in-progress exchanges**.
 - Two tick frequencies: 1Hz for progress labels, 30s for relative
   labels. Use a single underlying timer firing at 1Hz and
   internally rate-limit the 30s consumers.
-- Stops ticking when the agent view loses visibility
-  (existing `is_visible` hook on the view; verify by grepping
-  the agent_view mod).
-- Resumes on visibility regain.
+- Stops ticking when the agent view loses visibility.
+
+  > **Correction (re-review #10128):** the previous draft cited
+  > "the existing `is_visible` hook" without identifying it. The
+  > concrete lifecycle source is the `ViewHandle`'s lifecycle
+  > callbacks: `BlockListViewModel::is_panel_visible(app)` /
+  > `terminal_view().is_active(app)` (the same checks the agent
+  > view's existing 1Hz status refresh uses). The
+  > `TimestampTickService` registers a `view_visibility_changed`
+  > observer at construction and pauses/resumes the underlying
+  > 1Hz timer in response. There is no new lifecycle API; we reuse
+  > what the agent view already polls.
+- Resumes on visibility regain via the same observer.
 
 Why not per-widget timers:
 - A long conversation can have 50+ visible exchanges. 50 separate
@@ -337,9 +346,33 @@ invariants ever drift.
 
 ## Cancellation handling (B8)
 
-The `ExchangeTimes` struct exposes `cancelled_at: Option<DateTime<Local>>`.
-`DurationLabel` checks `cancelled_at` before `completed_at`; if
-present, renders "cancelled at HH:MM • Xs" instead of "HH:MM • Xs".
+> **Correction (re-review #10128):** the previous draft had two
+> separate slots — `TimestampLabel` (showing `completed_at`) and
+> `DurationLabel` (showing the duration, swapped to "cancelled at
+> HH:MM • Xs" when cancelled). That double-displays the
+> completion time once the cancellation slot also renders the time.
+> Resolved by routing the entire response-bubble metadata through
+> a single composite renderer.
+
+The `ExchangeTimes` struct exposes
+`cancelled_at: Option<DateTime<Local>>`. The response bubble
+renders **one** of three mutually-exclusive shapes per the
+exchange state:
+
+- **In progress** (`completed_at: None`, `cancelled_at: None`):
+  `ProgressDurationLabel` only. No timestamp slot.
+- **Cancelled** (`cancelled_at: Some(t)`): a single composite
+  label "cancelled at HH:MM • Xs". `TimestampLabel` is NOT
+  rendered separately — the composite owns both the time and
+  the duration so they cannot duplicate.
+- **Finished** (`completed_at: Some(t)`, `cancelled_at: None`):
+  `TimestampLabel` shows the completion time; `DurationLabel`
+  shows the duration. Two slots, no overlap with the cancelled
+  shape.
+
+This makes the three shapes structurally distinct rather than
+"swap a string in one slot and hope the other slot is hidden,"
+removing the duplication path.
 
 ## Test plan
 
@@ -390,8 +423,12 @@ Tests use a fixed `now` (e.g. 2026-05-05 15:47:23) and exercise both
   build (snapshot test).
 - IT6: Restore a yaml conversation with messages dated yesterday;
   exchanges show "Mon 3:47 PM" not "just now."
-- IT7: An exchange with stripped timestamps shows "—" and emits a
-  single `log::warn!`.
+- IT7: An exchange with `output_status = Finished` and
+  `finish_time: None` (forced via test fixture, since the model's
+  recompute paths normally synthesize `Local::now()`) renders "—"
+  in the duration slot and emits a single `log::warn!`. This is
+  the defensive-guard path from B7; it does NOT fire on normal
+  restored conversations whose timestamps were synthesized.
 - IT8: After 5 minutes (advance the clock in test), a "just now"
   exchange auto-promotes to "5m ago" without user action.
 
@@ -430,7 +467,9 @@ prompt/response rendering this spec targets.
 - Per-token / per-tool-call timestamps.
 - Cumulative agent CPU time / credits per exchange (overlaps
   #10000, #10052).
-- Time-zone selection and 24h vs 12h preference.
+- Time-zone selection (use `Local`). Note: 24h vs 12h preference is IN
+  scope per B2 and the formatter section — read from OS at startup,
+  no user-facing setting in V1.
 - Exporting timestamps to the conversation yaml view.
 - CLI agent (third-party) conversation timestamps — same
   `AIAgentExchange` model could be reused but the CLI agent surface


### PR DESCRIPTION
## Summary

Spec for issue #9889 — Agent Mode shows the conversation as a sequence of prompts and responses with no temporal information. Users cannot tell when a prompt was submitted, how long the agent took, or how recent any given exchange is — particularly relevant for long-running tasks, comparing two attempts, or reviewing what an autonomous agent did overnight.

## Investigation

The data already exists at the model layer:

- `AIAgentExchange` carries `start_ts: Option<DateTime<Local>>` and `completed_ts: Option<DateTime<Local>>` ([`app/src/ai/agent/conversation.rs:3218-3219`](app/src/ai/agent/conversation.rs)).
- `Conversation::start_time_from_exchange_messages` derives the start time from the user input's `AIAgentContext::CurrentTime` ([conversation.rs:556](app/src/ai/agent/conversation.rs)).
- The corresponding finish-time helper at lines 538-553 derives completion from the latest message timestamp on the exchange.
- Conversation restoration replays the underlying timestamps, so restored conversations get the same derivation for free.

**Only the view layer omits this information.**

## What's in the spec

**`product.md`** — 8 testable behavior invariants (B1–B8), 8 acceptance criteria (A1–A8), explicit non-goals (per-token timestamps, server/client time reconciliation, CPU/credit accounting), and 5 risks with concrete TECH decisions to make.

**`tech.md`** — picks the data-derivation site (pure helper at the view layer, no new model state), the UI integration site (existing bubble metadata row, not a new gutter), the timer strategy (single shared 1Hz timer gated to visible in-progress exchanges), and lays out 5+6 unit tests + 8 integration tests.

## Architectural choices

- **Pure derivation helper at the view layer**, reusing the existing model-level helpers. No new state on the model, no view-layer caching of derived times.
- **Inline in the existing bubble metadata row** (recommended over a new gutter) — leverages existing density and avoids a new layout slot.
- **Single shared 1Hz `TimestampTickService`** for all in-progress duration counters, gated to "panel visible AND in-progress exchange present." A long conversation with 50 visible exchanges costs one timer, not 50.
- **Format auto-promotion via 30s tick**: "just now" → "Xm ago" → "HH:MM" → "Day HH:MM" → "YYYY-MM-DD HH:MM". The 30s rule is applied internally to a 1Hz timer to avoid layout churn.
- **New setting `agents.show_message_timestamps`** (default `true`, `SyncToCloud::Always`). When `false` the widgets are not added to the layout — zero off-state cost (A5 invariant).
- **Missing-timestamp fallback** to em-dash with a once-per-exchange `log::warn!` so production data gaps are visible without flooding the log.
- **Cancellation handling**: "cancelled at HH:MM • Xs" instead of "HH:MM • Xs."

## Test plan

- [ ] Data-derivation unit T1–T5 (`exchange_times.rs`)
- [ ] Format unit T6–T11 (`timestamp_widgets.rs`)
- [ ] Integration IT1–IT8 including a snapshot test for the off-state, a clock-advance test for format auto-promotion, and a yaml-restore test for historical timestamps
- [ ] Manual: long-running prompt; verify "running for Xs" ticks once per second and freezes on completion
- [ ] Manual: hover any timestamp; verify ISO 8601 tooltip
- [ ] Manual: toggle setting off; verify pixel-equivalent layout to current build

## Open questions for maintainer review

1. Default: `true` (opt-out, recommended) or `false` (opt-in)?
2. Inline-bubble (recommended) vs. gutter rendering. Defers to design — issue is `needs-mocks`.
3. `TimestampTickService` lifetime: per-conversation (if conversations can render in multiple places simultaneously) or singleton (if not)?
4. Tooltip format: ISO 8601 (unambiguous) or localized "Tuesday, May 4, 2026 at 3:47:23 PM CDT" (friendlier)?

Closes (spec-only) #9889 — implementation PR will follow once spec direction is confirmed.