### PR TITLE
Decouple `DiffStateModel` and `CodeReviewView`

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -13,7 +13,6 @@ use crate::{
         blocklist::agent_view::AgentViewEntryOrigin,
     },
     code::editor::comment_editor::DEFAULT_COMMENT_MAX_WIDTH,
-    code_review::diff_state::InvalidationSource,
     coding_panel_enablement_state::CodingPanelEnablementState,
 };
 
@@ -46,7 +45,7 @@ use crate::{
         diff_state::{
             DiffHunk, DiffLineType, DiffMode, DiffState, DiffStateModel, DiffStateModelEvent,
             DiffStats, FileDiff, FileDiffAndContent, FileStatusInfo, GitDiffWithBaseContent,
-            GitFileStatus, InvalidationBehavior,
+            GitFileStatus,
         },
         editor_state::CodeReviewEditorState,
         hidden_lines::calculate_hidden_lines,
@@ -114,7 +113,6 @@ use warp_core::{
     channel::{Channel, ChannelState},
     features::FeatureFlag,
     safe_error, safe_info,
-    sync_queue::SyncQueue,
     ui::theme::color::internal_colors,
 };
 use warpui::{
@@ -150,7 +148,6 @@ use warpui::{
 };
 use warpui::{
     fonts::{Properties, Weight},
-    r#async::SpawnedFutureHandle,
     ModelHandle, WeakViewHandle,
 };
 
@@ -182,7 +179,6 @@ use super::{
     comment_list_view::{CommentListDebugState, CommentListEvent, CommentListView},
     comments::{attach_pending_imported_comments, AttachedReviewComment, CommentOrigin},
     diff_size_limits::DiffSize,
-    file_invalidation_queue::FileInvalidationTask,
     git_dialog::{GitDialog, GitDialogEvent, GitDialogKind},
     GlobalCodeReviewEvent, GlobalCodeReviewModel,
 };
@@ -468,26 +464,6 @@ impl Default for UiStateHandles {
     }
 }
 
-struct PendingFileUpdate {
-    repo_path: PathBuf,
-    pending_file_edits: HashSet<PathBuf>,
-}
-
-impl PendingFileUpdate {
-    fn update_with_file_invalidation(
-        &mut self,
-        repo_path: PathBuf,
-        invalidated_files: Vec<PathBuf>,
-    ) {
-        if self.repo_path != repo_path {
-            self.repo_path = repo_path;
-            self.pending_file_edits = HashSet::from_iter(invalidated_files);
-        } else {
-            self.pending_file_edits.extend(invalidated_files);
-        }
-    }
-}
-
 #[cfg_attr(target_family = "wasm", allow(dead_code))]
 struct GitSessionState {
     enablement: CodingPanelEnablementState,
@@ -603,42 +579,6 @@ struct PendingPreciseScroll {
     buffer: f32,
 }
 
-/// Tracks state for in-flight file invalidation tasks and full-reload coordination.
-struct FileInvalidationState {
-    /// Whether a full invalidation (`invalidate_all`) is in-flight.
-    /// When true, new `invalidate_files` requests are deferred to `pending_file_updates`.
-    invalidate_all_pending: bool,
-    /// Merge base commit for the current diff mode, computed eagerly during
-    /// full invalidation.
-    merge_base: Option<String>,
-    /// Handle for the in-flight merge base computation spawned during full
-    /// invalidation. Aborted when a new full invalidation starts.
-    merge_base_handle: Option<SpawnedFutureHandle>,
-    /// Queue for per-file invalidation tasks.
-    queue: SyncQueue<FileInvalidationTask>,
-}
-
-impl FileInvalidationState {
-    fn new(queue: SyncQueue<FileInvalidationTask>) -> Self {
-        Self {
-            invalidate_all_pending: false,
-            merge_base: None,
-            merge_base_handle: None,
-            queue,
-        }
-    }
-
-    /// Aborts all in-flight file invalidation tasks, cancels queued
-    /// tasks, and clears the merge base.
-    fn cancel_all(&mut self) {
-        self.queue.cancel_all();
-        self.merge_base = None;
-        if let Some(handle) = self.merge_base_handle.take() {
-            handle.abort();
-        }
-    }
-}
-
 /// Per-repository state container.
 struct RepositoryState {
     repo_path: PathBuf,
@@ -647,22 +587,15 @@ struct RepositoryState {
 
     /// Whether a file has been explicitly expanded (true) or collapsed (false).
     file_expanded: HashMap<PathBuf, bool>,
-    // TODO: Remove pending file invalidations — pause the queue instead.
-    /// Files that have been invalidated but not yet processed when diff is still loading.
-    pending_file_updates: Option<PendingFileUpdate>,
-    /// State for tracking in-flight file invalidation tasks.
-    file_invalidation: FileInvalidationState,
 }
 
 impl RepositoryState {
-    fn new(repo_path: PathBuf, queue: SyncQueue<FileInvalidationTask>) -> Self {
+    fn new(repo_path: PathBuf) -> Self {
         Self {
             repo_path,
             state: CodeReviewViewState::None,
             available_branches: Vec::new(),
             file_expanded: HashMap::new(),
-            pending_file_updates: None,
-            file_invalidation: FileInvalidationState::new(queue),
         }
     }
 
@@ -777,58 +710,15 @@ impl CodeReviewView {
         &self.diff_state_model
     }
 
-    pub fn update_current_repo(&mut self, repo_path: Option<PathBuf>, ctx: &mut ViewContext<Self>) {
-        safe_info!(
-            safe: ("Code Review: update_current_repo called. Branches cleared."),
-            full: ("Code Review: update_current_repo called with repo_path: {:?}", repo_path)
-        );
-        // Take the queue from the old state (after cancelling pending work) so
-        // we can reuse it in the new RepositoryState instead of dropping and
-        // recreating it.
-        let reused_queue = self.active_repo.take().map(|mut repo| {
-            repo.file_invalidation.cancel_all();
-            repo.file_invalidation.queue
-        });
-        let created_new_queue = reused_queue.is_none();
-        self.active_repo = repo_path.map(|p| {
-            let queue =
-                reused_queue.unwrap_or_else(|| SyncQueue::new_streaming(ctx.background_executor()));
-            RepositoryState::new(p, queue)
-        });
-        if created_new_queue {
-            self.start_streaming_listener(ctx);
-        }
-    }
-
-    /// Prepares for a full invalidation by aborting in-flight file invalidation
-    /// tasks and marking that a full reload is pending.
-    fn queue_full_invalidation(&mut self) {
-        if let Some(repo) = self.active_repo.as_mut() {
-            repo.file_invalidation.cancel_all();
-            repo.file_invalidation.invalidate_all_pending = true;
-        }
-    }
-
-    /// Cancels in-flight file invalidation tasks and triggers a full diff
-    /// reload for the active repository.
-    fn load_diffs_for_active_repo(&mut self, fetch_base: bool, ctx: &mut ViewContext<Self>) {
-        self.queue_full_invalidation();
-        self.diff_state_model.update(ctx, |model, ctx| {
-            model.load_diffs_for_current_repo(fetch_base, ctx);
-        });
-    }
-
     /// Called when the code review view is opened/attached to a pane group.
-    /// Subscribes to the diff state model and triggers diff loading.
-    pub fn on_open(&mut self, repo_path: Option<PathBuf>, ctx: &mut ViewContext<Self>) {
+    /// Subscribes to the diff state model and enables metadata refresh.
+    pub fn on_open(&mut self, ctx: &mut ViewContext<Self>) {
         if self.is_open {
             return;
         }
         self.is_open = true;
 
-        self.update_current_repo(repo_path, ctx);
         ctx.subscribe_to_model(&self.diff_state_model, Self::handle_diff_state_model_event);
-        self.load_diffs_for_active_repo(false, ctx);
         if self.repo_path().is_some() {
             self.fetch_branches_and_setup_dropdown(ctx);
         }
@@ -865,6 +755,7 @@ impl CodeReviewView {
 
         self.diff_state_model.update(ctx, |model, ctx| {
             model.set_code_review_metadata_refresh_enabled(true, ctx);
+            model.load_diffs_for_current_repo(false, ctx);
         });
     }
 
@@ -880,10 +771,6 @@ impl CodeReviewView {
         self.diff_state_model.update(ctx, |model, ctx| {
             model.set_code_review_metadata_refresh_enabled(false, ctx);
         });
-
-        if let Some(repo) = self.active_repo.as_mut() {
-            repo.file_invalidation.cancel_all();
-        }
     }
 
     /// Handles events from the global LSP footer in workspace mode.
@@ -1401,12 +1288,7 @@ impl CodeReviewView {
         });
 
         let has_repo = repo_path.is_some();
-        let active_repo = repo_path.map(|repo_path| {
-            RepositoryState::new(
-                repo_path.clone(),
-                SyncQueue::new_streaming(ctx.background_executor()),
-            )
-        });
+        let active_repo = repo_path.map(|repo_path| RepositoryState::new(repo_path.clone()));
 
         let mut view = Self {
             active_repo,
@@ -1454,7 +1336,6 @@ impl CodeReviewView {
         };
         view.set_active_repo_comment_model(comment_batch_model, ctx);
         if has_repo {
-            view.start_streaming_listener(ctx);
             view.fetch_branches_and_setup_dropdown(ctx);
             view.invalidate_all(None, ctx);
         }
@@ -2427,60 +2308,28 @@ impl CodeReviewView {
         ctx: &mut ViewContext<Self>,
     ) {
         match event {
-            DiffStateModelEvent::DiffMetadataChanged(InvalidationBehavior::All(source)) => {
-                // If the invalidation is an index lock change AND we don't have an already pending invalidation,
-                // don't eagerly reload all of the diffs.
-                if matches!(source, InvalidationSource::IndexLockChange) {
-                    if let Some(repo) = self.active_repo.as_mut() {
-                        if !repo.file_invalidation.invalidate_all_pending {
-                            return;
-                        }
-                    }
-                }
-                self.fetch_branches_and_setup_dropdown(ctx);
-                self.load_diffs_for_active_repo(false, ctx);
-                self.update_aggregate_stats(ctx);
-                if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
-                    self.update_git_operations_ui(ctx);
-                }
-            }
-            DiffStateModelEvent::DiffMetadataChanged(InvalidationBehavior::AllLockedIndex) => {
-                // The git index is locked (e.g. during pull/merge). Cancel
-                // in-flight work and mark a full invalidation pending, but skip
-                // the diff reload — the data would be stale. When the lock
-                // clears, the watcher will fire a normal `All` event.
-                self.queue_full_invalidation();
-            }
-            DiffStateModelEvent::DiffMetadataChanged(InvalidationBehavior::Files(files)) => {
-                self.invalidate_files(files.clone(), ctx);
-                self.update_aggregate_stats(ctx);
-                if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
-                    self.update_git_operations_ui(ctx);
-                }
-            }
-            DiffStateModelEvent::DiffMetadataChanged(InvalidationBehavior::PromptRefresh) => {
-                self.update_aggregate_stats(ctx);
-                if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
-                    self.update_git_operations_ui(ctx);
-                }
-            }
             DiffStateModelEvent::CurrentBranchChanged => {
+                self.fetch_branches_and_setup_dropdown(ctx);
                 self.update_diff_selector_selection(ctx);
             }
-            DiffStateModelEvent::DiffModeChanged { should_fetch_base } => {
-                // Update the dropdown selection to reflect the new mode
-                let should_fetch_base = *should_fetch_base;
+            DiffStateModelEvent::DiffModeChanged => {
                 self.update_diff_selector_selection(ctx);
-
-                self.load_diffs_for_active_repo(should_fetch_base, ctx);
                 self.invalidate_all(None, ctx);
-                ctx.notify();
             }
             DiffStateModelEvent::NewDiffsComputed(diffs) => {
                 self.invalidate_all(diffs.as_ref(), ctx);
-                // After the view state is refreshed with fresh diffs, re-evaluate
-                // the git operations button (Commit / Push / Create PR) so that
-                // e.g. committing shows "Push" instead of staying on "Commit".
+                if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
+                    self.update_git_operations_ui(ctx);
+                }
+            }
+            DiffStateModelEvent::SingleFileUpdated { path, diff } => {
+                self.update_from_single_file_diff_result(path.clone(), diff.clone(), ctx);
+                if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
+                    self.update_git_operations_ui(ctx);
+                }
+            }
+            DiffStateModelEvent::MetadataRefreshed => {
+                self.update_aggregate_stats(ctx);
                 if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
                     self.update_git_operations_ui(ctx);
                 }
@@ -2495,202 +2344,83 @@ impl CodeReviewView {
         });
     }
 
-    fn invalidate_files(&mut self, files: Vec<PathBuf>, ctx: &mut ViewContext<Self>) {
-        let diff_mode = self.diff_state_model.as_ref(ctx).diff_mode();
-
-        // TODO: Remove pending file invalidations — pause the queue instead.
-        // Defer file invalidation if a full reload is in-flight or the diff is still loading.
-        {
-            let Some(repo) = self.active_repo.as_mut() else {
-                return;
-            };
-            if repo.file_invalidation.invalidate_all_pending
-                || matches!(repo.state, CodeReviewViewState::None)
-            {
-                match &mut repo.pending_file_updates {
-                    Some(pending_file_update) => {
-                        pending_file_update
-                            .update_with_file_invalidation(repo.repo_path.clone(), files);
-                    }
-                    None => {
-                        repo.pending_file_updates = Some(PendingFileUpdate {
-                            repo_path: repo.repo_path.clone(),
-                            pending_file_edits: HashSet::from_iter(files),
-                        });
-                    }
-                }
-                return;
-            }
-        }
-
-        let Some(repo) = self.active_repo.as_ref() else {
-            return;
-        };
-        let repo_path = repo.repo_path.clone();
-        let merge_base = repo.file_invalidation.merge_base.clone();
-        self.enqueue_file_invalidations(files, diff_mode, merge_base, repo_path);
-    }
-
-    /// Processes any pending file invalidations that occurred during a full refresh.
-    fn flush_pending_invalidations(&mut self, ctx: &mut ViewContext<Self>) {
-        let pending = self.active_repo.as_mut().and_then(|repo| {
-            repo.file_invalidation.invalidate_all_pending = false;
-            repo.pending_file_updates
-                .take()
-                .filter(|p| p.repo_path == repo.repo_path)
-        });
-        if let Some(pending) = pending {
-            self.invalidate_files(pending.pending_file_edits.into_iter().collect(), ctx);
-        }
-    }
-
-    /// Starts the streaming listener that receives broadcast results from the
-    /// file invalidation queue.
-    fn start_streaming_listener(&mut self, ctx: &mut ViewContext<Self>) {
-        let Some(repo) = self.active_repo.as_ref() else {
-            return;
-        };
-        let rx = repo.file_invalidation.queue.subscribe();
-
-        ctx.spawn_stream_local(
-            rx,
-            |me, broadcast_result, ctx| {
-                let queue_active = me
-                    .active_repo
-                    .as_ref()
-                    .is_some_and(|repo| !repo.file_invalidation.invalidate_all_pending);
-                if queue_active {
-                    let anyhow_result = match broadcast_result {
-                        Ok(arc_value) => Arc::try_unwrap(arc_value).map_err(|_| {
-                            anyhow::anyhow!("broadcast result has multiple owners, cannot unwrap")
-                        }),
-                        Err(arc_error) => Err(anyhow::anyhow!("{arc_error}")),
-                    };
-                    me.update_from_single_file_diff_result(anyhow_result, ctx);
-                }
-            },
-            |_, _| {},
-        );
-    }
-
-    /// Enqueues individual file invalidation tasks into the [`SyncQueue`],
-    /// skipping files that are already queued.
-    fn enqueue_file_invalidations(
-        &mut self,
-        files: Vec<PathBuf>,
-        mode: DiffMode,
-        merge_base: Option<String>,
-        repo_path: PathBuf,
-    ) {
-        let Some(repo) = self.active_repo.as_ref() else {
-            return;
-        };
-        let queue = repo.file_invalidation.queue.clone();
-        for file in files {
-            let task = FileInvalidationTask {
-                file,
-                repo_path: repo_path.clone(),
-                mode: mode.clone(),
-                merge_base: merge_base.clone(),
-            };
-
-            queue.enqueue(task, None, "file-invalidation");
-        }
-    }
-
     /// Updates the code review view with the diff result for a single updated
     /// file from the queue-based invalidation path.
     fn update_from_single_file_diff_result(
         &mut self,
-        result: anyhow::Result<(PathBuf, Option<FileDiffAndContent>)>,
+        file_path: PathBuf,
+        updated_diff: Option<Arc<FileDiffAndContent>>,
         ctx: &mut ViewContext<Self>,
     ) {
-        match result {
-            Ok((file_path, updated_diff)) => {
-                let mut diff_data = {
-                    let Some(repo) = self.active_repo.as_mut() else {
-                        return;
-                    };
-                    match repo.pop_loaded_state() {
-                        Some(data) => data,
-                        None => return,
-                    }
-                };
-
-                let existing_index = diff_data.file_states.get_index_of(&file_path);
-
-                match (existing_index, updated_diff) {
-                    (Some(index), Some(diff)) => {
-                        let status_changed = file_status_changed_deleted_state(
-                            &diff_data.file_states[index].file_diff.status,
-                            &diff.file_diff.status,
-                        );
-
-                        if status_changed {
-                            diff_data.file_states.shift_remove_index(index);
-                            self.viewported_list_state.remove(index);
-                            let new_states = self
-                                .build_view_state_for_file_diffs(std::slice::from_ref(&diff), ctx);
-                            diff_data.file_states.extend(
-                                new_states
-                                    .into_iter()
-                                    .map(|state| (state.file_diff.file_path.clone(), state)),
-                            );
-                        } else {
-                            let current = &mut diff_data.file_states[index];
-                            let should_apply = current
-                                .editor_state
-                                .as_ref()
-                                .map(|es| !es.has_unsaved_changes(ctx))
-                                .unwrap_or(true);
-                            if should_apply {
-                                current.file_diff = diff.file_diff;
-                            }
-                            self.viewported_list_state
-                                .invalidate_height_for_index(index);
-                        }
-                    }
-                    (Some(index), None) => {
-                        diff_data.file_states.shift_remove_index(index);
-                        self.viewported_list_state.remove(index);
-                    }
-                    (None, Some(diff)) => {
-                        let new_states =
-                            self.build_view_state_for_file_diffs(std::slice::from_ref(&diff), ctx);
-                        diff_data.file_states.extend(
-                            new_states
-                                .into_iter()
-                                .map(|state| (state.file_diff.file_path.clone(), state)),
-                        );
-                    }
-                    (None, None) => {}
-                }
-
-                if let Some(repo) = self.active_repo.as_mut() {
-                    repo.state = CodeReviewViewState::Loaded(diff_data);
-                }
-
-                self.update_editor_comment_markers(ctx);
-                GlobalBufferModel::handle(ctx).update(ctx, |model, ctx| {
-                    model.remove_deallocated_buffers(ctx);
-                });
-                ctx.notify();
+        let mut diff_data = {
+            let Some(repo) = self.active_repo.as_mut() else {
+                return;
+            };
+            match repo.pop_loaded_state() {
+                Some(data) => data,
+                None => return,
             }
-            Err(e) => {
-                if ChannelState::enable_debug_features() {
-                    log::error!("Failed to retrieve diff state for single file: {e}. Retrying...");
-                }
+        };
 
-                send_telemetry_from_ctx!(
-                    CodeReviewTelemetryEvent::LoadDiffFailed {
-                        error: e.to_string(),
-                    },
-                    ctx
+        let existing_index = diff_data.file_states.get_index_of(&file_path);
+
+        match (existing_index, updated_diff) {
+            (Some(index), Some(diff)) => {
+                let diff = diff.as_ref();
+                let status_changed = file_status_changed_deleted_state(
+                    &diff_data.file_states[index].file_diff.status,
+                    &diff.file_diff.status,
                 );
 
-                self.load_diffs_for_active_repo(false, ctx);
+                if status_changed {
+                    diff_data.file_states.shift_remove_index(index);
+                    self.viewported_list_state.remove(index);
+                    let new_states =
+                        self.build_view_state_for_file_diffs(std::slice::from_ref(diff), ctx);
+                    diff_data.file_states.extend(
+                        new_states
+                            .into_iter()
+                            .map(|state| (state.file_diff.file_path.clone(), state)),
+                    );
+                } else {
+                    let current = &mut diff_data.file_states[index];
+                    let should_apply = current
+                        .editor_state
+                        .as_ref()
+                        .map(|es| !es.has_unsaved_changes(ctx))
+                        .unwrap_or(true);
+                    if should_apply {
+                        current.file_diff = diff.file_diff.clone();
+                    }
+                    self.viewported_list_state
+                        .invalidate_height_for_index(index);
+                }
             }
+            (Some(index), None) => {
+                diff_data.file_states.shift_remove_index(index);
+                self.viewported_list_state.remove(index);
+            }
+            (None, Some(diff)) => {
+                let new_states =
+                    self.build_view_state_for_file_diffs(std::slice::from_ref(diff.as_ref()), ctx);
+                diff_data.file_states.extend(
+                    new_states
+                        .into_iter()
+                        .map(|state| (state.file_diff.file_path.clone(), state)),
+                );
+            }
+            (None, None) => {}
         }
+
+        if let Some(repo) = self.active_repo.as_mut() {
+            repo.state = CodeReviewViewState::Loaded(diff_data);
+        }
+
+        self.update_editor_comment_markers(ctx);
+        GlobalBufferModel::handle(ctx).update(ctx, |model, ctx| {
+            model.remove_deallocated_buffers(ctx);
+        });
+        ctx.notify();
     }
 
     fn update_aggregate_stats(&mut self, ctx: &mut ViewContext<Self>) {
@@ -2788,8 +2518,6 @@ impl CodeReviewView {
             });
         }
 
-        self.recompute_merge_base_and_flush(ctx);
-
         if self.all_editors_loaded() {
             let diff_mode = self.diff_state_model.as_ref(ctx).diff_mode();
             self.reposition_comments_in_file(&diff_mode, ctx);
@@ -2802,54 +2530,6 @@ impl CodeReviewView {
         }
 
         ctx.notify();
-    }
-
-    /// Recomputes the merge base commit for the current diff mode after a full
-    /// reload, then flushes any file invalidations that were deferred while the
-    /// reload was in-flight.
-    ///
-    /// We cache the merge base on [`FileInvalidationState`] so that individual
-    /// file invalidations (triggered by the file watcher) can diff against the
-    /// correct base without re-running `git merge-base` on every file change.
-    /// The cache is invalidated by [`FileInvalidationState::cancel_all`] at the
-    /// start of every full reload, so it is always fresh by the time
-    /// watcher-driven invalidations resume.
-    ///
-    /// For non-Head diff modes the computation is async (it shells out to git),
-    /// so we keep the `invalidate_all_pending` flag set until it completes.
-    /// This ensures watcher-driven file invalidations are deferred rather than
-    /// enqueued without a merge base.
-    fn recompute_merge_base_and_flush(&mut self, ctx: &mut ViewContext<Self>) {
-        let diff_mode = self.diff_state_model.as_ref(ctx).diff_mode();
-        if !matches!(diff_mode, DiffMode::Head) {
-            if let Some(repo) = self.active_repo.as_ref() {
-                let repo_path = repo.repo_path.clone();
-                let handle = ctx.spawn(
-                    async move { DiffStateModel::compute_merge_base(&repo_path, &diff_mode).await },
-                    |me, result, ctx| {
-                        if let Some(repo) = me.active_repo.as_mut() {
-                            repo.file_invalidation.merge_base_handle = None;
-                        }
-                        match &result {
-                            Ok(merge_base) => {
-                                if let Some(repo) = me.active_repo.as_mut() {
-                                    repo.file_invalidation.merge_base = Some(merge_base.clone());
-                                }
-                            }
-                            Err(e) => {
-                                log::error!("Failed to compute merge base: {e}");
-                            }
-                        }
-                        me.flush_pending_invalidations(ctx);
-                    },
-                );
-                if let Some(repo) = self.active_repo.as_mut() {
-                    repo.file_invalidation.merge_base_handle = Some(handle);
-                }
-            }
-        } else {
-            self.flush_pending_invalidations(ctx);
-        }
     }
 
     /// Builds view state for the given file diffs, returning the list of newly created file states.
@@ -6621,12 +6301,12 @@ impl CodeReviewView {
         }
     }
 
-    /// Refreshes diffs, metadata, and PR info after a git operation (commit, push, etc.).
+    /// Refreshes metadata and PR info after a git operation (commit, push, etc.).
+    /// Diff reloading is left to the file watcher (for commits) or skipped
+    /// entirely (for push/create-PR where the working directory is unchanged).
     fn refresh_after_git_operation(&mut self, ctx: &mut ViewContext<Self>) {
-        self.load_diffs_for_active_repo(false, ctx);
         self.diff_state_model.update(ctx, |model, ctx| {
-            model.refresh_diff_metadata_for_current_repo(InvalidationBehavior::PromptRefresh, ctx);
-            model.refresh_pr_info(ctx);
+            model.refresh_metadata_and_pr_info(ctx);
         });
         ctx.notify();
     }
@@ -7463,7 +7143,10 @@ impl TypedActionView for CodeReviewView {
                 self.save_files(unsaved_files.as_slice(), ctx);
             }
             CodeReviewAction::RefreshGitState => {
-                self.load_diffs_for_active_repo(false, ctx);
+                self.diff_state_model.update(ctx, |model, ctx| {
+                    model.load_diffs_for_current_repo(false, ctx);
+                    model.refresh_metadata_and_pr_info(ctx);
+                });
             }
             CodeReviewAction::UndoRevert => {
                 self.maybe_undo_revert(ctx);

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -1616,6 +1616,8 @@ impl CodeReviewView {
         self.diff_state_model.update(ctx, |model, ctx| {
             model.set_diff_mode(mode, false, ctx);
         });
+        self.update_diff_selector_selection(ctx);
+        self.invalidate_all(None, ctx);
     }
 
     fn handle_find_event(
@@ -2312,10 +2314,6 @@ impl CodeReviewView {
                 self.fetch_branches_and_setup_dropdown(ctx);
                 self.update_diff_selector_selection(ctx);
             }
-            DiffStateModelEvent::DiffModeChanged => {
-                self.update_diff_selector_selection(ctx);
-                self.invalidate_all(None, ctx);
-            }
             DiffStateModelEvent::NewDiffsComputed(diffs) => {
                 self.invalidate_all(diffs.as_ref(), ctx);
                 if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
@@ -2328,11 +2326,27 @@ impl CodeReviewView {
                     self.update_git_operations_ui(ctx);
                 }
             }
-            DiffStateModelEvent::MetadataRefreshed => {
-                self.update_aggregate_stats(ctx);
+            DiffStateModelEvent::MetadataRefreshed(metadata) => {
+                let mode = self.diff_state_model.as_ref(ctx).diff_mode();
+                if let Some(CodeReviewViewState::Loaded(loaded_state)) = self.state_mut() {
+                    let stats = match mode {
+                        DiffMode::Head => Some(metadata.against_head.aggregate_stats),
+                        DiffMode::MainBranch => metadata
+                            .against_base_branch
+                            .as_ref()
+                            .map(|base| base.aggregate_stats),
+                        DiffMode::OtherBranch(_) => None,
+                    };
+                    if let Some(stats) = stats {
+                        loaded_state.total_additions = stats.total_additions;
+                        loaded_state.total_deletions = stats.total_deletions;
+                        loaded_state.files_changed = stats.files_changed;
+                    }
+                }
                 if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
                     self.update_git_operations_ui(ctx);
                 }
+                ctx.notify();
             }
         }
     }
@@ -2420,26 +2434,6 @@ impl CodeReviewView {
         GlobalBufferModel::handle(ctx).update(ctx, |model, ctx| {
             model.remove_deallocated_buffers(ctx);
         });
-        ctx.notify();
-    }
-
-    fn update_aggregate_stats(&mut self, ctx: &mut ViewContext<Self>) {
-        let Some(diff_stats) = self
-            .diff_state_model
-            .as_ref(ctx)
-            .get_stats_for_current_mode()
-        else {
-            return;
-        };
-
-        let Some(CodeReviewViewState::Loaded(loaded_state)) = self.state_mut() else {
-            return;
-        };
-
-        loaded_state.total_additions = diff_stats.total_additions;
-        loaded_state.total_deletions = diff_stats.total_deletions;
-        loaded_state.files_changed = diff_stats.files_changed;
-
         ctx.notify();
     }
 
@@ -5979,7 +5973,9 @@ impl CodeReviewView {
     pub(crate) fn set_diff_base(&mut self, diff_mode: DiffMode, ctx: &mut ViewContext<Self>) {
         self.diff_state_model.update(ctx, |diff_state_model, ctx| {
             diff_state_model.set_diff_mode_and_fetch_base(diff_mode, ctx);
-        })
+        });
+        self.update_diff_selector_selection(ctx);
+        self.invalidate_all(None, ctx);
     }
 
     /// Insert diff hunk as an inline attachment in the terminal input

--- a/app/src/code_review/code_review_view_tests.rs
+++ b/app/src/code_review/code_review_view_tests.rs
@@ -862,27 +862,13 @@ fn test_on_close_then_on_open_reinitializes_repo_state() {
 
         // Re-open the view
         ctx.code_review_view.update(&mut app, |view, view_ctx| {
-            view.on_open(Some(repo_path.clone()), view_ctx);
+            view.on_open(view_ctx);
 
             assert!(view.is_open, "View should be open after on_open");
             assert_eq!(
                 view.repo_path(),
                 Some(&repo_path),
-                "Repo path should be set after on_open"
-            );
-
-            // available_branches should be empty after on_open resets the repo state,
-            // because update_current_repo creates a fresh RepositoryState.
-            // The async fetch_branches_and_rebuild_diff_selector has been initiated
-            // but hasn't completed yet (git command will fail in test env).
-            let branches_count = view
-                .active_repo
-                .as_ref()
-                .map(|repo| repo.available_branches.len())
-                .unwrap_or(0);
-            assert_eq!(
-                branches_count, 0,
-                "Branches should be empty immediately after on_open (async fetch pending)"
+                "Repo path should be preserved after on_open (set at construction)"
             );
         });
     });

--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -341,21 +341,21 @@ struct DiffsWithBaseContent {
     changes: Result<GitDiffWithBaseContent, String>,
 }
 
-#[derive(Default)]
-struct DiffMetadata {
-    main_branch_name: String,
-    current_branch_name: String,
-    against_head: DiffMetadataAgainstBase,
-    against_base_branch: Option<DiffMetadataAgainstBase>,
-    has_head_commit: bool,
-    unpushed_commits: Vec<Commit>,
-    upstream_ref: Option<String>,
-    pr_info: Option<PrInfo>,
+#[derive(Clone, Debug, Default)]
+pub struct DiffMetadata {
+    pub main_branch_name: String,
+    pub current_branch_name: String,
+    pub against_head: DiffMetadataAgainstBase,
+    pub against_base_branch: Option<DiffMetadataAgainstBase>,
+    pub has_head_commit: bool,
+    pub unpushed_commits: Vec<Commit>,
+    pub upstream_ref: Option<String>,
+    pub pr_info: Option<PrInfo>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct DiffMetadataAgainstBase {
-    pub(super) aggregate_stats: DiffStats,
+    pub aggregate_stats: DiffStats,
 }
 
 impl DiffMetadataAgainstBase {
@@ -503,14 +503,13 @@ impl DiffStateModel {
                         ctx.emit(DiffStateModelEvent::SingleFileUpdated { path, diff });
                     }
                     Err(err) => {
-                        log::error!("File invalidation error: {err}. Falling back to full reload.");
+                        log::error!("File invalidation error: {err}");
                         send_telemetry_from_ctx!(
                             CodeReviewTelemetryEvent::LoadDiffFailed {
                                 error: err.to_string(),
                             },
                             ctx
                         );
-                        me.load_diffs_for_current_repo(false, ctx);
                     }
                 }
             },
@@ -714,22 +713,6 @@ impl DiffStateModel {
         }
     }
 
-    pub fn get_stats_for_current_mode(&self) -> Option<DiffStats> {
-        self.get_stats_for_mode(self.mode.clone())
-    }
-
-    pub fn get_stats_for_mode(&self, mode: DiffMode) -> Option<DiffStats> {
-        let metadata = self.metadata.as_ref()?;
-        match mode {
-            DiffMode::Head => Some(metadata.against_head.aggregate_stats),
-            DiffMode::MainBranch => metadata
-                .against_base_branch
-                .as_ref()
-                .map(|base| base.aggregate_stats),
-            DiffMode::OtherBranch(_) => None, // TODO: implement caching for arbitrary branches
-        }
-    }
-
     /// Returns `true` once the repository has at least one commit.
     pub(super) fn has_head(&self) -> bool {
         cfg_if::cfg_if! {
@@ -761,12 +744,8 @@ impl DiffStateModel {
     /// Cancels in-flight per-file invalidation tasks and marks a full
     /// invalidation pending so that stale queue results are suppressed
     /// until the reload completes.
-    ///
-    /// Called automatically by [`Self::load_diffs_for_current_repo`]. The
-    /// only standalone use is [`DiffStateRepositoryUpdate::InvalidationWithLockedIndex`],
-    /// which needs to suppress the queue without starting a reload.
     #[cfg(feature = "local_fs")]
-    fn prepare_full_reload(&mut self) {
+    fn queue_full_invalidation(&mut self) {
         self.file_invalidation.cancel_all();
         self.file_invalidation.invalidate_all_pending = true;
     }
@@ -780,7 +759,6 @@ impl DiffStateModel {
         if self.mode != mode {
             self.mode = mode;
             self.load_diffs_for_current_repo(should_fetch_base, ctx);
-            ctx.emit(DiffStateModelEvent::DiffModeChanged);
         }
     }
 
@@ -802,7 +780,7 @@ impl DiffStateModel {
     ) {
         // Cancels in-flight per-file invalidation tasks so that stale queue results cannot
         // race with the new full reload.
-        self.prepare_full_reload();
+        self.queue_full_invalidation();
 
         // Abort any previous diff loading operations before spawning a new one.
         if let Some(handle) = self.computing_diffs_abort_handle.take() {
@@ -1253,7 +1231,7 @@ impl DiffStateModel {
                     }
                 }
                 DiffStateRepositoryUpdate::InvalidationWithLockedIndex => {
-                    me.prepare_full_reload();
+                    me.queue_full_invalidation();
                 }
             },
             |_, _| {},
@@ -1271,9 +1249,8 @@ impl DiffStateModel {
     }
 
     #[cfg(feature = "local_fs")]
-    /// Processes a repository file-system update. Instead of emitting raw
-    /// invalidation signals, the model now acts on the decision directly:
-    /// full reloads or per-file invalidation queue.
+    /// Processes a repository file-system update and
+    /// decides whether to trigger a full reload or a per-file invalidation queue.
     ///
     /// Returns `true` if a metadata refresh should be triggered.
     fn handle_file_update(
@@ -1303,10 +1280,14 @@ impl DiffStateModel {
             // MetadataRefreshed with fresh stats/git-operations data.
             return true;
         } else if index_lock_detected {
-            // Index lock appeared/disappeared without a commit change.
-            // Suppress the per-file queue (data may be stale while lock is held)
-            // but don't start a reload — wait for the lock-release event.
-            self.prepare_full_reload();
+            if self.file_invalidation.invalidate_all_pending {
+                // Lock was released while a full invalidation was pending — reload now.
+                self.load_diffs_for_current_repo(false, ctx);
+                return true;
+            }
+            // Lock just appeared — suppress the per-file queue (data may be stale
+            // while the lock is held) and wait for the lock-release event.
+            self.queue_full_invalidation();
             return false;
         }
 
@@ -1361,7 +1342,8 @@ impl DiffStateModel {
         };
 
         if self.file_invalidation.invalidate_all_pending {
-            // Defer — a full reload will supersede these.
+            // TODO: Remove pending file invalidations — pause the queue instead.
+            // Defer file invalidation if a full reload is in-flight or the diff is still loading.
             match &mut self.pending_file_updates {
                 Some(pending) => {
                     pending.update_with_file_invalidation(repo_path, files);
@@ -1406,8 +1388,21 @@ impl DiffStateModel {
         }
     }
 
-    /// Recomputes the merge base for the current diff mode, then flushes
-    /// any deferred file invalidations.
+    /// Recomputes the merge base commit for the current diff mode after a full
+    /// reload, then flushes any file invalidations that were deferred while the
+    /// reload was in-flight.
+    ///
+    /// We cache the merge base on [`FileInvalidationState`] so that individual
+    /// file invalidations (triggered by the file watcher) can diff against the
+    /// correct base without re-running `git merge-base` on every file change.
+    /// The cache is invalidated by [`FileInvalidationState::cancel_all`] at the
+    /// start of every full reload, so it is always fresh by the time
+    /// watcher-driven invalidations resume.
+    ///
+    /// For non-Head diff modes the computation is async (it shells out to git),
+    /// so we keep the `invalidate_all_pending` flag set until it completes.
+    /// This ensures watcher-driven file invalidations are deferred rather than
+    /// enqueued without a merge base.
     #[cfg(feature = "local_fs")]
     fn recompute_merge_base_and_flush(&mut self, ctx: &mut ModelContext<Self>) {
         let diff_mode = self.mode.clone();
@@ -1701,7 +1696,9 @@ impl DiffStateModel {
         if should_reload_diffs {
             self.load_diffs_for_current_repo(false, ctx);
         }
-        ctx.emit(DiffStateModelEvent::MetadataRefreshed);
+        if let Some(metadata) = self.metadata.clone() {
+            ctx.emit(DiffStateModelEvent::MetadataRefreshed(metadata));
+        }
     }
 
     #[cfg(feature = "local_fs")]
@@ -3077,7 +3074,7 @@ impl DiffStateModel {
                 me.refreshing_pr_info_handle = None;
                 if let Some(metadata) = &mut me.metadata {
                     metadata.pr_info = pr_info;
-                    ctx.emit(DiffStateModelEvent::MetadataRefreshed);
+                    ctx.emit(DiffStateModelEvent::MetadataRefreshed(metadata.clone()));
                 }
             },
         );
@@ -3100,10 +3097,7 @@ pub enum DiffStateModelEvent {
         diff: Option<Arc<FileDiffAndContent>>,
     },
     /// Event dispatched when diff metadata (stats, branch info) is refreshed.
-    MetadataRefreshed,
-    /// Event dispatched when new diff mode is set. The model handles the
-    /// diff reload internally; the view only needs to update UI state.
-    DiffModeChanged,
+    MetadataRefreshed(DiffMetadata),
 }
 
 impl warpui::Entity for DiffStateModel {

--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -5,10 +5,8 @@
 
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "local_fs")]
-use std::time::Duration;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs::File,
     io::{BufRead, BufReader, Read, Seek},
     path::{Path, PathBuf},
@@ -43,7 +41,11 @@ use crate::code_review::CodeReviewTelemetryEvent;
 use crate::throttle::throttle;
 #[cfg(not(target_family = "wasm"))]
 use warp_core::channel::ChannelState;
+#[cfg(feature = "local_fs")]
+use warp_core::sync_queue::SyncQueue;
 use warp_core::{safe_warn, send_telemetry_from_ctx};
+
+use super::file_invalidation_queue::{FileInvalidationError, FileInvalidationTask};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
@@ -362,6 +364,66 @@ impl DiffMetadataAgainstBase {
     }
 }
 
+/// Tracks state for in-flight file invalidation tasks and full-reload coordination.
+#[cfg(feature = "local_fs")]
+struct FileInvalidationState {
+    /// Whether a full invalidation is in-flight.
+    /// When true, per-file invalidation requests are deferred to `pending_file_updates`.
+    invalidate_all_pending: bool,
+    /// Merge base commit for the current diff mode, computed eagerly during
+    /// full invalidation.
+    merge_base: Option<String>,
+    /// Handle for the in-flight merge base computation spawned during full
+    /// invalidation. Aborted when a new full invalidation starts.
+    merge_base_handle: Option<SpawnedFutureHandle>,
+    /// Queue for per-file invalidation tasks
+    queue: SyncQueue<FileInvalidationTask>,
+}
+
+#[cfg(feature = "local_fs")]
+impl FileInvalidationState {
+    fn new(queue: SyncQueue<FileInvalidationTask>) -> Self {
+        Self {
+            invalidate_all_pending: false,
+            merge_base: None,
+            merge_base_handle: None,
+            queue,
+        }
+    }
+
+    fn cancel_all(&mut self) {
+        self.queue.cancel_all();
+        self.merge_base = None;
+        if let Some(handle) = self.merge_base_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// Files that have been invalidated but not yet processed while a full diff
+/// reload is in-flight.
+#[cfg(feature = "local_fs")]
+struct PendingFileUpdate {
+    repo_path: PathBuf,
+    pending_file_edits: HashSet<PathBuf>,
+}
+
+#[cfg(feature = "local_fs")]
+impl PendingFileUpdate {
+    fn update_with_file_invalidation(
+        &mut self,
+        repo_path: PathBuf,
+        invalidated_files: Vec<PathBuf>,
+    ) {
+        if self.repo_path != repo_path {
+            self.repo_path = repo_path;
+            self.pending_file_edits = HashSet::from_iter(invalidated_files);
+        } else {
+            self.pending_file_edits.extend(invalidated_files);
+        }
+    }
+}
+
 /// Model that contains all state related to the current pane's open git repository.
 pub struct DiffStateModel {
     #[cfg(feature = "local_fs")]
@@ -377,6 +439,13 @@ pub struct DiffStateModel {
     /// Controls whether periodic throttled metadata refresh is active.
     /// Refresh is suppressed when the code review pane is not open.
     metadata_refresh_enabled: bool,
+    // TODO: Remove pending file invalidations — pause the queue instead.
+    /// Files that have been invalidated but not yet processed when diff is still loading.
+    #[cfg(feature = "local_fs")]
+    pending_file_updates: Option<PendingFileUpdate>,
+    /// State for tracking in-flight file invalidation tasks.
+    #[cfg(feature = "local_fs")]
+    file_invalidation: FileInvalidationState,
 }
 
 #[derive(Debug, Copy, Clone, Default)]
@@ -410,6 +479,44 @@ struct GitNumStatMetadata {
 impl DiffStateModel {
     #[cfg(feature = "local_fs")]
     pub fn new(repo_path: Option<String>, ctx: &mut ModelContext<Self>) -> Self {
+        // Set up file invalidation queue and subscribe to results
+        // so the model can emit SingleFileUpdated events.
+        let queue = SyncQueue::new_streaming(&ctx.background_executor());
+        let rx = queue.subscribe();
+
+        ctx.spawn_stream_local(
+            rx,
+            |me, broadcast_result: Result<_, Arc<FileInvalidationError>>, ctx| {
+                if me.file_invalidation.invalidate_all_pending {
+                    return;
+                }
+                match broadcast_result {
+                    Ok(arc_value) => {
+                        let (path, diff): (PathBuf, Option<Arc<FileDiffAndContent>>) =
+                            match Arc::try_unwrap(arc_value) {
+                                Ok((path, diff)) => (path, diff),
+                                Err(arc_value) => {
+                                    let (path, diff) = arc_value.as_ref();
+                                    (path.clone(), diff.clone())
+                                }
+                            };
+                        ctx.emit(DiffStateModelEvent::SingleFileUpdated { path, diff });
+                    }
+                    Err(err) => {
+                        log::error!("File invalidation error: {err}. Falling back to full reload.");
+                        send_telemetry_from_ctx!(
+                            CodeReviewTelemetryEvent::LoadDiffFailed {
+                                error: err.to_string(),
+                            },
+                            ctx
+                        );
+                        me.load_diffs_for_current_repo(false, ctx);
+                    }
+                }
+            },
+            |_, _| {},
+        );
+
         let model = Self {
             repository: None,
             state: InternalDiffState::default(),
@@ -420,6 +527,8 @@ impl DiffStateModel {
             computing_metadata_abort_handle: None,
             refreshing_pr_info_handle: None,
             metadata_refresh_enabled: false,
+            file_invalidation: FileInvalidationState::new(queue),
+            pending_file_updates: None,
         };
 
         if let Some(repo_path) = &repo_path {
@@ -649,6 +758,19 @@ impl DiffStateModel {
         None
     }
 
+    /// Cancels in-flight per-file invalidation tasks and marks a full
+    /// invalidation pending so that stale queue results are suppressed
+    /// until the reload completes.
+    ///
+    /// Called automatically by [`Self::load_diffs_for_current_repo`]. The
+    /// only standalone use is [`DiffStateRepositoryUpdate::InvalidationWithLockedIndex`],
+    /// which needs to suppress the queue without starting a reload.
+    #[cfg(feature = "local_fs")]
+    fn prepare_full_reload(&mut self) {
+        self.file_invalidation.cancel_all();
+        self.file_invalidation.invalidate_all_pending = true;
+    }
+
     pub fn set_diff_mode(
         &mut self,
         mode: DiffMode,
@@ -657,7 +779,8 @@ impl DiffStateModel {
     ) {
         if self.mode != mode {
             self.mode = mode;
-            ctx.emit(DiffStateModelEvent::DiffModeChanged { should_fetch_base });
+            self.load_diffs_for_current_repo(should_fetch_base, ctx);
+            ctx.emit(DiffStateModelEvent::DiffModeChanged);
         }
     }
 
@@ -677,6 +800,10 @@ impl DiffStateModel {
         should_fetch_base: bool,
         ctx: &mut ModelContext<Self>,
     ) {
+        // Cancels in-flight per-file invalidation tasks so that stale queue results cannot
+        // race with the new full reload.
+        self.prepare_full_reload();
+
         // Abort any previous diff loading operations before spawning a new one.
         if let Some(handle) = self.computing_diffs_abort_handle.take() {
             handle.abort();
@@ -990,10 +1117,7 @@ impl DiffStateModel {
             |me, result, ctx| match result {
                 Ok(_) => {
                     me.load_diffs_for_current_repo(false, ctx);
-                    me.refresh_diff_metadata_for_current_repo(
-                        InvalidationBehavior::PromptRefresh,
-                        ctx,
-                    );
+                    me.refresh_diff_metadata_for_current_repo(false, ctx);
                 }
                 Err(err) => {
                     log::error!("Failed to restore files: {err}");
@@ -1024,7 +1148,7 @@ impl DiffStateModel {
         let was_enabled = self.metadata_refresh_enabled;
         self.metadata_refresh_enabled = enabled;
         if !was_enabled && enabled {
-            self.refresh_diff_metadata_for_current_repo(InvalidationBehavior::PromptRefresh, ctx);
+            self.refresh_diff_metadata_for_current_repo(false, ctx);
         }
     }
 
@@ -1032,7 +1156,7 @@ impl DiffStateModel {
     #[cfg(feature = "local_fs")]
     pub fn refresh_diff_metadata_for_current_repo(
         &mut self,
-        invalidation_behavior: InvalidationBehavior,
+        should_reload_diffs: bool,
         ctx: &mut ModelContext<Self>,
     ) {
         if !self.metadata_refresh_enabled {
@@ -1055,9 +1179,7 @@ impl DiffStateModel {
             async move {
                 Self::load_metadata_for_repo(current_repository_path, include_base_branch).await
             },
-            move |me, res, ctx| {
-                me.handle_updated_metadata_for_repo(res, invalidation_behavior, ctx)
-            },
+            move |me, res, ctx| me.handle_updated_metadata_for_repo(res, should_reload_diffs, ctx),
         );
         self.computing_metadata_abort_handle = Some(abort_handle);
     }
@@ -1065,7 +1187,7 @@ impl DiffStateModel {
     #[cfg(not(feature = "local_fs"))]
     pub fn refresh_diff_metadata_for_current_repo(
         &mut self,
-        _invalidation_behavior: InvalidationBehavior,
+        _should_reload_diffs: bool,
         _ctx: &mut ModelContext<Self>,
     ) {
         // Noop on WASM builds.
@@ -1077,6 +1199,8 @@ impl DiffStateModel {
         new_repository: ModelHandle<Repository>,
         ctx: &mut ModelContext<Self>,
     ) {
+        use std::time::Duration;
+
         let new_repository_root = new_repository.as_ref(ctx).root_dir().to_local_path_lossy();
 
         // Always include base branch metadata since only code review uses this model now.
@@ -1086,13 +1210,7 @@ impl DiffStateModel {
                 async move {
                     Self::load_metadata_for_repo(new_repository_root, include_base_branch).await
                 },
-                move |me, res, ctx| {
-                    me.handle_updated_metadata_for_repo(
-                        res,
-                        InvalidationBehavior::All(InvalidationSource::MetadataChange),
-                        ctx,
-                    )
-                },
+                move |me, res, ctx| me.handle_updated_metadata_for_repo(res, true, ctx),
             );
 
         self.computing_metadata_abort_handle = Some(abort_handle);
@@ -1135,9 +1253,7 @@ impl DiffStateModel {
                     }
                 }
                 DiffStateRepositoryUpdate::InvalidationWithLockedIndex => {
-                    ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
-                        InvalidationBehavior::AllLockedIndex,
-                    ));
+                    me.prepare_full_reload();
                 }
             },
             |_, _| {},
@@ -1148,15 +1264,16 @@ impl DiffStateModel {
         ctx.spawn_stream_local(
             throttle(Duration::from_secs(5), throttled_repository_update_rx),
             |me, _, ctx| {
-                me.refresh_diff_metadata_for_current_repo(InvalidationBehavior::PromptRefresh, ctx);
+                me.refresh_diff_metadata_for_current_repo(false, ctx);
             },
             |_, _| {},
         );
     }
 
     #[cfg(feature = "local_fs")]
-    /// Processes a repository file-system update, emitting a `DiffMetadataChanged` event
-    /// when relevant (non-ignored) files are affected.
+    /// Processes a repository file-system update. Instead of emitting raw
+    /// invalidation signals, the model now acts on the decision directly:
+    /// full reloads or per-file invalidation queue.
     ///
     /// Returns `true` if a metadata refresh should be triggered.
     fn handle_file_update(
@@ -1178,44 +1295,156 @@ impl DiffStateModel {
             index_lock_detected,
         } = update;
 
-        let invalidation_behavior = if commit_updated {
-            InvalidationBehavior::All(InvalidationSource::MetadataChange)
+        if commit_updated {
+            self.load_diffs_for_current_repo(false, ctx);
+            // Don't emit MetadataRefreshed here — metadata hasn't been
+            // recomputed yet. NewDiffsComputed handles the immediate UI
+            // refresh, and the throttled metadata refresh will emit
+            // MetadataRefreshed with fresh stats/git-operations data.
+            return true;
         } else if index_lock_detected {
-            InvalidationBehavior::All(InvalidationSource::IndexLockChange)
+            // Index lock appeared/disappeared without a commit change.
+            // Suppress the per-file queue (data may be stale while lock is held)
+            // but don't start a reload — wait for the lock-release event.
+            self.prepare_full_reload();
+            return false;
+        }
+
+        // If a previous index-lock event set `invalidate_all_pending` but the
+        // lock has since cleared without a commit (e.g. aborted merge), recover
+        // by forcing a full reload. Without this, all subsequent file
+        // invalidations would be silently deferred forever.
+        if self.file_invalidation.invalidate_all_pending {
+            self.load_diffs_for_current_repo(false, ctx);
+            return true;
+        }
+
+        // Filter out gitignored files and extract paths
+        let changed_files = added
+            .into_iter()
+            .chain(modified)
+            .chain(deleted)
+            .chain(moved.into_iter().flat_map(|(k, v)| [k, v]))
+            .filter(|target_file| !target_file.is_ignored)
+            .map(|target_file| target_file.path)
+            .collect::<Vec<PathBuf>>();
+
+        if changed_files.is_empty() {
+            return false;
+        }
+
+        // Check if .gitignore was modified - if so, do a full reload since
+        // this can fundamentally change which files should appear in the diff
+        let gitignore_modified = changed_files.iter().any(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name == ".gitignore")
+        });
+
+        if gitignore_modified {
+            self.load_diffs_for_current_repo(false, ctx);
         } else {
-            // Filter out gitignored files and extract paths
-            let changed_files = added
-                .into_iter()
-                .chain(modified)
-                .chain(deleted)
-                .chain(moved.clone().into_keys())
-                .chain(moved.into_values())
-                .filter(|target_file| !target_file.is_ignored)
-                .map(|target_file| target_file.path)
-                .collect::<Vec<PathBuf>>();
-
-            if changed_files.is_empty() {
-                return false;
-            }
-
-            // Check if .gitignore was modified - if so, do a full reload since
-            // this can fundamentally change which files should appear in the diff
-            let gitignore_modified = changed_files.iter().any(|path| {
-                path.file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name == ".gitignore")
-            });
-
-            if gitignore_modified {
-                InvalidationBehavior::All(InvalidationSource::MetadataChange)
-            } else {
-                InvalidationBehavior::Files(changed_files)
-            }
-        };
-        ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
-            invalidation_behavior,
-        ));
+            self.enqueue_file_invalidations(changed_files, ctx);
+        }
+        // Don't emit MetadataRefreshed here — the metadata struct hasn't been
+        // recomputed yet. The throttled refresh path will emit it with fresh
+        // data once `refresh_diff_metadata_for_current_repo` completes.
         true
+    }
+
+    /// Enqueues per-file invalidation tasks into the model's SyncQueue.
+    /// Defers to `pending_file_updates` if a full reload is in-flight.
+    #[cfg(feature = "local_fs")]
+    fn enqueue_file_invalidations(&mut self, files: Vec<PathBuf>, ctx: &mut ModelContext<Self>) {
+        let Some(repo_path) = self.active_repository_path(ctx) else {
+            return;
+        };
+
+        if self.file_invalidation.invalidate_all_pending {
+            // Defer — a full reload will supersede these.
+            match &mut self.pending_file_updates {
+                Some(pending) => {
+                    pending.update_with_file_invalidation(repo_path, files);
+                }
+                None => {
+                    self.pending_file_updates = Some(PendingFileUpdate {
+                        repo_path,
+                        pending_file_edits: HashSet::from_iter(files),
+                    });
+                }
+            }
+            return;
+        }
+
+        let mode = self.mode.clone();
+        let merge_base = self.file_invalidation.merge_base.clone();
+        let queue = self.file_invalidation.queue.clone();
+        for file in files {
+            let task = FileInvalidationTask {
+                file,
+                repo_path: repo_path.clone(),
+                mode: mode.clone(),
+                merge_base: merge_base.clone(),
+            };
+            queue.enqueue(task, None, "file-invalidation");
+        }
+    }
+
+    /// Flushes deferred file invalidations that accumulated during a full reload.
+    #[cfg(feature = "local_fs")]
+    fn flush_pending_invalidations(&mut self, ctx: &mut ModelContext<Self>) {
+        self.file_invalidation.invalidate_all_pending = false;
+        let Some(repo_path) = self.active_repository_path(ctx) else {
+            return;
+        };
+        let pending = self
+            .pending_file_updates
+            .take()
+            .filter(|p| p.repo_path == repo_path);
+        if let Some(pending) = pending {
+            self.enqueue_file_invalidations(pending.pending_file_edits.into_iter().collect(), ctx);
+        }
+    }
+
+    /// Recomputes the merge base for the current diff mode, then flushes
+    /// any deferred file invalidations.
+    #[cfg(feature = "local_fs")]
+    fn recompute_merge_base_and_flush(&mut self, ctx: &mut ModelContext<Self>) {
+        let diff_mode = self.mode.clone();
+        if !matches!(diff_mode, DiffMode::Head) {
+            let Some(repo_path) = self.active_repository_path(ctx) else {
+                self.flush_pending_invalidations(ctx);
+                return;
+            };
+            // Abort the previous merge-base computation if still in-flight.
+            if let Some(old_handle) = self.file_invalidation.merge_base_handle.take() {
+                old_handle.abort();
+            }
+            let handle = ctx.spawn(
+                async move { Self::compute_merge_base(&repo_path, &diff_mode).await },
+                |me, result, ctx| {
+                    me.file_invalidation.merge_base_handle = None;
+                    if let Ok(merge_base) = &result {
+                        me.file_invalidation.merge_base = Some(merge_base.clone());
+                    } else if let Err(e) = &result {
+                        log::error!("Failed to compute merge base: {e}");
+                    }
+                    me.flush_pending_invalidations(ctx);
+                },
+            );
+            self.file_invalidation.merge_base_handle = Some(handle);
+        } else {
+            self.flush_pending_invalidations(ctx);
+        }
+    }
+
+    /// Refreshes metadata and PR info after a git operation (commit, push,
+    /// create PR). Does NOT reload diffs — for commits the file watcher
+    /// triggers that via `commit_updated`, and for push/create-PR the
+    /// working directory hasn't changed so the loaded diffs are still valid.
+    pub fn refresh_metadata_and_pr_info(&mut self, ctx: &mut ModelContext<Self>) {
+        self.refresh_diff_metadata_for_current_repo(false, ctx);
+        self.refresh_pr_info(ctx);
     }
 
     #[cfg(feature = "local_fs")]
@@ -1227,7 +1456,7 @@ impl DiffStateModel {
         if let Err(err) = result {
             log::warn!("Could not update repository: {err}");
 
-            let Some(repository) = &self.repository else {
+            let Some(repository) = self.repository.as_ref() else {
                 return;
             };
             let Some(subscriber_id) = self.subscriber_id.take() else {
@@ -1419,7 +1648,7 @@ impl DiffStateModel {
     fn handle_updated_metadata_for_repo(
         &mut self,
         metadata: Result<DiffMetadata>,
-        invalidation_behavior: InvalidationBehavior,
+        should_reload_diffs: bool,
         ctx: &mut ModelContext<Self>,
     ) {
         let previous_branch = self
@@ -1469,9 +1698,10 @@ impl DiffStateModel {
             self.refresh_pr_info(ctx);
         }
 
-        ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
-            invalidation_behavior,
-        ));
+        if should_reload_diffs {
+            self.load_diffs_for_current_repo(false, ctx);
+        }
+        ctx.emit(DiffStateModelEvent::MetadataRefreshed);
     }
 
     #[cfg(feature = "local_fs")]
@@ -1490,6 +1720,8 @@ impl DiffStateModel {
         }
 
         self.state = InternalDiffState::Loaded((&diffs).into());
+        // Compute merge base and flush deferred invalidations before emitting.
+        self.recompute_merge_base_and_flush(ctx);
         ctx.emit(DiffStateModelEvent::NewDiffsComputed(diffs.changes.ok()));
     }
 
@@ -1753,14 +1985,14 @@ impl DiffStateModel {
     /// Retrieves the diff state for a single invalidated file using scoped
     /// per-file git commands instead of full-repo operations.
     ///
-    /// Returns `(relative_path, Option<FileDiffAndContent>)` — `None` when the
+    /// Returns `(relative_path, Option<Arc<FileDiffAndContent>>)` — `None` when the
     /// file is no longer part of the diff (e.g. reverted).
     pub async fn retrieve_diff_state(
         repo_path: &Path,
         file: &Path,
         mode: &DiffMode,
         merge_base: Option<&str>,
-    ) -> Result<(PathBuf, Option<FileDiffAndContent>)> {
+    ) -> Result<(PathBuf, Option<Arc<FileDiffAndContent>>)> {
         let relative = file
             .strip_prefix(repo_path)
             .map(|p| p.to_path_buf())
@@ -1781,8 +2013,7 @@ impl DiffStateModel {
 
         let diff =
             Self::file_diff_for_path(is_binary, repo_path, &file_path, &status, merge_base).await?;
-
-        Ok((relative, diff))
+        Ok((relative, diff.map(Arc::new)))
     }
 
     async fn file_diff_for_path(
@@ -2846,9 +3077,7 @@ impl DiffStateModel {
                 me.refreshing_pr_info_handle = None;
                 if let Some(metadata) = &mut me.metadata {
                     metadata.pr_info = pr_info;
-                    ctx.emit(DiffStateModelEvent::DiffMetadataChanged(
-                        InvalidationBehavior::PromptRefresh,
-                    ));
+                    ctx.emit(DiffStateModelEvent::MetadataRefreshed);
                 }
             },
         );
@@ -2860,37 +3089,21 @@ impl DiffStateModel {
 }
 
 #[derive(Debug)]
-pub enum InvalidationBehavior {
-    All(InvalidationSource),
-    /// Like `All`, but the git index was locked when the update was detected.
-    /// Signals the view to cancel in-flight work without starting a new diff
-    /// reload (the data would be stale while the lock is held).
-    AllLockedIndex,
-    Files(Vec<PathBuf>),
-    PromptRefresh,
-}
-
-#[derive(Debug)]
-pub enum InvalidationSource {
-    /// This is from an actual underlying metadata change.
-    MetadataChange,
-    /// Index is unlocked. We will attempt to flush the invalidation if there is
-    /// an inflight pending invalidation.
-    IndexLockChange,
-}
-
-#[derive(Debug)]
 pub enum DiffStateModelEvent {
     /// Event dispatched when the current branch changes.
     CurrentBranchChanged,
-    /// Event dispatched whenever the diff metadata changes in any way.
-    DiffMetadataChanged(InvalidationBehavior),
-    /// Event dispatched when new diffs are computed.
+    /// Event dispatched when new diffs are computed (full reload).
     NewDiffsComputed(Option<GitDiffWithBaseContent>),
-    /// Event dispatched when new diff mode is set.
-    /// The boolean indicates whether the next diff load should attempt to
-    /// fetch the base branch from origin if it is not available locally.
-    DiffModeChanged { should_fetch_base: bool },
+    /// Event dispatched when a single file's diff is updated incrementally.
+    SingleFileUpdated {
+        path: PathBuf,
+        diff: Option<Arc<FileDiffAndContent>>,
+    },
+    /// Event dispatched when diff metadata (stats, branch info) is refreshed.
+    MetadataRefreshed,
+    /// Event dispatched when new diff mode is set. The model handles the
+    /// diff reload internally; the view only needs to update UI state.
+    DiffModeChanged,
 }
 
 impl warpui::Entity for DiffStateModel {
@@ -2952,7 +3165,7 @@ impl RepositorySubscriber for DiffStateModelRepositorySubscriber {
 #[cfg(test)]
 impl DiffStateModel {
     /// Test-only constructor that creates a bare model without a repository.
-    pub fn new_for_test(_ctx: &mut ModelContext<Self>) -> Self {
+    pub fn new_for_test(ctx: &mut ModelContext<Self>) -> Self {
         Self {
             #[cfg(feature = "local_fs")]
             repository: None,
@@ -2965,6 +3178,12 @@ impl DiffStateModel {
             computing_metadata_abort_handle: None,
             refreshing_pr_info_handle: None,
             metadata_refresh_enabled: false,
+            #[cfg(feature = "local_fs")]
+            file_invalidation: FileInvalidationState::new(SyncQueue::new_streaming(
+                &ctx.background_executor(),
+            )),
+            #[cfg(feature = "local_fs")]
+            pending_file_updates: None,
         }
     }
 }

--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -6,7 +6,7 @@
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fs::File,
     io::{BufRead, BufReader, Read, Seek},
     path::{Path, PathBuf},
@@ -45,10 +45,10 @@ use warp_core::channel::ChannelState;
 use warp_core::sync_queue::SyncQueue;
 use warp_core::{safe_warn, send_telemetry_from_ctx};
 
-use super::file_invalidation_queue::{FileInvalidationError, FileInvalidationTask};
-
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
+        use std::collections::HashSet;
+        use super::file_invalidation_queue::{FileInvalidationError, FileInvalidationTask};
         use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
         use repo_metadata::{
             repository::{RepositorySubscriber, SubscriberId},

--- a/app/src/code_review/file_invalidation_queue.rs
+++ b/app/src/code_review/file_invalidation_queue.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use warp_core::sync_queue::{IsTransientError, SyncQueueTaskTrait};
 
@@ -25,7 +26,7 @@ pub struct FileInvalidationTask {
 
 impl SyncQueueTaskTrait for FileInvalidationTask {
     type Error = FileInvalidationError;
-    type Result = (PathBuf, Option<FileDiffAndContent>);
+    type Result = (PathBuf, Option<Arc<FileDiffAndContent>>);
     #[cfg(not(target_arch = "wasm32"))]
     type Fut = Pin<Box<dyn Future<Output = Result<Self::Result, Self::Error>> + Send>>;
     #[cfg(target_arch = "wasm32")]

--- a/app/src/code_review/mod.rs
+++ b/app/src/code_review/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod comment_rendering;
 pub mod comments;
 pub(crate) mod diff_menu;
 pub(crate) mod diff_selector;
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 pub(crate) mod file_invalidation_queue;
 
 use code_review_view::CodeReviewAction;

--- a/app/src/workspace/view/right_panel.rs
+++ b/app/src/workspace/view/right_panel.rs
@@ -623,7 +623,7 @@ impl RightPanelView {
         if let Some(view) = existing_view {
             view.update(ctx, |view, ctx| {
                 view.set_terminal_view(terminal_view);
-                view.on_open(Some(repo_path.clone()), ctx);
+                view.on_open(ctx);
             });
             self.recompute_terminal_availability(ctx);
         } else if let Some(view) = self.create_code_review_view(
@@ -634,7 +634,7 @@ impl RightPanelView {
             ctx,
         ) {
             view.update(ctx, |view, ctx| {
-                view.on_open(Some(repo_path.clone()), ctx);
+                view.on_open(ctx);
             });
             self.recompute_terminal_availability(ctx);
         };
@@ -1588,9 +1588,8 @@ impl RightPanelView {
             if is_panel_open {
                 // on_open is idempotent (guards on is_open), so this is safe for
                 // already-open views and correctly re-opens cached-but-closed ones.
-                let repo_path = repo_path.to_path_buf();
                 view.update(ctx, |view, ctx| {
-                    view.on_open(Some(repo_path), ctx);
+                    view.on_open(ctx);
                 });
             }
         } else {
@@ -1623,9 +1622,8 @@ impl RightPanelView {
                         ctx,
                     ) {
                         if is_panel_open {
-                            let repo_path = repo_path.to_path_buf();
                             view.update(ctx, |view, ctx| {
-                                view.on_open(Some(repo_path), ctx);
+                                view.on_open(ctx);
                             });
                         }
                     }


### PR DESCRIPTION
## Description
* Built on https://github.com/warpdotdev/warp/pull/10283
* Part of the work needed to support the code review pane and git states on remote environments includes simplifying the contract between the `DiffStateModel` and `CodeReviewView`
* This decouples the model and view such that the model is the main orchestrator for when to refresh/load the new diffs and metadata, while the view simply consumes the changes it needs to render
  * Main change moves the invalidation queue to the model 

## Linked Issue
[APP-4352](https://linear.app/warpdotdev/issue/APP-4352/move-invalidation-queue-from-codereviewview-to-diffstatemodel)

## Testing
Verified code review pane locally --> should be a no-op
* Tested multiple repos on the same tab + different tabs 
* Tested switching branches
* Tested file changes

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode