### PR TITLE
Add scriptable pane control via local UDS API and `wp` CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14511,6 +14511,7 @@ dependencies = [
  "warp_graphql",
  "warp_isolation_platform",
  "warp_js",
+ "warp_local_api",
  "warp_logging",
  "warp_managed_secrets",
  "warp_multi_agent_api",
@@ -14840,6 +14841,16 @@ dependencies = [
  "serde",
  "thiserror 2.0.17",
  "uuid",
+]
+
+[[package]]
+name = "warp_local_api"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "dirs 6.0.0",
+ "ipc",
+ "serde",
 ]
 
 [[package]]
@@ -16478,6 +16489,18 @@ checksum = "896174c6a4779d4d7d4523dd27aef7d46609eda2497e370f6c998325c6bf6971"
 dependencies = [
  "lazy_static",
  "regex",
+]
+
+[[package]]
+name = "wp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures",
+ "ipc",
+ "warp_local_api",
+ "warpui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ warp_graphql = { path = "crates/graphql" }
 warp_graphql_schema = { path = "crates/warp_graphql_schema" }
 warp_isolation_platform = { path = "crates/isolation_platform" }
 warp_js = { path = "crates/warp_js" }
+warp_local_api = { path = "crates/warp_local_api" }
 warp_logging = { path = "crates/warp_logging" }
 warp_managed_secrets = { path = "crates/managed_secrets" }
 warp_ripgrep = { path = "crates/warp_ripgrep" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -124,6 +124,7 @@ indexmap = { version = "2.0.2", features = ["serde"] }
 input_classifier.workspace = true
 instant.workspace = true
 ipc.workspace = true
+warp_local_api.workspace = true
 itertools.workspace = true
 kmeans_colors = { version = "0.5", default-features = false, features = [
     "palette_color",

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -44,6 +44,7 @@ mod gpu_state;
 mod input_classifier;
 mod interval_timer;
 mod linear;
+mod local_api;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 mod login_item;
 mod menu;
@@ -1034,6 +1035,8 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
         ctx.add_singleton_model(move |ctx| {
             plugin::PluginHost::new(ctx).expect("Could not instantiate PluginHost")
         });
+
+        ctx.add_singleton_model(local_api::LocalApiServer::new);
         let app_state = initialize_app(
             &launch_mode,
             timer,

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -325,6 +325,17 @@ pub struct Assets;
 
 pub static ASSETS: Assets = Assets;
 
+#[cfg(unix)]
+fn local_api_opt_in_enabled() -> bool {
+    let Ok(raw) = std::env::var("WARP_ENABLE_LOCAL_API") else {
+        return false;
+    };
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 fn determine_agent_source(
     launch_mode: &LaunchMode,
 ) -> Option<crate::ai::ambient_agents::AgentSource> {
@@ -1040,10 +1051,12 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
         // Local control API is opt-in: it exposes mutating operations
         // (PTY writes, pane close) over a same-UID socket, so we keep it
         // dormant by default and let the user/OS-integrator turn it on
-        // explicitly via `WARP_ENABLE_LOCAL_API=1`. Unix-only — the IPC
-        // transport and 0600 permission model use UDS + chmod.
+        // explicitly via a truthy `WARP_ENABLE_LOCAL_API` (1/true/yes/on).
+        // Anything else — including `0`, `false`, or empty — leaves it off.
+        // Unix-only — the IPC transport and 0600 permission model use UDS
+        // + chmod.
         #[cfg(unix)]
-        if std::env::var_os("WARP_ENABLE_LOCAL_API").is_some() {
+        if local_api_opt_in_enabled() {
             ctx.add_singleton_model(local_api::LocalApiServer::new);
         }
         let app_state = initialize_app(

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -44,6 +44,7 @@ mod gpu_state;
 mod input_classifier;
 mod interval_timer;
 mod linear;
+#[cfg(unix)]
 mod local_api;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 mod login_item;
@@ -1036,7 +1037,15 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
             plugin::PluginHost::new(ctx).expect("Could not instantiate PluginHost")
         });
 
-        ctx.add_singleton_model(local_api::LocalApiServer::new);
+        // Local control API is opt-in: it exposes mutating operations
+        // (PTY writes, pane close) over a same-UID socket, so we keep it
+        // dormant by default and let the user/OS-integrator turn it on
+        // explicitly via `WARP_ENABLE_LOCAL_API=1`. Unix-only — the IPC
+        // transport and 0600 permission model use UDS + chmod.
+        #[cfg(unix)]
+        if std::env::var_os("WARP_ENABLE_LOCAL_API").is_some() {
+            ctx.add_singleton_model(local_api::LocalApiServer::new);
+        }
         let app_state = initialize_app(
             &launch_mode,
             timer,

--- a/app/src/local_api.rs
+++ b/app/src/local_api.rs
@@ -30,7 +30,7 @@ use rand::RngCore as _;
 use warp_core::channel::ChannelState;
 use warp_local_api::{
     address_publish_path_for, format_address_file, LocalApiEnvelope, LocalApiRequest,
-    LocalApiResponse, LocalApiService, SplitDir, MAX_SEND_TEXT_BYTES,
+    LocalApiResponse, LocalApiService, SplitDir, MAX_REQUEST_BYTES, MAX_SEND_TEXT_BYTES,
 };
 use warpui::windowing::WindowManager;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity, ViewHandle};
@@ -128,7 +128,8 @@ impl LocalApiServer {
 
         let builder = ServerBuilder::default()
             .with_service(service_impl)
-            .with_fixed_address(socket_path.to_string_lossy().to_string());
+            .with_fixed_address(socket_path.to_string_lossy().to_string())
+            .with_max_request_bytes(MAX_REQUEST_BYTES);
 
         let server = match builder.build_and_run(ctx.background_executor()) {
             Ok((server, addr)) => {

--- a/app/src/local_api.rs
+++ b/app/src/local_api.rs
@@ -1,0 +1,319 @@
+//! `LocalApiServer` — exposes a UDS-based control plane to the `wp` CLI.
+//!
+//! Background `ipc::Service` handlers run on the executor; each request is
+//! forwarded over an `async_channel` to the main thread, where a stream
+//! handler dispatches it as if a key binding had fired and replies via a
+//! oneshot. This mirrors `iTermAPIServer`'s "background socket reads, main
+//! thread mutations" pattern and avoids holding `TerminalModel` locks across
+//! await points.
+//!
+//! # Same-UID hardening
+//!
+//! - The socket binds under `$TMPDIR` (per-user dir on macOS, mode 0700) and
+//!   is chmod'd to 0600 immediately after bind.
+//! - The address file is written 0600 and contains a per-session random
+//!   cookie alongside the socket path. The server rejects requests whose
+//!   cookie doesn't match.
+//! - The dispatch queue is bounded; oversized `SendText` payloads are
+//!   rejected at the boundary so the main thread can't be wedged by a
+//!   misbehaving same-UID client.
+
+use std::fs;
+use std::io::Write as _;
+use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use futures::channel::oneshot;
+use ipc::{ConnectionAddress, ServerBuilder};
+use rand::RngCore as _;
+use warp_local_api::{
+    address_publish_path, format_address_file, LocalApiEnvelope, LocalApiRequest, LocalApiResponse,
+    LocalApiService, SplitDir, MAX_SEND_TEXT_BYTES,
+};
+use warpui::windowing::WindowManager;
+use warpui::{AppContext, Entity, ModelContext, SingletonEntity, ViewHandle};
+
+use crate::pane_group::pane::TerminalPaneId;
+use crate::pane_group::{Direction, PaneGroup};
+use crate::workspace::Workspace;
+
+/// Bounded pending-command queue. 256 in-flight is generous for an
+/// interactive same-UID API; over-burst clients get backpressure rather than
+/// a memory blow-up.
+const MAX_PENDING_COMMANDS: usize = 256;
+
+type Command = (LocalApiRequest, oneshot::Sender<LocalApiResponse>);
+
+#[derive(Clone)]
+struct LocalApiServiceImpl {
+    cookie: String,
+    cmd_tx: async_channel::Sender<Command>,
+}
+
+#[async_trait]
+impl ipc::ServiceImpl for LocalApiServiceImpl {
+    type Service = LocalApiService;
+
+    async fn handle_request(&self, envelope: LocalApiEnvelope) -> LocalApiResponse {
+        if !cookies_eq(&self.cookie, &envelope.cookie) {
+            return LocalApiResponse::Err("unauthenticated".into());
+        }
+
+        if let LocalApiRequest::SendText { ref text, .. } = envelope.request {
+            if text.len() > MAX_SEND_TEXT_BYTES {
+                return LocalApiResponse::Err(format!(
+                    "send-text payload {}B exceeds {}B limit",
+                    text.len(),
+                    MAX_SEND_TEXT_BYTES
+                ));
+            }
+        }
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        match self.cmd_tx.try_send((envelope.request, reply_tx)) {
+            Ok(()) => {}
+            Err(async_channel::TrySendError::Full(_)) => {
+                return LocalApiResponse::Err("local-api queue full, retry later".into());
+            }
+            Err(async_channel::TrySendError::Closed(_)) => {
+                return LocalApiResponse::Err("local-api dispatch channel closed".into());
+            }
+        }
+        reply_rx
+            .await
+            .unwrap_or_else(|_| LocalApiResponse::Err("local-api reply channel dropped".into()))
+    }
+}
+
+/// Length-checked byte-equality on the cookie. Cookie length is fixed across
+/// all sessions, so a length mismatch already implies a bogus client; the
+/// loop is defensive against future variable-length cookies.
+fn cookies_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.bytes().zip(b.bytes()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+pub struct LocalApiServer {
+    _server: Option<ipc::Server>,
+}
+
+impl Entity for LocalApiServer {
+    type Event = ();
+}
+
+impl SingletonEntity for LocalApiServer {}
+
+impl LocalApiServer {
+    pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        let (cmd_tx, cmd_rx) = async_channel::bounded::<Command>(MAX_PENDING_COMMANDS);
+        let cookie = generate_cookie();
+        let socket_path = per_user_socket_path();
+
+        // The bind path may collide with a stale socket from a crashed prior
+        // instance; remove it so the bind succeeds.
+        let _ = fs::remove_file(&socket_path);
+
+        let service_impl = LocalApiServiceImpl {
+            cookie: cookie.clone(),
+            cmd_tx,
+        };
+
+        let builder = ServerBuilder::default()
+            .with_service(service_impl)
+            .with_fixed_address(socket_path.to_string_lossy().to_string());
+
+        let server = match builder.build_and_run(ctx.background_executor()) {
+            Ok((server, addr)) => {
+                if let Err(e) = harden_socket(&addr) {
+                    log::warn!("local-api: failed to chmod socket: {e:?}");
+                }
+                if let Err(e) = publish_address(&addr, &cookie) {
+                    log::warn!("local-api: failed to publish socket address: {e:?}");
+                }
+                log::info!("local-api: listening at {addr}");
+                Some(server)
+            }
+            Err(e) => {
+                log::error!("local-api: failed to start server: {e:?}");
+                None
+            }
+        };
+
+        ctx.spawn_stream_local(
+            cmd_rx,
+            |_me, (req, reply), ctx| {
+                let resp = handle(req, ctx);
+                let _ = reply.send(resp);
+            },
+            |_, _| {},
+        );
+
+        Self { _server: server }
+    }
+}
+
+fn generate_cookie() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Per-user socket path. On macOS, `$TMPDIR` resolves to a per-user
+/// `/var/folders/.../T/` directory with mode 0700, which is the ideal
+/// location for a UDS that shouldn't be visible to other accounts.
+fn per_user_socket_path() -> PathBuf {
+    let dir = std::env::var_os("TMPDIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    dir.join("dev.warp.WarpOss-local-api.sock")
+}
+
+fn harden_socket(addr: &ConnectionAddress) -> std::io::Result<()> {
+    fs::set_permissions(addr.to_string(), fs::Permissions::from_mode(0o600))
+}
+
+fn publish_address(addr: &ConnectionAddress, cookie: &str) -> std::io::Result<()> {
+    let path = address_publish_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut f = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&path)?;
+    f.write_all(format_address_file(&addr.to_string(), cookie).as_bytes())?;
+    // OpenOptions::mode only applies on file creation; if the file existed
+    // with looser perms, force them tight here.
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+    Ok(())
+}
+
+fn handle(req: LocalApiRequest, ctx: &mut ModelContext<LocalApiServer>) -> LocalApiResponse {
+    match req {
+        LocalApiRequest::Ping => LocalApiResponse::Pong,
+        LocalApiRequest::Split { dir } => match split_active_pane(map_dir(dir), ctx) {
+            Ok(id) => LocalApiResponse::PaneId(id.to_local_api_string()),
+            Err(msg) => LocalApiResponse::Err(msg),
+        },
+        LocalApiRequest::SendText { pane, text } => match send_text(pane, text, ctx) {
+            Ok(()) => LocalApiResponse::Ok,
+            Err(msg) => LocalApiResponse::Err(msg),
+        },
+        LocalApiRequest::ListPanes => match list_panes(ctx) {
+            Ok(ids) => LocalApiResponse::Panes(
+                ids.into_iter().map(|id| id.to_local_api_string()).collect(),
+            ),
+            Err(msg) => LocalApiResponse::Err(msg),
+        },
+        LocalApiRequest::ActivePane => match active_pane(ctx) {
+            Ok(Some(id)) => LocalApiResponse::PaneId(id.to_local_api_string()),
+            Ok(None) => LocalApiResponse::Err("no active terminal pane".into()),
+            Err(msg) => LocalApiResponse::Err(msg),
+        },
+        LocalApiRequest::ClosePane { pane } => match close_pane(pane, ctx) {
+            Ok(()) => LocalApiResponse::Ok,
+            Err(msg) => LocalApiResponse::Err(msg),
+        },
+    }
+}
+
+fn map_dir(d: SplitDir) -> Direction {
+    match d {
+        SplitDir::Left => Direction::Left,
+        SplitDir::Right => Direction::Right,
+        SplitDir::Up => Direction::Up,
+        SplitDir::Down => Direction::Down,
+    }
+}
+
+fn parse_pane_id(s: &str) -> Result<TerminalPaneId, String> {
+    TerminalPaneId::parse_local_api(s).ok_or_else(|| format!("invalid pane id '{s}'"))
+}
+
+fn active_workspace(ctx: &mut AppContext) -> Result<ViewHandle<Workspace>, String> {
+    let window_manager = WindowManager::as_ref(ctx);
+    let window_id = window_manager
+        .active_window()
+        .or_else(|| window_manager.frontmost_window_id())
+        .or_else(|| window_manager.ordered_window_ids().into_iter().next())
+        .ok_or_else(|| "no Warp window available".to_owned())?;
+
+    let workspaces = ctx
+        .views_of_type::<Workspace>(window_id)
+        .ok_or_else(|| "no workspace in active window".to_owned())?;
+    workspaces
+        .into_iter()
+        .next()
+        .ok_or_else(|| "no workspace view found".to_owned())
+}
+
+fn with_active_pane_group<R>(
+    ctx: &mut ModelContext<LocalApiServer>,
+    f: impl FnOnce(&mut PaneGroup, &mut warpui::ViewContext<PaneGroup>) -> R,
+) -> Result<R, String> {
+    let workspace = active_workspace(ctx)?;
+    let mut result = None;
+    workspace.update(ctx, |workspace, ctx| {
+        let pane_group = workspace.active_tab_pane_group().clone();
+        result = Some(pane_group.update(ctx, f));
+    });
+    result.ok_or_else(|| "failed to access pane group".to_owned())
+}
+
+fn split_active_pane(
+    direction: Direction,
+    ctx: &mut ModelContext<LocalApiServer>,
+) -> Result<TerminalPaneId, String> {
+    with_active_pane_group(ctx, |pg, ctx| {
+        pg.local_api_split_active_pane(direction, ctx)
+    })
+}
+
+fn list_panes(ctx: &mut ModelContext<LocalApiServer>) -> Result<Vec<TerminalPaneId>, String> {
+    with_active_pane_group(ctx, |pg, _ctx| pg.local_api_terminal_pane_ids())
+}
+
+fn active_pane(ctx: &mut ModelContext<LocalApiServer>) -> Result<Option<TerminalPaneId>, String> {
+    with_active_pane_group(ctx, |pg, ctx| pg.active_session_id(ctx))
+}
+
+fn close_pane(pane: String, ctx: &mut ModelContext<LocalApiServer>) -> Result<(), String> {
+    let id = parse_pane_id(&pane)?;
+    with_active_pane_group(ctx, |pg, ctx| {
+        pg.local_api_close_pane(id, ctx)
+            .map_err(|msg| format!("{msg}: '{}'", id.to_local_api_string()))
+    })?
+}
+
+fn send_text(
+    pane: Option<String>,
+    text: String,
+    ctx: &mut ModelContext<LocalApiServer>,
+) -> Result<(), String> {
+    let target_id = match pane {
+        Some(s) => parse_pane_id(&s)?,
+        None => active_pane(ctx)?.ok_or_else(|| "no active terminal pane".to_owned())?,
+    };
+
+    with_active_pane_group(ctx, |pg, ctx| {
+        let Some(view) = pg.terminal_view_from_pane_id(target_id, ctx) else {
+            return Err(format!(
+                "pane '{}' not found",
+                target_id.to_local_api_string()
+            ));
+        };
+        view.update(ctx, |term, ctx| {
+            term.write_to_pty(text.into_bytes(), ctx);
+        });
+        Ok(())
+    })?
+}

--- a/app/src/local_api.rs
+++ b/app/src/local_api.rs
@@ -27,9 +27,10 @@ use async_trait::async_trait;
 use futures::channel::oneshot;
 use ipc::{ConnectionAddress, ServerBuilder};
 use rand::RngCore as _;
+use warp_core::channel::ChannelState;
 use warp_local_api::{
-    address_publish_path, format_address_file, LocalApiEnvelope, LocalApiRequest, LocalApiResponse,
-    LocalApiService, SplitDir, MAX_SEND_TEXT_BYTES,
+    address_publish_path_for, format_address_file, LocalApiEnvelope, LocalApiRequest,
+    LocalApiResponse, LocalApiService, SplitDir, MAX_SEND_TEXT_BYTES,
 };
 use warpui::windowing::WindowManager;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity, ViewHandle};
@@ -165,14 +166,29 @@ fn generate_cookie() -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
-/// Per-user socket path. On macOS, `$TMPDIR` resolves to a per-user
-/// `/var/folders/.../T/` directory with mode 0700, which is the ideal
-/// location for a UDS that shouldn't be visible to other accounts.
+/// Per-user, per-instance socket path. On macOS, `$TMPDIR` resolves to a
+/// per-user `/var/folders/.../T/` directory with mode 0700, which is the
+/// ideal location for a UDS that shouldn't be visible to other accounts.
+///
+/// The filename embeds:
+///   - `ChannelState::data_domain()` so dev / preview / stable / oss
+///     installations bind distinct sockets even when launched concurrently;
+///   - the current PID so multiple instances of the same channel cohabit
+///     without removing each other's bind path on startup.
 fn per_user_socket_path() -> PathBuf {
     let dir = std::env::var_os("TMPDIR")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/tmp"));
-    dir.join("dev.warp.WarpOss-local-api.sock")
+    let domain = ChannelState::data_domain();
+    let pid = std::process::id();
+    dir.join(format!("{domain}-local-api-{pid}.sock"))
+}
+
+/// Address-file path for the running app — namespaced by `data_domain` so
+/// concurrently running Warp channels don't clobber each other's address
+/// file.
+fn address_publish_path() -> PathBuf {
+    address_publish_path_for(&ChannelState::data_domain())
 }
 
 fn harden_socket(addr: &ConnectionAddress) -> std::io::Result<()> {

--- a/app/src/local_api.rs
+++ b/app/src/local_api.rs
@@ -196,21 +196,47 @@ fn harden_socket(addr: &ConnectionAddress) -> std::io::Result<()> {
     fs::set_permissions(addr.to_string(), fs::Permissions::from_mode(0o600))
 }
 
+/// Write the address file atomically under 0600 throughout. We never write
+/// the cookie into a file whose permissions could be looser than 0600 — if
+/// a previous Warp version left the target at 0644, opening it with
+/// `OpenOptions::mode(0o600)` would NOT tighten existing perms (mode only
+/// applies on creation), and the cookie bytes would be world-readable for
+/// the window between `write_all` and `set_permissions`.
+///
+/// Instead we write to a fresh sibling temp file that the kernel creates
+/// via `O_CREAT | O_EXCL` with mode 0600 (`create_new(true) + .mode`),
+/// flush, then atomically `rename(2)` it over the destination. The new
+/// inode replaces the old one with tight perms from inception.
 fn publish_address(addr: &ConnectionAddress, cookie: &str) -> std::io::Result<()> {
     let path = address_publish_path();
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "address path has no parent",
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+
+    let tmp_path = parent.join(format!(".local-api.address.{}.tmp", std::process::id()));
+    // Clear any stale temp from a prior crashed run; the open below uses
+    // O_EXCL so we must own a fresh inode.
+    let _ = fs::remove_file(&tmp_path);
+
+    let body = format_address_file(&addr.to_string(), cookie);
+    {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp_path)?;
+        f.write_all(body.as_bytes())?;
+        f.sync_all()?;
     }
-    let mut f = fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&path)?;
-    f.write_all(format_address_file(&addr.to_string(), cookie).as_bytes())?;
-    // OpenOptions::mode only applies on file creation; if the file existed
-    // with looser perms, force them tight here.
-    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+
+    if let Err(e) = fs::rename(&tmp_path, &path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
     Ok(())
 }
 

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -4002,6 +4002,42 @@ impl PaneGroup {
         new_pane_id
     }
 
+    /// Splits the currently focused pane in `direction`. Used by the local
+    /// control API (`wp split …`) to mirror the behavior of the keyboard
+    /// shortcut without going through the input/event system.
+    pub(crate) fn local_api_split_active_pane(
+        &mut self,
+        direction: Direction,
+        ctx: &mut ViewContext<Self>,
+    ) -> TerminalPaneId {
+        let base_pane_id = self.focused_pane_id(ctx);
+        self.insert_terminal_pane(direction, base_pane_id, None, ctx)
+    }
+
+    /// Returns terminal pane ids in this pane group as their stable
+    /// `TerminalPaneId`s, one per terminal pane.
+    pub(crate) fn local_api_terminal_pane_ids(&self) -> Vec<TerminalPaneId> {
+        self.terminal_pane_ids()
+            .filter_map(|p| p.as_terminal_pane_id())
+            .collect()
+    }
+
+    /// Closes a terminal pane identified by `pane_id`. Returns an error when
+    /// no terminal pane with that id exists in this group, so callers from
+    /// the local control API can surface a stale-id failure instead of
+    /// silently reporting success.
+    pub(crate) fn local_api_close_pane(
+        &mut self,
+        pane_id: TerminalPaneId,
+        ctx: &mut ViewContext<Self>,
+    ) -> Result<(), &'static str> {
+        if self.terminal_view_from_pane_id(pane_id, ctx).is_none() {
+            return Err("pane not found");
+        }
+        self.close_pane(pane_id.into(), ctx);
+        Ok(())
+    }
+
     /// Used when splitting panes.
     fn insert_terminal_pane(
         &mut self,

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -113,6 +113,19 @@ impl TerminalPaneId {
     pub fn dummy_terminal_pane_id() -> Self {
         Self(EntityId::new())
     }
+
+    /// Stable string serialization used by the local control API (`wp` CLI).
+    /// Round-trips with [`Self::parse_local_api`].
+    pub(crate) fn to_local_api_string(self) -> String {
+        self.0.to_string()
+    }
+
+    /// Inverse of [`Self::to_local_api_string`].
+    pub(crate) fn parse_local_api(s: &str) -> Option<Self> {
+        s.parse::<usize>()
+            .ok()
+            .map(|n| Self(EntityId::from_usize(n)))
+    }
 }
 
 /// An internal representation of a pane ID. Specifically, we don't want to allow

--- a/crates/ipc/src/client.rs
+++ b/crates/ipc/src/client.rs
@@ -189,7 +189,7 @@ impl Client {
 
                     }
                 }
-                response = receive_message(&mut reader).fuse() => {
+                response = receive_message(&mut reader, None).fuse() => {
                     match response {
                         Ok(response) => {
                             let (request_id, response_result) = match response {

--- a/crates/ipc/src/protocol.rs
+++ b/crates/ipc/src/protocol.rs
@@ -134,6 +134,13 @@ pub enum ProtocolError {
     #[error(transparent)]
     Disconnected(#[from] std::io::Error),
 
+    /// The peer announced a frame larger than the configured cap, before
+    /// any payload bytes were read. The caller must close the connection;
+    /// the stream is unusable because the announced bytes were never
+    /// consumed and any subsequent header read would be misaligned.
+    #[error("frame payload {announced}B exceeds {cap}B cap")]
+    FrameTooLarge { announced: usize, cap: usize },
+
     #[error("Unknown error occurred: {0}")]
     Other(String),
 }
@@ -189,9 +196,10 @@ where
 
     if let Some(cap) = max_payload_len {
         if payload_len > cap {
-            return Err(ProtocolError::Other(format!(
-                "frame payload {payload_len}B exceeds {cap}B cap"
-            )));
+            return Err(ProtocolError::FrameTooLarge {
+                announced: payload_len,
+                cap,
+            });
         }
     }
 

--- a/crates/ipc/src/protocol.rs
+++ b/crates/ipc/src/protocol.rs
@@ -161,7 +161,16 @@ where
 }
 
 /// Reads the next message from the given `reader`.
-pub(super) async fn receive_message<M, R>(reader: &mut BufReader<R>) -> Result<M, ProtocolError>
+///
+/// `max_payload_len`, when set, caps the announced frame size before any
+/// allocation. Frames whose declared payload exceeds the cap are rejected
+/// without reading the payload bytes off the wire. This is the only place a
+/// remote peer's untrusted length header drives a buffer allocation, so the
+/// cap is the right enforcement point.
+pub(super) async fn receive_message<M, R>(
+    reader: &mut BufReader<R>,
+    max_payload_len: Option<usize>,
+) -> Result<M, ProtocolError>
 where
     M: Message,
     R: AsyncRead + Unpin,
@@ -175,10 +184,16 @@ where
     reader.read_exact(&mut header_buf[..]).await?;
 
     // Parse the message header - we convert the bytes back into a usize, which
-    // tells us the size of the serialized message, in bytes.  We add the size
-    // of a usize to get the total number of bytes we expect to read off the
-    // wire.
+    // tells us the size of the serialized message, in bytes.
     let payload_len = usize::from_be_bytes(header_buf);
+
+    if let Some(cap) = max_payload_len {
+        if payload_len > cap {
+            return Err(ProtocolError::Other(format!(
+                "frame payload {payload_len}B exceeds {cap}B cap"
+            )));
+        }
+    }
 
     // Grow the initial buffer to a sufficient size and read the rest of the
     // message from the socket.

--- a/crates/ipc/src/server.rs
+++ b/crates/ipc/src/server.rs
@@ -116,6 +116,7 @@ impl Connection {
 pub struct ServerBuilder {
     services: HashMap<ServiceId, Box<dyn AnyServiceImpl>>,
     fixed_connection_address: Option<ConnectionAddress>,
+    max_request_bytes: Option<usize>,
 }
 
 impl ServerBuilder {
@@ -128,6 +129,17 @@ impl ServerBuilder {
     /// Use a fixed address name instead of a randomly generated one.
     pub fn with_fixed_address(mut self, fixed_address: String) -> Self {
         self.fixed_connection_address = Some(ConnectionAddress::from(fixed_address));
+        self
+    }
+
+    /// Cap the size (in bytes) of inbound request frames. Frames whose
+    /// length header exceeds the cap are rejected by the framing layer
+    /// before any payload is read or deserialized, so an unauthenticated
+    /// peer cannot force a large allocation by lying about its size.
+    ///
+    /// Defaults to unbounded for callers that don't set it.
+    pub fn with_max_request_bytes(mut self, max_request_bytes: usize) -> Self {
+        self.max_request_bytes = Some(max_request_bytes);
         self
     }
 
@@ -147,6 +159,7 @@ impl ServerBuilder {
         Server::run(
             connection_address.clone(),
             self.services,
+            self.max_request_bytes,
             background_executor,
         )
         .map(|server| (server, connection_address))
@@ -171,6 +184,7 @@ impl Server {
     fn run(
         connection_address: ConnectionAddress,
         services: HashMap<ServiceId, Box<dyn AnyServiceImpl>>,
+        max_request_bytes: Option<usize>,
         background_executor: Arc<Background>,
     ) -> Result<Self> {
         let listener = ConnectionListener::new(connection_address)?;
@@ -188,6 +202,7 @@ impl Server {
             )),
             background_executor.spawn(Self::accept_new_connections(
                 services,
+                max_request_bytes,
                 new_connection_rx,
                 background_executor.clone(),
             )),
@@ -220,6 +235,7 @@ impl Server {
     /// for processing incoming request messages and outgoing response messages.
     async fn accept_new_connections(
         services: HashMap<ServiceId, Box<dyn AnyServiceImpl>>,
+        max_request_bytes: Option<usize>,
         new_connection_rx: Receiver<Connection>,
         background_executor: Arc<Background>,
     ) {
@@ -239,6 +255,7 @@ impl Server {
             tasks.push(background_executor.spawn(Self::handle_incoming_requests(
                 reader,
                 services.clone(),
+                max_request_bytes,
                 response_tx,
             )));
             tasks.push(
@@ -258,11 +275,12 @@ impl Server {
     async fn handle_incoming_requests(
         reader: impl AsyncRead + Unpin,
         services: HashMap<ServiceId, Box<dyn AnyServiceImpl>>,
+        max_request_bytes: Option<usize>,
         response_tx: Sender<Response>,
     ) {
         let mut reader = BufReader::new(reader);
         loop {
-            match receive_message(&mut reader).await {
+            match receive_message(&mut reader, max_request_bytes).await {
                 Ok(Request {
                     id,
                     service_id,

--- a/crates/ipc/src/server.rs
+++ b/crates/ipc/src/server.rs
@@ -25,7 +25,7 @@ use super::{
 /// implementation.
 #[async_trait]
 pub(super) trait AnyServiceImpl: Send + Sync {
-    async fn handle_request(&self, request: &[u8]) -> Vec<u8>;
+    async fn handle_request(&self, request: &[u8]) -> std::result::Result<Vec<u8>, String>;
 
     fn clone_service(&self) -> Box<dyn AnyServiceImpl>;
 }
@@ -36,11 +36,16 @@ where
     S: Service,
     I: ServiceImpl<Service = S> + Clone + Sized,
 {
-    async fn handle_request(&self, request_bytes: &[u8]) -> Vec<u8> {
-        let request: S::Request =
-            bincode::deserialize(request_bytes).expect("Failed to deserialize request bytes.");
+    async fn handle_request(&self, request_bytes: &[u8]) -> std::result::Result<Vec<u8>, String> {
+        // The framing layer can hand us arbitrary bytes from any same-host
+        // peer that opened the socket. Failing to typed-deserialize those
+        // bytes is a peer-input error, not a programmer bug, so we surface
+        // it as a framework-level `Response::Failure` instead of panicking
+        // the connection task.
+        let request: S::Request = bincode::deserialize(request_bytes)
+            .map_err(|e| format!("failed to deserialize request: {e}"))?;
         bincode::serialize::<S::Response>(&I::handle_request(self, request).await)
-            .expect("Should be able to serialize response.")
+            .map_err(|e| format!("failed to serialize response: {e}"))
     }
 
     fn clone_service(&self) -> Box<dyn AnyServiceImpl> {
@@ -287,10 +292,10 @@ impl Server {
                     bytes,
                 }) => {
                     let response_message = match services.get(&service_id) {
-                        Some(service) => {
-                            let response_bytes = service.handle_request(&bytes[..]).await;
-                            Response::success(id, service_id, response_bytes)
-                        }
+                        Some(service) => match service.handle_request(&bytes[..]).await {
+                            Ok(response_bytes) => Response::success(id, service_id, response_bytes),
+                            Err(error_message) => Response::failure(id, error_message),
+                        },
                         None => {
                             Response::failure(id, format!("No such service (ID: {service_id})"))
                         }
@@ -306,11 +311,26 @@ impl Server {
                 Err(e) => {
                     match e {
                         ProtocolError::Serialization(e) => {
+                            // The framing layer already consumed the
+                            // announced payload, so the stream is aligned
+                            // for the next frame. Skip this frame and
+                            // continue serving the connection.
                             log::warn!("Failed to deserialize request: {e:?}");
                         }
                         ProtocolError::Disconnected(_) => {
                             // The socket is disconnected, so exit.
                             log::warn!("IPC server disconnected unexpectedly.");
+                            break;
+                        }
+                        ProtocolError::FrameTooLarge { announced, cap } => {
+                            // The announced bytes were never read off the
+                            // wire, so the stream is now misaligned —
+                            // continuing would let the unread payload be
+                            // re-interpreted as the next frame's header.
+                            // Close the connection.
+                            log::warn!(
+                                "IPC peer announced oversized frame ({announced}B > {cap}B cap); closing connection"
+                            );
                             break;
                         }
                         e => {

--- a/crates/warp_local_api/Cargo.toml
+++ b/crates/warp_local_api/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors.workspace = true
+edition = "2021"
+license.workspace = true
+name = "warp_local_api"
+version = "0.1.0"
+publish.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+dirs.workspace = true
+ipc.workspace = true
+serde = { workspace = true, features = ["derive"] }

--- a/crates/warp_local_api/src/lib.rs
+++ b/crates/warp_local_api/src/lib.rs
@@ -32,15 +32,22 @@ pub enum SplitDir {
 pub enum LocalApiRequest {
     Ping,
     /// Split the active pane in `dir`; reply contains the new pane's id.
-    Split { dir: SplitDir },
+    Split {
+        dir: SplitDir,
+    },
     /// Write `text` to the PTY of the named terminal pane (or active if None).
-    SendText { pane: Option<String>, text: String },
+    SendText {
+        pane: Option<String>,
+        text: String,
+    },
     /// Returns the ids of all terminal panes in the active workspace.
     ListPanes,
     /// Returns the id of the focused terminal pane in the active workspace.
     ActivePane,
     /// Closes the named terminal pane.
-    ClosePane { pane: String },
+    ClosePane {
+        pane: String,
+    },
 }
 
 /// Wire envelope: every request carries the per-session cookie, validated
@@ -71,11 +78,34 @@ impl ipc::Service for LocalApiService {
 /// Filesystem path where the running Warp publishes its current connection
 /// address + cookie. The `wp` CLI reads this file to find the live socket.
 /// Created with mode 0600.
+///
+/// Resolution order:
+/// 1. `WARP_LOCAL_API_ADDRESS` — full path override. The running Warp sets
+///    this in the env of every spawned shell so child `wp` invocations land
+///    on the same instance even when several Warp variants run side-by-side.
+/// 2. `<data-local-dir>/<WARP_LOCAL_API_DOMAIN or default>/local-api.address`
+///    — default for ad-hoc invocations from outside a Warp shell.
+///
+/// The default domain is the production app id `dev.warp.Warp`; dev / preview
+/// / oss instances each publish under their own domain so they don't clobber
+/// each other's address files.
 pub fn address_publish_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("WARP_LOCAL_API_ADDRESS") {
+        return PathBuf::from(p);
+    }
+    let domain =
+        std::env::var("WARP_LOCAL_API_DOMAIN").unwrap_or_else(|_| "dev.warp.Warp".to_owned());
+    address_publish_path_for(&domain)
+}
+
+/// Build the default address-file path for a specific data domain. Used by
+/// the running Warp app to publish under its own channel/installation
+/// namespace.
+pub fn address_publish_path_for(domain: &str) -> PathBuf {
     let base = dirs::data_local_dir()
         .or_else(dirs::data_dir)
         .unwrap_or_else(std::env::temp_dir);
-    base.join("dev.warp.Warp").join("local-api.address")
+    base.join(domain).join("local-api.address")
 }
 
 /// Format the address-file body. Two lines:

--- a/crates/warp_local_api/src/lib.rs
+++ b/crates/warp_local_api/src/lib.rs
@@ -1,0 +1,97 @@
+//! Wire types and `ipc::Service` definition for Warp's local control API.
+//!
+//! The running Warp process hosts a UDS server that speaks this protocol; the
+//! `wp` CLI is the canonical client. Both ends share these types via this
+//! crate so the bincode wire format stays in lockstep.
+//!
+//! # Authentication
+//!
+//! On startup, Warp generates a random per-session cookie and writes the
+//! socket path + cookie to a 0600 address file under the user's data dir.
+//! Possessing the file (i.e., being the same UID) is the authentication
+//! factor; every request carries the cookie inside [`LocalApiEnvelope`] and
+//! the server rejects mismatches before dispatching.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Maximum bytes accepted for `SendText.text`. Defends the in-app handler
+/// against unbounded payloads from a same-UID local client.
+pub const MAX_SEND_TEXT_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum SplitDir {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum LocalApiRequest {
+    Ping,
+    /// Split the active pane in `dir`; reply contains the new pane's id.
+    Split { dir: SplitDir },
+    /// Write `text` to the PTY of the named terminal pane (or active if None).
+    SendText { pane: Option<String>, text: String },
+    /// Returns the ids of all terminal panes in the active workspace.
+    ListPanes,
+    /// Returns the id of the focused terminal pane in the active workspace.
+    ActivePane,
+    /// Closes the named terminal pane.
+    ClosePane { pane: String },
+}
+
+/// Wire envelope: every request carries the per-session cookie, validated
+/// server-side before dispatch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalApiEnvelope {
+    pub cookie: String,
+    pub request: LocalApiRequest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum LocalApiResponse {
+    Pong,
+    Ok,
+    PaneId(String),
+    Panes(Vec<String>),
+    Err(String),
+}
+
+pub struct LocalApiService;
+
+#[async_trait]
+impl ipc::Service for LocalApiService {
+    type Request = LocalApiEnvelope;
+    type Response = LocalApiResponse;
+}
+
+/// Filesystem path where the running Warp publishes its current connection
+/// address + cookie. The `wp` CLI reads this file to find the live socket.
+/// Created with mode 0600.
+pub fn address_publish_path() -> PathBuf {
+    let base = dirs::data_local_dir()
+        .or_else(dirs::data_dir)
+        .unwrap_or_else(std::env::temp_dir);
+    base.join("dev.warp.Warp").join("local-api.address")
+}
+
+/// Format the address-file body. Two lines:
+///   line 1: socket path
+///   line 2: cookie hex
+pub fn format_address_file(socket: &str, cookie: &str) -> String {
+    format!("{socket}\n{cookie}\n")
+}
+
+/// Inverse of [`format_address_file`]. Returns `(socket, cookie)`.
+pub fn parse_address_file(s: &str) -> Option<(String, String)> {
+    let mut lines = s.lines();
+    let socket = lines.next()?.trim().to_owned();
+    let cookie = lines.next()?.trim().to_owned();
+    if socket.is_empty() || cookie.is_empty() {
+        return None;
+    }
+    Some((socket, cookie))
+}

--- a/crates/warp_local_api/src/lib.rs
+++ b/crates/warp_local_api/src/lib.rs
@@ -20,6 +20,14 @@ use std::path::PathBuf;
 /// against unbounded payloads from a same-UID local client.
 pub const MAX_SEND_TEXT_BYTES: usize = 256 * 1024;
 
+/// Hard cap on inbound IPC frame size, enforced by the framing layer
+/// before any payload is read off the wire or deserialized. Sized to fit
+/// `MAX_SEND_TEXT_BYTES` plus bincode envelope/cookie overhead with margin
+/// for future fields. An unauthenticated peer that announces a frame
+/// larger than this is rejected before allocation, so the cookie check
+/// can't be bypassed by exhausting memory first.
+pub const MAX_REQUEST_BYTES: usize = MAX_SEND_TEXT_BYTES + 4 * 1024;
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum SplitDir {
     Left,
@@ -75,37 +83,93 @@ impl ipc::Service for LocalApiService {
     type Response = LocalApiResponse;
 }
 
-/// Filesystem path where the running Warp publishes its current connection
-/// address + cookie. The `wp` CLI reads this file to find the live socket.
-/// Created with mode 0600.
+/// Default app-id domain used when no override is set and exactly one
+/// channel cannot be inferred.
+pub const DEFAULT_DATA_DOMAIN: &str = "dev.warp.Warp";
+
+/// Filename Warp uses for the published address file inside its
+/// per-channel data directory.
+pub const ADDRESS_FILE_NAME: &str = "local-api.address";
+
+/// Outcome of resolving which Warp instance a CLI invocation should target.
+pub enum AddressResolution {
+    /// A single address-file path was selected.
+    Single(PathBuf),
+    /// More than one channel currently publishes an address file. Caller must
+    /// disambiguate via `WARP_LOCAL_API_DOMAIN` / `WARP_LOCAL_API_ADDRESS`.
+    Ambiguous(Vec<PathBuf>),
+}
+
+/// Resolve the address-file path that the `wp` CLI should read.
 ///
 /// Resolution order:
-/// 1. `WARP_LOCAL_API_ADDRESS` — full path override. The running Warp sets
-///    this in the env of every spawned shell so child `wp` invocations land
-///    on the same instance even when several Warp variants run side-by-side.
-/// 2. `<data-local-dir>/<WARP_LOCAL_API_DOMAIN or default>/local-api.address`
-///    — default for ad-hoc invocations from outside a Warp shell.
-///
-/// The default domain is the production app id `dev.warp.Warp`; dev / preview
-/// / oss instances each publish under their own domain so they don't clobber
-/// each other's address files.
-pub fn address_publish_path() -> PathBuf {
+/// 1. `WARP_LOCAL_API_ADDRESS` — full-path override (e.g. set by an
+///    integration script that already knows the target instance).
+/// 2. `WARP_LOCAL_API_DOMAIN` — domain-only override; resolved through
+///    [`address_publish_path_for`].
+/// 3. Auto-discovery: scan `<data-local-dir>/*/{ADDRESS_FILE_NAME}` and
+///    return the single existing match, or `Ambiguous` if multiple
+///    channels are running.
+/// 4. Fall back to the default domain (`DEFAULT_DATA_DOMAIN`) so callers
+///    still get a deterministic path to surface in error messages.
+pub fn resolve_address_path() -> AddressResolution {
     if let Some(p) = std::env::var_os("WARP_LOCAL_API_ADDRESS") {
-        return PathBuf::from(p);
+        return AddressResolution::Single(PathBuf::from(p));
     }
-    let domain =
-        std::env::var("WARP_LOCAL_API_DOMAIN").unwrap_or_else(|_| "dev.warp.Warp".to_owned());
-    address_publish_path_for(&domain)
+    if let Ok(domain) = std::env::var("WARP_LOCAL_API_DOMAIN") {
+        return AddressResolution::Single(address_publish_path_for(&domain));
+    }
+    let candidates = discover_address_files();
+    match candidates.len() {
+        0 => AddressResolution::Single(address_publish_path_for(DEFAULT_DATA_DOMAIN)),
+        1 => AddressResolution::Single(candidates.into_iter().next().unwrap()),
+        _ => AddressResolution::Ambiguous(candidates),
+    }
+}
+
+/// Backwards-compatible accessor for the default address path. Prefer
+/// [`resolve_address_path`] in callers that want auto-discovery.
+pub fn address_publish_path() -> PathBuf {
+    match resolve_address_path() {
+        AddressResolution::Single(p) => p,
+        AddressResolution::Ambiguous(mut v) => {
+            v.sort();
+            v.into_iter()
+                .next()
+                .unwrap_or_else(|| address_publish_path_for(DEFAULT_DATA_DOMAIN))
+        }
+    }
 }
 
 /// Build the default address-file path for a specific data domain. Used by
 /// the running Warp app to publish under its own channel/installation
 /// namespace.
 pub fn address_publish_path_for(domain: &str) -> PathBuf {
-    let base = dirs::data_local_dir()
+    address_publish_root().join(domain).join(ADDRESS_FILE_NAME)
+}
+
+fn address_publish_root() -> PathBuf {
+    dirs::data_local_dir()
         .or_else(dirs::data_dir)
-        .unwrap_or_else(std::env::temp_dir);
-    base.join(domain).join("local-api.address")
+        .unwrap_or_else(std::env::temp_dir)
+}
+
+/// Walk the address-publish root one level deep and return every existing
+/// `<domain>/local-api.address` file. Read-only; no side effects.
+fn discover_address_files() -> Vec<PathBuf> {
+    let root = address_publish_root();
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let candidate = entry.path().join(ADDRESS_FILE_NAME);
+        if candidate.is_file() {
+            out.push(candidate);
+        }
+    }
+    out.sort();
+    out
 }
 
 /// Format the address-file body. Two lines:

--- a/crates/wp/Cargo.toml
+++ b/crates/wp/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+authors.workspace = true
+edition = "2021"
+license.workspace = true
+name = "wp"
+version = "0.1.0"
+publish.workspace = true
+
+[[bin]]
+name = "wp"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+futures.workspace = true
+ipc.workspace = true
+warp_local_api = { path = "../warp_local_api" }
+warpui = { workspace = true }

--- a/crates/wp/src/main.rs
+++ b/crates/wp/src/main.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 
 use ipc::{service_caller, ConnectionAddress};
 use warp_local_api::{
-    address_publish_path, parse_address_file, LocalApiEnvelope, LocalApiRequest, LocalApiResponse,
-    LocalApiService, SplitDir,
+    parse_address_file, resolve_address_path, AddressResolution, LocalApiEnvelope, LocalApiRequest,
+    LocalApiResponse, LocalApiService, SplitDir,
 };
 
 #[derive(Debug, Parser)]
@@ -69,10 +69,23 @@ fn main() -> Result<()> {
     let executor_for_block = executor.clone();
 
     let result: Result<LocalApiResponse> = warpui::r#async::block_on(async move {
-        let addr_path = address_publish_path();
+        let addr_path = match resolve_address_path() {
+            AddressResolution::Single(p) => p,
+            AddressResolution::Ambiguous(paths) => {
+                let listing = paths
+                    .iter()
+                    .map(|p| format!("  {}", p.display()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return Err(anyhow!(
+                    "multiple Warp instances are publishing local-api address files:\n{listing}\n\
+                     set WARP_LOCAL_API_DOMAIN=<channel> or WARP_LOCAL_API_ADDRESS=<path> to disambiguate"
+                ));
+            }
+        };
         let body = std::fs::read_to_string(&addr_path).with_context(|| {
             format!(
-                "could not read socket address from {} — is Warp running?",
+                "could not read socket address from {} — is Warp running with WARP_ENABLE_LOCAL_API=1?",
                 addr_path.display()
             )
         })?;

--- a/crates/wp/src/main.rs
+++ b/crates/wp/src/main.rs
@@ -1,0 +1,126 @@
+//! `wp` — Warp local control CLI.
+//!
+//! Reads the published address file (socket path + per-session cookie),
+//! connects via `ipc::Client`, and dispatches subcommands like
+//! `split`/`send-text`/`list-panes`/`close-pane` against the running Warp.
+
+use anyhow::{anyhow, Context, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use std::sync::Arc;
+
+use ipc::{service_caller, ConnectionAddress};
+use warp_local_api::{
+    address_publish_path, parse_address_file, LocalApiEnvelope, LocalApiRequest, LocalApiResponse,
+    LocalApiService, SplitDir,
+};
+
+#[derive(Debug, Parser)]
+#[command(name = "wp", about = "Warp local control CLI")]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Debug, Subcommand)]
+enum Cmd {
+    /// Round-trip health check against the running Warp.
+    Ping,
+    /// Split the active pane in the given direction. Prints the new pane id.
+    Split { direction: Direction },
+    /// Send text to a terminal pane (or the active pane if --pane is omitted).
+    SendText {
+        #[arg(long)]
+        pane: Option<String>,
+        text: String,
+    },
+    /// List all terminal pane ids in the active workspace, one per line.
+    ListPanes,
+    /// Print the id of the currently focused terminal pane.
+    ActivePane,
+    /// Close the given terminal pane.
+    ClosePane { pane: String },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Direction {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+impl From<Direction> for SplitDir {
+    fn from(d: Direction) -> Self {
+        match d {
+            Direction::Left => SplitDir::Left,
+            Direction::Right => SplitDir::Right,
+            Direction::Up => SplitDir::Up,
+            Direction::Down => SplitDir::Down,
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let executor = Arc::new(warpui::r#async::executor::Background::new(2, |i| {
+        format!("wp-cli-{i}")
+    }));
+    let executor_for_block = executor.clone();
+
+    let result: Result<LocalApiResponse> = warpui::r#async::block_on(async move {
+        let addr_path = address_publish_path();
+        let body = std::fs::read_to_string(&addr_path).with_context(|| {
+            format!(
+                "could not read socket address from {} — is Warp running?",
+                addr_path.display()
+            )
+        })?;
+        let (socket, cookie) = parse_address_file(&body).ok_or_else(|| {
+            anyhow!(
+                "address file at {} is malformed (expected two lines: socket\\ncookie\\n)",
+                addr_path.display()
+            )
+        })?;
+        let address = ConnectionAddress::from(socket);
+
+        let client = ipc::Client::connect(address, executor_for_block)
+            .await
+            .map_err(|e| anyhow!("failed to connect to Warp: {e:?}"))?;
+        let caller = service_caller::<LocalApiService>(Arc::new(client));
+
+        let request = match cli.cmd {
+            Cmd::Ping => LocalApiRequest::Ping,
+            Cmd::Split { direction } => LocalApiRequest::Split {
+                dir: direction.into(),
+            },
+            Cmd::SendText { pane, text } => LocalApiRequest::SendText { pane, text },
+            Cmd::ListPanes => LocalApiRequest::ListPanes,
+            Cmd::ActivePane => LocalApiRequest::ActivePane,
+            Cmd::ClosePane { pane } => LocalApiRequest::ClosePane { pane },
+        };
+
+        caller
+            .call(LocalApiEnvelope { cookie, request })
+            .await
+            .map_err(|e| anyhow!("call failed: {e:?}"))
+    });
+
+    drop(executor);
+
+    match result? {
+        LocalApiResponse::Pong => println!("pong"),
+        LocalApiResponse::Ok => {}
+        LocalApiResponse::PaneId(id) => println!("{id}"),
+        LocalApiResponse::Panes(ids) => {
+            for id in ids {
+                println!("{id}");
+            }
+        }
+        LocalApiResponse::Err(msg) => {
+            eprintln!("error: {msg}");
+            std::process::exit(1);
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Description

Adds a UDS-based local control plane plus a sibling `wp` CLI binary, giving Warp the same scripting affordance that iTerm2 ships through `it2cli`, kitty through `kitty @`, and wezterm through `wezterm cli`. External processes (build automations, dotfile managers, productivity tooling) can split panes, send text, list and close panes against the running Warp without going through the keyboard / event system.

### Architecture

Mirrors `iTermAPIServer`'s "background socket reads, main-thread mutations" pattern.

- **`crates/warp_local_api/`** — wire types and the `ipc::Service` definition. Typed `LocalApiRequest` / `LocalApiResponse` enums, address-publish-path helper.
- **`app/src/local_api.rs`** — `LocalApiServer` singleton entity registered at startup. Hosts an `ipc::Server` from `crates/ipc/` on the background executor; forwards each request over an `async_channel` to the main thread, where `spawn_stream_local` dispatches it into the active workspace's active pane group and replies via a oneshot. **This pattern avoids holding `TerminalModel` locks across awaits**, the documented deadlock hazard from `WARP.md`.
- **`crates/wp/`** — thin clap-based client. Reads the published socket address, connects via `ipc::Client`, calls `service_caller::<LocalApiService>`. Subcommands: `ping`, `split <dir>`, `send-text [--pane ID] TEXT`, `list-panes`, `active-pane`, `close-pane <ID>`.
- **`pane_group::PaneGroup`** gains three `pub(crate)` helpers used by the in-app handler: `local_api_split_active_pane`, `local_api_terminal_pane_ids`, `local_api_close_pane`.
- **`pane_group::pane::TerminalPaneId`** gains `pub(crate)` `to_local_api_string` / `parse_local_api` for stable wire serialization.

### Why

Every other terminal in the space (iTerm2, kitty, wezterm, alacritty + tmux) ships some external-control surface. Warp doesn't. This blocks scripts/automations that want to drive Warp from a sibling process: invoking a build in one pane while a watcher runs in another, opening a layout from a project's `Justfile`, integrating with productivity tools, etc. Today the only options are AppleScript (extremely limited and macOS-only) and the `warp://` deeplink scheme (one-shot, fire-and-forget, no return values). This PR adds the missing capability without breaking either of those surfaces.

### What this is *not*

This PR intentionally does not include:
- A custom integration adapter for any specific external tool. The CLI is a generic primitive; consumers (CI scripts, AI tools, dotfile managers) write their own wrappers as needed.
- Auth beyond same-UID UDS permissions. The address file lives under the user's data dir; only that user's processes can connect. If stronger auth is wanted (cookie-based, like iTerm2's API), that's a follow-up.
- Versioning of the wire protocol. The current types are unversioned; before any third-party adoption a `v1` namespace and protocol-version handshake should be added. Happy to do that here if reviewers prefer.

## Linked Issue

None — this is a net-new capability that didn't have an existing tracking issue. Happy to open one if the team prefers that workflow before review.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Screenshots / Videos

No UI changes. The verification flow looks like:

```
$ wp ping
pong
$ wp split right
12345
$ wp send-text --pane 12345 "echo hello"
$ wp list-panes
12345
67890
```

## Testing

- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p warp_local_api -p wp -p warp --all-targets --tests -- -D warnings` — clean.
- Manual end-to-end: launched the patched `warp-oss`, ran `wp ping → pong`, `wp split right` produced a new Warp pane and printed its id, `wp send-text --pane <id> "ls<newline>"` injected the keystrokes into the target terminal's PTY, `wp close-pane <id>` removed it.
- The IPC server uses the same `ipc::ServerBuilder` pattern as `PluginHost` (see `app/src/plugin/app/mod.rs`). Lock-discipline tested by exercising rapid split + send-text + close cycles — no deadlocks observed.

I did not add automated tests in this PR because the request-dispatch path needs a running app context, and I didn't see an existing fixture for that pattern in the workspace. Happy to add `cargo test` coverage for the bincode wire format and any unit-testable helpers if reviewers point me at the right testing pattern.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NEW-FEATURE: Add scriptable pane control via local UDS API and `wp` CLI, comparable to iTerm2's `it2cli`.
