### PR TITLE
Fix command palette zero-state query

### DIFF
--- a/app/src/search/command_palette/view.rs
+++ b/app/src/search/command_palette/view.rs
@@ -521,6 +521,10 @@ impl View {
     fn on_session_source_changed(&mut self, ctx: &mut ViewContext<Self>) {
         self.compute_recent_items_for_zero_state(ctx);
 
+        if self.search_bar_state.as_ref(ctx).should_show_zero_state() {
+            return;
+        }
+
         self.search_bar.update(ctx, |search_bar, ctx| {
             search_bar.run_query(ctx);
         });

--- a/app/src/search/search_bar.rs
+++ b/app/src/search/search_bar.rs
@@ -357,6 +357,14 @@ impl<T: Action + Clone> SearchBarState<T> {
     pub fn should_show_zero_state(&self) -> bool {
         self.should_show_zero_state
     }
+
+    fn should_show_zero_state_for_buffer(&self, buffer_text: &str) -> bool {
+        buffer_text.is_empty() && self.query_filter.zero_state()
+    }
+
+    fn should_run_query_for_buffer(&self, buffer_text: &str) -> bool {
+        !self.should_show_zero_state_for_buffer(buffer_text) || self.run_query_on_buffer_empty
+    }
 }
 
 impl<T: Action + Clone> Entity for SearchBarState<T> {
@@ -674,24 +682,29 @@ impl<T: Action + Clone> SearchBar<T> {
         });
 
         self.update_placeholder_text(ctx);
+        self.run_query(ctx);
     }
 
-    /// Updates the active filter and re-runs the query, since results may be affected by the newly
-    /// active filter.
+    /// Updates the active filter and re-runs the query if the current search state should show
+    /// results.
     ///
-    /// This method also updates UI state including the placeholder text and the show/hide
-    /// zero_state flag.
+    /// Empty zero-state buffers skip querying unless this search bar has opted into
+    /// `run_query_on_buffer_empty`.
     pub fn set_visible_query_filter(
         &mut self,
         filter_and_atom_text: Option<(QueryFilter, &'static str)>,
         ctx: &mut ViewContext<Self>,
     ) {
+        let current_buffer_text = self
+            .editor_handle
+            .read(ctx, |editor, ctx| editor.buffer_text(ctx));
+
         if self.filterable(ctx) {
             let new_filter = filter_and_atom_text.map(|(filter, _)| filter);
             let new_filter_atom_text = filter_and_atom_text.map(|(_, atom_text)| atom_text);
-            // NOTE: This event is deferred — handlers receive it after `run_query` (below) has
-            // already started an async search. Handlers must not reset or modify the mixer, as
-            // doing so would abort the in-flight query without re-running it.
+            // NOTE: This event is deferred. When this method starts a query below, handlers
+            // receive it after the async search has already started. Handlers must not reset or
+            // modify the mixer, as doing so would abort the in-flight query without re-running it.
             ctx.emit(SearchBarEvent::QueryFilterChanged { new_filter });
 
             self.state.update(ctx, |state, ctx| {
@@ -705,7 +718,18 @@ impl<T: Action + Clone> SearchBar<T> {
             });
         }
 
-        self.run_query(ctx);
+        let should_show_zero_state = {
+            let state = self.state.as_ref(ctx);
+            state.should_show_zero_state_for_buffer(&current_buffer_text)
+        };
+
+        if self
+            .state
+            .as_ref(ctx)
+            .should_run_query_for_buffer(&current_buffer_text)
+        {
+            self.run_query(ctx);
+        }
 
         // Update the editor placeholder text if necessary.
         self.update_placeholder_text(ctx);
@@ -714,13 +738,8 @@ impl<T: Action + Clone> SearchBar<T> {
         self.update_filter_autosuggestion_text(ctx);
 
         // Update the zero state show/hide flag.
-        let current_buffer_text = self
-            .editor_handle
-            .read(ctx, |editor, ctx| editor.buffer_text(ctx));
-
         self.state.update(ctx, |state, ctx| {
-            state.should_show_zero_state =
-                current_buffer_text.is_empty() && state.query_filter.zero_state();
+            state.should_show_zero_state = should_show_zero_state;
             ctx.notify();
         });
 
@@ -833,7 +852,11 @@ impl<T: Action + Clone> SearchBar<T> {
         let current_buffer_text = self
             .editor_handle
             .read(ctx, |editor, ctx| editor.buffer_text(ctx));
-        if current_buffer_text.is_empty() && self.state.as_ref(ctx).query_filter.zero_state() {
+        if self
+            .state
+            .as_ref(ctx)
+            .should_show_zero_state_for_buffer(&current_buffer_text)
+        {
             self.state.update(ctx, |state, ctx| {
                 state.should_show_zero_state = true;
                 ctx.notify();
@@ -962,6 +985,10 @@ impl<T: Action + Clone> SearchBar<T> {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "search_bar_tests.rs"]
+mod tests;
 
 impl<T: Action + Clone> Entity for SearchBar<T> {
     type Event = SearchBarEvent<T>;

--- a/app/src/search/search_bar_tests.rs
+++ b/app/src/search/search_bar_tests.rs
@@ -1,0 +1,40 @@
+use crate::search::QueryFilter;
+
+use super::{FilterState, SearchBarState, SearchResultOrdering};
+
+#[derive(Clone, Debug)]
+struct TestAction;
+
+#[test]
+fn skips_empty_query_when_showing_zero_state() {
+    let state = SearchBarState::<TestAction>::new(SearchResultOrdering::TopDown);
+
+    assert!(state.should_show_zero_state_for_buffer(""));
+    assert!(!state.should_run_query_for_buffer(""));
+}
+
+#[test]
+fn runs_empty_query_when_search_bar_opts_in() {
+    let state = SearchBarState::<TestAction>::new(SearchResultOrdering::TopDown)
+        .run_query_on_buffer_empty();
+
+    assert!(state.should_show_zero_state_for_buffer(""));
+    assert!(state.should_run_query_for_buffer(""));
+}
+
+#[test]
+fn runs_query_when_filter_is_visible() {
+    let mut state = SearchBarState::<TestAction>::new(SearchResultOrdering::TopDown);
+    state.query_filter = FilterState::Visible(QueryFilter::Files);
+
+    assert!(!state.should_show_zero_state_for_buffer(""));
+    assert!(state.should_run_query_for_buffer(""));
+}
+
+#[test]
+fn runs_query_when_buffer_has_text() {
+    let state = SearchBarState::<TestAction>::new(SearchResultOrdering::TopDown);
+
+    assert!(!state.should_show_zero_state_for_buffer("git"));
+    assert!(state.should_run_query_for_buffer("git"));
+}


### PR DESCRIPTION
## Description

Opening the command palette in large projects can kick off an empty, unfiltered
search while the palette is still showing its zero-state recents and suggested
items. In projects with many files, that work can make the command palette feel
slow before the user has selected the Files filter or typed a query.

This PR updates the shared search bar query decision so empty-buffer zero-state
views skip `run_query` unless a caller explicitly opts into
`run_query_on_buffer_empty`. The command palette also avoids re-running a query
from session-source updates while the zero state is active. Fixed-filter search
bars still run their initial query so filtered palettes continue to populate
immediately.

## Linked Issue

Closes https://github.com/warpdotdev/warp/issues/10256

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes). Not applicable: no visible UI change.

## Testing

Automated:

- [x] `cargo fmt --check`
- [x] `cargo test -p warp search_bar --features gui`
- [x] `cargo check -p warp --bin warp-oss --features gui`
- [x] `cargo clippy -p warp --features gui --lib -- -D warnings`
- [x] `git diff --check`
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not applicable. This is a performance fix with no visible UI change.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Warp <agent@warp.dev>

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-IMPROVEMENT: Opening the command palette in large projects is faster because it no longer runs an empty zero-state search before the user types.
-->
