### PR TITLE
Fix secret precedence in Oz CLI.

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -256,6 +256,12 @@ pub struct AgentDriver {
     /// - Secrets are passed to MCP servers during spawning.
     secrets: Arc<HashMap<String, ManagedSecretValue>>,
 
+    /// Env vars passed to the terminal session, including resolved secrets, cloud
+    /// provider vars, task vars, and sandbox flags. Shared with
+    /// `prepare_environment_config` so harnesses can look up resolved secret
+    /// values without re-deriving precedence.
+    resolved_env_vars: Arc<HashMap<OsString, OsString>>,
+
     output_format: OutputFormat,
 
     // The associated task ID for this agent run, if any.
@@ -554,10 +560,12 @@ impl AgentDriver {
             env_vars.insert(OsString::from("IS_SANDBOX"), OsString::from("1"));
         }
 
+        let resolved_env_vars = Arc::new(env_vars);
+
         let terminal_driver = terminal::TerminalDriver::create(
             terminal::TerminalDriverOptions {
                 working_dir: working_dir.clone(),
-                env_vars,
+                env_vars: HashMap::clone(&resolved_env_vars),
                 should_share,
                 task_id,
                 conversation_restoration,
@@ -600,6 +608,7 @@ impl AgentDriver {
             terminal_driver,
             working_dir,
             secrets: Arc::new(secrets),
+            resolved_env_vars,
             output_format: OutputFormat::default(),
             task_id,
             harness: None,
@@ -1514,11 +1523,17 @@ impl AgentDriver {
         };
 
         // Prepare harness config files (onboarding, trust dialog, API-key approval, etc.).
-        let secrets = foreground
-            .spawn(|me, _| Arc::clone(&me.secrets))
+        // Pass the terminal env vars (which include the resolved secrets) so harnesses
+        // can look up auth keys without re-deriving precedence.
+        let resolved_env_vars = foreground
+            .spawn(|me, _| Arc::clone(&me.resolved_env_vars))
             .await
             .map_err(|_| AgentDriverError::InvalidRuntimeState)?;
-        harness.prepare_environment_config(&working_dir, system_prompt.as_deref(), &secrets)?;
+        harness.prepare_environment_config(
+            &working_dir,
+            system_prompt.as_deref(),
+            &resolved_env_vars,
+        )?;
         let resume = foreground
             .spawn(|me, _| me.resume_payload.take())
             .await
@@ -2308,6 +2323,9 @@ impl AgentDriver {
 }
 
 /// Build the env-var map for the agent terminal session from managed secrets.
+///
+/// Invariant: the server resolves at most one typed auth secret per harness, so
+/// env-var collisions between typed secrets cannot occur in practice.
 ///
 /// Precedence order:
 /// 1. Worker-injected process env (already non-empty in `std::env`). Never overridden.

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -535,78 +535,7 @@ impl AgentDriver {
                     _ => None,
                 });
 
-        // Build environment variables from secrets for the terminal session.
-        // Do not override env vars that are already set to a non-empty value in the current
-        // process. This ensures that worker-injected credentials (e.g. harness auth secrets)
-        // and user-provided env vars (e.g. on self-hosted workers) take precedence over
-        // generic managed secrets.
-        let mut env_vars = HashMap::with_capacity(secrets.len() + 1);
-        for (name, secret) in &secrets {
-            let (env_name, env_value) = match secret {
-                ManagedSecretValue::RawValue { value } => (name.as_str(), value.as_str()),
-                ManagedSecretValue::AnthropicApiKey { api_key } => {
-                    ("ANTHROPIC_API_KEY", api_key.as_str())
-                }
-                ManagedSecretValue::AnthropicBedrockAccessKey {
-                    aws_access_key_id,
-                    aws_secret_access_key,
-                    aws_session_token,
-                    aws_region,
-                } => {
-                    // Inject env vars needed for Claude Code Bedrock access key authentication.
-                    // AWS_SESSION_TOKEN is only injected when the user provided one (i.e. for
-                    // temporary/STS credentials).
-                    let mut vars = vec![
-                        ("AWS_ACCESS_KEY_ID", aws_access_key_id.as_str()),
-                        ("AWS_SECRET_ACCESS_KEY", aws_secret_access_key.as_str()),
-                        ("CLAUDE_CODE_USE_BEDROCK", "1"),
-                        ("AWS_REGION", aws_region.as_str()),
-                    ];
-                    if let Some(token) = aws_session_token.as_deref() {
-                        vars.push(("AWS_SESSION_TOKEN", token));
-                    }
-                    for (env_name, env_value) in vars {
-                        if std::env::var(env_name).is_ok_and(|v| !v.is_empty()) {
-                            log::warn!(
-                                "Skipping managed secret {env_name}: already set in environment"
-                            );
-                            continue;
-                        }
-                        env_vars.insert(OsString::from(env_name), OsString::from(env_value));
-                    }
-                    continue; // Skip the single-var insert below since we handled all vars inline.
-                }
-                ManagedSecretValue::AnthropicBedrockApiKey {
-                    aws_bearer_token_bedrock,
-                    aws_region,
-                } => {
-                    // Inject all three env vars needed for Claude Code Bedrock authentication.
-                    let vars = [
-                        (
-                            "AWS_BEARER_TOKEN_BEDROCK",
-                            aws_bearer_token_bedrock.as_str(),
-                        ),
-                        ("CLAUDE_CODE_USE_BEDROCK", "1"),
-                        ("AWS_REGION", aws_region.as_str()),
-                    ];
-                    for (env_name, env_value) in vars {
-                        if std::env::var(env_name).is_ok_and(|v| !v.is_empty()) {
-                            log::warn!(
-                                "Skipping managed secret {env_name}: already set in environment"
-                            );
-                            continue;
-                        }
-                        env_vars.insert(OsString::from(env_name), OsString::from(env_value));
-                    }
-                    continue; // Skip the single-var insert below since we handled all vars inline.
-                }
-            };
-            if std::env::var(env_name).is_ok_and(|v| !v.is_empty()) {
-                log::warn!("Skipping managed secret {env_name}: already set in environment");
-                continue;
-            }
-            env_vars.insert(OsString::from(env_name), OsString::from(env_value));
-        }
+        let mut env_vars = build_secret_env_vars(&secrets);
 
         // Inject cloud provider env vars.
         cloud_provider::collect_env_vars(&cloud_providers, &mut env_vars)?;
@@ -2374,6 +2303,118 @@ impl AgentDriver {
                 "Snapshot upload timed out after {:?}; continuing with cleanup (task {task_id})",
                 upload_timeout
             ));
+        }
+    }
+}
+
+/// Build the env-var map for the agent terminal session from managed secrets.
+///
+/// Precedence order:
+/// 1. Worker-injected process env (already non-empty in `std::env`). Never overridden.
+/// 2. Typed auth secrets (`AnthropicApiKey`, `AnthropicBedrock*`). Inserted atomically:
+///    if any one env var for a typed secret is already worker-injected, the entire
+///    secret is skipped.
+/// 3. Generic `RawValue` secrets. Skipped on collision with either of the above.
+fn build_secret_env_vars(
+    secrets: &HashMap<String, ManagedSecretValue>,
+) -> HashMap<OsString, OsString> {
+    let mut env_vars = HashMap::with_capacity(secrets.len() + 1);
+
+    // Phase 1: Record which env-var names are claimed by typed auth secrets.
+    let typed_env_names = typed_secret_env_names(secrets);
+
+    // Phase 2: Insert typed auth secrets atomically.
+    for (name, secret) in secrets {
+        let entries = typed_secret_entries(secret);
+        if entries.is_empty() {
+            continue;
+        }
+
+        if let Some((conflict, _)) = entries
+            .iter()
+            .find(|(env_name, _)| std::env::var(env_name).is_ok_and(|v| !v.is_empty()))
+        {
+            log::warn!(
+                "Skipping auth secret '{name}' ({:?}): '{conflict}' is already set \
+                 in the process environment",
+                secret.secret_type(),
+            );
+            continue;
+        }
+
+        for (env_name, env_value) in entries {
+            env_vars.insert(OsString::from(env_name), OsString::from(env_value));
+        }
+    }
+
+    // Phase 3: Insert generic RawValue secrets, skipping any that collide
+    // with worker-injected env vars or typed-secret-claimed names.
+    for (name, secret) in secrets {
+        let ManagedSecretValue::RawValue { value } = secret else {
+            continue;
+        };
+        let env_name = name.as_str();
+
+        if std::env::var(env_name).is_ok_and(|v| !v.is_empty()) {
+            log::warn!("Skipping managed secret {env_name}: already set in environment");
+            continue;
+        }
+        if typed_env_names.contains(env_name) {
+            log::warn!("Skipping generic secret '{env_name}': overridden by a typed auth secret");
+            continue;
+        }
+
+        env_vars.insert(OsString::from(env_name), OsString::from(value.as_str()));
+    }
+
+    env_vars
+}
+
+/// The env-var names that any typed auth secret in `secrets` will populate.
+/// Used for phase-3 collision detection and by the suffix resolver.
+fn typed_secret_env_names(secrets: &HashMap<String, ManagedSecretValue>) -> HashSet<&'static str> {
+    let mut names = HashSet::new();
+    for secret in secrets.values() {
+        for (env_name, _) in typed_secret_entries(secret) {
+            names.insert(env_name);
+        }
+    }
+    names
+}
+
+fn typed_secret_entries(secret: &ManagedSecretValue) -> Vec<(&'static str, &str)> {
+    match secret {
+        ManagedSecretValue::RawValue { .. } => vec![],
+        ManagedSecretValue::AnthropicApiKey { api_key } => {
+            vec![("ANTHROPIC_API_KEY", api_key.as_str())]
+        }
+        ManagedSecretValue::AnthropicBedrockApiKey {
+            aws_bearer_token_bedrock,
+            aws_region,
+        } => vec![
+            (
+                "AWS_BEARER_TOKEN_BEDROCK",
+                aws_bearer_token_bedrock.as_str(),
+            ),
+            ("CLAUDE_CODE_USE_BEDROCK", "1"),
+            ("AWS_REGION", aws_region.as_str()),
+        ],
+        ManagedSecretValue::AnthropicBedrockAccessKey {
+            aws_access_key_id,
+            aws_secret_access_key,
+            aws_session_token,
+            aws_region,
+        } => {
+            let mut entries = vec![
+                ("AWS_ACCESS_KEY_ID", aws_access_key_id.as_str()),
+                ("AWS_SECRET_ACCESS_KEY", aws_secret_access_key.as_str()),
+                ("CLAUDE_CODE_USE_BEDROCK", "1"),
+                ("AWS_REGION", aws_region.as_str()),
+            ];
+            if let Some(token) = aws_session_token.as_deref() {
+                entries.push(("AWS_SESSION_TOKEN", token));
+            }
+            entries
         }
     }
 }

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -657,21 +657,23 @@ struct ClaudeSettings {
 fn resolve_anthropic_api_key_suffix(
     secrets: &HashMap<String, ManagedSecretValue>,
 ) -> Option<String> {
-    // First, check for an AnthropicApiKey variant anywhere in the secrets map,
-    // since the secret name doesn't necessarily match the env var.
+    // 1. Worker-injected process env wins.
+    if let Ok(key) = std::env::var(ANTHROPIC_API_KEY_ENV) {
+        if !key.is_empty() {
+            return suffix_of(&key).map(str::to_owned);
+        }
+    }
+    // 2. Typed AnthropicApiKey secret. The secret name does not have to match the env var.
     for secret in secrets.values() {
         if let ManagedSecretValue::AnthropicApiKey { api_key } = secret {
             return suffix_of(api_key).map(str::to_owned);
         }
     }
-    // Then check for a RawValue stored under the env var name.
+    // 3. Generic RawValue secret stored under the env var name.
     if let Some(ManagedSecretValue::RawValue { value }) = secrets.get(ANTHROPIC_API_KEY_ENV) {
         return suffix_of(value).map(str::to_owned);
     }
-    // Fall back to the environment variable, which a user may have set separately in the env.
-    std::env::var(ANTHROPIC_API_KEY_ENV)
-        .ok()
-        .and_then(|k| suffix_of(&k).map(str::to_owned))
+    None
 }
 
 fn suffix_of(key: &str) -> Option<&str> {

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -30,7 +31,7 @@ use super::claude_transcript::{
 use super::json_utils::{read_json_file_or_default, write_json_file};
 use super::{
     cli_agent_session_status, write_temp_file, HarnessCleanupDisposition, HarnessRunner,
-    ManagedSecretValue, ResumePayload, SavePoint, ThirdPartyHarness,
+    ResumePayload, SavePoint, ThirdPartyHarness,
 };
 mod parent_bridge;
 mod wake_driver;
@@ -73,9 +74,9 @@ impl ThirdPartyHarness for ClaudeHarness {
         &self,
         working_dir: &Path,
         _system_prompt: Option<&str>,
-        secrets: &HashMap<String, ManagedSecretValue>,
+        resolved_env_vars: &HashMap<OsString, OsString>,
     ) -> Result<(), AgentDriverError> {
-        prepare_claude_environment_config(working_dir, secrets).map_err(|error| {
+        prepare_claude_environment_config(working_dir, resolved_env_vars).map_err(|error| {
             AgentDriverError::HarnessConfigSetupFailed {
                 harness: self.cli_agent().command_prefix().to_owned(),
                 error,
@@ -542,12 +543,12 @@ async fn upload_transcript(
 }
 fn prepare_claude_environment_config(
     working_dir: &Path,
-    secrets: &HashMap<String, ManagedSecretValue>,
+    resolved_env_vars: &HashMap<OsString, OsString>,
 ) -> Result<()> {
     let home_dir = claude_home_dir()?;
     let claude_json_path = home_dir.join(CLAUDE_JSON_FILE_NAME);
     let claude_settings_path = claude_config_dir()?.join(CLAUDE_SETTINGS_FILE_NAME);
-    let api_key_suffix = resolve_anthropic_api_key_suffix(secrets);
+    let api_key_suffix = resolve_anthropic_api_key_suffix(resolved_env_vars);
     prepare_claude_config(&claude_json_path, working_dir, api_key_suffix.as_deref())?;
     prepare_claude_settings(&claude_settings_path)?;
     Ok(())
@@ -651,29 +652,23 @@ struct ClaudeSettings {
     extra: Map<String, Value>,
 }
 
-/// Try to get the last 20 chars of the ANTHROPIC_API_KEY from the secrets map,
-/// where 20 chars is the suffix length that Claude Code truncates keys to.
-/// Falls back to the environment variable.
+/// Try to get the last 20 chars of the ANTHROPIC_API_KEY, where 20 chars is the
+/// suffix length that Claude Code truncates keys to.
 fn resolve_anthropic_api_key_suffix(
-    secrets: &HashMap<String, ManagedSecretValue>,
+    resolved_env_vars: &HashMap<OsString, OsString>,
 ) -> Option<String> {
-    // 1. Worker-injected process env wins.
+    // Worker-injected process env wins.
     if let Ok(key) = std::env::var(ANTHROPIC_API_KEY_ENV) {
         if !key.is_empty() {
             return suffix_of(&key).map(str::to_owned);
         }
     }
-    // 2. Typed AnthropicApiKey secret. The secret name does not have to match the env var.
-    for secret in secrets.values() {
-        if let ManagedSecretValue::AnthropicApiKey { api_key } = secret {
-            return suffix_of(api_key).map(str::to_owned);
-        }
-    }
-    // 3. Generic RawValue secret stored under the env var name.
-    if let Some(ManagedSecretValue::RawValue { value }) = secrets.get(ANTHROPIC_API_KEY_ENV) {
-        return suffix_of(value).map(str::to_owned);
-    }
-    None
+    // Otherwise use the resolved value from the secrets map.
+    resolved_env_vars
+        .get(OsStr::new(ANTHROPIC_API_KEY_ENV))
+        .and_then(|v| v.to_str())
+        .and_then(suffix_of)
+        .map(str::to_owned)
 }
 
 fn suffix_of(key: &str) -> Option<&str> {

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -582,7 +582,9 @@ fn prepare_claude_config_none_suffix_preserves_existing_responses() {
 }
 
 #[test]
+#[serial_test::serial]
 fn resolve_suffix_from_raw_value_secret() {
+    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
     let key = "sk-ant-api03-abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghij1234567890QLWn-dUnuwQ-hIhDiAAA";
     let secrets = HashMap::from([(
         "ANTHROPIC_API_KEY".to_string(),
@@ -593,7 +595,9 @@ fn resolve_suffix_from_raw_value_secret() {
 }
 
 #[test]
+#[serial_test::serial]
 fn resolve_suffix_from_anthropic_api_key_secret() {
+    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
     let key = "sk-ant-api03-abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghij1234567890QLWn-dUnuwQ-hIhDiAAA";
     let secrets = HashMap::from([(
         "ANTHROPIC_API_KEY".to_string(),
@@ -604,7 +608,9 @@ fn resolve_suffix_from_anthropic_api_key_secret() {
 }
 
 #[test]
+#[serial_test::serial]
 fn resolve_suffix_from_anthropic_api_key_with_different_secret_name() {
+    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
     let key = "sk-ant-api03-abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghij1234567890QLWn-dUnuwQ-hIhDiAAA";
     // Secret name doesn't match the env var, but the AnthropicApiKey variant
     // should still be found by iterating all secrets.
@@ -617,7 +623,9 @@ fn resolve_suffix_from_anthropic_api_key_with_different_secret_name() {
 }
 
 #[test]
+#[serial_test::serial]
 fn resolve_suffix_prefers_anthropic_api_key_variant_over_raw_value() {
+    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
     let anthropic_key = "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-anthropic-suffix";
     let raw_key = "sk-ant-api03-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB-raw-suffix";
     let secrets = HashMap::from([
@@ -631,12 +639,14 @@ fn resolve_suffix_prefers_anthropic_api_key_variant_over_raw_value() {
         ),
     ]);
     let suffix = resolve_anthropic_api_key_suffix(&secrets);
-    // AnthropicApiKey variant should be preferred.
+    // AnthropicApiKey variant should be preferred over RawValue.
     assert_eq!(suffix.as_deref(), Some("AAA-anthropic-suffix"));
 }
 
 #[test]
+#[serial_test::serial]
 fn resolve_suffix_returns_none_for_short_key() {
+    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
     let secrets = HashMap::from([(
         "ANTHROPIC_API_KEY".to_string(),
         ManagedSecretValue::raw_value("short"),
@@ -725,12 +735,70 @@ fn prepare_local_wake_command_rehydrates_transcript_with_self_managed_listener()
 }
 
 #[test]
+#[serial_test::serial]
 fn resolve_suffix_returns_none_for_short_anthropic_api_key() {
+    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
     let secrets = HashMap::from([(
         "ANTHROPIC_API_KEY".to_string(),
         ManagedSecretValue::anthropic_api_key("short"),
     )]);
     assert_eq!(resolve_anthropic_api_key_suffix(&secrets), None);
+}
+
+// ── Suffix resolver precedence tests ────────────────────────────────────
+
+#[test]
+#[serial_test::serial]
+fn suffix_uses_worker_injected_env_when_present() {
+    // Key must be >= 20 chars. Last 20: "WWWW-worker--suffix!"
+    let worker_key = "sk-ant-api03-WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW-worker-suffix!";
+    let typed_key = "sk-ant-api03-TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT-typed-suffix!";
+    std::env::set_var(ANTHROPIC_API_KEY_ENV, worker_key);
+    let secrets = HashMap::from([(
+        "my-auth".to_string(),
+        ManagedSecretValue::anthropic_api_key(typed_key),
+    )]);
+    let suffix = resolve_anthropic_api_key_suffix(&secrets);
+    let expected = &worker_key[worker_key.len() - 20..];
+    // Worker-injected process env wins over the typed secret.
+    assert_eq!(suffix.as_deref(), Some(expected));
+    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
+}
+
+#[test]
+#[serial_test::serial]
+fn suffix_uses_typed_secret_when_no_worker_env() {
+    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
+    let typed_key = "sk-ant-api03-TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT-typed-suffix!";
+    let raw_key = "sk-ant-api03-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR-rawvl-suffix!";
+    let secrets = HashMap::from([
+        (
+            "my-auth".to_string(),
+            ManagedSecretValue::anthropic_api_key(typed_key),
+        ),
+        (
+            "ANTHROPIC_API_KEY".to_string(),
+            ManagedSecretValue::raw_value(raw_key),
+        ),
+    ]);
+    let suffix = resolve_anthropic_api_key_suffix(&secrets);
+    let expected = &typed_key[typed_key.len() - 20..];
+    // Typed secret wins over RawValue when no worker env is present.
+    assert_eq!(suffix.as_deref(), Some(expected));
+}
+
+#[test]
+#[serial_test::serial]
+fn suffix_uses_raw_value_when_no_worker_env_or_typed() {
+    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
+    let raw_key = "sk-ant-api03-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR-rawvl-suffix!";
+    let secrets = HashMap::from([(
+        "ANTHROPIC_API_KEY".to_string(),
+        ManagedSecretValue::raw_value(raw_key),
+    )]);
+    let suffix = resolve_anthropic_api_key_suffix(&secrets);
+    let expected = &raw_key[raw_key.len() - 20..];
+    assert_eq!(suffix.as_deref(), Some(expected));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -583,75 +583,27 @@ fn prepare_claude_config_none_suffix_preserves_existing_responses() {
 
 #[test]
 #[serial_test::serial]
-fn resolve_suffix_from_raw_value_secret() {
+fn resolve_suffix_from_resolved_env_vars() {
     std::env::remove_var(ANTHROPIC_API_KEY_ENV);
     let key = "sk-ant-api03-abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghij1234567890QLWn-dUnuwQ-hIhDiAAA";
-    let secrets = HashMap::from([(
-        "ANTHROPIC_API_KEY".to_string(),
-        ManagedSecretValue::raw_value(key),
-    )]);
-    let suffix = resolve_anthropic_api_key_suffix(&secrets);
+    let resolved = HashMap::from([(OsString::from("ANTHROPIC_API_KEY"), OsString::from(key))]);
+    let suffix = resolve_anthropic_api_key_suffix(&resolved);
     assert_eq!(suffix.as_deref(), Some("QLWn-dUnuwQ-hIhDiAAA"));
-}
-
-#[test]
-#[serial_test::serial]
-fn resolve_suffix_from_anthropic_api_key_secret() {
-    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
-    let key = "sk-ant-api03-abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghij1234567890QLWn-dUnuwQ-hIhDiAAA";
-    let secrets = HashMap::from([(
-        "ANTHROPIC_API_KEY".to_string(),
-        ManagedSecretValue::anthropic_api_key(key),
-    )]);
-    let suffix = resolve_anthropic_api_key_suffix(&secrets);
-    assert_eq!(suffix.as_deref(), Some("QLWn-dUnuwQ-hIhDiAAA"));
-}
-
-#[test]
-#[serial_test::serial]
-fn resolve_suffix_from_anthropic_api_key_with_different_secret_name() {
-    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
-    let key = "sk-ant-api03-abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghij1234567890QLWn-dUnuwQ-hIhDiAAA";
-    // Secret name doesn't match the env var, but the AnthropicApiKey variant
-    // should still be found by iterating all secrets.
-    let secrets = HashMap::from([(
-        "my-anthropic-key".to_string(),
-        ManagedSecretValue::anthropic_api_key(key),
-    )]);
-    let suffix = resolve_anthropic_api_key_suffix(&secrets);
-    assert_eq!(suffix.as_deref(), Some("QLWn-dUnuwQ-hIhDiAAA"));
-}
-
-#[test]
-#[serial_test::serial]
-fn resolve_suffix_prefers_anthropic_api_key_variant_over_raw_value() {
-    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
-    let anthropic_key = "sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-anthropic-suffix";
-    let raw_key = "sk-ant-api03-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB-raw-suffix";
-    let secrets = HashMap::from([
-        (
-            "my-anthropic-key".to_string(),
-            ManagedSecretValue::anthropic_api_key(anthropic_key),
-        ),
-        (
-            "ANTHROPIC_API_KEY".to_string(),
-            ManagedSecretValue::raw_value(raw_key),
-        ),
-    ]);
-    let suffix = resolve_anthropic_api_key_suffix(&secrets);
-    // AnthropicApiKey variant should be preferred over RawValue.
-    assert_eq!(suffix.as_deref(), Some("AAA-anthropic-suffix"));
 }
 
 #[test]
 #[serial_test::serial]
 fn resolve_suffix_returns_none_for_short_key() {
     std::env::remove_var(ANTHROPIC_API_KEY_ENV);
-    let secrets = HashMap::from([(
-        "ANTHROPIC_API_KEY".to_string(),
-        ManagedSecretValue::raw_value("short"),
-    )]);
-    assert_eq!(resolve_anthropic_api_key_suffix(&secrets), None);
+    let resolved = HashMap::from([(OsString::from("ANTHROPIC_API_KEY"), OsString::from("short"))]);
+    assert_eq!(resolve_anthropic_api_key_suffix(&resolved), None);
+}
+
+#[test]
+#[serial_test::serial]
+fn resolve_suffix_returns_none_when_empty() {
+    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
+    assert_eq!(resolve_anthropic_api_key_suffix(&HashMap::new()), None);
 }
 
 #[test]
@@ -736,69 +688,20 @@ fn prepare_local_wake_command_rehydrates_transcript_with_self_managed_listener()
 
 #[test]
 #[serial_test::serial]
-fn resolve_suffix_returns_none_for_short_anthropic_api_key() {
-    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
-    let secrets = HashMap::from([(
-        "ANTHROPIC_API_KEY".to_string(),
-        ManagedSecretValue::anthropic_api_key("short"),
-    )]);
-    assert_eq!(resolve_anthropic_api_key_suffix(&secrets), None);
-}
-
-// ── Suffix resolver precedence tests ────────────────────────────────────
-
-#[test]
-#[serial_test::serial]
 fn suffix_uses_worker_injected_env_when_present() {
-    // Key must be >= 20 chars. Last 20: "WWWW-worker--suffix!"
     let worker_key = "sk-ant-api03-WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW-worker-suffix!";
-    let typed_key = "sk-ant-api03-TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT-typed-suffix!";
     std::env::set_var(ANTHROPIC_API_KEY_ENV, worker_key);
-    let secrets = HashMap::from([(
-        "my-auth".to_string(),
-        ManagedSecretValue::anthropic_api_key(typed_key),
+    // Even when the resolved map has a different value, the worker env wins.
+    let resolved = HashMap::from([(
+        OsString::from("ANTHROPIC_API_KEY"),
+        OsString::from(
+            "sk-ant-api03-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR-resolved-val!",
+        ),
     )]);
-    let suffix = resolve_anthropic_api_key_suffix(&secrets);
+    let suffix = resolve_anthropic_api_key_suffix(&resolved);
     let expected = &worker_key[worker_key.len() - 20..];
-    // Worker-injected process env wins over the typed secret.
     assert_eq!(suffix.as_deref(), Some(expected));
     std::env::remove_var(ANTHROPIC_API_KEY_ENV);
-}
-
-#[test]
-#[serial_test::serial]
-fn suffix_uses_typed_secret_when_no_worker_env() {
-    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
-    let typed_key = "sk-ant-api03-TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT-typed-suffix!";
-    let raw_key = "sk-ant-api03-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR-rawvl-suffix!";
-    let secrets = HashMap::from([
-        (
-            "my-auth".to_string(),
-            ManagedSecretValue::anthropic_api_key(typed_key),
-        ),
-        (
-            "ANTHROPIC_API_KEY".to_string(),
-            ManagedSecretValue::raw_value(raw_key),
-        ),
-    ]);
-    let suffix = resolve_anthropic_api_key_suffix(&secrets);
-    let expected = &typed_key[typed_key.len() - 20..];
-    // Typed secret wins over RawValue when no worker env is present.
-    assert_eq!(suffix.as_deref(), Some(expected));
-}
-
-#[test]
-#[serial_test::serial]
-fn suffix_uses_raw_value_when_no_worker_env_or_typed() {
-    std::env::remove_var(ANTHROPIC_API_KEY_ENV);
-    let raw_key = "sk-ant-api03-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR-rawvl-suffix!";
-    let secrets = HashMap::from([(
-        "ANTHROPIC_API_KEY".to_string(),
-        ManagedSecretValue::raw_value(raw_key),
-    )]);
-    let suffix = resolve_anthropic_api_key_suffix(&secrets);
-    let expected = &raw_key[raw_key.len() - 20..];
-    assert_eq!(suffix.as_deref(), Some(expected));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
@@ -11,7 +12,6 @@ use serde_json::{Map, Value};
 use tempfile::NamedTempFile;
 use uuid::Uuid;
 use warp_cli::agent::Harness;
-use warp_managed_secrets::ManagedSecretValue;
 use warpui::{ModelHandle, ModelSpawner, SingletonEntity};
 
 use crate::ai::agent::conversation::AIConversationId;
@@ -58,14 +58,14 @@ impl ThirdPartyHarness for CodexHarness {
         &self,
         working_dir: &Path,
         system_prompt: Option<&str>,
-        secrets: &HashMap<String, ManagedSecretValue>,
+        resolved_env_vars: &HashMap<OsString, OsString>,
     ) -> Result<(), AgentDriverError> {
-        prepare_codex_environment_config(working_dir, system_prompt, secrets).map_err(|error| {
-            AgentDriverError::HarnessConfigSetupFailed {
+        prepare_codex_environment_config(working_dir, system_prompt, resolved_env_vars).map_err(
+            |error| AgentDriverError::HarnessConfigSetupFailed {
                 harness: self.cli_agent().command_prefix().to_owned(),
                 error,
-            }
-        })
+            },
+        )
     }
 
     /// Fetch the codex transcript for the current task's conversation and wrap it into a
@@ -439,7 +439,7 @@ const CODEX_OPENAI_BASE_URL: &str = "https://us.api.openai.com/v1";
 fn prepare_codex_environment_config(
     working_dir: &Path,
     system_prompt: Option<&str>,
-    secrets: &HashMap<String, ManagedSecretValue>,
+    resolved_env_vars: &HashMap<OsString, OsString>,
 ) -> Result<()> {
     let home_dir =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?;
@@ -449,7 +449,7 @@ fn prepare_codex_environment_config(
         write_codex_agents_override(&codex_dir, prompt)?;
     }
 
-    match resolve_openai_api_key(secrets) {
+    match resolve_openai_api_key(resolved_env_vars) {
         Some(api_key) => prepare_codex_auth(&codex_dir.join(CODEX_AUTH_FILE_NAME), &api_key)?,
         None => log::info!("No OPENAI_API_KEY available; skipping Codex auth.json seed"),
     }
@@ -535,24 +535,25 @@ fn write_codex_auth_json(path: &Path, auth: &CodexAuthDotJson) -> Result<()> {
     Ok(())
 }
 
-/// Returns the OpenAI API key for Codex auth, preferring the `OPENAI_API_KEY` env
-/// var so the seeded `auth.json` matches the credential the launched Codex process
-/// will see. [`AgentDriver::new`] skips a managed `OPENAI_API_KEY` secret when the
-/// env var is already set, so we mirror that precedence here.
-fn resolve_openai_api_key(secrets: &HashMap<String, ManagedSecretValue>) -> Option<String> {
+/// Returns the OpenAI API key for Codex auth.
+///
+/// Checks the worker-injected process env first (not in the resolved map since
+/// `build_secret_env_vars` skips env vars already present in the process env),
+/// then falls back to the resolved secret env vars map.
+fn resolve_openai_api_key(resolved_env_vars: &HashMap<OsString, OsString>) -> Option<String> {
+    // Worker-injected process env wins.
     if let Ok(value) = std::env::var(OPENAI_API_KEY_ENV) {
         let trimmed = value.trim();
         if !trimmed.is_empty() {
             return Some(trimmed.to_owned());
         }
     }
-    if let Some(ManagedSecretValue::RawValue { value }) = secrets.get(OPENAI_API_KEY_ENV) {
-        let trimmed = value.trim();
-        if !trimmed.is_empty() {
-            return Some(trimmed.to_owned());
-        }
-    }
-    None
+    // Otherwise use the resolved value from the secrets map.
+    resolved_env_vars
+        .get(OsStr::new(OPENAI_API_KEY_ENV))
+        .and_then(|v| v.to_str())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
 }
 
 /// Edit `~/.codex/config.toml` via `toml_edit` to seed the harness defaults

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::fs;
 use std::sync::Arc;
 
@@ -85,13 +86,13 @@ fn prepare_codex_auth_writes_with_0600_perms() {
 }
 
 #[test]
-fn resolve_openai_api_key_returns_value_from_raw_value_secret() {
-    let secrets = HashMap::from([(
-        "OPENAI_API_KEY".to_string(),
-        ManagedSecretValue::raw_value("sk-from-secret"),
+fn resolve_openai_api_key_returns_value_from_resolved_map() {
+    let resolved = HashMap::from([(
+        OsString::from("OPENAI_API_KEY"),
+        OsString::from("sk-from-secret"),
     )]);
     assert_eq!(
-        resolve_openai_api_key(&secrets).as_deref(),
+        resolve_openai_api_key(&resolved).as_deref(),
         Some("sk-from-secret")
     );
 }
@@ -113,7 +114,7 @@ fn resolve_openai_api_key_falls_back_to_env_var() {
 
 #[test]
 #[serial_test::serial]
-fn resolve_openai_api_key_returns_none_when_secrets_and_env_empty() {
+fn resolve_openai_api_key_returns_none_when_map_and_env_empty() {
     let prev = std::env::var(OPENAI_API_KEY_ENV).ok();
     std::env::remove_var(OPENAI_API_KEY_ENV);
 
@@ -127,17 +128,17 @@ fn resolve_openai_api_key_returns_none_when_secrets_and_env_empty() {
 
 #[test]
 #[serial_test::serial]
-fn resolve_openai_api_key_prefers_env_over_secret() {
-    // Mirrors `AgentDriver::new`'s precedence: an existing `OPENAI_API_KEY` env var
-    // wins over a managed secret so `auth.json` matches the launched process's env.
+fn resolve_openai_api_key_prefers_env_over_resolved_map() {
+    // Worker-injected env var wins over the resolved secret map because
+    // build_secret_env_vars skips secrets that collide with process env.
     let prev = std::env::var(OPENAI_API_KEY_ENV).ok();
     std::env::set_var(OPENAI_API_KEY_ENV, "sk-from-env");
-    let secrets = HashMap::from([(
-        "OPENAI_API_KEY".to_string(),
-        ManagedSecretValue::raw_value("sk-from-secret"),
+    let resolved = HashMap::from([(
+        OsString::from("OPENAI_API_KEY"),
+        OsString::from("sk-from-secret"),
     )]);
 
-    let result = resolve_openai_api_key(&secrets);
+    let result = resolve_openai_api_key(&resolved);
 
     match prev {
         Some(v) => std::env::set_var(OPENAI_API_KEY_ENV, v),
@@ -148,15 +149,15 @@ fn resolve_openai_api_key_prefers_env_over_secret() {
 
 #[test]
 #[serial_test::serial]
-fn resolve_openai_api_key_uses_secret_when_env_empty() {
+fn resolve_openai_api_key_uses_resolved_map_when_env_empty() {
     let prev = std::env::var(OPENAI_API_KEY_ENV).ok();
     std::env::set_var(OPENAI_API_KEY_ENV, "   ");
-    let secrets = HashMap::from([(
-        "OPENAI_API_KEY".to_string(),
-        ManagedSecretValue::raw_value("sk-from-secret"),
+    let resolved = HashMap::from([(
+        OsString::from("OPENAI_API_KEY"),
+        OsString::from("sk-from-secret"),
     )]);
 
-    let result = resolve_openai_api_key(&secrets);
+    let result = resolve_openai_api_key(&resolved);
 
     match prev {
         Some(v) => std::env::set_var(OPENAI_API_KEY_ENV, v),

--- a/app/src/ai/agent_sdk/driver/harness/gemini.rs
+++ b/app/src/ai/agent_sdk/driver/harness/gemini.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -9,7 +10,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use tempfile::NamedTempFile;
 use warp_cli::agent::Harness;
-use warp_managed_secrets::ManagedSecretValue;
 use warpui::{ModelHandle, ModelSpawner};
 
 use crate::ai::agent::conversation::AIConversationId;
@@ -53,7 +53,7 @@ impl ThirdPartyHarness for GeminiHarness {
         &self,
         working_dir: &Path,
         system_prompt: Option<&str>,
-        _secrets: &HashMap<String, ManagedSecretValue>,
+        _resolved_env_vars: &HashMap<OsString, OsString>,
     ) -> Result<(), AgentDriverError> {
         prepare_gemini_environment_config(working_dir, system_prompt).map_err(|error| {
             AgentDriverError::HarnessConfigSetupFailed {

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -10,7 +10,6 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use tempfile::NamedTempFile;
 use warp_cli::agent::Harness;
-use warp_managed_secrets::ManagedSecretValue;
 use warpui::{ModelHandle, ModelSpawner, SingletonEntity};
 
 use crate::ai::agent::conversation::AIConversationId;
@@ -138,11 +137,16 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
     }
 
     /// Prepare CLI-specific config files before launching the harness command.
+    ///
+    /// `resolved_env_vars` contains the already-resolved secret env vars produced by
+    /// `build_secret_env_vars`. Precedence (worker env > typed secrets > raw values)
+    /// has already been applied, so harnesses can look up values directly without
+    /// re-deriving which secret won.
     fn prepare_environment_config(
         &self,
         _working_dir: &Path,
         _system_prompt: Option<&str>,
-        _secrets: &HashMap<String, ManagedSecretValue>,
+        _resolved_env_vars: &HashMap<OsString, OsString>,
     ) -> Result<(), AgentDriverError> {
         Ok(())
     }

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -1,4 +1,9 @@
-use std::{ffi::OsString, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    ffi::OsString,
+    sync::Arc,
+    time::Duration,
+};
 
 use futures::channel::oneshot;
 use warp_cli::agent::Harness;
@@ -9,7 +14,7 @@ use warp_cli::{
 use warp_core::channel::ChannelState;
 
 use super::{
-    IdleTimeoutSender, LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV,
+    build_secret_env_vars, IdleTimeoutSender, LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV,
     LEGACY_OZ_PARENT_STATE_ROOT_ENV, OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV,
     OZ_MESSAGE_LISTENER_STATE_ROOT_ENV,
 };
@@ -19,6 +24,7 @@ use crate::ai::agent::{
 };
 use crate::ai::mcp::parsing::normalize_mcp_json;
 use crate::ai::{agent_sdk::task_env_vars, ambient_agents::AmbientAgentTaskId};
+use warp_managed_secrets::ManagedSecretValue;
 
 #[test]
 fn test_normalize_single_cli_server() {
@@ -385,4 +391,188 @@ fn json_format_input_omits_filepath_and_description_for_proto_upload_result() {
     assert_eq!(value["size_bytes"], 42);
     assert!(value.get("filepath").is_none());
     assert!(value.get("description").is_none());
+}
+
+// ── build_secret_env_vars tests ──────────────────────────────────────────────
+
+#[test]
+#[serial_test::serial]
+fn raw_value_only_writes_under_secret_name() {
+    std::env::remove_var("MY_SECRET");
+    let secrets = HashMap::from([(
+        "MY_SECRET".to_string(),
+        ManagedSecretValue::raw_value("s3cret"),
+    )]);
+    let env_vars = build_secret_env_vars(&secrets);
+    assert_eq!(
+        env_vars.get(&OsString::from("MY_SECRET")),
+        Some(&OsString::from("s3cret"))
+    );
+    assert_eq!(env_vars.len(), 1);
+}
+
+#[test]
+#[serial_test::serial]
+fn anthropic_api_key_writes_anthropic_env_var() {
+    std::env::remove_var("ANTHROPIC_API_KEY");
+    let secrets = HashMap::from([(
+        "my-custom-name".to_string(),
+        ManagedSecretValue::anthropic_api_key("sk-ant-test-key"),
+    )]);
+    let env_vars = build_secret_env_vars(&secrets);
+    assert_eq!(
+        env_vars.get(&OsString::from("ANTHROPIC_API_KEY")),
+        Some(&OsString::from("sk-ant-test-key"))
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn typed_secret_overrides_raw_value_with_same_env_name() {
+    std::env::remove_var("ANTHROPIC_API_KEY");
+    let typed_key = "sk-ant-typed-key-abcdef";
+    let raw_key = "sk-ant-raw-key-ghijkl";
+    let secrets = HashMap::from([
+        (
+            "my-auth".to_string(),
+            ManagedSecretValue::anthropic_api_key(typed_key),
+        ),
+        (
+            "ANTHROPIC_API_KEY".to_string(),
+            ManagedSecretValue::raw_value(raw_key),
+        ),
+    ]);
+    // Run multiple times to defeat HashMap iteration order flakiness.
+    for _ in 0..20 {
+        let env_vars = build_secret_env_vars(&secrets);
+        assert_eq!(
+            env_vars.get(&OsString::from("ANTHROPIC_API_KEY")),
+            Some(&OsString::from(typed_key)),
+            "Typed secret must always override RawValue with the same env name"
+        );
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn bedrock_api_key_writes_all_bedrock_env_vars() {
+    std::env::remove_var("AWS_BEARER_TOKEN_BEDROCK");
+    std::env::remove_var("CLAUDE_CODE_USE_BEDROCK");
+    std::env::remove_var("AWS_REGION");
+    let secrets = HashMap::from([
+        (
+            "bedrock-secret".to_string(),
+            ManagedSecretValue::anthropic_bedrock_api_key("token-123", "us-west-2"),
+        ),
+        (
+            "AWS_REGION".to_string(),
+            ManagedSecretValue::raw_value("eu-west-1"),
+        ),
+    ]);
+    let env_vars = build_secret_env_vars(&secrets);
+    assert_eq!(
+        env_vars.get(&OsString::from("AWS_BEARER_TOKEN_BEDROCK")),
+        Some(&OsString::from("token-123"))
+    );
+    assert_eq!(
+        env_vars.get(&OsString::from("CLAUDE_CODE_USE_BEDROCK")),
+        Some(&OsString::from("1"))
+    );
+    assert_eq!(
+        env_vars.get(&OsString::from("AWS_REGION")),
+        Some(&OsString::from("us-west-2")),
+        "Typed Bedrock secret should win over RawValue for AWS_REGION"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn bedrock_access_key_writes_all_aws_env_vars() {
+    std::env::remove_var("AWS_ACCESS_KEY_ID");
+    std::env::remove_var("AWS_SECRET_ACCESS_KEY");
+    std::env::remove_var("AWS_SESSION_TOKEN");
+    std::env::remove_var("CLAUDE_CODE_USE_BEDROCK");
+    std::env::remove_var("AWS_REGION");
+    let secrets = HashMap::from([(
+        "bedrock-access".to_string(),
+        ManagedSecretValue::anthropic_bedrock_access_key(
+            "AKID",
+            "secret-key",
+            Some("session-tok".to_string()),
+            "ap-southeast-1",
+        ),
+    )]);
+    let env_vars = build_secret_env_vars(&secrets);
+    assert_eq!(
+        env_vars.get(&OsString::from("AWS_ACCESS_KEY_ID")),
+        Some(&OsString::from("AKID"))
+    );
+    assert_eq!(
+        env_vars.get(&OsString::from("AWS_SECRET_ACCESS_KEY")),
+        Some(&OsString::from("secret-key"))
+    );
+    assert_eq!(
+        env_vars.get(&OsString::from("AWS_SESSION_TOKEN")),
+        Some(&OsString::from("session-tok"))
+    );
+    assert_eq!(
+        env_vars.get(&OsString::from("CLAUDE_CODE_USE_BEDROCK")),
+        Some(&OsString::from("1"))
+    );
+    assert_eq!(
+        env_vars.get(&OsString::from("AWS_REGION")),
+        Some(&OsString::from("ap-southeast-1"))
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn raw_value_skipped_when_process_env_already_set() {
+    std::env::set_var("WORKER_TOKEN", "injected-value");
+    let secrets = HashMap::from([(
+        "WORKER_TOKEN".to_string(),
+        ManagedSecretValue::raw_value("managed-value"),
+    )]);
+    let env_vars = build_secret_env_vars(&secrets);
+    // The worker-injected env var wins; env_vars should NOT contain it
+    // because the child inherits the process env directly.
+    assert!(!env_vars.contains_key(&OsString::from("WORKER_TOKEN")));
+    std::env::remove_var("WORKER_TOKEN");
+}
+
+#[test]
+#[serial_test::serial]
+fn worker_injected_env_wins_over_typed_secret() {
+    std::env::set_var("ANTHROPIC_API_KEY", "worker-key");
+    let secrets = HashMap::from([(
+        "my-auth".to_string(),
+        ManagedSecretValue::anthropic_api_key("managed-key"),
+    )]);
+    let env_vars = build_secret_env_vars(&secrets);
+    // The typed secret should be skipped entirely; the child inherits
+    // ANTHROPIC_API_KEY from the process env.
+    assert!(!env_vars.contains_key(&OsString::from("ANTHROPIC_API_KEY")));
+    std::env::remove_var("ANTHROPIC_API_KEY");
+}
+
+#[test]
+#[serial_test::serial]
+fn worker_injected_env_skips_entire_bedrock_secret() {
+    // Only AWS_REGION is worker-injected; the entire Bedrock secret should
+    // be atomically skipped — no partial insertion.
+    std::env::set_var("AWS_REGION", "us-east-1");
+    std::env::remove_var("AWS_BEARER_TOKEN_BEDROCK");
+    std::env::remove_var("CLAUDE_CODE_USE_BEDROCK");
+    let secrets = HashMap::from([(
+        "bedrock-secret".to_string(),
+        ManagedSecretValue::anthropic_bedrock_api_key("token-456", "eu-central-1"),
+    )]);
+    let env_vars = build_secret_env_vars(&secrets);
+    assert!(
+        !env_vars.contains_key(&OsString::from("AWS_BEARER_TOKEN_BEDROCK")),
+        "Entire Bedrock secret must be skipped when any field is worker-injected"
+    );
+    assert!(!env_vars.contains_key(&OsString::from("CLAUDE_CODE_USE_BEDROCK")));
+    assert!(!env_vars.contains_key(&OsString::from("AWS_REGION")));
+    std::env::remove_var("AWS_REGION");
 }

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    ffi::OsString,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, ffi::OsString, sync::Arc, time::Duration};
 
 use futures::channel::oneshot;
 use warp_cli::agent::Harness;

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -1,10 +1,5 @@
 use std::{collections::HashMap, ffi::OsString, path::PathBuf, sync::Arc};
 
-use shell_words::quote as shell_quote;
-use uuid::Uuid;
-use warp_cli::agent::Harness;
-use warp_managed_secrets::ManagedSecretValue;
-
 use crate::ai::{
     agent_sdk::{
         driver::{
@@ -18,6 +13,9 @@ use crate::ai::{
 use crate::server::server_api::ai::AIClient;
 use crate::terminal::cli_agent_sessions::plugin_manager::plugin_manager_for;
 use crate::terminal::shell::ShellType;
+use shell_words::quote as shell_quote;
+use uuid::Uuid;
+use warp_cli::agent::Harness;
 
 #[derive(Clone)]
 pub(super) struct PreparedLocalHarnessLaunch {
@@ -117,9 +115,9 @@ pub(super) async fn prepare_local_harness_child_launch(
             // auth/session state. We still prepare harness config files here,
             // but there are no Warp-managed secrets to materialize into the
             // hidden child pane.
-            let managed_secrets: HashMap<String, ManagedSecretValue> = HashMap::new();
+            let resolved_env_vars: HashMap<OsString, OsString> = HashMap::new();
             third_party_harness
-                .prepare_environment_config(&working_dir, None, &managed_secrets)
+                .prepare_environment_config(&working_dir, None, &resolved_env_vars)
                 .map_err(|error: AgentDriverError| error.to_string())?;
             if let Some(manager) = plugin_manager_for(third_party_harness.cli_agent()) {
                 if let Err(error) = manager.install().await {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Fixes an issue where secrets could collide if specified both as an auth secret and a generic secret. As part of that, we now enforce the following precedence order:

1. Worker-injected env vars
2. Any typed secrets (currently these are all auth secrets)
3. Any generic secrets

We insert typed secrets atomically. If any env var that is part of the auth secret is present in the environment, we skip setting any part of that secret.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?
-->

Tested locally that (2) takes precedence over (3).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

