### PR TITLE
Promote ConfigurableContextWindow to Stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -625,6 +625,7 @@ default = [
     "skip_firebase_anonymous_user",
     "settings_file",
     "directory_tab_colors",
+    "configurable_context_window",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -935,7 +935,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::LocalDockerSandbox,
     FeatureFlag::VerticalTabsSummaryMode,
     FeatureFlag::CloudModeSetupV2,
-    FeatureFlag::ConfigurableContextWindow,
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,
     FeatureFlag::CloudModeInputV2,


### PR DESCRIPTION
## Description
Promotes the `ConfigurableContextWindow` feature flag from Dogfood to Stable, enabling the user-configurable context window slider in AI settings and the execution profile editor for all users.

### Changes
- Added `configurable_context_window` to the `default` Cargo feature list in `app/Cargo.toml`
- Removed `FeatureFlag::ConfigurableContextWindow` from `DOGFOOD_FLAGS` in `crates/warp_features/src/lib.rs` (no longer needed since the Cargo default feature enables it in all builds via the existing bridge in `app/src/lib.rs`)

## Linked Issue
N/A

## Testing
Feature flag promotion only — no behavioral changes. The flag was previously validated in Dogfood builds.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: The context window size slider is now available to all users in AI settings and the execution profile editor.
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
