### PR TITLE
Add a background to harness icons in conversation details panel.

### DIFF
--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -66,7 +66,8 @@ use crate::workspaces::user_profiles::UserProfiles;
 
 const FIELD_SPACING: f32 = 16.0;
 const HEADER_SPACING: f32 = 12.0;
-const STATUS_ICON_SIZE: f32 = 12.0;
+const STATUS_ICON_SIZE: f32 = 16.0;
+const HARNESS_ICON_IN_CIRCLE: f32 = 9.0;
 const LABEL_VALUE_GAP: f32 = 4.0;
 const SECTION_HEADER_GAP: f32 = 8.0;
 
@@ -1095,18 +1096,24 @@ impl ConversationDetailsPanel {
         .with_color(blended_colors::text_sub(theme, theme.surface_1()))
         .finish();
 
-        let icon_tint = harness_display::brand_color(harness)
-            .map(Into::into)
-            .unwrap_or_else(|| theme.foreground());
-
-        let icon = ConstrainedBox::new(
+        let circle_bg = harness_display::circle_background(harness, theme);
+        let icon_fill = harness_display::icon_fill_on_circle(harness, theme);
+        let icon_glyph = ConstrainedBox::new(
             harness_display::icon_for(harness)
-                .to_warpui_icon(icon_tint)
+                .to_warpui_icon(icon_fill)
                 .finish(),
         )
-        .with_width(16.)
-        .with_height(16.)
+        .with_width(HARNESS_ICON_IN_CIRCLE)
+        .with_height(HARNESS_ICON_IN_CIRCLE)
         .finish();
+        let icon_padding = (STATUS_ICON_SIZE - HARNESS_ICON_IN_CIRCLE) / 2.;
+        let icon = Container::new(icon_glyph)
+            .with_uniform_padding(icon_padding)
+            .with_background(circle_bg)
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(
+                STATUS_ICON_SIZE / 2.,
+            )))
+            .finish();
 
         let name = Text::new(
             availability.display_name_for(harness).to_string(),

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -66,7 +66,8 @@ use crate::workspaces::user_profiles::UserProfiles;
 
 const FIELD_SPACING: f32 = 16.0;
 const HEADER_SPACING: f32 = 12.0;
-const STATUS_ICON_SIZE: f32 = 16.0;
+const STATUS_ICON_SIZE: f32 = 12.0;
+const HARNESS_CIRCLE_SIZE: f32 = 16.0;
 const HARNESS_ICON_IN_CIRCLE: f32 = 9.0;
 const LABEL_VALUE_GAP: f32 = 4.0;
 const SECTION_HEADER_GAP: f32 = 8.0;
@@ -1106,12 +1107,12 @@ impl ConversationDetailsPanel {
         .with_width(HARNESS_ICON_IN_CIRCLE)
         .with_height(HARNESS_ICON_IN_CIRCLE)
         .finish();
-        let icon_padding = (STATUS_ICON_SIZE - HARNESS_ICON_IN_CIRCLE) / 2.;
+        let icon_padding = (HARNESS_CIRCLE_SIZE - HARNESS_ICON_IN_CIRCLE) / 2.;
         let icon = Container::new(icon_glyph)
             .with_uniform_padding(icon_padding)
             .with_background(circle_bg)
             .with_corner_radius(CornerRadius::with_all(Radius::Pixels(
-                STATUS_ICON_SIZE / 2.,
+                HARNESS_CIRCLE_SIZE / 2.,
             )))
             .finish();
 

--- a/app/src/ai/harness_display.rs
+++ b/app/src/ai/harness_display.rs
@@ -7,9 +7,12 @@
 use pathfinder_color::ColorU;
 use warp_cli::agent::Harness;
 
+use warp_core::ui::theme::color::internal_colors;
+use warp_core::ui::theme::{Fill as WarpThemeFill, WarpTheme};
+
 use crate::ai::agent::conversation::AIAgentHarness;
 use crate::ai::blocklist::CLAUDE_ORANGE;
-use crate::terminal::cli_agent::{GEMINI_BLUE, OPENAI_COLOR};
+use crate::terminal::cli_agent::{GEMINI_BLUE, OPENAI_COLOR, OPENCODE_COLOR};
 use crate::ui_components::icons::Icon;
 
 /// User-visible display name for a [`Harness`].
@@ -46,6 +49,31 @@ pub fn brand_color(harness: Harness) -> Option<ColorU> {
         Harness::Gemini => Some(GEMINI_BLUE),
         Harness::Codex => Some(OPENAI_COLOR),
         Harness::Unknown => None,
+    }
+}
+
+/// Circle background fill for a [`Harness`] icon rendered in a branded circle.
+/// Matches the treatment used in the vertical-tabs sidebar.
+pub fn circle_background(harness: Harness, theme: &WarpTheme) -> WarpThemeFill {
+    match harness {
+        Harness::Oz => theme.background(),
+        Harness::Claude => WarpThemeFill::Solid(CLAUDE_ORANGE),
+        Harness::Codex => WarpThemeFill::Solid(OPENAI_COLOR),
+        Harness::Gemini => WarpThemeFill::Solid(GEMINI_BLUE),
+        Harness::OpenCode => WarpThemeFill::Solid(OPENCODE_COLOR),
+        Harness::Unknown => internal_colors::fg_overlay_2(theme),
+    }
+}
+
+/// Icon fill color when rendered on the branded circle background.
+pub fn icon_fill_on_circle(harness: Harness, theme: &WarpTheme) -> WarpThemeFill {
+    match harness {
+        Harness::Oz => theme.main_text_color(theme.background()),
+        Harness::Claude
+        | Harness::Codex
+        | Harness::Gemini
+        | Harness::OpenCode
+        | Harness::Unknown => WarpThemeFill::Solid(ColorU::white()),
     }
 }
 

--- a/app/src/ai/harness_display.rs
+++ b/app/src/ai/harness_display.rs
@@ -69,11 +69,10 @@ pub fn circle_background(harness: Harness, theme: &WarpTheme) -> WarpThemeFill {
 pub fn icon_fill_on_circle(harness: Harness, theme: &WarpTheme) -> WarpThemeFill {
     match harness {
         Harness::Oz => theme.main_text_color(theme.background()),
-        Harness::Claude
-        | Harness::Codex
-        | Harness::Gemini
-        | Harness::OpenCode
-        | Harness::Unknown => WarpThemeFill::Solid(ColorU::white()),
+        Harness::Claude | Harness::Codex | Harness::Gemini | Harness::OpenCode => {
+            WarpThemeFill::Solid(ColorU::white())
+        }
+        Harness::Unknown => theme.main_text_color(internal_colors::fg_overlay_2(theme)),
     }
 }
 

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -65,7 +65,7 @@ const DROID_COLOR: ColorU = ColorU {
 };
 
 /// OpenCode brand color (gray, used for contrast calculation only)
-const OPENCODE_COLOR: ColorU = ColorU {
+pub(crate) const OPENCODE_COLOR: ColorU = ColorU {
     r: 128,
     g: 128,
     b: 128,


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
This PR adds a background to the harness icons in the conversation details panel (as per your original suggestion, Harry 😛 ). This should make it easier to see all of the logos regardless of what theme someone is using.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end. 

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up. 
-->
Tested locally on a few different themes.
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

Before:
<img width="271" height="164" alt="image" src="https://github.com/user-attachments/assets/4547eb98-eba8-47a7-8689-412f5dbeabd5" />

After:
https://www.loom.com/share/fc7e9a250de04cff813a712ab22f10bc



## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
