### PR TITLE
Don't check server for new versions on wasm or during onboarding

### DIFF
--- a/app/src/autoupdate/mod.rs
+++ b/app/src/autoupdate/mod.rs
@@ -112,6 +112,10 @@ pub struct AutoupdateState {
     /// but to queue them instead.
     request_queue: VecDeque<RequestType>,
     server_api: Arc<ServerApi>,
+    /// Whether the polling loop has been explicitly started. Requests are silently queued but not
+    /// executed until `start_polling` is called. This ensures no version-check requests are made
+    /// before onboarding completes.
+    polling_started: bool,
 }
 
 impl AutoupdateState {
@@ -122,30 +126,37 @@ impl AutoupdateState {
             stage: AutoupdateStage::default(),
             downloaded_update: None,
             request_queue: VecDeque::new(),
+            polling_started: false,
         }
     }
 
     pub fn register(ctx: &mut AppContext, server_api: Arc<ServerApi>) {
-        ctx.add_singleton_model(move |ctx| {
+        ctx.add_singleton_model(move |_ctx| Self::new(server_api));
+    }
+
+    /// Start the autoupdate polling loop. Idempotent: subsequent calls are no-ops.
+    ///
+    /// Must be called explicitly once onboarding (if any) has completed. For returning users
+    /// who bypass onboarding, this should be called during app startup.
+    pub fn start_polling(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.polling_started {
+            return;
+        }
+        if FeatureFlag::Autoupdate.is_enabled() && AppExecutionMode::as_ref(ctx).can_autoupdate() {
+            self.polling_started = true;
+            // Initiate the polling loop.
+            self.poll_for_update(ctx);
+            // Queue a possible update check when the app gets activated, i.e. focused.
             let state_handle = WindowManager::handle(ctx);
-            let mut me = Self::new(server_api);
-            if FeatureFlag::Autoupdate.is_enabled()
-                && AppExecutionMode::as_ref(ctx).can_autoupdate()
-            {
-                // Initiate the polling loop
-                me.poll_for_update(ctx);
-                // Queue a possible update check when the app gets activated, i.e. focused.
-                ctx.subscribe_to_model(&state_handle, |me, event, ctx| {
-                    let windowing::StateEvent::ValueChanged { current, previous } = event;
-                    if previous.stage == ApplicationStage::Inactive
-                        && current.stage == ApplicationStage::Active
-                    {
-                        me.enqueue_request(RequestType::DailyCheck, ctx);
-                    }
-                });
-            }
-            me
-        });
+            ctx.subscribe_to_model(&state_handle, |me, event, ctx| {
+                let windowing::StateEvent::ValueChanged { current, previous } = event;
+                if previous.stage == ApplicationStage::Inactive
+                    && current.stage == ApplicationStage::Active
+                {
+                    me.enqueue_request(RequestType::DailyCheck, ctx);
+                }
+            });
+        }
     }
 
     /// Check if any requests are pending. If there are and we're ready to submit a new request,
@@ -159,8 +170,14 @@ impl AutoupdateState {
     /// Check if there are any requests in the queue. Return the next one, but only if there isn't
     /// already a request in-flight.
     fn get_next_request(&mut self, ctx: &mut ModelContext<Self>) -> Option<RequestType> {
-        // WASM cannot apply updates, so we should not check the server for new versions.
+        // WASM cannot apply updates, so no request type should ever contact the server.
         if cfg!(target_family = "wasm") {
+            return None;
+        }
+
+        // Don't execute any requests until polling has been explicitly started (i.e. onboarding
+        // has completed). Requests enqueued before that point are silently deferred.
+        if !self.polling_started {
             return None;
         }
 

--- a/app/src/autoupdate/mod.rs
+++ b/app/src/autoupdate/mod.rs
@@ -143,6 +143,7 @@ impl AutoupdateState {
             return;
         }
         if FeatureFlag::Autoupdate.is_enabled() && AppExecutionMode::as_ref(ctx).can_autoupdate() {
+            log::info!("Starting autoupdate polling loop");
             self.polling_started = true;
             // Initiate the polling loop.
             self.poll_for_update(ctx);

--- a/app/src/autoupdate/mod.rs
+++ b/app/src/autoupdate/mod.rs
@@ -159,6 +159,11 @@ impl AutoupdateState {
     /// Check if there are any requests in the queue. Return the next one, but only if there isn't
     /// already a request in-flight.
     fn get_next_request(&mut self, ctx: &mut ModelContext<Self>) -> Option<RequestType> {
+        // WASM cannot apply updates, so we should not check the server for new versions.
+        if cfg!(target_family = "wasm") {
+            return None;
+        }
+
         if !self.should_start_update_check() {
             return None;
         }

--- a/app/src/autoupdate/mod.rs
+++ b/app/src/autoupdate/mod.rs
@@ -202,6 +202,11 @@ impl AutoupdateState {
 
     /// After queueing the request, immediately try executing it.
     fn enqueue_request(&mut self, request_type: RequestType, ctx: &mut ModelContext<Self>) {
+        // WASM cannot execute any update requests; skip enqueuing entirely so the
+        // queue never grows with work that can never be consumed.
+        if cfg!(target_family = "wasm") {
+            return;
+        }
         self.request_queue.push_back(request_type);
         self.try_execute_request(ctx);
     }

--- a/app/src/autoupdate/mod_test.rs
+++ b/app/src/autoupdate/mod_test.rs
@@ -32,6 +32,8 @@ fn test_queueing_behavior() {
         let autoupdate_state = initialize_app(&mut app);
 
         app.update_model(&autoupdate_state, |autoupdate, ctx| {
+            // Simulate post-onboarding state so the polling_started gate doesn't interfere.
+            autoupdate.polling_started = true;
             assert_eq!(autoupdate.get_next_request(ctx), None);
             autoupdate.request_queue.push_back(RequestType::DailyCheck);
             assert_eq!(autoupdate.request_queue.len(), 1);
@@ -76,6 +78,8 @@ fn test_queue_behavior_sdk_mode() {
         let autoupdate_state = initialize_app(&mut app);
 
         app.update_model(&autoupdate_state, |autoupdate, ctx| {
+            // Set polling_started so the onboarding gate doesn't mask SDK-mode filtering logic.
+            autoupdate.polling_started = true;
             assert_eq!(autoupdate.get_next_request(ctx), None);
             autoupdate.request_queue.push_back(RequestType::DailyCheck);
             assert_eq!(autoupdate.request_queue.len(), 1);
@@ -122,6 +126,9 @@ fn test_cli_sdk_mode_prevents_autoupdate_polling() {
         let autoupdate_state = initialize_app(&mut app);
 
         app.update_model(&autoupdate_state, |autoupdate, ctx| {
+            // Set polling_started so the onboarding gate doesn't interfere with
+            // SDK-mode filtering, which is what this test exercises.
+            autoupdate.polling_started = true;
             // Simulate what the autoupdate poll loop would do: call poll_for_update.
             // In SDK mode, the Poll request enqueued by poll_for_update must be discarded
             // immediately without initiating a check (stage stays NoUpdateAvailable).

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -1798,7 +1798,21 @@ impl RootView {
             ctx.focus(onboarding_view);
         }
 
+        // For users who bypass onboarding (already logged in, or onboarding flags not active),
+        // start autoupdate polling immediately. For new users in onboarding, this is a no-op;
+        // polling will be started once onboarding completes.
+        root_view.start_autoupdate_polling(ctx);
+
         root_view
+    }
+
+    /// Starts the autoupdate polling loop, but only if we are already in the `Terminal` state
+    /// (i.e. onboarding has completed or was not shown). Safe to call unconditionally — it is
+    /// a no-op when still in a pre-terminal state.
+    fn start_autoupdate_polling(&self, ctx: &mut ViewContext<Self>) {
+        if matches!(self.auth_onboarding_state, AuthOnboardingState::Terminal(_)) {
+            AutoupdateState::handle(ctx).update(ctx, |state, ctx| state.start_polling(ctx));
+        }
     }
 
     /// Used for integration tests.
@@ -2112,6 +2126,7 @@ impl RootView {
                 self.auth_onboarding_state = AuthOnboardingState::Terminal(workspace);
                 ctx.emit(RootViewEvent::AuthOnboardingStateChanged);
                 self.start_pending_tutorial(ctx);
+                self.start_autoupdate_polling(ctx);
                 self.focus(ctx);
                 ctx.notify();
             }
@@ -2246,6 +2261,7 @@ impl RootView {
                 self.auth_onboarding_state = AuthOnboardingState::Terminal(workspace);
                 ctx.emit(RootViewEvent::AuthOnboardingStateChanged);
                 self.start_pending_tutorial(ctx);
+                self.start_autoupdate_polling(ctx);
                 ctx.notify();
             }
             AgentOnboardingEvent::OnboardingSkipped => {
@@ -2267,6 +2283,7 @@ impl RootView {
                 let workspace = target.to_workspace(ctx);
                 self.auth_onboarding_state = AuthOnboardingState::Terminal(workspace);
                 ctx.emit(RootViewEvent::AuthOnboardingStateChanged);
+                self.start_autoupdate_polling(ctx);
                 ctx.notify();
             }
             AgentOnboardingEvent::UpgradeRequested => {
@@ -2958,6 +2975,7 @@ impl RootView {
                         .complete_auth_and_create_workspace(ctx);
                 }
 
+                self.start_autoupdate_polling(ctx);
                 self.focus(ctx);
             }
             AuthManagerEvent::AuthFailed(err) => match err {
@@ -3009,6 +3027,7 @@ impl RootView {
                     ctx.emit(RootViewEvent::AuthOnboardingStateChanged);
                     self.start_pending_tutorial(ctx);
                 }
+                self.start_autoupdate_polling(ctx);
                 self.focus(ctx);
             }
             AuthManagerEvent::LoginOverrideDetected(interrupted_auth_payload) => {

--- a/crates/warp_core/src/execution_mode.rs
+++ b/crates/warp_core/src/execution_mode.rs
@@ -66,7 +66,7 @@ impl AppExecutionMode {
 
     /// Whether the app can *automatically* update. This does not prevent manual updates.
     pub fn can_autoupdate(&self) -> bool {
-        self.is_app()
+        self.is_app() && cfg!(not(target_family = "wasm"))
     }
 
     /// Whether the app can automatically start MCP servers from the previous session.


### PR DESCRIPTION
## Description

Don't check the server endpoint for new client versions on wasm, because wasm can't update anyway.

Also don't do this check during onboarding because we can't update at that time

## Testing

Tested manually
