### PR TITLE
Fix race condition causing permanent loss of active rule files

### DIFF
--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -183,6 +183,35 @@ pub struct RulesDelta {
     pub deleted_rules: Vec<PathBuf>,
 }
 
+impl RulesDelta {
+    /// Merge another delta into this one, preserving the ordering of operations.
+    ///
+    /// When the same path appears across sequential deltas the *last* operation
+    /// wins. For example:
+    ///   - (add A, delete A) → net effect is **delete**
+    ///   - (delete A, add A) → net effect is **add**
+    ///
+    /// This is important because consumers (e.g. persistence) apply the delta
+    /// incrementally; a symmetric "cancel both sides" approach would silently
+    /// drop real state changes.
+    fn merge(&mut self, other: RulesDelta) {
+        // Each newly-discovered path supersedes any prior deletion or earlier
+        // discovery of the same path.
+        for discovered in &other.discovered_rules {
+            self.deleted_rules.retain(|p| *p != discovered.path);
+            self.discovered_rules.retain(|r| r.path != discovered.path);
+        }
+        // Each newly-deleted path supersedes any prior discovery or earlier
+        // deletion of the same path.
+        for deleted in &other.deleted_rules {
+            self.discovered_rules.retain(|r| r.path != *deleted);
+            self.deleted_rules.retain(|p| *p != *deleted);
+        }
+        self.discovered_rules.extend(other.discovered_rules);
+        self.deleted_rules.extend(other.deleted_rules);
+    }
+}
+
 /// Events emitted by the ProjectContextModel
 pub enum ProjectContextModelEvent {
     /// Emitted when a path has been indexed
@@ -367,19 +396,30 @@ impl ProjectContextModel {
                 let repo_path = path_clone.clone();
                 let repo_path_for_closure = repo_path.clone();
                 ctx.spawn(
-                    async move {
-                        Self::process_repository_updates(update, rules, repo_path).await
-                    },
+                    async move { Self::process_repository_updates(update, rules, repo_path).await },
                     move |me, (rules, rule_delta), ctx| {
-                        ctx.emit(ProjectContextModelEvent::KnownRulesChanged(rule_delta));
-                        me.path_to_rules.insert(repo_path_for_closure.clone(), rules);
-                        me.drain_pending_updates(&repo_path_for_closure, ctx);
-                        ctx.emit(ProjectContextModelEvent::PathIndexed);
+                        me.apply_update_result(&repo_path_for_closure, rules, rule_delta, ctx);
                     },
                 );
             },
             |_, _| {},
         );
+    }
+
+    /// Called when an async update task completes: emits events, stores the new rules,
+    /// and drains any updates that queued up while the task was in flight.
+    #[cfg(feature = "local_fs")]
+    fn apply_update_result(
+        &mut self,
+        path: &Path,
+        rules: ProjectRules,
+        rule_delta: RulesDelta,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        ctx.emit(ProjectContextModelEvent::KnownRulesChanged(rule_delta));
+        self.path_to_rules.insert(path.to_path_buf(), rules);
+        self.drain_pending_updates(path, ctx);
+        ctx.emit(ProjectContextModelEvent::PathIndexed);
     }
 
     /// Processes any queued updates for a path after the previous async task completes.
@@ -413,18 +453,12 @@ impl ProjectContextModel {
                         Self::process_repository_updates(update, current_rules, repo_path.clone())
                             .await;
                     current_rules = updated_rules;
-                    combined_delta
-                        .discovered_rules
-                        .extend(delta.discovered_rules);
-                    combined_delta.deleted_rules.extend(delta.deleted_rules);
+                    combined_delta.merge(delta);
                 }
                 (current_rules, combined_delta)
             },
             move |me, (rules, rule_delta), ctx| {
-                ctx.emit(ProjectContextModelEvent::KnownRulesChanged(rule_delta));
-                me.path_to_rules.insert(repo_path_for_closure.clone(), rules);
-                me.drain_pending_updates(&repo_path_for_closure, ctx);
-                ctx.emit(ProjectContextModelEvent::PathIndexed);
+                me.apply_update_result(&repo_path_for_closure, rules, rule_delta, ctx);
             },
         );
     }

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -194,6 +194,7 @@ impl RulesDelta {
     /// This is important because consumers (e.g. persistence) apply the delta
     /// incrementally; a symmetric "cancel both sides" approach would silently
     /// drop real state changes.
+    #[cfg(any(feature = "local_fs", test))]
     fn merge(&mut self, other: RulesDelta) {
         // Each newly-discovered path supersedes any prior deletion or earlier
         // discovery of the same path.

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -25,7 +25,7 @@ pub struct ProjectRule {
     pub content: String,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct RuleAtPath {
     parent_path: PathBuf,
     warp_md: Option<ProjectRule>,
@@ -69,7 +69,7 @@ fn matches_rules_pattern(file_name_str: &str) -> bool {
     false
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct ProjectRules {
     rules: Vec<RuleAtPath>,
 }
@@ -170,6 +170,11 @@ impl ProjectRules {
 pub struct ProjectContextModel {
     /// Mapping from directory path to list of rule files found in that directory
     path_to_rules: HashMap<PathBuf, ProjectRules>,
+    /// Queued repository updates for paths that have an in-flight processing task.
+    /// The presence of a key indicates an active async task for that path;
+    /// the Vec holds updates that arrived while that task was running.
+    #[cfg(feature = "local_fs")]
+    pending_updates: HashMap<PathBuf, Vec<RepositoryUpdate>>,
 }
 
 #[derive(Default, Debug)]
@@ -345,24 +350,82 @@ impl ProjectContextModel {
                     return;
                 }
 
-                let existing_rules = me.path_to_rules.remove(&path_clone);
-                let repo_path = path_clone.clone();
-                if let Some(rules) = existing_rules {
-                    let repo_path_for_closure = repo_path.clone();
-                    ctx.spawn(
-                        async move {
-                            Self::process_repository_updates(update, rules, repo_path).await
-                        },
-                        move |me, (rules, rule_delta), ctx| {
-                            ctx.emit(ProjectContextModelEvent::KnownRulesChanged(rule_delta));
-
-                            me.path_to_rules.insert(repo_path_for_closure, rules);
-                            ctx.emit(ProjectContextModelEvent::PathIndexed);
-                        },
-                    );
+                // If there's already an in-flight task for this path, queue the update
+                // instead of spawning a concurrent task that could overwrite results.
+                if let Some(queued) = me.pending_updates.get_mut(&path_clone) {
+                    queued.push(update);
+                    return;
                 }
+
+                let Some(rules) = me.path_to_rules.get(&path_clone).cloned() else {
+                    return;
+                };
+
+                // Mark this path as having an in-flight task (empty queue).
+                me.pending_updates.insert(path_clone.clone(), Vec::new());
+
+                let repo_path = path_clone.clone();
+                let repo_path_for_closure = repo_path.clone();
+                ctx.spawn(
+                    async move {
+                        Self::process_repository_updates(update, rules, repo_path).await
+                    },
+                    move |me, (rules, rule_delta), ctx| {
+                        ctx.emit(ProjectContextModelEvent::KnownRulesChanged(rule_delta));
+                        me.path_to_rules.insert(repo_path_for_closure.clone(), rules);
+                        me.drain_pending_updates(&repo_path_for_closure, ctx);
+                        ctx.emit(ProjectContextModelEvent::PathIndexed);
+                    },
+                );
             },
             |_, _| {},
+        );
+    }
+
+    /// Processes any queued updates for a path after the previous async task completes.
+    /// Each batch runs sequentially against the latest rules, preventing stale-snapshot races.
+    #[cfg(feature = "local_fs")]
+    fn drain_pending_updates(&mut self, path: &Path, ctx: &mut ModelContext<Self>) {
+        let path_buf = path.to_path_buf();
+        let Some(queued) = self.pending_updates.get_mut(&path_buf) else {
+            return;
+        };
+
+        if queued.is_empty() {
+            self.pending_updates.remove(&path_buf);
+            return;
+        }
+
+        let updates = std::mem::take(queued);
+        let Some(rules) = self.path_to_rules.get(&path_buf).cloned() else {
+            self.pending_updates.remove(&path_buf);
+            return;
+        };
+
+        let repo_path = path_buf.clone();
+        let repo_path_for_closure = path_buf;
+        ctx.spawn(
+            async move {
+                let mut current_rules = rules;
+                let mut combined_delta = RulesDelta::default();
+                for update in updates {
+                    let (updated_rules, delta) =
+                        Self::process_repository_updates(update, current_rules, repo_path.clone())
+                            .await;
+                    current_rules = updated_rules;
+                    combined_delta
+                        .discovered_rules
+                        .extend(delta.discovered_rules);
+                    combined_delta.deleted_rules.extend(delta.deleted_rules);
+                }
+                (current_rules, combined_delta)
+            },
+            move |me, (rules, rule_delta), ctx| {
+                ctx.emit(ProjectContextModelEvent::KnownRulesChanged(rule_delta));
+                me.path_to_rules.insert(repo_path_for_closure.clone(), rules);
+                me.drain_pending_updates(&repo_path_for_closure, ctx);
+                ctx.emit(ProjectContextModelEvent::PathIndexed);
+            },
         );
     }
 

--- a/crates/ai/src/project_context/model_tests.rs
+++ b/crates/ai/src/project_context/model_tests.rs
@@ -183,3 +183,114 @@ fn test_find_applicable_rules_with_relative_paths() {
     assert!(paths.contains(&PathBuf::from("src/WARP.md")));
     assert!(paths.contains(&PathBuf::from("src/components/WARP.md")));
 }
+
+fn make_rule_path(path: &str) -> ProjectRulePath {
+    ProjectRulePath {
+        path: PathBuf::from(path),
+        project_root: PathBuf::from("/project"),
+    }
+}
+
+#[test]
+fn test_merge_independent_deltas() {
+    let mut delta = RulesDelta {
+        discovered_rules: vec![make_rule_path("/a/WARP.md")],
+        deleted_rules: vec![],
+    };
+    delta.merge(RulesDelta {
+        discovered_rules: vec![],
+        deleted_rules: vec![PathBuf::from("/b/WARP.md")],
+    });
+
+    assert_eq!(delta.discovered_rules.len(), 1);
+    assert_eq!(delta.discovered_rules[0].path, PathBuf::from("/a/WARP.md"));
+    assert_eq!(delta.deleted_rules, vec![PathBuf::from("/b/WARP.md")]);
+}
+
+#[test]
+fn test_merge_add_then_delete_yields_delete() {
+    let mut delta = RulesDelta {
+        discovered_rules: vec![make_rule_path("/a/WARP.md")],
+        deleted_rules: vec![],
+    };
+    delta.merge(RulesDelta {
+        discovered_rules: vec![],
+        deleted_rules: vec![PathBuf::from("/a/WARP.md")],
+    });
+
+    assert!(delta.discovered_rules.is_empty());
+    assert_eq!(delta.deleted_rules, vec![PathBuf::from("/a/WARP.md")]);
+}
+
+#[test]
+fn test_merge_delete_then_add_yields_add() {
+    let mut delta = RulesDelta {
+        discovered_rules: vec![],
+        deleted_rules: vec![PathBuf::from("/a/WARP.md")],
+    };
+    delta.merge(RulesDelta {
+        discovered_rules: vec![make_rule_path("/a/WARP.md")],
+        deleted_rules: vec![],
+    });
+
+    assert_eq!(delta.discovered_rules.len(), 1);
+    assert_eq!(delta.discovered_rules[0].path, PathBuf::from("/a/WARP.md"));
+    assert!(delta.deleted_rules.is_empty());
+}
+
+#[test]
+fn test_merge_add_delete_add_yields_add() {
+    let mut delta = RulesDelta::default();
+    delta.merge(RulesDelta {
+        discovered_rules: vec![make_rule_path("/a/WARP.md")],
+        deleted_rules: vec![],
+    });
+    delta.merge(RulesDelta {
+        discovered_rules: vec![],
+        deleted_rules: vec![PathBuf::from("/a/WARP.md")],
+    });
+    delta.merge(RulesDelta {
+        discovered_rules: vec![make_rule_path("/a/WARP.md")],
+        deleted_rules: vec![],
+    });
+
+    assert_eq!(delta.discovered_rules.len(), 1);
+    assert_eq!(delta.discovered_rules[0].path, PathBuf::from("/a/WARP.md"));
+    assert!(delta.deleted_rules.is_empty());
+}
+
+#[test]
+fn test_merge_delete_add_delete_yields_delete() {
+    let mut delta = RulesDelta::default();
+    delta.merge(RulesDelta {
+        discovered_rules: vec![],
+        deleted_rules: vec![PathBuf::from("/a/WARP.md")],
+    });
+    delta.merge(RulesDelta {
+        discovered_rules: vec![make_rule_path("/a/WARP.md")],
+        deleted_rules: vec![],
+    });
+    delta.merge(RulesDelta {
+        discovered_rules: vec![],
+        deleted_rules: vec![PathBuf::from("/a/WARP.md")],
+    });
+
+    assert!(delta.discovered_rules.is_empty());
+    assert_eq!(delta.deleted_rules, vec![PathBuf::from("/a/WARP.md")]);
+}
+
+#[test]
+fn test_merge_rediscovery_keeps_latest() {
+    let mut delta = RulesDelta {
+        discovered_rules: vec![make_rule_path("/a/WARP.md")],
+        deleted_rules: vec![],
+    };
+    // A second discovery of the same path (content update) should deduplicate.
+    delta.merge(RulesDelta {
+        discovered_rules: vec![make_rule_path("/a/WARP.md")],
+        deleted_rules: vec![],
+    });
+
+    assert_eq!(delta.discovered_rules.len(), 1);
+    assert!(delta.deleted_rules.is_empty());
+}


### PR DESCRIPTION
## Description

Fix a race condition in `ProjectContextModel's file watcher stream handler that can permanently lose active rule files until client restart.

### Root cause

The stream handler processes each `RepositoryUpdate` by spawning an async task. The original code called `path_to_rules.remove()` before spawning, then re-inserted the updated rules in the task's completion callback. This created two distinct race windows:

**Race 1 — concurrent task overwrites (original bug)**

Consider two updates, U1 and U2, arriving in quick succession for the same path:

1. U1 arrives → `remove()` extracts the current rules → async task T1 spawned with a snapshot of those rules.
2. U2 arrives while T1 is in flight → `remove()` returns `None` (the key is gone) → the `if let Some(rules) = existing_rules` guard fires → **U2 is silently dropped**.
3. T1 completes and re-inserts its result. If U1 was a deletion and U2 was the corresponding re-addition (common during an editor's atomic save: delete-then-write), the file is now permanently absent from `path_to_rules` until restart.

**Race 2 — stale-snapshot overwrites (Oz review finding)**

Even after fixing Race 1 by keeping rules in the map during async processing, a second race remained: if T1 and T2 both read the rules _before_ either writes back, T2's write silently discards T1's changes.

### Fix

**For Race 1:** Replace `remove()` with `get().cloned()` so the rules stay in `path_to_rules` throughout async processing. A `pending_updates` queue (keyed by path) is introduced: if a task is already in flight for a path, incoming updates are queued instead of spawned concurrently. When a task completes, it drains the queue — processing all accumulated updates sequentially against the freshest rules — before clearing the in-flight marker.

**For Race 2:** The drain loop combines multiple sequential deltas using a new `RulesDelta::merge()` method that is order-preserving: for each path, the _last_ operation wins. This correctly handles (add → delete) → net deletion and (delete → add) → net addition. The previous `deduplicate()` was symmetric — it cancelled both sides regardless of order — which would silently drop real state changes observed by persistence consumers.

### Changes

- `ProjectContextModel`: adds `pending_updates: HashMap<PathBuf, Vec<RepositoryUpdate>>` to serialize per-path processing.
- `RulesDelta::merge()`: replaces `deduplicate()` with an order-preserving combinator.
- `apply_update_result()`: extracted helper shared by the stream handler and the drain loop.
- Unit tests for all `merge()` orderings (add→delete, delete→add, add→delete→add, etc.).

## Linked Issue

N/A - discovered via debugging

## Testing

- Manual verification of the race condition scenario.
- Unit tests covering all `RulesDelta::merge()` orderings in `model_tests.rs`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation link](https://staging.warp.dev/conversation/6cf1e2ca-9c21-4a00-9751-5fc9d7136473)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!--
CHANGELOG-BUG-FIX: Fixed an issue where rule files (WARP.md / AGENTS.md) could permanently stop being included in AI conversations until client restart.
-->