### PR TITLE
Resolve Warp version via helper script in /feedback skill

### DIFF
--- a/resources/bundled/skills/feedback/references/platforms.md
+++ b/resources/bundled/skills/feedback/references/platforms.md
@@ -21,9 +21,14 @@ Use the script output directly when filling `Operating system`. Ask the user onl
 
 ## Warp version
 
-For packaged native Warp installs, read the bundled version metadata file directly:
-The bundled version metadata file lives at `../../metadata/version.json` relative to the skill root. Read its `warp_version` field and use that value directly.
+For packaged native Warp installs, run the bundled helper script to resolve the installed Warp version:
 
-Use the file contents directly when filling `Warp version`. Ask the user only if Python is unavailable, the bundled metadata file is missing or unreadable, or the report is about a browser or web session rather than a packaged native install.
+```bash
+python3 scripts/resolve_warp_version.py
+```
+
+The script reads the bundled version metadata file (`bundled/metadata/version.json`) relative to its own location and prints a JSON object. When the version is available, the output is `{"warp_version": "..."}`; use that value directly when filling `Warp version`. When the metadata file is missing or unreadable, the script prints `{}` and exits 0 — treat that as "version unknown" and follow the fallbacks below.
+
+Ask the user only if Python is unavailable, the script returns an empty object, or the report is about a browser or web session rather than a packaged native install.
 
 - Browser or web session with no local Warp executable: use the version or build identifier from the session URL or surrounding session metadata when present. If there is no concrete version string, record that it was a web session and leave `Warp version` as `Unknown` rather than guessing.

--- a/resources/bundled/skills/feedback/scripts/resolve_warp_version.py
+++ b/resources/bundled/skills/feedback/scripts/resolve_warp_version.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Resolve the bundled Warp version for the feedback skill.
+
+Reads bundled/metadata/version.json relative to this script's location and
+prints {"warp_version": "..."} when the version is available, or {} when the
+metadata file is missing or unreadable. Always exits 0 so the agent can treat
+an empty result as "version unknown" without interpreting a non-zero exit
+code.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+
+def resolve_version_file() -> Path:
+    # This script lives at:
+    #   <root>/bundled/skills/feedback/scripts/resolve_warp_version.py
+    # Bundled version metadata lives at:
+    #   <root>/bundled/metadata/version.json
+    script_dir = Path(__file__).resolve().parent
+    return script_dir.parent.parent.parent / "metadata" / "version.json"
+
+
+def read_warp_version(path: Path) -> str | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    value = data.get("warp_version")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def main() -> int:
+    version = read_warp_version(resolve_version_file())
+    payload: dict[str, str] = {}
+    if version:
+        payload["warp_version"] = version
+    json.dump(payload, sys.stdout, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

The `/feedback` skill has been recording `Warp version` as `Unknown` even on packaged builds where the bundled metadata is present (#10214). The skill's `references/platforms.md` told the agent to read `../../metadata/version.json` directly via prose, which is brittle: the agent runtime doesn't always surface adjacent skill resources, and the model can also skip a prose-only lookup.

This PR replaces the prose-only instruction with a `scripts/resolve_warp_version.py` helper that resolves the metadata path relative to its own location (`__file__`) and prints `{"warp_version": "..."}` as JSON when the file is present, or `{}` when it's missing. `references/platforms.md` is updated to invoke the helper, mirroring the existing `resolve_platform.py` pattern already used for OS resolution. The script always exits 0 so the agent treats an empty result as "version unknown" without having to interpret a non-zero exit code.

## Linked Issue

Fixes #10214

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

(Issue is labeled `bug` / `triaged`; no spec label, but the fix is small and mechanical.)

## Testing

Manually exercised both branches of the script from the repo root:

```
$ python3 resources/bundled/skills/feedback/scripts/resolve_warp_version.py
{}
$ mkdir -p resources/bundled/metadata && \
  printf '{\n  "warp_version": "v0.2026.05.06.01.23.stable_99"\n}\n' > resources/bundled/metadata/version.json && \
  python3 resources/bundled/skills/feedback/scripts/resolve_warp_version.py
{"warp_version": "v0.2026.05.06.01.23.stable_99"}
```

Documentation/script-only change: `cargo fmt` / `cargo clippy` / Rust tests not applicable.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed /feedback recording "Unknown" instead of the installed Warp version on packaged builds.

