### PR TITLE
feat: hide HandoffRehydration system query in restored conversations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14832,7 +14832,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=9824c453c746003aca2b61c526fb73d6ca910359#9824c453c746003aca2b61c526fb73d6ca910359"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=3dd0cd81eae83b4ce09c7805c8ef12599798aa26#3dd0cd81eae83b4ce09c7805c8ef12599798aa26"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "9824c453c746003aca2b61c526fb73d6ca910359" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "3dd0cd81eae83b4ce09c7805c8ef12599798aa26" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -436,7 +436,10 @@ impl ConvertToExchanges for &api::Task {
                         api::message::system_query::Type::ResumeConversation(_)
                         | api::message::system_query::Type::GeneratePassiveSuggestions(_)
                         // TODO: Implement this for real. ZB adding this to bump proto version for unrelated API changes.
-                        | api::message::system_query::Type::SummarizeConversation(_)=> false,
+                        | api::message::system_query::Type::SummarizeConversation(_)
+                        // HandoffRehydration is injected by the server for agent-only
+                        // context; the client must never render it as user input.
+                        | api::message::system_query::Type::HandoffRehydration(_) => false,
                     }
                 }
                 api::message::Message::ToolCallResult(tool_call_result) => {

--- a/app/src/ai/agent/api/convert_conversation_tests.rs
+++ b/app/src/ai/agent/api/convert_conversation_tests.rs
@@ -1979,3 +1979,72 @@ fn test_create_then_edit_then_create_version_tracking() {
         "Created doc B should have default version (v1), independent of doc A"
     );
 }
+
+/// Verify that a `SystemQuery::HandoffRehydration` message does not produce
+/// a displayed input when restoring a conversation. It must be treated as
+/// hidden, so the exchange should have zero user-visible inputs.
+#[test]
+fn test_handoff_rehydration_system_query_is_hidden() {
+    let messages = vec![
+        // HandoffRehydration system query – should be hidden
+        api::Message {
+            id: "msg_handoff".to_string(),
+            task_id: "task1".to_string(),
+            server_message_data: "".to_string(),
+            citations: vec![],
+            message: Some(api::message::Message::SystemQuery(
+                api::message::SystemQuery {
+                    r#type: Some(api::message::system_query::Type::HandoffRehydration(
+                        api::message::HandoffRehydration {
+                            instructions: "restore handoff state".to_string(),
+                        },
+                    )),
+                    context: None,
+                },
+            )),
+            request_id: "req1".to_string(),
+            timestamp: None,
+        },
+        // Agent output that follows the hidden system query
+        api::Message {
+            id: "msg_output".to_string(),
+            task_id: "task1".to_string(),
+            server_message_data: "".to_string(),
+            citations: vec![],
+            message: Some(api::message::Message::AgentOutput(
+                api::message::AgentOutput {
+                    text: "I have restored the handoff state.".to_string(),
+                },
+            )),
+            request_id: "req1".to_string(),
+            timestamp: None,
+        },
+    ];
+
+    let task = api::Task {
+        id: "task1".to_string(),
+        messages,
+        dependencies: None,
+        description: "".to_string(),
+        summary: "".to_string(),
+        server_data: "".to_string(),
+    };
+
+    let exchanges = task.into_exchanges();
+    assert_eq!(exchanges.len(), 1, "Should produce exactly one exchange");
+
+    let exchange = &exchanges[0];
+    // The HandoffRehydration should NOT appear as input
+    assert!(
+        exchange.input.is_empty(),
+        "HandoffRehydration must not produce a displayed input, got: {:?}",
+        exchange.input
+    );
+
+    // The agent output should still be present
+    let output = exchange.output_status.output().expect("should have output");
+    assert!(
+        !output.get().messages.is_empty(),
+        "Agent output should still be rendered"
+    );
+}


### PR DESCRIPTION
## Description
Client-side compatibility PR for the new `SystemQuery::HandoffRehydration` proto variant (REMOTE-1431).

When the server restores a handed-off conversation, it injects a `HandoffRehydration` system query message containing rehydration instructions for the agent. The client must treat this as **hidden/non-displayed** — it should never render as user-visible input. The real user prompt that follows is still rendered normally.

### Changes
- **Proto dependency**: Update `warp_multi_agent_api` to commit `0706c1a4` which adds `HandoffRehydration` (field 9) to `SystemQuery.type` oneof
- **`convert_conversation.rs`**: Add `HandoffRehydration` to the hidden arm alongside `ResumeConversation`, `GeneratePassiveSuggestions`, and `SummarizeConversation` — returns `false` (no displayed input)
- **Unit test**: Verify `HandoffRehydration` produces no displayed input when reconstructing restored conversations, while agent output is still rendered

### Other match sites (no changes needed)
- `convert_from.rs` `user_inputs_from_messages()` — uses `_ => {}` wildcard, implicitly excludes new variants
- `convert_from.rs` message→output — treats entire `SystemQuery` as `NoClientRepresentation`
- `conversation_yaml.rs` — `SystemQuery` is in the no-searchable-content arm
- `conversation_loader.rs` — only matches specific types (`AutoCodeDiff`, `UserQuery`), new variants are ignored
- `task.rs`, `conversation.rs`, `shared_session.rs` — access `SystemQuery` structurally (context extraction), not variant-specific

### No visible UI added
Handoff messages remain hidden. Real user prompts still render normally.

## Linked Issue
- REMOTE-1431

## Dependencies
- **Proto PR**: https://github.com/warpdotdev/warp-proto-apis/pull/305 (commit `0706c1a4`) — adds `HandoffRehydration` to `SystemQuery.type` oneof
- **Server PR**: https://github.com/warpdotdev/warp-server/pull/10877 (merged) — server-side handoff system prompt changes

## Testing
- `cargo check -p warp` ✅ — compiles cleanly
- `cargo fmt` ✅
- `cargo test -p warp --lib -- test_handoff_rehydration_system_query_is_hidden` ✅ — test passes (1 passed, 0 failed)

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/ff21250a-441a-4076-8886-e03fa10e2c32_
_Run: https://oz.staging.warp.dev/runs/019e04c1-52e0-78a0-83db-736f796b125f_

_This PR was generated with [Oz](https://warp.dev/oz)._
