### PR TITLE
Add harness availability model to the client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14601,6 +14601,7 @@ dependencies = [
  "color-print",
  "humantime",
  "jaq-all",
+ "serde",
  "serial_test",
  "url",
  "uuid",

--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -36,6 +36,7 @@ use crate::ai::conversation_details_panel::{
     ConversationDetailsData, ConversationDetailsPanel, ConversationDetailsPanelEvent,
 };
 use crate::ai::conversation_status_ui::render_status_element;
+use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::harness_display;
 use crate::app_state::PersistedAgentManagementFilters;
 use crate::appearance::Appearance;
@@ -220,6 +221,13 @@ impl AgentManagementView {
         ctx.subscribe_to_model(
             &AgentConversationsModel::handle(ctx),
             Self::handle_agent_management_model_event,
+        );
+
+        ctx.subscribe_to_model(
+            &HarnessAvailabilityModel::handle(ctx),
+            |me, _, _event, ctx| {
+                me.update_harness_dropdown(ctx);
+            },
         );
 
         let list_state = Self::construct_fresh_list_state(ctx.handle());
@@ -672,15 +680,25 @@ impl AgentManagementView {
         let mut dropdown = Dropdown::new(ctx);
         Self::setup_filter_menu(&mut dropdown, "Harness", ctx);
 
-        // "All" has no leading icon, matching the Status dropdown's "All" row.
+        let items = Self::build_harness_dropdown_items(ctx);
+        dropdown.set_rich_items(items, ctx);
+        dropdown.set_selected_by_index(0, ctx);
+        dropdown
+    }
+
+    fn build_harness_dropdown_items(
+        app: &AppContext,
+    ) -> Vec<MenuItem<DropdownAction<AgentManagementViewAction>>> {
         let mut items = vec![MenuItem::Item(
             MenuItemFields::new("All").with_on_select_action(DropdownAction::SelectActionAndClose(
                 AgentManagementViewAction::SetHarnessFilter(HarnessFilter::All),
             )),
         )];
 
-        for harness in [Harness::Oz, Harness::Claude, Harness::Gemini] {
-            let mut fields = MenuItemFields::new(harness_display::display_name(harness))
+        let availability = HarnessAvailabilityModel::as_ref(app);
+        for entry in availability.available_harnesses() {
+            let harness = entry.harness;
+            let mut fields = MenuItemFields::new(entry.display_name.clone())
                 .with_icon(harness_display::icon_for(harness))
                 .with_on_select_action(DropdownAction::SelectActionAndClose(
                     AgentManagementViewAction::SetHarnessFilter(HarnessFilter::Specific(harness)),
@@ -691,9 +709,7 @@ impl AgentManagementView {
             items.push(MenuItem::Item(fields));
         }
 
-        dropdown.set_rich_items(items, ctx);
-        dropdown.set_selected_by_index(0, ctx);
-        dropdown
+        items
     }
 
     fn create_environment_dropdown(
@@ -753,6 +769,13 @@ impl AgentManagementView {
         dropdown.set_main_axis_size(MainAxisSize::Min, ctx);
         dropdown.set_menu_header_text_override(move |text| format!("{}: {}", label_prefix, text));
         dropdown.set_button_variant(ButtonVariant::Secondary);
+    }
+
+    fn update_harness_dropdown(&mut self, ctx: &mut ViewContext<Self>) {
+        let items = Self::build_harness_dropdown_items(ctx);
+        self.harness_dropdown.update(ctx, |dropdown, ctx| {
+            dropdown.set_rich_items(items, ctx);
+        });
     }
 
     /// Since the valid set of environments depends on what tasks we have loaded in,
@@ -1836,11 +1859,12 @@ impl AgentManagementView {
             metadata_parts.push(format!("Source: {}", source.display_name()));
         }
 
-        if FeatureFlag::AgentHarness.is_enabled() {
+        let availability = HarnessAvailabilityModel::as_ref(app);
+        if availability.should_show_harness_selector() {
             if let Some(harness) = card_data.harness(app) {
                 metadata_parts.push(format!(
                     "Harness: {}",
-                    harness_display::display_name(harness)
+                    availability.display_name_for(harness)
                 ));
             }
         }
@@ -1972,7 +1996,7 @@ impl AgentManagementView {
                 .with_child(ChildView::new(&self.created_on_dropdown).finish())
                 .with_child(ChildView::new(&self.artifact_dropdown).finish());
 
-            if FeatureFlag::AgentHarness.is_enabled() {
+            if HarnessAvailabilityModel::as_ref(app).should_show_harness_selector() {
                 filters_wrap.add_child(ChildView::new(&self.harness_dropdown).finish());
             }
 

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -9,7 +9,6 @@ use pathfinder_color::ColorU;
 use warp_cli::agent::Harness;
 use warp_cli::skill::SkillSpec;
 use warp_core::channel::ChannelState;
-use warp_core::features::FeatureFlag;
 use warp_core::ui::color::coloru_with_opacity;
 use warpui::{
     clipboard::ClipboardContent,
@@ -39,6 +38,7 @@ use crate::ai::ambient_agents::{cancel_task_with_toast, AmbientAgentTaskId};
 use crate::ai::artifacts::{Artifact, ArtifactButtonsRow, ArtifactButtonsRowEvent};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEnvironment};
+use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::harness_display;
 use crate::appearance::Appearance;
 use crate::auth::UserUid;
@@ -982,8 +982,13 @@ impl ConversationDetailsPanel {
         )
     }
 
-    fn render_harness_section(&self, appearance: &Appearance) -> Option<Box<dyn Element>> {
-        if !FeatureFlag::AgentHarness.is_enabled() {
+    fn render_harness_section(
+        &self,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Option<Box<dyn Element>> {
+        let availability = HarnessAvailabilityModel::as_ref(app);
+        if !availability.should_show_harness_selector() {
             return None;
         }
         let harness = self.data.harness?;
@@ -1012,7 +1017,7 @@ impl ConversationDetailsPanel {
         .finish();
 
         let name = Text::new(
-            harness_display::display_name(harness).to_string(),
+            availability.display_name_for(harness).to_string(),
             appearance.ui_font_family(),
             ui_font_size,
         )
@@ -1659,7 +1664,7 @@ impl View for ConversationDetailsPanel {
             );
         }
 
-        if let Some(harness_section) = self.render_harness_section(appearance) {
+        if let Some(harness_section) = self.render_harness_section(appearance, app) {
             content.add_child(
                 Container::new(harness_section)
                     .with_margin_bottom(FIELD_SPACING)

--- a/app/src/ai/harness_availability.rs
+++ b/app/src/ai/harness_availability.rs
@@ -1,0 +1,155 @@
+use serde::{Deserialize, Serialize};
+use warp_cli::agent::Harness;
+use warp_core::features::FeatureFlag;
+use warp_core::user_preferences::GetUserPreferences;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+use crate::ai::harness_display;
+use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
+use crate::auth::AuthStateProvider;
+use crate::network::{NetworkStatus, NetworkStatusEvent, NetworkStatusKind};
+use crate::report_error;
+use crate::server::server_api::ServerApiProvider;
+use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
+
+const CACHE_KEY: &str = "AvailableHarnesses";
+
+/// Server-resolved harness availability entry.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HarnessAvailability {
+    pub harness: Harness,
+    pub display_name: String,
+    pub enabled: bool,
+}
+
+/// Default fallback used before the server responds.
+/// Oz is enabled by default so the UI is usable pre-fetch; the server
+/// list (which respects admin overrides) replaces this once available.
+fn default_harnesses() -> Vec<HarnessAvailability> {
+    vec![HarnessAvailability {
+        harness: Harness::Oz,
+        display_name: "Warp".to_string(),
+        enabled: true,
+    }]
+}
+
+pub enum HarnessAvailabilityEvent {
+    Changed,
+}
+
+pub struct HarnessAvailabilityModel {
+    harnesses: Vec<HarnessAvailability>,
+}
+
+impl HarnessAvailabilityModel {
+    pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        let harnesses = get_cached(ctx).unwrap_or_else(default_harnesses);
+
+        ctx.subscribe_to_model(&NetworkStatus::handle(ctx), |me, event, ctx| {
+            if let NetworkStatusEvent::NetworkStatusChanged {
+                new_status: NetworkStatusKind::Online,
+            } = event
+            {
+                me.refresh(ctx);
+            }
+        });
+
+        ctx.subscribe_to_model(&AuthManager::handle(ctx), |me, event, ctx| {
+            if let AuthManagerEvent::AuthComplete = event {
+                me.refresh(ctx);
+            }
+        });
+
+        ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), |me, event, ctx| {
+            if let UserWorkspacesEvent::TeamsChanged = event {
+                me.refresh(ctx);
+            }
+        });
+
+        let me = Self { harnesses };
+        me.refresh(ctx);
+        me
+    }
+
+    pub fn available_harnesses(&self) -> &[HarnessAvailability] {
+        &self.harnesses
+    }
+
+    pub fn display_name_for(&self, harness: Harness) -> &str {
+        self.harnesses
+            .iter()
+            .find(|h| h.harness == harness)
+            .map(|h| h.display_name.as_str())
+            .unwrap_or_else(|| harness_display::display_name(harness))
+    }
+
+    pub fn enabled_harness_count(&self) -> usize {
+        self.harnesses.iter().filter(|h| h.enabled).count()
+    }
+
+    /// Whether the harness selector should be shown (>1 enabled harness).
+    pub fn should_show_harness_selector(&self) -> bool {
+        FeatureFlag::AgentHarness.is_enabled() && self.enabled_harness_count() > 1
+    }
+
+    /// Whether any harness is available at all (at least one enabled).
+    pub fn has_any_enabled_harness(&self) -> bool {
+        self.harnesses.iter().any(|h| h.enabled)
+    }
+
+    /// Whether a harness is both known and enabled.
+    pub fn is_harness_enabled(&self, harness: Harness) -> bool {
+        self.harnesses
+            .iter()
+            .any(|h| h.harness == harness && h.enabled)
+    }
+
+    pub fn refresh(&self, ctx: &mut ModelContext<Self>) {
+        // The endpoint queries `user`, which requires auth.
+        if !AuthStateProvider::as_ref(ctx).get().is_logged_in() {
+            return;
+        }
+
+        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        ctx.spawn(
+            async move { ai_client.get_available_harnesses().await },
+            |me, result, ctx| match result {
+                Ok(new_harnesses) => {
+                    if new_harnesses != me.harnesses {
+                        me.harnesses = new_harnesses;
+                        me.cache(ctx);
+                        ctx.emit(HarnessAvailabilityEvent::Changed);
+                    }
+                }
+                Err(e) => {
+                    report_error!(e.context("Failed to fetch available harnesses"));
+                }
+            },
+        );
+    }
+
+    fn cache(&self, ctx: &ModelContext<Self>) {
+        if let Ok(serialized) = serde_json::to_string(&self.harnesses) {
+            if let Err(e) = ctx
+                .private_user_preferences()
+                .write_value(CACHE_KEY, serialized)
+            {
+                report_error!(anyhow::anyhow!(e).context("Failed to cache available harnesses"));
+            }
+        }
+    }
+}
+
+fn get_cached(ctx: &ModelContext<HarnessAvailabilityModel>) -> Option<Vec<HarnessAvailability>> {
+    let raw = ctx
+        .private_user_preferences()
+        .read_value(CACHE_KEY)
+        .ok()??;
+    serde_json::from_str::<Vec<HarnessAvailability>>(&raw).ok()
+}
+
+impl Entity for HarnessAvailabilityModel {
+    type Event = HarnessAvailabilityEvent;
+}
+
+impl SingletonEntity for HarnessAvailabilityModel {}

--- a/app/src/ai/harness_availability.rs
+++ b/app/src/ai/harness_availability.rs
@@ -83,13 +83,9 @@ impl HarnessAvailabilityModel {
             .unwrap_or_else(|| harness_display::display_name(harness))
     }
 
-    pub fn enabled_harness_count(&self) -> usize {
-        self.harnesses.iter().filter(|h| h.enabled).count()
-    }
-
-    /// Whether the harness selector should be shown (>1 enabled harness).
+    /// Whether the harness selector should be shown (>1 known harness, including disabled).
     pub fn should_show_harness_selector(&self) -> bool {
-        FeatureFlag::AgentHarness.is_enabled() && self.enabled_harness_count() > 1
+        FeatureFlag::AgentHarness.is_enabled() && self.harnesses.len() > 1
     }
 
     /// Whether any harness is available at all (at least one enabled).

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod conversation_status_ui;
 pub(crate) mod conversation_utils;
 pub(crate) mod document;
 pub(crate) mod get_relevant_files;
+pub mod harness_availability;
 pub(crate) mod harness_display;
 pub(crate) mod llms;
 pub mod onboarding;

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -196,6 +196,7 @@ use workflows::manager::WorkflowManager;
 use crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier;
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::facts::manager::AIFactManager;
+use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::llms::LLMPreferences;
 use crate::ai::mcp::MCPGalleryManager;
 use crate::ai::mcp::TemplatableMCPServerManager;
@@ -1794,6 +1795,7 @@ fn initialize_app(
     ctx.add_singleton_model(LocalWorkflows::new);
 
     ctx.add_singleton_model(LLMPreferences::new);
+    ctx.add_singleton_model(HarnessAvailabilityModel::new);
 
     ctx.add_singleton_model(|ctx| {
         ai::agent_tips::AITipModel::<ai::AgentTip>::new_for_agent_tips(ctx)

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -16,6 +16,7 @@ use crate::{
         },
         document::ai_document_model::AIDocumentModel,
         execution_profiles::profiles::AIExecutionProfilesModel,
+        harness_availability::HarnessAvailabilityModel,
         llms::LLMPreferences,
         mcp::{
             templatable_manager::TemplatableMCPServerManager, FileBasedMCPManager, FileMCPWatcher,
@@ -154,6 +155,7 @@ fn initialize_app(app: &mut App) {
     });
     app.add_singleton_model(SessionPermissionsManager::new);
     app.add_singleton_model(LLMPreferences::new);
+    app.add_singleton_model(HarnessAvailabilityModel::new);
     #[cfg(feature = "voice_input")]
     app.add_singleton_model(voice_input::VoiceInput::new);
     #[cfg(feature = "local_fs")]

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -18,7 +18,6 @@ use warp_multi_agent_api::ConversationData;
 use super::auth::AuthClient;
 use super::harness_support::UploadTarget;
 use super::ServerApi;
-use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{
     AIAgentConversationFormat, AIAgentHarness, AIAgentSerializedBlockFormat,
     ServerAIConversationMetadata,
@@ -32,6 +31,7 @@ use crate::ai::generate_code_review_content::api::{
 use crate::ai::request_usage_model::RequestLimitInfo;
 #[cfg(not(feature = "agent_mode_evals"))]
 use crate::ai::BonusGrant;
+use crate::ai::{agent::api::ServerConversationToken, harness_availability::HarnessAvailability};
 use crate::persistence::model::ConversationUsageMetadata;
 use crate::terminal::model::block::SerializedBlock;
 #[cfg(not(feature = "agent_mode_evals"))]
@@ -129,6 +129,7 @@ use warp_graphql::{
             FreeAvailableModels, FreeAvailableModelsInput, FreeAvailableModelsResult,
             FreeAvailableModelsVariables,
         },
+        get_available_harnesses::{GetAvailableHarnesses, GetAvailableHarnessesVariables},
         get_feature_model_choices::{GetFeatureModelChoices, GetFeatureModelChoicesVariables},
         get_relevant_fragments::{
             GetRelevantFragmentsQuery, GetRelevantFragmentsResult, GetRelevantFragmentsVariables,
@@ -831,6 +832,8 @@ pub trait AIClient: 'static + Send + Sync {
 
     async fn get_feature_model_choices(&self) -> Result<ModelsByFeature, anyhow::Error>;
 
+    async fn get_available_harnesses(&self) -> Result<Vec<HarnessAvailability>, anyhow::Error>;
+
     /// Fetches the free-tier available models without requiring authentication.
     /// Used during pre-login onboarding so logged-out users see an accurate model list
     /// instead of the hard-coded `ModelsByFeature::default()` fallback.
@@ -1345,6 +1348,33 @@ impl AIClient for ServerApi {
                 workspaces.remove(0).feature_model_choice.try_into()
             }
             _ => Err(anyhow!("Failed to get available feature model choices")),
+        }
+    }
+
+    async fn get_available_harnesses(&self) -> Result<Vec<HarnessAvailability>, anyhow::Error> {
+        let variables = GetAvailableHarnessesVariables {
+            request_context: get_request_context(),
+        };
+        let operation = GetAvailableHarnesses::build(variables);
+        let response = self.send_graphql_request(operation, None).await?;
+
+        match response.user {
+            warp_graphql::queries::get_available_harnesses::UserResult::UserOutput(output) => {
+                Ok(output
+                    .user
+                    .available_harnesses
+                    .harnesses
+                    .into_iter()
+                    .map(|h| HarnessAvailability {
+                        harness: convert_harness(h.harness).into(),
+                        display_name: h.display_name,
+                        enabled: h.enabled,
+                    })
+                    .collect())
+            }
+            warp_graphql::queries::get_available_harnesses::UserResult::Unknown => {
+                Err(anyhow!("Failed to get available harnesses"))
+            }
         }
     }
 

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -35,6 +35,7 @@ use crate::ai::blocklist::block::status_bar::BlocklistAIStatusBar;
 use crate::ai::blocklist::{ai_indicator_height, BlocklistAIActionModel, SlashCommandRequest};
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentVersion};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::predict::prompt_suggestions::{
     has_pending_code_or_unit_test_prompt_suggestion,
     is_accept_prompt_suggestion_bound_to_ctrl_enter,
@@ -12110,6 +12111,24 @@ impl Input {
                         .is_configuring_ambient_agent()
                 })
             {
+                if FeatureFlag::AgentHarness.is_enabled() {
+                    let availability = HarnessAvailabilityModel::as_ref(ctx);
+                    if !availability.has_any_enabled_harness() {
+                        let window_id = ctx.window_id();
+                        ToastStack::handle(ctx).update(ctx, |ts, ctx| {
+                            ts.add_ephemeral_toast(
+                                DismissibleToast::error(
+                                    "No agent harnesses are available. Contact your team admin."
+                                        .to_string(),
+                                ),
+                                window_id,
+                                ctx,
+                            );
+                        });
+                        return;
+                    }
+                }
+
                 let prompt = command.trim().to_owned();
                 if prompt.is_empty() {
                     return;

--- a/app/src/terminal/input/agent.rs
+++ b/app/src/terminal/input/agent.rs
@@ -7,13 +7,16 @@ use super::{
     Input, InputAction, InputDropTargetData,
 };
 use crate::{
-    ai::blocklist::{
-        agent_view::{
-            agent_view_bg_fill,
-            shortcuts::{render_agent_shortcuts_view, AgentShortcutsViewContext},
-            AgentViewState,
+    ai::{
+        blocklist::{
+            agent_view::{
+                agent_view_bg_fill,
+                shortcuts::{render_agent_shortcuts_view, AgentShortcutsViewContext},
+                AgentViewState,
+            },
+            InputType,
         },
-        InputType,
+        harness_availability::HarnessAvailabilityModel,
     },
     appearance::Appearance,
     context_chips::spacing::{self},
@@ -123,7 +126,7 @@ impl Input {
         }
 
         let show_harness_row = FeatureFlag::CloudMode.is_enabled()
-            && FeatureFlag::AgentHarness.is_enabled()
+            && HarnessAvailabilityModel::as_ref(app).should_show_harness_selector()
             && self
                 .ambient_agent_view_model()
                 .is_some_and(|ambient_agent_model| {

--- a/app/src/terminal/input_test.rs
+++ b/app/src/terminal/input_test.rs
@@ -5,6 +5,7 @@ use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::blocklist::{AIQueryHistory, BlocklistAIPermissions};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::llms::LLMPreferences;
 use crate::ai::mcp::gallery::MCPGalleryManager;
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManager;
@@ -143,6 +144,7 @@ pub fn initialize_app(app: &mut App) {
     app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
     app.add_singleton_model(AuthManager::new_for_test);
     app.add_singleton_model(LLMPreferences::new);
+    app.add_singleton_model(HarnessAvailabilityModel::new);
     app.add_singleton_model(SessionPermissionsManager::new);
     app.add_singleton_model(DirectoryWatcher::new);
     app.add_singleton_model(|_| DetectedRepositories::default());

--- a/app/src/terminal/view/ambient_agent/harness_selector.rs
+++ b/app/src/terminal/view/ambient_agent/harness_selector.rs
@@ -20,7 +20,8 @@ use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::Fill;
 
 use crate::ai::blocklist::agent_view::agent_input_footer::AgentInputButtonTheme;
-use crate::ai::harness_display::{display_name, icon_for};
+use crate::ai::harness_availability::{HarnessAvailability, HarnessAvailabilityModel};
+use crate::ai::harness_display::{brand_color, icon_for};
 use crate::menu::{Event as MenuEvent, Menu, MenuItem, MenuItemFields};
 use crate::terminal::input::{MenuPositioning, MenuPositioningProvider};
 use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
@@ -120,6 +121,13 @@ impl HarnessSelector {
             me.refresh_menu(ctx);
         });
 
+        ctx.subscribe_to_model(
+            &HarnessAvailabilityModel::handle(ctx),
+            |me, _, _event, ctx| {
+                me.refresh_menu(ctx);
+            },
+        );
+
         let mut me = Self {
             button,
             menu,
@@ -177,7 +185,9 @@ impl HarnessSelector {
 
     fn refresh_button(&mut self, ctx: &mut ViewContext<Self>) {
         let harness = self.ambient_agent_model.as_ref(ctx).selected_harness();
-        let label = display_name(harness).to_string();
+        let label = HarnessAvailabilityModel::as_ref(ctx)
+            .display_name_for(harness)
+            .to_string();
         let icon = icon_for(harness);
         self.button.update(ctx, |button, ctx| {
             button.set_label(label, ctx);
@@ -190,8 +200,15 @@ impl HarnessSelector {
         let theme = appearance.theme();
         let hover_background: Fill = internal_colors::neutral_4(theme).into();
         let header_text_color = theme.disabled_text_color(theme.surface_2()).into_solid();
+        let disabled_text_color = theme.disabled_text_color(theme.surface_2()).into_solid();
         let border = Border::all(1.).with_border_fill(theme.outline());
-        let items = build_menu_items(hover_background, header_text_color);
+        let availability_model = HarnessAvailabilityModel::as_ref(ctx);
+        let items = build_menu_items(
+            availability_model.available_harnesses(),
+            hover_background,
+            header_text_color,
+            disabled_text_color,
+        );
         self.menu.update(ctx, |menu, ctx| {
             menu.set_border(Some(border));
             menu.set_items(items, ctx);
@@ -216,13 +233,12 @@ impl HarnessSelector {
     }
 }
 
-/// Builds the menu items for the harness selector. The first item is a
-/// non-clickable header; the remaining items are the available harnesses.
-/// Item text colors are left as theme defaults; the header uses the theme's
-/// disabled-text color, and hovered/selected rows use `neutral_4`.
+/// Builds the menu items from server-provided harness availability data.
 fn build_menu_items(
+    harnesses: &[HarnessAvailability],
     hover_background: Fill,
     header_text_color: pathfinder_color::ColorU,
+    disabled_text_color: pathfinder_color::ColorU,
 ) -> Vec<MenuItem<HarnessSelectorAction>> {
     let header = MenuItem::Header {
         fields: MenuItemFields::new(MENU_HEADER_LABEL)
@@ -234,25 +250,30 @@ fn build_menu_items(
         right_side_fields: None,
     };
 
-    let item_for = |harness: Harness| {
-        MenuItem::Item(
-            MenuItemFields::new(display_name(harness))
-                .with_icon(icon_for(harness))
-                .with_icon_size_override(ITEM_ICON_SIZE)
-                .with_font_size_override(ITEM_FONT_SIZE)
-                .with_padding_override(ITEM_VERTICAL_PADDING, MENU_HORIZONTAL_PADDING)
-                .with_override_hover_background_color(hover_background)
-                .with_on_select_action(HarnessSelectorAction::SelectHarness(harness)),
-        )
-    };
+    let mut items = vec![header];
 
-    vec![
-        header,
-        item_for(Harness::Oz),
-        item_for(Harness::Claude),
-        item_for(Harness::Gemini),
-        item_for(Harness::Codex),
-    ]
+    for entry in harnesses {
+        let harness = entry.harness;
+        let is_disabled = !entry.enabled;
+        let mut fields = MenuItemFields::new(entry.display_name.clone())
+            .with_icon(icon_for(harness))
+            .with_icon_size_override(ITEM_ICON_SIZE)
+            .with_font_size_override(ITEM_FONT_SIZE)
+            .with_padding_override(ITEM_VERTICAL_PADDING, MENU_HORIZONTAL_PADDING)
+            .with_override_hover_background_color(hover_background)
+            .with_on_select_action(HarnessSelectorAction::SelectHarness(harness));
+        if let Some(color) = brand_color(harness) {
+            fields = fields.with_override_icon_color(Fill::from(color));
+        }
+        if is_disabled {
+            fields = fields
+                .with_disabled(true)
+                .with_override_text_color(disabled_text_color);
+        }
+        items.push(MenuItem::Item(fields));
+    }
+
+    items
 }
 
 impl Entity for HarnessSelector {

--- a/app/src/terminal/view/ambient_agent/harness_selector.rs
+++ b/app/src/terminal/view/ambient_agent/harness_selector.rs
@@ -125,6 +125,7 @@ impl HarnessSelector {
             &HarnessAvailabilityModel::handle(ctx),
             |me, _, _event, ctx| {
                 me.refresh_menu(ctx);
+                me.refresh_button(ctx);
             },
         );
 
@@ -268,7 +269,8 @@ fn build_menu_items(
         if is_disabled {
             fields = fields
                 .with_disabled(true)
-                .with_override_text_color(disabled_text_color);
+                .with_override_text_color(disabled_text_color)
+                .with_tooltip("Disabled by your administrator");
         }
         items.push(MenuItem::Item(fields));
     }

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -26,6 +26,7 @@ use crate::ai::blocklist::handoff::touched_repos::TouchedWorkspace;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::execution_profiles::{CloudAgentComputerUseState, ComputerUsePermission};
+use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
 use crate::server::cloud_objects::update_manager::UpdateManager;
@@ -188,6 +189,10 @@ impl AmbientAgentViewModel {
     pub fn new(terminal_view_id: EntityId, ctx: &mut ModelContext<Self>) -> Self {
         ctx.subscribe_to_model(&CloudModel::handle(ctx), |me, event, ctx| {
             me.handle_cloud_model_event(event, ctx);
+        });
+
+        ctx.subscribe_to_model(&HarnessAvailabilityModel::handle(ctx), |me, _event, ctx| {
+            me.validate_selected_harness(ctx);
         });
 
         // Validate the default environment once Warp Drive sync completes.
@@ -477,6 +482,16 @@ impl AmbientAgentViewModel {
         }
         self.environment_id = environment_id;
         ctx.emit(AmbientAgentViewModelEvent::EnvironmentSelected);
+    }
+
+    /// Resets to the first enabled harness if the current selection is no longer enabled.
+    fn validate_selected_harness(&mut self, ctx: &mut ModelContext<Self>) {
+        let model = HarnessAvailabilityModel::as_ref(ctx);
+        if !model.is_harness_enabled(self.harness) {
+            if let Some(first_enabled) = model.available_harnesses().iter().find(|h| h.enabled) {
+                self.set_harness(first_enabled.harness, ctx);
+            }
+        }
     }
 
     /// Whether or not this terminal session is for an ambient agent.

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -205,6 +205,20 @@ impl AmbientAgentViewModel {
 
         let ui_state = AmbientAgentProgressUIState::new(ctx);
 
+        let harness = Harness::default();
+        let availability = HarnessAvailabilityModel::as_ref(ctx);
+        // If the default harness is not available, find the first available one.
+        let harness = if !availability.is_harness_enabled(harness) {
+            availability
+                .available_harnesses()
+                .iter()
+                .find(|h| h.enabled)
+                .map(|h| h.harness)
+                .unwrap_or(harness)
+        } else {
+            harness
+        };
+
         Self {
             status: Status::Composing,
             request: None,
@@ -215,7 +229,7 @@ impl AmbientAgentViewModel {
             setup_commands_state: Default::default(),
             task_id: None,
             conversation_id: None,
-            harness: Harness::default(),
+            harness,
             worker_host: None,
             harness_command_started: false,
             active_execution_session_id: None,

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -27,6 +27,7 @@ use crate::ai::blocklist::task_status_sync_model::TaskStatusSyncModel;
 use crate::ai::blocklist::BlocklistAIPermissions;
 use crate::ai::blocklist::SerializedBlockListItem;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::llms::LLMPreferences;
 use crate::ai::outline::RepoOutlines;
 use crate::ai::restored_conversations::RestoredAgentConversations;
@@ -116,6 +117,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
     app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
     app.add_singleton_model(AuthManager::new_for_test);
     app.add_singleton_model(LLMPreferences::new);
+    app.add_singleton_model(HarnessAvailabilityModel::new);
     app.add_singleton_model(SessionPermissionsManager::new);
     app.add_singleton_model(DirectoryWatcher::new);
     app.add_singleton_model(|_| DetectedRepositories::default());

--- a/app/src/workspace/view_test.rs
+++ b/app/src/workspace/view_test.rs
@@ -3,6 +3,7 @@ use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::facts::manager::AIFactManager;
+use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::llms::LLMPreferences;
 use crate::ai::outline::RepoOutlines;
 use crate::ai::persisted_workspace::PersistedWorkspace;
@@ -140,6 +141,7 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(AgentConversationsModel::new);
     app.add_singleton_model(SessionPermissionsManager::new);
     app.add_singleton_model(LLMPreferences::new);
+    app.add_singleton_model(HarnessAvailabilityModel::new);
     app.add_singleton_model(|_| SettingsPaneManager::new());
     app.add_singleton_model(|_| AIFactManager::new());
 

--- a/crates/graphql/src/api/queries/get_available_harnesses.rs
+++ b/crates/graphql/src/api/queries/get_available_harnesses.rs
@@ -1,0 +1,48 @@
+use crate::{ai::AgentHarness, request_context::RequestContext, schema};
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct GetAvailableHarnessesVariables {
+    pub request_context: RequestContext,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    graphql_type = "RootQuery",
+    variables = "GetAvailableHarnessesVariables"
+)]
+pub struct GetAvailableHarnesses {
+    #[arguments(requestContext: $request_context)]
+    pub user: UserResult,
+}
+crate::client::define_operation! {
+    get_available_harnesses(GetAvailableHarnessesVariables) -> GetAvailableHarnesses;
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+pub enum UserResult {
+    UserOutput(UserOutput),
+    #[cynic(fallback)]
+    Unknown,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct UserOutput {
+    pub user: User,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct User {
+    pub available_harnesses: AvailableHarnesses,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct AvailableHarnesses {
+    pub harnesses: Vec<HarnessInfo>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct HarnessInfo {
+    pub harness: AgentHarness,
+    pub display_name: String,
+    pub enabled: bool,
+}

--- a/crates/graphql/src/api/queries/mod.rs
+++ b/crates/graphql/src/api/queries/mod.rs
@@ -3,6 +3,7 @@ pub mod codebase_context_config;
 pub mod free_available_models;
 pub mod get_ai_conversation_format;
 pub mod get_ai_overages_for_workspace;
+pub mod get_available_harnesses;
 pub mod get_blocks_for_user;
 pub mod get_cloud_environments;
 pub mod get_cloud_object;

--- a/crates/warp_cli/Cargo.toml
+++ b/crates/warp_cli/Cargo.toml
@@ -12,6 +12,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 cfg-if = { workspace = true }
 humantime.workspace = true
 jaq-all.workspace = true
+serde = { workspace = true, features = ["derive"] }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true }
 warp_core = { path = "../warp_core" }

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -119,7 +119,9 @@ impl HiddenComputerUseArgs {
     }
 }
 /// The execution harness for an agent run.
-#[derive(Debug, Copy, Clone, ValueEnum, Eq, PartialEq, Default)]
+#[derive(
+    Debug, Copy, Clone, ValueEnum, Eq, PartialEq, Default, serde::Serialize, serde::Deserialize,
+)]
 pub enum Harness {
     /// Use Warp's built-in MAA infrastructure (default).
     #[default]

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -220,6 +220,17 @@ enum AgentHarness {
   OZ
 }
 
+"""A harness available to the requesting user."""
+type HarnessInfo {
+  displayName: String!
+  enabled: Boolean!
+  harness: AgentHarness!
+}
+
+type AvailableHarnesses {
+  harnesses: [HarnessInfo!]!
+}
+
 """Controls how many agent identities (service accounts) a team can have."""
 type AgentIdentitiesPolicy {
   isUnlimited: Boolean!
@@ -3800,6 +3811,7 @@ type User {
   githubInstallations: UserGithubInstallationsOutput!
   isOnWorkDomain: Boolean!
   isOnboarded: Boolean!
+  availableHarnesses: AvailableHarnesses!
   llms: FeatureModelChoice!
   managedSecrets: ManagedSecretConfig
   onboardingSurveyStatus: OnboardingSurveyStatus

--- a/specs/REMOTE-1545/TECH.md
+++ b/specs/REMOTE-1545/TECH.md
@@ -1,0 +1,101 @@
+# REMOTE-1545: Server-driven harness availability
+
+## Context
+
+Harness UI (selector dropdown, filter dropdown, details panel, management view metadata) was previously driven by a hard-coded list of `Harness` variants gated behind `FeatureFlag::AgentHarness`. The server already knows which harnesses a user/team can access and whether each is enabled, but the client never queried this — every user saw the same list.
+
+The fix mirrors the established `LLMPreferences` pattern: a singleton model fetches server data, caches it locally, and all UI reads from the model instead of hard-coded lists.
+
+### Relevant code
+
+**Existing pattern — `LLMPreferences`** (`app/src/ai/llms.rs:519-1071`):
+- `SingletonEntity` registered in `lib.rs`
+- Subscribes to `NetworkStatus`, `AuthManager`, `UserWorkspaces` to trigger refresh
+- Fetches via `ServerApiProvider::get_ai_client().get_feature_model_choices()`
+- Caches in `private_user_preferences` under `"AvailableLLMs"` key
+- `on_server_update` invalidates stale per-profile model selections
+- Emits `LLMPreferencesEvent::UpdatedAvailableLLMs`
+
+**Harness enum** — `crates/warp_cli/src/agent.rs:122-148`: `Harness` with variants Oz, Claude, OpenCode, Gemini, Codex, Unknown. Now derives `Serialize`/`Deserialize` for caching.
+
+**GraphQL schema** — `crates/warp_graphql_schema/api/schema.graphql`: existing `AgentHarness` enum. New `HarnessInfo` type and `User.availableHarnesses` field.
+
+**UI consumers** — hard-coded harness lists in:
+- `app/src/terminal/view/ambient_agent/harness_selector.rs` — selector dropdown
+- `app/src/ai/agent_management/view.rs` — filter dropdown + card metadata
+- `app/src/ai/conversation_details_panel.rs` — details panel harness section
+- `app/src/terminal/input.rs` — submission guard
+- `app/src/terminal/input/agent.rs` — harness row visibility
+
+## Proposed changes
+
+### 1. GQL query + cynic module
+
+New file `crates/graphql/src/api/queries/get_available_harnesses.rs`:
+- `GetAvailableHarnesses` query on `User.availableHarnesses`
+- Returns `Vec<HarnessInfo>` with `harness: AgentHarness`, `displayName: String`, `enabled: Bool`
+
+Schema additions in `schema.graphql`:
+- `HarnessInfo` type, `AvailableHarnesses` wrapper, `User.availableHarnesses` field
+
+Conversion: `convert_agent_harness_to_cli` maps `AgentHarness → warp_cli::agent::Harness` (same pattern as existing model conversions in `ai.rs`).
+
+### 2. `HarnessAvailabilityModel` singleton
+
+New file `app/src/ai/harness_availability.rs`. Intentionally follows the `LLMPreferences` pattern:
+
+| Aspect | `LLMPreferences` | `HarnessAvailabilityModel` |
+|---|---|---|
+| Singleton | `SingletonEntity` in `lib.rs` | Same |
+| Refresh triggers | `NetworkStatus::Online`, `AuthComplete`, `TeamsChanged` | Same three |
+| Auth guard | `is_logged_in()` check before fetch | Same |
+| Cache | `private_user_preferences.write_value("AvailableLLMs", json)` | `write_value("AvailableHarnesses", json)` |
+| Default fallback | `ModelsByFeature::default()` (auto model) | `vec![HarnessAvailability { harness: Oz, enabled: true }]` |
+| Diff + emit | Compare old/new, emit if changed | Same |
+
+Key methods:
+- `available_harnesses() → &[HarnessAvailability]` — full list for UI
+- `should_show_harness_selector() → bool` — `FeatureFlag::AgentHarness.is_enabled() && enabled_count > 1`
+- `has_any_enabled_harness() → bool` — submission guard
+- `is_harness_enabled(harness) → bool` — selection validation
+
+### 3. Selection invalidation in `AmbientAgentViewModel`
+
+`LLMPreferences::on_server_update` clears stale profile model selections inside the model itself. Following this, `AmbientAgentViewModel` (not the `HarnessSelector` view) subscribes to `HarnessAvailabilityModel` and resets `self.harness` to `Harness::Oz` if the selected harness becomes unavailable. This ensures validation fires even when the selector view doesn't exist (e.g. agent management page, shared session joins).
+
+This parallels the existing `validate_environment_after_initial_load` + `handle_cloud_model_event` pattern already in `AmbientAgentViewModel` for environment IDs.
+
+### 4. UI migration: model reads replace hard-coded lists
+
+All UI sites switch from iterating `[Harness::Oz, Harness::Claude, ...]` or checking `FeatureFlag::AgentHarness.is_enabled()` to reading `HarnessAvailabilityModel`:
+
+- **Harness selector** (`harness_selector.rs`): `build_menu_items` takes `&[HarnessAvailability]`, renders disabled entries greyed-out. Subscribes to `Changed` to refresh menu.
+- **Filter dropdown** (`agent_management/view.rs`): `build_harness_dropdown_items` reads from model.
+- **Card metadata + filter visibility** (`agent_management/view.rs`): `should_show_harness_selector()` replaces `FeatureFlag::AgentHarness.is_enabled()`.
+- **Details panel** (`conversation_details_panel.rs`): same `should_show_harness_selector()` gate.
+- **Harness row** (`input/agent.rs`): same.
+- **Submission guard** (`input.rs`): blocks submission with error toast when `!has_any_enabled_harness()`.
+
+### 5. `FeatureFlag::AgentHarness` retained as kill switch
+
+The feature flag is NOT removed — it gates CLI harness parsing, conversation loading, experiment bucketing, and telemetry. `should_show_harness_selector()` combines the flag check with the server-driven enabled count, so the flag can still kill harness UI entirely.
+
+### 6. `Harness` serde support
+
+`crates/warp_cli/src/agent.rs`: `Harness` gains `Serialize`/`Deserialize` derives (+ `serde` dep in `warp_cli/Cargo.toml`) so `HarnessAvailability` can be cached as JSON.
+
+## Testing and validation
+
+- **Manual**: log in as user on team with restricted harnesses → verify only enabled harnesses appear in selector and filter dropdown; disabled harnesses appear greyed-out; selecting a disabled harness is blocked; switching teams refreshes the list.
+- **Offline fallback**: disconnect network after initial load → verify cached harness list persists across restart; reconnect → verify list refreshes.
+- **Selection invalidation**: select Claude → admin disables Claude server-side → verify selection auto-resets to Oz without requiring selector view to be open.
+- **Zero-harnesses**: all harnesses disabled → submission blocked with error toast.
+- **Feature flag kill switch**: disable `FeatureFlag::AgentHarness` → verify all harness UI disappears regardless of server data.
+
+## Follow-ups
+
+- Remove debug `[lili]` log statements before merge
+- **Block submission for disabled harness with `disableReason`**: show inline error when user tries to submit with a specifically-disabled harness (vs. zero-harnesses toast)
+- **CLI `--harness` pre-validation**: currently deferred; server rejects with generic error
+- Remove `FeatureFlag::AgentHarness` entirely after rollout stabilizes
+- Remove `OzMultiHarnessExperiment` after all non-Oz harnesses GA


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
This PR introduces a new `HarnessAvailabilityModel`, following server-side changes to expose the list of available harnesses for use with Oz in the `availableHarnesses` section of the `User` GraphQL query.

We model this new model (ha) after the existing models (ha) model, which stores the list of available LLMs (`LLMPreferences`) that we get from the server.

We also update the cloud mode UI, management view filter, and CLI so that we check this model to determine the list of harnesses to display (rather than hardcoding them), as well as to show enabled/disabled state when triggering something from cloud mode.

## Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->
Example of disabled state for harnesses in cloud mode:
<img width="878" height="419" alt="image" src="https://github.com/user-attachments/assets/a2b62e18-2a65-42aa-8b5b-c45b58d22855" />

No harnesses available state:
https://www.loom.com/share/65d9ed8f52be4a5ba4b1e320fdddff0b


## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?
-->
Tested locally, ensuring that:
- Disabled harnesses show up correctly
- Non-feature-flag-enabled harnesses don't show up
- Different UI surfaces all reflect the list from the server

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

