### PR TITLE
Fix Windows IME preedit rendering

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -960,8 +960,8 @@ pub const RELEASE_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::Autoupdate,
     FeatureFlag::Changelog,
     FeatureFlag::CrashReporting,
-    // Marked text is currently only supported on MacOS.
-    #[cfg(target_os = "macos")]
+    // Marked text is currently supported on macOS and the Windows winit IME path.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     FeatureFlag::ImeMarkedText,
     // Remote server binary is not yet supported on Windows.
     #[cfg(not(windows))]

--- a/crates/warpui/src/windowing/winit/event_loop/key_events.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/key_events.rs
@@ -141,6 +141,11 @@ pub fn convert_keyboard_input_event(
         return None;
     }
 
+    #[cfg(windows)]
+    let is_composing = window_state.ime_has_marked_text;
+    #[cfg(not(windows))]
+    let is_composing = false;
+
     Some(crate::event::Event::KeyDown {
         keystroke,
         chars,
@@ -149,7 +154,7 @@ pub fn convert_keyboard_input_event(
             right_alt: window_state.right_alt_pressed,
             key_without_modifiers,
         },
-        is_composing: false,
+        is_composing,
     })
 }
 

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -176,6 +176,9 @@ struct WindowState {
     /// UI element only requests the keyboard during LeftMouseDown.
     #[cfg(target_family = "wasm")]
     pending_soft_keyboard_request: bool,
+    /// Whether this window currently has IME preedit text owned by winit.
+    #[cfg(windows)]
+    ime_has_marked_text: bool,
 }
 
 impl WindowState {
@@ -195,6 +198,8 @@ impl WindowState {
             momentum_scroll_abort: None,
             #[cfg(target_family = "wasm")]
             pending_soft_keyboard_request: false,
+            #[cfg(windows)]
+            ime_has_marked_text: false,
         }
     }
 
@@ -1336,6 +1341,13 @@ impl EventLoop {
                 } else {
                     self.state.pending_active_window_change = Some(ActiveWindowChange::FocusOut);
                 }
+
+                #[cfg(windows)]
+                if !is_focused {
+                    window_state.ime_has_marked_text = false;
+                    return Some(ConvertedEvent::Event(ClearMarkedText));
+                }
+
                 None
             }
             WindowEvent::DroppedFile(path_buf) => {
@@ -1520,42 +1532,66 @@ impl EventLoop {
                 let Some(window_state) = self.state.windows.get_mut(&winit_window_id) else {
                     return;
                 };
-                let Some(window) = self
-                    .ui_app
-                    .read(|ctx| ctx.windows().platform_window(window_state.window_id))
-                else {
-                    return;
-                };
+                #[cfg(windows)]
+                {
+                    window_state.ime_has_marked_text = !preedit_text.is_empty();
+                }
+                let window_id = window_state.window_id;
 
-                let mut window_callbacks = self.callbacks.for_window(window.as_ref());
-                window_callbacks.dispatch_event(SetMarkedText {
-                    marked_text: preedit_text,
-                    selected_range: cursor_position
-                        .map(|cursor_position| cursor_position.0..cursor_position.1)
-                        .unwrap_or(0..0),
-                });
+                if preedit_text.is_empty() {
+                    self.dispatch_event_to_window(window_id, ClearMarkedText);
+                } else {
+                    self.dispatch_event_to_window(
+                        window_id,
+                        SetMarkedText {
+                            marked_text: preedit_text,
+                            selected_range: cursor_position
+                                .map(|cursor_position| cursor_position.0..cursor_position.1)
+                                .unwrap_or(0..0),
+                        },
+                    );
+                }
             }
             winit::event::Ime::Commit(chars) => {
                 let Some(window_state) = self.state.windows.get_mut(&winit_window_id) else {
                     return;
                 };
-                let Some(window) = self
-                    .ui_app
-                    .read(|ctx| ctx.windows().platform_window(window_state.window_id))
-                else {
-                    return;
-                };
+                #[cfg(windows)]
+                {
+                    window_state.ime_has_marked_text = false;
+                }
+                let window_id = window_state.window_id;
 
-                let mut window_callbacks = self.callbacks.for_window(window.as_ref());
                 // We clear the marked text state before inserting typed characters so that the Vim
                 // FSA knows it can interpret the committed text as a user insertion.
-                window_callbacks.dispatch_event(ClearMarkedText);
-                window_callbacks.dispatch_event(TypedCharacters { chars });
+                self.dispatch_event_to_window(window_id, ClearMarkedText);
+                self.dispatch_event_to_window(window_id, TypedCharacters { chars });
             }
             winit::event::Ime::Disabled => {
+                if let Some(window_state) = self.state.windows.get_mut(&winit_window_id) {
+                    #[cfg(windows)]
+                    {
+                        window_state.ime_has_marked_text = false;
+                    }
+                    let window_id = window_state.window_id;
+                    self.dispatch_event_to_window(window_id, ClearMarkedText);
+                }
                 self.ime_enabled = false;
             }
         };
+    }
+
+    fn dispatch_event_to_window(&mut self, window_id: WindowId, event: crate::Event) {
+        let Some(window) = self
+            .ui_app
+            .read(|ctx| ctx.windows().platform_window(window_id))
+        else {
+            return;
+        };
+
+        self.callbacks
+            .for_window(window.as_ref())
+            .dispatch_event(event);
     }
 
     /// Handle events that may be handled by warpui, or maybe not in some cases, e.g. window


### PR DESCRIPTION
## Summary

This PR fixes Windows IME composition rendering by routing winit IME preedit events into Warp's marked text pipeline and routing IME commit events into normal typed character insertion.

## Changes

- Enable `ImeMarkedText` for Windows release builds, matching the existing marked-text rendering path used by the terminal and editor.
- Dispatch `SetMarkedText` only for non-empty winit `Ime::Preedit` text and dispatch `ClearMarkedText` for empty preedit, IME disabled, and Windows focus loss.
- Track Windows winit preedit state per window so `KeyDown` events during composition are marked `is_composing`, avoiding normal Enter/Escape handling while the IME is still composing.
- Preserve the existing macOS Objective-C IME path.

## Manual test plan

1. Launch Warp on Windows.
2. Enable Microsoft IME Japanese.
3. Type `nihongo`.
4. Confirm composing text appears in the input field before pressing Enter.
5. Press Space to convert.
6. Confirm converted candidates update the visible composition text.
7. Press Enter.
8. Confirm committed Japanese text appears exactly once.
9. Press Escape during a new composition.
10. Confirm no stale composition text remains.
11. Switch to English input and verify normal typing and shortcuts.
12. Optional: repeat with Google Japanese Input.

## Notes

PR #9730 was used only as design context. This branch is based on upstream `master`; upstream does not currently expose a `main` branch.

## Verification

- `git diff --check` passes.
- `cargo fmt --check` and Rust compile checks could not be run in this local environment because `cargo`/`rustc` are not installed on PATH.