### PR TITLE
Refactor orchestration pill bar swapping (fixes cancellation of child agents)

### DIFF
--- a/app/src/ai/active_agent_views_model.rs
+++ b/app/src/ai/active_agent_views_model.rs
@@ -180,13 +180,8 @@ impl ActiveAgentViewsModel {
                 is_exit_before_new_entrance,
                 ..
             } => {
-                // When the controller is just swapping the active conversation in place
-                // (e.g. clicking a pill in the orchestration pill bar), the synthetic
-                // ExitedAgentView is part of a switch — not a real exit. Tearing down
-                // the streamer consumer here would close the SSE for the conversation
-                // we're navigating away from when no other consumer remains, dropping
-                // events for an in-progress conversation. The follow-up EnteredAgentView
-                // will register the new conversation's consumer.
+                // Skip if this exit is part of an in-place switch — the follow-up
+                // entrance will register the new conversation's consumer.
                 if *is_exit_before_new_entrance {
                     return;
                 }

--- a/app/src/ai/active_agent_views_model.rs
+++ b/app/src/ai/active_agent_views_model.rs
@@ -176,8 +176,21 @@ impl ActiveAgentViewsModel {
                 ctx.emit(ActiveAgentViewsEvent::TerminalViewFocused);
             }
             AgentViewControllerEvent::ExitedAgentView {
-                conversation_id, ..
+                conversation_id,
+                is_exit_before_new_entrance,
+                ..
             } => {
+                // When the controller is just swapping the active conversation in place
+                // (e.g. clicking a pill in the orchestration pill bar), the synthetic
+                // ExitedAgentView is part of a switch — not a real exit. Tearing down
+                // the streamer consumer here would close the SSE for the conversation
+                // we're navigating away from when no other consumer remains, dropping
+                // events for an in-progress conversation. The follow-up EnteredAgentView
+                // will register the new conversation's consumer.
+                if *is_exit_before_new_entrance {
+                    return;
+                }
+
                 model
                     .last_opened_times
                     .remove(&ConversationOrTaskId::ConversationId(*conversation_id));

--- a/app/src/ai/blocklist/agent_view/controller.rs
+++ b/app/src/ai/blocklist/agent_view/controller.rs
@@ -776,8 +776,19 @@ impl AgentViewController {
             });
             (id, 0)
         };
+        // Use the non-transferring `mark_active_conversation_id` here so that
+        // entering the agent view for a conversation that is also live in
+        // another terminal view (e.g. a child agent's hidden pane viewed via
+        // the orchestration pill bar) does not rip the conversation out of
+        // that other view's live list. Transferring would invalidate
+        // `conversation_id_for_action` lookups on the original owner and
+        // cause its in-flight requested commands to be silently dropped —
+        // the same class of bug PR #10241 fixed for the follow-up paths.
+        // Explicit cross-view navigation that should transfer ownership is
+        // handled by callers that invoke `set_active_conversation_id`
+        // directly (e.g. workspace history palette navigation).
         history_model.update(ctx, |history_model, ctx| {
-            history_model.set_active_conversation_id(conversation_id, self.terminal_view_id, ctx)
+            history_model.mark_active_conversation_id(conversation_id, self.terminal_view_id, ctx)
         });
 
         self.agent_view_state = AgentViewState::Active {

--- a/app/src/ai/blocklist/agent_view/controller.rs
+++ b/app/src/ai/blocklist/agent_view/controller.rs
@@ -776,17 +776,9 @@ impl AgentViewController {
             });
             (id, 0)
         };
-        // Use the non-transferring `mark_active_conversation_id` here so that
-        // entering the agent view for a conversation that is also live in
-        // another terminal view (e.g. a child agent's hidden pane viewed via
-        // the orchestration pill bar) does not rip the conversation out of
-        // that other view's live list. Transferring would invalidate
-        // `conversation_id_for_action` lookups on the original owner and
-        // cause its in-flight requested commands to be silently dropped —
-        // the same class of bug PR #10241 fixed for the follow-up paths.
-        // Explicit cross-view navigation that should transfer ownership is
-        // handled by callers that invoke `set_active_conversation_id`
-        // directly (e.g. workspace history palette navigation).
+        // Non-transferring: don't rip the conversation out of another terminal
+        // view's live list (e.g. a child agent's hidden pane). Explicit
+        // cross-view ownership transfer is handled by callers elsewhere.
         history_model.update(ctx, |history_model, ctx| {
             history_model.mark_active_conversation_id(conversation_id, self.terminal_view_id, ctx)
         });

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -472,20 +472,15 @@ impl OrchestrationPillBar {
         let history = BlocklistAIHistoryModel::as_ref(app);
         let active_conversation = history.conversation(&active_id)?;
 
-        // V2 same-pane semantics: render pills for both the orchestrator and
-        // any same-pane child. When the active conversation is a child,
-        // resolve its orchestrator (parent) so the pill set is anchored on
-        // the orchestrator regardless of which conversation is selected.
-        //
-        // Split-off child views render breadcrumbs only (no pill bar). Bail
-        // here so the pane header renders just the breadcrumbs returned by
-        // `render_orchestration_breadcrumbs` and not a redundant pill row
-        // below it. Without this short-circuit, the breadcrumbs in the title
-        // and the pill bar in the column would both render, producing
-        // duplicate orchestration chrome in the split-off pane/tab.
-        if is_split_off_child(self.agent_view_controller.as_ref(app), app) {
-            return None;
-        }
+        // Render pills for every conversation in the orchestration tree:
+        // the orchestrator pane and every child pane share the same pill
+        // bar, so navigating between them via pill clicks is symmetric.
+        // Walk the parent chain to find the orchestrator root, then render
+        // the bar anchored on it regardless of which conversation is
+        // currently active. The breadcrumb path (`render_orchestration_breadcrumbs`)
+        // is no longer wired up at the pane-header call site since pills
+        // already encode the same navigation affordance and would otherwise
+        // double-render alongside this bar on swapped-in child views.
         let orchestrator_id = parent_conversation_id(active_conversation, app).unwrap_or(active_id);
         let orchestrator = history.conversation(&orchestrator_id)?;
 
@@ -1819,11 +1814,12 @@ pub fn render_orchestration_breadcrumbs(
     if !agent_view_controller.is_fullscreen() {
         return None;
     }
-    // V2: only render breadcrumbs from a *split-off* pane/tab. Same-pane
-    // child views render the pill bar with the active child highlighted.
-    if !is_split_off_child(agent_view_controller, app) {
-        return None;
-    }
+    // The caller (pane header) decides whether this view should render
+    // breadcrumbs vs. the pill bar based on `TerminalView::is_orchestration_split_off`,
+    // which is set explicitly by the "Open in new pane" / "Open in new tab"
+    // flows. We deliberately don't gate on `is_split_off_child` here because
+    // that heuristic also matches the swap-target child pane (which should
+    // continue rendering the pill bar).
     let active_id = agent_view_controller
         .agent_view_state()
         .active_conversation_id()?;

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -1784,22 +1784,8 @@ pub fn render_orchestration_breadcrumbs(
     .with_propagate_mousewheel_if_not_handled(true)
     .finish();
 
-    // Wrap the scrollable in a `MainAxisSize::Max` row that horizontally
-    // centers the scrollable. The pane header's wrapping `Flex::column`
-    // uses `CrossAxisAlignment::Stretch`, which forces this secondary row
-    // to the full pane width. Without this centering wrapper the
-    // scrollable inherits that full width too and paints its inner
-    // (`MainAxisSize::Min`) breadcrumb row flush against the left edge of
-    // the pane.
-    //
-    // With this wrapper the scrollable is given an unconstrained main
-    // axis min and lays itself out at its child's natural width when the
-    // breadcrumbs fit. The centered outer row then positions it in the
-    // middle of the pane. When the breadcrumbs overflow, the scrollable
-    // clamps to the row's max width and horizontal scrolling kicks in as
-    // before — the visual result is identical to the previous left-aligned
-    // overflow behaviour because the scrollable now occupies the full
-    // available width.
+    // Center breadcrumbs while they fit; when they overflow, use the full
+    // width so horizontal scrolling still works.
     Some(
         Flex::row()
             .with_main_axis_size(MainAxisSize::Max)

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -33,7 +33,6 @@ use warpui::{
     ViewHandle,
 };
 
-use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::agent_view::orchestration_conversation_links::parent_conversation_id;
@@ -1747,40 +1746,6 @@ fn pane_group_id_containing_terminal_view(
     None
 }
 
-/// Returns `true` if the active conversation in `agent_view_controller` is a
-/// child agent that has been opened in a *different* terminal view than this
-/// one — i.e. "Open in new pane" or "Open in new tab" was used to split it
-/// off from its orchestrator. We use this to decide whether the pane header
-/// should render breadcrumbs (split-off) vs. the pill bar (same-pane).
-///
-/// Specifically: the active conversation is a child AND the *parent*
-/// (orchestrator) is currently the active conversation in some other
-/// terminal view (per `ActiveAgentViewsModel`). When the orchestrator pane
-/// switches in place to a child, the parent is no longer the active
-/// conversation in any pane, so this returns `false` and the pill bar keeps
-/// rendering with the active child highlighted.
-pub fn is_split_off_child(agent_view_controller: &AgentViewController, app: &AppContext) -> bool {
-    let Some(active_id) = agent_view_controller
-        .agent_view_state()
-        .active_conversation_id()
-    else {
-        return false;
-    };
-    let history = BlocklistAIHistoryModel::as_ref(app);
-    let Some(active_conversation) = history.conversation(&active_id) else {
-        return false;
-    };
-    let Some(parent_id) = parent_conversation_id(active_conversation, app) else {
-        return false;
-    };
-    let Some(parent_view_id) =
-        ActiveAgentViewsModel::as_ref(app).terminal_view_id_for_conversation(parent_id, app)
-    else {
-        return false;
-    };
-    parent_view_id != agent_view_controller.terminal_view_id()
-}
-
 /// Renders a `[Parent Avatar] [Parent Title] > [Child Avatar] [Child Name]`
 /// breadcrumb row when the active conversation is a child agent under an
 /// orchestrator that has been split off into another pane/tab. Returns
@@ -1817,9 +1782,9 @@ pub fn render_orchestration_breadcrumbs(
     // The caller (pane header) decides whether this view should render
     // breadcrumbs vs. the pill bar based on `TerminalView::is_orchestration_split_off`,
     // which is set explicitly by the "Open in new pane" / "Open in new tab"
-    // flows. We deliberately don't gate on `is_split_off_child` here because
-    // that heuristic also matches the swap-target child pane (which should
-    // continue rendering the pill bar).
+    // flows. We deliberately don't try to derive split-off-ness from the
+    // history model here because that heuristic would also match the
+    // swap-target child pane (which should continue rendering the pill bar).
     let active_id = agent_view_controller
         .agent_view_state()
         .active_conversation_id()?;

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -1,10 +1,6 @@
-//! Renders a horizontal pill bar in the agent view header containing the
-//! orchestrator agent and any child agents spawned by it. Clicking a pill
-//! switches the active pane to that agent's conversation.
-//!
-//! V1 scope: avatars (deterministic color + initial), pill labels, click to
-//! switch. Hover popover, pin / unpin, and the 3-dot menu (Open in new pane /
-//! Open in new tab / Stop agent / Kill agent) are tracked as follow-ups.
+//! Horizontal pill bar shown above the agent view header listing the
+//! orchestrator agent and its child agents. Clicking a pill switches the
+//! active pane to that agent's conversation.
 
 use std::cell::RefCell;
 use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
@@ -91,15 +87,11 @@ enum PillKind {
     Child,
 }
 
-/// Whether this pill's conversation is currently "pinned" — i.e. living in
-/// another visible terminal view (a separate pane or tab from this one). The
-/// orchestrator pane displays a pin glyph in front of pinned children's
-/// labels; clicking a pinned pill focuses that other pane/tab instead of
-/// switching this pane in place.
+/// Whether this pill's conversation lives in another visible terminal view
+/// (a separate pane or tab). Pinned pills focus that other view instead of
+/// switching in place. Pin detection is currently disabled (see `pill_specs`).
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)] // PinnedInOtherPane is wired up but currently never
-                    // constructed — pin detection is disabled until pane-visibility plumbing
-                    // lands. See `pill_specs` for context.
+#[allow(dead_code)]
 enum PillPinState {
     Unpinned,
     PinnedInOtherPane,
@@ -145,99 +137,52 @@ fn pill_body_position_id(conversation_id: AIConversationId) -> String {
 
 /// Width of the per-pill hover details card.
 const HOVER_CARD_WIDTH: f32 = 280.;
-/// Delay before the hover card appears after the cursor first lands on a
-/// pill. Matches the standard tooltip / popover delay so a quick scrub
-/// across the bar doesn't pop a card per pill.
+/// Delay before the hover card appears after the cursor lands on a pill.
 const HOVER_CARD_IN_DELAY: Duration = Duration::from_millis(300);
 /// Delay before the card disappears after the cursor leaves the pill.
-/// Small but nonzero so a single-pixel gap between pill and card doesn't
-/// instantly dismiss it. (V1 doesn't yet share hover state across the pill
-/// and the card itself, so the card disappears as soon as the pointer
-/// leaves the pill body — the hover-out delay just smooths that.)
 const HOVER_CARD_OUT_DELAY: Duration = Duration::from_millis(80);
 
-/// Typed actions dispatched by the pill bar's own widgets (the 3-dot
-/// overflow button and the items in its dropdown menu). Each action carries
-/// the `AIConversationId` of the child pill it targets so a single
-/// `Menu<OrchestrationPillBarAction>` instance can serve every child by being
-/// rebuilt with the right ids each time it opens.
+/// Typed actions dispatched by the pill bar's widgets. Each action carries
+/// the targeted child pill's conversation id so a single shared `Menu`
+/// instance can serve every child.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OrchestrationPillBarAction {
-    /// Open the 3-dot menu for the given child conversation. Dispatched by
-    /// the trailing `⋯` button on a child pill.
+    /// Open the 3-dot menu for the given child conversation.
     OpenMenu(AIConversationId),
-    /// Close the open menu. Dispatched by the `Menu`'s `Close` event so
-    /// click-outside dismissal is handled the same way as keyboard ESC.
+    /// Close the open menu (forwarded from the `Menu`'s `Close` event).
     CloseMenu,
-    /// Menu item: split the orchestrator pane right and host this child
-    /// agent in the new pane.
+    /// Menu item: split the pane and host this child in the new pane.
     OpenInNewPane(AIConversationId),
-    /// Menu item: open this child agent in a new tab in the same window.
+    /// Menu item: open this child in a new tab.
     OpenInNewTab(AIConversationId),
-    /// Menu item: stop the in-progress agent task without removing the
-    /// conversation from history.
-    ///
-    /// Currently unconstructed — the menu item is hidden because the
-    /// underlying behaviour isn't reliable yet (see
-    /// `open_menu_for`). The handler arm and the corresponding
-    /// `TerminalAction::StopAgentConversation` wiring stay in place
-    /// so re-adding the menu entry only requires uncommenting the
-    /// item.
+    /// Menu item: stop the in-progress task. Currently hidden; wiring kept
+    /// for re-enabling later.
     #[allow(dead_code)]
     Stop(AIConversationId),
-    /// Menu item: cancel any in-flight task and remove the conversation
-    /// from local history (no server delete).
-    ///
-    /// Currently unconstructed — see the comment on `Stop` above.
+    /// Menu item: cancel and remove from local history. Currently hidden.
     #[allow(dead_code)]
     Kill(AIConversationId),
-    /// Set or clear which pill the user is currently hovering. Dispatched
-    /// from the pill body's `on_hover` handler after the configured
-    /// hover-in delay so the details card can be rendered as an overlay.
-    /// `None` clears the hovered pill (cursor left the bar).
+    /// Set/clear which pill the user is hovering (drives the details card).
     SetHoveredPill(Option<AIConversationId>),
     /// Menu item: focus the existing pane/tab that already owns the
     /// child agent's transcript instead of splitting/opening a new one.
-    /// Used when the conversation is open elsewhere; mirrors the
-    /// breadcrumb parent click's `RestoreOrNavigateToConversation`
-    /// dispatch.
     FocusOpenedConversation(AIConversationId),
 }
 
-/// View that renders the orchestration pill bar above the agent view content.
-///
-/// Shows one pill for the orchestrator (parent of the active conversation, or
-/// the active conversation itself if it has no parent) and one pill per child
-/// agent spawned by that orchestrator. Clicking a non-active pill switches
-/// to that agent's pane.
+/// Renders the pill bar above the agent view: one pill for the orchestrator
+/// and one per child agent. Clicking a non-active pill switches to its pane.
 pub struct OrchestrationPillBar {
     agent_view_controller: ModelHandle<AgentViewController>,
-    /// Hover state per conversation id, persisted across renders so hover
-    /// effects work correctly. Wrapped in a `RefCell` so `render` (which only
-    /// has `&self`) can lazily insert handles for ids that aren't yet
-    /// populated by `ensure_mouse_states`. Synthesizing a fresh
-    /// `MouseStateHandle::default()` in the render hot path is *not*
-    /// equivalent: the next render after a mouse-down would produce yet
-    /// another fresh handle, losing the down-state before mouse-up arrives
-    /// and silently swallowing the click (per the WarpUI mouse-state rule).
+    /// Hover state per pill, persisted across renders. `RefCell` so
+    /// `render` can lazily insert handles missing from `ensure_mouse_states`.
     mouse_states: RefCell<HashMap<AIConversationId, MouseStateHandle>>,
-    /// Hover state per child pill's trailing 3-dot button. Kept separate
-    /// from `mouse_states` so the button has its own hover highlight
-    /// independent of the pill body.
+    /// Hover state per child pill's 3-dot button (separate from the pill body).
     overflow_button_mouse_states: RefCell<HashMap<AIConversationId, MouseStateHandle>>,
-    /// The single shared dropdown menu rendered when a child pill's 3-dot
-    /// button is clicked. Items are rebuilt per-open with the relevant
-    /// child id baked into each `on_select_action` so we don't need a
-    /// separate menu instance per pill.
+    /// Shared dropdown menu rebuilt per-open with the targeted child's id.
     menu: ViewHandle<Menu<OrchestrationPillBarAction>>,
-    /// `Some(id)` when the 3-dot menu is currently open and targeting the
-    /// child conversation `id`, `None` when no menu is open. Used both to
-    /// gate whether the menu overlay renders and to highlight the active
-    /// pill while the menu is open.
+    /// `Some(id)` when the 3-dot menu is open targeting that child.
     menu_open_for: Option<AIConversationId>,
-    /// `Some(id)` while the cursor is hovering the pill for that
-    /// conversation (after the configured hover-in delay) and the 3-dot
-    /// menu is not also open. Drives the per-pill details card overlay.
+    /// `Some(id)` when the cursor is hovering that pill (drives the details card).
     hovered_pill: Option<AIConversationId>,
 }
 
@@ -300,9 +245,7 @@ impl OrchestrationPillBar {
                 .prevent_interaction_with_other_elements()
         });
 
-        // The menu emits `Close { .. }` when the user clicks outside the
-        // menu or presses ESC. Forward that into our typed action surface
-        // so menu_open_for stays in sync with what's actually visible.
+        // Forward the menu's Close event so menu_open_for stays in sync.
         ctx.subscribe_to_view(&menu, |this, _, event, ctx| match event {
             MenuEvent::Close { .. } => {
                 this.handle_action(&OrchestrationPillBarAction::CloseMenu, ctx);
@@ -320,10 +263,7 @@ impl OrchestrationPillBar {
         }
     }
 
-    /// Rebuilds the menu items for the given child conversation id and
-    /// flips `menu_open_for` to that id. Called each time the user clicks
-    /// a child's 3-dot button so the menu items dispatch actions targeting
-    /// the right child.
+    /// Rebuilds menu items for the given child and opens the menu.
     fn open_menu_for(&mut self, conversation_id: AIConversationId, ctx: &mut ViewContext<Self>) {
         let appearance = Appearance::as_ref(ctx);
         let theme = appearance.theme();
@@ -341,32 +281,14 @@ impl OrchestrationPillBar {
             )
         };
 
-        // If this child conversation is already open in a *different*
-        // visible terminal view — whether that's a separate pane in this
-        // tab, another tab, or another window — collapse the create-new
-        // entries into a single "Focus pane" item that routes the user to
-        // the existing owner. The conversation has a single source of
-        // truth (one terminal view renders its AI blocks; see
-        // `ConversationOwnershipTransferred` in `BlocklistAIHistoryModel`),
-        // so offering separate "Open pane" / "Open tab" entries here
-        // would imply more than one destination exists.
-        //
-        // We deliberately do NOT use
-        // `ActiveAgentViewsModel::terminal_view_id_for_conversation` here:
-        // every child agent has a hidden child-agent pane registered in
-        // that model (its `AgentViewController` keeps the child as its
-        // `active_conversation_id` to receive events), which would falsely
-        // flag every child as "open elsewhere" even when the orchestrator
-        // is the only visible owner.
+        // If this child is already open in a *different* visible terminal
+        // view, collapse the create-new entries into a single "Focus pane"
+        // entry pointing at the existing owner.
         let self_terminal_view_id = self.agent_view_controller.as_ref(ctx).terminal_view_id();
         let is_open_elsewhere =
             is_conversation_open_in_other_visible_view(conversation_id, self_terminal_view_id, ctx);
 
-        // Stop / Kill items are intentionally omitted for now — their
-        // wiring is still in place (see `OrchestrationPillBarAction::Stop`
-        // / `Kill` and the matching `TerminalAction` handlers) but the
-        // current behaviour isn't reliable enough to ship. Re-add the
-        // menu items here when that's fixed.
+        // Stop / Kill items intentionally omitted (wiring still in place).
         let items = if is_open_elsewhere {
             vec![item(
                 "Focus pane",
@@ -392,9 +314,7 @@ impl OrchestrationPillBar {
             menu.set_items(items, ctx);
         });
         self.menu_open_for = Some(conversation_id);
-        // The hover card and the open 3-dot menu both anchor to the same
-        // pill, so suppress the card while the menu is shown to avoid
-        // overlapping overlays.
+        // Suppress the hover card while the menu overlays the same pill.
         self.hovered_pill = None;
         ctx.focus(&self.menu);
         ctx.notify();
@@ -434,16 +354,10 @@ impl OrchestrationPillBar {
             return;
         };
         let orchestrator_id = parent_conversation_id(active_conversation, ctx).unwrap_or(active_id);
-        // Build the set of conversation ids that should still have hover state
-        // tracked, then insert any missing entries and drop the rest. Without
-        // the retain step, switching between orchestrators within the same
-        // view would leak `MouseStateHandle`s for old orchestrators / their
-        // children indefinitely.
+        // Track only ids that are still rendered; retain step prevents leaking
+        // handles for old orchestrators / children when switching views.
         let mut alive: HashSet<AIConversationId> = HashSet::new();
         alive.insert(orchestrator_id);
-        // Include the parent id when the active conversation is a child, so
-        // the breadcrumb's parent crumb has a stable handle even before the
-        // parent `AIConversation` is loaded into history.
         if let Some(parent_id) = parent_conversation_id(active_conversation, ctx) {
             alive.insert(parent_id);
         }
@@ -460,8 +374,7 @@ impl OrchestrationPillBar {
         overflow_states.retain(|id, _| alive.contains(id));
     }
 
-    /// Builds the ordered list of pills to render. Returns `None` when the
-    /// pill bar should not be shown at all.
+    /// Builds the ordered pill list, or `None` when nothing should render.
     fn pill_specs(&self, app: &AppContext) -> Option<Vec<PillSpec>> {
         let active_id = self
             .agent_view_controller
@@ -471,25 +384,13 @@ impl OrchestrationPillBar {
         let history = BlocklistAIHistoryModel::as_ref(app);
         let active_conversation = history.conversation(&active_id)?;
 
-        // Render pills for every conversation in the orchestration tree:
-        // the orchestrator pane and every child pane share the same pill
-        // bar, so navigating between them via pill clicks is symmetric.
-        // Walk the parent chain to find the orchestrator root, then render
-        // the bar anchored on it regardless of which conversation is
-        // currently active. The breadcrumb path (`render_orchestration_breadcrumbs`)
-        // is no longer wired up at the pane-header call site since pills
-        // already encode the same navigation affordance and would otherwise
-        // double-render alongside this bar on swapped-in child views.
+        // Anchor the bar on the orchestrator root regardless of which
+        // conversation is active so navigation between siblings is symmetric.
         let orchestrator_id = parent_conversation_id(active_conversation, app).unwrap_or(active_id);
         let orchestrator = history.conversation(&orchestrator_id)?;
 
-        // `child_conversations_of` returns children in registration order
-        // (i.e. the order they were spawned by the orchestrator), which is
-        // the stable ordering we want for the pills. Don't re-sort by
-        // `first_exchange().start_time`: children whose first exchange
-        // hasn't started yet would otherwise sort to the front (because
-        // `Option::None < Option::Some`) and pop into their time-based
-        // position once they begin streaming, reshuffling the bar.
+        // Use registration order (stable). Don't re-sort by start_time:
+        // not-yet-started children would reshuffle once they begin streaming.
         let children = history.child_conversations_of(orchestrator_id);
 
         // Nothing to show if the orchestrator has no children yet.
@@ -502,9 +403,7 @@ impl OrchestrationPillBar {
 
         let mut specs = Vec::with_capacity(1 + children.len());
 
-        // Orchestrator pill first. The orchestrator never carries a pin
-        // glyph: it represents the home view of the orchestration tree, not
-        // a sibling that has been split off.
+        // Orchestrator pill first; never pinned (it's the home view).
         specs.push(PillSpec {
             conversation_id: orchestrator_id,
             label: orchestrator_label(orchestrator),
@@ -515,25 +414,9 @@ impl OrchestrationPillBar {
             pin_state: PillPinState::Unpinned,
         });
 
-        // Then a pill per child agent.
-        //
-        // V2-of-V2 NOTE: pin detection is intentionally disabled here. The
-        // intended signal was "this child has an active agent view in some
-        // *other* visible terminal view than the orchestrator pane" (using
-        // `ActiveAgentViewsModel::terminal_view_id_for_conversation`), but
-        // every child agent already has a hidden terminal view registered in
-        // `ActiveAgentViewsModel` (via `TerminalPane::attach` when the
-        // orchestrator's `StartAgentExecutor` creates the hidden child pane
-        // through `create_hidden_child_agent_conversation`). That makes the
-        // naive check fire for every child — swapping every avatar for the
-        // pin glyph and routing every click through `RevealChildAgent`
-        // instead of `SwitchAgentViewToConversation`, which broke the
-        // expected in-place switching.
-        //
-        // Restoring real pin detection requires plumbing pane visibility
-        // (visible vs. hidden-for-child-agent) into `ActiveAgentViewsModel`,
-        // or exposing a `is_child_agent_pane_visible(conversation_id)` accessor
-        // off `PaneGroup`. Tracked as a follow-up.
+        // Then a pill per child. Pin detection is currently disabled —
+        // restoring it requires plumbing pane visibility into the active
+        // views model so we can distinguish hidden vs. visible child panes.
         for child in children {
             let name = child
                 .agent_name()

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -1941,7 +1941,31 @@ pub fn render_orchestration_breadcrumbs(
     .with_horizontal_scrollbar(ScrollableAppearance::new(ScrollbarWidth::Auto, true))
     .with_propagate_mousewheel_if_not_handled(true)
     .finish();
-    Some(scrollable)
+
+    // Wrap the scrollable in a `MainAxisSize::Max` row that horizontally
+    // centers the scrollable. The pane header's wrapping `Flex::column`
+    // uses `CrossAxisAlignment::Stretch`, which forces this secondary row
+    // to the full pane width. Without this centering wrapper the
+    // scrollable inherits that full width too and paints its inner
+    // (`MainAxisSize::Min`) breadcrumb row flush against the left edge of
+    // the pane.
+    //
+    // With this wrapper the scrollable is given an unconstrained main
+    // axis min and lays itself out at its child's natural width when the
+    // breadcrumbs fit. The centered outer row then positions it in the
+    // middle of the pane. When the breadcrumbs overflow, the scrollable
+    // clamps to the row's max width and horizontal scrolling kicks in as
+    // before — the visual result is identical to the previous left-aligned
+    // overflow behaviour because the scrollable now occupies the full
+    // available width.
+    Some(
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::Center)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(scrollable)
+            .finish(),
+    )
 }
 
 fn render_crumb(

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -537,11 +537,8 @@ impl BlocklistAIController {
                 return;
             };
 
-            // When the controller is just swapping the active conversation in place
-            // (e.g. clicking a pill in the orchestration pill bar), the synthetic
-            // ExitedAgentView is part of a switch — not a real exit. Cancelling the
-            // previously-active conversation here would kill its in-flight response
-            // stream / pending actions every time the user navigates between agents.
+            // Skip if this exit is part of an in-place switch — cancelling here
+            // would kill an in-flight stream every time the user navigates.
             if *is_exit_before_new_entrance {
                 return;
             }

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -530,11 +530,21 @@ impl BlocklistAIController {
             let AgentViewControllerEvent::ExitedAgentView {
                 conversation_id,
                 final_exchange_count,
+                is_exit_before_new_entrance,
                 ..
             } = event
             else {
                 return;
             };
+
+            // When the controller is just swapping the active conversation in place
+            // (e.g. clicking a pill in the orchestration pill bar), the synthetic
+            // ExitedAgentView is part of a switch — not a real exit. Cancelling the
+            // previously-active conversation here would kill its in-flight response
+            // stream / pending actions every time the user navigates between agents.
+            if *is_exit_before_new_entrance {
+                return;
+            }
 
             // If we exited a brand-new empty conversation, there's nothing meaningful to cancel.
             if *final_exchange_count == 0 {

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -4446,7 +4446,14 @@ impl PaneGroup {
         // (e.g. via the undo stack expiring) also needs to relinquish any
         // child agent conversations back to their parents so the
         // orchestrator's pill bar keeps working in-place.
-        self.transfer_child_agent_conversations_to_parents_on_close(pane_id, ctx);
+        //
+        // Skip the transfer when the pane being discarded is itself a
+        // child agent pane: the child's `TerminalView` canonically owns
+        // its conversation, and transferring ownership away would orphan
+        // the conversation while the pane is being torn down.
+        if !self.is_child_agent_pane(pane_id) {
+            self.transfer_child_agent_conversations_to_parents_on_close(pane_id, ctx);
+        }
 
         if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
             let terminal_view_id = terminal_view.id();
@@ -4592,18 +4599,18 @@ impl PaneGroup {
             return;
         }
 
-        // Before any close path runs, transfer ownership of any child agent
-        // conversations live in this view back to the pane that owns each
-        // child's parent conversation. This keeps the orchestrator pane's
-        // orchestration pill bar in-place click working after the split-off
-        // pane that took over the child's transcript closes. Safe to run even
-        // for hide-for-undo: re-opening the closed pane would re-restore the
-        // conversation into the (visible) view via the normal load path.
-        self.transfer_child_agent_conversations_to_parents_on_close(pane_id, ctx);
-
         // If this pane is a child agent, return it to its off-tree state
         // instead of destroying it — future pill clicks will swap it back
         // into the user's anchor.
+        //
+        // The transfer-conversations-on-close step below is intentionally
+        // skipped for child agent panes: the child's `TerminalView` is
+        // being preserved in `pane_contents` + `child_agent_panes`, so it
+        // must keep canonical ownership of its conversation. Transferring
+        // ownership to the parent's view here would leave the preserved
+        // child pane stale — a subsequent pill click would resolve to it
+        // (via `child_agent_panes`) but its blocks are now being routed to
+        // the parent's view, breaking the pill UX.
         if self.is_child_agent_pane(pane_id) {
             // Case A: the child is currently the active swap target (in
             // the anchor's tree slot via temporary replacement). Revert
@@ -4641,6 +4648,15 @@ impl PaneGroup {
             ctx.emit(Event::AppStateChanged);
             return;
         }
+
+        // For non-child-agent closes, transfer ownership of any child agent
+        // conversations live in this view back to the pane that owns each
+        // child's parent conversation. This keeps the orchestrator pane's
+        // orchestration pill bar in-place click working after the split-off
+        // pane that took over the child's transcript closes. Safe to run
+        // even for hide-for-undo: re-opening the closed pane would re-restore
+        // the conversation into the (visible) view via the normal load path.
+        self.transfer_child_agent_conversations_to_parents_on_close(pane_id, ctx);
 
         // If this is a parent with child agents, discard the children first.
         if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
@@ -6708,11 +6724,12 @@ impl PaneGroup {
     /// commands and briefly leak the child transcript into the orchestrator
     /// pane while ownership shuffles.
     ///
-    /// If the child is currently the active swap target (in the
-    /// orchestrator's tree slot via temporary replacement), revert the swap
-    /// first so the orchestrator returns to its slot, then split the child
-    /// in next to it. Otherwise, split the child in next to the focused
-    /// pane.
+    /// Reverts any active swap in this pane group first so the orchestrator
+    /// (or whichever pane was swapped out) returns to its tree slot, then
+    /// splits the target child in next to that restored original. This
+    /// preserves the invariant that "Open in new pane" leaves the
+    /// orchestrator visible — even when a different child was the active
+    /// swap target at the time of the split.
     pub fn unhide_child_agent_pane_for_split_off(
         &mut self,
         conversation_id: AIConversationId,
@@ -6733,13 +6750,25 @@ impl PaneGroup {
             return Some(child_pane_id);
         }
 
-        // If the child pane is currently the active swap target, revert
-        // the swap so the orchestrator's pane returns to its tree slot.
-        // Then split the child in next to the orchestrator.
-        let split_base = if let Some(original_pane_id) =
-            self.panes.original_pane_for_replacement(child_pane_id)
+        // Revert any active swap in this pane group so the swapped-out
+        // original (typically the orchestrator) returns to its tree slot.
+        // The new child is then split in next to that restored original
+        // — not next to whichever child happened to be the swap target.
+        // Without this, opening child A while child B is currently in the
+        // orchestrator's slot would leave the tree as `[B, A]` with the
+        // orchestrator stranded as the hidden swap original, breaking
+        // back-navigation from A's breadcrumbs.
+        let split_base = if let Some((original_pane_id, replacement_pane_id)) =
+            self.panes.any_temporary_replacement()
         {
-            self.panes.revert_temporary_replacement(child_pane_id);
+            // Clear the split-off marker on whatever was swapped in so a
+            // future pill click renders pills, not breadcrumbs.
+            if let Some(terminal_view) = self.terminal_view_from_pane_id(replacement_pane_id, ctx) {
+                terminal_view.update(ctx, |view, ctx| {
+                    view.clear_orchestration_split_off(ctx);
+                });
+            }
+            self.panes.revert_temporary_replacement(replacement_pane_id);
             original_pane_id
         } else {
             self.focused_pane_id(ctx)
@@ -6787,6 +6816,14 @@ impl PaneGroup {
     ) -> Option<Box<dyn AnyPaneContent>> {
         let child_pane_id = self.child_agent_panes.remove(&conversation_id)?;
 
+        // Capture focus state before any tree mutation so we can shift
+        // focus to a sane neighbour regardless of whether the child
+        // leaves the tree via swap revert (Case A) or pane removal
+        // (Case B). Reading after the mutation would miss the swap-revert
+        // case because `is_pane_focused(child)` would still report true
+        // even though the child is no longer in the tree.
+        let was_focused = self.focus_state.as_ref(ctx).is_pane_focused(child_pane_id);
+
         // If the child is currently the active swap target, revert the swap
         // so the orchestrator returns to its slot. After this, the child
         // pane is off-tree.
@@ -6799,27 +6836,33 @@ impl PaneGroup {
         }
 
         // If the child is in the tree as a real sibling (split off), remove
-        // it from the tree. Off-tree panes are already not in the tree.
+        // it from the tree. Off-tree panes (after revert above, or if the
+        // child was never split) are already not in the tree.
         if self.panes.is_pane_in_tree(child_pane_id) {
-            let was_focused = self.focus_state.as_ref(ctx).is_pane_focused(child_pane_id);
-            self.focus_next_terminal_pane_and_activate_session(
-                child_pane_id,
-                PaneRemovalReason::Move,
-                ctx,
-            );
             if !self.panes.remove(child_pane_id) {
                 log::error!(
                     "take_child_agent_pane_for_split_off: failed to remove pane {child_pane_id:?} from tree"
                 );
             }
-            let in_split_pane = self.panes.visible_pane_count() > 1;
-            self.focus_state.update(ctx, |focus_state, ctx| {
-                focus_state.set_in_split_pane(in_split_pane, ctx);
-                if was_focused {
-                    focus_state.set_focused_pane_maximized(false, ctx);
-                }
-            });
         }
+
+        // Shift focus and active session away from the child pane if it
+        // held either, regardless of which path took it out of the tree.
+        // Without this, the source pane group can be left with
+        // `focused_pane_id` / `active_session_id` pointing at a pane that
+        // is about to be removed from `pane_contents` entirely.
+        self.focus_next_terminal_pane_and_activate_session(
+            child_pane_id,
+            PaneRemovalReason::Move,
+            ctx,
+        );
+        let in_split_pane = self.panes.visible_pane_count() > 1;
+        self.focus_state.update(ctx, |focus_state, ctx| {
+            focus_state.set_in_split_pane(in_split_pane, ctx);
+            if was_focused {
+                focus_state.set_focused_pane_maximized(false, ctx);
+            }
+        });
 
         if let Some(child_terminal_view) = self.terminal_view_from_pane_id(child_pane_id, ctx) {
             child_terminal_view.update(ctx, |view, ctx| {
@@ -6974,14 +7017,17 @@ impl PaneGroup {
     /// already-visible pane (e.g. "Open in new pane" was already used and the
     /// user is now clicking the pinned pill in the orchestrator's view).
     ///
-    /// Hidden-for-close panes are skipped: a pane that has been closed and is
-    /// only retained for the undo stack is not a valid focus target.
+    /// "Visible" here strictly means "present as a leaf in the layout tree
+    /// AND not hidden". Iterating over `terminal_pane_ids()` (which reads
+    /// from `pane_contents`) would erroneously include off-tree child
+    /// agent panes, since under the orchestration model those panes
+    /// remain in `pane_contents` even when they are not in the tree.
     pub(crate) fn find_visible_terminal_pane_for_conversation(
         &self,
         conversation_id: AIConversationId,
         ctx: &AppContext,
     ) -> Option<TerminalPaneId> {
-        for pane_id in self.terminal_pane_ids() {
+        for pane_id in self.panes.visible_pane_ids() {
             if FeatureFlag::UndoClosedPanes.is_enabled() && self.is_pane_hidden_for_close(pane_id) {
                 continue;
             }

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -2113,7 +2113,17 @@ impl PaneGroup {
                     .panes
                     .original_pane_for_replacement(*pane_id)
                     .unwrap_or(*pane_id);
-                let contents = match self.pane_contents.get(&snapshot_pane_id) {
+                let is_substituted = snapshot_pane_id != *pane_id;
+                // Whether the user-visible tree slot is the active
+                // terminal session. During an active swap, this is the
+                // replacement (e.g. a child agent). On restart the child
+                // is rebuilt off-tree and the orchestrator becomes the
+                // new visible leaf, so the orchestrator's snapshot
+                // should carry the active-session marker the user last
+                // saw — not whatever its own pane reported in isolation.
+                let visible_leaf_is_active_session =
+                    pane_id.as_terminal_pane_id() == self.active_session_id(app);
+                let mut contents = match self.pane_contents.get(&snapshot_pane_id) {
                     Some(pane) => pane.as_pane().snapshot(app),
                     None => {
                         // Create a new pane uuid if we have a bug where we didn't save it
@@ -2123,8 +2133,7 @@ impl PaneGroup {
                         LeafContents::Terminal(TerminalPaneSnapshot {
                             uuid: Uuid::new_v4().as_bytes().to_vec(),
                             cwd: None,
-                            is_active: snapshot_pane_id.as_terminal_pane_id()
-                                == self.active_session_id(app),
+                            is_active: visible_leaf_is_active_session,
                             is_read_only: false,
                             shell_launch_data: None,
                             input_config: Some(InputConfig::new(app)),
@@ -2135,6 +2144,20 @@ impl PaneGroup {
                         })
                     }
                 };
+
+                // After substitution, override `is_active` so the
+                // restored tab marks the right pane as the active
+                // terminal. Without this override the orchestrator's
+                // snapshot would carry `is_active = false` (because the
+                // child was the active session at snapshot time), and
+                // restore would either silently fall back to the
+                // leftmost terminal pane or, in multi-pane tabs, focus
+                // a different terminal than the user last saw.
+                if is_substituted && visible_leaf_is_active_session {
+                    if let LeafContents::Terminal(ref mut snapshot) = contents {
+                        snapshot.is_active = true;
+                    }
+                }
                 let custom_vertical_tabs_title =
                     self.pane_contents.get(&snapshot_pane_id).and_then(|pane| {
                         pane.as_pane()
@@ -4494,11 +4517,25 @@ impl PaneGroup {
         self.cleanup_closed_pane(pane_id, ctx);
     }
 
-    /// For each child agent conversation currently live in the closing
-    /// pane's terminal view, transfer ownership back to whichever pane owns
-    /// its parent (orchestrator) conversation. No-op for non-child
-    /// conversations and for child conversations whose parent has no
-    /// resolvable owning view.
+    /// Best-effort: for each child agent conversation currently live in
+    /// the closing pane's terminal view, ask the history model to
+    /// re-bind the child to whichever pane owns its parent
+    /// (orchestrator) conversation. This is defensive plumbing rather
+    /// than a true ownership transfer:
+    /// [`BlocklistAIHistoryModel::set_active_conversation_id`] requires
+    /// the destination view's live conversation list to already contain
+    /// the child, and in the typical orchestrator+child pane scenario
+    /// the parent's view does *not* own the child — the child has its
+    /// own dedicated `TerminalView`. In that case the call logs an
+    /// error inside the history model and no-ops, which is the correct
+    /// behavior.
+    ///
+    /// The call is still worth keeping as a hook for the rare paths
+    /// (e.g. a future split-off route that loads the child onto the
+    /// parent's view) where the parent's live list does include the
+    /// child. For non-child conversations and for child conversations
+    /// whose parent has no resolvable owning view, this method is a
+    /// silent no-op.
     fn transfer_child_agent_conversations_to_parents_on_close(
         &mut self,
         pane_id: PaneId,
@@ -4656,11 +4693,14 @@ impl PaneGroup {
             // from the child's pill bar — `replace_pane(child, sibling,
             // true)` recorded the child as the *original* of an active
             // TempRepl. Cases A and B don't touch that entry, so drop
-            // any hidden-pane record naming this child as either side
-            // of a swap. Without this, a future revert of the surviving
-            // sibling would try to splice the (now off-tree) child back
-            // into the tree, leaving a leaf that points to a stale
-            // pane.
+            // any hidden-pane record naming this child as the *original*
+            // side of a swap. (Replacement-side cleanup is already
+            // handled by Case A's explicit `revert_temporary_replacement`
+            // call, which removes the entry whose replacement matches
+            // the closing child.) Without this, a future revert of the
+            // surviving sibling would try to splice the (now off-tree)
+            // child back into the tree, leaving a leaf that points to a
+            // stale pane.
             self.panes.remove_hidden_pane(pane_id);
             // The pane stays in `pane_contents` and `child_agent_panes`
             // — it just goes back to off-tree state.

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -95,7 +95,8 @@ use warpui::notification::NotificationSendError;
 use warpui::windowing::WindowManager;
 use warpui::{
     elements::{ChildView, Element, ParentElement},
-    AppContext, Entity, EntityId, ModelHandle, TypedActionView, View, ViewHandle, WindowId,
+    AppContext, Entity, EntityId, ModelHandle, TypedActionView, View, ViewHandle, WeakViewHandle,
+    WindowId,
 };
 use warpui::{SingletonEntity, ViewContext};
 
@@ -914,8 +915,30 @@ pub struct PaneGroup {
     /// be revealed from the parent's status card.
     child_agent_panes: HashMap<AIConversationId, PaneId>,
 
+    /// Set on a pane group that was created by splitting off a child agent
+    /// pane into a new tab via `OpenChildAgentInNewTab`. Holds a weak handle
+    /// to the source pane group along with the child conversation id, so
+    /// that closing this tab can re-adopt the live pane back into the
+    /// source instead of letting the `TerminalView` be dropped.
+    child_agent_origin: Option<ChildAgentOrigin>,
+
     /// Tab-level custom title set via the rename-tab flow.
     custom_title: Option<String>,
+}
+
+/// Origin metadata stamped on a pane group whose sole pane is a child agent
+/// `TerminalView` that was split off from another pane group via
+/// `OpenChildAgentInNewTab`. Used at tab-close time to re-adopt the pane
+/// back to its source so the live conversation view survives the tab
+/// dismissal.
+#[derive(Clone)]
+pub struct ChildAgentOrigin {
+    /// Pane group the child agent pane originally lived in (as a hidden
+    /// pane registered in `child_agent_panes`). A weak handle so we don't
+    /// keep the source tab alive past its own close.
+    pub source_pane_group: WeakViewHandle<PaneGroup>,
+    /// The child agent conversation hosted in this tab's lone pane.
+    pub conversation_id: AIConversationId,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -3021,6 +3044,7 @@ impl PaneGroup {
             is_right_panel_maximized: false,
             pending_ambient_agent_conversation_restorations: HashMap::new(),
             child_agent_panes: HashMap::new(),
+            child_agent_origin: None,
             custom_title: None,
         };
 
@@ -4521,6 +4545,22 @@ impl PaneGroup {
         self.child_agent_panes.values().any(|&id| id == pane_id)
     }
 
+    /// Restore visibility for every pane that is currently hidden by an
+    /// `OrchestrationSwap`. Called from `close_pane` (and similar lifecycle
+    /// paths) so a tab/pane close while a pill-bar swap is active never
+    /// leaves a swapped-out pane stuck in the hidden state.
+    fn revert_active_orchestration_swaps(&mut self) {
+        let swap_hidden: Vec<PaneId> = self
+            .pane_contents
+            .keys()
+            .copied()
+            .filter(|id| self.panes.is_pane_hidden_for_orchestration_swap(*id))
+            .collect();
+        for id in swap_hidden {
+            self.panes.show_pane_for_orchestration_swap(id);
+        }
+    }
+
     /// Collects the child agent pane IDs whose conversations are parented by
     /// a conversation on the given terminal view.
     fn child_pane_ids_for_parent(
@@ -4567,6 +4607,14 @@ impl PaneGroup {
             return;
         }
 
+        // If an orchestration pill-bar swap is active, revert it before any
+        // close path runs so the previously-hidden pane (e.g. the
+        // orchestrator that was swapped out for a child) returns to view
+        // instead of leaving the user with no visible content. The swap is
+        // a transient UI state and never makes sense to persist across a
+        // close event.
+        self.revert_active_orchestration_swaps();
+
         // Before any close path runs, transfer ownership of any child agent
         // conversations live in this view back to the pane that owns each
         // child's parent conversation. This keeps the orchestrator pane's
@@ -4580,6 +4628,17 @@ impl PaneGroup {
         if self.is_child_agent_pane(pane_id) {
             if !self.panes.is_pane_hidden(&pane_id) {
                 self.panes.hide_pane_for_child_agent(pane_id);
+            }
+            // Clear the split-off marker on the child's terminal view so a
+            // subsequent reveal via the orchestration pill bar's swap path
+            // renders pills (in-place context) instead of breadcrumbs
+            // (split-off context). Without this, the flag is sticky from the
+            // initial "Open in new pane" and the pane stays in breadcrumbs
+            // mode forever.
+            if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
+                terminal_view.update(ctx, |view, ctx| {
+                    view.clear_orchestration_split_off(ctx);
+                });
             }
             self.focus_next_terminal_pane_and_activate_session(
                 pane_id,
@@ -6434,6 +6493,418 @@ impl PaneGroup {
     ) -> Option<ViewHandle<TerminalView>> {
         self.terminal_session_by_id(pane_id)
             .map(|session| session.terminal_view(ctx))
+    }
+
+    /// Resolve the pane id that owns a given conversation's `TerminalView`,
+    /// without applying any visibility filtering. Used by the pill-bar swap
+    /// path to find the orchestrator pane (or any non-child conversation's
+    /// owner) regardless of whether it's currently visible. Walks the pane
+    /// contents and returns the first terminal pane whose terminal view id
+    /// matches the history model's owner for `conversation_id`.
+    fn pane_id_for_conversation_owner(
+        &self,
+        conversation_id: AIConversationId,
+        ctx: &AppContext,
+    ) -> Option<PaneId> {
+        let owner_view_id = BlocklistAIHistoryModel::as_ref(ctx)
+            .terminal_view_id_for_conversation(&conversation_id)?;
+        for pane_id in self.pane_contents.keys() {
+            if let Some(terminal_view) = self.terminal_view_from_pane_id(*pane_id, ctx) {
+                if terminal_view.id() == owner_view_id {
+                    return Some(*pane_id);
+                }
+            }
+        }
+        None
+    }
+
+    /// Make the pane that owns `conversation_id`'s `TerminalView` the visible
+    /// one in the slot currently occupied by `focused_pane_id`. The
+    /// orchestrator's pane and each child's hidden pane stay in the tree at
+    /// their original positions; this method only flips visibility flags so
+    /// the right one renders. Used by the orchestration pill bar to switch
+    /// between conversations without cloning any AI state into the active
+    /// pane.
+    ///
+    /// Resolution order for the target pane:
+    /// 1. `child_agent_panes.get(&conversation_id)` for child agents.
+    /// 2. `find_visible_terminal_pane_for_conversation` if the conversation is
+    ///    already showing in some pane (e.g. "Open in new pane" was already
+    ///    used).
+    /// 3. `pane_id_for_conversation_owner` to fall back on the history model
+    ///    for the orchestrator (or any non-child) conversation.
+    pub fn swap_active_pane_to_conversation(
+        &mut self,
+        focused_pane_id: PaneId,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let from_child_panes = self.child_agent_panes.get(&conversation_id).copied();
+        let from_visible_pane = self
+            .find_visible_terminal_pane_for_conversation(conversation_id, ctx)
+            .map(PaneId::from);
+        let from_owner_lookup = self.pane_id_for_conversation_owner(conversation_id, ctx);
+        let target_pane_id = from_child_panes.or(from_visible_pane).or(from_owner_lookup);
+
+        let Some(target_pane_id) = target_pane_id else {
+            self.log_swap_resolution_failure(focused_pane_id, conversation_id, ctx);
+            return;
+        };
+
+        // No-op when the active pill is clicked.
+        if target_pane_id == focused_pane_id {
+            return;
+        }
+
+        // If the target pane is already visible (e.g. user split the child
+        // off into a sibling pane), just focus it.
+        if !self.panes.is_pane_hidden(&target_pane_id) {
+            self.focus_pane(target_pane_id, true, ctx);
+            ctx.emit(Event::AppStateChanged);
+            return;
+        }
+
+        // Hide the previously focused pane using the right reason. If the
+        // focused pane was a child agent's hidden pane that we'd previously
+        // unhidden, restore the `ChildAgent` reason so it returns to its
+        // normal hidden state. Otherwise (e.g. orchestrator), use the
+        // orchestration-swap reason so we can find it again on the way back.
+        if self.is_child_agent_pane(focused_pane_id) {
+            self.panes.hide_pane_for_child_agent(focused_pane_id);
+            // Clear the split-off flag (same rationale as `close_pane`):
+            // the next time this child pane becomes visible via the swap
+            // path, it should render pills, not breadcrumbs.
+            if let Some(terminal_view) = self.terminal_view_from_pane_id(focused_pane_id, ctx) {
+                terminal_view.update(ctx, |view, ctx| {
+                    view.clear_orchestration_split_off(ctx);
+                });
+            }
+        } else {
+            self.panes.hide_pane_for_orchestration_swap(focused_pane_id);
+        }
+
+        // Show the target pane by clearing whichever hidden reason is on it.
+        if self.panes.is_pane_hidden_for_child_agent(target_pane_id) {
+            self.panes.show_pane_for_child_agent(target_pane_id);
+        } else if self
+            .panes
+            .is_pane_hidden_for_orchestration_swap(target_pane_id)
+        {
+            self.panes.show_pane_for_orchestration_swap(target_pane_id);
+        } else {
+            log::warn!(
+                "swap_active_pane_to_conversation: target pane {target_pane_id:?} is hidden but \
+                 not by a recognized reason; aborting swap"
+            );
+            // Best-effort: undo the hide we just applied to the focused pane
+            // so the UI doesn't end up with both panes hidden.
+            if self.is_child_agent_pane(focused_pane_id) {
+                if self.panes.is_pane_hidden_for_child_agent(focused_pane_id) {
+                    self.panes.show_pane_for_child_agent(focused_pane_id);
+                }
+            } else if self
+                .panes
+                .is_pane_hidden_for_orchestration_swap(focused_pane_id)
+            {
+                self.panes.show_pane_for_orchestration_swap(focused_pane_id);
+            }
+            return;
+        }
+
+        self.handle_pane_count_change(ctx);
+        self.focus_pane(target_pane_id, true, ctx);
+
+        // Refresh the agent-view back button label/disabled state on both
+        // panes involved in the swap. The label depends on whether the
+        // active conversation is a child agent ("for Orchestrator") or
+        // not ("for terminal"), and is normally only computed when the
+        // pane enters agent view. Without this refresh, a pane that was
+        // already in agent view from earlier would carry a stale label
+        // until something else triggers a refresh.
+        for pane_id in [focused_pane_id, target_pane_id] {
+            if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
+                terminal_view.update(ctx, |view, ctx| {
+                    view.update_agent_view_back_button_state(ctx);
+                });
+            }
+        }
+
+        ctx.emit(Event::TerminalViewStateChanged);
+        ctx.emit(Event::AppStateChanged);
+    }
+
+    /// Reveal the existing hidden child agent pane for `conversation_id` so
+    /// it becomes a visible sibling of the orchestrator's pane ("Open in new
+    /// pane").
+    /// child conversation rather than creating a new one — creating a fresh
+    /// view and reloading the conversation into it would clone state across
+    /// two views, cancelling the in-flight commands running in the original
+    /// view and briefly leaking the child conversation into the orchestrator
+    /// pane while ownership shuffles. Returns the revealed pane id on
+    /// success.
+    pub fn unhide_child_agent_pane_for_split_off(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<PaneId> {
+        let child_pane_id = self.child_agent_panes.get(&conversation_id).copied()?;
+
+        // If the user invoked "Open in new pane" while currently swapped
+        // to view this child via the orchestration pill bar, the child
+        // is already the visible pane occupying the slot the orchestrator
+        // used to hold, and the orchestrator is hidden by an
+        // `OrchestrationSwap`. Revert the swap so the orchestrator pane
+        // returns to view; the child pane stays visible as a new sibling
+        // and remains focused below (the split-off pane is the new
+        // "primary" surface for the user to interact with).
+        let mut orchestrator_pane_to_refresh: Option<PaneId> = None;
+        if self.focused_pane_id(ctx) == child_pane_id {
+            let swapped_out_panes: Vec<PaneId> = self
+                .pane_contents
+                .keys()
+                .copied()
+                .filter(|id| self.panes.is_pane_hidden_for_orchestration_swap(*id))
+                .collect();
+            for id in &swapped_out_panes {
+                self.panes.show_pane_for_orchestration_swap(*id);
+            }
+            // The orchestrator pane that just returned to view needs its
+            // agent-view back-button label refreshed below.
+            orchestrator_pane_to_refresh = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .and_then(|c| c.parent_conversation_id())
+                .and_then(|parent_id| self.pane_id_for_conversation_owner(parent_id, ctx))
+                .or_else(|| swapped_out_panes.first().copied());
+            if !swapped_out_panes.is_empty() {
+                self.handle_pane_count_change(ctx);
+            }
+        }
+
+        if self.panes.is_pane_hidden_for_child_agent(child_pane_id) {
+            self.panes.show_pane_for_child_agent(child_pane_id);
+            self.handle_pane_count_change(ctx);
+        }
+
+        if let Some(child_terminal_view) = self.terminal_view_from_pane_id(child_pane_id, ctx) {
+            child_terminal_view.update(ctx, |view, ctx| {
+                view.mark_as_orchestration_split_off(ctx);
+            });
+        }
+
+        // Refresh the back-button label on the now-revealed orchestrator
+        // pane so it picks up the correct "for terminal" / "for
+        // Orchestrator" label after the swap revert.
+        if let Some(orch_pane) = orchestrator_pane_to_refresh {
+            if let Some(terminal_view) = self.terminal_view_from_pane_id(orch_pane, ctx) {
+                terminal_view.update(ctx, |view, ctx| {
+                    view.update_agent_view_back_button_state(ctx);
+                });
+            }
+        }
+
+        self.focus_pane(child_pane_id, true, ctx);
+        ctx.emit(Event::TerminalViewStateChanged);
+        ctx.emit(Event::AppStateChanged);
+        Some(child_pane_id)
+    }
+
+    /// Detach the existing hidden child agent pane for `conversation_id` from
+    /// this pane group so it can be re-parented into a new tab's pane group
+    /// ("Open in new tab"). Reuses the existing `TerminalView` rather than
+    /// creating a fresh one for the same reasons documented on
+    /// [`unhide_child_agent_pane_for_split_off`]. The caller is responsible
+    /// for adopting the returned pane content into a new pane group via
+    /// `Workspace::add_tab_from_existing_pane`.
+    pub fn take_child_agent_pane_for_split_off(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<Box<dyn AnyPaneContent>> {
+        let child_pane_id = self.child_agent_panes.remove(&conversation_id)?;
+
+        // Unhide the pane before removing it so `remove_pane_for_move` sees a
+        // normal visible pane in the tree and so the destination tab
+        // immediately renders it without needing to clear hidden state.
+        if self.panes.is_pane_hidden_for_child_agent(child_pane_id) {
+            self.panes.show_pane_for_child_agent(child_pane_id);
+        }
+
+        if let Some(child_terminal_view) = self.terminal_view_from_pane_id(child_pane_id, ctx) {
+            child_terminal_view.update(ctx, |view, ctx| {
+                view.mark_as_orchestration_split_off(ctx);
+            });
+        }
+
+        self.remove_pane_for_move(&child_pane_id, ctx)
+    }
+
+    /// Stamp this pane group as the destination of a split-off child agent
+    /// pane. Workspace plumbing calls this immediately after wrapping the
+    /// detached pane in a fresh tab so that closing the tab can re-adopt
+    /// the live `TerminalView` back to the source group instead of
+    /// dropping it.
+    pub fn set_child_agent_origin(&mut self, origin: ChildAgentOrigin) {
+        self.child_agent_origin = Some(origin);
+    }
+
+    /// Returns the [`ChildAgentOrigin`] stamped on this pane group via
+    /// [`Self::set_child_agent_origin`], if any. Used by the workspace tab
+    /// close path to detect split-off child agent tabs and route them
+    /// through the re-adoption flow.
+    pub fn child_agent_origin(&self) -> Option<&ChildAgentOrigin> {
+        self.child_agent_origin.as_ref()
+    }
+
+    /// Re-adopt a child agent pane that was previously detached for a
+    /// split-off tab via [`Self::take_child_agent_pane_for_split_off`].
+    /// Re-inserts the pane into this group's tree (hidden as a child
+    /// agent), re-registers it in `child_agent_panes`, and clears the
+    /// split-off marker on its `TerminalView` so a subsequent reveal via
+    /// the orchestration pill bar's swap path renders the full pill bar
+    /// rather than the parent → child breadcrumb.
+    ///
+    /// Used by the workspace tab close path when the closing tab is the
+    /// destination of a split-off child agent: the live `TerminalView`
+    /// is preserved by moving it back to its source group rather than
+    /// being torn down with the closing pane group.
+    pub fn re_adopt_child_agent_pane(
+        &mut self,
+        pane_content: Box<dyn AnyPaneContent>,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let pane_id = pane_content.as_pane().id();
+
+        // Pick a base pane to split relative to. Prefer the pane that owns
+        // the parent (orchestrator) conversation in this group so the new
+        // hidden child sits next to its parent, which mirrors the layout
+        // produced by `create_hidden_child_agent_pane` at spawn time.
+        // Fall back to the first visible pane if the parent's owner can't
+        // be resolved (e.g. parent is itself swapped out).
+        let base_pane_id = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .and_then(|c| c.parent_conversation_id())
+            .and_then(|parent_id| self.pane_id_for_conversation_owner(parent_id, ctx))
+            .or_else(|| self.panes.visible_pane_ids().first().copied());
+
+        // Mark the pane hidden in the tree's hidden-pane registry first so
+        // the split below doesn't briefly render it as a visible sibling.
+        self.panes.hide_pane_for_child_agent(pane_id);
+        self.pane_contents.insert(pane_id, pane_content);
+
+        let attach_ok = match self.pane_contents.get(&pane_id) {
+            Some(pane) => {
+                self.attach_pane(pane.as_ref(), ctx);
+                true
+            }
+            None => false,
+        };
+        if !attach_ok {
+            log::error!("re_adopt_child_agent_pane: failed to attach pane {pane_id:?}");
+            self.panes.remove_hidden_pane(pane_id);
+            self.pane_contents.remove(&pane_id);
+            return;
+        }
+
+        let split_succeeded = match base_pane_id {
+            Some(base) => self.panes.split(base, pane_id, Direction::Right),
+            None => {
+                self.panes.split_root(pane_id, Direction::Right);
+                true
+            }
+        };
+
+        if !split_succeeded {
+            log::error!(
+                "re_adopt_child_agent_pane: split failed when re-inserting pane {pane_id:?}"
+            );
+            self.panes.remove_hidden_pane(pane_id);
+            self.clean_up_pane(pane_id, ctx);
+            self.pane_contents.remove(&pane_id);
+            return;
+        }
+
+        self.child_agent_panes.insert(conversation_id, pane_id);
+
+        // Clear the split-off marker so the next reveal via the
+        // orchestration pill bar renders the full pill bar rather than
+        // the parent → child breadcrumb. The pane is once again a hidden
+        // child agent of the orchestrator, not a top-level split-off.
+        if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
+            terminal_view.update(ctx, |view, ctx| {
+                view.clear_orchestration_split_off(ctx);
+            });
+        }
+
+        self.handle_pane_count_change(ctx);
+        ctx.notify();
+        ctx.emit(Event::TerminalViewStateChanged);
+        ctx.emit(Event::AppStateChanged);
+    }
+
+    /// Diagnostic logging for [`swap_active_pane_to_conversation`] when none of
+    /// the three resolvers (`child_agent_panes`, visible-pane lookup, history
+    /// model owner lookup) finds a pane in this group for the target
+    /// conversation. Dumps enough state to identify which step is wrong.
+    fn log_swap_resolution_failure(
+        &self,
+        focused_pane_id: PaneId,
+        conversation_id: AIConversationId,
+        ctx: &AppContext,
+    ) {
+        let history_model = BlocklistAIHistoryModel::as_ref(ctx);
+        let history_owner_view_id =
+            history_model.terminal_view_id_for_conversation(&conversation_id);
+        let conversation_in_memory = history_model.conversation(&conversation_id).is_some();
+        let parent_id = history_model
+            .conversation(&conversation_id)
+            .and_then(|c| c.parent_conversation_id());
+        let is_remote_child = history_model
+            .conversation(&conversation_id)
+            .map(|c| c.is_remote_child())
+            .unwrap_or(false);
+
+        let focused_view_id = self
+            .terminal_view_from_pane_id(focused_pane_id, ctx)
+            .map(|v| v.id());
+
+        let child_pane_keys: Vec<AIConversationId> =
+            self.child_agent_panes.keys().copied().collect();
+        let has_child_entry = self.child_agent_panes.contains_key(&conversation_id);
+
+        // Per-pane summary: pane_id, terminal_view_id, hidden state,
+        // agent_view active conversation id.
+        let mut pane_summaries: Vec<String> = Vec::new();
+        for pane_id in self.pane_contents.keys().copied() {
+            let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) else {
+                pane_summaries.push(format!("{pane_id:?}=non_terminal"));
+                continue;
+            };
+            let view_id = terminal_view.id();
+            let active_conv = terminal_view
+                .as_ref(ctx)
+                .agent_view_controller()
+                .as_ref(ctx)
+                .agent_view_state()
+                .active_conversation_id();
+            let hidden_for_close = self.is_pane_hidden_for_close(pane_id);
+            let hidden_for_child_agent = self.panes.is_pane_hidden_for_child_agent(pane_id);
+            let hidden_for_orch_swap = self.panes.is_pane_hidden_for_orchestration_swap(pane_id);
+            let is_hidden_any = self.panes.is_pane_hidden(&pane_id);
+            pane_summaries.push(format!(
+                "{pane_id:?}{{view={view_id:?},active={active_conv:?},hidden={is_hidden_any},close={hidden_for_close},child_agent={hidden_for_child_agent},orch_swap={hidden_for_orch_swap}}}"
+            ));
+        }
+
+        log::warn!(
+            "swap_active_pane_to_conversation: no pane found for conversation {conversation_id:?} \
+             [focused_pane={focused_pane_id:?}, focused_view={focused_view_id:?}, \
+             history_owner_view={history_owner_view_id:?}, in_memory={conversation_in_memory}, \
+             parent={parent_id:?}, remote_child={is_remote_child}, \
+             child_agent_panes_has_entry={has_child_entry}, \
+             child_agent_panes_keys={child_pane_keys:?}, panes=[{}]]",
+            pane_summaries.join(", ")
+        );
     }
 
     /// Walk the visible terminal panes in this group looking for one whose

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -799,7 +799,6 @@ enum DefaultSessionModeBehavior {
 enum NewPaneVisibility {
     Visible,
     HiddenForMove,
-    HiddenForChildAgent,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -4049,10 +4048,12 @@ impl PaneGroup {
         new_pane_id
     }
 
-    /// Creates a terminal pane that is immediately hidden as a child agent pane.
-    /// Unlike `insert_terminal_pane`, the new pane is never focused and is hidden
-    /// before layout notifications propagate, preventing disturbance to the
-    /// existing pane arrangement.
+    /// Creates a terminal pane that lives off-tree as a child agent pane.
+    /// Unlike `insert_terminal_pane`, the new pane is never inserted into the
+    /// layout tree at creation time — it lives only in `pane_contents` and
+    /// `child_agent_panes`. The orchestration pill bar later inserts it into
+    /// the tree on demand via `replace_pane` (in-place swap) or `panes.split`
+    /// ("Open in new pane").
     fn insert_terminal_pane_hidden_for_child_agent(
         &mut self,
         base_pane_id: PaneId,
@@ -4066,28 +4067,17 @@ impl PaneGroup {
         let (pane_data, _view) =
             self.create_terminal_pane_data(startup_directory, env_vars, None, None, ctx);
         let new_pane_id = pane_data.terminal_pane_id();
-        let _ = self.add_pane_with_options(
-            Box::new(pane_data),
-            AddPaneOptions {
-                direction: Direction::Right,
-                base_pane_id: Some(base_pane_id),
-                focus_new_pane: false,
-                visibility: NewPaneVisibility::HiddenForChildAgent,
-                emit_app_state_changed: false,
-            },
-            ctx,
-        );
-
+        self.attach_child_pane_off_tree(Box::new(pane_data), ctx);
         new_pane_id
     }
 
-    /// Creates a cloud-mode pane that is immediately hidden as a child agent pane.
+    /// Creates a cloud-mode pane that lives off-tree as a child agent pane.
     /// Unlike `create_ambient_agent_pane`, this leaves the new terminal view
     /// uninitialized so callers can create and select the child conversation
     /// explicitly before the deferred shared-session viewer binds to it.
     fn insert_ambient_agent_pane_hidden_for_child_agent(
         &mut self,
-        base_pane_id: PaneId,
+        _base_pane_id: PaneId,
         ctx: &mut ViewContext<Self>,
     ) -> TerminalPaneId {
         let uuid = Uuid::new_v4();
@@ -4107,19 +4097,30 @@ impl PaneGroup {
             ctx,
         );
         let new_pane_id = pane_data.terminal_pane_id();
-        let _ = self.add_pane_with_options(
-            Box::new(pane_data),
-            AddPaneOptions {
-                direction: Direction::Right,
-                base_pane_id: Some(base_pane_id),
-                focus_new_pane: false,
-                visibility: NewPaneVisibility::HiddenForChildAgent,
-                emit_app_state_changed: false,
-            },
-            ctx,
-        );
-
+        self.attach_child_pane_off_tree(Box::new(pane_data), ctx);
         new_pane_id
+    }
+
+    /// Inserts `pane` into `pane_contents` and attaches it (so subscriptions,
+    /// focus handle, etc. are wired up) without adding it to the layout tree.
+    /// Used for child agent panes which only enter the tree later via the
+    /// pill bar's swap or split-off paths.
+    fn attach_child_pane_off_tree(
+        &mut self,
+        pane: Box<dyn AnyPaneContent>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<PaneId> {
+        let pane_id = pane.as_pane().id();
+        self.pane_contents.insert(pane_id, pane);
+        let pane = self
+            .pane_contents
+            .get(&pane_id)
+            .expect("Just inserted pane");
+        if !self.try_attach_pane(pane.as_ref(), ctx) {
+            self.pane_contents.remove(&pane_id);
+            return None;
+        }
+        Some(pane_id)
     }
 
     /// Get the [`PaneView<TerminalView>`] for the pane at `pane_index`, if that pane is:
@@ -4545,22 +4546,6 @@ impl PaneGroup {
         self.child_agent_panes.values().any(|&id| id == pane_id)
     }
 
-    /// Restore visibility for every pane that is currently hidden by an
-    /// `OrchestrationSwap`. Called from `close_pane` (and similar lifecycle
-    /// paths) so a tab/pane close while a pill-bar swap is active never
-    /// leaves a swapped-out pane stuck in the hidden state.
-    fn revert_active_orchestration_swaps(&mut self) {
-        let swap_hidden: Vec<PaneId> = self
-            .pane_contents
-            .keys()
-            .copied()
-            .filter(|id| self.panes.is_pane_hidden_for_orchestration_swap(*id))
-            .collect();
-        for id in swap_hidden {
-            self.panes.show_pane_for_orchestration_swap(id);
-        }
-    }
-
     /// Collects the child agent pane IDs whose conversations are parented by
     /// a conversation on the given terminal view.
     fn child_pane_ids_for_parent(
@@ -4607,14 +4592,6 @@ impl PaneGroup {
             return;
         }
 
-        // If an orchestration pill-bar swap is active, revert it before any
-        // close path runs so the previously-hidden pane (e.g. the
-        // orchestrator that was swapped out for a child) returns to view
-        // instead of leaving the user with no visible content. The swap is
-        // a transient UI state and never makes sense to persist across a
-        // close event.
-        self.revert_active_orchestration_swaps();
-
         // Before any close path runs, transfer ownership of any child agent
         // conversations live in this view back to the pane that owns each
         // child's parent conversation. This keeps the orchestrator pane's
@@ -4624,17 +4601,31 @@ impl PaneGroup {
         // conversation into the (visible) view via the normal load path.
         self.transfer_child_agent_conversations_to_parents_on_close(pane_id, ctx);
 
-        // If this pane is a child agent, re-hide it instead of closing it.
+        // If this pane is a child agent, return it to its off-tree state
+        // instead of destroying it — future pill clicks will swap it back
+        // into the user's anchor.
         if self.is_child_agent_pane(pane_id) {
-            if !self.panes.is_pane_hidden(&pane_id) {
-                self.panes.hide_pane_for_child_agent(pane_id);
+            // Case A: the child is currently the active swap target (in
+            // the anchor's tree slot via temporary replacement). Revert
+            // the swap so the anchor pane returns to its slot.
+            if self.panes.original_pane_for_replacement(pane_id).is_some() {
+                self.panes.revert_temporary_replacement(pane_id);
             }
-            // Clear the split-off marker on the child's terminal view so a
-            // subsequent reveal via the orchestration pill bar's swap path
-            // renders pills (in-place context) instead of breadcrumbs
-            // (split-off context). Without this, the flag is sticky from the
-            // initial "Open in new pane" and the pane stays in breadcrumbs
-            // mode forever.
+            // Case B: the child is in the tree as a real sibling (split
+            // off via "Open in new pane"). Remove it from the tree.
+            else if self.panes.is_pane_in_tree(pane_id) {
+                if !self.panes.remove(pane_id) {
+                    log::error!(
+                        "close_pane: failed to remove split-off child pane {pane_id:?} from tree"
+                    );
+                }
+            }
+            // The pane stays in `pane_contents` and `child_agent_panes`
+            // — it just goes back to off-tree state.
+
+            // Clear the split-off marker on the child's terminal view so
+            // a subsequent reveal via the swap path renders pills (in-place
+            // context) instead of breadcrumbs (split-off context).
             if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
                 terminal_view.update(ctx, |view, ctx| {
                     view.clear_orchestration_split_off(ctx);
@@ -4756,6 +4747,17 @@ impl PaneGroup {
         pane_to_focus: PaneId,
         ctx: &mut ViewContext<Self>,
     ) {
+        // Child agent panes route through `close_pane` so that closing them
+        // reverts the swap (or removes the split-off) without destroying
+        // the underlying `TerminalView`. The default temporary-replacement
+        // close path destroys the replacement pane, which would tear down
+        // the child's `TerminalView` — not what we want.
+        if self.is_child_agent_pane(pane_id) {
+            self.close_pane(pane_id, ctx);
+            ctx.emit(Event::FocusPane { pane_to_focus });
+            return;
+        }
+
         // Check if this is a temporary replacement that should be reverted
         if self.panes.is_temporary_replacement(pane_id) {
             // Remove the replacement pane and focus the original pane
@@ -6185,7 +6187,6 @@ impl PaneGroup {
         match options.visibility {
             NewPaneVisibility::Visible => {}
             NewPaneVisibility::HiddenForMove => self.panes.hide_pane_for_move(pane_id),
-            NewPaneVisibility::HiddenForChildAgent => self.panes.hide_pane_for_child_agent(pane_id),
         }
 
         let pane_id = self.init_pane(new_pane, ctx)?;
@@ -6519,12 +6520,14 @@ impl PaneGroup {
     }
 
     /// Make the pane that owns `conversation_id`'s `TerminalView` the visible
-    /// one in the slot currently occupied by `focused_pane_id`. The
-    /// orchestrator's pane and each child's hidden pane stay in the tree at
-    /// their original positions; this method only flips visibility flags so
-    /// the right one renders. Used by the orchestration pill bar to switch
-    /// between conversations without cloning any AI state into the active
-    /// pane.
+    /// one in the slot currently occupied by `focused_pane_id` (the swap
+    /// anchor).
+    ///
+    /// Implementation: uses `PaneData::replace_pane(anchor, target, true)` to
+    /// substitute the target pane into the anchor's tree slot. The anchor is
+    /// recorded as the temporary-replacement original so a subsequent revert
+    /// (back-button, ESC, pill-click on the anchor's conversation, close,
+    /// split-off, etc.) restores it to its slot.
     ///
     /// Resolution order for the target pane:
     /// 1. `child_agent_panes.get(&conversation_id)` for child agents.
@@ -6556,58 +6559,66 @@ impl PaneGroup {
             return;
         }
 
-        // If the target pane is already visible (e.g. user split the child
-        // off into a sibling pane), just focus it.
-        if !self.panes.is_pane_hidden(&target_pane_id) {
-            self.focus_pane(target_pane_id, true, ctx);
+        // If the anchor is currently a temporary-replacement target (i.e.
+        // some swap is already active in this slot), revert that swap first
+        // so the original pane returns to its tree slot. The anchor for the
+        // new operation becomes that original pane.
+        let anchor =
+            if let Some(original) = self.panes.original_pane_for_replacement(focused_pane_id) {
+                // Clear the split-off marker on the child we're swapping away
+                // from so it renders pills (not breadcrumbs) next time it
+                // becomes visible.
+                if let Some(terminal_view) = self.terminal_view_from_pane_id(focused_pane_id, ctx) {
+                    terminal_view.update(ctx, |view, ctx| {
+                        view.clear_orchestration_split_off(ctx);
+                    });
+                }
+                self.panes.revert_temporary_replacement(focused_pane_id);
+                original
+            } else {
+                focused_pane_id
+            };
+
+        // After revert, if we landed on the target itself, the user just
+        // clicked back to the orchestrator; just focus and return.
+        if anchor == target_pane_id {
+            self.handle_pane_count_change(ctx);
+            self.focus_pane(anchor, true, ctx);
+            if let Some(terminal_view) = self.terminal_view_from_pane_id(anchor, ctx) {
+                terminal_view.update(ctx, |view, ctx| {
+                    view.update_agent_view_back_button_state(ctx);
+                });
+            }
+            ctx.emit(Event::TerminalViewStateChanged);
             ctx.emit(Event::AppStateChanged);
             return;
         }
 
-        // Hide the previously focused pane using the right reason. If the
-        // focused pane was a child agent's hidden pane that we'd previously
-        // unhidden, restore the `ChildAgent` reason so it returns to its
-        // normal hidden state. Otherwise (e.g. orchestrator), use the
-        // orchestration-swap reason so we can find it again on the way back.
-        if self.is_child_agent_pane(focused_pane_id) {
-            self.panes.hide_pane_for_child_agent(focused_pane_id);
-            // Clear the split-off flag (same rationale as `close_pane`):
-            // the next time this child pane becomes visible via the swap
-            // path, it should render pills, not breadcrumbs.
-            if let Some(terminal_view) = self.terminal_view_from_pane_id(focused_pane_id, ctx) {
+        // If the target pane is already visible in the tree (e.g. user split
+        // the child off into a sibling pane), just focus it. Don't call
+        // `replace_pane` — it would put the target in two tree positions.
+        if self.panes.is_pane_in_tree(target_pane_id) && !self.panes.is_pane_hidden(&target_pane_id)
+        {
+            self.handle_pane_count_change(ctx);
+            self.focus_pane(target_pane_id, true, ctx);
+            if let Some(terminal_view) = self.terminal_view_from_pane_id(target_pane_id, ctx) {
                 terminal_view.update(ctx, |view, ctx| {
-                    view.clear_orchestration_split_off(ctx);
+                    view.update_agent_view_back_button_state(ctx);
                 });
             }
-        } else {
-            self.panes.hide_pane_for_orchestration_swap(focused_pane_id);
+            ctx.emit(Event::TerminalViewStateChanged);
+            ctx.emit(Event::AppStateChanged);
+            return;
         }
 
-        // Show the target pane by clearing whichever hidden reason is on it.
-        if self.panes.is_pane_hidden_for_child_agent(target_pane_id) {
-            self.panes.show_pane_for_child_agent(target_pane_id);
-        } else if self
-            .panes
-            .is_pane_hidden_for_orchestration_swap(target_pane_id)
-        {
-            self.panes.show_pane_for_orchestration_swap(target_pane_id);
-        } else {
+        // Place the target pane into the anchor's tree slot via temporary
+        // replacement. The anchor stays in `pane_contents` and is recorded
+        // as the original; revert returns it to its slot.
+        let success = self.panes.replace_pane(anchor, target_pane_id, true);
+        if !success {
             log::warn!(
-                "swap_active_pane_to_conversation: target pane {target_pane_id:?} is hidden but \
-                 not by a recognized reason; aborting swap"
+                "swap_active_pane_to_conversation: replace_pane failed for anchor={anchor:?} target={target_pane_id:?}"
             );
-            // Best-effort: undo the hide we just applied to the focused pane
-            // so the UI doesn't end up with both panes hidden.
-            if self.is_child_agent_pane(focused_pane_id) {
-                if self.panes.is_pane_hidden_for_child_agent(focused_pane_id) {
-                    self.panes.show_pane_for_child_agent(focused_pane_id);
-                }
-            } else if self
-                .panes
-                .is_pane_hidden_for_orchestration_swap(focused_pane_id)
-            {
-                self.panes.show_pane_for_orchestration_swap(focused_pane_id);
-            }
             return;
         }
 
@@ -6621,7 +6632,7 @@ impl PaneGroup {
         // pane enters agent view. Without this refresh, a pane that was
         // already in agent view from earlier would carry a stale label
         // until something else triggers a refresh.
-        for pane_id in [focused_pane_id, target_pane_id] {
+        for pane_id in [anchor, target_pane_id] {
             if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
                 terminal_view.update(ctx, |view, ctx| {
                     view.update_agent_view_back_button_state(ctx);
@@ -6633,15 +6644,18 @@ impl PaneGroup {
         ctx.emit(Event::AppStateChanged);
     }
 
-    /// Reveal the existing hidden child agent pane for `conversation_id` so
-    /// it becomes a visible sibling of the orchestrator's pane ("Open in new
-    /// pane").
-    /// child conversation rather than creating a new one — creating a fresh
-    /// view and reloading the conversation into it would clone state across
-    /// two views, cancelling the in-flight commands running in the original
-    /// view and briefly leaking the child conversation into the orchestrator
-    /// pane while ownership shuffles. Returns the revealed pane id on
-    /// success.
+    /// Reveal the existing child agent pane for `conversation_id` as a
+    /// visible sibling next to the orchestrator's pane ("Open in new
+    /// pane"). Reuses the existing `TerminalView` — creating a fresh view
+    /// and reloading the conversation into it would cancel in-flight
+    /// commands and briefly leak the child transcript into the orchestrator
+    /// pane while ownership shuffles.
+    ///
+    /// If the child is currently the active swap target (in the
+    /// orchestrator's tree slot via temporary replacement), revert the swap
+    /// first so the orchestrator returns to its slot, then split the child
+    /// in next to it. Otherwise, split the child in next to the focused
+    /// pane.
     pub fn unhide_child_agent_pane_for_split_off(
         &mut self,
         conversation_id: AIConversationId,
@@ -6649,40 +6663,36 @@ impl PaneGroup {
     ) -> Option<PaneId> {
         let child_pane_id = self.child_agent_panes.get(&conversation_id).copied()?;
 
-        // If the user invoked "Open in new pane" while currently swapped
-        // to view this child via the orchestration pill bar, the child
-        // is already the visible pane occupying the slot the orchestrator
-        // used to hold, and the orchestrator is hidden by an
-        // `OrchestrationSwap`. Revert the swap so the orchestrator pane
-        // returns to view; the child pane stays visible as a new sibling
-        // and remains focused below (the split-off pane is the new
-        // "primary" surface for the user to interact with).
-        let mut orchestrator_pane_to_refresh: Option<PaneId> = None;
-        if self.focused_pane_id(ctx) == child_pane_id {
-            let swapped_out_panes: Vec<PaneId> = self
-                .pane_contents
-                .keys()
-                .copied()
-                .filter(|id| self.panes.is_pane_hidden_for_orchestration_swap(*id))
-                .collect();
-            for id in &swapped_out_panes {
-                self.panes.show_pane_for_orchestration_swap(*id);
-            }
-            // The orchestrator pane that just returned to view needs its
-            // agent-view back-button label refreshed below.
-            orchestrator_pane_to_refresh = BlocklistAIHistoryModel::as_ref(ctx)
-                .conversation(&conversation_id)
-                .and_then(|c| c.parent_conversation_id())
-                .and_then(|parent_id| self.pane_id_for_conversation_owner(parent_id, ctx))
-                .or_else(|| swapped_out_panes.first().copied());
-            if !swapped_out_panes.is_empty() {
-                self.handle_pane_count_change(ctx);
-            }
+        // If the child pane is already a visible sibling in the tree (e.g.
+        // user already split it off), just focus it.
+        if self.panes.is_pane_in_tree(child_pane_id)
+            && !self.panes.is_pane_hidden(&child_pane_id)
+            && self
+                .panes
+                .original_pane_for_replacement(child_pane_id)
+                .is_none()
+        {
+            self.focus_pane(child_pane_id, true, ctx);
+            return Some(child_pane_id);
         }
 
-        if self.panes.is_pane_hidden_for_child_agent(child_pane_id) {
-            self.panes.show_pane_for_child_agent(child_pane_id);
-            self.handle_pane_count_change(ctx);
+        // If the child pane is currently the active swap target, revert
+        // the swap so the orchestrator's pane returns to its tree slot.
+        // Then split the child in next to the orchestrator.
+        let split_base = if let Some(original_pane_id) =
+            self.panes.original_pane_for_replacement(child_pane_id)
+        {
+            self.panes.revert_temporary_replacement(child_pane_id);
+            original_pane_id
+        } else {
+            self.focused_pane_id(ctx)
+        };
+
+        let split_ok = self
+            .panes
+            .split(split_base, child_pane_id, Direction::Right);
+        if !split_ok {
+            self.panes.split_root(child_pane_id, Direction::Right);
         }
 
         if let Some(child_terminal_view) = self.terminal_view_from_pane_id(child_pane_id, ctx) {
@@ -6691,24 +6701,22 @@ impl PaneGroup {
             });
         }
 
-        // Refresh the back-button label on the now-revealed orchestrator
-        // pane so it picks up the correct "for terminal" / "for
-        // Orchestrator" label after the swap revert.
-        if let Some(orch_pane) = orchestrator_pane_to_refresh {
-            if let Some(terminal_view) = self.terminal_view_from_pane_id(orch_pane, ctx) {
-                terminal_view.update(ctx, |view, ctx| {
-                    view.update_agent_view_back_button_state(ctx);
-                });
-            }
+        // Refresh the back-button label on the orchestrator pane (its
+        // visible content just changed from child to orchestrator).
+        if let Some(terminal_view) = self.terminal_view_from_pane_id(split_base, ctx) {
+            terminal_view.update(ctx, |view, ctx| {
+                view.update_agent_view_back_button_state(ctx);
+            });
         }
 
+        self.handle_pane_count_change(ctx);
         self.focus_pane(child_pane_id, true, ctx);
         ctx.emit(Event::TerminalViewStateChanged);
         ctx.emit(Event::AppStateChanged);
         Some(child_pane_id)
     }
 
-    /// Detach the existing hidden child agent pane for `conversation_id` from
+    /// Detach the existing child agent pane for `conversation_id` from
     /// this pane group so it can be re-parented into a new tab's pane group
     /// ("Open in new tab"). Reuses the existing `TerminalView` rather than
     /// creating a fresh one for the same reasons documented on
@@ -6722,11 +6730,38 @@ impl PaneGroup {
     ) -> Option<Box<dyn AnyPaneContent>> {
         let child_pane_id = self.child_agent_panes.remove(&conversation_id)?;
 
-        // Unhide the pane before removing it so `remove_pane_for_move` sees a
-        // normal visible pane in the tree and so the destination tab
-        // immediately renders it without needing to clear hidden state.
-        if self.panes.is_pane_hidden_for_child_agent(child_pane_id) {
-            self.panes.show_pane_for_child_agent(child_pane_id);
+        // If the child is currently the active swap target, revert the swap
+        // so the orchestrator returns to its slot. After this, the child
+        // pane is off-tree.
+        if self
+            .panes
+            .original_pane_for_replacement(child_pane_id)
+            .is_some()
+        {
+            self.panes.revert_temporary_replacement(child_pane_id);
+        }
+
+        // If the child is in the tree as a real sibling (split off), remove
+        // it from the tree. Off-tree panes are already not in the tree.
+        if self.panes.is_pane_in_tree(child_pane_id) {
+            let was_focused = self.focus_state.as_ref(ctx).is_pane_focused(child_pane_id);
+            self.focus_next_terminal_pane_and_activate_session(
+                child_pane_id,
+                PaneRemovalReason::Move,
+                ctx,
+            );
+            if !self.panes.remove(child_pane_id) {
+                log::error!(
+                    "take_child_agent_pane_for_split_off: failed to remove pane {child_pane_id:?} from tree"
+                );
+            }
+            let in_split_pane = self.panes.visible_pane_count() > 1;
+            self.focus_state.update(ctx, |focus_state, ctx| {
+                focus_state.set_in_split_pane(in_split_pane, ctx);
+                if was_focused {
+                    focus_state.set_focused_pane_maximized(false, ctx);
+                }
+            });
         }
 
         if let Some(child_terminal_view) = self.terminal_view_from_pane_id(child_pane_id, ctx) {
@@ -6735,7 +6770,18 @@ impl PaneGroup {
             });
         }
 
-        self.remove_pane_for_move(&child_pane_id, ctx)
+        // Detach the pane (DetachType::Moved) so the destination pane
+        // group can re-attach it cleanly.
+        if let Some(pane_data) = self.pane_contents.get(&child_pane_id) {
+            let pane = pane_data.as_pane();
+            pane.detach(self, DetachType::Moved, ctx);
+        }
+
+        let pane_content = self.pane_contents.remove(&child_pane_id);
+        ctx.notify();
+        ctx.emit(Event::TerminalViewStateChanged);
+        ctx.emit(Event::AppStateChanged);
+        pane_content
     }
 
     /// Stamp this pane group as the destination of a split-off child agent
@@ -6757,16 +6803,16 @@ impl PaneGroup {
 
     /// Re-adopt a child agent pane that was previously detached for a
     /// split-off tab via [`Self::take_child_agent_pane_for_split_off`].
-    /// Re-inserts the pane into this group's tree (hidden as a child
-    /// agent), re-registers it in `child_agent_panes`, and clears the
-    /// split-off marker on its `TerminalView` so a subsequent reveal via
-    /// the orchestration pill bar's swap path renders the full pill bar
-    /// rather than the parent → child breadcrumb.
+    /// Re-inserts the pane into this group's `pane_contents` and
+    /// `child_agent_panes` **off-tree**, and clears the split-off marker
+    /// on its `TerminalView` so a subsequent reveal via the orchestration
+    /// pill bar renders the full pill bar rather than breadcrumbs.
     ///
     /// Used by the workspace tab close path when the closing tab is the
-    /// destination of a split-off child agent: the live `TerminalView`
-    /// is preserved by moving it back to its source group rather than
-    /// being torn down with the closing pane group.
+    /// destination of a split-off child agent: the live `TerminalView` is
+    /// preserved by moving it back to its source group rather than being
+    /// torn down with the closing pane group. Subsequent pill clicks will
+    /// swap it into the user's anchor as needed.
     pub fn re_adopt_child_agent_pane(
         &mut self,
         pane_content: Box<dyn AnyPaneContent>,
@@ -6775,68 +6821,25 @@ impl PaneGroup {
     ) {
         let pane_id = pane_content.as_pane().id();
 
-        // Pick a base pane to split relative to. Prefer the pane that owns
-        // the parent (orchestrator) conversation in this group so the new
-        // hidden child sits next to its parent, which mirrors the layout
-        // produced by `create_hidden_child_agent_pane` at spawn time.
-        // Fall back to the first visible pane if the parent's owner can't
-        // be resolved (e.g. parent is itself swapped out).
-        let base_pane_id = BlocklistAIHistoryModel::as_ref(ctx)
-            .conversation(&conversation_id)
-            .and_then(|c| c.parent_conversation_id())
-            .and_then(|parent_id| self.pane_id_for_conversation_owner(parent_id, ctx))
-            .or_else(|| self.panes.visible_pane_ids().first().copied());
-
-        // Mark the pane hidden in the tree's hidden-pane registry first so
-        // the split below doesn't briefly render it as a visible sibling.
-        self.panes.hide_pane_for_child_agent(pane_id);
-        self.pane_contents.insert(pane_id, pane_content);
-
-        let attach_ok = match self.pane_contents.get(&pane_id) {
-            Some(pane) => {
-                self.attach_pane(pane.as_ref(), ctx);
-                true
-            }
-            None => false,
-        };
-        if !attach_ok {
+        if let Some(returned_pane_id) = self.attach_child_pane_off_tree(pane_content, ctx) {
+            debug_assert_eq!(returned_pane_id, pane_id);
+            self.child_agent_panes.insert(conversation_id, pane_id);
+        } else {
             log::error!("re_adopt_child_agent_pane: failed to attach pane {pane_id:?}");
-            self.panes.remove_hidden_pane(pane_id);
-            self.pane_contents.remove(&pane_id);
             return;
         }
-
-        let split_succeeded = match base_pane_id {
-            Some(base) => self.panes.split(base, pane_id, Direction::Right),
-            None => {
-                self.panes.split_root(pane_id, Direction::Right);
-                true
-            }
-        };
-
-        if !split_succeeded {
-            log::error!(
-                "re_adopt_child_agent_pane: split failed when re-inserting pane {pane_id:?}"
-            );
-            self.panes.remove_hidden_pane(pane_id);
-            self.clean_up_pane(pane_id, ctx);
-            self.pane_contents.remove(&pane_id);
-            return;
-        }
-
-        self.child_agent_panes.insert(conversation_id, pane_id);
 
         // Clear the split-off marker so the next reveal via the
         // orchestration pill bar renders the full pill bar rather than
-        // the parent → child breadcrumb. The pane is once again a hidden
-        // child agent of the orchestrator, not a top-level split-off.
+        // the parent → child breadcrumb. The pane is once again an
+        // off-tree child agent of the orchestrator, not a top-level
+        // split-off.
         if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
             terminal_view.update(ctx, |view, ctx| {
                 view.clear_orchestration_split_off(ctx);
             });
         }
 
-        self.handle_pane_count_change(ctx);
         ctx.notify();
         ctx.emit(Event::TerminalViewStateChanged);
         ctx.emit(Event::AppStateChanged);
@@ -6889,10 +6892,11 @@ impl PaneGroup {
                 .active_conversation_id();
             let hidden_for_close = self.is_pane_hidden_for_close(pane_id);
             let hidden_for_child_agent = self.panes.is_pane_hidden_for_child_agent(pane_id);
-            let hidden_for_orch_swap = self.panes.is_pane_hidden_for_orchestration_swap(pane_id);
+            let in_tree = self.panes.is_pane_in_tree(pane_id);
+            let is_temp_replacement = self.panes.original_pane_for_replacement(pane_id).is_some();
             let is_hidden_any = self.panes.is_pane_hidden(&pane_id);
             pane_summaries.push(format!(
-                "{pane_id:?}{{view={view_id:?},active={active_conv:?},hidden={is_hidden_any},close={hidden_for_close},child_agent={hidden_for_child_agent},orch_swap={hidden_for_orch_swap}}}"
+                "{pane_id:?}{{view={view_id:?},active={active_conv:?},in_tree={in_tree},hidden={is_hidden_any},close={hidden_for_close},child_agent={hidden_for_child_agent},temp_replacement={is_temp_replacement}}}"
             ));
         }
 

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -4698,9 +4698,10 @@ impl PaneGroup {
             // handled by Case A's explicit `revert_temporary_replacement`
             // call, which removes the entry whose replacement matches
             // the closing child.) Without this, a future revert of the
-            // surviving sibling would try to splice the (now off-tree)
-            // child back into the tree, leaving a leaf that points to a
-            // stale pane.
+            // surviving sibling — e.g. when the user closes the sibling
+            // — would splice the (off-tree but still live) child back
+            // into the tree and resurrect the just-closed pane as a
+            // visible leaf, which is not what the user asked for.
             self.panes.remove_hidden_pane(pane_id);
             // The pane stays in `pane_contents` and `child_agent_panes`
             // — it just goes back to off-tree state.
@@ -6753,15 +6754,10 @@ impl PaneGroup {
         if let Some(replacement_id) = self.panes.replacement_pane_for_original(target_pane_id) {
             // The replacement currently sitting in target's slot is
             // (always, in practice) a child agent pane swapped in via
-            // the pill bar. Clear its split-off marker so the next
-            // reveal renders pills, matching what the regular anchor
-            // revert below does.
-            if let Some(terminal_view) = self.terminal_view_from_pane_id(replacement_id, ctx) {
-                terminal_view.update(ctx, |view, ctx| {
-                    view.clear_orchestration_split_off(ctx);
-                });
-            }
-            self.panes.revert_temporary_replacement(replacement_id);
+            // the pill bar. The helper also clears its split-off marker
+            // so the next reveal renders pills, matching what the
+            // regular anchor revert below does.
+            self.revert_swap_clearing_split_off(replacement_id, ctx);
             self.handle_pane_count_change(ctx);
             self.focus_pane(target_pane_id, true, ctx);
             for pane_id in [replacement_id, target_pane_id] {
@@ -6782,15 +6778,10 @@ impl PaneGroup {
         // new operation becomes that original pane.
         let anchor =
             if let Some(original) = self.panes.original_pane_for_replacement(focused_pane_id) {
-                // Clear the split-off marker on the child we're swapping away
-                // from so it renders pills (not breadcrumbs) next time it
-                // becomes visible.
-                if let Some(terminal_view) = self.terminal_view_from_pane_id(focused_pane_id, ctx) {
-                    terminal_view.update(ctx, |view, ctx| {
-                        view.clear_orchestration_split_off(ctx);
-                    });
-                }
-                self.panes.revert_temporary_replacement(focused_pane_id);
+                // The helper also clears the split-off marker on the
+                // child we're swapping away from so it renders pills
+                // (not breadcrumbs) next time it becomes visible.
+                self.revert_swap_clearing_split_off(focused_pane_id, ctx);
                 original
             } else {
                 focused_pane_id

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -4627,6 +4627,17 @@ impl PaneGroup {
                     );
                 }
             }
+            // Case C (split-off, then swapped over): the child was a
+            // visible split-off sibling, then a sibling pill was clicked
+            // from the child's pill bar — `replace_pane(child, sibling,
+            // true)` recorded the child as the *original* of an active
+            // TempRepl. Cases A and B don't touch that entry, so drop
+            // any hidden-pane record naming this child as either side
+            // of a swap. Without this, a future revert of the surviving
+            // sibling would try to splice the (now off-tree) child back
+            // into the tree, leaving a leaf that points to a stale
+            // pane.
+            self.panes.remove_hidden_pane(pane_id);
             // The pane stays in `pane_contents` and `child_agent_panes`
             // — it just goes back to off-tree state.
 
@@ -6862,6 +6873,16 @@ impl PaneGroup {
                 );
             }
         }
+
+        // Drop any leftover hidden-pane entry naming the child. Covers
+        // the split-off-then-swapped-over case where the child sits in
+        // `hidden_panes` as the *original* of an active TempRepl (a
+        // sibling was swapped into the child's slot from its pill bar).
+        // The branches above don't clear that entry, and leaving it in
+        // place would let a future revert of the surviving sibling
+        // splice the (now-detached) child back into the tree, leaving
+        // a leaf that points to a pane this group no longer owns.
+        self.panes.remove_hidden_pane(child_pane_id);
 
         // Shift focus and active session away from the child pane if it
         // held either, regardless of which path took it out of the tree.

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -2095,7 +2095,25 @@ impl PaneGroup {
                 })
             }
             PaneNode::Leaf(pane_id) => {
-                let contents = match self.pane_contents.get(pane_id) {
+                // If this leaf is the *replacement* of an active
+                // `TemporaryReplacement` (i.e. a child agent pane was
+                // pill-swapped into the orchestrator's slot), persist the
+                // *original* pane's contents instead of the transient
+                // replacement. The swap is a UX-only state, not a
+                // structural change to the user's tab layout. Without
+                // this substitution the snapshot would record the child
+                // as the canonical leaf and lose the orchestrator
+                // entirely — child agent panes are intentionally excluded
+                // from snapshots and rebuilt on startup from the
+                // parent→child index, so on the next launch the tab
+                // would either come back with a stale child terminal as
+                // its root or fail to recreate the orchestrator pane at
+                // all.
+                let snapshot_pane_id = self
+                    .panes
+                    .original_pane_for_replacement(*pane_id)
+                    .unwrap_or(*pane_id);
+                let contents = match self.pane_contents.get(&snapshot_pane_id) {
                     Some(pane) => pane.as_pane().snapshot(app),
                     None => {
                         // Create a new pane uuid if we have a bug where we didn't save it
@@ -2105,7 +2123,8 @@ impl PaneGroup {
                         LeafContents::Terminal(TerminalPaneSnapshot {
                             uuid: Uuid::new_v4().as_bytes().to_vec(),
                             cwd: None,
-                            is_active: pane_id.as_terminal_pane_id() == self.active_session_id(app),
+                            is_active: snapshot_pane_id.as_terminal_pane_id()
+                                == self.active_session_id(app),
                             is_read_only: false,
                             shell_launch_data: None,
                             input_config: Some(InputConfig::new(app)),
@@ -2116,14 +2135,19 @@ impl PaneGroup {
                         })
                     }
                 };
-                let custom_vertical_tabs_title = self.pane_contents.get(pane_id).and_then(|pane| {
-                    pane.as_pane()
-                        .pane_configuration()
-                        .as_ref(app)
-                        .custom_vertical_tabs_title()
-                        .map(str::to_owned)
-                });
+                let custom_vertical_tabs_title =
+                    self.pane_contents.get(&snapshot_pane_id).and_then(|pane| {
+                        pane.as_pane()
+                            .pane_configuration()
+                            .as_ref(app)
+                            .custom_vertical_tabs_title()
+                            .map(str::to_owned)
+                    });
                 PaneNodeSnapshot::Leaf(LeafSnapshot {
+                    // Whether the user-visible tree slot is focused is
+                    // tracked against the replacement's pane id, so test
+                    // against the leaf id rather than the substituted
+                    // original.
                     is_focused: *pane_id == self.focused_pane_id(app),
                     custom_vertical_tabs_title,
                     contents,
@@ -4800,6 +4824,34 @@ impl PaneGroup {
             self.close_pane(pane_id, ctx);
             ctx.emit(Event::FocusPane { pane_to_focus });
         }
+    }
+
+    /// Reveal `pane_id` if it's currently the *original* of an active
+    /// `TemporaryReplacement` (i.e. another pane is occupying its tree
+    /// slot via swap), then focus it. Used by cross-tab navigation paths
+    /// that resolve a target pane via [`Self::find_pane_id_for_terminal_view`]
+    /// — which iterates `pane_contents` and can hand back a hidden
+    /// original pane id whose terminal slot is currently rendering the
+    /// replacement instead. Without reverting the swap first,
+    /// [`Self::focus_pane_by_id`] would set focus/active session on the
+    /// off-tree original and leave the user staring at the (still
+    /// visible) replacement, with focus stuck on a pane the user can't
+    /// see or reach.
+    pub fn reveal_and_focus_pane(&mut self, pane_id: PaneId, ctx: &mut ViewContext<Self>) {
+        if let Some(replacement_id) = self.panes.replacement_pane_for_original(pane_id) {
+            // Clear the split-off marker on whatever was swapped in so
+            // a subsequent reveal renders pills rather than breadcrumbs.
+            if let Some(terminal_view) = self.terminal_view_from_pane_id(replacement_id, ctx) {
+                terminal_view.update(ctx, |view, ctx| {
+                    view.clear_orchestration_split_off(ctx);
+                });
+            }
+            self.panes.revert_temporary_replacement(replacement_id);
+            self.handle_pane_count_change(ctx);
+            ctx.emit(Event::TerminalViewStateChanged);
+            ctx.emit(Event::AppStateChanged);
+        }
+        self.focus_pane_by_id(pane_id, ctx);
     }
 
     /// Temporarily replace a pane with another pane.

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -6724,12 +6724,16 @@ impl PaneGroup {
     /// commands and briefly leak the child transcript into the orchestrator
     /// pane while ownership shuffles.
     ///
-    /// Reverts any active swap in this pane group first so the orchestrator
-    /// (or whichever pane was swapped out) returns to its tree slot, then
-    /// splits the target child in next to that restored original. This
-    /// preserves the invariant that "Open in new pane" leaves the
-    /// orchestrator visible — even when a different child was the active
-    /// swap target at the time of the split.
+    /// If the orchestrator's pane is currently swapped out (i.e. some
+    /// child of the same orchestrator sits in the orchestrator's slot via
+    /// `TemporaryReplacement`), revert that specific swap first so the
+    /// orchestrator returns to its tree slot, then split the target child
+    /// in next to it. We deliberately do NOT touch swaps owned by other
+    /// orchestrators in the same pane group: with two orchestrators each
+    /// hosting an active swap, reverting an unrelated swap and then
+    /// splitting the target next to that unrelated original would leave
+    /// the target's own slot untouched and produce duplicate leaves in
+    /// the tree.
     pub fn unhide_child_agent_pane_for_split_off(
         &mut self,
         conversation_id: AIConversationId,
@@ -6750,30 +6754,43 @@ impl PaneGroup {
             return Some(child_pane_id);
         }
 
-        // Revert any active swap in this pane group so the swapped-out
-        // original (typically the orchestrator) returns to its tree slot.
-        // The new child is then split in next to that restored original
-        // — not next to whichever child happened to be the swap target.
-        // Without this, opening child A while child B is currently in the
-        // orchestrator's slot would leave the tree as `[B, A]` with the
-        // orchestrator stranded as the hidden swap original, breaking
-        // back-navigation from A's breadcrumbs.
-        let split_base = if let Some((original_pane_id, replacement_pane_id)) =
-            self.panes.any_temporary_replacement()
-        {
-            // Clear the split-off marker on whatever was swapped in so a
-            // future pill click renders pills, not breadcrumbs.
-            if let Some(terminal_view) = self.terminal_view_from_pane_id(replacement_pane_id, ctx) {
-                terminal_view.update(ctx, |view, ctx| {
-                    view.clear_orchestration_split_off(ctx);
-                });
+        // Resolve the orchestrator (parent) pane for this child in this
+        // pane group, if any. Used both to decide what to split next to
+        // and to scope swap-reverts to the correct orchestrator — we
+        // must not revert swaps belonging to a *different* orchestrator
+        // that happens to share this pane group.
+        let parent_pane_id = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .and_then(|c| c.parent_conversation_id())
+            .and_then(|parent_conv_id| self.pane_id_for_conversation_owner(parent_conv_id, ctx));
+
+        // If the orchestrator's pane is currently the original of an
+        // active swap (i.e. one of its children is sitting in its slot),
+        // revert that swap so the orchestrator returns to its tree slot.
+        // The replacement we revert may be the target child itself (the
+        // pre-existing single-orchestrator scenario) or a sibling child
+        // (the multi-children-of-same-orchestrator scenario). Either
+        // way, the swap we touch is scoped to the target's own
+        // orchestrator.
+        let split_base = if let Some(parent_pane_id) = parent_pane_id {
+            if let Some(replacement_pane_id) =
+                self.panes.replacement_pane_for_original(parent_pane_id)
+            {
+                // Clear the split-off marker on whatever was swapped in
+                // so a future pill click renders pills, not breadcrumbs.
+                if let Some(terminal_view) =
+                    self.terminal_view_from_pane_id(replacement_pane_id, ctx)
+                {
+                    terminal_view.update(ctx, |view, ctx| {
+                        view.clear_orchestration_split_off(ctx);
+                    });
+                }
+                self.panes.revert_temporary_replacement(replacement_pane_id);
             }
-            self.panes.revert_temporary_replacement(replacement_pane_id);
-            original_pane_id
+            parent_pane_id
         } else {
             self.focused_pane_id(ctx)
         };
-
         let split_ok = self
             .panes
             .split(split_base, child_pane_id, Direction::Right);

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -6550,12 +6550,69 @@ impl PaneGroup {
         let target_pane_id = from_child_panes.or(from_visible_pane).or(from_owner_lookup);
 
         let Some(target_pane_id) = target_pane_id else {
+            // The conversation isn't owned by any pane in this pane group
+            // (typical case: the child was opened via "Open in new tab"
+            // and now lives in a different tab's pane group, or the user
+            // is pressing ESC on a split-off-tab child whose orchestrator
+            // is in the source tab). Fall back to workspace-level
+            // navigation so the workspace can walk all tabs/windows and
+            // activate the containing tab as needed. Mirrors the
+            // breadcrumb parent-crumb click's cross-pane-group fallback.
+            if let Some(owner_view_id) = BlocklistAIHistoryModel::as_ref(ctx)
+                .terminal_view_id_for_conversation(&conversation_id)
+            {
+                ctx.dispatch_typed_action(&WorkspaceAction::FocusTerminalViewInWorkspace {
+                    terminal_view_id: owner_view_id,
+                });
+                return;
+            }
             self.log_swap_resolution_failure(focused_pane_id, conversation_id, ctx);
             return;
         };
 
         // No-op when the active pill is clicked.
         if target_pane_id == focused_pane_id {
+            return;
+        }
+
+        // If the *target* pane is currently the original of an active
+        // temporary replacement (i.e. some other pane is swapped into the
+        // target's slot right now), revert that replacement so the target
+        // returns to its slot and we can just focus it. Skipping this
+        // check would cause `replace_pane(anchor, target, true)` below to
+        // place `target` in `anchor`'s slot while `target` is also still
+        // recorded as the original of the existing replacement, leaving
+        // two `HiddenPane` entries pointing at the same pane and a tree
+        // node that subsequently corrupts on revert (duplicate leaf id).
+        //
+        // Concretely: child A is split off as a sibling of orchestrator
+        // O, child C is swapped into O's slot, user presses ESC on A
+        // (which emits `SwapPaneToConversation(O)`). Without this branch,
+        // we'd run `replace_pane(A, O, true)` even though O is currently
+        // hidden as the original of `TemporaryReplacement(C)`.
+        if let Some(replacement_id) = self.panes.replacement_pane_for_original(target_pane_id) {
+            // The replacement currently sitting in target's slot is
+            // (always, in practice) a child agent pane swapped in via
+            // the pill bar. Clear its split-off marker so the next
+            // reveal renders pills, matching what the regular anchor
+            // revert below does.
+            if let Some(terminal_view) = self.terminal_view_from_pane_id(replacement_id, ctx) {
+                terminal_view.update(ctx, |view, ctx| {
+                    view.clear_orchestration_split_off(ctx);
+                });
+            }
+            self.panes.revert_temporary_replacement(replacement_id);
+            self.handle_pane_count_change(ctx);
+            self.focus_pane(target_pane_id, true, ctx);
+            for pane_id in [replacement_id, target_pane_id] {
+                if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
+                    terminal_view.update(ctx, |view, ctx| {
+                        view.update_agent_view_back_button_state(ctx);
+                    });
+                }
+            }
+            ctx.emit(Event::TerminalViewStateChanged);
+            ctx.emit(Event::AppStateChanged);
             return;
         }
 

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -6885,6 +6885,30 @@ impl PaneGroup {
     ) -> Option<PaneId> {
         let child_pane_id = self.child_agent_panes.get(&conversation_id).copied()?;
 
+        // Split-off-then-swapped-over case: the child was previously split
+        // off as a sibling, then a sibling pill was clicked from the
+        // child's pill bar — `replace_pane(child, sibling, true)` recorded
+        // the child as the *original* of an active TempRepl. The child is
+        // off-tree but still listed in `hidden_panes` with that role, and
+        // the sibling occupies the child's old tree slot.
+        //
+        // Splitting the child back into the tree without first clearing
+        // that entry would corrupt the layout: the tree would hold the
+        // child as a fresh sibling AND the sibling at the child's old
+        // slot, while the TempRepl entry still says "child is hidden,
+        // sibling replaces it." A later revert of the surviving sibling
+        // (e.g. on close) would call `root.replace_pane(sibling, child)`
+        // and produce a duplicate-leaf tree.
+        //
+        // Reverting the swap is the right answer for "Open in new pane":
+        // the child *was* already split off, just temporarily hidden
+        // behind a swap. After reverting, the child is back in its old
+        // slot and the early-return below focuses it.
+        if let Some(replacement_pane_id) = self.panes.replacement_pane_for_original(child_pane_id) {
+            self.revert_swap_clearing_split_off(replacement_pane_id, ctx);
+            self.handle_pane_count_change(ctx);
+        }
+
         // If the child pane is already a visible sibling in the tree (e.g.
         // user already split it off), just focus it.
         if self.panes.is_pane_in_tree(child_pane_id)

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -4826,6 +4826,28 @@ impl PaneGroup {
         }
     }
 
+    /// Revert the temporary-replacement entry whose replacement pane is
+    /// `replacement_id` and clear any orchestration split-off marker on
+    /// the replacement's `TerminalView`. The split-off marker clear is
+    /// defensive: it is normally set only on panes split off via "Open
+    /// in new pane", but the Case-C scenario described in
+    /// [`Self::close_pane`] (a split-off pane that was later swapped
+    /// over by a sibling pill click) can leave it set on a pane that is
+    /// about to return to off-tree state, where it would otherwise
+    /// cause future reveals to render breadcrumbs instead of pills.
+    fn revert_swap_clearing_split_off(
+        &mut self,
+        replacement_id: PaneId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if let Some(terminal_view) = self.terminal_view_from_pane_id(replacement_id, ctx) {
+            terminal_view.update(ctx, |view, ctx| {
+                view.clear_orchestration_split_off(ctx);
+            });
+        }
+        self.panes.revert_temporary_replacement(replacement_id);
+    }
+
     /// Reveal `pane_id` if it's currently the *original* of an active
     /// `TemporaryReplacement` (i.e. another pane is occupying its tree
     /// slot via swap), then focus it. Used by cross-tab navigation paths
@@ -4837,19 +4859,38 @@ impl PaneGroup {
     /// off-tree original and leave the user staring at the (still
     /// visible) replacement, with focus stuck on a pane the user can't
     /// see or reach.
+    ///
+    /// If `pane_id` is neither in the layout tree nor the original of an
+    /// active swap, this method falls through to `focus_pane_by_id` and
+    /// logs a warning: focus will land on a pane that has no visible
+    /// slot, which is a bug in the caller (cross-tab paths should only
+    /// resolve to in-tree or swap-hidden panes).
     pub fn reveal_and_focus_pane(&mut self, pane_id: PaneId, ctx: &mut ViewContext<Self>) {
         if let Some(replacement_id) = self.panes.replacement_pane_for_original(pane_id) {
-            // Clear the split-off marker on whatever was swapped in so
-            // a subsequent reveal renders pills rather than breadcrumbs.
-            if let Some(terminal_view) = self.terminal_view_from_pane_id(replacement_id, ctx) {
-                terminal_view.update(ctx, |view, ctx| {
-                    view.clear_orchestration_split_off(ctx);
-                });
-            }
-            self.panes.revert_temporary_replacement(replacement_id);
+            self.revert_swap_clearing_split_off(replacement_id, ctx);
             self.handle_pane_count_change(ctx);
+            // The visible content of this tree slot just changed from
+            // the replacement back to the original. Refresh the
+            // agent-view back-button label on both panes — its label
+            // depends on whether the active conversation is a child
+            // agent and is normally only computed when the pane enters
+            // agent view, so a stale label would otherwise persist on
+            // the now-visible original until something else triggers a
+            // refresh. Mirrors the explicit refresh in
+            // [`Self::swap_active_pane_to_conversation`].
+            for refresh_pane_id in [pane_id, replacement_id] {
+                if let Some(terminal_view) = self.terminal_view_from_pane_id(refresh_pane_id, ctx) {
+                    terminal_view.update(ctx, |view, ctx| {
+                        view.update_agent_view_back_button_state(ctx);
+                    });
+                }
+            }
             ctx.emit(Event::TerminalViewStateChanged);
             ctx.emit(Event::AppStateChanged);
+        } else if !self.panes.is_pane_in_tree(pane_id) {
+            log::warn!(
+                "reveal_and_focus_pane: pane {pane_id:?} is off-tree and is not the original of an active TemporaryReplacement; focus will land on a non-visible pane"
+            );
         }
         self.focus_pane_by_id(pane_id, ctx);
     }
@@ -6839,16 +6880,7 @@ impl PaneGroup {
             if let Some(replacement_pane_id) =
                 self.panes.replacement_pane_for_original(parent_pane_id)
             {
-                // Clear the split-off marker on whatever was swapped in
-                // so a future pill click renders pills, not breadcrumbs.
-                if let Some(terminal_view) =
-                    self.terminal_view_from_pane_id(replacement_pane_id, ctx)
-                {
-                    terminal_view.update(ctx, |view, ctx| {
-                        view.clear_orchestration_split_off(ctx);
-                    });
-                }
-                self.panes.revert_temporary_replacement(replacement_pane_id);
+                self.revert_swap_clearing_split_off(replacement_pane_id, ctx);
             }
             parent_pane_id
         } else {

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -915,27 +915,19 @@ pub struct PaneGroup {
     /// be revealed from the parent's status card.
     child_agent_panes: HashMap<AIConversationId, PaneId>,
 
-    /// Set on a pane group that was created by splitting off a child agent
-    /// pane into a new tab via `OpenChildAgentInNewTab`. Holds a weak handle
-    /// to the source pane group along with the child conversation id, so
-    /// that closing this tab can re-adopt the live pane back into the
-    /// source instead of letting the `TerminalView` be dropped.
+    /// Set when this pane group hosts a split-off child agent pane that
+    /// should be re-adopted by its source group on tab close.
     child_agent_origin: Option<ChildAgentOrigin>,
 
     /// Tab-level custom title set via the rename-tab flow.
     custom_title: Option<String>,
 }
 
-/// Origin metadata stamped on a pane group whose sole pane is a child agent
-/// `TerminalView` that was split off from another pane group via
-/// `OpenChildAgentInNewTab`. Used at tab-close time to re-adopt the pane
-/// back to its source so the live conversation view survives the tab
-/// dismissal.
+/// Origin metadata for a split-off child agent tab; used to re-adopt the
+/// pane back to its source on tab close.
 #[derive(Clone)]
 pub struct ChildAgentOrigin {
-    /// Pane group the child agent pane originally lived in (as a hidden
-    /// pane registered in `child_agent_panes`). A weak handle so we don't
-    /// keep the source tab alive past its own close.
+    /// Source pane group; weak so we don't keep the source tab alive.
     pub source_pane_group: WeakViewHandle<PaneGroup>,
     /// The child agent conversation hosted in this tab's lone pane.
     pub conversation_id: AIConversationId,
@@ -2101,32 +2093,18 @@ impl PaneGroup {
                 })
             }
             PaneNode::Leaf(pane_id) => {
-                // If this leaf is the *replacement* of an active
-                // `TemporaryReplacement` (i.e. a child agent pane was
-                // pill-swapped into the orchestrator's slot), persist the
-                // *original* pane's contents instead of the transient
-                // replacement. The swap is a UX-only state, not a
-                // structural change to the user's tab layout. Without
-                // this substitution the snapshot would record the child
-                // as the canonical leaf and lose the orchestrator
-                // entirely — child agent panes are intentionally excluded
-                // from snapshots and rebuilt on startup from the
-                // parent→child index, so on the next launch the tab
-                // would either come back with a stale child terminal as
-                // its root or fail to recreate the orchestrator pane at
-                // all.
+                // If this leaf is the replacement side of an active swap,
+                // persist the original instead. The swap is UX-only and
+                // the replacement (a child agent pane) is rebuilt off-tree
+                // on restart.
                 let snapshot_pane_id = self
                     .panes
                     .original_pane_for_replacement(*pane_id)
                     .unwrap_or(*pane_id);
                 let is_substituted = snapshot_pane_id != *pane_id;
-                // Whether the user-visible tree slot is the active
-                // terminal session. During an active swap, this is the
-                // replacement (e.g. a child agent). On restart the child
-                // is rebuilt off-tree and the orchestrator becomes the
-                // new visible leaf, so the orchestrator's snapshot
-                // should carry the active-session marker the user last
-                // saw — not whatever its own pane reported in isolation.
+                // Did the visible leaf hold the active session at snapshot
+                // time? On restore the original takes the slot, so it
+                // should inherit the active-session marker.
                 let visible_leaf_is_active_session =
                     pane_id.as_terminal_pane_id() == self.active_session_id(app);
                 let mut contents = match self.pane_contents.get(&snapshot_pane_id) {
@@ -2151,14 +2129,8 @@ impl PaneGroup {
                     }
                 };
 
-                // After substitution, override `is_active` so the
-                // restored tab marks the right pane as the active
-                // terminal. Without this override the orchestrator's
-                // snapshot would carry `is_active = false` (because the
-                // child was the active session at snapshot time), and
-                // restore would either silently fall back to the
-                // leftmost terminal pane or, in multi-pane tabs, focus
-                // a different terminal than the user last saw.
+                // After substitution, propagate the visible leaf's
+                // active-session bit so restore focuses the right pane.
                 if is_substituted && visible_leaf_is_active_session {
                     if let LeafContents::Terminal(ref mut snapshot) = contents {
                         snapshot.is_active = true;
@@ -2173,10 +2145,8 @@ impl PaneGroup {
                             .map(str::to_owned)
                     });
                 PaneNodeSnapshot::Leaf(LeafSnapshot {
-                    // Whether the user-visible tree slot is focused is
-                    // tracked against the replacement's pane id, so test
-                    // against the leaf id rather than the substituted
-                    // original.
+                    // Focus is tracked against the visible leaf, not the
+                    // substituted original.
                     is_focused: *pane_id == self.focused_pane_id(app),
                     custom_vertical_tabs_title,
                     contents,
@@ -4500,15 +4470,8 @@ impl PaneGroup {
     /// Definitively close the pane. This does not go through the undo close check where we might hide the pane instead of
     /// discarding it.
     fn discard_pane(&mut self, pane_id: PaneId, ctx: &mut ViewContext<Self>) {
-        // Same ownership-transfer rationale as `close_pane`: a hard discard
-        // (e.g. via the undo stack expiring) also needs to relinquish any
-        // child agent conversations back to their parents so the
-        // orchestrator's pill bar keeps working in-place.
-        //
-        // Skip the transfer when the pane being discarded is itself a
-        // child agent pane: the child's `TerminalView` canonically owns
-        // its conversation, and transferring ownership away would orphan
-        // the conversation while the pane is being torn down.
+        // Skip ownership transfer for child agent panes (their view
+        // canonically owns the conversation).
         if !self.is_child_agent_pane(pane_id) {
             self.transfer_child_agent_conversations_to_parents_on_close(pane_id, ctx);
         }
@@ -4528,25 +4491,10 @@ impl PaneGroup {
         self.cleanup_closed_pane(pane_id, ctx);
     }
 
-    /// Best-effort: for each child agent conversation currently live in
-    /// the closing pane's terminal view, ask the history model to
-    /// re-bind the child to whichever pane owns its parent
-    /// (orchestrator) conversation. This is defensive plumbing rather
-    /// than a true ownership transfer:
-    /// [`BlocklistAIHistoryModel::set_active_conversation_id`] requires
-    /// the destination view's live conversation list to already contain
-    /// the child, and in the typical orchestrator+child pane scenario
-    /// the parent's view does *not* own the child — the child has its
-    /// own dedicated `TerminalView`. In that case the call logs an
-    /// error inside the history model and no-ops, which is the correct
-    /// behavior.
-    ///
-    /// The call is still worth keeping as a hook for the rare paths
-    /// (e.g. a future split-off route that loads the child onto the
-    /// parent's view) where the parent's live list does include the
-    /// child. For non-child conversations and for child conversations
-    /// whose parent has no resolvable owning view, this method is a
-    /// silent no-op.
+    /// Best-effort: re-bind each live child agent conversation on the
+    /// closing view to the pane that owns its parent. Defensive plumbing
+    /// for paths where the parent's view actually contains the child;
+    /// no-ops otherwise.
     fn transfer_child_agent_conversations_to_parents_on_close(
         &mut self,
         pane_id: PaneId,
@@ -4671,53 +4619,26 @@ impl PaneGroup {
             return;
         }
 
-        // If this pane is a child agent, return it to its off-tree state
-        // instead of destroying it — future pill clicks will swap it back
-        // into the user's anchor.
-        //
-        // The transfer-conversations-on-close step below is intentionally
-        // skipped for child agent panes: the child's `TerminalView` is
-        // being preserved in `pane_contents` + `child_agent_panes`, so it
-        // must keep canonical ownership of its conversation. Transferring
-        // ownership to the parent's view here would leave the preserved
-        // child pane stale — a subsequent pill click would resolve to it
-        // (via `child_agent_panes`) but its blocks are now being routed to
-        // the parent's view, breaking the pill UX.
+        // Child agent panes return to off-tree state instead of being
+        // destroyed; future pill clicks re-host the same view. The view
+        // keeps ownership of its conversation, so we skip the
+        // transfer-on-close step below.
         if self.is_child_agent_pane(pane_id) {
-            // Case A: the child is currently the active swap target (in
-            // the anchor's tree slot via temporary replacement). Revert
-            // the swap so the anchor pane returns to its slot.
+            // Revert the swap if the child is currently swapped in.
             if self.panes.original_pane_for_replacement(pane_id).is_some() {
                 self.panes.revert_temporary_replacement(pane_id);
             }
-            // Case B: the child is in the tree as a real sibling (split
-            // off via "Open in new pane"). Remove it from the tree.
+            // Or remove the child from the tree if it was split off.
             else if self.panes.is_pane_in_tree(pane_id) && !self.panes.remove(pane_id) {
-                log::error!(
-                    "close_pane: failed to remove split-off child pane {pane_id:?} from tree"
-                );
+                log::error!("close_pane: failed to remove split-off child pane from tree");
             }
-            // Case C (split-off, then swapped over): the child was a
-            // visible split-off sibling, then a sibling pill was clicked
-            // from the child's pill bar — `replace_pane(child, sibling,
-            // true)` recorded the child as the *original* of an active
-            // TempRepl. Cases A and B don't touch that entry, so drop
-            // any hidden-pane record naming this child as the *original*
-            // side of a swap. (Replacement-side cleanup is already
-            // handled by Case A's explicit `revert_temporary_replacement`
-            // call, which removes the entry whose replacement matches
-            // the closing child.) Without this, a future revert of the
-            // surviving sibling — e.g. when the user closes the sibling
-            // — would splice the (off-tree but still live) child back
-            // into the tree and resurrect the just-closed pane as a
-            // visible leaf, which is not what the user asked for.
+            // Drop any leftover swap entry recording this child as the
+            // original side. Otherwise a later revert of the surviving
+            // sibling could resurrect the just-closed pane.
             self.panes.remove_hidden_pane(pane_id);
-            // The pane stays in `pane_contents` and `child_agent_panes`
-            // — it just goes back to off-tree state.
 
-            // Clear the split-off marker on the child's terminal view so
-            // a subsequent reveal via the swap path renders pills (in-place
-            // context) instead of breadcrumbs (split-off context).
+            // Clear the split-off marker so the next reveal renders pills
+            // rather than breadcrumbs.
             if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
                 terminal_view.update(ctx, |view, ctx| {
                     view.clear_orchestration_split_off(ctx);
@@ -4734,13 +4655,9 @@ impl PaneGroup {
             return;
         }
 
-        // For non-child-agent closes, transfer ownership of any child agent
-        // conversations live in this view back to the pane that owns each
-        // child's parent conversation. This keeps the orchestrator pane's
-        // orchestration pill bar in-place click working after the split-off
-        // pane that took over the child's transcript closes. Safe to run
-        // even for hide-for-undo: re-opening the closed pane would re-restore
-        // the conversation into the (visible) view via the normal load path.
+        // Best-effort: re-bind any child conversations on this view back
+        // to the pane that owns their parent so the pill bar keeps
+        // working after this pane closes.
         self.transfer_child_agent_conversations_to_parents_on_close(pane_id, ctx);
 
         // If this is a parent with child agents, discard the children first.
@@ -4848,11 +4765,9 @@ impl PaneGroup {
         pane_to_focus: PaneId,
         ctx: &mut ViewContext<Self>,
     ) {
-        // Child agent panes route through `close_pane` so that closing them
-        // reverts the swap (or removes the split-off) without destroying
-        // the underlying `TerminalView`. The default temporary-replacement
-        // close path destroys the replacement pane, which would tear down
-        // the child's `TerminalView` — not what we want.
+        // Child agent panes go through the normal close path so the
+        // underlying view is preserved (the temp-replacement close path
+        // would destroy it).
         if self.is_child_agent_pane(pane_id) {
             self.close_pane(pane_id, ctx);
             ctx.emit(Event::FocusPane { pane_to_focus });
@@ -4876,15 +4791,9 @@ impl PaneGroup {
         }
     }
 
-    /// Revert the temporary-replacement entry whose replacement pane is
-    /// `replacement_id` and clear any orchestration split-off marker on
-    /// the replacement's `TerminalView`. The split-off marker clear is
-    /// defensive: it is normally set only on panes split off via "Open
-    /// in new pane", but the Case-C scenario described in
-    /// [`Self::close_pane`] (a split-off pane that was later swapped
-    /// over by a sibling pill click) can leave it set on a pane that is
-    /// about to return to off-tree state, where it would otherwise
-    /// cause future reveals to render breadcrumbs instead of pills.
+    /// Revert a temporary-replacement swap and clear the orchestration
+    /// split-off marker on the replacement's view, so a later reveal
+    /// renders pills rather than breadcrumbs.
     fn revert_swap_clearing_split_off(
         &mut self,
         replacement_id: PaneId,
@@ -4898,36 +4807,17 @@ impl PaneGroup {
         self.panes.revert_temporary_replacement(replacement_id);
     }
 
-    /// Reveal `pane_id` if it's currently the *original* of an active
-    /// `TemporaryReplacement` (i.e. another pane is occupying its tree
-    /// slot via swap), then focus it. Used by cross-tab navigation paths
-    /// that resolve a target pane via [`Self::find_pane_id_for_terminal_view`]
-    /// — which iterates `pane_contents` and can hand back a hidden
-    /// original pane id whose terminal slot is currently rendering the
-    /// replacement instead. Without reverting the swap first,
-    /// [`Self::focus_pane_by_id`] would set focus/active session on the
-    /// off-tree original and leave the user staring at the (still
-    /// visible) replacement, with focus stuck on a pane the user can't
-    /// see or reach.
-    ///
-    /// If `pane_id` is neither in the layout tree nor the original of an
-    /// active swap, this method falls through to `focus_pane_by_id` and
-    /// logs a warning: focus will land on a pane that has no visible
-    /// slot, which is a bug in the caller (cross-tab paths should only
-    /// resolve to in-tree or swap-hidden panes).
+    /// Reveal `pane_id` if it's currently the original of an active swap,
+    /// then focus it. Used by cross-tab navigation paths that may resolve
+    /// to a swapped-out pane; without the reveal, focus would land on an
+    /// off-tree pane the user can't see. Logs a warning if the pane is
+    /// neither in the tree nor swap-hidden.
     pub fn reveal_and_focus_pane(&mut self, pane_id: PaneId, ctx: &mut ViewContext<Self>) {
         if let Some(replacement_id) = self.panes.replacement_pane_for_original(pane_id) {
             self.revert_swap_clearing_split_off(replacement_id, ctx);
             self.handle_pane_count_change(ctx);
-            // The visible content of this tree slot just changed from
-            // the replacement back to the original. Refresh the
-            // agent-view back-button label on both panes — its label
-            // depends on whether the active conversation is a child
-            // agent and is normally only computed when the pane enters
-            // agent view, so a stale label would otherwise persist on
-            // the now-visible original until something else triggers a
-            // refresh. Mirrors the explicit refresh in
-            // [`Self::swap_active_pane_to_conversation`].
+            // The visible content of this slot changed; refresh agent-view
+            // back-button labels on both sides.
             for refresh_pane_id in [pane_id, replacement_id] {
                 if let Some(terminal_view) = self.terminal_view_from_pane_id(refresh_pane_id, ctx) {
                     terminal_view.update(ctx, |view, ctx| {
@@ -4939,7 +4829,7 @@ impl PaneGroup {
             ctx.emit(Event::AppStateChanged);
         } else if !self.panes.is_pane_in_tree(pane_id) {
             log::warn!(
-                "reveal_and_focus_pane: pane {pane_id:?} is off-tree and is not the original of an active TemporaryReplacement; focus will land on a non-visible pane"
+                "reveal_and_focus_pane: pane {pane_id:?} is off-tree; focus will land on a non-visible pane"
             );
         }
         self.focus_pane_by_id(pane_id, ctx);
@@ -6689,23 +6579,9 @@ impl PaneGroup {
         None
     }
 
-    /// Make the pane that owns `conversation_id`'s `TerminalView` the visible
-    /// one in the slot currently occupied by `focused_pane_id` (the swap
-    /// anchor).
-    ///
-    /// Implementation: uses `PaneData::replace_pane(anchor, target, true)` to
-    /// substitute the target pane into the anchor's tree slot. The anchor is
-    /// recorded as the temporary-replacement original so a subsequent revert
-    /// (back-button, ESC, pill-click on the anchor's conversation, close,
-    /// split-off, etc.) restores it to its slot.
-    ///
-    /// Resolution order for the target pane:
-    /// 1. `child_agent_panes.get(&conversation_id)` for child agents.
-    /// 2. `find_visible_terminal_pane_for_conversation` if the conversation is
-    ///    already showing in some pane (e.g. "Open in new pane" was already
-    ///    used).
-    /// 3. `pane_id_for_conversation_owner` to fall back on the history model
-    ///    for the orchestrator (or any non-child) conversation.
+    /// Make the pane that owns `conversation_id` the visible one in the
+    /// focused pane's slot via temporary replacement. The previous occupant
+    /// is restored on revert (back-button, ESC, pill-click, close, split-off).
     pub fn swap_active_pane_to_conversation(
         &mut self,
         focused_pane_id: PaneId,
@@ -6720,14 +6596,8 @@ impl PaneGroup {
         let target_pane_id = from_child_panes.or(from_visible_pane).or(from_owner_lookup);
 
         let Some(target_pane_id) = target_pane_id else {
-            // The conversation isn't owned by any pane in this pane group
-            // (typical case: the child was opened via "Open in new tab"
-            // and now lives in a different tab's pane group, or the user
-            // is pressing ESC on a split-off-tab child whose orchestrator
-            // is in the source tab). Fall back to workspace-level
-            // navigation so the workspace can walk all tabs/windows and
-            // activate the containing tab as needed. Mirrors the
-            // breadcrumb parent-crumb click's cross-pane-group fallback.
+            // No owning pane in this group (e.g. the conversation lives
+            // in another tab). Fall back to workspace-level navigation.
             if let Some(owner_view_id) = BlocklistAIHistoryModel::as_ref(ctx)
                 .terminal_view_id_for_conversation(&conversation_id)
             {
@@ -6745,27 +6615,11 @@ impl PaneGroup {
             return;
         }
 
-        // If the *target* pane is currently the original of an active
-        // temporary replacement (i.e. some other pane is swapped into the
-        // target's slot right now), revert that replacement so the target
-        // returns to its slot and we can just focus it. Skipping this
-        // check would cause `replace_pane(anchor, target, true)` below to
-        // place `target` in `anchor`'s slot while `target` is also still
-        // recorded as the original of the existing replacement, leaving
-        // two `HiddenPane` entries pointing at the same pane and a tree
-        // node that subsequently corrupts on revert (duplicate leaf id).
-        //
-        // Concretely: child A is split off as a sibling of orchestrator
-        // O, child C is swapped into O's slot, user presses ESC on A
-        // (which emits `SwapPaneToConversation(O)`). Without this branch,
-        // we'd run `replace_pane(A, O, true)` even though O is currently
-        // hidden as the original of `TemporaryReplacement(C)`.
+        // If the target is currently swapped out (some other pane sits in
+        // its slot), revert that swap and just focus the target. Skipping
+        // this would put the target in two tree positions and corrupt the
+        // layout on a later revert.
         if let Some(replacement_id) = self.panes.replacement_pane_for_original(target_pane_id) {
-            // The replacement currently sitting in target's slot is
-            // (always, in practice) a child agent pane swapped in via
-            // the pill bar. The helper also clears its split-off marker
-            // so the next reveal renders pills, matching what the
-            // regular anchor revert below does.
             self.revert_swap_clearing_split_off(replacement_id, ctx);
             self.handle_pane_count_change(ctx);
             self.focus_pane(target_pane_id, true, ctx);
@@ -6781,23 +6635,17 @@ impl PaneGroup {
             return;
         }
 
-        // If the anchor is currently a temporary-replacement target (i.e.
-        // some swap is already active in this slot), revert that swap first
-        // so the original pane returns to its tree slot. The anchor for the
-        // new operation becomes that original pane.
+        // If a swap is already active in this slot, revert it first; the
+        // anchor for the new operation becomes the original pane.
         let anchor =
             if let Some(original) = self.panes.original_pane_for_replacement(focused_pane_id) {
-                // The helper also clears the split-off marker on the
-                // child we're swapping away from so it renders pills
-                // (not breadcrumbs) next time it becomes visible.
                 self.revert_swap_clearing_split_off(focused_pane_id, ctx);
                 original
             } else {
                 focused_pane_id
             };
 
-        // After revert, if we landed on the target itself, the user just
-        // clicked back to the orchestrator; just focus and return.
+        // If revert landed us on the target, just focus and return.
         if anchor == target_pane_id {
             self.handle_pane_count_change(ctx);
             self.focus_pane(anchor, true, ctx);
@@ -6811,9 +6659,7 @@ impl PaneGroup {
             return;
         }
 
-        // If the target pane is already visible in the tree (e.g. user split
-        // the child off into a sibling pane), just focus it. Don't call
-        // `replace_pane` — it would put the target in two tree positions.
+        // If the target is already a visible sibling, just focus it.
         if self.panes.is_pane_in_tree(target_pane_id) && !self.panes.is_pane_hidden(&target_pane_id)
         {
             self.handle_pane_count_change(ctx);
@@ -6828,9 +6674,8 @@ impl PaneGroup {
             return;
         }
 
-        // Place the target pane into the anchor's tree slot via temporary
-        // replacement. The anchor stays in `pane_contents` and is recorded
-        // as the original; revert returns it to its slot.
+        // Substitute the target into the anchor's slot via temporary
+        // replacement; revert restores the anchor.
         let success = self.panes.replace_pane(anchor, target_pane_id, true);
         if !success {
             log::warn!(
@@ -6842,13 +6687,8 @@ impl PaneGroup {
         self.handle_pane_count_change(ctx);
         self.focus_pane(target_pane_id, true, ctx);
 
-        // Refresh the agent-view back button label/disabled state on both
-        // panes involved in the swap. The label depends on whether the
-        // active conversation is a child agent ("for Orchestrator") or
-        // not ("for terminal"), and is normally only computed when the
-        // pane enters agent view. Without this refresh, a pane that was
-        // already in agent view from earlier would carry a stale label
-        // until something else triggers a refresh.
+        // Refresh the back-button label on both swapped panes; otherwise
+        // a stale label would persist until the next agent-view entry.
         for pane_id in [anchor, target_pane_id] {
             if let Some(terminal_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
                 terminal_view.update(ctx, |view, ctx| {
@@ -6861,23 +6701,11 @@ impl PaneGroup {
         ctx.emit(Event::AppStateChanged);
     }
 
-    /// Reveal the existing child agent pane for `conversation_id` as a
-    /// visible sibling next to the orchestrator's pane ("Open in new
-    /// pane"). Reuses the existing `TerminalView` — creating a fresh view
-    /// and reloading the conversation into it would cancel in-flight
-    /// commands and briefly leak the child transcript into the orchestrator
-    /// pane while ownership shuffles.
-    ///
-    /// If the orchestrator's pane is currently swapped out (i.e. some
-    /// child of the same orchestrator sits in the orchestrator's slot via
-    /// `TemporaryReplacement`), revert that specific swap first so the
-    /// orchestrator returns to its tree slot, then split the target child
-    /// in next to it. We deliberately do NOT touch swaps owned by other
-    /// orchestrators in the same pane group: with two orchestrators each
-    /// hosting an active swap, reverting an unrelated swap and then
-    /// splitting the target next to that unrelated original would leave
-    /// the target's own slot untouched and produce duplicate leaves in
-    /// the tree.
+    /// Reveal the child agent pane for `conversation_id` as a visible
+    /// sibling of its orchestrator ("Open in new pane"). Reuses the
+    /// existing view to avoid cancelling in-flight commands. Reverts any
+    /// swap on the target's orchestrator first; swaps belonging to other
+    /// orchestrators in the same group are left alone.
     pub fn unhide_child_agent_pane_for_split_off(
         &mut self,
         conversation_id: AIConversationId,
@@ -6885,32 +6713,16 @@ impl PaneGroup {
     ) -> Option<PaneId> {
         let child_pane_id = self.child_agent_panes.get(&conversation_id).copied()?;
 
-        // Split-off-then-swapped-over case: the child was previously split
-        // off as a sibling, then a sibling pill was clicked from the
-        // child's pill bar — `replace_pane(child, sibling, true)` recorded
-        // the child as the *original* of an active TempRepl. The child is
-        // off-tree but still listed in `hidden_panes` with that role, and
-        // the sibling occupies the child's old tree slot.
-        //
-        // Splitting the child back into the tree without first clearing
-        // that entry would corrupt the layout: the tree would hold the
-        // child as a fresh sibling AND the sibling at the child's old
-        // slot, while the TempRepl entry still says "child is hidden,
-        // sibling replaces it." A later revert of the surviving sibling
-        // (e.g. on close) would call `root.replace_pane(sibling, child)`
-        // and produce a duplicate-leaf tree.
-        //
-        // Reverting the swap is the right answer for "Open in new pane":
-        // the child *was* already split off, just temporarily hidden
-        // behind a swap. After reverting, the child is back in its old
-        // slot and the early-return below focuses it.
+        // If the child was previously split off and then swapped over,
+        // it's recorded as the original of an active swap. Revert that
+        // swap first — the child returns to its old slot — so we don't
+        // splice it into the tree a second time.
         if let Some(replacement_pane_id) = self.panes.replacement_pane_for_original(child_pane_id) {
             self.revert_swap_clearing_split_off(replacement_pane_id, ctx);
             self.handle_pane_count_change(ctx);
         }
 
-        // If the child pane is already a visible sibling in the tree (e.g.
-        // user already split it off), just focus it.
+        // If the child is already a visible sibling, just focus it.
         if self.panes.is_pane_in_tree(child_pane_id)
             && !self.panes.is_pane_hidden(&child_pane_id)
             && self
@@ -6922,24 +6734,15 @@ impl PaneGroup {
             return Some(child_pane_id);
         }
 
-        // Resolve the orchestrator (parent) pane for this child in this
-        // pane group, if any. Used both to decide what to split next to
-        // and to scope swap-reverts to the correct orchestrator — we
-        // must not revert swaps belonging to a *different* orchestrator
-        // that happens to share this pane group.
+        // Resolve the target child's orchestrator. Used to scope swap
+        // reverts so we don't disturb swaps owned by other orchestrators.
         let parent_pane_id = BlocklistAIHistoryModel::as_ref(ctx)
             .conversation(&conversation_id)
             .and_then(|c| c.parent_conversation_id())
             .and_then(|parent_conv_id| self.pane_id_for_conversation_owner(parent_conv_id, ctx));
 
-        // If the orchestrator's pane is currently the original of an
-        // active swap (i.e. one of its children is sitting in its slot),
-        // revert that swap so the orchestrator returns to its tree slot.
-        // The replacement we revert may be the target child itself (the
-        // pre-existing single-orchestrator scenario) or a sibling child
-        // (the multi-children-of-same-orchestrator scenario). Either
-        // way, the swap we touch is scoped to the target's own
-        // orchestrator.
+        // If the orchestrator is swapped out, revert it so it returns to
+        // its slot before we split next to it.
         let split_base = if let Some(parent_pane_id) = parent_pane_id {
             if let Some(replacement_pane_id) =
                 self.panes.replacement_pane_for_original(parent_pane_id)
@@ -6963,8 +6766,7 @@ impl PaneGroup {
             });
         }
 
-        // Refresh the back-button label on the orchestrator pane (its
-        // visible content just changed from child to orchestrator).
+        // Refresh the back-button label on the orchestrator pane.
         if let Some(terminal_view) = self.terminal_view_from_pane_id(split_base, ctx) {
             terminal_view.update(ctx, |view, ctx| {
                 view.update_agent_view_back_button_state(ctx);
@@ -6978,13 +6780,9 @@ impl PaneGroup {
         Some(child_pane_id)
     }
 
-    /// Detach the existing child agent pane for `conversation_id` from
-    /// this pane group so it can be re-parented into a new tab's pane group
-    /// ("Open in new tab"). Reuses the existing `TerminalView` rather than
-    /// creating a fresh one for the same reasons documented on
-    /// [`unhide_child_agent_pane_for_split_off`]. The caller is responsible
-    /// for adopting the returned pane content into a new pane group via
-    /// `Workspace::add_tab_from_existing_pane`.
+    /// Detach the child agent pane for `conversation_id` so it can be
+    /// re-parented into a new tab ("Open in new tab"). Reuses the
+    /// existing view to avoid cancelling in-flight commands.
     pub fn take_child_agent_pane_for_split_off(
         &mut self,
         conversation_id: AIConversationId,
@@ -6992,17 +6790,11 @@ impl PaneGroup {
     ) -> Option<Box<dyn AnyPaneContent>> {
         let child_pane_id = self.child_agent_panes.remove(&conversation_id)?;
 
-        // Capture focus state before any tree mutation so we can shift
-        // focus to a sane neighbour regardless of whether the child
-        // leaves the tree via swap revert (Case A) or pane removal
-        // (Case B). Reading after the mutation would miss the swap-revert
-        // case because `is_pane_focused(child)` would still report true
-        // even though the child is no longer in the tree.
+        // Capture focus before mutating the tree so we can shift focus
+        // correctly afterwards regardless of how the child leaves it.
         let was_focused = self.focus_state.as_ref(ctx).is_pane_focused(child_pane_id);
 
-        // If the child is currently the active swap target, revert the swap
-        // so the orchestrator returns to its slot. After this, the child
-        // pane is off-tree.
+        // Revert the swap if the child is currently swapped in.
         if self
             .panes
             .original_pane_for_replacement(child_pane_id)
@@ -7011,30 +6803,17 @@ impl PaneGroup {
             self.panes.revert_temporary_replacement(child_pane_id);
         }
 
-        // If the child is in the tree as a real sibling (split off), remove
-        // it from the tree. Off-tree panes (after revert above, or if the
-        // child was never split) are already not in the tree.
+        // Remove the child from the tree if it was a real sibling.
         if self.panes.is_pane_in_tree(child_pane_id) && !self.panes.remove(child_pane_id) {
-            log::error!(
-                "take_child_agent_pane_for_split_off: failed to remove pane {child_pane_id:?} from tree"
-            );
+            log::error!("take_child_agent_pane_for_split_off: failed to remove pane from tree");
         }
 
-        // Drop any leftover hidden-pane entry naming the child. Covers
-        // the split-off-then-swapped-over case where the child sits in
-        // `hidden_panes` as the *original* of an active TempRepl (a
-        // sibling was swapped into the child's slot from its pill bar).
-        // The branches above don't clear that entry, and leaving it in
-        // place would let a future revert of the surviving sibling
-        // splice the (now-detached) child back into the tree, leaving
-        // a leaf that points to a pane this group no longer owns.
+        // Drop any leftover swap entry naming this child as the original
+        // side. Otherwise a later revert of a surviving sibling would
+        // splice the now-detached child back into this group's tree.
         self.panes.remove_hidden_pane(child_pane_id);
 
-        // Shift focus and active session away from the child pane if it
-        // held either, regardless of which path took it out of the tree.
-        // Without this, the source pane group can be left with
-        // `focused_pane_id` / `active_session_id` pointing at a pane that
-        // is about to be removed from `pane_contents` entirely.
+        // Shift focus and active session away from the departing child.
         self.focus_next_terminal_pane_and_activate_session(
             child_pane_id,
             PaneRemovalReason::Move,
@@ -7054,8 +6833,7 @@ impl PaneGroup {
             });
         }
 
-        // Detach the pane (DetachType::Moved) so the destination pane
-        // group can re-attach it cleanly.
+        // Detach so the destination group can re-attach cleanly.
         if let Some(pane_data) = self.pane_contents.get(&child_pane_id) {
             let pane = pane_data.as_pane();
             pane.detach(self, DetachType::Moved, ctx);
@@ -7068,35 +6846,22 @@ impl PaneGroup {
         pane_content
     }
 
-    /// Stamp this pane group as the destination of a split-off child agent
-    /// pane. Workspace plumbing calls this immediately after wrapping the
-    /// detached pane in a fresh tab so that closing the tab can re-adopt
-    /// the live `TerminalView` back to the source group instead of
-    /// dropping it.
+    /// Stamp this pane group as the destination of a split-off child
+    /// agent pane, so closing the tab re-adopts the live view back to
+    /// the source group.
     pub fn set_child_agent_origin(&mut self, origin: ChildAgentOrigin) {
         self.child_agent_origin = Some(origin);
     }
 
-    /// Returns the [`ChildAgentOrigin`] stamped on this pane group via
-    /// [`Self::set_child_agent_origin`], if any. Used by the workspace tab
-    /// close path to detect split-off child agent tabs and route them
-    /// through the re-adoption flow.
+    /// Returns the origin metadata if this group is hosting a split-off
+    /// child agent tab.
     pub fn child_agent_origin(&self) -> Option<&ChildAgentOrigin> {
         self.child_agent_origin.as_ref()
     }
 
-    /// Re-adopt a child agent pane that was previously detached for a
-    /// split-off tab via [`Self::take_child_agent_pane_for_split_off`].
-    /// Re-inserts the pane into this group's `pane_contents` and
-    /// `child_agent_panes` **off-tree**, and clears the split-off marker
-    /// on its `TerminalView` so a subsequent reveal via the orchestration
-    /// pill bar renders the full pill bar rather than breadcrumbs.
-    ///
-    /// Used by the workspace tab close path when the closing tab is the
-    /// destination of a split-off child agent: the live `TerminalView` is
-    /// preserved by moving it back to its source group rather than being
-    /// torn down with the closing pane group. Subsequent pill clicks will
-    /// swap it into the user's anchor as needed.
+    /// Re-adopt a previously detached child agent pane back into this
+    /// group as off-tree, and clear its split-off marker so the next
+    /// reveal renders pills instead of breadcrumbs.
     pub fn re_adopt_child_agent_pane(
         &mut self,
         pane_content: Box<dyn AnyPaneContent>,

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -439,7 +439,8 @@ fn test_insert_hidden_child_agent_pane_keeps_focus_and_active_session() {
 
         pane_group.update(&mut app, |panes, ctx| {
             let parent_pane_id = get_newly_created_pane_id(panes, &[]);
-            let initial_pane_count = panes.pane_count();
+            let initial_tree_pane_count = panes.pane_count();
+            let initial_content_pane_count = panes.pane_ids().count();
             let initial_visible_count = panes.visible_pane_count();
             let initial_active_session = panes.active_session_id(ctx);
 
@@ -449,11 +450,13 @@ fn test_insert_hidden_child_agent_pane_keeps_focus_and_active_session() {
                 ctx,
             );
 
-            assert_eq!(panes.pane_count(), initial_pane_count + 1);
+            assert_eq!(panes.pane_count(), initial_tree_pane_count);
+            assert_eq!(panes.pane_ids().count(), initial_content_pane_count + 1);
             assert_eq!(panes.visible_pane_count(), initial_visible_count);
             assert!(panes.has_pane_id(child_pane_id.into()));
+            assert!(!panes.panes.is_pane_in_tree(child_pane_id.into()));
 
-            // The new child pane should remain hidden and not affect visible ordering.
+            // The new child pane should remain off-tree and not affect visible ordering.
             assert_eq!(panes.pane_id_by_index(0), Some(parent_pane_id));
             assert_eq!(panes.pane_id_by_index(1), None);
 

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1149,6 +1149,16 @@ fn handle_terminal_view_event(
                     log::warn!("No pane found for child conversation {conversation_id:?}");
                 }
             }
+            Event::SwapPaneToConversation { conversation_id } => {
+                // Pill-bar navigation: instead of cloning the conversation
+                // into the active pane (which produces stale
+                // `LongRunningCommandSnapshot` results), make the pane
+                // that already owns this conversation's `TerminalView`
+                // the visible one in the active slot. The orchestrator's
+                // pane and each child's hidden pane stay in place; only
+                // their visibility flips.
+                group.swap_active_pane_to_conversation(pane_id, *conversation_id, ctx);
+            }
             Event::OpenChildAgentInNewTab { conversation_id } => {
                 // The pane group can't add a new tab — only the workspace
                 // can. Forward the request upward so `WorkspaceView` can
@@ -1159,33 +1169,21 @@ fn handle_terminal_view_event(
                 });
             }
             Event::OpenChildAgentInNewPane { conversation_id } => {
-                // Split a fresh terminal pane to the right and load the
-                // child conversation into it via
-                // `enter_agent_view_for_conversation`. We deliberately do
-                // *not* reveal the orchestrator's hidden child pane here:
-                // its terminal model never accumulated rendered AI blocks
-                // for the conversation (those go into whichever pane was
-                // last hosting the in-place agent view via
-                // `SwitchAgentViewToConversation`), so revealing it would
-                // show an empty transcript. Going through a fresh terminal
-                // view forces the cloud load+restore path, which mirrors
-                // what "Open in new tab" already does.
-                let new_pane_id =
-                    group.add_terminal_pane(Direction::Right, None /* chosen_shell */, ctx);
-                if let Some(new_terminal_view) = group.terminal_view_from_pane_id(new_pane_id, ctx)
+                // Reuse the existing hidden child agent pane: it already hosts
+                // the live `TerminalView` for this conversation. Creating a new
+                // pane and calling `enter_agent_view_for_conversation` on it
+                // would clone the conversation into a second view, cancelling
+                // any in-flight commands running in the original view and
+                // briefly leaking the child's transcript into the orchestrator
+                // pane while ownership shuffles between views. Just unhide the
+                // pane we already have so it becomes a visible sibling of the
+                // orchestrator pane.
+                if group
+                    .unhide_child_agent_pane_for_split_off(*conversation_id, ctx)
+                    .is_none()
                 {
-                    let conversation_id = *conversation_id;
-                    new_terminal_view.update(ctx, |terminal_view, ctx| {
-                        terminal_view.enter_agent_view_for_conversation(
-                            None,
-                            AgentViewEntryOrigin::OrchestrationPillBar,
-                            conversation_id,
-                            ctx,
-                        );
-                    });
-                } else {
                     log::warn!(
-                        "OpenChildAgentInNewPane: failed to resolve terminal view for newly created pane (conversation {conversation_id:?})"
+                        "OpenChildAgentInNewPane: no hidden child pane registered for conversation {conversation_id:?}"
                     );
                 }
             }

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1123,31 +1123,10 @@ fn handle_terminal_view_event(
                 ctx.emit(pane_group::Event::FreeTierLimitCheckTriggered);
             }
             Event::RevealChildAgent { conversation_id } => {
-                // Prefer a visible pane that already hosts the
-                // conversation over revealing the hidden child pane.
-                // Once the user has opened the child in a sibling pane
-                // (via "Open in new pane" / "Open in new tab"), the
-                // hidden pane that was originally created at agent
-                // start is empty — its terminal model never accumulated
-                // rendered AI blocks for the conversation — so revealing
-                // it would surface a blank pane next to the real one.
-                // The entry in `child_agent_panes` is never cleaned up
-                // when the child is split off, so we cannot rely on its
-                // presence as a signal that no visible pane exists.
-                if let Some(visible_pane_id) =
-                    group.find_visible_terminal_pane_for_conversation(*conversation_id, ctx)
-                {
-                    group.focus_pane(visible_pane_id.into(), true, ctx);
-                } else if let Some(&child_pane_id) = group.child_agent_panes.get(conversation_id) {
-                    // No visible pane has the conversation yet — reveal
-                    // the hidden child pane that was registered when the
-                    // child agent was first started.
-                    group.panes.show_pane_for_child_agent(child_pane_id);
-                    group.handle_pane_count_change(ctx);
-                    group.focus_pane(child_pane_id, true, ctx);
-                } else {
-                    log::warn!("No pane found for child conversation {conversation_id:?}");
-                }
+                // Route through the swap mechanism: it handles all the
+                // cases (already-visible split-off, off-tree child agent
+                // pane, currently swapped target) uniformly.
+                group.swap_active_pane_to_conversation(pane_id, *conversation_id, ctx);
             }
             Event::SwapPaneToConversation { conversation_id } => {
                 // Pill-bar navigation: instead of cloning the conversation

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1123,40 +1123,23 @@ fn handle_terminal_view_event(
                 ctx.emit(pane_group::Event::FreeTierLimitCheckTriggered);
             }
             Event::RevealChildAgent { conversation_id } => {
-                // Route through the swap mechanism: it handles all the
-                // cases (already-visible split-off, off-tree child agent
-                // pane, currently swapped target) uniformly.
+                // Routed through the swap mechanism to land all reveal cases in one path.
                 group.swap_active_pane_to_conversation(pane_id, *conversation_id, ctx);
             }
             Event::SwapPaneToConversation { conversation_id } => {
-                // Pill-bar navigation: instead of cloning the conversation
-                // into the active pane (which produces stale
-                // `LongRunningCommandSnapshot` results), make the pane
-                // that already owns this conversation's `TerminalView`
-                // the visible one in the active slot. The orchestrator's
-                // pane and each child's hidden pane stay in place; only
-                // their visibility flips.
+                // Swap visibility instead of cloning so in-flight state in the
+                // target pane is preserved.
                 group.swap_active_pane_to_conversation(pane_id, *conversation_id, ctx);
             }
             Event::OpenChildAgentInNewTab { conversation_id } => {
-                // The pane group can't add a new tab — only the workspace
-                // can. Forward the request upward so `WorkspaceView` can
-                // create a fresh tab and switch its agent view to this
-                // child conversation.
+                // Pane group can't add tabs; forward to the workspace.
                 ctx.emit(pane_group::Event::OpenChildAgentInNewTab {
                     conversation_id: *conversation_id,
                 });
             }
             Event::OpenChildAgentInNewPane { conversation_id } => {
-                // Reuse the existing hidden child agent pane: it already hosts
-                // the live `TerminalView` for this conversation. Creating a new
-                // pane and calling `enter_agent_view_for_conversation` on it
-                // would clone the conversation into a second view, cancelling
-                // any in-flight commands running in the original view and
-                // briefly leaking the child's transcript into the orchestrator
-                // pane while ownership shuffles between views. Just unhide the
-                // pane we already have so it becomes a visible sibling of the
-                // orchestrator pane.
+                // Reuse the existing hidden child pane to preserve in-flight
+                // state and the live transcript instead of creating a new view.
                 if group
                     .unhide_child_agent_pane_for_split_off(*conversation_id, ctx)
                     .is_none()

--- a/app/src/pane_group/tree.rs
+++ b/app/src/pane_group/tree.rs
@@ -75,6 +75,12 @@ pub enum HiddenPaneReason {
     // Pane is a child agent spawned by an orchestrator. It stays hidden
     // until the user explicitly reveals it from the status card.
     ChildAgent,
+
+    // Pane was hidden because the orchestration pill bar swapped it out
+    // for another conversation's pane in the same pane group. The
+    // pane stays in the tree at its original position so it can be
+    // re-shown by clicking back to it.
+    OrchestrationSwap,
 }
 
 impl HiddenPane {
@@ -106,6 +112,12 @@ impl HiddenPane {
         Self {
             pane_id,
             reason: HiddenPaneReason::ChildAgent,
+        }
+    }
+    pub fn from_orchestration_swap(pane_id: PaneId) -> Self {
+        Self {
+            pane_id,
+            reason: HiddenPaneReason::OrchestrationSwap,
         }
     }
 }
@@ -322,6 +334,39 @@ impl PaneData {
         } else {
             log::error!("Attempted to show child agent pane but couldn't find it.")
         }
+    }
+
+    pub fn hide_pane_for_orchestration_swap(&mut self, id: PaneId) {
+        if !self.is_pane_hidden(&id) {
+            self.hidden_panes
+                .push(HiddenPane::from_orchestration_swap(id));
+        }
+    }
+
+    pub fn show_pane_for_orchestration_swap(&mut self, id: PaneId) {
+        if let Some(pos) = self.hidden_panes.iter().position(|pane| {
+            pane.pane_id == id && pane.reason == HiddenPaneReason::OrchestrationSwap
+        }) {
+            self.hidden_panes.remove(pos);
+        } else {
+            log::error!("Attempted to show orchestration-swap pane but couldn't find it.")
+        }
+    }
+
+    /// Returns true if `id` is currently hidden because of an orchestration
+    /// pill-bar swap (i.e. another conversation's pane is showing in its
+    /// place in the same pane group).
+    pub fn is_pane_hidden_for_orchestration_swap(&self, id: PaneId) -> bool {
+        self.hidden_panes
+            .iter()
+            .any(|pane| pane.pane_id == id && pane.reason == HiddenPaneReason::OrchestrationSwap)
+    }
+
+    /// Returns true if `id` is currently hidden because it is a child
+    /// agent pane. Mirrors `is_pane_hidden_for_orchestration_swap` so
+    /// callers can branch on the right show/hide helper.
+    pub fn is_pane_hidden_for_child_agent(&self, id: PaneId) -> bool {
+        pane_hidden_for_child_agent(&self.hidden_panes, &id)
     }
 
     pub fn toggle_pane_visibility_for_job(&mut self, id: PaneId) -> bool {
@@ -593,6 +638,7 @@ impl PaneNode {
                     && !pane_hidden_for_undo(hidden_panes, pane_id)
                     && !pane_hidden_for_move(hidden_panes, pane_id)
                     && !pane_hidden_for_child_agent(hidden_panes, pane_id)
+                    && !pane_hidden_for_orchestration_swap(hidden_panes, pane_id)
             }
             PaneNode::Branch(branch) => branch.has_visible_children(hidden_panes),
         }
@@ -1292,6 +1338,12 @@ fn pane_hidden_for_child_agent(hidden_panes: &[HiddenPane], id: &PaneId) -> bool
     hidden_panes
         .iter()
         .any(|pane| pane.reason == HiddenPaneReason::ChildAgent && pane.pane_id == *id)
+}
+
+fn pane_hidden_for_orchestration_swap(hidden_panes: &[HiddenPane], id: &PaneId) -> bool {
+    hidden_panes
+        .iter()
+        .any(|pane| pane.reason == HiddenPaneReason::OrchestrationSwap && pane.pane_id == *id)
 }
 
 impl FindPaneByDirection for PaneBranch {

--- a/app/src/pane_group/tree.rs
+++ b/app/src/pane_group/tree.rs
@@ -382,6 +382,25 @@ impl PaneData {
         })
     }
 
+    /// Inverse of [`Self::original_pane_for_replacement`]: given an
+    /// `original_pane_id` that may currently be swapped out (i.e. it sits
+    /// in `hidden_panes` as the original of some active
+    /// `TemporaryReplacement`), return the replacement pane that took its
+    /// slot. Used by callers that want to revert a swap from the
+    /// original's side (e.g. "navigate back to this conversation" when
+    /// the conversation's pane is currently swapped out by another).
+    pub fn replacement_pane_for_original(&self, original_pane_id: PaneId) -> Option<PaneId> {
+        self.hidden_panes.iter().find_map(|hidden_pane| {
+            if hidden_pane.pane_id != original_pane_id {
+                return None;
+            }
+            match hidden_pane.reason {
+                HiddenPaneReason::TemporaryReplacement(replacement_id) => Some(replacement_id),
+                _ => None,
+            }
+        })
+    }
+
     pub fn is_hidden_closed_pane(&self, pane_id: &PaneId) -> bool {
         self.hidden_panes
             .iter()

--- a/app/src/pane_group/tree.rs
+++ b/app/src/pane_group/tree.rs
@@ -75,12 +75,6 @@ pub enum HiddenPaneReason {
     // Pane is a child agent spawned by an orchestrator. It stays hidden
     // until the user explicitly reveals it from the status card.
     ChildAgent,
-
-    // Pane was hidden because the orchestration pill bar swapped it out
-    // for another conversation's pane in the same pane group. The
-    // pane stays in the tree at its original position so it can be
-    // re-shown by clicking back to it.
-    OrchestrationSwap,
 }
 
 impl HiddenPane {
@@ -112,12 +106,6 @@ impl HiddenPane {
         Self {
             pane_id,
             reason: HiddenPaneReason::ChildAgent,
-        }
-    }
-    pub fn from_orchestration_swap(pane_id: PaneId) -> Self {
-        Self {
-            pane_id,
-            reason: HiddenPaneReason::OrchestrationSwap,
         }
     }
 }
@@ -336,32 +324,6 @@ impl PaneData {
         }
     }
 
-    pub fn hide_pane_for_orchestration_swap(&mut self, id: PaneId) {
-        if !self.is_pane_hidden(&id) {
-            self.hidden_panes
-                .push(HiddenPane::from_orchestration_swap(id));
-        }
-    }
-
-    pub fn show_pane_for_orchestration_swap(&mut self, id: PaneId) {
-        if let Some(pos) = self.hidden_panes.iter().position(|pane| {
-            pane.pane_id == id && pane.reason == HiddenPaneReason::OrchestrationSwap
-        }) {
-            self.hidden_panes.remove(pos);
-        } else {
-            log::error!("Attempted to show orchestration-swap pane but couldn't find it.")
-        }
-    }
-
-    /// Returns true if `id` is currently hidden because of an orchestration
-    /// pill-bar swap (i.e. another conversation's pane is showing in its
-    /// place in the same pane group).
-    pub fn is_pane_hidden_for_orchestration_swap(&self, id: PaneId) -> bool {
-        self.hidden_panes
-            .iter()
-            .any(|pane| pane.pane_id == id && pane.reason == HiddenPaneReason::OrchestrationSwap)
-    }
-
     /// Returns true if `id` is currently hidden because it is a child
     /// agent pane. Mirrors `is_pane_hidden_for_orchestration_swap` so
     /// callers can branch on the right show/hide helper.
@@ -529,6 +491,13 @@ impl PaneData {
             .any(|hidden_pane| hidden_pane.pane_id == *pane_id)
     }
 
+    /// Returns true if `pane_id` is currently a leaf in the layout tree.
+    /// A pane that lives only in `pane_contents` (e.g. an off-tree child
+    /// agent pane) returns false.
+    pub fn is_pane_in_tree(&self, pane_id: PaneId) -> bool {
+        self.root.contains_pane(pane_id)
+    }
+
     pub fn len(&self) -> usize {
         self.len
     }
@@ -638,7 +607,6 @@ impl PaneNode {
                     && !pane_hidden_for_undo(hidden_panes, pane_id)
                     && !pane_hidden_for_move(hidden_panes, pane_id)
                     && !pane_hidden_for_child_agent(hidden_panes, pane_id)
-                    && !pane_hidden_for_orchestration_swap(hidden_panes, pane_id)
             }
             PaneNode::Branch(branch) => branch.has_visible_children(hidden_panes),
         }
@@ -871,7 +839,7 @@ impl PaneNode {
         }
     }
 
-    fn contains_pane(&self, pane_id: PaneId) -> bool {
+    pub(crate) fn contains_pane(&self, pane_id: PaneId) -> bool {
         match self {
             PaneNode::Leaf(id) => *id == pane_id,
             PaneNode::Branch(branch) => branch.contains_pane(pane_id),
@@ -1338,12 +1306,6 @@ fn pane_hidden_for_child_agent(hidden_panes: &[HiddenPane], id: &PaneId) -> bool
     hidden_panes
         .iter()
         .any(|pane| pane.reason == HiddenPaneReason::ChildAgent && pane.pane_id == *id)
-}
-
-fn pane_hidden_for_orchestration_swap(hidden_panes: &[HiddenPane], id: &PaneId) -> bool {
-    hidden_panes
-        .iter()
-        .any(|pane| pane.reason == HiddenPaneReason::OrchestrationSwap && pane.pane_id == *id)
 }
 
 impl FindPaneByDirection for PaneBranch {

--- a/app/src/pane_group/tree.rs
+++ b/app/src/pane_group/tree.rs
@@ -406,21 +406,6 @@ impl PaneData {
         })
     }
 
-    /// Returns the `(original_pane_id, replacement_pane_id)` of any active
-    /// `TemporaryReplacement` in this pane group's hidden-pane list, or
-    /// `None` if no swap is currently active. Used by the orchestration
-    /// split-off paths to revert any in-flight swap before re-arranging
-    /// the tree, regardless of which child is the current swap target.
-    pub fn any_temporary_replacement(&self) -> Option<(PaneId, PaneId)> {
-        self.hidden_panes.iter().find_map(|hidden_pane| {
-            if let HiddenPaneReason::TemporaryReplacement(replacement_id) = hidden_pane.reason {
-                Some((hidden_pane.pane_id, replacement_id))
-            } else {
-                None
-            }
-        })
-    }
-
     pub fn is_hidden_closed_pane(&self, pane_id: &PaneId) -> bool {
         self.hidden_panes
             .iter()

--- a/app/src/pane_group/tree.rs
+++ b/app/src/pane_group/tree.rs
@@ -217,9 +217,14 @@ impl PaneData {
     }
 
     pub fn visible_pane_count(&self) -> usize {
-        let total_panes = self.pane_ids().len();
-        let hidden_count = self.num_hidden_panes();
-        total_panes.saturating_sub(hidden_count)
+        // `visible_pane_ids` does the right "is in tree AND not hidden"
+        // filter. Computing `pane_ids().len() - num_hidden_panes()` gives
+        // the wrong answer for `TemporaryReplacement`: the original is
+        // recorded in `hidden_panes` but is NOT in the tree (its slot now
+        // holds the replacement), so subtracting the hidden count
+        // double-counts that pane and produces values like 0 visible panes
+        // when there's actually 1 (the replacement).
+        self.visible_pane_ids().len()
     }
 
     pub fn has_horizontal_split(&self) -> bool {
@@ -397,6 +402,21 @@ impl PaneData {
             match hidden_pane.reason {
                 HiddenPaneReason::TemporaryReplacement(replacement_id) => Some(replacement_id),
                 _ => None,
+            }
+        })
+    }
+
+    /// Returns the `(original_pane_id, replacement_pane_id)` of any active
+    /// `TemporaryReplacement` in this pane group's hidden-pane list, or
+    /// `None` if no swap is currently active. Used by the orchestration
+    /// split-off paths to revert any in-flight swap before re-arranging
+    /// the tree, regardless of which child is the current swap target.
+    pub fn any_temporary_replacement(&self) -> Option<(PaneId, PaneId)> {
+        self.hidden_panes.iter().find_map(|hidden_pane| {
+            if let HiddenPaneReason::TemporaryReplacement(replacement_id) = hidden_pane.reason {
+                Some((hidden_pane.pane_id, replacement_id))
+            } else {
+                None
             }
         })
     }

--- a/app/src/pane_group/tree.rs
+++ b/app/src/pane_group/tree.rs
@@ -217,13 +217,8 @@ impl PaneData {
     }
 
     pub fn visible_pane_count(&self) -> usize {
-        // `visible_pane_ids` does the right "is in tree AND not hidden"
-        // filter. Computing `pane_ids().len() - num_hidden_panes()` gives
-        // the wrong answer for `TemporaryReplacement`: the original is
-        // recorded in `hidden_panes` but is NOT in the tree (its slot now
-        // holds the replacement), so subtracting the hidden count
-        // double-counts that pane and produces values like 0 visible panes
-        // when there's actually 1 (the replacement).
+        // Use `visible_pane_ids` directly; subtracting hidden count would
+        // double-count temporary-replacement originals (hidden but off-tree).
         self.visible_pane_ids().len()
     }
 
@@ -329,9 +324,7 @@ impl PaneData {
         }
     }
 
-    /// Returns true if `id` is currently hidden because it is a child
-    /// agent pane. Mirrors `is_pane_hidden_for_orchestration_swap` so
-    /// callers can branch on the right show/hide helper.
+    /// Returns true if `id` is hidden as a child agent pane.
     pub fn is_pane_hidden_for_child_agent(&self, id: PaneId) -> bool {
         pane_hidden_for_child_agent(&self.hidden_panes, &id)
     }
@@ -387,13 +380,9 @@ impl PaneData {
         })
     }
 
-    /// Inverse of [`Self::original_pane_for_replacement`]: given an
-    /// `original_pane_id` that may currently be swapped out (i.e. it sits
-    /// in `hidden_panes` as the original of some active
-    /// `TemporaryReplacement`), return the replacement pane that took its
-    /// slot. Used by callers that want to revert a swap from the
-    /// original's side (e.g. "navigate back to this conversation" when
-    /// the conversation's pane is currently swapped out by another).
+    /// Inverse of [`Self::original_pane_for_replacement`]: given a pane
+    /// currently swapped out as a temporary replacement's original,
+    /// return the replacement that took its slot.
     pub fn replacement_pane_for_original(&self, original_pane_id: PaneId) -> Option<PaneId> {
         self.hidden_panes.iter().find_map(|hidden_pane| {
             if hidden_pane.pane_id != original_pane_id {
@@ -516,8 +505,6 @@ impl PaneData {
     }
 
     /// Returns true if `pane_id` is currently a leaf in the layout tree.
-    /// A pane that lives only in `pane_contents` (e.g. an off-tree child
-    /// agent pane) returns false.
     pub fn is_pane_in_tree(&self, pane_id: PaneId) -> bool {
         self.root.contains_pane(pane_id)
     }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2007,13 +2007,13 @@ pub enum Event {
     /// 3-dot menu in the orchestration pill bar. Bubbles up to
     /// `PaneGroup`, which reuses the existing dedicated child agent pane
     /// (see [`PaneGroup::unhide_child_agent_pane_for_split_off`]) instead
-    /// of creating a fresh one: the child's `TerminalView` has been
-    /// receiving its own block stream all along (it was created up front
-    /// when the orchestrator spawned the child), so revealing it as a
-    /// sibling of the orchestrator preserves in-flight commands and the
-    /// full transcript. Creating a fresh view here would clone the
+    /// of creating a fresh one: creating a fresh view would clone the
     /// conversation into a second pane and cancel any in-flight commands
-    /// running in the original.
+    /// running in the original. Reusing the existing child pane keeps
+    /// in-flight commands running and the full transcript intact — the
+    /// child's `TerminalView` has been receiving its own block stream
+    /// all along (it was created up front when the orchestrator
+    /// spawned the child).
     OpenChildAgentInNewPane {
         conversation_id: AIConversationId,
     },
@@ -4609,23 +4609,43 @@ impl TerminalView {
     }
 
     /// If the active conversation is a child agent (has a
-    /// `parent_conversation_id`), emit a `SwapPaneToConversation` event
-    /// targeting the parent and return `true`. The pane group then makes
-    /// the parent's pane visible in the focused slot rather than exiting
-    /// agent view in place — a child agent's `TerminalView` is just a
-    /// vehicle for the AI conversation and has no meaningful shell to
-    /// fall back into. Both the ESC keypress and the agent-view back
-    /// button ("for Orchestrator") route through here so the visible
-    /// affordance and the action match. Returns `false` for
-    /// non-child-agent conversations so the caller can run the normal
-    /// exit-agent-view flow.
+    /// `parent_conversation_id`), navigate to the parent and return
+    /// `true`. The pane group then makes the parent's pane visible in
+    /// the focused slot rather than exiting agent view in place — a
+    /// child agent's `TerminalView` is just a vehicle for the AI
+    /// conversation and has no meaningful shell to fall back into.
+    /// Both the ESC keypress and the agent-view back button ("for
+    /// Orchestrator") route through here so the visible affordance and
+    /// the action match. Returns `false` for non-child-agent
+    /// conversations so the caller can run the normal exit-agent-view
+    /// flow.
+    ///
+    /// We dispatch [`WorkspaceAction::FocusTerminalViewInWorkspace`]
+    /// when the parent's owning `TerminalView` is known to the history
+    /// model. The workspace handler routes through
+    /// [`crate::pane_group::PaneGroup::reveal_and_focus_pane`], which
+    /// transparently handles all three relevant cases:
+    ///   * same-tab swap target (orchestrator hidden as a TempRepl
+    ///     original): reverts the swap so the orchestrator returns to
+    ///     its slot;
+    ///   * same-tab visible parent (e.g. orchestrator already split
+    ///     off): just focuses the parent's pane;
+    ///   * cross-tab parent (parent was opened in another tab via
+    ///     "Open in new tab"): switches to that tab and focuses there.
+    ///
+    /// As a fallback, if no `TerminalView` canonically owns the parent
+    /// (e.g. the parent's pane was closed but a child agent pane still
+    /// references the conversation), emit
+    /// [`Event::SwapPaneToConversation`] so the local pane group can
+    /// lazily reveal a hidden orchestrator pane via
+    /// [`crate::pane_group::PaneGroup::swap_active_pane_to_conversation`].
     ///
     /// Importantly, this check runs *before* `can_exit_agent_view_for_terminal_view`
     /// gating: a long-running child agent cannot "exit" in place anyway,
     /// but the user still expects ESC / the back button to navigate them
     /// to the orchestrator. Gating on `can_exit` first would silently
     /// turn both into no-ops in the common case.
-    fn try_navigate_to_parent_conversation(&self, ctx: &mut ViewContext<Self>) -> bool {
+    fn try_navigate_to_parent_conversation(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         if !FeatureFlag::AgentView.is_enabled() {
             return false;
         }
@@ -4637,15 +4657,28 @@ impl TerminalView {
         let Some(active_conv_id) = active_conv_id else {
             return false;
         };
-        let parent_id = BlocklistAIHistoryModel::as_ref(ctx)
+        let history = BlocklistAIHistoryModel::as_ref(ctx);
+        let parent_id = history
             .conversation(&active_conv_id)
             .and_then(|c| c.parent_conversation_id());
         let Some(parent_id) = parent_id else {
             return false;
         };
-        ctx.emit(Event::SwapPaneToConversation {
-            conversation_id: parent_id,
-        });
+        let parent_terminal_view_id = history.terminal_view_id_for_conversation(&parent_id);
+
+        if let Some(parent_terminal_view_id) = parent_terminal_view_id {
+            // Defer the dispatch so it runs after any in-flight event
+            // handling on this view completes — matches the pattern used
+            // for cross-pane-group navigation in
+            // `EnterAgentBlockAction::EnterAgentMode`.
+            ctx.dispatch_typed_action_deferred(WorkspaceAction::FocusTerminalViewInWorkspace {
+                terminal_view_id: parent_terminal_view_id,
+            });
+        } else {
+            ctx.emit(Event::SwapPaneToConversation {
+                conversation_id: parent_id,
+            });
+        }
         true
     }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -26039,36 +26039,42 @@ impl TypedActionView for TerminalView {
                 });
             }
             OpenChildAgentInNewPane { conversation_id } => {
-                // "Open in new pane": split a fresh terminal pane to the
-                // right and load the child conversation into it. We do
-                // *not* reveal the orchestrator's hidden child pane here
-                // — that pane's terminal model has no rendered AI blocks
-                // for the conversation (they live in whichever pane last
-                // hosted the in-place agent view via
-                // `SwitchAgentViewToConversation`), so revealing it would
-                // show an empty transcript. Going through a fresh view
-                // forces the cloud load+restore path in
-                // `enter_agent_view_for_conversation`, which mirrors what
-                // "Open in new tab" does and gives a fully populated
-                // history view.
+                // "Open in new pane": reveal the existing dedicated child
+                // agent pane as a sibling of the orchestrator. The pane
+                // group's `unhide_child_agent_pane_for_split_off` reverts
+                // any active swap (so the orchestrator returns to its
+                // slot) and splits the child pane in next to it. The
+                // child's `TerminalView` is preserved — not recreated —
+                // so in-flight commands keep running and the transcript
+                // stays intact.
                 ctx.emit(Event::OpenChildAgentInNewPane {
                     conversation_id: *conversation_id,
                 });
-                self.revert_agent_view_to_parent_if_displaying_child(*conversation_id, ctx);
+                // Note: we deliberately do NOT call
+                // `revert_agent_view_to_parent_if_displaying_child` here.
+                // `self` is the dedicated `TerminalView` for the child
+                // conversation (we're currently rendering it because the
+                // pill-bar swap put it in the orchestrator's slot).
+                // Reverting `self` to the parent would leave the
+                // freshly-split pane showing the orchestrator instead of
+                // the child.
             }
             OpenChildAgentInNewTab { conversation_id } => {
-                // "Open in new tab": bubble up to the workspace, which is
-                // the only layer that can add a new tab. The workspace will
-                // create a fresh session tab and call
-                // `enter_agent_view_for_conversation` with this id so the
-                // new tab opens directly into the child's agent view (not
-                // the orchestrator's). The current tab stays where it is
-                // and the workspace switches focus to the new tab as part
-                // of `add_new_session_tab_with_default_mode`.
+                // "Open in new tab": bubble up to the workspace so it can
+                // wrap the child's existing pane in a fresh tab. The
+                // workspace's handler calls
+                // `take_child_agent_pane_for_split_off` which reverts any
+                // active swap (so the orchestrator returns to its slot in
+                // this tab) and detaches the child pane for adoption into
+                // a new tab. The same `TerminalView` survives the move.
                 ctx.emit(Event::OpenChildAgentInNewTab {
                     conversation_id: *conversation_id,
                 });
-                self.revert_agent_view_to_parent_if_displaying_child(*conversation_id, ctx);
+                // Note: we deliberately do NOT call
+                // `revert_agent_view_to_parent_if_displaying_child` here.
+                // `self` is the dedicated `TerminalView` for the child
+                // conversation; switching it to the parent would surface
+                // the orchestrator in the new tab instead of the child.
             }
             StopAgentConversation { conversation_id } => {
                 // Cancel the ambient task only if the conversation is

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -1986,6 +1986,16 @@ pub enum Event {
     RevealChildAgent {
         conversation_id: AIConversationId,
     },
+    /// Emitted when the user clicks a pill in the orchestration pill bar.
+    /// The pane group swaps the currently focused pane's visible content
+    /// with the pane that already owns the target conversation's
+    /// `TerminalView` (the orchestrator's pane for the orchestrator
+    /// conversation, or the child's hidden pane for a child conversation).
+    /// This avoids cloning a child's `AIConversation` into the
+    /// orchestrator pane and the staleness that comes with it.
+    SwapPaneToConversation {
+        conversation_id: AIConversationId,
+    },
     /// Emitted when the user picks "Open in new tab" from a child pill's 3-dot
     /// menu in the orchestration pill bar. Bubbles up through `PaneGroup` to
     /// `Workspace`, which creates a new tab and switches its agent view to
@@ -2776,6 +2786,13 @@ pub struct TerminalView {
     /// child agents. Gated by `FeatureFlag::OrchestrationPillBar`. The view is
     /// always constructed; render-time guards control whether it draws anything.
     orchestration_pill_bar: ViewHandle<OrchestrationPillBar>,
+    /// `true` when this terminal view was created (or repurposed) to host
+    /// an orchestration child agent that has been split off from its
+    /// orchestrator via "Open in new pane" or "Open in new tab". Used at
+    /// render time to swap the orchestration pill bar for a parent → child
+    /// breadcrumb row in the pane header. Always false on the orchestrator
+    /// pane and on the child agent's hidden swap-target pane.
+    is_orchestration_split_off: bool,
     is_using_conversation_for_pane_header_title: bool,
 
     ambient_agent_view_model: Option<ModelHandle<ambient_agent::AmbientAgentViewModel>>,
@@ -4244,6 +4261,7 @@ impl TerminalView {
             agent_view_controller,
             agent_view_back_button,
             orchestration_pill_bar,
+            is_orchestration_split_off: false,
             is_using_conversation_for_pane_header_title: false,
             ambient_agent_view_model,
             conversation_details_panel,
@@ -4961,6 +4979,37 @@ impl TerminalView {
             input.append_to_buffer(content.as_str(), ctx);
             ctx.notify();
         });
+    }
+
+    /// Marks this terminal view as hosting a split-off orchestration child
+    /// ("Open in new pane" / "Open in new tab"). The pane header swaps the
+    /// orchestration pill bar for a parent → child breadcrumb row so the
+    /// user has a clear way to navigate back to the orchestrator without
+    /// rendering the full sibling pill list a second time alongside the
+    /// orchestrator's own pill bar.
+    pub fn mark_as_orchestration_split_off(&mut self, ctx: &mut ViewContext<Self>) {
+        if !self.is_orchestration_split_off {
+            self.is_orchestration_split_off = true;
+            ctx.notify();
+        }
+    }
+
+    /// Clears the split-off marker so this view goes back to rendering the
+    /// full orchestration pill bar (rather than the parent→child
+    /// breadcrumbs). Called by the pane group whenever a child agent pane
+    /// is re-hidden (close, swap-away) so a subsequent reveal via the pill
+    /// bar's swap path renders pills, not breadcrumbs.
+    pub fn clear_orchestration_split_off(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.is_orchestration_split_off {
+            self.is_orchestration_split_off = false;
+            ctx.notify();
+        }
+    }
+
+    /// Whether this terminal view should render the orchestration breadcrumb
+    /// row instead of the orchestration pill bar in its pane header.
+    pub fn is_orchestration_split_off(&self) -> bool {
+        self.is_orchestration_split_off
     }
 
     /// Returns true if the given conversation is currently selected in this terminal.
@@ -10373,15 +10422,46 @@ impl TerminalView {
         }
     }
 
-    /// Updates the agent view back button's disabled state and tooltip based on whether
-    /// the user can exit agent mode, and shows a tooltip explaining when exiting is blocked.
-    fn update_agent_view_back_button_state(&mut self, ctx: &mut ViewContext<Self>) {
-        let disabled_reason = self
-            .can_exit_agent_view_for_terminal_view(ctx)
-            .err()
-            .map(|e| e.to_string());
+    /// Updates the agent view back button's disabled state, tooltip, and
+    /// label based on the active conversation. For a child agent (a
+    /// conversation with a `parent_conversation_id`), ESC swaps back to
+    /// the orchestrator rather than exiting agent view in place — the
+    /// child's terminal view has no useful shell to fall back into — so
+    /// we relabel the back button to "for Orchestrator" so the affordance
+    /// matches the actual behavior. A second ESC on the orchestrator then
+    /// runs the normal exit-agent-view path.
+    pub(crate) fn update_agent_view_back_button_state(&mut self, ctx: &mut ViewContext<Self>) {
+        let active_conv_id = self
+            .agent_view_controller
+            .as_ref(ctx)
+            .agent_view_state()
+            .active_conversation_id();
+        let is_child_agent = active_conv_id
+            .and_then(|id| BlocklistAIHistoryModel::as_ref(ctx).conversation(&id))
+            .and_then(|c| c.parent_conversation_id())
+            .is_some();
+
+        // Child agents always swap back to the parent on ESC — no
+        // exit-agent-view check applies, and the swap path itself never
+        // gets blocked by an in-progress conversation. So the button is
+        // never disabled in the child agent case, regardless of what
+        // `can_exit_agent_view_for_terminal_view` would say about the
+        // child's own conversation.
+        let disabled_reason = if is_child_agent {
+            None
+        } else {
+            self.can_exit_agent_view_for_terminal_view(ctx)
+                .err()
+                .map(|e| e.to_string())
+        };
+        let label = if is_child_agent {
+            "for Orchestrator"
+        } else {
+            "for terminal"
+        };
 
         self.agent_view_back_button.update(ctx, |button, ctx| {
+            button.set_label(label, ctx);
             button.set_disabled(disabled_reason.is_some(), ctx);
             button.set_tooltip(disabled_reason, ctx);
         });
@@ -20307,6 +20387,34 @@ impl TerminalView {
                         return;
                     }
 
+                    // If the active conversation is a child agent (has a
+                    // parent_conversation_id), ESC navigates back to the
+                    // parent (orchestrator) instead of trying to exit agent
+                    // view in place. The child's terminal view has no
+                    // meaningful shell session to fall back into — it was
+                    // spun up purely as a vehicle for the child's AI
+                    // conversation — so dropping the user there would land
+                    // them in an empty/blank pane. The orchestrator pane is
+                    // their real working context. Once on the parent, a
+                    // second ESC does the normal exit-agent-view dance and
+                    // returns the user to the parent's terminal mode.
+                    let active_conv_id = self
+                        .agent_view_controller
+                        .as_ref(ctx)
+                        .agent_view_state()
+                        .active_conversation_id();
+                    if let Some(active_conv_id) = active_conv_id {
+                        let parent_id = BlocklistAIHistoryModel::as_ref(ctx)
+                            .conversation(&active_conv_id)
+                            .and_then(|c| c.parent_conversation_id());
+                        if let Some(parent_id) = parent_id {
+                            ctx.emit(Event::SwapPaneToConversation {
+                                conversation_id: parent_id,
+                            });
+                            return;
+                        }
+                    }
+
                     let is_long_running = self
                         .model
                         .lock()
@@ -25920,12 +26028,15 @@ impl TypedActionView for TerminalView {
                 });
             }
             SwitchAgentViewToConversation { conversation_id } => {
-                self.enter_agent_view_for_conversation(
-                    None,
-                    AgentViewEntryOrigin::OrchestrationPillBar,
-                    *conversation_id,
-                    ctx,
-                );
+                // Pill-bar navigation: emit a swap event so the pane group
+                // can switch the visible content to the pane that already
+                // owns this conversation's `TerminalView`. Cloning the
+                // conversation into this pane (the old behavior) produces
+                // stale `LongRunningCommandSnapshot` results that render as
+                // `⊘` even when the conversation is still in progress.
+                ctx.emit(Event::SwapPaneToConversation {
+                    conversation_id: *conversation_id,
+                });
             }
             OpenChildAgentInNewPane { conversation_id } => {
                 // "Open in new pane": split a fresh terminal pane to the

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2004,15 +2004,16 @@ pub enum Event {
         conversation_id: AIConversationId,
     },
     /// Emitted when the user picks "Open in new pane" from a child pill's
-    /// 3-dot menu in the orchestration pill bar. Bubbles up to `PaneGroup`,
-    /// which splits a fresh terminal pane to the right and loads the child
-    /// conversation into it via `enter_agent_view_for_conversation`. We
-    /// can't reuse the orchestrator's hidden child pane here — its
-    /// terminal model never received the rendered AI blocks for the
-    /// conversation (those are inserted into whichever pane was last
-    /// hosting the agent view in place), so revealing it would show a
-    /// blank transcript. Going through a fresh view + the cloud
-    /// load+restore path mirrors what "Open in new tab" already does.
+    /// 3-dot menu in the orchestration pill bar. Bubbles up to
+    /// `PaneGroup`, which reuses the existing dedicated child agent pane
+    /// (see [`PaneGroup::unhide_child_agent_pane_for_split_off`]) instead
+    /// of creating a fresh one: the child's `TerminalView` has been
+    /// receiving its own block stream all along (it was created up front
+    /// when the orchestrator spawned the child), so revealing it as a
+    /// sibling of the orchestrator preserves in-flight commands and the
+    /// full transcript. Creating a fresh view here would clone the
+    /// conversation into a second pane and cancel any in-flight commands
+    /// running in the original.
     OpenChildAgentInNewPane {
         conversation_id: AIConversationId,
     },
@@ -4605,6 +4606,47 @@ impl TerminalView {
             }
             result => result,
         }
+    }
+
+    /// If the active conversation is a child agent (has a
+    /// `parent_conversation_id`), emit a `SwapPaneToConversation` event
+    /// targeting the parent and return `true`. The pane group then makes
+    /// the parent's pane visible in the focused slot rather than exiting
+    /// agent view in place — a child agent's `TerminalView` is just a
+    /// vehicle for the AI conversation and has no meaningful shell to
+    /// fall back into. Both the ESC keypress and the agent-view back
+    /// button ("for Orchestrator") route through here so the visible
+    /// affordance and the action match. Returns `false` for
+    /// non-child-agent conversations so the caller can run the normal
+    /// exit-agent-view flow.
+    ///
+    /// Importantly, this check runs *before* `can_exit_agent_view_for_terminal_view`
+    /// gating: a long-running child agent cannot "exit" in place anyway,
+    /// but the user still expects ESC / the back button to navigate them
+    /// to the orchestrator. Gating on `can_exit` first would silently
+    /// turn both into no-ops in the common case.
+    fn try_navigate_to_parent_conversation(&self, ctx: &mut ViewContext<Self>) -> bool {
+        if !FeatureFlag::AgentView.is_enabled() {
+            return false;
+        }
+        let active_conv_id = self
+            .agent_view_controller
+            .as_ref(ctx)
+            .agent_view_state()
+            .active_conversation_id();
+        let Some(active_conv_id) = active_conv_id else {
+            return false;
+        };
+        let parent_id = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&active_conv_id)
+            .and_then(|c| c.parent_conversation_id());
+        let Some(parent_id) = parent_id else {
+            return false;
+        };
+        ctx.emit(Event::SwapPaneToConversation {
+            conversation_id: parent_id,
+        });
+        true
     }
 
     fn can_pop_nested_cloud_agent_view(&self, ctx: &AppContext) -> bool {
@@ -20346,37 +20388,22 @@ impl TerminalView {
                 if FeatureFlag::AgentView.is_enabled()
                     && self.agent_view_controller.as_ref(ctx).is_active()
                 {
-                    // Disable escape completely for ambient agents without a parent terminal.
-                    if self.can_exit_agent_view_for_terminal_view(ctx).is_err() {
+                    // For child agents, ESC navigates back to the orchestrator
+                    // regardless of whether we could exit agent view here —
+                    // the child's `TerminalView` is just a vehicle for the
+                    // AI conversation and has no meaningful shell session
+                    // to fall back into. Run this *before* the
+                    // `can_exit_agent_view_for_terminal_view` gate so a
+                    // long-running child agent can still navigate back to
+                    // its parent. Once on the parent, a second ESC runs
+                    // the normal exit-agent-view path.
+                    if self.try_navigate_to_parent_conversation(ctx) {
                         return;
                     }
 
-                    // If the active conversation is a child agent (has a
-                    // parent_conversation_id), ESC navigates back to the
-                    // parent (orchestrator) instead of trying to exit agent
-                    // view in place. The child's terminal view has no
-                    // meaningful shell session to fall back into — it was
-                    // spun up purely as a vehicle for the child's AI
-                    // conversation — so dropping the user there would land
-                    // them in an empty/blank pane. The orchestrator pane is
-                    // their real working context. Once on the parent, a
-                    // second ESC does the normal exit-agent-view dance and
-                    // returns the user to the parent's terminal mode.
-                    let active_conv_id = self
-                        .agent_view_controller
-                        .as_ref(ctx)
-                        .agent_view_state()
-                        .active_conversation_id();
-                    if let Some(active_conv_id) = active_conv_id {
-                        let parent_id = BlocklistAIHistoryModel::as_ref(ctx)
-                            .conversation(&active_conv_id)
-                            .and_then(|c| c.parent_conversation_id());
-                        if let Some(parent_id) = parent_id {
-                            ctx.emit(Event::SwapPaneToConversation {
-                                conversation_id: parent_id,
-                            });
-                            return;
-                        }
+                    // Disable escape completely for ambient agents without a parent terminal.
+                    if self.can_exit_agent_view_for_terminal_view(ctx).is_err() {
+                        return;
                     }
 
                     let is_long_running = self
@@ -25932,7 +25959,18 @@ impl TypedActionView for TerminalView {
                 ctx.notify();
             }
             ExitAgentView => {
-                if self.can_exit_agent_view_for_terminal_view(ctx).is_ok() {
+                // The agent-view back button labels itself "for Orchestrator"
+                // when a child agent is active (see
+                // `update_agent_view_back_button_state`). Match that
+                // affordance: navigate child → parent before falling back
+                // to the in-place exit-agent-view flow. Without this, a
+                // visible "for Orchestrator" button would still call
+                // `exit_agent_view` and either drop the user into the
+                // child's empty terminal (bad) or no-op silently if the
+                // child's run is long-running (also bad).
+                if self.try_navigate_to_parent_conversation(ctx) {
+                    ctx.notify();
+                } else if self.can_exit_agent_view_for_terminal_view(ctx).is_ok() {
                     self.exit_agent_view(ctx);
                     ctx.notify();
                 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5025,42 +5025,6 @@ impl TerminalView {
             .unwrap_or(false)
     }
 
-    /// If this terminal view's agent view is currently displaying the given
-    /// child conversation, switch the agent view back to its parent
-    /// orchestrator conversation.
-    ///
-    /// Used after the user picks "Open in new pane"/"Open in new tab" from
-    /// the orchestration pill bar's 3-dot menu. The new pane/tab takes over
-    /// ownership of the child conversation, so this view should silently
-    /// revert to the orchestrator so the user is left looking at the parent
-    /// (and the pill bar's in-place pill click works again).
-    fn revert_agent_view_to_parent_if_displaying_child(
-        &mut self,
-        child_conversation_id: AIConversationId,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        let active_conversation_id = self
-            .agent_view_controller
-            .as_ref(ctx)
-            .agent_view_state()
-            .active_conversation_id();
-        if active_conversation_id != Some(child_conversation_id) {
-            return;
-        }
-        let parent_conversation_id = BlocklistAIHistoryModel::as_ref(ctx)
-            .conversation(&child_conversation_id)
-            .and_then(|c| c.parent_conversation_id());
-        let Some(parent_conversation_id) = parent_conversation_id else {
-            return;
-        };
-        self.enter_agent_view_for_conversation(
-            None,
-            AgentViewEntryOrigin::OrchestrationPillBar,
-            parent_conversation_id,
-            ctx,
-        );
-    }
-
     fn handle_agent_todos_popup_event(
         &mut self,
         event: &AgentTodosPopupEvent,
@@ -26046,18 +26010,15 @@ impl TypedActionView for TerminalView {
                 // slot) and splits the child pane in next to it. The
                 // child's `TerminalView` is preserved — not recreated —
                 // so in-flight commands keep running and the transcript
-                // stays intact.
+                // stays intact. Note: `self` here is the dedicated
+                // `TerminalView` for the child (the pill-bar swap put it
+                // in the orchestrator's slot), so we deliberately do NOT
+                // touch `self`'s active conversation — doing so would
+                // leave the freshly-split pane showing the orchestrator
+                // instead of the child.
                 ctx.emit(Event::OpenChildAgentInNewPane {
                     conversation_id: *conversation_id,
                 });
-                // Note: we deliberately do NOT call
-                // `revert_agent_view_to_parent_if_displaying_child` here.
-                // `self` is the dedicated `TerminalView` for the child
-                // conversation (we're currently rendering it because the
-                // pill-bar swap put it in the orchestrator's slot).
-                // Reverting `self` to the parent would leave the
-                // freshly-split pane showing the orchestrator instead of
-                // the child.
             }
             OpenChildAgentInNewTab { conversation_id } => {
                 // "Open in new tab": bubble up to the workspace so it can
@@ -26067,14 +26028,13 @@ impl TypedActionView for TerminalView {
                 // active swap (so the orchestrator returns to its slot in
                 // this tab) and detaches the child pane for adoption into
                 // a new tab. The same `TerminalView` survives the move.
+                // As with `OpenChildAgentInNewPane`, `self` is the
+                // dedicated child `TerminalView`; we leave its active
+                // conversation alone so the new tab shows the child, not
+                // the orchestrator.
                 ctx.emit(Event::OpenChildAgentInNewTab {
                     conversation_id: *conversation_id,
                 });
-                // Note: we deliberately do NOT call
-                // `revert_agent_view_to_parent_if_displaying_child` here.
-                // `self` is the dedicated `TerminalView` for the child
-                // conversation; switching it to the parent would surface
-                // the orchestrator in the new tab instead of the child.
             }
             StopAgentConversation { conversation_id } => {
                 // Cancel the ambient task only if the conversation is

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -1986,33 +1986,17 @@ pub enum Event {
         conversation_id: AIConversationId,
     },
     /// Emitted when the user clicks a pill in the orchestration pill bar.
-    /// The pane group swaps the currently focused pane's visible content
-    /// with the pane that already owns the target conversation's
-    /// `TerminalView` (the orchestrator's pane for the orchestrator
-    /// conversation, or the child's hidden pane for a child conversation).
-    /// This avoids cloning a child's `AIConversation` into the
-    /// orchestrator pane and the staleness that comes with it.
+    /// The pane group swaps visibility instead of cloning the conversation.
     SwapPaneToConversation {
         conversation_id: AIConversationId,
     },
-    /// Emitted when the user picks "Open in new tab" from a child pill's 3-dot
-    /// menu in the orchestration pill bar. Bubbles up through `PaneGroup` to
-    /// `Workspace`, which creates a new tab and switches its agent view to
-    /// the given child conversation.
+    /// Emitted when "Open in new tab" is picked from a child pill's 3-dot menu.
+    /// Bubbles up to the workspace to create the new tab.
     OpenChildAgentInNewTab {
         conversation_id: AIConversationId,
     },
-    /// Emitted when the user picks "Open in new pane" from a child pill's
-    /// 3-dot menu in the orchestration pill bar. Bubbles up to
-    /// `PaneGroup`, which reuses the existing dedicated child agent pane
-    /// (see [`PaneGroup::unhide_child_agent_pane_for_split_off`]) instead
-    /// of creating a fresh one: creating a fresh view would clone the
-    /// conversation into a second pane and cancel any in-flight commands
-    /// running in the original. Reusing the existing child pane keeps
-    /// in-flight commands running and the full transcript intact — the
-    /// child's `TerminalView` has been receiving its own block stream
-    /// all along (it was created up front when the orchestrator
-    /// spawned the child).
+    /// Emitted when "Open in new pane" is picked from a child pill's 3-dot menu.
+    /// Reuses the existing dedicated child pane to preserve in-flight state.
     OpenChildAgentInNewPane {
         conversation_id: AIConversationId,
     },
@@ -2786,12 +2770,8 @@ pub struct TerminalView {
     /// child agents. Gated by `FeatureFlag::OrchestrationPillBar`. The view is
     /// always constructed; render-time guards control whether it draws anything.
     orchestration_pill_bar: ViewHandle<OrchestrationPillBar>,
-    /// `true` when this terminal view was created (or repurposed) to host
-    /// an orchestration child agent that has been split off from its
-    /// orchestrator via "Open in new pane" or "Open in new tab". Used at
-    /// render time to swap the orchestration pill bar for a parent → child
-    /// breadcrumb row in the pane header. Always false on the orchestrator
-    /// pane and on the child agent's hidden swap-target pane.
+    /// `true` when this view hosts a child agent split off into its own
+    /// pane/tab. Drives breadcrumb-vs-pill-bar rendering in the pane header.
     is_orchestration_split_off: bool,
     is_using_conversation_for_pane_header_title: bool,
 
@@ -4598,43 +4578,12 @@ impl TerminalView {
         }
     }
 
-    /// If the active conversation is a child agent (has a
-    /// `parent_conversation_id`), navigate to the parent and return
-    /// `true`. The pane group then makes the parent's pane visible in
-    /// the focused slot rather than exiting agent view in place — a
-    /// child agent's `TerminalView` is just a vehicle for the AI
-    /// conversation and has no meaningful shell to fall back into.
-    /// Both the ESC keypress and the agent-view back button ("for
-    /// Orchestrator") route through here so the visible affordance and
-    /// the action match. Returns `false` for non-child-agent
-    /// conversations so the caller can run the normal exit-agent-view
-    /// flow.
-    ///
-    /// We dispatch [`WorkspaceAction::FocusTerminalViewInWorkspace`]
-    /// when the parent's owning `TerminalView` is known to the history
-    /// model. The workspace handler routes through
-    /// [`crate::pane_group::PaneGroup::reveal_and_focus_pane`], which
-    /// transparently handles all three relevant cases:
-    ///   * same-tab swap target (orchestrator hidden as a TempRepl
-    ///     original): reverts the swap so the orchestrator returns to
-    ///     its slot;
-    ///   * same-tab visible parent (e.g. orchestrator already split
-    ///     off): just focuses the parent's pane;
-    ///   * cross-tab parent (parent was opened in another tab via
-    ///     "Open in new tab"): switches to that tab and focuses there.
-    ///
-    /// As a fallback, if no `TerminalView` canonically owns the parent
-    /// (e.g. the parent's pane was closed but a child agent pane still
-    /// references the conversation), emit
-    /// [`Event::SwapPaneToConversation`] so the local pane group can
-    /// lazily reveal a hidden orchestrator pane via
-    /// [`crate::pane_group::PaneGroup::swap_active_pane_to_conversation`].
-    ///
-    /// Importantly, this check runs *before* `can_exit_agent_view_for_terminal_view`
-    /// gating: a long-running child agent cannot "exit" in place anyway,
-    /// but the user still expects ESC / the back button to navigate them
-    /// to the orchestrator. Gating on `can_exit` first would silently
-    /// turn both into no-ops in the common case.
+    /// If the active conversation is a child agent, navigate to the parent
+    /// and return `true`; otherwise return `false` so the caller can run
+    /// the normal exit-agent-view flow. Cross-tab and swap-target cases
+    /// are handled by the workspace's focus path; falls back to emitting
+    /// a swap event when the parent has no canonical owner. Runs before
+    /// any can-exit gating so long-running children can still navigate back.
     fn try_navigate_to_parent_conversation(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         if !FeatureFlag::AgentView.is_enabled() {
             return false;
@@ -4657,10 +4606,7 @@ impl TerminalView {
         let parent_terminal_view_id = history.terminal_view_id_for_conversation(&parent_id);
 
         if let Some(parent_terminal_view_id) = parent_terminal_view_id {
-            // Defer the dispatch so it runs after any in-flight event
-            // handling on this view completes — matches the pattern used
-            // for cross-pane-group navigation in
-            // `EnterAgentBlockAction::EnterAgentMode`.
+            // Defer so it runs after in-flight event handling completes.
             ctx.dispatch_typed_action_deferred(WorkspaceAction::FocusTerminalViewInWorkspace {
                 terminal_view_id: parent_terminal_view_id,
             });
@@ -5046,12 +4992,8 @@ impl TerminalView {
         });
     }
 
-    /// Marks this terminal view as hosting a split-off orchestration child
-    /// ("Open in new pane" / "Open in new tab"). The pane header swaps the
-    /// orchestration pill bar for a parent → child breadcrumb row so the
-    /// user has a clear way to navigate back to the orchestrator without
-    /// rendering the full sibling pill list a second time alongside the
-    /// orchestrator's own pill bar.
+    /// Marks this view as hosting a split-off child; pane header switches
+    /// from the pill bar to a parent→child breadcrumb row.
     pub fn mark_as_orchestration_split_off(&mut self, ctx: &mut ViewContext<Self>) {
         if !self.is_orchestration_split_off {
             self.is_orchestration_split_off = true;
@@ -5059,11 +5001,7 @@ impl TerminalView {
         }
     }
 
-    /// Clears the split-off marker so this view goes back to rendering the
-    /// full orchestration pill bar (rather than the parent→child
-    /// breadcrumbs). Called by the pane group whenever a child agent pane
-    /// is re-hidden (close, swap-away) so a subsequent reveal via the pill
-    /// bar's swap path renders pills, not breadcrumbs.
+    /// Clears the split-off marker so the pill bar renders again.
     pub fn clear_orchestration_split_off(&mut self, ctx: &mut ViewContext<Self>) {
         if self.is_orchestration_split_off {
             self.is_orchestration_split_off = false;
@@ -5071,8 +5009,7 @@ impl TerminalView {
         }
     }
 
-    /// Whether this terminal view should render the orchestration breadcrumb
-    /// row instead of the orchestration pill bar in its pane header.
+    /// Whether this view renders the breadcrumb row instead of the pill bar.
     pub fn is_orchestration_split_off(&self) -> bool {
         self.is_orchestration_split_off
     }
@@ -10456,14 +10393,9 @@ impl TerminalView {
         }
     }
 
-    /// Updates the agent view back button's disabled state, tooltip, and
-    /// label based on the active conversation. For a child agent (a
-    /// conversation with a `parent_conversation_id`), ESC swaps back to
-    /// the orchestrator rather than exiting agent view in place — the
-    /// child's terminal view has no useful shell to fall back into — so
-    /// we relabel the back button to "for Orchestrator" so the affordance
-    /// matches the actual behavior. A second ESC on the orchestrator then
-    /// runs the normal exit-agent-view path.
+    /// Updates the back button's state and label. For child agents the
+    /// label becomes "for Orchestrator" since ESC swaps to the parent
+    /// instead of exiting in place.
     pub(crate) fn update_agent_view_back_button_state(&mut self, ctx: &mut ViewContext<Self>) {
         let active_conv_id = self
             .agent_view_controller
@@ -10475,12 +10407,7 @@ impl TerminalView {
             .and_then(|c| c.parent_conversation_id())
             .is_some();
 
-        // Child agents always swap back to the parent on ESC — no
-        // exit-agent-view check applies, and the swap path itself never
-        // gets blocked by an in-progress conversation. So the button is
-        // never disabled in the child agent case, regardless of what
-        // `can_exit_agent_view_for_terminal_view` would say about the
-        // child's own conversation.
+        // Never disable for child agents: the swap-back path can't be blocked.
         let disabled_reason = if is_child_agent {
             None
         } else {
@@ -20416,15 +20343,8 @@ impl TerminalView {
                 if FeatureFlag::AgentView.is_enabled()
                     && self.agent_view_controller.as_ref(ctx).is_active()
                 {
-                    // For child agents, ESC navigates back to the orchestrator
-                    // regardless of whether we could exit agent view here —
-                    // the child's `TerminalView` is just a vehicle for the
-                    // AI conversation and has no meaningful shell session
-                    // to fall back into. Run this *before* the
-                    // `can_exit_agent_view_for_terminal_view` gate so a
-                    // long-running child agent can still navigate back to
-                    // its parent. Once on the parent, a second ESC runs
-                    // the normal exit-agent-view path.
+                    // For child agents, ESC navigates to the parent first;
+                    // run this before any can-exit gating.
                     if self.try_navigate_to_parent_conversation(ctx) {
                         return;
                     }
@@ -25987,15 +25907,9 @@ impl TypedActionView for TerminalView {
                 ctx.notify();
             }
             ExitAgentView => {
-                // The agent-view back button labels itself "for Orchestrator"
-                // when a child agent is active (see
-                // `update_agent_view_back_button_state`). Match that
-                // affordance: navigate child → parent before falling back
-                // to the in-place exit-agent-view flow. Without this, a
-                // visible "for Orchestrator" button would still call
-                // `exit_agent_view` and either drop the user into the
-                // child's empty terminal (bad) or no-op silently if the
-                // child's run is long-running (also bad).
+                // Match the back button's "for Orchestrator" affordance for
+                // child agents: navigate to the parent before falling back
+                // to the in-place exit flow.
                 if self.try_navigate_to_parent_conversation(ctx) {
                     ctx.notify();
                 } else if self.can_exit_agent_view_for_terminal_view(ctx).is_ok() {
@@ -26058,46 +25972,23 @@ impl TypedActionView for TerminalView {
                 });
             }
             SwitchAgentViewToConversation { conversation_id } => {
-                // Pill-bar navigation: emit a swap event so the pane group
-                // can switch the visible content to the pane that already
-                // owns this conversation's `TerminalView`. Cloning the
-                // conversation into this pane (the old behavior) produces
-                // stale `LongRunningCommandSnapshot` results that render as
-                // `⊘` even when the conversation is still in progress.
+                // Pill-bar nav: swap visibility instead of cloning the
+                // conversation into this pane.
                 ctx.emit(Event::SwapPaneToConversation {
                     conversation_id: *conversation_id,
                 });
             }
             OpenChildAgentInNewPane { conversation_id } => {
-                // "Open in new pane": reveal the existing dedicated child
-                // agent pane as a sibling of the orchestrator. The pane
-                // group's `unhide_child_agent_pane_for_split_off` reverts
-                // any active swap (so the orchestrator returns to its
-                // slot) and splits the child pane in next to it. The
-                // child's `TerminalView` is preserved — not recreated —
-                // so in-flight commands keep running and the transcript
-                // stays intact. Note: `self` here is the dedicated
-                // `TerminalView` for the child (the pill-bar swap put it
-                // in the orchestrator's slot), so we deliberately do NOT
-                // touch `self`'s active conversation — doing so would
-                // leave the freshly-split pane showing the orchestrator
-                // instead of the child.
+                // Reveal the existing child pane as a sibling; preserves
+                // in-flight state. Don't touch `self`'s active conversation
+                // — `self` is the child view, swapped into the orchestrator's slot.
                 ctx.emit(Event::OpenChildAgentInNewPane {
                     conversation_id: *conversation_id,
                 });
             }
             OpenChildAgentInNewTab { conversation_id } => {
-                // "Open in new tab": bubble up to the workspace so it can
-                // wrap the child's existing pane in a fresh tab. The
-                // workspace's handler calls
-                // `take_child_agent_pane_for_split_off` which reverts any
-                // active swap (so the orchestrator returns to its slot in
-                // this tab) and detaches the child pane for adoption into
-                // a new tab. The same `TerminalView` survives the move.
-                // As with `OpenChildAgentInNewPane`, `self` is the
-                // dedicated child `TerminalView`; we leave its active
-                // conversation alone so the new tab shows the child, not
-                // the orchestrator.
+                // Workspace re-parents the existing child pane into a new tab.
+                // Don't touch `self`'s active conversation (same reason as above).
                 ctx.emit(Event::OpenChildAgentInNewTab {
                     conversation_id: *conversation_id,
                 });

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -481,7 +481,20 @@ impl TerminalView {
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
             history_model.restore_conversations(self.view_id, conversations, ctx);
             if let Some(active_conversation_id) = active_conversation_id {
-                history_model.set_active_conversation_id(active_conversation_id, self.view_id, ctx);
+                // Use `mark_active_conversation_id` (non-transferring) so we
+                // don't rip the conversation out of any other terminal view's
+                // live list. This matters for the orchestration pill bar's
+                // in-place navigation: the child agent's hidden pane must
+                // retain ownership so its `conversation_id_for_action`
+                // lookups for in-flight requested commands keep resolving.
+                // `restore_conversations` above just inserted the conversation
+                // into `self.view_id`'s live list, satisfying mark's
+                // precondition.
+                history_model.mark_active_conversation_id(
+                    active_conversation_id,
+                    self.view_id,
+                    ctx,
+                );
             }
         });
 

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -8,7 +8,6 @@ use crate::ai::agent::conversation::{
 };
 use crate::ai::blocklist::agent_view::agent_view_bg_fill;
 use crate::ai::blocklist::agent_view::orchestration_conversation_links::parent_conversation_navigation_card;
-use crate::ai::blocklist::agent_view::render_orchestration_breadcrumbs;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::appearance::Appearance;
 use crate::drive::sharing::ShareableObject;
@@ -41,8 +40,8 @@ use crate::workspace::tab_settings::TabSettings;
 use settings::Setting as _;
 use warp_core::context_flag::ContextFlag;
 use warpui::elements::{
-    ConstrainedBox, CrossAxisAlignment, Flex, MainAxisAlignment, MainAxisSize, ParentElement,
-    Shrinkable,
+    ConstrainedBox, CrossAxisAlignment, Empty, Flex, MainAxisAlignment, MainAxisSize,
+    ParentElement, Shrinkable,
 };
 use warpui::prelude::{ChildView, Container};
 use warpui::text_layout::ClipConfig;
@@ -280,27 +279,14 @@ impl TerminalView {
         header_ctx: &view::HeaderRenderContext,
         app: &AppContext,
     ) -> Box<dyn Element> {
-        // When viewing a child agent under an orchestrator, replace the
-        // regular conversation title with a breadcrumb path: [Parent] / [Child].
-        // Clicking the parent crumb navigates the current pane back to the
-        // orchestrator (which then shows the pill bar again).
-        //
-        // Return the breadcrumbs element directly. `render_three_column_header`
-        // wraps the title in `Shrinkable + Clipped` which gives the inner
-        // breadcrumbs Flex (whose crumbs are themselves Shrinkable) a finite
-        // main-axis constraint. Wrapping it in our own `MainAxisSize::Min`
-        // Flex here would forward an infinite constraint and panic.
-        // Pass our persistent `parent_conversation_header_link` mouse state
-        // to the breadcrumb's parent crumb so hover and click events work
-        // (a fresh `MouseStateHandle::default()` per render would not).
-        if let Some(breadcrumbs) = render_orchestration_breadcrumbs(
-            self.agent_view_controller.as_ref(app),
-            self.mouse_states.parent_conversation_header_link.clone(),
-            self.mouse_states.breadcrumbs_horizontal_scroll.clone(),
-            app,
-        ) {
-            return breadcrumbs;
-        }
+        // V2 swap-panes semantics: every conversation in the orchestration
+        // tree (orchestrator + each child) gets the orchestration pill bar
+        // rendered above the agent view header, so the pane title here
+        // falls back to the regular conversation title. Breadcrumbs used
+        // to render here for split-off child views, but the swap-panes
+        // refactor removed the split-off code path — the pill bar is now
+        // shown on every view, so a breadcrumb row alongside it would
+        // double-render the same navigation affordance.
 
         let appearance = Appearance::as_ref(app);
         let pane_config = self.pane_configuration.as_ref(app);
@@ -522,7 +508,11 @@ impl TerminalView {
     ) -> Box<dyn Element> {
         // When `OrchestrationPillBar` is on, the pill bar takes the place of the
         // parent navigation card (the parent pill is the "back to parent" link)
-        // and is shown for the orchestrator and all its children.
+        // and is shown for the orchestrator and the swap-target child panes.
+        // Split-off panes ("Open in new pane" / "Open in new tab") instead
+        // render a parent→child breadcrumb row so the user has a clear way
+        // back to the orchestrator without rendering the full sibling pill
+        // list a second time alongside the orchestrator's own pill bar.
         if FeatureFlag::OrchestrationPillBar.is_enabled()
             && FeatureFlag::AgentView.is_enabled()
             && self.agent_view_controller.as_ref(app).is_fullscreen()
@@ -536,15 +526,26 @@ impl TerminalView {
             // title to the top of the row. Pinning the header to its
             // standard `PANE_HEADER_HEIGHT` here restores the finite
             // vertical constraint the centering logic relies on, while
-            // letting the pill bar sit immediately below at its own height.
+            // letting the pill bar / breadcrumb row sit immediately below
+            // at its own height.
             let pinned_header = ConstrainedBox::new(header)
                 .with_height(PANE_HEADER_HEIGHT)
                 .finish();
-            let pill_bar = ChildView::new(&self.orchestration_pill_bar).finish();
+            let secondary_row: Box<dyn Element> = if self.is_orchestration_split_off() {
+                crate::ai::blocklist::agent_view::render_orchestration_breadcrumbs(
+                    self.agent_view_controller.as_ref(app),
+                    self.mouse_states.parent_conversation_header_link.clone(),
+                    self.mouse_states.breadcrumbs_horizontal_scroll.clone(),
+                    app,
+                )
+                .unwrap_or_else(|| Empty::new().finish())
+            } else {
+                ChildView::new(&self.orchestration_pill_bar).finish()
+            };
             return Flex::column()
                 .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
                 .with_child(pinned_header)
-                .with_child(pill_bar)
+                .with_child(secondary_row)
                 .finish();
         }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5369,15 +5369,8 @@ impl Workspace {
             .collect::<Vec<_>>()
     }
 
-    /// Focuses the given pane within the pane group.
-    ///
-    /// Routes through [`PaneGroup::reveal_and_focus_pane`] so cross-tab
-    /// navigation (e.g. the orchestration breadcrumb's parent crumb,
-    /// jump-to-toast, conversation history palette) can target a pane
-    /// that is currently swapped out of the tree as the original of an
-    /// active `TemporaryReplacement`. Without the reveal step, focus
-    /// would silently land on an off-tree pane and the user's view
-    /// wouldn't actually change.
+    /// Focuses the given pane, revealing it first if it is hidden behind a
+    /// temporary swap.
     pub fn focus_pane(&mut self, pane_view_locator: PaneViewLocator, ctx: &mut ViewContext<Self>) {
         if let Some((index, tab)) = self
             .tabs
@@ -10223,12 +10216,9 @@ impl Workspace {
         }
     }
 
-    /// If the tab at `index` was created by [`pane_group::Event::OpenChildAgentInNewTab`]
-    /// and still contains the lone child agent pane it was split off with,
-    /// move that pane back to the origin pane group as a hidden child agent
-    /// instead of letting the close path tear down its `TerminalView`.
-    /// Returns `true` if the re-adoption ran (the tab's pane group is now
-    /// empty) so the caller can skip the regular detach-for-close path.
+    /// If a closing tab is an untouched split-off child-agent tab, move its
+    /// pane back to the original tab instead of closing it. Returns true if
+    /// handled.
     fn try_re_adopt_split_off_child_agent_tab(
         &mut self,
         index: usize,
@@ -10250,10 +10240,8 @@ impl Workspace {
         };
 
         let pane_group = tab_data.pane_group.clone();
-        // Expect a single pane in the split-off tab — the child agent's
-        // `TerminalView` we want to preserve. Bail if the layout has
-        // changed (e.g. the user split additional panes into the tab) so
-        // we don't accidentally disturb unrelated state.
+        // Only re-adopt untouched split-off tabs; changed layouts use normal
+        // close handling.
         let pane_ids: Vec<PaneId> = pane_group.as_ref(ctx).pane_ids().collect();
         if pane_ids.len() != 1 {
             return false;
@@ -10285,10 +10273,7 @@ impl Workspace {
             return;
         };
 
-        // If the vertical-tabs detail sidecar is anchored to this tab's pane group, clear it.
-        // Otherwise it will try to position itself against a pane row that is about to disappear
-        // (either because the tab is being removed from `self.tabs`, or because we're about to
-        // close the window for the last tab).
+        // Clear a detail sidecar anchored to this tab before the tab disappears.
         self.vertical_tabs_panel
             .clear_detail_sidecar_if_for_pane_group(pane_group.id());
 
@@ -10301,19 +10286,9 @@ impl Workspace {
             return;
         }
 
-        // If this tab is a split-off child agent tab (created via
-        // `OpenChildAgentInNewTab`), re-adopt its lone pane back into the
-        // source pane group so the live `TerminalView` survives the tab
-        // close. When this succeeds, the tab's pane group becomes empty
-        // and we skip the regular detach-for-close path — there are no
-        // panes left to detach.
-        //
-        // Only run for actual close paths. `remove_tab_without_undo`
-        // (used by cross-window tab transfers / drag-to-other-window)
-        // calls us with `detach_panes_for_close = false` — the pane
-        // group is being moved, not torn down, and re-adoption would
-        // yank the child pane back to its source orchestrator,
-        // stranding the user's drag target with an empty pane group.
+        // Preserve split-off child-agent tabs by moving their lone pane back
+        // before close cleanup. Skip tab moves so the destination keeps the
+        // pane.
         let re_adopted =
             detach_panes_for_close && self.try_re_adopt_split_off_child_agent_tab(index, ctx);
 
@@ -10344,15 +10319,8 @@ impl Workspace {
         let removed_pane_group_id = tab_data.pane_group.id();
         self.tab_mru_order.retain(|id| *id != removed_pane_group_id);
 
-        // Skip the undo-close stack when the tab was re-adopted: its pane
-        // group is now empty (the lone pane moved back to the source
-        // group), but `panes.root` still points at the (now-departed)
-        // pane id since `PaneNode::remove` cannot remove a root leaf.
-        // Stashing that broken `tab_data` would let "reopen closed tab"
-        // restore a tab whose root references a pane no longer in
-        // `pane_contents`, producing a blank/error pane. The live
-        // `TerminalView` is preserved by the re-adoption itself, so
-        // there's nothing meaningful to undo here.
+        // Re-adopted child tabs leave no useful tab contents to restore; the
+        // live pane already moved back.
         if add_to_undo_stack && !re_adopted {
             let handle = ctx.handle();
             UndoCloseStack::handle(ctx).update(ctx, |stack, ctx| {
@@ -13917,17 +13885,8 @@ impl Workspace {
             #[cfg(not(feature = "local_fs"))]
             pane_group::Event::RemoteRepoNavigated { .. } => {}
             pane_group::Event::OpenChildAgentInNewTab { conversation_id } => {
-                // "Open in new tab" from the orchestration pill bar's 3-dot
-                // menu. Reuse the existing hidden child agent pane that
-                // already hosts the live `TerminalView` for this conversation
-                // by detaching it from the orchestrator's pane group and
-                // adopting it into a new tab's pane group. Creating a fresh
-                // tab with a new terminal view and calling
-                // `enter_agent_view_for_conversation` on it would clone the
-                // conversation into a second view, cancelling any in-flight
-                // commands running in the original view and briefly leaking
-                // the child transcript into the orchestrator pane while
-                // ownership shuffles between views.
+                // Move the existing child pane into a new tab so the live
+                // session stays intact.
                 let conversation_id = *conversation_id;
                 let removed_pane = pane_group.update(ctx, |pg, ctx| {
                     pg.take_child_agent_pane_for_split_off(conversation_id, ctx)
@@ -13944,10 +13903,7 @@ impl Workspace {
                 };
                 let source_pane_group = pane_group.downgrade();
                 self.add_tab_from_existing_pane(removed_pane, new_tab_index, ctx);
-                // Stamp the new tab's pane group with the source origin so
-                // closing the tab can re-adopt the live `TerminalView` back
-                // to the source instead of dropping it. The new tab is
-                // active after `add_tab_from_existing_pane`.
+                // Mark the new tab so closing it can move the pane back.
                 if let Some(new_pane_group) =
                     self.get_pane_group_view(self.active_tab_index).cloned()
                 {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5328,6 +5328,14 @@ impl Workspace {
     }
 
     /// Focuses the given pane within the pane group.
+    ///
+    /// Routes through [`PaneGroup::reveal_and_focus_pane`] so cross-tab
+    /// navigation (e.g. the orchestration breadcrumb's parent crumb,
+    /// jump-to-toast, conversation history palette) can target a pane
+    /// that is currently swapped out of the tree as the original of an
+    /// active `TemporaryReplacement`. Without the reveal step, focus
+    /// would silently land on an off-tree pane and the user's view
+    /// wouldn't actually change.
     pub fn focus_pane(&mut self, pane_view_locator: PaneViewLocator, ctx: &mut ViewContext<Self>) {
         if let Some((index, tab)) = self
             .tabs
@@ -5342,7 +5350,7 @@ impl Workspace {
             // remain focused (as opposed to the pane with pane_id) since its
             // input would remain focused.
             tab.pane_group.update(ctx, |view, ctx| {
-                view.focus_pane_by_id(pane_view_locator.pane_id, ctx);
+                view.reveal_and_focus_pane(pane_view_locator.pane_id, ctx);
             });
             self.activate_tab_internal(index, ctx);
             ctx.notify();
@@ -10274,7 +10282,16 @@ impl Workspace {
 
         let tab_data = self.tabs.remove(index);
 
-        if add_to_undo_stack {
+        // Skip the undo-close stack when the tab was re-adopted: its pane
+        // group is now empty (the lone pane moved back to the source
+        // group), but `panes.root` still points at the (now-departed)
+        // pane id since `PaneNode::remove` cannot remove a root leaf.
+        // Stashing that broken `tab_data` would let "reopen closed tab"
+        // restore a tab whose root references a pane no longer in
+        // `pane_contents`, producing a blank/error pane. The live
+        // `TerminalView` is preserved by the re-adoption itself, so
+        // there's nothing meaningful to undo here.
+        if add_to_undo_stack && !re_adopted {
             let handle = ctx.handle();
             UndoCloseStack::handle(ctx).update(ctx, |stack, ctx| {
                 log::info!("storing data for closed tab");

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -176,8 +176,9 @@ use crate::drive::export::ExportManager;
 use crate::drive::settings::WarpDriveSettings;
 use crate::launch_configs::launch_config::WindowTemplate;
 use crate::pane_group::{
-    AIFactPane, CodeReviewPanelArg, Direction as PaneGroupDirection, EnvironmentManagementPane,
-    ExecutionProfileEditorPane, NetworkLogPane, PaneGroup, PaneId, TerminalPaneId,
+    AIFactPane, ChildAgentOrigin, CodeReviewPanelArg, Direction as PaneGroupDirection,
+    EnvironmentManagementPane, ExecutionProfileEditorPane, NetworkLogPane, PaneGroup, PaneId,
+    TerminalPaneId,
 };
 use crate::quit_warning::UnsavedStateSummary;
 use crate::search::command_palette::view::NavigationMode;
@@ -10163,6 +10164,56 @@ impl Workspace {
         }
     }
 
+    /// If the tab at `index` was created by [`pane_group::Event::OpenChildAgentInNewTab`]
+    /// and still contains the lone child agent pane it was split off with,
+    /// move that pane back to the origin pane group as a hidden child agent
+    /// instead of letting the close path tear down its `TerminalView`.
+    /// Returns `true` if the re-adoption ran (the tab's pane group is now
+    /// empty) so the caller can skip the regular detach-for-close path.
+    fn try_re_adopt_split_off_child_agent_tab(
+        &mut self,
+        index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        let Some(tab_data) = self.tabs.get(index) else {
+            return false;
+        };
+        let Some(origin) = tab_data
+            .pane_group
+            .as_ref(ctx)
+            .child_agent_origin()
+            .cloned()
+        else {
+            return false;
+        };
+        let Some(source_pane_group) = origin.source_pane_group.upgrade(ctx) else {
+            return false;
+        };
+
+        let pane_group = tab_data.pane_group.clone();
+        // Expect a single pane in the split-off tab — the child agent's
+        // `TerminalView` we want to preserve. Bail if the layout has
+        // changed (e.g. the user split additional panes into the tab) so
+        // we don't accidentally disturb unrelated state.
+        let pane_ids: Vec<PaneId> = pane_group.as_ref(ctx).pane_ids().collect();
+        if pane_ids.len() != 1 {
+            return false;
+        }
+        let pane_id = pane_ids[0];
+
+        let Some(pane_content) =
+            pane_group.update(ctx, |pg, ctx| pg.remove_pane_for_move(&pane_id, ctx))
+        else {
+            return false;
+        };
+
+        source_pane_group.update(ctx, |pg, ctx| {
+            pg.re_adopt_child_agent_pane(pane_content, origin.conversation_id, ctx);
+        });
+
+        true
+    }
+
     fn remove_tab(
         &mut self,
         index: usize,
@@ -10170,7 +10221,7 @@ impl Workspace {
         detach_panes_for_close: bool,
         ctx: &mut ViewContext<Self>,
     ) {
-        let Some(tab_data) = self.tabs.get(index) else {
+        let Some(pane_group) = self.tabs.get(index).map(|t| t.pane_group.clone()) else {
             debug_assert!(false, "Tried to remove a tab with an invalid index");
             return;
         };
@@ -10180,7 +10231,7 @@ impl Workspace {
         // (either because the tab is being removed from `self.tabs`, or because we're about to
         // close the window for the last tab).
         self.vertical_tabs_panel
-            .clear_detail_sidecar_if_for_pane_group(tab_data.pane_group.id());
+            .clear_detail_sidecar_if_for_pane_group(pane_group.id());
 
         // If this is the last tab, close the window instead of actually removing
         // the tab.
@@ -10191,9 +10242,17 @@ impl Workspace {
             return;
         }
 
-        if detach_panes_for_close {
+        // If this tab is a split-off child agent tab (created via
+        // `OpenChildAgentInNewTab`), re-adopt its lone pane back into the
+        // source pane group so the live `TerminalView` survives the tab
+        // close. When this succeeds, the tab's pane group becomes empty
+        // and we skip the regular detach-for-close path — there are no
+        // panes left to detach.
+        let re_adopted = self.try_re_adopt_split_off_child_agent_tab(index, ctx);
+
+        if !re_adopted && detach_panes_for_close {
             let working_directories_model = self.working_directories_model.clone();
-            tab_data.pane_group.update(ctx, |pane_group, ctx| {
+            pane_group.update(ctx, |pane_group, ctx| {
                 pane_group.for_all_terminal_panes(
                     |terminal_view, ctx| {
                         if terminal_view
@@ -13719,38 +13778,45 @@ impl Workspace {
             pane_group::Event::RemoteRepoNavigated { .. } => {}
             pane_group::Event::OpenChildAgentInNewTab { conversation_id } => {
                 // "Open in new tab" from the orchestration pill bar's 3-dot
-                // menu. Spawn a fresh session tab and enter agent view for
-                // the child conversation. The conversation already lives in
-                // `BlocklistAIHistoryModel`, so the new terminal view can
-                // adopt it without any restoration plumbing — just call
-                // `enter_agent_view_for_conversation` on it.
+                // menu. Reuse the existing hidden child agent pane that
+                // already hosts the live `TerminalView` for this conversation
+                // by detaching it from the orchestrator's pane group and
+                // adopting it into a new tab's pane group. Creating a fresh
+                // tab with a new terminal view and calling
+                // `enter_agent_view_for_conversation` on it would clone the
+                // conversation into a second view, cancelling any in-flight
+                // commands running in the original view and briefly leaking
+                // the child transcript into the orchestrator pane while
+                // ownership shuffles between views.
                 let conversation_id = *conversation_id;
-                let window_id = ctx.window_id();
-                self.add_new_session_tab_with_default_mode(
-                    NewSessionSource::Tab,
-                    Some(window_id),
-                    None, /* chosen_shell */
-                    None, /* conversation_restoration */
-                    true, /* hide_homepage */
-                    ctx,
-                );
-                if let Some(terminal_view) = self
-                    .active_tab_pane_group()
-                    .as_ref(ctx)
-                    .active_session_view(ctx)
-                {
-                    terminal_view.update(ctx, |view, ctx| {
-                        view.enter_agent_view_for_conversation(
-                            None,
-                            AgentViewEntryOrigin::OrchestrationPillBar,
-                            conversation_id,
-                            ctx,
-                        );
-                    });
-                } else {
+                let removed_pane = pane_group.update(ctx, |pg, ctx| {
+                    pg.take_child_agent_pane_for_split_off(conversation_id, ctx)
+                });
+                let Some(removed_pane) = removed_pane else {
                     log::warn!(
-                        "OpenChildAgentInNewTab: no active terminal view in newly created tab"
+                        "OpenChildAgentInNewTab: no hidden child pane registered for conversation {conversation_id:?}"
                     );
+                    return;
+                };
+                let new_tab_index = match TabSettings::as_ref(ctx).new_tab_placement {
+                    NewTabPlacement::AfterAllTabs => self.tab_count(),
+                    NewTabPlacement::AfterCurrentTab => self.active_tab_index + 1,
+                };
+                let source_pane_group = pane_group.downgrade();
+                self.add_tab_from_existing_pane(removed_pane, new_tab_index, ctx);
+                // Stamp the new tab's pane group with the source origin so
+                // closing the tab can re-adopt the live `TerminalView` back
+                // to the source instead of dropping it. The new tab is
+                // active after `add_tab_from_existing_pane`.
+                if let Some(new_pane_group) =
+                    self.get_pane_group_view(self.active_tab_index).cloned()
+                {
+                    new_pane_group.update(ctx, |pg, _ctx| {
+                        pg.set_child_agent_origin(ChildAgentOrigin {
+                            source_pane_group,
+                            conversation_id,
+                        });
+                    });
                 }
             }
             pane_group::Event::DroppedOnTabBar { origin, pane_id } => {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -10307,7 +10307,15 @@ impl Workspace {
         // close. When this succeeds, the tab's pane group becomes empty
         // and we skip the regular detach-for-close path — there are no
         // panes left to detach.
-        let re_adopted = self.try_re_adopt_split_off_child_agent_tab(index, ctx);
+        //
+        // Only run for actual close paths. `remove_tab_without_undo`
+        // (used by cross-window tab transfers / drag-to-other-window)
+        // calls us with `detach_panes_for_close = false` — the pane
+        // group is being moved, not torn down, and re-adoption would
+        // yank the child pane back to its source orchestrator,
+        // stranding the user's drag target with an empty pane group.
+        let re_adopted =
+            detach_panes_for_close && self.try_re_adopt_split_off_child_agent_tab(index, ctx);
 
         if !re_adopted && detach_panes_for_close {
             let working_directories_model = self.working_directories_model.clone();


### PR DESCRIPTION
Loom: https://www.loom.com/share/77e59376fd5d4c51a15b1e3211b917ea
Fixes https://linear.app/warpdotdev/issue/QUALITY-627/remote-children-are-showing-blanks-agent-conversation-when-selected-in
Fixes https://linear.app/warpdotdev/issue/QUALITY-633/fix-child-agents-being-cancelled-when-switching-pills

------
## Problem

Fixes the cancelling of conversations due to exiting agent views.

The orchestration pill bar's swap mechanism kept two representations in sync: a hidden-pane visibility flag on the child's view, plus the layout tree itself. Steady state worked, but anything that took the child outside the in-place context — split-off into its own slot, open-in-new-tab, close, re-adopt, ESC back to the parent, cross-tab focus, app restart — accumulated bugs as the two drifted. The worst cases were the ones where a child was simultaneously the swap target of one orchestrator and a split-off sibling visible elsewhere, or where the parent was preserved on close but later resurrected the just-closed child via a stale entry.

## Design

Swaps now use one mechanism: a temporary replacement in the layout tree, with the original restored on revert. There is exactly one `TerminalView` per child agent for its entire lifetime. The child pane lives off-tree by default and only enters the layout when the user puts it there (swap, split, or open-in-new-tab); every path that changes the in-place context — close, split, re-adopt, exit-and-reenter agent view, cross-tab focus, snapshot persistence — reverts any active swap first and reuses the live view. The visibility flags are gone, so they can't drift. The persistence layer also substitutes the orchestrator for any swapped-in child when snapshotting a tab, so app restart restores the canonical layout rather than leaving the child stuck as the visible leaf.

A few smaller pieces fall out of this. A new history-model API updates the active-conversation pointer without ripping the conversation off other views (the existing transferring API is preserved for paths that genuinely move ownership). Guards on the agent-view exit path skip SSE teardown when the exit is part of an in-place swap. And the helper that reverts a swap also clears the orchestration-split-off marker, so a single call site handles both the in-place and split-off-then-swapped-over cases.

## UI fix

Breadcrumb row in split-off panes is now horizontally centered.

## Testing

- `cargo fmt && cargo check -p warp` and `cargo clippy -p warp --all-targets --tests -- -D warnings` both pass clean.
- Manually validated:
  - Pill-click swap between orchestrator and any child, in any order; child→child swap; orchestrator pill no-ops on self.
  - Open in new pane / Open in new tab on a child whether currently swapped in or not; live conversation survives across the move; Open in new tab close path re-adopts the live view back to the source pane group.
  - Close on a swapped-in child reverts cleanly and leaves the pill clickable.
  - Close on a split-off child preserves it off-tree; subsequent pill clicks swap as expected.
  - Close on a split-off-then-swapped-over child does not resurrect the just-closed pane via a future revert of the surviving sibling.
  - ESC + back button from a child navigates to the parent conversation, including across tabs.
  - Cross-tab focus to a pane currently occluded by a swap reveals it and refreshes back-button labels.
  - Tab restore on restart preserves the orchestrator (not the child) as the canonical leaf; active session marker matches what the user last saw.
  - Breadcrumbs centered when fitting; overflow scroll preserved.
