### PR TITLE
Preserve Windows path separators in completions

### DIFF
--- a/crates/warp_completer/src/completer/engine/path.rs
+++ b/crates/warp_completer/src/completer/engine/path.rs
@@ -173,6 +173,7 @@ async fn list_directory_contents(
         relative_to.as_str(),
         home_dir,
         path_separators.all,
+        path_separators.main,
     );
 
     let dir_entries = ctx
@@ -200,7 +201,7 @@ async fn list_directory_contents(
                 ROOT_DIR_STR.to_owned()
             } else {
                 if entry.is_dir() {
-                    file_name.push(path_separators.main);
+                    file_name.push(split_path.directory_separator);
                 }
                 // We use `shell_escape()` instead of `escape()` on the relative path name to allow
                 // home directory expansion if needed.
@@ -258,6 +259,9 @@ struct SplitPath {
 
     /// The name of the `file`.
     file_name: String,
+
+    /// The separator to append to directory completions.
+    directory_separator: char,
 }
 
 impl SplitPath {
@@ -275,11 +279,20 @@ impl SplitPath {
         relative_path: &str,
         home_directory: Option<&str>,
         path_separators: &[char],
+        main_path_separator: char,
     ) -> Self {
-        let (directory_relative_path_name, file_name) = match relative_path.rfind(path_separators) {
-            Some(pos) => relative_path.split_at(pos + 1),
-            None => ("", relative_path),
-        };
+        let (directory_relative_path_name, file_name, directory_separator) =
+            match relative_path.rfind(path_separators) {
+                Some(pos) => {
+                    let separator = relative_path[pos..]
+                        .chars()
+                        .next()
+                        .unwrap_or(main_path_separator);
+                    let (directory, file_name) = relative_path.split_at(pos + separator.len_utf8());
+                    (directory, file_name, separator)
+                }
+                None => ("", relative_path, main_path_separator),
+            };
 
         let directory_absolute_path = if directory_relative_path_name.is_empty() {
             current_directory.to_path_buf()
@@ -302,6 +315,7 @@ impl SplitPath {
             directory_absolute_path,
             directory_relative_path_name: directory_relative_path_name.to_owned(),
             file_name,
+            directory_separator,
         }
     }
 }

--- a/crates/warp_completer/src/completer/engine/path_test.rs
+++ b/crates/warp_completer/src/completer/engine/path_test.rs
@@ -1,6 +1,10 @@
 use warp_command_signatures::IconType;
+#[cfg(windows)]
+use warp_util::path::ShellFamily;
 
 use crate::completer::testing::MockPathCompletionContext;
+#[cfg(windows)]
+use crate::completer::PathSeparators;
 
 use super::*;
 
@@ -28,6 +32,7 @@ fn test_split_path() {
         "~/Warp.app",
         Some("/Users/warpuser"),
         &['/'],
+        '/',
     );
 
     assert_eq!(
@@ -35,7 +40,8 @@ fn test_split_path() {
         SplitPath {
             directory_absolute_path: path.clone(),
             directory_relative_path_name: "~/".to_owned(),
-            file_name: "Warp.app".to_owned()
+            file_name: "Warp.app".to_owned(),
+            directory_separator: '/',
         }
     );
 
@@ -44,13 +50,15 @@ fn test_split_path() {
         "Warp.app/Contents",
         Some("/Users/warpuser"),
         &['/'],
+        '/',
     );
     assert_eq!(
         split_path,
         SplitPath {
             directory_absolute_path: TypedPathBuf::from("/Users/warpuser/Warp.app/"),
             directory_relative_path_name: "Warp.app/".to_owned(),
-            file_name: "Contents".to_owned()
+            file_name: "Contents".to_owned(),
+            directory_separator: '/',
         }
     );
 
@@ -59,15 +67,41 @@ fn test_split_path() {
         "Warp.app/macOS/bin/warp.o",
         Some("/Users/warpuser"),
         &['/'],
+        '/',
     );
     assert_eq!(
         split_path,
         SplitPath {
             directory_absolute_path: TypedPathBuf::from("/Users/warpuser/Warp.app/macOS/bin/"),
             directory_relative_path_name: "Warp.app/macOS/bin/".to_owned(),
-            file_name: "warp.o".to_owned()
+            file_name: "warp.o".to_owned(),
+            directory_separator: '/',
         }
     );
+}
+
+#[test]
+fn test_split_path_preserves_last_typed_separator() {
+    let path = TypedPathBuf::from_windows(r"C:\Users\warpuser");
+    let split_path = SplitPath::new(
+        path.to_path(),
+        r"src/lib",
+        Some(r"C:\Users\warpuser"),
+        &['/', '\\'],
+        '\\',
+    );
+
+    assert_eq!(split_path.directory_separator, '/');
+
+    let split_path = SplitPath::new(
+        path.to_path(),
+        r"src\lib",
+        Some(r"C:\Users\warpuser"),
+        &['/', '\\'],
+        '\\',
+    );
+
+    assert_eq!(split_path.directory_separator, '\\');
 }
 
 fn file_entry(file_name: &str) -> EngineDirEntry {
@@ -181,6 +215,48 @@ pub fn test_sorted_paths_relative_to() {
             .with_file_type(EngineFileType::Directory),
             Suggestion::with_same_display_and_replacement(
                 ".hidden/",
+                Some("Directory".into()),
+                SuggestionType::Argument,
+                Priority::default(),
+            )
+            .with_icon_override(IconType::Folder)
+            .with_file_type(EngineFileType::Directory),
+        ]
+    );
+}
+
+#[cfg(windows)]
+#[test]
+pub fn test_windows_forward_slash_path_completion_preserves_slash() {
+    let pwd = TypedPathBuf::from_windows(r"C:\Users\test");
+    let entries = [file_entry("Cargo.toml"), dir_entry("src")];
+    let ctx = MockPathCompletionContext::new(pwd.clone())
+        .with_shell_family(ShellFamily::PowerShell)
+        .with_path_separators(PathSeparators::for_windows())
+        .with_entries(pwd.join("./"), entries);
+
+    assert_eq!(
+        warpui::r#async::block_on(sorted_paths_relative_to(
+            &ParsedToken::new("./"),
+            MatchStrategy::CaseInsensitive,
+            &ctx
+        ))
+        .into_iter()
+        .map(|matched_suggestion| matched_suggestion.suggestion)
+        .collect_vec(),
+        vec![
+            Suggestion::new(
+                "Cargo.toml",
+                "./Cargo.toml",
+                Some("File".into()),
+                SuggestionType::Argument,
+                Priority::default(),
+            )
+            .with_icon_override(IconType::File)
+            .with_file_type(EngineFileType::File),
+            Suggestion::new(
+                "src/",
+                "./src/",
                 Some("Directory".into()),
                 SuggestionType::Argument,
                 Priority::default(),

--- a/crates/warp_completer/src/completer/suggest/test.rs
+++ b/crates/warp_completer/src/completer/suggest/test.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::iter::FromIterator;
 
 use typed_path::TypedPathBuf;
+#[cfg(windows)]
+use warp_util::path::ShellFamily;
 
 use crate::completer::context::CompletionContext;
 use crate::completer::engine::EngineDirEntry;
@@ -9,6 +11,8 @@ use crate::completer::matchers::MatchStrategy;
 use crate::completer::testing::{
     FakeCompletionContext, MockGeneratorContext, MockPathCompletionContext,
 };
+#[cfg(windows)]
+use crate::completer::PathSeparators;
 use crate::meta::Span;
 use crate::signatures::testing::{
     cd_signature, create_test_command_registry, fuzzy_signature, git_signature, java_signature,
@@ -524,6 +528,29 @@ pub fn test_file_path_completions_only_trailing_whitespace() {
 
     // Only file paths should exist, no commands
     assert_eq!(gi_prefix_results, vec!["giants/", "gids/"]);
+}
+
+#[cfg(windows)]
+#[test]
+pub fn test_windows_forward_slash_current_dir_completions() {
+    let pwd = TypedPathBuf::from_windows(TEST_WORK_DIR);
+    let path_ctx = MockPathCompletionContext::new(pwd.clone())
+        .with_shell_family(ShellFamily::PowerShell)
+        .with_path_separators(PathSeparators::for_windows())
+        .with_entries(
+            pwd.join("./"),
+            [
+                EngineDirEntry::test_file("Cargo.toml"),
+                EngineDirEntry::test_dir("src"),
+            ],
+        );
+    let ctx = FakeCompletionContext::new(create_test_command_registry([]))
+        .with_path_completion_context(path_ctx);
+
+    assert_eq!(
+        complete_at_end_of_line("./", &ctx),
+        vec!["Cargo.toml", "src/"]
+    );
 }
 
 #[test]

--- a/crates/warp_completer/src/completer/testing/mod.rs
+++ b/crates/warp_completer/src/completer/testing/mod.rs
@@ -143,6 +143,8 @@ pub struct MockPathCompletionContext {
     home_directory: Option<String>,
     pwd: TypedPathBuf,
     directory_to_entries: HashMap<PathBuf, Vec<EngineDirEntry>>,
+    path_separators: PathSeparators,
+    shell_family: ShellFamily,
 }
 
 impl MockPathCompletionContext {
@@ -151,11 +153,23 @@ impl MockPathCompletionContext {
             home_directory: TEST_SESSION_HOME_DIR.clone(),
             pwd,
             directory_to_entries: HashMap::new(),
+            path_separators: PathSeparators::for_unix(),
+            shell_family: ShellFamily::Posix,
         }
     }
 
     pub fn with_home_directory(mut self, home_directory: String) -> Self {
         self.home_directory = Some(home_directory);
+        self
+    }
+
+    pub fn with_path_separators(mut self, path_separators: PathSeparators) -> Self {
+        self.path_separators = path_separators;
+        self
+    }
+
+    pub fn with_shell_family(mut self, shell_family: ShellFamily) -> Self {
+        self.shell_family = shell_family;
         self
     }
 
@@ -226,7 +240,7 @@ impl PathCompletionContext for MockPathCompletionContext {
     }
 
     fn shell_family(&self) -> ShellFamily {
-        ShellFamily::Posix
+        self.shell_family
     }
 
     fn home_directory(&self) -> Option<&str> {
@@ -238,7 +252,7 @@ impl PathCompletionContext for MockPathCompletionContext {
     }
 
     fn path_separators(&self) -> PathSeparators {
-        PathSeparators::for_unix()
+        self.path_separators.clone()
     }
 }
 


### PR DESCRIPTION
﻿## Summary
- Preserve the last path separator typed by the user when appending directory completions.
- Add Windows/PowerShell regression coverage for `./` path completion.
- Extend the completer test context so tests can model Windows separators and shell family explicitly.

## Root Cause
On Windows, path completion accepted both `/` and `\`, but directory suggestions always appended the platform's main separator (`\`). For a PowerShell input like `./`, that could produce mixed-separator replacements instead of continuing with `/`.

Fixes #5750.

## Testing
- `cargo fmt -- --check`
- `git diff --check`
- `cargo test -p warp_completer windows_forward_slash -- --nocapture`
- `cargo test -p warp_completer test_split_path -- --nocapture`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo test -p warp_completer --lib --features warp_core/test-util` (`147 passed; 7 ignored`)
- `cargo build --bin warp-oss --features gui`

Not run end-to-end: `./script/presubmit`. The focused package checks and OSS GUI build passed locally on Windows.