### PR TITLE
Support MCP servers for third-party harnesses.

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1628,9 +1628,16 @@ impl AgentDriver {
         }
 
         // Prepare harness config files (onboarding, trust dialog, API-key approval, etc.).
+        // `resolved_env_vars` carries the full env for the terminal session so harnesses
+        // can look up auth keys without re-deriving precedence.
+        let resolved_env_vars = foreground
+            .spawn(|me, _| Arc::clone(&me.resolved_env_vars))
+            .await
+            .map_err(|_| AgentDriverError::InvalidRuntimeState)?;
         harness.prepare_environment_config(
             &working_dir,
             system_prompt.as_deref(),
+            &resolved_env_vars,
             &secrets,
             &resolved_mcp_servers,
         )?;

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -17,7 +17,7 @@ use std::{
 use crate::ai::blocklist::task_status_sync_model::TaskStatusSyncModel;
 use crate::ai::document::ai_document_model::{AIDocumentModel, AIDocumentModelEvent};
 use crate::ai::llms::{LLMId, LLMPreferences};
-use crate::ai::mcp::MCPServerState;
+use crate::ai::mcp::{JSONMCPServer, MCPServerState};
 use crate::ai::skills::{SkillManager, SkillWatcher};
 use crate::ai::{
     agent::conversation::AIConversationId,
@@ -53,7 +53,7 @@ use crate::{
         execution_profiles::profiles::AIExecutionProfilesModel,
         mcp::{
             file_based_manager::{FileBasedMCPManager, FileBasedMCPManagerEvent},
-            parsing::{normalize_mcp_json, ParsedTemplatableMCPServerResult},
+            parsing::{normalize_mcp_json, resolve_json, ParsedTemplatableMCPServerResult},
             templatable_manager::TemplatableMCPServerManagerEvent,
             TemplatableMCPServerInstallation, TemplatableMCPServerManager,
         },
@@ -783,6 +783,44 @@ impl AgentDriver {
         }
     }
 
+    /// Resolve MCP specs into a map of MCP name to `JSONMCPServer` for use in
+    /// third-party harnesses. Each spec is fully resolved (secrets applied, templates
+    /// rendered) so harnesses can serialize directly into their native config format.
+    fn resolve_mcp_specs_to_json(
+        specs: &[MCPSpec],
+        secrets: &HashMap<String, ManagedSecretValue>,
+        ctx: &ModelContext<Self>,
+    ) -> Result<HashMap<String, JSONMCPServer>, AgentDriverError> {
+        let (existing_uuids, mut ephemeral_installations) = Self::resolve_mcp_specs(specs)?;
+        let mut result = HashMap::new();
+
+        // Resolve UUID-referenced servers from the TemplatableMCPServerManager.
+        let manager = TemplatableMCPServerManager::as_ref(ctx);
+        for uuid in &existing_uuids {
+            let installation = manager
+                .get_installed_server(uuid)
+                .ok_or(AgentDriverError::MCPServerNotFound(*uuid))?
+                .clone();
+            let mut installation = installation;
+            installation.apply_secrets(secrets);
+            let resolved = resolve_json(&installation);
+            let servers: HashMap<String, JSONMCPServer> = serde_json::from_str(&resolved)
+                .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
+            result.extend(servers);
+        }
+
+        // Resolve ephemeral (inline JSON) servers.
+        for installation in ephemeral_installations.iter_mut() {
+            installation.apply_secrets(secrets);
+            let resolved = resolve_json(installation);
+            let servers: HashMap<String, JSONMCPServer> = serde_json::from_str(&resolved)
+                .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
+            result.extend(servers);
+        }
+
+        Ok(result)
+    }
+
     /// Resolve MCP specs into UUIDs for existing servers and ephemeral installations for inline specs.
     ///
     /// Returns (existing_server_uuids, ephemeral_installations)
@@ -1444,8 +1482,13 @@ impl AgentDriver {
             }
             HarnessKind::ThirdParty(harness) => {
                 let harness_exit_rx = Self::setup_harness(harness.as_ref(), &foreground).await?;
-                let runner =
-                    Self::prepare_harness(&task.prompt, harness.as_ref(), &foreground).await?;
+                let runner = Self::prepare_harness(
+                    &task.prompt,
+                    &task.mcp_specs,
+                    harness.as_ref(),
+                    &foreground,
+                )
+                .await?;
 
                 if let Some(task_id) = task_id_for_refresh {
                     let harness_fut =
@@ -1507,6 +1550,7 @@ impl AgentDriver {
     /// return a handle to the harness runner.
     async fn prepare_harness(
         prompt: &AgentRunPrompt,
+        mcp_specs: &[MCPSpec],
         harness: &dyn ThirdPartyHarness,
         foreground: &ModelSpawner<Self>,
     ) -> Result<Arc<dyn harness::HarnessRunner>, AgentDriverError> {
@@ -1563,18 +1607,38 @@ impl AgentDriver {
             }
         };
 
-        // Prepare harness config files (onboarding, trust dialog, API-key approval, etc.).
-        // Pass the terminal env vars (which include the resolved secrets) so harnesses
-        // can look up auth keys without re-deriving precedence.
-        let resolved_env_vars = foreground
-            .spawn(|me, _| Arc::clone(&me.resolved_env_vars))
+        let secrets = foreground
+            .spawn(|me, _| Arc::clone(&me.secrets))
             .await
             .map_err(|_| AgentDriverError::InvalidRuntimeState)?;
+
+        // Resolve MCP specs into harness-native JSON format.
+        let mcp_specs = mcp_specs.to_vec();
+        let secrets_for_mcp = Arc::clone(&secrets);
+        let resolved_mcp_servers = foreground
+            .spawn(move |_, ctx| Self::resolve_mcp_specs_to_json(&mcp_specs, &secrets_for_mcp, ctx))
+            .await
+            .map_err(|_| AgentDriverError::InvalidRuntimeState)?;
+        let resolved_mcp_servers = resolved_mcp_servers?;
+        if !resolved_mcp_servers.is_empty() {
+            log::info!(
+                "Resolved {} MCP server(s) for third-party harness",
+                resolved_mcp_servers.len()
+            );
+        }
+
+        // Prepare harness config files (onboarding, trust dialog, API-key approval, etc.).
         harness.prepare_environment_config(
             &working_dir,
             system_prompt.as_deref(),
-            &resolved_env_vars,
+            &secrets,
+            &resolved_mcp_servers,
         )?;
+
+        // Pull the resume payload off the driver so the harness runner can rehydrate any
+        // existing session/conversation state before launching its CLI. The payload variant
+        // is harness-specific; harnesses match on their own [`ResumePayload`] variant and
+        // ignore others.
         let resume = foreground
             .spawn(|me, _| me.resume_payload.take())
             .await
@@ -1590,6 +1654,7 @@ impl AgentDriver {
                 server_api,
                 terminal_driver,
                 resume,
+                &resolved_mcp_servers,
             )?
             .into();
 

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1614,9 +1614,8 @@ impl AgentDriver {
 
         // Resolve MCP specs into harness-native JSON format.
         let mcp_specs = mcp_specs.to_vec();
-        let secrets_for_mcp = Arc::clone(&secrets);
         let resolved_mcp_servers = foreground
-            .spawn(move |_, ctx| Self::resolve_mcp_specs_to_json(&mcp_specs, &secrets_for_mcp, ctx))
+            .spawn(move |_, ctx| Self::resolve_mcp_specs_to_json(&mcp_specs, &secrets, ctx))
             .await
             .map_err(|_| AgentDriverError::InvalidRuntimeState)?;
         let resolved_mcp_servers = resolved_mcp_servers?;
@@ -1628,7 +1627,7 @@ impl AgentDriver {
         }
 
         // Prepare harness config files (onboarding, trust dialog, API-key approval, etc.).
-        // `resolved_env_vars` carries the full env for the terminal session so harnesses
+        // Pass the terminal env vars (which include the resolved secrets) so harnesses
         // can look up auth keys without re-deriving precedence.
         let resolved_env_vars = foreground
             .spawn(|me, _| Arc::clone(&me.resolved_env_vars))
@@ -1638,14 +1637,8 @@ impl AgentDriver {
             &working_dir,
             system_prompt.as_deref(),
             &resolved_env_vars,
-            &secrets,
             &resolved_mcp_servers,
         )?;
-
-        // Pull the resume payload off the driver so the harness runner can rehydrate any
-        // existing session/conversation state before launching its CLI. The payload variant
-        // is harness-specific; harnesses match on their own [`ResumePayload`] variant and
-        // ignore others.
         let resume = foreground
             .spawn(|me, _| me.resume_payload.take())
             .await

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -258,9 +258,9 @@ pub struct AgentDriver {
     secrets: Arc<HashMap<String, ManagedSecretValue>>,
 
     /// Env vars passed to the terminal session, including resolved secrets, cloud
-    /// provider vars, task vars, and sandbox flags. Shared with
-    /// `prepare_environment_config` so harnesses can look up resolved secret
-    /// values without re-deriving precedence.
+    /// provider vars, task vars, and sandbox flags. Passed to
+    /// `build_runner` so harnesses can look up resolved secret values
+    /// without re-deriving precedence.
     resolved_env_vars: Arc<HashMap<OsString, OsString>>,
 
     output_format: OutputFormat,
@@ -1626,19 +1626,10 @@ impl AgentDriver {
             );
         }
 
-        // Prepare harness config files (onboarding, trust dialog, API-key approval, etc.).
-        // Pass the terminal env vars (which include the resolved secrets) so harnesses
-        // can look up auth keys without re-deriving precedence.
         let resolved_env_vars = foreground
             .spawn(|me, _| Arc::clone(&me.resolved_env_vars))
             .await
             .map_err(|_| AgentDriverError::InvalidRuntimeState)?;
-        harness.prepare_environment_config(
-            &working_dir,
-            system_prompt.as_deref(),
-            &resolved_env_vars,
-            &resolved_mcp_servers,
-        )?;
         let resume = foreground
             .spawn(|me, _| me.resume_payload.take())
             .await
@@ -1654,6 +1645,7 @@ impl AgentDriver {
                 server_api,
                 terminal_driver,
                 resume,
+                &resolved_env_vars,
                 &resolved_mcp_servers,
             )?
             .into();

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -71,21 +71,6 @@ impl ThirdPartyHarness for ClaudeHarness {
         Some("https://code.claude.com/docs/en/quickstart")
     }
 
-    fn prepare_environment_config(
-        &self,
-        working_dir: &Path,
-        _system_prompt: Option<&str>,
-        resolved_env_vars: &HashMap<OsString, OsString>,
-        _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
-    ) -> Result<(), AgentDriverError> {
-        prepare_claude_environment_config(working_dir, resolved_env_vars).map_err(|error| {
-            AgentDriverError::HarnessConfigSetupFailed {
-                harness: self.cli_agent().command_prefix().to_owned(),
-                error,
-            }
-        })
-    }
-
     /// Fetch the Claude Code transcript for the current task's conversation and wrap it
     /// into a [`ResumePayload::Claude`]. Maps a server 404 to
     /// [`AgentDriverError::ConversationResumeStateMissing`] tagged as the `claude` harness
@@ -116,8 +101,17 @@ impl ThirdPartyHarness for ClaudeHarness {
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
         resume: Option<ResumePayload>,
+        resolved_env_vars: &HashMap<OsString, OsString>,
         resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
+        // Prepare the environment config files.
+        prepare_claude_environment_config(working_dir, resolved_env_vars).map_err(|error| {
+            AgentDriverError::HarnessConfigSetupFailed {
+                harness: self.cli_agent().command_prefix().to_owned(),
+                error,
+            }
+        })?;
+
         // The ResumePayload shouldn't contain non-Claude information, error if it does.
         let claude_resume = resume.map(ClaudeResumeInfo::try_from).transpose()?;
         // Claude treats the user-turn message as immediate intent, so the resumption preamble
@@ -566,7 +560,7 @@ async fn upload_transcript(
         .with_context(|| format!("Failed to get transcript upload target for {conversation_id}"))?;
     upload_to_target(client.http_client(), &target, body).await
 }
-fn prepare_claude_environment_config(
+pub(crate) fn prepare_claude_environment_config(
     working_dir: &Path,
     resolved_env_vars: &HashMap<OsString, OsString>,
 ) -> Result<()> {

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -32,7 +32,7 @@ use super::claude_transcript::{
 use super::json_utils::{read_json_file_or_default, write_json_file};
 use super::{
     cli_agent_session_status, write_temp_file, HarnessCleanupDisposition, HarnessRunner,
-    JSONMCPServer, ManagedSecretValue, ResumePayload, SavePoint, ThirdPartyHarness,
+    JSONMCPServer, ResumePayload, SavePoint, ThirdPartyHarness,
 };
 mod parent_bridge;
 mod wake_driver;
@@ -76,7 +76,6 @@ impl ThirdPartyHarness for ClaudeHarness {
         working_dir: &Path,
         _system_prompt: Option<&str>,
         resolved_env_vars: &HashMap<OsString, OsString>,
-        _secrets: &HashMap<String, ManagedSecretValue>,
         _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {
         prepare_claude_environment_config(working_dir, resolved_env_vars).map_err(|error| {
@@ -223,7 +222,7 @@ impl ClaudeHarnessRunner {
     ) -> Result<Self, AgentDriverError> {
         // Write the prompt to a temp file so we can feed it via stdin redirect,
         // avoiding shell-quoting issues with complex content (e.g. skill instructions).
-        let temp_file = write_temp_file("oz_prompt_", prompt)?;
+        let temp_file = write_temp_file("oz_prompt_", prompt, ".txt")?;
         let prompt_path = temp_file.path().display().to_string();
 
         let (session_id, preexisting_conversation_id) = match resume {
@@ -258,18 +257,19 @@ impl ClaudeHarnessRunner {
         };
 
         let temp_system_prompt_file = system_prompt
-            .map(|sp| write_temp_file("oz_system_prompt_", sp))
+            .map(|sp| write_temp_file("oz_system_prompt_", sp, ".txt"))
             .transpose()?;
         let system_prompt_path = temp_system_prompt_file
             .as_ref()
             .map(|f| f.path().display().to_string());
-        let temp_mcp_config_file = if resolved_mcp_servers.is_empty() {
-            None
-        } else {
-            let mcp_json = serialize_claude_mcp_config(resolved_mcp_servers)
-                .map_err(AgentDriverError::ConfigBuildFailed)?;
-            Some(write_temp_file("oz_mcp_config_", &mcp_json)?)
-        };
+
+        let temp_mcp_config_file = (!resolved_mcp_servers.is_empty())
+            .then(|| {
+                let mcp_json = serialize_claude_mcp_config(resolved_mcp_servers)
+                    .map_err(AgentDriverError::ConfigBuildFailed)?;
+                write_temp_file("oz_mcp_config_", &mcp_json, ".json")
+            })
+            .transpose()?;
         let mcp_config_path = temp_mcp_config_file
             .as_ref()
             .map(|f| f.path().display().to_string());
@@ -720,8 +720,8 @@ enum ClaudeMcpServerEntry {
         #[serde(skip_serializing_if = "HashMap::is_empty")]
         env: HashMap<String, String>,
     },
-    #[serde(rename = "sse")]
-    Sse {
+    #[serde(rename = "http")]
+    Http {
         url: String,
         #[serde(skip_serializing_if = "HashMap::is_empty")]
         headers: HashMap<String, String>,
@@ -738,7 +738,7 @@ impl ClaudeMcpServerEntry {
                 args: args.clone(),
                 env: env.clone(),
             },
-            JSONTransportType::SSEServer { url, headers } => Self::Sse {
+            JSONTransportType::SSEServer { url, headers } => Self::Http {
                 url: url.clone(),
                 headers: headers.clone(),
             },
@@ -748,7 +748,7 @@ impl ClaudeMcpServerEntry {
 
 /// Serialize resolved MCP servers into Claude Code's `--mcp-config` JSON format.
 ///
-/// Produces `{ "mcpServers": { "name": { "type": "stdio"|"sse", ... }, ... } }`.
+/// Produces `{ "mcpServers": { "name": { "type": "stdio"|"http", ... }, ... } }`.
 pub(crate) fn serialize_claude_mcp_config(
     servers: &HashMap<String, JSONMCPServer>,
 ) -> Result<String> {

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -713,6 +713,8 @@ enum ClaudeMcpServerEntry {
         args: Vec<String>,
         #[serde(skip_serializing_if = "HashMap::is_empty")]
         env: HashMap<String, String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cwd: Option<String>,
     },
     #[serde(rename = "http")]
     Http {
@@ -726,11 +728,15 @@ impl ClaudeMcpServerEntry {
     fn from_json_mcp_server(server: &JSONMCPServer) -> Self {
         match &server.transport_type {
             JSONTransportType::CLIServer {
-                command, args, env, ..
+                command,
+                args,
+                env,
+                working_directory,
             } => Self::Stdio {
                 command: command.clone(),
                 args: args.clone(),
                 env: env.clone(),
+                cwd: working_directory.clone(),
             },
             JSONTransportType::SSEServer { url, headers } => Self::Http {
                 url: url.clone(),

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ffi::{OsStr, OsString};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -16,6 +15,7 @@ use warpui::{ModelHandle, ModelSpawner};
 
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::ai::mcp::JSONTransportType;
 use crate::server::server_api::harness_support::{upload_to_target, HarnessSupportClient};
 use crate::server::server_api::ServerApi;
 use crate::terminal::model::block::BlockId;
@@ -31,7 +31,7 @@ use super::claude_transcript::{
 use super::json_utils::{read_json_file_or_default, write_json_file};
 use super::{
     cli_agent_session_status, write_temp_file, HarnessCleanupDisposition, HarnessRunner,
-    ResumePayload, SavePoint, ThirdPartyHarness,
+    JSONMCPServer, ManagedSecretValue, ResumePayload, SavePoint, ThirdPartyHarness,
 };
 mod parent_bridge;
 mod wake_driver;
@@ -74,9 +74,10 @@ impl ThirdPartyHarness for ClaudeHarness {
         &self,
         working_dir: &Path,
         _system_prompt: Option<&str>,
-        resolved_env_vars: &HashMap<OsString, OsString>,
+        secrets: &HashMap<String, ManagedSecretValue>,
+        _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {
-        prepare_claude_environment_config(working_dir, resolved_env_vars).map_err(|error| {
+        prepare_claude_environment_config(working_dir, secrets).map_err(|error| {
             AgentDriverError::HarnessConfigSetupFailed {
                 harness: self.cli_agent().command_prefix().to_owned(),
                 error,
@@ -114,6 +115,7 @@ impl ThirdPartyHarness for ClaudeHarness {
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
         resume: Option<ResumePayload>,
+        resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
         // The ResumePayload shouldn't contain non-Claude information, error if it does.
         let claude_resume = resume.map(ClaudeResumeInfo::try_from).transpose()?;
@@ -132,6 +134,7 @@ impl ThirdPartyHarness for ClaudeHarness {
             server_api,
             terminal_driver,
             claude_resume,
+            resolved_mcp_servers,
         )?))
     }
 }
@@ -153,12 +156,16 @@ fn claude_command(
     session_id: &Uuid,
     prompt_path: &str,
     system_prompt_path: Option<&str>,
+    mcp_config_path: Option<&str>,
     resuming: bool,
 ) -> String {
     let flag = if resuming { "--resume" } else { "--session-id" };
     let mut cmd = format!("{cli_name} {flag} {session_id} --dangerously-skip-permissions");
     if let Some(sp_path) = system_prompt_path {
         let _ = write!(cmd, " --append-system-prompt-file '{sp_path}'");
+    }
+    if let Some(mcp_path) = mcp_config_path {
+        let _ = write!(cmd, " --mcp-config '{mcp_path}'");
     }
     format!("{cmd} < '{prompt_path}'")
 }
@@ -182,6 +189,8 @@ struct ClaudeHarnessRunner {
     _temp_prompt_file: NamedTempFile,
     /// Held so the system prompt temp file is cleaned up when the runner is dropped.
     _temp_system_prompt_file: Option<NamedTempFile>,
+    /// Held so the MCP config temp file lives until the CLI exits.
+    _temp_mcp_config_file: Option<NamedTempFile>,
     client: Arc<dyn HarnessSupportClient>,
     server_api: Arc<ServerApi>,
     terminal_driver: ModelHandle<TerminalDriver>,
@@ -208,6 +217,7 @@ impl ClaudeHarnessRunner {
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
         resume: Option<ClaudeResumeInfo>,
+        resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<Self, AgentDriverError> {
         // Write the prompt to a temp file so we can feed it via stdin redirect,
         // avoiding shell-quoting issues with complex content (e.g. skill instructions).
@@ -251,6 +261,17 @@ impl ClaudeHarnessRunner {
         let system_prompt_path = temp_system_prompt_file
             .as_ref()
             .map(|f| f.path().display().to_string());
+        let temp_mcp_config_file = if resolved_mcp_servers.is_empty() {
+            None
+        } else {
+            let mcp_json = serialize_claude_mcp_config(resolved_mcp_servers)
+                .map_err(AgentDriverError::ConfigBuildFailed)?;
+            Some(write_temp_file("oz_mcp_config_", &mcp_json)?)
+        };
+        let mcp_config_path = temp_mcp_config_file
+            .as_ref()
+            .map(|f| f.path().display().to_string());
+
         let parent_bridge = task_id
             .map(|task_id| MessageBridge::new(task_id.to_string(), session_id))
             .transpose()
@@ -263,11 +284,13 @@ impl ClaudeHarnessRunner {
                 &session_id,
                 &prompt_path,
                 system_prompt_path.as_deref(),
+                mcp_config_path.as_deref(),
                 preexisting_conversation_id.is_some(),
             ),
             cli_name: cli_command.to_string(),
             _temp_prompt_file: temp_file,
             _temp_system_prompt_file: temp_system_prompt_file,
+            _temp_mcp_config_file: temp_mcp_config_file,
             client,
             server_api,
             terminal_driver,
@@ -543,12 +566,12 @@ async fn upload_transcript(
 }
 fn prepare_claude_environment_config(
     working_dir: &Path,
-    resolved_env_vars: &HashMap<OsString, OsString>,
+    secrets: &HashMap<String, ManagedSecretValue>,
 ) -> Result<()> {
     let home_dir = claude_home_dir()?;
     let claude_json_path = home_dir.join(CLAUDE_JSON_FILE_NAME);
     let claude_settings_path = claude_config_dir()?.join(CLAUDE_SETTINGS_FILE_NAME);
-    let api_key_suffix = resolve_anthropic_api_key_suffix(resolved_env_vars);
+    let api_key_suffix = resolve_anthropic_api_key_suffix(secrets);
     prepare_claude_config(&claude_json_path, working_dir, api_key_suffix.as_deref())?;
     prepare_claude_settings(&claude_settings_path)?;
     Ok(())
@@ -655,20 +678,23 @@ struct ClaudeSettings {
 /// Try to get the last 20 chars of the ANTHROPIC_API_KEY, where 20 chars is the
 /// suffix length that Claude Code truncates keys to.
 fn resolve_anthropic_api_key_suffix(
-    resolved_env_vars: &HashMap<OsString, OsString>,
+    secrets: &HashMap<String, ManagedSecretValue>,
 ) -> Option<String> {
-    // Worker-injected process env wins.
-    if let Ok(key) = std::env::var(ANTHROPIC_API_KEY_ENV) {
-        if !key.is_empty() {
-            return suffix_of(&key).map(str::to_owned);
+    // First, check for an AnthropicApiKey variant anywhere in the secrets map,
+    // since the secret name doesn't necessarily match the env var.
+    for secret in secrets.values() {
+        if let ManagedSecretValue::AnthropicApiKey { api_key } = secret {
+            return suffix_of(api_key).map(str::to_owned);
         }
     }
-    // Otherwise use the resolved value from the secrets map.
-    resolved_env_vars
-        .get(OsStr::new(ANTHROPIC_API_KEY_ENV))
-        .and_then(|v| v.to_str())
-        .and_then(suffix_of)
-        .map(str::to_owned)
+    // Then check for a RawValue stored under the env var name.
+    if let Some(ManagedSecretValue::RawValue { value }) = secrets.get(ANTHROPIC_API_KEY_ENV) {
+        return suffix_of(value).map(str::to_owned);
+    }
+    // Fall back to the environment variable, which a user may have set separately in the env.
+    std::env::var(ANTHROPIC_API_KEY_ENV)
+        .ok()
+        .and_then(|k| suffix_of(&k).map(str::to_owned))
 }
 
 fn suffix_of(key: &str) -> Option<&str> {
@@ -677,6 +703,68 @@ fn suffix_of(key: &str) -> Option<&str> {
     } else {
         None
     }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ClaudeMcpConfig {
+    mcp_servers: HashMap<String, ClaudeMcpServerEntry>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum ClaudeMcpServerEntry {
+    #[serde(rename = "stdio")]
+    Stdio {
+        command: String,
+        args: Vec<String>,
+        #[serde(skip_serializing_if = "HashMap::is_empty")]
+        env: HashMap<String, String>,
+    },
+    #[serde(rename = "sse")]
+    Sse {
+        url: String,
+        #[serde(skip_serializing_if = "HashMap::is_empty")]
+        headers: HashMap<String, String>,
+    },
+}
+
+impl ClaudeMcpServerEntry {
+    fn from_json_mcp_server(server: &JSONMCPServer) -> Self {
+        match &server.transport_type {
+            JSONTransportType::CLIServer {
+                command, args, env, ..
+            } => Self::Stdio {
+                command: command.clone(),
+                args: args.clone(),
+                env: env.clone(),
+            },
+            JSONTransportType::SSEServer { url, headers } => Self::Sse {
+                url: url.clone(),
+                headers: headers.clone(),
+            },
+        }
+    }
+}
+
+/// Serialize resolved MCP servers into Claude Code's `--mcp-config` JSON format.
+///
+/// Produces `{ "mcpServers": { "name": { "type": "stdio"|"sse", ... }, ... } }`.
+pub(crate) fn serialize_claude_mcp_config(
+    servers: &HashMap<String, JSONMCPServer>,
+) -> Result<String> {
+    let config = ClaudeMcpConfig {
+        mcp_servers: servers
+            .iter()
+            .map(|(name, server)| {
+                (
+                    name.clone(),
+                    ClaudeMcpServerEntry::from_json_mcp_server(server),
+                )
+            })
+            .collect(),
+    };
+    serde_json::to_string_pretty(&config).context("Failed to serialize Claude MCP config")
 }
 
 #[cfg(test)]

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -74,10 +75,11 @@ impl ThirdPartyHarness for ClaudeHarness {
         &self,
         working_dir: &Path,
         _system_prompt: Option<&str>,
-        secrets: &HashMap<String, ManagedSecretValue>,
+        resolved_env_vars: &HashMap<OsString, OsString>,
+        _secrets: &HashMap<String, ManagedSecretValue>,
         _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {
-        prepare_claude_environment_config(working_dir, secrets).map_err(|error| {
+        prepare_claude_environment_config(working_dir, resolved_env_vars).map_err(|error| {
             AgentDriverError::HarnessConfigSetupFailed {
                 harness: self.cli_agent().command_prefix().to_owned(),
                 error,
@@ -566,12 +568,12 @@ async fn upload_transcript(
 }
 fn prepare_claude_environment_config(
     working_dir: &Path,
-    secrets: &HashMap<String, ManagedSecretValue>,
+    resolved_env_vars: &HashMap<OsString, OsString>,
 ) -> Result<()> {
     let home_dir = claude_home_dir()?;
     let claude_json_path = home_dir.join(CLAUDE_JSON_FILE_NAME);
     let claude_settings_path = claude_config_dir()?.join(CLAUDE_SETTINGS_FILE_NAME);
-    let api_key_suffix = resolve_anthropic_api_key_suffix(secrets);
+    let api_key_suffix = resolve_anthropic_api_key_suffix(resolved_env_vars);
     prepare_claude_config(&claude_json_path, working_dir, api_key_suffix.as_deref())?;
     prepare_claude_settings(&claude_settings_path)?;
     Ok(())
@@ -678,23 +680,20 @@ struct ClaudeSettings {
 /// Try to get the last 20 chars of the ANTHROPIC_API_KEY, where 20 chars is the
 /// suffix length that Claude Code truncates keys to.
 fn resolve_anthropic_api_key_suffix(
-    secrets: &HashMap<String, ManagedSecretValue>,
+    resolved_env_vars: &HashMap<OsString, OsString>,
 ) -> Option<String> {
-    // First, check for an AnthropicApiKey variant anywhere in the secrets map,
-    // since the secret name doesn't necessarily match the env var.
-    for secret in secrets.values() {
-        if let ManagedSecretValue::AnthropicApiKey { api_key } = secret {
-            return suffix_of(api_key).map(str::to_owned);
+    // Worker-injected process env wins.
+    if let Ok(key) = std::env::var(ANTHROPIC_API_KEY_ENV) {
+        if !key.is_empty() {
+            return suffix_of(&key).map(str::to_owned);
         }
     }
-    // Then check for a RawValue stored under the env var name.
-    if let Some(ManagedSecretValue::RawValue { value }) = secrets.get(ANTHROPIC_API_KEY_ENV) {
-        return suffix_of(value).map(str::to_owned);
-    }
-    // Fall back to the environment variable, which a user may have set separately in the env.
-    std::env::var(ANTHROPIC_API_KEY_ENV)
-        .ok()
-        .and_then(|k| suffix_of(&k).map(str::to_owned))
+    // Otherwise use the resolved value from the secrets map.
+    resolved_env_vars
+        .get(OsStr::new(ANTHROPIC_API_KEY_ENV))
+        .and_then(|v| v.to_str())
+        .and_then(suffix_of)
+        .map(str::to_owned)
 }
 
 fn suffix_of(key: &str) -> Option<&str> {

--- a/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
@@ -193,7 +193,7 @@ impl ClaudeHarness {
         mut remote: ClaudeWakeRemoteContext,
     ) -> Result<String> {
         let working_dir = working_dir.unwrap_or_else(|| remote.envelope.cwd.clone());
-        prepare_claude_environment_config(&working_dir, &HashMap::new())
+        prepare_claude_environment_config(&working_dir, &HashMap::<OsString, OsString>::new())
             .context("Failed to prepare Claude environment for wake")?;
 
         remote.envelope.cwd = working_dir.clone();
@@ -217,6 +217,7 @@ impl ClaudeHarness {
             CLIAgent::Claude.command_prefix(),
             &remote.session_id,
             &prompt_path.display().to_string(),
+            None,
             None,
             true,
         );

--- a/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
@@ -193,7 +193,7 @@ impl ClaudeHarness {
         mut remote: ClaudeWakeRemoteContext,
     ) -> Result<String> {
         let working_dir = working_dir.unwrap_or_else(|| remote.envelope.cwd.clone());
-        prepare_claude_environment_config(&working_dir, &HashMap::<OsString, OsString>::new())
+        prepare_claude_environment_config(&working_dir, &HashMap::new())
             .context("Failed to prepare Claude environment for wake")?;
 
         remote.envelope.cwd = working_dir.clone();

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -164,7 +164,7 @@ fn serialize_claude_mcp_config_sse_server() {
     let json = serialize_claude_mcp_config(&servers).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
     let server = &parsed["mcpServers"]["remote"];
-    assert_eq!(server["type"], "sse");
+    assert_eq!(server["type"], "http");
     assert_eq!(server["url"], "https://mcp.example.com");
     assert_eq!(server["headers"]["Authorization"], "Bearer tok");
 }
@@ -631,16 +631,11 @@ fn prepare_claude_config_none_suffix_preserves_existing_responses() {
 
 #[test]
 #[serial_test::serial]
-fn resolve_suffix_from_raw_value_secret() {
+fn resolve_suffix_from_resolved_env_vars() {
     std::env::remove_var(ANTHROPIC_API_KEY_ENV);
     let key = "sk-ant-api03-abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghij1234567890QLWn-dUnuwQ-hIhDiAAA";
-    let secrets = HashMap::from([(
-        "ANTHROPIC_API_KEY".to_string(),
-        ManagedSecretValue::RawValue {
-            value: key.to_string(),
-        },
-    )]);
-    let suffix = resolve_anthropic_api_key_suffix(&secrets);
+    let resolved = HashMap::from([(OsString::from("ANTHROPIC_API_KEY"), OsString::from(key))]);
+    let suffix = resolve_anthropic_api_key_suffix(&resolved);
     assert_eq!(suffix.as_deref(), Some("QLWn-dUnuwQ-hIhDiAAA"));
 }
 
@@ -648,13 +643,8 @@ fn resolve_suffix_from_raw_value_secret() {
 #[serial_test::serial]
 fn resolve_suffix_returns_none_for_short_key() {
     std::env::remove_var(ANTHROPIC_API_KEY_ENV);
-    let secrets = HashMap::from([(
-        "ANTHROPIC_API_KEY".to_string(),
-        ManagedSecretValue::RawValue {
-            value: "short".to_string(),
-        },
-    )]);
-    assert_eq!(resolve_anthropic_api_key_suffix(&secrets), None);
+    let resolved = HashMap::from([(OsString::from("ANTHROPIC_API_KEY"), OsString::from("short"))]);
+    assert_eq!(resolve_anthropic_api_key_suffix(&resolved), None);
 }
 
 #[test]
@@ -749,15 +739,14 @@ fn prepare_local_wake_command_rehydrates_transcript_with_self_managed_listener()
 fn suffix_uses_worker_injected_env_when_present() {
     let worker_key = "sk-ant-api03-WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW-worker-suffix!";
     std::env::set_var(ANTHROPIC_API_KEY_ENV, worker_key);
-    // Even when the secrets map has a different value, the env var wins.
-    let secrets = HashMap::from([(
-        "ANTHROPIC_API_KEY".to_string(),
-        ManagedSecretValue::RawValue {
-            value: "sk-ant-api03-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR-resolved-val!"
-                .to_string(),
-        },
+    // Even when the resolved map has a different value, the worker env wins.
+    let resolved = HashMap::from([(
+        OsString::from("ANTHROPIC_API_KEY"),
+        OsString::from(
+            "sk-ant-api03-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR-resolved-val!",
+        ),
     )]);
-    let suffix = resolve_anthropic_api_key_suffix(&secrets);
+    let suffix = resolve_anthropic_api_key_suffix(&resolved);
     let expected = &worker_key[worker_key.len() - 20..];
     assert_eq!(suffix.as_deref(), Some(expected));
     std::env::remove_var(ANTHROPIC_API_KEY_ENV);

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -56,7 +56,7 @@ fn write_surfaced_parent_bridge_message(state_dir: &Path, record: &MessageBridge
 #[test]
 fn claude_command_uses_session_id_when_not_resuming() {
     let uuid = Uuid::new_v4();
-    let cmd = claude_command("claude", &uuid, "/tmp/prompt.txt", None, false);
+    let cmd = claude_command("claude", &uuid, "/tmp/prompt.txt", None, None, false);
     assert!(
         cmd.contains(&format!("--session-id {uuid}")),
         "expected --session-id flag in non-resume command, got: {cmd}"
@@ -70,7 +70,7 @@ fn claude_command_uses_session_id_when_not_resuming() {
 #[test]
 fn claude_command_uses_resume_flag_when_resuming() {
     let uuid = Uuid::new_v4();
-    let cmd = claude_command("claude", &uuid, "/tmp/prompt.txt", None, true);
+    let cmd = claude_command("claude", &uuid, "/tmp/prompt.txt", None, None, true);
     assert!(
         cmd.contains(&format!("--resume {uuid}")),
         "expected --resume flag in resume command, got: {cmd}"
@@ -84,7 +84,14 @@ fn claude_command_uses_resume_flag_when_resuming() {
 #[test]
 fn claude_command_pipes_prompt_path() {
     let uuid = Uuid::new_v4();
-    let cmd = claude_command("claude", &uuid, "/tmp/prompt with spaces.txt", None, true);
+    let cmd = claude_command(
+        "claude",
+        &uuid,
+        "/tmp/prompt with spaces.txt",
+        None,
+        None,
+        true,
+    );
     assert!(
         cmd.contains("< '/tmp/prompt with spaces.txt'"),
         "expected single-quoted stdin redirect of the prompt path, got: {cmd}"
@@ -119,6 +126,47 @@ fn write_session_index_entry_creates_expected_entry() {
         entry["transcriptPath"],
         Value::String(format!("projects/{encoded}/{session_id}.jsonl"))
     );
+}
+
+#[test]
+fn serialize_claude_mcp_config_cli_server() {
+    let servers = HashMap::from([(
+        "test-server".to_string(),
+        JSONMCPServer {
+            transport_type: JSONTransportType::CLIServer {
+                command: "node".to_string(),
+                args: vec!["server.js".to_string()],
+                env: HashMap::from([("API_KEY".to_string(), "secret".to_string())]),
+                working_directory: None,
+            },
+        },
+    )]);
+    let json = serialize_claude_mcp_config(&servers).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let server = &parsed["mcpServers"]["test-server"];
+    assert_eq!(server["type"], "stdio");
+    assert_eq!(server["command"], "node");
+    assert_eq!(server["args"][0], "server.js");
+    assert_eq!(server["env"]["API_KEY"], "secret");
+}
+
+#[test]
+fn serialize_claude_mcp_config_sse_server() {
+    let servers = HashMap::from([(
+        "remote".to_string(),
+        JSONMCPServer {
+            transport_type: JSONTransportType::SSEServer {
+                url: "https://mcp.example.com".to_string(),
+                headers: HashMap::from([("Authorization".to_string(), "Bearer tok".to_string())]),
+            },
+        },
+    )]);
+    let json = serialize_claude_mcp_config(&servers).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let server = &parsed["mcpServers"]["remote"];
+    assert_eq!(server["type"], "sse");
+    assert_eq!(server["url"], "https://mcp.example.com");
+    assert_eq!(server["headers"]["Authorization"], "Bearer tok");
 }
 
 #[test]
@@ -583,11 +631,16 @@ fn prepare_claude_config_none_suffix_preserves_existing_responses() {
 
 #[test]
 #[serial_test::serial]
-fn resolve_suffix_from_resolved_env_vars() {
+fn resolve_suffix_from_raw_value_secret() {
     std::env::remove_var(ANTHROPIC_API_KEY_ENV);
     let key = "sk-ant-api03-abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghij1234567890QLWn-dUnuwQ-hIhDiAAA";
-    let resolved = HashMap::from([(OsString::from("ANTHROPIC_API_KEY"), OsString::from(key))]);
-    let suffix = resolve_anthropic_api_key_suffix(&resolved);
+    let secrets = HashMap::from([(
+        "ANTHROPIC_API_KEY".to_string(),
+        ManagedSecretValue::RawValue {
+            value: key.to_string(),
+        },
+    )]);
+    let suffix = resolve_anthropic_api_key_suffix(&secrets);
     assert_eq!(suffix.as_deref(), Some("QLWn-dUnuwQ-hIhDiAAA"));
 }
 
@@ -595,8 +648,13 @@ fn resolve_suffix_from_resolved_env_vars() {
 #[serial_test::serial]
 fn resolve_suffix_returns_none_for_short_key() {
     std::env::remove_var(ANTHROPIC_API_KEY_ENV);
-    let resolved = HashMap::from([(OsString::from("ANTHROPIC_API_KEY"), OsString::from("short"))]);
-    assert_eq!(resolve_anthropic_api_key_suffix(&resolved), None);
+    let secrets = HashMap::from([(
+        "ANTHROPIC_API_KEY".to_string(),
+        ManagedSecretValue::RawValue {
+            value: "short".to_string(),
+        },
+    )]);
+    assert_eq!(resolve_anthropic_api_key_suffix(&secrets), None);
 }
 
 #[test]
@@ -691,14 +749,15 @@ fn prepare_local_wake_command_rehydrates_transcript_with_self_managed_listener()
 fn suffix_uses_worker_injected_env_when_present() {
     let worker_key = "sk-ant-api03-WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW-worker-suffix!";
     std::env::set_var(ANTHROPIC_API_KEY_ENV, worker_key);
-    // Even when the resolved map has a different value, the worker env wins.
-    let resolved = HashMap::from([(
-        OsString::from("ANTHROPIC_API_KEY"),
-        OsString::from(
-            "sk-ant-api03-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR-resolved-val!",
-        ),
+    // Even when the secrets map has a different value, the env var wins.
+    let secrets = HashMap::from([(
+        "ANTHROPIC_API_KEY".to_string(),
+        ManagedSecretValue::RawValue {
+            value: "sk-ant-api03-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR-resolved-val!"
+                .to_string(),
+        },
     )]);
-    let suffix = resolve_anthropic_api_key_suffix(&resolved);
+    let suffix = resolve_anthropic_api_key_suffix(&secrets);
     let expected = &worker_key[worker_key.len() - 20..];
     assert_eq!(suffix.as_deref(), Some(expected));
     std::env::remove_var(ANTHROPIC_API_KEY_ENV);

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -151,6 +151,44 @@ fn serialize_claude_mcp_config_cli_server() {
 }
 
 #[test]
+fn serialize_claude_mcp_config_cli_server_with_cwd() {
+    let servers = HashMap::from([(
+        "test-server".to_string(),
+        JSONMCPServer {
+            transport_type: JSONTransportType::CLIServer {
+                command: "node".to_string(),
+                args: vec!["server.js".to_string()],
+                env: HashMap::new(),
+                working_directory: Some("/opt/mcp".to_string()),
+            },
+        },
+    )]);
+    let json = serialize_claude_mcp_config(&servers).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let server = &parsed["mcpServers"]["test-server"];
+    assert_eq!(server["cwd"], "/opt/mcp");
+}
+
+#[test]
+fn serialize_claude_mcp_config_cli_server_omits_cwd_when_none() {
+    let servers = HashMap::from([(
+        "test-server".to_string(),
+        JSONMCPServer {
+            transport_type: JSONTransportType::CLIServer {
+                command: "node".to_string(),
+                args: vec![],
+                env: HashMap::new(),
+                working_directory: None,
+            },
+        },
+    )]);
+    let json = serialize_claude_mcp_config(&servers).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let server = &parsed["mcpServers"]["test-server"];
+    assert!(server.get("cwd").is_none());
+}
+
+#[test]
 fn serialize_claude_mcp_config_sse_server() {
     let servers = HashMap::from([(
         "remote".to_string(),

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
@@ -12,10 +11,12 @@ use serde_json::{Map, Value};
 use tempfile::NamedTempFile;
 use uuid::Uuid;
 use warp_cli::agent::Harness;
+use warp_managed_secrets::ManagedSecretValue;
 use warpui::{ModelHandle, ModelSpawner, SingletonEntity};
 
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::ai::mcp::JSONTransportType;
 use crate::server::server_api::harness_support::{upload_to_target, HarnessSupportClient};
 use crate::server::server_api::ServerApi;
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
@@ -30,7 +31,9 @@ use super::codex_transcript::{
     CodexTranscriptEnvelope,
 };
 use super::json_utils::read_json_file_or_default;
-use super::{write_temp_file, HarnessRunner, ResumePayload, SavePoint, ThirdPartyHarness};
+use super::{
+    write_temp_file, HarnessRunner, JSONMCPServer, ResumePayload, SavePoint, ThirdPartyHarness,
+};
 
 pub(crate) struct CodexHarness;
 
@@ -58,14 +61,14 @@ impl ThirdPartyHarness for CodexHarness {
         &self,
         working_dir: &Path,
         system_prompt: Option<&str>,
-        resolved_env_vars: &HashMap<OsString, OsString>,
+        secrets: &HashMap<String, ManagedSecretValue>,
+        resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {
-        prepare_codex_environment_config(working_dir, system_prompt, resolved_env_vars).map_err(
-            |error| AgentDriverError::HarnessConfigSetupFailed {
+        prepare_codex_environment_config(working_dir, system_prompt, secrets, resolved_mcp_servers)
+            .map_err(|error| AgentDriverError::HarnessConfigSetupFailed {
                 harness: self.cli_agent().command_prefix().to_owned(),
                 error,
-            },
-        )
+            })
     }
 
     /// Fetch the codex transcript for the current task's conversation and wrap it into a
@@ -96,6 +99,7 @@ impl ThirdPartyHarness for CodexHarness {
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
         resume: Option<ResumePayload>,
+        _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
         // The ResumePayload shouldn't contain non-Codex information, error if it does.
         let codex_resume = resume.map(CodexResumeInfo::try_from).transpose()?;
@@ -439,7 +443,8 @@ const CODEX_OPENAI_BASE_URL: &str = "https://us.api.openai.com/v1";
 fn prepare_codex_environment_config(
     working_dir: &Path,
     system_prompt: Option<&str>,
-    resolved_env_vars: &HashMap<OsString, OsString>,
+    secrets: &HashMap<String, ManagedSecretValue>,
+    resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
 ) -> Result<()> {
     let home_dir =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?;
@@ -449,12 +454,16 @@ fn prepare_codex_environment_config(
         write_codex_agents_override(&codex_dir, prompt)?;
     }
 
-    match resolve_openai_api_key(resolved_env_vars) {
+    match resolve_openai_api_key(secrets) {
         Some(api_key) => prepare_codex_auth(&codex_dir.join(CODEX_AUTH_FILE_NAME), &api_key)?,
         None => log::info!("No OPENAI_API_KEY available; skipping Codex auth.json seed"),
     }
 
-    prepare_codex_config_toml(&codex_dir.join(CODEX_CONFIG_TOML_FILE_NAME), working_dir)?;
+    prepare_codex_config_toml(
+        &codex_dir.join(CODEX_CONFIG_TOML_FILE_NAME),
+        working_dir,
+        resolved_mcp_servers,
+    )?;
     Ok(())
 }
 
@@ -535,25 +544,24 @@ fn write_codex_auth_json(path: &Path, auth: &CodexAuthDotJson) -> Result<()> {
     Ok(())
 }
 
-/// Returns the OpenAI API key for Codex auth.
-///
-/// Checks the worker-injected process env first (not in the resolved map since
-/// `build_secret_env_vars` skips env vars already present in the process env),
-/// then falls back to the resolved secret env vars map.
-fn resolve_openai_api_key(resolved_env_vars: &HashMap<OsString, OsString>) -> Option<String> {
-    // Worker-injected process env wins.
+/// Returns the OpenAI API key for Codex auth, preferring the `OPENAI_API_KEY` env
+/// var so the seeded `auth.json` matches the credential the launched Codex process
+/// will see. [`AgentDriver::new`] skips a managed `OPENAI_API_KEY` secret when the
+/// env var is already set, so we mirror that precedence here.
+fn resolve_openai_api_key(secrets: &HashMap<String, ManagedSecretValue>) -> Option<String> {
     if let Ok(value) = std::env::var(OPENAI_API_KEY_ENV) {
         let trimmed = value.trim();
         if !trimmed.is_empty() {
             return Some(trimmed.to_owned());
         }
     }
-    // Otherwise use the resolved value from the secrets map.
-    resolved_env_vars
-        .get(OsStr::new(OPENAI_API_KEY_ENV))
-        .and_then(|v| v.to_str())
-        .map(|s| s.trim().to_owned())
-        .filter(|s| !s.is_empty())
+    if let Some(ManagedSecretValue::RawValue { value }) = secrets.get(OPENAI_API_KEY_ENV) {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_owned());
+        }
+    }
+    None
 }
 
 /// Edit `~/.codex/config.toml` via `toml_edit` to seed the harness defaults
@@ -562,7 +570,11 @@ fn resolve_openai_api_key(resolved_env_vars: &HashMap<OsString, OsString>) -> Op
 ///   set the projects to `trusted`.
 /// - base URL: set `openai_base_url = "<US data-residency endpoint>"` so we
 ///   hit the regional host our API keys require.
-fn prepare_codex_config_toml(config_toml_path: &Path, working_dir: &Path) -> Result<()> {
+fn prepare_codex_config_toml(
+    config_toml_path: &Path,
+    working_dir: &Path,
+    resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
+) -> Result<()> {
     let existing = match fs::read_to_string(config_toml_path) {
         Ok(content) => content,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
@@ -598,6 +610,8 @@ fn prepare_codex_config_toml(config_toml_path: &Path, working_dir: &Path) -> Res
         let key = child_repo.to_string_lossy().into_owned();
         set_codex_project_trust_level(&mut doc, &key, CODEX_TRUST_LEVEL_TRUSTED);
     }
+
+    write_codex_mcp_servers(&mut doc, resolved_mcp_servers);
 
     if let Some(parent) = config_toml_path.parent() {
         fs::create_dir_all(parent).with_context(|| {
@@ -654,6 +668,65 @@ fn set_codex_project_trust_level(
         .expect("project entry is a table");
     proj_tbl.set_implicit(false);
     proj_tbl["trust_level"] = toml_edit::value(trust_level);
+}
+
+/// Write resolved MCP servers into `[mcp_servers.<name>]` sections in the Codex config.
+fn write_codex_mcp_servers(
+    doc: &mut toml_edit::DocumentMut,
+    servers: &HashMap<String, JSONMCPServer>,
+) {
+    if servers.is_empty() {
+        return;
+    }
+    if !doc.contains_table("mcp_servers") {
+        let mut tbl = toml_edit::Table::new();
+        tbl.set_implicit(true);
+        doc.insert("mcp_servers", toml_edit::Item::Table(tbl));
+    }
+    let mcp_tbl = doc["mcp_servers"]
+        .as_table_mut()
+        .expect("mcp_servers table inserted above");
+
+    for (name, server) in servers {
+        let entry = mcp_tbl
+            .entry(name)
+            .or_insert_with(toml_edit::table)
+            .as_table_mut()
+            .expect("mcp_servers entry is a table");
+        entry.set_implicit(false);
+
+        match &server.transport_type {
+            JSONTransportType::CLIServer {
+                command, args, env, ..
+            } => {
+                entry["command"] = toml_edit::value(command.as_str());
+                if !args.is_empty() {
+                    let mut arr = toml_edit::Array::new();
+                    for arg in args {
+                        arr.push(arg.as_str());
+                    }
+                    entry["args"] = toml_edit::value(arr);
+                }
+                if !env.is_empty() {
+                    let mut env_tbl = toml_edit::InlineTable::new();
+                    for (k, v) in env {
+                        env_tbl.insert(k, v.as_str().into());
+                    }
+                    entry["env"] = toml_edit::value(env_tbl);
+                }
+            }
+            JSONTransportType::SSEServer { url, headers } => {
+                entry["url"] = toml_edit::value(url.as_str());
+                if !headers.is_empty() {
+                    let mut hdrs_tbl = toml_edit::InlineTable::new();
+                    for (k, v) in headers {
+                        hdrs_tbl.insert(k, v.as_str().into());
+                    }
+                    entry["http_headers"] = toml_edit::value(hdrs_tbl);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
@@ -61,6 +62,7 @@ impl ThirdPartyHarness for CodexHarness {
         &self,
         working_dir: &Path,
         system_prompt: Option<&str>,
+        _resolved_env_vars: &HashMap<OsString, OsString>,
         secrets: &HashMap<String, ManagedSecretValue>,
         resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -697,7 +697,10 @@ fn write_codex_mcp_servers(
 
         match &server.transport_type {
             JSONTransportType::CLIServer {
-                command, args, env, ..
+                command,
+                args,
+                env,
+                working_directory,
             } => {
                 entry["command"] = toml_edit::value(command.as_str());
                 if !args.is_empty() {
@@ -713,6 +716,9 @@ fn write_codex_mcp_servers(
                         env_tbl.insert(k, v.as_str().into());
                     }
                     entry["env"] = toml_edit::value(env_tbl);
+                }
+                if let Some(cwd) = working_directory {
+                    entry["cwd"] = toml_edit::value(cwd.as_str());
                 }
             }
             JSONTransportType::SSEServer { url, headers } => {

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -57,25 +57,6 @@ impl ThirdPartyHarness for CodexHarness {
         Some("https://developers.openai.com/codex/cli")
     }
 
-    fn prepare_environment_config(
-        &self,
-        working_dir: &Path,
-        system_prompt: Option<&str>,
-        resolved_env_vars: &HashMap<OsString, OsString>,
-        resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
-    ) -> Result<(), AgentDriverError> {
-        prepare_codex_environment_config(
-            working_dir,
-            system_prompt,
-            resolved_env_vars,
-            resolved_mcp_servers,
-        )
-        .map_err(|error| AgentDriverError::HarnessConfigSetupFailed {
-            harness: self.cli_agent().command_prefix().to_owned(),
-            error,
-        })
-    }
-
     /// Fetch the codex transcript for the current task's conversation and wrap it into a
     /// [`ResumePayload::Codex`].
     async fn fetch_resume_payload(
@@ -104,8 +85,21 @@ impl ThirdPartyHarness for CodexHarness {
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
         resume: Option<ResumePayload>,
-        _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
+        resolved_env_vars: &HashMap<OsString, OsString>,
+        resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
+        // Prepare the environment config files.
+        prepare_codex_environment_config(
+            working_dir,
+            system_prompt,
+            resolved_env_vars,
+            resolved_mcp_servers,
+        )
+        .map_err(|error| AgentDriverError::HarnessConfigSetupFailed {
+            harness: self.cli_agent().command_prefix().to_owned(),
+            error,
+        })?;
+
         // The ResumePayload shouldn't contain non-Codex information, error if it does.
         let codex_resume = resume.map(CodexResumeInfo::try_from).transpose()?;
 

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
@@ -12,7 +12,6 @@ use serde_json::{Map, Value};
 use tempfile::NamedTempFile;
 use uuid::Uuid;
 use warp_cli::agent::Harness;
-use warp_managed_secrets::ManagedSecretValue;
 use warpui::{ModelHandle, ModelSpawner, SingletonEntity};
 
 use crate::ai::agent::conversation::AIConversationId;
@@ -62,15 +61,19 @@ impl ThirdPartyHarness for CodexHarness {
         &self,
         working_dir: &Path,
         system_prompt: Option<&str>,
-        _resolved_env_vars: &HashMap<OsString, OsString>,
-        secrets: &HashMap<String, ManagedSecretValue>,
+        resolved_env_vars: &HashMap<OsString, OsString>,
         resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {
-        prepare_codex_environment_config(working_dir, system_prompt, secrets, resolved_mcp_servers)
-            .map_err(|error| AgentDriverError::HarnessConfigSetupFailed {
-                harness: self.cli_agent().command_prefix().to_owned(),
-                error,
-            })
+        prepare_codex_environment_config(
+            working_dir,
+            system_prompt,
+            resolved_env_vars,
+            resolved_mcp_servers,
+        )
+        .map_err(|error| AgentDriverError::HarnessConfigSetupFailed {
+            harness: self.cli_agent().command_prefix().to_owned(),
+            error,
+        })
     }
 
     /// Fetch the codex transcript for the current task's conversation and wrap it into a
@@ -182,7 +185,7 @@ impl CodexHarnessRunner {
         terminal_driver: ModelHandle<TerminalDriver>,
         resume: Option<CodexResumeInfo>,
     ) -> Result<Self, AgentDriverError> {
-        let temp_file = write_temp_file("oz_prompt_", prompt)?;
+        let temp_file = write_temp_file("oz_prompt_", prompt, ".txt")?;
         let prompt_path = temp_file.path().display().to_string();
 
         let (session_id, preexisting_conversation_id, transcript_path) = match resume {
@@ -445,7 +448,7 @@ const CODEX_OPENAI_BASE_URL: &str = "https://us.api.openai.com/v1";
 fn prepare_codex_environment_config(
     working_dir: &Path,
     system_prompt: Option<&str>,
-    secrets: &HashMap<String, ManagedSecretValue>,
+    resolved_env_vars: &HashMap<OsString, OsString>,
     resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
 ) -> Result<()> {
     let home_dir =
@@ -456,7 +459,7 @@ fn prepare_codex_environment_config(
         write_codex_agents_override(&codex_dir, prompt)?;
     }
 
-    match resolve_openai_api_key(secrets) {
+    match resolve_openai_api_key(resolved_env_vars) {
         Some(api_key) => prepare_codex_auth(&codex_dir.join(CODEX_AUTH_FILE_NAME), &api_key)?,
         None => log::info!("No OPENAI_API_KEY available; skipping Codex auth.json seed"),
     }
@@ -546,24 +549,25 @@ fn write_codex_auth_json(path: &Path, auth: &CodexAuthDotJson) -> Result<()> {
     Ok(())
 }
 
-/// Returns the OpenAI API key for Codex auth, preferring the `OPENAI_API_KEY` env
-/// var so the seeded `auth.json` matches the credential the launched Codex process
-/// will see. [`AgentDriver::new`] skips a managed `OPENAI_API_KEY` secret when the
-/// env var is already set, so we mirror that precedence here.
-fn resolve_openai_api_key(secrets: &HashMap<String, ManagedSecretValue>) -> Option<String> {
+/// Returns the OpenAI API key for Codex auth.
+///
+/// Checks the worker-injected process env first (not in the resolved map since
+/// `build_secret_env_vars` skips env vars already present in the process env),
+/// then falls back to the resolved secret env vars map.
+fn resolve_openai_api_key(resolved_env_vars: &HashMap<OsString, OsString>) -> Option<String> {
+    // Worker-injected process env wins.
     if let Ok(value) = std::env::var(OPENAI_API_KEY_ENV) {
         let trimmed = value.trim();
         if !trimmed.is_empty() {
             return Some(trimmed.to_owned());
         }
     }
-    if let Some(ManagedSecretValue::RawValue { value }) = secrets.get(OPENAI_API_KEY_ENV) {
-        let trimmed = value.trim();
-        if !trimmed.is_empty() {
-            return Some(trimmed.to_owned());
-        }
-    }
-    None
+    // Otherwise use the resolved value from the secrets map.
+    resolved_env_vars
+        .get(OsStr::new(OPENAI_API_KEY_ENV))
+        .and_then(|v| v.to_str())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
 }
 
 /// Edit `~/.codex/config.toml` via `toml_edit` to seed the harness defaults

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -178,7 +178,7 @@ fn prepare_codex_config_toml_writes_fresh_config() {
     let working_dir = tmp.path().join("workspace/proj");
     fs::create_dir_all(&working_dir).unwrap();
 
-    prepare_codex_config_toml(&config_path, &working_dir).unwrap();
+    prepare_codex_config_toml(&config_path, &working_dir, &HashMap::new()).unwrap();
 
     let canonical = working_dir.canonicalize().unwrap();
     let key = canonical.to_string_lossy().into_owned();
@@ -202,7 +202,7 @@ fn prepare_codex_config_toml_preserves_unrelated_keys() {
     )
     .unwrap();
 
-    prepare_codex_config_toml(&config_path, &working_dir).unwrap();
+    prepare_codex_config_toml(&config_path, &working_dir, &HashMap::new()).unwrap();
 
     let canonical = working_dir.canonicalize().unwrap();
     let key = canonical.to_string_lossy().into_owned();
@@ -225,9 +225,9 @@ fn prepare_codex_config_toml_is_idempotent() {
     let working_dir = tmp.path().join("workspace");
     fs::create_dir_all(&working_dir).unwrap();
 
-    prepare_codex_config_toml(&config_path, &working_dir).unwrap();
+    prepare_codex_config_toml(&config_path, &working_dir, &HashMap::new()).unwrap();
     let after_first = fs::read_to_string(&config_path).unwrap();
-    prepare_codex_config_toml(&config_path, &working_dir).unwrap();
+    prepare_codex_config_toml(&config_path, &working_dir, &HashMap::new()).unwrap();
     let after_second = fs::read_to_string(&config_path).unwrap();
 
     assert_eq!(after_first, after_second);
@@ -256,7 +256,7 @@ fn prepare_codex_config_toml_upgrades_untrusted_entry() {
     )
     .unwrap();
 
-    prepare_codex_config_toml(&config_path, &working_dir).unwrap();
+    prepare_codex_config_toml(&config_path, &working_dir, &HashMap::new()).unwrap();
 
     let cfg = read_codex_config(&config_path);
     assert_eq!(
@@ -275,7 +275,7 @@ fn prepare_codex_config_toml_trusts_multiple_child_repos() {
     fs::create_dir_all(repo_a.join(".git")).unwrap();
     fs::create_dir_all(repo_b.join(".git")).unwrap();
 
-    prepare_codex_config_toml(&config_path, &working_dir).unwrap();
+    prepare_codex_config_toml(&config_path, &working_dir, &HashMap::new()).unwrap();
 
     let cfg = read_codex_config(&config_path);
     let projects = cfg["projects"].as_table().unwrap();
@@ -303,10 +303,67 @@ fn prepare_codex_config_toml_overwrites_stale_openai_base_url() {
     )
     .unwrap();
 
-    prepare_codex_config_toml(&config_path, &working_dir).unwrap();
+    prepare_codex_config_toml(&config_path, &working_dir, &HashMap::new()).unwrap();
 
     let cfg = read_codex_config(&config_path);
     assert_eq!(cfg["openai_base_url"].as_str(), Some(CODEX_OPENAI_BASE_URL));
+}
+
+#[test]
+fn write_codex_mcp_servers_cli_server() {
+    let tmp = TempDir::new().unwrap();
+    let config_path = tmp.path().join("config.toml");
+    let working_dir = tmp.path().join("workspace");
+    fs::create_dir_all(&working_dir).unwrap();
+
+    let servers = HashMap::from([(
+        "my-mcp".to_string(),
+        JSONMCPServer {
+            transport_type: JSONTransportType::CLIServer {
+                command: "npx".to_string(),
+                args: vec!["-y".to_string(), "@some/mcp".to_string()],
+                env: HashMap::from([("TOKEN".to_string(), "abc".to_string())]),
+                working_directory: None,
+            },
+        },
+    )]);
+    prepare_codex_config_toml(&config_path, &working_dir, &servers).unwrap();
+
+    let cfg = read_codex_config(&config_path);
+    let mcp = &cfg["mcp_servers"]["my-mcp"];
+    assert_eq!(mcp["command"].as_str(), Some("npx"));
+    let args: Vec<&str> = mcp["args"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(args, vec!["-y", "@some/mcp"]);
+    assert_eq!(mcp["env"]["TOKEN"].as_str(), Some("abc"));
+}
+
+#[test]
+fn write_codex_mcp_servers_sse_server() {
+    let tmp = TempDir::new().unwrap();
+    let config_path = tmp.path().join("config.toml");
+    let working_dir = tmp.path().join("workspace");
+    fs::create_dir_all(&working_dir).unwrap();
+
+    let servers = HashMap::from([(
+        "remote-mcp".to_string(),
+        JSONMCPServer {
+            transport_type: JSONTransportType::SSEServer {
+                url: "https://mcp.example.com/sse".to_string(),
+                headers: HashMap::from([("X-Key".to_string(), "val".to_string())]),
+            },
+        },
+    )]);
+    prepare_codex_config_toml(&config_path, &working_dir, &servers).unwrap();
+
+    let cfg = read_codex_config(&config_path);
+    let mcp = &cfg["mcp_servers"]["remote-mcp"];
+    assert_eq!(mcp["url"].as_str(), Some("https://mcp.example.com/sse"));
+    assert_eq!(mcp["http_headers"]["X-Key"].as_str(), Some("val"));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -367,6 +367,57 @@ fn write_codex_mcp_servers_sse_server() {
 }
 
 #[test]
+fn write_codex_mcp_servers_cli_server_with_cwd() {
+    let tmp = TempDir::new().unwrap();
+    let config_path = tmp.path().join("config.toml");
+    let working_dir = tmp.path().join("workspace");
+    fs::create_dir_all(&working_dir).unwrap();
+
+    let servers = HashMap::from([(
+        "my-mcp".to_string(),
+        JSONMCPServer {
+            transport_type: JSONTransportType::CLIServer {
+                command: "node".to_string(),
+                args: vec!["server.js".to_string()],
+                env: HashMap::new(),
+                working_directory: Some("/opt/mcp-server".to_string()),
+            },
+        },
+    )]);
+    prepare_codex_config_toml(&config_path, &working_dir, &servers).unwrap();
+
+    let cfg = read_codex_config(&config_path);
+    let mcp = &cfg["mcp_servers"]["my-mcp"];
+    assert_eq!(mcp["command"].as_str(), Some("node"));
+    assert_eq!(mcp["cwd"].as_str(), Some("/opt/mcp-server"));
+}
+
+#[test]
+fn write_codex_mcp_servers_cli_server_without_cwd_omits_key() {
+    let tmp = TempDir::new().unwrap();
+    let config_path = tmp.path().join("config.toml");
+    let working_dir = tmp.path().join("workspace");
+    fs::create_dir_all(&working_dir).unwrap();
+
+    let servers = HashMap::from([(
+        "my-mcp".to_string(),
+        JSONMCPServer {
+            transport_type: JSONTransportType::CLIServer {
+                command: "npx".to_string(),
+                args: vec![],
+                env: HashMap::new(),
+                working_directory: None,
+            },
+        },
+    )]);
+    prepare_codex_config_toml(&config_path, &working_dir, &servers).unwrap();
+
+    let cfg = read_codex_config(&config_path);
+    let mcp = &cfg["mcp_servers"]["my-mcp"];
+    assert!(mcp.get("cwd").is_none());
+}
+
+#[test]
 fn find_child_git_repos_returns_only_repo_children() {
     let tmp = TempDir::new().unwrap();
     let workspace = tmp.path().join("workspace");

--- a/app/src/ai/agent_sdk/driver/harness/gemini.rs
+++ b/app/src/ai/agent_sdk/driver/harness/gemini.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -53,6 +54,7 @@ impl ThirdPartyHarness for GeminiHarness {
         &self,
         working_dir: &Path,
         system_prompt: Option<&str>,
+        _resolved_env_vars: &HashMap<OsString, OsString>,
         _secrets: &HashMap<String, ManagedSecretValue>,
         _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {

--- a/app/src/ai/agent_sdk/driver/harness/gemini.rs
+++ b/app/src/ai/agent_sdk/driver/harness/gemini.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ffi::OsString;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -10,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use tempfile::NamedTempFile;
 use warp_cli::agent::Harness;
+use warp_managed_secrets::ManagedSecretValue;
 use warpui::{ModelHandle, ModelSpawner};
 
 use crate::ai::agent::conversation::AIConversationId;
@@ -23,8 +23,8 @@ use super::super::terminal::{CommandHandle, TerminalDriver};
 use super::super::{AgentDriver, AgentDriverError};
 use super::json_utils::{read_json_file_or_default, write_json_file};
 use super::{
-    write_temp_file, HarnessCleanupDisposition, HarnessRunner, ResumePayload, SavePoint,
-    ThirdPartyHarness,
+    write_temp_file, HarnessCleanupDisposition, HarnessRunner, JSONMCPServer, ResumePayload,
+    SavePoint, ThirdPartyHarness,
 };
 
 pub(crate) struct GeminiHarness;
@@ -53,7 +53,8 @@ impl ThirdPartyHarness for GeminiHarness {
         &self,
         working_dir: &Path,
         system_prompt: Option<&str>,
-        _resolved_env_vars: &HashMap<OsString, OsString>,
+        _secrets: &HashMap<String, ManagedSecretValue>,
+        _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {
         prepare_gemini_environment_config(working_dir, system_prompt).map_err(|error| {
             AgentDriverError::HarnessConfigSetupFailed {
@@ -73,6 +74,7 @@ impl ThirdPartyHarness for GeminiHarness {
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
         _resume: Option<ResumePayload>,
+        _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
         // Gemini does not support conversation resume yet. When it does, it will add its
         // own `ResumePayload::Gemini(..)` variant and override `fetch_resume_payload`,

--- a/app/src/ai/agent_sdk/driver/harness/gemini.rs
+++ b/app/src/ai/agent_sdk/driver/harness/gemini.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use tempfile::NamedTempFile;
 use warp_cli::agent::Harness;
-use warp_managed_secrets::ManagedSecretValue;
 use warpui::{ModelHandle, ModelSpawner};
 
 use crate::ai::agent::conversation::AIConversationId;
@@ -55,7 +54,6 @@ impl ThirdPartyHarness for GeminiHarness {
         working_dir: &Path,
         system_prompt: Option<&str>,
         _resolved_env_vars: &HashMap<OsString, OsString>,
-        _secrets: &HashMap<String, ManagedSecretValue>,
         _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {
         prepare_gemini_environment_config(working_dir, system_prompt).map_err(|error| {
@@ -127,7 +125,7 @@ impl GeminiHarnessRunner {
         client: Arc<dyn HarnessSupportClient>,
         terminal_driver: ModelHandle<TerminalDriver>,
     ) -> Result<Self, AgentDriverError> {
-        let temp_file = write_temp_file("oz_prompt_", prompt)?;
+        let temp_file = write_temp_file("oz_prompt_", prompt, ".txt")?;
         let prompt_path = temp_file.path().display().to_string();
 
         Ok(Self {

--- a/app/src/ai/agent_sdk/driver/harness/gemini.rs
+++ b/app/src/ai/agent_sdk/driver/harness/gemini.rs
@@ -49,21 +49,6 @@ impl ThirdPartyHarness for GeminiHarness {
         Some("https://geminicli.com/")
     }
 
-    fn prepare_environment_config(
-        &self,
-        working_dir: &Path,
-        system_prompt: Option<&str>,
-        _resolved_env_vars: &HashMap<OsString, OsString>,
-        _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
-    ) -> Result<(), AgentDriverError> {
-        prepare_gemini_environment_config(working_dir, system_prompt).map_err(|error| {
-            AgentDriverError::HarnessConfigSetupFailed {
-                harness: self.cli_agent().command_prefix().to_owned(),
-                error,
-            }
-        })
-    }
-
     fn build_runner(
         &self,
         prompt: &str,
@@ -74,8 +59,17 @@ impl ThirdPartyHarness for GeminiHarness {
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
         _resume: Option<ResumePayload>,
+        _resolved_env_vars: &HashMap<OsString, OsString>,
         _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError> {
+        // Prepare the environment config files.
+        prepare_gemini_environment_config(working_dir, system_prompt).map_err(|error| {
+            AgentDriverError::HarnessConfigSetupFailed {
+                harness: self.cli_agent().command_prefix().to_owned(),
+                error,
+            }
+        })?;
+
         // Gemini does not support conversation resume yet. When it does, it will add its
         // own `ResumePayload::Gemini(..)` variant and override `fetch_resume_payload`,
         // and decide how to surface the user-turn resumption preamble.

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -34,7 +34,7 @@ use super::{
     OZ_MESSAGE_LISTENER_STATE_ROOT_ENV,
 };
 
-mod claude_code;
+pub(crate) mod claude_code;
 pub(crate) mod claude_transcript;
 mod codex;
 pub(crate) mod codex_transcript;
@@ -137,22 +137,6 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
         validate_cli_installed(self.cli_agent().command_prefix(), self.install_docs_url())
     }
 
-    /// Prepare CLI-specific config files before launching the harness command.
-    ///
-    /// `resolved_env_vars` contains the already-resolved secret env vars produced by
-    /// `build_secret_env_vars`. Precedence (worker env > typed secrets > raw values)
-    /// has already been applied, so harnesses can look up values directly without
-    /// re-deriving which secret won.
-    fn prepare_environment_config(
-        &self,
-        _working_dir: &Path,
-        _system_prompt: Option<&str>,
-        _resolved_env_vars: &HashMap<OsString, OsString>,
-        _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
-    ) -> Result<(), AgentDriverError> {
-        Ok(())
-    }
-
     /// Fetch the harness-specific resume payload for an existing conversation.
     ///
     /// The driver calls this when the user passes `--conversation <id>` and the harness
@@ -173,14 +157,15 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
 
     /// Build a runner for executing this harness with the given prompt.
     ///
-    /// If `resume` is `Some`, the harness matches on its own [`ResumePayload`] variant and
-    /// reuses the stored session/conversation ids instead of minting fresh ones. Variants
-    /// belonging to other harnesses are ignored.
+    /// Responsible for all harness-specific setup: writing config files (auth,
+    /// trust, system prompt, MCP, etc.) and constructing the runner that will
+    /// execute the CLI command.
     ///
-    /// `resumption_prompt`, when non-empty, is a short user-turn preamble the server emits
-    /// during a resumed session. Each harness decides exactly how to surface it (e.g. Claude
-    /// prepends it to the user-turn prompt that gets piped into the CLI). Harnesses that
-    /// don't yet support resumption can ignore it.
+    /// `resolved_env_vars` contains already-resolved secret env vars (worker
+    /// env > typed secrets > raw values precedence already applied).
+    ///
+    /// If `resume` is `Some`, the harness matches on its own [`ResumePayload`]
+    /// variant and reuses stored session/conversation ids.
     #[allow(clippy::too_many_arguments)]
     fn build_runner(
         &self,
@@ -192,6 +177,7 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
         resume: Option<ResumePayload>,
+        resolved_env_vars: &HashMap<OsString, OsString>,
         resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError>;
 }

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -26,7 +26,6 @@ use warp_cli::{
     SESSION_SHARING_SERVER_URL_OVERRIDE_ENV, WS_SERVER_URL_OVERRIDE_ENV,
 };
 use warp_core::channel::ChannelState;
-use warp_managed_secrets::ManagedSecretValue;
 
 use super::terminal::{CommandHandle, TerminalDriver};
 use super::{
@@ -139,12 +138,16 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
     }
 
     /// Prepare CLI-specific config files before launching the harness command.
+    ///
+    /// `resolved_env_vars` contains the already-resolved secret env vars produced by
+    /// `build_secret_env_vars`. Precedence (worker env > typed secrets > raw values)
+    /// has already been applied, so harnesses can look up values directly without
+    /// re-deriving which secret won.
     fn prepare_environment_config(
         &self,
         _working_dir: &Path,
         _system_prompt: Option<&str>,
         _resolved_env_vars: &HashMap<OsString, OsString>,
-        _secrets: &HashMap<String, ManagedSecretValue>,
         _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {
         Ok(())
@@ -483,10 +486,11 @@ pub(crate) async fn cli_agent_session_status(
 pub(super) fn write_temp_file(
     prefix: &str,
     content: &str,
+    suffix: &str,
 ) -> Result<NamedTempFile, AgentDriverError> {
     let mut file = tempfile::Builder::new()
         .prefix(prefix)
-        .suffix(".txt")
+        .suffix(suffix)
         .tempfile()
         .map_err(|e| {
             AgentDriverError::ConfigBuildFailed(anyhow::anyhow!(

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -143,6 +143,7 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
         &self,
         _working_dir: &Path,
         _system_prompt: Option<&str>,
+        _resolved_env_vars: &HashMap<OsString, OsString>,
         _secrets: &HashMap<String, ManagedSecretValue>,
         _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -14,6 +14,7 @@ use warpui::{ModelHandle, ModelSpawner, SingletonEntity};
 
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::ai::mcp::JSONMCPServer;
 use crate::server::server_api::harness_support::{upload_to_target, HarnessSupportClient};
 use crate::server::server_api::ServerApi;
 use crate::terminal::cli_agent_sessions::{CLIAgentSessionStatus, CLIAgentSessionsModel};
@@ -25,6 +26,7 @@ use warp_cli::{
     SESSION_SHARING_SERVER_URL_OVERRIDE_ENV, WS_SERVER_URL_OVERRIDE_ENV,
 };
 use warp_core::channel::ChannelState;
+use warp_managed_secrets::ManagedSecretValue;
 
 use super::terminal::{CommandHandle, TerminalDriver};
 use super::{
@@ -137,16 +139,12 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
     }
 
     /// Prepare CLI-specific config files before launching the harness command.
-    ///
-    /// `resolved_env_vars` contains the already-resolved secret env vars produced by
-    /// `build_secret_env_vars`. Precedence (worker env > typed secrets > raw values)
-    /// has already been applied, so harnesses can look up values directly without
-    /// re-deriving which secret won.
     fn prepare_environment_config(
         &self,
         _working_dir: &Path,
         _system_prompt: Option<&str>,
-        _resolved_env_vars: &HashMap<OsString, OsString>,
+        _secrets: &HashMap<String, ManagedSecretValue>,
+        _resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<(), AgentDriverError> {
         Ok(())
     }
@@ -190,6 +188,7 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
         server_api: Arc<ServerApi>,
         terminal_driver: ModelHandle<TerminalDriver>,
         resume: Option<ResumePayload>,
+        resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     ) -> Result<Box<dyn HarnessRunner>, AgentDriverError>;
 }
 

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -1,7 +1,5 @@
 use std::{collections::HashMap, ffi::OsString, path::PathBuf, sync::Arc};
 
-use warp_managed_secrets::ManagedSecretValue;
-
 use crate::ai::{
     agent_sdk::{
         driver::{
@@ -118,16 +116,9 @@ pub(super) async fn prepare_local_harness_child_launch(
             // but there are no Warp-managed secrets to materialize into the
             // hidden child pane.
             let empty_env_vars = HashMap::new();
-            let managed_secrets: HashMap<String, ManagedSecretValue> = HashMap::new();
             let empty_mcp_servers = HashMap::new();
             third_party_harness
-                .prepare_environment_config(
-                    &working_dir,
-                    None,
-                    &empty_env_vars,
-                    &managed_secrets,
-                    &empty_mcp_servers,
-                )
+                .prepare_environment_config(&working_dir, None, &empty_env_vars, &empty_mcp_servers)
                 .map_err(|error: AgentDriverError| error.to_string())?;
             if let Some(manager) = plugin_manager_for(third_party_harness.cli_agent()) {
                 if let Err(error) = manager.install().await {

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -117,12 +117,14 @@ pub(super) async fn prepare_local_harness_child_launch(
             // auth/session state. We still prepare harness config files here,
             // but there are no Warp-managed secrets to materialize into the
             // hidden child pane.
+            let empty_env_vars = HashMap::new();
             let managed_secrets: HashMap<String, ManagedSecretValue> = HashMap::new();
             let empty_mcp_servers = HashMap::new();
             third_party_harness
                 .prepare_environment_config(
                     &working_dir,
                     None,
+                    &empty_env_vars,
                     &managed_secrets,
                     &empty_mcp_servers,
                 )

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, ffi::OsString, path::PathBuf, sync::Arc};
 use crate::ai::{
     agent_sdk::{
         driver::{
-            harness::{harness_kind, HarnessKind},
+            harness::{claude_code::prepare_claude_environment_config, harness_kind, HarnessKind},
             AgentDriverError,
         },
         task_env_vars, validate_cli_installed,
@@ -115,11 +115,8 @@ pub(super) async fn prepare_local_harness_child_launch(
             // auth/session state. We still prepare harness config files here,
             // but there are no Warp-managed secrets to materialize into the
             // hidden child pane.
-            let empty_env_vars = HashMap::new();
-            let empty_mcp_servers = HashMap::new();
-            third_party_harness
-                .prepare_environment_config(&working_dir, None, &empty_env_vars, &empty_mcp_servers)
-                .map_err(|error: AgentDriverError| error.to_string())?;
+            prepare_claude_environment_config(&working_dir, &HashMap::new())
+                .map_err(|error| error.to_string())?;
             if let Some(manager) = plugin_manager_for(third_party_harness.cli_agent()) {
                 if let Err(error) = manager.install().await {
                     log::warn!("Claude plugin installation failed for child harness: {error}");

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, ffi::OsString, path::PathBuf, sync::Arc};
 
+use warp_managed_secrets::ManagedSecretValue;
+
 use crate::ai::{
     agent_sdk::{
         driver::{
@@ -115,9 +117,15 @@ pub(super) async fn prepare_local_harness_child_launch(
             // auth/session state. We still prepare harness config files here,
             // but there are no Warp-managed secrets to materialize into the
             // hidden child pane.
-            let resolved_env_vars: HashMap<OsString, OsString> = HashMap::new();
+            let managed_secrets: HashMap<String, ManagedSecretValue> = HashMap::new();
+            let empty_mcp_servers = HashMap::new();
             third_party_harness
-                .prepare_environment_config(&working_dir, None, &resolved_env_vars)
+                .prepare_environment_config(
+                    &working_dir,
+                    None,
+                    &managed_secrets,
+                    &empty_mcp_servers,
+                )
                 .map_err(|error: AgentDriverError| error.to_string())?;
             if let Some(manager) = plugin_manager_for(third_party_harness.cli_agent()) {
                 if let Err(error) = manager.install().await {

--- a/specs/REMOTE-1345/TECH.md
+++ b/specs/REMOTE-1345/TECH.md
@@ -1,0 +1,106 @@
+# REMOTE-1345: MCP Servers for Third-Party Harnesses
+
+## Context
+
+MCP server setup in the agent driver is gated on `HarnessKind::Oz` (`driver.rs:1258-1303`). Third-party harnesses (Claude Code, Codex, Gemini) receive zero MCP servers even when the user specifies them via `--mcp` or environment config. File-based MCP discovery (`driver.rs:1325-1341`) is also Oz-only.
+
+The user's MCP config arrives as `Task.mcp_specs: Vec<MCPSpec>` (`driver.rs:336`), where each spec is either a `MCPSpec::Uuid` (reference to an installed server) or `MCPSpec::Json` (inline JSON config). For the Oz harness, `resolve_mcp_specs` (`driver.rs:826`) splits these into UUID refs and ephemeral `TemplatableMCPServerInstallation` objects, which are then spawned as child processes (stdio) or HTTP clients by `TemplatableMCPServerManager`.
+
+Third-party harnesses have their own MCP client implementations:
+- **Claude Code** reads `.mcp.json` or accepts `--mcp-config <json-file>` with `{ "mcpServers": { name: { command, args, env } } }` format.
+- **Codex** reads `~/.codex/config.toml` with `[mcp_servers.name]` sections: `command`/`args`/`env` (stdio) or `url`/`bearer_token_env_var` (HTTP).
+- **Gemini** has no documented MCP config support — out of scope for now.
+
+Each harness already has a `prepare_environment_config` hook (`driver/harness/mod.rs:84`) called before the CLI launches, which writes auth, trust, and onboarding config. This is the natural place to also write MCP config.
+
+### Key files
+- `app/src/ai/agent_sdk/driver.rs:1258-1303` — Oz-only MCP setup block
+- `app/src/ai/agent_sdk/driver.rs:826-858` — `resolve_mcp_specs`
+- `app/src/ai/agent_sdk/driver/harness/mod.rs:83-91` — `prepare_environment_config` trait method
+- `app/src/ai/agent_sdk/driver/harness/claude_code.rs:66-78` — Claude impl
+- `app/src/ai/agent_sdk/driver/harness/codex.rs:50-62` — Codex impl
+- `app/src/ai/mcp/parsing.rs:382-397` — `resolve_json` (template → final JSON)
+- `app/src/ai/mcp/templatable_installation.rs:113-156` — `apply_secrets`
+- `app/src/ai/mcp/mod.rs:178-228` — `JSONTransportType`, `JSONMCPServer`
+- `app/src/ai/agent_sdk/driver/environment.rs:289-300` — single-repo `cd` into repo subdir
+
+## Proposed changes
+
+### Approach: let each harness spawn its own MCP servers
+
+Write resolved MCP configs into each harness's native config format before the CLI launches. The harness CLI spawns/connects to servers itself. This avoids multiplexing stdio pipes and keeps MCP lifecycle owned by the harness.
+
+### 1. Resolve MCP specs to `HashMap<String, JSONMCPServer>` on the UI thread
+
+Add a new helper `resolve_mcp_specs_to_json` that runs on the foreground spawner (where model context is available):
+- For `MCPSpec::Uuid`: look up `TemplatableMCPServerManager::get_installed_server(uuid)` → `TemplatableMCPServerInstallation`, call `apply_secrets`, then `resolve_json(installation)` → parse via `MCPServer::from_user_json`.
+- For `MCPSpec::Json`: parse → `TemplatableMCPServerInstallation` → `apply_secrets` → `resolve_json`.
+- Collect all into `HashMap<String, JSONMCPServer>`.
+
+Call this in `prepare_harness` (around `driver.rs:1564`) before `prepare_environment_config`. This keeps harness impls free of Warp model context.
+
+No redundant work for Oz: `prepare_harness` is only called from the `HarnessKind::ThirdParty` branch of `run_internal` (line 1455). The Oz path (line 1435) goes straight to `execute_run` and continues to use its own `resolve_mcp_specs` → `start_mcp_servers` flow unchanged.
+
+### 2. Extend `ThirdPartyHarness::prepare_environment_config` signature
+
+Add a `resolved_mcp_servers: &HashMap<String, JSONMCPServer>` parameter to the trait method. Gemini ignores it; Claude and Codex use it.
+
+### 3. Claude Code: pass `--mcp-config <temp-file>`
+
+In `prepare_claude_environment_config`, if `resolved_mcp_servers` is non-empty:
+- Serialize to `{ "mcpServers": { name: config, ... } }` JSON. This is the same `McpJsonConfig` schema used by `.mcp.json`, `~/.claude.json`, and `--mcp-config` — `parseMcpConfigFromFilePath` (`config.ts:1384`) parses all three identically. The `--mcp-config` flag accepts a file path or inline JSON string; both go through `parseMcpConfig` → `McpJsonConfigSchema` validation.
+- Write to a `NamedTempFile` (same pattern as prompt files — held by `ClaudeHarnessRunner` so it lives until the CLI exits).
+- Pass the path as `--mcp-config '<path>'` in `claude_command()`.
+
+Using `--mcp-config` instead of writing `.mcp.json` avoids a cwd problem: in the single-repo case, `environment.rs:291-296` does `cd_in_terminal(repo_name)` so the terminal cwd is `{working_dir}/{repo}`, not `working_dir`. Claude discovers `.mcp.json` relative to its cwd, so a file at `working_dir/.mcp.json` wouldn't be found. The `--mcp-config` flag is path-independent and also avoids merge conflicts with repo-owned `.mcp.json` files.
+
+Implementation detail: `prepare_environment_config` currently returns `Result<(), AgentDriverError>`, not a temp file handle. Options:
+- (a) Return an optional `NamedTempFile` from `prepare_environment_config` and thread it to `build_runner` / the runner struct — messy signature change.
+- (b) Write the MCP config file inside `build_runner` instead — `build_runner` already has `working_dir` and creates temp files for prompts. This is cleaner; `prepare_environment_config` stays focused on static config, and `build_runner` handles per-run temp files.
+
+Option (b) is preferred. Pass `resolved_mcp_servers` to `build_runner` as well, and let `ClaudeHarnessRunner::new` write the temp file + append `--mcp-config` to the command.
+
+### 4. Codex: write `[mcp_servers]` entries to `config.toml`
+
+In `prepare_codex_environment_config`, if `resolved_mcp_servers` is non-empty:
+- Convert `JSONMCPServer` → TOML entries: `CLIServer { command, args, env }` → `[mcp_servers.name]` with `command`, `args`, `env`; `SSEServer { url, headers }` → `url` field.
+- Append to `~/.codex/config.toml` inside `prepare_codex_config_toml` (already writes to this file).
+
+This is safe to do in `prepare_environment_config` since codex config is global, not cwd-relative.
+
+### 5. Transport mapping
+
+Warp's `JSONTransportType` maps to each harness as follows:
+
+**`CLIServer { command, args, env, working_directory }`:**
+- Claude Code: `{ "type": "stdio", "command": "...", "args": [...], "env": {...} }`
+- Codex: `command = "..."`, `args = [...]`, `env = { ... }` under `[mcp_servers.name]`
+
+**`SSEServer { url, headers }`:**
+- Claude Code: `{ "type": "sse", "url": "...", "headers": {...} }`
+- Codex: `url = "..."` under `[mcp_servers.name]`. Codex's `StreamableHttp` transport (`mcp_types.rs:378-391`) supports three header mechanisms:
+  - `http_headers` — static `HashMap<String, String>`, maps directly from Warp's `SSEServer.headers`
+  - `env_http_headers` — headers where the value is an env var name (no Warp equivalent; unused)
+  - `bearer_token_env_var` — env var name for a bearer token (no direct Warp equivalent, but could be extracted from `headers` if there's an `Authorization: Bearer $ENV_VAR` pattern)
+
+  For now, map `SSEServer.headers` → `http_headers` directly. This covers the common case where headers contain literal values (API keys, auth tokens). The `env_http_headers` and `bearer_token_env_var` paths can be added later if needed.
+
+## Testing and validation
+
+1. **Unit tests for `resolve_mcp_specs_to_json`** — verify UUID and JSON specs both resolve to correct `JSONMCPServer` entries with secrets applied.
+2. **Unit tests for Claude MCP config serialization** — verify `HashMap<String, JSONMCPServer>` produces valid `.mcp.json`-format JSON.
+3. **Unit tests for Codex MCP config serialization** — verify `HashMap<String, JSONMCPServer>` produces valid `config.toml` `[mcp_servers]` entries.
+4. **Integration test (Claude)** — run a cloud agent with `--harness claude --mcp '{"test": {"command": "echo", "args": ["hello"]}}'` and verify the Claude CLI receives the MCP config (visible in logs or session output).
+5. **Integration test (Codex)** — same as above with `--harness codex`.
+6. **Regression** — verify Oz harness MCP setup is unchanged (existing tests should cover this).
+
+## Parallelization
+
+After step 1 (shared resolution helper) and step 2 (trait signature change) are merged:
+- Claude Code config generation (step 3) and Codex config generation (step 4) can be implemented by parallel agents — they touch separate files (`claude_code.rs` vs `codex.rs`) with no overlap.
+
+## Follow-ups
+
+- **File-based MCP discovery for Codex**: Claude Code auto-discovers `.mcp.json` in cloned repos. Codex would need discovered configs translated to `config.toml` format.
+- **Profile MCP servers**: `start_profile_mcp_servers` resolves UUID-based servers from the profile allowlist. Same resolution path as `task.mcp_specs` — could be included in a follow-up.
+- **Gemini MCP support**: add when Gemini CLI supports MCP configuration.

--- a/specs/REMOTE-1345/TECH.md
+++ b/specs/REMOTE-1345/TECH.md
@@ -9,9 +9,6 @@ The user's MCP config arrives as `Task.mcp_specs: Vec<MCPSpec>` (`driver.rs:336`
 Third-party harnesses have their own MCP client implementations:
 - **Claude Code** reads `.mcp.json` or accepts `--mcp-config <json-file>` with `{ "mcpServers": { name: { command, args, env } } }` format.
 - **Codex** reads `~/.codex/config.toml` with `[mcp_servers.name]` sections: `command`/`args`/`env` (stdio) or `url`/`bearer_token_env_var` (HTTP).
-- **Gemini** has no documented MCP config support — out of scope for now.
-
-Each harness already has a `prepare_environment_config` hook (`driver/harness/mod.rs:84`) called before the CLI launches, which writes auth, trust, and onboarding config. This is the natural place to also write MCP config.
 
 ### Key files
 - `app/src/ai/agent_sdk/driver.rs:1258-1303` — Oz-only MCP setup block
@@ -30,43 +27,49 @@ Each harness already has a `prepare_environment_config` hook (`driver/harness/mo
 
 Write resolved MCP configs into each harness's native config format before the CLI launches. The harness CLI spawns/connects to servers itself. This avoids multiplexing stdio pipes and keeps MCP lifecycle owned by the harness.
 
-### 1. Resolve MCP specs to `HashMap<String, JSONMCPServer>` on the UI thread
+### 1. Resolve MCP specs to `HashMap<String, JSONMCPServer>` on the foreground spawner
 
-Add a new helper `resolve_mcp_specs_to_json` that runs on the foreground spawner (where model context is available):
-- For `MCPSpec::Uuid`: look up `TemplatableMCPServerManager::get_installed_server(uuid)` → `TemplatableMCPServerInstallation`, call `apply_secrets`, then `resolve_json(installation)` → parse via `MCPServer::from_user_json`.
-- For `MCPSpec::Json`: parse → `TemplatableMCPServerInstallation` → `apply_secrets` → `resolve_json`.
+New helper `resolve_mcp_specs_to_json` on `AgentDriver` (`driver.rs:788`), runs on the foreground spawner (model context required):
+- Delegates to existing `resolve_mcp_specs` to split into `(existing_uuids, ephemeral_installations)`.
+- For UUIDs: `TemplatableMCPServerManager::get_installed_server(uuid)` → clone → `apply_secrets` → `resolve_json` → `serde_json::from_str::<HashMap<String, JSONMCPServer>>`.
+- For ephemeral: `apply_secrets` → `resolve_json` → `serde_json::from_str`.
 - Collect all into `HashMap<String, JSONMCPServer>`.
 
-Call this in `prepare_harness` (around `driver.rs:1564`) before `prepare_environment_config`. This keeps harness impls free of Warp model context.
+Called in `prepare_harness` before `build_runner`. `prepare_harness` is only called from the `HarnessKind::ThirdParty` branch; the Oz path uses its own `resolve_mcp_specs` → `start_mcp_servers` unchanged.
 
-No redundant work for Oz: `prepare_harness` is only called from the `HarnessKind::ThirdParty` branch of `run_internal` (line 1455). The Oz path (line 1435) goes straight to `execute_run` and continues to use its own `resolve_mcp_specs` → `start_mcp_servers` flow unchanged.
+### 2. Remove `prepare_environment_config` from the trait; fold config setup into `build_runner`
 
-### 2. Extend `ThirdPartyHarness::prepare_environment_config` signature
+The `prepare_environment_config` method was removed from `ThirdPartyHarness` entirely. Each harness now does its config setup (auth, trust, onboarding, MCP) inside `build_runner`, which already receives all the context it needs.
 
-Add a `resolved_mcp_servers: &HashMap<String, JSONMCPServer>` parameter to the trait method. Gemini ignores it; Claude and Codex use it.
+I did this because we started to split handling for environment config across `build_runner` and `prepare_environment_config` depending on the harness, which resulted in us passing the same parameters
+to both functions for all harnesses, but most harnesses would only use the parameters in one function or the other. `build_runner` and `prepare_environment_config` are always called
+back-to-back.
 
-### 3. Claude Code: pass `--mcp-config <temp-file>`
+`build_runner` signature gained two new params:
+- `resolved_env_vars: &HashMap<OsString, OsString>` (previously passed to `prepare_environment_config`)
+- `resolved_mcp_servers: &HashMap<String, JSONMCPServer>`
 
-In `prepare_claude_environment_config`, if `resolved_mcp_servers` is non-empty:
-- Serialize to `{ "mcpServers": { name: config, ... } }` JSON. This is the same `McpJsonConfig` schema used by `.mcp.json`, `~/.claude.json`, and `--mcp-config` — `parseMcpConfigFromFilePath` (`config.ts:1384`) parses all three identically. The `--mcp-config` flag accepts a file path or inline JSON string; both go through `parseMcpConfig` → `McpJsonConfigSchema` validation.
-- Write to a `NamedTempFile` (same pattern as prompt files — held by `ClaudeHarnessRunner` so it lives until the CLI exits).
-- Pass the path as `--mcp-config '<path>'` in `claude_command()`.
+This consolidates per-run setup (temp files, MCP config) and static config (auth, trust) into one method per harness. Gemini currently ignores `resolved_mcp_servers`.
 
-Using `--mcp-config` instead of writing `.mcp.json` avoids a cwd problem: in the single-repo case, `environment.rs:291-296` does `cd_in_terminal(repo_name)` so the terminal cwd is `{working_dir}/{repo}`, not `working_dir`. Claude discovers `.mcp.json` relative to its cwd, so a file at `working_dir/.mcp.json` wouldn't be found. The `--mcp-config` flag is path-independent and also avoids merge conflicts with repo-owned `.mcp.json` files.
+### 3. Claude Code: write MCP config in `ClaudeHarnessRunner::new`, pass via `--mcp-config`
 
-Implementation detail: `prepare_environment_config` currently returns `Result<(), AgentDriverError>`, not a temp file handle. Options:
-- (a) Return an optional `NamedTempFile` from `prepare_environment_config` and thread it to `build_runner` / the runner struct — messy signature change.
-- (b) Write the MCP config file inside `build_runner` instead — `build_runner` already has `working_dir` and creates temp files for prompts. This is cleaner; `prepare_environment_config` stays focused on static config, and `build_runner` handles per-run temp files.
+Inside `build_runner` → `ClaudeHarnessRunner::new`:
+- `prepare_claude_environment_config` is called first for static config (auth, trust, onboarding) — unchanged from before, just moved into `build_runner`.
+- If `resolved_mcp_servers` is non-empty, `serialize_claude_mcp_config` produces `{ "mcpServers": { name: config } }` JSON.
+- Written to a `NamedTempFile` with `.json` suffix, stored as `_temp_mcp_config_file` on the runner so it lives until the CLI exits.
+- `claude_command()` gained a `mcp_config_path: Option<&str>` param; when present, appends `--mcp-config '<path>'`.
 
-Option (b) is preferred. Pass `resolved_mcp_servers` to `build_runner` as well, and let `ClaudeHarnessRunner::new` write the temp file + append `--mcp-config` to the command.
+New types for serialization: `ClaudeMcpConfig` (wrapper with `mcp_servers` field) and `ClaudeMcpServerEntry` (tagged enum: `Stdio { command, args, env }` / `Http { url, headers }`).
+
+Using `--mcp-config` instead of writing `.mcp.json` avoids a cwd problem: in the single-repo case, `environment.rs` does `cd_in_terminal(repo_name)` so the terminal cwd is `{working_dir}/{repo}`, not `working_dir`. Claude discovers `.mcp.json` relative to its cwd, so a file at `working_dir/.mcp.json` wouldn't be found. The flag is path-independent and also avoids conflicts with repo-owned `.mcp.json` files.
 
 ### 4. Codex: write `[mcp_servers]` entries to `config.toml`
 
-In `prepare_codex_environment_config`, if `resolved_mcp_servers` is non-empty:
-- Convert `JSONMCPServer` → TOML entries: `CLIServer { command, args, env }` → `[mcp_servers.name]` with `command`, `args`, `env`; `SSEServer { url, headers }` → `url` field.
-- Append to `~/.codex/config.toml` inside `prepare_codex_config_toml` (already writes to this file).
+`prepare_codex_environment_config` (now called inside `build_runner`) passes `resolved_mcp_servers` through to `prepare_codex_config_toml`, which calls the new `write_codex_mcp_servers` helper:
+- `CLIServer { command, args, env }` → `[mcp_servers.name]` with `command`, `args`, `env` fields.
+- `SSEServer { url, headers }` → `[mcp_servers.name]` with `url` and `http_headers` (inline table) fields.
 
-This is safe to do in `prepare_environment_config` since codex config is global, not cwd-relative.
+Codex config is global (`~/.codex/config.toml`), not cwd-relative, so no path issues.
 
 ### 5. Transport mapping
 
@@ -77,27 +80,15 @@ Warp's `JSONTransportType` maps to each harness as follows:
 - Codex: `command = "..."`, `args = [...]`, `env = { ... }` under `[mcp_servers.name]`
 
 **`SSEServer { url, headers }`:**
-- Claude Code: `{ "type": "sse", "url": "...", "headers": {...} }`
-- Codex: `url = "..."` under `[mcp_servers.name]`. Codex's `StreamableHttp` transport (`mcp_types.rs:378-391`) supports three header mechanisms:
-  - `http_headers` — static `HashMap<String, String>`, maps directly from Warp's `SSEServer.headers`
-  - `env_http_headers` — headers where the value is an env var name (no Warp equivalent; unused)
-  - `bearer_token_env_var` — env var name for a bearer token (no direct Warp equivalent, but could be extracted from `headers` if there's an `Authorization: Bearer $ENV_VAR` pattern)
-
-  For now, map `SSEServer.headers` → `http_headers` directly. This covers the common case where headers contain literal values (API keys, auth tokens). The `env_http_headers` and `bearer_token_env_var` paths can be added later if needed.
+- Claude Code: `{ "type": "http", "url": "...", "headers": {...} }`
+- Codex: `url = "..."`, `http_headers = { ... }` under `[mcp_servers.name]`
 
 ## Testing and validation
 
-1. **Unit tests for `resolve_mcp_specs_to_json`** — verify UUID and JSON specs both resolve to correct `JSONMCPServer` entries with secrets applied.
-2. **Unit tests for Claude MCP config serialization** — verify `HashMap<String, JSONMCPServer>` produces valid `.mcp.json`-format JSON.
-3. **Unit tests for Codex MCP config serialization** — verify `HashMap<String, JSONMCPServer>` produces valid `config.toml` `[mcp_servers]` entries.
-4. **Integration test (Claude)** — run a cloud agent with `--harness claude --mcp '{"test": {"command": "echo", "args": ["hello"]}}'` and verify the Claude CLI receives the MCP config (visible in logs or session output).
-5. **Integration test (Codex)** — same as above with `--harness codex`.
-6. **Regression** — verify Oz harness MCP setup is unchanged (existing tests should cover this).
-
-## Parallelization
-
-After step 1 (shared resolution helper) and step 2 (trait signature change) are merged:
-- Claude Code config generation (step 3) and Codex config generation (step 4) can be implemented by parallel agents — they touch separate files (`claude_code.rs` vs `codex.rs`) with no overlap.
+1. **Unit tests for Claude MCP config serialization** (`claude_code_tests.rs`) — `serialize_claude_mcp_config_cli_server` and `serialize_claude_mcp_config_sse_server` verify `HashMap<String, JSONMCPServer>` produces valid `--mcp-config` JSON for both transport types.
+2. **Unit tests for Codex MCP config serialization** (`codex_tests.rs`) — `write_codex_mcp_servers_cli_server` and `write_codex_mcp_servers_sse_server` verify `HashMap<String, JSONMCPServer>` produces valid `[mcp_servers]` TOML entries.
+3. **Existing test updates** — `claude_command` tests, `prepare_codex_config_toml` tests updated for new function signatures.
+4. **Regression** — Oz harness MCP setup unchanged (existing tests cover this).
 
 ## Follow-ups
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
This PR adds support for MCP servers for third-party harnesses with cloud agents.

When setting up the driver for a third-party task, we add a new step `resolve_mcp_specs_to_json`, which converts MCP server config data from the task into a JSON format by applying any secret values to the templated MCP.

We thread this list of `JSONMCPServer`s into each harness's environment setup, where:
- Claude writes them to a temp file, which we pass a path to via `--mcp-config` flag
- Codex writes them to a section of `config.toml`

In this PR, I also remove `prepare_environment_config` from the `ThirdPartyHarness` trait and move its implementation into `build_runner`. Across Claude Code and Codex we started to do different parts of the environment setup process in each place (e.g. Codex would seed the system prompt in `prepare_environment_config`, while CC needed to do it in `build_runner` so we could hold onto the temp file), which resulted in adding the params to both functions that each harness would ignore in one place and user in the other. We always call `prepare_environment_config`, and `build_runner` back to back; now we fold `prepare_environment_config` responsibilities within `build_runner`.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end. 

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up. 
-->

Tested locally for both `codex` and `claude` with `./script/oz-local`, Loom available in Slack.
- [x] Just Linear (single MCP, stdio)
- [x] Linear and Sentry (multiple MCP servers, stdio)
- [x] Context7 (single MCP, http)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

