### PR TITLE
Re-index project rules on startup.

### DIFF
--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 #[cfg(feature = "local_fs")]
 use repo_metadata::repositories::RepoDetectionSource;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use warpui::{Entity, ModelContext, SingletonEntity};
 
@@ -175,6 +175,10 @@ pub struct ProjectContextModel {
     /// the Vec holds updates that arrived while that task was running.
     #[cfg(feature = "local_fs")]
     pending_updates: HashMap<PathBuf, Vec<RepositoryUpdate>>,
+    /// Repo roots that already have a watcher registered, so we never
+    /// subscribe more than once per root.
+    #[cfg(feature = "local_fs")]
+    watched_roots: HashSet<PathBuf>,
 }
 
 #[derive(Default, Debug)]
@@ -305,7 +309,7 @@ impl ProjectContextModel {
     /// the actual repo watcher might not have been registered yet. We will attempt to register that repo watcher
     /// if it doesn't yet exists.
     #[cfg(feature = "local_fs")]
-    fn try_initialize_and_register_watcher(&self, path: &Path, ctx: &mut ModelContext<Self>) {
+    fn try_initialize_and_register_watcher(&mut self, path: &Path, ctx: &mut ModelContext<Self>) {
         use repo_metadata::repositories::DetectedRepositories;
 
         let directory_watcher = DirectoryWatcher::handle(ctx);
@@ -334,12 +338,18 @@ impl ProjectContextModel {
     }
 
     #[cfg(feature = "local_fs")]
-    fn register_watcher_for_path(&self, path: &Path, ctx: &mut ModelContext<Self>) {
+    fn register_watcher_for_path(&mut self, path: &Path, ctx: &mut ModelContext<Self>) {
+        if self.watched_roots.contains(path) {
+            return;
+        }
+
         let Some(repository_model) =
             DirectoryWatcher::as_ref(ctx).get_watched_directory_for_path(path)
         else {
             return;
         };
+
+        self.watched_roots.insert(path.to_path_buf());
 
         let (repository_update_tx, repository_update_rx) = async_channel::unbounded();
         let start = repository_model.update(ctx, |repo, ctx| {

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 #[cfg(feature = "local_fs")]
 use repo_metadata::repositories::RepoDetectionSource;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+#[cfg(feature = "local_fs")]
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use warpui::{Entity, ModelContext, SingletonEntity};
 

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -254,9 +254,6 @@ impl ProjectContextModel {
         root_path: PathBuf,
         ctx: &mut ModelContext<Self>,
     ) -> Result<()> {
-        if self.path_to_rules.contains_key(&root_path) {
-            return Ok(());
-        }
         #[cfg(feature = "local_fs")]
         {
             let root_clone = root_path.clone();
@@ -571,6 +568,10 @@ impl ProjectContextModel {
                     match async_fs::read_to_string(&target_file.path).await {
                         Ok(content) => {
                             existing_rules.upsert_rule(&target_file.path, content);
+                            rules_delta.discovered_rules.push(ProjectRulePath {
+                                path: target_file.path.clone(),
+                                project_root: project_root.clone(),
+                            });
                         }
                         Err(e) => {
                             log::warn!(


### PR DESCRIPTION
Caching rule-paths for indexed repos is problematic because the entries could go stale and prevent re-indexing of the repo. For example, suppose we index a repo that has a root `WARP.md` file. Later on, the user adds a `dir/WARP.md` file. Currently, we would not detect the new sub-dir WARP.md file because we wouldn't re-index the repo (because we already have a rule-file for the repo).

If we think this is the correct solution, we should probably get rid of the `project_rules` sqlite table.