### PR TITLE
Enable global hotkey on Wayland (#4800)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a3c86f3fd70c0ffa500ed189abfa90b5a52398a45d5dc372fcc38ebeb7a645"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.4",
+ "serde",
+ "serde_repr",
+ "url",
+ "zbus",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,7 +3025,7 @@ dependencies = [
 name = "computer_use"
 version = "0.0.0"
 dependencies = [
- "ashpd",
+ "ashpd 0.11.1",
  "async-trait",
  "cfg-if",
  "cfg_aliases 0.2.1",
@@ -5474,15 +5492,17 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "global-hotkey"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+source = "git+https://github.com/0-don/global-hotkey?rev=83f5cf55a80111b29805eae453fd63b20b781a53#83f5cf55a80111b29805eae453fd63b20b781a53"
 dependencies = [
+ "ashpd 0.12.3",
  "crossbeam-channel",
+ "futures",
  "keyboard-types",
  "objc2 0.6.3",
  "objc2-app-kit 0.3.2",
  "once_cell",
  "thiserror 2.0.17",
+ "tokio",
  "windows-sys 0.59.0",
  "x11rb",
  "xkeysym",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -512,6 +512,14 @@ tink-hybrid = { git = "https://github.com/warpdotdev/tink-rust", branch = "warpd
 tikv-jemallocator = { git = "https://github.com/warpdotdev/jemallocator.git", rev = "2ee30bfdf7059223b54810e4ea6c666f0a379e0b" }
 tikv-jemalloc-sys = { git = "https://github.com/warpdotdev/jemallocator.git", rev = "2ee30bfdf7059223b54810e4ea6c666f0a379e0b" }
 
+# Pinned to the head of tauri-apps/global-hotkey#172 (`0-don/global-hotkey`
+# branch `unified-wayland`), which adds transparent Wayland support via the
+# XDG GlobalShortcuts portal while keeping the X11 backend unchanged.
+# Replace with a crates.io version once the upstream PR lands and a release
+# is cut (expected as global-hotkey 0.9). Removing this entry without an
+# upstream release will re-disable Wayland global hotkeys.
+global-hotkey = { git = "https://github.com/0-don/global-hotkey", rev = "83f5cf55a80111b29805eae453fd63b20b781a53" }
+
 [patch."https://github.com/warpdotdev/warp-proto-apis.git"]
 # Uncomment for local development of warp-proto-apis
 # warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }

--- a/app/src/settings_view/features_page.rs
+++ b/app/src/settings_view/features_page.rs
@@ -5355,63 +5355,29 @@ impl SettingsWidget for GlobalHotkeyWidget {
         app: &AppContext,
     ) -> Box<dyn Element> {
         let mut column = Flex::column();
-        let ui_builder = appearance.ui_builder();
-        if app.is_wayland() {
-            column.add_child(render_body_item::<FeaturesPageAction>(
-                "Global hotkey:".to_owned(),
-                None,
-                // Fine not to show local only icon state for this, as it's not a supported setting.
-                LocalOnlyIconState::Hidden,
-                ToggleState::Disabled,
-                appearance,
-                Flex::row()
-                    .with_children([
-                        ui_builder
-                            .span("Not supported on Wayland. ")
-                            .build()
-                            .finish(),
-                        ui_builder
-                            .link(
-                                "See docs.".to_owned(),
-                                Some(
-                                    "https://docs.warp.dev/terminal/windows/global-hotkey"
-                                        .to_owned(),
-                                ),
-                                None,
-                                view.button_mouse_states.global_hotkey_link.clone(),
-                            )
-                            .soft_wrap(false)
-                            .build()
-                            .finish(),
-                    ])
-                    .finish(),
-                None,
-            ))
-        } else {
-            add_setting(
-                &mut column,
-                &KeysSettings::as_ref(app).activation_hotkey_enabled,
-                || {
-                    render_dropdown_item(
-                        appearance,
-                        "Global hotkey:",
-                        None,
-                        None,
-                        LocalOnlyIconState::for_setting(
-                            ActivationHotkeyEnabled::storage_key(),
-                            ActivationHotkeyEnabled::sync_to_cloud(),
-                            &mut view
-                                .button_mouse_states
-                                .local_only_icon_tooltip_states
-                                .borrow_mut(),
-                            app,
-                        ),
-                        None,
-                        &view.global_hotkey_dropdown,
-                    )
-                },
-            );
-        }
+        add_setting(
+            &mut column,
+            &KeysSettings::as_ref(app).activation_hotkey_enabled,
+            || {
+                render_dropdown_item(
+                    appearance,
+                    "Global hotkey:",
+                    None,
+                    None,
+                    LocalOnlyIconState::for_setting(
+                        ActivationHotkeyEnabled::storage_key(),
+                        ActivationHotkeyEnabled::sync_to_cloud(),
+                        &mut view
+                            .button_mouse_states
+                            .local_only_icon_tooltip_states
+                            .borrow_mut(),
+                        app,
+                    ),
+                    None,
+                    &view.global_hotkey_dropdown,
+                )
+            },
+        );
 
         let global_hotkey_mode =
             KeysSettings::handle(app).read(app, |settings, ctx| settings.global_hotkey_mode(ctx));

--- a/app/src/terminal/keys_settings.rs
+++ b/app/src/terminal/keys_settings.rs
@@ -189,12 +189,8 @@ impl KeysSettings {
         report_if_error!(self.quake_mode_settings.set_value(quake_mode_settings, ctx));
     }
 
-    pub fn global_hotkey_mode(&self, app: &AppContext) -> GlobalHotkeyMode {
+    pub fn global_hotkey_mode(&self, _app: &AppContext) -> GlobalHotkeyMode {
         let mut selected = GlobalHotkeyMode::Disabled;
-
-        if app.is_wayland() {
-            return selected;
-        }
 
         if *self.quake_mode_enabled && *self.activation_hotkey_enabled {
             log::error!("Both quake mode AND activation hotkey enabled. Either one or the other should be active.");

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -1102,9 +1102,6 @@ impl AppContext {
     }
 
     pub fn unregister_global_shortcut(&mut self, shortcut: &Keystroke) {
-        if self.is_wayland() {
-            return;
-        }
         self.global_shortcuts.remove(shortcut);
         self.platform_delegate.unregister_global_shortcut(shortcut);
     }
@@ -1115,9 +1112,6 @@ impl AppContext {
         action: &'static str,
         arg: T,
     ) {
-        if self.is_wayland() {
-            return;
-        }
         // Note that for global hotkey we don't support registering the meta key so
         // we will treat meta key as alt.
         if shortcut.meta {


### PR DESCRIPTION
## Description

Closes #4800.

The `global-hotkey` crate (tauri-apps/global-hotkey) historically only shipped X11, macOS, and Windows backends, so Warp gated all global-shortcut registration and the related settings UI behind `!app.is_wayland()`. Wayland users had no way to use the activation hotkey or quake mode.

Upstream PR [tauri-apps/global-hotkey#172](https://github.com/tauri-apps/global-hotkey/pull/172) adds a Wayland backend via the XDG GlobalShortcuts portal. The PR is open in upstream but has not yet been reviewed or merged; this PR is intentionally premature pending that — see comments for discussion.

This PR pulls the upstream Wayland support in via `[patch.crates-io]` (pointing at the PR head, `0-don/global-hotkey` branch `unified-wayland`, rev `83f5cf55`) and removes the three Wayland gates so the existing global-hotkey machinery runs unchanged on Wayland:

- `AppContext::register_global_shortcut` / `AppContext::unregister_global_shortcut` no longer early-return on Wayland.
- `KeysSettings::global_hotkey_mode` no longer forces `Disabled` on Wayland.
- The Features settings page no longer renders the "Not supported on Wayland" placeholder for the Global hotkey row.

Portal support per upstream: KDE Plasma 5.27+, GNOME 48+ (49+ fixes a BindShortcuts bug), Hyprland. Compositors without portal support fall back to no-op via the upstream crate's runtime detection.

## Why `[patch.crates-io]` instead of reimplementing

Upstream has the right architecture. (Note: the upstream PR is not yet reviewed/merged; this Warp PR is intentionally not ready until that lands.) Once `global-hotkey` releases a version containing #172 (expected 0.9), bump `crates/warpui/Cargo.toml` and remove the patch entry. The patch comment in `Cargo.toml` documents this for the next reader.

## Linked Issue

- Closes #4800 (labeled `ready-to-implement`).

## Screenshots / Videos

No new UI. The change removes the "Global hotkey: Not supported on Wayland" placeholder in Settings → Features and re-enables the existing dropdown / quake-mode UI on Wayland.

## Testing

- `cargo metadata` resolves `global-hotkey` from the patched fork; Cargo.lock updated accordingly.
- I could not run full presubmit locally (system `fontconfig` missing on this dev box; unrelated to this change). Happy to follow up on anything CI flags.
- Suggested manual coverage:
  - GNOME 48+/Wayland: register an activation hotkey, toggle quake mode while the app is unfocused.
  - KDE Plasma 5.27+/Wayland: same.
  - Hyprland: same.
  - X11 + macOS + Windows: confirm no regression (only Wayland paths touched).

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Global hotkeys (activation hotkey and quake mode) now work on Wayland on compositors with XDG GlobalShortcuts portal support (KDE Plasma 5.27+, GNOME 48+, Hyprland).

Co-Authored-By: Warp <agent@warp.dev>

