### PR TITLE
remove slow filesystem operations for WSL sessions

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6826,14 +6826,18 @@ impl TerminalView {
                             self.sessions.as_ref(ctx).get(active_session_id)
                         })
                         .and_then(|active_session| {
-                            active_session
-                                .launch_data()
-                                .and_then(|data| data.maybe_convert_absolute_path(cwd))
+                            active_session.launch_data().and_then(|data| {
+                                data.maybe_convert_absolute_path(cwd)
+                                    .filter(|cwd| match data {
+                                        // Use Path::is_dir() to validate the path is still valid,
+                                        // e.g. hasn't been deleted, but skip this check in WSL
+                                        // because the WSL filesystem bridge is too slow.
+                                        ShellLaunchData::WSL { .. } => true,
+                                        _ => cwd.is_dir(),
+                                    })
+                            })
                         })
                 })
-                // Checking if the pwd from the active session actually exists
-                // and if not (ie. directory was removed) - return None.
-                .filter(|path| path.is_dir())
         } else {
             None
         }

--- a/crates/warp_util/src/path.rs
+++ b/crates/warp_util/src/path.rs
@@ -455,21 +455,26 @@ pub fn convert_wsl_to_windows_host_path(
     }
     let components = unix_path.components();
     let prefix = components.take(3).collect::<Vec<_>>();
-    let windows_path = match prefix.as_slice() {
+    let mut windows_path = TypedPathBuf::new(PathType::Windows);
+    match prefix.as_slice() {
         // Check if the prefix is "/mnt/c/" or similar, which is how WSL refers to Windows drive
         // "C:\". Valid drive names are a..=z, which are bytes 97..=122.
         [TypedComponent::Unix(UnixComponent::RootDir), TypedComponent::Unix(UnixComponent::Normal(b"mnt")), TypedComponent::Unix(UnixComponent::Normal(bytes))]
             if bytes.len() == 1 && (97..=122).contains(&bytes[0]) =>
         {
-            let mut windows_path = TypedPathBuf::new(PathType::Windows);
             windows_path.push([*bytes, b":\\"].concat());
             for component in unix_path.with_windows_encoding().components().skip(3) {
                 windows_path.push(component.as_bytes());
             }
-            windows_path
+            let pathbuf = PathBuf::try_from(windows_path)
+                .map_err(WSLPathConversionError::CouldNotConvertToPath)?;
+            // Many directories are symlinks into the underlying file-system location in Windows.
+            match std::fs::read_link(&pathbuf) {
+                Ok(linked_file) => Ok(linked_file),
+                Err(_) => Ok(pathbuf),
+            }
         }
         _ => {
-            let mut windows_path = TypedPathBuf::new(PathType::Windows);
             windows_path.push(format!(r"\\WSL$\{distro_name}"));
             for component in unix_path
                 .with_windows_encoding()
@@ -478,15 +483,8 @@ pub fn convert_wsl_to_windows_host_path(
             {
                 windows_path.push(component.as_bytes());
             }
-            windows_path
+            PathBuf::try_from(windows_path).map_err(WSLPathConversionError::CouldNotConvertToPath)
         }
-    };
-    let pathbuf =
-        PathBuf::try_from(windows_path).map_err(WSLPathConversionError::CouldNotConvertToPath)?;
-    // Many directories are symlinks into the underlying file-system location in Windows.
-    match std::fs::read_link(&pathbuf) {
-        Ok(linked_file) => Ok(linked_file),
-        Err(_) => Ok(pathbuf),
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

#9920

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?
-->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->
