### PR TITLE
[APP-3792] update `ServerApi` to handle optionally not refreshing token

### DIFF
--- a/app/src/auth/auth_state.rs
+++ b/app/src/auth/auth_state.rs
@@ -20,7 +20,10 @@ use super::{
     anonymous_id::get_or_create_anonymous_id,
     auth_manager::user_persistence::PersistedUser,
     credentials::Credentials,
-    user::{AnonymousUserType, FirebaseAuthTokens, PersonalObjectLimits, PrincipalType, User},
+    user::{
+        AnonymousUserType, FirebaseAuthTokens, PersonalObjectLimits, PrincipalType, User,
+        UserMetadata,
+    },
     UserUid, API_KEY_PREFIX,
 };
 
@@ -70,6 +73,15 @@ impl AuthState {
             anonymous_id: Uuid::new_v4(),
             needs_reauth: AtomicBool::new(false),
             credentials: RwLock::new(Some(Credentials::Test)),
+        }
+    }
+    #[cfg(test)]
+    pub fn new_logged_out_for_test() -> Self {
+        Self {
+            user: RwLock::new(None),
+            anonymous_id: Uuid::new_v4(),
+            needs_reauth: AtomicBool::new(false),
+            credentials: RwLock::new(None),
         }
     }
 
@@ -167,6 +179,7 @@ impl AuthState {
             (None, None) => PersistAction::Remove,
             // Do not persist if using API keys, session cookies, or test credentials.
             (Some(_), Some(Credentials::ApiKey { .. })) => PersistAction::DoNothing,
+            (Some(_), Some(Credentials::Bearer(_))) => PersistAction::DoNothing,
             (Some(_), Some(Credentials::SessionCookie)) => PersistAction::DoNothing,
             #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             (Some(_), Some(Credentials::Test)) => PersistAction::DoNothing,
@@ -213,6 +226,75 @@ impl AuthState {
     /// Sets the credentials. Should only be called within the auth module.
     pub(super) fn set_credentials(&self, credentials: Option<Credentials>) {
         *self.credentials.write() = credentials;
+    }
+    /// Applies auth data received by the remote server daemon handshake.
+    ///
+    /// Empty fields are intentionally ignored so reconnects or token-rotation messages can update
+    /// one part of the auth context without clearing the rest.
+    pub(crate) fn apply_remote_server_auth_context(
+        &self,
+        auth_token: Option<String>,
+        user_id: Option<String>,
+        user_email: Option<String>,
+    ) {
+        if let Some(auth_token) = auth_token.filter(|token| !token.is_empty()) {
+            self.set_remote_server_bearer_token(auth_token);
+        }
+
+        let Some(user_id) = user_id.filter(|user_id| !user_id.is_empty()) else {
+            return;
+        };
+
+        let existing_user = self.user.read().clone();
+        let user_email = user_email
+            .filter(|email| !email.is_empty())
+            .or_else(|| {
+                existing_user
+                    .as_ref()
+                    .map(|user| user.metadata.email.clone())
+            })
+            .unwrap_or_default();
+
+        let existing_metadata = existing_user.as_ref().map(|user| &user.metadata);
+        let user = User {
+            local_id: UserUid::new(user_id),
+            metadata: UserMetadata {
+                email: user_email,
+                display_name: existing_metadata.and_then(|metadata| metadata.display_name.clone()),
+                photo_url: existing_metadata.and_then(|metadata| metadata.photo_url.clone()),
+            },
+            is_onboarded: existing_user
+                .as_ref()
+                .map(|user| user.is_onboarded)
+                .unwrap_or_default(),
+            needs_sso_link: existing_user
+                .as_ref()
+                .map(|user| user.needs_sso_link)
+                .unwrap_or_default(),
+            anonymous_user_type: existing_user
+                .as_ref()
+                .and_then(|user| user.anonymous_user_type),
+            is_on_work_domain: existing_user
+                .as_ref()
+                .map(|user| user.is_on_work_domain)
+                .unwrap_or_default(),
+            linked_at: existing_user.as_ref().and_then(|user| user.linked_at),
+            personal_object_limits: existing_user
+                .as_ref()
+                .and_then(|user| user.personal_object_limits),
+            principal_type: existing_user
+                .as_ref()
+                .map(|user| user.principal_type)
+                .unwrap_or_default(),
+        };
+        self.set_user(Some(user));
+    }
+
+    pub(crate) fn set_remote_server_bearer_token(&self, auth_token: String) {
+        if auth_token.is_empty() {
+            return;
+        }
+        self.set_credentials(Some(Credentials::Bearer(auth_token)));
     }
 
     /// Updates the Firebase auth tokens within the current credentials.
@@ -497,12 +579,7 @@ impl AuthStateProvider {
     #[cfg(test)]
     pub fn new_logged_out_for_test() -> Self {
         Self {
-            auth_state: Arc::new(AuthState {
-                user: RwLock::new(None),
-                anonymous_id: Uuid::new_v4(),
-                needs_reauth: AtomicBool::new(false),
-                credentials: RwLock::new(None),
-            }),
+            auth_state: Arc::new(AuthState::new_logged_out_for_test()),
         }
     }
 

--- a/app/src/auth/auth_state.rs
+++ b/app/src/auth/auth_state.rs
@@ -229,72 +229,56 @@ impl AuthState {
     }
     /// Applies auth data received by the remote server daemon handshake.
     ///
-    /// Empty fields are intentionally ignored so reconnects or token-rotation messages can update
-    /// one part of the auth context without clearing the rest.
+    /// Empty values are authoritative: an empty token clears bearer credentials, and an empty user
+    /// ID clears the daemon user identity.
     pub(crate) fn apply_remote_server_auth_context(
         &self,
-        auth_token: Option<String>,
-        user_id: Option<String>,
-        user_email: Option<String>,
+        auth_token: String,
+        user_id: String,
+        user_email: String,
     ) {
-        if let Some(auth_token) = auth_token.filter(|token| !token.is_empty()) {
-            self.set_remote_server_bearer_token(auth_token);
-        }
-
-        let Some(user_id) = user_id.filter(|user_id| !user_id.is_empty()) else {
-            return;
-        };
-
-        let existing_user = self.user.read().clone();
-        let user_email = user_email
-            .filter(|email| !email.is_empty())
-            .or_else(|| {
-                existing_user
-                    .as_ref()
-                    .map(|user| user.metadata.email.clone())
-            })
-            .unwrap_or_default();
-
-        let existing_metadata = existing_user.as_ref().map(|user| &user.metadata);
-        let user = User {
-            local_id: UserUid::new(user_id),
-            metadata: UserMetadata {
-                email: user_email,
-                display_name: existing_metadata.and_then(|metadata| metadata.display_name.clone()),
-                photo_url: existing_metadata.and_then(|metadata| metadata.photo_url.clone()),
-            },
-            is_onboarded: existing_user
-                .as_ref()
-                .map(|user| user.is_onboarded)
-                .unwrap_or_default(),
-            needs_sso_link: existing_user
-                .as_ref()
-                .map(|user| user.needs_sso_link)
-                .unwrap_or_default(),
-            anonymous_user_type: existing_user
-                .as_ref()
-                .and_then(|user| user.anonymous_user_type),
-            is_on_work_domain: existing_user
-                .as_ref()
-                .map(|user| user.is_on_work_domain)
-                .unwrap_or_default(),
-            linked_at: existing_user.as_ref().and_then(|user| user.linked_at),
-            personal_object_limits: existing_user
-                .as_ref()
-                .and_then(|user| user.personal_object_limits),
-            principal_type: existing_user
-                .as_ref()
-                .map(|user| user.principal_type)
-                .unwrap_or_default(),
-        };
-        self.set_user(Some(user));
+        self.set_remote_server_bearer_token(auth_token);
+        self.set_remote_server_user(user_id, user_email);
     }
 
     pub(crate) fn set_remote_server_bearer_token(&self, auth_token: String) {
         if auth_token.is_empty() {
+            self.set_credentials(None);
             return;
         }
         self.set_credentials(Some(Credentials::Bearer(auth_token)));
+    }
+
+    fn set_remote_server_user(&self, user_id: String, user_email: String) {
+        let mut user = self.user.write();
+        if user_id.is_empty() {
+            *user = None;
+            return;
+        }
+
+        match user.as_mut() {
+            Some(user) => {
+                user.local_id = UserUid::new(&user_id);
+                user.metadata.email = user_email;
+            }
+            None => {
+                *user = Some(User {
+                    local_id: UserUid::new(&user_id),
+                    metadata: UserMetadata {
+                        email: user_email,
+                        display_name: None,
+                        photo_url: None,
+                    },
+                    is_onboarded: false,
+                    needs_sso_link: false,
+                    anonymous_user_type: None,
+                    is_on_work_domain: false,
+                    linked_at: None,
+                    personal_object_limits: None,
+                    principal_type: PrincipalType::default(),
+                });
+            }
+        }
     }
 
     /// Updates the Firebase auth tokens within the current credentials.

--- a/app/src/auth/auth_state.rs
+++ b/app/src/auth/auth_state.rs
@@ -231,6 +231,7 @@ impl AuthState {
     ///
     /// Empty values are authoritative: an empty token clears bearer credentials, and an empty user
     /// ID clears the daemon user identity.
+    #[cfg(any(not(target_family = "wasm"), test))]
     pub(crate) fn apply_remote_server_auth_context(
         &self,
         auth_token: String,
@@ -241,6 +242,7 @@ impl AuthState {
         self.set_remote_server_user(user_id, user_email);
     }
 
+    #[cfg(any(not(target_family = "wasm"), test))]
     pub(crate) fn set_remote_server_bearer_token(&self, auth_token: String) {
         if auth_token.is_empty() {
             self.set_credentials(None);
@@ -249,6 +251,7 @@ impl AuthState {
         self.set_credentials(Some(Credentials::Bearer(auth_token)));
     }
 
+    #[cfg(any(not(target_family = "wasm"), test))]
     fn set_remote_server_user(&self, user_id: String, user_email: String) {
         let mut user = self.user.write();
         if user_id.is_empty() {

--- a/app/src/auth/auth_state.rs
+++ b/app/src/auth/auth_state.rs
@@ -20,13 +20,12 @@ use super::{
     anonymous_id::get_or_create_anonymous_id,
     auth_manager::user_persistence::PersistedUser,
     credentials::Credentials,
-    user::{
-        AnonymousUserType, FirebaseAuthTokens, PersonalObjectLimits, PrincipalType, User,
-    },
-    #[cfg(any(not(target_family = "wasm"), test))]
-    user::UserMetadata,
+    user::{AnonymousUserType, FirebaseAuthTokens, PersonalObjectLimits, PrincipalType, User},
     UserUid, API_KEY_PREFIX,
 };
+
+#[cfg(any(not(target_family = "wasm"), test))]
+use super::user::UserMetadata;
 
 const ANONYMOUS_USER_NOTIFICATION_BLOCK_TIMER: Duration = Duration::days(7);
 

--- a/app/src/auth/auth_state.rs
+++ b/app/src/auth/auth_state.rs
@@ -22,6 +22,7 @@ use super::{
     credentials::Credentials,
     user::{
         AnonymousUserType, FirebaseAuthTokens, PersonalObjectLimits, PrincipalType, User,
+        #[cfg(any(not(target_family = "wasm"), test))]
         UserMetadata,
     },
     UserUid, API_KEY_PREFIX,

--- a/app/src/auth/auth_state.rs
+++ b/app/src/auth/auth_state.rs
@@ -22,9 +22,9 @@ use super::{
     credentials::Credentials,
     user::{
         AnonymousUserType, FirebaseAuthTokens, PersonalObjectLimits, PrincipalType, User,
-        #[cfg(any(not(target_family = "wasm"), test))]
-        UserMetadata,
     },
+    #[cfg(any(not(target_family = "wasm"), test))]
+    user::UserMetadata,
     UserUid, API_KEY_PREFIX,
 };
 

--- a/app/src/auth/credentials.rs
+++ b/app/src/auth/credentials.rs
@@ -107,6 +107,8 @@ pub enum AuthToken {
     Firebase(String),
     /// API key for direct server authentication.
     ApiKey(String),
+    /// Request-scoped or externally managed bearer token.
+    Bearer(String),
     /// No authentication token available (e.g. session cookie auth or test credentials).
     #[cfg_attr(
         not(any(test, feature = "integration_tests", feature = "skip_login")),
@@ -122,6 +124,7 @@ impl AuthToken {
         match self {
             AuthToken::Firebase(token) => Some(token),
             AuthToken::ApiKey(key) => Some(key),
+            AuthToken::Bearer(token) => Some(token),
             AuthToken::NoAuth => None,
         }
     }
@@ -131,6 +134,7 @@ impl AuthToken {
         match self {
             AuthToken::Firebase(token) => Some(token.clone()),
             AuthToken::ApiKey(key) => Some(key.clone()),
+            AuthToken::Bearer(token) => Some(token.clone()),
             AuthToken::NoAuth => None,
         }
     }

--- a/app/src/auth/credentials.rs
+++ b/app/src/auth/credentials.rs
@@ -23,6 +23,8 @@ pub enum Credentials {
         /// The owner type for this API key. Only set after user info is fetched from the server.
         owner_type: Option<OwnerType>,
     },
+    /// Request-scoped or externally managed bearer token.
+    Bearer(String),
     /// Authentication derived from an ambient browser session cookie.
     SessionCookie,
     /// Test credentials used in unit tests, integration tests, and skip_login builds.
@@ -36,6 +38,7 @@ impl Credentials {
         match self {
             Credentials::Firebase(tokens) => Some(tokens),
             Credentials::ApiKey { .. } => None,
+            Credentials::Bearer(_) => None,
             Credentials::SessionCookie => None,
             #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => None,
@@ -47,6 +50,7 @@ impl Credentials {
         match self {
             Credentials::ApiKey { key, .. } => Some(key),
             Credentials::Firebase(_) => None,
+            Credentials::Bearer(_) => None,
             Credentials::SessionCookie => None,
             #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => None,
@@ -58,6 +62,7 @@ impl Credentials {
         match self {
             Credentials::ApiKey { owner_type, .. } => *owner_type,
             Credentials::Firebase(_) => None,
+            Credentials::Bearer(_) => None,
             Credentials::SessionCookie => None,
             #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => None,
@@ -69,6 +74,7 @@ impl Credentials {
         match self {
             Credentials::Firebase(tokens) => Some(&tokens.refresh_token),
             Credentials::ApiKey { .. } => None,
+            Credentials::Bearer(_) => None,
             Credentials::SessionCookie => None,
             #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => None,
@@ -80,9 +86,22 @@ impl Credentials {
         match self {
             Credentials::Firebase(tokens) => AuthToken::Firebase(tokens.id_token.clone()),
             Credentials::ApiKey { key, .. } => AuthToken::ApiKey(key.clone()),
+            Credentials::Bearer(token) => AuthToken::Bearer(token.clone()),
             Credentials::SessionCookie => AuthToken::NoAuth,
             #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => AuthToken::NoAuth,
+        }
+    }
+    /// Returns whether these credentials are externally managed and should not trigger local token
+    /// refresh or reauth flows.
+    pub fn is_externally_managed(&self) -> bool {
+        match self {
+            Credentials::Bearer(_) => true,
+            Credentials::Firebase(_) | Credentials::ApiKey { .. } | Credentials::SessionCookie => {
+                false
+            }
+            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
+            Credentials::Test => false,
         }
     }
 
@@ -93,6 +112,7 @@ impl Credentials {
                 RefreshToken::new(&tokens.refresh_token),
             ))),
             Credentials::ApiKey { key, .. } => Some(LoginToken::ApiKey(key.clone())),
+            Credentials::Bearer(_) => None,
             Credentials::SessionCookie => Some(LoginToken::SessionCookie),
             #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
             Credentials::Test => None,

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -40,6 +40,7 @@ pub type ConnectionId = uuid::Uuid;
 use super::protocol::RequestId;
 use crate::ai::agent::FileLocations;
 use crate::ai::blocklist::{read_local_file_context, ReadFileContextResult};
+use crate::auth::auth_state::{AuthState, AuthStateProvider};
 use crate::terminal::model::session::command_executor::{
     ExecuteCommandOptions, LocalCommandExecutor,
 };
@@ -136,37 +137,6 @@ impl PendingFileOps {
     }
 }
 
-/// Client-supplied auth credentials and user identity for the daemon.
-///
-/// Populated by `Initialize` and `Authenticate` messages. The auth token
-/// is used for server API calls; the user identity is forwarded to Sentry
-/// so crash reports from the daemon are attributed to the connecting user.
-///
-/// All fields are intentionally retained across proxy connection teardown
-/// and cleared only by daemon process exit.
-struct DaemonAuthContext {
-    /// Bearer credential set by Initialize / Authenticate.
-    auth_token: Option<String>,
-    /// User ID from the most recent `Initialize` handshake (Firebase UID).
-    #[cfg(feature = "crash_reporting")]
-    user_id: Option<String>,
-    /// User email from the most recent `Initialize` handshake.
-    #[cfg(feature = "crash_reporting")]
-    user_email: Option<String>,
-}
-
-impl DaemonAuthContext {
-    fn new() -> Self {
-        Self {
-            auth_token: None,
-            #[cfg(feature = "crash_reporting")]
-            user_id: None,
-            #[cfg(feature = "crash_reporting")]
-            user_email: None,
-        }
-    }
-}
-
 /// The top-level server-side orchestrator model.
 ///
 /// Receives `ClientMessage`s from connected proxy sessions and routes
@@ -202,7 +172,7 @@ pub struct ServerModel {
     /// Tracks in-flight file write/delete operations and handles cleanup.
     pending_file_ops: PendingFileOps,
     /// Daemon-wide auth credentials and user identity.
-    auth: DaemonAuthContext,
+    auth_state: Arc<AuthState>,
     /// Tracks open buffers, per-buffer connection sets, and pending async
     /// buffer requests (OpenBuffer, SaveBuffer).
     buffers: ServerBufferTracker,
@@ -230,7 +200,7 @@ impl ServerModel {
             host_id,
             executors: HashMap::new(),
             pending_file_ops: PendingFileOps::new(),
-            auth: DaemonAuthContext::new(),
+            auth_state: AuthStateProvider::as_ref(ctx).get().clone(),
             buffers: ServerBufferTracker::new(),
         };
         // Subscribe to FileModel and RepoMetadataModel events
@@ -790,13 +760,6 @@ impl ServerModel {
         // Update crash reporting based on client-supplied preferences.
         #[cfg(feature = "crash_reporting")]
         {
-            if !msg.user_id.is_empty() {
-                self.auth.user_id = Some(msg.user_id.clone());
-            }
-            if !msg.user_email.is_empty() {
-                self.auth.user_email = Some(msg.user_email.clone());
-            }
-
             if msg.crash_reporting_enabled {
                 self.apply_sentry_user_id(ctx);
             } else {
@@ -816,22 +779,20 @@ impl ServerModel {
     /// Applies the auth token from an `Initialize` message.
     /// Extracted so unit tests can call it without a `ModelContext`.
     fn apply_initialize_auth(&mut self, msg: &Initialize) {
-        if !msg.auth_token.is_empty() {
-            self.auth.auth_token = Some(msg.auth_token.clone());
-        }
+        self.auth_state.apply_remote_server_auth_context(
+            Some(msg.auth_token.clone()),
+            Some(msg.user_id.clone()),
+            Some(msg.user_email.clone()),
+        );
     }
 
-    /// Sets the Sentry user identity from the stored `DaemonAuthContext`.
+    /// Sets the Sentry user identity from the stored `AuthState`.
     /// Called both during `Initialize` and when re-enabling crash reporting
     /// via `UpdatePreferences`.
     #[cfg(feature = "crash_reporting")]
     fn apply_sentry_user_id(&self, ctx: &mut warpui::AppContext) {
-        if let Some(user_id) = &self.auth.user_id {
-            crate::crash_reporting::set_user_id(
-                crate::auth::UserUid::new(user_id),
-                self.auth.user_email.clone(),
-                ctx,
-            );
+        if let Some(user_id) = self.auth_state.user_id() {
+            crate::crash_reporting::set_user_id(user_id, self.auth_state.user_email(), ctx);
         }
     }
 
@@ -866,11 +827,12 @@ impl ServerModel {
             log::warn!("Received Authenticate notification with empty auth token; ignoring");
             return;
         }
-        self.auth.auth_token = Some(msg.auth_token);
+        self.auth_state
+            .set_remote_server_bearer_token(msg.auth_token);
     }
 
-    pub fn auth_token(&self) -> Option<&str> {
-        self.auth.auth_token.as_deref()
+    pub fn auth_token(&self) -> Option<String> {
+        self.auth_state.get_access_token_ignoring_validity()
     }
 
     /// Handles `Abort` by cancelling the in-progress request it targets.

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -780,9 +780,9 @@ impl ServerModel {
     /// Extracted so unit tests can call it without a `ModelContext`.
     fn apply_initialize_auth(&mut self, msg: &Initialize) {
         self.auth_state.apply_remote_server_auth_context(
-            Some(msg.auth_token.clone()),
-            Some(msg.user_id.clone()),
-            Some(msg.user_email.clone()),
+            msg.auth_token.clone(),
+            msg.user_id.clone(),
+            msg.user_email.clone(),
         );
     }
 
@@ -823,10 +823,6 @@ impl ServerModel {
     /// Handles `Authenticate` by replacing the daemon-wide credential.
     /// This is a notification — no response is sent.
     fn handle_authenticate(&mut self, msg: Authenticate) {
-        if msg.auth_token.is_empty() {
-            log::warn!("Received Authenticate notification with empty auth token; ignoring");
-            return;
-        }
         self.auth_state
             .set_remote_server_bearer_token(msg.auth_token);
     }

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -1,9 +1,11 @@
+use crate::auth::auth_state::AuthState;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use super::super::proto::{Authenticate, Initialize};
 use super::super::protocol::RequestId;
 use super::super::server_buffer_tracker::ServerBufferTracker;
-use super::{DaemonAuthContext, PendingFileOps, ServerModel};
+use super::{PendingFileOps, ServerModel};
 
 fn test_model() -> ServerModel {
     ServerModel {
@@ -14,7 +16,7 @@ fn test_model() -> ServerModel {
         host_id: "test-host-id".to_string(),
         executors: HashMap::new(),
         pending_file_ops: PendingFileOps::new(),
-        auth: DaemonAuthContext::new(),
+        auth_state: Arc::new(AuthState::new_logged_out_for_test()),
         buffers: ServerBufferTracker::new(),
     }
 }
@@ -27,7 +29,7 @@ fn request_id() -> RequestId {
 fn fresh_model_starts_without_auth_token() {
     let model = test_model();
 
-    assert_eq!(model.auth_token(), None);
+    assert_eq!(model.auth_token().as_deref(), None);
 }
 
 #[test]
@@ -36,12 +38,20 @@ fn initialize_with_auth_token_stores_token() {
 
     model.apply_initialize_auth(&Initialize {
         auth_token: "initial-token".to_string(),
-        user_id: String::new(),
-        user_email: String::new(),
+        user_id: "test-user-id".to_string(),
+        user_email: "test@example.com".to_string(),
         crash_reporting_enabled: true,
     });
 
-    assert_eq!(model.auth_token(), Some("initial-token"));
+    assert_eq!(model.auth_token().as_deref(), Some("initial-token"));
+    assert_eq!(
+        model.auth_state.user_id().unwrap().as_string(),
+        "test-user-id"
+    );
+    assert_eq!(
+        model.auth_state.user_email().as_deref(),
+        Some("test@example.com")
+    );
 }
 
 #[test]
@@ -61,7 +71,7 @@ fn empty_initialize_preserves_existing_auth_token() {
         crash_reporting_enabled: true,
     });
 
-    assert_eq!(model.auth_token(), Some("initial-token"));
+    assert_eq!(model.auth_token().as_deref(), Some("initial-token"));
 }
 
 #[test]
@@ -78,7 +88,7 @@ fn authenticate_with_auth_token_replaces_auth_token() {
         auth_token: "rotated-token".to_string(),
     });
 
-    assert_eq!(model.auth_token(), Some("rotated-token"));
+    assert_eq!(model.auth_token().as_deref(), Some("rotated-token"));
 }
 
 #[test]
@@ -95,5 +105,5 @@ fn empty_authenticate_preserves_existing_auth_token() {
         auth_token: String::new(),
     });
 
-    assert_eq!(model.auth_token(), Some("initial-token"));
+    assert_eq!(model.auth_token().as_deref(), Some("initial-token"));
 }

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::super::proto::{Authenticate, Initialize};
-use super::super::protocol::RequestId;
 use super::super::server_buffer_tracker::ServerBufferTracker;
 use super::{PendingFileOps, ServerModel};
 
@@ -21,15 +20,13 @@ fn test_model() -> ServerModel {
     }
 }
 
-fn request_id() -> RequestId {
-    RequestId::from("test-request".to_string())
-}
-
 #[test]
 fn fresh_model_starts_without_auth_token() {
     let model = test_model();
 
     assert_eq!(model.auth_token().as_deref(), None);
+    assert_eq!(model.auth_state.user_id(), None);
+    assert_eq!(model.auth_state.user_email(), None);
 }
 
 #[test]
@@ -55,12 +52,12 @@ fn initialize_with_auth_token_stores_token() {
 }
 
 #[test]
-fn empty_initialize_preserves_existing_auth_token() {
+fn empty_initialize_clears_auth_context() {
     let mut model = test_model();
     model.apply_initialize_auth(&Initialize {
         auth_token: "initial-token".to_string(),
-        user_id: String::new(),
-        user_email: String::new(),
+        user_id: "test-user-id".to_string(),
+        user_email: "test@example.com".to_string(),
         crash_reporting_enabled: true,
     });
 
@@ -71,7 +68,9 @@ fn empty_initialize_preserves_existing_auth_token() {
         crash_reporting_enabled: true,
     });
 
-    assert_eq!(model.auth_token().as_deref(), Some("initial-token"));
+    assert_eq!(model.auth_token().as_deref(), None);
+    assert_eq!(model.auth_state.user_id(), None);
+    assert_eq!(model.auth_state.user_email(), None);
 }
 
 #[test]
@@ -92,7 +91,7 @@ fn authenticate_with_auth_token_replaces_auth_token() {
 }
 
 #[test]
-fn empty_authenticate_preserves_existing_auth_token() {
+fn empty_authenticate_clears_auth_token() {
     let mut model = test_model();
     model.apply_initialize_auth(&Initialize {
         auth_token: "initial-token".to_string(),
@@ -105,5 +104,5 @@ fn empty_authenticate_preserves_existing_auth_token() {
         auth_token: String::new(),
     });
 
-    assert_eq!(model.auth_token().as_deref(), Some("initial-token"));
+    assert_eq!(model.auth_token().as_deref(), None);
 }

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -20,10 +20,14 @@ use crate::ai::predict::predict_am_queries::{PredictAMQueriesRequest, PredictAMQ
 use crate::ai::voice::transcribe::{TranscribeRequest, TranscribeResponse};
 use crate::auth::auth_manager::AuthManager;
 use crate::auth::auth_state::AuthState;
+use crate::auth::credentials::AuthToken;
+use crate::auth::UserUid;
 use crate::server::graphql::default_request_options;
 use crate::server::server_api::presigned_upload::HttpStatusError;
 use ai::AIClient;
-use auth::{AuthClient, AMBIENT_WORKLOAD_TOKEN_HEADER, CLOUD_AGENT_ID_HEADER};
+use auth::{
+    AuthClient, AuthStateTokenSource, AMBIENT_WORKLOAD_TOKEN_HEADER, CLOUD_AGENT_ID_HEADER,
+};
 use base64::prelude::BASE64_URL_SAFE;
 use base64::Engine;
 use block::BlockClient;
@@ -386,6 +390,90 @@ impl fmt::Debug for ServerApiEvent {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TokenRefreshPolicy {
+    Allowed,
+    Disabled,
+}
+
+impl TokenRefreshPolicy {
+    pub fn allowed_to_refresh_token(self) -> bool {
+        match self {
+            TokenRefreshPolicy::Allowed => true,
+            TokenRefreshPolicy::Disabled => false,
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum ServerApiAuthError {
+    #[error("missing authentication credentials")]
+    MissingCredentials,
+    #[error("authentication token is expired and token refresh is disabled")]
+    ExpiredRefreshDisabled,
+    #[error("server rejected authentication credentials")]
+    CredentialsRejected,
+}
+
+/// Source of request authentication for [`ServerApi`].
+///
+/// Normal client usage is backed by [`AuthState`] with refresh enabled. Daemon/headless callers
+/// can inject a bearer-token source with refresh disabled so requests never attempt client
+/// `AuthState` refresh or emit client reauth events.
+pub trait ServerApiTokenSource: 'static + Send + Sync {
+    fn access_token(&self, refresh_policy: TokenRefreshPolicy) -> BoxFuture<'_, Result<AuthToken>>;
+
+    fn access_token_ignoring_validity(&self) -> Option<String> {
+        None
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Default)]
+pub struct BearerTokenSource {
+    token: RwLock<Option<String>>,
+}
+
+#[allow(dead_code)]
+impl BearerTokenSource {
+    pub fn new(token: Option<String>) -> Self {
+        Self {
+            token: RwLock::new(token.filter(|token| !token.is_empty())),
+        }
+    }
+
+    pub fn set_token(&self, token: impl Into<String>) {
+        let token = token.into();
+        if token.is_empty() {
+            self.clear_token();
+        } else {
+            *self.token.write() = Some(token);
+        }
+    }
+
+    pub fn clear_token(&self) {
+        *self.token.write() = None;
+    }
+}
+
+impl ServerApiTokenSource for BearerTokenSource {
+    fn access_token(
+        &self,
+        _refresh_policy: TokenRefreshPolicy,
+    ) -> BoxFuture<'_, Result<AuthToken>> {
+        Box::pin(async move {
+            let Some(token) = self.token.read().clone() else {
+                return Err(ServerApiAuthError::MissingCredentials.into());
+            };
+            Ok(AuthToken::Bearer(token))
+        })
+    }
+
+    fn access_token_ignoring_validity(&self) -> Option<String> {
+        self.token.read().clone()
+    }
+}
+
 /// An API wrapper struct with methods to requests to warp-server.
 ///
 /// Prefer NOT adding new methods directly on this struct; instead, add to one of the existing
@@ -393,7 +481,9 @@ impl fmt::Debug for ServerApiEvent {
 /// with disparate types of calls, and allows you to mock methods in tests.
 pub struct ServerApi {
     client: Arc<http_client::Client>,
-    auth_state: Arc<AuthState>,
+    auth_state: Option<Arc<AuthState>>,
+    token_source: Arc<dyn ServerApiTokenSource>,
+    token_refresh_policy: TokenRefreshPolicy,
     event_sender: async_channel::Sender<ServerApiEvent>,
     // TODO(jeff): Make `TelemetryApi` another type of client, and move it off `ServerApi`.
     telemetry_api: TelemetryApi,
@@ -417,6 +507,46 @@ impl ServerApi {
         event_sender: async_channel::Sender<ServerApiEvent>,
         agent_source: Option<ai::AgentSource>,
     ) -> Self {
+        let client = Arc::new(http_client::Client::new());
+        let token_source = Arc::new(AuthStateTokenSource::new(
+            auth_state.clone(),
+            client.clone(),
+            event_sender.clone(),
+        ));
+        Self::new_with_parts(
+            client,
+            Some(auth_state),
+            token_source,
+            TokenRefreshPolicy::Allowed,
+            event_sender,
+            agent_source,
+        )
+    }
+
+    pub fn new_with_token_source(
+        token_source: Arc<dyn ServerApiTokenSource>,
+        token_refresh_policy: TokenRefreshPolicy,
+        agent_source: Option<ai::AgentSource>,
+    ) -> Self {
+        let (event_sender, _) = async_channel::bounded(10);
+        Self::new_with_parts(
+            Arc::new(http_client::Client::new()),
+            None,
+            token_source,
+            token_refresh_policy,
+            event_sender,
+            agent_source,
+        )
+    }
+
+    fn new_with_parts(
+        client: Arc<http_client::Client>,
+        auth_state: Option<Arc<AuthState>>,
+        token_source: Arc<dyn ServerApiTokenSource>,
+        token_refresh_policy: TokenRefreshPolicy,
+        event_sender: async_channel::Sender<ServerApiEvent>,
+        agent_source: Option<ai::AgentSource>,
+    ) -> Self {
         // We generate a random user ID for evals so we can run evals in parallel.
         #[cfg(feature = "agent_mode_evals")]
         let eval_user_id = {
@@ -427,8 +557,10 @@ impl ServerApi {
         let oauth_client = Self::create_oauth_client();
 
         Self {
-            client: Arc::new(http_client::Client::new()),
+            client,
             auth_state,
+            token_source,
+            token_refresh_policy,
             event_sender,
             telemetry_api: TelemetryApi::new(),
             last_server_time: Arc::new(Mutex::new(None)),
@@ -444,22 +576,61 @@ impl ServerApi {
     #[cfg(test)]
     fn new_for_test() -> Self {
         let (tx, _) = async_channel::unbounded();
+        let auth_state = Arc::new(AuthState::new_for_test());
+        let client = Arc::new(http_client::Client::new_for_test());
+        let token_source = Arc::new(AuthStateTokenSource::new(
+            auth_state.clone(),
+            client.clone(),
+            tx.clone(),
+        ));
 
-        let oauth_client = Self::create_oauth_client();
+        Self::new_with_parts(
+            client,
+            Some(auth_state),
+            token_source,
+            TokenRefreshPolicy::Allowed,
+            tx,
+            None,
+        )
+    }
 
-        Self {
-            client: Arc::new(http_client::Client::new_for_test()),
-            auth_state: Arc::new(AuthState::new_for_test()),
-            event_sender: tx,
-            telemetry_api: TelemetryApi::new(),
-            last_server_time: Arc::new(Mutex::new(None)),
-            oauth_client,
-            ambient_workload_token: Arc::new(Mutex::new(None)),
-            ambient_agent_task_id: Arc::new(RwLock::new(None)),
-            agent_source: None,
-            #[cfg(feature = "agent_mode_evals")]
-            eval_user_id: None,
-        }
+    #[cfg(test)]
+    fn new_for_test_with_token_source(
+        token_source: Arc<dyn ServerApiTokenSource>,
+        token_refresh_policy: TokenRefreshPolicy,
+        event_sender: async_channel::Sender<ServerApiEvent>,
+    ) -> Self {
+        Self::new_with_parts(
+            Arc::new(http_client::Client::new_for_test()),
+            None,
+            token_source,
+            token_refresh_policy,
+            event_sender,
+            None,
+        )
+    }
+
+    async fn access_token(&self) -> Result<AuthToken> {
+        self.token_source
+            .access_token(self.token_refresh_policy)
+            .await
+    }
+
+    pub fn allowed_to_refresh_token(&self) -> bool {
+        self.token_refresh_policy.allowed_to_refresh_token()
+    }
+
+    pub(super) fn anonymous_id(&self) -> String {
+        self.auth_state
+            .as_ref()
+            .map(|auth_state| auth_state.anonymous_id())
+            .unwrap_or_default()
+    }
+
+    fn user_id(&self) -> Option<UserUid> {
+        self.auth_state
+            .as_ref()
+            .and_then(|auth_state| auth_state.user_id())
     }
 
     /// Sets the ambient agent task ID to be sent with all subsequent requests.
@@ -538,7 +709,7 @@ impl ServerApi {
         Box::pin(async move {
             let operation_name = operation.operation_name().map(Cow::into_owned);
             let auth_token = self
-                .get_or_refresh_access_token()
+                .access_token()
                 .await
                 .context("Failed to get access token for GraphQL request")?;
 
@@ -564,7 +735,12 @@ impl ServerApi {
                     let _ = event_sender.try_send(ServerApiEvent::StagingAccessBlocked);
                     anyhow::bail!(GraphQLError::StagingAccessBlocked)
                 }
-                Err(err) => anyhow::bail!(err),
+                Err(err) => {
+                    if !self.allowed_to_refresh_token() && Self::is_graphql_auth_rejection(&err) {
+                        anyhow::bail!(ServerApiAuthError::CredentialsRejected);
+                    }
+                    anyhow::bail!(err)
+                }
             };
 
             if let Some(errors) = response.errors.as_ref() {
@@ -577,9 +753,10 @@ impl ServerApi {
                 // to get a required user for some gql field. If we see that, since we have already
                 // successfully refreshed the user's access token earlier in this function, we know
                 // that this error is the result of the user's account being disabled/deleted.
-                if errors
-                    .iter()
-                    .any(|error| error.message.contains("User not in context: Not found"))
+                if self.allowed_to_refresh_token()
+                    && errors
+                        .iter()
+                        .any(|error| error.message.contains("User not in context: Not found"))
                 {
                     log::error!("GraphQL request failed due to unauthenticated user");
                     let _ = event_sender.try_send(ServerApiEvent::UserAccountDisabled);
@@ -613,6 +790,17 @@ impl ServerApi {
                 }
             })
         })
+    }
+
+    fn is_graphql_auth_rejection(err: &GraphQLError) -> bool {
+        match err {
+            GraphQLError::HttpError { status, .. } => {
+                *status == StatusCode::UNAUTHORIZED || *status == StatusCode::FORBIDDEN
+            }
+            GraphQLError::RequestError(_)
+            | GraphQLError::StagingAccessBlocked
+            | GraphQLError::ResponseError(_) => false,
+        }
     }
 
     /// Sends a GET request to a public API endpoint.
@@ -904,7 +1092,7 @@ impl ServerApi {
                     // content-type is sufficient (elides the content-length requirement), but
                     // since this request has no body, it makes more sense to set content-length.
                     .header(CONTENT_LENGTH, 0)
-                    .header(EXPERIMENT_ID_HEADER, self.auth_state.anonymous_id());
+                    .header(EXPERIMENT_ID_HEADER, self.anonymous_id());
 
                 let response = request.send().await;
                 if let Err(err) = response {
@@ -925,8 +1113,8 @@ impl ServerApi {
         event: impl TelemetryEvent,
         settings_snapshot: PrivacySettingsSnapshot,
     ) -> Result<()> {
-        let user_id = self.auth_state.user_id();
-        let anonymous_id = self.auth_state.anonymous_id();
+        let user_id = self.user_id();
+        let anonymous_id = self.anonymous_id();
         self.telemetry_api
             .send_telemetry_event(user_id, anonymous_id, event, settings_snapshot)
             .await
@@ -1304,7 +1492,7 @@ impl ServerApi {
             .client
             .get(url.as_str())
             .timeout(FETCH_CHANNEL_VERSIONS_TIMEOUT)
-            .header(EXPERIMENT_ID_HEADER, self.auth_state.anonymous_id());
+            .header(EXPERIMENT_ID_HEADER, self.anonymous_id());
 
         // Authorization for /client_version is optional. Attach authorization header if an access
         // token is present. First, try to get a valid token. If our cached one is expired, try to
@@ -1314,7 +1502,7 @@ impl ServerApi {
             .await
             .ok()
             .and_then(|token| token.bearer_token())
-            .or_else(|| self.auth_state.get_access_token_ignoring_validity());
+            .or_else(|| self.token_source.access_token_ignoring_validity());
         if let Some(token_str) = auth_token {
             request_builder = request_builder.bearer_auth(token_str);
         }
@@ -1466,3 +1654,230 @@ impl Entity for ServerApiProvider {
 }
 
 impl SingletonEntity for ServerApiProvider {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use cynic::GraphQlResponse;
+    use futures::executor::block_on;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct RecordingTokenSource {
+        token: Option<AuthToken>,
+        error: Option<ServerApiAuthError>,
+        calls: AtomicUsize,
+        policies: Mutex<Vec<TokenRefreshPolicy>>,
+    }
+
+    impl RecordingTokenSource {
+        fn with_token(token: AuthToken) -> Self {
+            Self {
+                token: Some(token),
+                error: None,
+                calls: AtomicUsize::new(0),
+                policies: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+
+        fn policies(&self) -> Vec<TokenRefreshPolicy> {
+            self.policies.lock().clone()
+        }
+    }
+
+    impl ServerApiTokenSource for RecordingTokenSource {
+        fn access_token(
+            &self,
+            refresh_policy: TokenRefreshPolicy,
+        ) -> BoxFuture<'_, Result<AuthToken>> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.policies.lock().push(refresh_policy);
+                match (&self.token, &self.error) {
+                    (Some(token), None) => Ok(token.clone()),
+                    (None, Some(error)) => Err(error.clone().into()),
+                    (None, None) => Err(ServerApiAuthError::MissingCredentials.into()),
+                    (Some(_), Some(error)) => Err(error.clone().into()),
+                }
+            })
+        }
+    }
+
+    struct FakeGraphqlOperation {
+        expected_auth_token: Option<String>,
+        send_count: Arc<AtomicUsize>,
+        rejected_status: Option<StatusCode>,
+    }
+
+    impl FakeGraphqlOperation {
+        fn successful(expected_auth_token: Option<&str>, send_count: Arc<AtomicUsize>) -> Self {
+            Self {
+                expected_auth_token: expected_auth_token.map(ToOwned::to_owned),
+                send_count,
+                rejected_status: None,
+            }
+        }
+
+        fn rejected(
+            expected_auth_token: Option<&str>,
+            send_count: Arc<AtomicUsize>,
+            status: StatusCode,
+        ) -> Self {
+            Self {
+                expected_auth_token: expected_auth_token.map(ToOwned::to_owned),
+                send_count,
+                rejected_status: Some(status),
+            }
+        }
+    }
+
+    impl warp_graphql::client::Operation<()> for FakeGraphqlOperation {
+        fn operation_name(&self) -> Option<Cow<'_, str>> {
+            Some(Cow::Borrowed("FakeGraphqlOperation"))
+        }
+
+        fn send_request(
+            self,
+            _client: Arc<http_client::Client>,
+            options: warp_graphql::client::RequestOptions,
+        ) -> Pin<
+            Box<
+                dyn Future<Output = std::result::Result<GraphQlResponse<()>, GraphQLError>>
+                    + Send
+                    + 'static,
+            >,
+        >
+        where
+            Self: Sized,
+        {
+            Box::pin(async move {
+                assert_eq!(options.auth_token, self.expected_auth_token);
+                self.send_count.fetch_add(1, Ordering::SeqCst);
+                if let Some(status) = self.rejected_status {
+                    return Err(GraphQLError::HttpError {
+                        status,
+                        body: "redacted auth rejection".to_string(),
+                    });
+                }
+                Ok(GraphQlResponse {
+                    data: Some(()),
+                    errors: None,
+                })
+            })
+        }
+    }
+
+    fn has_auth_error(error: &anyhow::Error, expected: ServerApiAuthError) -> bool {
+        error
+            .chain()
+            .any(|cause| cause.downcast_ref::<ServerApiAuthError>() == Some(&expected))
+    }
+
+    #[test]
+    fn send_graphql_request_refresh_enabled_uses_token_source() {
+        let (event_sender, _) = async_channel::unbounded();
+        let token_source = Arc::new(RecordingTokenSource::with_token(AuthToken::Bearer(
+            "client-token".to_string(),
+        )));
+        let server_api = ServerApi::new_for_test_with_token_source(
+            token_source.clone(),
+            TokenRefreshPolicy::Allowed,
+            event_sender,
+        );
+        let send_count = Arc::new(AtomicUsize::new(0));
+
+        block_on(server_api.send_graphql_request(
+            FakeGraphqlOperation::successful(Some("client-token"), send_count.clone()),
+            None,
+        ))
+        .unwrap();
+
+        assert_eq!(token_source.calls(), 1);
+        assert_eq!(token_source.policies(), vec![TokenRefreshPolicy::Allowed]);
+        assert_eq!(send_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn send_graphql_request_refresh_disabled_uses_provided_bearer_token() {
+        let (event_sender, _) = async_channel::unbounded();
+        let token_source = Arc::new(BearerTokenSource::new(None));
+        token_source.set_token("daemon-token");
+        let server_api = ServerApi::new_for_test_with_token_source(
+            token_source.clone(),
+            TokenRefreshPolicy::Disabled,
+            event_sender,
+        );
+        let send_count = Arc::new(AtomicUsize::new(0));
+
+        block_on(server_api.send_graphql_request(
+            FakeGraphqlOperation::successful(Some("daemon-token"), send_count.clone()),
+            None,
+        ))
+        .unwrap();
+
+        assert!(!server_api.allowed_to_refresh_token());
+        assert_eq!(send_count.load(Ordering::SeqCst), 1);
+        token_source.clear_token();
+        assert!(token_source.access_token_ignoring_validity().is_none());
+    }
+
+    #[test]
+    fn send_graphql_request_refresh_disabled_missing_token_returns_auth_error() {
+        let (event_sender, event_receiver) = async_channel::unbounded();
+        let token_source = Arc::new(BearerTokenSource::new(None));
+        let server_api = ServerApi::new_for_test_with_token_source(
+            token_source,
+            TokenRefreshPolicy::Disabled,
+            event_sender,
+        );
+        let send_count = Arc::new(AtomicUsize::new(0));
+
+        let error = block_on(server_api.send_graphql_request(
+            FakeGraphqlOperation::successful(Some("unused-token"), send_count.clone()),
+            None,
+        ))
+        .unwrap_err();
+
+        assert!(has_auth_error(
+            &error,
+            ServerApiAuthError::MissingCredentials
+        ));
+        assert_eq!(send_count.load(Ordering::SeqCst), 0);
+        assert!(event_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn send_graphql_request_refresh_disabled_auth_rejection_is_credentials_rejected() {
+        let (event_sender, event_receiver) = async_channel::unbounded();
+        let token_source = Arc::new(BearerTokenSource::new(Some("daemon-token".to_string())));
+        let server_api = ServerApi::new_for_test_with_token_source(
+            token_source,
+            TokenRefreshPolicy::Disabled,
+            event_sender,
+        );
+        let send_count = Arc::new(AtomicUsize::new(0));
+
+        let error = block_on(server_api.send_graphql_request(
+            FakeGraphqlOperation::rejected(
+                Some("daemon-token"),
+                send_count.clone(),
+                StatusCode::UNAUTHORIZED,
+            ),
+            None,
+        ))
+        .unwrap_err();
+
+        assert!(has_auth_error(
+            &error,
+            ServerApiAuthError::CredentialsRejected
+        ));
+        assert_eq!(send_count.load(Ordering::SeqCst), 1);
+        assert!(event_receiver.try_recv().is_err());
+    }
+}

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -681,13 +681,16 @@ impl ServerApi {
                 // to get a required user for some gql field. If we see that, since we have already
                 // successfully refreshed the user's access token earlier in this function, we know
                 // that this error is the result of the user's account being disabled/deleted.
-                if self.allowed_to_refresh_token()
-                    && errors
-                        .iter()
-                        .any(|error| error.message.contains("User not in context: Not found"))
+                if errors
+                    .iter()
+                    .any(|error| error.message.contains("User not in context: Not found"))
                 {
-                    log::error!("GraphQL request failed due to unauthenticated user");
-                    let _ = event_sender.try_send(ServerApiEvent::UserAccountDisabled);
+                    if self.allowed_to_refresh_token() {
+                        log::error!("GraphQL request failed due to unauthenticated user");
+                        let _ = event_sender.try_send(ServerApiEvent::UserAccountDisabled);
+                    } else {
+                        anyhow::bail!(ServerApiAuthError::CredentialsRejected);
+                    }
                 }
             }
 
@@ -1587,7 +1590,7 @@ impl SingletonEntity for ServerApiProvider {}
 mod tests {
     use super::*;
 
-    use cynic::GraphQlResponse;
+    use cynic::{GraphQlError, GraphQlResponse};
     use futures::executor::block_on;
     use std::future::Future;
     use std::pin::Pin;
@@ -1596,7 +1599,13 @@ mod tests {
     struct FakeGraphqlOperation {
         expected_auth_token: Option<String>,
         send_count: Arc<AtomicUsize>,
-        rejected_status: Option<StatusCode>,
+        result: FakeGraphqlResult,
+    }
+
+    enum FakeGraphqlResult {
+        Success,
+        Rejected(StatusCode),
+        ResponseErrors(Vec<String>),
     }
 
     impl FakeGraphqlOperation {
@@ -1604,7 +1613,7 @@ mod tests {
             Self {
                 expected_auth_token: expected_auth_token.map(ToOwned::to_owned),
                 send_count,
-                rejected_status: None,
+                result: FakeGraphqlResult::Success,
             }
         }
 
@@ -1616,7 +1625,19 @@ mod tests {
             Self {
                 expected_auth_token: expected_auth_token.map(ToOwned::to_owned),
                 send_count,
-                rejected_status: Some(status),
+                result: FakeGraphqlResult::Rejected(status),
+            }
+        }
+
+        fn response_errors(
+            expected_auth_token: Option<&str>,
+            send_count: Arc<AtomicUsize>,
+            messages: Vec<String>,
+        ) -> Self {
+            Self {
+                expected_auth_token: expected_auth_token.map(ToOwned::to_owned),
+                send_count,
+                result: FakeGraphqlResult::ResponseErrors(messages),
             }
         }
     }
@@ -1643,16 +1664,25 @@ mod tests {
             Box::pin(async move {
                 assert_eq!(options.auth_token, self.expected_auth_token);
                 self.send_count.fetch_add(1, Ordering::SeqCst);
-                if let Some(status) = self.rejected_status {
-                    return Err(GraphQLError::HttpError {
+                match self.result {
+                    FakeGraphqlResult::Success => Ok(GraphQlResponse {
+                        data: Some(()),
+                        errors: None,
+                    }),
+                    FakeGraphqlResult::Rejected(status) => Err(GraphQLError::HttpError {
                         status,
                         body: "redacted auth rejection".to_string(),
-                    });
+                    }),
+                    FakeGraphqlResult::ResponseErrors(messages) => Ok(GraphQlResponse {
+                        data: None,
+                        errors: Some(
+                            messages
+                                .into_iter()
+                                .map(|message| GraphQlError::new(message, None, None, None))
+                                .collect(),
+                        ),
+                    }),
                 }
-                Ok(GraphQlResponse {
-                    data: Some(()),
-                    errors: None,
-                })
             })
         }
     }
@@ -1731,6 +1761,33 @@ mod tests {
                 Some("daemon-token"),
                 send_count.clone(),
                 StatusCode::UNAUTHORIZED,
+            ),
+            None,
+        ))
+        .unwrap_err();
+
+        assert!(has_auth_error(
+            &error,
+            ServerApiAuthError::CredentialsRejected
+        ));
+        assert_eq!(send_count.load(Ordering::SeqCst), 1);
+        assert!(event_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn send_graphql_request_refresh_disabled_user_not_in_context_is_credentials_rejected() {
+        let (event_sender, event_receiver) = async_channel::unbounded();
+        let server_api = ServerApi::new_for_test_with_bearer_token(
+            Some("daemon-token".to_string()),
+            event_sender,
+        );
+        let send_count = Arc::new(AtomicUsize::new(0));
+
+        let error = block_on(server_api.send_graphql_request(
+            FakeGraphqlOperation::response_errors(
+                Some("daemon-token"),
+                send_count.clone(),
+                vec!["User not in context: Not found".to_string()],
             ),
             None,
         ))

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -20,14 +20,11 @@ use crate::ai::predict::predict_am_queries::{PredictAMQueriesRequest, PredictAMQ
 use crate::ai::voice::transcribe::{TranscribeRequest, TranscribeResponse};
 use crate::auth::auth_manager::AuthManager;
 use crate::auth::auth_state::AuthState;
-use crate::auth::credentials::AuthToken;
 use crate::auth::UserUid;
 use crate::server::graphql::default_request_options;
 use crate::server::server_api::presigned_upload::HttpStatusError;
 use ai::AIClient;
-use auth::{
-    AuthClient, AuthStateTokenSource, AMBIENT_WORKLOAD_TOKEN_HEADER, CLOUD_AGENT_ID_HEADER,
-};
+use auth::{AuthClient, AMBIENT_WORKLOAD_TOKEN_HEADER, CLOUD_AGENT_ID_HEADER};
 use base64::prelude::BASE64_URL_SAFE;
 use base64::Engine;
 use block::BlockClient;
@@ -415,65 +412,6 @@ pub enum ServerApiAuthError {
     CredentialsRejected,
 }
 
-/// Source of request authentication for [`ServerApi`].
-///
-/// Normal client usage is backed by [`AuthState`] with refresh enabled. Daemon/headless callers
-/// can inject a bearer-token source with refresh disabled so requests never attempt client
-/// `AuthState` refresh or emit client reauth events.
-pub trait ServerApiTokenSource: 'static + Send + Sync {
-    fn access_token(&self, refresh_policy: TokenRefreshPolicy) -> BoxFuture<'_, Result<AuthToken>>;
-
-    fn access_token_ignoring_validity(&self) -> Option<String> {
-        None
-    }
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Default)]
-pub struct BearerTokenSource {
-    token: RwLock<Option<String>>,
-}
-
-#[allow(dead_code)]
-impl BearerTokenSource {
-    pub fn new(token: Option<String>) -> Self {
-        Self {
-            token: RwLock::new(token.filter(|token| !token.is_empty())),
-        }
-    }
-
-    pub fn set_token(&self, token: impl Into<String>) {
-        let token = token.into();
-        if token.is_empty() {
-            self.clear_token();
-        } else {
-            *self.token.write() = Some(token);
-        }
-    }
-
-    pub fn clear_token(&self) {
-        *self.token.write() = None;
-    }
-}
-
-impl ServerApiTokenSource for BearerTokenSource {
-    fn access_token(
-        &self,
-        _refresh_policy: TokenRefreshPolicy,
-    ) -> BoxFuture<'_, Result<AuthToken>> {
-        Box::pin(async move {
-            let Some(token) = self.token.read().clone() else {
-                return Err(ServerApiAuthError::MissingCredentials.into());
-            };
-            Ok(AuthToken::Bearer(token))
-        })
-    }
-
-    fn access_token_ignoring_validity(&self) -> Option<String> {
-        self.token.read().clone()
-    }
-}
-
 /// An API wrapper struct with methods to requests to warp-server.
 ///
 /// Prefer NOT adding new methods directly on this struct; instead, add to one of the existing
@@ -482,7 +420,7 @@ impl ServerApiTokenSource for BearerTokenSource {
 pub struct ServerApi {
     client: Arc<http_client::Client>,
     auth_state: Option<Arc<AuthState>>,
-    token_source: Arc<dyn ServerApiTokenSource>,
+    bearer_token: Option<String>,
     token_refresh_policy: TokenRefreshPolicy,
     event_sender: async_channel::Sender<ServerApiEvent>,
     // TODO(jeff): Make `TelemetryApi` another type of client, and move it off `ServerApi`.
@@ -508,32 +446,26 @@ impl ServerApi {
         agent_source: Option<ai::AgentSource>,
     ) -> Self {
         let client = Arc::new(http_client::Client::new());
-        let token_source = Arc::new(AuthStateTokenSource::new(
-            auth_state.clone(),
-            client.clone(),
-            event_sender.clone(),
-        ));
         Self::new_with_parts(
             client,
             Some(auth_state),
-            token_source,
+            None,
             TokenRefreshPolicy::Allowed,
             event_sender,
             agent_source,
         )
     }
 
-    pub fn new_with_token_source(
-        token_source: Arc<dyn ServerApiTokenSource>,
-        token_refresh_policy: TokenRefreshPolicy,
+    pub fn new_with_bearer_token(
+        bearer_token: impl Into<String>,
         agent_source: Option<ai::AgentSource>,
     ) -> Self {
         let (event_sender, _) = async_channel::bounded(10);
         Self::new_with_parts(
             Arc::new(http_client::Client::new()),
             None,
-            token_source,
-            token_refresh_policy,
+            Some(bearer_token.into()).filter(|token| !token.is_empty()),
+            TokenRefreshPolicy::Disabled,
             event_sender,
             agent_source,
         )
@@ -542,7 +474,7 @@ impl ServerApi {
     fn new_with_parts(
         client: Arc<http_client::Client>,
         auth_state: Option<Arc<AuthState>>,
-        token_source: Arc<dyn ServerApiTokenSource>,
+        bearer_token: Option<String>,
         token_refresh_policy: TokenRefreshPolicy,
         event_sender: async_channel::Sender<ServerApiEvent>,
         agent_source: Option<ai::AgentSource>,
@@ -559,7 +491,7 @@ impl ServerApi {
         Self {
             client,
             auth_state,
-            token_source,
+            bearer_token,
             token_refresh_policy,
             event_sender,
             telemetry_api: TelemetryApi::new(),
@@ -578,16 +510,11 @@ impl ServerApi {
         let (tx, _) = async_channel::unbounded();
         let auth_state = Arc::new(AuthState::new_for_test());
         let client = Arc::new(http_client::Client::new_for_test());
-        let token_source = Arc::new(AuthStateTokenSource::new(
-            auth_state.clone(),
-            client.clone(),
-            tx.clone(),
-        ));
 
         Self::new_with_parts(
             client,
             Some(auth_state),
-            token_source,
+            None,
             TokenRefreshPolicy::Allowed,
             tx,
             None,
@@ -595,29 +522,30 @@ impl ServerApi {
     }
 
     #[cfg(test)]
-    fn new_for_test_with_token_source(
-        token_source: Arc<dyn ServerApiTokenSource>,
-        token_refresh_policy: TokenRefreshPolicy,
+    fn new_for_test_with_bearer_token(
+        bearer_token: Option<String>,
         event_sender: async_channel::Sender<ServerApiEvent>,
     ) -> Self {
         Self::new_with_parts(
             Arc::new(http_client::Client::new_for_test()),
             None,
-            token_source,
-            token_refresh_policy,
+            bearer_token.filter(|token| !token.is_empty()),
+            TokenRefreshPolicy::Disabled,
             event_sender,
             None,
         )
     }
 
-    async fn access_token(&self) -> Result<AuthToken> {
-        self.token_source
-            .access_token(self.token_refresh_policy)
-            .await
-    }
-
     pub fn allowed_to_refresh_token(&self) -> bool {
         self.token_refresh_policy.allowed_to_refresh_token()
+    }
+
+    fn access_token_ignoring_validity(&self) -> Option<String> {
+        self.bearer_token.clone().or_else(|| {
+            self.auth_state
+                .as_ref()
+                .and_then(|auth_state| auth_state.get_access_token_ignoring_validity())
+        })
     }
 
     pub(super) fn anonymous_id(&self) -> String {
@@ -1502,7 +1430,7 @@ impl ServerApi {
             .await
             .ok()
             .and_then(|token| token.bearer_token())
-            .or_else(|| self.token_source.access_token_ignoring_validity());
+            .or_else(|| self.access_token_ignoring_validity());
         if let Some(token_str) = auth_token {
             request_builder = request_builder.bearer_auth(token_str);
         }
@@ -1665,50 +1593,6 @@ mod tests {
     use std::pin::Pin;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    struct RecordingTokenSource {
-        token: Option<AuthToken>,
-        error: Option<ServerApiAuthError>,
-        calls: AtomicUsize,
-        policies: Mutex<Vec<TokenRefreshPolicy>>,
-    }
-
-    impl RecordingTokenSource {
-        fn with_token(token: AuthToken) -> Self {
-            Self {
-                token: Some(token),
-                error: None,
-                calls: AtomicUsize::new(0),
-                policies: Mutex::new(Vec::new()),
-            }
-        }
-
-        fn calls(&self) -> usize {
-            self.calls.load(Ordering::SeqCst)
-        }
-
-        fn policies(&self) -> Vec<TokenRefreshPolicy> {
-            self.policies.lock().clone()
-        }
-    }
-
-    impl ServerApiTokenSource for RecordingTokenSource {
-        fn access_token(
-            &self,
-            refresh_policy: TokenRefreshPolicy,
-        ) -> BoxFuture<'_, Result<AuthToken>> {
-            Box::pin(async move {
-                self.calls.fetch_add(1, Ordering::SeqCst);
-                self.policies.lock().push(refresh_policy);
-                match (&self.token, &self.error) {
-                    (Some(token), None) => Ok(token.clone()),
-                    (None, Some(error)) => Err(error.clone().into()),
-                    (None, None) => Err(ServerApiAuthError::MissingCredentials.into()),
-                    (Some(_), Some(error)) => Err(error.clone().into()),
-                }
-            })
-        }
-    }
-
     struct FakeGraphqlOperation {
         expected_auth_token: Option<String>,
         send_count: Arc<AtomicUsize>,
@@ -1780,37 +1664,25 @@ mod tests {
     }
 
     #[test]
-    fn send_graphql_request_refresh_enabled_uses_token_source() {
-        let (event_sender, _) = async_channel::unbounded();
-        let token_source = Arc::new(RecordingTokenSource::with_token(AuthToken::Bearer(
-            "client-token".to_string(),
-        )));
-        let server_api = ServerApi::new_for_test_with_token_source(
-            token_source.clone(),
-            TokenRefreshPolicy::Allowed,
-            event_sender,
-        );
+    fn send_graphql_request_refresh_enabled_uses_auth_state() {
+        let server_api = ServerApi::new_for_test();
         let send_count = Arc::new(AtomicUsize::new(0));
 
         block_on(server_api.send_graphql_request(
-            FakeGraphqlOperation::successful(Some("client-token"), send_count.clone()),
+            FakeGraphqlOperation::successful(None, send_count.clone()),
             None,
         ))
         .unwrap();
 
-        assert_eq!(token_source.calls(), 1);
-        assert_eq!(token_source.policies(), vec![TokenRefreshPolicy::Allowed]);
+        assert!(server_api.allowed_to_refresh_token());
         assert_eq!(send_count.load(Ordering::SeqCst), 1);
     }
 
     #[test]
     fn send_graphql_request_refresh_disabled_uses_provided_bearer_token() {
         let (event_sender, _) = async_channel::unbounded();
-        let token_source = Arc::new(BearerTokenSource::new(None));
-        token_source.set_token("daemon-token");
-        let server_api = ServerApi::new_for_test_with_token_source(
-            token_source.clone(),
-            TokenRefreshPolicy::Disabled,
+        let server_api = ServerApi::new_for_test_with_bearer_token(
+            Some("daemon-token".to_string()),
             event_sender,
         );
         let send_count = Arc::new(AtomicUsize::new(0));
@@ -1823,19 +1695,12 @@ mod tests {
 
         assert!(!server_api.allowed_to_refresh_token());
         assert_eq!(send_count.load(Ordering::SeqCst), 1);
-        token_source.clear_token();
-        assert!(token_source.access_token_ignoring_validity().is_none());
     }
 
     #[test]
     fn send_graphql_request_refresh_disabled_missing_token_returns_auth_error() {
         let (event_sender, event_receiver) = async_channel::unbounded();
-        let token_source = Arc::new(BearerTokenSource::new(None));
-        let server_api = ServerApi::new_for_test_with_token_source(
-            token_source,
-            TokenRefreshPolicy::Disabled,
-            event_sender,
-        );
+        let server_api = ServerApi::new_for_test_with_bearer_token(None, event_sender);
         let send_count = Arc::new(AtomicUsize::new(0));
 
         let error = block_on(server_api.send_graphql_request(
@@ -1855,10 +1720,8 @@ mod tests {
     #[test]
     fn send_graphql_request_refresh_disabled_auth_rejection_is_credentials_rejected() {
         let (event_sender, event_receiver) = async_channel::unbounded();
-        let token_source = Arc::new(BearerTokenSource::new(Some("daemon-token".to_string())));
-        let server_api = ServerApi::new_for_test_with_token_source(
-            token_source,
-            TokenRefreshPolicy::Disabled,
+        let server_api = ServerApi::new_for_test_with_bearer_token(
+            Some("daemon-token".to_string()),
             event_sender,
         );
         let send_count = Arc::new(AtomicUsize::new(0));

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -387,16 +387,6 @@ impl fmt::Debug for ServerApiEvent {
     }
 }
 
-#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
-pub enum ServerApiAuthError {
-    #[error("missing authentication credentials")]
-    MissingCredentials,
-    #[error("authentication token is expired and token refresh is disabled")]
-    ExpiredRefreshDisabled,
-    #[error("server rejected authentication credentials")]
-    CredentialsRejected,
-}
-
 /// An API wrapper struct with methods to requests to warp-server.
 ///
 /// Prefer NOT adding new methods directly on this struct; instead, add to one of the existing
@@ -610,7 +600,7 @@ impl ServerApi {
                 }
                 Err(err) => {
                     if !self.allowed_to_refresh_token() && Self::is_graphql_auth_rejection(&err) {
-                        anyhow::bail!(ServerApiAuthError::CredentialsRejected);
+                        anyhow::bail!("server rejected authentication credentials");
                     }
                     anyhow::bail!(err)
                 }
@@ -634,7 +624,7 @@ impl ServerApi {
                         log::error!("GraphQL request failed due to unauthenticated user");
                         let _ = event_sender.try_send(ServerApiEvent::UserAccountDisabled);
                     } else {
-                        anyhow::bail!(ServerApiAuthError::CredentialsRejected);
+                        anyhow::bail!("server rejected authentication credentials");
                     }
                 }
             }
@@ -1632,10 +1622,8 @@ mod tests {
         }
     }
 
-    fn has_auth_error(error: &anyhow::Error, expected: ServerApiAuthError) -> bool {
-        error
-            .chain()
-            .any(|cause| cause.downcast_ref::<ServerApiAuthError>() == Some(&expected))
+    fn has_error_message(error: &anyhow::Error, expected: &str) -> bool {
+        error.chain().any(|cause| cause.to_string() == expected)
     }
 
     #[test]
@@ -1684,9 +1672,9 @@ mod tests {
         ))
         .unwrap_err();
 
-        assert!(has_auth_error(
+        assert!(has_error_message(
             &error,
-            ServerApiAuthError::MissingCredentials
+            "missing authentication credentials"
         ));
         assert_eq!(send_count.load(Ordering::SeqCst), 0);
         assert!(event_receiver.try_recv().is_err());
@@ -1711,9 +1699,9 @@ mod tests {
         ))
         .unwrap_err();
 
-        assert!(has_auth_error(
+        assert!(has_error_message(
             &error,
-            ServerApiAuthError::CredentialsRejected
+            "server rejected authentication credentials"
         ));
         assert_eq!(send_count.load(Ordering::SeqCst), 1);
         assert!(event_receiver.try_recv().is_err());
@@ -1738,9 +1726,9 @@ mod tests {
         ))
         .unwrap_err();
 
-        assert!(has_auth_error(
+        assert!(has_error_message(
             &error,
-            ServerApiAuthError::CredentialsRejected
+            "server rejected authentication credentials"
         ));
         assert_eq!(send_count.load(Ordering::SeqCst), 1);
         assert!(event_receiver.try_recv().is_err());

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -387,21 +387,6 @@ impl fmt::Debug for ServerApiEvent {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum TokenRefreshPolicy {
-    Allowed,
-    Disabled,
-}
-
-impl TokenRefreshPolicy {
-    pub fn allowed_to_refresh_token(self) -> bool {
-        match self {
-            TokenRefreshPolicy::Allowed => true,
-            TokenRefreshPolicy::Disabled => false,
-        }
-    }
-}
-
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum ServerApiAuthError {
     #[error("missing authentication credentials")]
@@ -419,9 +404,7 @@ pub enum ServerApiAuthError {
 /// with disparate types of calls, and allows you to mock methods in tests.
 pub struct ServerApi {
     client: Arc<http_client::Client>,
-    auth_state: Option<Arc<AuthState>>,
-    bearer_token: Option<String>,
-    token_refresh_policy: TokenRefreshPolicy,
+    auth_state: Arc<AuthState>,
     event_sender: async_channel::Sender<ServerApiEvent>,
     // TODO(jeff): Make `TelemetryApi` another type of client, and move it off `ServerApi`.
     telemetry_api: TelemetryApi,
@@ -446,36 +429,12 @@ impl ServerApi {
         agent_source: Option<ai::AgentSource>,
     ) -> Self {
         let client = Arc::new(http_client::Client::new());
-        Self::new_with_parts(
-            client,
-            Some(auth_state),
-            None,
-            TokenRefreshPolicy::Allowed,
-            event_sender,
-            agent_source,
-        )
-    }
-
-    pub fn new_with_bearer_token(
-        bearer_token: impl Into<String>,
-        agent_source: Option<ai::AgentSource>,
-    ) -> Self {
-        let (event_sender, _) = async_channel::bounded(10);
-        Self::new_with_parts(
-            Arc::new(http_client::Client::new()),
-            None,
-            Some(bearer_token.into()).filter(|token| !token.is_empty()),
-            TokenRefreshPolicy::Disabled,
-            event_sender,
-            agent_source,
-        )
+        Self::new_with_parts(client, auth_state, event_sender, agent_source)
     }
 
     fn new_with_parts(
         client: Arc<http_client::Client>,
-        auth_state: Option<Arc<AuthState>>,
-        bearer_token: Option<String>,
-        token_refresh_policy: TokenRefreshPolicy,
+        auth_state: Arc<AuthState>,
         event_sender: async_channel::Sender<ServerApiEvent>,
         agent_source: Option<ai::AgentSource>,
     ) -> Self {
@@ -491,8 +450,6 @@ impl ServerApi {
         Self {
             client,
             auth_state,
-            bearer_token,
-            token_refresh_policy,
             event_sender,
             telemetry_api: TelemetryApi::new(),
             last_server_time: Arc::new(Mutex::new(None)),
@@ -511,14 +468,7 @@ impl ServerApi {
         let auth_state = Arc::new(AuthState::new_for_test());
         let client = Arc::new(http_client::Client::new_for_test());
 
-        Self::new_with_parts(
-            client,
-            Some(auth_state),
-            None,
-            TokenRefreshPolicy::Allowed,
-            tx,
-            None,
-        )
+        Self::new_with_parts(client, auth_state, tx, None)
     }
 
     #[cfg(test)]
@@ -526,39 +476,34 @@ impl ServerApi {
         bearer_token: Option<String>,
         event_sender: async_channel::Sender<ServerApiEvent>,
     ) -> Self {
+        let auth_state = Arc::new(AuthState::new_logged_out_for_test());
+        if let Some(bearer_token) = bearer_token {
+            auth_state.set_remote_server_bearer_token(bearer_token);
+        }
         Self::new_with_parts(
             Arc::new(http_client::Client::new_for_test()),
-            None,
-            bearer_token.filter(|token| !token.is_empty()),
-            TokenRefreshPolicy::Disabled,
+            auth_state,
             event_sender,
             None,
         )
     }
 
     pub fn allowed_to_refresh_token(&self) -> bool {
-        self.token_refresh_policy.allowed_to_refresh_token()
+        self.auth_state
+            .credentials()
+            .is_none_or(|credentials| !credentials.is_externally_managed())
     }
 
     fn access_token_ignoring_validity(&self) -> Option<String> {
-        self.bearer_token.clone().or_else(|| {
-            self.auth_state
-                .as_ref()
-                .and_then(|auth_state| auth_state.get_access_token_ignoring_validity())
-        })
+        self.auth_state.get_access_token_ignoring_validity()
     }
 
     pub(super) fn anonymous_id(&self) -> String {
-        self.auth_state
-            .as_ref()
-            .map(|auth_state| auth_state.anonymous_id())
-            .unwrap_or_default()
+        self.auth_state.anonymous_id()
     }
 
     fn user_id(&self) -> Option<UserUid> {
-        self.auth_state
-            .as_ref()
-            .and_then(|auth_state| auth_state.user_id())
+        self.auth_state.user_id()
     }
 
     /// Sets the ambient agent task ID to be sent with all subsequent requests.

--- a/app/src/server/server_api/auth.rs
+++ b/app/src/server/server_api/auth.rs
@@ -214,12 +214,12 @@ pub trait AuthClient: 'static + Send + Sync {
 
 impl ServerApi {
     pub(super) async fn access_token(&self) -> Result<AuthToken> {
-        if let Some(token) = self.bearer_token.clone() {
-            return Ok(AuthToken::Bearer(token));
-        }
 
         if cfg!(feature = "skip_login") {
             bail!("skip_login enabled; failing all authenticated requests");
+        }
+        if let Some(token) = self.bearer_token.clone() {
+            return Ok(AuthToken::Bearer(token));
         }
 
         let Some(auth_state) = self.auth_state.as_ref() else {

--- a/app/src/server/server_api/auth.rs
+++ b/app/src/server/server_api/auth.rs
@@ -19,6 +19,7 @@ use warp_graphql::queries::get_conversation_usage::{
     ConversationUsage, GetConversationUsage, GetConversationUsageVariables, UserResult,
 };
 
+use crate::auth::auth_state::AuthState;
 use warp_graphql::mutations::set_user_is_onboarded::{
     SetUserIsOnboarded, SetUserIsOnboardedResult, SetUserIsOnboardedVariables,
 };
@@ -64,7 +65,7 @@ use crate::{
     },
 };
 
-use super::ServerApi;
+use super::{ServerApi, ServerApiAuthError, ServerApiTokenSource, TokenRefreshPolicy};
 
 /// Error messages returned from the Firebase REST API when attempting to convert a refresh token
 /// into an access token that indicate the user's token is in an errored state.
@@ -212,6 +213,84 @@ pub trait AuthClient: 'static + Send + Sync {
     async fn get_or_create_ambient_workload_token(&self) -> Result<Option<String>>;
 }
 
+pub(super) struct AuthStateTokenSource {
+    auth_state: Arc<AuthState>,
+    client: Arc<http_client::Client>,
+    event_sender: async_channel::Sender<ServerApiEvent>,
+}
+
+impl AuthStateTokenSource {
+    pub(super) fn new(
+        auth_state: Arc<AuthState>,
+        client: Arc<http_client::Client>,
+        event_sender: async_channel::Sender<ServerApiEvent>,
+    ) -> Self {
+        Self {
+            auth_state,
+            client,
+            event_sender,
+        }
+    }
+}
+
+impl ServerApiTokenSource for AuthStateTokenSource {
+    fn access_token(&self, refresh_policy: TokenRefreshPolicy) -> BoxFuture<'_, Result<AuthToken>> {
+        Box::pin(async move {
+            if cfg!(feature = "skip_login") {
+                bail!("skip_login enabled; failing all authenticated requests");
+            }
+
+            let Some(credentials) = self.auth_state.credentials() else {
+                return Err(ServerApiAuthError::MissingCredentials.into());
+            };
+
+            match credentials {
+                Credentials::ApiKey { key, .. } => Ok(AuthToken::ApiKey(key)),
+                Credentials::Firebase(auth_tokens) => {
+                    let expiration_time = auth_tokens.expiration_time;
+
+                    // Generate a new ID token if the token has expired or will expire in the
+                    // next five minutes. This matches the behavior of the Firebase Auth SDK.
+                    if chrono::DateTime::now() + chrono::Duration::minutes(5) >= expiration_time {
+                        if !refresh_policy.allowed_to_refresh_token() {
+                            return Err(ServerApiAuthError::ExpiredRefreshDisabled.into());
+                        }
+
+                        let refresh_token = auth_tokens.refresh_token.clone();
+                        let firebase_token =
+                            FirebaseToken::Refresh(RefreshToken::new(refresh_token));
+
+                        let result = fetch_auth_tokens(self.client.clone(), firebase_token).await;
+
+                        if let Err(UserAuthenticationError::DeniedAccessToken(_)) = result {
+                            let _ = self.event_sender.send(ServerApiEvent::NeedsReauth).await;
+                        }
+                        let new_firebase_token_info = result?;
+                        self.auth_state
+                            .update_firebase_tokens(new_firebase_token_info.clone());
+                        let _ = self
+                            .event_sender
+                            .send(ServerApiEvent::AccessTokenRefreshed {
+                                token: new_firebase_token_info.id_token.clone(),
+                            })
+                            .await;
+                        return Ok(AuthToken::Firebase(new_firebase_token_info.id_token));
+                    }
+
+                    Ok(AuthToken::Firebase(auth_tokens.id_token))
+                }
+                Credentials::SessionCookie => Ok(AuthToken::NoAuth),
+                #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
+                Credentials::Test => Ok(AuthToken::NoAuth),
+            }
+        })
+    }
+
+    fn access_token_ignoring_validity(&self) -> Option<String> {
+        self.auth_state.get_access_token_ignoring_validity()
+    }
+}
+
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl AuthClient for ServerApi {
@@ -241,48 +320,7 @@ impl AuthClient for ServerApi {
     }
 
     async fn get_or_refresh_access_token(&self) -> Result<AuthToken> {
-        if cfg!(feature = "skip_login") {
-            bail!("skip_login enabled; failing all authenticated requests");
-        }
-
-        let Some(credentials) = self.auth_state.credentials() else {
-            bail!("Attempted to retrieve access token when user is logged out");
-        };
-
-        match credentials {
-            Credentials::ApiKey { key, .. } => Ok(AuthToken::ApiKey(key)),
-            Credentials::Firebase(auth_tokens) => {
-                let expiration_time = auth_tokens.expiration_time;
-
-                // Generate a new ID token if the token has expired or will expire in the
-                // next five minutes. This matches the behavior of the Firebase Auth SDK.
-                if chrono::DateTime::now() + chrono::Duration::minutes(5) >= expiration_time {
-                    let refresh_token = auth_tokens.refresh_token.clone();
-                    let firebase_token = FirebaseToken::Refresh(RefreshToken::new(refresh_token));
-
-                    let result = fetch_auth_tokens(self.client.clone(), firebase_token).await;
-
-                    if let Err(UserAuthenticationError::DeniedAccessToken(_)) = result {
-                        let _ = self.event_sender.send(ServerApiEvent::NeedsReauth).await;
-                    }
-                    let new_firebase_token_info = result?;
-                    self.auth_state
-                        .update_firebase_tokens(new_firebase_token_info.clone());
-                    let _ = self
-                        .event_sender
-                        .send(ServerApiEvent::AccessTokenRefreshed {
-                            token: new_firebase_token_info.id_token.clone(),
-                        })
-                        .await;
-                    return Ok(AuthToken::Firebase(new_firebase_token_info.id_token));
-                }
-
-                Ok(AuthToken::Firebase(auth_tokens.id_token))
-            }
-            Credentials::SessionCookie => Ok(AuthToken::NoAuth),
-            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
-            Credentials::Test => Ok(AuthToken::NoAuth),
-        }
+        self.access_token().await
     }
 
     async fn fetch_user(
@@ -367,7 +405,7 @@ impl AuthClient for ServerApi {
                     auth_token: auth_token.map(ToOwned::to_owned),
                     headers: std::collections::HashMap::from([(
                         EXPERIMENT_ID_HEADER.to_string(),
-                        self.auth_state.anonymous_id(),
+                        self.anonymous_id(),
                     )]),
                     ..default_request_options()
                 },

--- a/app/src/server/server_api/auth.rs
+++ b/app/src/server/server_api/auth.rs
@@ -19,7 +19,6 @@ use warp_graphql::queries::get_conversation_usage::{
     ConversationUsage, GetConversationUsage, GetConversationUsageVariables, UserResult,
 };
 
-use crate::auth::auth_state::AuthState;
 use warp_graphql::mutations::set_user_is_onboarded::{
     SetUserIsOnboarded, SetUserIsOnboardedResult, SetUserIsOnboardedVariables,
 };
@@ -65,7 +64,7 @@ use crate::{
     },
 };
 
-use super::{ServerApi, ServerApiAuthError, ServerApiTokenSource, TokenRefreshPolicy};
+use super::{ServerApi, ServerApiAuthError};
 
 /// Error messages returned from the Firebase REST API when attempting to convert a refresh token
 /// into an access token that indicate the user's token is in an errored state.
@@ -213,81 +212,61 @@ pub trait AuthClient: 'static + Send + Sync {
     async fn get_or_create_ambient_workload_token(&self) -> Result<Option<String>>;
 }
 
-pub(super) struct AuthStateTokenSource {
-    auth_state: Arc<AuthState>,
-    client: Arc<http_client::Client>,
-    event_sender: async_channel::Sender<ServerApiEvent>,
-}
-
-impl AuthStateTokenSource {
-    pub(super) fn new(
-        auth_state: Arc<AuthState>,
-        client: Arc<http_client::Client>,
-        event_sender: async_channel::Sender<ServerApiEvent>,
-    ) -> Self {
-        Self {
-            auth_state,
-            client,
-            event_sender,
+impl ServerApi {
+    pub(super) async fn access_token(&self) -> Result<AuthToken> {
+        if let Some(token) = self.bearer_token.clone() {
+            return Ok(AuthToken::Bearer(token));
         }
-    }
-}
 
-impl ServerApiTokenSource for AuthStateTokenSource {
-    fn access_token(&self, refresh_policy: TokenRefreshPolicy) -> BoxFuture<'_, Result<AuthToken>> {
-        Box::pin(async move {
-            if cfg!(feature = "skip_login") {
-                bail!("skip_login enabled; failing all authenticated requests");
-            }
+        if cfg!(feature = "skip_login") {
+            bail!("skip_login enabled; failing all authenticated requests");
+        }
 
-            let Some(credentials) = self.auth_state.credentials() else {
-                return Err(ServerApiAuthError::MissingCredentials.into());
-            };
+        let Some(auth_state) = self.auth_state.as_ref() else {
+            return Err(ServerApiAuthError::MissingCredentials.into());
+        };
 
-            match credentials {
-                Credentials::ApiKey { key, .. } => Ok(AuthToken::ApiKey(key)),
-                Credentials::Firebase(auth_tokens) => {
-                    let expiration_time = auth_tokens.expiration_time;
+        let Some(credentials) = auth_state.credentials() else {
+            return Err(ServerApiAuthError::MissingCredentials.into());
+        };
 
-                    // Generate a new ID token if the token has expired or will expire in the
-                    // next five minutes. This matches the behavior of the Firebase Auth SDK.
-                    if chrono::DateTime::now() + chrono::Duration::minutes(5) >= expiration_time {
-                        if !refresh_policy.allowed_to_refresh_token() {
-                            return Err(ServerApiAuthError::ExpiredRefreshDisabled.into());
-                        }
+        match credentials {
+            Credentials::ApiKey { key, .. } => Ok(AuthToken::ApiKey(key)),
+            Credentials::Firebase(auth_tokens) => {
+                let expiration_time = auth_tokens.expiration_time;
 
-                        let refresh_token = auth_tokens.refresh_token.clone();
-                        let firebase_token =
-                            FirebaseToken::Refresh(RefreshToken::new(refresh_token));
-
-                        let result = fetch_auth_tokens(self.client.clone(), firebase_token).await;
-
-                        if let Err(UserAuthenticationError::DeniedAccessToken(_)) = result {
-                            let _ = self.event_sender.send(ServerApiEvent::NeedsReauth).await;
-                        }
-                        let new_firebase_token_info = result?;
-                        self.auth_state
-                            .update_firebase_tokens(new_firebase_token_info.clone());
-                        let _ = self
-                            .event_sender
-                            .send(ServerApiEvent::AccessTokenRefreshed {
-                                token: new_firebase_token_info.id_token.clone(),
-                            })
-                            .await;
-                        return Ok(AuthToken::Firebase(new_firebase_token_info.id_token));
+                // Generate a new ID token if the token has expired or will expire in the
+                // next five minutes. This matches the behavior of the Firebase Auth SDK.
+                if chrono::DateTime::now() + chrono::Duration::minutes(5) >= expiration_time {
+                    if !self.allowed_to_refresh_token() {
+                        return Err(ServerApiAuthError::ExpiredRefreshDisabled.into());
                     }
 
-                    Ok(AuthToken::Firebase(auth_tokens.id_token))
-                }
-                Credentials::SessionCookie => Ok(AuthToken::NoAuth),
-                #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
-                Credentials::Test => Ok(AuthToken::NoAuth),
-            }
-        })
-    }
+                    let refresh_token = auth_tokens.refresh_token.clone();
+                    let firebase_token = FirebaseToken::Refresh(RefreshToken::new(refresh_token));
 
-    fn access_token_ignoring_validity(&self) -> Option<String> {
-        self.auth_state.get_access_token_ignoring_validity()
+                    let result = fetch_auth_tokens(self.client.clone(), firebase_token).await;
+
+                    if let Err(UserAuthenticationError::DeniedAccessToken(_)) = result {
+                        let _ = self.event_sender.send(ServerApiEvent::NeedsReauth).await;
+                    }
+                    let new_firebase_token_info = result?;
+                    auth_state.update_firebase_tokens(new_firebase_token_info.clone());
+                    let _ = self
+                        .event_sender
+                        .send(ServerApiEvent::AccessTokenRefreshed {
+                            token: new_firebase_token_info.id_token.clone(),
+                        })
+                        .await;
+                    return Ok(AuthToken::Firebase(new_firebase_token_info.id_token));
+                }
+
+                Ok(AuthToken::Firebase(auth_tokens.id_token))
+            }
+            Credentials::SessionCookie => Ok(AuthToken::NoAuth),
+            #[cfg(any(test, feature = "integration_tests", feature = "skip_login"))]
+            Credentials::Test => Ok(AuthToken::NoAuth),
+        }
     }
 }
 

--- a/app/src/server/server_api/auth.rs
+++ b/app/src/server/server_api/auth.rs
@@ -214,24 +214,17 @@ pub trait AuthClient: 'static + Send + Sync {
 
 impl ServerApi {
     pub(super) async fn access_token(&self) -> Result<AuthToken> {
-
         if cfg!(feature = "skip_login") {
             bail!("skip_login enabled; failing all authenticated requests");
         }
-        if let Some(token) = self.bearer_token.clone() {
-            return Ok(AuthToken::Bearer(token));
-        }
 
-        let Some(auth_state) = self.auth_state.as_ref() else {
-            return Err(ServerApiAuthError::MissingCredentials.into());
-        };
-
-        let Some(credentials) = auth_state.credentials() else {
+        let Some(credentials) = self.auth_state.credentials() else {
             return Err(ServerApiAuthError::MissingCredentials.into());
         };
 
         match credentials {
             Credentials::ApiKey { key, .. } => Ok(AuthToken::ApiKey(key)),
+            Credentials::Bearer(token) => Ok(AuthToken::Bearer(token)),
             Credentials::Firebase(auth_tokens) => {
                 let expiration_time = auth_tokens.expiration_time;
 
@@ -251,7 +244,8 @@ impl ServerApi {
                         let _ = self.event_sender.send(ServerApiEvent::NeedsReauth).await;
                     }
                     let new_firebase_token_info = result?;
-                    auth_state.update_firebase_tokens(new_firebase_token_info.clone());
+                    self.auth_state
+                        .update_firebase_tokens(new_firebase_token_info.clone());
                     let _ = self
                         .event_sender
                         .send(ServerApiEvent::AccessTokenRefreshed {

--- a/app/src/server/server_api/auth.rs
+++ b/app/src/server/server_api/auth.rs
@@ -64,7 +64,7 @@ use crate::{
     },
 };
 
-use super::{ServerApi, ServerApiAuthError};
+use super::ServerApi;
 
 /// Error messages returned from the Firebase REST API when attempting to convert a refresh token
 /// into an access token that indicate the user's token is in an errored state.
@@ -219,7 +219,7 @@ impl ServerApi {
         }
 
         let Some(credentials) = self.auth_state.credentials() else {
-            return Err(ServerApiAuthError::MissingCredentials.into());
+            bail!("missing authentication credentials");
         };
 
         match credentials {
@@ -231,10 +231,6 @@ impl ServerApi {
                 // Generate a new ID token if the token has expired or will expire in the
                 // next five minutes. This matches the behavior of the Firebase Auth SDK.
                 if chrono::DateTime::now() + chrono::Duration::minutes(5) >= expiration_time {
-                    if !self.allowed_to_refresh_token() {
-                        return Err(ServerApiAuthError::ExpiredRefreshDisabled.into());
-                    }
-
                     let refresh_token = auth_tokens.refresh_token.clone();
                     let firebase_token = FirebaseToken::Refresh(RefreshToken::new(refresh_token));
 

--- a/app/src/server/server_api/auth_tests.rs
+++ b/app/src/server/server_api/auth_tests.rs
@@ -1,4 +1,6 @@
 use crate::auth::credentials::{FirebaseToken, RefreshToken};
+#[cfg(feature = "skip_login")]
+use crate::server::server_api::ServerApi;
 use anyhow::Result;
 
 #[test]
@@ -33,4 +35,19 @@ fn test_firebase_token_urls() -> Result<()> {
         "https://staging.warp.dev/proxy/token?key=api_key"
     );
     Ok(())
+}
+
+#[cfg(feature = "skip_login")]
+#[test]
+fn access_token_skip_login_rejects_bearer_token() {
+    let (event_sender, _) = async_channel::unbounded();
+    let server_api =
+        ServerApi::new_for_test_with_bearer_token(Some("daemon-token".to_string()), event_sender);
+
+    let error = futures::executor::block_on(server_api.access_token()).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "skip_login enabled; failing all authenticated requests"
+    );
 }


### PR DESCRIPTION
## Description
We need to update `ServerApi` to optionally not auto refresh the token for the remote env auth case. This is based off of the specs in https://github.com/warpdotdev/warp/pull/9508

## Testing
Unit tests + manually tested w added logs
<img width="587" height="174" alt="Screenshot 2026-05-07 at 11 42 39 AM" src="https://github.com/user-attachments/assets/2e82407e-7f24-46bd-98e4-e9406a2032af" />

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<img width="587" height="174" alt="Screenshot 2026-05-07 at 11 42 39 AM" src="https://github.com/user-attachments/assets/9be6fffe-b346-4d4c-9c21-0fc77954c45f" />

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

* NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
* IMPROVEMENT: for new functionality of existing features.
* BUG-FIX: for fixes related to known bugs or regressions.
* IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
* OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->
