### PR TITLE
Fix feature flag cleanup API key

### DIFF
--- a/.github/workflows/feature_flag_cleanup.yml
+++ b/.github/workflows/feature_flag_cleanup.yml
@@ -63,7 +63,7 @@ jobs:
               * "date_enabled" - the date on which the feature flag was enabled by default
               * "enabling_commit" - the Git commit in which the feature flag was enabled by default
             * You are running as part of a GitHub automation and must not commit or push any changes. Another agent will process the file you produce.
-          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          warp_api_key: ${{ secrets.OSS_WARP_API_KEY }}
           share: team
 
       - name: Upload feature flag log
@@ -178,7 +178,7 @@ jobs:
 
             You are running as part of a GitHub automation that runs with a read-only token and will package your changes into a patch for a separate job to commit. Do not create a branch, do not commit, do not push, do not create a PR, and do not call `gh`. Leave your changes in the working tree only.
           share: team
-          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          warp_api_key: ${{ secrets.OSS_WARP_API_KEY }}
 
       - name: Generate cleanup patch
         env:


### PR DESCRIPTION
## Description
Updates the Feature Flag Cleanup workflow so both Oz agent steps pass `secrets.OSS_WARP_API_KEY` as the required `warp_api_key` input. This resolves the scheduled workflow failure where `warp_api_key` was empty.

## Linked Issue
No linked issue; requested from Slack.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
Not applicable; workflow-only change.

## Testing
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "namespace-profile-ubuntu-small" is unknown' .github/workflows/feature_flag_cleanup.yml`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._
