### PR TITLE
Simplify `DiffStateModel` to have one repo

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -2422,52 +2422,11 @@ impl CodeReviewView {
 
     fn handle_diff_state_model_event(
         &mut self,
-        diff_state_model: ModelHandle<DiffStateModel>,
+        _diff_state_model: ModelHandle<DiffStateModel>,
         event: &DiffStateModelEvent,
         ctx: &mut ViewContext<Self>,
     ) {
         match event {
-            DiffStateModelEvent::RepositoryChanged => {
-                let old_path = self.repo_path().cloned();
-                let repo_path =
-                    diff_state_model.read(ctx, |model, _| model.active_repository_path(ctx));
-
-                safe_info!(
-                    safe: ("Code Review: Repository changed. Branch list cleared."),
-                    full: (
-                        "Code Review: Repository changed event - old path: {:?}, new path: {:?}",
-                        old_path,
-                        repo_path
-                    )
-                );
-
-                // Abort in-flight file invalidation tasks on the old repo before
-                // it is potentially replaced.
-                self.queue_full_invalidation();
-
-                if self.repo_path() != repo_path.as_ref() {
-                    self.update_current_repo(repo_path.clone(), ctx);
-                }
-
-                // update_current_repo replaces active_repo with a fresh
-                // RepositoryState, discarding the invalidate_all_pending flag
-                // that queue_full_invalidation just set. Re-apply it so the
-                // new repo also defers file invalidations until the full reload
-                // completes. (state == None covers this today, but the explicit
-                // flag makes the invariant resilient to future changes.)
-                if let Some(repo) = self.active_repo.as_mut() {
-                    repo.file_invalidation.invalidate_all_pending = true;
-                }
-
-                let repo_path_for_list = repo_path.clone().unwrap_or_default();
-                self.comment_list_view.update(ctx, |view, ctx| {
-                    // TODO(alokedesai): Update how we model repo path so that it's optional.
-                    // There are no guarantees that CodeReviewView is within a repo.
-                    view.set_repo_path(repo_path_for_list.clone(), ctx);
-                });
-
-                self.invalidate_all(None, ctx);
-            }
             DiffStateModelEvent::DiffMetadataChanged(InvalidationBehavior::All(source)) => {
                 // If the invalidation is an index lock change AND we don't have an already pending invalidation,
                 // don't eagerly reload all of the diffs.

--- a/app/src/code_review/code_review_view_tests.rs
+++ b/app/src/code_review/code_review_view_tests.rs
@@ -260,7 +260,7 @@ impl TestContext {
         let (window_id, _) = app.add_window(WindowStyle::NotStealFocus, |_| TestView);
         let state = create_loaded_state_with_editors(app, window_id, vec![(file_path, editor)]);
 
-        let diff_state_model = app.add_model(|ctx| DiffStateModel::new_for_test(ctx));
+        let diff_state_model = app.add_model(DiffStateModel::new_for_test);
 
         let working_directories_model = app.add_model(|_| WorkingDirectoriesModel::new());
         let code_review_comment_batch =

--- a/app/src/code_review/code_review_view_tests.rs
+++ b/app/src/code_review/code_review_view_tests.rs
@@ -260,7 +260,7 @@ impl TestContext {
         let (window_id, _) = app.add_window(WindowStyle::NotStealFocus, |_| TestView);
         let state = create_loaded_state_with_editors(app, window_id, vec![(file_path, editor)]);
 
-        let diff_state_model = app.add_model(|ctx| DiffStateModel::new(None, ctx));
+        let diff_state_model = app.add_model(|ctx| DiffStateModel::new_for_test(ctx));
 
         let working_directories_model = app.add_model(|_| WorkingDirectoriesModel::new());
         let code_review_comment_batch =

--- a/app/src/code_review/comment_list_view.rs
+++ b/app/src/code_review/comment_list_view.rs
@@ -439,14 +439,6 @@ impl CommentListView {
         ctx.notify();
     }
 
-    pub fn set_repo_path(&mut self, repo_path: PathBuf, ctx: &mut ViewContext<Self>) {
-        self.repo_path = repo_path;
-        for state in self.comments_by_id.values_mut() {
-            state.card.update_title(Some(&self.repo_path));
-        }
-        ctx.notify();
-    }
-
     pub fn expand(&mut self, ctx: &mut ViewContext<Self>) {
         if self.is_collapsed {
             self.is_collapsed = false;

--- a/app/src/code_review/comment_rendering.rs
+++ b/app/src/code_review/comment_rendering.rs
@@ -449,11 +449,6 @@ impl CommentViewCard {
         matches!(self.diff_content, Some(CommentDiffContent::EditorLens))
     }
 
-    /// Recomputes the cached display title.
-    pub(crate) fn update_title(&mut self, repo_path: Option<&Path>) {
-        self.title = Self::compute_title(&self.source, repo_path);
-    }
-
     /// Refreshes the cached `last_updated_duration` to the current time.
     pub(crate) fn refresh_last_updated_duration(&mut self) {
         self.last_updated_duration = Local::now() - self.source.last_update_time;

--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -5,6 +5,8 @@
 
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "local_fs")]
+use std::time::Duration;
 use std::{
     collections::HashMap,
     fs::File,
@@ -37,14 +39,14 @@ use crate::util::git::{
 use super::diff_size_limits::compute_diff_size;
 
 use crate::code_review::CodeReviewTelemetryEvent;
+#[cfg(feature = "local_fs")]
+use crate::throttle::throttle;
 #[cfg(not(target_family = "wasm"))]
 use warp_core::channel::ChannelState;
 use warp_core::{safe_warn, send_telemetry_from_ctx};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
-        use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
-        use warpui::SingletonEntity;
         use repo_metadata::{
             repository::{RepositorySubscriber, SubscriberId},
             RepoMetadataError, Repository, RepositoryUpdate,
@@ -55,6 +57,8 @@ cfg_if::cfg_if! {
 }
 #[cfg(all(feature = "local_fs", feature = "local_tty"))]
 use crate::terminal::local_shell::LocalShellState;
+#[cfg(all(feature = "local_fs", feature = "local_tty"))]
+use warpui::SingletonEntity;
 
 const UNCOMMITTED_CHANGES: &str = "Uncommitted changes";
 
@@ -334,7 +338,6 @@ impl From<&DiffsWithBaseContent> for Diffs {
 /// at base. This should not be cloned at any time.
 struct DiffsWithBaseContent {
     changes: Result<GitDiffWithBaseContent, String>,
-    repository_path: PathBuf,
 }
 
 #[derive(Default)]
@@ -406,66 +409,103 @@ struct GitNumStatMetadata {
 }
 
 impl DiffStateModel {
-    #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
-    pub fn new(repo_path: Option<String>, ctx: &mut ModelContext<Self>) -> Self {
-        let model = Self {
-            #[cfg(feature = "local_fs")]
-            repository: None,
+    /// Creates a new `DiffStateModel` bound to the given repository.
+    #[cfg(feature = "local_fs")]
+    pub fn new(repository: ModelHandle<Repository>, ctx: &mut ModelContext<Self>) -> Self {
+        // Step 1: kick off initial metadata load.
+        let new_repository_root = repository.as_ref(ctx).root_dir().to_local_path_lossy();
+        // Always include base branch metadata since only code review uses this model now.
+        let include_base_branch = true;
+        let abort_handle =
+            ctx.spawn(
+                async move {
+                    Self::load_metadata_for_repo(new_repository_root, include_base_branch).await
+                },
+                move |me, res, ctx| {
+                    me.handle_updated_metadata_for_repo(
+                        res,
+                        InvalidationBehavior::All(InvalidationSource::MetadataChange),
+                        ctx,
+                    )
+                },
+            );
+
+        // Step 2: register the filesystem watcher.
+        let (repository_update_tx, repository_update_rx) = async_channel::unbounded();
+        let (throttled_repository_update_tx, throttled_repository_update_rx) =
+            async_channel::unbounded();
+        let start = repository.update(ctx, |repo, ctx| {
+            repo.start_watching(
+                Box::new(DiffStateModelRepositorySubscriber {
+                    repository_update_tx,
+                }),
+                ctx,
+            )
+        });
+        let subscriber_id = start.subscriber_id;
+        ctx.spawn(start.registration_future, Self::handle_repository_updated);
+
+        // Step 3: wire up the raw and throttled stream processors.
+        ctx.spawn_stream_local(
+            repository_update_rx,
+            move |me, item, ctx| match item {
+                DiffStateRepositoryUpdate::Invalidation(update) => {
+                    if me.handle_file_update(update, ctx) {
+                        log::debug!("[GIT OPERATION] handle_file_update found changes");
+                        let throttled_repository_update_tx_clone =
+                            throttled_repository_update_tx.clone();
+                        ctx.background_executor()
+                            .spawn(async move {
+                                let _ = throttled_repository_update_tx_clone.send(()).await;
+                            })
+                            .detach();
+                    } else {
+                        log::debug!("[GIT OPERATION] No changes found no metadata update.");
+                    }
+                }
+                DiffStateRepositoryUpdate::InvalidationWithLockedIndex => {
+                    ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
+                        InvalidationBehavior::AllLockedIndex,
+                    ));
+                }
+            },
+            |_, _| {},
+        );
+
+        // Only update metadata at most once every 5 seconds. The code review pane
+        // will refresh diffs at a faster rate if it's open (from the stream above).
+        ctx.spawn_stream_local(
+            throttle(Duration::from_secs(5), throttled_repository_update_rx),
+            |me, _, ctx| {
+                me.refresh_diff_metadata_for_current_repo(InvalidationBehavior::PromptRefresh, ctx);
+            },
+            |_, _| {},
+        );
+
+        Self {
+            repository: Some(repository),
+            subscriber_id: Some(subscriber_id),
+            state: InternalDiffState::Loading,
+            mode: DiffMode::default(),
+            metadata: None,
+            computing_diffs_abort_handle: None,
+            computing_metadata_abort_handle: Some(abort_handle),
+            refreshing_pr_info_handle: None,
+            metadata_refresh_enabled: false,
+        }
+    }
+
+    #[cfg(not(feature = "local_fs"))]
+    pub fn new(_ctx: &mut ModelContext<Self>) -> Self {
+        Self {
             state: InternalDiffState::default(),
-            #[cfg(feature = "local_fs")]
-            subscriber_id: None,
             mode: DiffMode::default(),
             metadata: None,
             computing_diffs_abort_handle: None,
             computing_metadata_abort_handle: None,
             refreshing_pr_info_handle: None,
             metadata_refresh_enabled: false,
-        };
-
-        #[cfg(feature = "local_fs")]
-        {
-            if let Some(repo_path) = &repo_path {
-                let fut = DetectedRepositories::handle(ctx).update(ctx, |model, ctx| {
-                    model.detect_possible_git_repo(
-                        repo_path,
-                        RepoDetectionSource::CodeReviewInitialization,
-                        ctx,
-                    )
-                });
-
-                ctx.spawn(fut, move |me, repo_path_opt, ctx| {
-                    me.maybe_set_new_active_repository(repo_path_opt.as_deref(), ctx);
-                });
-            }
         }
-        model
-    }
-
-    /// Given a repository path, sets the new active repository to track diffs for.
-    #[cfg(feature = "local_fs")]
-    pub fn maybe_set_new_active_repository(
-        &mut self,
-        repo_path: Option<&Path>,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let Some(repo_path) = repo_path else {
-            return;
-        };
-
-        // Check if the repository is new.
-        if self.repository.as_ref().is_some_and(|repository| {
-            repository.as_ref(ctx).root_dir().to_local_path().as_deref() == Some(repo_path)
-        }) {
-            return;
-        }
-
-        let Some(repository_model) =
-            DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(repo_path, ctx)
-        else {
-            return;
-        };
-
-        self.set_active_repository(repository_model, ctx);
     }
 
     pub fn get(&self) -> DiffState {
@@ -632,8 +672,8 @@ impl DiffStateModel {
         }
     }
 
-    // you'll have a HEAD after the first commit
-    pub fn has_head(&self) -> bool {
+    /// Returns `true` once the repository has at least one commit.
+    pub(super) fn has_head(&self) -> bool {
         cfg_if::cfg_if! {
             if #[cfg(feature = "local_fs")] {
                 self
@@ -647,7 +687,7 @@ impl DiffStateModel {
     }
 
     #[cfg(feature = "local_fs")]
-    pub fn active_repository_path(&self, app: &AppContext) -> Option<PathBuf> {
+    fn active_repository_path(&self, app: &AppContext) -> Option<PathBuf> {
         self.repository
             .as_ref()?
             .as_ref(app)
@@ -656,18 +696,8 @@ impl DiffStateModel {
     }
 
     #[cfg(not(feature = "local_fs"))]
-    pub fn active_repository_path(&self, _app: &warpui::AppContext) -> Option<PathBuf> {
+    fn active_repository_path(&self, _app: &warpui::AppContext) -> Option<PathBuf> {
         None
-    }
-
-    pub fn is_inside_repository(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "local_fs")] {
-                self.repository.is_some()
-            } else {
-                false
-            }
-        }
     }
 
     pub fn set_diff_mode(
@@ -1093,107 +1123,6 @@ impl DiffStateModel {
     }
 
     #[cfg(feature = "local_fs")]
-    pub fn set_active_repository(
-        &mut self,
-        new_repository: ModelHandle<Repository>,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        // Unsubscribe from the old repository.
-
-        use std::time::Duration;
-
-        use crate::throttle::throttle;
-        if let Some(old_repository) = &self.repository {
-            if let Some(subscriber_id) = self.subscriber_id {
-                old_repository.update(ctx, |old_repository, ctx| {
-                    old_repository.stop_watching(subscriber_id, ctx);
-                })
-            }
-        }
-
-        let new_repository_root = new_repository.as_ref(ctx).root_dir().to_local_path_lossy();
-        ctx.emit(DiffStateModelEvent::RepositoryChanged);
-
-        if let Some(handle) = self.computing_metadata_abort_handle.take() {
-            handle.abort();
-        }
-
-        // Always include base branch metadata since only code review uses this model now.
-        let include_base_branch = true;
-        let abort_handle =
-            ctx.spawn(
-                async move {
-                    Self::load_metadata_for_repo(new_repository_root, include_base_branch).await
-                },
-                move |me, res, ctx| {
-                    me.handle_updated_metadata_for_repo(
-                        res,
-                        InvalidationBehavior::All(InvalidationSource::MetadataChange),
-                        ctx,
-                    )
-                },
-            );
-
-        self.computing_metadata_abort_handle = Some(abort_handle);
-        self.state = InternalDiffState::Loading;
-
-        // Assign the repository handle before spawning the registration future.
-        // `registration_future` may resolve immediately (e.g. watcher already active), and
-        // `handle_repository_updated` relies on `self.repository` being available for cleanup.
-        self.repository = Some(new_repository.clone());
-
-        let (repository_update_tx, repository_update_rx) = async_channel::unbounded();
-        let (throttled_repository_update_tx, throttled_repository_update_rx) =
-            async_channel::unbounded();
-        let start = new_repository.update(ctx, |new_repository, ctx| {
-            new_repository.start_watching(
-                Box::new(DiffStateModelRepositorySubscriber {
-                    repository_update_tx,
-                }),
-                ctx,
-            )
-        });
-        self.subscriber_id = Some(start.subscriber_id);
-        ctx.spawn(start.registration_future, Self::handle_repository_updated);
-
-        ctx.spawn_stream_local(
-            repository_update_rx.clone(),
-            move |me, item, ctx| match item {
-                DiffStateRepositoryUpdate::Invalidation(update) => {
-                    if me.handle_file_update(update, ctx) {
-                        log::debug!("[GIT OPERATION] handle_file_update found changes");
-                        let throttled_repository_update_tx_clone =
-                            throttled_repository_update_tx.clone();
-                        ctx.background_executor()
-                            .spawn(async move {
-                                let _ = throttled_repository_update_tx_clone.send(()).await;
-                            })
-                            .detach();
-                    } else {
-                        log::debug!("[GIT OPERATION] No changes found no metadata update.");
-                    }
-                }
-                DiffStateRepositoryUpdate::InvalidationWithLockedIndex => {
-                    ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
-                        InvalidationBehavior::AllLockedIndex,
-                    ));
-                }
-            },
-            |_, _| {},
-        );
-
-        // Only update metadata at most once every 5 seconds. The code review pane
-        // will refresh diffs at a faster rate if it's open (from the stream above).
-        ctx.spawn_stream_local(
-            throttle(Duration::from_secs(5), throttled_repository_update_rx),
-            |me, _, ctx| {
-                me.refresh_diff_metadata_for_current_repo(InvalidationBehavior::PromptRefresh, ctx);
-            },
-            |_, _| {},
-        );
-    }
-
-    #[cfg(feature = "local_fs")]
     /// Processes a repository file-system update, emitting a `DiffMetadataChanged` event
     /// when relevant (non-ignored) files are affected.
     ///
@@ -1266,7 +1195,7 @@ impl DiffStateModel {
         if let Err(err) = result {
             log::warn!("Could not update repository: {err}");
 
-            let Some(repository) = self.repository.as_ref() else {
+            let Some(repository) = &self.repository else {
                 return;
             };
             let Some(subscriber_id) = self.subscriber_id.take() else {
@@ -1283,7 +1212,7 @@ impl DiffStateModel {
     /// Called when this model is about to be dropped to ensure the underlying
     /// `DirectoryWatcher` can be cleaned up.
     #[cfg(feature = "local_fs")]
-    pub fn stop_active_watcher(&mut self, ctx: &mut ModelContext<Self>) {
+    pub(crate) fn stop_active_watcher(&mut self, ctx: &mut ModelContext<Self>) {
         if let Some(repository) = &self.repository {
             if let Some(subscriber_id) = self.subscriber_id.take() {
                 repository.update(ctx, |repo, ctx| {
@@ -1291,28 +1220,6 @@ impl DiffStateModel {
                 });
             }
         }
-    }
-
-    #[cfg(feature = "local_fs")]
-    pub fn remove_active_repo(&mut self, ctx: &mut ModelContext<Self>) {
-        let Some(repository) = &self.repository else {
-            return;
-        };
-
-        // Unsubscribe from the repository watcher before releasing the handle.
-        if let Some(subscriber_id) = self.subscriber_id.take() {
-            repository.update(ctx, |repo, ctx| {
-                repo.stop_watching(subscriber_id, ctx);
-            });
-        }
-
-        let repository = self.repository.take().unwrap();
-        ctx.unsubscribe_from_model(&repository);
-        self.state = InternalDiffState::NotInRepository;
-        ctx.emit(DiffStateModelEvent::RepositoryChanged);
-        ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
-            InvalidationBehavior::All(InvalidationSource::MetadataChange),
-        ));
     }
 
     /// Gets the merge base between HEAD and the specified branch
@@ -1474,7 +1381,6 @@ impl DiffStateModel {
 
         DiffsWithBaseContent {
             changes: diffs.map_err(|err| err.to_string()),
-            repository_path: repo_path,
         }
     }
 
@@ -1542,17 +1448,6 @@ impl DiffStateModel {
         diffs: DiffsWithBaseContent,
         ctx: &mut ModelContext<Self>,
     ) {
-        if Some(diffs.repository_path.as_path()) != self.active_repository_path(ctx).as_deref() {
-            // The current repository is different from the one we fetched state for.
-            // Refetch metadata for this new repository (which will trigger any downstream consumers to
-            // recompute diffs if they so please.
-            self.refresh_diff_metadata_for_current_repo(
-                InvalidationBehavior::All(InvalidationSource::MetadataChange),
-                ctx,
-            );
-            return;
-        }
-
         if let Err(e) = &diffs.changes {
             send_telemetry_from_ctx!(
                 CodeReviewTelemetryEvent::LoadDiffFailed {
@@ -1615,7 +1510,9 @@ impl DiffStateModel {
         Ok(count)
     }
 
-    pub async fn diff_metadata_against_head(repo_path: &Path) -> Result<DiffMetadataAgainstBase> {
+    pub(crate) async fn diff_metadata_against_head(
+        repo_path: &Path,
+    ) -> Result<DiffMetadataAgainstBase> {
         // First, get the list of changed files with their status
         log::debug!(
             "[GIT OPERATION] diff_state.rs diff_metadata_against_head git --no-optional-locks status --untracked-files=all --branch --porcelain=2 -z"
@@ -2952,8 +2849,6 @@ pub enum InvalidationSource {
 
 #[derive(Debug)]
 pub enum DiffStateModelEvent {
-    /// The repository the diff state is for has changed.
-    RepositoryChanged,
     /// Event dispatched when the current branch changes.
     CurrentBranchChanged,
     /// Event dispatched whenever the diff metadata changes in any way.
@@ -3019,6 +2914,26 @@ impl RepositorySubscriber for DiffStateModelRepositorySubscriber {
             };
             let _ = tx.send(msg).await;
         })
+    }
+}
+
+#[cfg(test)]
+impl DiffStateModel {
+    /// Test-only constructor that creates a bare model without a repository.
+    pub fn new_for_test(_ctx: &mut ModelContext<Self>) -> Self {
+        Self {
+            #[cfg(feature = "local_fs")]
+            repository: None,
+            state: InternalDiffState::default(),
+            #[cfg(feature = "local_fs")]
+            subscriber_id: None,
+            mode: DiffMode::default(),
+            metadata: None,
+            computing_diffs_abort_handle: None,
+            computing_metadata_abort_handle: None,
+            refreshing_pr_info_handle: None,
+            metadata_refresh_enabled: false,
+        }
     }
 }
 

--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -47,18 +47,17 @@ use warp_core::{safe_warn, send_telemetry_from_ctx};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
+        use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
         use repo_metadata::{
             repository::{RepositorySubscriber, SubscriberId},
             RepoMetadataError, Repository, RepositoryUpdate,
         };
         use async_channel::Sender;
-        use warpui::ModelHandle;
+        use warpui::{ModelHandle, SingletonEntity};
     }
 }
 #[cfg(all(feature = "local_fs", feature = "local_tty"))]
 use crate::terminal::local_shell::LocalShellState;
-#[cfg(all(feature = "local_fs", feature = "local_tty"))]
-use warpui::SingletonEntity;
 
 const UNCOMMITTED_CHANGES: &str = "Uncommitted changes";
 
@@ -409,94 +408,44 @@ struct GitNumStatMetadata {
 }
 
 impl DiffStateModel {
-    /// Creates a new `DiffStateModel` bound to the given repository.
     #[cfg(feature = "local_fs")]
-    pub fn new(repository: ModelHandle<Repository>, ctx: &mut ModelContext<Self>) -> Self {
-        // Step 1: kick off initial metadata load.
-        let new_repository_root = repository.as_ref(ctx).root_dir().to_local_path_lossy();
-        // Always include base branch metadata since only code review uses this model now.
-        let include_base_branch = true;
-        let abort_handle =
-            ctx.spawn(
-                async move {
-                    Self::load_metadata_for_repo(new_repository_root, include_base_branch).await
-                },
-                move |me, res, ctx| {
-                    me.handle_updated_metadata_for_repo(
-                        res,
-                        InvalidationBehavior::All(InvalidationSource::MetadataChange),
-                        ctx,
-                    )
-                },
-            );
-
-        // Step 2: register the filesystem watcher.
-        let (repository_update_tx, repository_update_rx) = async_channel::unbounded();
-        let (throttled_repository_update_tx, throttled_repository_update_rx) =
-            async_channel::unbounded();
-        let start = repository.update(ctx, |repo, ctx| {
-            repo.start_watching(
-                Box::new(DiffStateModelRepositorySubscriber {
-                    repository_update_tx,
-                }),
-                ctx,
-            )
-        });
-        let subscriber_id = start.subscriber_id;
-        ctx.spawn(start.registration_future, Self::handle_repository_updated);
-
-        // Step 3: wire up the raw and throttled stream processors.
-        ctx.spawn_stream_local(
-            repository_update_rx,
-            move |me, item, ctx| match item {
-                DiffStateRepositoryUpdate::Invalidation(update) => {
-                    if me.handle_file_update(update, ctx) {
-                        log::debug!("[GIT OPERATION] handle_file_update found changes");
-                        let throttled_repository_update_tx_clone =
-                            throttled_repository_update_tx.clone();
-                        ctx.background_executor()
-                            .spawn(async move {
-                                let _ = throttled_repository_update_tx_clone.send(()).await;
-                            })
-                            .detach();
-                    } else {
-                        log::debug!("[GIT OPERATION] No changes found no metadata update.");
-                    }
-                }
-                DiffStateRepositoryUpdate::InvalidationWithLockedIndex => {
-                    ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
-                        InvalidationBehavior::AllLockedIndex,
-                    ));
-                }
-            },
-            |_, _| {},
-        );
-
-        // Only update metadata at most once every 5 seconds. The code review pane
-        // will refresh diffs at a faster rate if it's open (from the stream above).
-        ctx.spawn_stream_local(
-            throttle(Duration::from_secs(5), throttled_repository_update_rx),
-            |me, _, ctx| {
-                me.refresh_diff_metadata_for_current_repo(InvalidationBehavior::PromptRefresh, ctx);
-            },
-            |_, _| {},
-        );
-
-        Self {
-            repository: Some(repository),
-            subscriber_id: Some(subscriber_id),
-            state: InternalDiffState::Loading,
+    pub fn new(repo_path: Option<String>, ctx: &mut ModelContext<Self>) -> Self {
+        let model = Self {
+            repository: None,
+            state: InternalDiffState::default(),
+            subscriber_id: None,
             mode: DiffMode::default(),
             metadata: None,
             computing_diffs_abort_handle: None,
-            computing_metadata_abort_handle: Some(abort_handle),
+            computing_metadata_abort_handle: None,
             refreshing_pr_info_handle: None,
             metadata_refresh_enabled: false,
+        };
+
+        if let Some(repo_path) = &repo_path {
+            let fut = DetectedRepositories::handle(ctx).update(ctx, |model, ctx| {
+                model.detect_possible_git_repo(
+                    repo_path,
+                    RepoDetectionSource::CodeReviewInitialization,
+                    ctx,
+                )
+            });
+
+            ctx.spawn(fut, move |me, repo_path, ctx| {
+                if let Some(repo_path) = &repo_path {
+                    if let Some(repo_handle) =
+                        DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(repo_path, ctx)
+                    {
+                        me.set_active_repository(repo_handle, ctx);
+                    }
+                }
+            });
         }
+        model
     }
 
     #[cfg(not(feature = "local_fs"))]
-    pub fn new(_ctx: &mut ModelContext<Self>) -> Self {
+    pub fn new(_repo_path: Option<String>, _ctx: &mut ModelContext<Self>) -> Self {
         Self {
             state: InternalDiffState::default(),
             mode: DiffMode::default(),
@@ -1120,6 +1069,89 @@ impl DiffStateModel {
         _ctx: &mut ModelContext<Self>,
     ) {
         // Noop on WASM builds.
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn set_active_repository(
+        &mut self,
+        new_repository: ModelHandle<Repository>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let new_repository_root = new_repository.as_ref(ctx).root_dir().to_local_path_lossy();
+
+        // Always include base branch metadata since only code review uses this model now.
+        let include_base_branch = true;
+        let abort_handle =
+            ctx.spawn(
+                async move {
+                    Self::load_metadata_for_repo(new_repository_root, include_base_branch).await
+                },
+                move |me, res, ctx| {
+                    me.handle_updated_metadata_for_repo(
+                        res,
+                        InvalidationBehavior::All(InvalidationSource::MetadataChange),
+                        ctx,
+                    )
+                },
+            );
+
+        self.computing_metadata_abort_handle = Some(abort_handle);
+        self.state = InternalDiffState::Loading;
+
+        // Assign the repository handle before spawning the registration future.
+        // `registration_future` may resolve immediately (e.g. watcher already active), and
+        // `handle_repository_updated` relies on `self.repository` being available for cleanup.
+        self.repository = Some(new_repository.clone());
+
+        let (repository_update_tx, repository_update_rx) = async_channel::unbounded();
+        let (throttled_repository_update_tx, throttled_repository_update_rx) =
+            async_channel::unbounded();
+        let start = new_repository.update(ctx, |new_repository, ctx| {
+            new_repository.start_watching(
+                Box::new(DiffStateModelRepositorySubscriber {
+                    repository_update_tx,
+                }),
+                ctx,
+            )
+        });
+        self.subscriber_id = Some(start.subscriber_id);
+        ctx.spawn(start.registration_future, Self::handle_repository_updated);
+
+        ctx.spawn_stream_local(
+            repository_update_rx,
+            move |me, item, ctx| match item {
+                DiffStateRepositoryUpdate::Invalidation(update) => {
+                    if me.handle_file_update(update, ctx) {
+                        log::debug!("[GIT OPERATION] handle_file_update found changes");
+                        let throttled_repository_update_tx_clone =
+                            throttled_repository_update_tx.clone();
+                        ctx.background_executor()
+                            .spawn(async move {
+                                let _ = throttled_repository_update_tx_clone.send(()).await;
+                            })
+                            .detach();
+                    } else {
+                        log::debug!("[GIT OPERATION] No changes found no metadata update.");
+                    }
+                }
+                DiffStateRepositoryUpdate::InvalidationWithLockedIndex => {
+                    ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
+                        InvalidationBehavior::AllLockedIndex,
+                    ));
+                }
+            },
+            |_, _| {},
+        );
+
+        // Only update metadata at most once every 5 seconds. The code review pane
+        // will refresh diffs at a faster rate if it's open (from the stream above).
+        ctx.spawn_stream_local(
+            throttle(Duration::from_secs(5), throttled_repository_update_rx),
+            |me, _, ctx| {
+                me.refresh_diff_metadata_for_current_repo(InvalidationBehavior::PromptRefresh, ctx);
+            },
+            |_, _| {},
+        );
     }
 
     #[cfg(feature = "local_fs")]

--- a/app/src/code_review/find_model_tests.rs
+++ b/app/src/code_review/find_model_tests.rs
@@ -176,8 +176,7 @@ fn create_find_model_with_query(
 ) -> ModelHandle<CodeReviewFindModel> {
     let (window_id, _) = app.add_window(WindowStyle::NotStealFocus, |_| TestView);
 
-    let diff_state_model =
-        app.add_model(|ctx| DiffStateModel::new(Some("/tmp/test".to_string()), ctx));
+    let diff_state_model = app.add_model(|ctx| DiffStateModel::new_for_test(ctx));
     let repo_path = PathBuf::from("/tmp/test");
     let working_directories_model = app.add_model(|_| WorkingDirectoriesModel::new());
     let code_review_comment_batch =

--- a/app/src/code_review/find_model_tests.rs
+++ b/app/src/code_review/find_model_tests.rs
@@ -176,7 +176,7 @@ fn create_find_model_with_query(
 ) -> ModelHandle<CodeReviewFindModel> {
     let (window_id, _) = app.add_window(WindowStyle::NotStealFocus, |_| TestView);
 
-    let diff_state_model = app.add_model(|ctx| DiffStateModel::new_for_test(ctx));
+    let diff_state_model = app.add_model(DiffStateModel::new_for_test);
     let repo_path = PathBuf::from("/tmp/test");
     let working_directories_model = app.add_model(|_| WorkingDirectoriesModel::new());
     let code_review_comment_batch =

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -174,6 +174,8 @@ impl WorkingDirectoriesModel {
 
     /// Get or create a DiffStateModel for a specific repository.
     /// If the model doesn't exist, it will be created.
+    ///
+    /// Returns `None` if `repo_path` is not a tracked git repository.
     pub fn get_or_create_diff_state_model(
         &mut self,
         repo_path: PathBuf,
@@ -183,9 +185,10 @@ impl WorkingDirectoriesModel {
             return Some(model.clone());
         }
 
-        // Create new DiffStateModel for this repo
-        let diff_state_model =
-            ctx.add_model(|ctx| DiffStateModel::new(Some(repo_path.display().to_string()), ctx));
+        let repository =
+            DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(&repo_path, ctx)?;
+
+        let diff_state_model = ctx.add_model(|ctx| DiffStateModel::new(repository, ctx));
 
         self.diff_state_models
             .insert(repo_path.clone(), diff_state_model.clone());

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -174,8 +174,6 @@ impl WorkingDirectoriesModel {
 
     /// Get or create a DiffStateModel for a specific repository.
     /// If the model doesn't exist, it will be created.
-    ///
-    /// Returns `None` if `repo_path` is not a tracked git repository.
     pub fn get_or_create_diff_state_model(
         &mut self,
         repo_path: PathBuf,
@@ -185,10 +183,9 @@ impl WorkingDirectoriesModel {
             return Some(model.clone());
         }
 
-        let repository =
-            DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(&repo_path, ctx)?;
-
-        let diff_state_model = ctx.add_model(|ctx| DiffStateModel::new(repository, ctx));
+        // Create new DiffStateModel for this repo
+        let diff_state_model =
+            ctx.add_model(|ctx| DiffStateModel::new(Some(repo_path.display().to_string()), ctx));
 
         self.diff_state_models
             .insert(repo_path.clone(), diff_state_model.clone());


### PR DESCRIPTION
## Description
Part of the work needed to support the code review pane and git states on remote environments includes simplifying the contract between the `DiffStateModel` and `CodeReviewView`
  * This updates the assumption such that a `DiffStateModel` is responsible/associated with only one repo
  * Removes redundant "change repo" logic

## Linked Issue
 [APP-4353](https://linear.app/warpdotdev/issue/APP-4353/clean-up-diffstatemodel-api)

## Testing
Verified existing behaviour for code review view locally 
* Tested multiple repos in the same tab
* Tested multiple repos in different tabs 
* Tested switching branches

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode