### PR TITLE
Add environment setup flow for local -> cloud handoff

### DIFF
--- a/app/src/modal.rs
+++ b/app/src/modal.rs
@@ -19,6 +19,7 @@ pub const MODAL_CORNER_RADIUS: Radius = Radius::Pixels(8.);
 pub const MODAL_WIDTH: f32 = 440.;
 pub const MODAL_HEADER_HEIGHT: f32 = 70.;
 pub const MODAL_PADDING: f32 = 28.;
+pub const MODAL_BACKDROP_OPACITY: u8 = 179;
 
 #[derive(Clone)]
 pub struct Modal<T> {
@@ -156,7 +157,7 @@ impl<T: View> Modal<T> {
                 ..Default::default()
             },
             close_modal_hover_state: Default::default(),
-            background_opacity: 179,
+            background_opacity: MODAL_BACKDROP_OPACITY,
             offset_positioning: Self::default_offset_positioning(),
         }
     }

--- a/app/src/server/cloud_objects/update_manager.rs
+++ b/app/src/server/cloud_objects/update_manager.rs
@@ -3217,6 +3217,25 @@ impl UpdateManager {
     }
 
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    pub fn create_ambient_agent_environment_online(
+        &mut self,
+        ambient_agent_environment: AmbientAgentEnvironment,
+        client_id: ClientId,
+        owner: Owner,
+        ctx: &mut ModelContext<Self>,
+    ) -> impl Future<Output = anyhow::Result<ServerId>> {
+        self.create_object_online(
+            CloudAmbientAgentEnvironmentModel::new(ambient_agent_environment),
+            owner,
+            client_id,
+            Default::default(),
+            false,
+            None,
+            ctx,
+        )
+    }
+
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub fn create_scheduled_ambient_agent_online(
         &mut self,
         scheduled_ambient_agent: ScheduledAmbientAgent,

--- a/app/src/settings_view/agent_assisted_environment_modal.rs
+++ b/app/src/settings_view/agent_assisted_environment_modal.rs
@@ -23,6 +23,7 @@ use warpui::{
 
 use crate::{
     appearance::Appearance,
+    modal::MODAL_BACKDROP_OPACITY,
     themes::theme::Blend,
     ui_components::{
         buttons::icon_button,
@@ -663,7 +664,7 @@ impl AgentAssistedEnvironmentModal {
             .finish();
 
         Container::new(Align::new(dialog).finish())
-            .with_background_color(ColorU::new(0, 0, 0, 179))
+            .with_background_color(ColorU::new(0, 0, 0, MODAL_BACKDROP_OPACITY))
             .with_corner_radius(app.windows().window_corner_radius())
             .finish()
     }

--- a/app/src/settings_view/handoff_environment_creation_modal.rs
+++ b/app/src/settings_view/handoff_environment_creation_modal.rs
@@ -1,0 +1,231 @@
+use crate::ai::cloud_environments;
+use crate::appearance::Appearance;
+use crate::server::cloud_objects::update_manager::UpdateManager;
+use crate::server::ids::{ClientId, SyncId};
+use crate::settings_view::update_environment_form::{
+    AuthSource, EnvironmentFormInitArgs, GithubAuthRedirectTarget, UpdateEnvironmentForm,
+    UpdateEnvironmentFormEvent,
+};
+use crate::ui_components::dialog::{dialog_styles, Dialog};
+use crate::ui_components::icons::Icon;
+use crate::view_components::action_button::{ActionButton, SecondaryTheme};
+use pathfinder_color::ColorU;
+use warpui::elements::{
+    Align, ChildView, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox,
+    CrossAxisAlignment, Dismiss, Element, Empty, Flex, MouseStateHandle, ParentElement,
+    ScrollbarWidth,
+};
+use warpui::ui_components::components::UiComponent;
+use warpui::{AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle};
+
+use crate::ui_components::buttons::icon_button;
+
+const DIALOG_WIDTH: f32 = 600.;
+const FORM_MAX_HEIGHT: f32 = 520.;
+const FORM_PADDING: f32 = 8.;
+
+#[derive(Debug, Clone)]
+pub(crate) enum HandoffEnvironmentCreationModalEvent {
+    Created { env_id: SyncId },
+    Cancelled,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum HandoffEnvironmentCreationModalAction {
+    Cancel,
+}
+
+pub(crate) struct HandoffEnvironmentCreationModal {
+    visible: bool,
+    environment_form: ViewHandle<UpdateEnvironmentForm>,
+    cancel_button: ViewHandle<ActionButton>,
+    close_button_mouse_state: MouseStateHandle,
+    scroll_state: ClippedScrollStateHandle,
+}
+
+impl HandoffEnvironmentCreationModal {
+    pub(crate) fn new(ctx: &mut ViewContext<Self>) -> Self {
+        let environment_form = ctx.add_typed_action_view(|ctx| {
+            let mut form = UpdateEnvironmentForm::new(EnvironmentFormInitArgs::Create, ctx);
+            form.set_github_auth_redirect_target(GithubAuthRedirectTarget::FocusCloudMode);
+            form.set_show_header(false, ctx);
+            form.set_should_handle_escape_from_editor(true);
+            form.set_auth_source(AuthSource::CloudSetup);
+            form
+        });
+
+        ctx.subscribe_to_view(&environment_form, |me, _, event, ctx| {
+            me.handle_environment_form_event(event, ctx);
+        });
+
+        let cancel_button = ctx.add_typed_action_view(|_ctx| {
+            ActionButton::new("Cancel", SecondaryTheme).on_click(|ctx| {
+                ctx.dispatch_typed_action(HandoffEnvironmentCreationModalAction::Cancel);
+            })
+        });
+
+        Self {
+            visible: false,
+            environment_form,
+            cancel_button,
+            close_button_mouse_state: MouseStateHandle::default(),
+            scroll_state: ClippedScrollStateHandle::default(),
+        }
+    }
+
+    pub(crate) fn show(&mut self, ctx: &mut ViewContext<Self>) {
+        self.visible = true;
+        self.scroll_state = ClippedScrollStateHandle::default();
+        self.environment_form.update(ctx, |form, ctx| {
+            form.set_mode(EnvironmentFormInitArgs::Create, ctx);
+            form.focus(ctx);
+        });
+        ctx.notify();
+    }
+
+    fn hide(&mut self, ctx: &mut ViewContext<Self>) {
+        self.visible = false;
+        ctx.notify();
+    }
+
+    fn handle_environment_form_event(
+        &mut self,
+        event: &UpdateEnvironmentFormEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            UpdateEnvironmentFormEvent::Created {
+                environment,
+                share_with_team,
+            } => {
+                let owner = if *share_with_team {
+                    cloud_environments::owner_for_new_environment(ctx)
+                } else {
+                    cloud_environments::owner_for_new_personal_environment(ctx)
+                };
+
+                let Some(owner) = owner else {
+                    log::error!("Unable to create environment: not logged in");
+                    self.hide(ctx);
+                    ctx.emit(HandoffEnvironmentCreationModalEvent::Cancelled);
+                    return;
+                };
+
+                let client_id = ClientId::default();
+                UpdateManager::handle(ctx).update(ctx, |update_manager, ctx| {
+                    update_manager.create_ambient_agent_environment(
+                        environment.clone(),
+                        client_id,
+                        owner,
+                        ctx,
+                    );
+                });
+
+                let env_id = SyncId::ClientId(client_id);
+                self.hide(ctx);
+                ctx.emit(HandoffEnvironmentCreationModalEvent::Created { env_id });
+            }
+            UpdateEnvironmentFormEvent::Cancelled => {
+                self.hide(ctx);
+                ctx.emit(HandoffEnvironmentCreationModalEvent::Cancelled);
+            }
+            UpdateEnvironmentFormEvent::Updated { .. }
+            | UpdateEnvironmentFormEvent::DeleteRequested { .. } => {}
+        }
+    }
+
+    fn render_dialog(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
+        let theme = appearance.theme();
+
+        let close_button = icon_button(
+            appearance,
+            Icon::X,
+            false,
+            self.close_button_mouse_state.clone(),
+        )
+        .build()
+        .on_click(|ctx, _, _| {
+            ctx.dispatch_typed_action(HandoffEnvironmentCreationModalAction::Cancel);
+        })
+        .finish();
+
+        let form_content = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_child(ChildView::new(&self.environment_form).finish())
+            .finish();
+
+        let scrollable_form = ClippedScrollable::vertical(
+            self.scroll_state.clone(),
+            form_content,
+            ScrollbarWidth::Auto,
+            theme.nonactive_ui_text_color().into(),
+            theme.active_ui_text_color().into(),
+            warpui::elements::Fill::None,
+        )
+        .finish();
+
+        let constrained_form = ConstrainedBox::new(scrollable_form)
+            .with_max_height(FORM_MAX_HEIGHT)
+            .finish();
+
+        let padded_form = warpui::elements::Container::new(constrained_form)
+            .with_uniform_padding(FORM_PADDING)
+            .finish();
+
+        let dialog = Dialog::new(
+            "Create environment".to_string(),
+            None,
+            dialog_styles(appearance),
+        )
+        .with_close_button(close_button)
+        .with_child(padded_form)
+        .with_separator()
+        .with_bottom_row_child(ChildView::new(&self.cancel_button).finish())
+        .with_width(DIALOG_WIDTH)
+        .build();
+
+        let dialog = Dismiss::new(dialog.finish())
+            .prevent_interaction_with_other_elements()
+            .on_dismiss(|ctx, _app| {
+                ctx.dispatch_typed_action(HandoffEnvironmentCreationModalAction::Cancel);
+            })
+            .finish();
+
+        warpui::elements::Container::new(Align::new(dialog).finish())
+            .with_background_color(ColorU::new(0, 0, 0, 179))
+            .with_corner_radius(app.windows().window_corner_radius())
+            .finish()
+    }
+}
+
+impl Entity for HandoffEnvironmentCreationModal {
+    type Event = HandoffEnvironmentCreationModalEvent;
+}
+
+impl TypedActionView for HandoffEnvironmentCreationModal {
+    type Action = HandoffEnvironmentCreationModalAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            HandoffEnvironmentCreationModalAction::Cancel => {
+                self.hide(ctx);
+                ctx.emit(HandoffEnvironmentCreationModalEvent::Cancelled);
+            }
+        }
+    }
+}
+
+impl View for HandoffEnvironmentCreationModal {
+    fn ui_name() -> &'static str {
+        "HandoffEnvironmentCreationModal"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        if !self.visible {
+            return Empty::new().finish();
+        }
+
+        let appearance = Appearance::as_ref(app);
+        self.render_dialog(appearance, app)
+    }
+}

--- a/app/src/settings_view/handoff_environment_creation_modal.rs
+++ b/app/src/settings_view/handoff_environment_creation_modal.rs
@@ -6,28 +6,24 @@ use crate::settings_view::update_environment_form::{
     AuthSource, EnvironmentFormInitArgs, GithubAuthRedirectTarget, UpdateEnvironmentForm,
     UpdateEnvironmentFormEvent,
 };
+use crate::ui_components::buttons::icon_button;
 use crate::ui_components::dialog::{dialog_styles, Dialog};
 use crate::ui_components::icons::Icon;
-use crate::view_components::action_button::{ActionButton, SecondaryTheme};
 use pathfinder_color::ColorU;
 use warpui::elements::{
-    Align, ChildView, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox,
-    CrossAxisAlignment, Dismiss, Element, Empty, Flex, MouseStateHandle, ParentElement,
-    ScrollbarWidth,
+    Align, ChildView, ClippedScrollStateHandle, ClippedScrollable, CrossAxisAlignment, Dismiss,
+    Element, Empty, Flex, MouseStateHandle, ParentElement, ScrollbarWidth,
 };
 use warpui::ui_components::components::UiComponent;
 use warpui::{AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle};
 
-use crate::ui_components::buttons::icon_button;
-
 const DIALOG_WIDTH: f32 = 600.;
-const FORM_MAX_HEIGHT: f32 = 520.;
-const FORM_PADDING: f32 = 8.;
 
 #[derive(Debug, Clone)]
 pub(crate) enum HandoffEnvironmentCreationModalEvent {
     Created { env_id: SyncId },
     Cancelled,
+    CreationFailed { error_message: String },
 }
 
 #[derive(Debug, Clone)]
@@ -38,7 +34,6 @@ pub(crate) enum HandoffEnvironmentCreationModalAction {
 pub(crate) struct HandoffEnvironmentCreationModal {
     visible: bool,
     environment_form: ViewHandle<UpdateEnvironmentForm>,
-    cancel_button: ViewHandle<ActionButton>,
     close_button_mouse_state: MouseStateHandle,
     scroll_state: ClippedScrollStateHandle,
 }
@@ -58,16 +53,9 @@ impl HandoffEnvironmentCreationModal {
             me.handle_environment_form_event(event, ctx);
         });
 
-        let cancel_button = ctx.add_typed_action_view(|_ctx| {
-            ActionButton::new("Cancel", SecondaryTheme).on_click(|ctx| {
-                ctx.dispatch_typed_action(HandoffEnvironmentCreationModalAction::Cancel);
-            })
-        });
-
         Self {
             visible: false,
             environment_form,
-            cancel_button,
             close_button_mouse_state: MouseStateHandle::default(),
             scroll_state: ClippedScrollStateHandle::default(),
         }
@@ -107,23 +95,36 @@ impl HandoffEnvironmentCreationModal {
                 let Some(owner) = owner else {
                     log::error!("Unable to create environment: not logged in");
                     self.hide(ctx);
-                    ctx.emit(HandoffEnvironmentCreationModalEvent::Cancelled);
+                    ctx.emit(HandoffEnvironmentCreationModalEvent::CreationFailed {
+                        error_message: "Not logged in".to_string(),
+                    });
                     return;
                 };
 
                 let client_id = ClientId::default();
-                UpdateManager::handle(ctx).update(ctx, |update_manager, ctx| {
-                    update_manager.create_ambient_agent_environment(
-                        environment.clone(),
-                        client_id,
-                        owner,
-                        ctx,
-                    );
-                });
+                let create_future =
+                    UpdateManager::handle(ctx).update(ctx, |update_manager, ctx| {
+                        update_manager.create_ambient_agent_environment_online(
+                            environment.clone(),
+                            client_id,
+                            owner,
+                            ctx,
+                        )
+                    });
 
-                let env_id = SyncId::ClientId(client_id);
                 self.hide(ctx);
-                ctx.emit(HandoffEnvironmentCreationModalEvent::Created { env_id });
+                ctx.spawn(create_future, |_me, result, ctx| match result {
+                    Ok(server_id) => {
+                        let env_id = SyncId::ServerId(server_id);
+                        ctx.emit(HandoffEnvironmentCreationModalEvent::Created { env_id });
+                    }
+                    Err(err) => {
+                        log::error!("Failed to create environment for handoff: {err:#}");
+                        ctx.emit(HandoffEnvironmentCreationModalEvent::CreationFailed {
+                            error_message: err.to_string(),
+                        });
+                    }
+                });
             }
             UpdateEnvironmentFormEvent::Cancelled => {
                 self.hide(ctx);
@@ -164,12 +165,8 @@ impl HandoffEnvironmentCreationModal {
         )
         .finish();
 
-        let constrained_form = ConstrainedBox::new(scrollable_form)
-            .with_max_height(FORM_MAX_HEIGHT)
-            .finish();
-
-        let padded_form = warpui::elements::Container::new(constrained_form)
-            .with_uniform_padding(FORM_PADDING)
+        let padded_form = warpui::elements::Container::new(scrollable_form)
+            .with_uniform_padding(8.)
             .finish();
 
         let dialog = Dialog::new(
@@ -179,8 +176,6 @@ impl HandoffEnvironmentCreationModal {
         )
         .with_close_button(close_button)
         .with_child(padded_form)
-        .with_separator()
-        .with_bottom_row_child(ChildView::new(&self.cancel_button).finish())
         .with_width(DIALOG_WIDTH)
         .build();
 

--- a/app/src/settings_view/handoff_environment_creation_modal.rs
+++ b/app/src/settings_view/handoff_environment_creation_modal.rs
@@ -1,5 +1,6 @@
 use crate::ai::cloud_environments;
 use crate::appearance::Appearance;
+use crate::modal::MODAL_BACKDROP_OPACITY;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::{ClientId, SyncId};
 use crate::settings_view::update_environment_form::{
@@ -12,7 +13,7 @@ use crate::ui_components::icons::Icon;
 use pathfinder_color::ColorU;
 use warpui::elements::{
     Align, ChildView, ClippedScrollStateHandle, ClippedScrollable, CrossAxisAlignment, Dismiss,
-    Element, Empty, Flex, MouseStateHandle, ParentElement, ScrollbarWidth,
+    Element, Flex, MouseStateHandle, ParentElement, ScrollbarWidth,
 };
 use warpui::ui_components::components::UiComponent;
 use warpui::{AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle};
@@ -32,7 +33,6 @@ pub(crate) enum HandoffEnvironmentCreationModalAction {
 }
 
 pub(crate) struct HandoffEnvironmentCreationModal {
-    visible: bool,
     environment_form: ViewHandle<UpdateEnvironmentForm>,
     close_button_mouse_state: MouseStateHandle,
     scroll_state: ClippedScrollStateHandle,
@@ -54,7 +54,6 @@ impl HandoffEnvironmentCreationModal {
         });
 
         Self {
-            visible: false,
             environment_form,
             close_button_mouse_state: MouseStateHandle::default(),
             scroll_state: ClippedScrollStateHandle::default(),
@@ -62,17 +61,11 @@ impl HandoffEnvironmentCreationModal {
     }
 
     pub(crate) fn show(&mut self, ctx: &mut ViewContext<Self>) {
-        self.visible = true;
         self.scroll_state = ClippedScrollStateHandle::default();
         self.environment_form.update(ctx, |form, ctx| {
             form.set_mode(EnvironmentFormInitArgs::Create, ctx);
             form.focus(ctx);
         });
-        ctx.notify();
-    }
-
-    fn hide(&mut self, ctx: &mut ViewContext<Self>) {
-        self.visible = false;
         ctx.notify();
     }
 
@@ -94,7 +87,6 @@ impl HandoffEnvironmentCreationModal {
 
                 let Some(owner) = owner else {
                     log::error!("Unable to create environment: not logged in");
-                    self.hide(ctx);
                     ctx.emit(HandoffEnvironmentCreationModalEvent::CreationFailed {
                         error_message: "Not logged in".to_string(),
                     });
@@ -112,7 +104,6 @@ impl HandoffEnvironmentCreationModal {
                         )
                     });
 
-                self.hide(ctx);
                 ctx.spawn(create_future, |_me, result, ctx| match result {
                     Ok(server_id) => {
                         let env_id = SyncId::ServerId(server_id);
@@ -127,7 +118,6 @@ impl HandoffEnvironmentCreationModal {
                 });
             }
             UpdateEnvironmentFormEvent::Cancelled => {
-                self.hide(ctx);
                 ctx.emit(HandoffEnvironmentCreationModalEvent::Cancelled);
             }
             UpdateEnvironmentFormEvent::Updated { .. }
@@ -187,7 +177,7 @@ impl HandoffEnvironmentCreationModal {
             .finish();
 
         warpui::elements::Container::new(Align::new(dialog).finish())
-            .with_background_color(ColorU::new(0, 0, 0, 179))
+            .with_background_color(ColorU::new(0, 0, 0, MODAL_BACKDROP_OPACITY))
             .with_corner_radius(app.windows().window_corner_radius())
             .finish()
     }
@@ -203,7 +193,6 @@ impl TypedActionView for HandoffEnvironmentCreationModal {
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         match action {
             HandoffEnvironmentCreationModalAction::Cancel => {
-                self.hide(ctx);
                 ctx.emit(HandoffEnvironmentCreationModalEvent::Cancelled);
             }
         }
@@ -216,10 +205,6 @@ impl View for HandoffEnvironmentCreationModal {
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
-        if !self.visible {
-            return Empty::new().finish();
-        }
-
         let appearance = Appearance::as_ref(app);
         self.render_dialog(appearance, app)
     }

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -108,6 +108,7 @@ mod teams_page;
 mod telemetry;
 mod transfer_ownership_confirmation_modal;
 pub mod update_environment_form;
+pub(crate) mod handoff_environment_creation_modal;
 mod warp_drive_page;
 mod warpify_page;
 

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -89,6 +89,7 @@ pub(crate) mod environments_page;
 mod execution_profile_view;
 mod features;
 mod features_page;
+pub(crate) mod handoff_environment_creation_modal;
 pub mod keybindings;
 mod main_page;
 pub mod mcp_servers;
@@ -108,7 +109,6 @@ mod teams_page;
 mod telemetry;
 mod transfer_ownership_confirmation_modal;
 pub mod update_environment_form;
-pub(crate) mod handoff_environment_creation_modal;
 mod warp_drive_page;
 mod warpify_page;
 

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -117,6 +117,7 @@ use crate::ai::blocklist::handoff::{HandoffLaunchAttachments, PendingCloudLaunch
 use crate::ai::blocklist::AttachmentType;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::PendingAttachment;
+use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::mcp::TemplatableMCPServerManager;
 use crate::server::server_api::ai::AttachmentFileInfo;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -3926,7 +3927,7 @@ impl Input {
             return true;
         }
 
-        if crate::ai::cloud_environments::CloudAmbientAgentEnvironment::get_all(ctx).is_empty() {
+        if CloudAmbientAgentEnvironment::get_all(ctx).is_empty() {
             ctx.emit(Event::OpenHandoffEnvironmentCreationModal);
             return true;
         }
@@ -3941,13 +3942,7 @@ impl Input {
             attachments,
         };
 
-        self.exit_cloud_handoff_compose(ctx);
-        self.editor.update(ctx, |editor, ctx| {
-            editor.clear_buffer(ctx);
-        });
-        self.ai_context_model.update(ctx, |context_model, ctx| {
-            context_model.clear_pending_attachments(ctx);
-        });
+        self.exit_cloud_handoff_compose_and_clear(ctx);
 
         ctx.dispatch_typed_action_deferred(WorkspaceAction::OpenLocalToCloudHandoffPane {
             launch: Some(launch),

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -404,7 +404,7 @@ pub(super) const CLI_AGENT_RICH_INPUT_EDITOR_BOTTOM_PADDING: f32 = 8.;
 pub(super) const CLI_AGENT_RICH_INPUT_HINT_TEXT: &str = "Tell the agent what to build...";
 
 const CLOUD_MODE_V2_HINT_TEXT: &str = "Kick off a cloud agent";
-const CLOUD_HANDOFF_HINT_TEXT: &str = "Start a cloud run";
+const CLOUD_HANDOFF_HINT_TEXT: &str = "Handoff to cloud";
 const SHORT_CIRCUIT_HIGHLIGHTING_ACTIONS: [Option<PlainTextEditorViewAction>; 7] = [
     Some(PlainTextEditorViewAction::Space),
     Some(PlainTextEditorViewAction::NonExpandingSpace),
@@ -1093,6 +1093,7 @@ pub enum Event {
     OpenPluginInstructionsPane(CLIAgent, PluginModalKind),
     OpenShareSessionModal,
     StartRemoteControl,
+    OpenHandoffEnvironmentCreationModal,
 }
 
 pub enum InputState {
@@ -3749,6 +3750,16 @@ impl Input {
         ctx.notify();
     }
 
+    pub(crate) fn exit_cloud_handoff_compose_and_clear(&mut self, ctx: &mut ViewContext<Self>) {
+        self.exit_cloud_handoff_compose(ctx);
+        self.editor.update(ctx, |editor, ctx| {
+            editor.clear_buffer(ctx);
+        });
+        self.ai_context_model.update(ctx, |context_model, ctx| {
+            context_model.clear_pending_attachments(ctx);
+        });
+    }
+
     fn exit_cloud_handoff_compose(&mut self, ctx: &mut ViewContext<Self>) {
         if self.prefix_mode(ctx) != InputPrefixMode::CloudHandoff {
             return;
@@ -3832,7 +3843,7 @@ impl Input {
     }
 
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-    fn collect_cloud_launch_attachments(
+    pub(crate) fn collect_cloud_launch_attachments(
         &self,
         ctx: &mut ViewContext<Self>,
     ) -> HandoffLaunchAttachments {
@@ -3912,6 +3923,11 @@ impl Input {
 
         let prompt = self.editor.as_ref(ctx).buffer_text(ctx).trim().to_owned();
         if prompt.is_empty() {
+            return true;
+        }
+
+        if crate::ai::cloud_environments::CloudAmbientAgentEnvironment::get_all(ctx).is_empty() {
+            ctx.emit(Event::OpenHandoffEnvironmentCreationModal);
             return true;
         }
 

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -117,6 +117,7 @@ use crate::ai::blocklist::handoff::{HandoffLaunchAttachments, PendingCloudLaunch
 use crate::ai::blocklist::AttachmentType;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::PendingAttachment;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::mcp::TemplatableMCPServerManager;
 use crate::server::server_api::ai::AttachmentFileInfo;
@@ -3751,6 +3752,7 @@ impl Input {
         ctx.notify();
     }
 
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     pub(crate) fn exit_cloud_handoff_compose_and_clear(&mut self, ctx: &mut ViewContext<Self>) {
         self.exit_cloud_handoff_compose(ctx);
         self.editor.update(ctx, |editor, ctx| {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -20770,6 +20770,11 @@ impl TerminalView {
                     ctx,
                 );
             }
+            InputEvent::OpenHandoffEnvironmentCreationModal => {
+                ctx.dispatch_typed_action(
+                    &WorkspaceAction::ShowHandoffEnvironmentCreationModal,
+                );
+            }
         }
     }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -20771,9 +20771,7 @@ impl TerminalView {
                 );
             }
             InputEvent::OpenHandoffEnvironmentCreationModal => {
-                ctx.dispatch_typed_action(
-                    &WorkspaceAction::ShowHandoffEnvironmentCreationModal,
-                );
+                ctx.dispatch_typed_action(&WorkspaceAction::ShowHandoffEnvironmentCreationModal);
             }
         }
     }

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -497,6 +497,9 @@ pub enum WorkspaceAction {
         launch: Option<()>,
         explicit_environment_id: Option<crate::server::ids::SyncId>,
     },
+    /// Show the environment creation modal during `&` handoff compose when no
+    /// environments exist.
+    ShowHandoffEnvironmentCreationModal,
     /// Summarize the active AI conversation in the focused pane.
     SummarizeAIConversation {
         prompt: Option<String>,
@@ -955,6 +958,7 @@ impl WorkspaceAction {
             | OpenSettingsFile
             | FixSettingsWithOz { .. }
             | OpenLocalToCloudHandoffPane { .. }
+            | ShowHandoffEnvironmentCreationModal
             | OpenNetworkLogPane => false,
             #[cfg(debug_assertions)]
             ShowHoaOnboardingFlow => false,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -56,6 +56,8 @@ use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::ai::blocklist::handoff::touched_repos::{
     derive_touched_workspace, extract_paths_from_conversation, pick_handoff_overlap_env,
 };
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::blocklist::handoff::PendingCloudLaunch;
 use crate::ai::blocklist::history_model::{load_conversation_from_server, CloudConversationData};
 use crate::ai::blocklist::suggested_agent_mode_workflow_modal::SuggestedAgentModeWorkflowAndId;
 use crate::ai::blocklist::suggested_rule_modal::{
@@ -197,6 +199,9 @@ use crate::settings::{
     DefaultSessionMode, InputModeSettings,
 };
 use crate::settings_view::environments_page::EnvironmentsPage;
+use crate::settings_view::handoff_environment_creation_modal::{
+    HandoffEnvironmentCreationModal, HandoffEnvironmentCreationModalEvent,
+};
 use crate::settings_view::pane_manager::SettingsPaneManager;
 use crate::settings_view::{SettingsSection, SettingsView, SettingsViewEvent};
 #[cfg(all(target_os = "windows", feature = "local_tty"))]
@@ -277,8 +282,6 @@ use crate::terminal::keys_settings::KeysSettings;
 use crate::terminal::shared_session::SharedSessionActionSource;
 
 use crate::ai::blocklist::agent_view::editor::{AgentToolbarEditorEvent, AgentToolbarEditorModal};
-#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::blocklist::handoff::PendingCloudLaunch;
 use crate::prompt::editor_modal::{
     EditorModal as PromptEditorModal, EditorModalEvent as PromptEditorModalEvent,
     OpenSource as PromptEditorOpenSource,
@@ -1081,6 +1084,7 @@ pub struct Workspace {
     tab_config_action_sidecar_item: Option<SidecarItemKind>,
     tab_config_action_sidecar_mouse_states: crate::tab_configs::action_sidecar::SidecarMouseStates,
     remove_tab_config_confirmation_dialog: ViewHandle<RemoveTabConfigConfirmationDialog>,
+    handoff_environment_creation_modal: Option<ViewHandle<HandoffEnvironmentCreationModal>>,
 }
 
 impl Workspace {
@@ -3225,6 +3229,7 @@ impl Workspace {
             tab_config_action_sidecar_mouse_states: Default::default(),
             remove_tab_config_confirmation_dialog:
                 Self::build_remove_tab_config_confirmation_dialog(ctx),
+            handoff_environment_creation_modal: None,
         };
 
         ws.configure_new_workspace(workspace_setting, ctx);
@@ -13112,20 +13117,13 @@ impl Workspace {
     }
 
     fn show_handoff_environment_creation_modal(&mut self, ctx: &mut ViewContext<Self>) {
-        use crate::settings_view::handoff_environment_creation_modal::{
-            HandoffEnvironmentCreationModal, HandoffEnvironmentCreationModalEvent,
-        };
-
         let modal = ctx.add_typed_action_view(HandoffEnvironmentCreationModal::new);
         ctx.subscribe_to_view(&modal, |me, _, event, ctx| match event {
             HandoffEnvironmentCreationModalEvent::Created { env_id } => {
                 let env_id = *env_id;
-                // Read the prompt and attachments from the active input's `&` compose state,
-                // build a PendingCloudLaunch, clear the input, and dispatch the handoff.
+                me.handoff_environment_creation_modal = None;
                 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
                 {
-                    use crate::ai::blocklist::handoff::PendingCloudLaunch;
-
                     if let Some(source_view) = me
                         .active_tab_pane_group()
                         .as_ref(ctx)
@@ -13134,14 +13132,21 @@ impl Workspace {
                         let launch = source_view.update(ctx, |view, ctx| {
                             let input = view.input().clone();
                             input.update(ctx, |input, ctx| {
-                                let prompt =
-                                    input.editor().as_ref(ctx).buffer_text(ctx).trim().to_owned();
+                                let prompt = input
+                                    .editor()
+                                    .as_ref(ctx)
+                                    .buffer_text(ctx)
+                                    .trim()
+                                    .to_owned();
                                 let attachments = input.collect_cloud_launch_attachments(ctx);
                                 input.exit_cloud_handoff_compose_and_clear(ctx);
                                 if prompt.is_empty() {
                                     None
                                 } else {
-                                    Some(PendingCloudLaunch { prompt, attachments })
+                                    Some(PendingCloudLaunch {
+                                        prompt,
+                                        attachments,
+                                    })
                                 }
                             })
                         });
@@ -13159,11 +13164,26 @@ impl Workspace {
                 }
             }
             HandoffEnvironmentCreationModalEvent::Cancelled => {
+                me.handoff_environment_creation_modal = None;
+                me.focus_active_tab(ctx);
+            }
+            HandoffEnvironmentCreationModalEvent::CreationFailed { error_message } => {
+                me.handoff_environment_creation_modal = None;
+                me.toast_stack.update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::error(format!(
+                            "Failed to create environment: {error_message}"
+                        )),
+                        ctx,
+                    );
+                });
                 me.focus_active_tab(ctx);
             }
         });
         modal.update(ctx, |modal, ctx| modal.show(ctx));
         ctx.focus(&modal);
+        self.handoff_environment_creation_modal = Some(modal);
+        ctx.notify();
     }
 
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -23606,6 +23626,10 @@ impl View for Workspace {
 
         if let Some(lightbox_view) = &self.lightbox_view {
             stack.add_child(ChildView::new(lightbox_view).finish());
+        }
+
+        if let Some(handoff_modal) = &self.handoff_environment_creation_modal {
+            stack.add_child(ChildView::new(handoff_modal).finish());
         }
 
         if FeatureFlag::CreatingSharedSessions.is_enabled()

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13117,18 +13117,22 @@ impl Workspace {
     }
 
     fn show_handoff_environment_creation_modal(&mut self, ctx: &mut ViewContext<Self>) {
+        // Capture the initiating source view now, before async creation begins.
+        // If we waited until the Created callback, the user may have switched panes.
+        #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+        let source_view = self
+            .active_tab_pane_group()
+            .as_ref(ctx)
+            .active_session_view(ctx);
+
         let modal = ctx.add_typed_action_view(HandoffEnvironmentCreationModal::new);
-        ctx.subscribe_to_view(&modal, |me, _, event, ctx| match event {
+        ctx.subscribe_to_view(&modal, move |me, _, event, ctx| match event {
             HandoffEnvironmentCreationModalEvent::Created { env_id } => {
                 let env_id = *env_id;
                 me.handoff_environment_creation_modal = None;
                 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
                 {
-                    if let Some(source_view) = me
-                        .active_tab_pane_group()
-                        .as_ref(ctx)
-                        .active_session_view(ctx)
-                    {
+                    if let Some(source_view) = source_view.as_ref() {
                         let launch = source_view.update(ctx, |view, ctx| {
                             let input = view.input().clone();
                             input.update(ctx, |input, ctx| {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13111,6 +13111,61 @@ impl Workspace {
         });
     }
 
+    fn show_handoff_environment_creation_modal(&mut self, ctx: &mut ViewContext<Self>) {
+        use crate::settings_view::handoff_environment_creation_modal::{
+            HandoffEnvironmentCreationModal, HandoffEnvironmentCreationModalEvent,
+        };
+
+        let modal = ctx.add_typed_action_view(HandoffEnvironmentCreationModal::new);
+        ctx.subscribe_to_view(&modal, |me, _, event, ctx| match event {
+            HandoffEnvironmentCreationModalEvent::Created { env_id } => {
+                let env_id = *env_id;
+                // Read the prompt and attachments from the active input's `&` compose state,
+                // build a PendingCloudLaunch, clear the input, and dispatch the handoff.
+                #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+                {
+                    use crate::ai::blocklist::handoff::PendingCloudLaunch;
+
+                    if let Some(source_view) = me
+                        .active_tab_pane_group()
+                        .as_ref(ctx)
+                        .active_session_view(ctx)
+                    {
+                        let launch = source_view.update(ctx, |view, ctx| {
+                            let input = view.input().clone();
+                            input.update(ctx, |input, ctx| {
+                                let prompt =
+                                    input.editor().as_ref(ctx).buffer_text(ctx).trim().to_owned();
+                                let attachments = input.collect_cloud_launch_attachments(ctx);
+                                input.exit_cloud_handoff_compose_and_clear(ctx);
+                                if prompt.is_empty() {
+                                    None
+                                } else {
+                                    Some(PendingCloudLaunch { prompt, attachments })
+                                }
+                            })
+                        });
+                        ctx.dispatch_typed_action_deferred(
+                            WorkspaceAction::OpenLocalToCloudHandoffPane {
+                                launch,
+                                explicit_environment_id: Some(env_id),
+                            },
+                        );
+                    }
+                }
+                #[cfg(not(all(feature = "local_fs", not(target_family = "wasm"))))]
+                {
+                    let _ = env_id;
+                }
+            }
+            HandoffEnvironmentCreationModalEvent::Cancelled => {
+                me.focus_active_tab(ctx);
+            }
+        });
+        modal.update(ctx, |modal, ctx| modal.show(ctx));
+        ctx.focus(&modal);
+    }
+
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn show_handoff_prepare_failed_toast(window_id: WindowId, ctx: &mut ViewContext<Self>) {
         WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
@@ -20741,6 +20796,9 @@ impl TypedActionView for Workspace {
                 {
                     let _ = (launch, explicit_environment_id);
                 }
+            }
+            ShowHandoffEnvironmentCreationModal => {
+                self.show_handoff_environment_creation_modal(ctx);
             }
             OpenNetworkLogPane => {
                 self.open_network_log_pane(ctx);

--- a/specs/REMOTE-1591/PRODUCT.md
+++ b/specs/REMOTE-1591/PRODUCT.md
@@ -16,49 +16,49 @@ Figma: none provided
 
 ### Opening the creation modal
 
-5. When the user presses Enter while in `&` handoff-compose mode and no environments exist:
+3. When the user presses Enter while in `&` handoff-compose mode and no environments exist:
    - If the input buffer is non-empty, the prompt text is preserved (held in `&` compose state).
    - A modal dialog overlays the main window containing the `UpdateEnvironmentForm` in Create mode.
    - The modal uses the same form as Settings → Environments → Create (name, description, GitHub repos, Docker image, setup commands), rendered without the settings-page header (back button / page title) and instead with a modal-style close button and title.
 
-6. If the input buffer is empty and the user presses Enter with no environments, nothing happens.
+4. If the input buffer is empty and the user presses Enter with no environments, nothing happens.
 
 ### Modal behavior
 
-7. The modal renders as a centered overlay with a dark background overlay, a close button, and an Esc keybinding hint — the same pattern as other modals in the app (e.g. tab config modal, `EnvironmentSetupModeSelector`). Clicking outside the dialog or pressing Escape closes it.
+5. The modal renders as a centered overlay with a dark background overlay, a close button, and an Esc keybinding hint — the same pattern as other modals in the app (e.g. tab config modal, `EnvironmentSetupModeSelector`). Clicking outside the dialog or pressing Escape closes it.
 
-8. The form inside the modal is the existing `UpdateEnvironmentForm` in Create mode, with `show_header = false` and `should_handle_escape_from_editor = true`. The submit button renders at the bottom-right of the form body (the existing non-header layout).
+6. The form inside the modal is the existing `UpdateEnvironmentForm` in Create mode, with `show_header = false` and `should_handle_escape_from_editor = true`. The submit button renders at the bottom-right of the form body (the existing non-header layout).
 
-9. Focus moves into the form's name field when the modal opens. Tab order cycles through form fields as it does in the settings page.
+7. Focus moves into the form's name field when the modal opens. Tab order cycles through form fields as it does in the settings page.
 
-10. Pressing Escape anywhere in the form, or clicking outside the dialog, closes the modal. This is the "dismiss without creating" path — see (14).
+8. Pressing Escape anywhere in the form, or clicking outside the dialog, closes the modal. This is the "dismiss without creating" path — see (13).
 
 ### Successful environment creation
 
-11. When the user fills out the form and submits (Create button or Enter on the focused submit button), the form emits `UpdateEnvironmentFormEvent::Created`. The modal closes.
+9. When the user fills out the form and submits (Create button or Enter on the focused submit button), the modal closes immediately.
 
-12. The newly created environment is automatically selected in the handoff-compose state.
+10. The environment is created on the server via an online-only API call (`create_ambient_agent_environment_online`). The modal waits for the server to confirm creation and return a `ServerId` before proceeding — this avoids race conditions with unsynced client IDs.
 
-13. If the user had a non-empty prompt in the input buffer when the modal opened, the handoff auto-submits immediately: the prompt and any pending attachments are sent to `WorkspaceAction::OpenLocalToCloudHandoffPane` with the new environment, following the same path as a normal `& query` submit. If the prompt was empty, `&` compose mode remains active with the new environment selected so the user can type a prompt.
+11. Once the server confirms, the handoff auto-submits: the prompt and any pending attachments are sent to `WorkspaceAction::OpenLocalToCloudHandoffPane` with the new environment's `ServerId`, following the same path as a normal `& query` submit.
+
+### Failure during server creation
+
+12. If the server call fails (network error, validation failure, etc.), the error is logged and an error toast is shown ("Failed to create environment: \<error\>"). The `&` compose input is preserved so the user can retry.
 
 ### Dismissal without creating
 
-14. If the user closes the modal without creating an environment (Escape, clicking outside, or the close button), the input returns to `&` handoff-compose mode unchanged — the prompt text, attachments, and chip state are all preserved exactly as they were before the modal opened.
+13. If the user closes the modal without creating an environment (Escape, clicking outside, or the close button), the input returns to `&` handoff-compose mode unchanged — the prompt text, attachments, and chip state are all preserved exactly as they were before the modal opened.
 
-15. The user can re-trigger the modal by pressing Enter again, or exit `&` mode entirely via Backspace-on-empty / Escape as usual.
+14. The user can re-trigger the modal by pressing Enter again, or exit `&` mode entirely via Backspace-on-empty / Escape as usual.
 
 ### Interaction with existing environment flows
 
-16. If the user already has one or more environments, Enter in `&` compose mode submits the handoff as it does today — the modal never opens when environments exist.
+15. If the user already has one or more environments, Enter in `&` compose mode submits the handoff as it does today — the modal never opens when environments exist.
 
-17. If the user creates their first environment through Settings → Environments while `&` compose mode is active, the environment chip should update reactively (via the existing `CloudModel` subscription) to show the new environment name. At that point, Enter submits the handoff normally without opening the modal.
+16. If the user creates their first environment through Settings → Environments while `&` compose mode is active, the environment chip should update reactively (via the existing `CloudModel` subscription) to show the new environment name. At that point, Enter submits the handoff normally without opening the modal.
 
-18. The modal does not interfere with the "share with team" checkbox — it renders the same as in the settings page create flow. If the user is on a team, the option appears.
+17. The modal does not interfere with the "share with team" checkbox — it renders the same as in the settings page create flow. If the user is on a team, the option appears.
 
 ### Edge cases
 
-19. If the environment creation request fails server-side (network error, validation failure), the form stays open with the error displayed inline (same as the settings page behavior). The modal does not close on failure.
-
-20. If the user opens the modal, creates an environment, and the `CloudModel` subscription fires before the modal's `Created` event is processed, the handoff should still use the environment from the `Created` event (not race with a different default selection).
-
-21. If the user is not logged in or not authenticated, the form's GitHub auth flow (repo selection) works the same as in settings — the OAuth redirect opens in the browser and the form refreshes on app focus.
+18. If the user is not logged in or not authenticated, the form's GitHub auth flow (repo selection) works the same as in settings — the OAuth redirect opens in the browser and the form refreshes on app focus.

--- a/specs/REMOTE-1591/PRODUCT.md
+++ b/specs/REMOTE-1591/PRODUCT.md
@@ -1,0 +1,64 @@
+# REMOTE-1591: Environment creation flow for local-to-cloud handoff
+
+## Summary
+
+When a user enters `&` handoff-compose mode but has no cloud environments, they should be able to create one inline via a modal overlaying the main window. After creating the environment, the handoff auto-submits with the new environment. Dismissing the modal without creating leaves the input unchanged.
+
+Figma: none provided
+
+## Behavior
+
+### Entry into `&` compose mode with no environments
+
+1. Typing `&` in agent view activates handoff-compose mode regardless of whether the user has any environments. The `&` prefix indicator, message bar hints, and locked-AI input behavior all apply the same as when environments exist.
+
+2. The ghost text / placeholder in the input reads **"Handoff to cloud"** (the generic fallback), since there is no environment name to display in the "Hand off to \<env\>" pattern.
+
+### Opening the creation modal
+
+5. When the user presses Enter while in `&` handoff-compose mode and no environments exist:
+   - If the input buffer is non-empty, the prompt text is preserved (held in `&` compose state).
+   - A modal dialog overlays the main window containing the `UpdateEnvironmentForm` in Create mode.
+   - The modal uses the same form as Settings → Environments → Create (name, description, GitHub repos, Docker image, setup commands), rendered without the settings-page header (back button / page title) and instead with a modal-style close button and title.
+
+6. If the input buffer is empty and the user presses Enter with no environments, nothing happens.
+
+### Modal behavior
+
+7. The modal renders as a centered overlay with a dark background overlay, a close button, and an Esc keybinding hint — the same pattern as other modals in the app (e.g. tab config modal, `EnvironmentSetupModeSelector`). Clicking outside the dialog or pressing Escape closes it.
+
+8. The form inside the modal is the existing `UpdateEnvironmentForm` in Create mode, with `show_header = false` and `should_handle_escape_from_editor = true`. The submit button renders at the bottom-right of the form body (the existing non-header layout).
+
+9. Focus moves into the form's name field when the modal opens. Tab order cycles through form fields as it does in the settings page.
+
+10. Pressing Escape anywhere in the form, or clicking outside the dialog, closes the modal. This is the "dismiss without creating" path — see (14).
+
+### Successful environment creation
+
+11. When the user fills out the form and submits (Create button or Enter on the focused submit button), the form emits `UpdateEnvironmentFormEvent::Created`. The modal closes.
+
+12. The newly created environment is automatically selected in the handoff-compose state.
+
+13. If the user had a non-empty prompt in the input buffer when the modal opened, the handoff auto-submits immediately: the prompt and any pending attachments are sent to `WorkspaceAction::OpenLocalToCloudHandoffPane` with the new environment, following the same path as a normal `& query` submit. If the prompt was empty, `&` compose mode remains active with the new environment selected so the user can type a prompt.
+
+### Dismissal without creating
+
+14. If the user closes the modal without creating an environment (Escape, clicking outside, or the close button), the input returns to `&` handoff-compose mode unchanged — the prompt text, attachments, and chip state are all preserved exactly as they were before the modal opened.
+
+15. The user can re-trigger the modal by pressing Enter again, or exit `&` mode entirely via Backspace-on-empty / Escape as usual.
+
+### Interaction with existing environment flows
+
+16. If the user already has one or more environments, Enter in `&` compose mode submits the handoff as it does today — the modal never opens when environments exist.
+
+17. If the user creates their first environment through Settings → Environments while `&` compose mode is active, the environment chip should update reactively (via the existing `CloudModel` subscription) to show the new environment name. At that point, Enter submits the handoff normally without opening the modal.
+
+18. The modal does not interfere with the "share with team" checkbox — it renders the same as in the settings page create flow. If the user is on a team, the option appears.
+
+### Edge cases
+
+19. If the environment creation request fails server-side (network error, validation failure), the form stays open with the error displayed inline (same as the settings page behavior). The modal does not close on failure.
+
+20. If the user opens the modal, creates an environment, and the `CloudModel` subscription fires before the modal's `Created` event is processed, the handoff should still use the environment from the `Created` event (not race with a different default selection).
+
+21. If the user is not logged in or not authenticated, the form's GitHub auth flow (repo selection) works the same as in settings — the OAuth redirect opens in the browser and the form refreshes on app focus.

--- a/specs/REMOTE-1591/TECH.md
+++ b/specs/REMOTE-1591/TECH.md
@@ -43,17 +43,17 @@ A thin modal wrapper around `UpdateEnvironmentForm`, following the `AgentAssiste
 **Public API:**
 - `show(&mut self, ctx)` — sets `visible = true`, resets form to `Create` mode, focuses name field
 - `hide(&mut self, ctx)` — sets `visible = false`
-- `is_visible(&self) -> bool`
 
 **Events:**
 ```rust
 enum HandoffEnvironmentCreationModalEvent {
     Created { env_id: SyncId },
     Cancelled,
+    CreationFailed { error_message: String },
 }
 ```
 
-The `Created` event carries the `SyncId` of the newly created environment (computed from the `ClientId` used in `UpdateManager::create_ambient_agent_environment`). The modal handles environment creation internally — the caller only sees the resulting `SyncId`.
+The `Created` event carries a `SyncId::ServerId` — guaranteed to be a server-recognized ID. The modal uses `create_ambient_agent_environment_online` (an inline server call with built-in retries) so the `ServerId` is available before the event is emitted, eliminating any `ClientId` → `ServerId` sync race. On failure, `CreationFailed` is emitted with the error message so the workspace can show a toast.
 
 **Form configuration** (matching `FirstTimeCloudAgentSetupView`):
 - `show_header = false` → submit button renders at bottom-right of form body
@@ -64,62 +64,54 @@ The `Created` event carries the `SyncId` of the newly created environment (compu
 - On `UpdateEnvironmentFormEvent::Created { environment, share_with_team }`:
   1. Resolve owner via `cloud_environments::owner_for_new_environment()` / `owner_for_new_personal_environment()`
   2. Generate `ClientId::default()`
-  3. Call `UpdateManager::create_ambient_agent_environment()`
-  4. Emit `HandoffEnvironmentCreationModalEvent::Created { env_id: SyncId::ClientId(client_id) }`
-  5. The environment is immediately available in `CloudModel` after this call
+  3. Call `UpdateManager::create_ambient_agent_environment_online()` — returns `Future<Result<ServerId>>`
+  4. Hide the modal immediately
+  5. `ctx.spawn` the future:
+     - On `Ok(server_id)`: emit `Created { env_id: SyncId::ServerId(server_id) }`
+     - On `Err(err)`: log the error and emit `CreationFailed { error_message }`
 
 **Rendering** (following `AgentAssistedEnvironmentModal`):
 - When `visible == false`, render `Empty`
-- When visible: `Dialog::new("Create environment", None, dialog_styles(appearance)).with_close_button(...).with_child(scrollable_form).with_width(MODAL_WIDTH).build()` → `Dismiss::new().prevent_interaction_with_other_elements().on_dismiss(cancel)` → `Container` with dark overlay background + window corner radius
+- When visible: `Dialog::new("Create environment", None, dialog_styles(appearance)).with_close_button(...).with_child(scrollable_form).with_width(DIALOG_WIDTH).build()` → `Dismiss::new().prevent_interaction_with_other_elements().on_dismiss(cancel)` → `Container` with dark overlay background + window corner radius
+- The form content has no fixed max height — the dialog sizes to its content, with a `ClippedScrollable` safety net for very small windows
 
 ### 2. Input: intercept Enter when no environments exist
 
 In `input.rs`, `maybe_launch_cloud_handoff_request()`:
 
-After confirming we're in handoff compose mode, before collecting attachments and dispatching the handoff, add a check:
+After the existing empty-prompt early return (which already handles the no-op case), check whether environments are empty. If so, emit `Event::OpenHandoffEnvironmentCreationModal` and return early instead of collecting attachments. A new `OpenHandoffEnvironmentCreationModal` variant is added to `Input::Event`.
 
-```
-if CloudAmbientAgentEnvironment::get_all(ctx).is_empty() {
-    if prompt.is_empty() {
-        // Behavior 6: nothing happens on empty buffer with no envs
-        return true;
-    }
-    // Behavior 5: open environment creation modal
-    ctx.emit(Event::OpenHandoffEnvironmentCreationModal);
-    return true;
-}
-```
-
-Add a new variant to the `Input::Event` enum:
-```rust
-OpenHandoffEnvironmentCreationModal,
-```
-
-The prompt and attachments stay in the input buffer — the user will see them unchanged when the modal closes (behavior 14).
+The prompt and attachments stay in the input buffer — the user will see them unchanged when the modal closes.
 
 ### 3. Workspace: own the modal and wire up handoff auto-submit
 
 In `workspace/view.rs`:
 
-**New field** on `WorkspaceViewState` (or `Workspace`):
+**New field** on `Workspace`:
 ```rust
-handoff_environment_creation_modal: ViewHandle<HandoffEnvironmentCreationModal>,
+handoff_environment_creation_modal: Option<ViewHandle<HandoffEnvironmentCreationModal>>,
 ```
 
-**Subscribe to modal events** during workspace construction:
+The modal is created on-demand (not pre-constructed at workspace init) to avoid unnecessary overhead. It is stored as `Option<ViewHandle>` and rendered as a `ChildView` in the workspace's `render()` method when `Some`, following the same pattern as `lightbox_view`.
+
+**Subscribe to modal events** when the modal is created in `show_handoff_environment_creation_modal`:
 - `HandoffEnvironmentCreationModalEvent::Created { env_id }` →
-  1. Hide the modal
+  1. Set `handoff_environment_creation_modal = None`
   2. Get the active terminal view's input and read the prompt + attachments from its `&` compose state
   3. Use the input's `collect_cloud_launch_attachments()` and `editor.buffer_text()` to build a `PendingCloudLaunch`
   4. Clear the input buffer and exit `&` compose mode
   5. Dispatch `WorkspaceAction::OpenLocalToCloudHandoffPane { launch, explicit_environment_id: Some(env_id) }`
 - `HandoffEnvironmentCreationModalEvent::Cancelled` →
-  1. Hide the modal
+  1. Set `handoff_environment_creation_modal = None`
   2. Re-focus the active terminal input (the `&` compose state and prompt are already preserved)
+- `HandoffEnvironmentCreationModalEvent::CreationFailed { error_message }` →
+  1. Set `handoff_environment_creation_modal = None`
+  2. Show an error toast: "Failed to create environment: \<error_message\>"
+  3. Re-focus the active terminal input
 
-**New workspace action** `ShowHandoffEnvironmentCreationModal` — shows the modal. The terminal view subscribes to `Input::Event::OpenHandoffEnvironmentCreationModal` and dispatches this action.
+**New workspace action** `ShowHandoffEnvironmentCreationModal` — creates the modal on-demand, subscribes to its events, stores the handle, and calls `ctx.notify()` to trigger a re-render. The terminal view subscribes to `Input::Event::OpenHandoffEnvironmentCreationModal` and dispatches this action.
 
-**Render** — add the modal overlay to the workspace's render output when `is_visible()` returns `true`, using the same overlay stacking pattern as existing workspace modals.
+**Render** — add the modal overlay to the workspace's render output when `handoff_environment_creation_modal.is_some()`, using the same overlay stacking pattern as `lightbox_view`.
 
 ### 4. Ghost text fallback
 

--- a/specs/REMOTE-1591/TECH.md
+++ b/specs/REMOTE-1591/TECH.md
@@ -1,0 +1,145 @@
+# REMOTE-1591: Tech spec — Environment creation modal for handoff
+
+## Context
+
+When a user enters `&` handoff-compose mode but has zero cloud environments, there is currently no way to create one without leaving the flow. See `PRODUCT.md` for detailed user-facing behavior.
+
+### Relevant code
+
+**Handoff compose flow (input layer)**
+- `app/src/terminal/input.rs` — `maybe_launch_cloud_handoff_request()` (line ~3810) is the Enter handler for `&` compose mode. Currently returns `true` (consumed) when the prompt is empty, or collects attachments and dispatches `WorkspaceAction::OpenLocalToCloudHandoffPane`.
+- `app/src/terminal/input/handoff_compose.rs` — `HandoffComposeState` model tracking `&` mode activation and selected environment.
+
+**Environment selector chip**
+- `app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs` — `refresh_button()` (line 437) sets the chip label. Falls back to `"New environment"` when no env is selected.
+
+**Environment creation form**
+- `app/src/settings_view/update_environment_form.rs` — `UpdateEnvironmentForm` view. Already supports modal-style use via `show_header` (line 332), `should_handle_escape_from_editor` (line 336), and `auth_source` (line 342). Emits `UpdateEnvironmentFormEvent::Created { environment, share_with_team }` on submit.
+
+**Prior art: embedding the form in non-settings contexts**
+- `app/src/terminal/view/ambient_agent/first_time_setup.rs` — `FirstTimeCloudAgentSetupView` wraps the form with `show_header=false`, `should_handle_escape_from_editor=true`, handles `Created` by calling `UpdateManager::create_ambient_agent_environment()`. This is the pattern to follow for environment creation logic.
+
+**Prior art: modal overlay rendering**
+- `app/src/settings_view/agent_assisted_environment_modal.rs` — `AgentAssistedEnvironmentModal` renders using `Dialog::new().with_close_button().with_child().build()` wrapped in `Dismiss::new().prevent_interaction_with_other_elements()`, inside a `Container` with `ColorU::new(0, 0, 0, 179)` background. Uses `show()`/`hide()` visibility toggle and emits `Cancelled`/`Confirmed` events. This is the rendering pattern to follow.
+- `app/src/ui_components/dialog.rs` — `Dialog` component used by modal overlays. Provides title, close button, child content, and bottom row.
+
+**Workspace handoff dispatch**
+- `app/src/workspace/view.rs` — `start_local_to_cloud_handoff()` (line 12972) and `start_fresh_cloud_launch()` (line 12938) handle `WorkspaceAction::OpenLocalToCloudHandoffPane`. The workspace is also where top-level overlays like `remove_tab_config_confirmation_dialog` are owned and rendered.
+
+## Proposed changes
+
+### 1. New view: `HandoffEnvironmentCreationModal`
+
+New file: `app/src/settings_view/handoff_environment_creation_modal.rs`
+
+A thin modal wrapper around `UpdateEnvironmentForm`, following the `AgentAssistedEnvironmentModal` pattern for rendering and `FirstTimeCloudAgentSetupView` for form configuration and environment creation logic.
+
+**View state:**
+- `visible: bool`
+- `environment_form: ViewHandle<UpdateEnvironmentForm>`
+- `close_button_mouse_state: MouseStateHandle`
+- `scroll_state: ClippedScrollStateHandle` (the form is tall — needs scrolling within the modal)
+
+**Public API:**
+- `show(&mut self, ctx)` — sets `visible = true`, resets form to `Create` mode, focuses name field
+- `hide(&mut self, ctx)` — sets `visible = false`
+- `is_visible(&self) -> bool`
+
+**Events:**
+```rust
+enum HandoffEnvironmentCreationModalEvent {
+    Created { env_id: SyncId },
+    Cancelled,
+}
+```
+
+The `Created` event carries the `SyncId` of the newly created environment (computed from the `ClientId` used in `UpdateManager::create_ambient_agent_environment`). The modal handles environment creation internally — the caller only sees the resulting `SyncId`.
+
+**Form configuration** (matching `FirstTimeCloudAgentSetupView`):
+- `show_header = false` → submit button renders at bottom-right of form body
+- `should_handle_escape_from_editor = true` → Escape in any editor emits `Cancelled`
+- `auth_source = AuthSource::CloudSetup` → GitHub auth redirects back in-place
+
+**Environment creation** (inside the modal's `handle_environment_form_event`):
+- On `UpdateEnvironmentFormEvent::Created { environment, share_with_team }`:
+  1. Resolve owner via `cloud_environments::owner_for_new_environment()` / `owner_for_new_personal_environment()`
+  2. Generate `ClientId::default()`
+  3. Call `UpdateManager::create_ambient_agent_environment()`
+  4. Emit `HandoffEnvironmentCreationModalEvent::Created { env_id: SyncId::ClientId(client_id) }`
+  5. The environment is immediately available in `CloudModel` after this call
+
+**Rendering** (following `AgentAssistedEnvironmentModal`):
+- When `visible == false`, render `Empty`
+- When visible: `Dialog::new("Create environment", None, dialog_styles(appearance)).with_close_button(...).with_child(scrollable_form).with_width(MODAL_WIDTH).build()` → `Dismiss::new().prevent_interaction_with_other_elements().on_dismiss(cancel)` → `Container` with dark overlay background + window corner radius
+
+### 2. Input: intercept Enter when no environments exist
+
+In `input.rs`, `maybe_launch_cloud_handoff_request()`:
+
+After confirming we're in handoff compose mode, before collecting attachments and dispatching the handoff, add a check:
+
+```
+if CloudAmbientAgentEnvironment::get_all(ctx).is_empty() {
+    if prompt.is_empty() {
+        // Behavior 6: nothing happens on empty buffer with no envs
+        return true;
+    }
+    // Behavior 5: open environment creation modal
+    ctx.emit(Event::OpenHandoffEnvironmentCreationModal);
+    return true;
+}
+```
+
+Add a new variant to the `Input::Event` enum:
+```rust
+OpenHandoffEnvironmentCreationModal,
+```
+
+The prompt and attachments stay in the input buffer — the user will see them unchanged when the modal closes (behavior 14).
+
+### 3. Workspace: own the modal and wire up handoff auto-submit
+
+In `workspace/view.rs`:
+
+**New field** on `WorkspaceViewState` (or `Workspace`):
+```rust
+handoff_environment_creation_modal: ViewHandle<HandoffEnvironmentCreationModal>,
+```
+
+**Subscribe to modal events** during workspace construction:
+- `HandoffEnvironmentCreationModalEvent::Created { env_id }` →
+  1. Hide the modal
+  2. Get the active terminal view's input and read the prompt + attachments from its `&` compose state
+  3. Use the input's `collect_cloud_launch_attachments()` and `editor.buffer_text()` to build a `PendingCloudLaunch`
+  4. Clear the input buffer and exit `&` compose mode
+  5. Dispatch `WorkspaceAction::OpenLocalToCloudHandoffPane { launch, explicit_environment_id: Some(env_id) }`
+- `HandoffEnvironmentCreationModalEvent::Cancelled` →
+  1. Hide the modal
+  2. Re-focus the active terminal input (the `&` compose state and prompt are already preserved)
+
+**New workspace action** `ShowHandoffEnvironmentCreationModal` — shows the modal. The terminal view subscribes to `Input::Event::OpenHandoffEnvironmentCreationModal` and dispatches this action.
+
+**Render** — add the modal overlay to the workspace's render output when `is_visible()` returns `true`, using the same overlay stacking pattern as existing workspace modals.
+
+### 4. Ghost text fallback
+
+In `input.rs`, `set_zero_state_hint_text()` (line ~6120), the handoff compose branch falls back to `CLOUD_HANDOFF_HINT_TEXT` when no environment is found. Update this constant from `"Start a cloud run"` to `"Handoff to cloud"` to match behavior 2 in `PRODUCT.md`.
+
+## Testing and validation
+
+**Unit tests** (in `handoff_compose_tests.rs` and `input_test.rs`):
+- Test that `maybe_launch_cloud_handoff_request` emits `OpenHandoffEnvironmentCreationModal` when environments list is empty and prompt is non-empty (behavior 5)
+- Test that empty prompt + no environments returns `true` without emitting (behavior 6)
+- Test that with environments present, Enter submits normally (behavior 16)
+
+**Unit tests** (new file `handoff_environment_creation_modal_tests.rs`):
+- Test `show()` resets form to Create mode and sets `visible = true`
+- Test that form `Created` event triggers `UpdateManager::create_ambient_agent_environment` and emits `Created { env_id }`
+- Test that form `Cancelled` event emits `Cancelled`
+
+**Manual validation:**
+- Enter `&` with no environments → ghost text shows "Handoff to cloud"
+- Type a prompt and press Enter → modal opens with environment creation form, prompt preserved in input behind modal
+- Fill out form, submit → environment created, handoff auto-submits with new environment
+- Escape from modal → returns to `&` compose with prompt intact
+- Create env via Settings while in `&` mode → chip updates reactively (behavior 17)


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

If a user is doing local -> cloud handoff but doesn't have any environments set up, we shouldn't just fail silently or throw an error. Instead, we should kick them into a quick environment setup modal. We already have an in-app form for environment setup, so we can just put that in a modal and, once the user has created their environment, use that environment for handoff.

## Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/0403c32c83fe41c08daa990174e39787

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
