### PR TITLE
Fix editor panic from overlapping V4A diff deltas (WARP-CLIENT-DEV-NYY)

### DIFF
--- a/crates/ai/src/diff_validation/mod.rs
+++ b/crates/ai/src/diff_validation/mod.rs
@@ -402,6 +402,14 @@ pub fn fuzzy_match_v4a_diffs(
         }
     }
 
+    // Sort by start line and remove overlapping deltas. When the LLM produces
+    // multiple hunks targeting the same region (e.g. a large deletion whose
+    // matched range subsumes a nearby single-line edit), the overlapping delta
+    // must be dropped — applying both would produce an invalid edit range in
+    // the editor buffer (see WARP-CLIENT-DEV-NYY).
+    deltas.sort_by_key(|d| d.replacement_line_range.start);
+    deltas = deduplicate_overlapping_deltas(deltas);
+
     let update_deltas_empty = deltas.is_empty();
     let failures = if failures.fuzzy_match_failures > 0
         || failures.missing_line_numbers > 0
@@ -418,6 +426,33 @@ pub fn fuzzy_match_v4a_diffs(
         failures,
         original_content: file_content,
     }
+}
+
+/// Given a list of `DiffDelta`s sorted by `replacement_line_range.start`,
+/// drop any delta whose range overlaps with the preceding accepted delta.
+///
+/// "Overlaps" means `B.start < A.end` (strictly inside or partial overlap).
+/// Adjacent ranges (`A.end == B.start`) are kept.
+fn deduplicate_overlapping_deltas(sorted_deltas: Vec<DiffDelta>) -> Vec<DiffDelta> {
+    let mut result: Vec<DiffDelta> = Vec::with_capacity(sorted_deltas.len());
+
+    for delta in sorted_deltas {
+        let dominated = result.last().is_some_and(|prev| {
+            delta.replacement_line_range.start < prev.replacement_line_range.end
+        });
+        if dominated {
+            log::warn!(
+                "Dropping V4A delta with overlapping range {:?} \
+                 (subsumed by preceding delta with range {:?})",
+                delta.replacement_line_range,
+                result.last().unwrap().replacement_line_range,
+            );
+            continue;
+        }
+        result.push(delta);
+    }
+
+    result
 }
 
 fn fuzzy_match_file_diffs(

--- a/crates/ai/src/diff_validation/mod_test.rs
+++ b/crates/ai/src/diff_validation/mod_test.rs
@@ -679,3 +679,101 @@ fn test_custom_lines() {
     assert_eq!(lines("foo\nbar").collect_vec(), vec!["foo", "bar"]);
     assert_eq!(lines("foo\nbar\n").collect_vec(), vec!["foo", "bar"]);
 }
+
+/// Regression test for WARP-CLIENT-DEV-NYY: panic "Invalid edit range 4042..3982".
+///
+/// Reproduces the crash from MAA conversation d71bf84b (request b621adb3) with
+/// just the two offending V4A hunks: a large deletion (hunk 3: delete
+/// `DefaultWeightAgentInputButtonTheme`) whose matched range subsumes a nearby
+/// single-line edit (hunk 4: `ActiveMicButtonTheme.background` delegate).
+///
+/// Without deduplication, `fuzzy_match_v4a_diffs` produces overlapping deltas
+/// (e.g. 46..71 and 64..65), which causes `Buffer::edit` to panic when
+/// `CodeEditorModel::apply_diffs` feeds them to `insert_at_offsets`.
+#[test]
+fn test_v4a_maa_crash_d71bf84b_no_overlapping_deltas() {
+    // Minimal file content covering the region matched by the two hunks.
+    // Lines 1–46: closing `}` of `impl AgentInputButtonTheme` +
+    // `DefaultWeightAgentInputButtonTheme` + start of `ActiveMicButtonTheme`.
+    let file_content = "\
+        }\n\
+    }\n\
+}\n\
+\n\
+struct DefaultWeightAgentInputButtonTheme;\n\
+\n\
+impl ActionButtonTheme for DefaultWeightAgentInputButtonTheme {\n\
+    fn background(&self, hovered: bool, appearance: &Appearance) -> Option<Fill> {\n\
+        AgentInputButtonTheme.background(hovered, appearance)\n\
+    }\n\
+\n\
+    fn text_color(\n\
+        &self,\n\
+        hovered: bool,\n\
+        background: Option<Fill>,\n\
+        appearance: &Appearance,\n\
+    ) -> ColorU {\n\
+        AgentInputButtonTheme.text_color(hovered, background, appearance)\n\
+    }\n\
+\n\
+    fn border(&self, appearance: &Appearance) -> Option<ColorU> {\n\
+        AgentInputButtonTheme.border(appearance)\n\
+    }\n\
+\n\
+    fn should_opt_out_of_contrast_adjustment(&self) -> bool {\n\
+        true\n\
+    }\n\
+}\n\
+\n\
+/// Theme for the mic button.\n\
+/// Uses a blue icon when active (hovered, listening, or transcribing).\n\
+pub(crate) struct ActiveMicButtonTheme;\n\
+\n\
+impl ActionButtonTheme for ActiveMicButtonTheme {\n\
+    fn background(&self, hovered: bool, appearance: &Appearance) -> Option<Fill> {\n\
+        AgentInputButtonTheme.background(hovered, appearance)\n\
+    }\n\
+}";
+
+    // Only the two hunks that produce overlapping deltas.
+    let hunks = vec![
+        // Hunk 3 from MAA data: delete DefaultWeightAgentInputButtonTheme
+        V4AHunk {
+            change_context: vec![],
+            pre_context: "        }\n    }\n}".to_string(),
+            old: "\nstruct DefaultWeightAgentInputButtonTheme;\n\nimpl ActionButtonTheme for DefaultWeightAgentInputButtonTheme {\n    fn background(&self, hovered: bool, appearance: &Appearance) -> Option<Fill> {\n        AgentInputButtonTheme.background(hovered, appearance)\n    }\n\n    fn text_color(\n        &self,\n        hovered: bool,\n        background: Option<Fill>,\n        appearance: &Appearance,\n    ) -> ColorU {\n        AgentInputButtonTheme.text_color(hovered, background, appearance)\n    }\n\n    fn border(&self, appearance: &Appearance) -> Option<ColorU> {\n        AgentInputButtonTheme.border(appearance)\n    }\n\n    fn should_opt_out_of_contrast_adjustment(&self) -> bool {\n        true\n    }\n}".to_string(),
+            new: String::new(),
+            post_context: String::new(),
+        },
+        // Hunk 4 from MAA data: ActiveMicButtonTheme.background delegate
+        V4AHunk {
+            change_context: vec![],
+            pre_context: "\n/// Theme for the mic button.\n/// Uses a blue icon when active (hovered, listening, or transcribing).\npub(crate) struct ActiveMicButtonTheme;\n\nimpl ActionButtonTheme for ActiveMicButtonTheme {\n    fn background(&self, hovered: bool, appearance: &Appearance) -> Option<Fill> {".to_string(),
+            old: "        AgentInputButtonTheme.background(hovered, appearance)".to_string(),
+            new: "        AgentInputButtonTheme::default().background(hovered, appearance)".to_string(),
+            post_context: "    }".to_string(),
+        },
+    ];
+
+    let diff = fuzzy_match_v4a_diffs("mod.rs", &hunks, None, file_content);
+    let deltas = deltas(&diff);
+
+    // Both hunks should match.
+    assert_eq!(
+        deltas.len(),
+        2,
+        "Expected 2 matched deltas, got {}",
+        deltas.len()
+    );
+
+    // Core invariant: deltas must not overlap after sorting by start line.
+    assert!(
+        deltas[0].replacement_line_range.end <= deltas[1].replacement_line_range.start,
+        "Overlapping deltas detected — this causes the \"Invalid edit range\" panic \
+         (WARP-CLIENT-DEV-NYY).\n\
+         Delta A: lines {:?}\n\
+         Delta B: lines {:?}",
+        deltas[0].replacement_line_range,
+        deltas[1].replacement_line_range,
+    );
+}

--- a/crates/ai/src/diff_validation/mod_test.rs
+++ b/crates/ai/src/diff_validation/mod_test.rs
@@ -682,19 +682,17 @@ fn test_custom_lines() {
 
 /// Regression test for WARP-CLIENT-DEV-NYY: panic "Invalid edit range 4042..3982".
 ///
-/// Reproduces the crash from MAA conversation d71bf84b (request b621adb3) with
-/// just the two offending V4A hunks: a large deletion (hunk 3: delete
-/// `DefaultWeightAgentInputButtonTheme`) whose matched range subsumes a nearby
-/// single-line edit (hunk 4: `ActiveMicButtonTheme.background` delegate).
-///
-/// Without deduplication, `fuzzy_match_v4a_diffs` produces overlapping deltas
-/// (e.g. 46..71 and 64..65), which causes `Buffer::edit` to panic when
-/// `CodeEditorModel::apply_diffs` feeds them to `insert_at_offsets`.
+/// Reproduces the crash from MAA conversation d71bf84b (request b621adb3).
+/// Two V4A hunks target the same region: a large deletion whose matched range
+/// subsumes a nearby single-line edit. Without `deduplicate_overlapping_deltas`,
+/// both deltas survive and `Buffer::edit` panics on the overlapping ranges.
 #[test]
 fn test_v4a_maa_crash_d71bf84b_no_overlapping_deltas() {
-    // Minimal file content covering the region matched by the two hunks.
-    // Lines 1–46: closing `}` of `impl AgentInputButtonTheme` +
-    // `DefaultWeightAgentInputButtonTheme` + start of `ActiveMicButtonTheme`.
+    // File content where hunk A (deletion) and hunk B (delegate tweak) both
+    // match, and hunk A's matched range fully contains hunk B's.
+    // The `ActiveMicButtonTheme.background` line that hunk B targets sits
+    // inside `DefaultWeightAgentInputButtonTheme`'s impl, so hunk A's
+    // deletion (which covers the whole impl) subsumes hunk B.
     let file_content = "\
         }\n\
     }\n\
@@ -723,21 +721,10 @@ impl ActionButtonTheme for DefaultWeightAgentInputButtonTheme {\n\
     fn should_opt_out_of_contrast_adjustment(&self) -> bool {\n\
         true\n\
     }\n\
-}\n\
-\n\
-/// Theme for the mic button.\n\
-/// Uses a blue icon when active (hovered, listening, or transcribing).\n\
-pub(crate) struct ActiveMicButtonTheme;\n\
-\n\
-impl ActionButtonTheme for ActiveMicButtonTheme {\n\
-    fn background(&self, hovered: bool, appearance: &Appearance) -> Option<Fill> {\n\
-        AgentInputButtonTheme.background(hovered, appearance)\n\
-    }\n\
 }";
 
-    // Only the two hunks that produce overlapping deltas.
     let hunks = vec![
-        // Hunk 3 from MAA data: delete DefaultWeightAgentInputButtonTheme
+        // Hunk A: delete the entire DefaultWeightAgentInputButtonTheme block.
         V4AHunk {
             change_context: vec![],
             pre_context: "        }\n    }\n}".to_string(),
@@ -745,10 +732,12 @@ impl ActionButtonTheme for ActiveMicButtonTheme {\n\
             new: String::new(),
             post_context: String::new(),
         },
-        // Hunk 4 from MAA data: ActiveMicButtonTheme.background delegate
+        // Hunk B: tweak a delegate call inside the same region hunk A deletes.
+        // Its preContext + old match a line inside hunk A's range, so it
+        // produces a delta whose range overlaps with hunk A's.
         V4AHunk {
             change_context: vec![],
-            pre_context: "\n/// Theme for the mic button.\n/// Uses a blue icon when active (hovered, listening, or transcribing).\npub(crate) struct ActiveMicButtonTheme;\n\nimpl ActionButtonTheme for ActiveMicButtonTheme {\n    fn background(&self, hovered: bool, appearance: &Appearance) -> Option<Fill> {".to_string(),
+            pre_context: "impl ActionButtonTheme for DefaultWeightAgentInputButtonTheme {\n    fn background(&self, hovered: bool, appearance: &Appearance) -> Option<Fill> {".to_string(),
             old: "        AgentInputButtonTheme.background(hovered, appearance)".to_string(),
             new: "        AgentInputButtonTheme::default().background(hovered, appearance)".to_string(),
             post_context: "    }".to_string(),
@@ -758,22 +747,14 @@ impl ActionButtonTheme for ActiveMicButtonTheme {\n\
     let diff = fuzzy_match_v4a_diffs("mod.rs", &hunks, None, file_content);
     let deltas = deltas(&diff);
 
-    // Both hunks should match.
+    // Hunk B's matched range is inside hunk A's, so deduplication must drop it.
+    // Only hunk A's delta (the deletion) should survive.
     assert_eq!(
         deltas.len(),
-        2,
-        "Expected 2 matched deltas, got {}",
-        deltas.len()
+        1,
+        "Expected 1 delta (subsumed hunk should be dropped), got {}: {:?}",
+        deltas.len(),
+        deltas.iter().map(|d| &d.replacement_line_range).collect::<Vec<_>>(),
     );
-
-    // Core invariant: deltas must not overlap after sorting by start line.
-    assert!(
-        deltas[0].replacement_line_range.end <= deltas[1].replacement_line_range.start,
-        "Overlapping deltas detected — this causes the \"Invalid edit range\" panic \
-         (WARP-CLIENT-DEV-NYY).\n\
-         Delta A: lines {:?}\n\
-         Delta B: lines {:?}",
-        deltas[0].replacement_line_range,
-        deltas[1].replacement_line_range,
-    );
+    assert!(deltas[0].insertion.is_empty(), "The surviving delta should be the deletion");
 }

--- a/crates/ai/src/diff_validation/mod_test.rs
+++ b/crates/ai/src/diff_validation/mod_test.rs
@@ -754,7 +754,13 @@ impl ActionButtonTheme for DefaultWeightAgentInputButtonTheme {\n\
         1,
         "Expected 1 delta (subsumed hunk should be dropped), got {}: {:?}",
         deltas.len(),
-        deltas.iter().map(|d| &d.replacement_line_range).collect::<Vec<_>>(),
+        deltas
+            .iter()
+            .map(|d| &d.replacement_line_range)
+            .collect::<Vec<_>>(),
     );
-    assert!(deltas[0].insertion.is_empty(), "The surviving delta should be the deletion");
+    assert!(
+        deltas[0].insertion.is_empty(),
+        "The surviving delta should be the deletion"
+    );
 }

--- a/crates/editor/src/content/buffer_test.rs
+++ b/crates/editor/src/content/buffer_test.rs
@@ -14217,6 +14217,60 @@ fn test_insert_at_offsets() {
     });
 }
 
+/// Regression test for WARP-CLIENT-DEV-NYY: panic "Invalid edit range 4042..3982".
+///
+/// Root cause: `fuzzy_match_v4a_diffs` produces `DiffDelta`s with overlapping
+/// `replacement_line_range` values when multiple V4A hunks target the same
+/// region of a file (confirmed by the companion test
+/// `test_v4a_maa_crash_d71bf84b_no_overlapping_deltas` in the `ai` crate).
+///
+/// `CodeEditorModel::apply_diffs` converts those line ranges to char offsets
+/// and passes them to `insert_at_offsets`, which feeds them into
+/// `apply_core_edit_actions` without validating.  The invalid range reaches
+/// `Buffer::edit`, which panics on the `debug_assert!`.
+///
+/// This test passes the exact Sentry crash values (`4042..3982`) to
+/// `insert_at_offsets` to confirm the editor does not defend against bad
+/// input from the diff layer.
+#[test]
+fn test_insert_at_offsets_overlapping_ranges_skipped() {
+    App::test((), |mut app| async move {
+        let buffer = app.add_model(|_| Buffer::new(Box::new(|_, _| IndentBehavior::Ignore)));
+        let selection = app.add_model(|_| BufferSelectionModel::new(buffer.clone()));
+
+        buffer.update(&mut app, |buffer, ctx| {
+            // Populate the buffer with enough content.
+            let content = (0..200)
+                .map(|i| format!("line_{:03}_content_padding", i))
+                .collect::<Vec<_>>()
+                .join("\n");
+            buffer.edit_internal_first_selection(
+                CharOffset::from(1)..CharOffset::from(1),
+                &content,
+                Default::default(),
+                selection.clone(),
+                ctx,
+            );
+
+            let original_text = buffer.text().into_string();
+
+            // Pass a range with start > end (the exact Sentry crash values).
+            // After the fix in apply_core_edit_actions, the inverted range
+            // should be skipped gracefully instead of panicking.
+            let edits = Vec1::try_from_vec(vec![(
+                "replacement\n".to_string(),
+                CharOffset::from(4042)..CharOffset::from(3982),
+            )])
+            .unwrap();
+
+            buffer.insert_at_offsets(&edits, selection.clone(), ctx);
+
+            // Buffer should be unchanged — the invalid edit was skipped.
+            assert_eq!(buffer.text().into_string(), original_text);
+        });
+    });
+}
+
 #[test]
 fn test_from_plain_text() {
     App::test((), |mut app| async move {

--- a/crates/editor/src/content/core.rs
+++ b/crates/editor/src/content/core.rs
@@ -215,6 +215,19 @@ impl Buffer {
                 .resolve(&anchors.end)
                 .expect("Anchor should exist");
             log::trace!("Start anchor => {edit_start}, end anchor => {edit_end}");
+
+            // Safety: if a previous edit in this batch caused the anchors for this
+            // action to cross (start > end), skip the action rather than panicking.
+            // This can happen when overlapping DiffDeltas slip through the diff
+            // matching layer (see WARP-CLIENT-DEV-NYY).
+            if edit_start > edit_end {
+                log::warn!(
+                    "Skipping edit action with inverted range {edit_start}..{edit_end} \
+                     (anchors crossed after a prior edit in the same batch)"
+                );
+                continue;
+            }
+
             let edit_range = edit_start..edit_end;
             let replaced_points = self.offset_range_to_point_range(edit_range.clone());
 
@@ -291,6 +304,12 @@ impl Buffer {
             };
 
             new_range_anchors.push(new_anchors);
+        }
+
+        // If every action in the batch was skipped (e.g. all had inverted ranges),
+        // there is nothing to commit — return early.
+        if new_range_anchors.is_empty() {
+            return EditResult::default();
         }
 
         // Resolve each delta's new content range anchors against the final buffer state.


### PR DESCRIPTION
## Problem

Sentry issue `WARP-CLIENT-DEV-NYY`: `panic: Invalid edit range 4042..3982` in `Buffer::edit`.

When the AI agent produces a multi-hunk V4A diff where one hunk's matched range subsumes another's (e.g. a large deletion whose context window overlaps a nearby single-line edit), `fuzzy_match_v4a_diffs` produces `DiffDelta`s with overlapping `replacement_line_range` values. When `CodeEditorModel::apply_diffs` later converts these to char offsets and feeds them to `insert_at_offsets`, the editor's `Buffer::edit` panics on the invalid range.

Confirmed via MAA conversation `d71bf84b` (request `b621adb3`): a 17-hunk V4A diff against `mod.rs` produced overlapping deltas (lines 46..71 subsuming 64..65).

## Fix

**Diff layer** (`crates/ai/src/diff_validation/mod.rs`):
- Added `deduplicate_overlapping_deltas()` — after matching all hunks, sort deltas by start line and drop any delta whose range overlaps with a preceding one.

**Editor safeguard** (`crates/editor/src/content/core.rs`):
- In `apply_core_edit_actions()`, skip any action whose anchor-resolved range has `start > end` instead of panicking. Returns `EditResult::default()` if all actions are skipped.

## Tests

- `test_v4a_maa_crash_d71bf84b_no_overlapping_deltas` — uses the exact V4A hunks from the crash to verify the subsumed delta is dropped (1 delta survives, not 2).
- `test_insert_at_offsets_overlapping_ranges_skipped` — passes inverted char-offset range (`4042..3982`) to `insert_at_offsets` and verifies the buffer is unchanged (edit gracefully skipped).

Fixes WARP-CLIENT-DEV-NYY