### PR TITLE
remove block attachment in has_locking_attachment

### DIFF
--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -358,9 +358,9 @@ impl BlocklistAIContextModel {
     }
 
     /// Returns `true` if the next AI query has any context that should force the input to be
-    /// locked in AI mode (skipping NLD): a pending image or file attachment, or a pending block.
+    /// locked in AI mode (skipping NLD): a pending image or file attachment.
     pub fn has_locking_attachment(&self) -> bool {
-        !self.pending_context_block_ids.is_empty() || !self.pending_attachments.is_empty()
+        !self.pending_attachments.is_empty()
     }
 
     /// Returns the set `BlockId`s corresponding to blocks to be included as context with the next

--- a/app/src/ai/blocklist/context_model_tests.rs
+++ b/app/src/ai/blocklist/context_model_tests.rs
@@ -100,7 +100,9 @@ fn has_locking_attachment_is_false_for_default_state() {
 }
 
 #[test]
-fn has_locking_attachment_is_true_with_pending_block_id() {
+fn has_locking_attachment_is_false_with_only_pending_block_id() {
+    // A pending block alone is *not* a locking attachment: only image/file attachments
+    // should force the input into AI mode (skipping NLD).
     App::test((), |mut app| async move {
         let model = build_test_context_model(&mut app);
 
@@ -108,7 +110,7 @@ fn has_locking_attachment_is_true_with_pending_block_id() {
             m.insert_pending_block_id_for_test(BlockId::new());
         });
 
-        model.read(&app, |m, _| assert!(m.has_locking_attachment()));
+        model.read(&app, |m, _| assert!(!m.has_locking_attachment()));
     });
 }
 
@@ -116,7 +118,7 @@ fn has_locking_attachment_is_true_with_pending_block_id() {
 fn has_locking_attachment_is_false_with_only_pending_selected_text() {
     // Selected text alone is *not* a locking attachment: the user could be selecting shell
     // command text (e.g. to copy a previously-run command), and forcing the input into AI
-    // mode in that case would be wrong. Only images, files, or blocks should force the lock.
+    // mode in that case would be wrong. Only image or file attachments should force the lock.
     App::test((), |mut app| async move {
         let model = build_test_context_model(&mut app);
 

--- a/app/src/ai/blocklist/input_model.rs
+++ b/app/src/ai/blocklist/input_model.rs
@@ -149,8 +149,8 @@ pub struct BlocklistAIInputModel {
 
     agent_view_controller: ModelHandle<AgentViewController>,
 
-    /// Handle to the per-pane context model. Used to read pending attachments / blocks when
-    /// deciding whether to force-lock the input to AI mode (see
+    /// Handle to the per-pane context model. Used to read pending image / file attachments
+    /// when deciding whether to force-lock the input to AI mode (see
     /// [`BlocklistAIContextModel::has_locking_attachment`]).
     ai_context_model: ModelHandle<BlocklistAIContextModel>,
 
@@ -276,10 +276,9 @@ impl BlocklistAIInputModel {
                         );
                     } else if me.has_locking_attachment(ctx) {
                         // Interaction patterns that should fully bypass NLD on
-                        // entry: image / file attachment in progress / attached, or block
-                        // already in pending context. Force-lock to AI regardless of the
-                        // user's NLD setting so the classifier never gets a chance to drop
-                        // the buffer back to shell.
+                        // entry: image / file attachment in progress / attached.
+                        // Force-lock to AI regardless of the user's NLD setting so the
+                        // classifier never gets a chance to drop the buffer back to shell.
                         me.set_input_config_internal(
                             InputConfig {
                                 input_type: InputType::AI,
@@ -514,10 +513,10 @@ impl BlocklistAIInputModel {
             return false;
         }
 
-        // Defense in depth: while there is a pending attachment (image / file) or block,
-        // the classifier must never have a chance to flip the input back to shell mode, even
-        // per-keystroke. The `EnteredAgentView` subscriber and `set_input_mode_agent` already
-        // lock at entry; this guard protects the window if any future caller forgets.
+        // Defense in depth: while there is a pending image / file attachment, the classifier
+        // must never have a chance to flip the input back to shell mode, even per-keystroke.
+        // The `EnteredAgentView` subscriber and `set_input_mode_agent` already lock at entry;
+        // this guard protects the window if any future caller forgets.
         if self.has_locking_attachment(app) {
             return false;
         }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -13220,9 +13220,9 @@ impl Input {
         // When AgentView is enabled, reverting to AI mode in an active agent view with an empty
         // buffer should unlock (re-enable autodetection) - semantically like clearing the "!".
         //
-        // If there is a pending image / file attachment or block, do NOT unlock. The user's
-        // intent is unambiguously "talk to the agent"; letting the classifier flip the input
-        // back to shell mode would be a bug.
+        // If there is a pending image / file attachment, do NOT unlock. The user's intent is
+        // unambiguously "talk to the agent"; letting the classifier flip the input back to
+        // shell mode would be a bug.
         let has_locking_attachment = self.ai_context_model.as_ref(ctx).has_locking_attachment();
         let should_unlock = FeatureFlag::AgentView.is_enabled()
             && self.agent_view_controller.as_ref(ctx).is_fullscreen()


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
Context [slack thread](https://warpdev.slack.com/archives/C08KTPNQN65/p1778169331998099)
Remove block attachment as a quick fix to unblock release
## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end. 

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up. 
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->
attach image/file: lock NLD to agent
attach/click block: no lock applied; NLD will be triggered
https://www.loom.com/share/44f8c980cd61415e8f22667e0bb699cd
## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->

## Reviewer
@szgupta @vorporeal @harryalbert @danielpeng2 
