### PR TITLE
Add Reveal in Finder to File menu

### DIFF
--- a/app/src/app_menus.rs
+++ b/app/src/app_menus.rs
@@ -251,6 +251,8 @@ fn make_new_file_menu(ctx: &AppContext) -> Menu {
     file_menu_options.extend([
         MenuItem::Separator,
         updateable_custom_item_without_checkmark(CustomAction::OpenRepository, ctx),
+        #[cfg(target_os = "macos")]
+        updateable_custom_item_without_checkmark(CustomAction::RevealInFinder, ctx),
         MenuItem::Custom(CustomMenuItem::new_with_submenu(
             "Open Recent",
             |_| (),

--- a/app/src/util/bindings.rs
+++ b/app/src/util/bindings.rs
@@ -132,6 +132,8 @@ pub enum CustomAction {
     NewPersonalAIPrompt,
     NewTeamAIPrompt,
     OpenRepository,
+    #[cfg(target_os = "macos")]
+    RevealInFinder,
     NewTerminalTab,
     NewAgentTab,
     GoToLine,
@@ -418,6 +420,8 @@ pub fn custom_tag_to_keystroke(custom: CustomTag) -> Option<Keystroke> {
                 Keystroke::parse("alt-shift-O").ok()
             }
         }
+        #[cfg(target_os = "macos")]
+        CustomAction::RevealInFinder => Keystroke::parse("cmd-alt-r").ok(),
         CustomAction::GoToLine => Keystroke::parse("ctrl-g").ok(),
         CustomAction::ToggleGlobalSearch => {
             if OperatingSystem::get().is_mac() {

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -970,6 +970,8 @@ impl WorkspaceAction {
             #[cfg(target_os = "macos")]
             SampleProcess => false,
             #[cfg(target_os = "macos")]
+            RevealInFinder => false,
+            #[cfg(target_os = "macos")]
             InstallCLI | UninstallCLI => false,
             #[cfg(feature = "local_fs")]
             FileRenamed { .. } => false, // File rename doesn't change workspace state

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -534,6 +534,9 @@ pub enum WorkspaceAction {
     OpenRepository {
         path: Option<String>,
     },
+    /// Reveal the active local terminal session's current working directory in Finder.
+    #[cfg(target_os = "macos")]
+    RevealInFinder,
     /// Open the native folder picker for a repo param in the tab-config modal after the
     /// current interaction cycle finishes.
     OpenTabConfigRepoPicker {

--- a/app/src/workspace/action_tests.rs
+++ b/app/src/workspace/action_tests.rs
@@ -25,6 +25,12 @@ fn settings_popup_toggle_does_not_save_workspace_state() {
     assert!(!WorkspaceAction::ToggleVerticalTabsSettingsPopup.should_save_app_state_on_action());
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn reveal_in_finder_does_not_save_workspace_state() {
+    assert!(!WorkspaceAction::RevealInFinder.should_save_app_state_on_action());
+}
+
 #[test]
 fn display_granularity_change_does_not_save_workspace_state() {
     assert!(!WorkspaceAction::SetVerticalTabsDisplayGranularity(

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -1288,6 +1288,16 @@ pub fn init(app: &mut AppContext) {
         .with_context_predicate(id!("Workspace"))
         .with_custom_action(CustomAction::OpenRepository)
         .with_group(bindings::BindingGroup::Folders.as_str()),
+        #[cfg(target_os = "macos")]
+        EditableBinding::new(
+            "workspace:reveal_in_finder",
+            BindingDescription::new("Reveal in Finder")
+                .with_custom_description(bindings::MAC_MENUS_CONTEXT, "Reveal in Finder"),
+            WorkspaceAction::RevealInFinder,
+        )
+        .with_context_predicate(id!("Workspace"))
+        .with_custom_action(CustomAction::RevealInFinder)
+        .with_group(bindings::BindingGroup::Folders.as_str()),
         EditableBinding::new(
             "workspace:open_ai_fact_collection",
             BindingDescription::new("Open AI Rules")

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6489,6 +6489,20 @@ impl Workspace {
         }
     }
 
+    #[cfg(target_os = "macos")]
+    fn reveal_active_session_in_finder(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(path) = self
+            .active_session_view(ctx)
+            .and_then(|view| view.as_ref(ctx).pwd_if_local(ctx))
+            .map(PathBuf::from)
+        else {
+            log::warn!("Reveal in Finder requested, but the active session has no local cwd");
+            return;
+        };
+
+        ctx.open_file_path_in_explorer(&path);
+    }
+
     /// Writes the default tab config template to an unused path in `~/.warp/tab_configs/`
     /// and opens it respecting the user's configured editor setting.
     #[cfg(feature = "local_fs")]
@@ -21643,6 +21657,10 @@ impl TypedActionView for Workspace {
             }
             OpenRepository { path } => {
                 self.open_repository(path.as_deref(), ctx);
+            }
+            #[cfg(target_os = "macos")]
+            RevealInFinder => {
+                self.reveal_active_session_in_finder(ctx);
             }
             OpenTabConfigRepoPicker { param_index } => {
                 self.open_repo_picker_for_tab_config_modal(*param_index, ctx);


### PR DESCRIPTION
## Summary
- Add a macOS File menu item for `Reveal in Finder`.
- Wire the menu item to the active terminal session's local current working directory.
- Add the suggested default shortcut, Cmd+Option+R.
- Handle `WorkspaceAction::RevealInFinder` in `should_save_app_state_on_action` and cover it with a unit test.

Fixes #10257

## Tests
- `git diff --check`
- Attempted `cargo test -p warp reveal_in_finder`, but this machine ran out of disk while compiling dependencies.

## Visual verification
- Not captured in this environment. This runner is headless Linux and the requested menu behavior is macOS Finder-specific, so I cannot produce a local macOS screenshot or recording from here.
