### PR TITLE
Reserve titlebar space for right-side window controls

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18085,15 +18085,7 @@ impl Workspace {
         let zoom_factor = WindowSettings::as_ref(ctx).zoom_level.as_zoom_factor();
         let traffic_light_data = traffic_light_data(ctx, self.window_id);
         if let Some(traffic_light_data) = traffic_light_data.as_ref() {
-            let vertical_tabs_active = FeatureFlag::VerticalTabs.is_enabled()
-                && *TabSettings::as_ref(ctx).use_vertical_tabs;
-            let right_panel_open = self.current_workspace_state.is_right_panel_open();
-            let should_reserve_right_traffic_light_space =
-                vertical_tabs_active || !right_panel_open;
-
-            if traffic_light_data.side == TrafficLightSide::Right
-                && should_reserve_right_traffic_light_space
-            {
+            if should_reserve_traffic_light_space_in_tab_bar(traffic_light_data.side) {
                 target.add_child(
                     ConstrainedBox::new(Empty::new().finish())
                         .with_width(traffic_light_data.width(zoom_factor))
@@ -24474,6 +24466,10 @@ impl Workspace {
 
         current_index
     }
+}
+
+fn should_reserve_traffic_light_space_in_tab_bar(side: TrafficLightSide) -> bool {
+    side == TrafficLightSide::Right
 }
 
 /// Returns every tab-bar-equivalent rect laid out in `window_id` (horizontal

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -79,20 +79,6 @@ use ai::index::full_source_code_embedding::manager::CodebaseIndexManager;
 use ai::project_context::model::ProjectContextModel;
 use pane_group::{NotebookPane, PaneState, SplitPaneState, TerminalPaneId};
 use session_sharing_protocol::common::SessionId;
-
-#[test]
-fn tab_bar_reserves_space_for_right_side_traffic_lights() {
-    assert!(should_reserve_traffic_light_space_in_tab_bar(
-        TrafficLightSide::Right
-    ));
-}
-
-#[test]
-fn tab_bar_does_not_reserve_space_for_left_side_traffic_lights() {
-    assert!(!should_reserve_traffic_light_space_in_tab_bar(
-        TrafficLightSide::Left
-    ));
-}
 use terminal::shared_session::permissions_manager::SessionPermissionsManager;
 use terminal::view::ActiveSessionState;
 use warp_editor::editor::NavigationKey;
@@ -290,6 +276,24 @@ fn transferred_tab_workspace(
         )
     });
     workspace
+}
+
+#[test]
+fn test_tab_bar_traffic_light_space_regression_for_resource_center_overlap() {
+    // Regression for #10139: the Resource Center/right panel can be open on
+    // Windows/Linux, but vertical-tabs and right-panel state should not decide
+    // whether the tab bar reserves space for titlebar controls.
+    let cases = [
+        (TrafficLightSide::Left, false),
+        (TrafficLightSide::Right, true),
+    ];
+
+    for (side, should_reserve_space) in cases {
+        assert_eq!(
+            should_reserve_traffic_light_space_in_tab_bar(side),
+            should_reserve_space
+        );
+    }
 }
 
 #[cfg(feature = "local_fs")]
@@ -1835,7 +1839,7 @@ fn test_view_only_session() {
 
 #[test]
 // This tests the end-to-end behavior to correctly switch focus among panels.
-// (The only panels that can be focused currently are WD, workspace, & AI assistant.)
+// (The only panels that can be focused currently are WD, workspace, & the agent panel.)
 fn test_switch_focus_panels() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);
@@ -1886,7 +1890,7 @@ fn test_switch_focus_panels() {
             );
         });
 
-        // Shift focus from workspace to right panel when AI assistant is open
+        // Shift focus from workspace to right panel when the agent panel is open
         workspace.update(&mut app, |view, ctx| {
             view.current_workspace_state.is_ai_assistant_panel_open = true;
             view.focus_right_panel(ctx);

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -79,6 +79,20 @@ use ai::index::full_source_code_embedding::manager::CodebaseIndexManager;
 use ai::project_context::model::ProjectContextModel;
 use pane_group::{NotebookPane, PaneState, SplitPaneState, TerminalPaneId};
 use session_sharing_protocol::common::SessionId;
+
+#[test]
+fn tab_bar_reserves_space_for_right_side_traffic_lights() {
+    assert!(should_reserve_traffic_light_space_in_tab_bar(
+        TrafficLightSide::Right
+    ));
+}
+
+#[test]
+fn tab_bar_does_not_reserve_space_for_left_side_traffic_lights() {
+    assert!(!should_reserve_traffic_light_space_in_tab_bar(
+        TrafficLightSide::Left
+    ));
+}
 use terminal::shared_session::permissions_manager::SessionPermissionsManager;
 use terminal::view::ActiveSessionState;
 use warp_editor::editor::NavigationKey;


### PR DESCRIPTION
## Description
- Always reserve right-side titlebar control space in the tab bar when custom window controls are on the right.
- Keeps the Resource Center / What's New toolbar controls out from underneath Windows/Linux close, minimize, and maximize controls while preserving left-side macOS behavior.

## Linked Issue
- Fixes #10139
- [x] The linked issue is labeled `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
Linux Xvfb run of `warp-oss`:

![Linux titlebar spacing](https://raw.githubusercontent.com/gabrimatic/warp/pr-10178-linux-evidence/evidence/pr-10178/pr10178-linux-titlebar-window.png)

Short video: [pr10178-linux-titlebar.mp4](https://raw.githubusercontent.com/gabrimatic/warp/pr-10178-linux-evidence/evidence/pr-10178/pr10178-linux-titlebar.mp4)

## Testing
- `cargo test -p warp traffic_light`
- `cargo fmt -- --check`
- `git diff --check`
- `cargo check -p warp --lib --target x86_64-pc-windows-gnu --tests`
- `cargo clippy -p warp --lib --all-features -- -D warnings`
- Linux container: `cargo test -p warp traffic_light -- --nocapture`
- Linux container: `cargo build -p warp --bin warp-oss --features gui,fast_dev -j1`
- Linux Xvfb capture of the built `warp-oss` binary
