### PR TITLE
Align pane header and vertical tabs agent status with #10067 pattern

### DIFF
--- a/app/src/ai/conversation_status_ui.rs
+++ b/app/src/ai/conversation_status_ui.rs
@@ -2,7 +2,10 @@ use warp_core::ui::appearance::Appearance;
 use warp_core::ui::color::coloru_with_opacity;
 use warp_core::ui::theme::{Fill, WarpTheme};
 use warpui::color::ColorU;
-use warpui::elements::{ConstrainedBox, Container, CornerRadius, Radius};
+use warpui::elements::{
+    ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Flex, MainAxisSize, ParentElement,
+    Radius, Shrinkable,
+};
 use warpui::Element;
 
 use crate::ai::agent::conversation::ConversationStatus;
@@ -47,4 +50,22 @@ pub fn render_status_element(
     .with_background(coloru_with_opacity(color, 10))
     .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
     .finish()
+}
+
+/// Prefix row for title content: optional leading element (status pill or spacer), 4px gap,
+/// then a shrinkable title. Returns `title` unchanged when `prefix` is `None`.
+pub fn render_status_title_prefix_row(
+    title: Box<dyn Element>,
+    prefix: Option<Box<dyn Element>>,
+) -> Box<dyn Element> {
+    let Some(prefix) = prefix else {
+        return title;
+    };
+    Flex::row()
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_spacing(4.)
+        .with_child(prefix)
+        .with_child(Shrinkable::new(1., title).finish())
+        .finish()
 }

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -10,6 +10,7 @@ use crate::ai::blocklist::agent_view::agent_view_bg_fill;
 use crate::ai::blocklist::agent_view::orchestration_conversation_links::parent_conversation_navigation_card;
 use crate::ai::blocklist::agent_view::render_orchestration_breadcrumbs;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
+use crate::ai::conversation_status_ui::render_status_element;
 use crate::appearance::Appearance;
 use crate::drive::sharing::ShareableObject;
 use crate::features::FeatureFlag;
@@ -35,7 +36,9 @@ use crate::terminal::TerminalView;
 use crate::ui_components::agent_icon::terminal_view_agent_icon_variant;
 use crate::ui_components::blended_colors;
 use crate::ui_components::buttons::icon_button_with_color;
-use crate::ui_components::icon_with_status::render_icon_with_status;
+use crate::ui_components::icon_with_status::{
+    render_icon_without_status, split_status_from_variant, IconWithStatusVariant,
+};
 use crate::ui_components::icons;
 use crate::workspace::tab_settings::TabSettings;
 use settings::Setting as _;
@@ -52,11 +55,21 @@ use warpui::ui_components::components::UiComponentStyles;
 use warpui::WeakModelHandle;
 use warpui::{AppContext, Element, ModelHandle, SingletonEntity, TypedActionView, ViewContext};
 
-/// Total size of the agent icon-with-status component rendered in the pane header.
-/// Sub-components (circle, badge, cloud) are derived inside `render_icon_with_status`.
-/// Sized so the component fits comfortably within `PANE_HEADER_HEIGHT` (34px) with a
-/// few pixels of vertical buffer.
-const PANE_HEADER_AGENT_SIZE: f32 = 26.;
+const PANE_HEADER_AGENT_SIZE: f32 = 24.;
+const PANE_HEADER_AGENT_STATUS_ICON_SIZE: f32 = 10.;
+
+fn resolve_pane_agent_icon_and_status(
+    variant: IconWithStatusVariant,
+    appearance: &Appearance,
+) -> (Box<dyn Element>, Option<ConversationStatus>) {
+    let (variant_without_status, status) = split_status_from_variant(variant);
+    let icon = render_icon_without_status(
+        variant_without_status,
+        PANE_HEADER_AGENT_SIZE,
+        appearance.theme(),
+    );
+    (icon, status)
+}
 
 impl TerminalView {
     /// Returns a reference to the focus handle if one has been set.
@@ -319,41 +332,41 @@ impl TerminalView {
                     Some(ConversationTranscriptViewerStatus::ViewingAmbientConversation(_))
                 )
         };
-        let theme = appearance.theme();
-        let render_agent_circle = |variant| {
-            render_icon_with_status(
-                variant,
-                PANE_HEADER_AGENT_SIZE,
-                0.,
-                theme,
-                theme.background(),
-            )
-        };
-        let pane_indicator = if should_render_ambient_agent_indicator {
-            // Shared/viewed ambient session: route through the shared helper so the pane header
-            // renders the same brand-color circle + cloud lobe + status as the vertical tab.
-            terminal_view_agent_icon_variant(self, app).map(render_agent_circle)
+        let (pane_indicator, agent_status) = if should_render_ambient_agent_indicator {
+            match terminal_view_agent_icon_variant(self, app) {
+                Some(variant) => {
+                    let (icon, status) = resolve_pane_agent_icon_and_status(variant, appearance);
+                    (Some(icon), status)
+                }
+                None => (None, None),
+            }
         } else if let Some(shared_session) = self.shared_session.as_ref() {
             if let Some(Viewer {
                 sharer: Some(sharer),
                 ..
             }) = shared_session.kind().as_viewer()
             {
-                Some(
-                    Container::new(ChildView::new(&sharer.avatar).finish())
-                        .with_margin_right(4.)
-                        .finish(),
+                (
+                    Some(
+                        Container::new(ChildView::new(&sharer.avatar).finish())
+                            .with_margin_right(4.)
+                            .finish(),
+                    ),
+                    None,
                 )
             } else {
-                Some(
-                    ConstrainedBox::new(
-                        icons::Icon::Sharing
-                            .to_warpui_icon(shared_session_indicator_color(appearance).into())
-                            .finish(),
-                    )
-                    .with_height(appearance.ui_font_size())
-                    .with_width(appearance.ui_font_size())
-                    .finish(),
+                (
+                    Some(
+                        ConstrainedBox::new(
+                            icons::Icon::Sharing
+                                .to_warpui_icon(shared_session_indicator_color(appearance).into())
+                                .finish(),
+                        )
+                        .with_height(appearance.ui_font_size())
+                        .with_width(appearance.ui_font_size())
+                        .finish(),
+                    ),
+                    None,
                 )
             }
         } else if self.is_using_conversation_for_pane_header_title
@@ -364,11 +377,15 @@ impl TerminalView {
                     .selected_conversation(app)
                     .is_some())
         {
-            // Conversation-bound terminal: same shared helper — produces an OzAgent variant for
-            // local conversations and a CLIAgent variant for the (rare) CLI-backed terminal.
-            terminal_view_agent_icon_variant(self, app).map(render_agent_circle)
+            match terminal_view_agent_icon_variant(self, app) {
+                Some(variant) => {
+                    let (icon, status) = resolve_pane_agent_icon_and_status(variant, appearance);
+                    (Some(icon), status)
+                }
+                None => (None, None),
+            }
         } else {
-            self.render_terminal_mode_indicator(app)
+            (self.render_terminal_mode_indicator(app), None)
         };
 
         let is_pane_dragging = header_ctx.draggable_state.is_dragging();
@@ -378,6 +395,17 @@ impl TerminalView {
             .with_main_axis_size(MainAxisSize::Min);
         if let Some(indicator) = pane_indicator {
             center_row.add_child(Container::new(indicator).with_margin_right(4.).finish());
+        }
+        if let Some(status) = agent_status {
+            center_row.add_child(
+                Container::new(render_status_element(
+                    &status,
+                    PANE_HEADER_AGENT_STATUS_ICON_SIZE,
+                    appearance,
+                ))
+                .with_margin_right(4.)
+                .finish(),
+            );
         }
         let title_text = render_pane_header_title_text(title, appearance, clip_config);
         if is_pane_dragging {

--- a/app/src/ui_components/icon_with_status.rs
+++ b/app/src/ui_components/icon_with_status.rs
@@ -115,6 +115,90 @@ pub(crate) enum IconWithStatusVariant {
     },
 }
 
+pub(crate) fn split_status_from_variant(
+    variant: IconWithStatusVariant,
+) -> (IconWithStatusVariant, Option<ConversationStatus>) {
+    match variant {
+        IconWithStatusVariant::OzAgent { status, is_ambient } => (
+            IconWithStatusVariant::OzAgent {
+                status: None,
+                is_ambient,
+            },
+            status,
+        ),
+        IconWithStatusVariant::CLIAgent {
+            agent,
+            status,
+            is_ambient,
+        } => (
+            IconWithStatusVariant::CLIAgent {
+                agent,
+                status: None,
+                is_ambient,
+            },
+            status,
+        ),
+        variant => (variant, None),
+    }
+}
+
+pub(crate) fn render_icon_without_status(
+    variant: IconWithStatusVariant,
+    total_size: f32,
+    theme: &WarpTheme,
+) -> Box<dyn Element> {
+    let sub_text = theme.sub_text_color(theme.background());
+
+    match variant {
+        IconWithStatusVariant::Neutral { icon, icon_color } => render_neutral_circle(
+            icon.to_warpui_icon(icon_color).finish(),
+            internal_colors::fg_overlay_2(theme),
+            total_size,
+        ),
+        IconWithStatusVariant::NeutralElement { icon_element } => render_neutral_circle(
+            icon_element,
+            internal_colors::fg_overlay_2(theme),
+            total_size,
+        ),
+        IconWithStatusVariant::OzAgent { is_ambient, .. } => {
+            let background = if is_ambient {
+                ThemeFill::Solid(OZ_AMBIENT_BACKGROUND_COLOR)
+            } else {
+                theme.background()
+            };
+            let glyph = if is_ambient {
+                WarpIcon::OzCloud
+            } else {
+                WarpIcon::Oz
+            };
+            let glyph_color = if is_ambient {
+                WarpThemeFill::Solid(ColorU::black())
+            } else {
+                theme.main_text_color(theme.background())
+            };
+            render_neutral_circle(
+                glyph.to_warpui_icon(glyph_color).finish(),
+                background,
+                total_size,
+            )
+        }
+        IconWithStatusVariant::CLIAgent { agent, .. } => {
+            let brand_color = agent
+                .brand_color()
+                .unwrap_or(ColorU::new(100, 100, 100, 255));
+            let icon_color = agent.brand_icon_color();
+            let icon_element = agent
+                .icon()
+                .map(|icon| {
+                    icon.to_warpui_icon(WarpThemeFill::Solid(icon_color))
+                        .finish()
+                })
+                .unwrap_or_else(|| WarpIcon::Terminal.to_warpui_icon(sub_text).finish());
+            render_neutral_circle(icon_element, ThemeFill::Solid(brand_color), total_size)
+        }
+    }
+}
+
 /// Renders an icon-with-status component sized entirely from a single `total_size`. All
 /// sub-components (brand circle, status badge, cloud lobe) are derived proportionally,
 /// so callers only need to pick the size they want.

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -12,7 +12,10 @@ use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::terminal::view::TerminalViewState;
 use crate::terminal::CLIAgent;
 use crate::ui_components::agent_icon::terminal_view_agent_icon_variant;
-use crate::ui_components::icon_with_status::{render_icon_with_status, IconWithStatusVariant};
+use crate::ui_components::icon_with_status::{
+    render_icon_with_status, render_icon_without_status, split_status_from_variant,
+    IconWithStatusVariant,
+};
 use crate::workspace::view::vertical_tabs::telemetry::{
     VerticalTabsChipEntrypoint, VerticalTabsTelemetryEvent,
 };
@@ -247,17 +250,33 @@ fn oz_icon_fill(theme: &WarpTheme) -> WarpThemeFill {
     theme.main_text_color(theme.background())
 }
 
-fn render_pane_icon_with_status(
+fn render_pane_icon_without_status(
     variant: IconWithStatusVariant,
     theme: &WarpTheme,
 ) -> Box<dyn Element> {
-    render_icon_with_status(
-        variant,
-        VERTICAL_TABS_ICON_SIZE,
-        0.,
-        theme,
-        theme.background(),
-    )
+    let (variant_without_status, _) = split_status_from_variant(variant);
+    render_icon_without_status(variant_without_status, VERTICAL_TABS_ICON_SIZE, theme)
+}
+
+fn prefix_with_status_pill(
+    element: Box<dyn Element>,
+    status: Option<ConversationStatus>,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let Some(status) = status else {
+        return element;
+    };
+    Flex::row()
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_spacing(4.)
+        .with_child(render_status_element(
+            &status,
+            VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE,
+            appearance,
+        ))
+        .with_child(Shrinkable::new(1., element).finish())
+        .finish()
 }
 
 #[derive(Clone, Default)]
@@ -2462,10 +2481,9 @@ fn render_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn Element> {
     let theme = appearance.theme();
     let font_family = appearance.ui_font_family();
 
-    let icon = render_pane_icon_with_status(
-        resolve_icon_with_status_variant(&props.typed, &props.title, appearance, app),
-        theme,
-    );
+    let variant = resolve_icon_with_status_variant(&props.typed, &props.title, appearance, app);
+    let (variant_without_status, status) = split_status_from_variant(variant);
+    let icon = render_icon_without_status(variant_without_status, VERTICAL_TABS_ICON_SIZE, theme);
 
     // Top-align the icon when there are multiple lines of content so it sits next to
     // the first line; center it for single-line rows (Settings, Notebook with no subtitle, etc.).
@@ -2480,36 +2498,34 @@ fn render_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn Element> {
         render_terminal_row_content(
             &props,
             terminal_pane.terminal_view(app).as_ref(app),
+            status,
             appearance,
             app,
         )
     } else {
         let has_indicator =
             props.typed.badge(app).is_some() || has_unread_activity(&props.typed, app);
+        let title_slot = render_pane_title_slot(
+            &props,
+            || {
+                Text::new_inline(props.displayed_title().to_string(), font_family, 12.)
+                    .with_clip(ClipConfig::ellipsis())
+                    .with_color(theme.main_text_color(theme.background()).into())
+                    .finish()
+            },
+            12.,
+            theme.main_text_color(theme.background()),
+            ClipConfig::ellipsis(),
+            appearance,
+            app,
+        );
+        let title_with_status = prefix_with_status_pill(title_slot, status, appearance);
+
         let mut title_row = Flex::row()
             .with_main_axis_size(MainAxisSize::Max)
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
             .with_cross_axis_alignment(CrossAxisAlignment::Center);
-        title_row.add_child(
-            Shrinkable::new(
-                1.,
-                render_pane_title_slot(
-                    &props,
-                    || {
-                        Text::new_inline(props.displayed_title().to_string(), font_family, 12.)
-                            .with_clip(ClipConfig::ellipsis())
-                            .with_color(theme.main_text_color(theme.background()).into())
-                            .finish()
-                    },
-                    12.,
-                    theme.main_text_color(theme.background()),
-                    ClipConfig::ellipsis(),
-                    appearance,
-                    app,
-                ),
-            )
-            .finish(),
-        );
+        title_row.add_child(Shrinkable::new(1., title_with_status).finish());
         if has_indicator {
             title_row.add_child(
                 Container::new(render_title_indicator(theme))
@@ -3262,6 +3278,7 @@ impl PaneGroup {
 fn render_terminal_row_content(
     props: &PaneProps<'_>,
     terminal_view: &TerminalView,
+    status: Option<ConversationStatus>,
     appearance: &Appearance,
     app: &AppContext,
 ) -> Box<dyn Element> {
@@ -3367,12 +3384,13 @@ fn render_terminal_row_content(
         }
     };
 
+    let first_line_with_status = prefix_with_status_pill(first_line, status, appearance);
     let first_line_element = if has_unread_activity(&props.typed, app) {
         Flex::row()
             .with_main_axis_size(MainAxisSize::Max)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
-            .with_child(Shrinkable::new(1., first_line).finish())
+            .with_child(Shrinkable::new(1., first_line_with_status).finish())
             .with_child(
                 Container::new(render_title_indicator(theme))
                     .with_margin_left(4.)
@@ -3380,7 +3398,7 @@ fn render_terminal_row_content(
             )
             .finish()
     } else {
-        first_line
+        first_line_with_status
     };
 
     let mut content = Flex::column()
@@ -3589,7 +3607,7 @@ fn render_summary_tab_item(
     let icon = summary_pane_kind_icons
         .map(|icons| render_summary_pane_kind_icons(icons, appearance))
         .unwrap_or_else(|| {
-            render_pane_icon_with_status(
+            render_pane_icon_without_status(
                 resolve_icon_with_status_variant(&props.typed, &props.title, appearance, app),
                 theme,
             )
@@ -6041,10 +6059,9 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
     let font_family = appearance.ui_font_family();
     let has_indicator = props.typed.badge(app).is_some() || has_unread_activity(&props.typed, app);
 
-    let icon = render_pane_icon_with_status(
-        resolve_icon_with_status_variant(&props.typed, &props.title, appearance, app),
-        theme,
-    );
+    let variant = resolve_icon_with_status_variant(&props.typed, &props.title, appearance, app);
+    let (variant_without_status, status) = split_status_from_variant(variant);
+    let icon = render_icon_without_status(variant_without_status, VERTICAL_TABS_ICON_SIZE, theme);
 
     let primary_info = *TabSettings::as_ref(app).vertical_tabs_primary_info.value();
     let compact_subtitle = resolve_compact_subtitle(
@@ -6186,13 +6203,14 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
             (title, subtitle)
         };
 
-    // Title row with optional indicator
+    // Title row with optional status prefix and indicator
+    let title_with_status = prefix_with_status_pill(title_element, status, appearance);
     let title_row = if has_indicator {
         Flex::row()
             .with_main_axis_size(MainAxisSize::Max)
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(Shrinkable::new(1., title_element).finish())
+            .with_child(Shrinkable::new(1., title_with_status).finish())
             .with_child(
                 Container::new(render_title_indicator(theme))
                     .with_margin_left(4.)
@@ -6200,7 +6218,7 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
             )
             .finish()
     } else {
-        title_element
+        title_with_status
     };
 
     // Assemble text column: title + optional subtitle

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2,7 +2,9 @@ pub mod telemetry;
 
 use crate::ai::agent::conversation::ConversationStatus;
 use crate::ai::agent_management::AgentNotificationsModel;
-use crate::ai::conversation_status_ui::render_status_element;
+use crate::ai::conversation_status_ui::{
+    render_status_element, render_status_title_prefix_row, STATUS_ELEMENT_PADDING,
+};
 use crate::code::editor::{add_color, remove_color};
 use crate::code::icon_from_file_path;
 use crate::safe_triangle::SafeTriangle;
@@ -263,20 +265,10 @@ fn prefix_with_status_pill(
     status: Option<ConversationStatus>,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
-    let Some(status) = status else {
-        return element;
-    };
-    Flex::row()
-        .with_main_axis_size(MainAxisSize::Max)
-        .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .with_spacing(4.)
-        .with_child(render_status_element(
-            &status,
-            VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE,
-            appearance,
-        ))
-        .with_child(Shrinkable::new(1., element).finish())
-        .finish()
+    let prefix = status
+        .as_ref()
+        .map(|s| render_status_element(s, VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE, appearance));
+    render_status_title_prefix_row(element, prefix)
 }
 
 #[derive(Clone, Default)]
@@ -3763,10 +3755,9 @@ fn render_summary_primary_label_line(
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     // Reserve a slot wide enough for the status pill so non-conversation lines align with
-    // conversation lines in the same region. STATUS_ELEMENT_PADDING is the 2px padding inside
-    // the pill from `render_status_element`.
-    const STATUS_ELEMENT_PADDING: f32 = 2.;
-    let prefix_slot_size = VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE + STATUS_ELEMENT_PADDING * 2.;
+    // conversation lines in the same region.
+    let prefix_slot_size =
+        VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE + STATUS_ELEMENT_PADDING * 2.;
     let text = render_text_line(&label.text, text_color, ClipConfig::end(), appearance);
 
     let prefix: Option<Box<dyn Element>> = match (label.status.as_ref(), reserve_prefix_slot) {
@@ -3784,16 +3775,7 @@ fn render_summary_primary_label_line(
         (None, false) => None,
     };
 
-    let Some(prefix) = prefix else {
-        return text;
-    };
-    Flex::row()
-        .with_main_axis_size(MainAxisSize::Max)
-        .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .with_spacing(4.)
-        .with_child(prefix)
-        .with_child(Shrinkable::new(1., text).finish())
-        .finish()
+    render_status_title_prefix_row(text, prefix)
 }
 
 fn render_summary_overflow_line(


### PR DESCRIPTION
## Description
This extends #10067 which moved conversation status out of the agent icon overlay for the tab view in the vertical tab summary mode. We now fix the same design issues which were present like the agent/CLI icons being too small be default (As mentioned in #9897).

*OLD*
<img width="246" height="54" alt="image" src="https://github.com/user-attachments/assets/4ec182a3-3f7d-404e-91e7-3979a3f2669a" />

*NEW*
<img width="260" height="62" alt="image" src="https://github.com/user-attachments/assets/1c038b86-ac4c-4a60-8cc2-188d05d569d7" />



## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end. 

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up. 
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->
