### PR TITLE
fix(terminal): paint full-width background for wide-char SGR attrs

### DIFF
--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -926,6 +926,18 @@ fn render_cell(
         ctx,
     );
 
+    // Extend the cached background to also cover the WIDE_CHAR_SPACER cell on the right.
+    // Spacer cells are skipped during cell iteration (they're placeholders for the wide
+    // glyph drawn by the leading cell), so without this extension the spacer's column
+    // would never paint a background. That breaks any background attribute applied to a
+    // wide character via SGR — most visibly the reverse-video pseudo-cursor that
+    // Ink-based TUIs (Claude Code, ink-text-input, etc.) emit via `chalk.inverse(<cjk>)`,
+    // which would otherwise show only the left half of the wide character highlighted.
+    if cell.flags().intersects(Flags::WIDE_CHAR) && col + 1 < grid.columns() {
+        cached_background_color =
+            cached_background_color.map(|cached| cached.with_end(col + 1, offset_row));
+    }
+
     let glyph_offset = cell_size * vec2f(col as f32, offset_row as f32);
 
     render_cell_glyph(
@@ -1350,6 +1362,16 @@ fn render_grid_with_ligatures<'a>(
                 cell_colors.background_color,
                 ctx,
             );
+
+            // Same wide-char background extension as in `render_cell` above. The ligature
+            // rendering path also skips WIDE_CHAR_SPACER cells via `continue;` earlier in
+            // this loop, so without this extension the spacer's column would not receive
+            // the leading cell's background — manifesting as half-reversed wide chars when
+            // a TUI emits e.g. `chalk.inverse(<cjk>)`.
+            if cell.flags().intersects(Flags::WIDE_CHAR) && col + 1 < grid.columns() {
+                cached_background_color =
+                    cached_background_color.map(|cached| cached.with_end(col + 1, offset_row));
+            }
 
             let glyph_offset = cell_size * vec2f(col as f32, offset_row as f32);
             if first_cell_in_link {


### PR DESCRIPTION
## Summary

When a wide character (CJK / emoji) is emitted with a non-default background — most visibly via SGR `\e[7m...\e[27m` (reverse video) — only the leading half of the character receives the attribute background. The right half (the WIDE_CHAR_SPACER cell) stays at the default / previous background. This breaks any TUI that draws an inline pseudo-cursor by emitting `chalk.inverse(<wide-char>)` instead of using the terminal's native block cursor — most notably **Ink's `<TextInput>`**, used by Claude Code, opencode, and many other Ink-based CLIs.

## Repro

Inside Warp, run a TUI that uses Ink (e.g., Claude Code), type any CJK string into the input box, and arrow-key the cursor onto a wide character. Expected: the cursor block fully covers the wide char. Actual: only the left half is highlighted; the right half stays normal.

The same path is exercised by simply emitting:

    printf '\e[7m遮\e[27m\n'

inside Warp — the right half of `遮` is not reversed.

## Root cause

Ink's `<TextInput>` emits the cursor as inline reverse-video bytes ([source](https://github.com/vadimdemedes/ink-text-input/blob/master/source/index.tsx)):

\`\`\`js
// Fake mouse cursor, because it's too inconvenient to deal with
// actual cursor and ansi escapes
renderedValue += i >= cursorOffset - cursorActualWidth && i <= cursorOffset
    ? chalk.inverse(char)
    : char;
\`\`\`

Warp's grid handler correctly inherits the INVERSE flag from the SGR template onto **both** the leading WIDE_CHAR cell and the WIDE_CHAR_SPACER cell at the model layer (\`app/src/terminal/model/grid/ansi_handler.rs::write_at_cursor\`). The bug is purely in the renderer.

In \`app/src/terminal/grid_renderer.rs\`, the cell iteration loop skips WIDE_CHAR_SPACER cells with a hard \`continue;\` — they are treated as pure placeholders for the wide glyph drawn by the leading cell. That skip cuts off background painting too. The leading WIDE_CHAR cell only contributes 1 column to the batched-bg cache, the spacer contributes 0, so the bg is painted as 1 cell wide instead of 2.

## Fix

In \`render_cell()\`, after \`maybe_draw_background()\` returns, if the current cell is a leading WIDE_CHAR, extend the cached bg's end column by one (to the spacer's position). This makes the batched paint span both halves of the wide char — which is what every other terminal emulator does. The spacer's \`continue;\` skip elsewhere remains correct: the leading cell now paints both columns of bg, and the wide glyph itself was already drawn spanning both columns.

12 lines added, no other changes.

## Verification

- \`cargo check -p warp --bin warp-oss --features gui\` clean (0 errors).
- Manual repro on a \`cargo bundle --release\` build of this branch:
  - Before: \`printf '\e[7m遮\e[27m'\` shows half-reversed \`遮\`. Claude Code input with cursor on CJK shows half-cursor.
  - After: full-character reverse. Cursor block fully covers wide char.

## Related issues

- #1823 (Chinese support master, 2022)
- #4700 (Chinese input not displaying, \`ready-to-implement\`)
- #7436 (Chinese display anomalies, \`ready-to-implement\`)
- #4972 (double-wide underline half-width, closed \`not-planned\` — same class of bug, may want to revisit)

## Notes

LEADING_WIDE_CHAR_SPACER (the wrap-around spacer at the previous row's last column when a wide char wraps to the next line) is a separate case and unaffected by this change.

This change is independent and safe to ship in isolation.