### PR TITLE
Fix restoring cloud conversation transcripts

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -3376,14 +3376,10 @@ impl PaneGroup {
                     conversation_id,
                     ambient_agent_task_id: _,
                 }) => {
-                    let loaded =
-                        self.terminal_view_from_pane_id(pane_id, ctx)
-                            .is_some_and(|target_view| {
-                                Self::fetch_and_load_transcript(target_view, conversation_id, ctx)
-                            });
-                    if !loaded {
-                        self.pending_ambient_agent_conversation_restorations
-                            .insert(task_id, pane_id);
+                    if let Some(target_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
+                        Self::fetch_and_load_transcript(target_view, conversation_id, ctx);
+                    } else {
+                        self.replace_pane_with_new_cloud_conversation(pane_id, ctx);
                     }
                 }
                 _ => {
@@ -3394,27 +3390,16 @@ impl PaneGroup {
     }
 
     /// Fetches conversation data and loads it into the given transcript viewer.
-    ///
-    /// Returns `true` if the conversation metadata was found and the async load
-    /// was kicked off, or `false` if the metadata isn't available yet (caller
-    /// should defer and retry later).
     fn fetch_and_load_transcript(
         target_view: ViewHandle<TerminalView>,
         server_conversation_token: ServerConversationToken,
         ctx: &mut ViewContext<Self>,
-    ) -> bool {
+    ) {
         let history_model_handle = BlocklistAIHistoryModel::handle(ctx);
-        let ai_conversation_id = history_model_handle
-            .as_ref(ctx)
-            .find_conversation_id_by_server_token(&server_conversation_token);
-
-        let Some(ai_conversation_id) = ai_conversation_id else {
-            return false;
-        };
 
         let future = history_model_handle
             .as_ref(ctx)
-            .load_conversation_data(ai_conversation_id, ctx);
+            .load_conversation_by_server_token(&server_conversation_token, ctx);
         ctx.spawn(future, move |group, conversation, ctx| {
             if let Some(conversation) = conversation {
                 group.load_data_into_transcript_viewer(target_view, conversation, ctx);
@@ -3427,7 +3412,6 @@ impl PaneGroup {
                 group.replace_pane_with_new_cloud_conversation(pane_id, ctx);
             }
         });
-        true
     }
 
     /// Replaces a pane with a new cloud conversation.


### PR DESCRIPTION
## Description

Fix cloud conversation transcript viewer pane getting permanently stuck in the loading state after quit and restart.

When a pane was viewing a cloud conversation transcript (from an ambient agent run), the pane is saved as an `AmbientAgent` snapshot. On restore, it creates a loading pane and defers restoration until task data arrives from the server. The deferred handler calls `fetch_and_load_transcript`, which used a two-step lookup: first `find_conversation_id_by_server_token` to map the server token to a local `AIConversationId`, then `load_conversation_data`. If the conversation's metadata wasn't included in the initial cloud metadata fetch (e.g., 3 requested but only 2 returned), the token was never found locally. The task was re-inserted into the pending restorations map, but no further events fired to retry — leaving the pane stuck in `Loading` forever.

The fix switches `fetch_and_load_transcript` to use `load_conversation_by_server_token`, which already has a built-in server fallback when the token isn't in the local cache.

## Testing

- Quit Warp while a pane is viewing a cloud conversation transcript
- Restart Warp
- Verify the pane loads the conversation transcript instead of staying in the loading spinner

- [x] I have manually tested my changes locally with `./script/run`

https://www.loom.com/share/58201254f6014ef496b25fbe78472eb6

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed cloud conversation transcript pane getting stuck in loading state after restarting Warp