### PR TITLE
Fix Ctrl-A in multiline terminal prompts

### DIFF
--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -1437,6 +1437,7 @@ pub struct EditorOptions {
     pub autocomplete_symbols: bool,
     pub soft_wrap: bool,
     pub placeholder_soft_wrap: bool,
+    pub line_start_behavior: LineStartBehavior,
     /// Whether or not this editor should acknowledge the AppEditorSettings::vim_mode option.
     pub supports_vim_mode: bool,
     /// Closures that should return a top section, left notch and right notch elements, if we want to paint them
@@ -1471,6 +1472,13 @@ pub struct EditorOptions {
     pub keymap_context_modifier: Option<KeymapContextModifierFn>,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LineStartBehavior {
+    #[default]
+    CurrentLine,
+    PreviousLineWhenAtStart,
+}
+
 impl Default for EditorOptions {
     fn default() -> Self {
         Self {
@@ -1486,6 +1494,7 @@ impl Default for EditorOptions {
             autocomplete_symbols: false,
             soft_wrap: false,
             placeholder_soft_wrap: false,
+            line_start_behavior: LineStartBehavior::CurrentLine,
             supports_vim_mode: false,
             render_decorator_elements: None,
             select_all_on_focus: false,
@@ -1521,6 +1530,7 @@ impl From<SingleLineEditorOptions> for EditorOptions {
             autocomplete_symbols: options.autocomplete_symbols,
             soft_wrap: options.soft_wrap,
             placeholder_soft_wrap: options.placeholder_soft_wrap,
+            line_start_behavior: LineStartBehavior::CurrentLine,
             supports_vim_mode: false,
             render_decorator_elements: None,
             select_all_on_focus: options.select_all_on_focus,
@@ -1805,6 +1815,7 @@ pub struct EditorView {
     enter_settings: EnterSettings,
     soft_wrap: bool,
     placeholder_soft_wrap: bool,
+    line_start_behavior: LineStartBehavior,
     /// What the starting text of the view was. Helpful for determining if the editor is
     /// "dirty", i.e., a user has changed the contents from what is persisted elsewhere.
     base_buffer_text: String,
@@ -3154,6 +3165,7 @@ impl EditorView {
             enter_settings: options.enter_settings,
             soft_wrap: options.soft_wrap,
             placeholder_soft_wrap: options.placeholder_soft_wrap,
+            line_start_behavior: options.line_start_behavior,
             base_buffer_text: base_text,
             supports_vim_mode: options.supports_vim_mode,
             vim_model,
@@ -5678,6 +5690,13 @@ impl EditorView {
         self.change_selections(ctx, |editor_model, ctx| {
             editor_model.cursor_line_start(false, ctx);
         });
+    }
+
+    fn handle_move_to_line_start_action(&mut self, ctx: &mut ViewContext<Self>) {
+        match self.line_start_behavior {
+            LineStartBehavior::CurrentLine => self.move_to_line_start(ctx),
+            LineStartBehavior::PreviousLineWhenAtStart => self.move_to_paragraph_start(ctx),
+        }
     }
 
     pub fn move_to_paragraph_start(&mut self, ctx: &mut ViewContext<Self>) {
@@ -8475,7 +8494,7 @@ impl TypedActionView for EditorView {
             ClearLines => self.clear_lines(ctx),
             ClearAndCopyLines => self.clear_and_copy_lines(ctx),
             CtrlC => self.handle_ctrl_c(ctx),
-            MoveToLineStart => self.move_to_line_start(ctx),
+            MoveToLineStart => self.handle_move_to_line_start_action(ctx),
             MoveToParagraphStart => self.move_to_paragraph_start(ctx),
             MoveToBufferStart => self.move_to_buffer_start(ctx),
             SelectToLineStart => self.select_to_line_start(ctx),

--- a/app/src/editor/view/mod_tests.rs
+++ b/app/src/editor/view/mod_tests.rs
@@ -1749,6 +1749,79 @@ fn test_cursor_line_start() {
 }
 
 #[test]
+fn test_move_to_line_start_previous_line_when_at_start() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let (_, editor) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            let options = EditorOptions {
+                line_start_behavior: LineStartBehavior::PreviousLineWhenAtStart,
+                ..Default::default()
+            };
+            let mut editor = EditorView::new_with_base_text("first\nsecond", options, ctx);
+            editor
+                .select_ranges(vec![DisplayPoint::new(1, 3)..DisplayPoint::new(1, 3)], ctx)
+                .unwrap();
+            editor.handle_action(&EditorAction::MoveToLineStart, ctx);
+            editor
+        });
+
+        editor.read(&app, |view, app| {
+            assert_eq!(
+                view.selected_ranges(app),
+                vec![DisplayPoint::new(1, 0)..DisplayPoint::new(1, 0),]
+            );
+        });
+
+        editor.update(&mut app, |view, ctx| {
+            view.handle_action(&EditorAction::MoveToLineStart, ctx);
+        });
+
+        editor.read(&app, |view, app| {
+            assert_eq!(
+                view.selected_ranges(app),
+                vec![DisplayPoint::new(0, 0)..DisplayPoint::new(0, 0),]
+            );
+        });
+    })
+}
+
+#[test]
+fn test_move_to_line_start_previous_line_when_at_start_from_soft_wrap_row() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let (_, editor) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            let options = EditorOptions {
+                line_start_behavior: LineStartBehavior::PreviousLineWhenAtStart,
+                ..Default::default()
+            };
+            let mut editor = EditorView::new_with_base_text("firstsecond", options, ctx);
+            let frame_layouts =
+                FrameLayouts::new(vec![Arc::new(TextFrame::mock("first\nsecond"))], 0, 2);
+            editor
+                .editor_model
+                .as_ref(ctx)
+                .display_map(ctx)
+                .soft_wrap_state()
+                .update(frame_layouts);
+            editor
+                .select_ranges(vec![DisplayPoint::new(0, 5)..DisplayPoint::new(0, 5)], ctx)
+                .unwrap();
+            editor.handle_action(&EditorAction::MoveToLineStart, ctx);
+            editor
+        });
+
+        editor.read(&app, |view, app| {
+            assert_eq!(
+                view.selected_ranges(app),
+                vec![DisplayPoint::new(0, 0)..DisplayPoint::new(0, 0),]
+            );
+        });
+    })
+}
+
+#[test]
 fn test_cursor_line_end() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -150,10 +150,10 @@ use crate::{
         AutosuggestionLocation, AutosuggestionType, BaselinePositionComputationMethod,
         CommandXRayAnchor, CrdtOperation, CursorColors, DisplayPoint, EditOrigin, EditorAction,
         EditorDecoratorElements, EditorOptions, EditorSnapshot, EditorView, Event as EditorEvent,
-        ImageContextOptions, InteractionState, PathTransformerFn, PlainTextEditorViewAction,
-        Point as BufferPoint, PropagateAndNoOpEscapeKey, PropagateAndNoOpNavigationKeys,
-        PropagateHorizontalNavigationKeys, ReplicaId, TextColors, TextRun,
-        MAX_IMAGES_PER_CONVERSATION,
+        ImageContextOptions, InteractionState, LineStartBehavior, PathTransformerFn,
+        PlainTextEditorViewAction, Point as BufferPoint, PropagateAndNoOpEscapeKey,
+        PropagateAndNoOpNavigationKeys, PropagateHorizontalNavigationKeys, ReplicaId, TextColors,
+        TextRun, MAX_IMAGES_PER_CONVERSATION,
     },
     features::FeatureFlag,
     input_suggestions::{
@@ -2563,6 +2563,8 @@ impl Input {
                         PropagateHorizontalNavigationKeys::AtBoundary,
                     propagate_and_no_op_escape_key: PropagateAndNoOpEscapeKey::PropagateFirst,
                     soft_wrap: true,
+                    // TODO: Revisit terminal-style Ctrl-E behavior for multiline prompts.
+                    line_start_behavior: LineStartBehavior::PreviousLineWhenAtStart,
                     supports_vim_mode: true,
                     use_settings_line_height_ratio: true,
                     render_decorator_elements: Some(Box::new(

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -3718,6 +3718,48 @@ fn test_should_not_insert_newline_on_enter_in_empty_buffer() {
     })
 }
 
+#[test]
+fn test_terminal_input_line_start_moves_to_previous_line_when_at_start() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let terminal = add_window_with_bootstrapped_terminal(
+            &mut app, None, /* history_file_commands */
+            None,
+        )
+        .await;
+
+        let input = terminal.read(&app, |terminal, _| terminal.input().clone());
+        input.update(&mut app, |input, ctx| {
+            input.replace_buffer_content("first\nsecond", ctx);
+            input.editor.update(ctx, |editor, ctx| {
+                editor.reset_selections_to_point(&Point::new(1, 3), ctx);
+                editor.handle_action(&EditorAction::MoveToLineStart, ctx);
+            });
+        });
+
+        input.read(&app, |input, ctx| {
+            assert_eq!(
+                input.editor.as_ref(ctx).single_cursor_to_point(ctx),
+                Some(Point::new(1, 0))
+            );
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.editor.update(ctx, |editor, ctx| {
+                editor.handle_action(&EditorAction::MoveToLineStart, ctx);
+            });
+        });
+
+        input.read(&app, |input, ctx| {
+            assert_eq!(
+                input.editor.as_ref(ctx).single_cursor_to_point(ctx),
+                Some(Point::new(0, 0))
+            );
+        });
+    })
+}
+
 #[cfg_attr(windows, ignore = "TODO(CORE-3626)")]
 #[test]
 fn test_should_insert_newline_on_enter() {


### PR DESCRIPTION
## Description

Fixes terminal input `Ctrl-A` behavior for multiline prompts. Terminal input now opts into a line-start behavior where `Ctrl-A` first moves to the start of the current prompt line, and pressing it again from column 0 moves to the start of the previous prompt line. Other editor surfaces keep the existing current-line behavior.

This intentionally leaves `Ctrl-E` unchanged for now, with a TODO to revisit terminal-style line-end behavior separately.

## Linked Issue

https://github.com/warpdotdev/warp/issues/10763

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos

<img width="898" height="555" alt="warp-ctrl-a-recording" src="https://github.com/user-attachments/assets/0148b369-123d-493e-aedc-12ca1795f28a" />

## Testing

- `cargo fmt --check`
- `cargo test -p warp test_move_to_line_start_previous_line_when_at_start`
- `cargo test -p warp test_terminal_input_line_start_moves_to_previous_line_when_at_start`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`

Validation was run on the remote laptop because the local laptop cannot build Warp without the full Xcode Metal toolchain.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed Ctrl-A behavior in multiline terminal prompts to move by prompt line.

Co-Authored-By: Warp <agent@warp.dev>
