### PR TITLE
Use file-based secure storage for macOS debug builds

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1074,6 +1074,12 @@ pub(crate) fn initialize_app(
             warpui_extras::secure_storage::register_with_fallback(&data_domain, warp_core::paths::state_dir(), ctx)
         } else if #[cfg(target_os = "windows")] {
             warpui_extras::secure_storage::register_with_dir(&data_domain, warp_core::paths::state_dir(), ctx)
+        } else if #[cfg(all(target_os = "macos", debug_assertions))] {
+            // Debug builds produce a different binary signature on every
+            // recompile, which invalidates macOS Keychain ACL entries and
+            // causes repeated password prompts. Use file-based storage
+            // instead so developers aren't interrupted on every launch.
+            warpui_extras::secure_storage::register_file_based(&data_domain, warp_core::paths::state_dir(), ctx);
         } else {
             warpui_extras::secure_storage::register(&data_domain, ctx);
         }

--- a/crates/warpui_extras/src/secure_storage/file.rs
+++ b/crates/warpui_extras/src/secure_storage/file.rs
@@ -1,0 +1,54 @@
+//! File-based [`SecureStorage`] for build configurations where the OS
+//! keychain is unavailable or undesirable (e.g. macOS debug builds that
+//! produce a different binary signature on every recompile, causing repeated
+//! Keychain password prompts).
+
+use std::path::PathBuf;
+
+use super::Error;
+
+pub struct SecureStorage {
+    service_name: String,
+    storage_dir: PathBuf,
+}
+
+impl SecureStorage {
+    pub fn new(service_name: &str, storage_dir: PathBuf) -> Self {
+        Self {
+            service_name: service_name.to_string(),
+            storage_dir,
+        }
+    }
+
+    fn storage_file(&self, key: &str) -> PathBuf {
+        let filename = format!("{}-{key}", self.service_name);
+        self.storage_dir.join(filename)
+    }
+}
+
+impl super::SecureStorage for SecureStorage {
+    fn write_value(&self, key: &str, value: &str) -> Result<(), Error> {
+        let storage_file = self.storage_file(key);
+        if let Some(parent) = storage_file.parent() {
+            std::fs::create_dir_all(parent).map_err(|err| Error::Unknown(err.into()))?;
+        }
+        std::fs::write(storage_file, value.as_bytes()).map_err(|err| Error::Unknown(err.into()))
+    }
+
+    fn read_value(&self, key: &str) -> Result<String, Error> {
+        let storage_file = self.storage_file(key);
+        let bytes = std::fs::read(&storage_file).map_err(|err| match err.kind() {
+            std::io::ErrorKind::NotFound => Error::NotFound,
+            _ => Error::Unknown(err.into()),
+        })?;
+        String::from_utf8(bytes).map_err(|err| Error::DecodeError(err.utf8_error()))
+    }
+
+    fn remove_value(&self, key: &str) -> Result<(), Error> {
+        let storage_file = self.storage_file(key);
+        std::fs::remove_file(storage_file).map_err(|err| match err.kind() {
+            std::io::ErrorKind::NotFound => Error::NotFound,
+            _ => Error::Unknown(err.into()),
+        })
+    }
+}

--- a/crates/warpui_extras/src/secure_storage/mod.rs
+++ b/crates/warpui_extras/src/secure_storage/mod.rs
@@ -5,6 +5,8 @@
 //! utilities, and extension traits to improve ergonomics of using the APIs.
 
 #[cfg(not(target_family = "wasm"))]
+mod file;
+#[cfg(not(target_family = "wasm"))]
 #[cfg_attr(target_os = "macos", path = "mac.rs")]
 #[cfg_attr(any(target_os = "linux", target_os = "freebsd"), path = "linux.rs")]
 #[cfg_attr(target_os = "windows", path = "windows.rs")]
@@ -58,6 +60,23 @@ pub fn register(service_name: &str, ctx: &mut warpui::AppContext) {
 /// Registers a no-op Secure Storage provider with the application.
 pub fn register_noop(service_name: &str, ctx: &mut warpui::AppContext) {
     ctx.add_singleton_model(|_| -> Model { Box::new(noop::SecureStorage::new(service_name)) });
+}
+
+/// Registers a file-based Secure Storage provider with the application.
+///
+/// Secrets are stored as plain files in the given directory. This is intended
+/// for local development builds where the OS keychain is impractical (e.g.
+/// macOS debug builds whose binary signature changes on every recompile,
+/// causing repeated Keychain password prompts).
+#[cfg(not(target_family = "wasm"))]
+pub fn register_file_based(
+    service_name: &str,
+    storage_dir: std::path::PathBuf,
+    ctx: &mut warpui::AppContext,
+) {
+    ctx.add_singleton_model(|_| -> Model {
+        Box::new(file::SecureStorage::new(service_name, storage_dir))
+    });
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]


### PR DESCRIPTION
## Description
macOS Keychain ties "Always Allow" to the binary's code signature. Debug builds produce a different signature on every recompile, which invalidates the ACL entries and causes repeated password prompts (typically 3) on every launch of a local build.

This switches macOS debug builds to a simple file-based storage backend — similar to what Linux and Windows already use — so developers are never interrupted by Keychain dialogs. Release builds continue to use the native Keychain.

### Changes
- **`crates/warpui_extras/src/secure_storage/file.rs`** (new): File-based `SecureStorage` implementation that stores values as plain files in the app's state directory.
- **`crates/warpui_extras/src/secure_storage/mod.rs`**: Added the `file` module and `register_file_based()` registration function.
- **`app/src/lib.rs`**: Added a `cfg(all(target_os = "macos", debug_assertions))` branch that uses file-based storage instead of Keychain.

### Note
After this lands, developers will need to re-login once since existing Keychain-stored tokens won't be migrated, but after that auth persists across recompiles with zero prompts.

## Linked Issue
N/A — Developer experience improvement.

## Testing
- [x] Verified `cargo check -p warpui_extras` compiles clean
- [x] Verified `cargo fmt` passes
- [x] Verified `cargo clippy -p warpui_extras -p warp` passes with no warnings
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation link](https://staging.warp.dev/conversation/a4d21cc7-5cd8-4c07-bca3-24e4def14a23)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!--
CHANGELOG-IMPROVEMENT: Eliminated repeated macOS Keychain password prompts when running local debug builds.
-->
