### PR TITLE
[QUALITY-598] Exclude child agent initial prompt from history completions

### DIFF
--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1757,7 +1757,17 @@ impl BlocklistAIHistoryModel {
 
             for conversation_id in conversation_ids {
                 if let Some(conversation) = self.conversations_by_id.get(conversation_id) {
-                    for exchange in conversation.root_task_exchanges() {
+                    // For child agent conversations, skip the first exchange — it
+                    // contains the synthetic orchestrator prompt, not user input.
+                    // TODO(QUALITY-636): Replace positional skip with an
+                    // `is_agent_initiated` field on the MAA UserQuery proto
+                    // message so the flag survives server restoration.
+                    let skip_count = if conversation.is_child_agent_conversation() {
+                        1
+                    } else {
+                        0
+                    };
+                    for exchange in conversation.root_task_exchanges().skip(skip_count) {
                         if let Some(query) = ai_exchange_to_query_history(exchange, history_order) {
                             live_queries_vec.push(query);
                         }
@@ -1778,7 +1788,12 @@ impl BlocklistAIHistoryModel {
 
             for conversation_id in conversation_ids {
                 if let Some(conversation) = self.conversations_by_id.get(conversation_id) {
-                    for exchange in conversation.root_task_exchanges() {
+                    let skip_count = if conversation.is_child_agent_conversation() {
+                        1
+                    } else {
+                        0
+                    };
+                    for exchange in conversation.root_task_exchanges().skip(skip_count) {
                         if let Some(query) = ai_exchange_to_query_history(exchange, history_order) {
                             cleared_queries_vec.push(query);
                         }
@@ -2108,6 +2123,7 @@ impl BlocklistAIHistoryModel {
         self.all_conversations_metadata.clear();
         self.agent_id_to_conversation_id.clear();
         self.server_token_to_conversation_id.clear();
+        self.children_by_parent.clear();
     }
 }
 


### PR DESCRIPTION
## Description
Skip the synthetic orchestrator prompt in child agent conversations by using `.skip(1)` on `root_task_exchanges()` when the conversation is a child (`is_child_agent_conversation()`). User follow-up queries in the same child conversation are preserved.

This approach requires no persistence changes — `is_child_agent_conversation()` is derived from `parent_conversation_id`/`parent_agent_id` which are already persisted in `AgentConversationData`. It works correctly across app restarts and server-restored conversations.

Also clears `children_by_parent` in `reset()` for consistency (pre-existing omission).

## Linked Issue
- [QUALITY-598](https://linear.app/warpdotdev/issue/QUALITY-598/exclude-child-agent-prompts-from-history-completions)

## Testing
Manual: ran orchestration spawning child agents, verified the orchestrator's initial prompt no longer appears in agent input completions while user follow-up queries in revealed child panes still appear.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

---
[Conversation](https://staging.warp.dev/conversation/1cd70e6d-e2d8-44a1-86fd-33a12fdd585c) | [Plan](https://staging.warp.dev/drive/notebook/RatsJ03TieFO8Ax5hxso9b)

CHANGELOG-BUG-FIX: Child agent initial prompts (from orchestrator) no longer appear in the agent input completion history.