### PR TITLE
Prevent new conversation speedbump for cloud conversations

### DIFF
--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -160,7 +160,6 @@ fn get_supported_tools(params: &RequestParams) -> Vec<api::ToolType> {
         api::ToolType::InitProject,
         api::ToolType::OpenCodeReview,
         api::ToolType::RunShellCommand,
-        api::ToolType::SuggestNewConversation,
         api::ToolType::Subagent,
         api::ToolType::WriteToLongRunningShellCommand,
         api::ToolType::ReadShellCommandOutput,
@@ -169,6 +168,12 @@ fn get_supported_tools(params: &RequestParams) -> Vec<api::ToolType> {
         api::ToolType::EditDocuments,
         api::ToolType::SuggestPrompt,
     ];
+
+    // Cloud agents run autonomously and can't present the new-conversation speedbump UI.
+    let is_ambient_agent = params.ambient_agent_task_id.is_some();
+    if !is_ambient_agent {
+        supported_tools.push(api::ToolType::SuggestNewConversation);
+    }
 
     if FeatureFlag::ConversationsAsContext.is_enabled() {
         supported_tools.push(api::ToolType::FetchConversation);

--- a/app/src/ai/agent/api/impl_tests.rs
+++ b/app/src/ai/agent/api/impl_tests.rs
@@ -80,3 +80,26 @@ fn supported_tools_omit_upload_artifact_when_feature_flag_is_disabled() {
 
     assert!(!supported_tools.contains(&api::ToolType::UploadFileArtifact));
 }
+
+#[test]
+fn supported_tools_include_suggest_new_conversation_for_local_conversations() {
+    let params = request_params_with_ask_user_question_enabled(false);
+    let supported_tools = get_supported_tools(&params);
+
+    assert!(supported_tools.contains(&api::ToolType::SuggestNewConversation));
+}
+
+#[test]
+fn supported_tools_omit_suggest_new_conversation_for_ambient_agent() {
+    use crate::ai::ambient_agents::AmbientAgentTaskId;
+
+    let mut params = request_params_with_ask_user_question_enabled(false);
+    params.ambient_agent_task_id = Some(
+        "00000000-0000-0001-0000-000000000001"
+            .parse::<AmbientAgentTaskId>()
+            .unwrap(),
+    );
+    let supported_tools = get_supported_tools(&params);
+
+    assert!(!supported_tools.contains(&api::ToolType::SuggestNewConversation));
+}


### PR DESCRIPTION
## Problem

Cloud conversations should not hit the suggested conversation speed-bump (the main reason being that there's no way to accept or reject the speed bump in a cloud agent session). The main fix for this was in the server-side PR for this ticket, wherein we early return from the new conversation speedbump fn when we're in a cloud conversation.

However, we can also be defensive on the client and remove the new conversation tool from the list of available tools when we're in a cloud conversation.

_Conversation: https://staging.warp.dev/conversation/e95dfa82-6895-4171-82b3-d13b95cc3cc6_
_Run: https://oz.staging.warp.dev/runs/019e032a-ab3a-7eaa-8454-d6045a0d7b09_
_This PR was generated with [Oz](https://warp.dev/oz)._
