### PR TITLE
Skip periodic chip refresh when fingerprint matches

### DIFF
--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -982,7 +982,7 @@ impl CurrentPrompt {
                     chip_kind_clone
                 },
                 |me, chip_kind, ctx| {
-                    me.fetch_chip_value_at_interval(&chip_kind, None, None, false, ctx);
+                    me.fetch_chip_value_at_interval(&chip_kind, None, None, true, ctx);
                 },
             );
 

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -518,9 +518,21 @@ impl CurrentPrompt {
             return false;
         };
 
+        // A retryable failure (`Error`, `TimedOut`) is not a usable cached
+        // result: `last_fingerprint` is recorded before the command runs, and
+        // such failures intentionally do not populate `last_failure_fingerprint`.
+        // Without this guard, the next periodic tick would treat the failed
+        // attempt as a cache hit and never retry. Deterministic failures
+        // continue to be suppressed via `last_failure_fingerprint`.
         let should_skip = self
             .states
             .get(chip_kind)
+            .filter(|state| {
+                !matches!(
+                    state.update_status,
+                    ChipUpdateStatus::Error | ChipUpdateStatus::TimedOut
+                )
+            })
             .and_then(|state| state.last_fingerprint.as_ref())
             .is_some_and(|existing| existing == &new_fingerprint);
 

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -964,11 +964,17 @@ fn test_github_pr_chip_transient_failure_retries_with_same_fingerprint() {
                     .to_chip()
                     .expect("expected github pr chip");
                 let generator = chip.generator().clone();
+                // Pass `allow_fingerprint_skip = true` to exercise the same
+                // path the periodic timer uses. The previous attempt left the
+                // chip in `Error` state with the fingerprint already recorded;
+                // without status-aware skip handling, this call would short-
+                // circuit as `Cached` and the transient failure would become
+                // sticky.
                 current_prompt.fetch_chip_value_once(
                     &ContextChipKind::GithubPullRequest,
                     &generator,
                     None,
-                    false,
+                    true,
                     ctx,
                 );
                 current_prompt.await_generators(ctx)


### PR DESCRIPTION
The 30s timer passed `allow_fingerprint_skip = false`, so the GitHub PR chip re-ran `gh pr view` every tick. Each `gh` invocation makes a GraphQL viewer precheck; across 3+ tabs this exhausts a user's 5,000-pt/hr quota (#9830).

Pass `true` so the timer uses the chip's fingerprint as a cache key. Branch, cwd, and `git`/`gh`/`gt` commands still bust it.

Make the fingerprint skip status-aware so a previous `Error` or `TimedOut` is treated as a cache miss. Otherwise retryable failures would become sticky: `last_fingerprint` is recorded before the command runs and `last_failure_fingerprint` is intentionally empty for non-deterministic failures. Deterministic auth failures continue to be suppressed via `last_failure_fingerprint`.

## Description

The recursive timer continuation in `fetch_chip_value_at_interval` was the only call site passing `allow_fingerprint_skip = false`. Every other entry point passes `true`. The chip's fingerprint inputs (`SessionId`, `WorkingDirectory`, `GitBranch`, `RequiredExecutablesPresence`, `InvalidatingCommandCount`) combined with `invalidate_on_commands ["git", "gh", "gt"]` already capture every input that can change the PR URL.

`maybe_skip_fetch_due_to_matching_fingerprint` now filters out states whose `update_status` is `Error` or `TimedOut` before the fingerprint-equality check, so the periodic timer still retries transient failures while successful refreshes are skipped.

Other periodic chips are unaffected. `Time`/`Date` have no fingerprint inputs, so the skip check is a no-op. `ShellGitBranch`/`GitDiffStats` route through the `GitRepoStatusModel` filesystem watcher on local sessions and don't reach this path.

Warp version v0.2026.04.29.08.57.stable_01

## Linked Issue

Closes #9830.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

Measured GraphQL rate-limit consumption before and after disabling the chip locally on macOS:

- Before: ~0.66 calls/sec sustained.
- After: ~0.012 calls/sec (1 external call in 84s; the rest were the polling query itself).

`test_github_pr_chip_transient_failure_retries_with_same_fingerprint` now passes `allow_fingerprint_skip = true` to exercise the same path the periodic timer uses; without the status-aware filter it would short-circuit as `Cached` and the transient failure would become sticky.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Stop the GitHub PR prompt chip from polling `gh pr view` every 30 seconds when nothing has changed, preventing it from draining the user's GitHub GraphQL rate limit.