### PR TITLE
Verify thinking block tooltip: add integration test and SavePosition support

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3453,9 +3453,10 @@ fn render_collapsible_header(
     };
     let message_id_clone = message_id.clone();
     let toggle_mouse_state = element_state.expansion_toggle_mouse_state.clone();
+    let ui_builder = appearance.ui_builder().clone();
 
-    let expandable = Hoverable::new(toggle_mouse_state, move |_is_hovered| {
-        Flex::row()
+    let expandable = Hoverable::new(toggle_mouse_state, move |mouse_state| {
+        let row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_child(
                 Text::new(
@@ -3477,7 +3478,27 @@ fn render_collapsible_header(
                 .with_margin_right(4.)
                 .finish(),
             )
-            .finish()
+            .finish();
+
+        if mouse_state.is_hovered() {
+            let tooltip_text = if is_expanded { "Collapse" } else { "Expand" };
+            let tooltip = ui_builder
+                .tool_tip(tooltip_text.to_string())
+                .build()
+                .finish();
+            let offset = OffsetPositioning::offset_from_parent(
+                vec2f(0., -8.),
+                ParentOffsetBounds::WindowByPosition,
+                ParentAnchor::TopMiddle,
+                ChildAnchor::BottomMiddle,
+            );
+            let mut stack = Stack::new();
+            stack.add_child(row);
+            stack.add_positioned_overlay_child(tooltip, offset);
+            stack.finish()
+        } else {
+            row
+        }
     })
     .with_cursor(Cursor::PointingHand)
     .on_click(move |ctx, _, _| {

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3507,9 +3507,19 @@ fn render_collapsible_header(
         ));
     });
 
-    Container::new(Flex::row().with_child(expandable.finish()).finish())
+    let container = Container::new(Flex::row().with_child(expandable.finish()).finish())
         .with_horizontal_margin(CONTENT_HORIZONTAL_PADDING + icon_size + 16.)
-        .finish()
+        .finish();
+
+    #[cfg(feature = "integration_tests")]
+    {
+        use warpui::elements::SavePosition;
+        let position_id = format!("collapsible_header:{}", message_id);
+        return SavePosition::new(container, &position_id).finish();
+    }
+
+    #[allow(unreachable_code)]
+    container
 }
 
 pub fn are_all_text_sections_empty(text_sections: &[AIAgentTextSection]) -> bool {

--- a/crates/integration/Cargo.toml
+++ b/crates/integration/Cargo.toml
@@ -27,6 +27,7 @@ log = { version = "0.4", features = ["serde"] }
 mockito.workspace = true
 parking_lot = { version = "0.12.1", features = ["serde"] }
 pathfinder_geometry.workspace = true
+prost-types.workspace = true
 rand = "0.8.2"
 regex.workspace = true
 rust-embed.workspace = true

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -410,6 +410,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_selection_last_to_ai_semantic);
     register_test!(test_selection_last_to_ai_lines);
     register_test!(test_restored_ai_block_renders_mermaid_and_local_images);
+    register_test!(test_thinking_block_tooltip);
 
     register_test!(test_agent_mode_pane_minimum_size);
     register_test!(test_git_prompt_chips);

--- a/crates/integration/src/test/agent_mode.rs
+++ b/crates/integration/src/test/agent_mode.rs
@@ -22,6 +22,7 @@ use warp::{
     },
     settings::SelectionSettings,
 };
+use prost_types;
 use warp_multi_agent_api as api;
 use warpui::{async_assert, integration::TestStep, text::SelectionType, Event, SingletonEntity};
 
@@ -183,6 +184,129 @@ fn restored_markdown_visuals_conversation_data() -> api::ConversationData {
         }],
         ..Default::default()
     }
+}
+
+const REASONING_MESSAGE_ID: &str = "reasoning-msg";
+
+fn reasoning_conversation_data() -> api::ConversationData {
+    let task_id = "reasoning-task";
+    let request_id = "reasoning-request";
+    api::ConversationData {
+        tasks: vec![api::Task {
+            id: task_id.to_string(),
+            messages: vec![
+                api::Message {
+                    id: "user-query".to_string(),
+                    task_id: task_id.to_string(),
+                    server_message_data: String::new(),
+                    citations: vec![],
+                    message: Some(api::message::Message::UserQuery(api::message::UserQuery {
+                        query: "What is 2+2?".to_string(),
+                        context: None,
+                        referenced_attachments: HashMap::new(),
+                        mode: None,
+                        intended_agent: Default::default(),
+                    })),
+                    request_id: request_id.to_string(),
+                    timestamp: None,
+                },
+                api::Message {
+                    id: REASONING_MESSAGE_ID.to_string(),
+                    task_id: task_id.to_string(),
+                    server_message_data: String::new(),
+                    citations: vec![],
+                    message: Some(api::message::Message::AgentReasoning(
+                        api::message::AgentReasoning {
+                            reasoning: "Let me think about this carefully. 2+2 is 4.".to_string(),
+                            finished_duration: Some(prost_types::Duration {
+                                seconds: 2,
+                                nanos: 0,
+                            }),
+                        },
+                    )),
+                    request_id: request_id.to_string(),
+                    timestamp: None,
+                },
+                api::Message {
+                    id: "agent-output".to_string(),
+                    task_id: task_id.to_string(),
+                    server_message_data: String::new(),
+                    citations: vec![],
+                    message: Some(api::message::Message::AgentOutput(
+                        api::message::AgentOutput {
+                            text: "The answer is 4.".to_string(),
+                        },
+                    )),
+                    request_id: request_id.to_string(),
+                    timestamp: None,
+                },
+            ],
+            dependencies: None,
+            description: String::new(),
+            summary: String::new(),
+            server_data: String::new(),
+        }],
+        ..Default::default()
+    }
+}
+
+/// Verifies that hovering over a finished thinking block header shows the correct tooltip.
+/// The thinking block auto-collapses after streaming finishes, so the tooltip should say "Expand".
+/// After clicking to expand, hovering should show "Collapse".
+///
+/// This test requires a real display and must be run manually:
+///   WARPUI_USE_REAL_DISPLAY_IN_INTEGRATION_TESTS=1 cargo run -p integration --bin integration -- test_thinking_block_tooltip
+#[allow(dead_code)]
+pub fn test_thinking_block_tooltip() -> Builder {
+    let position_id = format!("collapsible_header:{REASONING_MESSAGE_ID}");
+    let position_id_clone = position_id.clone();
+
+    new_builder()
+        .with_real_display()
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(clear_blocklist_to_remove_bootstrapped_blocks())
+        .with_step(
+            new_step_with_default_assertions("Load reasoning conversation")
+                .with_action(|app, window_id, _| {
+                    let terminal_view = single_terminal_view_for_tab(app, window_id, 0);
+                    terminal_view.update(app, |view, ctx| {
+                        view.load_conversation_from_tasks(reasoning_conversation_data(), ctx);
+                    });
+                }),
+        )
+        .with_step(
+            TestStep::new("Wait for AI block with thinking header and take initial screenshot")
+                .set_timeout(Duration::from_secs(20))
+                .with_take_screenshot("thinking_block_initial.png")
+                .add_named_assertion(
+                    "AI block with thinking header should be present",
+                    |app, window_id| {
+                        let terminal_view = single_terminal_view_for_tab(app, window_id, 0);
+                        terminal_view.read(app, |view, _ctx| {
+                            async_assert!(
+                                view.last_ai_block().is_some(),
+                                "AI block should exist after loading conversation"
+                            )
+                        })
+                    },
+                ),
+        )
+        .with_step(
+            TestStep::new("Hover over collapsed thinking block header and take screenshot")
+                .set_timeout(Duration::from_secs(10))
+                .with_hover_over_saved_position(position_id.clone())
+                .with_take_screenshot("thinking_block_hover_collapsed.png"),
+        )
+        .with_step(
+            new_step_with_default_assertions("Click thinking block header to expand it")
+                .with_click_on_saved_position(position_id.clone()),
+        )
+        .with_step(
+            TestStep::new("Hover over expanded thinking block header and take screenshot")
+                .set_timeout(Duration::from_secs(10))
+                .with_hover_over_saved_position(position_id_clone)
+                .with_take_screenshot("thinking_block_hover_expanded.png"),
+        )
 }
 
 pub fn test_restored_ai_block_renders_mermaid_and_local_images() -> Builder {


### PR DESCRIPTION
## Description

Adds integration test infrastructure and visual verification for the thinking block expand/collapse tooltip added in the parent commit.

## What

- Added `SavePosition` wrapper to `render_collapsible_header` (gated by `#[cfg(feature = "integration_tests")]`) so integration tests can reference the collapsible header by position ID for hover simulation
- Added `test_thinking_block_tooltip` integration test that loads a fake AI conversation with a finished reasoning block, hovers over the "Thought for X seconds" header, and captures screenshots showing the tooltip in both collapsed ("Expand") and expanded ("Collapse") states
- Added `prost-types` as a dependency to the integration crate (needed to construct `AgentReasoning` with a `finished_duration`)

## Testing

Verified visually by launching Warp with `--features skip_login` and a pre-loaded fake thinking block conversation:
- When block is **collapsed** (default after streaming finishes): hovering shows **"Expand"** tooltip ✓
- When block is **expanded** (after clicking header): hovering shows **"Collapse"** tooltip ✓
- Tooltip correctly appears above the header with proper styling ✓

The manual integration test can be run with real display to capture screenshots:
```
WARPUI_USE_REAL_DISPLAY_IN_INTEGRATION_TESTS=1 cargo run -p integration --bin integration -- test_thinking_block_tooltip
```

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/c23a8175-cb20-4262-9266-aea966af1add_
_Run: https://oz.staging.warp.dev/runs/019dfe86-419b-707f-b71c-b0e2c0631bbf_
_This PR was generated with [Oz](https://warp.dev/oz)._
