### PR TITLE
fix(windows): prevent warp.exe from hanging after window closes

### DIFF
--- a/app/src/terminal/local_tty/mio_channel.rs
+++ b/app/src/terminal/local_tty/mio_channel.rs
@@ -91,14 +91,14 @@ impl<T> Sender<T> {
     /// This works the same way as [`mpsc::Sender::send`]. After sending the
     /// value, it wakes upthe [`mio::poll::Poll`].
     ///
-    /// Note that I/O errors from waking up the [`mio::poll::Poll`] are
-    /// swallowed.
     pub fn send(&self, t: T) -> Result<(), SendError<T>> {
         self.tx.send(t)?;
 
         let mut state = self.state.lock().unwrap();
         if let Some(waker) = &mut state.waker {
-            let _ = waker.wake();
+            if let Err(e) = waker.wake() {
+                log::error!("PTY mio Waker::wake() failed: {e:?}; event loop may not wake up to process shutdown");
+            }
         } else {
             state.needs_wake_on_register = true;
         }

--- a/app/src/terminal/local_tty/mio_channel.rs
+++ b/app/src/terminal/local_tty/mio_channel.rs
@@ -88,16 +88,15 @@ pub struct Sender<T> {
 impl<T> Sender<T> {
     /// Try to send a value.
     ///
-    /// This works the same way as [`mpsc::Sender::send`]. After sending the
-    /// value, it wakes upthe [`mio::poll::Poll`].
-    ///
+    /// This works the same way as [`mpsc::Sender::send`]. After sending the value, it wakes up the
+    /// [`mio::poll::Poll`].
     pub fn send(&self, t: T) -> Result<(), SendError<T>> {
         self.tx.send(t)?;
 
         let mut state = self.state.lock().unwrap();
         if let Some(waker) = &mut state.waker {
             if let Err(e) = waker.wake() {
-                log::error!("PTY mio Waker::wake() failed: {e:?}; event loop may not wake up to process shutdown");
+                log::error!("PTY mio Waker::wake() failed: {e:#}");
             }
         } else {
             state.needs_wake_on_register = true;

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -194,39 +194,31 @@ impl TerminalManager {
             log::info!("Failed to send Shutdown {e:?}");
         }
 
+        // On Windows, poll with a timeout instead of blocking indefinitely. If the event loop hangs
+        // (e.g. due to a pipe read or mio waker failure), a stuck join would prevent
+        // on_will_terminate from returning and thus prevent std::process::exit(0) from ever being
+        // called, leaving the warp.exe process alive with no visible window. If we time out,
+        // std::process::exit(0) will still kill the thread. The ConPTY handle will be closed by the
+        // OS when the process exits, which signals OpenConsole to exit on its own.
         if let Some(join_handle) = self.event_loop_handle.take() {
-            // On Windows, poll with a timeout instead of blocking indefinitely.
-            // If the event loop hangs (e.g. due to a pipe read or mio waker failure),
-            // a stuck join would prevent on_will_terminate from returning and thus
-            // prevent std::process::exit(0) from ever being called — leaving the
-            // warp.exe process alive with no visible window (APP-3702).
-            //
-            // If we time out, std::process::exit(0) will still kill the thread.
-            // The ConPTY handle will be closed by the OS when the process exits,
-            // which signals OpenConsole to exit on its own.
             #[cfg(windows)]
             {
-                const SHUTDOWN_TIMEOUT: std::time::Duration =
-                    std::time::Duration::from_secs(5);
-                const POLL_INTERVAL: std::time::Duration =
-                    std::time::Duration::from_millis(10);
-                let deadline = std::time::Instant::now() + SHUTDOWN_TIMEOUT;
+                use std::time::{Duration, Instant};
+                const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+                const POLL_INTERVAL: Duration = Duration::from_millis(10);
+                let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
                 while !join_handle.is_finished() {
-                    if std::time::Instant::now() >= deadline {
+                    if Instant::now() >= deadline {
                         log::warn!(
-                            "PTY event loop did not exit within {SHUTDOWN_TIMEOUT:?}; \
-                             proceeding with app shutdown"
+                            "PTY event loop did not exit within {SHUTDOWN_TIMEOUT:?}. Proceeding \
+                            with app shutdown."
                         );
                         self.inactive_pty_reads_rx.close();
                         return;
                     }
                     std::thread::sleep(POLL_INTERVAL);
                 }
-                if let Err(e) = join_handle.join() {
-                    log::error!("Failed to join event loop handle {e:?}");
-                }
             }
-            #[cfg(not(windows))]
             if let Err(e) = join_handle.join() {
                 log::error!("Failed to join event loop handle {e:?}");
             }

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -195,6 +195,38 @@ impl TerminalManager {
         }
 
         if let Some(join_handle) = self.event_loop_handle.take() {
+            // On Windows, poll with a timeout instead of blocking indefinitely.
+            // If the event loop hangs (e.g. due to a pipe read or mio waker failure),
+            // a stuck join would prevent on_will_terminate from returning and thus
+            // prevent std::process::exit(0) from ever being called — leaving the
+            // warp.exe process alive with no visible window (APP-3702).
+            //
+            // If we time out, std::process::exit(0) will still kill the thread.
+            // The ConPTY handle will be closed by the OS when the process exits,
+            // which signals OpenConsole to exit on its own.
+            #[cfg(windows)]
+            {
+                const SHUTDOWN_TIMEOUT: std::time::Duration =
+                    std::time::Duration::from_secs(5);
+                const POLL_INTERVAL: std::time::Duration =
+                    std::time::Duration::from_millis(10);
+                let deadline = std::time::Instant::now() + SHUTDOWN_TIMEOUT;
+                while !join_handle.is_finished() {
+                    if std::time::Instant::now() >= deadline {
+                        log::warn!(
+                            "PTY event loop did not exit within {SHUTDOWN_TIMEOUT:?}; \
+                             proceeding with app shutdown"
+                        );
+                        self.inactive_pty_reads_rx.close();
+                        return;
+                    }
+                    std::thread::sleep(POLL_INTERVAL);
+                }
+                if let Err(e) = join_handle.join() {
+                    log::error!("Failed to join event loop handle {e:?}");
+                }
+            }
+            #[cfg(not(windows))]
             if let Err(e) = join_handle.join() {
                 log::error!("Failed to join event loop handle {e:?}");
             }


### PR DESCRIPTION
## Description

Fixes the intermittent bug (#10202) where `warp.exe` stays alive after the window visually closes on Windows.

### Root cause

When the user closes Warp, the event loop fires `LoopExiting`:

1. **Window is hidden** (`hide_app()`) — this is the visual close the user sees
2. **`on_will_terminate` runs synchronously** — `std::process::exit(0)` is only called after this returns
3. On Windows, `on_will_terminate` calls `shutdown_all_pty_event_loops()`, which sends `Message::Shutdown` to each PTY event loop thread and then calls `join_handle.join()` **with no timeout**
4. If a PTY event loop thread fails to exit — due to e.g. a blocking pipe operation in `Pty::drop()` after `conpty_api.close()`, or a mio `Waker::wake()` failure that goes unnoticed — the `join` blocks forever
5. `on_will_terminate` never returns → `std::process::exit(0)` is never called → process stays alive with no visible window

The intermittency is explained by the race between ConPTY/OpenConsole teardown timing and whether the pipe read in `Pty::drop()` returns `WouldBlock` or stalls momentarily.

### Fix

**`terminal_manager.rs`**: Add a 5-second timeout to `shutdown_event_loop` on Windows. If a PTY event loop thread doesn't exit within the timeout, log a warning and proceed. `std::process::exit(0)` will kill the remaining thread. The OS will close the ConPTY handle when the process exits, which signals OpenConsole to exit on its own.

**`mio_channel.rs`**: Surface `Waker::wake()` failures as logged errors instead of silently swallowing them (`let _ = waker.wake()`). This makes it easier to diagnose whether a Waker failure is causing the event loop to stay blocked in `poll.poll()`.

## Linked Issue

- Fixes #10202

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Screenshots / Videos

N/A — internal shutdown timing fix.

## Testing

The bug is intermittent and Windows-only, which makes it difficult to add a deterministic automated test. The DEV-channel sleep in `autoupdate/windows.rs` (which simulates a slow shutdown) can be used on a Windows dev machine to verify the process now exits promptly.

Manual test plan:
- [ ] Open Warp on Windows with one or more active terminal sessions
- [ ] Close the window; verify `warp.exe` disappears from Task Manager promptly
- [ ] Trigger an auto-update; verify the installer completes without hanging

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- CHANGELOG-BUG-FIX: Fix intermittent issue where warp.exe process remained running after closing the window on Windows -->

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._