### PR TITLE
Refactor SSH transport error handling and types

### DIFF
--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -18,8 +18,11 @@ use remote_server::manager::RemoteServerExitStatus;
 use remote_server::setup::{
     parse_uname_output, remote_server_daemon_dir, PreinstallCheckResult, RemotePlatform,
 };
-use remote_server::ssh::ssh_args;
-use remote_server::transport::{Connection, RemoteTransport};
+use remote_server::ssh::{ssh_args, SshCommandError};
+use remote_server::transport::{
+    CheckBinaryError, Connection, DetectPlatformError, InstallBinaryError, PreinstallCheckError,
+    RemoteTransport,
+};
 
 /// SSH transport: connects via a ControlMaster socket.
 ///
@@ -78,7 +81,7 @@ impl SshTransport {
 impl RemoteTransport for SshTransport {
     fn detect_platform(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<RemotePlatform, String>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<RemotePlatform, DetectPlatformError>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
             match remote_server::ssh::run_ssh_command(
@@ -90,21 +93,25 @@ impl RemoteTransport for SshTransport {
             {
                 Ok(output) if output.status.success() => {
                     let stdout = String::from_utf8_lossy(&output.stdout);
-                    parse_uname_output(&stdout).map_err(|e| format!("{e:#}"))
+                    parse_uname_output(&stdout)
+                        .map_err(|e| DetectPlatformError::UnsupportedPlatform(e))
                 }
                 Ok(output) => {
                     let code = output.status.code().unwrap_or(-1);
                     let stderr = String::from_utf8_lossy(&output.stderr);
-                    Err(format!("uname -sm exited with code {code}: {stderr}"))
+                    Err(DetectPlatformError::Other(anyhow::anyhow!(
+                        "uname -sm exited with code {code}: {stderr}"
+                    )))
                 }
-                Err(e) => Err(format!("{e:#}")),
+                Err(e) => Err(e.into()),
             }
         })
     }
 
     fn run_preinstall_check(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<PreinstallCheckResult, String>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<PreinstallCheckResult, PreinstallCheckError>> + Send>>
+    {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
             match remote_server::ssh::run_ssh_script(
@@ -120,17 +127,15 @@ impl RemoteTransport for SshTransport {
                 }
                 Ok(output) => {
                     let code = output.status.code().unwrap_or(-1);
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    Err(format!(
-                        "Preinstall check exited with code {code}: {stderr}"
-                    ))
+                    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                    Err(PreinstallCheckError::ScriptFailed { code, stderr })
                 }
-                Err(e) => Err(format!("{e:#}")),
+                Err(e) => Err(PreinstallCheckError::Other(e.into())),
             }
         })
     }
 
-    fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, String>> + Send>> {
+    fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, CheckBinaryError>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
             let bin_path = remote_server::setup::remote_server_binary();
@@ -149,11 +154,16 @@ impl RemoteTransport for SshTransport {
                     Some(1) => Ok(false),
                     Some(code) => {
                         let stderr = String::from_utf8_lossy(&output.stderr);
-                        Err(format!("binary check exited with code {code}: {stderr}"))
+                        Err(CheckBinaryError::Other(anyhow::anyhow!(
+                            "binary check exited with code {code}: {stderr}"
+                        )))
                     }
-                    None => Err("binary check terminated by signal".into()),
+                    None => Err(CheckBinaryError::Other(anyhow::anyhow!(
+                        "binary check terminated by signal"
+                    ))),
                 },
-                Err(e) => Err(format!("{e:#}")),
+                Err(SshCommandError::TimedOut { .. }) => Err(CheckBinaryError::TimedOut),
+                Err(e) => Err(CheckBinaryError::Other(e.into())),
             }
         })
     }
@@ -191,7 +201,9 @@ impl RemoteTransport for SshTransport {
         })
     }
 
-    fn install_binary(&self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send>> {
+    fn install_binary(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<(), InstallBinaryError>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
             let script = remote_server::setup::install_script();
@@ -210,9 +222,12 @@ impl RemoteTransport for SshTransport {
                 Ok(output) => {
                     let code = output.status.code().unwrap_or(-1);
                     let stderr = String::from_utf8_lossy(&output.stderr);
-                    Err(format!("install script failed (exit {code}): {stderr}"))
+                    Err(InstallBinaryError::Other(anyhow::anyhow!(
+                        "install script failed (exit {code}): {stderr}"
+                    )))
                 }
-                Err(e) => Err(format!("{e:#}")),
+                Err(SshCommandError::TimedOut { .. }) => Err(InstallBinaryError::TimedOut),
+                Err(e) => Err(InstallBinaryError::Other(e.into())),
             }
         })
     }

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -135,36 +135,8 @@ impl RemoteTransport for SshTransport {
     }
 
     fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, CheckBinaryError>> + Send>> {
-        let socket_path = self.socket_path.clone();
-        Box::pin(async move {
-            let bin_path = remote_server::setup::remote_server_binary();
-            log::info!("Checking for remote server binary at {bin_path}");
-            match remote_server::ssh::run_ssh_command(
-                &socket_path,
-                &remote_server::setup::binary_check_command(),
-                remote_server::setup::CHECK_TIMEOUT,
-            )
-            .await
-            {
-                // `test -x` exits 0 when present, 1 when missing.
-                // Any other exit code (or None / signal) is treated as a check failure.
-                Ok(output) => match output.status.code() {
-                    Some(0) => Ok(true),
-                    Some(1) => Ok(false),
-                    Some(code) => {
-                        let stderr = String::from_utf8_lossy(&output.stderr);
-                        Err(CheckBinaryError::Other(anyhow::anyhow!(
-                            "binary check exited with code {code}: {stderr}"
-                        )))
-                    }
-                    None => Err(CheckBinaryError::Other(anyhow::anyhow!(
-                        "binary check terminated by signal"
-                    ))),
-                },
-                Err(SshCommandError::TimedOut { .. }) => Err(CheckBinaryError::TimedOut),
-                Err(e) => Err(CheckBinaryError::Other(e.into())),
-            }
-        })
+        // TEST HACK: return Ok(false) so install flow triggers
+        Box::pin(async move { Ok(false) })
     }
 
     fn check_has_old_binary(&self) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
@@ -203,40 +175,11 @@ impl RemoteTransport for SshTransport {
     fn install_binary(
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<(), InstallBinaryError>> + Send>> {
-        let socket_path = self.socket_path.clone();
+        // TEST HACK: force InstallBinaryError::Other
         Box::pin(async move {
-            let script = remote_server::setup::install_script(None);
-            log::info!(
-                "Installing remote server binary to {}",
-                remote_server::setup::remote_server_binary()
-            );
-            match remote_server::ssh::run_ssh_script(
-                &socket_path,
-                &script,
-                remote_server::setup::INSTALL_TIMEOUT,
-            )
-            .await
-            {
-                Ok(output) if output.status.success() => Ok(()),
-                Ok(output)
-                    if output.status.code()
-                        == Some(remote_server::setup::NO_HTTP_CLIENT_EXIT_CODE) =>
-                {
-                    log::info!("Remote server has no curl/wget, falling back to SCP upload");
-                    scp_install_fallback(&socket_path)
-                        .await
-                        .map_err(|e| InstallBinaryError::Other(e))
-                }
-                Ok(output) => {
-                    let code = output.status.code().unwrap_or(-1);
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    Err(InstallBinaryError::Other(anyhow::anyhow!(
-                        "install script failed (exit {code}): {stderr}"
-                    )))
-                }
-                Err(SshCommandError::TimedOut { .. }) => Err(InstallBinaryError::TimedOut),
-                Err(e) => Err(InstallBinaryError::Other(e.into())),
-            }
+            Err(InstallBinaryError::Other(anyhow::anyhow!(
+                "install script failed (exit 1): /bin/sh: curl: not found"
+            )))
         })
     }
 

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -135,8 +135,36 @@ impl RemoteTransport for SshTransport {
     }
 
     fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, CheckBinaryError>> + Send>> {
-        // TEST HACK: return Ok(false) so install flow triggers
-        Box::pin(async move { Ok(false) })
+        let socket_path = self.socket_path.clone();
+        Box::pin(async move {
+            let bin_path = remote_server::setup::remote_server_binary();
+            log::info!("Checking for remote server binary at {bin_path}");
+            match remote_server::ssh::run_ssh_command(
+                &socket_path,
+                &remote_server::setup::binary_check_command(),
+                remote_server::setup::CHECK_TIMEOUT,
+            )
+            .await
+            {
+                // `test -x` exits 0 when present, 1 when missing.
+                // Any other exit code (or None / signal) is treated as a check failure.
+                Ok(output) => match output.status.code() {
+                    Some(0) => Ok(true),
+                    Some(1) => Ok(false),
+                    Some(code) => {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        Err(CheckBinaryError::Other(anyhow::anyhow!(
+                            "binary check exited with code {code}: {stderr}"
+                        )))
+                    }
+                    None => Err(CheckBinaryError::Other(anyhow::anyhow!(
+                        "binary check terminated by signal"
+                    ))),
+                },
+                Err(SshCommandError::TimedOut { .. }) => Err(CheckBinaryError::TimedOut),
+                Err(e) => Err(CheckBinaryError::Other(e.into())),
+            }
+        })
     }
 
     fn check_has_old_binary(&self) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>> {
@@ -175,11 +203,40 @@ impl RemoteTransport for SshTransport {
     fn install_binary(
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<(), InstallBinaryError>> + Send>> {
-        // TEST HACK: force InstallBinaryError::Other
+        let socket_path = self.socket_path.clone();
         Box::pin(async move {
-            Err(InstallBinaryError::Other(anyhow::anyhow!(
-                "install script failed (exit 1): /bin/sh: curl: not found"
-            )))
+            let script = remote_server::setup::install_script(None);
+            log::info!(
+                "Installing remote server binary to {}",
+                remote_server::setup::remote_server_binary()
+            );
+            match remote_server::ssh::run_ssh_script(
+                &socket_path,
+                &script,
+                remote_server::setup::INSTALL_TIMEOUT,
+            )
+            .await
+            {
+                Ok(output) if output.status.success() => Ok(()),
+                Ok(output)
+                    if output.status.code()
+                        == Some(remote_server::setup::NO_HTTP_CLIENT_EXIT_CODE) =>
+                {
+                    log::info!("Remote server has no curl/wget, falling back to SCP upload");
+                    scp_install_fallback(&socket_path)
+                        .await
+                        .map_err(|e| InstallBinaryError::Other(e))
+                }
+                Ok(output) => {
+                    let code = output.status.code().unwrap_or(-1);
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    Err(InstallBinaryError::Other(anyhow::anyhow!(
+                        "install script failed (exit {code}): {stderr}"
+                    )))
+                }
+                Err(SshCommandError::TimedOut { .. }) => Err(InstallBinaryError::TimedOut),
+                Err(e) => Err(InstallBinaryError::Other(e.into())),
+            }
         })
     }
 

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -80,9 +80,7 @@ impl SshTransport {
 
 /// Runs `uname -sm` on the remote host via the ControlMaster socket and
 /// parses the output into a [`RemotePlatform`].
-async fn detect_remote_platform(
-    socket_path: &Path,
-) -> Result<RemotePlatform, DetectPlatformError> {
+async fn detect_remote_platform(socket_path: &Path) -> Result<RemotePlatform, DetectPlatformError> {
     let output = remote_server::ssh::run_ssh_command(
         socket_path,
         "uname -sm",
@@ -91,7 +89,7 @@ async fn detect_remote_platform(
     .await?;
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
-        parse_uname_output(&stdout).map_err(DetectPlatformError::UnsupportedPlatform)
+        parse_uname_output(&stdout)
     } else {
         let code = output.status.code().unwrap_or(-1);
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -19,10 +19,7 @@ use remote_server::setup::{
     parse_uname_output, remote_server_daemon_dir, PreinstallCheckResult, RemotePlatform,
 };
 use remote_server::ssh::{ssh_args, SshCommandError};
-use remote_server::transport::{
-    CheckBinaryError, Connection, DetectPlatformError, InstallBinaryError, PreinstallCheckError,
-    RemoteTransport,
-};
+use remote_server::transport::{Connection, Error, RemoteTransport};
 
 /// SSH transport: connects via a ControlMaster socket.
 ///
@@ -80,7 +77,7 @@ impl SshTransport {
 
 /// Runs `uname -sm` on the remote host via the ControlMaster socket and
 /// parses the output into a [`RemotePlatform`].
-async fn detect_remote_platform(socket_path: &Path) -> Result<RemotePlatform, DetectPlatformError> {
+async fn detect_remote_platform(socket_path: &Path) -> Result<RemotePlatform, Error> {
     let output = remote_server::ssh::run_ssh_command(
         socket_path,
         "uname -sm",
@@ -93,7 +90,7 @@ async fn detect_remote_platform(socket_path: &Path) -> Result<RemotePlatform, De
     } else {
         let code = output.status.code().unwrap_or(-1);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(DetectPlatformError::Other(anyhow::anyhow!(
+        Err(Error::Other(anyhow::anyhow!(
             "uname -sm exited with code {code}: {stderr}"
         )))
     }
@@ -102,15 +99,14 @@ async fn detect_remote_platform(socket_path: &Path) -> Result<RemotePlatform, De
 impl RemoteTransport for SshTransport {
     fn detect_platform(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<RemotePlatform, DetectPlatformError>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<RemotePlatform, Error>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move { detect_remote_platform(&socket_path).await })
     }
 
     fn run_preinstall_check(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<PreinstallCheckResult, PreinstallCheckError>> + Send>>
-    {
+    ) -> Pin<Box<dyn Future<Output = Result<PreinstallCheckResult, Error>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
             match remote_server::ssh::run_ssh_script(
@@ -125,45 +121,26 @@ impl RemoteTransport for SshTransport {
                     Ok(PreinstallCheckResult::parse(&stdout))
                 }
                 Ok(output) => {
-                    let code = output.status.code().unwrap_or(-1);
+                    let exit_code = output.status.code().unwrap_or(-1);
                     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-                    Err(PreinstallCheckError::ScriptFailed { code, stderr })
+                    Err(Error::ScriptFailed { exit_code, stderr })
                 }
-                Err(e) => Err(PreinstallCheckError::Other(e.into())),
+                Err(e) => Err(e.into()),
             }
         })
     }
 
-    fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, CheckBinaryError>> + Send>> {
+    fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, Error>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
-            let bin_path = remote_server::setup::remote_server_binary();
-            log::info!("Checking for remote server binary at {bin_path}");
-            match remote_server::ssh::run_ssh_command(
+            let cmd = format!("test -x {}", remote_server::setup::remote_server_binary());
+            let output = remote_server::ssh::run_ssh_command(
                 &socket_path,
-                &remote_server::setup::binary_check_command(),
+                &cmd,
                 remote_server::setup::CHECK_TIMEOUT,
             )
-            .await
-            {
-                // `test -x` exits 0 when present, 1 when missing.
-                // Any other exit code (or None / signal) is treated as a check failure.
-                Ok(output) => match output.status.code() {
-                    Some(0) => Ok(true),
-                    Some(1) => Ok(false),
-                    Some(code) => {
-                        let stderr = String::from_utf8_lossy(&output.stderr);
-                        Err(CheckBinaryError::Other(anyhow::anyhow!(
-                            "binary check exited with code {code}: {stderr}"
-                        )))
-                    }
-                    None => Err(CheckBinaryError::Other(anyhow::anyhow!(
-                        "binary check terminated by signal"
-                    ))),
-                },
-                Err(SshCommandError::TimedOut { .. }) => Err(CheckBinaryError::TimedOut),
-                Err(e) => Err(CheckBinaryError::Other(e.into())),
-            }
+            .await?;
+            Ok(output.status.success())
         })
     }
 
@@ -200,9 +177,7 @@ impl RemoteTransport for SshTransport {
         })
     }
 
-    fn install_binary(
-        &self,
-    ) -> Pin<Box<dyn Future<Output = Result<(), InstallBinaryError>> + Send>> {
+    fn install_binary(&self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
             let script = remote_server::setup::install_script(None);
@@ -225,17 +200,15 @@ impl RemoteTransport for SshTransport {
                     log::info!("Remote server has no curl/wget, falling back to SCP upload");
                     scp_install_fallback(&socket_path)
                         .await
-                        .map_err(|e| InstallBinaryError::Other(e))
+                        .map_err(Error::Other)
                 }
                 Ok(output) => {
-                    let code = output.status.code().unwrap_or(-1);
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    Err(InstallBinaryError::Other(anyhow::anyhow!(
-                        "install script failed (exit {code}): {stderr}"
-                    )))
+                    let exit_code = output.status.code().unwrap_or(-1);
+                    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                    Err(Error::ScriptFailed { exit_code, stderr })
                 }
-                Err(SshCommandError::TimedOut { .. }) => Err(InstallBinaryError::TimedOut),
-                Err(e) => Err(InstallBinaryError::Other(e.into())),
+                Err(SshCommandError::TimedOut { .. }) => Err(Error::TimedOut),
+                Err(e) => Err(Error::Other(e.into())),
             }
         })
     }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4339,7 +4339,6 @@ impl TerminalView {
                         me.show_ssh_remote_server_failed_banner(
                             *session_id,
                             SshRemoteServerFailureKind::Launch,
-                            None,
                             error,
                             ctx,
                         );
@@ -4393,8 +4392,7 @@ impl TerminalView {
                             me.show_ssh_remote_server_failed_banner(
                                 *session_id,
                                 SshRemoteServerFailureKind::BinaryInstall,
-                                error.user_facing_message(),
-                                &error.to_string(),
+                                &error.user_facing_message(),
                                 ctx,
                             );
                         }
@@ -4428,8 +4426,7 @@ impl TerminalView {
                             me.show_ssh_remote_server_failed_banner(
                                 *session_id,
                                 SshRemoteServerFailureKind::BinaryCheck,
-                                error.user_facing_message(),
-                                &error.to_string(),
+                                &error.user_facing_message(),
                                 ctx,
                             );
                         }
@@ -11789,8 +11786,7 @@ impl TerminalView {
         &mut self,
         session_id: SessionId,
         kind: SshRemoteServerFailureKind,
-        user_message: Option<String>,
-        detail: &str,
+        error: &str,
         ctx: &mut ViewContext<Self>,
     ) {
         let already_present = self.rich_content_views.iter().any(|view| {
@@ -11804,9 +11800,9 @@ impl TerminalView {
             return;
         }
 
-        let detail = detail.to_owned();
+        let error = error.to_owned();
         let banner = ctx.add_typed_action_view(|_| {
-            SshRemoteServerFailedBanner::new(session_id, kind, user_message, detail)
+            SshRemoteServerFailedBanner::new(session_id, kind, error)
         });
 
         ctx.subscribe_to_view(&banner, move |me, _, event, ctx| match event {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -158,7 +158,7 @@ use crate::terminal::view::ssh_remote_server_choice_view::{
     SshRemoteServerChoiceView, SshRemoteServerChoiceViewEvent,
 };
 use crate::terminal::view::ssh_remote_server_failed_banner::{
-    SshRemoteServerFailedBanner, SshRemoteServerFailedBannerEvent, SshRemoteServerFailureKind,
+    SshRemoteServerFailedBanner, SshRemoteServerFailedBannerEvent,
 };
 use crate::terminal::view::telemetry::PromptSuggestionFallbackReason;
 use crate::workspace::view::cloud_agent_capacity_modal::CloudAgentCapacityModalVariant;
@@ -4338,8 +4338,15 @@ impl TerminalView {
                         );
                         me.show_ssh_remote_server_failed_banner(
                             *session_id,
-                            SshRemoteServerFailureKind::Launch,
-                            error,
+                            remote_server::transport::UserFacingError {
+                                title: "Could not establish connection to host",
+                                body: "Failed to start SSH extension".into(),
+                                detail: if error.is_empty() {
+                                    None
+                                } else {
+                                    Some(error.clone())
+                                },
+                            },
                             ctx,
                         );
                     }
@@ -4391,8 +4398,9 @@ impl TerminalView {
                         if let Err(error) = result {
                             me.show_ssh_remote_server_failed_banner(
                                 *session_id,
-                                SshRemoteServerFailureKind::BinaryInstall,
-                                &error.user_facing_message(),
+                                error.user_facing_error(
+                                    remote_server::transport::SetupStage::InstallBinary,
+                                ),
                                 ctx,
                             );
                         }
@@ -4425,8 +4433,9 @@ impl TerminalView {
                         if let Err(error) = result {
                             me.show_ssh_remote_server_failed_banner(
                                 *session_id,
-                                SshRemoteServerFailureKind::BinaryCheck,
-                                &error.user_facing_message(),
+                                error.user_facing_error(
+                                    remote_server::transport::SetupStage::CheckBinary,
+                                ),
                                 ctx,
                             );
                         }
@@ -11785,8 +11794,7 @@ impl TerminalView {
     fn show_ssh_remote_server_failed_banner(
         &mut self,
         session_id: SessionId,
-        kind: SshRemoteServerFailureKind,
-        error: &str,
+        error: remote_server::transport::UserFacingError,
         ctx: &mut ViewContext<Self>,
     ) {
         let already_present = self.rich_content_views.iter().any(|view| {
@@ -11800,10 +11808,8 @@ impl TerminalView {
             return;
         }
 
-        let error = error.to_owned();
-        let banner = ctx.add_typed_action_view(|_| {
-            SshRemoteServerFailedBanner::new(session_id, kind, error)
-        });
+        let banner =
+            ctx.add_typed_action_view(|_| SshRemoteServerFailedBanner::new(session_id, error));
 
         ctx.subscribe_to_view(&banner, move |me, _, event, ctx| match event {
             SshRemoteServerFailedBannerEvent::Dismissed => {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4339,6 +4339,7 @@ impl TerminalView {
                         me.show_ssh_remote_server_failed_banner(
                             *session_id,
                             SshRemoteServerFailureKind::Launch,
+                            None,
                             error,
                             ctx,
                         );
@@ -4382,7 +4383,7 @@ impl TerminalView {
                             .unwrap_or((None, None));
                         send_telemetry_from_ctx!(
                             TelemetryEvent::RemoteServerInstallation {
-                                error: result.as_ref().err().cloned(),
+                                error: result.as_ref().err().map(|e| e.to_string()),
                                 remote_os,
                                 remote_arch,
                             },
@@ -4392,7 +4393,8 @@ impl TerminalView {
                             me.show_ssh_remote_server_failed_banner(
                                 *session_id,
                                 SshRemoteServerFailureKind::BinaryInstall,
-                                error,
+                                error.user_facing_message(),
+                                &error.to_string(),
                                 ctx,
                             );
                         }
@@ -4416,7 +4418,7 @@ impl TerminalView {
                         send_telemetry_from_ctx!(
                             TelemetryEvent::RemoteServerBinaryCheck {
                                 found: matches!(result, Ok(true)),
-                                error: result.as_ref().err().cloned(),
+                                error: result.as_ref().err().map(|e| e.to_string()),
                                 remote_os,
                                 remote_arch,
                             },
@@ -4426,7 +4428,8 @@ impl TerminalView {
                             me.show_ssh_remote_server_failed_banner(
                                 *session_id,
                                 SshRemoteServerFailureKind::BinaryCheck,
-                                error,
+                                error.user_facing_message(),
+                                &error.to_string(),
                                 ctx,
                             );
                         }
@@ -11786,7 +11789,8 @@ impl TerminalView {
         &mut self,
         session_id: SessionId,
         kind: SshRemoteServerFailureKind,
-        error: &str,
+        user_message: Option<String>,
+        detail: &str,
         ctx: &mut ViewContext<Self>,
     ) {
         let already_present = self.rich_content_views.iter().any(|view| {
@@ -11800,9 +11804,10 @@ impl TerminalView {
             return;
         }
 
-        let error = error.to_owned();
-        let banner = ctx
-            .add_typed_action_view(|_| SshRemoteServerFailedBanner::new(session_id, kind, error));
+        let detail = detail.to_owned();
+        let banner = ctx.add_typed_action_view(|_| {
+            SshRemoteServerFailedBanner::new(session_id, kind, user_message, detail)
+        });
 
         ctx.subscribe_to_view(&banner, move |me, _, event, ctx| match event {
             SshRemoteServerFailedBannerEvent::Dismissed => {

--- a/app/src/terminal/view/ssh_remote_server_failed_banner.rs
+++ b/app/src/terminal/view/ssh_remote_server_failed_banner.rs
@@ -36,23 +36,15 @@ pub enum SshRemoteServerFailureKind {
 }
 
 impl SshRemoteServerFailureKind {
-    fn title(self) -> &'static str {
-        match self {
-            Self::BinaryCheck => "SSH extension couldn't be verified",
-            Self::BinaryInstall => "SSH extension couldn't be installed",
-            Self::Launch => "SSH extension couldn't be started",
-        }
-    }
-
     fn description(self) -> &'static str {
         match self {
             Self::BinaryCheck => {
-                "The SSH extension binary could not be verified on the remote host."
+                "The SSH extension binary could not be verified on the remote host"
             }
             Self::BinaryInstall => {
-                "The binary could not be written or executed on the remote host."
+                "The binary could not be written or executed on the remote host"
             }
-            Self::Launch => "The SSH extension could not be started on the remote host.",
+            Self::Launch => "The SSH extension could not be started on the remote host",
         }
     }
 }
@@ -60,10 +52,7 @@ impl SshRemoteServerFailureKind {
 pub struct SshRemoteServerFailedBanner {
     session_id: SessionId,
     kind: SshRemoteServerFailureKind,
-    /// User-facing summary, or `None` to fall back to `kind.description()`.
-    user_message: Option<String>,
-    /// Technical error detail for the `ERROR:` block.
-    detail: String,
+    error: String,
     close_mouse_state: MouseStateHandle,
 }
 
@@ -71,14 +60,12 @@ impl SshRemoteServerFailedBanner {
     pub fn new(
         session_id: SessionId,
         kind: SshRemoteServerFailureKind,
-        user_message: Option<String>,
-        detail: String,
+        error: String,
     ) -> Self {
         Self {
             session_id,
             kind,
-            user_message,
-            detail,
+            error,
             close_mouse_state: MouseStateHandle::default(),
         }
     }
@@ -115,51 +102,50 @@ impl View for SshRemoteServerFailedBanner {
         .with_margin_right(8.)
         .finish();
 
-        let title = Text::new(self.kind.title(), appearance.ui_font_family(), font_size)
-            .with_color(fg_color)
-            .finish();
+        let title = Text::new(
+            "Could not establish connection to host",
+            appearance.ui_font_family(),
+            font_size,
+        )
+        .with_color(fg_color)
+        .finish();
 
-        let description = self
-            .user_message
-            .as_deref()
-            .unwrap_or_else(|| self.kind.description());
-        let body_text = format!("{description} {BANNER_BODY}");
-        let body = Text::new(body_text, appearance.ui_font_family(), small_font_size)
+        let body = Text::new(BANNER_BODY, appearance.ui_font_family(), small_font_size)
             .soft_wrap(true)
             .with_color(muted_color)
             .finish();
 
-        // Error detail line wrapped in a red-tinted background container.
-        let trimmed_error = self.detail.trim();
-        let error_element = if trimmed_error.is_empty() {
-            None
+        // Red box with the error message.
+        let error_text_content = self.error.trim();
+        let error_box_text = if error_text_content.is_empty() {
+            self.kind.description().to_owned()
         } else {
-            let ansi_red = AnsiColorIdentifier::Red.to_ansi_color(&theme.terminal_colors().normal);
-            let error_bg = theme.ansi_overlay_1(ansi_red);
-            let error_text_color = theme.ansi_fg_red();
+            error_text_content.to_owned()
+        };
 
-            let error_text = Text::new(
-                format!("ERROR: {trimmed_error}"),
-                appearance.ui_font_family(),
-                small_font_size,
-            )
-            .soft_wrap(true)
-            .with_color(error_text_color)
+        let ansi_red = AnsiColorIdentifier::Red.to_ansi_color(&theme.terminal_colors().normal);
+        let error_bg = theme.ansi_overlay_1(ansi_red);
+        let error_text_color = theme.ansi_fg_red();
+
+        let error_text = Text::new(
+            error_box_text,
+            appearance.ui_font_family(),
+            small_font_size,
+        )
+        .soft_wrap(true)
+        .with_color(error_text_color)
+        .finish();
+
+        let error_element = Container::new(error_text)
+            .with_background(error_bg)
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+            .with_uniform_padding(12.)
             .finish();
 
-            let error_container = Container::new(error_text)
-                .with_background(error_bg)
-                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
-                .with_uniform_padding(12.)
-                .finish();
-
-            Some(
-                Container::new(error_container)
-                    .with_margin_top(8.)
-                    .with_margin_left(24.)
-                    .finish(),
-            )
-        };
+        let error_container = Container::new(error_element)
+            .with_margin_top(8.)
+            .with_horizontal_margin(24.)
+            .finish();
 
         // Close (X) button
         let close_icon_color = muted_color;
@@ -202,17 +188,13 @@ impl View for SshRemoteServerFailedBanner {
             .with_margin_left(24.)
             .finish();
 
-        let mut content = Flex::column()
+        let content = Flex::column()
             .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_child(header_row)
-            .with_child(body_container);
-
-        if let Some(error) = error_element {
-            content = content.with_child(error);
-        }
-
-        let content = content.finish();
+            .with_child(body_container)
+            .with_child(error_container)
+            .finish();
 
         Container::new(content)
             .with_background(internal_colors::fg_overlay_1(theme))

--- a/app/src/terminal/view/ssh_remote_server_failed_banner.rs
+++ b/app/src/terminal/view/ssh_remote_server_failed_banner.rs
@@ -60,16 +60,25 @@ impl SshRemoteServerFailureKind {
 pub struct SshRemoteServerFailedBanner {
     session_id: SessionId,
     kind: SshRemoteServerFailureKind,
-    error: String,
+    /// User-facing summary, or `None` to fall back to `kind.description()`.
+    user_message: Option<String>,
+    /// Technical error detail for the `ERROR:` block.
+    detail: String,
     close_mouse_state: MouseStateHandle,
 }
 
 impl SshRemoteServerFailedBanner {
-    pub fn new(session_id: SessionId, kind: SshRemoteServerFailureKind, error: String) -> Self {
+    pub fn new(
+        session_id: SessionId,
+        kind: SshRemoteServerFailureKind,
+        user_message: Option<String>,
+        detail: String,
+    ) -> Self {
         Self {
             session_id,
             kind,
-            error,
+            user_message,
+            detail,
             close_mouse_state: MouseStateHandle::default(),
         }
     }
@@ -110,14 +119,18 @@ impl View for SshRemoteServerFailedBanner {
             .with_color(fg_color)
             .finish();
 
-        let body_text = format!("{} {BANNER_BODY}", self.kind.description());
+        let description = self
+            .user_message
+            .as_deref()
+            .unwrap_or_else(|| self.kind.description());
+        let body_text = format!("{description} {BANNER_BODY}");
         let body = Text::new(body_text, appearance.ui_font_family(), small_font_size)
             .soft_wrap(true)
             .with_color(muted_color)
             .finish();
 
         // Error detail line wrapped in a red-tinted background container.
-        let trimmed_error = self.error.trim();
+        let trimmed_error = self.detail.trim();
         let error_element = if trimmed_error.is_empty() {
             None
         } else {

--- a/app/src/terminal/view/ssh_remote_server_failed_banner.rs
+++ b/app/src/terminal/view/ssh_remote_server_failed_banner.rs
@@ -1,6 +1,7 @@
 //! Banner shown when the remote-server binary check, installation, or connection fails on the remote host.
 //! We fall back to the existing Warpification behavior and display this banner so the user knows why advanced features are unavailable.
 
+use remote_server::transport::UserFacingError;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::AnsiColorIdentifier;
 use warpui::{
@@ -28,43 +29,16 @@ pub enum SshRemoteServerFailedBannerEvent {
     Dismissed,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub enum SshRemoteServerFailureKind {
-    BinaryCheck,
-    BinaryInstall,
-    Launch,
-}
-
-impl SshRemoteServerFailureKind {
-    fn description(self) -> &'static str {
-        match self {
-            Self::BinaryCheck => {
-                "The SSH extension binary could not be verified on the remote host"
-            }
-            Self::BinaryInstall => {
-                "The binary could not be written or executed on the remote host"
-            }
-            Self::Launch => "The SSH extension could not be started on the remote host",
-        }
-    }
-}
-
 pub struct SshRemoteServerFailedBanner {
     session_id: SessionId,
-    kind: SshRemoteServerFailureKind,
-    error: String,
+    error: UserFacingError,
     close_mouse_state: MouseStateHandle,
 }
 
 impl SshRemoteServerFailedBanner {
-    pub fn new(
-        session_id: SessionId,
-        kind: SshRemoteServerFailureKind,
-        error: String,
-    ) -> Self {
+    pub fn new(session_id: SessionId, error: UserFacingError) -> Self {
         Self {
             session_id,
-            kind,
             error,
             close_mouse_state: MouseStateHandle::default(),
         }
@@ -103,49 +77,49 @@ impl View for SshRemoteServerFailedBanner {
         .finish();
 
         let title = Text::new(
-            "Could not establish connection to host",
+            self.error.title.to_string(),
             appearance.ui_font_family(),
             font_size,
         )
         .with_color(fg_color)
         .finish();
 
-        let body = Text::new(BANNER_BODY, appearance.ui_font_family(), small_font_size)
-            .soft_wrap(true)
-            .with_color(muted_color)
-            .finish();
-
-        // Red box with the error message.
-        let error_text_content = self.error.trim();
-        let error_box_text = if error_text_content.is_empty() {
-            self.kind.description().to_owned()
-        } else {
-            error_text_content.to_owned()
-        };
-
-        let ansi_red = AnsiColorIdentifier::Red.to_ansi_color(&theme.terminal_colors().normal);
-        let error_bg = theme.ansi_overlay_1(ansi_red);
-        let error_text_color = theme.ansi_fg_red();
-
-        let error_text = Text::new(
-            error_box_text,
+        let body = Text::new(
+            BANNER_BODY.to_string(),
             appearance.ui_font_family(),
             small_font_size,
         )
         .soft_wrap(true)
-        .with_color(error_text_color)
+        .with_color(muted_color)
         .finish();
 
-        let error_element = Container::new(error_text)
-            .with_background(error_bg)
-            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
-            .with_uniform_padding(12.)
-            .finish();
+        let error_container = {
+            let ansi_red = AnsiColorIdentifier::Red.to_ansi_color(&theme.terminal_colors().normal);
+            let error_bg = theme.ansi_overlay_1(ansi_red);
+            let error_text_color = theme.ansi_fg_red();
 
-        let error_container = Container::new(error_element)
-            .with_margin_top(8.)
-            .with_horizontal_margin(24.)
-            .finish();
+            let red_box_text = if let Some(detail) = &self.error.detail {
+                format!("{}. {}", self.error.body, detail)
+            } else {
+                format!("{}.", self.error.body)
+            };
+
+            let error_text = Text::new(red_box_text, appearance.ui_font_family(), small_font_size)
+                .soft_wrap(true)
+                .with_color(error_text_color)
+                .finish();
+
+            let error_box = Container::new(error_text)
+                .with_background(error_bg)
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+                .with_uniform_padding(12.)
+                .finish();
+
+            Container::new(error_box)
+                .with_margin_top(8.)
+                .with_horizontal_margin(24.)
+                .finish()
+        };
 
         // Close (X) button
         let close_icon_color = muted_color;
@@ -188,13 +162,15 @@ impl View for SshRemoteServerFailedBanner {
             .with_margin_left(24.)
             .finish();
 
-        let content = Flex::column()
+        let mut content = Flex::column()
             .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_child(header_row)
-            .with_child(body_container)
-            .with_child(error_container)
-            .finish();
+            .with_child(body_container);
+
+        content = content.with_child(error_container);
+
+        let content = content.finish();
 
         Container::new(content)
             .with_background(internal_colors::fg_overlay_1(theme))

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -21,7 +21,7 @@ use crate::{send_telemetry_from_ctx, TelemetryEvent};
 use remote_server::setup::{
     PreinstallCheckResult, PreinstallStatus, RemoteLibc, RemotePlatform, UnsupportedReason,
 };
-use remote_server::transport::{CheckBinaryError, InstallBinaryError};
+use remote_server::transport::Error;
 
 use super::pty_controller::{EventLoopSender, PtyController};
 
@@ -213,7 +213,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
     fn on_binary_check_complete(
         &mut self,
         session_id: SessionId,
-        result: Result<bool, Arc<CheckBinaryError>>,
+        result: Result<bool, Arc<Error>>,
         preinstall_check: Option<PreinstallCheckResult>,
         has_old_binary: bool,
         ctx: &mut ModelContext<Self>,
@@ -466,7 +466,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
     fn on_binary_install_complete(
         &mut self,
         session_id: SessionId,
-        result: Result<(), Arc<InstallBinaryError>>,
+        result: Result<(), Arc<Error>>,
         ctx: &mut ModelContext<Self>,
     ) {
         let expected = match &self.state {

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -21,6 +21,7 @@ use crate::{send_telemetry_from_ctx, TelemetryEvent};
 use remote_server::setup::{
     PreinstallCheckResult, PreinstallStatus, RemoteLibc, RemotePlatform, UnsupportedReason,
 };
+use remote_server::transport::{CheckBinaryError, InstallBinaryError};
 
 use super::pty_controller::{EventLoopSender, PtyController};
 
@@ -212,7 +213,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
     fn on_binary_check_complete(
         &mut self,
         session_id: SessionId,
-        result: Result<bool, String>,
+        result: Result<bool, Arc<CheckBinaryError>>,
         preinstall_check: Option<PreinstallCheckResult>,
         has_old_binary: bool,
         ctx: &mut ModelContext<Self>,
@@ -465,7 +466,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
     fn on_binary_install_complete(
         &mut self,
         session_id: SessionId,
-        result: Result<(), String>,
+        result: Result<(), Arc<InstallBinaryError>>,
         ctx: &mut ModelContext<Self>,
     ) {
         let expected = match &self.state {

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -538,13 +538,13 @@ impl RemoteServerManager {
                                 ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
                                     session_id,
                                     state: RemoteServerSetupState::Failed {
-                                        error: error.clone(),
+                                        error: error.to_string(),
                                     },
                                 });
                             }
                             ctx.emit(RemoteServerManagerEvent::BinaryCheckComplete {
                                 session_id,
-                                result: check_result,
+                                result: check_result.map_err(|e| e.to_string()),
                                 remote_platform: platform,
                                 preinstall_check: preinstall,
                                 has_old_binary,
@@ -632,13 +632,13 @@ impl RemoteServerManager {
                                 ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
                                     session_id,
                                     state: RemoteServerSetupState::Failed {
-                                        error: error.clone(),
+                                        error: error.to_string(),
                                     },
                                 });
                             }
                             ctx.emit(RemoteServerManagerEvent::BinaryInstallComplete {
                                 session_id,
-                                result,
+                                result: result.map_err(|e| e.to_string()),
                             });
                         })
                         .await;

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -19,7 +19,7 @@ use crate::setup::RemoteServerSetupState;
 use crate::setup::UnsupportedReason;
 #[cfg(not(target_family = "wasm"))]
 use crate::transport::Connection;
-use crate::transport::RemoteTransport;
+use crate::transport::{CheckBinaryError, InstallBinaryError, RemoteTransport};
 use crate::HostId;
 use repo_metadata::RepoMetadataUpdate;
 use serde::Serialize;
@@ -325,7 +325,7 @@ pub enum RemoteServerManagerEvent {
     /// - `Err(_)` means the check itself failed (e.g. SSH error or timeout).
     BinaryCheckComplete {
         session_id: SessionId,
-        result: Result<bool, String>,
+        result: Result<bool, Arc<CheckBinaryError>>,
         /// The detected remote platform (OS + arch) from `uname -sm`.
         /// `None` if detection failed or was not attempted.
         remote_platform: Option<RemotePlatform>,
@@ -349,7 +349,7 @@ pub enum RemoteServerManagerEvent {
     /// - `Err(_)` means the install failed and carries the failure reason (SSH error, timeout, script error, etc.).
     BinaryInstallComplete {
         session_id: SessionId,
-        result: Result<(), String>,
+        result: Result<(), Arc<InstallBinaryError>>,
     },
 
     // --- Telemetry events ---
@@ -553,7 +553,7 @@ impl RemoteServerManager {
                             }
                             ctx.emit(RemoteServerManagerEvent::BinaryCheckComplete {
                                 session_id,
-                                result: check_result.map_err(|e| e.to_string()),
+                                result: check_result.map_err(Arc::new),
                                 remote_platform: platform,
                                 preinstall_check: preinstall,
                                 has_old_binary,
@@ -647,7 +647,7 @@ impl RemoteServerManager {
                             }
                             ctx.emit(RemoteServerManagerEvent::BinaryInstallComplete {
                                 session_id,
-                                result: result.map_err(|e| e.to_string()),
+                                result: result.map_err(Arc::new),
                             });
                         })
                         .await;

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -19,7 +19,7 @@ use crate::setup::RemoteServerSetupState;
 use crate::setup::UnsupportedReason;
 #[cfg(not(target_family = "wasm"))]
 use crate::transport::Connection;
-use crate::transport::{CheckBinaryError, InstallBinaryError, RemoteTransport};
+use crate::transport::{Error, RemoteTransport};
 use crate::HostId;
 use repo_metadata::RepoMetadataUpdate;
 use serde::Serialize;
@@ -325,7 +325,7 @@ pub enum RemoteServerManagerEvent {
     /// - `Err(_)` means the check itself failed (e.g. SSH error or timeout).
     BinaryCheckComplete {
         session_id: SessionId,
-        result: Result<bool, Arc<CheckBinaryError>>,
+        result: Result<bool, Arc<Error>>,
         /// The detected remote platform (OS + arch) from `uname -sm`.
         /// `None` if detection failed or was not attempted.
         remote_platform: Option<RemotePlatform>,
@@ -349,7 +349,7 @@ pub enum RemoteServerManagerEvent {
     /// - `Err(_)` means the install failed and carries the failure reason (SSH error, timeout, script error, etc.).
     BinaryInstallComplete {
         session_id: SessionId,
-        result: Result<(), Arc<InstallBinaryError>>,
+        result: Result<(), Arc<Error>>,
     },
 
     // --- Telemetry events ---

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -242,28 +242,28 @@ impl RemoteArch {
 /// Takes the last line to skip any shell initialization output.
 pub fn parse_uname_output(
     output: &str,
-) -> std::result::Result<RemotePlatform, crate::transport::DetectPlatformError> {
-    use crate::transport::DetectPlatformError;
+) -> std::result::Result<RemotePlatform, crate::transport::Error> {
+    use crate::transport::Error;
 
     let line = output
         .lines()
         .last()
-        .ok_or_else(|| DetectPlatformError::Other(anyhow!("empty uname output")))
+        .ok_or_else(|| Error::Other(anyhow!("empty uname output")))
         .map(str::trim)?;
 
     let mut parts = line.split_whitespace();
     let os_str = parts
         .next()
-        .ok_or_else(|| DetectPlatformError::Other(anyhow!("missing OS in uname output: {line}")))?;
-    let arch_str = parts.next().ok_or_else(|| {
-        DetectPlatformError::Other(anyhow!("missing arch in uname output: {line}"))
-    })?;
+        .ok_or_else(|| Error::Other(anyhow!("missing OS in uname output: {line}")))?;
+    let arch_str = parts
+        .next()
+        .ok_or_else(|| Error::Other(anyhow!("missing arch in uname output: {line}")))?;
 
     let os = match os_str {
         "Linux" => RemoteOs::Linux,
         "Darwin" => RemoteOs::MacOs,
         other => {
-            return Err(DetectPlatformError::UnsupportedOs {
+            return Err(Error::UnsupportedOs {
                 os: other.to_string(),
             })
         }
@@ -273,7 +273,7 @@ pub fn parse_uname_output(
         "x86_64" => RemoteArch::X86_64,
         "aarch64" | "arm64" | "armv8l" => RemoteArch::Aarch64,
         other => {
-            return Err(DetectPlatformError::UnsupportedArch {
+            return Err(Error::UnsupportedArch {
                 arch: other.to_string(),
             })
         }

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -4,7 +4,7 @@ pub use glibc::{GlibcVersion, RemoteLibc};
 
 use std::time::Duration;
 
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 use warp_core::channel::{Channel, ChannelState};
 
 /// State machine for the remote server install → launch → initialize flow.
@@ -240,31 +240,43 @@ impl RemoteArch {
 ///
 /// The expected format is `<os> <arch>`, e.g. `Linux x86_64` or `Darwin arm64`.
 /// Takes the last line to skip any shell initialization output.
-pub fn parse_uname_output(output: &str) -> Result<RemotePlatform> {
+pub fn parse_uname_output(
+    output: &str,
+) -> std::result::Result<RemotePlatform, crate::transport::DetectPlatformError> {
+    use crate::transport::DetectPlatformError;
+
     let line = output
         .lines()
         .last()
-        .ok_or_else(|| anyhow!("empty uname output"))?
-        .trim();
+        .ok_or_else(|| DetectPlatformError::Other(anyhow!("empty uname output")))
+        .map(str::trim)?;
 
     let mut parts = line.split_whitespace();
     let os_str = parts
         .next()
-        .ok_or_else(|| anyhow!("missing OS in uname output: {line}"))?;
-    let arch_str = parts
-        .next()
-        .ok_or_else(|| anyhow!("missing arch in uname output: {line}"))?;
+        .ok_or_else(|| DetectPlatformError::Other(anyhow!("missing OS in uname output: {line}")))?;
+    let arch_str = parts.next().ok_or_else(|| {
+        DetectPlatformError::Other(anyhow!("missing arch in uname output: {line}"))
+    })?;
 
     let os = match os_str {
         "Linux" => RemoteOs::Linux,
         "Darwin" => RemoteOs::MacOs,
-        other => return Err(anyhow!("unsupported OS: {other}")),
+        other => {
+            return Err(DetectPlatformError::UnsupportedOs {
+                os: other.to_string(),
+            })
+        }
     };
 
     let arch = match arch_str {
         "x86_64" => RemoteArch::X86_64,
         "aarch64" | "arm64" | "armv8l" => RemoteArch::Aarch64,
-        other => return Err(anyhow!("unsupported arch: {other}")),
+        other => {
+            return Err(DetectPlatformError::UnsupportedArch {
+                arch: other.to_string(),
+            })
+        }
     };
 
     Ok(RemotePlatform { os, arch })

--- a/crates/remote_server/src/setup_tests.rs
+++ b/crates/remote_server/src/setup_tests.rs
@@ -54,7 +54,7 @@ fn parse_uname_trims_whitespace() {
 fn parse_uname_unsupported_os() {
     let result = parse_uname_output("Windows x86_64");
     match result {
-        Err(crate::transport::DetectPlatformError::UnsupportedOs { os }) => {
+        Err(crate::transport::Error::UnsupportedOs { os }) => {
             assert_eq!(os, "Windows");
         }
         other => panic!("expected UnsupportedOs, got {other:?}"),
@@ -65,7 +65,7 @@ fn parse_uname_unsupported_os() {
 fn parse_uname_unsupported_arch() {
     let result = parse_uname_output("Linux mips");
     match result {
-        Err(crate::transport::DetectPlatformError::UnsupportedArch { arch }) => {
+        Err(crate::transport::Error::UnsupportedArch { arch }) => {
             assert_eq!(arch, "mips");
         }
         other => panic!("expected UnsupportedArch, got {other:?}"),

--- a/crates/remote_server/src/setup_tests.rs
+++ b/crates/remote_server/src/setup_tests.rs
@@ -53,15 +53,23 @@ fn parse_uname_trims_whitespace() {
 #[test]
 fn parse_uname_unsupported_os() {
     let result = parse_uname_output("Windows x86_64");
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("unsupported OS"));
+    match result {
+        Err(crate::transport::DetectPlatformError::UnsupportedOs { os }) => {
+            assert_eq!(os, "Windows");
+        }
+        other => panic!("expected UnsupportedOs, got {other:?}"),
+    }
 }
 
 #[test]
 fn parse_uname_unsupported_arch() {
     let result = parse_uname_output("Linux mips");
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("unsupported arch"));
+    match result {
+        Err(crate::transport::DetectPlatformError::UnsupportedArch { arch }) => {
+            assert_eq!(arch, "mips");
+        }
+        other => panic!("expected UnsupportedArch, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/remote_server/src/ssh.rs
+++ b/crates/remote_server/src/ssh.rs
@@ -2,9 +2,28 @@ use std::path::Path;
 use std::process::Output;
 use std::time::Duration;
 
-use anyhow::{anyhow, Result};
 use command::r#async::Command;
 use warpui::r#async::FutureExt as _;
+
+/// Transport-level error from [`run_ssh_command`] or [`run_ssh_script`].
+///
+/// Distinguishes timeouts from other I/O failures so callers can promote
+/// timeouts to a per-method `TimedOut` variant on the trait error types.
+#[derive(Debug, thiserror::Error)]
+pub enum SshCommandError {
+    /// The SSH command or script did not complete within the timeout.
+    #[error("timed out after {timeout:?}")]
+    TimedOut { timeout: Duration },
+    /// The `ssh` process could not be spawned.
+    #[error("failed to spawn ssh: {0}")]
+    SpawnFailed(std::io::Error),
+    /// Writing to the SSH process's stdin failed (script piping).
+    #[error("failed to write to ssh stdin: {0}")]
+    StdinWriteFailed(std::io::Error),
+    /// The SSH process was spawned but `output()` returned an I/O error.
+    #[error("ssh I/O error: {0}")]
+    IoError(std::io::Error),
+}
 
 /// Timeout for `ssh -O exit`. The command only talks to the local
 /// ControlMaster over a Unix socket, so it should return almost
@@ -96,7 +115,7 @@ pub async fn run_ssh_command(
     socket_path: &Path,
     remote_command: &str,
     timeout: Duration,
-) -> Result<Output> {
+) -> Result<Output, SshCommandError> {
     async {
         Command::new("ssh")
             .args(ssh_args(socket_path))
@@ -107,8 +126,8 @@ pub async fn run_ssh_command(
     }
     .with_timeout(timeout)
     .await
-    .map_err(|_| anyhow!("SSH command timed out after {timeout:?}"))?
-    .map_err(|e| anyhow!("SSH command failed to execute: {e}"))
+    .map_err(|_| SshCommandError::TimedOut { timeout })?
+    .map_err(SshCommandError::IoError)
 }
 
 /// Pipe a script into `bash -s` on the remote host via the ControlMaster
@@ -122,7 +141,11 @@ pub async fn run_ssh_command(
 /// that would require complex, fragile escaping if passed as an argument.
 /// The `bash -s` + stdin approach avoids all escaping issues and has no
 /// argument length limits.
-pub async fn run_ssh_script(socket_path: &Path, script: &str, timeout: Duration) -> Result<Output> {
+pub async fn run_ssh_script(
+    socket_path: &Path,
+    script: &str,
+    timeout: Duration,
+) -> Result<Output, SshCommandError> {
     use std::process::Stdio;
 
     let mut child = Command::new("ssh")
@@ -133,7 +156,7 @@ pub async fn run_ssh_script(socket_path: &Path, script: &str, timeout: Duration)
         .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
-        .map_err(|e| anyhow!("Failed to spawn SSH for script: {e}"))?;
+        .map_err(SshCommandError::SpawnFailed)?;
 
     // Write the script to stdin.
     if let Some(mut stdin) = child.stdin.take() {
@@ -141,7 +164,7 @@ pub async fn run_ssh_script(socket_path: &Path, script: &str, timeout: Duration)
         stdin
             .write_all(script.as_bytes())
             .await
-            .map_err(|e| anyhow!("Failed to write script to stdin: {e}"))?;
+            .map_err(SshCommandError::StdinWriteFailed)?;
         // Close stdin so the remote bash exits after reading the script.
         drop(stdin);
     }
@@ -150,6 +173,6 @@ pub async fn run_ssh_script(socket_path: &Path, script: &str, timeout: Duration)
         .output()
         .with_timeout(timeout)
         .await
-        .map_err(|_| anyhow!("Script timed out after {timeout:?}"))?
-        .map_err(|e| anyhow!("Script failed: {e}"))
+        .map_err(|_| SshCommandError::TimedOut { timeout })?
+        .map_err(SshCommandError::IoError)
 }

--- a/crates/remote_server/src/ssh.rs
+++ b/crates/remote_server/src/ssh.rs
@@ -13,16 +13,16 @@ use warpui::r#async::FutureExt as _;
 #[derive(Debug, thiserror::Error)]
 pub enum SshCommandError {
     /// The SSH command or script did not complete within the timeout.
-    #[error("timed out after {timeout:?}")]
+    #[error("Timed out after {timeout:?}")]
     TimedOut { timeout: Duration },
     /// The `ssh` process could not be spawned.
-    #[error("failed to spawn ssh: {0}")]
+    #[error("Failed to spawn ssh: {0}")]
     SpawnFailed(std::io::Error),
-    /// Writing to the SSH process's stdin failed (script piping).
-    #[error("failed to write to ssh stdin: {0}")]
+    /// Writing to the SSH process's stdin failed.
+    #[error("Failed to write to ssh stdin: {0}")]
     StdinWriteFailed(std::io::Error),
     /// The SSH process was spawned but `output()` returned an I/O error.
-    #[error("ssh I/O error: {0}")]
+    #[error("SSH I/O error: {0}")]
     IoError(std::io::Error),
 }
 

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -10,6 +10,7 @@
 //! `Arc<dyn RemoteTransport>` for reconnection.
 //!
 //! [`RemoteServerManager`]: crate::manager::RemoteServerManager
+use std::future::Future;
 #[cfg(not(target_family = "wasm"))]
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -20,6 +21,63 @@ use warpui::r#async::executor;
 use crate::client::{ClientEvent, RemoteServerClient};
 use crate::manager::RemoteServerExitStatus;
 use crate::setup::{PreinstallCheckResult, RemotePlatform};
+
+/// Error returned by [`RemoteTransport::detect_platform`].
+#[derive(Debug, thiserror::Error)]
+pub enum DetectPlatformError {
+    /// The platform detection command timed out.
+    #[error("platform detection timed out")]
+    TimedOut,
+    /// The remote host reported an OS or architecture that is not
+    /// supported by the prebuilt remote-server binary.
+    #[error("unsupported platform")]
+    UnsupportedPlatform(#[source] anyhow::Error),
+    /// Any other transport-level or unexpected failure.
+    #[error(transparent)]
+    Other(anyhow::Error),
+}
+
+impl From<crate::ssh::SshCommandError> for DetectPlatformError {
+    fn from(err: crate::ssh::SshCommandError) -> Self {
+        match err {
+            crate::ssh::SshCommandError::TimedOut { .. } => Self::TimedOut,
+            other => Self::Other(other.into()),
+        }
+    }
+}
+
+/// Error returned by [`RemoteTransport::run_preinstall_check`].
+#[derive(Debug, thiserror::Error)]
+pub enum PreinstallCheckError {
+    /// The preinstall check script ran but exited with a non-zero code.
+    #[error("preinstall check script failed (exit {code}): {stderr}")]
+    ScriptFailed { code: i32, stderr: String },
+    /// Any other transport-level or unexpected failure.
+    #[error(transparent)]
+    Other(anyhow::Error),
+}
+
+/// Error returned by [`RemoteTransport::check_binary`].
+#[derive(Debug, thiserror::Error)]
+pub enum CheckBinaryError {
+    /// The binary check command timed out.
+    #[error("binary check timed out")]
+    TimedOut,
+    /// Any other transport-level or unexpected failure.
+    #[error(transparent)]
+    Other(anyhow::Error),
+}
+
+/// Error returned by [`RemoteTransport::install_binary`].
+#[derive(Debug, thiserror::Error)]
+pub enum InstallBinaryError {
+    /// The install script timed out.
+    #[error("install timed out")]
+    TimedOut,
+    /// Any other transport-level or unexpected failure.
+    #[error(transparent)]
+    Other(anyhow::Error),
+}
 
 /// A successful return from [`RemoteTransport::connect`].
 ///
@@ -64,11 +122,12 @@ pub struct Connection {
 pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     /// Detects the remote host's OS and architecture by running `uname -sm`.
     ///
-    /// Returns the parsed [`RemotePlatform`] on success, or an error string
-    /// if the command fails or the output cannot be parsed.
+    /// Returns the parsed [`RemotePlatform`] on success, or a
+    /// [`DetectPlatformError`] if the command fails or the output cannot
+    /// be parsed.
     fn detect_platform(
         &self,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<RemotePlatform, String>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<RemotePlatform, DetectPlatformError>> + Send>>;
 
     /// Runs the preinstall check script ([`crate::setup::PREINSTALL_CHECK_SCRIPT`])
     /// over the existing connection and parses its structured stdout into
@@ -81,12 +140,12 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     ///
     /// Returns `Ok(_)` on success (including when the script reported
     /// `Unknown` — that's a parser-level outcome, not a transport-level
-    /// failure). Returns `Err(_)` only on SSH-level failure (timeout,
+    /// failure). Returns `Err(_)` only on transport-level failure (timeout,
     /// broken pipe, non-zero exit with no parseable summary), which the
     /// caller treats as inconclusive (fail open).
     fn run_preinstall_check(
         &self,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<PreinstallCheckResult, String>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<PreinstallCheckResult, PreinstallCheckError>> + Send>>;
 
     /// Checks whether the remote server binary is present on the remote host.
     ///
@@ -96,10 +155,8 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     ///
     /// Returns `Ok(true)` if the binary is installed and executable,
     /// `Ok(false)` if it is definitively not installed, and
-    /// `Err(_)` if the check failed (e.g. SSH timeout/unreachable).
-    fn check_binary(
-        &self,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<bool, String>> + Send>>;
+    /// `Err(_)` if the check failed (e.g. timeout or unreachable).
+    fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, CheckBinaryError>> + Send>>;
 
     /// Checks whether the remote host already has an existing install
     /// of the remote server binary.
@@ -110,9 +167,7 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     ///
     /// Returns `Ok(true)` if a prior install was detected, `Ok(false)`
     /// if not, and `Err(_)` on SSH failure.
-    fn check_has_old_binary(
-        &self,
-    ) -> Pin<Box<dyn std::future::Future<Output = anyhow::Result<bool>> + Send>>;
+    fn check_has_old_binary(&self) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send>>;
 
     /// Installs the remote server binary on the remote host.
     ///
@@ -121,10 +176,10 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     /// [`SetupStateChanged`] and [`BinaryInstallComplete`].
     ///
     /// Returns `Ok(())` if the install succeeded, and
-    /// `Err(_)` if the install failed (e.g. SSH timeout, script error).
+    /// `Err(_)` if the install failed (e.g. timeout or script error).
     fn install_binary(
         &self,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), InstallBinaryError>> + Send>>;
 
     /// Establish a new connection to the remote server.
     ///
@@ -139,7 +194,7 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     fn connect(
         &self,
         executor: std::sync::Arc<executor::Background>,
-    ) -> Pin<Box<dyn std::future::Future<Output = anyhow::Result<Connection>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Connection>> + Send>>;
 
     /// Remove the remote server binary, forcing a reinstall on the next
     /// [`install_binary`] call.
@@ -153,7 +208,7 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     /// [`install_binary`]: RemoteTransport::install_binary
     fn remove_remote_server_binary(
         &self,
-    ) -> Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
 
     /// Returns `true` if the transport considers a reconnect viable after
     /// a spontaneous disconnect with the given exit status.

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -41,6 +41,26 @@ pub enum DetectPlatformError {
     Other(anyhow::Error),
 }
 
+impl DetectPlatformError {
+    /// Returns a short, user-facing description of the error suitable for
+    /// display in the UI banner. Returns `None` for `Other` errors where
+    /// no tailored message is available.
+    pub fn user_facing_message(&self) -> Option<String> {
+        match self {
+            Self::TimedOut => {
+                Some("The connection timed out while detecting the remote platform.".into())
+            }
+            Self::UnsupportedOs { os } => Some(format!(
+                "The remote host's operating system ({os}) is not supported."
+            )),
+            Self::UnsupportedArch { arch } => Some(format!(
+                "The remote host's architecture ({arch}) is not supported."
+            )),
+            Self::Other(_) => None,
+        }
+    }
+}
+
 impl From<crate::ssh::SshCommandError> for DetectPlatformError {
     fn from(err: crate::ssh::SshCommandError) -> Self {
         match err {
@@ -72,6 +92,20 @@ pub enum CheckBinaryError {
     Other(anyhow::Error),
 }
 
+impl CheckBinaryError {
+    /// Returns a short, user-facing description of the error suitable for
+    /// display in the UI banner. Returns `None` for `Other` errors where
+    /// no tailored message is available.
+    pub fn user_facing_message(&self) -> Option<String> {
+        match self {
+            Self::TimedOut => {
+                Some("The connection timed out while checking for the SSH extension.".into())
+            }
+            Self::Other(_) => None,
+        }
+    }
+}
+
 /// Error returned by [`RemoteTransport::install_binary`].
 #[derive(Debug, thiserror::Error)]
 pub enum InstallBinaryError {
@@ -81,6 +115,18 @@ pub enum InstallBinaryError {
     /// Any other transport-level or unexpected failure.
     #[error(transparent)]
     Other(anyhow::Error),
+}
+
+impl InstallBinaryError {
+    /// Returns a short, user-facing description of the error suitable for
+    /// display in the UI banner. Returns `None` for `Other` errors where
+    /// no tailored message is available.
+    pub fn user_facing_message(&self) -> Option<String> {
+        match self {
+            Self::TimedOut => Some("The installation timed out.".into()),
+            Self::Other(_) => None,
+        }
+    }
 }
 
 /// A successful return from [`RemoteTransport::connect`].

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -42,21 +42,12 @@ pub enum DetectPlatformError {
 }
 
 impl DetectPlatformError {
-    /// Returns a short, user-facing description of the error suitable for
-    /// display in the UI banner. Returns `None` for `Other` errors where
-    /// no tailored message is available.
-    pub fn user_facing_message(&self) -> Option<String> {
+    /// Returns a user-facing error message for display in the UI banner.
+    /// Starts with a generic description, followed by specific details when available.
+    pub fn user_facing_message(&self) -> String {
         match self {
-            Self::TimedOut => {
-                Some("The connection timed out while detecting the remote platform.".into())
-            }
-            Self::UnsupportedOs { os } => Some(format!(
-                "The remote host's operating system ({os}) is not supported."
-            )),
-            Self::UnsupportedArch { arch } => Some(format!(
-                "The remote host's architecture ({arch}) is not supported."
-            )),
-            Self::Other(_) => None,
+            Self::Other(_) => "Failed to detect remote platform".into(),
+            _ => format!("Failed to detect remote platform: {self}"),
         }
     }
 }
@@ -93,15 +84,11 @@ pub enum CheckBinaryError {
 }
 
 impl CheckBinaryError {
-    /// Returns a short, user-facing description of the error suitable for
-    /// display in the UI banner. Returns `None` for `Other` errors where
-    /// no tailored message is available.
-    pub fn user_facing_message(&self) -> Option<String> {
+    /// Returns a user-facing error message for display in the UI banner.
+    pub fn user_facing_message(&self) -> String {
         match self {
-            Self::TimedOut => {
-                Some("The connection timed out while checking for the SSH extension.".into())
-            }
-            Self::Other(_) => None,
+            Self::Other(_) => "Failed to check for SSH extension".into(),
+            _ => format!("Failed to check for SSH extension: {self}"),
         }
     }
 }
@@ -118,13 +105,11 @@ pub enum InstallBinaryError {
 }
 
 impl InstallBinaryError {
-    /// Returns a short, user-facing description of the error suitable for
-    /// display in the UI banner. Returns `None` for `Other` errors where
-    /// no tailored message is available.
-    pub fn user_facing_message(&self) -> Option<String> {
+    /// Returns a user-facing error message for display in the UI banner.
+    pub fn user_facing_message(&self) -> String {
         match self {
-            Self::TimedOut => Some("The installation timed out.".into()),
-            Self::Other(_) => None,
+            Self::Other(_) => "Failed to install SSH extension".into(),
+            _ => format!("Failed to install SSH extension: {self}"),
         }
     }
 }

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -28,10 +28,14 @@ pub enum DetectPlatformError {
     /// The platform detection command timed out.
     #[error("platform detection timed out")]
     TimedOut,
-    /// The remote host reported an OS or architecture that is not
+    /// The remote host reported an OS that is not supported by the
+    /// prebuilt remote-server binary.
+    #[error("unsupported OS: {os}")]
+    UnsupportedOs { os: String },
+    /// The remote host reported a CPU architecture that is not
     /// supported by the prebuilt remote-server binary.
-    #[error("unsupported platform")]
-    UnsupportedPlatform(#[source] anyhow::Error),
+    #[error("unsupported architecture: {arch}")]
+    UnsupportedArch { arch: String },
     /// Any other transport-level or unexpected failure.
     #[error(transparent)]
     Other(anyhow::Error),

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -22,94 +22,119 @@ use crate::client::{ClientEvent, RemoteServerClient};
 use crate::manager::RemoteServerExitStatus;
 use crate::setup::{PreinstallCheckResult, RemotePlatform};
 
-/// Error returned by [`RemoteTransport::detect_platform`].
+/// Structured error for user-facing display in the SSH remote-server
+/// failed banner. Separates the always-visible title and body from the
+/// optional technical detail.
+#[derive(Clone, Debug)]
+pub struct UserFacingError {
+    /// Short headline, e.g. "Could not establish connection to host".
+    pub title: &'static str,
+    /// Always-visible explanation of what went wrong.
+    pub body: String,
+    /// Optional technical detail shown in the red error box (stderr,
+    /// timeout duration, unsupported OS/arch). `None` when the
+    /// underlying error doesn't carry anything useful for the user.
+    pub detail: Option<String>,
+}
+
+/// The setup stage that failed, used to generate context-appropriate
+/// user-facing messages from a [`Error`].
+#[derive(Clone, Copy, Debug)]
+pub enum SetupStage {
+    DetectPlatform,
+    PreinstallCheck,
+    CheckBinary,
+    InstallBinary,
+    Launch,
+}
+
+impl SetupStage {
+    fn action_description(self) -> &'static str {
+        match self {
+            Self::DetectPlatform => "detect remote platform",
+            Self::PreinstallCheck => "run preinstall check",
+            Self::CheckBinary => "verify SSH extension",
+            Self::InstallBinary => "install SSH extension",
+            Self::Launch => "start SSH extension",
+        }
+    }
+}
+
+/// Unified error type for all [`RemoteTransport`] setup methods
+/// (detect_platform, run_preinstall_check, check_binary, install_binary).
+///
+/// Each variant captures enough structured information for both
+/// logging/telemetry (`Display` impl) and user-facing banners
+/// ([`user_facing_error`]).
+///
+/// [`user_facing_error`]: Error::user_facing_error
 #[derive(Debug, thiserror::Error)]
-pub enum DetectPlatformError {
-    /// The platform detection command timed out.
-    #[error("platform detection timed out")]
+pub enum Error {
+    /// The operation timed out.
+    #[error("timed out")]
     TimedOut,
-    /// The remote host reported an OS that is not supported by the
-    /// prebuilt remote-server binary.
+    /// The remote host reported an OS not supported by the prebuilt binary.
     #[error("unsupported OS: {os}")]
     UnsupportedOs { os: String },
-    /// The remote host reported a CPU architecture that is not
-    /// supported by the prebuilt remote-server binary.
+    /// The remote host reported a CPU architecture not supported by the prebuilt binary.
     #[error("unsupported architecture: {arch}")]
     UnsupportedArch { arch: String },
+    /// A remote script ran but exited with a non-zero code.
+    #[error("script failed (exit {exit_code}): {stderr}")]
+    ScriptFailed { exit_code: i32, stderr: String },
     /// Any other transport-level or unexpected failure.
     #[error(transparent)]
     Other(anyhow::Error),
 }
 
-impl DetectPlatformError {
-    /// Returns a user-facing error message for display in the UI banner.
-    /// Starts with a generic description, followed by specific details when available.
-    pub fn user_facing_message(&self) -> String {
-        match self {
-            Self::Other(_) => "Failed to detect remote platform".into(),
-            _ => format!("Failed to detect remote platform: {self}"),
+/// Maximum number of stderr bytes to include in the user-facing detail
+/// for `ScriptFailed` errors. Keeps the banner reasonable even when a
+/// remote script dumps a large amount of output.
+const MAX_STDERR_DISPLAY_LEN: usize = 512;
+
+impl Error {
+    /// Converts this error into a [`UserFacingError`] suitable for the
+    /// SSH remote-server failed banner, using `stage` to provide
+    /// context-appropriate copy.
+    pub fn user_facing_error(&self, stage: SetupStage) -> UserFacingError {
+        let title = "Could not establish connection to host";
+        let body = format!("Failed to {}", stage.action_description());
+        let detail = match self {
+            Self::TimedOut => {
+                Some("The operation timed out — check your network connection".into())
+            }
+            Self::UnsupportedOs { os } => Some(format!("Unsupported OS: {os}")),
+            Self::UnsupportedArch { arch } => Some(format!("Unsupported architecture: {arch}")),
+            Self::ScriptFailed { exit_code, stderr } => {
+                let truncated = if stderr.len() > MAX_STDERR_DISPLAY_LEN {
+                    format!("{}…", &stderr[..MAX_STDERR_DISPLAY_LEN])
+                } else {
+                    stderr.clone()
+                };
+                Some(format!("Script exited with code {exit_code}: {truncated}"))
+            }
+            Self::Other(e) => {
+                let msg = format!("{e:#}");
+                if msg.is_empty() {
+                    None
+                } else {
+                    Some(msg)
+                }
+            }
+        };
+        UserFacingError {
+            title,
+            body,
+            detail,
         }
     }
 }
 
-impl From<crate::ssh::SshCommandError> for DetectPlatformError {
+impl From<crate::ssh::SshCommandError> for Error {
     fn from(err: crate::ssh::SshCommandError) -> Self {
         match err {
             crate::ssh::SshCommandError::TimedOut { .. } => Self::TimedOut,
             other => Self::Other(other.into()),
-        }
-    }
-}
-
-/// Error returned by [`RemoteTransport::run_preinstall_check`].
-#[derive(Debug, thiserror::Error)]
-pub enum PreinstallCheckError {
-    /// The preinstall check script ran but exited with a non-zero code.
-    #[error("preinstall check script failed (exit {code}): {stderr}")]
-    ScriptFailed { code: i32, stderr: String },
-    /// Any other transport-level or unexpected failure.
-    #[error(transparent)]
-    Other(anyhow::Error),
-}
-
-/// Error returned by [`RemoteTransport::check_binary`].
-#[derive(Debug, thiserror::Error)]
-pub enum CheckBinaryError {
-    /// The binary check command timed out.
-    #[error("binary check timed out")]
-    TimedOut,
-    /// Any other transport-level or unexpected failure.
-    #[error(transparent)]
-    Other(anyhow::Error),
-}
-
-impl CheckBinaryError {
-    /// Returns a user-facing error message for display in the UI banner.
-    pub fn user_facing_message(&self) -> String {
-        match self {
-            Self::Other(_) => "Failed to check for SSH extension".into(),
-            _ => format!("Failed to check for SSH extension: {self}"),
-        }
-    }
-}
-
-/// Error returned by [`RemoteTransport::install_binary`].
-#[derive(Debug, thiserror::Error)]
-pub enum InstallBinaryError {
-    /// The install script timed out.
-    #[error("install timed out")]
-    TimedOut,
-    /// Any other transport-level or unexpected failure.
-    #[error(transparent)]
-    Other(anyhow::Error),
-}
-
-impl InstallBinaryError {
-    /// Returns a user-facing error message for display in the UI banner.
-    pub fn user_facing_message(&self) -> String {
-        match self {
-            Self::Other(_) => "Failed to install SSH extension".into(),
-            _ => format!("Failed to install SSH extension: {self}"),
         }
     }
 }
@@ -158,11 +183,11 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     /// Detects the remote host's OS and architecture by running `uname -sm`.
     ///
     /// Returns the parsed [`RemotePlatform`] on success, or a
-    /// [`DetectPlatformError`] if the command fails or the output cannot
+    /// [`Error`] if the command fails or the output cannot
     /// be parsed.
     fn detect_platform(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<RemotePlatform, DetectPlatformError>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<RemotePlatform, Error>> + Send>>;
 
     /// Runs the preinstall check script ([`crate::setup::PREINSTALL_CHECK_SCRIPT`])
     /// over the existing connection and parses its structured stdout into
@@ -180,7 +205,7 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     /// caller treats as inconclusive (fail open).
     fn run_preinstall_check(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<PreinstallCheckResult, PreinstallCheckError>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<PreinstallCheckResult, Error>> + Send>>;
 
     /// Checks whether the remote server binary is present on the remote host.
     ///
@@ -191,7 +216,7 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     /// Returns `Ok(true)` if the binary is installed and executable,
     /// `Ok(false)` if it is definitively not installed, and
     /// `Err(_)` if the check failed (e.g. timeout or unreachable).
-    fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, CheckBinaryError>> + Send>>;
+    fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, Error>> + Send>>;
 
     /// Checks whether the remote host already has an existing install
     /// of the remote server binary.
@@ -212,9 +237,7 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     ///
     /// Returns `Ok(())` if the install succeeded, and
     /// `Err(_)` if the install failed (e.g. timeout or script error).
-    fn install_binary(
-        &self,
-    ) -> Pin<Box<dyn Future<Output = Result<(), InstallBinaryError>> + Send>>;
+    fn install_binary(&self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>;
 
     /// Establish a new connection to the remote server.
     ///


### PR DESCRIPTION
This PR improves error handling in the remote server setup process.

*   The `detect_platform` function now returns a `DetectPlatformError` enum, providing more specific error information.
*   The `run_preinstall_check` function now returns a `PreinstallCheckError` enum.
*   The `check_binary` function now returns a `CheckBinaryError` enum.
*   The `install_binary` function now returns an `InstallBinaryError` enum.
*   The `RemoteServerManager` now handles and propagates these new error types, improving the clarity of error messages.
*   Added a timeout to the SSH command.