### PR TITLE
Fix orchestration confirmation block UI bugs

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -134,7 +134,6 @@ pub const LOAD_OUTPUT_MESSAGE: &str = "Warping...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_ADJUSTING: &str = "Adjusting tasks...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_PASSIVE_CODE_GEN: &str = "Generating fix...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_CREATING_DIFF: &str = "Creating diff...";
-pub const LOAD_OUTPUT_MESSAGE_FOR_RUN_AGENTS: &str = "Spawning agents...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_PREPARING_QUESTION: &str = "Preparing question...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_GENERATING_PLAN: &str = "Generating plan...";
 pub const LOAD_OUTPUT_MESSAGE_FOR_UPDATING_PLAN: &str = "Updating plan...";
@@ -247,19 +246,6 @@ pub fn render_warping_indicator<V: View>(
         })
     });
 
-    let is_last_message_run_agents = output_to_render.as_ref().is_some_and(|output| {
-        let output = output.get();
-        output.messages.last().is_some_and(|m| {
-            matches!(
-                m.message,
-                AIAgentOutputMessageType::Action(AIAgentAction {
-                    action: AIAgentActionType::RunAgents(_),
-                    ..
-                })
-            )
-        })
-    });
-
     let is_last_message_asking_user_question = output_to_render.as_ref().is_some_and(|output| {
         let output = output.get();
         output.messages.last().is_some_and(|m| {
@@ -345,8 +331,6 @@ pub fn render_warping_indicator<V: View>(
         LOAD_OUTPUT_MESSAGE_FOR_PASSIVE_CODE_GEN.to_string()
     } else if is_last_message_requesting_file_edits {
         LOAD_OUTPUT_MESSAGE_FOR_CREATING_DIFF.to_string()
-    } else if is_last_message_run_agents && FeatureFlag::RunAgentsTool.is_enabled() {
-        LOAD_OUTPUT_MESSAGE_FOR_RUN_AGENTS.to_string()
     } else if is_last_message_asking_user_question {
         LOAD_OUTPUT_MESSAGE_FOR_PREPARING_QUESTION.to_string()
     } else if is_searching_web {

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -788,17 +788,14 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                             ..
                         }) if FeatureFlag::RunAgentsTool.is_enabled() => {
                             // Embed the per-action `RunAgentsCardView`
-                            // via `ChildView`. The view itself handles
-                            // the streaming gate and in-flight dispatch
-                            // states (a card is mid-dispatch when its
-                            // `is_spawning()` getter returns true).
+                            // via `ChildView`. The view renders a
+                            // "Configuring agents..." placeholder while
+                            // streaming, then transitions to the full
+                            // confirmation card once complete.
                             should_render_footer = false;
                             should_render_suggestions = false;
                             if let Some(card_view) = props.run_agents_card_views.get(id) {
-                                let is_spawning = card_view.as_ref(app).is_spawning();
-                                if !status.is_streaming() || is_spawning {
-                                    output_items.add_child(ChildView::new(card_view).finish());
-                                }
+                                output_items.add_child(ChildView::new(card_view).finish());
                             }
                         }
                         AIAgentOutputMessageType::Action(AIAgentAction {

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -301,6 +301,20 @@ pub fn populate_model_picker<A: OrchestrationControlAction, V: View>(
     populate_model_picker_for_harness(dropdown, initial_model_id, "", ctx);
 }
 
+/// Returns whether the given LLM matches the harness filter.
+/// Claude → Anthropic only, Codex → OpenAI only, Oz/empty → all.
+fn matches_harness_filter(harness: Option<Harness>, provider: &LLMProvider) -> bool {
+    match harness {
+        Some(Harness::Claude) => matches!(provider, LLMProvider::Anthropic),
+        Some(Harness::Codex) => matches!(provider, LLMProvider::OpenAI),
+        Some(Harness::Oz)
+        | Some(Harness::Gemini)
+        | Some(Harness::OpenCode)
+        | Some(Harness::Unknown)
+        | None => true,
+    }
+}
+
 /// Populates the model picker, filtering choices by harness.
 /// Claude → Anthropic models only, Codex → OpenAI models only,
 /// Oz/empty → all models.
@@ -318,15 +332,7 @@ pub fn populate_model_picker_for_harness<A: OrchestrationControlAction, V: View>
         let harness = Harness::parse_orchestration_harness(&harness_type);
         let choices: Vec<_> = all_choices
             .into_iter()
-            .filter(|llm| match harness {
-                Some(Harness::Claude) => matches!(llm.provider, LLMProvider::Anthropic),
-                Some(Harness::Codex) => matches!(llm.provider, LLMProvider::OpenAI),
-                Some(Harness::Oz)
-                | Some(Harness::Gemini)
-                | Some(Harness::OpenCode)
-                | Some(Harness::Unknown)
-                | None => true,
-            })
+            .filter(|llm| matches_harness_filter(harness, &llm.provider))
             .collect();
         let selected_display_name = choices
             .iter()
@@ -360,15 +366,7 @@ pub fn is_model_in_filtered_choices<V: View>(
     let harness = Harness::parse_orchestration_harness(harness_type);
     llm_prefs
         .get_base_llm_choices_for_agent_mode()
-        .filter(|llm| match harness {
-            Some(Harness::Claude) => matches!(llm.provider, LLMProvider::Anthropic),
-            Some(Harness::Codex) => matches!(llm.provider, LLMProvider::OpenAI),
-            Some(Harness::Oz)
-            | Some(Harness::Gemini)
-            | Some(Harness::OpenCode)
-            | Some(Harness::Unknown)
-            | None => true,
-        })
+        .filter(|llm| matches_harness_filter(harness, &llm.provider))
         .any(|llm| llm.id.to_string() == model_id)
 }
 
@@ -382,15 +380,7 @@ pub fn first_filtered_model_id<V: View>(
     let harness = Harness::parse_orchestration_harness(harness_type);
     llm_prefs
         .get_base_llm_choices_for_agent_mode()
-        .find(|llm| match harness {
-            Some(Harness::Claude) => matches!(llm.provider, LLMProvider::Anthropic),
-            Some(Harness::Codex) => matches!(llm.provider, LLMProvider::OpenAI),
-            Some(Harness::Oz)
-            | Some(Harness::Gemini)
-            | Some(Harness::OpenCode)
-            | Some(Harness::Unknown)
-            | None => true,
-        })
+        .find(|llm| matches_harness_filter(harness, &llm.provider))
         .map(|llm| llm.id.to_string())
 }
 

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -11,8 +11,9 @@ use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationExecutio
 use pathfinder_color::ColorU;
 use std::fmt::Debug;
 use warpui::elements::{
-    ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty, Expanded, Flex,
-    Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement, Radius, Text,
+    ChildAnchor, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty,
+    Expanded, Flex, Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement,
+    PositionedElementAnchor, Radius, Text,
 };
 use warpui::platform::Cursor;
 use warpui::ui_components::button::ButtonVariant;
@@ -27,11 +28,12 @@ use warp_core::ui::theme::Fill;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::execution_profiles::model_menu_items::available_model_menu_items;
 use crate::ai::harness_display;
+use crate::ai::llms::LLMProvider;
 use crate::appearance::Appearance;
 use crate::menu::{MenuItem, MenuItemFields};
 use crate::ui_components::blended_colors;
 use crate::view_components::dropdown::{Dropdown, DropdownAction, DropdownStyle};
-use crate::view_components::FilterableDropdown;
+use crate::view_components::{FilterableDropdown, FilterableDropdownOrientation};
 use crate::LLMPreferences;
 
 // ── Shared constants ────────────────────────────────────────────────
@@ -61,7 +63,7 @@ pub trait OrchestrationControlAction: Clone + Debug + Send + Sync + 'static {
 
 /// Run-wide configuration fields shared between the confirmation card
 /// editor and the plan-card config block. Card-specific fields
-/// (agent_run_configs, base_prompt, summary, skills, is_editor_open)
+/// (agent_run_configs, base_prompt, summary, skills)
 /// remain on the per-view state structs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrchestrationEditState {
@@ -280,19 +282,52 @@ pub fn new_standard_picker_dropdown<A: OrchestrationControlAction, V: View>(
         dropdown.set_border_width(ORCHESTRATION_PICKER_BORDER_WIDTH, ctx_dropdown);
         dropdown.set_font_size(ORCHESTRATION_PICKER_FONT_SIZE, ctx_dropdown);
         dropdown.set_font_color(font_color, ctx_dropdown);
+        // Open menus above the trigger to avoid overlapping the input box.
+        dropdown.set_menu_position(
+            PositionedElementAnchor::TopLeft,
+            ChildAnchor::BottomLeft,
+            ctx_dropdown,
+        );
         dropdown
     })
 }
 
+/// Populates the model picker with all available models (no harness filter).
 pub fn populate_model_picker<A: OrchestrationControlAction, V: View>(
     dropdown: &ViewHandle<Dropdown<A>>,
     initial_model_id: &str,
     ctx: &mut ViewContext<V>,
 ) {
+    populate_model_picker_for_harness(dropdown, initial_model_id, "", ctx);
+}
+
+/// Populates the model picker, filtering choices by harness.
+/// Claude → Anthropic models only, Codex → OpenAI models only,
+/// Oz/empty → all models.
+pub fn populate_model_picker_for_harness<A: OrchestrationControlAction, V: View>(
+    dropdown: &ViewHandle<Dropdown<A>>,
+    initial_model_id: &str,
+    harness_type: &str,
+    ctx: &mut ViewContext<V>,
+) {
     let initial_model_id = initial_model_id.to_string();
+    let harness_type = harness_type.to_string();
     dropdown.update(ctx, |dropdown, ctx_dropdown| {
         let llm_prefs = LLMPreferences::as_ref(ctx_dropdown);
-        let choices: Vec<_> = llm_prefs.get_base_llm_choices_for_agent_mode().collect();
+        let all_choices: Vec<_> = llm_prefs.get_base_llm_choices_for_agent_mode().collect();
+        let harness = Harness::parse_orchestration_harness(&harness_type);
+        let choices: Vec<_> = all_choices
+            .into_iter()
+            .filter(|llm| match harness {
+                Some(Harness::Claude) => matches!(llm.provider, LLMProvider::Anthropic),
+                Some(Harness::Codex) => matches!(llm.provider, LLMProvider::OpenAI),
+                Some(Harness::Oz)
+                | Some(Harness::Gemini)
+                | Some(Harness::OpenCode)
+                | Some(Harness::Unknown)
+                | None => true,
+            })
+            .collect();
         let selected_display_name = choices
             .iter()
             .find(|llm| llm.id.to_string() == initial_model_id)
@@ -311,6 +346,52 @@ pub fn populate_model_picker<A: OrchestrationControlAction, V: View>(
             dropdown.set_selected_by_name(name, ctx_dropdown);
         }
     });
+}
+
+/// Returns whether the given model_id is present in the harness-filtered
+/// model choices. Used to detect when a harness change invalidates the
+/// current model selection.
+pub fn is_model_in_filtered_choices<V: View>(
+    model_id: &str,
+    harness_type: &str,
+    ctx: &mut ViewContext<V>,
+) -> bool {
+    let llm_prefs = LLMPreferences::as_ref(ctx);
+    let harness = Harness::parse_orchestration_harness(harness_type);
+    llm_prefs
+        .get_base_llm_choices_for_agent_mode()
+        .filter(|llm| match harness {
+            Some(Harness::Claude) => matches!(llm.provider, LLMProvider::Anthropic),
+            Some(Harness::Codex) => matches!(llm.provider, LLMProvider::OpenAI),
+            Some(Harness::Oz)
+            | Some(Harness::Gemini)
+            | Some(Harness::OpenCode)
+            | Some(Harness::Unknown)
+            | None => true,
+        })
+        .any(|llm| llm.id.to_string() == model_id)
+}
+
+/// Returns the model_id of the first model in the harness-filtered set,
+/// or `None` if the filtered set is empty.
+pub fn first_filtered_model_id<V: View>(
+    harness_type: &str,
+    ctx: &mut ViewContext<V>,
+) -> Option<String> {
+    let llm_prefs = LLMPreferences::as_ref(ctx);
+    let harness = Harness::parse_orchestration_harness(harness_type);
+    llm_prefs
+        .get_base_llm_choices_for_agent_mode()
+        .find(|llm| match harness {
+            Some(Harness::Claude) => matches!(llm.provider, LLMProvider::Anthropic),
+            Some(Harness::Codex) => matches!(llm.provider, LLMProvider::OpenAI),
+            Some(Harness::Oz)
+            | Some(Harness::Gemini)
+            | Some(Harness::OpenCode)
+            | Some(Harness::Unknown)
+            | None => true,
+        })
+        .map(|llm| llm.id.to_string())
 }
 
 pub fn populate_harness_picker<A: OrchestrationControlAction, V: View>(
@@ -365,6 +446,8 @@ pub fn create_environment_picker<A: OrchestrationControlAction, V: View>(
         dropdown.set_style(styles);
         dropdown.set_top_bar_height(ORCHESTRATION_PICKER_HEIGHT, ctx_dropdown);
         dropdown.set_top_bar_max_width(f32::INFINITY);
+        // Open menu above the trigger to avoid overlapping the input box.
+        dropdown.set_orientation(FilterableDropdownOrientation::Up);
         dropdown
     });
     dropdown_handle.update(ctx, |dropdown, ctx_dropdown| {

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -376,6 +376,20 @@ impl RunAgentsCardView {
         ctx.subscribe_to_model(&LLMPreferences::handle(ctx), |me, _, event, ctx| {
             if let LLMPreferencesEvent::UpdatedAvailableLLMs = event {
                 if let Some(handle) = &me.handles.pickers.model_picker {
+                    // Re-validate model_id against the updated choices.
+                    // This handles the case where harness was changed while
+                    // models hadn't loaded yet.
+                    if !oc::is_model_in_filtered_choices(
+                        &me.state.orch.model_id,
+                        &me.state.orch.harness_type,
+                        ctx,
+                    ) {
+                        if let Some(first_id) =
+                            oc::first_filtered_model_id(&me.state.orch.harness_type, ctx)
+                        {
+                            me.state.orch.model_id = first_id;
+                        }
+                    }
                     oc::populate_model_picker_for_harness(
                         handle,
                         &me.state.orch.model_id,
@@ -635,27 +649,26 @@ impl View for RunAgentsCardView {
             return render_spawning_card(&snapshot, appearance, app);
         }
 
-        // Still streaming: show "Configuring agents..." placeholder until
-        // the action reaches Blocked status (i.e., streaming is complete
-        // and the action is queued for user confirmation). This prevents
-        // showing an interactive confirmation card backed by a partial
-        // request that is still being streamed.
-        if !matches!(status, Some(AIActionStatus::Blocked)) {
-            return render_status_only_card(
-                "Configuring agents\u{2026}".to_string(),
-                appearance,
-                StatusKind::Spawning,
-                app,
-            );
-        }
-
         // Restored-from-history: dispatch state is lost, render as
-        // Cancelled.
+        // Cancelled. Must be checked before the streaming gate below,
+        // because restored blocks have no pending action status.
         if self.block_model.is_restored() {
             return render_status_only_card(
                 "Spawn agents cancelled".to_string(),
                 appearance,
                 StatusKind::Cancelled,
+                app,
+            );
+        }
+
+        // Still streaming: show "Configuring agents..." placeholder until
+        // the action reaches Blocked status (i.e., streaming is complete
+        // and the action is queued for user confirmation).
+        if !matches!(status, Some(AIActionStatus::Blocked)) {
+            return render_status_only_card(
+                "Configuring agents\u{2026}".to_string(),
+                appearance,
+                StatusKind::Spawning,
                 app,
             );
         }
@@ -729,8 +742,9 @@ impl TypedActionView for RunAgentsCardView {
                         harness_type,
                         ctx,
                     ) {
-                        self.state.orch.model_id =
-                            oc::first_filtered_model_id(harness_type, ctx).unwrap_or_default();
+                        if let Some(first_id) = oc::first_filtered_model_id(harness_type, ctx) {
+                            self.state.orch.model_id = first_id;
+                        }
                         oc::populate_model_picker_for_harness(
                             handle,
                             &self.state.orch.model_id,

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -358,6 +358,15 @@ impl RunAgentsCardView {
                     action_model.execute_run_agents(&action_id, request, action_ctx);
                 });
             }
+            BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(action_id)
+                if action_id == &action_id_for_action_events =>
+            {
+                // Normal case: streaming is complete and the action is
+                // ready for user confirmation. Re-render so the card
+                // transitions from the "Configuring agents..." placeholder
+                // to the full confirmation UI.
+                ctx.notify();
+            }
             _ => {}
         });
 

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -15,7 +15,7 @@ use warpui::elements::{
     Border, ChildView, Container, CornerRadius, CrossAxisAlignment, Empty, Flex, MainAxisSize,
     OffsetPositioning, ParentElement, Radius, Stack, Text,
 };
-use warpui::keymap::{FixedBinding, Keystroke};
+use warpui::keymap::FixedBinding;
 use warpui::{
     AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
     ViewHandle,
@@ -52,9 +52,7 @@ use crate::view_components::compactible_split_action_button::CompactibleSplitAct
 use crate::view_components::dropdown::DropdownEvent;
 use crate::view_components::FilterableDropdownEvent;
 
-const RUN_AGENTS_CARD_TITLE: &str = "Can I add additional agents to this task?";
-
-const RUN_AGENTS_EDITOR_OPEN: &str = "RunAgentsEditorOpen";
+const RUN_AGENTS_CARD_TITLE: &str = "Can I start additional agents for this task?";
 
 pub fn init(app: &mut AppContext) {
     use warpui::keymap::macros::*;
@@ -75,17 +73,6 @@ pub fn init(app: &mut AppContext) {
             RunAgentsCardViewAction::Reject,
             id!(RunAgentsCardView::ui_name()),
         ),
-        FixedBinding::new(
-            "cmdorctrl-e",
-            RunAgentsCardViewAction::ToggleEdit,
-            id!(RunAgentsCardView::ui_name()),
-        ),
-        // Esc closes the editor; Reject is Ctrl-C.
-        FixedBinding::new(
-            "escape",
-            RunAgentsCardViewAction::DiscardEdits,
-            id!(RunAgentsCardView::ui_name()) & id!(RUN_AGENTS_EDITOR_OPEN),
-        ),
     ]);
 }
 
@@ -94,7 +81,6 @@ pub fn init(app: &mut AppContext) {
 /// and adds card-specific fields.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunAgentsEditState {
-    pub is_editor_open: bool,
     pub orch: oc::OrchestrationEditState,
     pub agent_run_configs: Vec<RunAgentsAgentRunConfig>,
     pub base_prompt: String,
@@ -106,7 +92,6 @@ pub struct RunAgentsEditState {
 impl RunAgentsEditState {
     pub fn from_request(req: &RunAgentsRequest) -> Self {
         Self {
-            is_editor_open: false,
             orch: oc::OrchestrationEditState::from_run_agents_fields(
                 &req.model_id,
                 &req.harness_type,
@@ -150,12 +135,10 @@ impl OrchestrationControlAction for RunAgentsCardViewAction {
     }
 }
 
-/// Per-action UI handles. Picker views are lazily created on first
-/// editor open.
+/// Per-action UI handles for the confirmation card.
 #[derive(Default, Clone)]
 struct RunAgentsCardHandles {
     reject_button: Option<CompactibleActionButton>,
-    edit_button: Option<CompactibleActionButton>,
     accept_button: Option<CompactibleSplitActionButton>,
     pickers: OrchestrationPickerHandles<RunAgentsCardViewAction>,
 }
@@ -166,8 +149,6 @@ pub enum RunAgentsCardViewAction {
     AcceptWithoutOrchestration,
     ToggleAcceptMenu,
     Reject,
-    ToggleEdit,
-    DiscardEdits,
     ExecutionModeToggled { is_remote: bool },
     ModelChanged { model_id: String },
     HarnessChanged { harness_type: String },
@@ -183,9 +164,6 @@ pub enum RunAgentsCardViewEvent {
 pub struct RunAgentsCardView {
     action_id: AIAgentActionId,
     state: RunAgentsEditState,
-    /// Snapshot of the request as received from the tool call, used to
-    /// reset on "Discard edits".
-    original_request: RunAgentsRequest,
     handles: RunAgentsCardHandles,
     spawning: Option<RunAgentsSpawningSnapshot>,
     /// Set when the active config was approved and matched the request,
@@ -220,12 +198,7 @@ pub(crate) fn should_auto_launch(
     state: &RunAgentsEditState,
     active_config: &Option<(OrchestrationConfig, OrchestrationConfigStatus)>,
 ) -> bool {
-    if auto_launched
-        || is_denied
-        || is_spawning
-        || state.is_editor_open
-        || state.agent_run_configs.is_empty()
-    {
+    if auto_launched || is_denied || is_spawning || state.agent_run_configs.is_empty() {
         return false;
     }
     match active_config {
@@ -295,8 +268,6 @@ impl RunAgentsCardView {
         let auto_launched = should_auto_launch(false, is_denied, false, &state, &active_config);
 
         let reject_keystroke = CTRL_C_KEYSTROKE.clone();
-        let edit_keystroke =
-            Keystroke::parse("cmdorctrl-e").expect("orchestrate edit keystroke literal must parse");
         let accept_keystroke = ENTER_KEYSTROKE.clone();
 
         let reject_button = CompactibleActionButton::new(
@@ -305,15 +276,6 @@ impl RunAgentsCardView {
             ButtonSize::Small,
             RunAgentsCardViewAction::Reject,
             Icon::X,
-            std::sync::Arc::new(NakedTheme),
-            ctx,
-        );
-        let edit_button = CompactibleActionButton::new(
-            "Edit".to_string(),
-            Some(KeystrokeSource::Fixed(edit_keystroke)),
-            ButtonSize::Small,
-            RunAgentsCardViewAction::ToggleEdit,
-            Icon::Pencil,
             std::sync::Arc::new(NakedTheme),
             ctx,
         );
@@ -405,7 +367,12 @@ impl RunAgentsCardView {
         ctx.subscribe_to_model(&LLMPreferences::handle(ctx), |me, _, event, ctx| {
             if let LLMPreferencesEvent::UpdatedAvailableLLMs = event {
                 if let Some(handle) = &me.handles.pickers.model_picker {
-                    oc::populate_model_picker(handle, &me.state.orch.model_id, ctx);
+                    oc::populate_model_picker_for_harness(
+                        handle,
+                        &me.state.orch.model_id,
+                        &me.state.orch.harness_type,
+                        ctx,
+                    );
                 }
             }
         });
@@ -413,13 +380,11 @@ impl RunAgentsCardView {
         // When auto_launched is true, execution is deferred to the
         // ActionBlockedOnUserConfirmation subscription above — the action
         // hasn't been queued in pending_actions yet at construction time.
-        Self {
+        let mut view = Self {
             action_id,
             state: RunAgentsEditState::from_request(request),
-            original_request: request.clone(),
             handles: RunAgentsCardHandles {
                 reject_button: Some(reject_button),
-                edit_button: Some(edit_button),
                 accept_button: Some(accept_button),
                 ..Default::default()
             },
@@ -432,27 +397,23 @@ impl RunAgentsCardView {
             position_id_prefix,
             action_model,
             block_model,
-        }
-    }
+        };
 
-    pub fn is_spawning(&self) -> bool {
-        self.spawning.is_some()
+        // Eagerly create picker views so the editor section is always
+        // visible without requiring a toggle.
+        view.ensure_pickers(ctx);
+
+        view
     }
 
     /// Re-sync edit state from the latest streaming request.
-    /// No-op when the editor is open (user edits take precedence).
     pub fn update_request(&mut self, request: &RunAgentsRequest, ctx: &mut ViewContext<Self>) {
-        if self.state.is_editor_open
-            || self.spawning.is_some()
-            || self.auto_launched
-            || self.is_denied
-        {
+        if self.spawning.is_some() || self.auto_launched || self.is_denied {
             return;
         }
         let new_state = RunAgentsEditState::from_request(request);
         if self.state != new_state {
             self.state = new_state;
-            self.original_request = request.clone();
             ctx.notify();
         }
     }
@@ -494,52 +455,13 @@ impl RunAgentsCardView {
             );
             return;
         }
-        // Close the editor before dispatching.
-        if self.state.is_editor_open {
-            self.state.is_editor_open = false;
-            self.sync_card_buttons(ctx);
-        }
         let action_id = self.action_id.clone();
         self.action_model.update(ctx, |action_model, action_ctx| {
             action_model.execute_run_agents(&action_id, request, action_ctx);
         });
     }
 
-    fn handle_toggle_edit(&mut self, ctx: &mut ViewContext<Self>) {
-        self.state.is_editor_open = !self.state.is_editor_open;
-
-        // Lazily build picker views on first editor open.
-        if self.state.is_editor_open {
-            self.ensure_pickers(ctx);
-        }
-
-        self.sync_card_buttons(ctx);
-        ctx.notify();
-    }
-
-    /// Swap Edit ↔ "Discard edits" label/keystroke.
-    fn sync_card_buttons(&mut self, ctx: &mut ViewContext<Self>) {
-        let Some(edit_button) = self.handles.edit_button.as_mut() else {
-            return;
-        };
-        let (label, keystroke) = if self.state.is_editor_open {
-            (
-                "Discard edits".to_string(),
-                Keystroke::parse("escape")
-                    .expect("orchestrate discard-edits keystroke literal must parse"),
-            )
-        } else {
-            (
-                "Edit".to_string(),
-                Keystroke::parse("cmdorctrl-e")
-                    .expect("orchestrate edit keystroke literal must parse"),
-            )
-        };
-        edit_button.set_label(label, ctx);
-        edit_button.set_keybinding(Some(KeystrokeSource::Fixed(keystroke)), ctx);
-    }
-
-    /// Lazily construct the picker dropdown views (idempotent).
+    /// Construct the picker dropdown views (idempotent).
     fn ensure_pickers(&mut self, ctx: &mut ViewContext<Self>) {
         let appearance = Appearance::as_ref(ctx);
         let (styles, colors) = oc::picker_styles(appearance);
@@ -558,7 +480,12 @@ impl RunAgentsCardView {
                 state.orch.model_id.clone()
             };
             let handle = oc::new_standard_picker_dropdown(&colors, ctx);
-            oc::populate_model_picker(&handle, &initial_model_id, ctx);
+            oc::populate_model_picker_for_harness(
+                &handle,
+                &initial_model_id,
+                &state.orch.harness_type,
+                ctx,
+            );
             Self::subscribe_picker_close(&handle, ctx);
             self.handles.pickers.model_picker = Some(handle);
         }
@@ -699,6 +626,19 @@ impl View for RunAgentsCardView {
             return render_spawning_card(&snapshot, appearance, app);
         }
 
+        // Still streaming: show a "Configuring agents..." placeholder
+        // until agent_run_configs are populated.
+        if self.state.agent_run_configs.is_empty()
+            && !matches!(status, Some(AIActionStatus::Blocked))
+        {
+            return render_status_only_card(
+                "Configuring agents\u{2026}".to_string(),
+                appearance,
+                StatusKind::Spawning,
+                app,
+            );
+        }
+
         // Restored-from-history: dispatch state is lost, render as
         // Cancelled.
         if self.block_model.is_restored() {
@@ -731,14 +671,6 @@ impl View for RunAgentsCardView {
 
         root_stack.finish()
     }
-
-    fn keymap_context(&self, _app: &AppContext) -> warpui::keymap::Context {
-        let mut context = Self::default_keymap_context();
-        if self.state.is_editor_open {
-            context.set.insert(RUN_AGENTS_EDITOR_OPEN);
-        }
-        context
-    }
 }
 
 impl TypedActionView for RunAgentsCardView {
@@ -761,18 +693,6 @@ impl TypedActionView for RunAgentsCardView {
             RunAgentsCardViewAction::Reject => {
                 ctx.emit(RunAgentsCardViewEvent::RejectRequested);
             }
-            RunAgentsCardViewAction::ToggleEdit => {
-                self.handle_toggle_edit(ctx);
-            }
-            RunAgentsCardViewAction::DiscardEdits => {
-                if self.state.is_editor_open {
-                    // Reset to the original tool-call values.
-                    self.state = RunAgentsEditState::from_request(&self.original_request);
-                    self.sync_card_buttons(ctx);
-                    self.sync_picker_selections(ctx);
-                    ctx.notify();
-                }
-            }
             RunAgentsCardViewAction::ExecutionModeToggled { is_remote } => {
                 self.state.orch.toggle_execution_mode_to_remote(*is_remote);
                 self.sync_picker_selections(ctx);
@@ -784,6 +704,31 @@ impl TypedActionView for RunAgentsCardView {
             }
             RunAgentsCardViewAction::HarnessChanged { harness_type } => {
                 self.state.orch.harness_type = harness_type.clone();
+                // Re-populate model picker with harness-filtered choices.
+                // Reset to the first available model if the current selection
+                // is no longer in the filtered set.
+                if let Some(handle) = &self.handles.pickers.model_picker {
+                    oc::populate_model_picker_for_harness(
+                        handle,
+                        &self.state.orch.model_id,
+                        harness_type,
+                        ctx,
+                    );
+                    if !oc::is_model_in_filtered_choices(
+                        &self.state.orch.model_id,
+                        harness_type,
+                        ctx,
+                    ) {
+                        self.state.orch.model_id =
+                            oc::first_filtered_model_id(harness_type, ctx).unwrap_or_default();
+                        oc::populate_model_picker_for_harness(
+                            handle,
+                            &self.state.orch.model_id,
+                            harness_type,
+                            ctx,
+                        );
+                    }
+                }
                 ctx.notify();
             }
             RunAgentsCardViewAction::EnvironmentChanged { environment_id } => {
@@ -815,9 +760,7 @@ fn render_confirmation_card(
         .with_child(header)
         .with_child(body);
 
-    if state.is_editor_open {
-        content.add_child(render_editor(state, handles, app));
-    }
+    content.add_child(render_editor(state, handles, app));
 
     let border_color = if is_blocked {
         theme.accent()
@@ -839,16 +782,12 @@ fn render_header(handles: &RunAgentsCardHandles, app: &AppContext) -> Box<dyn El
         .with_icon(icons::yellow_stop_icon(appearance))
         .with_corner_radius_override(CornerRadius::with_top(Radius::Pixels(8.)));
 
-    if let (Some(reject), Some(edit), Some(accept)) = (
+    if let (Some(reject), Some(accept)) = (
         handles.reject_button.as_ref(),
-        handles.edit_button.as_ref(),
         handles.accept_button.as_ref(),
     ) {
-        let action_buttons: Vec<Rc<dyn RenderCompactibleActionButton>> = vec![
-            Rc::new(reject.clone()),
-            Rc::new(edit.clone()),
-            Rc::new(accept.clone()),
-        ];
+        let action_buttons: Vec<Rc<dyn RenderCompactibleActionButton>> =
+            vec![Rc::new(reject.clone()), Rc::new(accept.clone())];
         config = config.with_interaction_mode(InteractionMode::ActionButtons {
             action_buttons,
             size_switch_threshold: MEDIUM_SIZE_SWITCH_THRESHOLD,

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -626,11 +626,12 @@ impl View for RunAgentsCardView {
             return render_spawning_card(&snapshot, appearance, app);
         }
 
-        // Still streaming: show a "Configuring agents..." placeholder
-        // until agent_run_configs are populated.
-        if self.state.agent_run_configs.is_empty()
-            && !matches!(status, Some(AIActionStatus::Blocked))
-        {
+        // Still streaming: show "Configuring agents..." placeholder until
+        // the action reaches Blocked status (i.e., streaming is complete
+        // and the action is queued for user confirmation). This prevents
+        // showing an interactive confirmation card backed by a partial
+        // request that is still being streamed.
+        if !matches!(status, Some(AIActionStatus::Blocked)) {
             return render_status_only_card(
                 "Configuring agents\u{2026}".to_string(),
                 appearance,

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
@@ -356,14 +356,6 @@ mod should_auto_launch_tests {
     }
 
     #[test]
-    fn returns_false_when_editor_open() {
-        let mut state = default_state();
-        state.is_editor_open = true;
-        let config = Some(matching_config());
-        assert!(!should_auto_launch(false, false, false, &state, &config));
-    }
-
-    #[test]
     fn returns_false_when_agent_run_configs_empty() {
         let mut state = default_state();
         state.agent_run_configs.clear();


### PR DESCRIPTION
## What
Fix five bugs in the orchestration (run_agents) confirmation block UI:

- **QUALITY-616**: Reword card title to "Can I start additional agents for this task?"
- **QUALITY-622**: Config editor always visible — removed Edit/Discard toggle, keybindings, and is_editor_open state; pickers created eagerly
- **QUALITY-625**: Dropdown menus open above trigger element to avoid overlapping the input box
- **QUALITY-623**: Model picker filters choices by harness (Claude shows Anthropic models only, Codex shows OpenAI only, Oz shows all); auto-resets to first valid model on harness change
- **QUALITY-621**: Shows "Configuring agents..." placeholder during streaming; removed redundant "Spawning agents..." status bar text

Demo: https://www.loom.com/share/7602b80731d44ea39e7c1ad4b22c6c23

## Why
Bug bash feedback — these issues were identified during testing of the orchestration confirmation UI.

## Agent Mode
- [x] This PR was created by Warp Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>