### PR TITLE
fix: use fixed font sizes for orchestration pill bar avatars and labels

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -568,15 +568,11 @@ pub fn render_static_agent_pill(name: &str, app: &AppContext) -> Box<dyn Element
     let avatar_color = pill_avatar_color(name, theme);
     let avatar_glyph = AvatarGlyph::Letter(pill_initial(name));
     let avatar = render_avatar_disc(avatar_color, avatar_glyph, theme, appearance);
-    let label_text = Text::new(
-        name.to_string(),
-        appearance.ui_font_family(),
-        appearance.monospace_font_size() - 1.,
-    )
-    .with_color(internal_colors::text_main(theme, theme.background()))
-    .soft_wrap(false)
-    .with_clip(ClipConfig::ellipsis())
-    .finish();
+    let label_text = Text::new(name.to_string(), appearance.ui_font_family(), 12.)
+        .with_color(internal_colors::text_main(theme, theme.background()))
+        .soft_wrap(false)
+        .with_clip(ClipConfig::ellipsis())
+        .finish();
 
     let row = Flex::row()
         .with_cross_axis_alignment(CrossAxisAlignment::Center)
@@ -1611,17 +1607,15 @@ fn render_avatar_disc(
     .finish();
 
     let glyph_element: Box<dyn Element> = match glyph {
-        AvatarGlyph::Letter(letter) => Text::new(
-            letter.to_string(),
-            appearance.ui_font_family(),
-            (appearance.monospace_font_size() - 2.).max(9.),
-        )
-        .with_color(theme.background().into_solid())
-        .with_style(Properties {
-            weight: Weight::Bold,
-            ..Default::default()
-        })
-        .finish(),
+        AvatarGlyph::Letter(letter) => {
+            Text::new(letter.to_string(), appearance.ui_font_family(), 10.)
+                .with_color(theme.background().into_solid())
+                .with_style(Properties {
+                    weight: Weight::Bold,
+                    ..Default::default()
+                })
+                .finish()
+        }
         AvatarGlyph::Icon(icon) => {
             ConstrainedBox::new(icon.to_warpui_icon(theme.background()).finish())
                 .with_width(10.)


### PR DESCRIPTION
## Description

Fix letter avatar and pill label font sizes in the orchestration pill bar to use fixed values instead of the user-configurable terminal font size.

The avatar disc has a fixed size (AVATAR_SIZE = 16px), but the letter inside it was sized relative to `appearance.monospace_font_size()`, causing visual inconsistency when the user changes their terminal font size. Similarly, the static pill label font was derived from the terminal font size.

Changes:
- `render_avatar_disc`: use fixed `10.` font size for letter glyphs (matches session sharing avatars for 16px discs)
- `render_static_agent_pill`: use fixed `12.` font size for pill labels

## Linked Issue

- QUALITY-617

## Testing

- Verified `cargo fmt`, `cargo clippy`, and `cargo check` all pass

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed orchestration pill bar letter avatars scaling with terminal font size instead of using a fixed size
-->

_Conversation: https://staging.warp.dev/conversation/730ca6be-2cf5-4a2e-86cf-b899cdfff6fa_
_Run: https://oz.staging.warp.dev/runs/019dff66-f5e4-7d4d-b720-9848e5da4202_

_This PR was generated with [Oz](https://warp.dev/oz)._
