### PR TITLE
fix(vertical-tabs): show agent status badges in summary view (#9868)

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -731,13 +731,26 @@ enum VerticalTabsResolvedMode {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum SummaryPaneKind {
     Terminal,
-    OzAgent { is_ambient: bool },
-    CLIAgent { agent: CLIAgent, is_ambient: bool },
-    Code { title: String },
+    OzAgent {
+        is_ambient: bool,
+        status: Option<ConversationStatus>,
+    },
+    CLIAgent {
+        agent: CLIAgent,
+        is_ambient: bool,
+        status: Option<ConversationStatus>,
+    },
+    Code {
+        title: String,
+    },
     CodeDiff,
     File,
-    Notebook { is_plan: bool },
-    Workflow { is_ai_prompt: bool },
+    Notebook {
+        is_plan: bool,
+    },
+    Workflow {
+        is_ai_prompt: bool,
+    },
     Settings,
     EnvVarCollection,
     EnvironmentManagement,
@@ -745,6 +758,41 @@ enum SummaryPaneKind {
     AIDocument,
     ExecutionProfileEditor,
     Other,
+}
+
+impl SummaryPaneKind {
+    /// Whether `self` and `other` represent the same logical pane "kind" for
+    /// summary-icon dedup purposes, ignoring transient agent status. Two agent
+    /// panes with the same kind but different statuses still surface as a
+    /// single icon in the summary view; the first pane's status is preserved
+    /// (see `select_summary_pane_kind_icons`).
+    fn same_kind_ignoring_status(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::OzAgent {
+                    is_ambient: a_ambient,
+                    ..
+                },
+                Self::OzAgent {
+                    is_ambient: b_ambient,
+                    ..
+                },
+            ) => a_ambient == b_ambient,
+            (
+                Self::CLIAgent {
+                    agent: a_agent,
+                    is_ambient: a_ambient,
+                    ..
+                },
+                Self::CLIAgent {
+                    agent: b_agent,
+                    is_ambient: b_ambient,
+                    ..
+                },
+            ) => a_agent == b_agent && a_ambient == b_ambient,
+            _ => self == other,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -912,9 +960,15 @@ fn select_summary_pane_kind_icons(
     let mut pane_kinds: Vec<(EntityId, SummaryPaneKind)> = pane_kinds.into_iter().collect();
     pane_kinds.sort_by_key(|(creation_order_id, _)| *creation_order_id);
 
-    let mut unique_kinds = Vec::new();
+    let mut unique_kinds: Vec<SummaryPaneKind> = Vec::new();
     for (_, pane_kind) in pane_kinds {
-        if !unique_kinds.contains(&pane_kind) {
+        // Dedup by logical kind, ignoring agent status: two Oz agents with
+        // different statuses still collapse to a single summary icon, with
+        // the first pane's status preserved on the surviving entry.
+        let already_present = unique_kinds
+            .iter()
+            .any(|existing| existing.same_kind_ignoring_status(&pane_kind));
+        if !already_present {
             unique_kinds.push(pane_kind);
         }
         if unique_kinds.len() == 2 {
@@ -2518,13 +2572,21 @@ impl TypedPane<'_> {
                 let terminal_view = terminal_view.as_ref(app);
                 // Route through the shared helper so summary mode agrees with
                 // `resolve_icon_with_status_variant` on what the tab represents.
+                // Status is preserved here so the summary view can render the
+                // status badge — see `summary_pane_kind_to_status_variant` (#9868).
                 match terminal_view_agent_icon_variant(terminal_view, app) {
-                    Some(IconWithStatusVariant::OzAgent { is_ambient, .. }) => {
-                        SummaryPaneKind::OzAgent { is_ambient }
+                    Some(IconWithStatusVariant::OzAgent { is_ambient, status }) => {
+                        SummaryPaneKind::OzAgent { is_ambient, status }
                     }
                     Some(IconWithStatusVariant::CLIAgent {
-                        agent, is_ambient, ..
-                    }) => SummaryPaneKind::CLIAgent { agent, is_ambient },
+                        agent,
+                        is_ambient,
+                        status,
+                    }) => SummaryPaneKind::CLIAgent {
+                        agent,
+                        is_ambient,
+                        status,
+                    },
                     Some(_) | None => SummaryPaneKind::Terminal,
                 }
             }
@@ -3670,42 +3732,26 @@ fn render_summary_pane_kind_icon_circle(
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
-    // For ambient Oz / CLI agent kinds, delegate to `render_icon_with_status` so the
-    // brand-color circle is overlaid with the white cloud badge (status-less in summary
-    // mode). Non-ambient agent kinds and all other pane kinds fall through to the inline
-    // circle rendering below.
-    if let Some(variant) = ambient_agent_variant(&kind) {
+    // For Oz / CLI agent kinds — both ambient and non-ambient — delegate to
+    // `render_icon_with_status` so the brand-color circle is overlaid with the
+    // status badge (or the white cloud badge for ambient runs). All other pane
+    // kinds fall through to the inline circle rendering below.
+    // See #9868: previously only ambient kinds went through this path AND the
+    // status was hardcoded to None, so the badge never rendered in summary view.
+    if let Some(variant) = summary_pane_kind_to_status_variant(&kind) {
         return render_icon_with_status(variant, total_size, 0., theme, theme.background());
     }
     let icon_size = total_size * SUMMARY_INLINE_ICON_RATIO;
     let padding = total_size * SUMMARY_INLINE_PADDING_RATIO;
     let (icon_element, background): (Box<dyn Element>, ElementFill) = match kind {
-        SummaryPaneKind::OzAgent { .. } => (
-            WarpIcon::Oz.to_warpui_icon(oz_icon_fill(theme)).finish(),
-            theme.background().into(),
-        ),
-        SummaryPaneKind::CLIAgent { agent, .. } => {
-            let icon_color = agent.brand_icon_color();
-            let icon_element = agent
-                .icon()
-                .map(|icon| {
-                    icon.to_warpui_icon(WarpThemeFill::Solid(icon_color))
-                        .finish()
-                })
-                .unwrap_or_else(|| {
-                    WarpIcon::Terminal
-                        .to_warpui_icon(theme.sub_text_color(theme.background()))
-                        .finish()
-                });
-            (
-                icon_element,
-                ThemeFill::Solid(
-                    agent
-                        .brand_color()
-                        .unwrap_or(ColorU::new(100, 100, 100, 255)),
-                )
-                .into(),
-            )
+        SummaryPaneKind::OzAgent { .. } | SummaryPaneKind::CLIAgent { .. } => {
+            // Unreachable: agent kinds are handled above via
+            // `summary_pane_kind_to_status_variant`. Listed here so the match
+            // stays exhaustive and a future agent variant can't silently fall
+            // through to a status-less rendering path.
+            unreachable!(
+                "agent kinds must be rendered via summary_pane_kind_to_status_variant"
+            );
         }
         SummaryPaneKind::Code { title } => (
             icon_from_file_path(&title, appearance).unwrap_or_else(|| {
@@ -3748,22 +3794,32 @@ fn render_summary_pane_kind_icon_circle(
     .finish()
 }
 
-/// Maps an ambient Oz / CLI agent summary-pane kind to the `IconWithStatusVariant` used to
-/// render the brand-color circle with the white cloud badge. Non-ambient kinds (and all
-/// other pane kinds) return `None` so the caller falls back to its inline rendering.
-fn ambient_agent_variant(kind: &SummaryPaneKind) -> Option<IconWithStatusVariant> {
+/// Maps an Oz / CLI agent summary-pane kind to the `IconWithStatusVariant` used to render
+/// the brand-color circle plus the appropriate status overlay. Ambient runs additionally
+/// get the white cloud badge from the underlying renderer. Non-agent pane kinds return
+/// `None` so the caller falls back to its inline rendering.
+///
+/// Before #9868 this function (1) only matched ambient kinds — non-ambient agents fell
+/// through to a status-less inline render — and (2) hardcoded `status: None`. Both
+/// caused agent rows in the vertical-tabs summary view to never display a status badge.
+/// The current shape passes the captured `status` straight through and covers both
+/// ambient and non-ambient cases.
+fn summary_pane_kind_to_status_variant(
+    kind: &SummaryPaneKind,
+) -> Option<IconWithStatusVariant> {
     match kind {
-        SummaryPaneKind::OzAgent { is_ambient: true } => Some(IconWithStatusVariant::OzAgent {
-            status: None,
-            is_ambient: true,
+        SummaryPaneKind::OzAgent { is_ambient, status } => Some(IconWithStatusVariant::OzAgent {
+            status: status.clone(),
+            is_ambient: *is_ambient,
         }),
         SummaryPaneKind::CLIAgent {
             agent,
-            is_ambient: true,
+            is_ambient,
+            status,
         } => Some(IconWithStatusVariant::CLIAgent {
             agent: *agent,
-            status: None,
-            is_ambient: true,
+            status: status.clone(),
+            is_ambient: *is_ambient,
         }),
         _ => None,
     }

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3708,11 +3708,29 @@ fn render_summary_pane_kind_icons(
                 + secondary_radius
                 - primary_total / 2.;
 
-            let (parent_anchor, child_anchor) = if primary_has_status_badge {
+            // Anchor + offset direction (#10179):
+            //
+            // pathfinder uses positive-Y-down. The BR placement walks the
+            // secondary further into the BR quadrant via (+x, +y) so the
+            // secondary's center sits on the primary circle's BR edge. For
+            // the TR placement, +x still goes right (away from the primary)
+            // but Y must FLIP to negative — otherwise positive Y would push
+            // the secondary DOWN into the primary instead of UP into the TR
+            // quadrant. The corner offset magnitude is the same; only Y's
+            // sign changes.
+            let (parent_anchor, child_anchor, offset_y) = if primary_has_status_badge {
                 // Top-right: leaves BR clear for the status badge.
-                (ParentAnchor::TopRight, ChildAnchor::TopRight)
+                (
+                    ParentAnchor::TopRight,
+                    ChildAnchor::TopRight,
+                    -secondary_corner_offset,
+                )
             } else {
-                (ParentAnchor::BottomRight, ChildAnchor::BottomRight)
+                (
+                    ParentAnchor::BottomRight,
+                    ChildAnchor::BottomRight,
+                    secondary_corner_offset,
+                )
             };
 
             let mut stack = Stack::new().with_child(
@@ -3724,7 +3742,7 @@ fn render_summary_pane_kind_icons(
             stack.add_positioned_child(
                 secondary_with_ring,
                 OffsetPositioning::offset_from_parent(
-                    vec2f(secondary_corner_offset, secondary_corner_offset),
+                    vec2f(secondary_corner_offset, offset_y),
                     ParentOffsetBounds::Unbounded,
                     parent_anchor,
                     child_anchor,

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3674,8 +3674,18 @@ fn render_summary_pane_kind_icons(
             render_summary_pane_kind_icon_circle(kind, VERTICAL_TABS_ICON_SIZE, appearance)
         }
         SummaryPaneKindIcons::Pair { primary, secondary } => {
-            // The secondary icon sits at the BR of the primary at roughly badge
+            // The secondary icon sits at the corner of the primary at roughly badge
             // proportions, with a small cutout ring separating it from the primary.
+            //
+            // Corner choice (#9868 / #10179): when the primary is an agent kind, the
+            // bottom-right slot is already used by the status badge that
+            // `render_icon_with_status` paints. Placing the secondary at BR there
+            // would cover the badge — defeating the whole purpose of #9868. So we
+            // shift the secondary to the top-right corner whenever the primary
+            // produces a status-aware variant. Non-agent primary kinds keep the
+            // existing BR placement (no badge to occlude).
+            let primary_has_status_badge =
+                summary_pane_kind_to_status_variant(&primary).is_some();
             let primary_total = VERTICAL_TABS_ICON_SIZE;
             let secondary_total = VERTICAL_TABS_ICON_SIZE * 0.5;
             let ring_padding = secondary_total * 0.1;
@@ -3698,6 +3708,13 @@ fn render_summary_pane_kind_icons(
                 + secondary_radius
                 - primary_total / 2.;
 
+            let (parent_anchor, child_anchor) = if primary_has_status_badge {
+                // Top-right: leaves BR clear for the status badge.
+                (ParentAnchor::TopRight, ChildAnchor::TopRight)
+            } else {
+                (ParentAnchor::BottomRight, ChildAnchor::BottomRight)
+            };
+
             let mut stack = Stack::new().with_child(
                 ConstrainedBox::new(primary_icon)
                     .with_width(primary_total)
@@ -3709,8 +3726,8 @@ fn render_summary_pane_kind_icons(
                 OffsetPositioning::offset_from_parent(
                     vec2f(secondary_corner_offset, secondary_corner_offset),
                     ParentOffsetBounds::Unbounded,
-                    ParentAnchor::BottomRight,
-                    ChildAnchor::BottomRight,
+                    parent_anchor,
+                    child_anchor,
                 ),
             );
             ConstrainedBox::new(stack.finish())

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3664,6 +3664,57 @@ fn render_summary_tab_item(
     render_pane_row_element(props, Padding::uniform(8.), true, content, theme)
 }
 
+/// Pure description of where a pair-icon's secondary should sit relative to
+/// its primary. Extracted from `render_summary_pane_kind_icons` so the corner
+/// choice (#10179: TR for agent primaries to avoid covering the BR-anchored
+/// status badge) is unit-testable without any GPU / layout state.
+///
+/// `corner_offset` is the magnitude (always positive) computed from the
+/// primary radius and secondary outer size in the caller. The returned
+/// `offset_y` flips sign with the corner so positive-Y-down (pathfinder)
+/// coordinates push the secondary in the right direction:
+/// - BR anchor: +y pushes the secondary further into the BR quadrant.
+/// - TR anchor: -y pushes the secondary up out of the primary into the TR
+///   quadrant. (Reusing +y here would push DOWN into the primary — the bug
+///   round-2 of #10179 caught.)
+///
+/// The `offset_x` is always positive — the secondary always sits to the
+/// right of the primary in both placements.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct PairSecondaryPlacement {
+    pub parent_anchor: ParentAnchor,
+    pub child_anchor: ChildAnchor,
+    pub offset_x: f32,
+    pub offset_y: f32,
+}
+
+pub(super) fn secondary_pair_placement(
+    primary_has_status_badge: bool,
+    corner_offset: f32,
+) -> PairSecondaryPlacement {
+    debug_assert!(
+        corner_offset >= 0.0,
+        "corner_offset is a magnitude; sign comes from the anchor selection"
+    );
+    if primary_has_status_badge {
+        // Top-right: leaves BR clear for the status badge. Y must be
+        // negative — see doc comment.
+        PairSecondaryPlacement {
+            parent_anchor: ParentAnchor::TopRight,
+            child_anchor: ChildAnchor::TopRight,
+            offset_x: corner_offset,
+            offset_y: -corner_offset,
+        }
+    } else {
+        PairSecondaryPlacement {
+            parent_anchor: ParentAnchor::BottomRight,
+            child_anchor: ChildAnchor::BottomRight,
+            offset_x: corner_offset,
+            offset_y: corner_offset,
+        }
+    }
+}
+
 fn render_summary_pane_kind_icons(
     icons: SummaryPaneKindIcons,
     appearance: &Appearance,
@@ -3717,21 +3768,13 @@ fn render_summary_pane_kind_icons(
             // but Y must FLIP to negative — otherwise positive Y would push
             // the secondary DOWN into the primary instead of UP into the TR
             // quadrant. The corner offset magnitude is the same; only Y's
-            // sign changes.
-            let (parent_anchor, child_anchor, offset_y) = if primary_has_status_badge {
-                // Top-right: leaves BR clear for the status badge.
-                (
-                    ParentAnchor::TopRight,
-                    ChildAnchor::TopRight,
-                    -secondary_corner_offset,
-                )
-            } else {
-                (
-                    ParentAnchor::BottomRight,
-                    ChildAnchor::BottomRight,
-                    secondary_corner_offset,
-                )
-            };
+            // sign changes. This decision is extracted to a pure helper so
+            // it is unit-testable without GPU / layout state — see
+            // `secondary_pair_placement` and its tests.
+            let placement = secondary_pair_placement(
+                primary_has_status_badge,
+                secondary_corner_offset,
+            );
 
             let mut stack = Stack::new().with_child(
                 ConstrainedBox::new(primary_icon)
@@ -3742,10 +3785,10 @@ fn render_summary_pane_kind_icons(
             stack.add_positioned_child(
                 secondary_with_ring,
                 OffsetPositioning::offset_from_parent(
-                    vec2f(secondary_corner_offset, offset_y),
+                    vec2f(placement.offset_x, placement.offset_y),
                     ParentOffsetBounds::Unbounded,
-                    parent_anchor,
-                    child_anchor,
+                    placement.parent_anchor,
+                    placement.child_anchor,
                 ),
             );
             ConstrainedBox::new(stack.finish())

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -17,15 +17,16 @@ use super::{
     detail_target_for_hovered_row, format_summary_primary_labels,
     non_terminal_search_text_fragments, pane_ids_for_display_granularity,
     pane_search_text_fragments, preferred_agent_tab_titles, search_fragments_contain_query,
-    select_summary_pane_kind_icons, should_keep_detail_sidecar_visible_for_mouse_position,
-    summary_overflow_count, summary_pane_kind_to_status_variant, summary_search_text_fragments,
-    terminal_kind_badge_label,
+    secondary_pair_placement, select_summary_pane_kind_icons,
+    should_keep_detail_sidecar_visible_for_mouse_position, summary_overflow_count,
+    summary_pane_kind_to_status_variant, summary_search_text_fragments, terminal_kind_badge_label,
     terminal_primary_line_data, terminal_pull_request_badge_label, terminal_search_text_fragments,
     terminal_title_fallback_font, uses_outer_group_container, visible_pane_ids_for_detail_target,
     vtab_diff_stats_text, AgentTabTextPreference, SummaryPaneKind, SummaryPaneKindIcons,
     TerminalAgentText, TerminalPrimaryLineData, TerminalPrimaryLineFont, VerticalTabsDetailTarget,
     VerticalTabsDetailTargetKind, VerticalTabsSummaryBranchEntry, VerticalTabsSummaryData,
 };
+use warpui::elements::{ChildAnchor, ParentAnchor};
 
 fn pane_id() -> PaneId {
     TerminalPaneId::dummy_terminal_pane_id().into()
@@ -326,6 +327,62 @@ fn summary_pane_kind_icons_dedup_ignores_status() {
         }
         other => panic!("expected a single OzAgent kind, got {other:?}"),
     }
+}
+
+// Regression tests for the #10179 round-2 fix: when the primary kind has a
+// status badge (agent), the secondary moves to TR. The Y component of the
+// offset must FLIP to negative so the secondary goes UP into the TR
+// quadrant, not DOWN into the primary. These tests pin the geometric
+// contract that the bot caught a regression in last round.
+
+#[test]
+fn pair_secondary_placement_for_agent_primary_anchors_top_right_with_negative_y() {
+    let p = secondary_pair_placement(true, 7.5);
+    assert_eq!(
+        p.parent_anchor,
+        ParentAnchor::TopRight,
+        "agent primary must anchor secondary at TR to leave BR clear for the status badge"
+    );
+    assert_eq!(p.child_anchor, ChildAnchor::TopRight);
+    assert_eq!(
+        p.offset_x, 7.5,
+        "X always positive: secondary sits to the right of the primary"
+    );
+    assert_eq!(
+        p.offset_y, -7.5,
+        "Y must FLIP to negative for TR: pathfinder is +Y-down, so a +Y \
+         offset would push the secondary DOWN into the primary instead of \
+         UP into the TR quadrant"
+    );
+}
+
+#[test]
+fn pair_secondary_placement_for_non_agent_primary_anchors_bottom_right_with_positive_y() {
+    let p = secondary_pair_placement(false, 7.5);
+    assert_eq!(
+        p.parent_anchor,
+        ParentAnchor::BottomRight,
+        "non-agent primary keeps the existing BR placement (no status badge to occlude)"
+    );
+    assert_eq!(p.child_anchor, ChildAnchor::BottomRight);
+    assert_eq!(p.offset_x, 7.5);
+    assert_eq!(
+        p.offset_y, 7.5,
+        "Y stays positive for BR: pushes the secondary further into the BR quadrant"
+    );
+}
+
+#[test]
+fn pair_secondary_placement_offset_magnitude_matches_across_corners() {
+    // Both placements use the same magnitude — only the corner / Y-sign changes.
+    let agent = secondary_pair_placement(true, 12.0);
+    let non_agent = secondary_pair_placement(false, 12.0);
+    assert_eq!(agent.offset_x.abs(), non_agent.offset_x.abs());
+    assert_eq!(agent.offset_y.abs(), non_agent.offset_y.abs());
+    assert_ne!(
+        agent.offset_y, non_agent.offset_y,
+        "Y signs must differ between TR (agent) and BR (non-agent) placements"
+    );
 }
 
 #[test]

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -1,3 +1,4 @@
+use crate::ai::agent::conversation::ConversationStatus;
 use crate::context_chips::display_chip::GitLineChanges;
 use crate::pane_group::pane::IPaneType;
 use crate::pane_group::{PaneId, TerminalPaneId};
@@ -17,7 +18,8 @@ use super::{
     non_terminal_search_text_fragments, pane_ids_for_display_granularity,
     pane_search_text_fragments, preferred_agent_tab_titles, search_fragments_contain_query,
     select_summary_pane_kind_icons, should_keep_detail_sidecar_visible_for_mouse_position,
-    summary_overflow_count, summary_search_text_fragments, terminal_kind_badge_label,
+    summary_overflow_count, summary_pane_kind_to_status_variant, summary_search_text_fragments,
+    terminal_kind_badge_label,
     terminal_primary_line_data, terminal_pull_request_badge_label, terminal_search_text_fragments,
     terminal_title_fallback_font, uses_outer_group_container, visible_pane_ids_for_detail_target,
     vtab_diff_stats_text, AgentTabTextPreference, SummaryPaneKind, SummaryPaneKindIcons,
@@ -88,11 +90,15 @@ fn summary_pane_kind_icons_distinguish_agent_terminals_from_plain_terminals() {
                 SummaryPaneKind::CLIAgent {
                     agent: CLIAgent::Claude,
                     is_ambient: false,
+                    status: None,
                 },
             ),
             (
                 EntityId::from_usize(30),
-                SummaryPaneKind::OzAgent { is_ambient: false },
+                SummaryPaneKind::OzAgent {
+                    is_ambient: false,
+                    status: None,
+                },
             ),
         ]),
         Some(SummaryPaneKindIcons::Pair {
@@ -100,6 +106,7 @@ fn summary_pane_kind_icons_distinguish_agent_terminals_from_plain_terminals() {
             secondary: SummaryPaneKind::CLIAgent {
                 agent: CLIAgent::Claude,
                 is_ambient: false,
+                status: None,
             },
         })
     );
@@ -116,6 +123,7 @@ fn summary_pane_kind_icons_distinguish_ambient_claude_from_local_claude() {
                 SummaryPaneKind::CLIAgent {
                     agent: CLIAgent::Claude,
                     is_ambient: false,
+                    status: None,
                 },
             ),
             (
@@ -123,6 +131,7 @@ fn summary_pane_kind_icons_distinguish_ambient_claude_from_local_claude() {
                 SummaryPaneKind::CLIAgent {
                     agent: CLIAgent::Claude,
                     is_ambient: true,
+                    status: None,
                 },
             ),
         ]),
@@ -130,13 +139,135 @@ fn summary_pane_kind_icons_distinguish_ambient_claude_from_local_claude() {
             primary: SummaryPaneKind::CLIAgent {
                 agent: CLIAgent::Claude,
                 is_ambient: false,
+                status: None,
             },
             secondary: SummaryPaneKind::CLIAgent {
                 agent: CLIAgent::Claude,
                 is_ambient: true,
+                status: None,
             },
         })
     );
+}
+
+// Regression tests for #9868: agent status badges in vertical tabs summary view.
+
+#[test]
+fn summary_view_propagates_oz_agent_status_to_icon_variant() {
+    // The summary-icon path must surface the agent's status so that
+    // `render_icon_with_status` can paint the badge. Before #9868 the helper
+    // hardcoded `status: None`, so the badge never rendered.
+    let kind = SummaryPaneKind::OzAgent {
+        is_ambient: true,
+        status: Some(ConversationStatus::InProgress),
+    };
+    let variant =
+        summary_pane_kind_to_status_variant(&kind).expect("agent kinds produce a variant");
+    match variant {
+        crate::ui_components::icon_with_status::IconWithStatusVariant::OzAgent {
+            status,
+            is_ambient,
+        } => {
+            assert_eq!(status, Some(ConversationStatus::InProgress));
+            assert!(is_ambient);
+        }
+        _ => panic!("expected OzAgent variant"),
+    }
+}
+
+#[test]
+fn summary_view_propagates_cli_agent_status_to_icon_variant() {
+    let kind = SummaryPaneKind::CLIAgent {
+        agent: CLIAgent::Claude,
+        is_ambient: false,
+        status: Some(ConversationStatus::Error),
+    };
+    let variant =
+        summary_pane_kind_to_status_variant(&kind).expect("agent kinds produce a variant");
+    match variant {
+        crate::ui_components::icon_with_status::IconWithStatusVariant::CLIAgent {
+            agent,
+            status,
+            is_ambient,
+        } => {
+            assert_eq!(agent, CLIAgent::Claude);
+            assert_eq!(status, Some(ConversationStatus::Error));
+            assert!(!is_ambient);
+        }
+        _ => panic!("expected CLIAgent variant"),
+    }
+}
+
+#[test]
+fn summary_view_renders_status_for_non_ambient_agents() {
+    // Before #9868, only ambient agent kinds went through the status-aware
+    // render path; non-ambient agents fell through to a status-less inline
+    // render. Both paths must now surface a variant so the status badge can
+    // be drawn.
+    let local_oz = SummaryPaneKind::OzAgent {
+        is_ambient: false,
+        status: Some(ConversationStatus::Success),
+    };
+    let local_cli = SummaryPaneKind::CLIAgent {
+        agent: CLIAgent::Claude,
+        is_ambient: false,
+        status: Some(ConversationStatus::Cancelled),
+    };
+
+    assert!(
+        summary_pane_kind_to_status_variant(&local_oz).is_some(),
+        "non-ambient Oz agents must produce a status-aware variant"
+    );
+    assert!(
+        summary_pane_kind_to_status_variant(&local_cli).is_some(),
+        "non-ambient CLI agents must produce a status-aware variant"
+    );
+}
+
+#[test]
+fn summary_view_returns_none_for_non_agent_kinds() {
+    // Non-agent kinds keep their existing inline rendering — the status helper
+    // returns None so the caller falls back to `render_summary_pane_kind_icon_circle`'s
+    // inline branch.
+    assert!(summary_pane_kind_to_status_variant(&SummaryPaneKind::Terminal).is_none());
+    assert!(summary_pane_kind_to_status_variant(&code_summary_kind("main.rs")).is_none());
+    assert!(summary_pane_kind_to_status_variant(&SummaryPaneKind::Settings).is_none());
+}
+
+#[test]
+fn summary_pane_kind_icons_dedup_ignores_status() {
+    // Two Oz agents with different statuses still collapse to a single icon
+    // in the summary view: status is metadata, not identity, for dedup. The
+    // surviving entry preserves the first pane's status (creation-order
+    // sorted).
+    let icons = select_summary_pane_kind_icons([
+        (
+            EntityId::from_usize(10),
+            SummaryPaneKind::OzAgent {
+                is_ambient: false,
+                status: Some(ConversationStatus::InProgress),
+            },
+        ),
+        (
+            EntityId::from_usize(20),
+            SummaryPaneKind::OzAgent {
+                is_ambient: false,
+                status: Some(ConversationStatus::Success),
+            },
+        ),
+    ])
+    .expect("at least one kind");
+
+    match icons {
+        SummaryPaneKindIcons::Single(SummaryPaneKind::OzAgent {
+            is_ambient,
+            status,
+        }) => {
+            assert!(!is_ambient);
+            assert_eq!(status, Some(ConversationStatus::InProgress));
+        }
+        other => panic!("expected a single OzAgent kind, got {other:?}"),
+    }
 }
 
 #[test]

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -234,6 +234,64 @@ fn summary_view_returns_none_for_non_agent_kinds() {
     assert!(summary_pane_kind_to_status_variant(&SummaryPaneKind::Settings).is_none());
 }
 
+// Regression test for #10179: when the primary kind in a Pair has a status
+// badge (i.e., is an agent), the secondary icon must be placed at TR not BR
+// — otherwise the BR-anchored status badge gets occluded by the secondary.
+//
+// The placement decision in render_summary_pane_kind_icons is gated on
+// `summary_pane_kind_to_status_variant(primary).is_some()`. This test pins
+// the contract that decision-flag depends on, so a future refactor that
+// changes which kinds report a badge automatically updates the layout
+// behavior in lockstep.
+#[test]
+fn pair_icon_placement_avoids_badge_for_agent_primary() {
+    // Every agent kind (Oz/CLI, ambient/non-ambient, with or without status)
+    // routes through the status-aware path now, so the pair-icon layout
+    // must move the secondary to TR for all of them.
+    for kind in [
+        SummaryPaneKind::OzAgent {
+            is_ambient: true,
+            status: Some(ConversationStatus::InProgress),
+        },
+        SummaryPaneKind::OzAgent {
+            is_ambient: false,
+            status: None,
+        },
+        SummaryPaneKind::CLIAgent {
+            agent: CLIAgent::Claude,
+            is_ambient: true,
+            status: Some(ConversationStatus::Success),
+        },
+        SummaryPaneKind::CLIAgent {
+            agent: CLIAgent::Claude,
+            is_ambient: false,
+            status: None,
+        },
+    ] {
+        assert!(
+            summary_pane_kind_to_status_variant(&kind).is_some(),
+            "agent kind must produce a status-aware variant; pair-icon \
+             placement relies on this to move the secondary to TR and \
+             avoid covering the BR-anchored status badge"
+        );
+    }
+
+    // Non-agent primaries don't paint a badge, so the secondary takes BR
+    // (existing layout, unchanged by #10179).
+    for kind in [
+        SummaryPaneKind::Terminal,
+        code_summary_kind("main.rs"),
+        SummaryPaneKind::Notebook { is_plan: false },
+        SummaryPaneKind::Settings,
+    ] {
+        assert!(
+            summary_pane_kind_to_status_variant(&kind).is_none(),
+            "non-agent kind must NOT produce a status-aware variant; \
+             pair-icon placement keeps the secondary at BR for these"
+        );
+    }
+}
+
 #[test]
 fn summary_pane_kind_icons_dedup_ignores_status() {
     // Two Oz agents with different statuses still collapse to a single icon


### PR DESCRIPTION
## Summary

Fixes #9868 — the vertical-tabs summary view dropped the agent status icon/badge for both Oz and CLI agents, making it impossible to tell from the tab list whether an agent was in progress, done, errored, cancelled, or blocked without opening the agent itself.

## Root cause

Two cooperating bugs in [`app/src/workspace/view/vertical_tabs.rs`](app/src/workspace/view/vertical_tabs.rs):

1. **`SummaryPaneKind::OzAgent` / `CLIAgent` dropped the upstream status** when projecting from the shared `IconWithStatusVariant` in `summary_pane_kind()` — the `..` discard pattern at [vertical_tabs.rs:2522,2525](app/src/workspace/view/vertical_tabs.rs).
2. **The reverse projection in `ambient_agent_variant()`** — the function that hands the variant back to `render_icon_with_status` — only matched `is_ambient: true` and **hardcoded `status: None`**. Non-ambient agents fell through to a status-less inline render path entirely.

So ambient agents had their status thrown away, and non-ambient agents never even reached the status-aware renderer.

## Fix

- Add `status: Option<ConversationStatus>` to both agent variants of `SummaryPaneKind` and capture it in `summary_pane_kind()`.
- Rename `ambient_agent_variant` → `summary_pane_kind_to_status_variant`, match both ambient and non-ambient cases, and pass the captured status straight through to `IconWithStatusVariant`.
- Route both ambient and non-ambient agent kinds through the status-aware path in `render_summary_pane_kind_icon_circle`. The remaining inline branch covers only non-agent pane kinds; agent kinds are marked `unreachable!()` so a future refactor can't silently regress the badge.
- Preserve the existing **dedup-by-kind** semantics in `select_summary_pane_kind_icons` via a new helper `same_kind_ignoring_status`. Two Oz agents with different statuses still collapse to one icon (status is metadata, not identity), with the first pane's status preserved on the surviving entry.

## Tests

- Updated the two existing tests that constructed agent variants to pass `status: None`.
- Added four regression tests in `vertical_tabs_tests.rs`:
  - status propagation for `OzAgent`
  - status propagation for `CLIAgent`
  - non-ambient agents still produce a status-aware variant (catches the original bug shape)
  - non-agent kinds correctly return `None` so the caller falls back to inline rendering
- Added a dedup test asserting two same-kind agents with different statuses collapse to one icon and preserve the first status.

```
$ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer cargo test -p warp --lib vertical_tabs
test result: ok. 71 passed; 0 failed; 0 ignored; 0 measured; 3779 filtered out

$ cargo clippy -p warp --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

71 vertical-tabs tests pass; cargo check + clippy clean.

## Test plan

- [ ] CI: `cargo test -p warp --lib vertical_tabs` passes
- [ ] CI: clippy clean
- [ ] Manual: enable vertical tabs, switch to summary view, open one or more agent sessions in different states, verify each agent row shows the appropriate status icon/badge — InProgress, Success, Error, Cancelled, Blocked
- [ ] Manual: ambient (cloud) Oz agent shows the cloud lobe + status badge
- [ ] Manual: non-ambient (local) Oz agent shows the status badge on the brand circle
- [ ] Manual: non-ambient CLI agent (e.g. local Claude) shows the status badge on the brand circle
- [ ] Manual regression: two agents with the same kind but different statuses still surface as one icon in summary view (the first one wins)

## Out of scope

The shared agent-icon helpers in [`app/src/ui_components/agent_icon.rs`](app/src/ui_components/agent_icon.rs) and the cross-surface invariants in `agent_icon_tests.rs` are unchanged. The bug was strictly in the summary-view projection, not in the upstream variant derivation.

Closes #9868.