### PR TITLE
Promote DirectoryTabColors to Stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -624,6 +624,7 @@ default = [
     "open_warp_new_settings_modes",
     "skip_firebase_anonymous_user",
     "settings_file",
+    "directory_tab_colors",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -920,7 +920,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::FullSourceCodeEmbedding,
     FeatureFlag::CodebaseIndexSpeedbump,
     // End manually enabled Code features.
-    FeatureFlag::DirectoryTabColors,
     FeatureFlag::EditableMarkdownMermaid,
     FeatureFlag::CodeReviewScrollPreservation,
     FeatureFlag::OzIdentityFederation,


### PR DESCRIPTION
## Description

WISOTT. We should've released this a while ago but it fell off my radar.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NEW-FEATURE: You can now associate colors with directories so tabs automatically adopt the configured color when their working directory matches. Configure in Settings > Appearance.

_Conversation: https://staging.warp.dev/conversation/d05ec6ff-9581-424a-9e58-e64425cc5985_
_Run: https://oz.staging.warp.dev/runs/019dfe93-b731-7c79-a492-37edf6efcc61_
_This PR was generated with [Oz](https://warp.dev/oz)._
