### PR TITLE
Add acarl005 as bootstrap script stakeholder

### DIFF
--- a/.github/STAKEHOLDERS
+++ b/.github/STAKEHOLDERS
@@ -113,6 +113,12 @@
 /app/assets/bundled/bootstrap/ @zachbai
 /crates/warp_completer/ @zachbai @szgupta @alokedesai
 
+# Repository bootstrap scripts
+/script/bootstrap @acarl005
+/script/linux/bootstrap @acarl005
+/script/macos/bootstrap @acarl005
+/script/windows/bootstrap.ps1 @acarl005
+
 # Agent mode
 /app/src/ai/agent/ @zachbai
 


### PR DESCRIPTION
## Description
Adds @acarl005 as the stakeholder owner for the repository bootstrap scripts in `.github/STAKEHOLDERS`.

## Linked Issue
N/A. Slack request.

## Screenshots / Videos
N/A. Metadata-only change.

## Testing
Validated that each listed bootstrap script path exists and has a matching stakeholder entry in `.github/STAKEHOLDERS`. No automated tests added because this only updates triage metadata.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._