### PR TITLE
fix(ai): inject .ai/progress.md as project context in AI sessions

### DIFF
--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -15,6 +15,7 @@ use crate::ai::{
 
 use super::agent_view::{AgentViewController, AgentViewEntryOrigin, EnterAgentViewError};
 use ai::project_context::model::ProjectContextModel;
+use crate::ai::project_progress::ProjectProgressContext;
 use parking_lot::FairMutex;
 use warp_core::features::FeatureFlag;
 use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
@@ -429,15 +430,20 @@ impl BlocklistAIContextModel {
                 })
         };
 
-        let project_rules = if let Some(pwd) = pwd.clone().and_then(|path| {
+        let canonical_pwd = pwd.clone().and_then(|path| {
             PathBuf::from_str(&path)
                 .ok()
                 .and_then(|s| s.canonicalize().ok())
-        }) {
-            ProjectContextModel::as_ref(app).find_applicable_rules(&pwd)
-        } else {
-            None
-        };
+        });
+
+        let project_rules = canonical_pwd
+            .as_deref()
+            .and_then(|p| ProjectContextModel::as_ref(app).find_applicable_rules(p));
+
+        // Load .ai/progress.md context when present in the working directory.
+        let project_progress = canonical_pwd
+            .as_deref()
+            .and_then(ProjectProgressContext::load);
 
         let mut context = Vec::new();
 
@@ -482,6 +488,26 @@ impl BlocklistAIContextModel {
                     })
                     .collect(),
                 additional_rule_paths: rules.additional_rule_paths,
+            });
+        }
+
+        // Inject project progress context when `.ai/progress.md` is present.
+        // The formatted block is sent as a virtual "rule file" so the AI has
+        // structured, always-current knowledge of what is being worked on —
+        // consistent across every Warp window pointing at the same project.
+        if let Some(progress) = project_progress {
+            let formatted = progress.to_formatted_string();
+            let line_count = formatted.lines().count();
+            context.push(AIAgentContext::ProjectRules {
+                root_path: progress.project_path.to_string_lossy().into(),
+                active_rules: vec![FileContext {
+                    file_name: ".ai/progress.md".to_owned(),
+                    content: AnyFileContent::StringContent(formatted),
+                    line_range: None,
+                    last_modified: None,
+                    line_count,
+                }],
+                additional_rule_paths: vec![],
             });
         }
 

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod llms;
 pub mod onboarding;
 pub(crate) mod persisted_workspace;
 pub(crate) mod predict;
+pub(crate) mod project_progress;
 pub mod request_usage_model;
 pub(crate) mod restored_conversations;
 pub(crate) mod skills;

--- a/app/src/ai/project_progress.rs
+++ b/app/src/ai/project_progress.rs
@@ -61,22 +61,32 @@ pub struct ProjectProgressContext {
 }
 
 impl ProjectProgressContext {
-    /// Loads progress context for `project_path`.
+    /// Maximum number of ancestor directories to walk when looking for
+    /// `.ai/progress.md`. Bounds the I/O for pathological deep paths.
+    const MAX_ANCESTOR_WALK: usize = 30;
+
+    /// Loads progress context, starting at `start_dir` and walking up its
+    /// ancestors until a directory containing `.ai/progress.md` is found.
     ///
-    /// Returns `None` when `.ai/progress.md` does not exist, so callers can
+    /// Returns `None` when no ancestor contains `.ai/progress.md`, or when
+    /// the file exists but contains no parseable task entries — callers can
     /// cheaply skip the feature for projects that haven't opted in.
-    pub fn load(project_path: &Path) -> Option<Self> {
+    pub fn load(start_dir: &Path) -> Option<Self> {
+        let project_path = Self::find_project_root(start_dir)?;
         let progress_path = project_path.join(PROGRESS_FILE);
-        if !progress_path.exists() {
-            return None;
-        }
 
         let content = std::fs::read_to_string(&progress_path).ok()?;
         let mut tasks = Self::parse_progress(&content);
 
         // Best-effort: update task statuses from git history.
-        if let Some(git_log) = Self::read_git_log_sync(project_path) {
+        if let Some(git_log) = Self::read_git_log_sync(&project_path) {
             Self::derive_status_from_git(&mut tasks, &git_log);
+        }
+
+        // No parseable tasks → skip injection entirely. The feature is opt-in,
+        // so an empty / malformed file shouldn't surface placeholder context.
+        if tasks.is_empty() {
+            return None;
         }
 
         let current_task = tasks
@@ -92,7 +102,7 @@ impl ProjectProgressContext {
         let global_ctx_dir = dirs::home_dir().map(|h| h.join(GLOBAL_CTX_SUBDIR));
 
         Some(ProjectProgressContext {
-            project_path: project_path.to_path_buf(),
+            project_path,
             current_task,
             next_task,
             goal: Self::read_ctx_head(&ctx_dir, global_ctx_dir.as_deref(), "00_goal.md", 15),
@@ -110,6 +120,16 @@ impl ProjectProgressContext {
                 3,
             ),
         })
+    }
+
+    /// Walks ancestors of `start_dir` (including `start_dir` itself) and
+    /// returns the first one containing `.ai/progress.md`.
+    fn find_project_root(start_dir: &Path) -> Option<PathBuf> {
+        start_dir
+            .ancestors()
+            .take(Self::MAX_ANCESTOR_WALK)
+            .find(|dir| dir.join(PROGRESS_FILE).exists())
+            .map(Path::to_path_buf)
     }
 
     /// Formats the context as a concise block (< 100 lines) suitable for
@@ -386,6 +406,57 @@ mod tests {
         assert_eq!(tasks[0].status, TaskStatus::Done);
         assert_eq!(tasks[1].status, TaskStatus::Doing);
         assert_eq!(tasks[2].status, TaskStatus::Todo);
+    }
+
+    #[test]
+    fn load_walks_ancestors_to_find_progress_file() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".ai")).unwrap();
+        std::fs::write(
+            root.join(".ai/progress.md"),
+            "[1] Setup  doing\n[2] Build  todo\n",
+        )
+        .unwrap();
+
+        let nested = root.join("a/b/c");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let ctx = ProjectProgressContext::load(&nested).expect("should resolve from subdir");
+        // The resolved root must be an ancestor of the starting directory and
+        // must itself contain `.ai/progress.md`.
+        assert!(
+            nested.starts_with(&ctx.project_path),
+            "resolved project_path must be an ancestor of the start dir"
+        );
+        assert!(ctx.project_path.join(".ai/progress.md").exists());
+        assert!(ctx.current_task.is_some());
+    }
+
+    #[test]
+    fn load_returns_none_when_no_progress_file_in_any_ancestor() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let nested = tmp.path().join("a/b");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert!(ProjectProgressContext::load(&nested).is_none());
+    }
+
+    #[test]
+    fn load_returns_none_when_progress_file_has_no_parseable_tasks() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".ai")).unwrap();
+        // Only comments / blank lines / malformed lines — no valid task entries.
+        std::fs::write(
+            root.join(".ai/progress.md"),
+            "# my project\n\nnot a task line\n[abc] bad number  doing\n",
+        )
+        .unwrap();
+
+        assert!(
+            ProjectProgressContext::load(root).is_none(),
+            "empty / unparseable progress.md must not inject placeholder context"
+        );
     }
 
     #[test]

--- a/app/src/ai/project_progress.rs
+++ b/app/src/ai/project_progress.rs
@@ -1,0 +1,413 @@
+//! Project progress context derived from `.ai/progress.md`.
+//!
+//! When a project contains `.ai/progress.md`, this module reads it to surface
+//! the current and next tasks as structured AI context. Task status is
+//! auto-derived from recent git commit messages so the context stays in sync
+//! across every Warp window without manual maintenance.
+//!
+//! File layout expected under `<project>/.ai/`:
+//!
+//! ```text
+//! .ai/
+//! ├── progress.md          # task list: "[N] Task name  done|doing|todo"
+//! └── ctx/
+//!     ├── 00_goal.md       # project goal (optional)
+//!     ├── 04_constraint.md # tech constraints (optional)
+//!     ├── 05_api.md        # API spec (optional)
+//!     └── 07_issue.md      # known issues log (optional)
+//! ```
+//!
+//! A global fallback directory (`~/.ai/ctx/`) is consulted when a project-level
+//! file is absent, matching the behaviour of the original aiflow shell tool.
+
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+
+const PROGRESS_FILE: &str = ".ai/progress.md";
+const CTX_DIR: &str = ".ai/ctx";
+const GLOBAL_CTX_SUBDIR: &str = ".ai/ctx";
+
+/// Status of a single task in `progress.md`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskStatus {
+    Done,
+    Doing,
+    Todo,
+}
+
+/// A parsed task entry from `progress.md`.
+#[derive(Debug, Clone)]
+pub struct ProgressTask {
+    pub number: u32,
+    pub name: String,
+    pub status: TaskStatus,
+}
+
+/// All context assembled from a project's `.ai/` directory.
+#[derive(Debug, Clone, Default)]
+pub struct ProjectProgressContext {
+    pub project_path: PathBuf,
+    pub current_task: Option<ProgressTask>,
+    pub next_task: Option<ProgressTask>,
+    /// First 15 lines of `00_goal.md`, if present and non-empty.
+    pub goal: Option<String>,
+    /// First 10 lines of `05_api.md`, if present and non-empty.
+    pub api_spec: Option<String>,
+    /// First 10 lines of `04_constraint.md`, if present and non-empty.
+    pub constraints: Option<String>,
+    /// Last 3 non-blank lines of `07_issue.md`, if present and non-empty.
+    pub recent_issues: Option<String>,
+}
+
+impl ProjectProgressContext {
+    /// Loads progress context for `project_path`.
+    ///
+    /// Returns `None` when `.ai/progress.md` does not exist, so callers can
+    /// cheaply skip the feature for projects that haven't opted in.
+    pub fn load(project_path: &Path) -> Option<Self> {
+        let progress_path = project_path.join(PROGRESS_FILE);
+        if !progress_path.exists() {
+            return None;
+        }
+
+        let content = std::fs::read_to_string(&progress_path).ok()?;
+        let mut tasks = Self::parse_progress(&content);
+
+        // Best-effort: update task statuses from git history.
+        if let Some(git_log) = Self::read_git_log_sync(project_path) {
+            Self::derive_status_from_git(&mut tasks, &git_log);
+        }
+
+        let current_task = tasks
+            .iter()
+            .find(|t| t.status == TaskStatus::Doing)
+            .cloned();
+        let next_task = tasks
+            .iter()
+            .find(|t| t.status == TaskStatus::Todo)
+            .cloned();
+
+        let ctx_dir = project_path.join(CTX_DIR);
+        let global_ctx_dir = dirs::home_dir().map(|h| h.join(GLOBAL_CTX_SUBDIR));
+
+        Some(ProjectProgressContext {
+            project_path: project_path.to_path_buf(),
+            current_task,
+            next_task,
+            goal: Self::read_ctx_head(&ctx_dir, global_ctx_dir.as_deref(), "00_goal.md", 15),
+            api_spec: Self::read_ctx_head(&ctx_dir, global_ctx_dir.as_deref(), "05_api.md", 10),
+            constraints: Self::read_ctx_head(
+                &ctx_dir,
+                global_ctx_dir.as_deref(),
+                "04_constraint.md",
+                10,
+            ),
+            recent_issues: Self::read_ctx_tail(
+                &ctx_dir,
+                global_ctx_dir.as_deref(),
+                "07_issue.md",
+                3,
+            ),
+        })
+    }
+
+    /// Formats the context as a concise block (< 100 lines) suitable for
+    /// injection into an AI session alongside other project context.
+    pub fn to_formatted_string(&self) -> String {
+        let mut lines: Vec<String> = Vec::new();
+
+        // CURRENT is always emitted; it signals the active task even when absent.
+        match &self.current_task {
+            Some(t) => lines.push(format!("[CURRENT] [{}] {}", t.number, t.name)),
+            None => lines.push("[CURRENT] (no task in progress)".to_string()),
+        }
+
+        if let Some(t) = &self.next_task {
+            lines.push(format!("[NEXT]    [{}] {}", t.number, t.name));
+        }
+
+        if let Some(goal) = &self.goal {
+            lines.push(String::new());
+            lines.push("[GOAL]".to_string());
+            lines.extend(goal.lines().take(15).map(str::to_owned));
+        }
+
+        if let Some(api) = &self.api_spec {
+            lines.push(String::new());
+            lines.push("[API]".to_string());
+            lines.extend(api.lines().take(10).map(str::to_owned));
+        }
+
+        if let Some(c) = &self.constraints {
+            lines.push(String::new());
+            lines.push("[CONSTRAINTS]".to_string());
+            lines.extend(c.lines().take(10).map(str::to_owned));
+        }
+
+        if let Some(issues) = &self.recent_issues {
+            lines.push(String::new());
+            lines.push("[RECENT ISSUES]".to_string());
+            lines.push(issues.clone());
+        }
+
+        lines.join("\n")
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    /// Parses `progress.md` into a list of tasks.
+    ///
+    /// Each line must match `[N] Task name  done|doing|todo`.
+    /// Comment lines, blank lines and headings are silently ignored so users
+    /// can annotate their task list freely.
+    fn parse_progress(content: &str) -> Vec<ProgressTask> {
+        // Allow trailing whitespace and multiple spaces between fields.
+        let re = Regex::new(r"^\[(\d+)\]\s+(.+?)\s+(done|doing|todo)\s*$")
+            .expect("hardcoded regex is valid");
+
+        content
+            .lines()
+            .filter_map(|line| {
+                let caps = re.captures(line.trim())?;
+                let number: u32 = caps[1].parse().ok()?;
+                let name = caps[2].trim().to_owned();
+                let status = match &caps[3] {
+                    "done" => TaskStatus::Done,
+                    "doing" => TaskStatus::Doing,
+                    _ => TaskStatus::Todo,
+                };
+                Some(ProgressTask {
+                    number,
+                    name,
+                    status,
+                })
+            })
+            .collect()
+    }
+
+    /// Reads `git log --oneline -50` synchronously.
+    ///
+    /// Returns `None` on any failure (not a git repo, git not installed, etc.)
+    /// so the caller falls back to the statuses already written in
+    /// `progress.md` rather than crashing.
+    fn read_git_log_sync(project_path: &Path) -> Option<String> {
+        let output = command::blocking::Command::new("git")
+            .args(["log", "--oneline", "-50"])
+            .current_dir(project_path)
+            .stdout(command::Stdio::piped())
+            .stderr(command::Stdio::null())
+            .env("GIT_OPTIONAL_LOCKS", "0")
+            .output()
+            .ok()?;
+
+        if output.status.success() {
+            Some(String::from_utf8_lossy(&output.stdout).into_owned())
+        } else {
+            None
+        }
+    }
+
+    /// Updates task statuses in-place using commit-message heuristics.
+    ///
+    /// Rules (matching the original aiflow shell logic):
+    /// - A commit containing `[N]` or the task name (case-insensitive) marks
+    ///   that task as `done`.
+    /// - Tasks already marked `done` are left untouched.
+    /// - The first remaining non-done task becomes `doing`.
+    /// - All subsequent non-done tasks become `todo`.
+    fn derive_status_from_git(tasks: &mut Vec<ProgressTask>, git_log: &str) {
+        let log_lower = git_log.to_lowercase();
+        let mut first_undone_found = false;
+
+        for task in tasks.iter_mut() {
+            if task.status == TaskStatus::Done {
+                continue;
+            }
+
+            let bracket_marker = format!("[{}]", task.number);
+            let name_lower = task.name.to_lowercase();
+
+            let completed_in_git = git_log.contains(&bracket_marker)
+                || log_lower.contains(&name_lower);
+
+            if completed_in_git {
+                task.status = TaskStatus::Done;
+            } else if !first_undone_found {
+                task.status = TaskStatus::Doing;
+                first_undone_found = true;
+            } else {
+                task.status = TaskStatus::Todo;
+            }
+        }
+    }
+
+    /// Reads the first `max_lines` of a context file.
+    ///
+    /// Project-level (`ctx_dir`) takes priority over the global fallback
+    /// (`global_ctx_dir`). Returns `None` when the file is absent or contains
+    /// only comments / blank lines.
+    fn read_ctx_head(
+        ctx_dir: &Path,
+        global_ctx_dir: Option<&Path>,
+        name: &str,
+        max_lines: usize,
+    ) -> Option<String> {
+        let path = Self::resolve_ctx_file(ctx_dir, global_ctx_dir, name)?;
+        let content = std::fs::read_to_string(&path).ok()?;
+        if Self::has_meaningful_content(&content) {
+            Some(
+                content
+                    .lines()
+                    .take(max_lines)
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            )
+        } else {
+            None
+        }
+    }
+
+    /// Reads the last `n` meaningful lines of a context file.
+    fn read_ctx_tail(
+        ctx_dir: &Path,
+        global_ctx_dir: Option<&Path>,
+        name: &str,
+        n: usize,
+    ) -> Option<String> {
+        let path = Self::resolve_ctx_file(ctx_dir, global_ctx_dir, name)?;
+        let content = std::fs::read_to_string(&path).ok()?;
+        let meaningful: Vec<&str> = content
+            .lines()
+            .filter(|l| {
+                let t = l.trim();
+                !t.is_empty() && !t.starts_with('#') && !t.starts_with("<!--")
+            })
+            .collect();
+
+        if meaningful.is_empty() {
+            return None;
+        }
+
+        let tail: Vec<&str> = meaningful
+            .iter()
+            .rev()
+            .take(n)
+            .copied()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+
+        Some(tail.join("\n"))
+    }
+
+    fn resolve_ctx_file(
+        ctx_dir: &Path,
+        global_ctx_dir: Option<&Path>,
+        name: &str,
+    ) -> Option<PathBuf> {
+        let local = ctx_dir.join(name);
+        if local.exists() {
+            return Some(local);
+        }
+        if let Some(global) = global_ctx_dir {
+            let fallback = global.join(name);
+            if fallback.exists() {
+                return Some(fallback);
+            }
+        }
+        None
+    }
+
+    fn has_meaningful_content(content: &str) -> bool {
+        content.lines().any(|l| {
+            let t = l.trim();
+            !t.is_empty() && !t.starts_with('#') && !t.starts_with("<!--")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_progress_basic() {
+        let content = "
+[1] Login UI         done
+[2] API integration  doing
+[3] Error handling   todo
+[4] Unit tests       todo
+";
+        let tasks = ProjectProgressContext::parse_progress(content);
+        assert_eq!(tasks.len(), 4);
+        assert_eq!(tasks[0].status, TaskStatus::Done);
+        assert_eq!(tasks[1].status, TaskStatus::Doing);
+        assert_eq!(tasks[1].name, "API integration");
+        assert_eq!(tasks[2].status, TaskStatus::Todo);
+    }
+
+    #[test]
+    fn parse_progress_ignores_comments_and_blanks() {
+        let content = "
+# My project tasks
+[1] Setup  done
+
+# In progress
+[2] Build  doing
+";
+        let tasks = ProjectProgressContext::parse_progress(content);
+        assert_eq!(tasks.len(), 2);
+    }
+
+    #[test]
+    fn derive_status_marks_committed_tasks_done() {
+        let mut tasks = vec![
+            ProgressTask {
+                number: 1,
+                name: "Setup".to_owned(),
+                status: TaskStatus::Todo,
+            },
+            ProgressTask {
+                number: 2,
+                name: "API integration".to_owned(),
+                status: TaskStatus::Todo,
+            },
+            ProgressTask {
+                number: 3,
+                name: "Tests".to_owned(),
+                status: TaskStatus::Todo,
+            },
+        ];
+        let git_log = "abc1234 [1] Setup complete\ndef5678 some unrelated commit";
+        ProjectProgressContext::derive_status_from_git(&mut tasks, git_log);
+
+        assert_eq!(tasks[0].status, TaskStatus::Done);
+        assert_eq!(tasks[1].status, TaskStatus::Doing);
+        assert_eq!(tasks[2].status, TaskStatus::Todo);
+    }
+
+    #[test]
+    fn to_formatted_string_contains_current_and_next() {
+        let ctx = ProjectProgressContext {
+            project_path: PathBuf::from("/tmp/proj"),
+            current_task: Some(ProgressTask {
+                number: 2,
+                name: "API integration".to_owned(),
+                status: TaskStatus::Doing,
+            }),
+            next_task: Some(ProgressTask {
+                number: 3,
+                name: "Error handling".to_owned(),
+                status: TaskStatus::Todo,
+            }),
+            ..Default::default()
+        };
+        let s = ctx.to_formatted_string();
+        assert!(s.contains("[CURRENT]"));
+        assert!(s.contains("API integration"));
+        assert!(s.contains("[NEXT]"));
+        assert!(s.contains("Error handling"));
+    }
+}

--- a/specs/GH10342/product.md
+++ b/specs/GH10342/product.md
@@ -1,0 +1,112 @@
+# Product Spec: Project progress context for AI sessions (`.ai/progress.md`)
+
+**Issue:** warpdotdev/warp#10342
+
+## Problem
+
+When a developer works across multiple Warp windows or panes, each AI session
+starts completely blank. There is no shared knowledge of:
+
+- Which task is actively being worked on
+- What has already been completed
+- Project-specific goals or constraints
+
+This forces the user to manually re-explain context at the start of every
+conversation — a recurring interruption that compounds with every context
+switch.
+
+## Goals
+
+1. AI sessions in any Warp window automatically know the current task and
+   what comes next, without the user having to type it in.
+2. Task progress self-updates from git commit history; no manual bookkeeping.
+3. Opt-in per project — zero impact on projects that don't use this feature.
+4. Works alongside the existing `WARP.md` / `AGENTS.md` project rules.
+
+## Non-goals
+
+- Replacing or deprecating `WARP.md` / `AGENTS.md`.
+- A GUI for editing `progress.md` (plain-text editor is sufficient for v1).
+- Syncing progress state to Warp Drive or the server (all processing is local).
+
+## User experience
+
+### Setup (once per project)
+
+```bash
+mkdir -p .ai && cat > .ai/progress.md << 'EOF'
+[1] Auth service    done
+[2] Payment API     doing
+[3] Email service   todo
+[4] Unit tests      todo
+EOF
+```
+
+### Every subsequent AI session (automatic)
+
+When the user opens Warp AI in any window whose working directory is inside
+the project, the AI automatically receives:
+
+```
+[CURRENT] [2] Payment API
+[NEXT]    [3] Email service
+
+[GOAL]
+Build a resilient checkout backend.
+```
+
+No command needed. No copy-paste. Every window is in sync.
+
+### Auto-advance on commit
+
+```bash
+git commit -m "[2] Payment API — charge endpoint complete"
+# Next AI session automatically shows [3] Email service as CURRENT
+```
+
+### Optional context files
+
+Additional markdown files in `.ai/ctx/` are included when present:
+
+| File                  | Included as | Max lines |
+|-----------------------|-------------|-----------|
+| `00_goal.md`          | `[GOAL]`    | 15        |
+| `05_api.md`           | `[API]`     | 10        |
+| `04_constraint.md`    | `[CONSTRAINTS]` | 10   |
+| `07_issue.md`         | `[RECENT ISSUES]` | last 3 |
+
+A global fallback directory (`~/.ai/ctx/`) is consulted when a project-level
+file is absent, enabling shared defaults across all projects.
+
+## Behaviour invariants
+
+1. If `.ai/progress.md` does not exist in the project, no extra context is
+   injected. Existing behaviour is unchanged.
+2. If `.ai/progress.md` exists, the assembled context block (≤ 100 lines) is
+   injected into every AI session whose `pwd` is within that project tree.
+3. Task statuses are derived from `git log --oneline -50` at query time:
+   a. A commit whose message contains `[N]` or the task name marks that task
+      done.
+   b. The first non-done task becomes `doing`.
+   c. Remaining non-done tasks remain `todo`.
+4. If git is unavailable (non-git project, git not installed), statuses
+   already written in `progress.md` are used as-is.
+5. Context files in `.ai/ctx/` are read from the project directory first;
+   `~/.ai/ctx/` is the fallback.
+6. The progress context is always injected **after** `WARP.md`/`AGENTS.md`
+   rules so project rules take precedence.
+7. The assembled block never exceeds 100 lines to avoid degrading model focus.
+
+## Edge cases
+
+- **Empty progress.md:** No context is injected (no meaningful tasks parsed).
+- **All tasks done:** `[CURRENT] (no task in progress)` is emitted; no
+  `[NEXT]` line.
+- **progress.md parse error on one line:** That line is skipped; valid tasks
+  are still processed.
+- **git command fails:** Git-derived status update is skipped silently; the
+  statuses in `progress.md` are used.
+- **ctx files contain only comments/blanks:** The corresponding section is
+  omitted from the injected block.
+- **Concurrent windows:** All windows read the same on-disk file; context is
+  naturally consistent.

--- a/specs/GH10342/tech.md
+++ b/specs/GH10342/tech.md
@@ -1,0 +1,192 @@
+# Tech Spec: Project progress context for AI sessions (`.ai/progress.md`)
+
+**Issue:** warpdotdev/warp#10342
+
+## Context
+
+### The problem in code
+
+Every AI query assembles context in
+`app/src/ai/blocklist/context_model.rs:pending_context()` (line ~419).
+Currently this function injects:
+
+- `AIAgentContext::Directory` — working directory
+- `AIAgentContext::Git` — current branch / HEAD
+- `AIAgentContext::ProjectRules` — contents of `WARP.md` / `AGENTS.md` (via
+  `ProjectContextModel`)
+
+There is no mechanism to carry task-level progress state between sessions.
+Each window starts from zero context about *what the developer is building*.
+
+### Existing infrastructure to reuse
+
+| Component | Location | Reuse |
+|-----------|----------|-------|
+| `ProjectContextModel` | `crates/ai/src/project_context/model.rs` | Pattern reference for file-watching + singleton |
+| `AIAgentContext::ProjectRules` | `app/src/ai/agent/mod.rs:1978` | Transport for the new context (no new enum variant needed) |
+| `convert_context()` | `app/src/ai/agent/api/convert_to.rs:723` | Already serialises `ProjectRules` to the server API |
+| `run_git_command_with_env` / `list_local_branches_sync` | `app/src/util/git.rs` | Pattern for synchronous git subprocess calls |
+| `command::blocking::Command` | `crates/command/` | Sandboxed subprocess wrapper (already in `app` crate) |
+
+### Why no new `AIAgentContext` variant
+
+Adding a variant would require a matching proto change in `warp_multi_agent_api`
+(a private repo) and changes to the server. Re-using `ProjectRules` as the
+transport keeps the change entirely client-side and reviewable in one PR.
+
+## Proposed changes
+
+### New file: `app/src/ai/project_progress.rs`
+
+Self-contained module with no warpui/model dependencies.
+
+**Key types:**
+
+```rust
+pub enum TaskStatus { Done, Doing, Todo }
+
+pub struct ProgressTask { pub number: u32, pub name: String, pub status: TaskStatus }
+
+pub struct ProjectProgressContext {
+    pub project_path: PathBuf,
+    pub current_task: Option<ProgressTask>,
+    pub next_task:    Option<ProgressTask>,
+    pub goal:         Option<String>,   // 00_goal.md, 15 lines
+    pub api_spec:     Option<String>,   // 05_api.md,  10 lines
+    pub constraints:  Option<String>,   // 04_constraint.md, 10 lines
+    pub recent_issues: Option<String>,  // 07_issue.md, last 3 lines
+}
+```
+
+**`ProjectProgressContext::load(project_path: &Path) -> Option<Self>`**
+
+1. Return `None` if `<project>/.ai/progress.md` does not exist.
+2. Parse `progress.md` with regex `^\[(\d+)\]\s+(.+?)\s+(done|doing|todo)\s*$`.
+3. Call `read_git_log_sync` → `derive_status_from_git` (best-effort, silent
+   on failure).
+4. Read optional ctx files from `<project>/.ai/ctx/`, falling back to
+   `~/.ai/ctx/` via `dirs::home_dir()`.
+5. Return assembled struct.
+
+**`to_formatted_string(&self) -> String`**
+
+Renders the struct into the structured block injected into the AI session.
+Always emits `[CURRENT]`; other sections are conditional on presence.
+Total output is capped at ~100 lines by the per-section line limits.
+
+**`derive_status_from_git`**
+
+For each non-done task, searches `git log --oneline -50` for `[N]` or the
+task name (case-insensitive). First unmatched task → `Doing`. Rest → `Todo`.
+Matches the shell logic in the original aiflow implementation.
+
+### Modified: `app/src/ai/mod.rs`
+
+Add one line:
+
+```rust
+pub(crate) mod project_progress;
+```
+
+### Modified: `app/src/ai/blocklist/context_model.rs`
+
+In `pending_context()`, after the `ProjectRules` injection block (line ~492):
+
+```rust
+// Inject project progress context when `.ai/progress.md` is present.
+if let Some(progress) = canonical_pwd.as_deref().and_then(ProjectProgressContext::load) {
+    let formatted = progress.to_formatted_string();
+    let line_count = formatted.lines().count();
+    context.push(AIAgentContext::ProjectRules {
+        root_path: progress.project_path.to_string_lossy().into(),
+        active_rules: vec![FileContext {
+            file_name: ".ai/progress.md".to_owned(),
+            content: AnyFileContent::StringContent(formatted),
+            line_range: None,
+            last_modified: None,
+            line_count,
+        }],
+        additional_rule_paths: vec![],
+    });
+}
+```
+
+Also refactors the `pwd`-canonicalisation into a shared `canonical_pwd`
+binding to avoid duplicating the `PathBuf::from_str` + `canonicalize` chain.
+
+### No changes needed
+
+- `convert_to.rs` — `AIAgentContext::ProjectRules` is already handled.
+- `convert_conversation.rs` — same.
+- `Cargo.toml` files — all dependencies (`regex`, `dirs`, `command`) are
+  already in the `ai` / `app` workspace.
+
+## End-to-end flow
+
+```
+User opens Warp AI in window with pwd = /home/user/myproject
+  │
+  ├── pending_context() called
+  │     ├── canonical_pwd = /home/user/myproject
+  │     ├── ProjectContextModel::find_applicable_rules → WARP.md rules
+  │     └── ProjectProgressContext::load(/home/user/myproject)
+  │           ├── reads .ai/progress.md
+  │           ├── git log --oneline -50 (subprocess, sync)
+  │           ├── derives task statuses
+  │           ├── reads .ai/ctx/00_goal.md (optional)
+  │           └── returns ProjectProgressContext { current: [2] Payment API, … }
+  │
+  └── context pushed to server as AIAgentContext::ProjectRules {
+        file_name: ".ai/progress.md",
+        content: "[CURRENT] [2] Payment API\n[NEXT] [3] Email …"
+      }
+```
+
+## Testing and validation
+
+### Unit tests (in `app/src/ai/project_progress.rs`)
+
+Map to product spec invariants:
+
+| Test | Invariant |
+|------|-----------|
+| `parse_progress_basic` | Tasks with `done`/`doing`/`todo` parsed correctly |
+| `parse_progress_ignores_comments_and_blanks` | Non-task lines skipped |
+| `derive_status_marks_committed_tasks_done` | Git log updates status; first undone → Doing |
+| `to_formatted_string_contains_current_and_next` | Output contains expected sections |
+
+Additional tests to add:
+
+- `load_returns_none_when_no_progress_file` — `ProjectProgressContext::load` on a
+  tmpdir without `.ai/progress.md` returns `None`.
+- `load_uses_written_status_when_git_unavailable` — in a non-git tmpdir, statuses
+  from the file are preserved.
+- `to_formatted_string_max_lines` — output for a maxed-out context is ≤ 100 lines.
+
+### Manual testing
+
+1. Create `.ai/progress.md` in any project, set one task to `doing`.
+2. Open Warp AI — confirm the progress block appears in the conversation
+   context (visible in the "context" chip or by asking "what are you working on").
+3. Commit with `[N]` in the message; reopen AI — confirm the task advances.
+4. Open a second Warp window in the same directory — confirm both show the
+   same current task.
+5. Remove `.ai/progress.md` — confirm AI session is unaffected (invariant 1).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| `git log` adds latency to every AI query | Command runs synchronously but is capped at 50 commits; typical wall time < 20 ms |
+| `progress.md` may be large | Line limits on every section cap total output at ≤ 100 lines |
+| Regex may reject valid task lines | Regex is liberal with whitespace; ill-formed lines are silently skipped without affecting valid ones |
+| Two `ProjectRules` entries (WARP.md + progress) may confuse the model | Both are standard rule files; the server already supports multiple `ProjectRules` entries |
+
+## Follow-ups
+
+- Watch `.ai/progress.md` for changes with `DirectoryWatcher` to avoid the
+  git subprocess on every query (follow-up perf improvement).
+- Add a `/warp-progress` slash command to render the current progress block
+  in the terminal for quick inspection.
+- Consider a `warp_context_max_lines` setting to let power users raise the
+  100-line cap.


### PR DESCRIPTION
Closes #10342

When a project contains .ai/progress.md, the current and next task are automatically injected into every AI session whose pwd is inside that project. Task status is auto-derived from git commit history, keeping context in sync across all Warp windows without manual maintenance.

- Add app/src/ai/project_progress.rs: parser, git-log deriver, context formatter
- Inject progress context via AIAgentContext::ProjectRules in context_model.rs::pending_context()
- Add specs/GH10342/product.md and tech.md

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end. 

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up. 
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->
