### PR TITLE
Fix deadlock in terminal view rendering.

### DIFF
--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -1154,10 +1154,11 @@ impl View for BlocklistAIStatusBar {
                     .ambient_agent_view_model
                     .as_ref()
                     .is_some_and(|ambient_agent_view_model| {
+                        let terminal_model = self.terminal_model.lock();
                         is_cloud_agent_pre_first_exchange(
                             Some(ambient_agent_view_model),
                             &self.agent_view_controller,
-                            &self.terminal_model,
+                            &terminal_model,
                             app,
                         )
                     })

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -57,6 +57,7 @@ use crate::appearance::Appearance;
 use crate::settings::{AISettings, InputModeSettings, InputSettings};
 use crate::terminal::model::blocks::{BlockHeightItem, RemovableBlocklistItem, RichContentItem};
 use crate::terminal::model::rich_content::RichContentType;
+use crate::terminal::view::ambient_agent::is_cloud_agent_pre_first_exchange;
 use crate::terminal::TerminalView;
 use crate::util::truncation::truncate_from_end;
 
@@ -987,15 +988,14 @@ impl View for AIBlock {
         let terminal_model = self.terminal_model.lock();
         let shared_session_status = terminal_model.shared_session_status().clone();
         let is_conversation_transcript_viewer = terminal_model.is_conversation_transcript_viewer();
-        drop(terminal_model);
 
-        let is_cloud_agent_pre_first_exchange =
-            crate::terminal::view::ambient_agent::is_cloud_agent_pre_first_exchange(
-                self.ambient_agent_view_model.as_ref(),
-                &self.agent_view_controller,
-                &self.terminal_model,
-                app,
-            );
+        let is_cloud_agent_pre_first_exchange = is_cloud_agent_pre_first_exchange(
+            self.ambient_agent_view_model.as_ref(),
+            &self.agent_view_controller,
+            &terminal_model,
+            app,
+        );
+        drop(terminal_model);
 
         contents.add_child(output::render(
             output::Props {

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -1001,12 +1001,15 @@ impl TerminalManager {
                     // sync reflects environment setup commands. Skip applying remote edits so
                     // the visible input isn't populated with setup-command text.
                     if FeatureFlag::CloudModeSetupV2.is_enabled()
-                        && is_cloud_agent_pre_first_exchange(
-                            view.ambient_agent_view_model(),
-                            view.agent_view_controller(),
-                            &view.model,
-                            ctx,
-                        )
+                        && {
+                            let model = view.model.lock();
+                            is_cloud_agent_pre_first_exchange(
+                                view.ambient_agent_view_model(),
+                                view.agent_view_controller(),
+                                &model,
+                                ctx,
+                            )
+                        }
                     {
                         return;
                     }
@@ -1317,10 +1320,11 @@ impl TerminalManager {
         // and ignore remote shell/ai mode toggles from session-sharing context sync.
         let is_pre_first_exchange = FeatureFlag::CloudModeSetupV2.is_enabled() && {
             let view_ref = view.as_ref(ctx);
+            let model = view_ref.model.lock();
             is_cloud_agent_pre_first_exchange(
                 view_ref.ambient_agent_view_model(),
                 view_ref.agent_view_controller(),
-                &view_ref.model,
+                &model,
                 ctx,
             )
         };

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -17,7 +17,6 @@ use crate::ai::block_context::BlockContext;
 #[cfg(feature = "local_fs")]
 use crate::ai::skills::SkillOpenOrigin;
 use crate::global_resource_handles::GlobalResourceHandlesProvider;
-use crate::terminal::view::ambient_agent::is_cloud_agent_pre_first_exchange;
 pub use init_project::{
     InitActionResult, InitProjectModel, InitProjectModelEvent, InitStepBlock, InitStepKind,
     ProjectScopedRulesResult,
@@ -2892,10 +2891,6 @@ impl TerminalView {
         self.current_repo_path.as_ref()
     }
 
-    /// Create a SyncEvent for other terminals to use based on
-    /// the state of this terminal. If this terminal view has an active input
-    /// editor, other terminals should match those contents.
-    /// Otherwise, they should just start syncing.
     fn is_nested_cloud_mode(&self, app: &AppContext) -> bool {
         if !self.is_ambient_agent_session(app) {
             return false;
@@ -2917,17 +2912,10 @@ impl TerminalView {
             .is_some_and(|index| index > 0)
     }
 
-    /// True when this pane's cloud agent is in any pre-first-exchange phase.
-    /// Thin wrapper over the free function that threads `self`'s handles.
-    fn is_cloud_agent_pre_first_exchange(&self, app: &AppContext) -> bool {
-        is_cloud_agent_pre_first_exchange(
-            self.ambient_agent_view_model.as_ref(),
-            &self.agent_view_controller,
-            &self.model,
-            app,
-        )
-    }
-
+    /// Create a SyncEvent for other terminals to use based on
+    /// the state of this terminal. If this terminal view has an active input
+    /// editor, other terminals should match those contents.
+    /// Otherwise, they should just start syncing.
     pub fn create_sync_event_based_on_terminal_state(&self, app_ctx: &AppContext) -> SyncEvent {
         if !matches!(
             self.model.lock().terminal_input_state(),
@@ -7122,7 +7110,12 @@ impl TerminalView {
         // agent exchange arrives, we hide the interactive input view. A non-interactive footer is
         // rendered instead (see `TerminalView::render`).
         if !FeatureFlag::CloudModeSetupV2.is_enabled()
-            && self.is_cloud_agent_pre_first_exchange(app)
+            && ambient_agent::is_cloud_agent_pre_first_exchange(
+                self.ambient_agent_view_model.as_ref(),
+                &self.agent_view_controller,
+                model,
+                app,
+            )
         {
             return false;
         }
@@ -26130,7 +26123,14 @@ impl View for TerminalView {
 
                     if self.is_input_box_visible(&model, app) {
                         column.add_child(self.render_input());
-                    } else if !model.is_read_only() && self.is_cloud_agent_pre_first_exchange(app) {
+                    } else if !model.is_read_only()
+                        && ambient_agent::is_cloud_agent_pre_first_exchange(
+                            self.ambient_agent_view_model.as_ref(),
+                            &self.agent_view_controller,
+                            &model,
+                            app,
+                        )
+                    {
                         column.add_child(ambient_agent::render_loading_footer(appearance));
                     } else if self.show_remote_server_loading_footer(&model, app) {
                         column.add_child(

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -29,8 +29,6 @@ pub use progress::{render_progress, ProgressProps, ProgressStep, ProgressStepSta
 pub use progress_ui_state::AmbientAgentProgressUIState;
 pub use tips::{get_cloud_mode_tips, CloudModeTip};
 
-use parking_lot::FairMutex;
-use std::sync::Arc;
 use warp_core::features::FeatureFlag;
 use warpui::geometry::vector::Vector2F;
 use warpui::{AppContext, ModelHandle, ViewHandle, WindowId};
@@ -132,7 +130,7 @@ pub fn create_cloud_mode_view(
 pub fn is_cloud_agent_pre_first_exchange(
     ambient_agent_view_model: Option<&ModelHandle<AmbientAgentViewModel>>,
     agent_view_controller: &ModelHandle<AgentViewController>,
-    terminal_model: &Arc<FairMutex<TerminalModel>>,
+    terminal_model: &TerminalModel,
     app: &AppContext,
 ) -> bool {
     if !(FeatureFlag::CloudMode.is_enabled() && FeatureFlag::AgentView.is_enabled()) {
@@ -179,7 +177,6 @@ pub fn is_cloud_agent_pre_first_exchange(
     }
 
     terminal_model
-        .lock()
         .block_list()
         .is_executing_oz_environment_startup_commands()
 }

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -952,15 +952,21 @@ impl TerminalView {
     /// the post-session pre-first-exchange phase (session ready, harness not started, no
     /// exchange yet). In either case the run is committed and we want the UI to read as busy.
     fn is_in_cloud_agent_setup_phase(&self, ctx: &AppContext) -> bool {
-        self.ambient_agent_view_model
+        if self
+            .ambient_agent_view_model
             .as_ref()
             .is_some_and(|model| model.as_ref(ctx).is_waiting_for_session())
-            || is_cloud_agent_pre_first_exchange(
-                self.ambient_agent_view_model.as_ref(),
-                &self.agent_view_controller,
-                &self.model,
-                ctx,
-            )
+        {
+            return true;
+        }
+
+        let model = self.model.lock();
+        is_cloud_agent_pre_first_exchange(
+            self.ambient_agent_view_model.as_ref(),
+            &self.agent_view_controller,
+            &model,
+            ctx,
+        )
     }
 
     /// Selected conversation status for chrome, or [`ConversationStatus::InProgress`] while the


### PR DESCRIPTION
## Description
Update `is_cloud_agent_pre_first_exchange` to take in `&TerminalModel` instead of locking internally, which is super prone to deadlocks
