### PR TITLE
Update mermaid_to_svg dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "dagre_rust"
 version = "0.0.5"
-source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=f7233f69965c59760fad98d684c786569814d821#f7233f69965c59760fad98d684c786569814d821"
+source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=4761588218f747c07d72fd324efcd2032d873aaf#4761588218f747c07d72fd324efcd2032d873aaf"
 dependencies = [
  "graphlib_rust",
  "ordered_hashmap",
@@ -7852,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "mermaid_to_svg"
 version = "0.1.0"
-source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=f7233f69965c59760fad98d684c786569814d821#f7233f69965c59760fad98d684c786569814d821"
+source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=4761588218f747c07d72fd324efcd2032d873aaf#4761588218f747c07d72fd324efcd2032d873aaf"
 dependencies = [
  "dagre_rust",
  "graphlib_rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ lazy_static = "1.4.0"
 libc = "0.2.81"
 line-ending = "1.4.0"
 log = { version = "0.4", features = ["serde", "std"] }
-mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev = "f7233f69965c59760fad98d684c786569814d821" }
+mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev = "4761588218f747c07d72fd324efcd2032d873aaf" }
 mime_guess = "2.0"
 minimp4 = "0.1.2"
 nix = { version = "0.26.4", default-features = false, features = ["signal"] }


### PR DESCRIPTION
## Description
Updates the workspace `mermaid_to_svg` git dependency to the latest upstream commit.

- Old rev: `f7233f69965c59760fad98d684c786569814d821`
- New rev: `4761588218f747c07d72fd324efcd2032d873aaf`

This also refreshes the corresponding `Cargo.lock` entries for `mermaid_to_svg` and its in-repo `dagre_rust` dependency.

## Linked Issue
N/A

## Screenshots / Videos
N/A — dependency bump only.

## Testing
- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`

Note: clippy completed successfully. During the run, `command-signatures-v2` logged a non-fatal build-script warning that it proceeded with stale generated command signatures JS.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Agent artifacts:
- Conversation: https://staging.warp.dev/conversation/7967da60-8ae2-4747-9db4-3bb49f727a32

Co-Authored-By: Oz <oz-agent@warp.dev>
