### PR TITLE
Hide unnecessary chips when in handoff input mode

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -1976,6 +1976,13 @@ impl AgentInputFooter {
         {
             return None;
         }
+
+        if self.handoff_compose_state.as_ref(app).is_active()
+            && !item.is_available_during_handoff_compose()
+        {
+            return None;
+        }
+
         match item {
             AgentToolbarItemKind::ContextChip(chip_kind) => {
                 let chips = match SessionSettings::as_ref(app)

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
@@ -150,6 +150,23 @@ impl AgentToolbarItemKind {
         }
     }
 
+    /// Whether this item should remain visible during `&` handoff-compose mode.
+    /// Only items relevant to composing a cloud run are shown.
+    pub(super) fn is_available_during_handoff_compose(&self) -> bool {
+        match self {
+            Self::ModelSelector | Self::VoiceInput | Self::FileAttach => true,
+            Self::ContextChip(_)
+            | Self::NLDToggle
+            | Self::ContextWindowUsage
+            | Self::FastForwardToggle
+            | Self::HandoffToCloud
+            | Self::ShareSession
+            | Self::FileExplorer
+            | Self::RichInput
+            | Self::Settings => false,
+        }
+    }
+
     pub fn is_context_chip(&self) -> bool {
         matches!(self, Self::ContextChip(_))
     }

--- a/specs/REMOTE-1595/PRODUCT.md
+++ b/specs/REMOTE-1595/PRODUCT.md
@@ -1,0 +1,31 @@
+# Handoff-Compose Footer Chip Filtering — Product Spec
+Linear: [REMOTE-1595](https://linear.app/warpdotdev/issue/REMOTE-1595)
+## Summary
+When `&` handoff-compose mode is active, the agent view footer should show only the chips relevant to composing a cloud run — hiding local-context and local-agent-only items that do not apply.
+## Problem
+The default agent footer shows chips for local context (working directory, git branch, diff stats, SSH, etc.) and local-agent controls (autodetection toggle, fast-forward, context window usage, handoff-to-cloud chip). None of these are meaningful when the user is drafting a prompt to hand off to a cloud agent. Showing them adds clutter and implies they affect the cloud run.
+## Behavior
+### Shown items
+While `&` handoff-compose mode is active, the footer shows only:
+1. **Environment selector** — the transient `&` selector, already wired (not a toolbar item).
+2. **ModelSelector** — the user may want to choose which model the cloud agent uses.
+3. **VoiceInput** — alternative input method for dictating the prompt.
+4. **FileAttach** — file/image attachments carry to the cloud run.
+### Hidden items
+All other `AgentToolbarItemKind` variants are hidden while `&` is active:
+- All `ContextChip(...)` variants — local context, not sent to the cloud run.
+- `NLDToggle` — input is locked AI in `&` mode; autodetection is irrelevant.
+- `ContextWindowUsage` — shows local conversation context, not cloud.
+- `FastForwardToggle` — fast-forward state does not carry into cloud runs.
+- `HandoffToCloud` — already in handoff mode; redundant.
+- `ShareSession` — not relevant to composing a handoff.
+### Constraints
+- The user's configured footer layout is not modified. Items are only visually hidden while `&` is active; exiting `&` mode restores the normal footer.
+- Items the user has explicitly hidden in their toolbar config remain hidden regardless.
+- The filtering applies only in the agent view footer, not the CLI agent footer.
+## Figma
+None provided.
+## Validation
+- Enter `&` mode in a local fullscreen agent view. Confirm only ModelSelector, VoiceInput, FileAttach, and the environment selector are visible.
+- Exit `&` mode. Confirm the full configured footer layout is restored.
+- Verify that hidden items are not removed from the user's toolbar config.

--- a/specs/REMOTE-1595/TECH.md
+++ b/specs/REMOTE-1595/TECH.md
@@ -1,0 +1,30 @@
+# Handoff-Compose Footer Chip Filtering — Tech Spec
+Product spec: `specs/REMOTE-1595/PRODUCT.md`
+Linear: [REMOTE-1595](https://linear.app/warpdotdev/issue/REMOTE-1595)
+## Context
+`AgentInputFooter::render_toolbar_item` (`app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs:1945`) is called for each user-configured left/right toolbar item during footer rendering. It already filters by `available_in()` and `available_to_session_viewer()`. The footer already has access to `handoff_compose_state: ModelHandle<HandoffComposeState>` (added in the REMOTE-1558 PR).
+The environment selector for `&` mode is rendered separately at `mod.rs:2108`, outside the toolbar item loop, so it is unaffected by toolbar filtering.
+## Proposed changes
+### 1. Add `AgentToolbarItemKind::is_available_during_handoff_compose`
+Add a method on `AgentToolbarItemKind` in `toolbar_item.rs` that returns whether the item should render during `&` handoff-compose mode:
+```rust path=null start=null
+fn is_available_during_handoff_compose(&self) -> bool {
+    matches!(
+        self,
+        Self::ModelSelector | Self::VoiceInput | Self::FileAttach
+    )
+}
+```
+### 2. Guard in `render_toolbar_item`
+At the top of `render_toolbar_item` (`mod.rs:1945`), after the existing `available_in()` / `available_to_session_viewer()` guard, add:
+```rust path=null start=null
+if self.handoff_compose_state.as_ref(app).is_active()
+    && !item.is_available_during_handoff_compose()
+{
+    return None;
+}
+```
+This is purely a render-time filter; it does not mutate the user's configured layout.
+## Testing
+- Unit test: verify `is_available_during_handoff_compose` returns `true` only for `ModelSelector`, `VoiceInput`, `FileAttach`.
+- Integration/manual: enter `&` mode, confirm only those three items plus the environment selector render. Exit `&`, confirm full footer restores.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Most of the chips in the agent view input don't make sense when you're in the `&` input mode. We also want to make the chip transition a little more pronounced, because when you enter the `&` mode we add in an environment selector chip that it would be good for people to notice.

For both of these reasons, this PR hides all of the chips in the agent view input that don't make sense for `&` mode when you're in `&` mode.

## Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/df78cd1dade94dce834172ae38d04668

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode