### PR TITLE
Add platform credits counting to client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14894,7 +14894,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=02997b8fc6a468783642d93bf1bfa89fb7f42502#02997b8fc6a468783642d93bf1bfa89fb7f42502"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=9824c453c746003aca2b61c526fb73d6ca910359#9824c453c746003aca2b61c526fb73d6ca910359"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "02997b8fc6a468783642d93bf1bfa89fb7f42502" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "9824c453c746003aca2b61c526fb73d6ca910359" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_to.rs
+++ b/app/src/ai/agent/api/convert_to.rs
@@ -808,6 +808,8 @@ fn convert_context(context: &[AIAgentContext]) -> api::InputContext {
                 api_context.git = Some(api::input_context::Git {
                     head,
                     branch: branch.unwrap_or_default(),
+                    repository: None,   // TODO: populate?
+                    pull_request: None, // TODO: populate?
                 });
             }
             AIAgentContext::Skills { skills } => {

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2822,9 +2822,10 @@ impl BlocklistAIController {
             // persisting the conversation.
             history_model.update_conversation_cost_and_usage_for_request(
                 conversation_id,
-                finished_event
-                    .request_cost
-                    .map(|cost| RequestCost::new(cost.exact.into())),
+                finished_event.request_cost.map(|cost| {
+                    // Total credits charged for this request = inference (`exact`) + platform.
+                    RequestCost::new(f64::from(cost.exact) + f64::from(cost.platform_credits))
+                }),
                 finished_event.token_usage,
                 finished_event.conversation_usage_metadata.take(),
                 did_request_contain_user_query,


### PR DESCRIPTION
## Description

For certain teams, the server may report that an AI query cost platform credits; this just makes the client sum up both inference + platform credits so the cost totals shown in the UI are accurate.

## Testing

Verified that the total credits being reported matched the sum of inference + AI credits in the backend.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode