### PR TITLE
Gate git credential refresh behind dogfood flag

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1395,7 +1395,10 @@ impl AgentDriver {
 
         let (task_id_for_refresh, ai_client_for_refresh) = foreground
             .spawn(|me, ctx| {
-                let task_id = me.task_id.map(|id| id.to_string());
+                let task_id = FeatureFlag::GitCredentialRefresh
+                    .is_enabled()
+                    .then(|| me.task_id.map(|id| id.to_string()))
+                    .flatten();
                 let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client().clone();
                 (task_id, ai_client)
             })

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -999,6 +999,10 @@ impl AgentDriverRunner {
         let git_creds_ai_client = ai_client.clone();
         let git_creds_task_id = task_id_str.clone();
         let git_credentials = async move {
+            if !FeatureFlag::GitCredentialRefresh.is_enabled() {
+                log::debug!("Skipping git credentials fetch: feature flag disabled");
+                return Ok(vec![]);
+            }
             let workload_token = match warp_isolation_platform::issue_workload_token(Some(
                 std::time::Duration::from_mins(5),
             ))

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -859,6 +859,9 @@ pub enum FeatureFlag {
     /// conversation into a fresh cloud agent run with the current workspace
     /// snapshot attached. Requires `OzHandoff` to also be enabled.
     HandoffLocalCloud,
+
+    /// Enables fetching, writing, and refreshing git credentials for cloud agent tasks.
+    GitCredentialRefresh,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -940,6 +943,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::CloudModeInputV2,
     FeatureFlag::HandoffLocalCloud,
     FeatureFlag::DragTabsToWindows,
+    FeatureFlag::GitCredentialRefresh,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Summary
- Add a `GitCredentialRefresh` feature flag enabled only for dogfood builds
- Gate the startup `taskGitCredentials` fetch/write path when loading existing tasks
- Gate the periodic git credential refresh loop for Oz and third-party harness runs

## Testing
- `cargo fmt`
- `cargo check -p warp_features`
- `cargo check -p warp`

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._