### PR TITLE
Fix `tail` path in script/macos/run --open_with_launchd for OSS channel

### DIFF
--- a/script/macos/run
+++ b/script/macos/run
@@ -134,7 +134,12 @@ if [ "$DONT_OPEN" = false ] ; then
     if  [ "$OPEN_WITH_LAUNCHD" = true ]; then
         echo "Launching with MacOS application launcher"
         PATH="" /usr/bin/open "./$WARP_APP_PATH"
-        tail -f ~/Library/Logs/warp_local.log
+        if [ "$WARP_CHANNEL" = "local" ]; then
+            LOG_FILE=~/Library/Logs/warp_local.log
+        else
+            LOG_FILE=~/Library/Logs/warp-oss.log
+        fi
+        tail -F "$LOG_FILE"
     else
         echo "Opening app at ./$WARP_APP_PATH/Contents/MacOS/$WARP_BIN_NAME"
         "./$WARP_APP_PATH/Contents/MacOS/$WARP_BIN_NAME" "${WARP_ARGS[@]}"

--- a/script/macos/run
+++ b/script/macos/run
@@ -136,7 +136,10 @@ if [ "$DONT_OPEN" = false ] ; then
         PATH="" /usr/bin/open "./$WARP_APP_PATH"
         if [ "$WARP_CHANNEL" = "local" ]; then
             LOG_FILE=~/Library/Logs/warp_local.log
+        elif [ "$WARP_CHANNEL" = "oss" ]; then
+            LOG_FILE=~/Library/Logs/warp-oss.log
         else
+            echo "Warning: unrecognized WARP_CHANNEL '$WARP_CHANNEL', defaulting to OSS log path" >&2
             LOG_FILE=~/Library/Logs/warp-oss.log
         fi
         tail -F "$LOG_FILE"


### PR DESCRIPTION
## Summary

`./script/run --open_with_launchd` (macOS, OSS channel) ends with:

```
tail: /Users/.../Library/Logs/warp_local.log: No such file or directory
```

The script hardcodes `tail -f ~/Library/Logs/warp_local.log`, but the OSS binary writes to `~/Library/Logs/warp-oss.log` (see `app/src/bin/oss.rs` — `logfile_name: "warp-oss.log"`). External contributors who can't install `warp-channel-config` always build the OSS channel and so always hit this.

This branches on `$WARP_CHANNEL` so:
- **OSS** tails `~/Library/Logs/warp-oss.log` (verified path).
- **Local** keeps tailing `~/Library/Logs/warp_local.log` (unchanged — local channel `logfile_name` lives in the closed `warp-channel-config` repo, so I didn't touch it).

Also swaps `tail -f` → `tail -F` so the tail survives the brief window before launchd has created the log file.

## Test plan
- [x] `./script/run --open_with_launchd` on OSS channel → app launches and `warp-oss.log` is tailed correctly.
- [ ] Internal: `./script/run --open_with_launchd` on local channel → unchanged behavior, still tails `warp_local.log`.