### PR TITLE
Add Codex local child harness support

### DIFF
--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -67,9 +67,7 @@ use crate::ai::skills::{
     clone_repo_for_skill, resolve_skill_spec, ResolveSkillError, ResolvedSkill,
 };
 
-pub(crate) use driver::harness::{
-    task_env_vars, validate_cli_installed, ClaudeHarness, ThirdPartyHarness,
-};
+pub(crate) use driver::harness::{task_env_vars, validate_cli_installed, ClaudeHarness};
 pub use driver::AgentDriver;
 use telemetry::CliTelemetryEvent;
 use warp_cli::agent::{Harness, Prompt, RunAgentArgs};

--- a/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
@@ -198,7 +198,7 @@ fn execute_returns_error_when_local_harness_child_requires_orchestration_v2() {
         });
         let action = build_start_agent_action(
             StartAgentVersion::V2,
-            StartAgentExecutionMode::local_harness("claude".to_string()),
+            StartAgentExecutionMode::local_harness("codex".to_string()),
         );
 
         let execution = executor.update(&mut app, |executor, ctx| {
@@ -235,7 +235,7 @@ fn execute_rejects_invalid_local_harness_names_before_pane_creation() {
         });
         let action = build_start_agent_action(
             StartAgentVersion::V2,
-            StartAgentExecutionMode::local_harness("codex".to_string()),
+            StartAgentExecutionMode::local_harness("gemini".to_string()),
         );
 
         let execution = executor.update(&mut app, |executor, ctx| {
@@ -254,7 +254,7 @@ fn execute_rejects_invalid_local_harness_names_before_pane_creation() {
         assert!(matches!(
             result,
             AIAgentActionResultType::StartAgent(StartAgentResult::Error { error, version })
-                if error == "Unsupported local child harness 'codex'."
+                if error == "Unsupported local child harness 'gemini'."
                     && version == StartAgentVersion::V2
         ));
     });

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -96,9 +96,8 @@ pub(super) async fn prepare_local_harness_child_launch(
     let command = match harness {
         Harness::Oz => unreachable!("normalize_local_child_harness filters out Oz"),
         Harness::Unknown => unreachable!("normalize_local_child_harness filters out Unknown"),
-        Harness::Claude | Harness::Codex => {
+        Harness::Claude => {
             let working_dir = startup_directory
-                .clone()
                 .or_else(|| std::env::current_dir().ok())
                 .ok_or_else(|| {
                     format!(
@@ -109,7 +108,7 @@ pub(super) async fn prepare_local_harness_child_launch(
             let HarnessKind::ThirdParty(third_party_harness) =
                 harness_kind(harness).map_err(|error: AgentDriverError| error.to_string())?
             else {
-                unreachable!("Codex and Claude both resolve to third-party harnesses")
+                unreachable!("Claude resolves to a third-party harness")
             };
             third_party_harness
                 .validate()
@@ -122,27 +121,34 @@ pub(super) async fn prepare_local_harness_child_launch(
             third_party_harness
                 .prepare_environment_config(&working_dir, None, &managed_secrets)
                 .map_err(|error: AgentDriverError| error.to_string())?;
-
-            if harness == Harness::Claude {
-                if let Some(manager) = plugin_manager_for(third_party_harness.cli_agent()) {
-                    if let Err(error) = manager.install().await {
-                        log::warn!("Claude plugin installation failed for child harness: {error}");
-                    }
-                    if let Err(error) = manager.install_platform_plugin().await {
-                        log::warn!(
-                            "Claude platform plugin installation failed for child harness: {error}"
-                        );
-                    }
+            if let Some(manager) = plugin_manager_for(third_party_harness.cli_agent()) {
+                if let Err(error) = manager.install().await {
+                    log::warn!("Claude plugin installation failed for child harness: {error}");
+                }
+                if let Err(error) = manager.install_platform_plugin().await {
+                    log::warn!(
+                        "Claude platform plugin installation failed for child harness: {error}"
+                    );
                 }
             }
 
-            match harness {
-                Harness::Claude => build_local_claude_child_command(&prompt),
-                Harness::Codex => build_local_codex_child_command(&prompt),
-                Harness::Oz | Harness::OpenCode | Harness::Gemini | Harness::Unknown => {
-                    unreachable!("only Claude and Codex reach this branch")
-                }
-            }
+            build_local_claude_child_command(&prompt)
+        }
+        Harness::Codex => {
+            let HarnessKind::ThirdParty(third_party_harness) =
+                harness_kind(harness).map_err(|error: AgentDriverError| error.to_string())?
+            else {
+                unreachable!("Codex resolves to a third-party harness")
+            };
+            third_party_harness
+                .validate()
+                .map_err(|error: AgentDriverError| error.to_string())?;
+
+            // Local Codex child panes must rely on the user's existing local
+            // auth/session state. Do not run the shared Codex environment prep
+            // here: it can seed OPENAI_API_KEY into ~/.codex/auth.json and
+            // rewrite ~/.codex/config.toml for the whole machine.
+            build_local_codex_child_command(&prompt)
         }
         Harness::OpenCode => {
             validate_cli_installed("opencode", Some("https://opencode.ai/docs"))

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -7,8 +7,11 @@ use warp_managed_secrets::ManagedSecretValue;
 
 use crate::ai::{
     agent_sdk::{
-        driver::AgentDriverError, task_env_vars, validate_cli_installed, ClaudeHarness,
-        ThirdPartyHarness,
+        driver::{
+            harness::{harness_kind, HarnessKind},
+            AgentDriverError,
+        },
+        task_env_vars, validate_cli_installed,
     },
     ambient_agents::{task::HarnessConfig, AgentConfigSnapshot, AmbientAgentTaskId},
 };
@@ -56,16 +59,20 @@ pub(super) fn build_local_opencode_child_command(prompt: &str) -> String {
     let quoted_prompt = shell_quote(prompt);
     format!("opencode --prompt {quoted_prompt}")
 }
+pub(super) fn build_local_codex_child_command(prompt: &str) -> String {
+    let quoted_prompt = shell_quote(prompt);
+    format!("codex --dangerously-bypass-approvals-and-sandbox {quoted_prompt}")
+}
 
 fn local_child_task_config(harness: Harness) -> Option<AgentConfigSnapshot> {
     match harness {
-        Harness::Oz | Harness::OpenCode | Harness::Gemini | Harness::Codex | Harness::Unknown => {
-            None
+        Harness::Oz | Harness::Unknown => None,
+        Harness::Claude | Harness::OpenCode | Harness::Gemini | Harness::Codex => {
+            Some(AgentConfigSnapshot {
+                harness: Some(HarnessConfig::from_harness_type(harness)),
+                ..Default::default()
+            })
         }
-        Harness::Claude => Some(AgentConfigSnapshot {
-            harness: Some(HarnessConfig::from_harness_type(harness)),
-            ..Default::default()
-        }),
     }
 }
 
@@ -89,43 +96,59 @@ pub(super) async fn prepare_local_harness_child_launch(
     let command = match harness {
         Harness::Oz => unreachable!("normalize_local_child_harness filters out Oz"),
         Harness::Unknown => unreachable!("normalize_local_child_harness filters out Unknown"),
-        Harness::Claude => {
+        Harness::Claude | Harness::Codex => {
             let working_dir = startup_directory
+                .clone()
                 .or_else(|| std::env::current_dir().ok())
                 .ok_or_else(|| {
-                    "Could not resolve a working directory for the local Claude child.".to_string()
+                    format!(
+                        "Could not resolve a working directory for the local {} child.",
+                        harness.display_name()
+                    )
                 })?;
-            let claude_harness = ClaudeHarness;
-            claude_harness
+            let HarnessKind::ThirdParty(third_party_harness) =
+                harness_kind(harness).map_err(|error: AgentDriverError| error.to_string())?
+            else {
+                unreachable!("Codex and Claude both resolve to third-party harnesses")
+            };
+            third_party_harness
                 .validate()
                 .map_err(|error: AgentDriverError| error.to_string())?;
-            // Local child harness panes inherit the user's existing local Claude
-            // auth/session state. We still prepare Claude's config files here,
+            // Local child harness panes inherit the user's existing local
+            // auth/session state. We still prepare harness config files here,
             // but there are no Warp-managed secrets to materialize into the
             // hidden child pane.
             let managed_secrets: HashMap<String, ManagedSecretValue> = HashMap::new();
-            claude_harness
+            third_party_harness
                 .prepare_environment_config(&working_dir, None, &managed_secrets)
                 .map_err(|error: AgentDriverError| error.to_string())?;
-            if let Some(manager) = plugin_manager_for(claude_harness.cli_agent()) {
-                if let Err(error) = manager.install().await {
-                    log::warn!("Claude plugin installation failed for child harness: {error}");
-                }
-                if let Err(error) = manager.install_platform_plugin().await {
-                    log::warn!(
-                        "Claude platform plugin installation failed for child harness: {error}"
-                    );
+
+            if harness == Harness::Claude {
+                if let Some(manager) = plugin_manager_for(third_party_harness.cli_agent()) {
+                    if let Err(error) = manager.install().await {
+                        log::warn!("Claude plugin installation failed for child harness: {error}");
+                    }
+                    if let Err(error) = manager.install_platform_plugin().await {
+                        log::warn!(
+                            "Claude platform plugin installation failed for child harness: {error}"
+                        );
+                    }
                 }
             }
 
-            build_local_claude_child_command(&prompt)
+            match harness {
+                Harness::Claude => build_local_claude_child_command(&prompt),
+                Harness::Codex => build_local_codex_child_command(&prompt),
+                Harness::Oz | Harness::OpenCode | Harness::Gemini | Harness::Unknown => {
+                    unreachable!("only Claude and Codex reach this branch")
+                }
+            }
         }
         Harness::OpenCode => {
             validate_cli_installed("opencode", Some("https://opencode.ai/docs"))
                 .map_err(|error: AgentDriverError| error.to_string())?;
             build_local_opencode_child_command(&prompt)
         }
-        Harness::Codex => unreachable!("normalize_local_child_harness filters out Codex"),
         Harness::Gemini => unreachable!("normalize_local_child_harness filters out Gemini"),
     };
 

--- a/app/src/pane_group/pane/local_harness_launch_tests.rs
+++ b/app/src/pane_group/pane/local_harness_launch_tests.rs
@@ -1,8 +1,10 @@
+use crate::ai::ambient_agents::task::HarnessConfig;
 use warp_cli::agent::Harness;
 
 use super::{
-    build_local_claude_child_command, build_local_opencode_child_command,
-    normalize_local_child_harness, validate_local_harness_shell,
+    build_local_claude_child_command, build_local_codex_child_command,
+    build_local_opencode_child_command, local_child_task_config, normalize_local_child_harness,
+    validate_local_harness_shell,
 };
 use crate::terminal::shell::ShellType;
 
@@ -32,12 +34,13 @@ fn normalize_local_child_harness_accepts_supported_aliases() {
         normalize_local_child_harness("open_code"),
         Some(Harness::OpenCode)
     );
+    assert_eq!(normalize_local_child_harness("codex"), Some(Harness::Codex));
 }
 
 #[test]
 fn normalize_local_child_harness_rejects_unsupported_values() {
     assert_eq!(normalize_local_child_harness("oz"), None);
-    assert_eq!(normalize_local_child_harness("codex"), None);
+    assert_eq!(normalize_local_child_harness("gemini"), None);
     assert_eq!(normalize_local_child_harness(""), None);
 }
 
@@ -80,4 +83,25 @@ fn build_local_opencode_child_command_quotes_the_prompt() {
         build_local_opencode_child_command("hello world"),
         "opencode --prompt 'hello world'"
     );
+}
+
+#[test]
+fn build_local_codex_child_command_quotes_the_prompt() {
+    assert_eq!(
+        build_local_codex_child_command("hello world"),
+        "codex --dangerously-bypass-approvals-and-sandbox 'hello world'"
+    );
+}
+
+#[test]
+fn local_child_task_config_records_supported_third_party_harnesses() {
+    for harness in [Harness::Claude, Harness::OpenCode, Harness::Codex] {
+        assert_eq!(
+            local_child_task_config(harness),
+            Some(crate::ai::ambient_agents::task::AgentConfigSnapshot {
+                harness: Some(HarnessConfig::from_harness_type(harness)),
+                ..Default::default()
+            }),
+        );
+    }
 }

--- a/app/src/pane_group/pane/local_harness_launch_tests.rs
+++ b/app/src/pane_group/pane/local_harness_launch_tests.rs
@@ -1,12 +1,64 @@
-use crate::ai::ambient_agents::task::HarnessConfig;
+use std::{ffi::OsString, fs, sync::Arc};
+
+use tempfile::TempDir;
 use warp_cli::agent::Harness;
 
 use super::{
     build_local_claude_child_command, build_local_codex_child_command,
     build_local_opencode_child_command, local_child_task_config, normalize_local_child_harness,
-    validate_local_harness_shell,
+    prepare_local_harness_child_launch, validate_local_harness_shell,
 };
+use crate::ai::ambient_agents::task::HarnessConfig;
+use crate::server::server_api::ai::MockAIClient;
 use crate::terminal::shell::ShellType;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl Into<OsString>) -> Self {
+        let original = std::env::var_os(key);
+        std::env::set_var(key, value.into());
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(original) = &self.original {
+            std::env::set_var(self.key, original);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+fn write_fake_cli(bin_dir: &std::path::Path, name: &str) {
+    let executable_name = if cfg!(windows) {
+        format!("{name}.cmd")
+    } else {
+        name.to_string()
+    };
+    let executable_path = bin_dir.join(executable_name);
+    let script = if cfg!(windows) {
+        "@echo off\r\n"
+    } else {
+        "#!/bin/sh\n"
+    };
+
+    fs::write(&executable_path, script).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(&executable_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&executable_path, permissions).unwrap();
+    }
+}
 
 #[test]
 fn normalize_local_child_harness_accepts_supported_aliases() {
@@ -104,4 +156,40 @@ fn local_child_task_config_records_supported_third_party_harnesses() {
             }),
         );
     }
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn prepare_local_codex_child_launch_does_not_rewrite_global_codex_state() {
+    let fake_home = TempDir::new().unwrap();
+    let fake_bin_dir = TempDir::new().unwrap();
+    let working_dir = fake_home.path().join("workspace");
+    fs::create_dir_all(&working_dir).unwrap();
+    write_fake_cli(fake_bin_dir.path(), "codex");
+
+    let _home = EnvVarGuard::set("HOME", fake_home.path().as_os_str().to_os_string());
+    let _path = EnvVarGuard::set("PATH", fake_bin_dir.path().as_os_str().to_os_string());
+
+    let mut ai_client = MockAIClient::new();
+    ai_client
+        .expect_create_agent_task()
+        .times(1)
+        .returning(|_, _, _, _| Ok("550e8400-e29b-41d4-a716-446655440000".parse().unwrap()));
+
+    let prepared = prepare_local_harness_child_launch(
+        "hello world".to_string(),
+        "codex".to_string(),
+        Some("parent-run".to_string()),
+        Some(ShellType::Zsh),
+        Some(working_dir),
+        Arc::new(ai_client),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        prepared.command,
+        "codex --dangerously-bypass-approvals-and-sandbox 'hello world'"
+    );
+    assert!(!fake_home.path().join(".codex").exists());
 }

--- a/app/src/util/path.rs
+++ b/app/src/util/path.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     env,
     ffi::OsStr,
-    path::{self, Path},
+    path::{self, Path, PathBuf},
 };
 
 use is_executable::IsExecutable as _;
@@ -39,12 +39,43 @@ pub fn resolve_executable_in_path<'a>(command: &'a str, path_env: &OsStr) -> Opt
         return file_exists_and_is_executable(path).then_some(Cow::Borrowed(path));
     }
     for path_dir in env::split_paths(path_env).unique() {
-        let resolved = path_dir.join(command);
-        if file_exists_and_is_executable(&resolved) {
+        if let Some(resolved) = resolve_executable_in_dir(&path_dir, command) {
             return Some(Cow::Owned(resolved));
         }
     }
     None
+}
+
+fn resolve_executable_in_dir(path_dir: &Path, command: &str) -> Option<PathBuf> {
+    let resolved = path_dir.join(command);
+    if file_exists_and_is_executable(&resolved) {
+        return Some(resolved);
+    }
+
+    #[cfg(windows)]
+    if Path::new(command).extension().is_none() {
+        for ext in windows_path_extensions() {
+            let resolved = path_dir.join(format!("{command}{ext}"));
+            if file_exists_and_is_executable(&resolved) {
+                return Some(resolved);
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(windows)]
+fn windows_path_extensions() -> impl Iterator<Item = String> {
+    env::var_os("PATHEXT")
+        .unwrap_or_default()
+        .to_string_lossy()
+        .split(';')
+        .map(str::trim)
+        .filter(|ext| !ext.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>()
+        .into_iter()
 }
 
 #[cfg(test)]

--- a/app/src/util/path_test.rs
+++ b/app/src/util/path_test.rs
@@ -86,6 +86,8 @@ fn test_resolve_command_uses_pathext() {
 
     let _pathext = EnvVarGuard::set("PATHEXT", ".CMD;.EXE");
     let resolved = resolve_executable_in_path("codex", temp_dir.path().as_os_str()).unwrap();
-
-    assert_eq!(resolved.as_ref(), command_path.as_path());
+    assert_eq!(
+        resolved.as_ref().to_string_lossy().to_ascii_lowercase(),
+        command_path.to_string_lossy().to_ascii_lowercase()
+    );
 }

--- a/app/src/util/path_test.rs
+++ b/app/src/util/path_test.rs
@@ -47,3 +47,45 @@ fn test_resolve_command() {
     // Note the trailing space.
     assert!(resolve_executable("zsh ").is_none());
 }
+
+#[cfg(windows)]
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<std::ffi::OsString>,
+}
+
+#[cfg(windows)]
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl Into<std::ffi::OsString>) -> Self {
+        let original = std::env::var_os(key);
+        std::env::set_var(key, value.into());
+        Self { key, original }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(original) = &self.original {
+            std::env::set_var(self.key, original);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+#[cfg(windows)]
+#[test]
+#[serial_test::serial]
+fn test_resolve_command_uses_pathext() {
+    use crate::util::path::resolve_executable_in_path;
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let command_path = temp_dir.path().join("codex.cmd");
+    std::fs::write(&command_path, "@echo off\r\n").unwrap();
+
+    let _pathext = EnvVarGuard::set("PATHEXT", ".CMD;.EXE");
+    let resolved = resolve_executable_in_path("codex", temp_dir.path().as_os_str()).unwrap();
+
+    assert_eq!(resolved.as_ref(), command_path.as_path());
+}

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -153,9 +153,8 @@ impl Harness {
 
     pub fn parse_local_child_harness(value: &str) -> Option<Self> {
         match Self::parse_orchestration_harness(value) {
-            Some(harness @ (Self::Claude | Self::OpenCode)) => Some(harness),
-            Some(Self::Oz) | Some(Self::Gemini) | Some(Self::Codex) | Some(Self::Unknown)
-            | None => None,
+            Some(harness @ (Self::Claude | Self::OpenCode | Self::Codex)) => Some(harness),
+            Some(Self::Oz) | Some(Self::Gemini) | Some(Self::Unknown) | None => None,
         }
     }
 

--- a/crates/warp_cli/src/agent_tests.rs
+++ b/crates/warp_cli/src/agent_tests.rs
@@ -10,6 +10,7 @@ fn harness_config_name_round_trips_for_known_variants() {
         Harness::Claude,
         Harness::OpenCode,
         Harness::Gemini,
+        Harness::Codex,
     ] {
         assert_eq!(
             Harness::from_config_name(harness.config_name()),

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -1571,8 +1571,11 @@ fn harness_parse_orchestration_harness_accepts_codex() {
 }
 
 #[test]
-fn harness_parse_local_child_harness_rejects_codex() {
-    assert_eq!(Harness::parse_local_child_harness("codex"), None);
+fn harness_parse_local_child_harness_accepts_codex() {
+    assert_eq!(
+        Harness::parse_local_child_harness("codex"),
+        Some(Harness::Codex)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description
Add Codex as a supported local child-agent harness in the Warp client.
This updates local harness normalization and launch command construction, and wires the CLI parsing and test coverage needed for local child launches.
This is the client-side counterpart to https://github.com/warpdotdev/warp-server/pull/10880.

## Linked Issue
https://linear.app/warpdotdev/issue/QUALITY-578/codex-support-for-orchestration
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo +1.92.0 fmt --all`
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo +1.92.0 clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo +1.92.0 clippy -p warp_completer --all-targets --tests -- -D warnings`
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo +1.92.0 test -p warp_cli`
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo +1.92.0 test -p warp local_child_task_config_records_supported_third_party_harnesses`
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo +1.92.0 test -p warp execute_returns_error_when_local_harness_child_requires_orchestration_v2`
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo +1.92.0 test -p warp execute_rejects_invalid_local_harness_names_before_pane_creation`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Artifacts
- Conversation: https://app.warp.dev/conversation/e4346560-106f-4bfc-a931-b705a9906799
- Plan: https://app.warp.dev/drive/notebook/BiU3vIJVoZ4jALRYFtNzdz

CHANGELOG-OZ: Add Codex as a supported harness for local child agents.

Co-Authored-By: Oz <oz-agent@warp.dev>
