### PR TITLE
Clip directory from left for orchestration pills

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -23,7 +23,7 @@ use warpui::elements::{
 };
 use warpui::fonts::{Properties, Weight};
 use warpui::platform::Cursor;
-use warpui::text_layout::ClipConfig;
+use warpui::text_layout::{ClipConfig, ClipDirection, ClipStyle};
 use warpui::{
     AppContext, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
     ViewHandle,
@@ -956,7 +956,10 @@ fn render_hover_card(
                 appearance.monospace_font_size() - 1.,
             )
             .with_color(main_text)
-            .with_clip(ClipConfig::ellipsis())
+            .with_clip(ClipConfig {
+                direction: ClipDirection::Start,
+                style: ClipStyle::Ellipsis,
+            })
             .soft_wrap(false)
             .finish()
         });


### PR DESCRIPTION
Confirmed clipping from left works:
<img width="448" height="243" alt="image" src="https://github.com/user-attachments/assets/7afe6cf0-ce1a-41b6-9a0f-cc06a25bf3f9" />

Fixes https://linear.app/warpdotdev/issue/QUALITY-660/clip-directory-from-left-in-hover-card


## Description
The hover card on orchestration pills was clipping the directory path from the right, hiding the meaningful end of the path (e.g. showing `~/.warp-dev/worktrees/warp/moira/app-3…` instead of `…warp/moira/app-3`).

Changed the CWD line's `ClipConfig` from `ClipConfig::ellipsis()` (which clips from the end) to `ClipConfig { direction: ClipDirection::Start, style: ClipStyle::Ellipsis }` so the trailing (most informative) directories stay visible when the path overflows the card width.

This matches the same pattern already used in `render_file_search_row` for file paths.

## Testing
- [x] Builds and passes `cargo clippy` and `cargo fmt`
