### PR TITLE
feat(harness-support): add report-shutdown command

### DIFF
--- a/app/src/ai/agent_sdk/driver/snapshot_tests.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot_tests.rs
@@ -116,6 +116,14 @@ impl HarnessSupportClient for TestClient {
         unimplemented!("not used by upload_snapshot_from_declarations_file")
     }
 
+    async fn report_shutdown(
+        &self,
+        _error_category: Option<String>,
+        _error_message: Option<String>,
+    ) -> Result<()> {
+        unimplemented!("not used by upload_snapshot_from_declarations_file")
+    }
+
     async fn get_snapshot_upload_targets(
         &self,
         request: &SnapshotUploadRequest,

--- a/app/src/ai/agent_sdk/driver/snapshot_tests.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot_tests.rs
@@ -116,10 +116,14 @@ impl HarnessSupportClient for TestClient {
         unimplemented!("not used by upload_snapshot_from_declarations_file")
     }
 
-    async fn report_shutdown(
+    async fn report_clean_shutdown(&self) -> Result<()> {
+        unimplemented!("not used by upload_snapshot_from_declarations_file")
+    }
+
+    async fn report_error_shutdown(
         &self,
-        _error_category: Option<String>,
-        _error_message: Option<String>,
+        _error_category: String,
+        _error_message: String,
     ) -> Result<()> {
         unimplemented!("not used by upload_snapshot_from_declarations_file")
     }

--- a/app/src/ai/agent_sdk/harness_support.rs
+++ b/app/src/ai/agent_sdk/harness_support.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use warp_cli::agent::OutputFormat;
 use warp_cli::harness_support::{
     FinishTaskArgs, HarnessSupportArgs, HarnessSupportCommand, NotifyUserArgs, ReportArtifactArgs,
-    ReportArtifactCommand, TaskStatus,
+    ReportArtifactCommand, ReportShutdownArgs, TaskStatus,
 };
 use warp_cli::GlobalOptions;
 use warp_core::features::FeatureFlag;
@@ -42,6 +42,9 @@ pub fn run(
         }
         HarnessSupportCommand::FinishTask(finish_args) => {
             finish_task(ctx, runner, finish_args, global_options.output_format)
+        }
+        HarnessSupportCommand::ReportShutdown(shutdown_args) => {
+            report_shutdown(ctx, runner, shutdown_args, global_options.output_format)
         }
     }
 }
@@ -189,6 +192,44 @@ fn finish_task(
                         }
                         OutputFormat::Pretty | OutputFormat::Text => {
                             println!("Task finished.");
+                        }
+                    }
+                    ctx.terminate_app(TerminationMode::ForceTerminate, None);
+                }
+                Err(err) => {
+                    super::report_fatal_error(err, ctx);
+                }
+            },
+        );
+    });
+
+    Ok(())
+}
+
+/// Report that the agent process is shutting down.
+fn report_shutdown(
+    ctx: &mut AppContext,
+    runner: ModelHandle<HarnessSupportRunner>,
+    args: ReportShutdownArgs,
+    output_format: OutputFormat,
+) -> Result<()> {
+    runner.update(ctx, |_, ctx| {
+        let client = ServerApiProvider::as_ref(ctx).get_harness_support_client();
+
+        ctx.spawn(
+            async move {
+                client
+                    .report_shutdown(args.error_category, args.error_message)
+                    .await
+            },
+            move |_, result, ctx| match result {
+                Ok(()) => {
+                    match output_format {
+                        OutputFormat::Json | OutputFormat::Ndjson => {
+                            println!("{{}}");
+                        }
+                        OutputFormat::Pretty | OutputFormat::Text => {
+                            println!("Shutdown reported.");
                         }
                     }
                     ctx.terminate_app(TerminationMode::ForceTerminate, None);

--- a/app/src/ai/agent_sdk/harness_support.rs
+++ b/app/src/ai/agent_sdk/harness_support.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use warp_cli::agent::OutputFormat;
 use warp_cli::harness_support::{
     FinishTaskArgs, HarnessSupportArgs, HarnessSupportCommand, NotifyUserArgs, ReportArtifactArgs,
-    ReportArtifactCommand, ReportErrorShutdownArgs, TaskStatus,
+    ReportArtifactCommand, ReportShutdownArgs, TaskStatus,
 };
 use warp_cli::GlobalOptions;
 use warp_core::features::FeatureFlag;
@@ -43,11 +43,8 @@ pub fn run(
         HarnessSupportCommand::FinishTask(finish_args) => {
             finish_task(ctx, runner, finish_args, global_options.output_format)
         }
-        HarnessSupportCommand::ReportCleanShutdown => {
-            report_clean_shutdown(ctx, runner, global_options.output_format)
-        }
-        HarnessSupportCommand::ReportErrorShutdown(shutdown_args) => {
-            report_error_shutdown(ctx, runner, shutdown_args, global_options.output_format)
+        HarnessSupportCommand::ReportShutdown(shutdown_args) => {
+            report_shutdown(ctx, runner, shutdown_args, global_options.output_format)
         }
     }
 }
@@ -209,44 +206,14 @@ fn finish_task(
     Ok(())
 }
 
-/// Report a clean shutdown of the agent process.
-fn report_clean_shutdown(
+/// Report that the agent process is shutting down.
+///
+/// Routes to `report_clean_shutdown` or `report_error_shutdown` on the API client
+/// depending on whether error arguments were provided.
+fn report_shutdown(
     ctx: &mut AppContext,
     runner: ModelHandle<HarnessSupportRunner>,
-    output_format: OutputFormat,
-) -> Result<()> {
-    runner.update(ctx, |_, ctx| {
-        let client = ServerApiProvider::as_ref(ctx).get_harness_support_client();
-
-        ctx.spawn(
-            async move { client.report_clean_shutdown().await },
-            move |_, result, ctx| match result {
-                Ok(()) => {
-                    match output_format {
-                        OutputFormat::Json | OutputFormat::Ndjson => {
-                            println!("{{}}");
-                        }
-                        OutputFormat::Pretty | OutputFormat::Text => {
-                            println!("Shutdown reported.");
-                        }
-                    }
-                    ctx.terminate_app(TerminationMode::ForceTerminate, None);
-                }
-                Err(err) => {
-                    super::report_fatal_error(err, ctx);
-                }
-            },
-        );
-    });
-
-    Ok(())
-}
-
-/// Report an error shutdown of the agent process.
-fn report_error_shutdown(
-    ctx: &mut AppContext,
-    runner: ModelHandle<HarnessSupportRunner>,
-    args: ReportErrorShutdownArgs,
+    args: ReportShutdownArgs,
     output_format: OutputFormat,
 ) -> Result<()> {
     runner.update(ctx, |_, ctx| {
@@ -254,9 +221,15 @@ fn report_error_shutdown(
 
         ctx.spawn(
             async move {
-                client
-                    .report_error_shutdown(args.error_category, args.error_message)
-                    .await
+                match (args.error_category, args.error_message) {
+                    (Some(category), Some(message)) => {
+                        client.report_error_shutdown(category, message).await
+                    }
+                    (None, None) => client.report_clean_shutdown().await,
+                    _ => anyhow::bail!(
+                        "--error-category and --error-message must be provided together"
+                    ),
+                }
             },
             move |_, result, ctx| match result {
                 Ok(()) => {

--- a/app/src/ai/agent_sdk/harness_support.rs
+++ b/app/src/ai/agent_sdk/harness_support.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use warp_cli::agent::OutputFormat;
 use warp_cli::harness_support::{
     FinishTaskArgs, HarnessSupportArgs, HarnessSupportCommand, NotifyUserArgs, ReportArtifactArgs,
-    ReportArtifactCommand, ReportShutdownArgs, TaskStatus,
+    ReportArtifactCommand, ReportErrorShutdownArgs, TaskStatus,
 };
 use warp_cli::GlobalOptions;
 use warp_core::features::FeatureFlag;
@@ -43,8 +43,11 @@ pub fn run(
         HarnessSupportCommand::FinishTask(finish_args) => {
             finish_task(ctx, runner, finish_args, global_options.output_format)
         }
-        HarnessSupportCommand::ReportShutdown(shutdown_args) => {
-            report_shutdown(ctx, runner, shutdown_args, global_options.output_format)
+        HarnessSupportCommand::ReportCleanShutdown => {
+            report_clean_shutdown(ctx, runner, global_options.output_format)
+        }
+        HarnessSupportCommand::ReportErrorShutdown(shutdown_args) => {
+            report_error_shutdown(ctx, runner, shutdown_args, global_options.output_format)
         }
     }
 }
@@ -206,11 +209,44 @@ fn finish_task(
     Ok(())
 }
 
-/// Report that the agent process is shutting down.
-fn report_shutdown(
+/// Report a clean shutdown of the agent process.
+fn report_clean_shutdown(
     ctx: &mut AppContext,
     runner: ModelHandle<HarnessSupportRunner>,
-    args: ReportShutdownArgs,
+    output_format: OutputFormat,
+) -> Result<()> {
+    runner.update(ctx, |_, ctx| {
+        let client = ServerApiProvider::as_ref(ctx).get_harness_support_client();
+
+        ctx.spawn(
+            async move { client.report_clean_shutdown().await },
+            move |_, result, ctx| match result {
+                Ok(()) => {
+                    match output_format {
+                        OutputFormat::Json | OutputFormat::Ndjson => {
+                            println!("{{}}");
+                        }
+                        OutputFormat::Pretty | OutputFormat::Text => {
+                            println!("Shutdown reported.");
+                        }
+                    }
+                    ctx.terminate_app(TerminationMode::ForceTerminate, None);
+                }
+                Err(err) => {
+                    super::report_fatal_error(err, ctx);
+                }
+            },
+        );
+    });
+
+    Ok(())
+}
+
+/// Report an error shutdown of the agent process.
+fn report_error_shutdown(
+    ctx: &mut AppContext,
+    runner: ModelHandle<HarnessSupportRunner>,
+    args: ReportErrorShutdownArgs,
     output_format: OutputFormat,
 ) -> Result<()> {
     runner.update(ctx, |_, ctx| {
@@ -219,7 +255,7 @@ fn report_shutdown(
         ctx.spawn(
             async move {
                 client
-                    .report_shutdown(args.error_category, args.error_message)
+                    .report_error_shutdown(args.error_category, args.error_message)
                     .await
             },
             move |_, result, ctx| match result {

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1558,6 +1558,9 @@ fn command_to_telemetry_event(command: &CliCommand) -> CliTelemetryEvent {
                     success: finish_args.status == TaskStatus::Success,
                 }
             }
+            HarnessSupportCommand::ReportShutdown(_) => {
+                CliTelemetryEvent::HarnessSupportReportShutdown
+            }
         },
         CliCommand::Artifact(artifact_cmd) => match artifact_cmd {
             ArtifactCommand::Upload(_) => CliTelemetryEvent::ArtifactUpload,

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1558,11 +1558,8 @@ fn command_to_telemetry_event(command: &CliCommand) -> CliTelemetryEvent {
                     success: finish_args.status == TaskStatus::Success,
                 }
             }
-            HarnessSupportCommand::ReportCleanShutdown => {
-                CliTelemetryEvent::HarnessSupportReportCleanShutdown
-            }
-            HarnessSupportCommand::ReportErrorShutdown(_) => {
-                CliTelemetryEvent::HarnessSupportReportErrorShutdown
+            HarnessSupportCommand::ReportShutdown(_) => {
+                CliTelemetryEvent::HarnessSupportReportShutdown
             }
         },
         CliCommand::Artifact(artifact_cmd) => match artifact_cmd {

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1558,8 +1558,11 @@ fn command_to_telemetry_event(command: &CliCommand) -> CliTelemetryEvent {
                     success: finish_args.status == TaskStatus::Success,
                 }
             }
-            HarnessSupportCommand::ReportShutdown(_) => {
-                CliTelemetryEvent::HarnessSupportReportShutdown
+            HarnessSupportCommand::ReportCleanShutdown => {
+                CliTelemetryEvent::HarnessSupportReportCleanShutdown
+            }
+            HarnessSupportCommand::ReportErrorShutdown(_) => {
+                CliTelemetryEvent::HarnessSupportReportErrorShutdown
             }
         },
         CliCommand::Artifact(artifact_cmd) => match artifact_cmd {

--- a/app/src/ai/agent_sdk/telemetry.rs
+++ b/app/src/ai/agent_sdk/telemetry.rs
@@ -417,7 +417,9 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             | Self::HarnessSupportReportArtifact
             | Self::HarnessSupportNotifyUser
             | Self::HarnessSupportFinishTask
-            | Self::HarnessSupportReportShutdown => EnablementState::Flag(FeatureFlag::AgentHarness),
+            | Self::HarnessSupportReportShutdown => {
+                EnablementState::Flag(FeatureFlag::AgentHarness)
+            }
             Self::ArtifactUpload | Self::ArtifactGet | Self::ArtifactDownload => {
                 EnablementState::Flag(FeatureFlag::ArtifactCommand)
             }

--- a/app/src/ai/agent_sdk/telemetry.rs
+++ b/app/src/ai/agent_sdk/telemetry.rs
@@ -112,6 +112,8 @@ pub(super) enum CliTelemetryEvent {
     HarnessSupportNotifyUser,
     /// Executing `warp harness-support finish-task`
     HarnessSupportFinishTask { success: bool },
+    /// Executing `warp harness-support report-shutdown`
+    HarnessSupportReportShutdown,
 }
 
 impl TelemetryEvent for CliTelemetryEvent {
@@ -188,6 +190,7 @@ impl TelemetryEvent for CliTelemetryEvent {
             CliTelemetryEvent::HarnessSupportFinishTask { success } => {
                 Some(json!({ "success": success }))
             }
+            CliTelemetryEvent::HarnessSupportReportShutdown => None,
         }
     }
 
@@ -273,6 +276,9 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             }
             CliTelemetryEventDiscriminants::HarnessSupportFinishTask => {
                 "CLI.Execute.HarnessSupport.FinishTask"
+            }
+            CliTelemetryEventDiscriminants::HarnessSupportReportShutdown => {
+                "CLI.Execute.HarnessSupport.ReportShutdown"
             }
         }
     }
@@ -396,6 +402,9 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             CliTelemetryEventDiscriminants::HarnessSupportFinishTask => {
                 "Reported task completion via harness-support from the Warp CLI"
             }
+            CliTelemetryEventDiscriminants::HarnessSupportReportShutdown => {
+                "Reported agent shutdown via harness-support from the Warp CLI"
+            }
         }
     }
 
@@ -407,7 +416,8 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             Self::HarnessSupportPing
             | Self::HarnessSupportReportArtifact
             | Self::HarnessSupportNotifyUser
-            | Self::HarnessSupportFinishTask => EnablementState::Flag(FeatureFlag::AgentHarness),
+            | Self::HarnessSupportFinishTask
+            | Self::HarnessSupportReportShutdown => EnablementState::Flag(FeatureFlag::AgentHarness),
             Self::ArtifactUpload | Self::ArtifactGet | Self::ArtifactDownload => {
                 EnablementState::Flag(FeatureFlag::ArtifactCommand)
             }

--- a/app/src/ai/agent_sdk/telemetry.rs
+++ b/app/src/ai/agent_sdk/telemetry.rs
@@ -112,10 +112,8 @@ pub(super) enum CliTelemetryEvent {
     HarnessSupportNotifyUser,
     /// Executing `warp harness-support finish-task`
     HarnessSupportFinishTask { success: bool },
-    /// Executing `warp harness-support report-clean-shutdown`
-    HarnessSupportReportCleanShutdown,
-    /// Executing `warp harness-support report-error-shutdown`
-    HarnessSupportReportErrorShutdown,
+    /// Executing `warp harness-support report-shutdown`
+    HarnessSupportReportShutdown,
 }
 
 impl TelemetryEvent for CliTelemetryEvent {
@@ -192,8 +190,7 @@ impl TelemetryEvent for CliTelemetryEvent {
             CliTelemetryEvent::HarnessSupportFinishTask { success } => {
                 Some(json!({ "success": success }))
             }
-            CliTelemetryEvent::HarnessSupportReportCleanShutdown => None,
-            CliTelemetryEvent::HarnessSupportReportErrorShutdown => None,
+            CliTelemetryEvent::HarnessSupportReportShutdown => None,
         }
     }
 
@@ -280,11 +277,8 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             CliTelemetryEventDiscriminants::HarnessSupportFinishTask => {
                 "CLI.Execute.HarnessSupport.FinishTask"
             }
-            CliTelemetryEventDiscriminants::HarnessSupportReportCleanShutdown => {
-                "CLI.Execute.HarnessSupport.ReportCleanShutdown"
-            }
-            CliTelemetryEventDiscriminants::HarnessSupportReportErrorShutdown => {
-                "CLI.Execute.HarnessSupport.ReportErrorShutdown"
+            CliTelemetryEventDiscriminants::HarnessSupportReportShutdown => {
+                "CLI.Execute.HarnessSupport.ReportShutdown"
             }
         }
     }
@@ -408,11 +402,8 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             CliTelemetryEventDiscriminants::HarnessSupportFinishTask => {
                 "Reported task completion via harness-support from the Warp CLI"
             }
-            CliTelemetryEventDiscriminants::HarnessSupportReportCleanShutdown => {
-                "Reported clean agent shutdown via harness-support from the Warp CLI"
-            }
-            CliTelemetryEventDiscriminants::HarnessSupportReportErrorShutdown => {
-                "Reported error agent shutdown via harness-support from the Warp CLI"
+            CliTelemetryEventDiscriminants::HarnessSupportReportShutdown => {
+                "Reported agent shutdown via harness-support from the Warp CLI"
             }
         }
     }

--- a/app/src/ai/agent_sdk/telemetry.rs
+++ b/app/src/ai/agent_sdk/telemetry.rs
@@ -112,8 +112,10 @@ pub(super) enum CliTelemetryEvent {
     HarnessSupportNotifyUser,
     /// Executing `warp harness-support finish-task`
     HarnessSupportFinishTask { success: bool },
-    /// Executing `warp harness-support report-shutdown`
-    HarnessSupportReportShutdown,
+    /// Executing `warp harness-support report-clean-shutdown`
+    HarnessSupportReportCleanShutdown,
+    /// Executing `warp harness-support report-error-shutdown`
+    HarnessSupportReportErrorShutdown,
 }
 
 impl TelemetryEvent for CliTelemetryEvent {
@@ -190,7 +192,8 @@ impl TelemetryEvent for CliTelemetryEvent {
             CliTelemetryEvent::HarnessSupportFinishTask { success } => {
                 Some(json!({ "success": success }))
             }
-            CliTelemetryEvent::HarnessSupportReportShutdown => None,
+            CliTelemetryEvent::HarnessSupportReportCleanShutdown => None,
+            CliTelemetryEvent::HarnessSupportReportErrorShutdown => None,
         }
     }
 
@@ -277,8 +280,11 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             CliTelemetryEventDiscriminants::HarnessSupportFinishTask => {
                 "CLI.Execute.HarnessSupport.FinishTask"
             }
-            CliTelemetryEventDiscriminants::HarnessSupportReportShutdown => {
-                "CLI.Execute.HarnessSupport.ReportShutdown"
+            CliTelemetryEventDiscriminants::HarnessSupportReportCleanShutdown => {
+                "CLI.Execute.HarnessSupport.ReportCleanShutdown"
+            }
+            CliTelemetryEventDiscriminants::HarnessSupportReportErrorShutdown => {
+                "CLI.Execute.HarnessSupport.ReportErrorShutdown"
             }
         }
     }
@@ -402,8 +408,11 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             CliTelemetryEventDiscriminants::HarnessSupportFinishTask => {
                 "Reported task completion via harness-support from the Warp CLI"
             }
-            CliTelemetryEventDiscriminants::HarnessSupportReportShutdown => {
-                "Reported agent shutdown via harness-support from the Warp CLI"
+            CliTelemetryEventDiscriminants::HarnessSupportReportCleanShutdown => {
+                "Reported clean agent shutdown via harness-support from the Warp CLI"
+            }
+            CliTelemetryEventDiscriminants::HarnessSupportReportErrorShutdown => {
+                "Reported error agent shutdown via harness-support from the Warp CLI"
             }
         }
     }
@@ -416,10 +425,7 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             Self::HarnessSupportPing
             | Self::HarnessSupportReportArtifact
             | Self::HarnessSupportNotifyUser
-            | Self::HarnessSupportFinishTask
-            | Self::HarnessSupportReportShutdown => {
-                EnablementState::Flag(FeatureFlag::AgentHarness)
-            }
+            | Self::HarnessSupportFinishTask => EnablementState::Flag(FeatureFlag::AgentHarness),
             Self::ArtifactUpload | Self::ArtifactGet | Self::ArtifactDownload => {
                 EnablementState::Flag(FeatureFlag::ArtifactCommand)
             }

--- a/app/src/server/server_api/harness_support.rs
+++ b/app/src/server/server_api/harness_support.rs
@@ -112,6 +112,32 @@ struct FinishTaskRequest {
     summary: String,
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+struct ShutdownError {
+    category: String,
+    message: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ReportShutdownRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<ShutdownError>,
+}
+
+impl ReportShutdownRequest {
+    /// A clean shutdown with no error payload.
+    pub fn clean() -> Self {
+        Self { error: None }
+    }
+
+    /// An abnormal shutdown carrying an error category and message.
+    pub fn abnormal(category: String, message: String) -> Self {
+        Self {
+            error: Some(ShutdownError { category, message }),
+        }
+    }
+}
+
 /// Trait for API endpoints used to support third-party agent harnesses in Oz.
 #[cfg_attr(test, automock)]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
@@ -144,6 +170,16 @@ pub trait HarnessSupportClient: 'static + Send + Sync {
     /// Report task completion or failure. The server derives PR links/branches from
     /// artifacts already reported via `report_artifact`.
     async fn finish_task(&self, success: bool, summary: &str) -> Result<()>;
+
+    /// Report that the agent process is shutting down.
+    ///
+    /// For a clean shutdown, pass `None` for both category/message.
+    /// For an abnormal shutdown, pass the error category and message.
+    async fn report_shutdown(
+        &self,
+        error_category: Option<String>,
+        error_message: Option<String>,
+    ) -> Result<()>;
 
     /// Get presigned upload targets for a workspace state snapshot.
     ///
@@ -355,6 +391,21 @@ impl HarnessSupportClient for ServerApi {
             },
         )
         .await
+    }
+
+    async fn report_shutdown(
+        &self,
+        error_category: Option<String>,
+        error_message: Option<String>,
+    ) -> Result<()> {
+        let request = match (error_category, error_message) {
+            (Some(category), Some(message)) => {
+                ReportShutdownRequest::abnormal(category, message)
+            }
+            _ => ReportShutdownRequest::clean(),
+        };
+        self.post_public_api_unit("harness-support/report-shutdown", &request)
+            .await
     }
 
     async fn get_snapshot_upload_targets(

--- a/app/src/server/server_api/harness_support.rs
+++ b/app/src/server/server_api/harness_support.rs
@@ -399,9 +399,7 @@ impl HarnessSupportClient for ServerApi {
         error_message: Option<String>,
     ) -> Result<()> {
         let request = match (error_category, error_message) {
-            (Some(category), Some(message)) => {
-                ReportShutdownRequest::abnormal(category, message)
-            }
+            (Some(category), Some(message)) => ReportShutdownRequest::abnormal(category, message),
             _ => ReportShutdownRequest::clean(),
         };
         self.post_public_api_unit("harness-support/report-shutdown", &request)

--- a/app/src/server/server_api/harness_support.rs
+++ b/app/src/server/server_api/harness_support.rs
@@ -399,8 +399,13 @@ impl HarnessSupportClient for ServerApi {
         error_message: Option<String>,
     ) -> Result<()> {
         let request = match (error_category, error_message) {
-            (Some(category), Some(message)) => ReportShutdownRequest::abnormal(category, message),
-            _ => ReportShutdownRequest::clean(),
+            (Some(category), Some(message)) => {
+                ReportShutdownRequest::abnormal(category, message)
+            }
+            (None, None) => ReportShutdownRequest::clean(),
+            (Some(_), None) | (None, Some(_)) => {
+                anyhow::bail!("error-category and error-message must be provided together");
+            }
         };
         self.post_public_api_unit("harness-support/report-shutdown", &request)
             .await

--- a/app/src/server/server_api/harness_support.rs
+++ b/app/src/server/server_api/harness_support.rs
@@ -399,9 +399,7 @@ impl HarnessSupportClient for ServerApi {
         error_message: Option<String>,
     ) -> Result<()> {
         let request = match (error_category, error_message) {
-            (Some(category), Some(message)) => {
-                ReportShutdownRequest::abnormal(category, message)
-            }
+            (Some(category), Some(message)) => ReportShutdownRequest::abnormal(category, message),
             (None, None) => ReportShutdownRequest::clean(),
             (Some(_), None) | (None, Some(_)) => {
                 anyhow::bail!("error-category and error-message must be provided together");

--- a/app/src/server/server_api/harness_support.rs
+++ b/app/src/server/server_api/harness_support.rs
@@ -171,14 +171,14 @@ pub trait HarnessSupportClient: 'static + Send + Sync {
     /// artifacts already reported via `report_artifact`.
     async fn finish_task(&self, success: bool, summary: &str) -> Result<()>;
 
-    /// Report that the agent process is shutting down.
-    ///
-    /// For a clean shutdown, pass `None` for both category/message.
-    /// For an abnormal shutdown, pass the error category and message.
-    async fn report_shutdown(
+    /// Report a clean shutdown of the agent process.
+    async fn report_clean_shutdown(&self) -> Result<()>;
+
+    /// Report an error shutdown of the agent process.
+    async fn report_error_shutdown(
         &self,
-        error_category: Option<String>,
-        error_message: Option<String>,
+        error_category: String,
+        error_message: String,
     ) -> Result<()>;
 
     /// Get presigned upload targets for a workspace state snapshot.
@@ -393,20 +393,24 @@ impl HarnessSupportClient for ServerApi {
         .await
     }
 
-    async fn report_shutdown(
+    async fn report_clean_shutdown(&self) -> Result<()> {
+        self.post_public_api_unit(
+            "harness-support/report-shutdown",
+            &ReportShutdownRequest::clean(),
+        )
+        .await
+    }
+
+    async fn report_error_shutdown(
         &self,
-        error_category: Option<String>,
-        error_message: Option<String>,
+        error_category: String,
+        error_message: String,
     ) -> Result<()> {
-        let request = match (error_category, error_message) {
-            (Some(category), Some(message)) => ReportShutdownRequest::abnormal(category, message),
-            (None, None) => ReportShutdownRequest::clean(),
-            (Some(_), None) | (None, Some(_)) => {
-                anyhow::bail!("error-category and error-message must be provided together");
-            }
-        };
-        self.post_public_api_unit("harness-support/report-shutdown", &request)
-            .await
+        self.post_public_api_unit(
+            "harness-support/report-shutdown",
+            &ReportShutdownRequest::abnormal(error_category, error_message),
+        )
+        .await
     }
 
     async fn get_snapshot_upload_targets(

--- a/app/src/server/server_api/harness_support_tests.rs
+++ b/app/src/server/server_api/harness_support_tests.rs
@@ -23,3 +23,29 @@ fn pull_request_artifact_serializes_to_expected_wire_format() {
         })
     );
 }
+
+#[test]
+fn report_shutdown_clean_serializes_without_error() {
+    use super::ReportShutdownRequest;
+
+    let request = ReportShutdownRequest::clean();
+    let json = serde_json::to_value(&request).unwrap();
+    assert_eq!(json, serde_json::json!({}));
+}
+
+#[test]
+fn report_shutdown_abnormal_serializes_with_error() {
+    use super::ReportShutdownRequest;
+
+    let request = ReportShutdownRequest::abnormal("oom".to_string(), "out of memory".to_string());
+    let json = serde_json::to_value(&request).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "error": {
+                "category": "oom",
+                "message": "out of memory"
+            }
+        })
+    );
+}

--- a/crates/warp_cli/src/harness_support.rs
+++ b/crates/warp_cli/src/harness_support.rs
@@ -28,6 +28,9 @@ pub enum HarnessSupportCommand {
 
     /// Report task completion or failure, as well as a summary of the task.
     FinishTask(FinishTaskArgs),
+
+    /// Report that the agent process is shutting down.
+    ReportShutdown(ReportShutdownArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -75,4 +78,17 @@ pub struct FinishTaskArgs {
     /// A summary of the task outcome.
     #[arg(long)]
     pub summary: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ReportShutdownArgs {
+    /// Error category for abnormal shutdown (e.g. "oom", "timeout").
+    /// Omit for clean shutdown.
+    #[arg(long)]
+    pub error_category: Option<String>,
+
+    /// Human-readable error message for abnormal shutdown.
+    /// Omit for clean shutdown.
+    #[arg(long)]
+    pub error_message: Option<String>,
 }

--- a/crates/warp_cli/src/harness_support.rs
+++ b/crates/warp_cli/src/harness_support.rs
@@ -29,8 +29,11 @@ pub enum HarnessSupportCommand {
     /// Report task completion or failure, as well as a summary of the task.
     FinishTask(FinishTaskArgs),
 
-    /// Report that the agent process is shutting down.
-    ReportShutdown(ReportShutdownArgs),
+    /// Report a clean shutdown of the agent process.
+    ReportCleanShutdown,
+
+    /// Report an error shutdown of the agent process.
+    ReportErrorShutdown(ReportErrorShutdownArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -81,14 +84,12 @@ pub struct FinishTaskArgs {
 }
 
 #[derive(Debug, Clone, Args)]
-pub struct ReportShutdownArgs {
-    /// Error category for abnormal shutdown (e.g. "oom", "timeout").
-    /// Omit for clean shutdown.
+pub struct ReportErrorShutdownArgs {
+    /// Error category for the abnormal shutdown (e.g. "oom", "timeout").
     #[arg(long)]
-    pub error_category: Option<String>,
+    pub error_category: String,
 
-    /// Human-readable error message for abnormal shutdown.
-    /// Omit for clean shutdown.
+    /// Human-readable error message for the abnormal shutdown.
     #[arg(long)]
-    pub error_message: Option<String>,
+    pub error_message: String,
 }

--- a/crates/warp_cli/src/harness_support.rs
+++ b/crates/warp_cli/src/harness_support.rs
@@ -29,11 +29,8 @@ pub enum HarnessSupportCommand {
     /// Report task completion or failure, as well as a summary of the task.
     FinishTask(FinishTaskArgs),
 
-    /// Report a clean shutdown of the agent process.
-    ReportCleanShutdown,
-
-    /// Report an error shutdown of the agent process.
-    ReportErrorShutdown(ReportErrorShutdownArgs),
+    /// Report that the agent process is shutting down.
+    ReportShutdown(ReportShutdownArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -84,12 +81,14 @@ pub struct FinishTaskArgs {
 }
 
 #[derive(Debug, Clone, Args)]
-pub struct ReportErrorShutdownArgs {
-    /// Error category for the abnormal shutdown (e.g. "oom", "timeout").
+pub struct ReportShutdownArgs {
+    /// Error category for abnormal shutdown (e.g. "oom", "timeout").
+    /// Omit for clean shutdown.
     #[arg(long)]
-    pub error_category: String,
+    pub error_category: Option<String>,
 
-    /// Human-readable error message for the abnormal shutdown.
+    /// Human-readable error message for abnormal shutdown.
+    /// Omit for clean shutdown.
     #[arg(long)]
-    pub error_message: String,
+    pub error_message: Option<String>,
 }

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -1894,3 +1894,60 @@ fn finish_task_rejects_missing_status() {
     ]);
     assert!(result.is_err());
 }
+
+#[test]
+fn report_shutdown_clean_parses() {
+    let args = Args::try_parse_from([
+        "warp",
+        "harness-support",
+        "--run-id",
+        "run-1",
+        "report-shutdown",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected harness-support command");
+    };
+    let CliCommand::HarnessSupport(hs_args) = boxed_cmd.as_ref() else {
+        panic!("Expected harness-support command");
+    };
+    let HarnessSupportCommand::ReportShutdown(shutdown_args) = &hs_args.command else {
+        panic!("Expected report-shutdown subcommand");
+    };
+
+    assert!(shutdown_args.error_category.is_none());
+    assert!(shutdown_args.error_message.is_none());
+}
+
+#[test]
+fn report_shutdown_abnormal_parses() {
+    let args = Args::try_parse_from([
+        "warp",
+        "harness-support",
+        "--run-id",
+        "run-1",
+        "report-shutdown",
+        "--error-category",
+        "oom",
+        "--error-message",
+        "out of memory",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected harness-support command");
+    };
+    let CliCommand::HarnessSupport(hs_args) = boxed_cmd.as_ref() else {
+        panic!("Expected harness-support command");
+    };
+    let HarnessSupportCommand::ReportShutdown(shutdown_args) = &hs_args.command else {
+        panic!("Expected report-shutdown subcommand");
+    };
+
+    assert_eq!(shutdown_args.error_category.as_deref(), Some("oom"));
+    assert_eq!(
+        shutdown_args.error_message.as_deref(),
+        Some("out of memory")
+    );
+}

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -1896,13 +1896,13 @@ fn finish_task_rejects_missing_status() {
 }
 
 #[test]
-fn report_shutdown_clean_parses() {
+fn report_clean_shutdown_parses() {
     let args = Args::try_parse_from([
         "warp",
         "harness-support",
         "--run-id",
         "run-1",
-        "report-shutdown",
+        "report-clean-shutdown",
     ])
     .unwrap();
 
@@ -1912,22 +1912,20 @@ fn report_shutdown_clean_parses() {
     let CliCommand::HarnessSupport(hs_args) = boxed_cmd.as_ref() else {
         panic!("Expected harness-support command");
     };
-    let HarnessSupportCommand::ReportShutdown(shutdown_args) = &hs_args.command else {
-        panic!("Expected report-shutdown subcommand");
-    };
-
-    assert!(shutdown_args.error_category.is_none());
-    assert!(shutdown_args.error_message.is_none());
+    assert!(matches!(
+        hs_args.command,
+        HarnessSupportCommand::ReportCleanShutdown
+    ));
 }
 
 #[test]
-fn report_shutdown_abnormal_parses() {
+fn report_error_shutdown_parses() {
     let args = Args::try_parse_from([
         "warp",
         "harness-support",
         "--run-id",
         "run-1",
-        "report-shutdown",
+        "report-error-shutdown",
         "--error-category",
         "oom",
         "--error-message",
@@ -1941,13 +1939,22 @@ fn report_shutdown_abnormal_parses() {
     let CliCommand::HarnessSupport(hs_args) = boxed_cmd.as_ref() else {
         panic!("Expected harness-support command");
     };
-    let HarnessSupportCommand::ReportShutdown(shutdown_args) = &hs_args.command else {
-        panic!("Expected report-shutdown subcommand");
+    let HarnessSupportCommand::ReportErrorShutdown(shutdown_args) = &hs_args.command else {
+        panic!("Expected report-error-shutdown subcommand");
     };
 
-    assert_eq!(shutdown_args.error_category.as_deref(), Some("oom"));
-    assert_eq!(
-        shutdown_args.error_message.as_deref(),
-        Some("out of memory")
-    );
+    assert_eq!(shutdown_args.error_category, "oom");
+    assert_eq!(shutdown_args.error_message, "out of memory");
+}
+
+#[test]
+fn report_error_shutdown_rejects_missing_fields() {
+    let result = Args::try_parse_from([
+        "warp",
+        "harness-support",
+        "--run-id",
+        "run-1",
+        "report-error-shutdown",
+    ]);
+    assert!(result.is_err());
 }

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -1896,13 +1896,13 @@ fn finish_task_rejects_missing_status() {
 }
 
 #[test]
-fn report_clean_shutdown_parses() {
+fn report_shutdown_clean_parses() {
     let args = Args::try_parse_from([
         "warp",
         "harness-support",
         "--run-id",
         "run-1",
-        "report-clean-shutdown",
+        "report-shutdown",
     ])
     .unwrap();
 
@@ -1912,20 +1912,22 @@ fn report_clean_shutdown_parses() {
     let CliCommand::HarnessSupport(hs_args) = boxed_cmd.as_ref() else {
         panic!("Expected harness-support command");
     };
-    assert!(matches!(
-        hs_args.command,
-        HarnessSupportCommand::ReportCleanShutdown
-    ));
+    let HarnessSupportCommand::ReportShutdown(shutdown_args) = &hs_args.command else {
+        panic!("Expected report-shutdown subcommand");
+    };
+
+    assert!(shutdown_args.error_category.is_none());
+    assert!(shutdown_args.error_message.is_none());
 }
 
 #[test]
-fn report_error_shutdown_parses() {
+fn report_shutdown_abnormal_parses() {
     let args = Args::try_parse_from([
         "warp",
         "harness-support",
         "--run-id",
         "run-1",
-        "report-error-shutdown",
+        "report-shutdown",
         "--error-category",
         "oom",
         "--error-message",
@@ -1939,22 +1941,13 @@ fn report_error_shutdown_parses() {
     let CliCommand::HarnessSupport(hs_args) = boxed_cmd.as_ref() else {
         panic!("Expected harness-support command");
     };
-    let HarnessSupportCommand::ReportErrorShutdown(shutdown_args) = &hs_args.command else {
-        panic!("Expected report-error-shutdown subcommand");
+    let HarnessSupportCommand::ReportShutdown(shutdown_args) = &hs_args.command else {
+        panic!("Expected report-shutdown subcommand");
     };
 
-    assert_eq!(shutdown_args.error_category, "oom");
-    assert_eq!(shutdown_args.error_message, "out of memory");
-}
-
-#[test]
-fn report_error_shutdown_rejects_missing_fields() {
-    let result = Args::try_parse_from([
-        "warp",
-        "harness-support",
-        "--run-id",
-        "run-1",
-        "report-error-shutdown",
-    ]);
-    assert!(result.is_err());
+    assert_eq!(shutdown_args.error_category.as_deref(), Some("oom"));
+    assert_eq!(
+        shutdown_args.error_message.as_deref(),
+        Some("out of memory")
+    );
 }


### PR DESCRIPTION
## Description

Add a new `report-shutdown` subcommand to `oz harness-support` that reports agent process shutdown to the Oz platform.

This supports the agent reporting shutdown and execution completion discretely at the end of an Oz cloud agent turn. `finish-task` remains the user-facing task outcome signal, while `report-shutdown` lets the runtime close out the active execution after the agent process has finished its post-completion idle period.

This supports both clean shutdown (no error payload) and abnormal shutdown (with `--error-category` and `--error-message` flags).

**Command syntax:**
- Clean shutdown: `oz harness-support --run-id "$OZ_RUN_ID" report-shutdown`
- Abnormal shutdown: `oz harness-support --run-id "$OZ_RUN_ID" report-shutdown --error-category oom --error-message "out of memory"`

**Payload shape:**
- Clean: `{}` (empty JSON body, `error` field is omitted via `skip_serializing_if`)
- Abnormal: `{ "error": { "category": "oom", "message": "out of memory" } }`

**Server endpoint:** `POST /api/v1/harness-support/report-shutdown`

### Files changed:
- `crates/warp_cli/src/harness_support.rs` — CLI argument definitions (`ReportShutdownArgs`, `ReportShutdown` variant)
- `app/src/server/server_api/harness_support.rs` — `HarnessSupportClient::report_shutdown()` trait method and `ServerApi` impl
- `app/src/ai/agent_sdk/harness_support.rs` — Command dispatch
- `app/src/ai/agent_sdk/telemetry.rs` — Telemetry event
- `app/src/ai/agent_sdk/mod.rs` — Telemetry mapping
- `app/src/ai/agent_sdk/driver/snapshot_tests.rs` — TestClient impl
- `crates/warp_cli/src/lib_tests.rs` — CLI parsing tests
- `app/src/server/server_api/harness_support_tests.rs` — Serialization tests

## Linked Issue

N/A — This is part of the Docker sandbox report-shutdown feature.

## Testing

- CLI parsing tests pass for both clean and abnormal shutdown variants
- Serialization tests verify the wire format for both clean (`{}`) and abnormal (`{ "error": { ... } }`) payloads
- `cargo fmt` and `cargo clippy` pass cleanly

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/de2bb31c-8c5f-440d-8373-175529dc7cf2_
_Run: https://oz.staging.warp.dev/runs/019e044c-c561-7931-a402-1fa2ff60bb28_
_This PR was generated with [Oz](https://warp.dev/oz)._
