### PR TITLE
[REMOTE-1370] Phase 2a: taskGitCredentials schema, query, and AIClient

### DIFF
--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -120,6 +120,10 @@ use warp_graphql::{
             UpdateMerkleTreeVariables,
         },
     },
+    queries::task_git_credentials::{
+        TaskGitCredentials, TaskGitCredentialsInput, TaskGitCredentialsResult,
+        TaskGitCredentialsVariables,
+    },
     queries::{
         codebase_context_config::{
             CodebaseContextConfigQuery, CodebaseContextConfigResult, CodebaseContextConfigVariables,
@@ -515,6 +519,19 @@ pub struct CreateFileArtifactUploadResponse {
     pub upload_target: FileArtifactUploadTargetInfo,
 }
 
+/// A single git credential entry returned by `taskGitCredentials`.
+#[derive(Debug, Clone)]
+pub struct GitCredential {
+    /// The GitHub token (OAuth user token or App installation token).
+    pub token: String,
+    /// The GitHub username. `None` for service-account (installation token) principals.
+    pub username: Option<String>,
+    /// The GitHub email. `None` for service-account principals.
+    pub email: Option<String>,
+    /// The host (always `"github.com"` in V1).
+    pub host: String,
+}
+
 /// Filter parameters for listing ambient agent tasks.
 #[derive(Clone, Debug, Default)]
 pub struct TaskListFilter {
@@ -900,6 +917,12 @@ pub trait AIClient: 'static + Send + Sync {
         &self,
         task_id: &AmbientAgentTaskId,
     ) -> anyhow::Result<(), anyhow::Error>;
+
+    async fn get_task_git_credentials(
+        &self,
+        task_id: String,
+        workload_token: String,
+    ) -> anyhow::Result<Vec<GitCredential>, anyhow::Error>;
 
     async fn get_task_attachments(
         &self,
@@ -1778,6 +1801,44 @@ impl AIClient for ServerApi {
             .post_public_api(&format!("agent/tasks/{task_id}/cancel"), &())
             .await?;
         Ok(())
+    }
+
+    async fn get_task_git_credentials(
+        &self,
+        task_id: String,
+        workload_token: String,
+    ) -> anyhow::Result<Vec<GitCredential>, anyhow::Error> {
+        let variables = TaskGitCredentialsVariables {
+            input: TaskGitCredentialsInput {
+                task_id: cynic::Id::new(task_id),
+                workload_token,
+            },
+            request_context: get_request_context(),
+        };
+        let operation = TaskGitCredentials::build(variables);
+        let response = self.send_graphql_request(operation, None).await?;
+
+        match response.task_git_credentials {
+            TaskGitCredentialsResult::TaskGitCredentialsOutput(output) => {
+                let credentials = output
+                    .credentials
+                    .into_iter()
+                    .map(|c| GitCredential {
+                        token: c.token,
+                        username: c.username,
+                        email: c.email,
+                        host: c.host,
+                    })
+                    .collect();
+                Ok(credentials)
+            }
+            TaskGitCredentialsResult::UserFacingError(error) => {
+                Err(anyhow!(get_user_facing_error_message(error)))
+            }
+            TaskGitCredentialsResult::Unknown => {
+                Err(anyhow!("Failed to fetch task git credentials"))
+            }
+        }
     }
 
     async fn get_task_attachments(

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -520,7 +520,7 @@ pub struct CreateFileArtifactUploadResponse {
 }
 
 /// A single git credential entry returned by `taskGitCredentials`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct GitCredential {
     /// The GitHub token (OAuth user token or App installation token).
     pub token: String,

--- a/crates/graphql/src/api/queries/mod.rs
+++ b/crates/graphql/src/api/queries/mod.rs
@@ -28,6 +28,7 @@ pub mod rerank_fragments;
 pub mod suggest_cloud_environment_image;
 pub mod sync_merkle_tree;
 pub mod task_attachments;
+pub mod task_git_credentials;
 pub mod task_secrets;
 pub mod user_github_info;
 pub mod user_repo_auth_status;

--- a/crates/graphql/src/api/queries/task_git_credentials.rs
+++ b/crates/graphql/src/api/queries/task_git_credentials.rs
@@ -1,0 +1,50 @@
+use crate::{error::UserFacingError, request_context::RequestContext, schema};
+
+/// A GraphQL query to fetch git credentials for a specific task.
+///
+/// This query is used by Agent Mode tasks to retrieve a fresh GitHub token that the
+/// driver uses to configure git and the gh CLI, and to refresh those credentials
+/// periodically so long-running agents retain GitHub access for their full duration.
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "RootQuery", variables = "TaskGitCredentialsVariables")]
+pub struct TaskGitCredentials {
+    #[arguments(input: $input, requestContext: $request_context)]
+    pub task_git_credentials: TaskGitCredentialsResult,
+}
+
+crate::client::define_operation! {
+    task_git_credentials(TaskGitCredentialsVariables) -> TaskGitCredentials;
+}
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct TaskGitCredentialsVariables {
+    pub input: TaskGitCredentialsInput,
+    pub request_context: RequestContext,
+}
+
+#[derive(cynic::InputObject, Debug)]
+pub struct TaskGitCredentialsInput {
+    pub task_id: cynic::Id,
+    pub workload_token: String,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+pub enum TaskGitCredentialsResult {
+    TaskGitCredentialsOutput(TaskGitCredentialsOutput),
+    UserFacingError(UserFacingError),
+    #[cynic(fallback)]
+    Unknown,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct TaskGitCredentialsOutput {
+    pub credentials: Vec<TaskGitCredential>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct TaskGitCredential {
+    pub token: String,
+    pub username: Option<String>,
+    pub email: Option<String>,
+    pub host: String,
+}

--- a/crates/warp_graphql_schema/api/client-schema.ts
+++ b/crates/warp_graphql_schema/api/client-schema.ts
@@ -97,6 +97,7 @@ const clientQueries = [
   'getIntegrationsUsingEnvironment',
   'scheduledAgentHistory',
   'task',
+  'taskGitCredentials',
   'taskSecrets',
   'listAIConversations',
   'suggestCloudEnvironmentImage'

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -2769,6 +2769,7 @@ type RootQuery {
   In the future, this may be merged with taskSecrets into a single task query.
   """
   task(input: TaskInput!, requestContext: RequestContext!): TaskResult!
+  taskGitCredentials(input: TaskGitCredentialsInput!, requestContext: RequestContext!): TaskGitCredentialsResult!
   taskSecrets(input: TaskSecretsInput!, requestContext: RequestContext!): TaskSecretsResult!
   updatedCloudObjects(input: UpdatedCloudObjectsInput!, requestContext: RequestContext!): UpdatedCloudObjectsResult!
   user(requestContext: RequestContext!): UserResult!
@@ -3182,6 +3183,43 @@ type TaskSecretEntry {
   name: String!
   value: ManagedSecretValue!
 }
+
+"""A set of git credentials for a single hosting provider."""
+type TaskGitCredential {
+  """
+  The email address associated with the token, if available.
+  Null for service-account (installation) tokens.
+  """
+  email: String
+
+  """The git hosting provider (e.g. \"github.com\")."""
+  host: String!
+
+  """The OAuth or installation access token."""
+  token: String!
+
+  """
+  The GitHub username associated with the token, if available.
+  Null for service-account (installation) tokens.
+  """
+  username: String
+}
+
+"""Input for the taskGitCredentials query."""
+input TaskGitCredentialsInput {
+  """The ID of the task."""
+  taskId: ID!
+
+  """A short-lived token authorizing credential retrieval for the workload."""
+  workloadToken: String!
+}
+
+type TaskGitCredentialsOutput implements Response {
+  credentials: [TaskGitCredential!]!
+  responseContext: ResponseContext!
+}
+
+union TaskGitCredentialsResult = TaskGitCredentialsOutput | UserFacingError
 
 """Input for the taskSecrets query."""
 input TaskSecretsInput {


### PR DESCRIPTION
## Description

First half of Phase 2 of REMOTE-1370. Adds the GraphQL plumbing for \`taskGitCredentials\` so the driver can call it in the next PR.

**Changes:**
- Add \`taskGitCredentials\` types to \`schema.graphql\` and add to the \`clientQueries\` allowlist in \`client-schema.ts\`
- New \`task_git_credentials.rs\` cynic query file, following the \`task_secrets\` pattern
- Add \`GitCredential\` struct and \`get_task_git_credentials\` to \`AIClient\` trait + \`ServerApi\` implementation

No behaviour change — nothing calls \`get_task_git_credentials\` yet; that's in the follow-on PR.

**schema.graphql approach:** \`yarn generate -p staging\` was run to verify the new types, but the output was not committed wholesale because the current staging server also has other unrelated schema changes (removed \`freeAvailableModels\`, new \`VOYAGE_4_512\` EmbeddingConfig variant, etc.) that are out of scope and would break existing Rust bindings. Instead, only the \`taskGitCredentials\` types were cherry-picked — the field names, nullability, and doc comments were verified to be identical to what the server generates.

Warp-server staging is deployed with the new query.

Followed by: #10153.

## Linked Issue

Linear: REMOTE-1370

## Testing

- \`cargo build -p warp\` clean
- \`cargo fmt\` and \`cargo clippy\` clean

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/e16dc3e2-8e2f-4499-8c9b-59b200e17c50

Co-Authored-By: Oz <oz-agent@warp.dev>