### PR TITLE
Disable harness selector for local -> cloud handoff

### DIFF
--- a/app/src/terminal/view/ambient_agent/harness_selector.rs
+++ b/app/src/terminal/view/ambient_agent/harness_selector.rs
@@ -92,6 +92,7 @@ impl HarnessSelector {
             ActionButton::new("", AgentInputButtonTheme)
                 .with_size(ButtonSize::AgentInputButton)
                 .with_menu(true)
+                .with_disabled_theme(AgentInputButtonTheme)
                 .with_tooltip(BUTTON_TOOLTIP)
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(HarnessSelectorAction::ToggleMenu);
@@ -147,6 +148,9 @@ impl HarnessSelector {
 
     /// Programmatically opens the harness selector popover. No-op if already open.
     pub fn open_menu(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.is_locked_to_oz(ctx) {
+            return;
+        }
         self.set_menu_visibility(true, ctx);
     }
 
@@ -161,17 +165,18 @@ impl HarnessSelector {
         });
     }
 
-    pub fn set_button_theme(
-        &self,
-        theme: impl ActionButtonTheme + 'static,
-        ctx: &mut ViewContext<Self>,
-    ) {
+    pub fn set_button_theme<T>(&self, theme: T, ctx: &mut ViewContext<Self>)
+    where
+        T: ActionButtonTheme + Clone + 'static,
+    {
         self.button.update(ctx, |button, ctx| {
-            button.set_theme(theme, ctx);
+            button.set_theme(theme.clone(), ctx);
+            button.set_disabled_theme(theme, ctx);
         });
     }
 
     fn set_menu_visibility(&mut self, is_open: bool, ctx: &mut ViewContext<Self>) {
+        let is_open = is_open && !self.is_locked_to_oz(ctx);
         if self.is_menu_open == is_open {
             return;
         }
@@ -184,7 +189,14 @@ impl HarnessSelector {
         ctx.notify();
     }
 
+    fn is_locked_to_oz(&self, app: &AppContext) -> bool {
+        self.ambient_agent_model
+            .as_ref(app)
+            .is_local_to_cloud_handoff()
+    }
+
     fn refresh_button(&mut self, ctx: &mut ViewContext<Self>) {
+        let is_locked_to_oz = self.is_locked_to_oz(ctx);
         let harness = self.ambient_agent_model.as_ref(ctx).selected_harness();
         let label = HarnessAvailabilityModel::as_ref(ctx)
             .display_name_for(harness)
@@ -193,7 +205,20 @@ impl HarnessSelector {
         self.button.update(ctx, |button, ctx| {
             button.set_label(label, ctx);
             button.set_icon(Some(icon), ctx);
+            button.set_has_menu(!is_locked_to_oz, ctx);
+            button.set_disabled(is_locked_to_oz, ctx);
+            button.set_tooltip(
+                Some(if is_locked_to_oz {
+                    "This conversation is with the Warp Agent, so the cloud handoff will also use Warp"
+                } else {
+                    BUTTON_TOOLTIP
+                }),
+                ctx,
+            );
         });
+        if is_locked_to_oz {
+            self.set_menu_visibility(false, ctx);
+        }
     }
 
     fn refresh_menu(&mut self, ctx: &mut ViewContext<Self>) {
@@ -288,10 +313,18 @@ impl TypedActionView for HarnessSelector {
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         match action {
             HarnessSelectorAction::ToggleMenu => {
+                if self.is_locked_to_oz(ctx) {
+                    self.set_menu_visibility(false, ctx);
+                    return;
+                }
                 let new_state = !self.is_menu_open;
                 self.set_menu_visibility(new_state, ctx);
             }
             HarnessSelectorAction::SelectHarness(harness) => {
+                if self.is_locked_to_oz(ctx) {
+                    self.set_menu_visibility(false, ctx);
+                    return;
+                }
                 let harness = *harness;
                 self.ambient_agent_model.update(ctx, |model, ctx| {
                     model.set_harness(harness, ctx);

--- a/app/src/terminal/view/ambient_agent/host_selector.rs
+++ b/app/src/terminal/view/ambient_agent/host_selector.rs
@@ -298,6 +298,7 @@ impl View for HostSelector {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct NakedHeaderButtonTheme;
 
 impl ActionButtonTheme for NakedHeaderButtonTheme {

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -32,7 +32,9 @@ use crate::server::server_api::ai::InitialSnapshotToken;
 use crate::server::server_api::ai::{
     AgentConfigSnapshot, AmbientAgentTaskState, AttachmentInput, SpawnAgentRequest,
 };
-use crate::server::server_api::{AIApiError, CloudAgentCapacityError, ServerApiProvider};
+use crate::server::server_api::{
+    AIApiError, ClientError, CloudAgentCapacityError, ServerApiProvider,
+};
 use crate::terminal::view::ambient_agent::{SetupCommandGroupId, SetupCommandState};
 use crate::terminal::CLIAgent;
 
@@ -383,10 +385,23 @@ impl AmbientAgentViewModel {
     }
 
     pub fn selected_harness(&self) -> Harness {
-        self.harness
+        if self.is_local_to_cloud_handoff() {
+            Harness::Oz
+        } else {
+            self.harness
+        }
     }
 
     pub fn set_harness(&mut self, harness: Harness, ctx: &mut ModelContext<Self>) {
+        // for local to cloud handoff, oz is the only option
+        // (we'll need to update this to lock to the correct 3p harness if/when
+        // we implement local -> cloud handoff for non-oz conversations).
+        let harness = if self.is_local_to_cloud_handoff() {
+            Harness::Oz
+        } else {
+            harness
+        };
+
         if self.harness == harness {
             return;
         }
@@ -401,7 +416,7 @@ impl AmbientAgentViewModel {
     /// True when the run is configured to use a non-Oz execution harness and the
     /// required feature flags are enabled.
     pub(super) fn is_third_party_harness(&self) -> bool {
-        FeatureFlag::AgentHarness.is_enabled() && self.harness != Harness::Oz
+        FeatureFlag::AgentHarness.is_enabled() && self.selected_harness() != Harness::Oz
     }
 
     /// Returns the [`CLIAgent`] corresponding to the currently selected harness when it is a
@@ -409,7 +424,7 @@ impl AmbientAgentViewModel {
     /// Used to drive the correct tab icon for a cloud run as soon as a non-oz harness is
     /// selected, even before the CLI session is registered with [`CLIAgentSessionsModel`].
     pub fn selected_third_party_cli_agent(&self) -> Option<CLIAgent> {
-        CLIAgent::from_harness(self.harness)
+        CLIAgent::from_harness(self.selected_harness())
     }
 
     /// True when this pane is a local-to-cloud handoff pane. Set when the handoff opens
@@ -452,7 +467,11 @@ impl AmbientAgentViewModel {
         pending: Option<PendingHandoff>,
         ctx: &mut ModelContext<Self>,
     ) {
+        let previous_harness = self.selected_harness();
         self.pending_handoff = pending;
+        if self.selected_harness() != previous_harness {
+            ctx.emit(AmbientAgentViewModelEvent::HarnessSelected);
+        }
         ctx.emit(AmbientAgentViewModelEvent::PendingHandoffChanged);
     }
 
@@ -798,8 +817,9 @@ impl AmbientAgentViewModel {
             ComputerUsePermission::resolve_cloud_agent_state(ctx);
         let computer_use_enabled = Some(enabled);
 
-        let harness_override =
-            (self.harness != Harness::Oz).then(|| HarnessConfig::from_harness_type(self.harness));
+        let selected_harness = self.selected_harness();
+        let harness_override = (selected_harness != Harness::Oz)
+            .then(|| HarnessConfig::from_harness_type(selected_harness));
 
         AgentConfigSnapshot {
             environment_id: self.environment_id.as_ref().map(|id| id.to_string()),
@@ -1068,7 +1088,6 @@ impl AmbientAgentViewModel {
             ctx
         );
 
-        use crate::server::server_api::ClientError;
         if let Some(client_error) = err.downcast_ref::<ClientError>() {
             if let Some(auth_url) = &client_error.auth_url {
                 self.handle_needs_github_auth(auth_url.clone(), client_error.error.clone(), ctx);

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -324,6 +324,10 @@ impl ActionButton {
         self.has_menu = has_menu;
         self
     }
+    pub fn set_has_menu(&mut self, has_menu: bool, ctx: &mut ViewContext<Self>) {
+        self.has_menu = has_menu;
+        ctx.notify();
+    }
 
     #[allow(dead_code)]
     pub fn with_callout(mut self, callout: Callout) -> Self {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

For local -> cloud handoff, we should disable the harness selector (as you can't go from a local warp conversation to a cloud claude conversation, using the same conversation).

This PR just locks the selector to Warp, but if/when we implement local->cloud for non-warp-harnesses we'll have to make the code respect the harness that's kicking off the cloud run.

## Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/845bedb3e7e040dca0bb1413f8364b45

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
