### PR TITLE
fix: update openssl to resolve CVE-2026-42327

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9082,15 +9082,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -9114,9 +9113,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary

Updates the `openssl` Rust crate from 0.10.78 to 0.10.79 to resolve [CVE-2026-42327](https://github.com/advisories/GHSA-xp3w-r5p5-63rr) (HIGH severity).

**Vulnerability:** Undefined behavior in `X509Ref::ocsp_responders` for certificates with non-UTF-8 OCSP URLs in the `rust-openssl` crate.

- **Advisory:** https://github.com/rust-openssl/rust-openssl/security/advisories/GHSA-xp3w-r5p5-63rr
- **Dependabot alert:** https://github.com/warpdotdev/warp/security/dependabot/8

## Changes

- Updated `openssl` 0.10.78 → 0.10.79 (transitive dependency via `native-tls`)
- Updated `openssl-sys` 0.9.114 → 0.9.115

This is a transitive dependency update — only `Cargo.lock` is changed. No code changes required.

## Verification

- `cargo audit` confirms CVE-2026-42327 / GHSA-xp3w-r5p5-63rr no longer appears in the lockfile.

---

_Conversation: https://staging.warp.dev/conversation/7f0937c9-19a2-446e-980f-fbe3607295aa_
_Run: https://oz.staging.warp.dev/runs/019e032a-efca-74b6-bb04-7d04f7b1466f_

_This PR was generated with [Oz](https://warp.dev/oz)._
