### PR TITLE
Scope upward menu positioning to confirmation card only

### DIFF
--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -11,9 +11,8 @@ use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationExecutio
 use pathfinder_color::ColorU;
 use std::fmt::Debug;
 use warpui::elements::{
-    ChildAnchor, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty,
-    Expanded, Flex, Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement,
-    PositionedElementAnchor, Radius, Text,
+    ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty, Expanded, Flex,
+    Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement, Radius, Text,
 };
 use warpui::platform::Cursor;
 use warpui::ui_components::button::ButtonVariant;
@@ -33,7 +32,7 @@ use crate::appearance::Appearance;
 use crate::menu::{MenuItem, MenuItemFields};
 use crate::ui_components::blended_colors;
 use crate::view_components::dropdown::{Dropdown, DropdownAction, DropdownStyle};
-use crate::view_components::{FilterableDropdown, FilterableDropdownOrientation};
+use crate::view_components::FilterableDropdown;
 use crate::LLMPreferences;
 
 // ── Shared constants ────────────────────────────────────────────────
@@ -282,12 +281,6 @@ pub fn new_standard_picker_dropdown<A: OrchestrationControlAction, V: View>(
         dropdown.set_border_width(ORCHESTRATION_PICKER_BORDER_WIDTH, ctx_dropdown);
         dropdown.set_font_size(ORCHESTRATION_PICKER_FONT_SIZE, ctx_dropdown);
         dropdown.set_font_color(font_color, ctx_dropdown);
-        // Open menus above the trigger to avoid overlapping the input box.
-        dropdown.set_menu_position(
-            PositionedElementAnchor::TopLeft,
-            ChildAnchor::BottomLeft,
-            ctx_dropdown,
-        );
         dropdown
     })
 }
@@ -436,8 +429,6 @@ pub fn create_environment_picker<A: OrchestrationControlAction, V: View>(
         dropdown.set_style(styles);
         dropdown.set_top_bar_height(ORCHESTRATION_PICKER_HEIGHT, ctx_dropdown);
         dropdown.set_top_bar_max_width(f32::INFINITY);
-        // Open menu above the trigger to avoid overlapping the input box.
-        dropdown.set_orientation(FilterableDropdownOrientation::Up);
         dropdown
     });
     dropdown_handle.update(ctx, |dropdown, ctx_dropdown| {

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -50,7 +50,7 @@ use crate::view_components::compactible_action_button::{
 };
 use crate::view_components::compactible_split_action_button::CompactibleSplitActionButton;
 use crate::view_components::dropdown::DropdownEvent;
-use crate::view_components::FilterableDropdownEvent;
+use crate::view_components::{FilterableDropdownEvent, FilterableDropdownOrientation};
 
 const RUN_AGENTS_CARD_TITLE: &str = "Can I start additional agents for this task?";
 
@@ -503,6 +503,7 @@ impl RunAgentsCardView {
                 state.orch.model_id.clone()
             };
             let handle = oc::new_standard_picker_dropdown(&colors, ctx);
+            Self::set_upward_menu_position(&handle, ctx);
             oc::populate_model_picker_for_harness(
                 &handle,
                 &initial_model_id,
@@ -515,6 +516,7 @@ impl RunAgentsCardView {
 
         if self.handles.pickers.harness_picker.is_none() {
             let handle = oc::new_standard_picker_dropdown(&colors, ctx);
+            Self::set_upward_menu_position(&handle, ctx);
             oc::populate_harness_picker(&handle, &state.orch.harness_type, ctx);
             Self::subscribe_picker_close(&handle, ctx);
             self.handles.pickers.harness_picker = Some(handle);
@@ -526,6 +528,9 @@ impl RunAgentsCardView {
                 RunAgentsExecutionMode::Local => "",
             };
             let handle = oc::create_environment_picker(initial_env, &styles, ctx);
+            handle.update(ctx, |d, _| {
+                d.set_orientation(FilterableDropdownOrientation::Up)
+            });
             ctx.subscribe_to_view(&handle, |me, _, event, ctx| {
                 if let FilterableDropdownEvent::Close = event {
                     me.refocus_after_picker_close(ctx);
@@ -540,12 +545,31 @@ impl RunAgentsCardView {
                 RunAgentsExecutionMode::Local => oc::ORCHESTRATION_WARP_WORKER_HOST,
             };
             let handle = oc::new_standard_picker_dropdown(&colors, ctx);
+            Self::set_upward_menu_position(&handle, ctx);
             oc::populate_host_picker(&handle, initial_host, ctx);
             Self::subscribe_picker_close(&handle, ctx);
             self.handles.pickers.host_picker = Some(handle);
         }
 
         self.sync_picker_selections(ctx);
+    }
+
+    /// Opens the dropdown menu above the trigger to avoid overlapping
+    /// the input box. Only used by the confirmation card — the plan
+    /// config card renders higher up where downward menus are fine.
+    fn set_upward_menu_position(
+        dropdown_handle: &ViewHandle<
+            crate::view_components::dropdown::Dropdown<RunAgentsCardViewAction>,
+        >,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        dropdown_handle.update(ctx, |dropdown, ctx| {
+            dropdown.set_menu_position(
+                warpui::elements::PositionedElementAnchor::TopLeft,
+                warpui::elements::ChildAnchor::BottomLeft,
+                ctx,
+            );
+        });
     }
 
     fn subscribe_picker_close(


### PR DESCRIPTION
## What
Move upward dropdown positioning (TopLeft/BottomLeft anchors, FilterableDropdownOrientation::Up) out of the shared picker helpers and apply it only in RunAgentsCardView::ensure_pickers. This prevents the plan config card's pickers from also opening upward.

## Why
Follow-up to #10399 — the upward positioning was baked into the shared helpers, affecting both the confirmation card (where it's needed to avoid input overlap) and the plan config card (where it's not needed and looks wrong).

## Demo
https://www.loom.com/share/6fbd59a6a7364368b0eef0922710e3b4

## Agent Mode
- [x] This PR was created by Warp Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>