### PR TITLE
fix(ui): reduce excess indentation on spawned agents status card (QUALITY-626)

### DIFF
--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -949,17 +949,12 @@ fn render_status_only_card(
         false,
         app,
     );
-    Container::new(
-        Container::new(row)
-            .with_background_color(blended_colors::neutral_2(theme))
-            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
-            .finish(),
-    )
-    .with_margin_left(16.)
-    .with_margin_right(16.)
-    .finish()
-    .with_agent_output_item_spacing(app)
-    .finish()
+    Container::new(row)
+        .with_background_color(blended_colors::neutral_2(theme))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+        .finish()
+        .with_agent_output_item_spacing(app)
+        .finish()
 }
 
 fn render_editor(


### PR DESCRIPTION
## Description

**What:** Removed the redundant wrapping `Container` with 16px left/right margins from `render_status_only_card`, so the card goes directly through `with_agent_output_item_spacing(app)`. This aligns the "Spawned N agents" status card with the agent output text that follows it.

**Why:** The status card had double indentation — a wrapping `Container` added 16px left/right margins, and then `with_agent_output_item_spacing(app)` added another ~48-52px left margin on top. Removing the extra wrapper keeps the card aligned with adjacent agent output content.

Fixes QUALITY-626

## Testing

- Verified compilation passes (`cargo check -p warp`)
- Visually confirmed the status card now aligns with adjacent agent output

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fix excess left indentation on spawned agents status card
-->

Co-Authored-By: Oz <oz-agent@warp.dev>