### PR TITLE
Assign feedback skill stakeholder

### DIFF
--- a/.github/STAKEHOLDERS
+++ b/.github/STAKEHOLDERS
@@ -78,6 +78,7 @@
 /app/src/ai/mcp/ @peicodes @vkodithala
 /app/src/ai/skills/ @peicodes @vkodithala
 /crates/mcp/ @peicodes @vkodithala
+/resources/bundled/skills/feedback/ @captainsafia
 
 # File-based MCP (overrides MCP and skills above)
 /app/src/ai/mcp/file_based_manager.rs @vkodithala


### PR DESCRIPTION
## Description
Assigns `@captainsafia` as the stakeholder for the bundled `feedback` skill by adding a specific `.github/STAKEHOLDERS` mapping for `/resources/bundled/skills/feedback/`.

## Linked Issue
No linked issue. This is a stakeholder metadata update requested from Slack.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
Not applicable.

## Testing
Validated `.github/STAKEHOLDERS` entries have path-plus-owner format with `awk`. No automated tests were added because this is a triage metadata-only change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._