### PR TITLE
Enrich SSH control master with remote server enablement

### DIFF
--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -1371,7 +1371,9 @@ pub enum TelemetryEvent {
     /// We attempted to bootstrap an SSH session via the SSH wrapper.  The
     /// argument is the name of the remote shell.
     SSHBootstrapAttempt(String),
-    SSHControlMasterError,
+    SSHControlMasterError {
+        has_remote_server: bool,
+    },
     KeybindingChanged {
         action: String,
         keystroke: Keystroke,
@@ -4128,7 +4130,6 @@ impl TelemetryEvent {
             | TelemetryEvent::SettingsImportResetButtonClicked
             | TelemetryEvent::ITermMultipleHotkeys
             | TelemetryEvent::DriveSharingOnboardingBlockShown
-            | TelemetryEvent::SSHControlMasterError
             | TelemetryEvent::SettingsImportInitiated
             | TelemetryEvent::GrepToolSucceeded
             | TelemetryEvent::FileGlobToolSucceeded
@@ -4141,6 +4142,11 @@ impl TelemetryEvent {
             | TelemetryEvent::GlobalSearchOpened
             | TelemetryEvent::GlobalSearchQueryStarted
             | TelemetryEvent::GetStartedSkipToTerminal => None,
+            TelemetryEvent::SSHControlMasterError {
+                has_remote_server,
+            } => Some(json!({
+                "has_remote_server": has_remote_server,
+            })),
             TelemetryEvent::RemoteServerBinaryCheck {
                 found,
                 error,
@@ -4659,7 +4665,7 @@ impl TelemetryEvent {
             | TelemetryEvent::LoggedOutStartup
             | TelemetryEvent::DownloadSource(_)
             | TelemetryEvent::SSHBootstrapAttempt(_)
-            | TelemetryEvent::SSHControlMasterError
+            | TelemetryEvent::SSHControlMasterError { .. }
             | TelemetryEvent::KeybindingChanged { .. }
             | TelemetryEvent::KeybindingResetToDefault { .. }
             | TelemetryEvent::KeybindingRemoved { .. }

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -4142,9 +4142,7 @@ impl TelemetryEvent {
             | TelemetryEvent::GlobalSearchOpened
             | TelemetryEvent::GlobalSearchQueryStarted
             | TelemetryEvent::GetStartedSkipToTerminal => None,
-            TelemetryEvent::SSHControlMasterError {
-                has_remote_server,
-            } => Some(json!({
+            TelemetryEvent::SSHControlMasterError { has_remote_server } => Some(json!({
                 "has_remote_server": has_remote_server,
             })),
             TelemetryEvent::RemoteServerBinaryCheck {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8102,15 +8102,18 @@ impl TerminalView {
             ctx.notify();
 
             let has_remote_server = active_session_id.is_some_and(|session_id| {
-                self.sessions.as_ref(ctx).get(session_id).is_some_and(|session| {
-                    matches!(
-                        session.session_type(),
-                        SessionType::WarpifiedRemote {
-                            host_id: Some(_),
-                            ..
-                        }
-                    )
-                })
+                self.sessions
+                    .as_ref(ctx)
+                    .get(session_id)
+                    .is_some_and(|session| {
+                        matches!(
+                            session.session_type(),
+                            SessionType::WarpifiedRemote {
+                                host_id: Some(_),
+                                ..
+                            }
+                        )
+                    })
             });
             send_telemetry_from_ctx!(
                 TelemetryEvent::SSHControlMasterError { has_remote_server },

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8101,7 +8101,21 @@ impl TerminalView {
 
             ctx.notify();
 
-            send_telemetry_from_ctx!(TelemetryEvent::SSHControlMasterError, ctx);
+            let has_remote_server = active_session_id.is_some_and(|session_id| {
+                self.sessions.as_ref(ctx).get(session_id).is_some_and(|session| {
+                    matches!(
+                        session.session_type(),
+                        SessionType::WarpifiedRemote {
+                            host_id: Some(_),
+                            ..
+                        }
+                    )
+                })
+            });
+            send_telemetry_from_ctx!(
+                TelemetryEvent::SSHControlMasterError { has_remote_server },
+                ctx
+            );
         }
     }
 


### PR DESCRIPTION
## Description
Fixes APP-4385

We already have the SSH warpification open failed event. This enrich it so we could track whether user has the remote server enabled when running into this error
