### PR TITLE
Lighten agent input toolbar chip outlines

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -2539,8 +2539,8 @@ impl ActionButtonTheme for AgentInputButtonTheme {
         appearance.theme().sub_text_color(effective_bg).into_solid()
     }
 
-    fn border(&self, appearance: &Appearance) -> Option<ColorU> {
-        Some(internal_colors::neutral_3(appearance.theme()))
+    fn border(&self, _appearance: &Appearance) -> Option<ColorU> {
+        None
     }
 
     fn should_opt_out_of_contrast_adjustment(&self) -> bool {


### PR DESCRIPTION
## Description

Removes the persistent border from Agent input toolbar chips to reduce visual weight and simplify the toolbar appearance.

## Linked Issue

Closes #10393

* [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
* [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

* [ ] I have manually tested my changes locally with `./script/run`

### Verification

* Ran `rustfmt app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs`.
* Ran `cargo check -p warp`; local compilation progressed through dependency compilation but failed in `warpui` build setup because the Apple Metal compiler utility (`metal`) is not available in PATH.

### Manual testing note

I was not able to complete local manual testing because the local macOS toolchain is missing the Apple Metal compiler utility (`metal`), which prevents the Warp app from building/running locally. The change is limited to removing the persistent border returned by `AgentInputButtonTheme::border`.

### Screenshots / Videos

Not included. I could not run the app locally due to the missing Apple Metal compiler utility (`metal`) described above.

## Agent Mode

* [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
