### PR TITLE
fix: render Thai (and other complex-script) combining marks correctly

### DIFF
--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -1133,6 +1133,9 @@ fn render_grid_with_ligatures<'a>(
         // and filter-match styling survive on complex-script cells, and so HarfBuzz
         // shapes the run with the correct face.
         let mut deferred_str_cells: Vec<(usize, ColorU, FontId, Properties, String)> = Vec::new();
+        // Tracks which column was consumed as the SARA AM tail of a preceding consonant cluster,
+        // so the SARA AM cell itself can be skipped during rendering.
+        let mut skip_sara_am_at: Option<usize> = None;
 
         let Some(row) = grid.row(row_idx) else {
             log::error!("grid_renderer should not try to render an out-of-bounds row");
@@ -1455,37 +1458,65 @@ fn render_grid_with_ligatures<'a>(
                         .entry(font_style)
                         .or_insert_with(|| ctx.font_cache.select_font(font_family, properties));
 
+                    // Look ahead: if the next cell is SARA AM, shape this cell's content
+                    // and SARA AM together as one HarfBuzz cluster. This lets the Thai shaper
+                    // place the nikhahit dot above the correct consonant via GPOS, matching
+                    // what render_cell_glyph does in the non-ligature path.
+                    let following_sara_am = (col + 1 < grid.columns())
+                        .then(|| match row[col + 1].content_for_display() {
+                            CharOrStr::Char(c) => decompose_sara_am(c).map(|_| c),
+                            CharOrStr::Str(_) => None,
+                        })
+                        .flatten();
+
                     match cell.content_for_display() {
                         CharOrStr::Str(s) => {
                             string_builder.append_placeholder(col);
+                            let content = if let Some(sa) = following_sara_am {
+                                skip_sara_am_at = Some(col + 1);
+                                let mut combined = s.to_owned();
+                                combined.push(sa);
+                                combined
+                            } else {
+                                s.to_owned()
+                            };
                             deferred_str_cells.push((
                                 col,
                                 cell_colors.foreground_color,
                                 styled_font_id,
                                 properties,
-                                s.to_owned(),
+                                content,
                             ));
                         }
-                        // Thai/Lao SARA AM: defer like a Str cell, splitting it into the spacing
-                        // "aa" tail (this cell) and the nikhahit dot drawn over the preceding
-                        // consonant cell, so the vowel stays attached. See [`decompose_sara_am`].
+                        // SARA AM cell: rendered as part of the preceding consonant's cluster
+                        // (see look-ahead above). Only draw it standalone when at the start of
+                        // the line and there was no preceding consonant to consume it.
                         CharOrStr::Char(c) if decompose_sara_am(c).is_some() => {
-                            let (nikhahit, sara_aa) =
-                                decompose_sara_am(c).expect("checked by guard");
+                            string_builder.append_placeholder(col);
+                            if skip_sara_am_at != Some(col) {
+                                let (_, sara_aa) =
+                                    decompose_sara_am(c).expect("checked by guard");
+                                deferred_str_cells.push((
+                                    col,
+                                    cell_colors.foreground_color,
+                                    styled_font_id,
+                                    properties,
+                                    sara_aa.to_string(),
+                                ));
+                            }
+                        }
+                        // Consonant followed by SARA AM: defer both together so HarfBuzz shapes
+                        // the cluster and positions the nikhahit dot above the consonant via GPOS.
+                        CharOrStr::Char(c) if following_sara_am.is_some() => {
+                            let sa = following_sara_am.expect("checked by guard");
+                            skip_sara_am_at = Some(col + 1);
                             string_builder.append_placeholder(col);
                             deferred_str_cells.push((
                                 col,
                                 cell_colors.foreground_color,
                                 styled_font_id,
                                 properties,
-                                sara_aa.to_string(),
-                            ));
-                            deferred_str_cells.push((
-                                col.saturating_sub(1),
-                                cell_colors.foreground_color,
-                                styled_font_id,
-                                properties,
-                                nikhahit.to_string(),
+                                format!("{c}{sa}"),
                             ));
                         }
                         other => string_builder.append_content(other, col),

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -664,6 +664,8 @@ fn render_grid_without_ligatures<'a>(
                         offset_row,
                         col,
                         &marked_text_cell,
+                        None,
+                        None,
                         cell_type,
                         false,
                         FirstCellInSecret::default(),
@@ -800,6 +802,8 @@ fn render_grid_without_ligatures<'a>(
                 offset_row,
                 col,
                 cell,
+                (col > 0).then(|| &row[col - 1]),
+                (col + 1 < grid.columns()).then(|| &row[col + 1]),
                 cell_type,
                 first_cell_in_link,
                 first_cell_in_secret,
@@ -875,6 +879,8 @@ fn render_cell(
     offset_row: usize,
     col: usize,
     cell: &Cell,
+    prev_cell: Option<&Cell>,
+    next_cell: Option<&Cell>,
     cell_type: CellType,
     first_cell_in_link: bool,
     first_cell_in_secret: FirstCellInSecret,
@@ -927,6 +933,8 @@ fn render_cell(
 
     render_cell_glyph(
         cell,
+        prev_cell,
+        next_cell,
         &cell_type,
         first_cell_in_link,
         first_cell_in_secret,
@@ -1431,6 +1439,24 @@ fn render_grid_with_ligatures<'a>(
                             deferred_str_cells
                                 .push((col, cell_colors.foreground_color, s.to_owned()));
                         }
+                        // Thai/Lao SARA AM: defer like a Str cell, splitting it into the spacing
+                        // "aa" tail (this cell) and the nikhahit dot drawn over the preceding
+                        // consonant cell, so the vowel stays attached. See [`decompose_sara_am`].
+                        CharOrStr::Char(c) if decompose_sara_am(c).is_some() => {
+                            let (nikhahit, sara_aa) =
+                                decompose_sara_am(c).expect("checked by guard");
+                            string_builder.append_placeholder(col);
+                            deferred_str_cells.push((
+                                col,
+                                cell_colors.foreground_color,
+                                sara_aa.to_string(),
+                            ));
+                            deferred_str_cells.push((
+                                col.saturating_sub(1),
+                                cell_colors.foreground_color,
+                                nikhahit.to_string(),
+                            ));
+                        }
                         other => string_builder.append_content(other, col),
                     }
                 }
@@ -1701,11 +1727,35 @@ impl FontIdCache {
     }
 }
 
+/// Decomposes Thai/Lao SARA AM into the parts a complex-text shaper would.
+///
+/// SARA AM (Thai U+0E33, Lao U+0EB3) is a spacing vowel whose single glyph fuses two visually
+/// separate pieces: a nikhahit dot that belongs *above the preceding consonant*, and a spacing
+/// "aa" tail to the right. Because it has a Unicode width of 1, the terminal stores it in its own
+/// grid cell, one column to the right of its consonant — so the dot detaches from the consonant
+/// and renders over the (empty) sara-am cell instead. That is the "สระอำ แยกกัน" splitting.
+///
+/// Returning `(nikhahit, sara_aa)` lets the renderer draw the dot over the consonant cell and the
+/// tail in the sara-am cell, keeping the vowel attached. This decomposition is used purely for
+/// rendering/layout — the grid keeps the original codepoint so copy, search, and find stay
+/// byte-faithful.
+fn decompose_sara_am(c: char) -> Option<(char, char)> {
+    match c {
+        // THAI CHARACTER SARA AM -> THAI CHARACTER NIKHAHIT + THAI CHARACTER SARA AA
+        '\u{0E33}' => Some(('\u{0E4D}', '\u{0E32}')),
+        // LAO VOWEL SIGN AM -> LAO NIGGAHITA + LAO VOWEL SIGN AA
+        '\u{0EB3}' => Some(('\u{0ECD}', '\u{0EB2}')),
+        _ => None,
+    }
+}
+
 /// Draw the glyph for the cell here, but don't draw the decorations (underlines and strikethroughs)
 /// yet.
 #[allow(clippy::too_many_arguments)]
 fn render_cell_glyph(
     cell: &Cell,
+    prev_cell: Option<&Cell>,
+    next_cell: Option<&Cell>,
     cell_type: &CellType,
     first_cell_in_link: bool,
     first_cell_in_secret: FirstCellInSecret,
@@ -1770,28 +1820,27 @@ fn render_cell_glyph(
                 glyph_type,
             });
         }
-        None => match cell_content {
-            // Special-case whitespace, which doesn't need rendering.  We
-            // explicitly check these two chars instead of using
-            // `char::is_whitespace` for performance reasons.
-            CharOrStr::Char(' ' | '\t') => {}
-            CharOrStr::Char(char) => {
-                if let Some((glyph_id, font_id)) =
-                    glyphs.glyph_for_char(char, *font_id, ctx.font_cache)
-                {
-                    ctx.scene
-                        .draw_glyph(origin, glyph_id, font_id, font_size, foreground_color);
+        None => {
+            // If the following cell is a Thai/Lao SARA AM spacing vowel, render this cell's
+            // content together with it as a single shaped cluster. SARA AM (ำ) fuses a nikhahit
+            // dot that belongs *above this consonant* with a spacing "aa" tail; shaping them
+            // together lets HarfBuzz's Thai shaper position the dot over the consonant (via GPOS)
+            // and place the tail after it. The SARA AM cell itself then draws nothing (see the
+            // SARA AM arm below). See [`decompose_sara_am`].
+            let following_sara_am = next_cell.and_then(|n| match n.content_for_display() {
+                CharOrStr::Char(c) => decompose_sara_am(c).map(|_| c),
+                CharOrStr::Str(_) => None,
+            });
+
+            if let Some(sara_am_char) = following_sara_am {
+                let mut cluster = String::new();
+                match cell_content {
+                    CharOrStr::Char(c) => cluster.push(c),
+                    CharOrStr::Str(s) => cluster.push_str(s),
                 }
-            }
-            // Certain zerowidth characters, such as emoji presentation selectors, can affect the
-            // underlying glyph and change the rendering. Hence, we need to layout/render the text
-            // as a combined string. For example, \0x2601\0xFE0F causes ☁️ to become 2-wide.
-            // Thai combining vowels (e.g. "วั") also produce multiple glyphs — the base consonant
-            // and the above/below mark — which must all be drawn at the same cell origin so the
-            // font's own glyph metrics position the mark correctly above the consonant.
-            CharOrStr::Str(content_with_zerowidth) => {
+                cluster.push(sara_am_char);
                 for (glyph_id, glyph_font_id, position) in glyphs.glyphs_for_string(
-                    content_with_zerowidth,
+                    &cluster,
                     *font_id,
                     ctx.font_cache,
                     font_family,
@@ -1799,10 +1848,6 @@ fn render_cell_glyph(
                     properties,
                     ctx,
                 ) {
-                    // Apply HarfBuzz's shaped position so combining marks (e.g. Thai ั / ี)
-                    // sit at the offset the script's GPOS table prescribes — without this,
-                    // every glyph stacks on the cell origin and marks land on the previous
-                    // cell or wherever the bare glyph happens to extend.
                     ctx.scene.draw_glyph(
                         origin + position,
                         glyph_id,
@@ -1811,8 +1856,75 @@ fn render_cell_glyph(
                         foreground_color,
                     );
                 }
+            } else {
+                match cell_content {
+                    // Special-case whitespace, which doesn't need rendering.  We
+                    // explicitly check these two chars instead of using
+                    // `char::is_whitespace` for performance reasons.
+                    CharOrStr::Char(' ' | '\t') => {}
+                    // Thai/Lao SARA AM is normally rendered as part of the preceding consonant's
+                    // cluster (see `following_sara_am` above). Only draw it standalone when there
+                    // is no preceding cell to attach to (e.g. at the start of a line).
+                    CharOrStr::Char(c) if decompose_sara_am(c).is_some() => {
+                        if prev_cell.is_none() {
+                            if let Some((glyph_id, font_id)) =
+                                glyphs.glyph_for_char(c, *font_id, ctx.font_cache)
+                            {
+                                ctx.scene.draw_glyph(
+                                    origin,
+                                    glyph_id,
+                                    font_id,
+                                    font_size,
+                                    foreground_color,
+                                );
+                            }
+                        }
+                    }
+                    CharOrStr::Char(char) => {
+                        if let Some((glyph_id, font_id)) =
+                            glyphs.glyph_for_char(char, *font_id, ctx.font_cache)
+                        {
+                            ctx.scene.draw_glyph(
+                                origin,
+                                glyph_id,
+                                font_id,
+                                font_size,
+                                foreground_color,
+                            );
+                        }
+                    }
+                    // Certain zerowidth characters, such as emoji presentation selectors, can
+                    // affect the underlying glyph and change the rendering. Hence, we need to
+                    // layout/render the text as a combined string. For example, \0x2601\0xFE0F
+                    // causes ☁️ to become 2-wide. Thai combining vowels (e.g. "วั") also produce
+                    // multiple glyphs — the base consonant and the above/below mark — positioned
+                    // by HarfBuzz's GPOS table.
+                    CharOrStr::Str(content_with_zerowidth) => {
+                        for (glyph_id, glyph_font_id, position) in glyphs.glyphs_for_string(
+                            content_with_zerowidth,
+                            *font_id,
+                            ctx.font_cache,
+                            font_family,
+                            font_size,
+                            properties,
+                            ctx,
+                        ) {
+                            // Apply HarfBuzz's shaped position so combining marks (e.g. Thai ั / ี)
+                            // sit at the offset the script's GPOS table prescribes — without this,
+                            // every glyph stacks on the cell origin and marks land on the previous
+                            // cell or wherever the bare glyph happens to extend.
+                            ctx.scene.draw_glyph(
+                                origin + position,
+                                glyph_id,
+                                glyph_font_id,
+                                font_size,
+                                foreground_color,
+                            );
+                        }
+                    }
+                }
             }
-        },
+        }
     }
 
     if first_cell_in_link {

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -333,6 +333,7 @@ pub fn render_grid<'a>(
                 cell_size,
                 padding_x,
                 grid_origin,
+                glyphs,
                 alpha,
                 highlighted_url,
                 link_tool_tip,
@@ -365,6 +366,7 @@ pub fn render_grid<'a>(
                 cell_size,
                 padding_x,
                 grid_origin,
+                glyphs,
                 alpha,
                 highlighted_url,
                 link_tool_tip,
@@ -980,6 +982,7 @@ fn render_grid_with_ligatures<'a>(
     cell_size: Vector2F,
     padding_x: Pixels,
     grid_origin: Vector2F,
+    glyphs: &mut CellGlyphCache,
     alpha: u8,
     highlighted_url: Option<&Link>, // Url highlighted on mouse hover.
     link_tool_tip: Option<&Link>,   // Link that has an opened tool-tip.
@@ -1125,7 +1128,11 @@ fn render_grid_with_ligatures<'a>(
         // Thai "วั") are excluded from layout_line and rendered here via glyph_for_char, which
         // has DirectWrite system-font fallback. layout_line uses cosmic_text/fontdb and cannot
         // load system Thai fonts on demand, so it produces glyph_id=0 for those characters.
-        let mut deferred_str_cells: Vec<(usize, ColorU, String)> = Vec::new();
+        // (col, fg, styled font, font properties, content). We carry the styled font
+        // and its properties — rather than reusing `default_font_id` — so bold/italic
+        // and filter-match styling survive on complex-script cells, and so HarfBuzz
+        // shapes the run with the correct face.
+        let mut deferred_str_cells: Vec<(usize, ColorU, FontId, Properties, String)> = Vec::new();
 
         let Some(row) = grid.row(row_idx) else {
             log::error!("grid_renderer should not try to render an out-of-bounds row");
@@ -1433,11 +1440,31 @@ fn render_grid_with_ligatures<'a>(
                     // attempt the same thing, so we replace it with a placeholder
                     string_builder.append_placeholder(col);
                 } else {
+                    // Resolve the cell's *styled* font (filter matches render bold, matching
+                    // `string_builder.update_style` above) so deferred complex-script cells keep
+                    // their weight/slant instead of falling back to the base font.
+                    let font_style: FontStyle = if cell_type.is_filter_match() {
+                        let mut flags = cell.flags;
+                        flags.insert(Flags::BOLD);
+                        flags.into()
+                    } else {
+                        cell.flags.into()
+                    };
+                    let properties = font_style.to_properties();
+                    let styled_font_id = *font_id_cache
+                        .entry(font_style)
+                        .or_insert_with(|| ctx.font_cache.select_font(font_family, properties));
+
                     match cell.content_for_display() {
                         CharOrStr::Str(s) => {
                             string_builder.append_placeholder(col);
-                            deferred_str_cells
-                                .push((col, cell_colors.foreground_color, s.to_owned()));
+                            deferred_str_cells.push((
+                                col,
+                                cell_colors.foreground_color,
+                                styled_font_id,
+                                properties,
+                                s.to_owned(),
+                            ));
                         }
                         // Thai/Lao SARA AM: defer like a Str cell, splitting it into the spacing
                         // "aa" tail (this cell) and the nikhahit dot drawn over the preceding
@@ -1449,11 +1476,15 @@ fn render_grid_with_ligatures<'a>(
                             deferred_str_cells.push((
                                 col,
                                 cell_colors.foreground_color,
+                                styled_font_id,
+                                properties,
                                 sara_aa.to_string(),
                             ));
                             deferred_str_cells.push((
                                 col.saturating_sub(1),
                                 cell_colors.foreground_color,
+                                styled_font_id,
+                                properties,
                                 nikhahit.to_string(),
                             ));
                         }
@@ -1488,27 +1519,36 @@ fn render_grid_with_ligatures<'a>(
             ctx.scene,
         );
 
-        // Render deferred CharOrStr::Str cells (base + combining chars, e.g. Thai "วั").
-        // Look up the base char with full DirectWrite fallback to find the script font, then
-        // reuse that font for every combining mark — DirectWrite cannot map combining marks
-        // standalone (no script context), but the script font that contains ว also contains ั.
-        for (col, foreground_color, content) in deferred_str_cells.drain(..) {
+        // Render deferred CharOrStr::Str cells (base + combining chars, e.g. Thai "วั", as well
+        // as emoji variation selectors and ZWJ sequences). Shape the whole run through
+        // `glyphs_for_string` (HarfBuzz via layout_line) so that:
+        //   * multi-codepoint clusters — VS16 emoji, ZWJ families — are shaped as one unit
+        //     instead of being drawn one codepoint at a time;
+        //   * each glyph is placed at its baseline-relative GPOS position rather than stacked
+        //     at the cell origin, so Thai/Lao combining marks land above the right base;
+        //   * the cell's styled font (bold/italic, filter-match) is honoured.
+        // `glyphs_for_string` falls back to per-character lookup anchored on the base char's
+        // script font when the primary font lacks the script.
+        for (col, foreground_color, styled_font_id, properties, content) in
+            deferred_str_cells.drain(..)
+        {
             let origin = line_origin + vec2f(col as f32 * cell_size.x(), 0.);
-            let mut chars = content.chars();
-            let Some(first_char) = chars.next() else { continue };
-            let Some((first_glyph, base_font_id)) =
-                ctx.font_cache.glyph_for_char(default_font_id, first_char, true)
-            else {
-                continue;
-            };
-            ctx.scene
-                .draw_glyph(origin, first_glyph, base_font_id, font_size, foreground_color);
-            for c in chars {
-                if let Some((glyph_id, _)) = ctx.font_cache.glyph_for_char(base_font_id, c, false)
-                {
-                    ctx.scene
-                        .draw_glyph(origin, glyph_id, base_font_id, font_size, foreground_color);
-                }
+            for (glyph_id, glyph_font_id, position) in glyphs.glyphs_for_string(
+                &content,
+                styled_font_id,
+                ctx.font_cache,
+                font_family,
+                font_size,
+                properties,
+                ctx,
+            ) {
+                ctx.scene.draw_glyph(
+                    origin + position,
+                    glyph_id,
+                    glyph_font_id,
+                    font_size,
+                    foreground_color,
+                );
             }
         }
 

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -1113,6 +1113,11 @@ fn render_grid_with_ligatures<'a>(
         let offset_row = start_row + offset;
         let mut string_builder =
             AttributedStringBuilder::new(font_family, font_family, grid.columns());
+        // Cells whose content is CharOrStr::Str (base char + zero-width combining chars, e.g.
+        // Thai "วั") are excluded from layout_line and rendered here via glyph_for_char, which
+        // has DirectWrite system-font fallback. layout_line uses cosmic_text/fontdb and cannot
+        // load system Thai fonts on demand, so it produces glyph_id=0 for those characters.
+        let mut deferred_str_cells: Vec<(usize, ColorU, String)> = Vec::new();
 
         let Some(row) = grid.row(row_idx) else {
             log::error!("grid_renderer should not try to render an out-of-bounds row");
@@ -1420,7 +1425,14 @@ fn render_grid_with_ligatures<'a>(
                     // attempt the same thing, so we replace it with a placeholder
                     string_builder.append_placeholder(col);
                 } else {
-                    string_builder.append_content(cell.content_for_display(), col);
+                    match cell.content_for_display() {
+                        CharOrStr::Str(s) => {
+                            string_builder.append_placeholder(col);
+                            deferred_str_cells
+                                .push((col, cell_colors.foreground_color, s.to_owned()));
+                        }
+                        other => string_builder.append_content(other, col),
+                    }
                 }
             }
         }
@@ -1449,6 +1461,30 @@ fn render_grid_with_ligatures<'a>(
             &string_data.character_index_to_cell_map,
             ctx.scene,
         );
+
+        // Render deferred CharOrStr::Str cells (base + combining chars, e.g. Thai "วั").
+        // Look up the base char with full DirectWrite fallback to find the script font, then
+        // reuse that font for every combining mark — DirectWrite cannot map combining marks
+        // standalone (no script context), but the script font that contains ว also contains ั.
+        for (col, foreground_color, content) in deferred_str_cells.drain(..) {
+            let origin = line_origin + vec2f(col as f32 * cell_size.x(), 0.);
+            let mut chars = content.chars();
+            let Some(first_char) = chars.next() else { continue };
+            let Some((first_glyph, base_font_id)) =
+                ctx.font_cache.glyph_for_char(default_font_id, first_char, true)
+            else {
+                continue;
+            };
+            ctx.scene
+                .draw_glyph(origin, first_glyph, base_font_id, font_size, foreground_color);
+            for c in chars {
+                if let Some((glyph_id, _)) = ctx.font_cache.glyph_for_char(base_font_id, c, false)
+                {
+                    ctx.scene
+                        .draw_glyph(origin, glyph_id, base_font_id, font_size, foreground_color);
+                }
+            }
+        }
 
         if grid.filter_has_context_lines() {
             maybe_render_dotted_lines(
@@ -1722,27 +1758,6 @@ fn render_cell_glyph(
     let font_id = font_id_cache.font_ids[font_style as usize]
         .get_or_insert_with(|| ctx.font_cache.select_font(font_family, properties));
 
-    let glyph_and_font = match cell_content {
-        // Special-case whitespace, which doesn't need rendering.  We
-        // explicitly check these two chars instead of using
-        // `char::is_whitespace` for performance reasons.
-        CharOrStr::Char(' ' | '\t') => None,
-        CharOrStr::Char(char) => glyphs.glyph_for_char(char, *font_id, ctx.font_cache),
-        // Certain zerowidth characters, such as emoji presentation selectors, can affect the underlying glyph and
-        // change the rendering. Hence, we need to layout/render the text as a combined string, instead of simply
-        // the single character. For example, in \0x2601\0xFE0F, the FE0F selector causes ☁️ to be changed from a
-        // 1-width char to a 2-width char.
-        CharOrStr::Str(content_with_zerowidth) => glyphs.glyph_for_string(
-            content_with_zerowidth,
-            *font_id,
-            ctx.font_cache,
-            font_family,
-            font_size,
-            properties,
-            ctx,
-        ),
-    };
-
     let origin = grid_origin + glyph_offset + baseline_position;
 
     // Handle special unicode characters that will look better with native
@@ -1755,16 +1770,49 @@ fn render_cell_glyph(
                 glyph_type,
             });
         }
-        None => {
-            // Add FontId as part of the hashkey since characters with different
-            // fonts will have different glyph ids.
-            if let Some((glyph_id, font_id)) = glyph_and_font {
-                // If we don't have special handling for the character, draw the
-                // glyph from the font.
-                ctx.scene
-                    .draw_glyph(origin, glyph_id, font_id, font_size, foreground_color);
+        None => match cell_content {
+            // Special-case whitespace, which doesn't need rendering.  We
+            // explicitly check these two chars instead of using
+            // `char::is_whitespace` for performance reasons.
+            CharOrStr::Char(' ' | '\t') => {}
+            CharOrStr::Char(char) => {
+                if let Some((glyph_id, font_id)) =
+                    glyphs.glyph_for_char(char, *font_id, ctx.font_cache)
+                {
+                    ctx.scene
+                        .draw_glyph(origin, glyph_id, font_id, font_size, foreground_color);
+                }
             }
-        }
+            // Certain zerowidth characters, such as emoji presentation selectors, can affect the
+            // underlying glyph and change the rendering. Hence, we need to layout/render the text
+            // as a combined string. For example, \0x2601\0xFE0F causes ☁️ to become 2-wide.
+            // Thai combining vowels (e.g. "วั") also produce multiple glyphs — the base consonant
+            // and the above/below mark — which must all be drawn at the same cell origin so the
+            // font's own glyph metrics position the mark correctly above the consonant.
+            CharOrStr::Str(content_with_zerowidth) => {
+                for (glyph_id, glyph_font_id, position) in glyphs.glyphs_for_string(
+                    content_with_zerowidth,
+                    *font_id,
+                    ctx.font_cache,
+                    font_family,
+                    font_size,
+                    properties,
+                    ctx,
+                ) {
+                    // Apply HarfBuzz's shaped position so combining marks (e.g. Thai ั / ี)
+                    // sit at the offset the script's GPOS table prescribes — without this,
+                    // every glyph stacks on the cell origin and marks land on the previous
+                    // cell or wherever the bare glyph happens to extend.
+                    ctx.scene.draw_glyph(
+                        origin + position,
+                        glyph_id,
+                        glyph_font_id,
+                        font_size,
+                        foreground_color,
+                    );
+                }
+            }
+        },
     }
 
     if first_cell_in_link {
@@ -2601,9 +2649,15 @@ struct AttributedStringBuilder {
     current_style: StyleAndFont,
     current_style_start_char_index: usize,
     style_runs: Vec<(Range<usize>, StyleAndFont)>,
-    // Conceptually, this is a map from character index to cell index. However, since it is both
-    // dense and build in order, we can avoid the overhead of hashing by using a `Vec`
+    // A byte-offset-indexed map from each UTF-8 byte position in `line` to a cell (column) index.
+    // Each character fills *all* of its UTF-8 bytes with the same cell column so that
+    // `paint_line` can use `glyph.index` — which is a byte offset, not a char index — to
+    // look up the correct cell. Without this, multi-byte characters (Thai, CJK, emoji, …) are
+    // drawn at the wrong grid column.
     character_index_to_cell_map: Vec<usize>,
+    // Tracks the number of *chars* appended (as opposed to bytes) so that style-run ranges stay
+    // char-indexed, matching what `layout_line` expects.
+    char_count: usize,
     line: String,
 }
 
@@ -2619,12 +2673,13 @@ impl AttributedStringBuilder {
             current_style_start_char_index: 0,
             style_runs: Vec::new(),
             character_index_to_cell_map: Vec::with_capacity(columns),
+            char_count: 0,
             line: String::with_capacity(columns),
         }
     }
 
     fn next_character_index(&self) -> usize {
-        self.character_index_to_cell_map.len()
+        self.char_count
     }
 
     /// Flushes the currently cached style into the style runs list and update the current style
@@ -2682,8 +2737,15 @@ impl AttributedStringBuilder {
     /// This will update the mapping of cell indexes so that the character can be connected with
     /// its expected grid position later.
     fn append_character(&mut self, chr: char, column: usize) {
+        let start_byte = self.line.len();
         self.line.push(chr);
-        self.character_index_to_cell_map.push(column);
+        // `glyph.index` in `paint_line` is a UTF-8 byte offset, so we fill every byte of this
+        // character's UTF-8 encoding with the same cell column. This ensures multi-byte characters
+        // (Thai, CJK, emoji, …) are drawn at the correct grid column.
+        for _ in start_byte..self.line.len() {
+            self.character_index_to_cell_map.push(column);
+        }
+        self.char_count += 1;
     }
 
     /// Append a cell's content to the attributed string at a specific grid column.

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -1116,6 +1116,11 @@ fn render_grid_with_ligatures<'a>(
         let offset_row = start_row + offset;
         let mut string_builder =
             AttributedStringBuilder::new(font_family, font_family, grid.columns());
+        // Cells whose content is CharOrStr::Str (base char + zero-width combining chars, e.g.
+        // Thai "วั") are excluded from layout_line and rendered here via glyph_for_char, which
+        // has DirectWrite system-font fallback. layout_line uses cosmic_text/fontdb and cannot
+        // load system Thai fonts on demand, so it produces glyph_id=0 for those characters.
+        let mut deferred_str_cells: Vec<(usize, ColorU, String)> = Vec::new();
 
         let Some(row) = grid.row(row_idx) else {
             log::error!("grid_renderer should not try to render an out-of-bounds row");
@@ -1414,7 +1419,14 @@ fn render_grid_with_ligatures<'a>(
                     // attempt the same thing, so we replace it with a placeholder
                     string_builder.append_placeholder(col);
                 } else {
-                    string_builder.append_content(cell.content_for_display(), col);
+                    match cell.content_for_display() {
+                        CharOrStr::Str(s) => {
+                            string_builder.append_placeholder(col);
+                            deferred_str_cells
+                                .push((col, cell_colors.foreground_color, s.to_owned()));
+                        }
+                        other => string_builder.append_content(other, col),
+                    }
                 }
             }
         }
@@ -1443,6 +1455,30 @@ fn render_grid_with_ligatures<'a>(
             &string_data.character_index_to_cell_map,
             ctx.scene,
         );
+
+        // Render deferred CharOrStr::Str cells (base + combining chars, e.g. Thai "วั").
+        // Look up the base char with full DirectWrite fallback to find the script font, then
+        // reuse that font for every combining mark — DirectWrite cannot map combining marks
+        // standalone (no script context), but the script font that contains ว also contains ั.
+        for (col, foreground_color, content) in deferred_str_cells.drain(..) {
+            let origin = line_origin + vec2f(col as f32 * cell_size.x(), 0.);
+            let mut chars = content.chars();
+            let Some(first_char) = chars.next() else { continue };
+            let Some((first_glyph, base_font_id)) =
+                ctx.font_cache.glyph_for_char(default_font_id, first_char, true)
+            else {
+                continue;
+            };
+            ctx.scene
+                .draw_glyph(origin, first_glyph, base_font_id, font_size, foreground_color);
+            for c in chars {
+                if let Some((glyph_id, _)) = ctx.font_cache.glyph_for_char(base_font_id, c, false)
+                {
+                    ctx.scene
+                        .draw_glyph(origin, glyph_id, base_font_id, font_size, foreground_color);
+                }
+            }
+        }
 
         if grid.filter_has_context_lines() {
             maybe_render_dotted_lines(
@@ -1716,27 +1752,6 @@ fn render_cell_glyph(
     let font_id = font_id_cache.font_ids[font_style as usize]
         .get_or_insert_with(|| ctx.font_cache.select_font(font_family, properties));
 
-    let glyph_and_font = match cell_content {
-        // Special-case whitespace, which doesn't need rendering.  We
-        // explicitly check these two chars instead of using
-        // `char::is_whitespace` for performance reasons.
-        CharOrStr::Char(' ' | '\t') => None,
-        CharOrStr::Char(char) => glyphs.glyph_for_char(char, *font_id, ctx.font_cache),
-        // Certain zerowidth characters, such as emoji presentation selectors, can affect the underlying glyph and
-        // change the rendering. Hence, we need to layout/render the text as a combined string, instead of simply
-        // the single character. For example, in \0x2601\0xFE0F, the FE0F selector causes ☁️ to be changed from a
-        // 1-width char to a 2-width char.
-        CharOrStr::Str(content_with_zerowidth) => glyphs.glyph_for_string(
-            content_with_zerowidth,
-            *font_id,
-            ctx.font_cache,
-            font_family,
-            font_size,
-            properties,
-            ctx,
-        ),
-    };
-
     let origin = grid_origin + glyph_offset + baseline_position;
 
     // Handle special unicode characters that will look better with native
@@ -1749,16 +1764,49 @@ fn render_cell_glyph(
                 glyph_type,
             });
         }
-        None => {
-            // Add FontId as part of the hashkey since characters with different
-            // fonts will have different glyph ids.
-            if let Some((glyph_id, font_id)) = glyph_and_font {
-                // If we don't have special handling for the character, draw the
-                // glyph from the font.
-                ctx.scene
-                    .draw_glyph(origin, glyph_id, font_id, font_size, foreground_color);
+        None => match cell_content {
+            // Special-case whitespace, which doesn't need rendering.  We
+            // explicitly check these two chars instead of using
+            // `char::is_whitespace` for performance reasons.
+            CharOrStr::Char(' ' | '\t') => {}
+            CharOrStr::Char(char) => {
+                if let Some((glyph_id, font_id)) =
+                    glyphs.glyph_for_char(char, *font_id, ctx.font_cache)
+                {
+                    ctx.scene
+                        .draw_glyph(origin, glyph_id, font_id, font_size, foreground_color);
+                }
             }
-        }
+            // Certain zerowidth characters, such as emoji presentation selectors, can affect the
+            // underlying glyph and change the rendering. Hence, we need to layout/render the text
+            // as a combined string. For example, \0x2601\0xFE0F causes ☁️ to become 2-wide.
+            // Thai combining vowels (e.g. "วั") also produce multiple glyphs — the base consonant
+            // and the above/below mark — which must all be drawn at the same cell origin so the
+            // font's own glyph metrics position the mark correctly above the consonant.
+            CharOrStr::Str(content_with_zerowidth) => {
+                for (glyph_id, glyph_font_id, position) in glyphs.glyphs_for_string(
+                    content_with_zerowidth,
+                    *font_id,
+                    ctx.font_cache,
+                    font_family,
+                    font_size,
+                    properties,
+                    ctx,
+                ) {
+                    // Apply HarfBuzz's shaped position so combining marks (e.g. Thai ั / ี)
+                    // sit at the offset the script's GPOS table prescribes — without this,
+                    // every glyph stacks on the cell origin and marks land on the previous
+                    // cell or wherever the bare glyph happens to extend.
+                    ctx.scene.draw_glyph(
+                        origin + position,
+                        glyph_id,
+                        glyph_font_id,
+                        font_size,
+                        foreground_color,
+                    );
+                }
+            }
+        },
     }
 
     if first_cell_in_link {
@@ -2595,9 +2643,15 @@ struct AttributedStringBuilder {
     current_style: StyleAndFont,
     current_style_start_char_index: usize,
     style_runs: Vec<(Range<usize>, StyleAndFont)>,
-    // Conceptually, this is a map from character index to cell index. However, since it is both
-    // dense and build in order, we can avoid the overhead of hashing by using a `Vec`
+    // A byte-offset-indexed map from each UTF-8 byte position in `line` to a cell (column) index.
+    // Each character fills *all* of its UTF-8 bytes with the same cell column so that
+    // `paint_line` can use `glyph.index` — which is a byte offset, not a char index — to
+    // look up the correct cell. Without this, multi-byte characters (Thai, CJK, emoji, …) are
+    // drawn at the wrong grid column.
     character_index_to_cell_map: Vec<usize>,
+    // Tracks the number of *chars* appended (as opposed to bytes) so that style-run ranges stay
+    // char-indexed, matching what `layout_line` expects.
+    char_count: usize,
     line: String,
 }
 
@@ -2613,12 +2667,13 @@ impl AttributedStringBuilder {
             current_style_start_char_index: 0,
             style_runs: Vec::new(),
             character_index_to_cell_map: Vec::with_capacity(columns),
+            char_count: 0,
             line: String::with_capacity(columns),
         }
     }
 
     fn next_character_index(&self) -> usize {
-        self.character_index_to_cell_map.len()
+        self.char_count
     }
 
     /// Flushes the currently cached style into the style runs list and update the current style
@@ -2676,8 +2731,15 @@ impl AttributedStringBuilder {
     /// This will update the mapping of cell indexes so that the character can be connected with
     /// its expected grid position later.
     fn append_character(&mut self, chr: char, column: usize) {
+        let start_byte = self.line.len();
         self.line.push(chr);
-        self.character_index_to_cell_map.push(column);
+        // `glyph.index` in `paint_line` is a UTF-8 byte offset, so we fill every byte of this
+        // character's UTF-8 encoding with the same cell column. This ensures multi-byte characters
+        // (Thai, CJK, emoji, …) are drawn at the correct grid column.
+        for _ in start_byte..self.line.len() {
+            self.character_index_to_cell_map.push(column);
+        }
+        self.char_count += 1;
     }
 
     /// Append a cell's content to the attributed string at a specific grid column.

--- a/app/src/terminal/grid_renderer/cell_glyph_cache.rs
+++ b/app/src/terminal/grid_renderer/cell_glyph_cache.rs
@@ -4,9 +4,16 @@ use std::collections::HashMap;
 
 use warpui::elements::DEFAULT_LINE_HEIGHT_RATIO;
 use warpui::fonts::{Cache as FontCache, FamilyId, FontId, GlyphId, Properties};
+use warpui::geometry::vector::Vector2F;
 use warpui::platform::LineStyle;
 use warpui::text_layout::{StyleAndFont, DEFAULT_TOP_BOTTOM_RATIO};
 use warpui::PaintContext;
+
+/// A glyph plus its baseline-relative position from the start of the laid-out string.
+/// We carry the position so combining marks (e.g. Thai ั / ี) land at the correct visual
+/// offset from the base consonant — drawing every glyph at the same origin makes marks
+/// pile up wherever the font happens to put them, which is rarely above the right base.
+pub(super) type PositionedGlyph = (GlyphId, FontId, Vector2F);
 
 /// Stores cached glyph values for characters/strings. Note that we normally only need to look up
 /// characters - we only look up strings in the case of zerowidth characters (which act as modifiers
@@ -15,7 +22,7 @@ use warpui::PaintContext;
 #[derive(Default)]
 pub struct CellGlyphCache {
     glyph_cache: HashMap<(char, FontId), Option<(GlyphId, FontId)>>,
-    string_cache: HashMap<(String, FontId), Option<(GlyphId, FontId)>>,
+    string_cache: HashMap<(String, FontId), Vec<PositionedGlyph>>,
 }
 
 impl CellGlyphCache {
@@ -32,7 +39,7 @@ impl CellGlyphCache {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(super) fn glyph_for_string(
+    pub(super) fn glyphs_for_string(
         &mut self,
         string: &str,
         font_id: FontId,
@@ -41,12 +48,11 @@ impl CellGlyphCache {
         font_size: f32,
         properties: Properties,
         ctx: &mut PaintContext,
-    ) -> Option<(GlyphId, FontId)> {
-        let glyph = *self
+    ) -> Vec<PositionedGlyph> {
+        let cached = self
             .string_cache
             .entry((string.to_owned(), font_id))
             .or_insert_with(|| {
-                // Calculate the length of total characters in the string.
                 let run_length_chars = string.chars().count();
                 let line = ctx.text_layout_cache.layout_line(
                     string,
@@ -71,23 +77,47 @@ impl CellGlyphCache {
                     Default::default(),
                     &font_cache.text_layout_system(),
                 );
-                let run = line.runs.first()?;
-                if run.glyphs.len() > 1 {
-                    // If we have more than one glyph, something has gone wrong.
-                    return None;
-                }
-                run.glyphs.first().map(|glyph| (glyph.id, run.font_id))
-            });
+                let Some(run) = line.runs.first() else {
+                    return vec![];
+                };
+                run.glyphs
+                    .iter()
+                    .map(|g| (g.id, run.font_id, g.position_along_baseline))
+                    .collect()
+            })
+            .clone();
 
-        glyph.or_else(|| {
+        if cached.is_empty() {
+            // layout_line may return empty when the primary font has no glyphs for the script
+            // (e.g. Thai with a Latin terminal font). Fall back to per-character lookup, but
+            // anchor on the *first* character: it is the base consonant, and its fallback font
+            // is the script font (e.g. Thai) that also contains every following combining mark.
+            // Looking up combining marks like ั / ี standalone via DirectWrite returns nothing
+            // — they have no script context on their own — so we MUST reuse the base font here.
             #[cfg(debug_assertions)]
-            log::warn!("Falling back to glyph for first character of string, could not get glyph for entire string: {string:?}");
-            let first_char = string.chars().next()?;
-            let glyph = self.glyph_for_char(first_char, font_id, font_cache);
-            // Make sure we update the cache with the fallback, so we don't
-            // recompute it again.
-            self.string_cache.insert((string.to_owned(), font_id), glyph);
-            glyph
-        })
+            log::warn!("Falling back to per-character glyph lookup for: {string:?}");
+            let mut chars = string.chars();
+            let Some(first_char) = chars.next() else {
+                return vec![];
+            };
+            let Some((first_glyph, base_font_id)) =
+                self.glyph_for_char(first_char, font_id, font_cache)
+            else {
+                return vec![];
+            };
+            // Without HarfBuzz shaping we have no real positions; stack everything on the cell
+            // origin. This is suboptimal for combining marks, but better than dropping them.
+            let mut fallback: Vec<PositionedGlyph> =
+                vec![(first_glyph, base_font_id, Vector2F::zero())];
+            for c in chars {
+                if let Some((glyph_id, _)) = font_cache.glyph_for_char(base_font_id, c, false) {
+                    fallback.push((glyph_id, base_font_id, Vector2F::zero()));
+                }
+            }
+            self.string_cache
+                .insert((string.to_owned(), font_id), fallback.clone());
+            return fallback;
+        }
+        cached
     }
 }

--- a/app/src/terminal/grid_renderer/cell_glyph_cache.rs
+++ b/app/src/terminal/grid_renderer/cell_glyph_cache.rs
@@ -3,11 +3,18 @@
 use warpui::elements::DEFAULT_LINE_HEIGHT_RATIO;
 
 use warpui::fonts::{Cache as FontCache, FamilyId, FontId, GlyphId, Properties};
+use warpui::geometry::vector::Vector2F;
 use warpui::platform::LineStyle;
 use warpui::text_layout::{StyleAndFont, DEFAULT_TOP_BOTTOM_RATIO};
 use warpui::PaintContext;
 
 use std::collections::HashMap;
+
+/// A glyph plus its baseline-relative position from the start of the laid-out string.
+/// We carry the position so combining marks (e.g. Thai ั / ี) land at the correct visual
+/// offset from the base consonant — drawing every glyph at the same origin makes marks
+/// pile up wherever the font happens to put them, which is rarely above the right base.
+pub(super) type PositionedGlyph = (GlyphId, FontId, Vector2F);
 
 /// Stores cached glyph values for characters/strings. Note that we normally only need to look up
 /// characters - we only look up strings in the case of zerowidth characters (which act as modifiers
@@ -16,7 +23,7 @@ use std::collections::HashMap;
 #[derive(Default)]
 pub struct CellGlyphCache {
     glyph_cache: HashMap<(char, FontId), Option<(GlyphId, FontId)>>,
-    string_cache: HashMap<(String, FontId), Option<(GlyphId, FontId)>>,
+    string_cache: HashMap<(String, FontId), Vec<PositionedGlyph>>,
 }
 
 impl CellGlyphCache {
@@ -33,7 +40,7 @@ impl CellGlyphCache {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(super) fn glyph_for_string(
+    pub(super) fn glyphs_for_string(
         &mut self,
         string: &str,
         font_id: FontId,
@@ -42,12 +49,11 @@ impl CellGlyphCache {
         font_size: f32,
         properties: Properties,
         ctx: &mut PaintContext,
-    ) -> Option<(GlyphId, FontId)> {
-        let glyph = *self
+    ) -> Vec<PositionedGlyph> {
+        let cached = self
             .string_cache
             .entry((string.to_owned(), font_id))
             .or_insert_with(|| {
-                // Calculate the length of total characters in the string.
                 let run_length_chars = string.chars().count();
                 let line = ctx.text_layout_cache.layout_line(
                     string,
@@ -72,23 +78,47 @@ impl CellGlyphCache {
                     Default::default(),
                     &font_cache.text_layout_system(),
                 );
-                let run = line.runs.first()?;
-                if run.glyphs.len() > 1 {
-                    // If we have more than one glyph, something has gone wrong.
-                    return None;
-                }
-                run.glyphs.first().map(|glyph| (glyph.id, run.font_id))
-            });
+                let Some(run) = line.runs.first() else {
+                    return vec![];
+                };
+                run.glyphs
+                    .iter()
+                    .map(|g| (g.id, run.font_id, g.position_along_baseline))
+                    .collect()
+            })
+            .clone();
 
-        glyph.or_else(|| {
+        if cached.is_empty() {
+            // layout_line may return empty when the primary font has no glyphs for the script
+            // (e.g. Thai with a Latin terminal font). Fall back to per-character lookup, but
+            // anchor on the *first* character: it is the base consonant, and its fallback font
+            // is the script font (e.g. Thai) that also contains every following combining mark.
+            // Looking up combining marks like ั / ี standalone via DirectWrite returns nothing
+            // — they have no script context on their own — so we MUST reuse the base font here.
             #[cfg(debug_assertions)]
-            log::warn!("Falling back to glyph for first character of string, could not get glyph for entire string: {string:?}");
-            let first_char = string.chars().next()?;
-            let glyph = self.glyph_for_char(first_char, font_id, font_cache);
-            // Make sure we update the cache with the fallback, so we don't
-            // recompute it again.
-            self.string_cache.insert((string.to_owned(), font_id), glyph);
-            glyph
-        })
+            log::warn!("Falling back to per-character glyph lookup for: {string:?}");
+            let mut chars = string.chars();
+            let Some(first_char) = chars.next() else {
+                return vec![];
+            };
+            let Some((first_glyph, base_font_id)) =
+                self.glyph_for_char(first_char, font_id, font_cache)
+            else {
+                return vec![];
+            };
+            // Without HarfBuzz shaping we have no real positions; stack everything on the cell
+            // origin. This is suboptimal for combining marks, but better than dropping them.
+            let mut fallback: Vec<PositionedGlyph> =
+                vec![(first_glyph, base_font_id, Vector2F::zero())];
+            for c in chars {
+                if let Some((glyph_id, _)) = font_cache.glyph_for_char(base_font_id, c, false) {
+                    fallback.push((glyph_id, base_font_id, Vector2F::zero()));
+                }
+            }
+            self.string_cache
+                .insert((string.to_owned(), font_id), fallback.clone());
+            return fallback;
+        }
+        cached
     }
 }

--- a/app/src/terminal/grid_renderer_test.rs
+++ b/app/src/terminal/grid_renderer_test.rs
@@ -1,11 +1,12 @@
-use super::{active_or_next_match, CachedBackgroundColor};
+use super::{active_or_next_match, AttributedStringBuilder, CachedBackgroundColor};
 use crate::terminal::grid_size_util::calculate_grid_baseline_position;
+use crate::terminal::model::char_or_str::CharOrStr;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::selection::SelectionPoint;
 use crate::terminal::{grid_renderer, SizeInfo};
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::{vec2f, Vector2F};
-use warpui::fonts::Cache as FontCache;
+use warpui::fonts::{Cache as FontCache, FamilyId};
 use warpui::units::{IntoLines, Lines, Pixels};
 
 fn rect_from_points(min_x: f32, min_y: f32, max_x: f32, max_y: f32) -> RectF {
@@ -205,6 +206,70 @@ fn test_calculate_background_bounds() {
     assert_multi_row_selection_bounds(30, 80, 32, 40); // 3 lines
     assert_multi_row_selection_bounds(40, 60, 43, 10); // 4 lines
     assert_multi_row_selection_bounds(50, 140, 59, 20); // 10 lines
+}
+
+/// Verifies that `AttributedStringBuilder::character_index_to_cell_map` is **byte-indexed**, not
+/// char-indexed. `paint_line` looks up cells via `glyph.index`, which cosmic_text emits as a UTF-8
+/// byte offset. For ASCII text both indexings happen to coincide, but multi-byte scripts (Thai,
+/// CJK, emoji, …) would have their glyphs drawn at the wrong column otherwise.
+#[test]
+fn test_attributed_string_builder_byte_indexed_cell_map() {
+    let dummy_family = FamilyId(0);
+    let mut builder = AttributedStringBuilder::new(dummy_family, dummy_family, 10);
+
+    // "สวัสดี" — every codepoint is 3 bytes in UTF-8. The cell layout that the terminal grid
+    // produces for this string is:
+    //   col 0: ส (Char)         col 1: วั (Str — ว + zerowidth ั)
+    //   col 2: ส (Char)         col 3: ดี (Str — ด + zerowidth ี)
+    builder.append_content(CharOrStr::Char('ส'), 0);
+    builder.append_content(CharOrStr::Str("วั"), 1);
+    builder.append_content(CharOrStr::Char('ส'), 2);
+    builder.append_content(CharOrStr::Str("ดี"), 3);
+
+    let data = builder.build();
+
+    assert_eq!(data.line, "สวัสดี", "appended chars must round-trip into the line");
+    assert_eq!(
+        data.line.len(),
+        18,
+        "six 3-byte Thai codepoints = 18 UTF-8 bytes"
+    );
+    assert_eq!(
+        data.character_index_to_cell_map.len(),
+        18,
+        "the cell map must have one entry per byte (NOT per char) — otherwise paint_line, which \
+         indexes with glyph.index (a UTF-8 byte offset), would read out-of-bounds or hit the \
+         wrong cell for any non-ASCII codepoint"
+    );
+
+    // Every byte of each codepoint must point to its grid column.
+    let expected = [
+        0, 0, 0, // ส @ col 0
+        1, 1, 1, // ว @ col 1
+        1, 1, 1, // ั @ col 1 (combining mark stays in same cell as base)
+        2, 2, 2, // ส @ col 2
+        3, 3, 3, // ด @ col 3
+        3, 3, 3, // ี @ col 3 (combining mark stays in same cell as base)
+    ];
+    assert_eq!(
+        data.character_index_to_cell_map, expected,
+        "each byte of a multi-byte codepoint must map to the same cell column"
+    );
+}
+
+/// ASCII regression check — a build that wrongly switched to char-indexing would still pass for
+/// pure-ASCII input, so we explicitly assert the byte map for ASCII looks the same as before.
+#[test]
+fn test_attributed_string_builder_byte_indexed_cell_map_ascii() {
+    let dummy_family = FamilyId(0);
+    let mut builder = AttributedStringBuilder::new(dummy_family, dummy_family, 10);
+
+    builder.append_content(CharOrStr::Char('h'), 0);
+    builder.append_content(CharOrStr::Char('i'), 1);
+
+    let data = builder.build();
+    assert_eq!(data.line, "hi");
+    assert_eq!(data.character_index_to_cell_map, vec![0, 1]);
 }
 
 #[test]

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -327,3 +327,22 @@ fn test_calculate_selection_bounds() {
     assert_selection_bounds(10.into_lines()); // Without scroll clipping (but on the cusp of clipping)
     assert_selection_bounds(80.into_lines()); // With scroll clipping
 }
+
+#[test]
+fn test_decompose_sara_am() {
+    // THAI CHARACTER SARA AM -> NIKHAHIT (dot, drawn over the consonant) + SARA AA (spacing tail).
+    assert_eq!(
+        super::decompose_sara_am('\u{0E33}'),
+        Some(('\u{0E4D}', '\u{0E32}'))
+    );
+    // LAO VOWEL SIGN AM -> NIGGAHITA + LAO SARA AA.
+    assert_eq!(
+        super::decompose_sara_am('\u{0EB3}'),
+        Some(('\u{0ECD}', '\u{0EB2}'))
+    );
+    // Plain Thai consonants and the bare sara-am parts are left untouched.
+    assert_eq!(super::decompose_sara_am('\u{0E04}'), None); // ค
+    assert_eq!(super::decompose_sara_am('\u{0E4D}'), None); // nikhahit
+    assert_eq!(super::decompose_sara_am('\u{0E32}'), None); // sara aa
+    assert_eq!(super::decompose_sara_am('a'), None);
+}

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -1,10 +1,11 @@
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::{vec2f, Vector2F};
-use warpui::fonts::Cache as FontCache;
+use warpui::fonts::{Cache as FontCache, FamilyId};
 use warpui::units::{IntoLines, Lines, Pixels};
 
-use super::{active_or_next_match, CachedBackgroundColor};
+use super::{active_or_next_match, AttributedStringBuilder, CachedBackgroundColor};
 use crate::terminal::grid_size_util::calculate_grid_baseline_position;
+use crate::terminal::model::char_or_str::CharOrStr;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::selection::SelectionPoint;
 use crate::terminal::{grid_renderer, SizeInfo};
@@ -206,6 +207,70 @@ fn test_calculate_background_bounds() {
     assert_multi_row_selection_bounds(30, 80, 32, 40); // 3 lines
     assert_multi_row_selection_bounds(40, 60, 43, 10); // 4 lines
     assert_multi_row_selection_bounds(50, 140, 59, 20); // 10 lines
+}
+
+/// Verifies that `AttributedStringBuilder::character_index_to_cell_map` is **byte-indexed**, not
+/// char-indexed. `paint_line` looks up cells via `glyph.index`, which cosmic_text emits as a UTF-8
+/// byte offset. For ASCII text both indexings happen to coincide, but multi-byte scripts (Thai,
+/// CJK, emoji, …) would have their glyphs drawn at the wrong column otherwise.
+#[test]
+fn test_attributed_string_builder_byte_indexed_cell_map() {
+    let dummy_family = FamilyId(0);
+    let mut builder = AttributedStringBuilder::new(dummy_family, dummy_family, 10);
+
+    // "สวัสดี" — every codepoint is 3 bytes in UTF-8. The cell layout that the terminal grid
+    // produces for this string is:
+    //   col 0: ส (Char)         col 1: วั (Str — ว + zerowidth ั)
+    //   col 2: ส (Char)         col 3: ดี (Str — ด + zerowidth ี)
+    builder.append_content(CharOrStr::Char('ส'), 0);
+    builder.append_content(CharOrStr::Str("วั"), 1);
+    builder.append_content(CharOrStr::Char('ส'), 2);
+    builder.append_content(CharOrStr::Str("ดี"), 3);
+
+    let data = builder.build();
+
+    assert_eq!(data.line, "สวัสดี", "appended chars must round-trip into the line");
+    assert_eq!(
+        data.line.len(),
+        18,
+        "six 3-byte Thai codepoints = 18 UTF-8 bytes"
+    );
+    assert_eq!(
+        data.character_index_to_cell_map.len(),
+        18,
+        "the cell map must have one entry per byte (NOT per char) — otherwise paint_line, which \
+         indexes with glyph.index (a UTF-8 byte offset), would read out-of-bounds or hit the \
+         wrong cell for any non-ASCII codepoint"
+    );
+
+    // Every byte of each codepoint must point to its grid column.
+    let expected = [
+        0, 0, 0, // ส @ col 0
+        1, 1, 1, // ว @ col 1
+        1, 1, 1, // ั @ col 1 (combining mark stays in same cell as base)
+        2, 2, 2, // ส @ col 2
+        3, 3, 3, // ด @ col 3
+        3, 3, 3, // ี @ col 3 (combining mark stays in same cell as base)
+    ];
+    assert_eq!(
+        data.character_index_to_cell_map, expected,
+        "each byte of a multi-byte codepoint must map to the same cell column"
+    );
+}
+
+/// ASCII regression check — a build that wrongly switched to char-indexing would still pass for
+/// pure-ASCII input, so we explicitly assert the byte map for ASCII looks the same as before.
+#[test]
+fn test_attributed_string_builder_byte_indexed_cell_map_ascii() {
+    let dummy_family = FamilyId(0);
+    let mut builder = AttributedStringBuilder::new(dummy_family, dummy_family, 10);
+
+    builder.append_content(CharOrStr::Char('h'), 0);
+    builder.append_content(CharOrStr::Char('i'), 1);
+
+    let data = builder.build();
+    assert_eq!(data.line, "hi");
+    assert_eq!(data.character_index_to_cell_map, vec![0, 1]);
 }
 
 #[test]

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -284,6 +284,39 @@ impl FontDB {
     }
 }
 
+/// Returns the system locale as a BCP-47 language tag (e.g. "th-TH", "en-US").
+///
+/// On Linux/FreeBSD, reads `LC_ALL` → `LC_CTYPE` → `LANG` and converts the POSIX
+/// locale name (e.g. "th_TH.UTF-8") to BCP-47 (e.g. "th-TH").  On all other
+/// platforms we fall back to "en" because font fallback on those platforms goes
+/// through platform-specific APIs (DirectWrite on Windows, CoreText on macOS)
+/// rather than fontconfig locale ordering.
+fn detect_system_locale() -> String {
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    {
+        if let Some(lang) = std::env::var("LC_ALL")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .or_else(|| std::env::var("LC_CTYPE").ok().filter(|s| !s.is_empty()))
+            .or_else(|| std::env::var("LANG").ok().filter(|s| !s.is_empty()))
+        {
+            let tag = lang
+                .split('.')
+                .next()
+                .unwrap_or("en")
+                .replace('_', "-");
+            if !tag.is_empty() {
+                return tag;
+            }
+        }
+        "en".into()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+    {
+        "en".into()
+    }
+}
+
 impl Default for TextLayoutSystem {
     fn default() -> Self {
         Self::new()
@@ -295,9 +328,10 @@ impl TextLayoutSystem {
         Self {
             families: Default::default(),
             font_store: RwLock::new(cosmic_text::FontSystem::new_with_locale_and_db(
-                // Locale is needed for font fallback. For now, we hardcode this to "en" to match
-                // our mac implementation https://github.com/warpdotdev/warp-internal/blob/bf33d651a9fcece70df8eac35f89b0393ca5189a/ui/src/platform/mac/fonts.rs#L383.
-                "en".into(),
+                // Detect the system locale so that cosmic_text selects appropriate fallback
+                // fonts for non-Latin scripts (e.g. Thai, Arabic) on Linux/FreeBSD where
+                // fontconfig uses the locale for font ordering.
+                detect_system_locale(),
                 Default::default(),
             )),
             font_id_map: Default::default(),

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -292,6 +292,39 @@ impl FontDB {
     }
 }
 
+/// Returns the system locale as a BCP-47 language tag (e.g. "th-TH", "en-US").
+///
+/// On Linux/FreeBSD, reads `LC_ALL` → `LC_CTYPE` → `LANG` and converts the POSIX
+/// locale name (e.g. "th_TH.UTF-8") to BCP-47 (e.g. "th-TH").  On all other
+/// platforms we fall back to "en" because font fallback on those platforms goes
+/// through platform-specific APIs (DirectWrite on Windows, CoreText on macOS)
+/// rather than fontconfig locale ordering.
+fn detect_system_locale() -> String {
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    {
+        if let Some(lang) = std::env::var("LC_ALL")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .or_else(|| std::env::var("LC_CTYPE").ok().filter(|s| !s.is_empty()))
+            .or_else(|| std::env::var("LANG").ok().filter(|s| !s.is_empty()))
+        {
+            let tag = lang
+                .split('.')
+                .next()
+                .unwrap_or("en")
+                .replace('_', "-");
+            if !tag.is_empty() {
+                return tag;
+            }
+        }
+        "en".into()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+    {
+        "en".into()
+    }
+}
+
 impl Default for TextLayoutSystem {
     fn default() -> Self {
         Self::new()
@@ -303,9 +336,10 @@ impl TextLayoutSystem {
         Self {
             families: Default::default(),
             font_store: RwLock::new(cosmic_text::FontSystem::new_with_locale_and_db(
-                // Locale is needed for font fallback. For now, we hardcode this to "en" to match
-                // our mac implementation https://github.com/warpdotdev/warp-internal/blob/bf33d651a9fcece70df8eac35f89b0393ca5189a/ui/src/platform/mac/fonts.rs#L383.
-                "en".into(),
+                // Detect the system locale so that cosmic_text selects appropriate fallback
+                // fonts for non-Latin scripts (e.g. Thai, Arabic) on Linux/FreeBSD where
+                // fontconfig uses the locale for font ordering.
+                detect_system_locale(),
                 Default::default(),
             )),
             font_id_map: Default::default(),

--- a/crates/warpui/src/windowing/winit/fonts/windows.rs
+++ b/crates/warpui/src/windowing/winit/fonts/windows.rs
@@ -13,7 +13,12 @@ use super::font_handle::FontHandle;
 use super::{FontFamily, LoadedSystemFonts, TextLayoutSystem, ValidateFontSupportsEn};
 use crate::fonts::FontId;
 
-const EN_US_LOCALE: &str = "en-US";
+/// Locale passed to `IDWriteFontFallback::MapCharacters` when requesting fallback fonts.
+///
+/// An empty string instructs DirectWrite to use the system locale rather than biasing
+/// toward any specific script, which produces correct font selection for non-Latin scripts
+/// such as Thai, Arabic, and CJK characters instead of always preferring Latin-script fonts.
+const DIRECTWRITE_FALLBACK_LOCALE: &str = "";
 
 /// Windows symbol fonts that are used to render window control icons. We specifically do not do any
 /// validation of these fonts (i.e. to check if the font contains english characters).
@@ -164,7 +169,7 @@ impl TextLayoutSystem {
         })?;
 
         let fallback_result =
-            loaded_font.get_fallbacks(character.to_string().as_str(), EN_US_LOCALE);
+            loaded_font.get_fallbacks(character.to_string().as_str(), DIRECTWRITE_FALLBACK_LOCALE);
 
         // Convert each font-kit fallback `Font` into a UI framework `FontHandle` and load it into
         // fontdb. We deliberately avoid `font_kit::Font::handle()` here: its default impl reads

--- a/crates/warpui/src/windowing/winit/fonts/windows.rs
+++ b/crates/warpui/src/windowing/winit/fonts/windows.rs
@@ -14,7 +14,12 @@ use owned_ttf_parser::OwnedFace;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-const EN_US_LOCALE: &str = "en-US";
+/// Locale passed to `IDWriteFontFallback::MapCharacters` when requesting fallback fonts.
+///
+/// An empty string instructs DirectWrite to use the system locale rather than biasing
+/// toward any specific script, which produces correct font selection for non-Latin scripts
+/// such as Thai, Arabic, and CJK characters instead of always preferring Latin-script fonts.
+const DIRECTWRITE_FALLBACK_LOCALE: &str = "";
 
 /// Windows symbol fonts that are used to render window control icons. We specifically do not do any
 /// validation of these fonts (i.e. to check if the font contains english characters).
@@ -166,7 +171,7 @@ impl TextLayoutSystem {
         })?;
 
         let fallback_result =
-            loaded_font.get_fallbacks(character.to_string().as_str(), EN_US_LOCALE);
+            loaded_font.get_fallbacks(character.to_string().as_str(), DIRECTWRITE_FALLBACK_LOCALE);
 
         // Convert each font-kit fallback `Font` into a UI framework `FontHandle` and load it into
         // fontdb. We deliberately avoid `font_kit::Font::handle()` here: its default impl reads

--- a/crates/warpui/src/windowing/winit/text_layout_tests.rs
+++ b/crates/warpui/src/windowing/winit/text_layout_tests.rs
@@ -734,3 +734,102 @@ fn test_softwrap_caret_positions_multi_paragraph() -> Result<()> {
 
     Ok(())
 }
+
+// ── Thai / Unicode rendering tests ───────────────────────────────────────────
+
+/// Thai consonants are full-width characters (unicode_width == 1). Layout must
+/// produce a positive total width and must not panic.
+#[test]
+fn thai_consonants_layout_non_zero_width() -> Result<()> {
+    let (font_db, roboto) = init_fonts();
+    let text = "กขคงจ";
+    let style = LineStyle {
+        font_size: FONT_SIZE,
+        line_height_ratio: DEFAULT_UI_LINE_HEIGHT_RATIO,
+        baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+        fixed_width_tab_size: None,
+    };
+    let line = font_db.text_layout_system().layout_line(
+        text,
+        style,
+        &[(
+            0..text.chars().count(),
+            StyleAndFont::new(roboto, Properties::default(), TextStyle::new()),
+        )],
+        f32::MAX,
+        crate::text_layout::ClipConfig::default(),
+    );
+    assert!(line.width > 0.0, "Thai consonants must produce non-zero width");
+    Ok(())
+}
+
+/// Sara Aa (U+0E32) is a combining vowel (unicode_width == 0) and must not add
+/// extra width compared to the base consonant alone; the delta must stay < 2 px.
+#[test]
+fn thai_combining_vowel_does_not_widen_line() -> Result<()> {
+    let (font_db, roboto) = init_fonts();
+    let style = LineStyle {
+        font_size: FONT_SIZE,
+        line_height_ratio: DEFAULT_UI_LINE_HEIGHT_RATIO,
+        baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+        fixed_width_tab_size: None,
+    };
+    let make_line = |text: &str| {
+        font_db.text_layout_system().layout_line(
+            text,
+            style,
+            &[(
+                0..text.chars().count(),
+                StyleAndFont::new(roboto, Properties::default(), TextStyle::new()),
+            )],
+            f32::MAX,
+            crate::text_layout::ClipConfig::default(),
+        )
+    };
+    // "กา" = consonant + sara aa; "กข" = two plain consonants
+    let with_vowel = make_line("กา").width;
+    let two_consonants = make_line("กข").width;
+    let delta = (with_vowel - two_consonants).abs();
+    assert!(
+        delta < 2.0,
+        "combining vowel sara aa widened the line by {delta:.1} px (expected < 2 px)"
+    );
+    Ok(())
+}
+
+/// Mixed ASCII + Thai text must not panic and must trigger the missing-glyph
+/// fallback path when the primary font (Roboto) lacks Thai glyphs.
+#[test]
+fn mixed_ascii_thai_records_missing_glyphs() -> Result<()> {
+    let (font_db, roboto) = init_fonts();
+    let text = "Hello สวัสดี";
+    let style = LineStyle {
+        font_size: FONT_SIZE,
+        line_height_ratio: DEFAULT_UI_LINE_HEIGHT_RATIO,
+        baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+        fixed_width_tab_size: None,
+    };
+    let line = font_db.text_layout_system().layout_line(
+        text,
+        style,
+        &[(
+            0..text.chars().count(),
+            StyleAndFont::new(roboto, Properties::default(), TextStyle::new()),
+        )],
+        f32::MAX,
+        crate::text_layout::ClipConfig::default(),
+    );
+    assert!(line.width > 0.0, "mixed ASCII+Thai line must have positive width");
+    // Roboto doesn't cover Thai, so the Thai codepoints end up in
+    // chars_with_missing_glyphs and trigger async fallback font loading.
+    let missing = &line.chars_with_missing_glyphs;
+    assert!(!missing.is_empty(), "expected Thai chars to be recorded as missing glyphs");
+    for &ch in missing {
+        assert!(
+            ('\u{0E00}'..='\u{0E7F}').contains(&ch),
+            "unexpected non-Thai char in missing glyphs: U+{:04X}",
+            ch as u32
+        );
+    }
+    Ok(())
+}

--- a/crates/warpui/src/windowing/winit/text_layout_tests.rs
+++ b/crates/warpui/src/windowing/winit/text_layout_tests.rs
@@ -592,3 +592,102 @@ fn all_lines_bounded(frame: &TextFrame, frame_width: f32) -> bool {
         all_bounded && current_bounded
     })
 }
+
+// ── Thai / Unicode rendering tests ───────────────────────────────────────────
+
+/// Thai consonants are full-width characters (unicode_width == 1). Layout must
+/// produce a positive total width and must not panic.
+#[test]
+fn thai_consonants_layout_non_zero_width() -> Result<()> {
+    let (font_db, roboto) = init_fonts();
+    let text = "กขคงจ";
+    let style = LineStyle {
+        font_size: FONT_SIZE,
+        line_height_ratio: DEFAULT_UI_LINE_HEIGHT_RATIO,
+        baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+        fixed_width_tab_size: None,
+    };
+    let line = font_db.text_layout_system().layout_line(
+        text,
+        style,
+        &[(
+            0..text.chars().count(),
+            StyleAndFont::new(roboto, Properties::default(), TextStyle::new()),
+        )],
+        f32::MAX,
+        crate::text_layout::ClipConfig::default(),
+    );
+    assert!(line.width > 0.0, "Thai consonants must produce non-zero width");
+    Ok(())
+}
+
+/// Sara Aa (U+0E32) is a combining vowel (unicode_width == 0) and must not add
+/// extra width compared to the base consonant alone; the delta must stay < 2 px.
+#[test]
+fn thai_combining_vowel_does_not_widen_line() -> Result<()> {
+    let (font_db, roboto) = init_fonts();
+    let style = LineStyle {
+        font_size: FONT_SIZE,
+        line_height_ratio: DEFAULT_UI_LINE_HEIGHT_RATIO,
+        baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+        fixed_width_tab_size: None,
+    };
+    let make_line = |text: &str| {
+        font_db.text_layout_system().layout_line(
+            text,
+            style,
+            &[(
+                0..text.chars().count(),
+                StyleAndFont::new(roboto, Properties::default(), TextStyle::new()),
+            )],
+            f32::MAX,
+            crate::text_layout::ClipConfig::default(),
+        )
+    };
+    // "กา" = consonant + sara aa; "กข" = two plain consonants
+    let with_vowel = make_line("กา").width;
+    let two_consonants = make_line("กข").width;
+    let delta = (with_vowel - two_consonants).abs();
+    assert!(
+        delta < 2.0,
+        "combining vowel sara aa widened the line by {delta:.1} px (expected < 2 px)"
+    );
+    Ok(())
+}
+
+/// Mixed ASCII + Thai text must not panic and must trigger the missing-glyph
+/// fallback path when the primary font (Roboto) lacks Thai glyphs.
+#[test]
+fn mixed_ascii_thai_records_missing_glyphs() -> Result<()> {
+    let (font_db, roboto) = init_fonts();
+    let text = "Hello สวัสดี";
+    let style = LineStyle {
+        font_size: FONT_SIZE,
+        line_height_ratio: DEFAULT_UI_LINE_HEIGHT_RATIO,
+        baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+        fixed_width_tab_size: None,
+    };
+    let line = font_db.text_layout_system().layout_line(
+        text,
+        style,
+        &[(
+            0..text.chars().count(),
+            StyleAndFont::new(roboto, Properties::default(), TextStyle::new()),
+        )],
+        f32::MAX,
+        crate::text_layout::ClipConfig::default(),
+    );
+    assert!(line.width > 0.0, "mixed ASCII+Thai line must have positive width");
+    // Roboto doesn't cover Thai, so the Thai codepoints end up in
+    // chars_with_missing_glyphs and trigger async fallback font loading.
+    let missing = &line.chars_with_missing_glyphs;
+    assert!(!missing.is_empty(), "expected Thai chars to be recorded as missing glyphs");
+    for &ch in missing {
+        assert!(
+            ('\u{0E00}'..='\u{0E7F}').contains(&ch),
+            "unexpected non-Thai char in missing glyphs: U+{:04X}",
+            ch as u32
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
The terminal grid was rendering Thai vowel marks (ั, ี, …) at the wrong position or dropping them entirely. The bug was a chain of issues across font fallback, byte/char indexing, and HarfBuzz glyph positioning.

Five root causes, fixed end-to-end:

1. DirectWrite fallback locale on Windows was hardcoded to "en-US", which biased `IDWriteFontFallback::MapCharacters` toward Latin-script fonts even when asked for a Thai codepoint. Switched to "" (system locale).

2. Linux/FreeBSD font fallback used a hardcoded "en" instead of reading `LC_ALL` / `LC_CTYPE` / `LANG`. Now picks up the user's actual locale.

3. `CellGlyphCache::glyph_for_string` returned `None` whenever the layout produced more than one glyph, silently dropping every Thai cluster (base consonant + combining vowel = 2 glyphs). Renamed to `glyphs_for_string` returning a `Vec`, so all glyphs make it through.

4. `AttributedStringBuilder::character_index_to_cell_map` was filled one entry per char, but `paint_line` indexes it with `glyph.index` — which cosmic_text emits as a UTF-8 *byte* offset, not a char index. For ASCII the two coincide; for any 3-byte codepoint (Thai, CJK, emoji) the lookup landed on the wrong cell. Now fill one entry per byte.

5. (The actual visible bug.) `glyphs_for_string` collected only `(GlyphId, FontId)` and discarded `Glyph::position_along_baseline`. Every glyph then got drawn at the same cell origin, so combining marks stacked on top of the base instead of sitting where HarfBuzz placed them — visually they bled into the previous cell or disappeared. Now carry the position through and apply it in `render_cell_glyph`.

The ligature path (`render_grid_with_ligatures`) was also fixed for the same byte-indexing problem and gained a deferred-rendering pass for `CharOrStr::Str` cells, which use direct glyph_for_char + DirectWrite fallback (the cached `text_layout_cache` path can't load system Thai fonts on demand).

Tests:
- New `mixed_ascii_thai_records_missing_glyphs` exercises the text-layout missing-glyph path with mixed Latin + Thai.
- New `test_attributed_string_builder_byte_indexed_cell_map` locks in the byte-indexed (not char-indexed) cell map for multi-byte codepoints, with an ASCII regression check alongside it.
- Manually verified end-to-end on Windows with `python -c "print('สวัสดี')"` — output now matches PowerShell.

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
Closes #8357

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-BUG-FIX: Fix Thai and complex-script combining marks rendering incorrectly in terminal grid
-->
