### PR TITLE
Resolve agent skills during CLI startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14294,7 +14294,6 @@ dependencies = [
  "enclose",
  "enum-iterator",
  "env_logger",
- "event-listener",
  "field_mask",
  "firebase",
  "flate2",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -103,7 +103,6 @@ email_address = { git = "https://github.com/warpdotdev/rust-email_address", bran
 embed_plist = "1.2"
 enclose = "1.1.8"
 enum-iterator.workspace = true
-event-listener = "5.4.0"
 field_mask.workspace = true
 firebase.workspace = true
 flate2 = "1.0.17"

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -29,6 +29,7 @@ use ai::skills::ParsedSkill;
 use warp_cli::agent::{Harness, OutputFormat};
 use warp_cli::mcp::MCPSpec;
 use warp_cli::share::ShareRequest;
+use warp_cli::skill::SkillSpec;
 use warp_core::{features::FeatureFlag, report_error, report_if_error, safe_debug, safe_info};
 use warp_graphql::ai::AgentTaskState;
 use warp_managed_secrets::ManagedSecretValue;
@@ -41,7 +42,9 @@ use crate::ai::blocklist::task_status_sync_model::TaskStatusSyncModel;
 use crate::ai::document::ai_document_model::{AIDocumentModel, AIDocumentModelEvent};
 use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::ai::mcp::{JSONMCPServer, MCPServerState};
-use crate::ai::skills::{resolve_skill_repos, SkillManager, SkillWatcher};
+use crate::ai::skills::{
+    filter_explicit_global_skills, resolve_skill_repos, SkillManager, SkillWatcher,
+};
 use crate::ai::{
     agent::conversation::AIConversationId,
     agent_sdk::driver::harness::{
@@ -358,6 +361,22 @@ pub struct Task {
     pub mcp_specs: Vec<MCPSpec>,
     /// Which harness to use for executing the agent run.
     pub harness: HarnessKind,
+}
+
+struct GlobalSkillResolution {
+    specs: Vec<SkillSpec>,
+    repos: Vec<GithubRepo>,
+}
+
+/// Configuration for which skills in a repository should be loaded.
+enum SkillRepoLoadMode {
+    All,
+    ExplicitGlobal(Vec<SkillSpec>),
+}
+
+struct SkillRepoLoadRequest {
+    repo: GithubRepo,
+    load_mode: SkillRepoLoadMode,
 }
 
 /// Prompt that we initialize an agent driver with. Can represent either a local prompt or
@@ -1229,23 +1248,28 @@ impl AgentDriver {
         })
     }
 
-    /// Resolve additional GitHub repositories that should be cloned to provide
-    /// agent skills.
-    async fn resolve_global_skill_repos(
+    /// Resolve global skill specs and the GitHub repositories that should be cloned for them.
+    async fn resolve_global_skills(
         foreground: &ModelSpawner<Self>,
-    ) -> Result<Vec<GithubRepo>, AgentDriverError> {
+    ) -> Result<GlobalSkillResolution, AgentDriverError> {
         if !FeatureFlag::OzPlatformSkills.is_enabled() {
-            return Ok(Vec::new());
+            return Ok(GlobalSkillResolution {
+                specs: Vec::new(),
+                repos: Vec::new(),
+            });
         }
 
-        let global_specs = foreground
+        let raw_global_specs = foreground
             .spawn(|_, ctx| AuthStateProvider::as_ref(ctx).get().global_skills())
             .await?;
-        let global_repos = resolve_skill_repos(&global_specs);
+        let (global_specs, global_repos) = resolve_skill_repos(&raw_global_specs);
         if !global_repos.is_empty() {
             log::info!("Resolving {} global skill repo(s)", global_repos.len());
         }
-        Ok(global_repos)
+        Ok(GlobalSkillResolution {
+            specs: global_specs,
+            repos: global_repos,
+        })
     }
 
     /// Clone all passed-in global skill repositories.
@@ -1282,30 +1306,79 @@ impl AgentDriver {
         Ok(())
     }
 
-    /// Scan a set of cloned GitHub repositories for their skills.
-    async fn load_skills_from_repos(foreground: &ModelSpawner<Self>, repos: Vec<GithubRepo>) {
+    fn skill_repo_load_requests(
+        environment_repos: Vec<GithubRepo>,
+        global_skill_repos: Vec<GithubRepo>,
+        global_skill_specs: &[SkillSpec],
+    ) -> Vec<SkillRepoLoadRequest> {
+        let mut requests = environment_repos
+            .into_iter()
+            .map(|repo| SkillRepoLoadRequest {
+                repo,
+                load_mode: SkillRepoLoadMode::All,
+            })
+            .collect::<Vec<_>>();
+
+        for repo in global_skill_repos {
+            if requests.iter().any(|request| request.repo == repo) {
+                continue;
+            }
+
+            let explicit_global_specs = global_skill_specs
+                .iter()
+                .filter(|spec| {
+                    spec.org.as_deref() == Some(repo.owner.as_str())
+                        && spec.repo.as_deref() == Some(repo.repo.as_str())
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+
+            if explicit_global_specs.is_empty() {
+                continue;
+            }
+
+            requests.push(SkillRepoLoadRequest {
+                repo,
+                load_mode: SkillRepoLoadMode::ExplicitGlobal(explicit_global_specs),
+            });
+        }
+
+        requests
+    }
+
+    /// Scan cloned GitHub repositories for their skills.
+    async fn load_skills_from_repos(
+        foreground: &ModelSpawner<Self>,
+        repos: Vec<SkillRepoLoadRequest>,
+    ) {
         if repos.is_empty() {
             log::info!("No repositories found for skill loading");
             return;
         }
         safe_info!(
             safe: ("Loading skills from {} repositories", repos.len()),
-            full: ("Loading skills from repositories: {}", repos.iter().format(", "))
+            full: (
+                "Loading skills from repositories: {}",
+                repos.iter().map(|request| &request.repo).format(", ")
+            )
         );
 
         let repo_index_waits = foreground
             .spawn(move |me, ctx| {
-                let repo_paths = repos
-                    .iter()
-                    .map(|repo| me.working_dir.join(&repo.repo))
+                let repo_loads = repos
+                    .into_iter()
+                    .map(|request| (me.working_dir.join(&request.repo.repo), request.load_mode))
                     .collect::<Vec<_>>();
                 log::debug!(
                     "Repository paths for skill loading: {}",
-                    repo_paths.iter().map(|p| p.display()).format(", ")
+                    repo_loads
+                        .iter()
+                        .map(|(repo_path, _)| repo_path.display())
+                        .format(", ")
                 );
                 let repo_metadata = RepoMetadataModel::handle(ctx);
                 let mut repo_index_waits = Vec::new();
-                for repo_path in &repo_paths {
+                for (repo_path, _) in &repo_loads {
                     let Some(id) = RepositoryIdentifier::try_local(repo_path) else {
                         log::warn!(
                             "Cannot wait for repository metadata indexing for non-local path {}",
@@ -1318,11 +1391,11 @@ impl AgentDriver {
                     });
                     repo_index_waits.push((repo_path.clone(), id, wait));
                 }
-                (repo_paths, repo_index_waits)
+                (repo_loads, repo_index_waits)
             })
             .await;
 
-        let (repo_paths, repo_index_waits) = match repo_index_waits {
+        let (repo_loads, repo_index_waits) = match repo_index_waits {
             Ok(result) => result,
             Err(err) => {
                 log::warn!("Failed to prepare repository skill loading: {err}");
@@ -1385,7 +1458,24 @@ impl AgentDriver {
 
         let load_skills_result = foreground
             .spawn(move |_, ctx| {
-                let skills = SkillWatcher::read_skills_for_repos(&repo_paths, ctx);
+                let mut skills = Vec::new();
+                for (repo_path, load_mode) in repo_loads {
+                    let repo_skills =
+                        SkillWatcher::read_skills_for_repos(std::slice::from_ref(&repo_path), ctx);
+                    match load_mode {
+                        SkillRepoLoadMode::All => skills.extend(repo_skills),
+                        SkillRepoLoadMode::ExplicitGlobal(explicit_global_specs) => {
+                            // We filter down to the requested skills after scanning the repository. Since
+                            // the scan is based on an in-memory index of the repository contents, it's not
+                            // much more performant to locate the requested skills directly.
+                            skills.extend(filter_explicit_global_skills(
+                                &repo_path,
+                                repo_skills,
+                                &explicit_global_specs,
+                            ));
+                        }
+                    }
+                }
                 if !skills.is_empty() {
                     log::info!("Loaded {} skill(s) from repositories", skills.len());
                 } else {
@@ -1445,7 +1535,7 @@ impl AgentDriver {
         Self::setup_cloud_providers(&foreground).await?;
 
         // For the Oz harness only: set up MCP servers, model overrides, and profile information.
-        if matches!(task.harness, HarnessKind::Oz) {
+        if matches!(&task.harness, HarnessKind::Oz) {
             // Resolve MCP specs into existing server UUIDs and ephemeral installations.
             let mcp_specs = task.mcp_specs.clone();
             let (existing_uuids, ephemeral_installations) = foreground
@@ -1500,22 +1590,26 @@ impl AgentDriver {
             })
             .await?
             .await?;
-        let mut skill_repos = if matches!(&task.harness, HarnessKind::Oz) {
-            let global_skill_repos = Self::resolve_global_skill_repos(&foreground).await?;
+        let global_skill_resolution = if matches!(&task.harness, HarnessKind::Oz) {
+            let global_skill_resolution = Self::resolve_global_skills(&foreground).await?;
             // Clone global skill repos before environment prep can change the
             // terminal's cwd into a single environment repo.
-            Self::clone_global_skill_repos(&foreground, &global_skill_repos).await?;
-            global_skill_repos
+            Self::clone_global_skill_repos(&foreground, &global_skill_resolution.repos).await?;
+            global_skill_resolution
         } else {
-            Vec::new()
+            GlobalSkillResolution {
+                specs: Vec::new(),
+                repos: Vec::new(),
+            }
         };
+        let mut environment_skill_repos = Vec::new();
 
         let environment_opt = foreground.spawn(|me, _| me.environment.clone()).await?;
 
         if let Some(environment) = environment_opt {
             log::info!("Loading environment...");
             let environment_github_repos = environment.github_repos.clone();
-            skill_repos.extend(environment_github_repos.clone());
+            environment_skill_repos = environment_github_repos.clone();
 
             // Subscribe to file-based MCP discovery BEFORE prepare_environment triggers the
             // pipeline so no CloudEnvMcpScanComplete events are missed.
@@ -1595,43 +1689,23 @@ impl AgentDriver {
             }
         }
 
-            // Skill loading is Oz-only; third-party harnesses have their own skill systems.
-            match &task.harness {
-                HarnessKind::Oz => {
-                    // Load skills from environment repos synchronously so the initial
-                    // message includes them. File trees are ready after prepare_environment.
-                    let github_repos = environment_github_repos.clone();
-                    let load_skills_result = foreground
-                        .spawn(move |me, ctx| {
-                            let repo_paths: Vec<PathBuf> = github_repos
-                                .iter()
-                                .map(|repo| me.working_dir.join(&repo.repo))
-                                .collect();
-                            let skills = SkillWatcher::read_skills_for_repos(&repo_paths, ctx);
-                            if !skills.is_empty() {
-                                log::info!(
-                                    "Loaded {} skill(s) from environment repos",
-                                    skills.len()
-                                );
-                            }
-                            SkillManager::handle(ctx).update(ctx, |manager, _| {
-                                // All repo skills should be in scope regardless of cwd when
-                                // a cloud environment is configured.
-                                manager.set_cloud_environment(true);
-                                manager.handle_skills_added(skills);
-                            });
-                        })
-                        .await;
-
-                    if let Err(err) = load_skills_result {
-                        log::warn!("Failed to load environment repo skills: {err}");
-                    }
-                }
-                HarnessKind::ThirdParty(_) | HarnessKind::Unsupported(_) => {}
-            }
+        // Skill loading is Oz-only; third-party harnesses have their own skill systems.
+        if matches!(&task.harness, HarnessKind::Oz) {
+            // Load skills from repos synchronously so the initial message includes them.
+            // File trees are ready after prepare_environment and global skill repo cloning above.
+            let GlobalSkillResolution {
+                specs: global_skill_specs,
+                repos: global_skill_repos,
+            } = global_skill_resolution;
+            let skill_load_requests = Self::skill_repo_load_requests(
+                environment_skill_repos,
+                global_skill_repos,
+                &global_skill_specs,
+            );
+            Self::load_skills_from_repos(&foreground, skill_load_requests).await;
         }
 
-        let (task_id_for_refresh, ai_client_for_refresh) = foreground
+         let (task_id_for_refresh, ai_client_for_refresh) = foreground
             .spawn(|me, ctx| {
                 let task_id = if FeatureFlag::GitCredentialRefresh.is_enabled() {
                     me.task_id.map(|id| id.to_string())

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -14,11 +14,34 @@ use std::{
     time::Duration,
 };
 
+use anyhow::{anyhow, Context as _};
+use futures::{
+    channel::oneshot,
+    future::{self, join_all, Either},
+    FutureExt as _,
+};
+use itertools::Itertools as _;
+use oneshot::{Canceled, Receiver, Sender};
+use repo_metadata::{local_model::IndexedRepoState, RepoMetadataModel, RepositoryIdentifier};
+use uuid::Uuid;
+
+use ai::skills::ParsedSkill;
+use warp_cli::agent::{Harness, OutputFormat};
+use warp_cli::mcp::MCPSpec;
+use warp_cli::share::ShareRequest;
+use warp_core::{features::FeatureFlag, report_error, report_if_error, safe_debug, safe_info};
+use warp_graphql::ai::AgentTaskState;
+use warp_managed_secrets::ManagedSecretValue;
+use warpui::{
+    r#async::{FutureExt, TimeoutError},
+    AppContext, Entity, ModelContext, ModelHandle, ModelSpawner, SingletonEntity,
+};
+
 use crate::ai::blocklist::task_status_sync_model::TaskStatusSyncModel;
 use crate::ai::document::ai_document_model::{AIDocumentModel, AIDocumentModelEvent};
 use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::ai::mcp::{JSONMCPServer, MCPServerState};
-use crate::ai::skills::{SkillManager, SkillWatcher};
+use crate::ai::skills::{resolve_skill_repos, SkillManager, SkillWatcher};
 use crate::ai::{
     agent::conversation::AIConversationId,
     agent_sdk::driver::harness::{
@@ -49,7 +72,7 @@ use crate::{
             },
             BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIPermissions,
         },
-        cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEnvironment},
+        cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEnvironment, GithubRepo},
         execution_profiles::profiles::AIExecutionProfilesModel,
         mcp::{
             file_based_manager::{FileBasedMCPManager, FileBasedMCPManagerEvent},
@@ -71,25 +94,6 @@ use crate::{
         },
     },
     terminal::view::ConversationRestorationInNewPaneType,
-};
-use ai::skills::ParsedSkill;
-use anyhow::{anyhow, Context as _};
-use futures::{
-    channel::oneshot,
-    future::{self, Either},
-    FutureExt as _,
-};
-use oneshot::{Canceled, Receiver, Sender};
-use uuid::Uuid;
-use warp_cli::agent::{Harness, OutputFormat};
-use warp_cli::mcp::MCPSpec;
-use warp_cli::share::ShareRequest;
-use warp_core::{features::FeatureFlag, report_error, report_if_error, safe_debug, safe_info};
-use warp_graphql::ai::AgentTaskState;
-use warp_managed_secrets::ManagedSecretValue;
-use warpui::{
-    r#async::{FutureExt, TimeoutError},
-    AppContext, Entity, ModelContext, ModelHandle, ModelSpawner, SingletonEntity,
 };
 
 pub(crate) mod attachments;
@@ -1225,6 +1229,182 @@ impl AgentDriver {
         })
     }
 
+    /// Resolve additional GitHub repositories that should be cloned to provide
+    /// agent skills.
+    async fn resolve_global_skill_repos(
+        foreground: &ModelSpawner<Self>,
+    ) -> Result<Vec<GithubRepo>, AgentDriverError> {
+        if !FeatureFlag::OzPlatformSkills.is_enabled() {
+            return Ok(Vec::new());
+        }
+
+        let global_specs = foreground
+            .spawn(|_, ctx| AuthStateProvider::as_ref(ctx).get().global_skills())
+            .await?;
+        let global_repos = resolve_skill_repos(&global_specs);
+        if !global_repos.is_empty() {
+            log::info!("Resolving {} global skill repo(s)", global_repos.len());
+        }
+        Ok(global_repos)
+    }
+
+    /// Clone all passed-in global skill repositories.
+    async fn clone_global_skill_repos(
+        foreground: &ModelSpawner<Self>,
+        global_skill_repos: &[GithubRepo],
+    ) -> Result<(), AgentDriverError> {
+        for repo in global_skill_repos {
+            let repo = repo.clone();
+            let repo_for_log = repo.clone();
+            let clone_future = foreground
+                .spawn(move |me, ctx| {
+                    let working_dir = me.working_dir.clone();
+                    me.terminal_driver.update(ctx, |_, ctx| {
+                        let spawner = ctx.spawner();
+                        async move {
+                            environment::ensure_repo_cloned(
+                                &repo,
+                                &working_dir,
+                                false, /* is_sandbox */
+                                &spawner,
+                            )
+                            .await
+                        }
+                    })
+                })
+                .await?;
+
+            if let Err(err) = clone_future.await {
+                log::warn!("Failed to clone global-skill repo {repo_for_log}: {err}");
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Scan a set of cloned GitHub repositories for their skills.
+    async fn load_skills_from_repos(foreground: &ModelSpawner<Self>, repos: Vec<GithubRepo>) {
+        if repos.is_empty() {
+            log::info!("No repositories found for skill loading");
+            return;
+        }
+        safe_info!(
+            safe: ("Loading skills from {} repositories", repos.len()),
+            full: ("Loading skills from repositories: {}", repos.iter().format(", "))
+        );
+
+        let repo_index_waits = foreground
+            .spawn(move |me, ctx| {
+                let repo_paths = repos
+                    .iter()
+                    .map(|repo| me.working_dir.join(&repo.repo))
+                    .collect::<Vec<_>>();
+                log::debug!(
+                    "Repository paths for skill loading: {}",
+                    repo_paths.iter().map(|p| p.display()).format(", ")
+                );
+                let repo_metadata = RepoMetadataModel::handle(ctx);
+                let mut repo_index_waits = Vec::new();
+                for repo_path in &repo_paths {
+                    let Some(id) = RepositoryIdentifier::try_local(repo_path) else {
+                        log::warn!(
+                            "Cannot wait for repository metadata indexing for non-local path {}",
+                            repo_path.display()
+                        );
+                        continue;
+                    };
+                    let wait = repo_metadata.update(ctx, |repo_metadata, ctx| {
+                        repo_metadata.repository_indexed(&id, ctx)
+                    });
+                    repo_index_waits.push((repo_path.clone(), id, wait));
+                }
+                (repo_paths, repo_index_waits)
+            })
+            .await;
+
+        let (repo_paths, repo_index_waits) = match repo_index_waits {
+            Ok(result) => result,
+            Err(err) => {
+                log::warn!("Failed to prepare repository skill loading: {err}");
+                return;
+            }
+        };
+
+        if !repo_index_waits.is_empty() {
+            log::info!(
+                "Waiting for repository metadata indexing before loading skills from {} repo(s)",
+                repo_index_waits.len()
+            );
+            let (repo_index_targets, wait_futures): (Vec<_>, Vec<_>) = repo_index_waits
+                .into_iter()
+                .map(|(repo_path, id, wait)| ((repo_path, id), wait))
+                .unzip();
+            join_all(wait_futures).await;
+            let repo_index_statuses = foreground
+                .spawn(move |_, ctx| {
+                    let repo_metadata = RepoMetadataModel::handle(ctx);
+                    repo_index_targets
+                        .into_iter()
+                        .map(|(repo_path, id)| {
+                            let repo_id_path = match &id {
+                                RepositoryIdentifier::Local(path) => path,
+                                RepositoryIdentifier::Remote(remote_id) => &remote_id.path,
+                            };
+                            let error = match repo_metadata.as_ref(ctx).repository_state(&id, ctx) {
+                                Some(IndexedRepoState::Indexed(_)) => None,
+                                Some(IndexedRepoState::Pending(_)) => Some(format!(
+                                    "Repository indexing is still pending: {repo_id_path}"
+                                )),
+                                Some(IndexedRepoState::Failed(error)) => {
+                                    Some(format!("Repository indexing failed: {error}"))
+                                }
+                                None => Some(format!("Repository not found: {repo_id_path}")),
+                            };
+                            (repo_path, error)
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .await;
+
+            let repo_index_statuses = match repo_index_statuses {
+                Ok(repo_index_statuses) => repo_index_statuses,
+                Err(err) => {
+                    log::warn!("Failed to check repository indexing status: {err}");
+                    Vec::new()
+                }
+            };
+            for (repo_path, error) in repo_index_statuses {
+                if let Some(err) = error {
+                    log::warn!(
+                        "Repository metadata indexing was not ready for skill loading in {}: {err}",
+                        repo_path.display()
+                    );
+                }
+            }
+        }
+
+        let load_skills_result = foreground
+            .spawn(move |_, ctx| {
+                let skills = SkillWatcher::read_skills_for_repos(&repo_paths, ctx);
+                if !skills.is_empty() {
+                    log::info!("Loaded {} skill(s) from repositories", skills.len());
+                } else {
+                    log::info!("No repository skills found");
+                }
+                SkillManager::handle(ctx).update(ctx, |manager, _| {
+                    // All repo skills should be in scope regardless of cwd when
+                    // an environment or global skill repo is configured.
+                    manager.set_cloud_environment(true);
+                    manager.handle_skills_added(skills);
+                });
+            })
+            .await;
+
+        if let Err(err) = load_skills_result {
+            log::warn!("Failed to load repository skills: {err}");
+        }
+    }
+
     /// Runs the agent to completion.
     /// Driving the agent mostly requires main-thread UI framework updates, but using `async` and
     /// a `ModelSpawner` lets us express the high-level process linearly rather than in a
@@ -1320,12 +1500,22 @@ impl AgentDriver {
             })
             .await?
             .await?;
+        let mut skill_repos = if matches!(&task.harness, HarnessKind::Oz) {
+            let global_skill_repos = Self::resolve_global_skill_repos(&foreground).await?;
+            // Clone global skill repos before environment prep can change the
+            // terminal's cwd into a single environment repo.
+            Self::clone_global_skill_repos(&foreground, &global_skill_repos).await?;
+            global_skill_repos
+        } else {
+            Vec::new()
+        };
 
         let environment_opt = foreground.spawn(|me, _| me.environment.clone()).await?;
 
         if let Some(environment) = environment_opt {
             log::info!("Loading environment...");
             let environment_github_repos = environment.github_repos.clone();
+            skill_repos.extend(environment_github_repos.clone());
 
             // Subscribe to file-based MCP discovery BEFORE prepare_environment triggers the
             // pipeline so no CloudEnvMcpScanComplete events are missed.
@@ -1403,6 +1593,7 @@ impl AgentDriver {
                         .await;
                 }
             }
+        }
 
             // Skill loading is Oz-only; third-party harnesses have their own skill systems.
             match &task.harness {

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -25,7 +25,7 @@ use oneshot::{Canceled, Receiver, Sender};
 use repo_metadata::{local_model::IndexedRepoState, RepoMetadataModel, RepositoryIdentifier};
 use uuid::Uuid;
 
-use ai::skills::ParsedSkill;
+use ai::skills::{ParsedSkill, SKILL_PROVIDER_DEFINITIONS};
 use warp_cli::agent::{Harness, OutputFormat};
 use warp_cli::mcp::MCPSpec;
 use warp_cli::share::ShareRequest;
@@ -43,7 +43,8 @@ use crate::ai::document::ai_document_model::{AIDocumentModel, AIDocumentModelEve
 use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::ai::mcp::{JSONMCPServer, MCPServerState};
 use crate::ai::skills::{
-    filter_explicit_global_skills, resolve_skill_repos, SkillManager, SkillWatcher,
+    filter_skills_by_spec, read_skills_from_directories, resolve_skill_repos, SkillManager,
+    SkillWatcher,
 };
 use crate::ai::{
     agent::conversation::AIConversationId,
@@ -366,17 +367,6 @@ pub struct Task {
 struct GlobalSkillResolution {
     specs: Vec<SkillSpec>,
     repos: Vec<GithubRepo>,
-}
-
-/// Configuration for which skills in a repository should be loaded.
-enum SkillRepoLoadMode {
-    All,
-    ExplicitGlobal(Vec<SkillSpec>),
-}
-
-struct SkillRepoLoadRequest {
-    repo: GithubRepo,
-    load_mode: SkillRepoLoadMode,
 }
 
 /// Prompt that we initialize an agent driver with. Can represent either a local prompt or
@@ -1273,6 +1263,11 @@ impl AgentDriver {
     }
 
     /// Clone all passed-in global skill repositories.
+    ///
+    /// These repositories are not registered with the `DetectedRepositories`
+    /// model, so that we don't automatically detect *all* skills they contain.
+    /// This is important when using registry-like skill repos where loading all
+    /// skills would bloat the context window.
     async fn clone_global_skill_repos(
         foreground: &ModelSpawner<Self>,
         global_skill_repos: &[GithubRepo],
@@ -1285,15 +1280,7 @@ impl AgentDriver {
                     let working_dir = me.working_dir.clone();
                     me.terminal_driver.update(ctx, |_, ctx| {
                         let spawner = ctx.spawner();
-                        async move {
-                            environment::ensure_repo_cloned(
-                                &repo,
-                                &working_dir,
-                                false, /* is_sandbox */
-                                &spawner,
-                            )
-                            .await
-                        }
+                        async move { environment::clone_repo(&repo, &working_dir, &spawner).await }
                     })
                 })
                 .await?;
@@ -1306,79 +1293,35 @@ impl AgentDriver {
         Ok(())
     }
 
-    fn skill_repo_load_requests(
-        environment_repos: Vec<GithubRepo>,
-        global_skill_repos: Vec<GithubRepo>,
-        global_skill_specs: &[SkillSpec],
-    ) -> Vec<SkillRepoLoadRequest> {
-        let mut requests = environment_repos
-            .into_iter()
-            .map(|repo| SkillRepoLoadRequest {
-                repo,
-                load_mode: SkillRepoLoadMode::All,
-            })
-            .collect::<Vec<_>>();
-
-        for repo in global_skill_repos {
-            if requests.iter().any(|request| request.repo == repo) {
-                continue;
-            }
-
-            let explicit_global_specs = global_skill_specs
-                .iter()
-                .filter(|spec| {
-                    spec.org.as_deref() == Some(repo.owner.as_str())
-                        && spec.repo.as_deref() == Some(repo.repo.as_str())
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-
-            if explicit_global_specs.is_empty() {
-                continue;
-            }
-
-            requests.push(SkillRepoLoadRequest {
-                repo,
-                load_mode: SkillRepoLoadMode::ExplicitGlobal(explicit_global_specs),
-            });
-        }
-
-        requests
-    }
-
-    /// Scan cloned GitHub repositories for their skills.
-    async fn load_skills_from_repos(
-        foreground: &ModelSpawner<Self>,
-        repos: Vec<SkillRepoLoadRequest>,
-    ) {
+    /// Load skills from environment repositories.
+    ///
+    /// It's assumed that `prepare_environment` registers all cloned repositories
+    /// with the `DetectedRepositories` model, so that we can scan for skills
+    // here.
+    async fn load_environment_skills(foreground: &ModelSpawner<Self>, repos: Vec<GithubRepo>) {
         if repos.is_empty() {
-            log::info!("No repositories found for skill loading");
+            log::info!("No environment repositories for skill loading");
             return;
         }
         safe_info!(
-            safe: ("Loading skills from {} repositories", repos.len()),
+            safe: ("Loading skills from {} environment repositories", repos.len()),
             full: (
-                "Loading skills from repositories: {}",
-                repos.iter().map(|request| &request.repo).format(", ")
+                "Loading environment skills from repositories: {}",
+                repos.iter().format(", ")
             )
         );
 
+        // Skill-scanning depends on the in-memory RepoMetadataModel index, so wait for
+        // initial indexing of all repos to complete.
         let repo_index_waits = foreground
             .spawn(move |me, ctx| {
-                let repo_loads = repos
-                    .into_iter()
-                    .map(|request| (me.working_dir.join(&request.repo.repo), request.load_mode))
-                    .collect::<Vec<_>>();
-                log::debug!(
-                    "Repository paths for skill loading: {}",
-                    repo_loads
-                        .iter()
-                        .map(|(repo_path, _)| repo_path.display())
-                        .format(", ")
-                );
+                let repo_paths: Vec<PathBuf> = repos
+                    .iter()
+                    .map(|repo| me.working_dir.join(&repo.repo))
+                    .collect();
                 let repo_metadata = RepoMetadataModel::handle(ctx);
                 let mut repo_index_waits = Vec::new();
-                for (repo_path, _) in &repo_loads {
+                for repo_path in &repo_paths {
                     let Some(id) = RepositoryIdentifier::try_local(repo_path) else {
                         log::warn!(
                             "Cannot wait for repository metadata indexing for non-local path {}",
@@ -1391,14 +1334,14 @@ impl AgentDriver {
                     });
                     repo_index_waits.push((repo_path.clone(), id, wait));
                 }
-                (repo_loads, repo_index_waits)
+                (repo_paths, repo_index_waits)
             })
             .await;
 
-        let (repo_loads, repo_index_waits) = match repo_index_waits {
+        let (repo_paths, repo_index_waits) = match repo_index_waits {
             Ok(result) => result,
             Err(err) => {
-                log::warn!("Failed to prepare repository skill loading: {err}");
+                log::warn!("Failed to prepare environment skill loading: {err}");
                 return;
             }
         };
@@ -1418,10 +1361,9 @@ impl AgentDriver {
                     let repo_metadata = RepoMetadataModel::handle(ctx);
                     repo_index_targets
                         .into_iter()
-                        .map(|(repo_path, id)| {
-                            let repo_id_path = match &id {
-                                RepositoryIdentifier::Local(path) => path,
-                                RepositoryIdentifier::Remote(remote_id) => &remote_id.path,
+                        .filter_map(|(repo_path, id)| {
+                            let RepositoryIdentifier::Local(repo_id_path) = &id else {
+                                return None;
                             };
                             let error = match repo_metadata.as_ref(ctx).repository_state(&id, ctx) {
                                 Some(IndexedRepoState::Indexed(_)) => None,
@@ -1433,7 +1375,7 @@ impl AgentDriver {
                                 }
                                 None => Some(format!("Repository not found: {repo_id_path}")),
                             };
-                            (repo_path, error)
+                            Some((repo_path, error))
                         })
                         .collect::<Vec<_>>()
                 })
@@ -1458,32 +1400,13 @@ impl AgentDriver {
 
         let load_skills_result = foreground
             .spawn(move |_, ctx| {
-                let mut skills = Vec::new();
-                for (repo_path, load_mode) in repo_loads {
-                    let repo_skills =
-                        SkillWatcher::read_skills_for_repos(std::slice::from_ref(&repo_path), ctx);
-                    match load_mode {
-                        SkillRepoLoadMode::All => skills.extend(repo_skills),
-                        SkillRepoLoadMode::ExplicitGlobal(explicit_global_specs) => {
-                            // We filter down to the requested skills after scanning the repository. Since
-                            // the scan is based on an in-memory index of the repository contents, it's not
-                            // much more performant to locate the requested skills directly.
-                            skills.extend(filter_explicit_global_skills(
-                                &repo_path,
-                                repo_skills,
-                                &explicit_global_specs,
-                            ));
-                        }
-                    }
-                }
+                let skills = SkillWatcher::read_skills_for_repos(&repo_paths, ctx);
                 if !skills.is_empty() {
-                    log::info!("Loaded {} skill(s) from repositories", skills.len());
+                    log::info!("Loaded {} environment skill(s)", skills.len());
                 } else {
-                    log::info!("No repository skills found");
+                    log::info!("No environment skills found");
                 }
                 SkillManager::handle(ctx).update(ctx, |manager, _| {
-                    // All repo skills should be in scope regardless of cwd when
-                    // an environment or global skill repo is configured.
                     manager.set_cloud_environment(true);
                     manager.handle_skills_added(skills);
                 });
@@ -1491,7 +1414,71 @@ impl AgentDriver {
             .await;
 
         if let Err(err) = load_skills_result {
-            log::warn!("Failed to load repository skills: {err}");
+            log::warn!("Failed to load environment skills: {err}");
+        }
+    }
+
+    /// Load explicitly requested global skills by reading directly from disk.
+    async fn load_global_skills(
+        foreground: &ModelSpawner<Self>,
+        specs: Vec<SkillSpec>,
+        repos: Vec<GithubRepo>,
+    ) {
+        if specs.is_empty() || repos.is_empty() {
+            return;
+        }
+        safe_info!(
+            safe: ("Loading {} global skill(s) from {} repo(s)", specs.len(), repos.len()),
+            full: (
+                "Loading global skills {} from repos: {}",
+                specs.iter().map(|s| &s.skill_identifier).format(", "),
+                repos.iter().format(", ")
+            )
+        );
+
+        let load_result = foreground
+            .spawn(move |me, _| {
+                let mut all_skills = Vec::new();
+                for repo in &repos {
+                    let repo_path = me.working_dir.join(&repo.repo);
+                    // Read skills from all known provider directories on disk,
+                    // without depending on RepoMetadataModel.
+                    let skill_dirs = SKILL_PROVIDER_DEFINITIONS
+                        .iter()
+                        .map(|def| repo_path.join(&def.skills_path));
+                    let repo_skills = read_skills_from_directories(skill_dirs);
+                    let filtered = filter_skills_by_spec(&repo_path, repo_skills, &specs);
+                    all_skills.extend(filtered);
+                }
+                all_skills
+            })
+            .await;
+
+        let skills = match load_result {
+            Ok(skills) => skills,
+            Err(err) => {
+                log::warn!("Failed to load global skills: {err}");
+                return;
+            }
+        };
+
+        if skills.is_empty() {
+            log::info!("No global skills matched the requested specs");
+            return;
+        }
+
+        log::info!("Loaded {} global skill(s)", skills.len());
+        let add_result = foreground
+            .spawn(move |_, ctx| {
+                SkillManager::handle(ctx).update(ctx, |manager, _| {
+                    manager.set_cloud_environment(true);
+                    manager.handle_skills_added(skills);
+                });
+            })
+            .await;
+
+        if let Err(err) = add_result {
+            log::warn!("Failed to add global skills to SkillManager: {err}");
         }
     }
 
@@ -1590,18 +1577,12 @@ impl AgentDriver {
             })
             .await?
             .await?;
-        let global_skill_resolution = if matches!(&task.harness, HarnessKind::Oz) {
-            let global_skill_resolution = Self::resolve_global_skills(&foreground).await?;
-            // Clone global skill repos before environment prep can change the
-            // terminal's cwd into a single environment repo.
-            Self::clone_global_skill_repos(&foreground, &global_skill_resolution.repos).await?;
-            global_skill_resolution
-        } else {
-            GlobalSkillResolution {
-                specs: Vec::new(),
-                repos: Vec::new(),
-            }
-        };
+        let global_skill_resolution = Self::resolve_global_skills(&foreground).await?;
+        // Clone global skill repos before environment prep can change the
+        // terminal's cwd into a single environment repo.
+        // We do this for all harnesses, so that the skills *may* be discovered by third-party
+        // harnesses if appropriate.
+        Self::clone_global_skill_repos(&foreground, &global_skill_resolution.repos).await?;
         let mut environment_skill_repos = Vec::new();
 
         let environment_opt = foreground.spawn(|me, _| me.environment.clone()).await?;
@@ -1697,15 +1678,11 @@ impl AgentDriver {
                 specs: global_skill_specs,
                 repos: global_skill_repos,
             } = global_skill_resolution;
-            let skill_load_requests = Self::skill_repo_load_requests(
-                environment_skill_repos,
-                global_skill_repos,
-                &global_skill_specs,
-            );
-            Self::load_skills_from_repos(&foreground, skill_load_requests).await;
+            Self::load_environment_skills(&foreground, environment_skill_repos).await;
+            Self::load_global_skills(&foreground, global_skill_specs, global_skill_repos).await;
         }
 
-         let (task_id_for_refresh, ai_client_for_refresh) = foreground
+        let (task_id_for_refresh, ai_client_for_refresh) = foreground
             .spawn(|me, ctx| {
                 let task_id = if FeatureFlag::GitCredentialRefresh.is_enabled() {
                     me.task_id.map(|id| id.to_string())

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -651,6 +651,45 @@ impl AgentDriver {
         })
     }
 
+    /// Minimal constructor for unit tests that need a live `AgentDriver` model to call
+    /// methods on (e.g. `load_environment_skills`, `load_global_skills`) without
+    /// bootstrapping a full agent run.
+    ///
+    /// The caller is responsible for creating the `TerminalDriver` handle beforehand
+    /// (e.g. via `TerminalDriver::create_from_existing_view`) and for registering all
+    /// required singleton models before constructing the driver.
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        working_dir: PathBuf,
+        terminal_driver: ModelHandle<terminal::TerminalDriver>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        ctx.subscribe_to_model(&terminal_driver, |me, event, ctx| {
+            me.handle_terminal_driver_event(event, ctx);
+        });
+        Self {
+            terminal_driver,
+            working_dir,
+            secrets: Arc::new(HashMap::new()),
+            resolved_env_vars: Arc::new(HashMap::new()),
+            output_format: OutputFormat::default(),
+            task_id: None,
+            harness: None,
+            idle_on_complete: None,
+            restored_conversation_id: None,
+            resume_payload: None,
+            cloud_providers: Vec::new(),
+            environment: None,
+            snapshot_disabled: false,
+            snapshot_upload_timeout: snapshot::DEFAULT_SNAPSHOT_UPLOAD_TIMEOUT,
+            snapshot_script_timeout: snapshot::DEFAULT_DECLARATIONS_SCRIPT_TIMEOUT,
+            run_conversation_id: None,
+            parent_run_id: None,
+            third_party_harness_model_id: None,
+            snapshot_file_writer: None,
+        }
+    }
+
     /// Pair to the registration in `new` / `execute_run`. No-op when
     /// nothing was registered.
     fn unregister_streamer_consumer(&self, ctx: &mut ModelContext<Self>) {

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -235,8 +235,19 @@ pub(super) async fn ensure_repo_cloned(
 ) -> Result<(), PrepareEnvironmentError> {
     let repo_name = format!("{}/{}", repo.owner, repo.repo);
     let repo_url = format!("https://github.com/{repo_name}.git");
+    // Get the session's shell type for proper escaping, falling back to Bash
+    // when the session is not yet bootstrapped or the spawn fails.
+    let shell_type = spawner
+        .spawn(|driver, ctx| {
+            driver
+                .active_session_shell_type(ctx)
+                .unwrap_or(ShellType::Bash)
+        })
+        .await
+        .unwrap_or(ShellType::Bash);
+    let escaped_url = shell_escape_single_quotes(&repo_url, shell_type);
     // We do a partial clone here to speed up environment setup time.
-    let command = format!("git clone --filter=tree:0 {repo_url}");
+    let command = format!("git clone --filter=tree:0 '{escaped_url}'");
 
     let repo_dir = working_dir.join(&repo.repo);
     // Always ask the session whether the repo dir already exists, rather

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -121,85 +121,8 @@ async fn prepare_environment_impl(
     let mut codebase_context_receivers = Vec::new();
 
     for repo in github_repos {
-        let repo_name = format!("{}/{}", repo.owner, repo.repo);
-        let repo_url = format!("https://github.com/{repo_name}.git");
-        // We do a partial clone here to speed up environment setup time.
-        let command = format!("git clone --filter=tree:0 {repo_url}");
-
-        let repo_dir = working_dir.join(&repo.repo);
-        // Always ask the session whether the repo dir already exists, rather
-        // than stat'ing from the host. The session knows about sandbox-only
-        // paths, and this goes through the silent executor so `test -d` is
-        // not added to the user-visible blocklist. Pass the absolute path
-        // explicitly so the probe doesn't rely on the session's CWD.
-        let dir_exists = terminal_directory_exists(&repo_dir.to_string_lossy(), spawner).await?;
-
-        if dir_exists {
-            safe_warn!(
-                safe: ("We already have a directory with the same repository name in the terminal working directory, skipping clone..."),
-                full: (
-                "We already have a directory with the name {} in the terminal working directory, skipping clone...",
-                repo.repo)
-            );
-        } else {
-            safe_info!(
-                safe: ("Cloning repository via terminal"),
-                full: ("Cloning repository via terminal: {repo_name}")
-            );
-
-            let exit_code = execute_command(command, spawner).await?;
-            if exit_code != 0.into() {
-                return Err(PrepareEnvironmentError::CloneRepo {
-                    repo_name: repo_name.clone(),
-                });
-            }
-
-            safe_info!(
-                safe: ("Successfully cloned repository"),
-                full: ("Successfully cloned: {repo_name}")
-            );
-        }
-
-        // Register the repo with DetectedRepositories so that the skill watcher
-        // and other repo-aware subsystems can discover it before the first query.
-        //
-        // TODO(advait): When the remote code server lands for Docker sandboxes,
-        // sandbox-only working directories will be reachable from the host and
-        // we should register + index them here too (likely via a remote-aware
-        // path instead of `detect_possible_git_repo`/`index_directory`, which
-        // both assume a local filesystem). For now, skip so we don't try to
-        // stat paths that only exist inside the sandbox.
-        if is_sandbox {
-            safe_info!(
-                safe: ("Skipping local repo detection for sandbox-only working directory"),
-                full: (
-                    "Skipping local repo detection and indexing for sandbox-only working directory {}",
-                    working_dir.display()
-                )
-            );
-        } else {
-            let repo_dir_str = repo_dir.to_string_lossy().to_string();
-            let detect_future = spawner
-                .spawn(move |_, ctx| {
-                    DetectedRepositories::handle(ctx).update(ctx, |repos, ctx| {
-                        repos.detect_possible_git_repo(
-                            &repo_dir_str,
-                            RepoDetectionSource::CloudEnvironmentPrep,
-                            ctx,
-                        )
-                    })
-                })
-                .await
-                .map_err(|_| PrepareEnvironmentError::InvalidRuntimeState)?;
-            // Await detection so the repo is registered in DirectoryWatcher
-            // before the agent's first query.
-            if detect_future.await.is_none() {
-                safe_warn!(
-                    safe: ("Repository detection returned no path"),
-                    full: ("Repository detection returned no path for {}", repo_dir.display())
-                );
-            }
-
+        ensure_repo_cloned(repo, working_dir, is_sandbox, spawner).await?;
+        if !is_sandbox {
             if should_index_codebase {
                 let receiver = index_repo_codebase(
                     &repo.repo,
@@ -296,6 +219,97 @@ async fn prepare_environment_impl(
         let exit_code = cd_in_terminal(repo_name.clone(), spawner).await?;
         if exit_code != 0.into() {
             return Err(PrepareEnvironmentError::ChangeDirectory { repo_name });
+        }
+    }
+
+    Ok(())
+}
+
+/// Ensure that a GitHub repository has been cloned to `{working_dir}/{repo.repo}`. This will not
+/// overwrite existing clones.
+pub(super) async fn ensure_repo_cloned(
+    repo: &GithubRepo,
+    working_dir: &Path,
+    is_sandbox: bool,
+    spawner: &ModelSpawner<TerminalDriver>,
+) -> Result<(), PrepareEnvironmentError> {
+    let repo_name = format!("{}/{}", repo.owner, repo.repo);
+    let repo_url = format!("https://github.com/{repo_name}.git");
+    // We do a partial clone here to speed up environment setup time.
+    let command = format!("git clone --filter=tree:0 {repo_url}");
+
+    let repo_dir = working_dir.join(&repo.repo);
+    // Always ask the session whether the repo dir already exists, rather
+    // than stat'ing from the host. The session knows about sandbox-only
+    // paths, and this goes through the silent executor so `test -d` is
+    // not added to the user-visible blocklist. Pass the absolute path
+    // explicitly so the probe doesn't rely on the session's CWD.
+    let dir_exists = terminal_directory_exists(&repo_dir.to_string_lossy(), spawner).await?;
+
+    if dir_exists {
+        safe_warn!(
+            safe: ("We already have a directory with the same repository name in the terminal working directory, skipping clone..."),
+            full: (
+            "We already have a directory with the name {} in the terminal working directory, skipping clone...",
+            repo.repo)
+        );
+    } else {
+        safe_info!(
+            safe: ("Cloning repository via terminal"),
+            full: ("Cloning repository via terminal: {repo_name}")
+        );
+
+        let exit_code = execute_command(command, spawner).await?;
+        if exit_code != 0.into() {
+            return Err(PrepareEnvironmentError::CloneRepo {
+                repo_name: repo_name.clone(),
+            });
+        }
+
+        safe_info!(
+            safe: ("Successfully cloned repository"),
+            full: ("Successfully cloned: {repo_name}")
+        );
+    }
+
+    // Register the repo with DetectedRepositories so that the skill watcher
+    // and other repo-aware subsystems can discover it before the first query.
+    //
+    // TODO(advait): When the remote code server lands for Docker sandboxes,
+    // sandbox-only working directories will be reachable from the host and
+    // we should register + index them here too (likely via a remote-aware
+    // path instead of `detect_possible_git_repo`/`index_directory`, which
+    // both assume a local filesystem). For now, skip so we don't try to
+    // stat paths that only exist inside the sandbox.
+    if is_sandbox {
+        safe_info!(
+            safe: ("Skipping local repo detection for sandbox-only working directory"),
+            full: (
+                "Skipping local repo detection and indexing for sandbox-only working directory {}",
+                working_dir.display()
+            )
+        );
+    } else {
+        let repo_dir_str = repo_dir.to_string_lossy().to_string();
+        let detect_future = spawner
+            .spawn(move |_, ctx| {
+                DetectedRepositories::handle(ctx).update(ctx, |repos, ctx| {
+                    repos.detect_possible_git_repo(
+                        &repo_dir_str,
+                        RepoDetectionSource::CloudEnvironmentPrep,
+                        ctx,
+                    )
+                })
+            })
+            .await
+            .map_err(|_| PrepareEnvironmentError::InvalidRuntimeState)?;
+        // Await detection so the repo is registered in DirectoryWatcher
+        // before the agent's first query.
+        if detect_future.await.is_none() {
+            safe_warn!(
+                safe: ("Repository detection returned no path"),
+                full: ("Repository detection returned no path for {}", repo_dir.display())
+            );
         }
     }
 

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -122,18 +122,12 @@ async fn prepare_environment_impl(
 
     for repo in github_repos {
         ensure_repo_cloned(repo, working_dir, is_sandbox, spawner).await?;
-        if !is_sandbox {
-            if should_index_codebase {
-                let receiver = index_repo_codebase(
-                    &repo.repo,
-                    working_dir,
-                    Arc::clone(&repo_channels),
-                    spawner,
-                )
-                .await?;
-                if let Some(receiver) = receiver {
-                    codebase_context_receivers.push(receiver);
-                }
+        if !is_sandbox && should_index_codebase {
+            let receiver =
+                index_repo_codebase(&repo.repo, working_dir, Arc::clone(&repo_channels), spawner)
+                    .await?;
+            if let Some(receiver) = receiver {
+                codebase_context_receivers.push(receiver);
             }
         }
     }
@@ -225,12 +219,11 @@ async fn prepare_environment_impl(
     Ok(())
 }
 
-/// Ensure that a GitHub repository has been cloned to `{working_dir}/{repo.repo}`. This will not
-/// overwrite existing clones.
-pub(super) async fn ensure_repo_cloned(
+/// Clone a GitHub repository to `{working_dir}/{repo.repo}` if it does not already exist.
+/// This only performs the clone -- it does NOT register the repo with `DetectedRepositories`.
+pub(super) async fn clone_repo(
     repo: &GithubRepo,
     working_dir: &Path,
-    is_sandbox: bool,
     spawner: &ModelSpawner<TerminalDriver>,
 ) -> Result<(), PrepareEnvironmentError> {
     let repo_name = format!("{}/{}", repo.owner, repo.repo);
@@ -282,6 +275,21 @@ pub(super) async fn ensure_repo_cloned(
             full: ("Successfully cloned: {repo_name}")
         );
     }
+
+    Ok(())
+}
+
+/// Clone a GitHub repository and register it with `DetectedRepositories` so that
+/// the skill watcher and other repo-aware subsystems can discover it.
+pub(super) async fn ensure_repo_cloned(
+    repo: &GithubRepo,
+    working_dir: &Path,
+    is_sandbox: bool,
+    spawner: &ModelSpawner<TerminalDriver>,
+) -> Result<(), PrepareEnvironmentError> {
+    clone_repo(repo, working_dir, spawner).await?;
+
+    let repo_dir = working_dir.join(&repo.repo);
 
     // Register the repo with DetectedRepositories so that the skill watcher
     // and other repo-aware subsystems can discover it before the first query.

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ffi::OsString, sync::Arc, time::Duration};
+use std::{collections::HashMap, ffi::OsString, fs, path::Path, sync::Arc, time::Duration};
 
 use futures::channel::oneshot;
 use warp_cli::agent::Harness;
@@ -8,10 +8,16 @@ use warp_cli::{
 };
 use warp_core::channel::ChannelState;
 
+use repo_metadata::{DirectoryWatcher, RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
+use tempfile::TempDir;
+use warp_cli::skill::SkillSpec;
+use warp_util::standardized_path::StandardizedPath;
+use warpui::{App, SingletonEntity as _};
+
 use super::{
-    build_secret_env_vars, IdleTimeoutSender, LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV,
-    LEGACY_OZ_PARENT_STATE_ROOT_ENV, OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV,
-    OZ_MESSAGE_LISTENER_STATE_ROOT_ENV,
+    build_secret_env_vars, AgentDriver, IdleTimeoutSender,
+    LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV, LEGACY_OZ_PARENT_STATE_ROOT_ENV,
+    OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV, OZ_MESSAGE_LISTENER_STATE_ROOT_ENV,
 };
 use crate::ai::agent::{
     task::TaskId, AIAgentActionResult, AIAgentActionResultType, AIAgentInput, AIAgentOutput,
@@ -19,6 +25,10 @@ use crate::ai::agent::{
 };
 use crate::ai::mcp::parsing::normalize_mcp_json;
 use crate::ai::{agent_sdk::task_env_vars, ambient_agents::AmbientAgentTaskId};
+use crate::{
+    ai::{cloud_environments::GithubRepo, skills::SkillManager},
+    test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view},
+};
 use warp_managed_secrets::ManagedSecretValue;
 
 #[test]
@@ -570,4 +580,260 @@ fn worker_injected_env_skips_entire_bedrock_secret() {
     assert!(!env_vars.contains_key(&OsString::from("CLAUDE_CODE_USE_BEDROCK")));
     assert!(!env_vars.contains_key(&OsString::from("AWS_REGION")));
     std::env::remove_var("AWS_REGION");
+}
+
+// ── Skill-loading integration test ───────────────────────────────────────────
+
+/// Verifies that `load_environment_skills` loads every skill from an env repo
+/// while `load_global_skills` loads only the explicitly requested subset from a
+/// global-only repo.
+///
+/// The test writes real SKILL.md files on disk, seeds `RepoMetadataModel` with a
+/// minimal file-tree for the env repo so the indexing wait resolves immediately,
+/// and drives both loading methods through a live `AgentDriver` model via a
+/// `ModelSpawner`.
+#[test]
+fn split_loading_env_loads_all_global_loads_subset() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        // Create real skill files on disk.
+        let temp = TempDir::new().unwrap();
+        let working_dir = dunce::canonicalize(temp.path()).unwrap();
+
+        // Environment repo: three skills. All should be loaded.
+        let env_repo = working_dir.join("env-repo");
+        write_skill_file(&env_repo, "build");
+        write_skill_file(&env_repo, "test-skill");
+        write_skill_file(&env_repo, "deploy");
+
+        // Global-only repo: three skills; only "linter" is explicitly requested.
+        let global_repo = working_dir.join("global-repo");
+        write_skill_file(&global_repo, "linter");
+        write_skill_file(&global_repo, "formatter");
+        write_skill_file(&global_repo, "docs");
+
+        // Trigger a real filesystem scan of the env repo so `repository_indexed`
+        // resolves immediately once indexing completes.
+        let env_repo_std = StandardizedPath::from_local_canonicalized(&env_repo).unwrap();
+        let repo_handle = DirectoryWatcher::handle(&app).update(&mut app, |watcher, ctx| {
+            watcher.add_directory(env_repo_std.clone(), ctx).unwrap()
+        });
+        let (indexed_tx, indexed_rx) = futures::channel::oneshot::channel::<()>();
+        let tx_cell = std::rc::Rc::new(std::cell::RefCell::new(Some(indexed_tx)));
+        let env_repo_for_event = env_repo_std.clone();
+        app.update(|ctx| {
+            let tx_cell = tx_cell.clone();
+            ctx.subscribe_to_model(
+                &RepoMetadataModel::handle(ctx),
+                move |_, event: &RepoMetadataEvent, _ctx| {
+                    if let RepoMetadataEvent::RepositoryUpdated {
+                        id: RepositoryIdentifier::Local(path),
+                    } = event
+                    {
+                        if *path == env_repo_for_event {
+                            if let Some(tx) = tx_cell.borrow_mut().take() {
+                                let _ = tx.send(());
+                            }
+                        }
+                    }
+                },
+            );
+        });
+        RepoMetadataModel::handle(&app).update(&mut app, |model: &mut RepoMetadataModel, ctx| {
+            model.index_directory(repo_handle, ctx).unwrap();
+        });
+        indexed_rx.await.expect("env repo should be indexed");
+
+        // Construct a minimal AgentDriver backed by a stub terminal view.
+        let terminal_view = add_window_with_terminal(&mut app, None);
+        let driver_handle = app.add_model(|ctx| {
+            let terminal_driver =
+                super::terminal::TerminalDriver::create_from_existing_view(terminal_view, ctx);
+            AgentDriver::new_for_test(working_dir.clone(), terminal_driver, ctx)
+        });
+
+        // Run both loading methods through the driver's ModelSpawner.
+        let (done_tx, done_rx) = futures::channel::oneshot::channel::<()>();
+        let env_repos = vec![GithubRepo::new("org".to_string(), "env-repo".to_string())];
+        let global_repos = vec![GithubRepo::new(
+            "org".to_string(),
+            "global-repo".to_string(),
+        )];
+        let global_specs: Vec<SkillSpec> = ["org/global-repo:linter".to_string()]
+            .iter()
+            .map(|s| s.parse().unwrap())
+            .collect();
+        driver_handle.update(&mut app, |_, ctx| {
+            let spawner = ctx.spawner();
+            ctx.spawn(
+                async move {
+                    AgentDriver::load_environment_skills(&spawner, env_repos).await;
+                    AgentDriver::load_global_skills(&spawner, global_specs, global_repos).await;
+                    let _ = done_tx.send(());
+                },
+                |_, _, _| {},
+            );
+        });
+        done_rx.await.expect("loading task should complete");
+
+        // Verify SkillManager contains the right skills.
+        // is_cloud_environment=true (set by both loaders), so get_skills_for_working_directory
+        // with cwd=None returns all registered skills.
+        let skill_names = SkillManager::handle(&app).read(&app, |manager: &SkillManager, ctx| {
+            manager
+                .get_skills_for_working_directory(None, ctx)
+                .into_iter()
+                .map(|s| s.name.clone())
+                .collect::<Vec<_>>()
+        });
+
+        assert!(
+            skill_names.contains(&"build".to_string()),
+            "env skill 'build' should be loaded; got: {skill_names:?}"
+        );
+        assert!(
+            skill_names.contains(&"test-skill".to_string()),
+            "env skill 'test-skill' should be loaded; got: {skill_names:?}"
+        );
+        assert!(
+            skill_names.contains(&"deploy".to_string()),
+            "env skill 'deploy' should be loaded; got: {skill_names:?}"
+        );
+        assert!(
+            skill_names.contains(&"linter".to_string()),
+            "requested global skill 'linter' should be loaded; got: {skill_names:?}"
+        );
+        assert!(
+            !skill_names.contains(&"formatter".to_string()),
+            "unrequested global skill 'formatter' should NOT be loaded; got: {skill_names:?}"
+        );
+        assert!(
+            !skill_names.contains(&"docs".to_string()),
+            "unrequested global skill 'docs' should NOT be loaded; got: {skill_names:?}"
+        );
+    });
+}
+
+/// Verifies that when a repo is in both the environment list and the global skill
+/// specs, all skills from that repo are loaded (environment wins), the targeted
+/// global skill is present, and no skill is registered more than once.
+#[test]
+fn overlap_repo_in_env_and_global_loads_all_skills_without_duplicates() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let temp = TempDir::new().unwrap();
+        let working_dir = dunce::canonicalize(temp.path()).unwrap();
+
+        // A single repo with three skills, appearing in both the environment
+        // and a global spec that targets only one of them.
+        let shared_repo = working_dir.join("shared-repo");
+        write_skill_file(&shared_repo, "deploy");
+        write_skill_file(&shared_repo, "lint");
+        write_skill_file(&shared_repo, "test-cmd");
+
+        // Index the repo so `load_environment_skills` can scan it.
+        let shared_repo_std = StandardizedPath::from_local_canonicalized(&shared_repo).unwrap();
+        let repo_handle = DirectoryWatcher::handle(&app).update(&mut app, |watcher, ctx| {
+            watcher.add_directory(shared_repo_std.clone(), ctx).unwrap()
+        });
+        let (indexed_tx, indexed_rx) = futures::channel::oneshot::channel::<()>();
+        let tx_cell = std::rc::Rc::new(std::cell::RefCell::new(Some(indexed_tx)));
+        let shared_repo_for_event = shared_repo_std.clone();
+        app.update(|ctx| {
+            let tx_cell = tx_cell.clone();
+            ctx.subscribe_to_model(
+                &RepoMetadataModel::handle(ctx),
+                move |_, event: &RepoMetadataEvent, _ctx| {
+                    if let RepoMetadataEvent::RepositoryUpdated {
+                        id: RepositoryIdentifier::Local(path),
+                    } = event
+                    {
+                        if *path == shared_repo_for_event {
+                            if let Some(tx) = tx_cell.borrow_mut().take() {
+                                let _ = tx.send(());
+                            }
+                        }
+                    }
+                },
+            );
+        });
+        RepoMetadataModel::handle(&app).update(&mut app, |model: &mut RepoMetadataModel, ctx| {
+            model.index_directory(repo_handle, ctx).unwrap();
+        });
+        indexed_rx.await.expect("shared repo should be indexed");
+
+        let terminal_view = add_window_with_terminal(&mut app, None);
+        let driver_handle = app.add_model(|ctx| {
+            let terminal_driver =
+                super::terminal::TerminalDriver::create_from_existing_view(terminal_view, ctx);
+            AgentDriver::new_for_test(working_dir.clone(), terminal_driver, ctx)
+        });
+
+        // The same repo is listed in both env repos and global repos.
+        // The global spec targets only "deploy".
+        let (done_tx, done_rx) = futures::channel::oneshot::channel::<()>();
+        let env_repos = vec![GithubRepo::new(
+            "org".to_string(),
+            "shared-repo".to_string(),
+        )];
+        let global_repos = vec![GithubRepo::new(
+            "org".to_string(),
+            "shared-repo".to_string(),
+        )];
+        let global_specs: Vec<SkillSpec> = ["org/shared-repo:deploy".to_string()]
+            .iter()
+            .map(|s| s.parse().unwrap())
+            .collect();
+        driver_handle.update(&mut app, |_, ctx| {
+            let spawner = ctx.spawner();
+            ctx.spawn(
+                async move {
+                    AgentDriver::load_environment_skills(&spawner, env_repos).await;
+                    AgentDriver::load_global_skills(&spawner, global_specs, global_repos).await;
+                    let _ = done_tx.send(());
+                },
+                |_, _, _| {},
+            );
+        });
+        done_rx.await.expect("loading task should complete");
+
+        let skill_names = SkillManager::handle(&app).read(&app, |manager: &SkillManager, ctx| {
+            manager
+                .get_skills_for_working_directory(None, ctx)
+                .into_iter()
+                .map(|s| s.name.clone())
+                .collect::<Vec<_>>()
+        });
+
+        // All three skills from the repo are present (env loading wins).
+        assert!(
+            skill_names.contains(&"deploy".to_string()),
+            "'deploy' should be loaded; got: {skill_names:?}"
+        );
+        assert!(
+            skill_names.contains(&"lint".to_string()),
+            "'lint' should be loaded; got: {skill_names:?}"
+        );
+        assert!(
+            skill_names.contains(&"test-cmd".to_string()),
+            "'test-cmd' should be loaded; got: {skill_names:?}"
+        );
+
+        // No skill is duplicated.
+        let deploy_count = skill_names.iter().filter(|n| *n == "deploy").count();
+        assert_eq!(
+            deploy_count, 1,
+            "'deploy' should appear exactly once; got: {skill_names:?}"
+        );
+    });
+}
+
+/// Write a minimal SKILL.md at `{repo}/.agents/skills/{name}/SKILL.md`.
+/// The name is derived from the parent directory name, so no frontmatter is required.
+fn write_skill_file(repo: &Path, name: &str) {
+    let skill_dir = repo.join(".agents").join("skills").join(name);
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), format!("Skill: {name}.")).unwrap();
 }

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -9,16 +9,18 @@ use warp_cli::{
 use warp_core::channel::ChannelState;
 
 use super::{
-    build_secret_env_vars, IdleTimeoutSender, LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV,
-    LEGACY_OZ_PARENT_STATE_ROOT_ENV, OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV,
-    OZ_MESSAGE_LISTENER_STATE_ROOT_ENV,
+    AgentDriver, build_secret_env_vars, IdleTimeoutSender, SkillRepoLoadMode,
+    LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV, LEGACY_OZ_PARENT_STATE_ROOT_ENV,
+    OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV, OZ_MESSAGE_LISTENER_STATE_ROOT_ENV,
 };
 use crate::ai::agent::{
     task::TaskId, AIAgentActionResult, AIAgentActionResultType, AIAgentInput, AIAgentOutput,
     AIAgentOutputMessage, ArtifactCreatedData, MessageId, UploadArtifactResult,
 };
 use crate::ai::mcp::parsing::normalize_mcp_json;
-use crate::ai::{agent_sdk::task_env_vars, ambient_agents::AmbientAgentTaskId};
+use crate::ai::{
+    agent_sdk::task_env_vars, ambient_agents::AmbientAgentTaskId, cloud_environments::GithubRepo,
+};
 use warp_managed_secrets::ManagedSecretValue;
 
 #[test]
@@ -176,6 +178,62 @@ fn idle_timeout_sender_later_send_after_supersedes_earlier() {
 
     std::thread::sleep(Duration::from_millis(100));
     assert_eq!(rx.try_recv().unwrap(), Some(2));
+}
+
+#[test]
+fn skill_repo_load_requests_loads_all_environment_repos() {
+    let environment_repo = github_repo("warpdotdev", "warp-internal");
+    let global_repo = github_repo("warpdotdev", "warp-skills");
+    let global_specs = vec![
+        skill_spec("warpdotdev/warp-internal:env-skill"),
+        skill_spec("warpdotdev/warp-skills:global-skill"),
+    ];
+
+    let requests = AgentDriver::skill_repo_load_requests(
+        vec![environment_repo.clone()],
+        vec![environment_repo.clone(), global_repo.clone()],
+        &global_specs,
+    );
+
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].repo, environment_repo);
+    assert!(matches!(&requests[0].load_mode, SkillRepoLoadMode::All));
+    assert_eq!(requests[1].repo, global_repo);
+    let SkillRepoLoadMode::ExplicitGlobal(specs) = &requests[1].load_mode else {
+        panic!("expected explicit global skill load mode");
+    };
+    assert_eq!(specs.len(), 1);
+    assert_eq!(specs[0].skill_identifier, "global-skill");
+}
+
+#[test]
+fn skill_repo_load_requests_filters_global_only_repos_to_matching_specs() {
+    let first_repo = github_repo("warpdotdev", "warp-skills");
+    let second_repo = github_repo("warpdotdev", "warp-server-skills");
+    let global_specs = vec![
+        skill_spec("warpdotdev/warp-skills:first"),
+        skill_spec("warpdotdev/warp-server-skills:second"),
+        skill_spec("warpdotdev/warp-skills:third"),
+    ];
+
+    let requests = AgentDriver::skill_repo_load_requests(
+        Vec::new(),
+        vec![first_repo.clone(), second_repo],
+        &global_specs,
+    );
+
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].repo, first_repo);
+    let SkillRepoLoadMode::ExplicitGlobal(specs) = &requests[0].load_mode else {
+        panic!("expected explicit global skill load mode");
+    };
+    assert_eq!(
+        specs
+            .iter()
+            .map(|spec| spec.skill_identifier.as_str())
+            .collect::<Vec<_>>(),
+        vec!["first", "third"]
+    );
 }
 
 #[test]
@@ -386,6 +444,14 @@ fn json_format_input_omits_filepath_and_description_for_proto_upload_result() {
     assert_eq!(value["size_bytes"], 42);
     assert!(value.get("filepath").is_none());
     assert!(value.get("description").is_none());
+}
+
+fn github_repo(owner: &str, repo: &str) -> GithubRepo {
+    GithubRepo::new(owner.to_string(), repo.to_string())
+}
+
+fn skill_spec(raw: &str) -> warp_cli::skill::SkillSpec {
+    raw.parse().unwrap()
 }
 
 // ── build_secret_env_vars tests ──────────────────────────────────────────────

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -9,7 +9,7 @@ use warp_cli::{
 use warp_core::channel::ChannelState;
 
 use super::{
-    AgentDriver, build_secret_env_vars, IdleTimeoutSender, SkillRepoLoadMode,
+    build_secret_env_vars, AgentDriver, IdleTimeoutSender, SkillRepoLoadMode,
     LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV, LEGACY_OZ_PARENT_STATE_ROOT_ENV,
     OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV, OZ_MESSAGE_LISTENER_STATE_ROOT_ENV,
 };

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -9,18 +9,16 @@ use warp_cli::{
 use warp_core::channel::ChannelState;
 
 use super::{
-    build_secret_env_vars, AgentDriver, IdleTimeoutSender, SkillRepoLoadMode,
-    LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV, LEGACY_OZ_PARENT_STATE_ROOT_ENV,
-    OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV, OZ_MESSAGE_LISTENER_STATE_ROOT_ENV,
+    build_secret_env_vars, IdleTimeoutSender, LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV,
+    LEGACY_OZ_PARENT_STATE_ROOT_ENV, OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV,
+    OZ_MESSAGE_LISTENER_STATE_ROOT_ENV,
 };
 use crate::ai::agent::{
     task::TaskId, AIAgentActionResult, AIAgentActionResultType, AIAgentInput, AIAgentOutput,
     AIAgentOutputMessage, ArtifactCreatedData, MessageId, UploadArtifactResult,
 };
 use crate::ai::mcp::parsing::normalize_mcp_json;
-use crate::ai::{
-    agent_sdk::task_env_vars, ambient_agents::AmbientAgentTaskId, cloud_environments::GithubRepo,
-};
+use crate::ai::{agent_sdk::task_env_vars, ambient_agents::AmbientAgentTaskId};
 use warp_managed_secrets::ManagedSecretValue;
 
 #[test]
@@ -178,62 +176,6 @@ fn idle_timeout_sender_later_send_after_supersedes_earlier() {
 
     std::thread::sleep(Duration::from_millis(100));
     assert_eq!(rx.try_recv().unwrap(), Some(2));
-}
-
-#[test]
-fn skill_repo_load_requests_loads_all_environment_repos() {
-    let environment_repo = github_repo("warpdotdev", "warp-internal");
-    let global_repo = github_repo("warpdotdev", "warp-skills");
-    let global_specs = vec![
-        skill_spec("warpdotdev/warp-internal:env-skill"),
-        skill_spec("warpdotdev/warp-skills:global-skill"),
-    ];
-
-    let requests = AgentDriver::skill_repo_load_requests(
-        vec![environment_repo.clone()],
-        vec![environment_repo.clone(), global_repo.clone()],
-        &global_specs,
-    );
-
-    assert_eq!(requests.len(), 2);
-    assert_eq!(requests[0].repo, environment_repo);
-    assert!(matches!(&requests[0].load_mode, SkillRepoLoadMode::All));
-    assert_eq!(requests[1].repo, global_repo);
-    let SkillRepoLoadMode::ExplicitGlobal(specs) = &requests[1].load_mode else {
-        panic!("expected explicit global skill load mode");
-    };
-    assert_eq!(specs.len(), 1);
-    assert_eq!(specs[0].skill_identifier, "global-skill");
-}
-
-#[test]
-fn skill_repo_load_requests_filters_global_only_repos_to_matching_specs() {
-    let first_repo = github_repo("warpdotdev", "warp-skills");
-    let second_repo = github_repo("warpdotdev", "warp-server-skills");
-    let global_specs = vec![
-        skill_spec("warpdotdev/warp-skills:first"),
-        skill_spec("warpdotdev/warp-server-skills:second"),
-        skill_spec("warpdotdev/warp-skills:third"),
-    ];
-
-    let requests = AgentDriver::skill_repo_load_requests(
-        Vec::new(),
-        vec![first_repo.clone(), second_repo],
-        &global_specs,
-    );
-
-    assert_eq!(requests.len(), 2);
-    assert_eq!(requests[0].repo, first_repo);
-    let SkillRepoLoadMode::ExplicitGlobal(specs) = &requests[0].load_mode else {
-        panic!("expected explicit global skill load mode");
-    };
-    assert_eq!(
-        specs
-            .iter()
-            .map(|spec| spec.skill_identifier.as_str())
-            .collect::<Vec<_>>(),
-        vec!["first", "third"]
-    );
 }
 
 #[test]
@@ -444,14 +386,6 @@ fn json_format_input_omits_filepath_and_description_for_proto_upload_result() {
     assert_eq!(value["size_bytes"], 42);
     assert!(value.get("filepath").is_none());
     assert!(value.get("description").is_none());
-}
-
-fn github_repo(owner: &str, repo: &str) -> GithubRepo {
-    GithubRepo::new(owner.to_string(), repo.to_string())
-}
-
-fn skill_spec(raw: &str) -> warp_cli::skill::SkillSpec {
-    raw.parse().unwrap()
 }
 
 // ── build_secret_env_vars tests ──────────────────────────────────────────────

--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use warpui::{AppContext, SingletonEntity as _};
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GithubRepo {
     /// Repository owner (e.g. "warpdotdev")
     pub owner: String,

--- a/app/src/ai/skills/file_watchers/mod.rs
+++ b/app/src/ai/skills/file_watchers/mod.rs
@@ -4,4 +4,4 @@ mod skill_watcher;
 pub use skill_watcher::{SkillWatcher, SkillWatcherEvent};
 
 mod utils;
-pub use utils::extract_skill_parent_directory;
+pub use utils::{extract_skill_parent_directory, read_skills_from_directories};

--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -25,7 +25,7 @@ use ai::skills::{
 use async_channel::Sender;
 use chrono::{DateTime, Duration, Utc};
 use repo_metadata::{
-    repositories::{DetectedRepositories, RepoDetectionSource},
+    repositories::DetectedRepositories,
     repository::{Repository, SubscriberId},
     DirectoryWatcher, RepoMetadataModel, RepositoryUpdate,
 };
@@ -159,15 +159,11 @@ impl SkillWatcher {
             }
         }
 
-        // Two subscriptions handle different aspects of skill loading:
-        //
-        // 1. RepositoryMetadataEvent::RepositoryUpdated - Loads initial skills from the file tree.
-        //    This fires after the tree is built, so we can query it for skill directories.
-        //
-        // 2. DetectedRepositoriesEvent::DetectedGitRepo - Sets up file watchers for incremental
-        //    updates (add/delete/move). This handles changes after initial load.
-        //
-        // The order of these events doesn't matter - both are idempotent and serve different purposes.
+        // RepositoryMetadataEvent::RepositoryUpdated fires after the file tree is
+        // built, so we can query it for skill directories. This covers both local
+        // project repos and environment repos registered via CloudEnvironmentPrep
+        // (which flow through DetectedRepositories -> DirectoryWatcher ->
+        // RepoMetadataModel).
         ctx.subscribe_to_model(&RepoMetadataModel::handle(ctx), |me, event, ctx| {
             use repo_metadata::wrapper_model::RepoMetadataEvent;
             use repo_metadata::RepositoryIdentifier;
@@ -188,27 +184,6 @@ impl SkillWatcher {
                 | RepoMetadataEvent::FileTreeUpdated { .. }
                 | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
                 | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
-            }
-        });
-
-        // Subscribe to DetectedRepositories to watch repos registered via CloudEnvironmentPrep.
-        // This fires when AgentDriver calls prepare_environment (for any run with a configured
-        // environment, Warp-hosted or self-hosted). The CloudEnvironmentPrep source filter means
-        // this is a no-op on local runs where no environment is configured.
-        ctx.subscribe_to_model(&DetectedRepositories::handle(ctx), |me, event, ctx| {
-            use repo_metadata::repositories::DetectedRepositoriesEvent;
-            match event {
-                DetectedRepositoriesEvent::DetectedGitRepo { source, .. }
-                    if *source == RepoDetectionSource::CloudEnvironmentPrep =>
-                {
-                    // The repo root is already registered in DirectoryWatcher by the time
-                    // this event fires. Extract its path from the repository handle.
-                    let DetectedRepositoriesEvent::DetectedGitRepo { repository, .. } = event;
-                    let repo_path = repository.as_ref(ctx).root_dir().to_local_path_lossy();
-                    me.watch_repo(repo_path.clone(), ctx);
-                    me.scan_repository_for_skills(&repo_path, ctx);
-                }
-                DetectedRepositoriesEvent::DetectedGitRepo { .. } => {}
             }
         });
 

--- a/app/src/ai/skills/global_skills.rs
+++ b/app/src/ai/skills/global_skills.rs
@@ -1,0 +1,42 @@
+//! Helpers for resolving service-account "global" skill specs into repos to
+//! ensure are available on disk before agent runs.
+
+use std::{collections::BTreeSet, str::FromStr};
+
+use warp_cli::skill::SkillSpec;
+
+use crate::ai::cloud_environments::GithubRepo;
+
+/// Parse raw skill spec strings into the unique set of GitHub repos they reference.
+///
+/// Specs that fail to parse are logged and skipped. Specs without an org/repo
+/// qualifier are not cloneable, so they are skipped here and left to normal
+/// on-disk skill discovery.
+pub fn resolve_skill_repos(specs: &[String]) -> Vec<GithubRepo> {
+    let mut seen = BTreeSet::new();
+    let mut repos = Vec::new();
+
+    for raw in specs {
+        let spec = match SkillSpec::from_str(raw) {
+            Ok(spec) => spec,
+            Err(err) => {
+                log::warn!("Failed to parse global skill spec '{raw}': {err}");
+                continue;
+            }
+        };
+
+        let (Some(org), Some(repo)) = (spec.org.as_ref(), spec.repo.as_ref()) else {
+            continue;
+        };
+
+        if seen.insert((org.clone(), repo.clone())) {
+            repos.push(GithubRepo::new(org.clone(), repo.clone()));
+        }
+    }
+
+    repos
+}
+
+#[cfg(test)]
+#[path = "global_skills_tests.rs"]
+mod tests;

--- a/app/src/ai/skills/global_skills.rs
+++ b/app/src/ai/skills/global_skills.rs
@@ -1,30 +1,42 @@
 //! Helpers for resolving service-account "global" skill specs into repos to
 //! ensure are available on disk before agent runs.
 
-use std::{collections::BTreeSet, str::FromStr};
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
+use ai::skills::{provider_rank, ParsedSkill};
 use warp_cli::skill::SkillSpec;
 
 use crate::ai::cloud_environments::GithubRepo;
 
-/// Parse raw skill spec strings into the unique set of GitHub repos they reference.
+/// Parse raw skill spec strings into skill specs.
 ///
-/// Specs that fail to parse are logged and skipped. Specs without an org/repo
-/// qualifier are not cloneable, so they are skipped here and left to normal
-/// on-disk skill discovery.
-pub fn resolve_skill_repos(specs: &[String]) -> Vec<GithubRepo> {
-    let mut seen = BTreeSet::new();
-    let mut repos = Vec::new();
-
-    for raw in specs {
-        let spec = match SkillSpec::from_str(raw) {
-            Ok(spec) => spec,
+/// Specs that fail to parse are logged and skipped.
+fn parse_global_skill_specs(raw_specs: &[String]) -> Vec<SkillSpec> {
+    raw_specs
+        .iter()
+        .filter_map(|raw| match SkillSpec::from_str(raw) {
+            Ok(spec) => Some(spec),
             Err(err) => {
                 log::warn!("Failed to parse global skill spec '{raw}': {err}");
-                continue;
+                None
             }
-        };
+        })
+        .collect()
+}
 
+/// Parse raw skill spec strings and resolve the unique set of GitHub repos they reference.
+///
+/// Specs without an org/repo qualifier are not cloneable, so they are skipped
+/// for repo resolution and left to normal on-disk skill discovery.
+pub fn resolve_skill_repos(raw_specs: &[String]) -> (Vec<SkillSpec>, Vec<GithubRepo>) {
+    let specs = parse_global_skill_specs(raw_specs);
+    let mut seen = BTreeSet::new();
+    let mut repos = Vec::new();
+    for spec in &specs {
         let (Some(org), Some(repo)) = (spec.org.as_ref(), spec.repo.as_ref()) else {
             continue;
         };
@@ -34,7 +46,74 @@ pub fn resolve_skill_repos(specs: &[String]) -> Vec<GithubRepo> {
         }
     }
 
-    repos
+    (specs, repos)
+}
+
+/// Returns the subset of skills that were explicitly requested by parsed global skill specs.
+///
+/// For simple skill names, this mirrors cached skill resolution by checking parsed skill names
+/// in provider precedence order. For full-path specs, it matches the exact path relative to the
+/// repo root.
+pub fn filter_explicit_global_skills(
+    repo_path: &Path,
+    skills: Vec<ParsedSkill>,
+    specs: &[SkillSpec],
+) -> Vec<ParsedSkill> {
+    if specs.is_empty() || skills.is_empty() {
+        return Vec::new();
+    }
+
+    let skills_by_path = skills
+        .iter()
+        .map(|skill| (skill.path.clone(), skill))
+        .collect::<HashMap<_, _>>();
+    let mut selected_paths = Vec::new();
+    let mut seen_paths = HashSet::new();
+
+    for spec in specs {
+        if let Some(path) = matching_skill_path(repo_path, &skills_by_path, spec) {
+            if seen_paths.insert(path.clone()) {
+                selected_paths.push(path);
+            }
+        }
+    }
+
+    let selected_paths = selected_paths.into_iter().collect::<HashSet<_>>();
+    skills
+        .into_iter()
+        .filter(|skill| selected_paths.contains(&skill.path))
+        .collect()
+}
+
+fn matching_skill_path(
+    repo_path: &Path,
+    skills_by_path: &HashMap<PathBuf, &ParsedSkill>,
+    spec: &SkillSpec,
+) -> Option<PathBuf> {
+    if spec.is_full_path() {
+        let path = repo_path.join(&spec.skill_identifier);
+        return skills_by_path.contains_key(&path).then_some(path);
+    }
+    matching_simple_skill_path(repo_path, skills_by_path, &spec.skill_identifier)
+}
+
+fn matching_simple_skill_path(
+    repo_path: &Path,
+    skills_by_path: &HashMap<PathBuf, &ParsedSkill>,
+    skill_name: &str,
+) -> Option<PathBuf> {
+    let mut matches = skills_by_path
+        .values()
+        .copied()
+        .filter(|skill| skill.path.starts_with(repo_path) && skill.name == skill_name)
+        .collect::<Vec<_>>();
+
+    matches.sort_by(|left, right| {
+        provider_rank(left.provider)
+            .cmp(&provider_rank(right.provider))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    matches.into_iter().map(|skill| skill.path.clone()).next()
 }
 
 #[cfg(test)]

--- a/app/src/ai/skills/global_skills.rs
+++ b/app/src/ai/skills/global_skills.rs
@@ -1,5 +1,5 @@
-//! Helpers for resolving service-account "global" skill specs into repos to
-//! ensure are available on disk before agent runs.
+//! Helpers for resolving per-agent "global" skill specs into repos to
+//! ensure are available on disk before the agent runs.
 
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
@@ -12,11 +12,12 @@ use warp_cli::skill::SkillSpec;
 
 use crate::ai::cloud_environments::GithubRepo;
 
-/// Parse raw skill spec strings into skill specs.
+/// Parse raw skill spec strings and resolve the unique set of GitHub repos they reference.
 ///
-/// Specs that fail to parse are logged and skipped.
-fn parse_global_skill_specs(raw_specs: &[String]) -> Vec<SkillSpec> {
-    raw_specs
+/// Specs without an org/repo qualifier are not cloneable, so they are skipped
+/// for repo resolution and left to normal on-disk skill discovery.
+pub fn resolve_skill_repos(raw_specs: &[String]) -> (Vec<SkillSpec>, Vec<GithubRepo>) {
+    let specs: Vec<SkillSpec> = raw_specs
         .iter()
         .filter_map(|raw| match SkillSpec::from_str(raw) {
             Ok(spec) => Some(spec),
@@ -25,15 +26,7 @@ fn parse_global_skill_specs(raw_specs: &[String]) -> Vec<SkillSpec> {
                 None
             }
         })
-        .collect()
-}
-
-/// Parse raw skill spec strings and resolve the unique set of GitHub repos they reference.
-///
-/// Specs without an org/repo qualifier are not cloneable, so they are skipped
-/// for repo resolution and left to normal on-disk skill discovery.
-pub fn resolve_skill_repos(raw_specs: &[String]) -> (Vec<SkillSpec>, Vec<GithubRepo>) {
-    let specs = parse_global_skill_specs(raw_specs);
+        .collect();
     let mut seen = BTreeSet::new();
     let mut repos = Vec::new();
     for spec in &specs {
@@ -49,12 +42,12 @@ pub fn resolve_skill_repos(raw_specs: &[String]) -> (Vec<SkillSpec>, Vec<GithubR
     (specs, repos)
 }
 
-/// Returns the subset of skills that were explicitly requested by parsed global skill specs.
+/// Returns the subset of skills that were explicitly requested by the given skill specs.
 ///
 /// For simple skill names, this mirrors cached skill resolution by checking parsed skill names
 /// in provider precedence order. For full-path specs, it matches the exact path relative to the
 /// repo root.
-pub fn filter_explicit_global_skills(
+pub fn filter_skills_by_spec(
     repo_path: &Path,
     skills: Vec<ParsedSkill>,
     specs: &[SkillSpec],

--- a/app/src/ai/skills/global_skills_tests.rs
+++ b/app/src/ai/skills/global_skills_tests.rs
@@ -1,18 +1,31 @@
-use super::resolve_skill_repos;
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use ai::skills::{get_provider_for_path, ParsedSkill, SkillProvider, SkillScope};
+use warp_cli::skill::SkillSpec;
+
+use super::{filter_explicit_global_skills, resolve_skill_repos};
 use crate::ai::cloud_environments::GithubRepo;
 
 #[test]
 fn resolve_skill_repos_returns_empty_for_empty_input() {
-    assert_eq!(resolve_skill_repos(&[]), Vec::<GithubRepo>::new());
+    let (specs, repos) = resolve_skill_repos(&[]);
+
+    assert!(specs.is_empty());
+    assert_eq!(repos, Vec::<GithubRepo>::new());
 }
 
 #[test]
 fn resolve_skill_repos_skips_parse_failures() {
-    let repos = resolve_skill_repos(&[
+    let (specs, repos) = resolve_skill_repos(&[
         String::new(),
         "warpdotdev/warp-internal:read-google-doc".to_string(),
     ]);
 
+    assert_eq!(specs.len(), 1);
+    assert_eq!(specs[0].skill_identifier, "read-google-doc");
     assert_eq!(
         repos,
         vec![GithubRepo::new(
@@ -24,7 +37,7 @@ fn resolve_skill_repos_skips_parse_failures() {
 
 #[test]
 fn resolve_skill_repos_skips_unqualified_and_repo_only_specs() {
-    let repos = resolve_skill_repos(&[
+    let (_specs, repos) = resolve_skill_repos(&[
         "bare-name".to_string(),
         ".agents/skills/read-google-doc/SKILL.md".to_string(),
         "warp-internal:read-google-doc".to_string(),
@@ -35,7 +48,7 @@ fn resolve_skill_repos_skips_unqualified_and_repo_only_specs() {
 
 #[test]
 fn resolve_skill_repos_collects_org_qualified_repos() {
-    let repos = resolve_skill_repos(&[
+    let (_specs, repos) = resolve_skill_repos(&[
         "warpdotdev/warp-internal:read-google-doc".to_string(),
         "warpdotdev/warp-server:deploy".to_string(),
     ]);
@@ -50,8 +63,111 @@ fn resolve_skill_repos_collects_org_qualified_repos() {
 }
 
 #[test]
+fn filter_explicit_global_skills_only_loads_requested_simple_names() {
+    let repo_path = Path::new("/work/warp-internal");
+    let requested_skill_path = skill_path(repo_path, ".agents", "read-google-doc");
+    let other_skill_path = skill_path(repo_path, ".agents", "deploy");
+    let skills = vec![
+        parsed_skill(requested_skill_path.clone(), "read-google-doc"),
+        parsed_skill(other_skill_path, "deploy"),
+    ];
+    let specs = global_specs(&["warpdotdev/warp-internal:read-google-doc".to_string()]);
+
+    let filtered = filter_explicit_global_skills(repo_path, skills, &specs);
+
+    assert_eq!(skill_paths(filtered), vec![requested_skill_path]);
+}
+
+#[test]
+fn filter_explicit_global_skills_matches_simple_names_by_parsed_skill_name() {
+    let repo_path = Path::new("/work/warp-internal");
+    let requested_skill_path = skill_path(repo_path, ".agents", "google-doc");
+    let directory_name_match_path = skill_path(repo_path, ".agents", "read-google-doc");
+    let skills = vec![
+        parsed_skill(requested_skill_path.clone(), "read-google-doc"),
+        parsed_skill(directory_name_match_path, "unrelated-skill"),
+    ];
+    let specs = global_specs(&["warpdotdev/warp-internal:read-google-doc".to_string()]);
+
+    let filtered = filter_explicit_global_skills(repo_path, skills, &specs);
+
+    assert_eq!(skill_paths(filtered), vec![requested_skill_path]);
+}
+
+#[test]
+fn filter_explicit_global_skills_uses_provider_precedence_for_simple_names() {
+    let repo_path = Path::new("/work/warp-internal");
+    let agents_skill_path = skill_path(repo_path, ".agents", "deploy");
+    let claude_skill_path = skill_path(repo_path, ".claude", "deploy");
+    let skills = vec![
+        parsed_skill(claude_skill_path, "deploy"),
+        parsed_skill(agents_skill_path.clone(), "deploy"),
+    ];
+    let specs = global_specs(&["warpdotdev/warp-internal:deploy".to_string()]);
+
+    let filtered = filter_explicit_global_skills(repo_path, skills, &specs);
+
+    assert_eq!(skill_paths(filtered), vec![agents_skill_path]);
+}
+
+#[test]
+fn filter_explicit_global_skills_matches_full_path_specs() {
+    let repo_path = Path::new("/work/warp-internal");
+    let requested_relative_path = PathBuf::from(".claude")
+        .join("skills")
+        .join("deploy")
+        .join("SKILL.md");
+    let requested_skill_path = repo_path.join(&requested_relative_path);
+    let other_skill_path = skill_path(repo_path, ".agents", "deploy");
+    let skills = vec![
+        parsed_skill(other_skill_path, "deploy"),
+        parsed_skill(requested_skill_path.clone(), "deploy-from-full-path"),
+    ];
+    let specs = global_specs(&[format!(
+        "warpdotdev/warp-internal:{}",
+        requested_relative_path.display()
+    )]);
+
+    let filtered = filter_explicit_global_skills(repo_path, skills, &specs);
+
+    assert_eq!(skill_paths(filtered), vec![requested_skill_path]);
+}
+
+fn global_specs(raw_specs: &[String]) -> Vec<SkillSpec> {
+    raw_specs
+        .iter()
+        .map(|raw| SkillSpec::from_str(raw).unwrap())
+        .collect()
+}
+
+fn skill_path(repo_path: &Path, provider_dir: &str, skill_name: &str) -> PathBuf {
+    repo_path
+        .join(provider_dir)
+        .join("skills")
+        .join(skill_name)
+        .join("SKILL.md")
+}
+
+fn parsed_skill(path: PathBuf, name: &str) -> ParsedSkill {
+    let provider = get_provider_for_path(&path).unwrap_or(SkillProvider::Agents);
+    ParsedSkill {
+        path,
+        name: name.to_string(),
+        description: String::new(),
+        content: String::new(),
+        line_range: None,
+        provider,
+        scope: SkillScope::Project,
+    }
+}
+
+fn skill_paths(skills: Vec<ParsedSkill>) -> Vec<PathBuf> {
+    skills.into_iter().map(|skill| skill.path).collect()
+}
+
+#[test]
 fn resolve_skill_repos_collapses_duplicates_preserving_first_seen_order() {
-    let repos = resolve_skill_repos(&[
+    let (_specs, repos) = resolve_skill_repos(&[
         "org-b/foo:first".to_string(),
         "org-a/foo:second".to_string(),
         "org-b/foo:third".to_string(),

--- a/app/src/ai/skills/global_skills_tests.rs
+++ b/app/src/ai/skills/global_skills_tests.rs
@@ -1,0 +1,67 @@
+use super::resolve_skill_repos;
+use crate::ai::cloud_environments::GithubRepo;
+
+#[test]
+fn resolve_skill_repos_returns_empty_for_empty_input() {
+    assert_eq!(resolve_skill_repos(&[]), Vec::<GithubRepo>::new());
+}
+
+#[test]
+fn resolve_skill_repos_skips_parse_failures() {
+    let repos = resolve_skill_repos(&[
+        String::new(),
+        "warpdotdev/warp-internal:read-google-doc".to_string(),
+    ]);
+
+    assert_eq!(
+        repos,
+        vec![GithubRepo::new(
+            "warpdotdev".to_string(),
+            "warp-internal".to_string(),
+        )]
+    );
+}
+
+#[test]
+fn resolve_skill_repos_skips_unqualified_and_repo_only_specs() {
+    let repos = resolve_skill_repos(&[
+        "bare-name".to_string(),
+        ".agents/skills/read-google-doc/SKILL.md".to_string(),
+        "warp-internal:read-google-doc".to_string(),
+    ]);
+
+    assert_eq!(repos, Vec::<GithubRepo>::new());
+}
+
+#[test]
+fn resolve_skill_repos_collects_org_qualified_repos() {
+    let repos = resolve_skill_repos(&[
+        "warpdotdev/warp-internal:read-google-doc".to_string(),
+        "warpdotdev/warp-server:deploy".to_string(),
+    ]);
+
+    assert_eq!(
+        repos,
+        vec![
+            GithubRepo::new("warpdotdev".to_string(), "warp-internal".to_string()),
+            GithubRepo::new("warpdotdev".to_string(), "warp-server".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn resolve_skill_repos_collapses_duplicates_preserving_first_seen_order() {
+    let repos = resolve_skill_repos(&[
+        "org-b/foo:first".to_string(),
+        "org-a/foo:second".to_string(),
+        "org-b/foo:third".to_string(),
+    ]);
+
+    assert_eq!(
+        repos,
+        vec![
+            GithubRepo::new("org-b".to_string(), "foo".to_string()),
+            GithubRepo::new("org-a".to_string(), "foo".to_string()),
+        ]
+    );
+}

--- a/app/src/ai/skills/global_skills_tests.rs
+++ b/app/src/ai/skills/global_skills_tests.rs
@@ -6,7 +6,7 @@ use std::{
 use ai::skills::{get_provider_for_path, ParsedSkill, SkillProvider, SkillScope};
 use warp_cli::skill::SkillSpec;
 
-use super::{filter_explicit_global_skills, resolve_skill_repos};
+use super::{filter_skills_by_spec, resolve_skill_repos};
 use crate::ai::cloud_environments::GithubRepo;
 
 #[test]
@@ -63,7 +63,7 @@ fn resolve_skill_repos_collects_org_qualified_repos() {
 }
 
 #[test]
-fn filter_explicit_global_skills_only_loads_requested_simple_names() {
+fn filter_skills_by_spec_only_loads_requested_simple_names() {
     let repo_path = Path::new("/work/warp-internal");
     let requested_skill_path = skill_path(repo_path, ".agents", "read-google-doc");
     let other_skill_path = skill_path(repo_path, ".agents", "deploy");
@@ -73,13 +73,13 @@ fn filter_explicit_global_skills_only_loads_requested_simple_names() {
     ];
     let specs = global_specs(&["warpdotdev/warp-internal:read-google-doc".to_string()]);
 
-    let filtered = filter_explicit_global_skills(repo_path, skills, &specs);
+    let filtered = filter_skills_by_spec(repo_path, skills, &specs);
 
     assert_eq!(skill_paths(filtered), vec![requested_skill_path]);
 }
 
 #[test]
-fn filter_explicit_global_skills_matches_simple_names_by_parsed_skill_name() {
+fn filter_skills_by_spec_matches_simple_names_by_parsed_skill_name() {
     let repo_path = Path::new("/work/warp-internal");
     let requested_skill_path = skill_path(repo_path, ".agents", "google-doc");
     let directory_name_match_path = skill_path(repo_path, ".agents", "read-google-doc");
@@ -89,13 +89,13 @@ fn filter_explicit_global_skills_matches_simple_names_by_parsed_skill_name() {
     ];
     let specs = global_specs(&["warpdotdev/warp-internal:read-google-doc".to_string()]);
 
-    let filtered = filter_explicit_global_skills(repo_path, skills, &specs);
+    let filtered = filter_skills_by_spec(repo_path, skills, &specs);
 
     assert_eq!(skill_paths(filtered), vec![requested_skill_path]);
 }
 
 #[test]
-fn filter_explicit_global_skills_uses_provider_precedence_for_simple_names() {
+fn filter_skills_by_spec_uses_provider_precedence_for_simple_names() {
     let repo_path = Path::new("/work/warp-internal");
     let agents_skill_path = skill_path(repo_path, ".agents", "deploy");
     let claude_skill_path = skill_path(repo_path, ".claude", "deploy");
@@ -105,13 +105,13 @@ fn filter_explicit_global_skills_uses_provider_precedence_for_simple_names() {
     ];
     let specs = global_specs(&["warpdotdev/warp-internal:deploy".to_string()]);
 
-    let filtered = filter_explicit_global_skills(repo_path, skills, &specs);
+    let filtered = filter_skills_by_spec(repo_path, skills, &specs);
 
     assert_eq!(skill_paths(filtered), vec![agents_skill_path]);
 }
 
 #[test]
-fn filter_explicit_global_skills_matches_full_path_specs() {
+fn filter_skills_by_spec_matches_full_path_specs() {
     let repo_path = Path::new("/work/warp-internal");
     let requested_relative_path = PathBuf::from(".claude")
         .join("skills")
@@ -128,7 +128,7 @@ fn filter_explicit_global_skills_matches_full_path_specs() {
         requested_relative_path.display()
     )]);
 
-    let filtered = filter_explicit_global_skills(repo_path, skills, &specs);
+    let filtered = filter_skills_by_spec(repo_path, skills, &specs);
 
     assert_eq!(skill_paths(filtered), vec![requested_skill_path]);
 }

--- a/app/src/ai/skills/mod.rs
+++ b/app/src/ai/skills/mod.rs
@@ -11,7 +11,7 @@ cfg_if::cfg_if! {
 pub use ai::skills::SkillReference;
 
 mod global_skills;
-pub use global_skills::resolve_skill_repos;
+pub use global_skills::{filter_explicit_global_skills, resolve_skill_repos};
 
 mod listed_skill;
 pub use listed_skill::SkillDescriptor;

--- a/app/src/ai/skills/mod.rs
+++ b/app/src/ai/skills/mod.rs
@@ -10,6 +10,9 @@ cfg_if::cfg_if! {
 
 pub use ai::skills::SkillReference;
 
+mod global_skills;
+pub use global_skills::resolve_skill_repos;
+
 mod listed_skill;
 pub use listed_skill::SkillDescriptor;
 

--- a/app/src/ai/skills/mod.rs
+++ b/app/src/ai/skills/mod.rs
@@ -10,8 +10,10 @@ cfg_if::cfg_if! {
 
 pub use ai::skills::SkillReference;
 
+#[cfg(not(target_family = "wasm"))]
 mod global_skills;
-pub use global_skills::{filter_explicit_global_skills, resolve_skill_repos};
+#[cfg(not(target_family = "wasm"))]
+pub use global_skills::{filter_skills_by_spec, resolve_skill_repos};
 
 mod listed_skill;
 pub use listed_skill::SkillDescriptor;
@@ -32,6 +34,6 @@ pub use resolve_skill_spec::{
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
         mod skill_manager;
-        pub use skill_manager::{SkillManager, SkillWatcher};
+        pub use skill_manager::{read_skills_from_directories, SkillManager, SkillWatcher};
     }
 }

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -1,7 +1,9 @@
 #[path = "file_watchers/mod.rs"]
 mod file_watchers;
 use crate::ai::mcp::{McpIntegration, TemplatableMCPServerManager};
-pub use file_watchers::{extract_skill_parent_directory, SkillWatcher, SkillWatcherEvent};
+pub use file_watchers::{
+    extract_skill_parent_directory, read_skills_from_directories, SkillWatcher, SkillWatcherEvent,
+};
 
 use std::{
     collections::{HashMap, HashSet},

--- a/app/src/auth/auth_state.rs
+++ b/app/src/auth/auth_state.rs
@@ -215,6 +215,7 @@ impl AuthState {
             linked_at: persisted.linked_at,
             personal_object_limits: persisted.personal_object_limits,
             principal_type: PrincipalType::default(),
+            global_skills: Vec::new(),
         };
         *self.user.write() = Some(user);
 
@@ -541,6 +542,15 @@ impl AuthState {
     /// Returns whether the authenticated principal is a service account.
     pub fn is_service_account(&self) -> bool {
         matches!(self.principal_type(), Some(PrincipalType::ServiceAccount))
+    }
+
+    /// Returns the cached global skill specs for the current user.
+    pub fn global_skills(&self) -> Vec<String> {
+        self.user
+            .read()
+            .as_ref()
+            .map(|user| user.global_skills.clone())
+            .unwrap_or_default()
     }
 
     /// Returns the owner type of the currently-authenticated API key.

--- a/app/src/auth/auth_state.rs
+++ b/app/src/auth/auth_state.rs
@@ -294,6 +294,7 @@ impl AuthState {
                     linked_at: None,
                     personal_object_limits: None,
                     principal_type: PrincipalType::default(),
+                    global_skills: Vec::new(),
                 });
             }
         }

--- a/app/src/auth/user.rs
+++ b/app/src/auth/user.rs
@@ -100,6 +100,8 @@ pub struct User {
     /// Type of principal (user or service account). Fetched fresh from the server
     /// on each login/refresh.
     pub principal_type: PrincipalType,
+    /// Skill specs that should be available to this principal in every agent run.
+    pub global_skills: Vec<String>,
 }
 
 /// This struct holds extra information about the user. Most of this information comes directly
@@ -181,6 +183,7 @@ impl User {
             linked_at: None,
             personal_object_limits: None,
             principal_type: PrincipalType::User,
+            global_skills: Vec::new(),
         }
     }
 

--- a/app/src/auth/user_tests.rs
+++ b/app/src/auth/user_tests.rs
@@ -23,6 +23,7 @@ fn test_parse_user_profile() -> Result<()> {
         linked_at: None,
         personal_object_limits: None,
         principal_type: PrincipalType::User,
+        global_skills: Vec::new(),
     };
     assert_eq!(user.metadata.display_name.as_deref(), Some("Test User"));
     assert_eq!(user.metadata.email, "test_user@example.com");
@@ -33,4 +34,9 @@ fn test_parse_user_profile() -> Result<()> {
     assert!(user.needs_sso_link);
 
     Ok(())
+}
+
+#[test]
+fn test_user_global_skills_defaults_to_empty() {
+    assert_eq!(User::test().global_skills, Vec::<String>::new());
 }

--- a/app/src/server/server_api/auth.rs
+++ b/app/src/server/server_api/auth.rs
@@ -818,6 +818,7 @@ impl From<GqlUserOutput> for UserProperties {
 
         let is_on_work_domain = user_properties.is_on_work_domain;
         let is_onboarded = user_properties.is_onboarded;
+        let global_skills = user_properties.global_skills;
         let api_key_owner_type = user_output.api_key_owner_type;
 
         let linked_at = user_properties
@@ -854,6 +855,7 @@ impl From<GqlUserOutput> for UserProperties {
             linked_at,
             personal_object_limits: personal_object_limits.and_then(|t| t.try_into().ok()),
             principal_type,
+            global_skills,
         };
 
         UserProperties {

--- a/crates/graphql/src/api/queries/get_user.rs
+++ b/crates/graphql/src/api/queries/get_user.rs
@@ -21,6 +21,7 @@ query GetUser($requestContext: RequestContext!) {
           }
         }
         experiments
+        globalSkills
         isOnWorkDomain
         isOnboarded
         profile {
@@ -134,6 +135,7 @@ pub enum PrincipalType {
 pub struct User {
     pub anonymous_user_info: Option<AnonymousUserInfo>,
     pub experiments: Option<Vec<Experiment>>,
+    pub global_skills: Vec<String>,
     pub is_onboarded: bool,
     pub is_on_work_domain: bool,
     pub profile: FirebaseProfile,

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -3875,6 +3875,7 @@ type User {
   - `[]` means that the user is not part of any server-side enabled experiments.
   """
   experiments: [Experiment!]
+  globalSkills: [String!]!
   githubInstallations: UserGithubInstallationsOutput!
   isOnWorkDomain: Boolean!
   isOnboarded: Boolean!

--- a/specs/REMOTE-1453/PRODUCT.md
+++ b/specs/REMOTE-1453/PRODUCT.md
@@ -1,0 +1,50 @@
+# REMOTE-1453: Resolve service-account global skills at agent driver startup
+## Summary
+Service accounts (a.k.a. agents in the product UI) can have a configured set of "global skill specs" that should be available in every conversation on every device. The server already exposes those specs on `User.globalSkills` (warp-server PR #10799). This spec defines what the client guarantees about those skills at agent run time: namely that, before the agent's first query runs, the SKILL.md files referenced by `globalSkills` are reachable on the agent's filesystem and discoverable by the existing skill machinery.
+## Problem
+Today, an `oz agent run` (local CLI run, sandboxed cloud run, scheduled / triggered run, etc.) only sees skills that:
+- Live in directories already present on disk (`.agents/skills/`, `.warp/skills/`, `.claude/skills/`, `.codex/skills/`).
+- Are explicitly requested via `--skill <SPEC>`. For sandboxed runs, an `org/repo:skill` spec triggers a one-shot clone of `org/repo` into the working directory before resolution.
+There is no mechanism for "this agent always has these skills available" — every run that wants them has to repeat the spec on the command line, and any skill whose source repo is not in the run's environment is silently unavailable.
+## Goals
+- For service-account-authenticated agent runs, ensure that every skill referenced by `User.globalSkills` is discoverable before the agent processes its first query.
+- Reuse the existing skill discovery, parsing, and `--skill` resolution paths — no parallel skill registry.
+- Reuse the existing repo-cloning flow used for cloud-environment repos — no Warp-managed cache directory.
+- Keep behavior unchanged for user (non-service-account) principals: `globalSkills` is empty for them today, so the run looks identical to before this spec.
+## Non-goals
+- A general plugin / skill registry mechanism beyond this one-time-per-run resolution.
+- Cloning skill repos into a Warp-managed cache or data directory, or periodically syncing them outside an agent run.
+- Supporting `globalSkills` for individual users (not service accounts).
+- Changing how `--skill` is resolved at the CLI layer, except to share the same underlying repo-cloning helpers.
+- Periodic or background refresh of the global skill list during a single run; for now, the list is read once at startup.
+## Behavior
+1. When an agent driver starts a run (any of `oz agent run`, scheduled / triggered runs, cloud runs that re-enter the agent driver inside the sandbox) and the principal is a service account, the client reads `User.globalSkills` from the server. The list is a flat `Vec<String>` of skill specs in the same format accepted by `--skill`: `skill_name`, `repo:skill_name`, `org/repo:skill_name`, or full-path variants.
+2. For non-service-account principals, the server returns an empty list and the client treats `globalSkills` as empty. No additional work runs and behavior is identical to today.
+3. If `OzPlatformSkills` is disabled, the client treats `globalSkills` as empty regardless of what the server returns. The feature is gated by the existing platform-skills flag rather than introducing a new one.
+4. Each spec in `globalSkills` is parsed using the existing `SkillSpec` parser. Parse failures are logged at warn level and the offending entry is skipped; the rest of the list still resolves.
+5. The client classifies each parsed spec into one of two buckets:
+   - **Cloneable**: `org/repo:skill` (org-qualified). The repo `org/repo` can be cloned from `https://github.com/org/repo.git` if it is not already present.
+   - **Non-cloneable**: bare `skill_name`, bare `repo:skill_name`, or full-path variants without an org. The client cannot deterministically locate the source repo for these entries, so they are not cloned. They are still passed through to the same resolution path as `--skill` and may resolve if the matching skill is present on disk (e.g. an environment repo already includes it, the user's home skills directory contains it). This matches how `--skill` handles unqualified / repo-only specs today: no implicit clone, fall back to on-disk discovery.
+6. For each cloneable spec, the client computes `(org, repo)` and dedupes the set of repos to clone (multiple skills in the same repo result in one clone).
+7. For each `(org, repo)` pair from step 6:
+   - If a repo with the same `(owner, repo)` is already in the run's cloud environment (`AmbientAgentEnvironment.github_repos`), no extra action is taken; the existing environment-prep flow will clone it. The skill becomes discoverable when the existing post-environment skill load runs.
+   - If a directory at `working_dir/<repo>` already exists and contains a `.git` subdirectory, it is treated as already cloned and reused. No re-clone, no error.
+   - If a directory at `working_dir/<repo>` exists and is not a git repo, the run logs a warning and skips this repo. Other global-skill repos still clone. The agent run does not fail.
+   - Otherwise, the client clones `https://github.com/<org>/<repo>.git` into `working_dir/<repo>` using the same shallow / partial clone semantics already used for environment repos.
+8. Cloning of global-skill repos happens as part of the same repo-cloning step that clones environment repos. From a user's perspective, the setup-commands phase shows one combined cloning step rather than two distinct phases.
+9. After cloning completes, the existing skill scanner picks up SKILL.md files from the newly cloned repos. Specifically, the cloud-environment skill load (`SkillManager::set_cloud_environment(true)` + `read_skills_for_repos`) runs over the union of the environment's `github_repos` and the global-skill repos.
+10. Once skills are loaded, any subsequent skill resolution in the run — `--skill` resolution, slash-command lookups, agent skill listings — sees global skills exactly the same way it sees environment-cloned skills. There is no special "global" badge or precedence; ordering follows the existing skill-directory precedence rules.
+11. Failure modes:
+    - Network failure cloning a global-skill repo: log a warn-level message naming the repo and continue with the rest of the run. The skill is unavailable for this run; the agent's prompt and other skills still execute. (This is a deliberate departure from the existing `--skill` clone path, which surfaces clone failures as run-fatal errors. Global skills are best-effort: a single broken entry should not block the run.)
+    - Failure fetching `User.globalSkills` from the server: log a warn-level message and continue with `globalSkills` treated as empty. The run does not fail.
+    - The same repo appears in `globalSkills` and as an explicit `--skill org/repo:...` argument: the existing `--skill` resolver still wins for the explicit selection; the global-skills clone is a no-op since the repo is already present.
+12. Replays and historical runs: this spec only changes behavior for newly starting agent driver runs. Historical conversations are unaffected; their stored transcripts already reflect whatever skills were available at the time they ran.
+13. Local (non-sandboxed) developer runs as a service account: the same flow applies. Cloned global-skill repos land in `working_dir`, the same place existing `--skill` clones land in sandboxed runs.
+## Edge cases
+1. `globalSkills` contains a duplicate spec (same `org/repo:skill` listed twice). Dedup is by `(org, repo)` for cloning; resolution downstream handles duplicate skill names via existing precedence rules.
+2. `globalSkills` contains two specs that point to different repos but the same `repo` name (e.g. `org-a/foo:x` and `org-b/foo:y`). The first wins for the `working_dir/foo` slot; the second logs a warn-level conflict message and skips its clone. This matches today's `clone_repo_for_skill` behavior, which only ever clones one repo per `repo` directory name. (The existing `--skill` resolver already validates org via the cloned repo's git remote when needed.)
+3. The agent run uses an environment whose `github_repos` already covers every cloneable global skill. The client performs no extra clones and the run looks identical to a normal environment-only run.
+4. The agent run has no environment configured (`AgentDriverOptions.environment == None`). Global-skill repos still clone into `working_dir`. The cloud-environment skill load path is invoked with the global-skill repos as its repo set so the skills are picked up.
+5. The agent run is configured for a non-Oz harness (Claude / Gemini / etc.). Global-skill cloning still occurs (the harness shouldn't influence whether the repo can be made available), but the existing post-environment skill load is Oz-only and remains so. Non-Oz harnesses pick up SKILL.md files via their own discovery (e.g. claude reading `.claude/skills/`) once the repo is cloned, which is the same behavior as for environment repos today.
+6. `working_dir` does not exist (misconfigured run). The existing working-directory check in the agent driver fails first; this spec adds nothing to that path.
+7. The user is logged out / has no credentials at run start. Fetch fails; per (11) we log and continue with empty `globalSkills`.

--- a/specs/REMOTE-1453/PRODUCT.md
+++ b/specs/REMOTE-1453/PRODUCT.md
@@ -1,50 +1,43 @@
 # REMOTE-1453: Resolve service-account global skills at agent driver startup
 ## Summary
-Service accounts (a.k.a. agents in the product UI) can have a configured set of "global skill specs" that should be available in every conversation on every device. The server already exposes those specs on `User.globalSkills` (warp-server PR #10799). This spec defines what the client guarantees about those skills at agent run time: namely that, before the agent's first query runs, the SKILL.md files referenced by `globalSkills` are reachable on the agent's filesystem and discoverable by the existing skill machinery.
+Service accounts can have a configured set of global skill specs that should be available in every Oz agent run. The client resolves those specs at agent-driver startup, clones any org-qualified source repos that are not already on disk, and loads skills before the first query runs.
+Global skills are intentionally not treated as permission to load every skill in their source repos. Repos that are part of the run's environment still use normal environment behavior and autodiscover all skills. Repos cloned only because they contain global skills load only the explicitly requested global skills.
 ## Problem
-Today, an `oz agent run` (local CLI run, sandboxed cloud run, scheduled / triggered run, etc.) only sees skills that:
-- Live in directories already present on disk (`.agents/skills/`, `.warp/skills/`, `.claude/skills/`, `.codex/skills/`).
-- Are explicitly requested via `--skill <SPEC>`. For sandboxed runs, an `org/repo:skill` spec triggers a one-shot clone of `org/repo` into the working directory before resolution.
-There is no mechanism for "this agent always has these skills available" — every run that wants them has to repeat the spec on the command line, and any skill whose source repo is not in the run's environment is silently unavailable.
+Before this work, an `oz agent run` only saw skills that were already present on disk or explicitly requested with `--skill <SPEC>`. Service-account global skills exposed by `User.globalSkills` were not made available automatically, and a repo cloned only to satisfy one global skill could accidentally expose unrelated skills in that repo.
 ## Goals
-- For service-account-authenticated agent runs, ensure that every skill referenced by `User.globalSkills` is discoverable before the agent processes its first query.
-- Reuse the existing skill discovery, parsing, and `--skill` resolution paths — no parallel skill registry.
-- Reuse the existing repo-cloning flow used for cloud-environment repos — no Warp-managed cache directory.
-- Keep behavior unchanged for user (non-service-account) principals: `globalSkills` is empty for them today, so the run looks identical to before this spec.
+- For service-account-authenticated Oz agent runs, make every explicitly requested global skill available before the agent processes its first query.
+- Autodiscover all skills from repositories that are part of the configured environment.
+- For repositories cloned solely as global-skill sources, load only the global skills explicitly listed in `User.globalSkills`.
+- If the same `(owner, repo)` appears both in the environment and in `User.globalSkills`, environment behavior wins and all skills from that repo are autodiscovered.
+- Reuse existing skill parsing, repository cloning, skill watching, and skill manager flows where possible.
+- Keep behavior unchanged for user principals and runs with no global skills.
 ## Non-goals
-- A general plugin / skill registry mechanism beyond this one-time-per-run resolution.
-- Cloning skill repos into a Warp-managed cache or data directory, or periodically syncing them outside an agent run.
-- Supporting `globalSkills` for individual users (not service accounts).
-- Changing how `--skill` is resolved at the CLI layer, except to share the same underlying repo-cloning helpers.
-- Periodic or background refresh of the global skill list during a single run; for now, the list is read once at startup.
+- A general plugin or skill registry mechanism beyond startup-time resolution.
+- A Warp-managed cache directory for cloned skill repositories.
+- Periodic or background refresh of the global skill list during a run.
+- Changing CLI `--skill` resolution semantics.
+- Adding global-skill loading to non-Oz harnesses in this iteration.
 ## Behavior
-1. When an agent driver starts a run (any of `oz agent run`, scheduled / triggered runs, cloud runs that re-enter the agent driver inside the sandbox) and the principal is a service account, the client reads `User.globalSkills` from the server. The list is a flat `Vec<String>` of skill specs in the same format accepted by `--skill`: `skill_name`, `repo:skill_name`, `org/repo:skill_name`, or full-path variants.
-2. For non-service-account principals, the server returns an empty list and the client treats `globalSkills` as empty. No additional work runs and behavior is identical to today.
-3. If `OzPlatformSkills` is disabled, the client treats `globalSkills` as empty regardless of what the server returns. The feature is gated by the existing platform-skills flag rather than introducing a new one.
-4. Each spec in `globalSkills` is parsed using the existing `SkillSpec` parser. Parse failures are logged at warn level and the offending entry is skipped; the rest of the list still resolves.
-5. The client classifies each parsed spec into one of two buckets:
-   - **Cloneable**: `org/repo:skill` (org-qualified). The repo `org/repo` can be cloned from `https://github.com/org/repo.git` if it is not already present.
-   - **Non-cloneable**: bare `skill_name`, bare `repo:skill_name`, or full-path variants without an org. The client cannot deterministically locate the source repo for these entries, so they are not cloned. They are still passed through to the same resolution path as `--skill` and may resolve if the matching skill is present on disk (e.g. an environment repo already includes it, the user's home skills directory contains it). This matches how `--skill` handles unqualified / repo-only specs today: no implicit clone, fall back to on-disk discovery.
-6. For each cloneable spec, the client computes `(org, repo)` and dedupes the set of repos to clone (multiple skills in the same repo result in one clone).
-7. For each `(org, repo)` pair from step 6:
-   - If a repo with the same `(owner, repo)` is already in the run's cloud environment (`AmbientAgentEnvironment.github_repos`), no extra action is taken; the existing environment-prep flow will clone it. The skill becomes discoverable when the existing post-environment skill load runs.
-   - If a directory at `working_dir/<repo>` already exists and contains a `.git` subdirectory, it is treated as already cloned and reused. No re-clone, no error.
-   - If a directory at `working_dir/<repo>` exists and is not a git repo, the run logs a warning and skips this repo. Other global-skill repos still clone. The agent run does not fail.
-   - Otherwise, the client clones `https://github.com/<org>/<repo>.git` into `working_dir/<repo>` using the same shallow / partial clone semantics already used for environment repos.
-8. Cloning of global-skill repos happens as part of the same repo-cloning step that clones environment repos. From a user's perspective, the setup-commands phase shows one combined cloning step rather than two distinct phases.
-9. After cloning completes, the existing skill scanner picks up SKILL.md files from the newly cloned repos. Specifically, the cloud-environment skill load (`SkillManager::set_cloud_environment(true)` + `read_skills_for_repos`) runs over the union of the environment's `github_repos` and the global-skill repos.
-10. Once skills are loaded, any subsequent skill resolution in the run — `--skill` resolution, slash-command lookups, agent skill listings — sees global skills exactly the same way it sees environment-cloned skills. There is no special "global" badge or precedence; ordering follows the existing skill-directory precedence rules.
-11. Failure modes:
-    - Network failure cloning a global-skill repo: log a warn-level message naming the repo and continue with the rest of the run. The skill is unavailable for this run; the agent's prompt and other skills still execute. (This is a deliberate departure from the existing `--skill` clone path, which surfaces clone failures as run-fatal errors. Global skills are best-effort: a single broken entry should not block the run.)
-    - Failure fetching `User.globalSkills` from the server: log a warn-level message and continue with `globalSkills` treated as empty. The run does not fail.
-    - The same repo appears in `globalSkills` and as an explicit `--skill org/repo:...` argument: the existing `--skill` resolver still wins for the explicit selection; the global-skills clone is a no-op since the repo is already present.
-12. Replays and historical runs: this spec only changes behavior for newly starting agent driver runs. Historical conversations are unaffected; their stored transcripts already reflect whatever skills were available at the time they ran.
-13. Local (non-sandboxed) developer runs as a service account: the same flow applies. Cloned global-skill repos land in `working_dir`, the same place existing `--skill` clones land in sandboxed runs.
+1. When an Oz agent driver starts, it reads the cached `User.globalSkills` list. The list uses the same skill spec format accepted by `--skill`: `skill_name`, `repo:skill_name`, `org/repo:skill_name`, or full-path variants.
+2. If `OzPlatformSkills` is disabled, the client treats `globalSkills` as empty and bypasses the flow.
+3. Each raw global skill string is parsed with the existing `SkillSpec` parser. Parse failures are logged at warn level and skipped; the rest of the list still resolves.
+4. Specs without an org-qualified repository are not cloneable, so they do not add any repository to the global-skill clone set. They may still resolve through normal on-disk skill discovery if the skill is already present.
+5. Specs with an `org/repo` qualifier contribute `(org, repo)` to the global-skill repo set. Multiple specs for the same `(org, repo)` result in one clone attempt and retain the explicit specs for later filtering.
+6. Global-skill repos are cloned best-effort into `working_dir/<repo>` using the same environment clone helper and partial-clone behavior as environment repos. If the target repo already exists, it is reused. If a clone fails, the run logs a warning and continues without those global-only skills.
+7. Environment preparation still clones the environment's `github_repos`, runs setup commands, and performs its normal repo registration. If a global-skill repo and an environment repo share the same `(owner, repo)`, whichever clone path reaches disk first is reused by the other path.
+8. Skill loading is classified by source:
+   - Environment repos: scan and load all discovered `SKILL.md` files.
+   - Global-only repos: scan the repo tree, then keep only skills whose parsed names or explicit paths match the global skill specs for that repo.
+   - Overlapping repos: treat the repo as an environment repo, so all skills are loaded.
+9. For simple global skill names such as `org/repo:deploy`, filtering matches parsed skill names and mirrors normal provider precedence when multiple providers define the same name. For full-path specs, filtering matches the exact path relative to the repo root.
+10. Once loaded, the selected skills participate in the existing `SkillManager` flow. There is no separate global-skill registry or global-skill badge.
+11. The flow is Oz-only for now. Non-Oz harnesses keep their existing behavior.
+12. Historical conversations are unaffected; they retain whatever skills were available when they ran.
 ## Edge cases
-1. `globalSkills` contains a duplicate spec (same `org/repo:skill` listed twice). Dedup is by `(org, repo)` for cloning; resolution downstream handles duplicate skill names via existing precedence rules.
-2. `globalSkills` contains two specs that point to different repos but the same `repo` name (e.g. `org-a/foo:x` and `org-b/foo:y`). The first wins for the `working_dir/foo` slot; the second logs a warn-level conflict message and skips its clone. This matches today's `clone_repo_for_skill` behavior, which only ever clones one repo per `repo` directory name. (The existing `--skill` resolver already validates org via the cloned repo's git remote when needed.)
-3. The agent run uses an environment whose `github_repos` already covers every cloneable global skill. The client performs no extra clones and the run looks identical to a normal environment-only run.
-4. The agent run has no environment configured (`AgentDriverOptions.environment == None`). Global-skill repos still clone into `working_dir`. The cloud-environment skill load path is invoked with the global-skill repos as its repo set so the skills are picked up.
-5. The agent run is configured for a non-Oz harness (Claude / Gemini / etc.). Global-skill cloning still occurs (the harness shouldn't influence whether the repo can be made available), but the existing post-environment skill load is Oz-only and remains so. Non-Oz harnesses pick up SKILL.md files via their own discovery (e.g. claude reading `.claude/skills/`) once the repo is cloned, which is the same behavior as for environment repos today.
-6. `working_dir` does not exist (misconfigured run). The existing working-directory check in the agent driver fails first; this spec adds nothing to that path.
-7. The user is logged out / has no credentials at run start. Fetch fails; per (11) we log and continue with empty `globalSkills`.
+1. Duplicate global skill specs: cloning is deduped by `(org, repo)` and skill filtering dedupes by selected skill path.
+2. Multiple global skills in one global-only repo: only those explicit skills load; unrelated skills in the same repo do not.
+3. A repo appears both in the environment and in `globalSkills`: all skills from that repo load because the environment classification wins.
+4. No environment configured: cloneable global-skill repos still clone into `working_dir`, but only explicitly requested global skills load from those repos.
+5. A global skill references a missing or inaccessible repo: the clone warning is logged, and the run continues without that repo's global-only skills.
+6. A non-cloneable global skill spec is present: no repo is cloned for it, and it only resolves if the skill is already discoverable on disk.
+7. `working_dir` does not exist: the existing agent-driver working-directory check fails before this flow changes anything.

--- a/specs/REMOTE-1453/TECH.md
+++ b/specs/REMOTE-1453/TECH.md
@@ -1,0 +1,179 @@
+# REMOTE-1453: Tech Spec — Resolve service-account global skills at agent driver startup
+## Context
+The product behavior is defined in `specs/REMOTE-1453/PRODUCT.md`. This spec covers how to plug global-skill resolution into the existing agent-driver startup, the GraphQL plumbing for the new `User.globalSkills` field, and how to share the existing repo-cloning code path so we do not introduce a parallel skill registry.
+The relevant existing pieces:
+- Server: `User.globalSkills: [String!]!` on the GraphQL schema and `logic.GetGlobalSkillSpecsForPrincipal` (warp-server PR #10799).
+- Client GraphQL fetch: `crates/graphql/src/api/queries/get_user.rs:107-141` defines `GetUser` and the `User` fragment. `app/src/server/server_api/auth.rs:282-379` runs `fetch_user_properties` / `fetch_user`.
+- Client user model: `app/src/auth/user.rs:79-103` (`User` struct), `app/src/auth/auth_state.rs:453-461` (`AuthState::is_service_account`).
+- Skill spec parsing and resolution:
+  - `crates/warp_cli/src/skill.rs` — `SkillSpec`, `SkillSpec::from_str`, `is_full_path`, `with_org_and_repo`.
+  - `app/src/ai/skills/resolve_skill_spec.rs:139-204` — `clone_repo_for_skill(org, repo, working_dir)` clones `https://github.com/<org>/<repo>.git` into `working_dir/<repo>` and is idempotent when the directory already contains a git repo.
+  - `app/src/ai/skills/mod.rs:22-27` — re-exports `clone_repo_for_skill`, `resolve_skill_spec`, etc.
+- Agent driver startup:
+  - `app/src/ai/agent_sdk/mod.rs:540-667` (`AgentDriverRunner::setup_and_run_driver`) drives the run: `refresh_team_metadata` → `refresh_warp_drive` → `build_driver_options_and_task` → `resolve_environment` → `create_and_run_driver`.
+  - `app/src/ai/agent_sdk/mod.rs:683-726` (`resolve_skill`) is the existing `--skill` resolution, including the sandboxed-mode `clone_repo_for_skill` call.
+  - `app/src/ai/agent_sdk/driver.rs:200-228` (`AgentDriverOptions`) — what the `AgentDriver` is constructed with.
+  - `app/src/ai/agent_sdk/driver.rs:1216-1333` — the section of `run_internal` that loads the environment, calls `prepare_environment`, then runs the Oz-only `SkillWatcher::read_skills_for_repos` over `environment.github_repos`.
+- Environment preparation:
+  - `app/src/ai/cloud_environments/mod.rs:21-39, 85-147` — `GithubRepo { owner, repo }` and `AmbientAgentEnvironment.github_repos`.
+  - `app/src/ai/agent_sdk/driver/environment.rs:52-303` — `prepare_environment` loops over `github_repos`, clones each via `git clone --filter=tree:0`, registers them with `DetectedRepositories`, runs setup commands, optionally `cd`s into a single repo. Also includes the `is_sandbox` parameter that gates host-side detection.
+- Feature flag: `FeatureFlag::OzPlatformSkills` (`crates/warp_features/src/lib.rs:659`).
+## Current state
+- `User.globalSkills` is exposed by the server but the client does not request it; the field is invisible to the agent driver today.
+- `AgentDriver::run_internal` only clones `environment.github_repos` and only loads skills from those repos.
+- `clone_repo_for_skill` is the only existing client-side helper that clones a GitHub repo for skill purposes. It is invoked exactly once today, in `resolve_skill` for sandboxed `--skill <org/repo:...>` runs. It does the right thing for our needs (HTTPS clone, skip-if-already-git, error if non-git directory) but it does not honor the partial-clone optimization used by `prepare_environment`.
+## Proposed changes
+### 1. Extend the `GetUser` GraphQL query
+`crates/graphql/src/api/queries/get_user.rs`
+- Add `global_skills: Vec<String>` to the `User` fragment (server already exposes the field as non-null `[String!]!`).
+- Update the embedded query string in the `/* query GetUser ... */` doc comment to include `globalSkills` next to `experiments`, `is_onboarded`, etc.
+This is a single-line schema-shape change; cynic regenerates types via the existing `./script/codegen` flow.
+### 2. Plumb `global_skills` into the auth `User` model
+`app/src/auth/user.rs`
+- Add `pub global_skills: Vec<String>` to `User` (alongside `principal_type`).
+- Default to empty in `User::test()` and any other constructors.
+- Update the `From<warp_graphql::queries::get_user::User>`-style conversion in the `auth_state.rs` / `auth/user.rs` boundary so `global_skills` carries through. (The `UserProperties::user` shape is built in `app/src/server/server_api/auth.rs` around line 295-300 and friends; trace and forward the new field there.)
+- The agent driver reads the field directly off `User` via `AuthStateProvider::as_ref(ctx).get().user.read().as_ref().map(|u| u.global_skills.clone()).unwrap_or_default()`. No new `AuthState` accessor is added.
+### 3. New module: `app/src/ai/skills/global_skills.rs`
+A small module that owns parsing skill specs into a deduped list of GitHub repos. Re-export through `app/src/ai/skills/mod.rs`.
+```rust path=null start=null
+//! Helpers for resolving service-account "global" skill specs into repos to
+//! ensure are available on disk before agent runs.
+
+use std::collections::BTreeSet;
+
+use warp_cli::skill::SkillSpec;
+
+use crate::ai::cloud_environments::GithubRepo;
+
+/// Parse a list of raw skill spec strings into the unique set of GitHub repos
+/// they reference.
+///
+/// - Specs that fail to parse are logged at warn level and skipped.
+/// - Specs without an `org/repo` qualifier produce no repo (they fall back to
+///   on-disk discovery in the existing skill resolver, the same way `--skill`
+///   handles unqualified specs).
+/// - Duplicates by `(org, repo)` are collapsed.
+pub fn resolve_skill_repos(specs: &[String]) -> Vec<GithubRepo> {
+    let mut repos: BTreeSet<(String, String)> = BTreeSet::new();
+    for raw in specs {
+        let spec = match SkillSpec::from_str(raw) {
+            Ok(spec) => spec,
+            Err(err) => {
+                log::warn!("Failed to parse global skill spec '{raw}': {err}");
+                continue;
+            }
+        };
+        let (Some(org), Some(repo)) = (spec.org.as_ref(), spec.repo.as_ref()) else {
+            continue;
+        };
+        repos.insert((org.clone(), repo.clone()));
+    }
+    repos
+        .into_iter()
+        .map(|(owner, repo)| GithubRepo::new(owner, repo))
+        .collect()
+}
+```
+Tests in `global_skills_tests.rs` cover: empty input, parse failures, unqualified / repo-only entries (silently skipped), org/repo entries collected, duplicates collapsed.
+No dedup against the environment's `github_repos` lives here. The clone helper introduced in step 4 already short-circuits when the target directory exists, so a global-skill repo that is already covered by the environment is a no-op when we attempt to clone it — no separate filtering function is needed.
+### 4. Factor a per-repo clone helper out of `prepare_environment`
+`app/src/ai/agent_sdk/driver/environment.rs`
+The body of the existing `for repo in github_repos` loop in `prepare_environment_impl` (the `terminal_directory_exists` probe, the `git clone --filter=tree:0` invocation, and the `DetectedRepositories::detect_possible_git_repo` registration when `!is_sandbox`) is extracted into a single helper that the driver can call for any repo set:
+```rust path=null start=null
+pub(super) async fn ensure_repo_cloned(
+    repo: &GithubRepo,
+    working_dir: &Path,
+    is_sandbox: bool,
+    spawner: &ModelSpawner<TerminalDriver>,
+) -> Result<(), PrepareEnvironmentError>;
+```
+Behavior matches the current loop body exactly:
+- Probe the session for `working_dir/<repo>`; if the directory already exists, log a skip and return `Ok(())`.
+- Otherwise run `git clone --filter=tree:0 https://github.com/<owner>/<repo>.git` via the silent terminal executor; on non-zero exit, return `PrepareEnvironmentError::CloneRepo`.
+- When `!is_sandbox`, register the freshly-cloned path with `DetectedRepositories` so the skill watcher and other repo-aware subsystems pick it up.
+`prepare_environment_impl` becomes a thin wrapper that calls `ensure_repo_cloned` for each env `GithubRepo` and otherwise keeps its current responsibilities (setup-commands phase, single-repo `cd`, codebase-index waiting). This is a pure refactor — no behavior change for existing env runs. The helper's `pub(super)` visibility lets `AgentDriver::run_internal` call it directly for global-skill repos without going through `prepare_environment`.
+### 5. Resolve and clone global-skill repos in the driver
+`app/src/ai/agent_sdk/driver.rs` — `AgentDriver::run_internal`
+The driver checks the user's `globalSkills` directly during initialization rather than threading anything through `AgentDriverOptions`. After the existing `prepare_environment` step (or in place of it for runs without an environment) the driver runs:
+```rust path=null start=null
+if FeatureFlag::OzPlatformSkills.is_enabled() {
+    let global_specs = foreground
+        .spawn(|_, ctx| {
+            AuthStateProvider::as_ref(ctx)
+                .get()
+                .user
+                .read()
+                .as_ref()
+                .map(|u| u.global_skills.clone())
+                .unwrap_or_default()
+        })
+        .await?;
+    let global_repos = resolve_skill_repos(&global_specs);
+    if !global_repos.is_empty() {
+        log::info!("Resolving {} global skill repo(s)", global_repos.len());
+        for repo in &global_repos {
+            if let Err(err) = foreground
+                .spawn({
+                    let repo = repo.clone();
+                    let working_dir = self.working_dir.clone();
+                    move |_, ctx| {
+                        terminal_driver(ctx).update(ctx, |_, ctx| {
+                            ensure_repo_cloned(
+                                &repo,
+                                &working_dir,
+                                /* is_sandbox */ false,
+                                ctx.spawner(),
+                            )
+                        })
+                    }
+                })
+                .await?
+                .await
+            {
+                log::warn!("Failed to clone global-skill repo {repo}: {err}");
+            }
+        }
+    }
+}
+```
+The exact spawning shape mirrors the existing `prepare_environment` invocation; the important properties are:
+- The driver reads `User.global_skills` directly via `AuthStateProvider`. The CLI run-time invariant is that `User` is already populated by `fetch_user_properties` at login / refresh, so no extra async fetch is needed here. There's no client-side check for whether the principal is a service account; the server resolver returns an empty list for non-service-account principals, so non-SA runs naturally take the fast empty path.
+- Each repo is cloned best-effort; per-repo failures are logged and the run continues.
+- The clone helper's existing "directory exists → skip" check is the dedup mechanism. If a global-skill repo's `(owner, repo)` is also in the environment's `github_repos`, the env-repo clone runs first (during `prepare_environment`) and the global-skill loop's call becomes a no-op. No upfront filter against `env.github_repos` is needed.
+After cloning, the existing post-environment skill load (`SkillWatcher::read_skills_for_repos` at driver.rs:1304-1322) extends its repo list with the global-skill repos so the SKILL.md files are picked up. For runs without an environment, this load runs over just the global-skill repos and `SkillManager::set_cloud_environment(true)` is still set when the list is non-empty so the new skills are in scope regardless of `cwd`.
+### 6. Reuse `clone_repo_for_skill` for the explicit `--skill` flow only
+No change. The existing sandboxed `--skill` clone in `agent_sdk/mod.rs:resolve_skill` continues to call `clone_repo_for_skill` directly. After this spec lands, that path is still useful for the case where `--skill org/repo:...` references a repo that's neither in the env nor in `globalSkills`.
+### 7. Feature flag interaction
+- `OzPlatformSkills` gates the entire flow (already used to gate `--skill` resolution). When disabled, the driver's global-skill block is skipped entirely and behavior is identical to today.
+- No new feature flag is introduced.
+### 8. Telemetry / logs
+Log lines:
+- Info: "Resolving N global skill repo(s)" when `global_repos` is non-empty.
+- Warn: parse failures, clone failures (per-repo).
+No new telemetry events for the first cut.
+## Parallelization
+Not applicable. This is a small, single-developer change that lands in one PR.
+## Risks and mitigations
+- **Stale `globalSkills` for long-running clients**: `User.globalSkills` is read from the cached `User` populated at login. If a service account's skills are updated after login but before a new run, the run won't see the change. Mitigated by service-account credentials always being short-lived (API key login refetches user) and by being explicit in the spec that this is read-once-per-run.
+- **Repo-name conflicts**: If `org-a/foo` is in the env and `org-b/foo` is in `globalSkills`, the global-skill clone would otherwise try to land at `working_dir/foo` which is taken. The existing `dir_exists` guard inside `ensure_repo_cloned` already skips the clone. Detection of org mismatch is the existing `--skill` resolver's responsibility (it validates via git remote when an org filter is present); for global skills we tolerate the conflict and let resolution downstream pick the on-disk repo.
+- **Sandbox host-detection skip**: the `is_sandbox` path inside `ensure_repo_cloned` already skips host-side `DetectedRepositories::detect_possible_git_repo` for sandbox-only paths. Global-skill repos cloned in a sandbox follow the same skip and are detected by the in-sandbox skill scanner.
+## Testing and validation
+Unit coverage:
+- `resolve_skill_repos` with: empty input, parse failures, unqualified / repo-only entries, org/repo entries, duplicates collapsed.
+- A test for `User` serialization round-trip covering the new `global_skills` field default-empty case.
+Driver-level coverage (using the existing `agent_sdk` test surfaces under `app/src/ai/agent_sdk/test_support`):
+- The driver clones the resolved global-skill repos when `User.global_skills` is non-empty, and the loop is a no-op when the list is empty (which is the server-side default for non-service-account principals).
+- The clone helper is a no-op when the target directory already exists (covers the env-overlap case).
+Manual / integration:
+- Configure a test service account with `globalSkills = ["warpdotdev/warp-internal:read-google-doc"]`. Run `oz agent run -p "..."` (sandboxed cloud run) using that SA's API key. Verify the run logs the resolved global skill list, that `warp-internal` is cloned in the sandbox, and that the skill is listed by `oz agent list`.
+- Configure the same SA with no environment. Verify the global-skill repo still clones into `working_dir` and the skill is discoverable. Repeat with the env including `warpdotdev/warp-internal` and confirm the global-skills code path becomes a no-op (no extra clone).
+- Configure `globalSkills = ["bare-name", "warp-internal:foo", "warpdotdev/warp-internal:bar"]`. Verify the first two are silently skipped (not cloneable; they fall back to on-disk discovery), only `warpdotdev/warp-internal` is cloned, and `bar` resolves once cloned.
+- Verify maps onto Behavior #11: simulate a clone failure (point at a non-existent repo), confirm a warn log is emitted and the run still completes.
+- Re-run all `oz agent run --skill org/repo:foo` scenarios with `OzPlatformSkills` enabled to confirm no regression in the existing `--skill` flow.
+- Disable `OzPlatformSkills` and confirm the new flow is fully bypassed.
+## Follow-ups
+- Refresh `User.globalSkills` periodically (e.g. on a long-running cloud run) so changes propagate without re-fetching the user.
+- Allow user (non-service-account) principals to configure `globalSkills` once we have a UX for it.
+- Consider moving the cloned repos into a Warp-managed cache directory so repeated runs reuse them across `working_dir`s; today repeated runs in fresh sandboxes re-clone every time.
+- Surface global-skill provenance in `oz agent list --skill ...` output ("source: global skill").

--- a/specs/REMOTE-1453/TECH.md
+++ b/specs/REMOTE-1453/TECH.md
@@ -1,179 +1,65 @@
-# REMOTE-1453: Tech Spec — Resolve service-account global skills at agent driver startup
+# REMOTE-1453: Tech Spec - Resolve service-account global skills at agent driver startup
 ## Context
-The product behavior is defined in `specs/REMOTE-1453/PRODUCT.md`. This spec covers how to plug global-skill resolution into the existing agent-driver startup, the GraphQL plumbing for the new `User.globalSkills` field, and how to share the existing repo-cloning code path so we do not introduce a parallel skill registry.
-The relevant existing pieces:
-- Server: `User.globalSkills: [String!]!` on the GraphQL schema and `logic.GetGlobalSkillSpecsForPrincipal` (warp-server PR #10799).
-- Client GraphQL fetch: `crates/graphql/src/api/queries/get_user.rs:107-141` defines `GetUser` and the `User` fragment. `app/src/server/server_api/auth.rs:282-379` runs `fetch_user_properties` / `fetch_user`.
-- Client user model: `app/src/auth/user.rs:79-103` (`User` struct), `app/src/auth/auth_state.rs:453-461` (`AuthState::is_service_account`).
-- Skill spec parsing and resolution:
-  - `crates/warp_cli/src/skill.rs` — `SkillSpec`, `SkillSpec::from_str`, `is_full_path`, `with_org_and_repo`.
-  - `app/src/ai/skills/resolve_skill_spec.rs:139-204` — `clone_repo_for_skill(org, repo, working_dir)` clones `https://github.com/<org>/<repo>.git` into `working_dir/<repo>` and is idempotent when the directory already contains a git repo.
-  - `app/src/ai/skills/mod.rs:22-27` — re-exports `clone_repo_for_skill`, `resolve_skill_spec`, etc.
-- Agent driver startup:
-  - `app/src/ai/agent_sdk/mod.rs:540-667` (`AgentDriverRunner::setup_and_run_driver`) drives the run: `refresh_team_metadata` → `refresh_warp_drive` → `build_driver_options_and_task` → `resolve_environment` → `create_and_run_driver`.
-  - `app/src/ai/agent_sdk/mod.rs:683-726` (`resolve_skill`) is the existing `--skill` resolution, including the sandboxed-mode `clone_repo_for_skill` call.
-  - `app/src/ai/agent_sdk/driver.rs:200-228` (`AgentDriverOptions`) — what the `AgentDriver` is constructed with.
-  - `app/src/ai/agent_sdk/driver.rs:1216-1333` — the section of `run_internal` that loads the environment, calls `prepare_environment`, then runs the Oz-only `SkillWatcher::read_skills_for_repos` over `environment.github_repos`.
-- Environment preparation:
-  - `app/src/ai/cloud_environments/mod.rs:21-39, 85-147` — `GithubRepo { owner, repo }` and `AmbientAgentEnvironment.github_repos`.
-  - `app/src/ai/agent_sdk/driver/environment.rs:52-303` — `prepare_environment` loops over `github_repos`, clones each via `git clone --filter=tree:0`, registers them with `DetectedRepositories`, runs setup commands, optionally `cd`s into a single repo. Also includes the `is_sandbox` parameter that gates host-side detection.
-- Feature flag: `FeatureFlag::OzPlatformSkills` (`crates/warp_features/src/lib.rs:659`).
-## Current state
-- `User.globalSkills` is exposed by the server but the client does not request it; the field is invisible to the agent driver today.
-- `AgentDriver::run_internal` only clones `environment.github_repos` and only loads skills from those repos.
-- `clone_repo_for_skill` is the only existing client-side helper that clones a GitHub repo for skill purposes. It is invoked exactly once today, in `resolve_skill` for sandboxed `--skill <org/repo:...>` runs. It does the right thing for our needs (HTTPS clone, skip-if-already-git, error if non-git directory) but it does not honor the partial-clone optimization used by `prepare_environment`.
-## Proposed changes
-### 1. Extend the `GetUser` GraphQL query
-`crates/graphql/src/api/queries/get_user.rs`
-- Add `global_skills: Vec<String>` to the `User` fragment (server already exposes the field as non-null `[String!]!`).
-- Update the embedded query string in the `/* query GetUser ... */` doc comment to include `globalSkills` next to `experiments`, `is_onboarded`, etc.
-This is a single-line schema-shape change; cynic regenerates types via the existing `./script/codegen` flow.
-### 2. Plumb `global_skills` into the auth `User` model
-`app/src/auth/user.rs`
-- Add `pub global_skills: Vec<String>` to `User` (alongside `principal_type`).
-- Default to empty in `User::test()` and any other constructors.
-- Update the `From<warp_graphql::queries::get_user::User>`-style conversion in the `auth_state.rs` / `auth/user.rs` boundary so `global_skills` carries through. (The `UserProperties::user` shape is built in `app/src/server/server_api/auth.rs` around line 295-300 and friends; trace and forward the new field there.)
-- The agent driver reads the field directly off `User` via `AuthStateProvider::as_ref(ctx).get().user.read().as_ref().map(|u| u.global_skills.clone()).unwrap_or_default()`. No new `AuthState` accessor is added.
-### 3. New module: `app/src/ai/skills/global_skills.rs`
-A small module that owns parsing skill specs into a deduped list of GitHub repos. Re-export through `app/src/ai/skills/mod.rs`.
-```rust path=null start=null
-//! Helpers for resolving service-account "global" skill specs into repos to
-//! ensure are available on disk before agent runs.
-
-use std::collections::BTreeSet;
-
-use warp_cli::skill::SkillSpec;
-
-use crate::ai::cloud_environments::GithubRepo;
-
-/// Parse a list of raw skill spec strings into the unique set of GitHub repos
-/// they reference.
-///
-/// - Specs that fail to parse are logged at warn level and skipped.
-/// - Specs without an `org/repo` qualifier produce no repo (they fall back to
-///   on-disk discovery in the existing skill resolver, the same way `--skill`
-///   handles unqualified specs).
-/// - Duplicates by `(org, repo)` are collapsed.
-pub fn resolve_skill_repos(specs: &[String]) -> Vec<GithubRepo> {
-    let mut repos: BTreeSet<(String, String)> = BTreeSet::new();
-    for raw in specs {
-        let spec = match SkillSpec::from_str(raw) {
-            Ok(spec) => spec,
-            Err(err) => {
-                log::warn!("Failed to parse global skill spec '{raw}': {err}");
-                continue;
-            }
-        };
-        let (Some(org), Some(repo)) = (spec.org.as_ref(), spec.repo.as_ref()) else {
-            continue;
-        };
-        repos.insert((org.clone(), repo.clone()));
-    }
-    repos
-        .into_iter()
-        .map(|(owner, repo)| GithubRepo::new(owner, repo))
-        .collect()
-}
-```
-Tests in `global_skills_tests.rs` cover: empty input, parse failures, unqualified / repo-only entries (silently skipped), org/repo entries collected, duplicates collapsed.
-No dedup against the environment's `github_repos` lives here. The clone helper introduced in step 4 already short-circuits when the target directory exists, so a global-skill repo that is already covered by the environment is a no-op when we attempt to clone it — no separate filtering function is needed.
-### 4. Factor a per-repo clone helper out of `prepare_environment`
-`app/src/ai/agent_sdk/driver/environment.rs`
-The body of the existing `for repo in github_repos` loop in `prepare_environment_impl` (the `terminal_directory_exists` probe, the `git clone --filter=tree:0` invocation, and the `DetectedRepositories::detect_possible_git_repo` registration when `!is_sandbox`) is extracted into a single helper that the driver can call for any repo set:
-```rust path=null start=null
-pub(super) async fn ensure_repo_cloned(
-    repo: &GithubRepo,
-    working_dir: &Path,
-    is_sandbox: bool,
-    spawner: &ModelSpawner<TerminalDriver>,
-) -> Result<(), PrepareEnvironmentError>;
-```
-Behavior matches the current loop body exactly:
-- Probe the session for `working_dir/<repo>`; if the directory already exists, log a skip and return `Ok(())`.
-- Otherwise run `git clone --filter=tree:0 https://github.com/<owner>/<repo>.git` via the silent terminal executor; on non-zero exit, return `PrepareEnvironmentError::CloneRepo`.
-- When `!is_sandbox`, register the freshly-cloned path with `DetectedRepositories` so the skill watcher and other repo-aware subsystems pick it up.
-`prepare_environment_impl` becomes a thin wrapper that calls `ensure_repo_cloned` for each env `GithubRepo` and otherwise keeps its current responsibilities (setup-commands phase, single-repo `cd`, codebase-index waiting). This is a pure refactor — no behavior change for existing env runs. The helper's `pub(super)` visibility lets `AgentDriver::run_internal` call it directly for global-skill repos without going through `prepare_environment`.
-### 5. Resolve and clone global-skill repos in the driver
-`app/src/ai/agent_sdk/driver.rs` — `AgentDriver::run_internal`
-The driver checks the user's `globalSkills` directly during initialization rather than threading anything through `AgentDriverOptions`. After the existing `prepare_environment` step (or in place of it for runs without an environment) the driver runs:
-```rust path=null start=null
-if FeatureFlag::OzPlatformSkills.is_enabled() {
-    let global_specs = foreground
-        .spawn(|_, ctx| {
-            AuthStateProvider::as_ref(ctx)
-                .get()
-                .user
-                .read()
-                .as_ref()
-                .map(|u| u.global_skills.clone())
-                .unwrap_or_default()
-        })
-        .await?;
-    let global_repos = resolve_skill_repos(&global_specs);
-    if !global_repos.is_empty() {
-        log::info!("Resolving {} global skill repo(s)", global_repos.len());
-        for repo in &global_repos {
-            if let Err(err) = foreground
-                .spawn({
-                    let repo = repo.clone();
-                    let working_dir = self.working_dir.clone();
-                    move |_, ctx| {
-                        terminal_driver(ctx).update(ctx, |_, ctx| {
-                            ensure_repo_cloned(
-                                &repo,
-                                &working_dir,
-                                /* is_sandbox */ false,
-                                ctx.spawner(),
-                            )
-                        })
-                    }
-                })
-                .await?
-                .await
-            {
-                log::warn!("Failed to clone global-skill repo {repo}: {err}");
-            }
-        }
-    }
-}
-```
-The exact spawning shape mirrors the existing `prepare_environment` invocation; the important properties are:
-- The driver reads `User.global_skills` directly via `AuthStateProvider`. The CLI run-time invariant is that `User` is already populated by `fetch_user_properties` at login / refresh, so no extra async fetch is needed here. There's no client-side check for whether the principal is a service account; the server resolver returns an empty list for non-service-account principals, so non-SA runs naturally take the fast empty path.
-- Each repo is cloned best-effort; per-repo failures are logged and the run continues.
-- The clone helper's existing "directory exists → skip" check is the dedup mechanism. If a global-skill repo's `(owner, repo)` is also in the environment's `github_repos`, the env-repo clone runs first (during `prepare_environment`) and the global-skill loop's call becomes a no-op. No upfront filter against `env.github_repos` is needed.
-After cloning, the existing post-environment skill load (`SkillWatcher::read_skills_for_repos` at driver.rs:1304-1322) extends its repo list with the global-skill repos so the SKILL.md files are picked up. For runs without an environment, this load runs over just the global-skill repos and `SkillManager::set_cloud_environment(true)` is still set when the list is non-empty so the new skills are in scope regardless of `cwd`.
-### 6. Reuse `clone_repo_for_skill` for the explicit `--skill` flow only
-No change. The existing sandboxed `--skill` clone in `agent_sdk/mod.rs:resolve_skill` continues to call `clone_repo_for_skill` directly. After this spec lands, that path is still useful for the case where `--skill org/repo:...` references a repo that's neither in the env nor in `globalSkills`.
-### 7. Feature flag interaction
-- `OzPlatformSkills` gates the entire flow (already used to gate `--skill` resolution). When disabled, the driver's global-skill block is skipped entirely and behavior is identical to today.
-- No new feature flag is introduced.
-### 8. Telemetry / logs
-Log lines:
-- Info: "Resolving N global skill repo(s)" when `global_repos` is non-empty.
-- Warn: parse failures, clone failures (per-repo).
-No new telemetry events for the first cut.
-## Parallelization
-Not applicable. This is a small, single-developer change that lands in one PR.
-## Risks and mitigations
-- **Stale `globalSkills` for long-running clients**: `User.globalSkills` is read from the cached `User` populated at login. If a service account's skills are updated after login but before a new run, the run won't see the change. Mitigated by service-account credentials always being short-lived (API key login refetches user) and by being explicit in the spec that this is read-once-per-run.
-- **Repo-name conflicts**: If `org-a/foo` is in the env and `org-b/foo` is in `globalSkills`, the global-skill clone would otherwise try to land at `working_dir/foo` which is taken. The existing `dir_exists` guard inside `ensure_repo_cloned` already skips the clone. Detection of org mismatch is the existing `--skill` resolver's responsibility (it validates via git remote when an org filter is present); for global skills we tolerate the conflict and let resolution downstream pick the on-disk repo.
-- **Sandbox host-detection skip**: the `is_sandbox` path inside `ensure_repo_cloned` already skips host-side `DetectedRepositories::detect_possible_git_repo` for sandbox-only paths. Global-skill repos cloned in a sandbox follow the same skip and are detected by the in-sandbox skill scanner.
+The product behavior is defined in `specs/REMOTE-1453/PRODUCT.md`. This spec covers the client-side runtime implementation for resolving service-account `User.globalSkills` during Oz agent startup.
+Relevant existing pieces:
+- `crates/warp_cli/src/skill.rs`: `SkillSpec`, `SkillSpec::from_str`, `SkillSpec::is_full_path`.
+- `app/src/ai/skills/file_watchers/skill_watcher.rs`: scans repository trees for `SKILL.md` files.
+- `app/src/ai/skills/skill_manager.rs`: stores the loaded skills for the active run.
+- `app/src/ai/agent_sdk/driver/environment.rs`: environment repository clone helper used by environment prep.
+- `app/src/ai/cloud_environments/mod.rs`: `GithubRepo { owner, repo }` and `AmbientAgentEnvironment.github_repos`.
+- `app/src/ai/agent_sdk/driver.rs`: agent startup sequence, environment prep, and Oz-only repo skill loading.
+## Implemented approach
+### 1. Global skill parsing helpers
+`app/src/ai/skills/global_skills.rs` owns the reusable parsing and filtering helpers and is re-exported through `app/src/ai/skills/mod.rs`.
+- `resolve_skill_repos(raw_specs: &[String]) -> (Vec<SkillSpec>, Vec<GithubRepo>)` parses raw server strings with the existing CLI parser, logs warn-level parse failures, skips invalid entries, and extracts org-qualified `(org, repo)` pairs from the parsed specs while preserving first-seen order.
+- `filter_explicit_global_skills(repo_path, skills, specs)` takes the full scan result for one global-only repo and returns only the parsed skills explicitly requested for that repo.
+Filtering behavior:
+- Full-path specs match `repo_path.join(spec.skill_identifier)` exactly.
+- Simple-name specs match parsed `ParsedSkill::name` values and pick the first match by provider-directory precedence.
+- Duplicate selected paths are collapsed.
+### 2. Driver source classification
+`app/src/ai/agent_sdk/driver.rs` separates global skill resolution from repository skill loading.
+- `GlobalSkillResolution` carries parsed global specs and cloneable global skill repos.
+- `SkillRepoLoadRequest` carries one repo plus a `SkillRepoLoadMode`, so a repo either loads all discovered skills or filters to explicit global specs without representing contradictory states.
+- `skill_repo_load_requests(environment_repos, global_skill_repos, global_skill_specs)` builds the load requests:
+  - Environment repos use `SkillRepoLoadMode::All`.
+  - Global repos that are not also environment repos use `SkillRepoLoadMode::ExplicitGlobal` with only specs matching that repo.
+  - Global repos already present in the environment are skipped as separate global requests, so the environment request wins.
+Repository identity is `(owner, repo)` via derived `GithubRepo` equality.
+### 3. Driver startup sequence
+For Oz harnesses, `AgentDriver::run_internal` now does the following after the session is shared and before environment prep:
+1. Read cached `AuthStateProvider::get().global_skills()`.
+2. Parse specs and resolve cloneable repos with `resolve_skill_repos`.
+3. Clone those repos best-effort with `environment::ensure_repo_cloned`.
+4. Prepare the configured environment, if any, preserving the existing file-based MCP discovery and setup-command sequencing.
+5. Build `SkillRepoLoadRequest`s from environment repos and global skill repos.
+6. Load skills synchronously before the initial Oz prompt is sent.
+Global-skill cloning currently remains Oz-only because the skill loading path is Oz-only and third-party harnesses have separate skill systems.
+### 4. Repo skill loading
+`load_skills_from_repos` now accepts `Vec<SkillRepoLoadRequest>` instead of raw `Vec<GithubRepo>`.
+- It still waits for repository metadata indexing before scanning.
+- It scans each repo with `SkillWatcher::read_skills_for_repos`.
+- For `SkillRepoLoadMode::All` requests, it appends all scanned skills.
+- For `SkillRepoLoadMode::ExplicitGlobal` requests, it applies `filter_explicit_global_skills` before appending. Filtering happens after the scan because the required repository metadata tree has already been built for the whole repo.
+- It then sets `SkillManager::set_cloud_environment(true)` and adds the final selected skill list, preserving the existing in-scope behavior for repo-loaded skills.
+## Behavior guarantees
+- Environment repos continue to autodiscover all skills.
+- Global-only repos do not expose unrelated skills from the same repo.
+- Environment/global overlap is resolved in favor of environment autodiscovery.
+- Clone failures for global-skill repos are warn-and-continue.
+- Invalid global skill specs are warn-and-skip.
+- Non-cloneable specs do not trigger clone attempts.
 ## Testing and validation
-Unit coverage:
-- `resolve_skill_repos` with: empty input, parse failures, unqualified / repo-only entries, org/repo entries, duplicates collapsed.
-- A test for `User` serialization round-trip covering the new `global_skills` field default-empty case.
-Driver-level coverage (using the existing `agent_sdk` test surfaces under `app/src/ai/agent_sdk/test_support`):
-- The driver clones the resolved global-skill repos when `User.global_skills` is non-empty, and the loop is a no-op when the list is empty (which is the server-side default for non-service-account principals).
-- The clone helper is a no-op when the target directory already exists (covers the env-overlap case).
-Manual / integration:
-- Configure a test service account with `globalSkills = ["warpdotdev/warp-internal:read-google-doc"]`. Run `oz agent run -p "..."` (sandboxed cloud run) using that SA's API key. Verify the run logs the resolved global skill list, that `warp-internal` is cloned in the sandbox, and that the skill is listed by `oz agent list`.
-- Configure the same SA with no environment. Verify the global-skill repo still clones into `working_dir` and the skill is discoverable. Repeat with the env including `warpdotdev/warp-internal` and confirm the global-skills code path becomes a no-op (no extra clone).
-- Configure `globalSkills = ["bare-name", "warp-internal:foo", "warpdotdev/warp-internal:bar"]`. Verify the first two are silently skipped (not cloneable; they fall back to on-disk discovery), only `warpdotdev/warp-internal` is cloned, and `bar` resolves once cloned.
-- Verify maps onto Behavior #11: simulate a clone failure (point at a non-existent repo), confirm a warn log is emitted and the run still completes.
-- Re-run all `oz agent run --skill org/repo:foo` scenarios with `OzPlatformSkills` enabled to confirm no regression in the existing `--skill` flow.
-- Disable `OzPlatformSkills` and confirm the new flow is fully bypassed.
+Unit coverage added or expected:
+- `resolve_skill_repos` skips invalid specs and handles empty input, unqualified specs, org-qualified specs, and duplicate repos.
+- `filter_explicit_global_skills` loads only requested simple-name skills, respects provider precedence, and matches full-path specs.
+- `AgentDriver::skill_repo_load_requests` verifies that environment repos use the all-skills mode, global-only repos keep matching specs, and environment/global overlap is not emitted as a separate global-only request.
+Validation commands:
+- `cargo fmt`
+- Targeted `cargo nextest` for the `global_skills` and `driver` tests touched by this change.
+- A targeted `cargo check` or package build if test compilation exposes broader type issues.
 ## Follow-ups
-- Refresh `User.globalSkills` periodically (e.g. on a long-running cloud run) so changes propagate without re-fetching the user.
-- Allow user (non-service-account) principals to configure `globalSkills` once we have a UX for it.
-- Consider moving the cloned repos into a Warp-managed cache directory so repeated runs reuse them across `working_dir`s; today repeated runs in fresh sandboxes re-clone every time.
-- Surface global-skill provenance in `oz agent list --skill ...` output ("source: global skill").
+- Add integration coverage around a real service-account run once the test harness can inject `User.globalSkills` and cloned repo contents cheaply.
+- Consider refreshing `User.globalSkills` at run start if cached user state can become stale for long-lived clients.
+- Consider global-skill provenance in skill listing UI or logs if users need to debug why a skill was available.
+- Revisit third-party harness behavior if those harnesses adopt the same runtime skill loading path.

--- a/specs/REMOTE-1453/TECH.md
+++ b/specs/REMOTE-1453/TECH.md
@@ -12,36 +12,30 @@ Relevant existing pieces:
 ### 1. Global skill parsing helpers
 `app/src/ai/skills/global_skills.rs` owns the reusable parsing and filtering helpers and is re-exported through `app/src/ai/skills/mod.rs`.
 - `resolve_skill_repos(raw_specs: &[String]) -> (Vec<SkillSpec>, Vec<GithubRepo>)` parses raw server strings with the existing CLI parser, logs warn-level parse failures, skips invalid entries, and extracts org-qualified `(org, repo)` pairs from the parsed specs while preserving first-seen order.
-- `filter_explicit_global_skills(repo_path, skills, specs)` takes the full scan result for one global-only repo and returns only the parsed skills explicitly requested for that repo.
+- `filter_skills_by_spec(repo_path, skills, specs)` takes the full scan result for one global-only repo and returns only the parsed skills explicitly requested for that repo.
 Filtering behavior:
 - Full-path specs match `repo_path.join(spec.skill_identifier)` exactly.
 - Simple-name specs match parsed `ParsedSkill::name` values and pick the first match by provider-directory precedence.
 - Duplicate selected paths are collapsed.
 ### 2. Driver source classification
-`app/src/ai/agent_sdk/driver.rs` separates global skill resolution from repository skill loading.
+`app/src/ai/agent_sdk/driver.rs` separates global skill resolution from repository skill loading using two explicit async methods rather than a unified load-request type.
 - `GlobalSkillResolution` carries parsed global specs and cloneable global skill repos.
-- `SkillRepoLoadRequest` carries one repo plus a `SkillRepoLoadMode`, so a repo either loads all discovered skills or filters to explicit global specs without representing contradictory states.
-- `skill_repo_load_requests(environment_repos, global_skill_repos, global_skill_specs)` builds the load requests:
-  - Environment repos use `SkillRepoLoadMode::All`.
-  - Global repos that are not also environment repos use `SkillRepoLoadMode::ExplicitGlobal` with only specs matching that repo.
-  - Global repos already present in the environment are skipped as separate global requests, so the environment request wins.
-Repository identity is `(owner, repo)` via derived `GithubRepo` equality.
+- `load_environment_skills` handles all repos that are part of the configured environment: it waits for `RepoMetadataModel` indexing to complete, then scans with `SkillWatcher::read_skills_for_repos` and loads all discovered skills.
+- `load_global_skills` handles global-only repos: it reads directly from the known provider directories on disk via `read_skills_from_directories` (no `RepoMetadataModel` dependency), then applies `filter_skills_by_spec` to keep only the explicitly requested skills.
+Because global skill repos are cloned before environment prep and are not registered with `DetectedRepositories`, they are not picked up by `SkillWatcher`'s `RepositoryMetadataEvent` path; `load_global_skills` reads them directly from disk instead. If a repo appears in both the environment and the global skill set, `load_environment_skills` runs over it and loads all skills; `load_global_skills` may also process it and add the filtered subset, but `SkillManager` deduplicates by path so the effective result is all skills from that repo.
 ### 3. Driver startup sequence
 For Oz harnesses, `AgentDriver::run_internal` now does the following after the session is shared and before environment prep:
 1. Read cached `AuthStateProvider::get().global_skills()`.
 2. Parse specs and resolve cloneable repos with `resolve_skill_repos`.
-3. Clone those repos best-effort with `environment::ensure_repo_cloned`.
-4. Prepare the configured environment, if any, preserving the existing file-based MCP discovery and setup-command sequencing.
-5. Build `SkillRepoLoadRequest`s from environment repos and global skill repos.
-6. Load skills synchronously before the initial Oz prompt is sent.
-Global-skill cloning currently remains Oz-only because the skill loading path is Oz-only and third-party harnesses have separate skill systems.
+3. Clone those repos best-effort with `environment::clone_repo` (which clones the repo but does NOT register it with `DetectedRepositories`, so only the explicitly requested global skills are loaded from it).
+4. Prepare the configured environment, if any, preserving the existing file-based MCP discovery and setup-command sequencing. Environment repos are cloned via `ensure_repo_cloned`, which both clones and registers with `DetectedRepositories`.
+5. Call `load_environment_skills` with the environment's `github_repos`, then `load_global_skills` with the global specs and repos.
+Global-skill cloning is performed for all harnesses (before the Oz-only guard) so that skills are on disk, but skill loading into `SkillManager` remains Oz-only because third-party harnesses have separate skill systems.
 ### 4. Repo skill loading
-`load_skills_from_repos` now accepts `Vec<SkillRepoLoadRequest>` instead of raw `Vec<GithubRepo>`.
-- It still waits for repository metadata indexing before scanning.
-- It scans each repo with `SkillWatcher::read_skills_for_repos`.
-- For `SkillRepoLoadMode::All` requests, it appends all scanned skills.
-- For `SkillRepoLoadMode::ExplicitGlobal` requests, it applies `filter_explicit_global_skills` before appending. Filtering happens after the scan because the required repository metadata tree has already been built for the whole repo.
-- It then sets `SkillManager::set_cloud_environment(true)` and adds the final selected skill list, preserving the existing in-scope behavior for repo-loaded skills.
+Skill loading is split into two separate functions instead of a single unified `load_skills_from_repos`:
+- `load_environment_skills(foreground, repos)`: waits for `RepoMetadataModel` indexing on each repo, then scans with `SkillWatcher::read_skills_for_repos` and loads all discovered skills into `SkillManager`.
+- `load_global_skills(foreground, specs, repos)`: reads skills directly from provider directories via `read_skills_from_directories` (using `SKILL_PROVIDER_DEFINITIONS`), applies `filter_skills_by_spec` to keep only explicitly requested skills, and loads the result into `SkillManager`. This path does not depend on `RepoMetadataModel` because global-skill repos are not registered with `DetectedRepositories`.
+Both functions call `SkillManager::set_cloud_environment(true)` and `handle_skills_added`, preserving the existing in-scope behavior for repo-loaded skills.
 ## Behavior guarantees
 - Environment repos continue to autodiscover all skills.
 - Global-only repos do not expose unrelated skills from the same repo.
@@ -52,8 +46,7 @@ Global-skill cloning currently remains Oz-only because the skill loading path is
 ## Testing and validation
 Unit coverage added or expected:
 - `resolve_skill_repos` skips invalid specs and handles empty input, unqualified specs, org-qualified specs, and duplicate repos.
-- `filter_explicit_global_skills` loads only requested simple-name skills, respects provider precedence, and matches full-path specs.
-- `AgentDriver::skill_repo_load_requests` verifies that environment repos use the all-skills mode, global-only repos keep matching specs, and environment/global overlap is not emitted as a separate global-only request.
+- `filter_skills_by_spec` loads only requested simple-name skills, respects provider precedence, and matches full-path specs.
 Validation commands:
 - `cargo fmt`
 - Targeted `cargo nextest` for the `global_skills` and `driver` tests touched by this change.


### PR DESCRIPTION
## Description

Named agents will have attached skills, which Oz ensures are available on every cloud run. To implement this, we're:

1. Fetching the list of agent skills from the server (via the `User.globalSkills` property, which is only populated for agents)
2. Cloning the repos for each skill, using the same approach as for GitHub repos in an environment
3. Scanning each cloned repository (environment or agent-attached) for skills

As a side effect of this, I fixed a race condition where we would not properly wait for repository indexing to complete before scanning for skills. This was masked by waiting on codebase indexing, which typically (but not always) took long enough that skills would be indexed too. Fixing this depends on #25393, the parent to this PR.

There are a couple obvious followups, which are not in scope here:

1. Supporting global skills for users
2. Supporting global skills in the desktop app, such as by cloning to a managed `~/.warp/skills` directory and making them available regardless of a session's working directory
3. Periodically refreshing skill repositories

Unlike with skills from repositories in the run's environment, *only* the explicitly-requested skills are loaded. This lets the user attach marketplace-like repos with many skills, without bloating the agent's skillset. The resolution behavior is:
1. All skills from repositories in the environment are loaded
2. All skills in the current and home directories are loaded
3. Any explicitly-attached agent skills are loaded

## Testing

* Updated unit tests for resolution logic
* Manually tested e2e that the agent had access to attached skills, but not other skills in the same repo

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

