### PR TITLE
fix(terminal): treat CJK / full-width punctuation as path-detection boundaries (#10245)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14486,6 +14486,7 @@ dependencies = [
  "typed-path 0.10.0",
  "ui_components",
  "unicase",
+ "unicode-general-category",
  "unicode-width 0.1.14",
  "unindent 0.1.11",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,6 +298,7 @@ arborium = { version = "2", default-features = false, features = [
   "lang-vue",
   "lang-dockerfile",
 ] }
+unicode-general-category = "1.1"
 unicode-width = "0.1.12"
 uuid = { version = "1.1.2", features = ["v4", "serde", "js"] }
 vec1 = { version = "1.8.0", features = ["serde"] }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -203,6 +203,7 @@ toml_edit.workspace = true
 tracing.workspace = true
 ui_components.workspace = true
 unicase = "2.7.0"
+unicode-general-category.workspace = true
 unicode-width.workspace = true
 unindent = "0.1.7"
 url = { workspace = true, features = ["serde"] }

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -25,6 +25,7 @@ use std::{
 use bounded_vec_deque::BoundedVecDeque;
 use itertools::Itertools;
 use lazy_static::lazy_static;
+use unicode_general_category::{get_general_category, GeneralCategory};
 use unicode_width::UnicodeWidthChar;
 use urlocator::{UrlLocation, UrlLocator};
 use warp_core::features::FeatureFlag;
@@ -165,20 +166,41 @@ pub fn is_file_link_separator(c: char) -> bool {
     ) {
         return true;
     }
-    use unicode_general_category::{get_general_category, GeneralCategory};
-    matches!(
-        get_general_category(c),
+    match get_general_category(c) {
         GeneralCategory::ConnectorPunctuation
-            | GeneralCategory::DashPunctuation
-            | GeneralCategory::OpenPunctuation
-            | GeneralCategory::ClosePunctuation
-            | GeneralCategory::InitialPunctuation
-            | GeneralCategory::FinalPunctuation
-            | GeneralCategory::OtherPunctuation
-            | GeneralCategory::SpaceSeparator
-            | GeneralCategory::LineSeparator
-            | GeneralCategory::ParagraphSeparator
-    )
+        | GeneralCategory::DashPunctuation
+        | GeneralCategory::OpenPunctuation
+        | GeneralCategory::ClosePunctuation
+        | GeneralCategory::InitialPunctuation
+        | GeneralCategory::FinalPunctuation
+        | GeneralCategory::OtherPunctuation
+        | GeneralCategory::SpaceSeparator
+        | GeneralCategory::LineSeparator
+        | GeneralCategory::ParagraphSeparator => true,
+        GeneralCategory::Control
+        | GeneralCategory::CurrencySymbol
+        | GeneralCategory::DecimalNumber
+        | GeneralCategory::EnclosingMark
+        | GeneralCategory::Format
+        | GeneralCategory::LetterNumber
+        | GeneralCategory::LowercaseLetter
+        | GeneralCategory::MathSymbol
+        | GeneralCategory::ModifierLetter
+        | GeneralCategory::ModifierSymbol
+        | GeneralCategory::NonspacingMark
+        | GeneralCategory::OtherLetter
+        | GeneralCategory::OtherNumber
+        | GeneralCategory::OtherSymbol
+        | GeneralCategory::PrivateUse
+        | GeneralCategory::SpacingMark
+        | GeneralCategory::Surrogate
+        | GeneralCategory::TitlecaseLetter
+        | GeneralCategory::Unassigned
+        | GeneralCategory::UppercaseLetter => false,
+        // `GeneralCategory` is non-exhaustive. Future Unicode categories
+        // should remain non-separating until intentionally supported here.
+        _ => false,
+    }
 }
 
 /// Represents a range of cells with information on their combined content and total

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -88,19 +88,97 @@ const FG_SGR_PARAM: u8 = 38;
 const BG_SGR_PARAM: u8 = 48;
 
 lazy_static! {
-    pub static ref FILE_LINK_SEPARATORS: HashSet<char> =
-        HashSet::from([
-            '\0', '\t', ' ', '(', ')', ':', '\\', ',', '"', '\'', '[', ']', '{', '}', '<', '>',
-            ';', '|', '`', '=',
-            // Box-drawing characters used by tree-style directory listers.
-            '│', '├', '└', '─', '┬', '┴', '┼', '║', '╠', '╚', '═', '╦', '╩', '╬',
-        ]);
-
     /// The set of characters where, if we encounter them, we have a high degree of confidence that
     /// we're not in a valid URL. Other characters (e.g. '%') might be used in such a way that they
     /// result in invalid URLs, but we don't halt detection if we find them.
     /// See https://datatracker.ietf.org/doc/html/rfc3986 for more details.
     static ref URL_SEPARATORS: HashSet<char> = HashSet::from([' ', '<', '>', '"', '{', '}', '|', '\\', '^', '`']);
+}
+
+/// Returns whether `c` is a separator that should split a token during file
+/// path / link detection.
+///
+/// The set is the union of:
+///
+/// 1. An explicit ASCII list of common token separators (whitespace, control,
+///    and a curated set of punctuation that does not appear in valid file
+///    paths). This is the original list used by Warp prior to CJK support.
+/// 2. The non-ASCII box-drawing glyphs emitted by tree-style directory
+///    listers (e.g. `tree`, `eza --tree`).
+/// 3. Any non-ASCII character whose Unicode General Category is
+///    `P*` (any Punctuation) or `Z*` (any Separator). This makes
+///    full-width / CJK punctuation such as `：` (U+FF1A FULLWIDTH COLON),
+///    `，` (U+FF0C), `。` (U+3002), `「` `」` (U+300C / U+300D),
+///    `（` `）` (U+FF08 / U+FF09) terminate a path token, so output like
+///    `路径：/Users/me/foo.md` correctly extracts `/Users/me/foo.md`
+///    even though there is no ASCII whitespace between the prose and the
+///    path.
+///
+/// CJK ideographs (`Lo`) are intentionally **not** treated as separators
+/// because filenames and directories may contain them — the existing
+/// `test_possible_file_paths_in_word_multibyte` test asserts that
+/// `/path/音楽/テストファイル.txt` is recognised as a single path, and
+/// that contract must be preserved.
+pub fn is_file_link_separator(c: char) -> bool {
+    if c.is_ascii() {
+        return matches!(
+            c,
+            '\0' | '\t'
+                | ' '
+                | '('
+                | ')'
+                | ':'
+                | '\\'
+                | ','
+                | '"'
+                | '\''
+                | '['
+                | ']'
+                | '{'
+                | '}'
+                | '<'
+                | '>'
+                | ';'
+                | '|'
+                | '`'
+                | '='
+        );
+    }
+    // Box-drawing characters used by tree-style directory listers. These are
+    // `So` (Symbol_Other), so they are not caught by the P*/Z* categories
+    // below and need to be matched explicitly.
+    if matches!(
+        c,
+        '│' | '├'
+            | '└'
+            | '─'
+            | '┬'
+            | '┴'
+            | '┼'
+            | '║'
+            | '╠'
+            | '╚'
+            | '═'
+            | '╦'
+            | '╩'
+            | '╬'
+    ) {
+        return true;
+    }
+    use unicode_general_category::{get_general_category, GeneralCategory};
+    matches!(
+        get_general_category(c),
+        GeneralCategory::ConnectorPunctuation
+            | GeneralCategory::DashPunctuation
+            | GeneralCategory::OpenPunctuation
+            | GeneralCategory::ClosePunctuation
+            | GeneralCategory::InitialPunctuation
+            | GeneralCategory::FinalPunctuation
+            | GeneralCategory::OtherPunctuation
+            | GeneralCategory::SpaceSeparator
+            | GeneralCategory::LineSeparator
+            | GeneralCategory::ParagraphSeparator
+    )
 }
 
 /// Represents a range of cells with information on their combined content and total
@@ -113,9 +191,7 @@ struct Fragment {
 
 impl Fragment {
     fn has_separator(&self) -> bool {
-        self.content
-            .chars()
-            .any(|c| FILE_LINK_SEPARATORS.contains(&c))
+        self.content.chars().any(is_file_link_separator)
     }
 }
 
@@ -1081,7 +1157,7 @@ impl GridHandler {
     /// Words are separated by the file link separators.
     pub fn fragment_boundary_at_point(&self, point: &Point) -> FragmentBoundary {
         fn is_at_boundary(cell: &Cell) -> bool {
-            FILE_LINK_SEPARATORS.contains(&cell.c)
+            is_file_link_separator(cell.c)
         }
 
         // Start by scanning backward.
@@ -1240,7 +1316,7 @@ impl GridHandler {
                 .content
                 .chars()
                 .next()
-                .map(|c| FILE_LINK_SEPARATORS.contains(&c))
+                .map(is_file_link_separator)
                 .unwrap_or(false),
             None => true,
         };
@@ -1420,7 +1496,7 @@ impl GridHandler {
             {
                 // If is a separator, we push the last fragment to the vector and push
                 // the separator as its own fragment.
-                if FILE_LINK_SEPARATORS.contains(&cell.c) {
+                if is_file_link_separator(cell.c) {
                     if !last_fragment.is_empty() {
                         let mut fragment_text = String::new();
                         mem::swap(&mut fragment_text, &mut last_fragment);

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -1072,6 +1072,22 @@ fn test_possible_file_paths() {
 }
 
 #[test]
+fn test_possible_file_paths_with_cjk_fullwidth_separator() {
+    let blockgrid = mock_blockgrid("路径：/tmp/foo.md");
+    let possible_paths = blockgrid
+        .grid_handler
+        .possible_file_paths_at_point(Point { row: 0, col: 6 });
+
+    assert!(possible_paths.contains(&PossiblePath {
+        path: CleanPathResult {
+            path: "/tmp/foo.md".into(),
+            line_and_column_num: None,
+        },
+        range: Point { row: 0, col: 6 }..=Point { row: 0, col: 16 },
+    }));
+}
+
+#[test]
 fn test_fragment_boundary_at_point() {
     let assert_fragment_boundary =
         |blockgrid: &BlockGrid,
@@ -1112,6 +1128,9 @@ fn test_fragment_boundary_at_point() {
     let blockgrid = mock_blockgrid("line one\r\nline two");
     assert_fragment_boundary(&blockgrid, (0, 6), (0, 5)..(0, 8)); // Should give boundary of fragment "one"
     assert_fragment_boundary(&blockgrid, (1, 3), (1, 0)..(1, 4)); // Should give boundary of fragment "line"
+
+    let blockgrid = mock_blockgrid("路径：/tmp/foo.md");
+    assert_fragment_boundary(&blockgrid, (0, 6), (0, 6)..(0, 17)); // Should give boundary of fragment "/tmp/foo.md"
 
     // The `ls` command performs indenting via a tab '\t' followed by a series of null characters '\0'
     let blockgrid = mock_blockgrid("migrations\t\0\0\0resources");

--- a/app/src/util/link_detection.rs
+++ b/app/src/util/link_detection.rs
@@ -10,7 +10,7 @@ use crate::ai::agent::{AIAgentActionType, AIAgentOutput, AIAgentTextSection, Rea
 use crate::ai::blocklist::block::view_impl::output::LinkActionConstructors;
 use crate::ai::blocklist::block::TextLocation;
 use crate::terminal::links::should_directly_open_link;
-use crate::terminal::model::grid::grid_handler::FILE_LINK_SEPARATORS;
+use crate::terminal::model::grid::grid_handler::is_file_link_separator;
 use crate::terminal::ShellLaunchData;
 use warpui::elements::MouseStateHandle;
 use warpui::text::char_slice;
@@ -219,7 +219,7 @@ fn addr_of(s: &str) -> usize {
 /// - macOS PATH_MAX: 1024 bytes.
 /// - Windows long-path cap: 32,767 UTF-16 units = 98,301 bytes.
 const MAX_WORD_LEN_FOR_FILE_PATH: usize = 96 * 1024;
-/// Maximum [`FILE_LINK_SEPARATORS`] characters per token, to bound candidate substrings.
+/// Maximum [`is_file_link_separator`] hits per token, to bound candidate substrings.
 /// 256 keeps per-token allocations under ~1 MiB and is far above any real path.
 const MAX_SEPARATORS_PER_WORD: usize = 256;
 
@@ -244,7 +244,7 @@ fn separator_byte_ranges_for_file_path_search(word: &str) -> Vec<SeparatorByteRa
     // We use char_indices() to get byte indices of each char which are used to index the string,
     // rather than chars().enumerate() would give char indices.
     for (i, c) in word.char_indices() {
-        if FILE_LINK_SEPARATORS.contains(&c) {
+        if is_file_link_separator(c) {
             if separator_byte_ranges.len() > MAX_SEPARATORS_PER_WORD {
                 return Vec::new();
             }
@@ -266,8 +266,8 @@ fn separator_byte_ranges_for_file_path_search(word: &str) -> Vec<SeparatorByteRa
 }
 
 /// Given a word with no whitespace in it, returns all the possible file paths within the word
-/// from longest to shortest. File paths within a word can be split by a list of FILE_LINK_SEPARATORS,
-/// and those separators may be part of file paths themselves.
+/// from longest to shortest. File paths within a word can be split by characters for which
+/// [`is_file_link_separator`] returns true, and those separators may be part of file paths themselves.
 /// Possible file paths begin after a separator and end before a separator.
 /// For example, given /path/to/file:16:hello, it will return
 /// ["/path/to/file:16:hello", "/path/to/file:16", "/path/to/file", "16:hello", "hello"]

--- a/app/src/util/link_detection_tests.rs
+++ b/app/src/util/link_detection_tests.rs
@@ -129,3 +129,54 @@ fn test_possible_file_paths_in_word_accepts_token_at_separator_count_cap() {
     }
     assert!(possible_file_paths_in_word(&at_cap).next().is_some());
 }
+
+/// Paths preceded by CJK / full-width punctuation (e.g. `路径：/path/to/foo.md`)
+/// should still be recognised. These punctuation characters live in Unicode
+/// category `P*` and are now treated as token separators alongside the legacy
+/// ASCII set. See GH#10245.
+#[test]
+fn test_possible_file_paths_in_word_with_fullwidth_colon() {
+    let word = "路径：/Users/me/foo.md";
+    let possible_paths = possible_file_paths_in_word(word).collect_vec();
+    assert!(possible_paths.contains(&"/Users/me/foo.md"));
+}
+
+#[test]
+fn test_possible_file_paths_in_word_with_ideographic_full_stop() {
+    let word = "/tmp/foo.md。これは説明";
+    let possible_paths = possible_file_paths_in_word(word).collect_vec();
+    assert!(possible_paths.contains(&"/tmp/foo.md"));
+}
+
+#[test]
+fn test_possible_file_paths_in_word_with_cjk_corner_brackets() {
+    let word = "「/tmp/foo.md」";
+    let possible_paths = possible_file_paths_in_word(word).collect_vec();
+    assert!(possible_paths.contains(&"/tmp/foo.md"));
+}
+
+#[test]
+fn test_possible_file_paths_in_word_with_fullwidth_parens() {
+    let word = "（/tmp/foo.md）";
+    let possible_paths = possible_file_paths_in_word(word).collect_vec();
+    assert!(possible_paths.contains(&"/tmp/foo.md"));
+}
+
+#[test]
+fn test_possible_file_paths_in_word_with_fullwidth_comma() {
+    let word = "/tmp/foo.md，/tmp/bar.md";
+    let possible_paths = possible_file_paths_in_word(word).collect_vec();
+    assert!(possible_paths.contains(&"/tmp/foo.md"));
+    assert!(possible_paths.contains(&"/tmp/bar.md"));
+}
+
+/// Regression guard: CJK ideographs (Unicode category `Lo`) inside a path
+/// must NOT be treated as separators, otherwise filenames containing kanji
+/// or kana stop being clickable. This complements
+/// [`test_possible_file_paths_in_word_multibyte`] above.
+#[test]
+fn test_possible_file_paths_in_word_preserves_cjk_letters_in_path() {
+    let word = "/path/to/日本語ファイル.md";
+    let possible_paths = possible_file_paths_in_word(word).collect_vec();
+    assert!(possible_paths.contains(&"/path/to/日本語ファイル.md"));
+}


### PR DESCRIPTION
## Description

Warp's clickable-path detection treats only ASCII whitespace plus a curated set of ASCII punctuation as token boundaries. When terminal output is generated by AI CLIs or by Chinese / Japanese developer tooling that prints file paths inline in prose, paths preceded by full-width punctuation (with no ASCII whitespace between the prose and the path) become un-clickable. The bug reporter's concrete repro:

```
路径：/Users/me/foo.md      ← NOT clickable (full-width ：touching /)
路径: /Users/me/foo.md      ← clickable     (ASCII : + space)
/Users/me/foo.md            ← clickable     (bare)
```

The only difference between line 1 and line 2 is `：` (U+FF1A FULLWIDTH COLON) directly touching `/` vs an ASCII colon + space.

This PR replaces the `lazy_static FILE_LINK_SEPARATORS: HashSet<char>` in `app/src/terminal/model/grid/grid_handler.rs` with a function `is_file_link_separator(c: char) -> bool`. The function checks, in order:

1. **ASCII match arm** with the original ASCII separator set (fast path — this matters because `fragment_boundary_at_point` calls it per-cell on hover);
2. **Legacy non-ASCII box-drawing glyphs** emitted by tree-style directory listers (these are `So` and would not be caught by the category fallback);
3. **Any non-ASCII character whose Unicode General Category is `P*` (Punctuation) or `Z*` (Separator)**, via `unicode-general-category`.

This covers all the punctuation classes the reporter calls out (U+FF1A, U+FF0C, U+3002, U+300C/D, U+300E/F, U+FF08/9) and any other CJK / full-width punctuation that wasn't enumerated.

### Trade-offs / call-outs for review

- **`Lo` (CJK ideographs) are intentionally excluded** even though the issue suggests including them. Filenames and directory names commonly contain CJK letters, and the existing `test_possible_file_paths_in_word_multibyte` test asserts that `/path/音楽/テストファイル.txt` is recognised as a single path. Treating `Lo` as a boundary would break that contract. A new test (`test_possible_file_paths_in_word_preserves_cjk_letters_in_path`) adds an explicit regression guard.
- **`S*` (Symbols, including emoji / arrows) is also excluded** to stay conservative and match the explicit examples in the issue. Happy to extend if maintainers prefer.
- **`unicode-general-category` becomes a direct dependency on the `app` crate.** It was already in `Cargo.lock` transitively, so there is no new compile cost. An alternative is to hand-curate an explicit char list — but that would not cover unforeseen CJK / full-width punctuation. The function approach is the one the issue author proposed; happy to convert if you prefer the explicit list.

## Linked Issue

Fixes #10245

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos

No UI changes; the diff is contained to path/link detection. Behavior is exactly the steps in #10245: each of the three lines above is now clickable.

## Testing

`./script/presubmit` equivalents all pass locally on macOS:

- `cargo fmt --check` ✓
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` ✓
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings` ✓
- `./script/run-clang-format.py -r --extensions 'c,h,cpp,m' ./crates/warpui/src/ ./app/src/` ✓
- `cargo nextest run -p warp link_detection` — 15/15 pass (9 existing + 6 new)
- `cargo nextest run -p warp fragment_boundary` — 1/1 pass
- `cargo test --doc -p warp` ✓

New tests added in `app/src/util/link_detection_tests.rs` covering each punctuation class called out in the issue, plus a regression guard:

- `test_possible_file_paths_in_word_with_fullwidth_colon` — `路径：/Users/me/foo.md` extracts `/Users/me/foo.md`
- `test_possible_file_paths_in_word_with_ideographic_full_stop` — `/tmp/foo.md。これは説明` extracts `/tmp/foo.md`
- `test_possible_file_paths_in_word_with_cjk_corner_brackets` — `「/tmp/foo.md」` extracts `/tmp/foo.md`
- `test_possible_file_paths_in_word_with_fullwidth_parens` — `（/tmp/foo.md）` extracts `/tmp/foo.md`
- `test_possible_file_paths_in_word_with_fullwidth_comma` — `/tmp/foo.md，/tmp/bar.md` extracts both
- `test_possible_file_paths_in_word_preserves_cjk_letters_in_path` — `/path/to/日本語ファイル.md` stays a single clickable token

Manually verified against the issue repro on macOS:

```
printf '路径：/tmp/warp-repro.md\n路径: /tmp/warp-repro.md\n/tmp/warp-repro.md\n'
```

All three lines are now hover-underlined and Cmd+Click opens the file in the configured editor.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Treat CJK / full-width punctuation as path-detection word boundaries so paths printed inline after Chinese / Japanese prose (e.g. `路径：/Users/me/foo.md`) become clickable.
-->