### PR TITLE
Stop re-firing gh pr view on every fs event in Code Review

### DIFF
--- a/app/src/code_review/diff_state.rs
+++ b/app/src/code_review/diff_state.rs
@@ -374,6 +374,12 @@ pub struct DiffStateModel {
     computing_diffs_abort_handle: Option<SpawnedFutureHandle>,
     computing_metadata_abort_handle: Option<SpawnedFutureHandle>,
     refreshing_pr_info_handle: Option<SpawnedFutureHandle>,
+    /// Branch name for which `refresh_pr_info` has been called at least once.
+    /// Gates the metadata-refresh fallback so it only retries `gh pr view` once
+    /// per branch when `pr_info` is `None` (e.g. branch has no PR, lookup
+    /// failed). Without this, every filesystem event on the repo would re-fire
+    /// `gh pr view` for branches that legitimately have no PR.
+    pr_info_attempted_for_branch: Option<String>,
     /// Controls whether periodic throttled metadata refresh is active.
     /// Refresh is suppressed when the code review pane is not open.
     metadata_refresh_enabled: bool,
@@ -419,6 +425,7 @@ impl DiffStateModel {
             computing_diffs_abort_handle: None,
             computing_metadata_abort_handle: None,
             refreshing_pr_info_handle: None,
+            pr_info_attempted_for_branch: None,
             metadata_refresh_enabled: false,
         };
 
@@ -453,6 +460,7 @@ impl DiffStateModel {
             computing_diffs_abort_handle: None,
             computing_metadata_abort_handle: None,
             refreshing_pr_info_handle: None,
+            pr_info_attempted_for_branch: None,
             metadata_refresh_enabled: false,
         }
     }
@@ -1465,7 +1473,13 @@ impl DiffStateModel {
         } else if FeatureFlag::GitOperationsInCodeReview.is_enabled()
             && self.pr_info().is_none()
             && !self.is_pr_info_refreshing()
+            && self.pr_info_attempted_for_branch != current_branch
         {
+            // Initial-load fallback: if metadata arrived without a successful
+            // PR lookup yet on this branch, try once. Gated by
+            // `pr_info_attempted_for_branch` so subsequent metadata refreshes
+            // (every fs event on the repo) don't re-fire `gh pr view` when the
+            // branch has no PR or the lookup failed.
             self.refresh_pr_info(ctx);
         }
 
@@ -2826,6 +2840,10 @@ impl DiffStateModel {
         let Some(repo_path) = self.active_repository_path(ctx) else {
             return;
         };
+        // Mark this branch as attempted before spawning so the fallback in
+        // `handle_updated_metadata_for_repo` won't re-fire while the lookup
+        // is in flight or after it completes with no PR.
+        self.pr_info_attempted_for_branch = self.get_current_branch_name();
         #[cfg(feature = "local_tty")]
         let path_future = LocalShellState::handle(ctx).update(ctx, |shell_state, ctx| {
             shell_state.get_interactive_path_env_var(ctx)
@@ -2964,6 +2982,7 @@ impl DiffStateModel {
             computing_diffs_abort_handle: None,
             computing_metadata_abort_handle: None,
             refreshing_pr_info_handle: None,
+            pr_info_attempted_for_branch: None,
             metadata_refresh_enabled: false,
         }
     }


### PR DESCRIPTION
`DiffStateModel.handle_updated_metadata_for_repo` runs on every filesystem event the repo watcher emits. After the branch-change path, a fallback called `refresh_pr_info` whenever `pr_info` was `None`. Branches that legitimately have no PR (and lookups that returned `Ok(None)` from `unwrap_or(None)` on transient failures) keep `pr_info` at `None`, so this fallback re-shelled `gh pr view` on every fs event for the lifetime of the session.

Track whether `refresh_pr_info` has been called for the current branch in a new `pr_info_attempted_for_branch` field. The fallback now fires at most once per branch. Branch change still triggers a fresh refresh because the branch-change path always calls `refresh_pr_info`, which overwrites the attempted branch. After-push refreshes from `refresh_after_git_operation` continue to work for the same reason.

## Description

The chip-refresh side of #9830 was addressed in #10307. This PR addresses the second `gh pr view` call site identified in that issue — the Code Review header / `DiffStateModel`. Same bug shape: a network call gated only by per-fs-event metadata refresh, with no caching of the attempted state.

The new `pr_info_attempted_for_branch` field is set inside `refresh_pr_info` itself, so any caller (branch change, after-push, fallback) marks the branch as attempted. The fallback's existence is preserved (initial-load case where metadata arrives without a successful PR lookup yet); only the spam is removed.

Other code paths are unaffected:
- The branch-change refresh in `handle_updated_metadata_for_repo` always fires `refresh_pr_info`.
- The explicit `refresh_pr_info` from `refresh_after_git_operation` (post-commit, post-push) always fires.
- `metadata_refresh_enabled` and the `GitOperationsInCodeReview` feature flag continue to gate the entry points as before.

## Linked Issue

Related to #9830 (complements #10307).

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

No new automated tests. The change is small and the existing `gh`-shelling path is hard to test without subprocess mocks. Verified by:

- Reading the call graph: `handle_updated_metadata_for_repo` is called from `set_active_repository`, `refresh_diff_metadata_for_current_repo` (throttled fs-event handler), and post-git-operation refreshes. The fallback at the modified site is the only path that previously re-fired without a branch change.
- `pr_info_attempted_for_branch` is set inside `refresh_pr_info` before the spawn, so it's recorded even if the lookup is aborted or fails.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Stop the Code Review pane from re-running `gh pr view` on every filesystem event when the current branch has no PR.
