### PR TITLE
Disable CLI auto-indexing outside agent run REMOTE-664

### DIFF
--- a/app/src/ai/outline/native.rs
+++ b/app/src/ai/outline/native.rs
@@ -55,12 +55,18 @@ pub struct RepoOutlines {
 
     /// An `AbortHandle` for the active outline computation task.
     active_outline_task: Option<AbortHandle>,
+
+    indexing_enabled: bool,
 }
 
 const REPO_WATCHER_DEBOUNCE_DURATION: Duration = Duration::from_secs(10);
 
 impl RepoOutlines {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        Self::new_with_indexing_enabled(true, ctx)
+    }
+
+    pub fn new_with_indexing_enabled(indexing_enabled: bool, ctx: &mut ModelContext<Self>) -> Self {
         ctx.subscribe_to_model(&AISettings::handle(ctx), |me, event, ctx| {
             if let AISettingsChangedEvent::IsAnyAIEnabled { .. } = event {
                 Self::handle_setting_change_event(me, ctx);
@@ -73,11 +79,13 @@ impl RepoOutlines {
             }
         });
 
-        if !cfg!(any(
-            test,
-            feature = "fast_dev",
-            feature = "integration_tests"
-        )) {
+        if indexing_enabled
+            && !cfg!(any(
+                test,
+                feature = "fast_dev",
+                feature = "integration_tests"
+            ))
+        {
             ctx.subscribe_to_model(&DetectedRepositories::handle(ctx), |me, event, ctx| {
                 let DetectedRepositoriesEvent::DetectedGitRepo {
                     repository,
@@ -98,6 +106,7 @@ impl RepoOutlines {
             outlines: Default::default(),
             outline_queue: Default::default(),
             active_outline_task: Default::default(),
+            indexing_enabled,
         }
     }
 
@@ -108,13 +117,14 @@ impl RepoOutlines {
             outlines: Default::default(),
             outline_queue: Default::default(),
             active_outline_task: Default::default(),
+            indexing_enabled: true,
         }
     }
 
     fn index_repo(&mut self, repository: ModelHandle<Repository>, ctx: &mut ModelContext<Self>) {
         let repo_path = repository.as_ref(ctx).root_dir().to_local_path_lossy();
         if self.get_outline_internal(&repo_path).is_none()
-            && Self::should_build_outlines(ctx)
+            && self.should_build_outlines(ctx)
             && !self.outline_queue.contains(&repo_path)
         {
             let outline_state = OutlineState {
@@ -130,15 +140,16 @@ impl RepoOutlines {
 
     /// Check if outlines should be built based on if codebase context enabled OR
     /// outline codebase symbols for @ context menu settings.
-    fn should_build_outlines(ctx: &ModelContext<Self>) -> bool {
-        UserWorkspaces::as_ref(ctx).is_codebase_context_enabled(ctx)
-            || *InputSettings::as_ref(ctx)
-                .outline_codebase_symbols_for_at_context_menu
-                .value()
+    fn should_build_outlines(&self, ctx: &ModelContext<Self>) -> bool {
+        self.indexing_enabled
+            && (UserWorkspaces::as_ref(ctx).is_codebase_context_enabled(ctx)
+                || *InputSettings::as_ref(ctx)
+                    .outline_codebase_symbols_for_at_context_menu
+                    .value())
     }
 
     fn handle_setting_change_event(me: &mut RepoOutlines, ctx: &mut ModelContext<Self>) {
-        if Self::should_build_outlines(ctx) {
+        if me.should_build_outlines(ctx) {
             // Add all working directories to the queue and start processing.
             for dir in all_working_directories(ctx).into_iter() {
                 if let Some(repository) =
@@ -193,7 +204,7 @@ impl RepoOutlines {
 
     /// Computes the outline for the repo containing the next path in the queue, if any.
     fn compute_next_outline(&mut self, ctx: &mut ModelContext<Self>) {
-        if Self::should_build_outlines(ctx) && self.active_outline_task.is_none() {
+        if self.should_build_outlines(ctx) && self.active_outline_task.is_none() {
             if let Some(repo_root) = self.outline_queue.pop_front() {
                 self.compute_outline_for_repo(repo_root, ctx);
             }
@@ -222,7 +233,7 @@ impl RepoOutlines {
                 move |me, res, ctx| {
                     // Don't process this result if the setting has been disabled.
                     // The abort handle doesn't always abort.
-                    if Self::should_build_outlines(ctx) {
+                    if me.should_build_outlines(ctx) {
                         match res {
                             Ok((canonicalized_path, outline, parse_duration)) => {
                                 send_telemetry_from_ctx!(

--- a/app/src/ai/outline/wasm.rs
+++ b/app/src/ai/outline/wasm.rs
@@ -11,6 +11,13 @@ impl RepoOutlines {
         Self {}
     }
 
+    pub fn new_with_indexing_enabled(
+        _indexing_enabled: bool,
+        _ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        Self {}
+    }
+
     pub fn get_outline(&self, _path: &Path) -> Option<(&OutlineStatus, PathBuf)> {
         None
     }

--- a/app/src/ai/persisted_workspace.rs
+++ b/app/src/ai/persisted_workspace.rs
@@ -306,7 +306,8 @@ impl PersistedWorkspace {
             test,
             feature = "fast_dev",
             feature = "integration_tests"
-        )) {
+        )) && CodebaseIndexManager::as_ref(ctx).is_indexing_enabled()
+        {
             ctx.subscribe_to_model(&DetectedRepositories::handle(ctx), |me, event, ctx| {
                 let DetectedRepositoriesEvent::DetectedGitRepo { repository, .. } = event;
                 let repo_path = repository.as_ref(ctx).root_dir().to_local_path_lossy();
@@ -625,6 +626,9 @@ impl PersistedWorkspace {
     /// Enables or disables codebase indexing according to the setting.
     fn maybe_enable_codebase_indexing(ctx: &mut ModelContext<Self>) {
         CodebaseIndexManager::handle(ctx).update(ctx, |manager, ctx| {
+            if !manager.is_indexing_enabled() {
+                return;
+            }
             if UserWorkspaces::as_ref(ctx).is_codebase_context_enabled(ctx) {
                 Self::enable_codebase_indexing(manager, ctx);
             } else {

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1668,7 +1668,11 @@ fn initialize_app(
         );
     }
 
-    ctx.add_singleton_model(RepoOutlines::new);
+    if launch_mode.supports_indexing() {
+        ctx.add_singleton_model(RepoOutlines::new);
+    } else {
+        ctx.add_singleton_model(|ctx| RepoOutlines::new_with_indexing_enabled(false, ctx));
+    }
     ctx.add_singleton_model(|ctx| {
         warp_core::sync_queue::SyncQueue::<SyncTask>::new_with_rate_limit(
             &ctx.background_executor(),
@@ -1840,6 +1844,7 @@ fn initialize_app(
             codebase_limits.max_files_per_repo,
             codebase_limits.embedding_generation_batch_size,
             server_api_provider.as_ref(ctx).get(),
+            launch_mode.supports_indexing(),
             ctx,
         )
     });

--- a/crates/ai/src/index/full_source_code_embedding/manager.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager.rs
@@ -485,7 +485,7 @@ impl CodebaseIndexManager {
     }
 
     pub fn handle_active_session_changed(&mut self, active_directory: &Path) {
-        if !self.indexing_enabled {
+        if !self.is_indexing_enabled() {
             return;
         }
         let Some(root_path) = self.root_path_for_codebase(active_directory) else {
@@ -543,7 +543,7 @@ impl CodebaseIndexManager {
 
     /// Ensures the current number of indices is below the maximum.
     pub fn can_create_new_indices(&self) -> bool {
-        if !self.indexing_enabled {
+        if !self.is_indexing_enabled() {
             return false;
         }
         self.max_indices
@@ -551,7 +551,7 @@ impl CodebaseIndexManager {
     }
 
     pub fn handle_session_bootstrapped(&mut self, working_directory: &Path) {
-        if !self.indexing_enabled {
+        if !self.is_indexing_enabled() {
             return;
         }
         let Some(root_path) = self.root_path_for_codebase(working_directory) else {
@@ -598,7 +598,7 @@ impl CodebaseIndexManager {
     }
 
     pub fn index_directory(&mut self, directory: PathBuf, ctx: &mut ModelContext<Self>) {
-        if !self.indexing_enabled {
+        if !self.is_indexing_enabled() {
             return;
         }
         let directory = dunce::canonicalize(&directory).unwrap_or(directory);
@@ -647,7 +647,7 @@ impl CodebaseIndexManager {
         build_source: BuildSource,
         ctx: &mut ModelContext<Self>,
     ) {
-        if !self.indexing_enabled {
+        if !self.is_indexing_enabled() {
             return;
         }
         if !self.can_create_new_indices() {
@@ -1016,7 +1016,7 @@ impl CodebaseIndexManager {
         directory_path: &Path,
         ctx: &mut ModelContext<Self>,
     ) -> anyhow::Result<()> {
-        if !self.indexing_enabled {
+        if !self.is_indexing_enabled() {
             return Ok(());
         }
         // Find the root path for this directory's codebase

--- a/crates/ai/src/index/full_source_code_embedding/manager.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager.rs
@@ -1058,3 +1058,7 @@ impl Entity for CodebaseIndexManager {
 }
 
 impl SingletonEntity for CodebaseIndexManager {}
+
+#[cfg(test)]
+#[path = "manager_tests.rs"]
+mod tests;

--- a/crates/ai/src/index/full_source_code_embedding/manager.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager.rs
@@ -179,6 +179,8 @@ pub struct CodebaseIndexManager {
     max_files_repo_limit: usize,
 
     embedding_generation_batch_size: usize,
+
+    indexing_enabled: bool,
 }
 
 impl CodebaseIndexManager {
@@ -189,6 +191,7 @@ impl CodebaseIndexManager {
         max_files_repo_limit: usize,
         embedding_generation_batch_size: usize,
         store_client: Arc<dyn StoreClient>,
+        indexing_enabled: bool,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         cfg_if::cfg_if! {
@@ -196,6 +199,24 @@ impl CodebaseIndexManager {
                 let file_watcher = ctx.add_model(|ctx| BulkFilesystemWatcher::new(REPO_WATCHER_DEBOUNCE_DURATION, ctx));
                 ctx.subscribe_to_model(&file_watcher, Self::handle_watcher_event);
             }
+        }
+        if !indexing_enabled {
+            log::debug!(
+                "Codebase indexing disabled for this launch mode; skipping restore of {:?} persisted codebase indices",
+                persisted_index_metadata.len()
+            );
+
+            return Self {
+                codebase_indices: HashMap::new(),
+                store_client,
+                #[cfg(feature = "local_fs")]
+                watcher: file_watcher,
+                build_queue: BuildQueue::empty(),
+                max_indices: max_index_count,
+                max_files_repo_limit,
+                embedding_generation_batch_size,
+                indexing_enabled,
+            };
         }
 
         log::debug!(
@@ -234,6 +255,7 @@ impl CodebaseIndexManager {
             max_indices: max_index_count,
             max_files_repo_limit,
             embedding_generation_batch_size,
+            indexing_enabled,
         };
 
         // Start building the first index in the queue.
@@ -257,6 +279,7 @@ impl CodebaseIndexManager {
             max_indices: None,
             max_files_repo_limit: 0,
             embedding_generation_batch_size: 100,
+            indexing_enabled: true,
         }
     }
 
@@ -462,6 +485,9 @@ impl CodebaseIndexManager {
     }
 
     pub fn handle_active_session_changed(&mut self, active_directory: &Path) {
+        if !self.indexing_enabled {
+            return;
+        }
         let Some(root_path) = self.root_path_for_codebase(active_directory) else {
             return;
         };
@@ -517,11 +543,17 @@ impl CodebaseIndexManager {
 
     /// Ensures the current number of indices is below the maximum.
     pub fn can_create_new_indices(&self) -> bool {
+        if !self.indexing_enabled {
+            return false;
+        }
         self.max_indices
             .is_none_or(|max_indices| self.codebase_indices.len() < max_indices)
     }
 
     pub fn handle_session_bootstrapped(&mut self, working_directory: &Path) {
+        if !self.indexing_enabled {
+            return;
+        }
         let Some(root_path) = self.root_path_for_codebase(working_directory) else {
             return;
         };
@@ -561,7 +593,14 @@ impl CodebaseIndexManager {
         self.codebase_indices.len()
     }
 
+    pub fn is_indexing_enabled(&self) -> bool {
+        self.indexing_enabled
+    }
+
     pub fn index_directory(&mut self, directory: PathBuf, ctx: &mut ModelContext<Self>) {
+        if !self.indexing_enabled {
+            return;
+        }
         let directory = dunce::canonicalize(&directory).unwrap_or(directory);
         if !self.codebase_indices.contains_key(&directory) {
             self.build_and_sync_codebase_index(BuildSource::FromPath(&directory), ctx);
@@ -608,6 +647,9 @@ impl CodebaseIndexManager {
         build_source: BuildSource,
         ctx: &mut ModelContext<Self>,
     ) {
+        if !self.indexing_enabled {
+            return;
+        }
         if !self.can_create_new_indices() {
             return;
         }
@@ -974,6 +1016,9 @@ impl CodebaseIndexManager {
         directory_path: &Path,
         ctx: &mut ModelContext<Self>,
     ) -> anyhow::Result<()> {
+        if !self.indexing_enabled {
+            return Ok(());
+        }
         // Find the root path for this directory's codebase
         let Some(repo_path) = self.root_path_for_codebase(directory_path) else {
             return Err(anyhow::anyhow!("Failed to find root path for directory"));

--- a/crates/ai/src/index/full_source_code_embedding/manager_tests.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager_tests.rs
@@ -3,14 +3,12 @@ use std::{
     sync::Arc,
 };
 
-use warpui::App;
 use crate::index::full_source_code_embedding::store_client::MockStoreClient;
+use warpui::App;
 
 use crate::workspace::WorkspaceMetadata;
 
-use super::{
-    BuildSource, CodebaseIndexManager,
-};
+use super::{BuildSource, CodebaseIndexManager};
 
 fn workspace_metadata(path: impl Into<PathBuf>) -> WorkspaceMetadata {
     WorkspaceMetadata {
@@ -21,6 +19,28 @@ fn workspace_metadata(path: impl Into<PathBuf>) -> WorkspaceMetadata {
     }
 }
 
+#[test]
+fn initializes_with_indexing_enabled_when_configured() {
+    App::test((), |app| async move {
+        let manager = app.add_singleton_model(|ctx| {
+            CodebaseIndexManager::new(
+                vec![workspace_metadata("repo")],
+                Some(1),
+                1000,
+                32,
+                Arc::new(MockStoreClient),
+                true,
+                ctx,
+            )
+        });
+
+        manager.read(&app, |manager, _| {
+            assert!(manager.is_indexing_enabled());
+            assert_eq!(manager.num_active_indices(), 0);
+            assert!(manager.can_create_new_indices());
+        });
+    });
+}
 #[test]
 fn initializes_with_indexing_disabled_when_configured() {
     App::test((), |app| async move {
@@ -44,6 +64,28 @@ fn initializes_with_indexing_disabled_when_configured() {
     });
 }
 
+#[test]
+fn can_create_new_indices_honors_max_limit_when_enabled() {
+    App::test((), |mut app| async move {
+        let manager = app.add_singleton_model(|ctx| {
+            CodebaseIndexManager::new(
+                Vec::new(),
+                Some(1),
+                1000,
+                32,
+                Arc::new(MockStoreClient),
+                true,
+                ctx,
+            )
+        });
+
+        manager.update(&mut app, |manager, ctx| {
+            assert!(manager.can_create_new_indices());
+            manager.update_max_limits(Some(0), 1000, 32, ctx);
+            assert!(!manager.can_create_new_indices());
+        });
+    });
+}
 #[test]
 fn index_directory_is_noop_when_indexing_disabled() {
     App::test((), |mut app| async move {
@@ -88,6 +130,27 @@ fn build_and_sync_is_noop_when_indexing_disabled() {
     });
 }
 
+#[test]
+fn trigger_incremental_sync_returns_err_when_enabled_and_index_missing() {
+    App::test((), |mut app| async move {
+        let manager = app.add_singleton_model(|ctx| {
+            CodebaseIndexManager::new(
+                Vec::new(),
+                Some(1),
+                1000,
+                32,
+                Arc::new(MockStoreClient),
+                true,
+                ctx,
+            )
+        });
+
+        manager.update(&mut app, |manager, ctx| {
+            let result = manager.trigger_incremental_sync_for_path(Path::new("repo"), ctx);
+            assert!(result.is_err());
+        });
+    });
+}
 #[test]
 fn trigger_incremental_sync_returns_ok_when_indexing_disabled() {
     App::test((), |mut app| async move {

--- a/crates/ai/src/index/full_source_code_embedding/manager_tests.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager_tests.rs
@@ -1,0 +1,111 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use warpui::App;
+use crate::index::full_source_code_embedding::store_client::MockStoreClient;
+
+use crate::workspace::WorkspaceMetadata;
+
+use super::{
+    BuildSource, CodebaseIndexManager,
+};
+
+fn workspace_metadata(path: impl Into<PathBuf>) -> WorkspaceMetadata {
+    WorkspaceMetadata {
+        path: path.into(),
+        navigated_ts: None,
+        modified_ts: None,
+        queried_ts: None,
+    }
+}
+
+#[test]
+fn initializes_with_indexing_disabled_when_configured() {
+    App::test((), |app| async move {
+        let manager = app.add_singleton_model(|ctx| {
+            CodebaseIndexManager::new(
+                vec![workspace_metadata("repo")],
+                Some(1),
+                1000,
+                32,
+                Arc::new(MockStoreClient),
+                false,
+                ctx,
+            )
+        });
+
+        manager.read(&app, |manager, _| {
+            assert!(!manager.is_indexing_enabled());
+            assert_eq!(manager.num_active_indices(), 0);
+            assert!(!manager.can_create_new_indices());
+        });
+    });
+}
+
+#[test]
+fn index_directory_is_noop_when_indexing_disabled() {
+    App::test((), |mut app| async move {
+        let manager = app.add_singleton_model(|ctx| {
+            CodebaseIndexManager::new(
+                Vec::new(),
+                Some(1),
+                1000,
+                32,
+                Arc::new(MockStoreClient),
+                false,
+                ctx,
+            )
+        });
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.index_directory(PathBuf::from("repo"), ctx);
+            assert_eq!(manager.num_active_indices(), 0);
+        });
+    });
+}
+
+#[test]
+fn build_and_sync_is_noop_when_indexing_disabled() {
+    App::test((), |mut app| async move {
+        let manager = app.add_singleton_model(|ctx| {
+            CodebaseIndexManager::new(
+                Vec::new(),
+                Some(1),
+                1000,
+                32,
+                Arc::new(MockStoreClient),
+                false,
+                ctx,
+            )
+        });
+
+        manager.update(&mut app, |manager, ctx| {
+            manager.build_and_sync_codebase_index(BuildSource::FromPath(Path::new("repo")), ctx);
+            assert_eq!(manager.num_active_indices(), 0);
+        });
+    });
+}
+
+#[test]
+fn trigger_incremental_sync_returns_ok_when_indexing_disabled() {
+    App::test((), |mut app| async move {
+        let manager = app.add_singleton_model(|ctx| {
+            CodebaseIndexManager::new(
+                Vec::new(),
+                Some(1),
+                1000,
+                32,
+                Arc::new(MockStoreClient),
+                false,
+                ctx,
+            )
+        });
+
+        manager.update(&mut app, |manager, ctx| {
+            let result = manager.trigger_incremental_sync_for_path(Path::new("repo"), ctx);
+            assert!(result.is_ok());
+        });
+    });
+}


### PR DESCRIPTION
Below is Warp generated.

Basically a new flag was added to CodebaseIndexManager

REMOTE-664

## Description
Disable codebase-context auto-indexing in CLI modes other than `warp agent run` by threading `launch_mode.supports_indexing()` through indexing entry points and outline-indexing flows.

This change:
- adds `indexing_enabled` gating in `CodebaseIndexManager` to skip restore/build/sync in unsupported launch modes
- gates `PersistedWorkspace` repo-discovery auto-indexing and settings-driven enablement when indexing is disabled
- gates `RepoOutlines` repo discovery + outline build queue in unsupported modes
- wires startup initialization in `app/src/lib.rs` so non-agent CLI constructs disabled outline/index-manager behavior

## Linked Issue
- Linear: https://linear.app/warpdotdev/issue/REMOTE-664/disable-codebase-context-auto-indexing-for-the-cli
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt -- --check`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo build`
- `cargo check -p warp --lib`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://app.warp.dev/conversation/88de3f89-a332-4297-b4dc-b4913b561054

Co-Authored-By: Oz <oz-agent@warp.dev>
