### PR TITLE
Send context (skills, env) with /compact summarization requests

### DIFF
--- a/app/src/ai/agent/api/convert_to.rs
+++ b/app/src/ai/agent/api/convert_to.rs
@@ -209,9 +209,9 @@ pub(super) fn convert_input(
                     )),
                 });
             }
-            AIAgentInput::SummarizeConversation { prompt } => {
+            AIAgentInput::SummarizeConversation { prompt, context } => {
                 return Ok(api::request::Input {
-                    context: None,
+                    context: Some(convert_context(context.as_ref())),
                     r#type: Some(api::request::input::Type::SummarizeConversation(
                         api::request::input::SummarizeConversation {
                             prompt: prompt.unwrap_or_default(),

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -2455,6 +2455,7 @@ pub enum AIAgentInput {
 
     SummarizeConversation {
         prompt: Option<String>,
+        context: Arc<[AIAgentContext]>,
     },
 
     /// Invoke a skill. The skill content is passed as instructions to the agent.
@@ -2757,8 +2758,8 @@ impl AIAgentInput {
             | Self::InvokeSkill { context, .. }
             | Self::StartFromAmbientRunPrompt { context, .. }
             | Self::PassiveSuggestionResult { context, .. } => Some(context),
-            Self::SummarizeConversation { .. }
-            | Self::MessagesReceivedFromAgents { .. }
+            Self::SummarizeConversation { context, .. } => Some(context),
+            Self::MessagesReceivedFromAgents { .. }
             | Self::EventsFromAgents { .. }
             | Self::OrchestrationConfigUpdate { .. } => None,
         }

--- a/app/src/ai/agent/redaction.rs
+++ b/app/src/ai/agent/redaction.rs
@@ -53,10 +53,11 @@ pub(crate) fn redact_inputs(inputs: &mut [AIAgentInput]) {
             | AIAgentInput::StartFromAmbientRunPrompt { context, .. } => {
                 redact_context(Arc::make_mut(context));
             }
-            AIAgentInput::SummarizeConversation { prompt } => {
+            AIAgentInput::SummarizeConversation { prompt, context } => {
                 if let Some(p) = prompt {
                     redact_secrets(p);
                 }
+                redact_context(Arc::make_mut(context));
             }
             AIAgentInput::CreateEnvironment { context, .. } => {
                 redact_context(Arc::make_mut(context));

--- a/app/src/ai/blocklist/controller/slash_command.rs
+++ b/app/src/ai/blocklist/controller/slash_command.rs
@@ -241,7 +241,7 @@ impl SlashCommandRequest {
                 }]
             }
             SlashCommandRequest::Summarize { prompt, .. } => {
-                vec![AIAgentInput::SummarizeConversation { prompt }]
+                vec![AIAgentInput::SummarizeConversation { prompt, context }]
             }
             SlashCommandRequest::FetchReviewComments { repo_path } => {
                 vec![AIAgentInput::FetchReviewComments { repo_path, context }]


### PR DESCRIPTION
## Description

The `SummarizeConversation` input variant did not carry `AIAgentContext`, so `/compact` requests were sent to the server with `context: None`. This meant the server received no skills list, execution environment, codebases, or other context data on summarization requests.

Adds a `context` field to `SummarizeConversation`, wires it through the slash command handler, API conversion, and secret redaction paths. The context is now populated from the same `input_context_for_request` call that all other slash commands use.

## Linked Issue

[QUALITY-615](https://linear.app/warpdotdev/issue/QUALITY-615/summarization-elides-available-skills-and-external-context)

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

- [x] `cargo check` passes
- [x] All existing match arms use `..` patterns that cover the new field (verified by compilation)
- [x] Verified the three explicit destructure sites (convert_to.rs, redaction.rs, slash_command.rs) correctly handle the new field

Companion server PR: https://github.com/warpdotdev/warp-server/pull/10919

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/38229205-9edd-4787-883a-c775cebeaeb8)

Co-Authored-By: Oz <oz-agent@warp.dev>