### PR TITLE
load files for the command palette async so it opens faster

### DIFF
--- a/app/src/search/command_palette/files/data_source.rs
+++ b/app/src/search/command_palette/files/data_source.rs
@@ -127,47 +127,56 @@ impl FileDataSource {
 
         let (contents, git_changed_files) = self.contents_with_git_changes(app);
 
-        let mut results = Vec::new();
-
         let opened_files = OpenedFilesModel::as_ref(app);
 
         let repo_root = file_search_model.repo_root(app);
-        let opened_files =
-            repo_root.and_then(|repo_root| opened_files.opened_files_for_repo(&repo_root));
+        let opened_files = repo_root
+            .and_then(|repo_root| opened_files.opened_files_for_repo(&repo_root))
+            .cloned();
 
-        for item in contents.iter() {
-            let mut file_ranking = if git_changed_files.contains(&item.path) {
-                FileRanking::ChangedInGit
-            } else {
-                FileRanking::None
-            };
+        const CHUNK_SIZE: usize = 50;
 
-            if let Some(last_opened_timestamp) =
-                opened_files.and_then(|opened_files| opened_files.get(&PathBuf::from(&item.path)))
-            {
-                file_ranking = FileRanking::OpenedInWarp {
-                    timestamp: *last_opened_timestamp,
-                };
+        Box::pin(async move {
+            let mut results = Vec::new();
+
+            for chunk in contents.chunks(CHUNK_SIZE) {
+                for item in chunk {
+                    let mut file_ranking = if git_changed_files.contains(&item.path) {
+                        FileRanking::ChangedInGit
+                    } else {
+                        FileRanking::None
+                    };
+
+                    if let Some(last_opened_timestamp) = opened_files
+                        .as_ref()
+                        .and_then(|opened_files| opened_files.get(&PathBuf::from(&item.path)))
+                    {
+                        file_ranking = FileRanking::OpenedInWarp {
+                            timestamp: *last_opened_timestamp,
+                        };
+                    }
+
+                    let match_result = FuzzyMatchResult {
+                        score: 0,
+                        matched_indices: vec![], // No highlighting needed for zero state
+                    };
+
+                    let search_item = FileSearchItem {
+                        path: PathBuf::from(&item.path),
+                        project_directory: item.project_directory.clone(),
+                        match_result,
+                        line_and_column_arg: None,
+                        is_directory: item.is_directory,
+                    };
+                    results.push((file_ranking, QueryResult::from(search_item)));
+                }
+                futures_lite::future::yield_now().await;
             }
 
-            let match_result = FuzzyMatchResult {
-                score: 0,
-                matched_indices: vec![], // No highlighting needed for zero state
-            };
+            results.sort_by_key(|(ranking, _)| *ranking);
 
-            let search_item = FileSearchItem {
-                path: PathBuf::from(&item.path),
-                project_directory: item.project_directory.clone(),
-                match_result,
-                line_and_column_arg: None,
-                is_directory: item.is_directory,
-            };
-            results.push((file_ranking, QueryResult::from(search_item)));
-        }
-
-        results.sort_by_key(|(ranking, _)| *ranking);
-
-        Box::pin(async move { Ok(results.into_iter().map(|(_, ranking)| ranking).collect()) })
+            Ok(results.into_iter().map(|(_, ranking)| ranking).collect())
+        })
     }
 
     /// Handle non-empty query with fuzzy matching (no git status needed)

--- a/app/src/search/command_palette/files/data_source.rs
+++ b/app/src/search/command_palette/files/data_source.rs
@@ -134,12 +134,10 @@ impl FileDataSource {
             .and_then(|repo_root| opened_files.opened_files_for_repo(&repo_root))
             .cloned();
 
-        const CHUNK_SIZE: usize = 50;
-
         Box::pin(async move {
             let mut results = Vec::new();
 
-            for chunk in contents.chunks(CHUNK_SIZE) {
+            for chunk in contents.chunks(50) {
                 for item in chunk {
                     let mut file_ranking = if git_changed_files.contains(&item.path) {
                         FileRanking::ChangedInGit


### PR DESCRIPTION
## Description

This PR refactors the `FileDataSource` to load the files asynchronously. This avoids blocking the main thread and solves the momentary pause when opening the command palette.

## Linked Issue

Fixes #10256


## Testing

No perceived changes in local testing. On slower machines, the results may not actually appear for a couple of seconds while the data source is still computing the results.

I sent the user a custom built from this branch and they have confirmed it solves the issue

https://github.com/warpdotdev/warp/issues/10256#issuecomment-4394618726


## Changelog Entries for Stable


CHANGELOG-IMPROVEMENT: Performance improvement for opening the command palette when in a project with a lot of files.
