### PR TITLE
Hide orchestration hover card as soon as cursor leaves the pill

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -851,10 +851,32 @@ impl View for OrchestrationPillBar {
         // the hover details card under that pill instead. The two overlays
         // are mutually exclusive by design: opening the menu clears
         // `hovered_pill` (see `open_menu_for`).
+        //
+        // Defensive: only render the hover card if the cursor is still
+        // genuinely over the pill. The `SetHoveredPill(None)` action that
+        // the pill's `on_hover` callback dispatches when the cursor leaves
+        // can be missed in edge cases (window-focus changes, layout drops
+        // mid-hover, the cursor exiting the app entirely, or a re-entry
+        // into a stale Hoverable that suppresses the synthetic
+        // hover-out), leaving `hovered_pill` stuck on a stale id and the
+        // card visible until something else triggers a re-render. Reading
+        // `MouseState::is_mouse_over_element` directly at render time
+        // makes the overlay strictly track the cursor: as soon as the
+        // pointer moves off the pill, the next render hides the card,
+        // regardless of whether the typed-action callback fired.
         let overlay = if let Some(target_id) = self.menu_open_for {
             Some(MenuOrCard::Menu(target_id))
         } else {
             self.hovered_pill.and_then(|id| {
+                let mouse_states = self.mouse_states.borrow();
+                let still_over_pill = mouse_states
+                    .get(&id)
+                    .and_then(|handle| handle.lock().ok().map(|s| s.is_mouse_over_element()))
+                    .unwrap_or(false);
+                drop(mouse_states);
+                if !still_over_pill {
+                    return None;
+                }
                 render_hover_card(id, self.agent_view_controller.as_ref(app), app)
                     .map(|card| MenuOrCard::Card { id, card })
             })


### PR DESCRIPTION
## Description
Exiting the orchestration pill bar's hover details card in certain ways (cursor leaving the app window, focus changes, layout drops mid-hover, or the cursor passing through a stale `Hoverable` that suppresses the synthetic hover-out) could leave the card visible after the cursor was no longer over any pill. The pill's `on_hover(false)` callback didn't fire in those cases, so the `SetHoveredPill(None)` typed action was never dispatched and `hovered_pill` got stuck on a stale id until something else triggered a re-render.

**Fix:** add a defensive render-time check in `OrchestrationPillBar::render`. Only render the hover card if the underlying pill's `MouseState::is_mouse_over_element` still reports the cursor as being over it. The overlay now strictly tracks the cursor — as soon as the pointer moves off the pill, the next render hides the card, regardless of whether the typed-action callback fired.

**Trade-off:** the existing 80ms `HOVER_CARD_OUT_DELAY` (intended to bridge the 6px gap between pill and card) becomes a no-op at the render layer because `is_mouse_over_element` is not delayed. The card was never meant to be interactive (its docstring already notes the card disappears as soon as the pointer leaves the pill body), so losing the smoothing is acceptable in exchange for guaranteed dismissal.

## Screenshots / Videos
N/A — this is a removal of a sticky-overlay state. Pre-fix: hover card stays visible after cursor moves off pill in certain exit paths. Post-fix: hover card disappears as soon as the cursor leaves the pill.

## Testing
Manual repro:
1. Hover over a pill in the orchestration pill bar; wait for the hover card to appear.
2. Move the cursor in one of these ways:
   - Out of the app window entirely.
   - Onto the card and then sideways off the bar.
   - Onto a different element that triggers a focus change mid-hover.
3. Before this fix: the hover card lingered until the next unrelated re-render. After this fix: the card disappears as soon as the cursor leaves the pill.

The check uses `MouseState::is_mouse_over_element` which is already maintained by `Hoverable` on every mouse-move event, so no new state is introduced.