### PR TITLE
Hide notification chip in ambient sessions

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -982,10 +982,10 @@ impl AgentInputFooter {
         }
         #[cfg(not(target_family = "wasm"))]
         {
-            if self.plugin_operation_in_progress {
-                return None;
-            }
-            if !FeatureFlag::HOANotifications.is_enabled() {
+            if self.plugin_operation_in_progress
+                || self.terminal_model.lock().is_shared_ambient_agent_session()
+                || !FeatureFlag::HOANotifications.is_enabled()
+            {
                 return None;
             }
 


### PR DESCRIPTION
## Summary
We shouldn't show the plugin installation chip on Oz runs (doesn't make sense to install the plugin over a shared session or in an ambient agent run).

## Tests
<img width="1160" height="1385" alt="image" src="https://github.com/user-attachments/assets/2b1756ae-50a5-4b9c-a43b-25d5e47efd83" />


_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._
