### PR TITLE
Fix `RowIterator` crashes for third-party agents.

### DIFF
--- a/app/src/terminal/model/grid/grid_handler_test.rs
+++ b/app/src/terminal/model/grid/grid_handler_test.rs
@@ -2211,10 +2211,10 @@ fn content_len_equals_len_when_no_trailing_blanks() {
 #[test]
 fn test_full_grid_clear_resize_then_scroll_does_not_panic_on_row_iteration() {
     // Regression test for issue with `FullGridClearBehavior`: make sure that
-    // when FullGridClearBehavior::Clear is active, resize_storage 
+    // when FullGridClearBehavior::Clear is active, resize_storage
     // resizes the active GridStorage and the flat storage correctly.
-    // Before, we didn't set 'flat_storage.set_columns(), and subsequent scrolls pushed 
-	// wider rows into the narrower flat storage, corrupting the index. Iterating
+    // Before, we didn't set 'flat_storage.set_columns(), and subsequent scrolls pushed
+    // wider rows into the narrower flat storage, corrupting the index. Iterating
     // those rows then panicked.
     let old_cols = 10;
     let new_cols = 20;
@@ -2224,7 +2224,7 @@ fn test_full_grid_clear_resize_then_scroll_does_not_panic_on_row_iteration() {
         GridHandler::new_for_test_with_scroll_limit(num_rows, old_cols, MAX_SCROLL_LIMIT);
     grid.enable_full_grid_clear_behavior();
 
-    // Resize grid wider. 
+    // Resize grid wider.
     grid.resize(SizeInfo::new_without_font_metrics(num_rows, new_cols));
 
     // Fill visible rows with new-width content and trigger a scroll so

--- a/app/src/terminal/model/grid/grid_handler_test.rs
+++ b/app/src/terminal/model/grid/grid_handler_test.rs
@@ -2205,3 +2205,110 @@ fn content_len_equals_len_when_no_trailing_blanks() {
     let expected = grid.grid_storage().max_cursor_point.row.0 + grid.history_size() + 1;
     assert_eq!(grid.content_len(), expected);
 }
+
+// ─── FullGridClearBehavior::Clear resize + scroll desync ─────────────
+
+#[test]
+fn test_full_grid_clear_resize_then_scroll_does_not_panic_on_row_iteration() {
+    // Regression test for issue with `FullGridClearBehavior`: make sure that
+    // when FullGridClearBehavior::Clear is active, resize_storage 
+    // resizes the active GridStorage and the flat storage correctly.
+    // Before, we didn't set 'flat_storage.set_columns(), and subsequent scrolls pushed 
+	// wider rows into the narrower flat storage, corrupting the index. Iterating
+    // those rows then panicked.
+    let old_cols = 10;
+    let new_cols = 20;
+    let num_rows = 3;
+
+    let mut grid =
+        GridHandler::new_for_test_with_scroll_limit(num_rows, old_cols, MAX_SCROLL_LIMIT);
+    grid.enable_full_grid_clear_behavior();
+
+    // Resize grid wider. 
+    grid.resize(SizeInfo::new_without_font_metrics(num_rows, new_cols));
+
+    // Fill visible rows with new-width content and trigger a scroll so
+    // a wide row gets pushed into narrow flat storage.
+    for _ in 0..num_rows {
+        for c in "abcdefghijklmnopqrst".chars() {
+            grid.input(c);
+        }
+        grid.carriage_return();
+        grid.linefeed();
+    }
+
+    // Iterating flat storage rows should not panic.
+    for row_idx in 0..grid.flat_storage.total_rows() {
+        let _ = grid.flat_storage.rows_from(row_idx).next();
+    }
+}
+
+#[test]
+fn test_full_grid_clear_resize_narrower_then_scroll_does_not_panic() {
+    // Same scenario but resizing to a narrower width.
+    let old_cols = 20;
+    let new_cols = 10;
+    let num_rows = 3;
+
+    let mut grid =
+        GridHandler::new_for_test_with_scroll_limit(num_rows, old_cols, MAX_SCROLL_LIMIT);
+
+    // Fill grid with wide content before enabling Clear behavior.
+    for _ in 0..num_rows {
+        for c in "abcdefghijklmnopqrst".chars() {
+            grid.input(c);
+        }
+        grid.carriage_return();
+        grid.linefeed();
+    }
+
+    grid.enable_full_grid_clear_behavior();
+    grid.resize(SizeInfo::new_without_font_metrics(num_rows, new_cols));
+
+    // Trigger more scrolling with narrow content.
+    for _ in 0..num_rows {
+        for c in "abcdefghij".chars() {
+            grid.input(c);
+        }
+        grid.carriage_return();
+        grid.linefeed();
+    }
+
+    for row_idx in 0..grid.flat_storage.total_rows() {
+        let _ = grid.flat_storage.rows_from(row_idx).next();
+    }
+}
+
+#[test]
+fn test_full_grid_clear_resize_then_bounds_to_string_does_not_panic() {
+    // End-to-end repro via the same code path as block_snapshot:
+    // bounds_to_string → line_to_string → row() → RowIterator::next.
+    let old_cols = 10;
+    let new_cols = 20;
+    let num_rows = 3;
+
+    let mut grid =
+        GridHandler::new_for_test_with_scroll_limit(num_rows, old_cols, MAX_SCROLL_LIMIT);
+    grid.enable_full_grid_clear_behavior();
+    grid.resize(SizeInfo::new_without_font_metrics(num_rows, new_cols));
+
+    for _ in 0..num_rows {
+        for c in "abcdefghijklmnopqrst".chars() {
+            grid.input(c);
+        }
+        grid.carriage_return();
+        grid.linefeed();
+    }
+
+    let total = grid.total_rows();
+    if total > 0 {
+        let _ = grid.bounds_to_string(
+            Point::new(0, 0),
+            Point::new(total - 1, grid.columns().saturating_sub(1)),
+            false,
+            RespectObfuscatedSecrets::No,
+            false,
+            RespectDisplayedOutput::No,
+        );
+    }
+}

--- a/app/src/terminal/model/grid/resize.rs
+++ b/app/src/terminal/model/grid/resize.rs
@@ -73,6 +73,16 @@ impl GridHandler {
             // We can delegate to the old grid resizing logic, as there's no
             // flat storage for the alt screen.
             self.grid.resize(false, num_rows, num_cols, self.finished);
+
+            // Keep flat_storage's column count in sync so that rows
+            // scrolled into it later (via scroll_region_up) match the
+            // width the iterator expects. Without this, rows from the
+            // wider/narrower grid get pushed with process_grapheme_info_
+            // unchecked and RowIterator::next panics.
+            if !self.ansi_handler_state.is_alt_screen {
+                self.flat_storage.set_columns(num_cols);
+            }
+
             return;
         }
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

We introduced a new resize pathway for third-party CLIs in https://github.com/warpdotdev/warp/pull/9877, which returns early during the `resize` code to clear the screen without reflowing the grid. 

Even though we don't want to push new things into scrollback during this resize, we still want to update the flat storage settings themselves so we are aware of the new width. The panic path was:
1. CLIAgent is running, so we have `FullGridClearBehavior::Clear`
2. The screen is made wider — grid storage gets resized but flat storage is untouched
3. We push a new row into flat storage scrollback, which is too big 
4. When we try to read from flat storage (in the cloud agent context, this happens when we run `block_snapshot`), we crash when we find that the grapheme index has more content in the row than `storage.columns` expects

Step (2) often happens when joining a cloud agent session (we automatically resize the sharer to match the viewer), so this would explain why we've been seeing this a lot for specifically cloud agents. 

The proposed fix here is to set the flat storage `columns` in the new resize pathway, even though we aren't reflowing the grid.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?
-->
Added integration tests that fail before the fix and pass afterwards. 

Also manually tested—I can repro pretty consistently by resizing a codex window to get it to crash, and I could not get it to crash the same way on my local branch.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
