### PR TITLE
feat: Enable BYOK for all users without workspace policy check

### DIFF
--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -6374,17 +6374,6 @@ impl ApiKeysWidget {
                             AISettings::handle(ctx).as_ref(ctx).is_any_ai_enabled(ctx);
                         let is_byo_enabled = workspace.as_ref(ctx).is_byo_api_key_enabled();
                         let is_enabled = is_any_ai_enabled && is_byo_enabled;
-                        let has_key = !editor_clone.as_ref(ctx).is_empty(ctx);
-
-                        // If BYO is disabled, clear the API key from the editor and storage
-                        if !is_byo_enabled && has_key {
-                            editor_clone.update(ctx, |editor, ctx| {
-                                editor.set_buffer_text("", ctx);
-                            });
-                            ApiKeyManager::handle(ctx).update(ctx, |model, ctx| {
-                                model.$set_func(None, ctx);
-                            });
-                        }
 
                         AISettingsPageView::update_editor_interaction_state(
                             editor_clone.clone(),

--- a/app/src/workspaces/workspace.rs
+++ b/app/src/workspaces/workspace.rs
@@ -131,7 +131,8 @@ impl Workspace {
     }
 
     pub fn is_byo_api_key_enabled(&self) -> bool {
-        self.billing_metadata.is_byo_api_key_enabled()
+        // BYOK is now enabled for all users
+        true
     }
 
     /// Returns true if the workspace has reached or exceeded its monthly addon credits spend limit.
@@ -574,9 +575,8 @@ impl BillingMetadata {
     }
 
     pub fn is_byo_api_key_enabled(&self) -> bool {
-        self.tier
-            .byo_api_key_policy
-            .is_some_and(|policy| policy.enabled)
+        // BYOK is now enabled for all users
+        true
     }
 
     pub fn has_overages_used(&self) -> bool {


### PR DESCRIPTION
## Description
This PR makes BYOK available to free/open-source users without requiring a Pro plan.

The change removes the entitlement gate for configuring and using personal API keys, while keeping paid-plan value in hosted/cloud features, premium models, and other non-self-hosted capabilities. This aligns the open-source build with the expectation that users can run Warp with their own provider keys.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below, especially for user-visible or UI changes.

Issue: #9288

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode