### PR TITLE
Correctly hide input when cloud agent session is over and cloud handoff feature flag is off

### DIFF
--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -1585,18 +1585,23 @@ impl TerminalManager {
         model
             .lock()
             .clear_write_to_pty_events_for_shared_session_tx();
-        if FeatureFlag::HandoffCloudCloud.is_enabled() {
-            terminal_view.update(ctx, |terminal_view, ctx| {
-                if let Some(ambient_agent_view_model) =
-                    terminal_view.ambient_agent_view_model().cloned()
-                {
-                    ambient_agent_view_model.update(ctx, |model, _| {
-                        model.record_ambient_execution_ended(ended_session_id);
-                    });
-                }
+        terminal_view.update(ctx, |terminal_view, ctx| {
+            if let Some(ambient_agent_view_model) =
+                terminal_view.ambient_agent_view_model().cloned()
+            {
+                ambient_agent_view_model.update(ctx, |model, _| {
+                    model.record_ambient_execution_ended(ended_session_id);
+                });
+            }
+            if FeatureFlag::HandoffCloudCloud.is_enabled() {
                 terminal_view.on_ambient_agent_execution_ended(ctx);
-            });
-        }
+            } else {
+                terminal_view.on_session_share_ended(ctx);
+                model
+                    .lock()
+                    .set_shared_session_status(SharedSessionStatus::FinishedViewer);
+            }
+        });
         if Self::current_network(current_network)
             .is_some_and(|network| network.as_ref(ctx).session_id() == ended_session_id)
         {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6949,13 +6949,14 @@ impl TerminalView {
             if self.pending_cloud_followup_task_id == Some(task_id) {
                 return;
             }
-            if self.owned_ambient_agent_task_id(ctx).is_some() {
-                if FeatureFlag::HandoffCloudCloud.is_enabled()
-                    && !self
-                        .model
-                        .lock()
-                        .shared_session_status()
-                        .is_sharer_or_viewer()
+            if self.owned_ambient_agent_task_id(ctx).is_some()
+                && FeatureFlag::HandoffCloudCloud.is_enabled()
+            {
+                if !self
+                    .model
+                    .lock()
+                    .shared_session_status()
+                    .is_sharer_or_viewer()
                 {
                     self.enable_owned_cloud_followup_input(task_id, ctx);
                 }

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -729,7 +729,8 @@ impl TerminalView {
             let model = self.model.lock();
             FeatureFlag::CloudModeSetupV2.is_enabled()
                 && model.is_shared_ambient_agent_session()
-                && viewed_ambient_task_id_owned_by_current_user.is_none()
+                && (viewed_ambient_task_id_owned_by_current_user.is_none()
+                    || !FeatureFlag::HandoffCloudCloud.is_enabled())
                 && self.conversation_ended_tombstone_view_id.is_none()
                 && !model.is_receiving_agent_conversation_replay()
         };
@@ -772,7 +773,9 @@ impl TerminalView {
         });
 
         if self.pending_cloud_followup_task_id.is_none() {
-            if let Some(task_id) = viewed_ambient_task_id_owned_by_current_user {
+            if let Some(task_id) = viewed_ambient_task_id_owned_by_current_user
+                .filter(|_| FeatureFlag::HandoffCloudCloud.is_enabled())
+            {
                 self.enable_owned_cloud_followup_input(task_id, ctx);
             } else if self.model.lock().shared_session_status().is_viewer() {
                 // When the session is ended, the input should be uneditable iff this is a viewer.
@@ -811,18 +814,19 @@ impl TerminalView {
             });
         }
         self.refresh_conversation_details_panel_if_open(ctx);
-        if !FeatureFlag::HandoffCloudCloud.is_enabled()
-            || !FeatureFlag::CloudModeSetupV2.is_enabled()
+        if !FeatureFlag::CloudModeSetupV2.is_enabled()
             || self.conversation_ended_tombstone_view_id.is_some()
             || self.pending_cloud_followup_task_id.is_some()
         {
             return;
         }
-        if let Some(task_id) = self.owned_ambient_agent_task_id(ctx) {
-            if !has_live_shared_session {
-                self.enable_owned_cloud_followup_input(task_id, ctx);
+        if FeatureFlag::HandoffCloudCloud.is_enabled() {
+            if let Some(task_id) = self.owned_ambient_agent_task_id(ctx) {
+                if !has_live_shared_session {
+                    self.enable_owned_cloud_followup_input(task_id, ctx);
+                }
+                return;
             }
-            return;
         }
 
         self.insert_conversation_ended_tombstone(ctx);

--- a/app/src/terminal/view/shared_session/view_impl_test.rs
+++ b/app/src/terminal/view/shared_session/view_impl_test.rs
@@ -469,6 +469,7 @@ fn cloud_mode_terminal_for_test(app: &mut App) -> ViewHandle<TerminalView> {
 #[test]
 fn test_on_session_share_ended_enables_followup_input_without_tombstone_for_owned_ambient_session()
 {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
     let _flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
 
     App::test((), |mut app| async move {
@@ -512,6 +513,7 @@ fn test_on_session_share_ended_enables_followup_input_without_tombstone_for_owne
 
 #[test]
 fn test_on_session_share_ended_clears_frozen_followup_input_for_owned_ambient_session() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
     let _flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
 
     App::test((), |mut app| async move {
@@ -876,7 +878,7 @@ fn test_on_ambient_agent_execution_ended_refreshes_open_details_panel_to_termina
 }
 
 #[test]
-fn test_on_ambient_agent_execution_ended_does_not_insert_tombstone_without_handoff() {
+fn test_on_ambient_agent_execution_ended_inserts_tombstone_without_handoff() {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(false);
     let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
 
@@ -893,8 +895,8 @@ fn test_on_ambient_agent_execution_ended_does_not_insert_tombstone_without_hando
         terminal.read(&app, |view, _| {
             let final_block_height_items =
                 view.model.lock().block_list().block_heights().items().len();
-            assert_eq!(final_block_height_items, initial_block_height_items);
-            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert_eq!(final_block_height_items, initial_block_height_items + 1);
+            assert!(view.conversation_ended_tombstone_view_id.is_some());
         });
     });
 }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

There was a bug where, even if the cloud->cloud handoff feature flag was disabled, we would still show the input. We should be hiding the input and showing the tombstone in this case (which was the pre-existing behavior), as sending a prompt when the feature flag is off does nothing.

## Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/ec96521050f74d3c9e795eab110fbcc7

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
