### PR TITLE
update MCP update/install modal primary button with correct text color

### DIFF
--- a/app/src/settings_view/mcp_servers/installation_modal.rs
+++ b/app/src/settings_view/mcp_servers/installation_modal.rs
@@ -459,10 +459,13 @@ impl InstallationModalBody {
             .on_click(|ctx, _, _| ctx.dispatch_typed_action(InstallationModalBodyAction::Cancel))
             .finish();
 
+        let accent_text_color =
+            appearance.theme().font_color(appearance.theme().accent());
+
         let corner_down_left_icon = Container::new(
             ConstrainedBox::new(
                 Icon::CornerDownLeft
-                    .to_warpui_icon(appearance.theme().active_ui_text_color())
+                    .to_warpui_icon(accent_text_color)
                     .finish(),
             )
             .with_width(appearance.monospace_font_size())
@@ -471,7 +474,7 @@ impl InstallationModalBody {
         )
         .with_uniform_padding(2.)
         .with_border(Border::all(1.).with_border_fill(coloru_with_opacity(
-            appearance.theme().active_ui_text_color().into(),
+            accent_text_color.into(),
             60,
         )))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
@@ -485,7 +488,7 @@ impl InstallationModalBody {
                     appearance.ui_font_family(),
                     appearance.ui_font_size(),
                 )
-                .with_color(appearance.theme().active_ui_text_color().into())
+                .with_color(accent_text_color.into())
                 .with_style(Properties::default().weight(Weight::Bold))
                 .finish(),
             )

--- a/app/src/settings_view/mcp_servers/installation_modal.rs
+++ b/app/src/settings_view/mcp_servers/installation_modal.rs
@@ -459,8 +459,7 @@ impl InstallationModalBody {
             .on_click(|ctx, _, _| ctx.dispatch_typed_action(InstallationModalBodyAction::Cancel))
             .finish();
 
-        let accent_text_color =
-            appearance.theme().font_color(appearance.theme().accent());
+        let accent_text_color = appearance.theme().font_color(appearance.theme().accent());
 
         let corner_down_left_icon = Container::new(
             ConstrainedBox::new(
@@ -473,10 +472,9 @@ impl InstallationModalBody {
             .finish(),
         )
         .with_uniform_padding(2.)
-        .with_border(Border::all(1.).with_border_fill(coloru_with_opacity(
-            accent_text_color.into(),
-            60,
-        )))
+        .with_border(
+            Border::all(1.).with_border_fill(coloru_with_opacity(accent_text_color.into(), 60)),
+        )
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
         .finish();
 

--- a/app/src/settings_view/mcp_servers/installation_modal.rs
+++ b/app/src/settings_view/mcp_servers/installation_modal.rs
@@ -441,17 +441,18 @@ impl InstallationModalBody {
     }
 
     fn render_action_buttons(&self, appearance: &Appearance) -> Box<dyn Element> {
+        let theme = appearance.theme();
         let cancel_button = appearance
             .ui_builder()
             .button(ButtonVariant::Text, self.cancel_mouse_state.clone())
             .with_text_label("Cancel".into())
             .with_style(UiComponentStyles {
                 font_weight: Some(Weight::Bold),
-                font_color: Some(appearance.theme().active_ui_text_color().into()),
+                font_color: Some(theme.active_ui_text_color().into()),
                 ..Default::default()
             })
             .with_hovered_styles(UiComponentStyles {
-                font_color: Some(appearance.theme().disabled_ui_text_color().into()),
+                font_color: Some(theme.disabled_ui_text_color().into()),
                 ..Default::default()
             })
             .build()
@@ -459,7 +460,7 @@ impl InstallationModalBody {
             .on_click(|ctx, _, _| ctx.dispatch_typed_action(InstallationModalBodyAction::Cancel))
             .finish();
 
-        let accent_text_color = appearance.theme().font_color(appearance.theme().accent());
+        let accent_text_color = theme.font_color(theme.accent());
 
         let corner_down_left_icon = Container::new(
             ConstrainedBox::new(

--- a/app/src/settings_view/mcp_servers/update_modal.rs
+++ b/app/src/settings_view/mcp_servers/update_modal.rs
@@ -317,24 +317,24 @@ impl UpdateModalBody {
             .on_click(|ctx, _, _| ctx.dispatch_typed_action(UpdateModalBodyAction::Cancel))
             .finish();
 
-        let accent_text_color =
-            appearance.theme().font_color(appearance.theme().accent());
+        // Disable the update button if no updates are selected
+        let has_selection = self.selected_updates.iter().any(|&x| x);
+        let label_color = if has_selection {
+            appearance.theme().font_color(appearance.theme().accent())
+        } else {
+            appearance
+                .theme()
+                .disabled_text_color(appearance.theme().surface_3())
+        };
 
         let corner_down_left_icon = Container::new(
-            ConstrainedBox::new(
-                Icon::CornerDownLeft
-                    .to_warpui_icon(accent_text_color)
-                    .finish(),
-            )
-            .with_width(appearance.monospace_font_size())
-            .with_height(appearance.monospace_font_size())
-            .finish(),
+            ConstrainedBox::new(Icon::CornerDownLeft.to_warpui_icon(label_color).finish())
+                .with_width(appearance.monospace_font_size())
+                .with_height(appearance.monospace_font_size())
+                .finish(),
         )
         .with_uniform_padding(2.)
-        .with_border(Border::all(1.).with_border_fill(coloru_with_opacity(
-            accent_text_color.into(),
-            60,
-        )))
+        .with_border(Border::all(1.).with_border_fill(coloru_with_opacity(label_color.into(), 60)))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
         .finish();
 
@@ -346,7 +346,7 @@ impl UpdateModalBody {
                     appearance.ui_font_family(),
                     appearance.ui_font_size(),
                 )
-                .with_color(accent_text_color.into())
+                .with_color(label_color.into())
                 .with_style(Properties::default().weight(Weight::Bold))
                 .finish(),
             )
@@ -365,9 +365,6 @@ impl UpdateModalBody {
                 padding: Some(Coords::uniform(5.).left(10.).right(10.)),
                 ..Default::default()
             });
-
-        // Disable the update button if no updates are selected
-        let has_selection = self.selected_updates.iter().any(|&x| x);
 
         if !has_selection {
             update_button_builder = update_button_builder.disabled();

--- a/app/src/settings_view/mcp_servers/update_modal.rs
+++ b/app/src/settings_view/mcp_servers/update_modal.rs
@@ -317,10 +317,13 @@ impl UpdateModalBody {
             .on_click(|ctx, _, _| ctx.dispatch_typed_action(UpdateModalBodyAction::Cancel))
             .finish();
 
+        let accent_text_color =
+            appearance.theme().font_color(appearance.theme().accent());
+
         let corner_down_left_icon = Container::new(
             ConstrainedBox::new(
                 Icon::CornerDownLeft
-                    .to_warpui_icon(appearance.theme().active_ui_text_color())
+                    .to_warpui_icon(accent_text_color)
                     .finish(),
             )
             .with_width(appearance.monospace_font_size())
@@ -329,7 +332,7 @@ impl UpdateModalBody {
         )
         .with_uniform_padding(2.)
         .with_border(Border::all(1.).with_border_fill(coloru_with_opacity(
-            appearance.theme().active_ui_text_color().into(),
+            accent_text_color.into(),
             60,
         )))
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
@@ -343,7 +346,7 @@ impl UpdateModalBody {
                     appearance.ui_font_family(),
                     appearance.ui_font_size(),
                 )
-                .with_color(appearance.theme().active_ui_text_color().into())
+                .with_color(accent_text_color.into())
                 .with_style(Properties::default().weight(Weight::Bold))
                 .finish(),
             )

--- a/app/src/settings_view/mcp_servers/update_modal.rs
+++ b/app/src/settings_view/mcp_servers/update_modal.rs
@@ -317,8 +317,7 @@ impl UpdateModalBody {
             .on_click(|ctx, _, _| ctx.dispatch_typed_action(UpdateModalBodyAction::Cancel))
             .finish();
 
-        let accent_text_color =
-            appearance.theme().font_color(appearance.theme().accent());
+        let accent_text_color = appearance.theme().font_color(appearance.theme().accent());
 
         let corner_down_left_icon = Container::new(
             ConstrainedBox::new(
@@ -331,10 +330,9 @@ impl UpdateModalBody {
             .finish(),
         )
         .with_uniform_padding(2.)
-        .with_border(Border::all(1.).with_border_fill(coloru_with_opacity(
-            accent_text_color.into(),
-            60,
-        )))
+        .with_border(
+            Border::all(1.).with_border_fill(coloru_with_opacity(accent_text_color.into(), 60)),
+        )
         .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
         .finish();
 

--- a/app/src/settings_view/mcp_servers/update_modal.rs
+++ b/app/src/settings_view/mcp_servers/update_modal.rs
@@ -299,17 +299,18 @@ impl UpdateModalBody {
     }
 
     fn render_action_buttons(&self, appearance: &Appearance) -> Box<dyn Element> {
+        let theme = appearance.theme();
         let cancel_button = appearance
             .ui_builder()
             .button(ButtonVariant::Text, self.cancel_mouse_state.clone())
             .with_text_label("Cancel".into())
             .with_style(UiComponentStyles {
                 font_weight: Some(Weight::Bold),
-                font_color: Some(appearance.theme().active_ui_text_color().into()),
+                font_color: Some(theme.active_ui_text_color().into()),
                 ..Default::default()
             })
             .with_hovered_styles(UiComponentStyles {
-                font_color: Some(appearance.theme().disabled_ui_text_color().into()),
+                font_color: Some(theme.disabled_ui_text_color().into()),
                 ..Default::default()
             })
             .build()
@@ -320,11 +321,9 @@ impl UpdateModalBody {
         // Disable the update button if no updates are selected
         let has_selection = self.selected_updates.iter().any(|&x| x);
         let label_color = if has_selection {
-            appearance.theme().font_color(appearance.theme().accent())
+            theme.font_color(theme.accent())
         } else {
-            appearance
-                .theme()
-                .disabled_text_color(appearance.theme().surface_3())
+            theme.disabled_text_color(theme.surface_3())
         };
 
         let corner_down_left_icon = Container::new(


### PR DESCRIPTION
## Description

Fixes: #10517

This PR fixes the primary buttons on the MCP modals for install and update to use the same text color as other primary buttons.

See here for the "source of truth":

https://github.com/warpdotdev/warp/blob/10b2540c1d493a1869949d5f5a7d69a7b0c8d377/app/src/view_components/action_button.rs#L1229-L1240

## Testing

### Before

<img width="2560" height="1528" alt="Screenshot 2026-05-05 101722" src="https://github.com/user-attachments/assets/c2cc4523-eefc-40ac-b8ac-86d9bfc813e3" />

### After

<img width="1920" height="1200" alt="Screenshot 2026-05-05 105447" src="https://github.com/user-attachments/assets/1df0419f-a270-4e15-be19-a33758791622" />
