### PR TITLE
Add vim ctrl-d/ctrl-u and zz scroll commands in code editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,12 @@ app/src/persistence/schema.rs.orig
 # Don't include Claude Code worktrees
 .claude/worktrees/
 
+# Don't include Claude Code scheduled task lock
+.claude/scheduled_tasks.lock
+
+# Don't include ctags output
+tags
+
 # Tab drag development notes
 pr_cleanup.md
 desired_behavior.md

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -2361,8 +2361,14 @@ impl View for CodeEditorView {
         }
         if let Some(vim_mode) = self.vim_mode(app) {
             context.set.insert("Vim");
-            if vim_mode == VimMode::Normal {
-                context.set.insert("VimNormalMode");
+            match vim_mode {
+                VimMode::Normal => {
+                    context.set.insert("VimNormalMode");
+                }
+                VimMode::Visual(_) => {
+                    context.set.insert("VimVisualMode");
+                }
+                _ => {}
             }
         }
         if self.find_bar.is_some() {

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -2368,7 +2368,7 @@ impl View for CodeEditorView {
                 VimMode::Visual(_) => {
                     context.set.insert("VimVisualMode");
                 }
-                _ => {}
+                VimMode::Insert | VimMode::Replace => {}
             }
         }
         if self.find_bar.is_some() {

--- a/app/src/code/editor/view/actions.rs
+++ b/app/src/code/editor/view/actions.rs
@@ -34,7 +34,7 @@ use warpui::{
     elements::Axis,
     event::ModifiersState,
     keymap::{EditableBinding, FixedBinding, Keystroke, PerPlatformKeystroke},
-    units::Pixels,
+    units::{IntoPixels, Pixels},
     AppContext, TypedActionView, ViewContext, WeakViewHandle,
 };
 
@@ -508,8 +508,24 @@ pub fn init(app: &mut AppContext) {
         .with_context_predicate(text_entry.clone())
         .with_key_binding("cmdorctrl-/"),
         EditableBinding::new("editor_view:delete", "Delete", CodeEditorViewAction::Delete)
-            .with_context_predicate(text_entry.clone())
+            .with_context_predicate(
+                text_entry.clone() & !id!("VimNormalMode") & !id!("VimVisualMode"),
+            )
             .with_key_binding("ctrl-d"),
+        EditableBinding::new(
+            "editor_view:vim_scroll_half_page_down",
+            "Scroll down half a page (vim)",
+            CodeEditorViewAction::ScrollHalfPageDown,
+        )
+        .with_context_predicate(text_entry.clone() & (id!("VimNormalMode") | id!("VimVisualMode")))
+        .with_key_binding("ctrl-d"),
+        EditableBinding::new(
+            "editor_view:vim_scroll_half_page_up",
+            "Scroll up half a page (vim)",
+            CodeEditorViewAction::ScrollHalfPageUp,
+        )
+        .with_context_predicate(text_entry.clone() & (id!("VimNormalMode") | id!("VimVisualMode")))
+        .with_key_binding("ctrl-u"),
         EditableBinding::new(
             "editor_view:cut_word_left",
             "Cut word left",
@@ -616,6 +632,8 @@ pub enum CodeEditorViewAction {
     ToggleComment,
     ScrollVertical(Pixels),
     ScrollHorizontal(Pixels),
+    ScrollHalfPageDown,
+    ScrollHalfPageUp,
     SelectUp,
     SelectDown,
     SelectLeft,
@@ -753,6 +771,8 @@ impl CodeEditorViewAction {
             Self::WindowsCtrlC => true,
             Self::ScrollVertical(_)
             | Self::ScrollHorizontal(_)
+            | Self::ScrollHalfPageDown
+            | Self::ScrollHalfPageUp
             | Self::SelectUp
             | Self::SelectDown
             | Self::SelectLeft
@@ -867,6 +887,32 @@ impl TypedActionView for CodeEditorView {
                     render_state.scroll_horizontal(*delta, ctx);
                 })
             }),
+            ScrollHalfPageDown => {
+                let model = self.model.as_ref(ctx);
+                let half = (model.lines_in_viewport(ctx) / 2).max(1);
+                let scroll_pixels = (-(half as f32 * model.line_height(ctx))).into_pixels();
+                self.model.update(ctx, |model, ctx| {
+                    for _ in 0..half {
+                        model.move_down(ctx);
+                    }
+                    model.render_state().update(ctx, |render_state, ctx| {
+                        render_state.scroll(scroll_pixels, ctx);
+                    });
+                });
+            }
+            ScrollHalfPageUp => {
+                let model = self.model.as_ref(ctx);
+                let half = (model.lines_in_viewport(ctx) / 2).max(1);
+                let scroll_pixels = (half as f32 * model.line_height(ctx)).into_pixels();
+                self.model.update(ctx, |model, ctx| {
+                    for _ in 0..half {
+                        model.move_up(ctx);
+                    }
+                    model.render_state().update(ctx, |render_state, ctx| {
+                        render_state.scroll(scroll_pixels, ctx);
+                    });
+                });
+            }
             SelectUp => self.model.update(ctx, |model, ctx| {
                 model.select_up(ctx);
             }),

--- a/app/src/code/editor/view/vim_handler.rs
+++ b/app/src/code/editor/view/vim_handler.rs
@@ -18,6 +18,7 @@ use warp_editor::{
         ToBufferCharOffset as _, VimInsertPoint,
     },
     model::{CoreEditorModel, PlainTextEditorModel},
+    render::model::AutoScrollMode,
     selection::{TextDirection, TextUnit},
 };
 use warpui::{text::point::Point, SingletonEntity, ViewContext};
@@ -920,6 +921,24 @@ impl VimHandler for CodeEditorView {
 
     fn show_hover(&mut self, ctx: &mut ViewContext<Self>) {
         ctx.emit(CodeEditorEvent::VimShowHover);
+    }
+
+    fn center_cursor_vertically(&mut self, ctx: &mut ViewContext<Self>) {
+        let cursor_offset = self
+            .model
+            .as_ref(ctx)
+            .buffer_selection_model()
+            .as_ref(ctx)
+            .first_selection_head();
+        self.model
+            .as_ref(ctx)
+            .render_state()
+            .clone()
+            .update(ctx, |render_state, _ctx| {
+                render_state.request_autoscroll_to(AutoScrollMode::PositionOffsetInViewportCenter(
+                    cursor_offset,
+                ));
+            });
     }
 }
 

--- a/app/src/code/editor/view/vim_handler_tests.rs
+++ b/app/src/code/editor/view/vim_handler_tests.rs
@@ -1436,3 +1436,94 @@ fn test_vim_visual_linewise_delete_first_line_does_not_panic() {
         assert_eq!(buffer_text(&editor, &app), "bbb\nccc");
     });
 }
+
+#[test]
+fn test_vim_zz_in_normal_mode_preserves_cursor_and_mode() {
+    let _feature_flag_guard = FeatureFlag::VimCodeEditor.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_code_editor_app(&mut app);
+        let editor = add_code_editor(
+            "line 1
+            line 2
+            line 3
+            line 4
+            line 5",
+            &mut app,
+        );
+
+        layout_editor_view(&mut app, &editor).await;
+
+        // Place cursor on line 3, then center it. zz scrolls but should not move
+        // the cursor or change the mode.
+        set_cursor_position(&editor, 3, 0, &mut app);
+        assert_eq!(cursor_position(&editor, &app), (3, 0));
+        assert_eq!(vim_mode(&editor, &app), Some(VimMode::Normal));
+
+        vim_user_insert(&editor, "zz", &mut app);
+
+        assert_eq!(cursor_position(&editor, &app), (3, 0));
+        assert_eq!(vim_mode(&editor, &app), Some(VimMode::Normal));
+    });
+}
+
+#[test]
+fn test_vim_zz_in_visual_mode_preserves_cursor_and_mode() {
+    let _feature_flag_guard = FeatureFlag::VimCodeEditor.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_code_editor_app(&mut app);
+        let editor = add_code_editor(
+            "line 1
+            line 2
+            line 3
+            line 4
+            line 5",
+            &mut app,
+        );
+
+        layout_editor_view(&mut app, &editor).await;
+
+        set_cursor_position(&editor, 3, 0, &mut app);
+        vim_user_insert(&editor, "v", &mut app);
+        assert_eq!(
+            vim_mode(&editor, &app),
+            Some(VimMode::Visual(MotionType::Charwise))
+        );
+
+        vim_user_insert(&editor, "zz", &mut app);
+
+        assert_eq!(cursor_position(&editor, &app), (3, 0));
+        assert_eq!(
+            vim_mode(&editor, &app),
+            Some(VimMode::Visual(MotionType::Charwise))
+        );
+    });
+}
+
+#[test]
+fn test_vim_z_followed_by_non_z_clears_pending() {
+    let _feature_flag_guard = FeatureFlag::VimCodeEditor.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_code_editor_app(&mut app);
+        let editor = add_code_editor(
+            "line 1
+            line 2
+            line 3",
+            &mut app,
+        );
+
+        layout_editor_view(&mut app, &editor).await;
+
+        // `z` followed by an unrecognized char should clear the pending action.
+        // After that, a subsequent `j` should move the cursor down one line as normal.
+        set_cursor_position(&editor, 1, 0, &mut app);
+        vim_user_insert(&editor, "z", &mut app);
+        vim_user_insert(&editor, "x", &mut app);
+        assert_eq!(cursor_position(&editor, &app), (1, 0));
+
+        vim_user_insert(&editor, "j", &mut app);
+        assert_eq!(cursor_position(&editor, &app), (2, 0));
+    });
+}

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -245,6 +245,8 @@ enum PendingAction {
     },
     /// the full "g" command
     G,
+    /// the full "z" command (e.g. zz)
+    Z,
     FindChar {
         direction: Direction,
         destination: FindCharDestination,
@@ -269,6 +271,7 @@ impl From<char> for PendingAction {
                 pending_operand: None,
             },
             'g' => Self::G,
+            'z' => Self::Z,
             'f' => Self::FindChar {
                 direction: Direction::Forward,
                 destination: FindCharDestination::AtChar,
@@ -586,6 +589,8 @@ pub enum VimEventType {
     GotoDefinition,
     FindReferences,
     ShowHover,
+    /// Center the current line vertically in the viewport. Triggered by `zz`.
+    CenterCursorVertically,
 }
 
 impl VimEventType {
@@ -643,7 +648,8 @@ impl VimEventType {
             | VimEventType::Escape
             | VimEventType::GotoDefinition
             | VimEventType::FindReferences
-            | VimEventType::ShowHover => None,
+            | VimEventType::ShowHover
+            | VimEventType::CenterCursorVertically => None,
         }
     }
 }
@@ -917,7 +923,7 @@ impl VimFSA {
                     },
                 ),
                 'r' => self.change_mode(VimMode::Replace.into()),
-                'g' | 'd' | 'c' | 'y' | 'f' | 'F' | 't' | 'T' | '[' | ']' | '"' => {
+                'g' | 'd' | 'c' | 'y' | 'z' | 'f' | 'F' | 't' | 'T' | '[' | ']' | '"' => {
                     self.pending_action = Some(PendingAction::from(c));
                     return None;
                 }
@@ -1025,6 +1031,13 @@ impl VimFSA {
         action: PendingAction,
     ) -> Option<VimEventType> {
         let event = match action {
+            PendingAction::Z => match c {
+                'z' => VimEventType::CenterCursorVertically,
+                _ => {
+                    self.clear();
+                    return None;
+                }
+            },
             PendingAction::G => match c {
                 'e' | 'E' => VimEventType::Navigate(VimMotion::Word(WordMotion {
                     direction: Direction::Backward,
@@ -1467,7 +1480,7 @@ impl VimFSA {
                     write_register_name,
                 }
             }
-            'g' | 'f' | 'F' | 't' | 'T' | '[' | ']' | '"' => {
+            'g' | 'z' | 'f' | 'F' | 't' | 'T' | '[' | ']' | '"' => {
                 self.pending_action = Some(PendingAction::from(c));
                 return None;
             }
@@ -1502,6 +1515,13 @@ impl VimFSA {
         pending_action: PendingAction,
     ) -> Option<VimEventType> {
         let event_type = match pending_action {
+            PendingAction::Z => match c {
+                'z' => VimEventType::CenterCursorVertically,
+                _ => {
+                    self.clear();
+                    return None;
+                }
+            },
             PendingAction::G => match c {
                 'e' | 'E' => VimEventType::Navigate(VimMotion::Word(WordMotion {
                     direction: Direction::Backward,
@@ -1885,6 +1905,7 @@ where
             VimEventType::GotoDefinition => self.goto_definition(ctx),
             VimEventType::FindReferences => self.find_references(ctx),
             VimEventType::ShowHover => self.show_hover(ctx),
+            VimEventType::CenterCursorVertically => self.center_cursor_vertically(ctx),
         };
     }
 }
@@ -2003,4 +2024,6 @@ pub trait VimHandler {
     fn find_references(&mut self, _ctx: &mut ViewContext<Self>) {}
     /// Show hover information for the symbol under cursor (gh).
     fn show_hover(&mut self, _ctx: &mut ViewContext<Self>) {}
+    /// Center the current line vertically in the viewport (zz).
+    fn center_cursor_vertically(&mut self, _ctx: &mut ViewContext<Self>) {}
 }


### PR DESCRIPTION
## Description

Adds vim normal/visual mode support for two missing scroll commands in
the code editor:

- **`ctrl-d` / `ctrl-u`** — scroll the viewport down/up by half a page
  (cursor and view together). Previously `ctrl-d` deleted the character
  under the cursor.
- **`zz`** — scroll the viewport so the cursor's line is centered
  vertically. Cursor position and mode are preserved.

Both behaviors work in vim normal mode and visual mode. Insert mode is
unchanged.

## Linked Issue

Fixes #8953 (ctrl-d/ctrl-u half-page scroll)
Fixes #8364 (zz center cursor vertically)

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- 3 unit tests in `vim_handler_tests.rs`: `zz` in normal mode, `zz` in
  visual mode, `z<non-z>` clearing pending state.
- `cargo fmt --check` and
  `cargo clippy -p warp -p vim --tests --no-deps -- -D warnings` pass cleanly.
- Manually verified ctrl-d, ctrl-u, and zz in vim normal/visual mode in
  an open file. Insert mode behavior unchanged.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

ctrl-d and ctrl-u
https://github.com/user-attachments/assets/56fd0523-45c9-4933-b829-ebf62db9f83d

zz
https://github.com/user-attachments/assets/bc6737e1-186e-4998-8693-5b3ef38664a8

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Used claude code

CHANGELOG-IMPROVEMENT: vim ctrl-d / ctrl-u scroll the code editor by half a page in normal and visual mode
CHANGELOG-IMPROVEMENT: vim zz centers the cursor's line vertically in the code editor