### PR TITLE
Reference README badges from brand assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </a>
 &nbsp;
 <p align="center">
-  <a href="https://www.warp.dev"><img height="20" alt="Built with Warp" src="./images/Built-With-Warp-Export@2x.png" /></a>
+  <a href="https://www.warp.dev"><img height="20" alt="Built with Warp" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/images/Built-With-Warp-Export@2x.png" /></a>
   &nbsp;
-  <a href="https://oz.warp.dev"><img height="20" alt="Powered by Oz" src="./images/Powered-By-Oz-Export@2x.png" /></a>
+  <a href="https://oz.warp.dev"><img height="20" alt="Powered by Oz" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/images/Powered-By-Oz-Export@2x.png" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </a>
 &nbsp;
 <p align="center">
-  <a href="https://www.warp.dev"><img height="20" alt="Built with Warp" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/images/Built-With-Warp-Export@2x.png" /></a>
+  <a href="https://www.warp.dev"><img height="20" alt="Built with Warp" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Built-With-Warp-Export@2x.png" /></a>
   &nbsp;
-  <a href="https://oz.warp.dev"><img height="20" alt="Powered by Oz" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/images/Powered-By-Oz-Export@2x.png" /></a>
+  <a href="https://oz.warp.dev"><img height="20" alt="Powered by Oz" src="https://raw.githubusercontent.com/warpdotdev/brand-assets/main/Github/Powered-By-Oz-Export@2x.png" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Description
- Update the README badge image sources to use the actual `warpdotdev/brand-assets` paths added in brand-assets PR #4.
- Keep the existing badge links, dimensions, and alt text unchanged.
- Depends on `warpdotdev/brand-assets#4` being merged so these `main/Github/` raw URLs resolve.

## Linked Issue
- None. Follow-up to `warpdotdev/brand-assets#4`.

## Testing
- Confirmed `warpdotdev/brand-assets#4` adds `Github/Built-With-Warp-Export@2x.png` and `Github/Powered-By-Oz-Export@2x.png`.
- Ran `git diff --check`.
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not applicable. README-only URL update.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp AI Agent Mode

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._