### PR TITLE
Add Oz for OSS README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Explore [build.warp.dev](https://build.warp.dev) to:
 - Track your own issues with GitHub sign-in
 - Click into active agent sessions in a web-compiled Warp terminal
 
+## Oz for OSS
+
+Maintaining a popular open-source project? [Apply for Oz credits](https://tally.so/r/LZWxqG) to explore [Oz for OSS](https://github.com/warpdotdev/oz-for-oss).
+
+Oz for OSS is our partner program for bringing the same agentic open-source management workflows used in this repository to select partner repositories. We work directly with maintainers to implement workflows for issue triage, PR review, community management, and contributor coordination in a way that fits each project.
+
 ## Licensing
 
 Warp's UI framework (the `warpui_core` and `warpui` crates) are licensed under the [MIT license](LICENSE-MIT).
@@ -57,8 +63,6 @@ Warp's client codebase is open source and lives in this repository. We welcome c
 
 > [!TIP]
 > **Chat with contributors and the Warp team** in the [`#oss-contributors`](https://warpcommunity.slack.com/archives/C0B0LM8N4DB) Slack channel — a good place for ad-hoc questions, design discussion, and pairing with maintainers. New here? [Join the Warp Slack community](https://go.warp.dev/join-preview) first, then jump into `#oss-contributors`.
-
-Maintaining a popular open-source project? [Apply for Oz credits](https://tally.so/r/LZWxqG) to bring [agentic workflows](https://github.com/warpdotdev/oz-for-oss) like issue triage, PR review, and community management to your repo.
 
 ### Issue to PR
 


### PR DESCRIPTION
## Description
Adds a standalone Oz for OSS section to the README and clarifies that Warp is working with select open-source partners to bring the same agentic OSS management workflows used in this repo to their repositories.

## Linked Issue
None. Slack request.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
Not relevant for this README copy update.

## Testing
Docs-only change; reviewed the rendered Markdown source/diff locally. No automated tests were run.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._
