### PR TITLE
Keep empty child agent pills visible after exiting agent view

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -3259,8 +3259,20 @@ impl TerminalView {
                     let was_new = *original_exchange_count == 0;
                     let was_modified = *final_exchange_count != *original_exchange_count;
 
-                    // Delete the conversation if it's unmodified, new, and has no init steps
-                    if !was_modified && was_new && !has_init_steps {
+                    // Child agents in an orchestration tree are part of the
+                    // orchestrator's pill bar and should remain visible even
+                    // when they're empty (e.g. failed-to-start, or just
+                    // haven't received their first event yet). The auto-
+                    // remove below is meant to prune accidentally-opened
+                    // empty *root* conversations, not children of an
+                    // orchestrator.
+                    let is_child_agent = BlocklistAIHistoryModel::as_ref(ctx)
+                        .conversation(conversation_id)
+                        .is_some_and(|c| c.is_child_agent_conversation());
+
+                    // Delete the conversation if it's unmodified, new, has no init steps,
+                    // and isn't a child agent in an orchestration tree.
+                    if !was_modified && was_new && !has_init_steps && !is_child_agent {
                         conversation_utils::remove_conversation(
                             *conversation_id,
                             me.view_id,


### PR DESCRIPTION
Loom: https://www.loom.com/share/1e0d5494fe99423eb7a3cd042d0eaf14
Fixes https://linear.app/warpdotdev/issue/QUALITY-602/fix-child-agents-disappearing-when-opening-via-pill

## Description
When a child agent failed to start (or simply hadn't received its first event yet), clicking its pill in the orchestration pill bar correctly opened an empty conversation — but navigating back to the parent or switching to another child caused the failed pill to disappear from the bar.

**Cause:** the `ExitedAgentView` handler in `TerminalView` auto-removes any conversation that was "new" (zero original exchanges) and "unmodified" (zero added exchanges) on exit. That cleanup is meant to prune accidentally-opened empty *root* conversations, but it was also firing for child agents that legitimately had zero exchanges and that the orchestrator's pill bar still needs to render.

**Fix:** skip the auto-remove when the conversation is part of an orchestration tree, detected via `AIConversation::is_child_agent_conversation()` (true when `parent_conversation_id` or `parent_agent_id` is set). Empty *root* conversations still get pruned as before.

## Screenshots / Videos
N/A — pill bar repro is identical before/after click; the behavioral fix is "the pill no longer vanishes".

## Testing
Manual repro:
1. Start an orchestrator that spawns a child agent that fails to start (or just spawn a child and don't let it receive its first event).
2. Click the failed child's pill in the orchestration pill bar → empty conversation opens (unchanged).
3. Click the parent pill (or another child) → before this fix, the failed pill disappears from the bar; after this fix, it stays.

The check reuses an existing `AIConversation::is_child_agent_conversation()` accessor; no new state introduced.

