### PR TITLE
spec: toolbelt buttons on collapsed conversation blocklist items (#9810)

### DIFF
--- a/specs/GH9810/PRODUCT.md
+++ b/specs/GH9810/PRODUCT.md
@@ -34,8 +34,21 @@ available, copy debug link).
   expands the conversation into the modal view, the existing
   modal-side toolbelt is the source of truth and the inline
   toolbelt is hidden (no duplication).
-- B6. Keyboard: Tab/Shift-Tab moves focus between rows; pressing
-  Enter on the kebab opens it; arrow keys navigate within.
+- B6. Keyboard focus uses row-roving navigation. Tab/Shift-Tab
+  moves focus between collapsed conversation rows as it does today;
+  the inline Fork button and kebab are not separate Tab stops.
+  When a collapsed row is focused, Left/Right arrow moves the
+  active in-row control between the row body, Fork button, and
+  kebab. Enter or Space activates the active in-row control:
+  - Row body: opens/expands the conversation using today's row
+    behavior.
+  - Fork button: forks the conversation with the same semantics as
+    pointer-clicking Fork.
+  - Kebab: opens the overflow menu.
+- B7. Once the kebab menu is open, Up/Down arrow moves between menu
+  items, Enter/Space activates the highlighted item, Escape closes
+  the menu and restores focus to the collapsed row, and Tab follows
+  the app's existing menu-dismiss behavior.
 
 ## Acceptance criteria
 
@@ -47,6 +60,9 @@ available, copy debug link).
 - A4. Right-click row → kebab menu opens at the cursor.
 - A5. Expanding the conversation into the modal view hides the
   inline toolbelt.
+- A6. With keyboard focus on a collapsed row, users can reach and
+  activate both Fork and kebab without leaving row-roving
+  navigation.
 
 ## Implementation pointers
 
@@ -66,6 +82,10 @@ available, copy debug link).
   presence rules.
 - T3. Right-click outside the toolbelt opens the kebab menu.
 - T4. Modal-open state hides the inline toolbelt (snapshot test).
+- T5. Keyboard navigation reaches row body, Fork, and kebab with
+  Left/Right; Enter/Space activate the focused in-row control.
+- T6. Kebab menu supports Up/Down, Enter/Space, and Escape without
+  dropping focus from the collapsed row.
 
 ## Out of scope
 

--- a/specs/GH9810/PRODUCT.md
+++ b/specs/GH9810/PRODUCT.md
@@ -1,54 +1,125 @@
-# Spec: Toolbelt buttons on collapsed conversation blocklist items (GH-9810)
+# GH-9810: Toolbelt buttons on collapsed conversation blocklist items
+
+GitHub issue: https://github.com/warpdotdev/warp/issues/9810
+
+## Summary
+
+When a conversation is collapsed in the blocklist (i.e., not opened in
+the modal view), users have no quick way to fork it or copy a debug /
+share link. Today they must first expand the conversation, then locate
+the action — friction for the "I just want to share this debug link"
+workflow. This feature adds an inline toolbelt to collapsed
+conversation rows with a primary Fork button and a kebab overflow
+menu for secondary link-copy actions.
 
 ## Problem
 
-When a conversation is collapsed in the blocklist (i.e., not
-opened in the modal view), users have no quick way to fork it or
-copy a debug/share link. They must first expand the conversation,
-then locate the action — friction for the "I just want to share
-this debug link" workflow.
+- Forking and link-copying are common conversation actions; on a
+  collapsed row they're invisible until the user expands the row,
+  which requires extra clicks and changes the user's view context.
+- The link-copy actions (conversation, share, debug) already exist
+  inside the modal-side toolbelt, but the collapsed-row surface has
+  no entry point for them at all.
+- Right-click context menus on collapsed rows are currently unused;
+  they're a natural surface for the secondary actions but were not
+  wired up.
 
-## Goal
+## Goals
 
-Add a toolbelt to collapsed conversation blocklist items with two
-controls: a primary **Fork** button and a kebab overflow menu for
-secondary actions (copy conversation link, copy share link when
-available, copy debug link).
+1. Add an inline toolbelt to collapsed conversation blocklist items
+   exposing a primary Fork action and a kebab overflow menu for
+   conversation-link / share-link / debug-link copy.
+2. Make the new actions reuse the exact same internal entry points
+   that the modal-side toolbelt uses, so authorization, redaction,
+   audit, and URL formatting are guaranteed identical.
+3. Make the new controls keyboard- and screen-reader accessible
+   without changing the row-level Tab-stop model (a collapsed row
+   stays a single Tab stop).
+4. Mirror the kebab overflow menu under right-click on the row.
 
-## Behavior contract
+## Non-goals
+
+- New top-level actions beyond the four listed (Fork, copy
+  conversation link, copy share link, copy debug link).
+- Drag-and-drop or multi-select on collapsed rows.
+- Touch / mobile gesture support.
+- Changing the modal-side toolbelt or the underlying share / debug
+  link generation pipelines. The modal remains the source of truth;
+  the inline toolbelt is a new entry point only.
+
+## User-facing behavior
+
+### Inline toolbelt on collapsed rows
 
 - B1. Collapsed conversation blocklist items render an inline
   toolbelt aligned to the trailing edge.
-- B2. Primary action: **Fork**. Single-click forks the
-  conversation; identical semantics to the Fork button inside the
-  modal view.
+- B2. Primary action: **Fork**. Single-click forks the conversation;
+  identical semantics to the Fork button inside the modal view.
 - B3. Kebab overflow menu (⋯) contains:
   - "Copy conversation link" (always present).
   - "Copy share link" (present only when the conversation has a
     share URL — same condition the modal uses).
-  - "Copy debug link" (present only in dev / debug-mode builds OR
-    when the user has the existing developer-tools setting on).
-- B4. Right-click on the row anywhere outside the toolbelt opens
-  the same kebab overflow menu (per @david's request in the issue).
-- B5. The toolbelt is collapsed-state-only — when the user
-  expands the conversation into the modal view, the existing
-  modal-side toolbelt is the source of truth and the inline
-  toolbelt is hidden (no duplication).
-- B6. Keyboard focus uses row-roving navigation. Tab/Shift-Tab
-  moves focus between collapsed conversation rows as it does today;
-  the inline Fork button and kebab are not separate Tab stops.
-  When a collapsed row is focused, Left/Right arrow moves the
-  active in-row control between the row body, Fork button, and
-  kebab. Enter or Space activates the active in-row control:
-  - Row body: opens/expands the conversation using today's row
-    behavior.
-  - Fork button: forks the conversation with the same semantics as
-    pointer-clicking Fork.
-  - Kebab: opens the overflow menu.
-- B7. Once the kebab menu is open, Up/Down arrow moves between menu
-  items, Enter/Space activates the highlighted item, Escape closes
-  the menu and restores focus to the collapsed row, and Tab follows
-  the app's existing menu-dismiss behavior.
+  - "Copy debug link" (present only when debug-mode is active for
+    the conversation — same condition the modal uses, including
+    any developer-tools setting gate).
+- B4. Right-click on the row anywhere outside the toolbelt opens the
+  same kebab overflow menu (per @david's request in the issue).
+- B5. The toolbelt is collapsed-state-only — when the user expands
+  the conversation into the modal view, the existing modal-side
+  toolbelt is the source of truth and the inline toolbelt is
+  hidden (no duplication).
+
+### Link-copy privacy contract
+
+- B6. The share-link and debug-link copy actions in the kebab menu
+  reuse the **exact same** authorization, redaction, audit, and URL
+  formatting pathways as the modal-side share / debug surfaces.
+  The collapsed-row menu is a new entry point but does NOT bypass
+  any modal precondition. Concretely:
+  - **Auth state.** If the user is not authenticated for share, the
+    Copy share link item is hidden or disabled with the same
+    wording the modal uses.
+  - **Share permission.** If share permission is revoked for the
+    conversation, the item is hidden or disabled with the same
+    wording the modal uses.
+  - **Debug-mode gate.** If debug mode is not active for the
+    conversation, the Copy debug link item is not shown.
+  - **Redaction.** Whatever redaction the modal applies before
+    producing a share / debug URL also applies on the collapsed
+    row. The collapsed row never holds raw conversation content
+    that the modal would have redacted.
+  - **Audit.** Each copy action emits the same audit / telemetry
+    event the modal emits, with `source = "collapsed_row"` so the
+    surface is distinguishable in audit logs.
+- B7. URL parity. The URL placed on the clipboard from the kebab
+  menu is byte-for-byte identical to the URL the modal-side action
+  would produce for the same conversation in the same state.
+
+### Keyboard model
+
+The collapsed row remains a **single Tab stop**; the inline buttons
+inside it are not individually Tab-stoppable. Roving focus between
+in-row controls is via arrow keys.
+
+- B8. Tab / Shift-Tab moves focus between collapsed conversation
+  rows as it does today. Inline Fork and kebab are not separate
+  Tab stops.
+- B9. When a collapsed row has Tab focus:
+  - Left / Right arrow rove the active in-row control between the
+    row body, the Fork button, and the kebab.
+  - Enter or Space activates the active in-row control:
+    - Row body: opens / expands the conversation using today's row
+      behavior.
+    - Fork button: forks the conversation.
+    - Kebab: opens the overflow menu.
+  - Escape, when no menu is open, returns the active control to
+    the row body (no-op if it was already there).
+- B10. When the kebab menu is open:
+  - Up / Down arrow moves between menu items.
+  - Enter / Space activates the highlighted item.
+  - Escape closes the menu and restores Tab focus to the kebab
+    button (and therefore to the row).
+  - Tab follows the app's existing menu-dismiss behavior.
 
 ## Acceptance criteria
 
@@ -62,33 +133,40 @@ available, copy debug link).
   inline toolbelt.
 - A6. With keyboard focus on a collapsed row, users can reach and
   activate both Fork and kebab without leaving row-roving
-  navigation.
+  navigation; arrow-roving and Enter/Space activation behave per
+  B9 / B10.
+- A7. **Share-link parity.** The "Copy share link" item, when
+  enabled, places on the clipboard a URL byte-for-byte equal to
+  the URL produced by the modal-side share-link action for the
+  same conversation in the same state.
+- A8. **Debug-link gate.** The "Copy debug link" item is shown only
+  when debug mode is active for the conversation, matching the
+  modal-side gate exactly.
+- A9. **Revoked-share state.** When share permission has been
+  revoked for the conversation, the inline "Copy share link" item
+  is hidden or disabled with the same wording the modal-side
+  surface uses for the same state.
+- A10. **Audit parity.** A copy action from the inline kebab menu
+  emits the same audit / telemetry event as the modal-side action,
+  with `source = "collapsed_row"`.
 
-## Implementation pointers
+## Open questions
 
-- Collapsed conversation row renderer lives in
-  `app/src/ai/blocklist/agent_view/` (search for
-  `collapsed_conversation` or grep the existing collapsed-row
-  layout).
-- The modal-side Fork action and link-copy actions are the
-  source-of-truth implementations; the new buttons dispatch the
-  same actions via the existing action-bus pattern.
+None outstanding. Resolved during spec review:
 
-## Test plan
+- Right-click on the row outside the toolbelt is the agreed
+  surface for the overflow menu (per @david).
+- The kebab is the only mouse-click affordance for the secondary
+  actions; no second visible button per item.
 
-- T1. Click handler dispatches Fork action; reuses the existing
-  fork test fixture.
-- T2. Kebab menu shows the three entries with conditional
-  presence rules.
-- T3. Right-click outside the toolbelt opens the kebab menu.
-- T4. Modal-open state hides the inline toolbelt (snapshot test).
-- T5. Keyboard navigation reaches row body, Fork, and kebab with
-  Left/Right; Enter/Space activate the focused in-row control.
-- T6. Kebab menu supports Up/Down, Enter/Space, and Escape without
-  dropping focus from the collapsed row.
+## Success metrics
 
-## Out of scope
+- Time-to-copy share link from a collapsed row: target reduction
+  versus the current expand-then-copy flow (instrumented via the
+  `source = "collapsed_row"` audit field).
+- Adoption: percentage of share-link / debug-link copies originating
+  from the collapsed row vs the modal, segmented by week.
 
-- New top-level actions beyond the four listed.
-- Drag-and-drop or multi-select on collapsed rows.
-- Touch / mobile gesture support.
+## See also
+
+- Tech spec: `specs/GH9810/TECH.md`

--- a/specs/GH9810/SPEC.md
+++ b/specs/GH9810/SPEC.md
@@ -1,0 +1,74 @@
+# Spec: Toolbelt buttons on collapsed conversation blocklist items (GH-9810)
+
+## Problem
+
+When a conversation is collapsed in the blocklist (i.e., not
+opened in the modal view), users have no quick way to fork it or
+copy a debug/share link. They must first expand the conversation,
+then locate the action — friction for the "I just want to share
+this debug link" workflow.
+
+## Goal
+
+Add a toolbelt to collapsed conversation blocklist items with two
+controls: a primary **Fork** button and a kebab overflow menu for
+secondary actions (copy conversation link, copy share link when
+available, copy debug link).
+
+## Behavior contract
+
+- B1. Collapsed conversation blocklist items render an inline
+  toolbelt aligned to the trailing edge.
+- B2. Primary action: **Fork**. Single-click forks the
+  conversation; identical semantics to the Fork button inside the
+  modal view.
+- B3. Kebab overflow menu (⋯) contains:
+  - "Copy conversation link" (always present).
+  - "Copy share link" (present only when the conversation has a
+    share URL — same condition the modal uses).
+  - "Copy debug link" (present only in dev / debug-mode builds OR
+    when the user has the existing developer-tools setting on).
+- B4. Right-click on the row anywhere outside the toolbelt opens
+  the same kebab overflow menu (per @david's request in the issue).
+- B5. The toolbelt is collapsed-state-only — when the user
+  expands the conversation into the modal view, the existing
+  modal-side toolbelt is the source of truth and the inline
+  toolbelt is hidden (no duplication).
+- B6. Keyboard: Tab/Shift-Tab moves focus between rows; pressing
+  Enter on the kebab opens it; arrow keys navigate within.
+
+## Acceptance criteria
+
+- A1. Collapsed conversation row shows a Fork button + kebab.
+- A2. Click Fork: conversation forks with the same outcome as
+  modal-side Fork.
+- A3. Click kebab → "Copy conversation link" copies the same URL
+  the modal-side action would.
+- A4. Right-click row → kebab menu opens at the cursor.
+- A5. Expanding the conversation into the modal view hides the
+  inline toolbelt.
+
+## Implementation pointers
+
+- Collapsed conversation row renderer lives in
+  `app/src/ai/blocklist/agent_view/` (search for
+  `collapsed_conversation` or grep the existing collapsed-row
+  layout).
+- The modal-side Fork action and link-copy actions are the
+  source-of-truth implementations; the new buttons dispatch the
+  same actions via the existing action-bus pattern.
+
+## Test plan
+
+- T1. Click handler dispatches Fork action; reuses the existing
+  fork test fixture.
+- T2. Kebab menu shows the three entries with conditional
+  presence rules.
+- T3. Right-click outside the toolbelt opens the kebab menu.
+- T4. Modal-open state hides the inline toolbelt (snapshot test).
+
+## Out of scope
+
+- New top-level actions beyond the four listed.
+- Drag-and-drop or multi-select on collapsed rows.
+- Touch / mobile gesture support.

--- a/specs/GH9810/TECH.md
+++ b/specs/GH9810/TECH.md
@@ -50,17 +50,64 @@ roves between three logical positions via arrow keys:
 [ row body ] <— Left/Right —> [ Fork ] <— Left/Right —> [ Kebab ]
 ```
 
-- Roving focus is implemented via `tabindex="-1"` on the inline
-  buttons + `tabindex="0"` on the row container, with a JS-managed
-  `aria-activedescendant` (or roving `tabindex` swap) per existing
-  patterns in the codebase.
-- Enter / Space on the row activates whichever logical position is
-  active.
-- Escape with no menu open returns the active position to the row
-  body.
-- The kebab menu, when open, owns its own focus loop (Up/Down to
-  navigate, Enter/Space to activate, Escape to close + restore
-  focus to the kebab button).
+### Canonical focus implementation: `aria-activedescendant`
+
+V1 uses **`aria-activedescendant` exclusively** for in-row focus
+movement. The roving-`tabindex` alternative is explicitly NOT
+used. This is the canonical contract; ambiguity between the two
+approaches caused the round-N nit and is resolved here.
+
+Concrete requirements:
+
+1. **DOM-focus owner.** The row container is the only element
+   within the row that receives DOM focus. It has
+   `tabindex="0"`. The inline Fork button and the kebab button
+   have `tabindex="-1"` and DO NOT receive DOM focus during
+   in-row arrow navigation. (`document.activeElement` stays on
+   the row container as the user presses Left/Right.)
+2. **`aria-activedescendant`.** The row container exposes
+   `aria-activedescendant="<id-of-active-inner-element>"`,
+   updated by the keyboard handler as the user presses Left /
+   Right. The three valid descendant ids are the row-body
+   sentinel, the Fork button, and the kebab button. Each inner
+   element has a stable id.
+3. **Visual focus ring.** Because DOM focus stays on the row
+   container, the visual focus ring on the active inner element
+   is rendered via CSS `:where([id=...])` keyed off
+   `aria-activedescendant`, NOT via `:focus` /
+   `:focus-visible`. This is asserted by snapshot in T5a (added
+   below).
+4. **Enter / Space.** Pressing Enter or Space on the row
+   container dispatches the activation handler for whichever
+   element id is currently the `aria-activedescendant` value.
+   Activation is a method call on the descendant, not a
+   synthetic `click()` on a focused element (since the
+   descendant is never DOM-focused).
+5. **Escape (no menu open).** Resets
+   `aria-activedescendant` to the row-body sentinel id.
+6. **Roving-`tabindex` is forbidden in V1.** The implementation
+   MUST NOT toggle `tabindex` between `0` and `-1` on the
+   inline buttons during arrow navigation. If a future
+   accessibility-engine constraint requires roving-`tabindex`
+   instead, that is a follow-up spec change with its own test
+   plan. The lint/code-review rule for this section: any commit
+   that changes `tabindex` on the inline Fork or kebab button
+   in response to a keyboard event is rejected.
+7. **Menu open.** The kebab menu, when open, owns its own focus
+   loop. Inside the open menu, the menu itself takes DOM focus
+   (a separate scope from the in-row `aria-activedescendant`
+   model). Up/Down navigate menu items; Enter/Space activate;
+   Escape closes the menu and restores DOM focus to the row
+   container with `aria-activedescendant` pointing at the
+   kebab button id.
+
+This single-implementation contract makes T5 (keyboard
+navigation), T6 (menu key handling), and T11 (accessibility
+audit) deterministic: tests assert
+`document.activeElement === rowContainer` throughout in-row
+navigation, and assert the value of
+`row.getAttribute("aria-activedescendant")` after each
+Left/Right keypress.
 
 ## Accessibility contract
 
@@ -131,10 +178,54 @@ parity (A10).
   against the same predicate's modal-side return values.
 - T3. Right-click outside the toolbelt opens the kebab menu at the
   cursor.
+- T3a. **Right-click no-expand regression.** Right-clicking on a
+  collapsed row to open the overflow menu MUST NOT also expand
+  the row, open it, or otherwise change its collapsed/expanded
+  state. Specifically, the test asserts:
+  1. The row's `aria-expanded` (or equivalent
+     collapsed/expanded state attribute) is unchanged from
+     before the right-click to after the right-click and after
+     the menu closes.
+  2. The row's body content remains in its pre-right-click
+     rendered form (no expansion DOM mutations).
+  3. The activation handler that toggles expand/collapse is NOT
+     invoked on the right-click event path. The test uses a spy
+     on the toggle handler and asserts zero invocations.
+  4. Closing the menu (Escape, click-away, item activation)
+     also does NOT toggle expand/collapse.
+  5. The same invariants hold whether the right-click lands on
+     the row body, on the Fork button, or on the kebab button
+     itself.
+  This guards against the common regression where a right-click
+  fires both a `contextmenu` handler (opens menu) AND a
+  `mousedown` / `click` handler (toggles expand). The
+  implementation MUST `preventDefault()` and `stopPropagation()`
+  on the `contextmenu` event so the row's click/expand handler
+  never sees it.
 - T4. Modal-open state hides the inline toolbelt (snapshot test).
 - T5. Keyboard navigation reaches row body, Fork, and kebab with
   Left/Right; Enter / Space activate the focused in-row control.
   Tab moves between rows, not into in-row controls.
+- T5a. **`aria-activedescendant` canonical-implementation test.**
+  Drive Left/Right keys through the row and assert, after each
+  keypress, that:
+  1. `document.activeElement === rowContainer` (DOM focus
+     stays on the row container; never moves to the Fork or
+     kebab button).
+  2. `rowContainer.getAttribute("aria-activedescendant")`
+     transitions through the three sentinel ids in the
+     documented order (row body → Fork → kebab on Right,
+     reverse on Left).
+  3. The Fork and kebab buttons both have `tabindex="-1"`
+     throughout, NEVER `tabindex="0"`, regardless of which is
+     the active descendant. (Guards against an accidental
+     drift to roving-`tabindex`.)
+  4. The visual focus ring is keyed off `aria-activedescendant`
+     via CSS, not via the native `:focus` pseudo-class
+     (snapshot assertion of the rendered styles).
+  5. Pressing Enter / Space with each descendant active
+     invokes the descendant's activation handler exactly once
+     (asserted by spies on Fork-activate and kebab-activate).
 - T6. Kebab menu supports Up/Down, Enter/Space, and Escape without
   dropping focus from the collapsed row.
 - T7. **Share-link parity test.** For a conversation in a fixture

--- a/specs/GH9810/TECH.md
+++ b/specs/GH9810/TECH.md
@@ -1,0 +1,159 @@
+# GH-9810: Tech Spec
+
+GitHub issue: https://github.com/warpdotdev/warp/issues/9810
+Product spec: `specs/GH9810/PRODUCT.md`
+
+## Problem
+
+The collapsed conversation blocklist row currently has no inline
+controls for Fork or link-copy. The implementation needs to add an
+inline toolbelt + kebab overflow menu, mirror the menu under
+right-click, and route every action through the same internal API
+the modal-side toolbelt already uses, so authorization, redaction,
+audit, and URL formatting are guaranteed identical to the modal.
+
+## Relevant code
+
+- Collapsed conversation row renderer: `app/src/ai/blocklist/agent_view/`
+  (search for `collapsed_conversation` or grep the existing
+  collapsed-row layout).
+- Modal-side conversation toolbelt: source-of-truth implementations
+  for Fork, copy conversation link, copy share link, copy debug link.
+  The new inline toolbelt dispatches the same actions via the
+  existing action-bus pattern. **Do not reimplement** any URL
+  formatting, redaction, or auth-state evaluation; route through the
+  modal's existing entry points.
+- Overflow / context-menu primitives in
+  `app/src/ai/blocklist/agent_view/` (or the shared menu primitive
+  used elsewhere in the agent view).
+
+## Implementation pointers
+
+- Reuse existing action constants for the four actions; do not
+  introduce parallel ones.
+- Audit / telemetry event payloads gain a `source` field with values
+  `"modal"` (existing) and `"collapsed_row"` (new). Every emit
+  point must populate it.
+- The kebab menu's conditional items (share / debug) MUST consult
+  the same predicate function the modal uses to decide
+  visibility / enabled state — extract that predicate to a shared
+  helper if it isn't already one. Do not duplicate the conditions
+  inline.
+
+## Focus model
+
+The collapsed row is a **single Tab stop**. Inline Fork and kebab
+buttons are not individually Tab-stoppable. Within the row, focus
+roves between three logical positions via arrow keys:
+
+```
+[ row body ] <— Left/Right —> [ Fork ] <— Left/Right —> [ Kebab ]
+```
+
+- Roving focus is implemented via `tabindex="-1"` on the inline
+  buttons + `tabindex="0"` on the row container, with a JS-managed
+  `aria-activedescendant` (or roving `tabindex` swap) per existing
+  patterns in the codebase.
+- Enter / Space on the row activates whichever logical position is
+  active.
+- Escape with no menu open returns the active position to the row
+  body.
+- The kebab menu, when open, owns its own focus loop (Up/Down to
+  navigate, Enter/Space to activate, Escape to close + restore
+  focus to the kebab button).
+
+## Accessibility contract
+
+The collapsed row + inline toolbelt + kebab menu MUST satisfy the
+following ARIA structure:
+
+- The row container:
+  - `role="listitem"` (it lives inside the existing list).
+  - `tabindex="0"` (single Tab stop).
+  - `aria-label="Conversation row, [collapsed|expanded]: <title>"`.
+- The inline button group (Fork + kebab) within the row:
+  - `role="toolbar"` with `aria-label="Conversation actions"`.
+- The Fork button:
+  - `tabindex="-1"`.
+  - `aria-label="Fork conversation"`.
+- The kebab button:
+  - `tabindex="-1"`.
+  - `aria-label="More conversation actions"`.
+  - `aria-haspopup="menu"`.
+  - `aria-expanded` reflecting menu open / closed state.
+  - `aria-controls` referencing the menu's id when open.
+- The overflow menu, when open:
+  - `role="menu"` with `aria-label="More conversation actions"`.
+- Each menu item:
+  - `role="menuitem"`.
+  - Disabled items use `aria-disabled="true"` (not removed from the
+    DOM) so screen readers can announce the disabled-state wording
+    that matches the modal.
+
+Screen reader announcement order:
+
+1. Row label (e.g., "Conversation row, collapsed: <title>").
+2. On Right-arrow into the toolbar: "Conversation actions toolbar,
+   Fork button" (or whichever control receives focus).
+3. On Right-arrow further: "More conversation actions, menu popup,
+   collapsed".
+4. On kebab activation: menu items announce in their list order.
+
+## Privacy / authorization implementation
+
+The link-copy actions are routed through the same internal API the
+modal uses. Concretely:
+
+1. The kebab menu builder calls the shared `is_share_link_available`
+   predicate (extracted if not already shared) — same return value
+   as the modal sees in the same state.
+2. The kebab menu builder calls the shared `is_debug_link_available`
+   predicate — same return value as the modal sees.
+3. On activation, each item dispatches the existing action with the
+   conversation id; the action impl is unchanged.
+4. The action impl is the only place URL formatting, redaction, and
+   audit emission happen. The collapsed-row entry point does not
+   touch raw conversation data.
+5. Audit emit gains `source = "collapsed_row"` (versus the modal's
+   `source = "modal"`).
+
+This guarantees URL parity with the modal (PRODUCT A7), debug-link
+gating parity (A8), revoked-share state parity (A9), and audit
+parity (A10).
+
+## Test plan
+
+- T1. Click handler dispatches Fork action; reuses the existing
+  fork test fixture and asserts the same post-state as a modal-side
+  fork.
+- T2. Kebab menu shows the three entries with conditional presence
+  rules. Driven by the shared availability predicates, asserted
+  against the same predicate's modal-side return values.
+- T3. Right-click outside the toolbelt opens the kebab menu at the
+  cursor.
+- T4. Modal-open state hides the inline toolbelt (snapshot test).
+- T5. Keyboard navigation reaches row body, Fork, and kebab with
+  Left/Right; Enter / Space activate the focused in-row control.
+  Tab moves between rows, not into in-row controls.
+- T6. Kebab menu supports Up/Down, Enter/Space, and Escape without
+  dropping focus from the collapsed row.
+- T7. **Share-link parity test.** For a conversation in a fixture
+  state with share enabled, assert the URL placed on the clipboard
+  by the inline "Copy share link" action equals byte-for-byte the
+  URL the modal-side action produces for the same fixture.
+- T8. **Debug-link gate test.** For a fixture conversation without
+  debug mode, assert the "Copy debug link" item is not present in
+  the kebab menu and the keyboard never lands on it. For the same
+  fixture with debug mode active, assert presence.
+- T9. **Revoked-share parity test.** For a fixture conversation
+  with share permission revoked, assert the inline "Copy share
+  link" item is hidden or disabled with the same wording / state
+  the modal-side surface shows for the same fixture.
+- T10. **Audit parity test.** Activating each link-copy action from
+  the inline kebab emits the same audit event as the modal-side
+  action with `source = "collapsed_row"`. Assert the rest of the
+  payload is identical.
+- T11. **Accessibility audit.** Run an accessibility tree audit
+  against a rendered collapsed row; assert the ARIA structure in
+  this file (row, toolbar, buttons, kebab haspopup/expanded, menu,
+  menuitems) is present and labels match.


### PR DESCRIPTION
Closes #9810

Spec for #9810. Inline toolbelt on collapsed conversation rows: primary Fork button + kebab overflow (copy conversation/share/debug link). Right-click on the row also opens the kebab menu (per @david). Modal-open hides the inline toolbelt to avoid duplication.

Closes (spec-only) #9810.