### PR TITLE
feat: gate git credential refresh behind GitCredentialRefresh flag (dogfood only)

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -933,6 +933,7 @@ cloud_mode_setup_v2 = ["cloud_mode"]
 cloud_mode_input_v2 = ["cloud_mode"]
 configurable_context_window = []
 handoff_cloud_cloud = ["cloud_mode_setup_v2"]
+git_credential_refresh = []
 
 [package.metadata.bundle.bin.warp-oss]
 category = "public.app-category.developer-tools"

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1395,7 +1395,11 @@ impl AgentDriver {
 
         let (task_id_for_refresh, ai_client_for_refresh) = foreground
             .spawn(|me, ctx| {
-                let task_id = me.task_id.map(|id| id.to_string());
+                let task_id = if FeatureFlag::GitCredentialRefresh.is_enabled() {
+                    me.task_id.map(|id| id.to_string())
+                } else {
+                    None
+                };
                 let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client().clone();
                 (task_id, ai_client)
             })

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -999,6 +999,9 @@ impl AgentDriverRunner {
         let git_creds_ai_client = ai_client.clone();
         let git_creds_task_id = task_id_str.clone();
         let git_credentials = async move {
+            if !FeatureFlag::GitCredentialRefresh.is_enabled() {
+                return Ok(vec![]);
+            }
             let workload_token = match warp_isolation_platform::issue_workload_token(Some(
                 std::time::Duration::from_mins(5),
             ))
@@ -1056,21 +1059,23 @@ impl AgentDriverRunner {
             }
         }
 
-        match git_credentials_result {
-            Ok(credentials) if !credentials.is_empty() => {
-                driver::git_credentials::setup_git_config(&credentials);
-                driver::git_credentials::configure_git_identity(&credentials);
-                if let Err(e) = driver::git_credentials::write_git_credentials(&credentials) {
-                    log::warn!("Failed to write git credentials: {e:#}");
-                } else {
-                    log::info!("Git credentials configured from taskGitCredentials");
+        if FeatureFlag::GitCredentialRefresh.is_enabled() {
+            match git_credentials_result {
+                Ok(credentials) if !credentials.is_empty() => {
+                    driver::git_credentials::setup_git_config(&credentials);
+                    driver::git_credentials::configure_git_identity(&credentials);
+                    if let Err(e) = driver::git_credentials::write_git_credentials(&credentials) {
+                        log::warn!("Failed to write git credentials: {e:#}");
+                    } else {
+                        log::info!("Git credentials configured from taskGitCredentials");
+                    }
                 }
-            }
-            Ok(_) => {
-                log::debug!("No git credentials returned; skipping credential file setup");
-            }
-            Err(e) => {
-                log::warn!("Failed to fetch git credentials: {e:#}");
+                Ok(_) => {
+                    log::debug!("No git credentials returned; skipping credential file setup");
+                }
+                Err(e) => {
+                    log::warn!("Failed to fetch git credentials: {e:#}");
+                }
             }
         }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2901,6 +2901,8 @@ pub fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::ConfigurableContextWindow,
         #[cfg(feature = "handoff_cloud_cloud")]
         FeatureFlag::HandoffCloudCloud,
+        #[cfg(feature = "git_credential_refresh")]
+        FeatureFlag::GitCredentialRefresh,
     ]);
 
     flags

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -859,6 +859,11 @@ pub enum FeatureFlag {
     /// conversation into a fresh cloud agent run with the current workspace
     /// snapshot attached. Requires `OzHandoff` to also be enabled.
     HandoffLocalCloud,
+
+    /// Gates the driver behavior that writes GitHub credentials to disk
+    /// (`~/.git-credentials`, `~/.config/gh/hosts.yaml`) and runs the
+    /// background refresh loop that keeps them fresh during a task run.
+    GitCredentialRefresh,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -940,6 +945,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::CloudModeInputV2,
     FeatureFlag::HandoffLocalCloud,
     FeatureFlag::DragTabsToWindows,
+    FeatureFlag::GitCredentialRefresh,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Summary

- Adds a `GitCredentialRefresh` feature flag to gate the credential-writing and background refresh-loop behavior introduced in #10153
- Flag is **dogfood-only** (added to `DOGFOOD_FLAGS`); off by default in Preview and Stable builds
- When the flag is off, the `git_credentials` fetch future short-circuits to `Ok(vec![])`, the credential file write block is skipped, and `task_id_for_refresh` is forced to `None` so the background refresh loop never spawns

## Files changed

| File | Change |
|------|--------|
| `crates/warp_features/src/lib.rs` | New `GitCredentialRefresh` variant; added to `DOGFOOD_FLAGS` |
| `app/Cargo.toml` | New `git_credential_refresh = []` Cargo feature |
| `app/src/lib.rs` | Compile-time bridge: `#[cfg(feature = "git_credential_refresh")] FeatureFlag::GitCredentialRefresh` |
| `app/src/ai/agent_sdk/mod.rs` | Guard fetch future and write block behind flag |
| `app/src/ai/agent_sdk/driver.rs` | Guard refresh loop (`task_id_for_refresh`) behind flag |

## Test plan

- [x] Build dogfood — credential fetch and refresh loop should be active
loop still working with flag enabled: https://www.loom.com/share/14d64e5c90414328a9a9387d9820be7c 
- [ ] Build stable/preview (without `git_credential_refresh` feature) — `git_credentials` returns early, no credential files written, no refresh loop spawned

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._