### PR TITLE
specs: GH10208 auto-save for code editor

### DIFF
--- a/specs/GH10208/product.md
+++ b/specs/GH10208/product.md
@@ -1,0 +1,75 @@
+# PRODUCT.md - Auto-save for Code Editor
+
+Issue: https://github.com/warpdotdev/warp/issues/10208
+
+## Summary
+
+Add VS Code-like auto-save behavior to Warp's built-in code editor, configurable
+from Settings > Code. This spec focuses on auto-save; external file auto-reload
+already exists and is not being redesigned here.
+
+Figma: none provided.
+
+## Goals / Non-goals
+
+Goals:
+
+- Add a user-visible auto-save setting with clear modes.
+- Auto-save only when it is safe (no unresolved file-version conflict).
+- Keep manual-save UX intact while reducing noisy save toasts for automatic saves.
+
+Non-goals:
+
+- Redesigning or replacing external file auto-reload behavior.
+- Changing save semantics for notebooks or terminal input surfaces.
+- Adding new background-save telemetry requirements in this spec.
+
+## Behavior
+
+1. Warp exposes a new Code setting named "Auto-save" with four values:
+   - `off`
+   - `after_delay`
+   - `on_focus_change`
+   - `after_delay_and_focus_change`
+
+2. The default auto-save value is `off`.
+
+3. When `off` is selected, editor behavior remains manual-save only. Existing
+   explicit save actions continue to work exactly as today.
+
+4. When `after_delay` is selected, user edits in a code editor tab trigger an
+   automatic save after a short debounce interval (approximately one second)
+   once editing pauses.
+
+5. When `on_focus_change` is selected, an automatic save is attempted when the
+   editor loses focus (for example, the user clicks away to another pane/view).
+
+6. When `after_delay_and_focus_change` is selected, both triggers are active:
+   save-on-pause and save-on-editor-blur.
+
+7. Auto-save only runs for editors backed by a real file. Unsaved/new buffers
+   that require a save location do not silently create files.
+
+8. Auto-save is skipped when there are no unsaved changes.
+
+9. Auto-save is skipped when a version conflict is present (for example, file
+   content changed on disk and the editor has diverged local edits). In this
+   state, existing conflict resolution UX remains the source of truth.
+
+10. Successful manual saves continue to show save success feedback exactly as
+    today.
+
+11. Successful auto-saves do not show the same manual "File saved" success toast,
+    to avoid noisy repeated notifications while typing.
+
+12. Failed auto-saves surface the same error behavior as failed manual saves.
+
+13. Auto-save mode changes in Settings apply to newly opened and currently open
+    code editors without requiring app restart.
+
+14. The auto-save setting participates in normal settings persistence and sync
+    semantics for Code settings.
+
+15. Existing external file auto-reload behavior remains available and unchanged
+    by this feature.
+

--- a/specs/GH10208/tech.md
+++ b/specs/GH10208/tech.md
@@ -1,0 +1,138 @@
+# TECH.md - Auto-save for Code Editor
+
+Issue: https://github.com/warpdotdev/warp/issues/10208
+Product spec: `specs/GH10208/product.md`
+
+## Context
+
+Current master has manual save behavior in the code editor and already performs
+external file refresh when file-model updates arrive.
+
+Relevant code paths:
+
+- `app/src/settings/code.rs:5-63` defines `CodeSettings`; there is currently no
+  auto-save mode setting.
+- `app/src/settings_view/code_page.rs:286-311` builds the "Code Editor and
+  Review" widget list; there is currently no auto-save control.
+- `app/src/settings_view/code_page.rs:521-748` defines settings actions and
+  handlers; no action currently writes an auto-save mode.
+- `app/src/code/local_code_editor.rs:110-167` defines `LocalCodeEditorEvent`;
+  `FileSaved` currently has no save-origin metadata.
+- `app/src/code/local_code_editor.rs:1526-1528` emits `FileSaved` when the
+  buffer model reports a save completion.
+- `app/src/code/local_code_editor.rs:1549-1556` implements manual save entrypoint.
+- `app/src/code/view.rs:520-524` always shows save success toast on `FileSaved`.
+- `app/src/code/global_buffer_model.rs:390-446` already reacts to
+  `FileModelEvent::FileUpdated` and refreshes buffers under safe conditions.
+
+The issue thread explicitly confirms auto-reload already exists; this spec
+targets auto-save behavior.
+
+## Proposed changes
+
+1. Add auto-save settings model in `app/src/settings/code.rs`.
+   - Introduce `CodeAutoSaveMode` enum with values:
+     `Off`, `AfterDelay`, `OnFocusChange`, `AfterDelayAndFocusChange`.
+   - Add a new setting field under `CodeSettings` at TOML path
+     `code.editor.auto_save.mode`.
+   - Keep default at `Off`.
+
+2. Add auto-save UI in `app/src/settings_view/code_page.rs`.
+   - Add an "Auto-save" dropdown widget in the "Code Editor and Review" section.
+   - Add a typed action that updates the new setting field.
+   - Ensure dropdown reflects live setting updates and remains searchable.
+
+3. Add autosave trigger execution in `app/src/code/local_code_editor.rs`.
+   - Introduce a debounced autosave trigger channel driven from user-origin
+     content changes.
+   - Add a focus-change trigger on editor blur.
+   - Gate execution by selected mode (`Off` / delay / blur / both).
+   - Reuse existing save path (format-and-save + global buffer save), not a
+     parallel save implementation.
+   - Guard autosave with:
+     - file-backed buffer present
+     - unsaved changes present
+     - no unresolved version conflict
+
+4. Differentiate manual vs automatic save origin.
+   - Add save-origin metadata to local editor save completion events.
+   - Track save origin through local save initiation and global buffer save
+     completion callbacks.
+   - Preserve existing behavior for manual saves.
+
+5. Toast behavior update in `app/src/code/view.rs`.
+   - Show save success toast only for manual saves.
+   - Keep path/title synchronization and error handling unchanged for both
+     manual and automatic saves.
+
+6. Keep external auto-reload unchanged.
+   - No behavioral changes to `GlobalBufferModel` file-update application logic
+     are required by this spec.
+
+## Testing and validation
+
+Map to `product.md` behavior invariants:
+
+- (1, 2, 13, 14) Settings model + UI:
+  - Add/update settings-view tests asserting:
+    - Auto-save dropdown renders in Code Editor and Review page.
+    - Setting writes persist and UI reflects current selection.
+    - Defaults are `off`.
+
+- (3) Off mode:
+  - Unit test: user edit in `Off` mode does not trigger save call after debounce.
+
+- (4) After-delay mode:
+  - Unit test in local editor model: user edit schedules one save after debounce.
+  - Ensure multiple rapid edits coalesce into one save attempt.
+
+- (5) Focus-change mode:
+  - Unit test: blur triggers save when unsaved changes exist.
+  - Unit test: blur does not trigger save when no unsaved changes.
+
+- (6) Combined mode:
+  - Unit test: both debounce and blur paths are enabled.
+
+- (7, 8) Save preconditions:
+  - Unit tests: autosave no-ops for non-file-backed/new buffers and no-unsaved
+    state.
+
+- (9) Conflict gate:
+  - Unit test: autosave no-ops when version conflict exists.
+
+- (10, 11) Toast behavior:
+  - Code view test(s): manual save shows success toast; auto-save path does not.
+
+- (12) Error behavior:
+  - Unit/integration test: autosave failure emits existing save failure event and
+    surfaces existing error UI.
+
+- (15) Auto-reload unchanged:
+  - Regression check: existing tests around file update handling continue to pass.
+
+Validation commands:
+
+- `cargo fmt`
+- `cargo check -p warp`
+- Targeted tests for code settings page, local code editor autosave paths, and
+  code view save-toast behavior.
+- `./script/presubmit` before implementation PR (not required for spec-only PR).
+
+## Risks and mitigations
+
+- Risk: autosave introduces noisy UX via repeated toasts.
+  - Mitigation: gate success toast to manual saves only.
+
+- Risk: autosave attempts during conflict states may overwrite user intent.
+  - Mitigation: skip autosave when version-conflict predicate is true.
+
+- Risk: subtle behavior differences between save triggers.
+  - Mitigation: centralize trigger gating and route both paths through one
+    save entrypoint.
+
+## Follow-ups
+
+- If maintainers want explicit user control for existing auto-reload behavior,
+  propose a separate issue/spec that builds on current `GlobalBufferModel`
+  semantics without coupling to this auto-save feature.
+


### PR DESCRIPTION
## Summary
- add product spec for GH10208 auto-save behavior in the built-in code editor
- add tech spec with implementation approach, wiring, and validation plan
- scope this PR to specs only under specs/GH10208/

## Linked issue
- Closes #10208

## Notes
- Per maintainer guidance, external auto-reload is treated as existing behavior and this spec focuses on auto-save.