### PR TITLE
[codex] Fix caret positioning around ligatures

### DIFF
--- a/app/src/editor/soft_wrap.rs
+++ b/app/src/editor/soft_wrap.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use warpui::text_layout;
 
-use crate::editor::{view::DisplayPoint, Point};
+use crate::editor::{Point, view::DisplayPoint};
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
 pub struct SoftWrapPoint(Point);
@@ -56,7 +56,9 @@ impl SoftWrapState {
         let frame_layouts = self.0.lock();
         match &*frame_layouts {
             Some(frame_layouts) => callback(Ok(frame_layouts)),
-            None => callback(Err(anyhow!("No frame layout. This should only happen if we attempt to read before a frame of the editor has been laid out"))),
+            None => callback(Err(anyhow!(
+                "No frame layout. This should only happen if we attempt to read before a frame of the editor has been laid out"
+            ))),
         }
     }
 }
@@ -171,14 +173,10 @@ impl FrameLayouts {
             acc_lines += frame.lines().len()
         }
         if let Some(line) = self.get_line(point.row() as usize) {
-            if let Some(glyph) = line.last_glyph() {
-                if point.column() as usize == glyph.index + 1 {
-                    clamp_direction = ClampDirection::Up;
-                }
-            } else if let Some(glyph) = line.first_glyph() {
-                if point.column() as usize == glyph.index {
-                    clamp_direction = ClampDirection::Down;
-                }
+            if point.column() as usize == line.end_index() {
+                clamp_direction = ClampDirection::Up;
+            } else if point.column() as usize == line.first_index() {
+                clamp_direction = ClampDirection::Down;
             }
         }
 

--- a/app/src/editor/soft_wrap_test.rs
+++ b/app/src/editor/soft_wrap_test.rs
@@ -1,6 +1,36 @@
 use super::*;
 use vec1::vec1;
 
+fn line_with_final_two_char_ligature() -> text_layout::Line {
+    text_layout::Line {
+        width: 20.,
+        trailing_whitespace_width: 0.,
+        runs: vec![text_layout::Run {
+            font_id: warpui::fonts::FontId(0),
+            glyphs: vec![text_layout::Glyph {
+                id: Default::default(),
+                position_along_baseline: Default::default(),
+                index: 0,
+                width: 20.,
+            }],
+            styles: text_layout::TextStyle::new(),
+            width: 20.,
+        }],
+        font_size: 10.,
+        line_height_ratio: 1.,
+        baseline_ratio: text_layout::DEFAULT_TOP_BOTTOM_RATIO,
+        clip_config: None,
+        ascent: 8.,
+        descent: 2.,
+        caret_positions: vec![text_layout::CaretPosition {
+            position_in_line: 0.,
+            start_offset: 0,
+            last_offset: 1,
+        }],
+        chars_with_missing_glyphs: vec![],
+    }
+}
+
 #[test]
 fn test_singleton_frames_displayed_lines() {
     let frame_layouts = FrameLayouts {
@@ -72,4 +102,45 @@ fn test_soft_wrapped_frame_displayed_lines() {
     assert_eq!(iter.next().expect("Should have line").font_size, 13.);
     assert_eq!(iter.next().expect("Should have line").font_size, 14.);
     assert!(iter.next().is_none());
+}
+
+#[test]
+fn test_soft_wrap_point_uses_caret_end_for_ligature_line() {
+    let frame_layouts = FrameLayouts {
+        frames: vec![Arc::new(text_layout::TextFrame::new(
+            vec1![
+                line_with_final_two_char_ligature(),
+                text_layout::Line::empty(10., 1., 2),
+            ],
+            20.,
+            Default::default(),
+        ))],
+        start_line: 0,
+        end_line: 2,
+    };
+
+    let soft_wrap_point = frame_layouts
+        .to_soft_wrap_point(DisplayPoint::new(0, 2), ClampDirection::Up)
+        .expect("ligature end should be within the first soft-wrapped line");
+
+    assert_eq!(soft_wrap_point.row(), 0);
+    assert_eq!(soft_wrap_point.column(), 2);
+}
+
+#[test]
+fn test_display_point_marks_ligature_line_end_as_clamped_up() {
+    let frame_layouts = FrameLayouts {
+        frames: vec![Arc::new(text_layout::TextFrame::new(
+            vec1![line_with_final_two_char_ligature()],
+            20.,
+            Default::default(),
+        ))],
+        start_line: 0,
+        end_line: 1,
+    };
+
+    let display_point = frame_layouts.to_display_point(SoftWrapPoint::new(0, 2));
+
+    assert_eq!(display_point.point, DisplayPoint::new(0, 2));
+    assert_eq!(display_point.clamp_direction, ClampDirection::Up);
 }

--- a/app/src/editor/view/element.rs
+++ b/app/src/editor/view/element.rs
@@ -2369,17 +2369,11 @@ impl PaintState {
 
         let x = shifted_position.x() + (scroll_position.x() * view_snapshot.em_width);
 
-        let col = if let Some(col) = line.caret_index_for_x(x).map(|ix| ix as u32) {
-            col
-        } else {
-            // Clamp to the left or right if the x pos is before or after the buffer text, respectively.
+        if x < 0. || x >= line.width {
             is_clamped = true;
-            if x >= 0. {
-                line.end_index() as u32
-            } else {
-                line.first_index() as u32
-            }
-        };
+        }
+        let col = line.caret_index_for_x_unbounded(x) as u32;
+
         // Now convert from SoftWrapPoint to DisplayPoint.
         let soft_wrap_point = SoftWrapPoint::new(row, col);
 

--- a/app/src/editor/view/element.rs
+++ b/app/src/editor/view/element.rs
@@ -4,13 +4,13 @@ use super::super::soft_wrap::{
 use super::model::MarkedTextState;
 use super::snapshot::VOICE_INPUT_ICON_CURSOR_GAP;
 use super::{
-    position_id_for_cached_point, snapshot::ViewSnapshot, CursorColors, DisplayPoint,
-    DrawableSelection, EditorAction, ScrollState, SelectAction,
+    CursorColors, DisplayPoint, DrawableSelection, EditorAction, ScrollState, SelectAction,
+    position_id_for_cached_point, snapshot::ViewSnapshot,
 };
-use super::{position_id_for_cursor, LocalDrawableSelectionData, ReplicaId};
+use super::{LocalDrawableSelectionData, ReplicaId, position_id_for_cursor};
 use crate::appearance::Appearance;
 use crate::editor::accept_autosuggestion_keybinding_view::{
-    AcceptAutosuggestionKeybinding, AUTOSUGGESTION_HINT_MINIMUM_HEIGHT,
+    AUTOSUGGESTION_HINT_MINIMUM_HEIGHT, AcceptAutosuggestionKeybinding,
 };
 use crate::editor::autosuggestion_ignore_view::AutosuggestionIgnore;
 use crate::editor::position_id_for_first_cursor;
@@ -20,18 +20,18 @@ use crate::ui_components::icons::Icon;
 use itertools::Itertools;
 use pathfinder_geometry::{
     rect::RectF,
-    vector::{vec2f, Vector2F},
+    vector::{Vector2F, vec2f},
 };
 use vim::vim::{MotionType, VimMode};
 use warp_core::features::FeatureFlag;
 use warp_core::ui::appearance::DEFAULT_UI_FONT_SIZE;
 use warp_util::user_input::UserInput;
+use warpui::ViewHandle;
 use warpui::event::KeyState;
 use warpui::text_selection_utils::{
-    calculate_tick_width, create_newline_tick_rect, selection_crosses_newline_row_based,
-    NewlineTickParams,
+    NewlineTickParams, calculate_tick_width, create_newline_tick_rect,
+    selection_crosses_newline_row_based,
 };
-use warpui::ViewHandle;
 use warpui::{event::ModifiersState, text_layout::ComputeBaselinePositionArgs};
 
 use crate::editor::view::AutosuggestionLocation;
@@ -45,15 +45,15 @@ use std::{
     time::Duration,
 };
 use warpui::{
+    AppContext, SingletonEntity, TaskId,
     elements::{
         AfterLayoutContext, CornerRadius, Element, Event, EventContext, LayoutContext,
         PaintContext, Point, SizeConstraint,
     },
     event::DispatchedEvent,
     keymap::Keystroke,
-    text_layout::{self, LayoutCache, DEFAULT_TOP_BOTTOM_RATIO},
+    text_layout::{self, DEFAULT_TOP_BOTTOM_RATIO, LayoutCache},
     ui_components::components::UiComponent,
-    AppContext, SingletonEntity, TaskId,
 };
 
 use warpui::elements::{
@@ -62,7 +62,7 @@ use warpui::elements::{
 use warpui::platform::keyboard::KeyCode;
 
 use instant::Instant;
-use warpui::elements::{Radius, DEFAULT_UI_LINE_HEIGHT_RATIO};
+use warpui::elements::{DEFAULT_UI_LINE_HEIGHT_RATIO, Radius};
 
 // Similar to the terminal::model::ansi::CursorShape, this Editor Element has different cursor
 // shapes. However, this element doesn't implement all the same variants, so we don't share that
@@ -774,12 +774,12 @@ impl EditorElement {
         };
 
         let start_x = if row == selection.start.row() {
-            line_layout.x_for_index(selection.start.column() as usize)
+            line_layout.caret_position_for_index(selection.start.column() as usize)
         } else {
             0.
         };
         let end_x = if row == selection.end.row() {
-            line_layout.x_for_index(selection.end.column() as usize)
+            line_layout.caret_position_for_index(selection.end.column() as usize)
         } else {
             line_layout.width
         };
@@ -1005,7 +1005,9 @@ impl EditorElement {
                     let cursor_row_layout = match layout.frame_layouts.get_line(index) {
                         Some(layout) => layout,
                         None => {
-                            log::warn!("Attempting to access line {index}, but there are fewer lines in the layout.");
+                            log::warn!(
+                                "Attempting to access line {index}, but there are fewer lines in the layout."
+                            );
                             continue;
                         }
                     };
@@ -1047,15 +1049,21 @@ impl EditorElement {
                                 .max(0.0),
                         )
                         + vec2f(
-                            cursor_row_layout.x_for_index(cursor_x_index),
+                            cursor_row_layout.caret_position_for_index(cursor_x_index),
                             (selection.end.row() - first_visible_row) as f32
                                 * line_parameters.line_height,
                         );
 
-                    let block_cursor_width = cursor_row_layout
-                        .width_for_index(selection.end.column() as usize)
-                        .filter(|value| *value > 0.)
-                        .unwrap_or(fallback_block_cursor_width);
+                    let cursor_start_x =
+                        cursor_row_layout.caret_position_for_index(selection.end.column() as usize);
+                    let cursor_end_x = cursor_row_layout
+                        .caret_position_for_index(selection.end.column() as usize + 1);
+                    let caret_width = (cursor_end_x - cursor_start_x).abs();
+                    let block_cursor_width = if caret_width > 0. {
+                        caret_width
+                    } else {
+                        fallback_block_cursor_width
+                    };
 
                     // `should_draw_cursors` is set differently for local and remote cursors:
                     // * remote cursors are drawn based on their block selections
@@ -1302,7 +1310,7 @@ impl EditorElement {
             if let Some(point) =
                 x_ray_display_point.filter(|point| point.row() == first_visible_row + ix as u32)
             {
-                let x = line.x_for_index(point.column() as usize);
+                let x = line.caret_position_for_index(point.column() as usize);
                 ctx.position_cache.cache_position_indefinitely(
                     self.x_ray_position_id(),
                     RectF::new(
@@ -2058,7 +2066,7 @@ impl Element for EditorElement {
                     content_origin
                 };
 
-                let x_offset = line.x_for_index(soft_wrap_point.column() as usize);
+                let x_offset = line.caret_position_for_index(soft_wrap_point.column() as usize);
                 let bounds = text_content_origin + vec2f(x_offset, y_offset);
 
                 ctx.position_cache.cache_position_indefinitely(
@@ -2361,18 +2369,15 @@ impl PaintState {
 
         let x = shifted_position.x() + (scroll_position.x() * view_snapshot.em_width);
 
-        let col = if let Some(col) = line.index_for_x(x).map(|ix| ix as u32) {
+        let col = if let Some(col) = line.caret_index_for_x(x).map(|ix| ix as u32) {
             col
         } else {
             // Clamp to the left or right if the x pos is before or after the buffer text, respectively.
             is_clamped = true;
             if x >= 0. {
-                // If the line has no glyphs, the index is zero. Otherwise, we take one more index
-                // beyond the last start index in the line to get the last position.
-                line.last_glyph()
-                    .map_or(0, |glyph| (glyph.index + 1) as u32)
+                line.end_index() as u32
             } else {
-                0
+                line.first_index() as u32
             }
         };
         // Now convert from SoftWrapPoint to DisplayPoint.

--- a/app/src/editor/view/model/display_map/mod.rs
+++ b/app/src/editor/view/model/display_map/mod.rs
@@ -114,7 +114,7 @@ impl DisplayMap {
                 .context("Should have current line as it should not be possible for it to be beyond bounds, but was not able to retrieve it")?;
             // Note that the index here will correspond to that of the original text so if
             // this line is soft wrapped, it will be higher than 0.
-            let line_first_index = line.first_glyph().map_or(0, |glyph| glyph.index);
+            let line_first_index = line.first_index();
 
             let relative_index = point.column() - line_first_index as u32;
 
@@ -130,13 +130,12 @@ impl DisplayMap {
                 let prev_line = frame_layouts
                     .get_line(point.row() as usize - 1)
                     .context("Should have next line based on max point bounds check, but was not able to retrieve it")?;
-                let prev_line_first_column = prev_line.first_glyph().map_or(0, |glyph| glyph.index as u32);
+                let prev_line_first_column = prev_line.first_index() as u32;
                 // Note that goal column is a relative value, rather than based
                 // on the original string.
                 let new_column = prev_line_first_column + goal_column;
 
-                let last_index_in_line = prev_line.last_glyph().map(|glyph| glyph.index as u32 + 1)
-                    .unwrap_or(0);
+                let last_index_in_line = prev_line.end_index() as u32;
 
                 (SoftWrapPoint::new(
                     point.row() - 1,
@@ -176,7 +175,7 @@ impl DisplayMap {
                 .context("Should have current line as it should not be possible for it to be beyond bounds, but was not able to retrieve it")?;
             // Note that the index here will correspond to that of the original text so if
             // this line is soft wrapped, it will be higher than 0.
-            let line_first_index = line.first_glyph().map_or(0, |glyph| glyph.index);
+            let line_first_index = line.first_index();
 
             let relative_index = point.column() - line_first_index as u32;
 
@@ -191,20 +190,19 @@ impl DisplayMap {
             let max_row = frame_layouts.num_lines() - 1;
             let max_col = frame_layouts
                 .get_line(max_row)
-                .and_then(|line| line.last_glyph().map(|glyph| glyph.index + 1))
+                .map(|line| line.end_index())
                 .unwrap_or(0);
             let max_point = SoftWrapPoint::new(max_row as u32, max_col as u32);
             let (point, is_same_row) = if point.row() < max_point.row() {
                 let next_line = frame_layouts
                     .get_line(point.row() as usize + 1)
                     .context("Should have next line based on max point bounds check, but was not able to retrieve it")?;
-                let next_line_first_column = next_line.first_glyph().map_or(0, |glyph| glyph.index as u32);
+                let next_line_first_column = next_line.first_index() as u32;
                 // Note that goal column is a relative value, rather than based
                 // on the original string.
                 let new_column = next_line_first_column + goal_column;
 
-                let last_index_in_line = next_line.last_glyph().map(|glyph| glyph.index as u32 + 1)
-                    .unwrap_or(0);
+                let last_index_in_line = next_line.end_index() as u32;
 
                 (SoftWrapPoint::new(
                     point.row() + 1,

--- a/app/src/editor/view/snapshot.rs
+++ b/app/src/editor/view/snapshot.rs
@@ -12,7 +12,7 @@ use crate::editor::soft_wrap::FrameLayouts;
 use crate::terminal::grid_size_util::grid_compute_baseline_position_fn;
 
 use parking_lot::Mutex;
-use pathfinder_geometry::vector::{vec2f, Vector2F};
+use pathfinder_geometry::vector::{Vector2F, vec2f};
 
 use anyhow::Result;
 use core::f32;
@@ -31,17 +31,17 @@ use warpui::text::point::Point;
 
 use string_offset::ByteOffset;
 
+use warpui::EntityId;
 use warpui::fonts::{FamilyId, Properties};
 use warpui::platform::LineStyle;
 use warpui::text_layout::{
-    default_compute_baseline_position_fn, ClipConfig, ComputeBaselinePositionFn, StyleAndFont,
-    TextAlignment, TextStyle, DEFAULT_TOP_BOTTOM_RATIO,
+    ClipConfig, ComputeBaselinePositionFn, DEFAULT_TOP_BOTTOM_RATIO, StyleAndFont, TextAlignment,
+    TextStyle, default_compute_baseline_position_fn,
 };
-use warpui::EntityId;
 use warpui::{
+    AppContext, ModelHandle,
     fonts::Cache as FontCache,
     text_layout::{self, LayoutCache},
-    AppContext, ModelHandle,
 };
 
 /// Ratio to calculate font size of cursor avatar.
@@ -369,11 +369,11 @@ impl ViewSnapshot {
             let end_column = cmp::min(map.line_len(head.row(), app).unwrap(), head.column() + 3);
 
             if let Some(line) = layouts.get((head.row() - start_row) as usize) {
-                target_left = target_left.min(line.x_for_index(start_column as usize));
+                target_left = target_left.min(line.caret_position_for_index(start_column as usize));
             }
             if let Some(line) = layouts.get((head.row() - start_row) as usize) {
-                target_right =
-                    target_right.max(line.x_for_index(end_column as usize) + max_glyph_width);
+                target_right = target_right
+                    .max(line.caret_position_for_index(end_column as usize) + max_glyph_width);
             }
         }
         target_right = target_right.min(scroll_width);

--- a/crates/warpui_core/src/text_layout.rs
+++ b/crates/warpui_core/src/text_layout.rs
@@ -1,4 +1,4 @@
-use crate::elements::{Fill, DEFAULT_UI_LINE_HEIGHT_RATIO};
+use crate::elements::{DEFAULT_UI_LINE_HEIGHT_RATIO, Fill};
 use crate::fonts::{
     Cache as FontCache, FamilyId, Properties, RequestedFallbackFontSource, TextLayoutSystem,
 };
@@ -7,9 +7,9 @@ use crate::geometry::vector::vec2f;
 use crate::platform::LineStyle;
 use crate::scene::{Border, CornerRadius, Dash};
 use crate::{
+    Scene,
     fonts::{FontId, GlyphId},
     scene::GlyphFade,
-    Scene,
 };
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
@@ -25,7 +25,7 @@ use std::{
     ops::Range,
     sync::Arc,
 };
-use vec1::{vec1, Vec1};
+use vec1::{Vec1, vec1};
 
 type StyleRun = (Range<usize>, StyleAndFont);
 
@@ -828,10 +828,10 @@ impl TextFrame {
     /// index of the below line.
     pub fn row_within_frame(&self, index: usize, clamp_above: bool) -> usize {
         for (i, line) in self.lines.iter().enumerate() {
-            if let Some(last_glyph) = line.last_glyph() {
+            if !line.caret_positions.is_empty() || line.last_glyph().is_some() {
                 let last_index_in_row = match clamp_above {
-                    true => last_glyph.index + 1,
-                    false => last_glyph.index,
+                    true => line.end_index(),
+                    false => line.last_index(),
                 };
                 if last_index_in_row >= index {
                     return i;
@@ -1122,14 +1122,18 @@ impl Line {
     pub fn first_index(&self) -> usize {
         self.caret_positions
             .first()
-            .map_or(0, |caret| caret.start_offset)
+            .map(|caret| caret.start_offset)
+            .or_else(|| self.first_glyph().map(|glyph| glyph.index))
+            .unwrap_or(0)
     }
 
     /// The last character index that's within this line (inclusive).
     pub fn last_index(&self) -> usize {
         self.caret_positions
             .last()
-            .map_or(0, |caret| caret.last_offset)
+            .map(|caret| caret.last_offset)
+            .or_else(|| self.last_glyph().map(|glyph| glyph.index))
+            .unwrap_or(0)
     }
 
     /// The first character index that's after this line.


### PR DESCRIPTION
## Summary
- switch editor cursor, selection, mouse hit-testing, and autoscroll positioning to caret-aware text layout APIs
- use caret-aware line boundaries for soft-wrap/display-map conversions
- let mouse hit-testing choose the logical line end when clicking or dragging over the trailing half of the final glyph/ligature
- add regression coverage for a visual line ending in a two-character ligature

## Root Cause
The editor was mixing glyph-index APIs with caret-index APIs. When text shaping collapses multiple characters into a single glyph, such as an `fi` ligature in words like `Specifications` or `specification`, cursor and selection coordinates could drift from the rendered text. Long pasted prompts with Windows paths make this easier to notice because they trigger soft wrapping around those shaped glyphs.

## Impact
This should make the blinking cursor, drag selection, soft-wrap clamping, and horizontal autoscroll agree with the actual caret positions produced by text layout.

## Validation
- `cargo test -p warp test_soft_wrap --lib`
- `cargo test -p warp test_display_point_marks_ligature --lib`
- `cargo test -p warp test_add_cursor --lib`
- `cargo test -p warp test_autoscroll_vertical --lib`
- `cargo test -p warpui_core --lib`

## Manual Testing
Not captured in this Codex session. The change needs a native patched Warp GUI session to produce a meaningful cursor/selection screen recording, and this environment only gives me shell access to the checkout rather than an interactive patched Warp window. The focused validation above exercises the soft-wrap/caret boundary logic and compiles the affected editor path.