### PR TITLE
Restore ambient agent conversations into cloud mode panes, supporting continuation

### DIFF
--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -175,6 +175,12 @@ impl BlocklistAIController {
         }
 
         self.shared_session_state.current_response_id = Some(stream_id.clone());
+        if existing_conversation_id.is_some() {
+            history.update(ctx, |history, ctx| {
+                history.set_viewing_shared_session_for_conversation(conversation_id, true);
+                ctx.notify();
+            });
+        }
 
         let Some(conversation) = history.as_ref(ctx).conversation(&conversation_id) else {
             log::error!(

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -3414,12 +3414,18 @@ impl PaneGroup {
                 }
                 Some(WorkspaceAction::OpenConversationTranscriptViewer {
                     conversation_id,
-                    ambient_agent_task_id: _,
+                    ambient_agent_task_id,
                 }) => {
                     if let Some(target_view) = self.terminal_view_from_pane_id(pane_id, ctx) {
-                        Self::fetch_and_load_transcript(target_view, conversation_id, ctx);
+                        Self::fetch_and_load_transcript(
+                            target_view,
+                            conversation_id,
+                            ambient_agent_task_id,
+                            ctx,
+                        );
                     } else {
-                        self.replace_pane_with_new_cloud_conversation(pane_id, ctx);
+                        self.pending_ambient_agent_conversation_restorations
+                            .insert(task_id, pane_id);
                     }
                 }
                 _ => {
@@ -3433,6 +3439,7 @@ impl PaneGroup {
     fn fetch_and_load_transcript(
         target_view: ViewHandle<TerminalView>,
         server_conversation_token: ServerConversationToken,
+        ambient_agent_task_id: Option<AmbientAgentTaskId>,
         ctx: &mut ViewContext<Self>,
     ) {
         let history_model_handle = BlocklistAIHistoryModel::handle(ctx);
@@ -3442,7 +3449,12 @@ impl PaneGroup {
             .load_conversation_by_server_token(&server_conversation_token, ctx);
         ctx.spawn(future, move |group, conversation, ctx| {
             if let Some(conversation) = conversation {
-                group.load_data_into_transcript_viewer(target_view, conversation, ctx);
+                group.load_data_into_transcript_viewer(
+                    target_view,
+                    conversation,
+                    ambient_agent_task_id,
+                    ctx,
+                );
             } else if let Some(pane_id) =
                 group.find_pane_id_for_terminal_view(target_view.id(), ctx)
             {
@@ -3829,6 +3841,7 @@ impl PaneGroup {
     pub fn load_data_into_conversation_transcript_viewer(
         &mut self,
         conversation: CloudConversationData,
+        ambient_agent_task_id: Option<AmbientAgentTaskId>,
         ctx: &mut ViewContext<Self>,
     ) {
         // Get the active terminal view
@@ -3836,7 +3849,12 @@ impl PaneGroup {
             log::error!("No active terminal view to load conversation into");
             return;
         };
-        self.load_data_into_transcript_viewer(terminal_view, conversation, ctx);
+        self.load_data_into_transcript_viewer(
+            terminal_view,
+            conversation,
+            ambient_agent_task_id,
+            ctx,
+        );
     }
 
     /// Load conversation data into a specific transcript viewer terminal view.
@@ -3844,6 +3862,7 @@ impl PaneGroup {
         &mut self,
         terminal_view: ViewHandle<TerminalView>,
         cloud_conversation: CloudConversationData,
+        ambient_agent_task_id: Option<AmbientAgentTaskId>,
         ctx: &mut ViewContext<Self>,
     ) {
         let terminal_manager = self
@@ -3852,14 +3871,39 @@ impl PaneGroup {
             .and_then(|tpid| self.terminal_session_by_id(tpid))
             .map(|session| session.terminal_manager(ctx));
 
-        let ambient_agent_task_id = match &cloud_conversation {
-            CloudConversationData::Oz(conversation) => conversation
-                .server_metadata()
-                .and_then(|metadata| metadata.ambient_agent_task_id),
-            CloudConversationData::CLIAgent(cli_conversation) => {
-                cli_conversation.metadata.ambient_agent_task_id
+        let ambient_agent_task_id =
+            ambient_agent_task_id.or_else(|| Self::ambient_agent_task_id(&cloud_conversation));
+
+        if FeatureFlag::HandoffCloudCloud.is_enabled() {
+            if let Some(task_id) = ambient_agent_task_id {
+                if terminal_view
+                    .as_ref(ctx)
+                    .ambient_agent_view_model()
+                    .is_some()
+                {
+                    Self::load_data_into_restored_ambient_cloud_mode_view(
+                        terminal_view,
+                        cloud_conversation,
+                        task_id,
+                        ctx,
+                    );
+                    ctx.notify();
+                    return;
+                }
+
+                if let Some(pane_id) = self.find_pane_id_for_terminal_view(terminal_view.id(), ctx)
+                {
+                    self.replace_loading_pane_with_restored_ambient_cloud_mode_pane(
+                        pane_id,
+                        cloud_conversation,
+                        task_id,
+                        ctx,
+                    );
+                    ctx.notify();
+                    return;
+                }
             }
-        };
+        }
 
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, _ctx| {
             history_model.mark_terminal_view_as_conversation_transcript_viewer(terminal_view.id());
@@ -5171,6 +5215,138 @@ impl PaneGroup {
         success
     }
 
+    fn ambient_agent_task_id(
+        cloud_conversation: &CloudConversationData,
+    ) -> Option<AmbientAgentTaskId> {
+        match cloud_conversation {
+            CloudConversationData::Oz(conversation) => conversation
+                .server_metadata()
+                .and_then(|metadata| metadata.ambient_agent_task_id),
+            CloudConversationData::CLIAgent(cli_conversation) => {
+                cli_conversation.metadata.ambient_agent_task_id
+            }
+        }
+    }
+
+    fn replace_loading_pane_with_restored_ambient_cloud_mode_pane(
+        &mut self,
+        loading_pane_id: PaneId,
+        cloud_conversation: CloudConversationData,
+        task_id: AmbientAgentTaskId,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        let resources = TerminalViewResources {
+            tips_completed: self.tips_completed.clone(),
+            server_api: self.server_api.clone(),
+            model_event_sender: self.model_event_sender.clone(),
+        };
+        let view_bounds = Self::estimated_view_bounds(ctx);
+        let (terminal_view, terminal_manager) =
+            Self::create_cloud_mode_terminal(resources, view_bounds.size(), ctx);
+        let terminal_view_id = terminal_view.id();
+
+        Self::load_data_into_restored_ambient_cloud_mode_view(
+            terminal_view.clone(),
+            cloud_conversation,
+            task_id,
+            ctx,
+        );
+
+        let pane_data = TerminalPane::new(
+            Uuid::new_v4().as_bytes().to_vec(),
+            terminal_manager,
+            terminal_view,
+            self.model_event_sender.clone(),
+            ctx,
+        );
+
+        let success = self.replace_pane(loading_pane_id, pane_data, false, ctx);
+        if success {
+            let new_pane_id = self
+                .find_pane_id_for_terminal_view(terminal_view_id, ctx)
+                .unwrap_or(loading_pane_id);
+            self.create_missing_child_agent_panes(new_pane_id, ctx);
+        }
+
+        success
+    }
+
+    fn load_data_into_restored_ambient_cloud_mode_view(
+        terminal_view: ViewHandle<TerminalView>,
+        cloud_conversation: CloudConversationData,
+        task_id: AmbientAgentTaskId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let mut conversation_id = None;
+        terminal_view.update(ctx, |view, ctx| {
+            match cloud_conversation {
+                CloudConversationData::Oz(conversation) => {
+                    let id = conversation.id();
+                    view.restore_conversation_after_view_creation(
+                        RestoredAIConversation::new(*conversation),
+                        true,
+                        ctx,
+                    );
+                    view.enter_agent_view(None, Some(id), AgentViewEntryOrigin::CloudAgent, ctx);
+                    conversation_id = Some(id);
+                }
+                CloudConversationData::CLIAgent(cli_conversation) => {
+                    if !FeatureFlag::AgentHarness.is_enabled() {
+                        log::warn!(
+                            "AgentHarness flag is disabled; ignoring CLI agent conversation"
+                        );
+                        return;
+                    }
+                    let harness = match cli_conversation.metadata.harness {
+                        AIAgentHarness::ClaudeCode => Some(Harness::Claude),
+                        AIAgentHarness::Gemini => Some(Harness::Gemini),
+                        AIAgentHarness::Codex => Some(Harness::Codex),
+                        AIAgentHarness::Oz => None,
+                        AIAgentHarness::Unknown => Some(Harness::Unknown),
+                    };
+                    view.restore_conversation_and_directory_context(
+                        CloudConversationData::CLIAgent(cli_conversation),
+                        true,
+                        |_, _| {},
+                        ctx,
+                    );
+                    if let Some(harness) = harness {
+                        if let Some(ambient_agent_view_model) =
+                            view.ambient_agent_view_model().cloned()
+                        {
+                            ambient_agent_view_model.update(ctx, |model, ctx| {
+                                model.set_harness(harness, ctx);
+                            });
+                        }
+                    }
+                    view.enter_agent_view_for_new_conversation(
+                        None,
+                        AgentViewEntryOrigin::ThirdPartyCloudAgent,
+                        ctx,
+                    );
+                    if let Some(vehicle_conversation_id) = view.active_conversation_id(ctx) {
+                        view.model
+                            .lock()
+                            .block_list_mut()
+                            .attach_non_startup_blocks_to_conversation(vehicle_conversation_id);
+                    }
+                }
+            }
+
+            if let Some(ambient_agent_view_model) = view.ambient_agent_view_model().cloned() {
+                ambient_agent_view_model.update(ctx, |model, ctx| {
+                    model.set_conversation_id(conversation_id);
+                    model.enter_viewing_existing_session(task_id, ctx);
+                });
+            }
+            view.insert_conversation_ended_tombstone(ctx);
+        });
+
+        ActiveAgentViewsModel::handle(ctx).update(ctx, |active_views, ctx| {
+            active_views.register_ambient_session(terminal_view.id(), task_id, ctx);
+        });
+    }
+
     /// Clear all panes that were hidden due to being closed (for undo functionality)
     /// This is typically called when starting pane rearrangement operations
     fn clear_hidden_closed_panes(&mut self, ctx: &mut ViewContext<Self>) {
@@ -5939,6 +6115,16 @@ impl PaneGroup {
         cloud_conversation: CloudConversationData,
         ctx: &mut ViewContext<Self>,
     ) -> bool {
+        if FeatureFlag::HandoffCloudCloud.is_enabled() {
+            if let Some(task_id) = Self::ambient_agent_task_id(&cloud_conversation) {
+                return self.replace_loading_pane_with_restored_ambient_cloud_mode_pane(
+                    loading_pane_id,
+                    cloud_conversation,
+                    task_id,
+                    ctx,
+                );
+            }
+        }
         let restoration = match cloud_conversation {
             CloudConversationData::Oz(conversation) => {
                 ConversationRestorationInNewPaneType::Historical {

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -5339,6 +5339,12 @@ impl PaneGroup {
                     model.enter_viewing_existing_session(task_id, ctx);
                 });
             }
+            let status = if view.owned_ambient_agent_task_id(ctx).is_some() {
+                shared_session::SharedSessionStatus::NotShared
+            } else {
+                shared_session::SharedSessionStatus::FinishedViewer
+            };
+            view.model.lock().set_shared_session_status(status);
             view.insert_conversation_ended_tombstone(ctx);
         });
 

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -1,9 +1,14 @@
+use crate::ai::blocklist::history_model::CloudConversationData;
+use crate::server::ids::ServerId;
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::{
     ai::{
         active_agent_views_model::ActiveAgentViewsModel,
         agent::{
-            conversation::{AIConversation, AIConversationId},
+            api::ServerConversationToken,
+            conversation::{
+                AIAgentHarness, AIConversation, AIConversationId, ServerAIConversationMetadata,
+            },
             PassiveSuggestionTrigger,
         },
         agent_conversations_model::AgentConversationsModel,
@@ -30,6 +35,7 @@ use crate::{
     auth::auth_manager::AuthManager,
     changelog_model::ChangelogModel,
     cloud_object::model::persistence::CloudModel,
+    cloud_object::{Owner, Revision, ServerMetadata, ServerPermissions},
     context_chips::prompt::Prompt,
     experiments,
     network::NetworkStatus,
@@ -50,6 +56,7 @@ use crate::{
     suggestions::ignored_suggestions_model::IgnoredSuggestionsModel,
     system::SystemStats,
     terminal::history::History,
+    terminal::model::terminal_model::ConversationTranscriptViewerStatus,
     terminal::{
         alt_screen_reporting::AltScreenReporting,
         keys::TerminalKeybindings,
@@ -71,6 +78,8 @@ use crate::{
     },
     AgentNotificationsModel, GlobalResourceHandles, GlobalResourceHandlesProvider,
 };
+use chrono::Utc;
+use persistence::model::ConversationUsageMetadata;
 #[cfg(feature = "local_fs")]
 use repo_metadata::RepoMetadataModel;
 use repo_metadata::{repositories::DetectedRepositories, watcher::DirectoryWatcher};
@@ -249,6 +258,59 @@ fn new_notebook(ctx: &mut ViewContext<PaneGroup>) -> ViewHandle<NotebookView> {
 
 fn new_ambient_agent_task_id() -> AmbientAgentTaskId {
     Uuid::new_v4().to_string().parse().unwrap()
+}
+
+fn mock_server_metadata() -> ServerMetadata {
+    ServerMetadata {
+        uid: ServerId::default(),
+        revision: Revision::now(),
+        metadata_last_updated_ts: Utc::now().into(),
+        trashed_ts: None,
+        folder_id: None,
+        is_welcome_object: false,
+        creator_uid: None,
+        last_editor_uid: None,
+        current_editor_uid: None,
+    }
+}
+
+fn mock_server_permissions() -> ServerPermissions {
+    ServerPermissions {
+        space: Owner::mock_current_user(),
+        guests: Vec::new(),
+        anyone_link_sharing: None,
+        permissions_last_updated_ts: Utc::now().into(),
+    }
+}
+
+fn test_server_conversation_metadata(
+    task_id: Option<AmbientAgentTaskId>,
+) -> ServerAIConversationMetadata {
+    ServerAIConversationMetadata {
+        title: "Restored cloud conversation".to_string(),
+        working_directory: None,
+        harness: AIAgentHarness::Oz,
+        usage: ConversationUsageMetadata {
+            was_summarized: false,
+            context_window_usage: 0.0,
+            credits_spent: 0.0,
+            credits_spent_for_last_block: None,
+            token_usage: vec![],
+            tool_usage_metadata: Default::default(),
+        },
+        metadata: mock_server_metadata(),
+        permissions: mock_server_permissions(),
+        ambient_agent_task_id: task_id,
+        server_conversation_token: ServerConversationToken::new("test-server-token".to_string()),
+        artifacts: Vec::new(),
+    }
+}
+
+fn cloud_conversation_with_ambient_task(task_id: AmbientAgentTaskId) -> CloudConversationData {
+    let mut conversation = AIConversation::new(false);
+    conversation.set_task_id(task_id);
+    conversation.set_server_metadata(test_server_conversation_metadata(Some(task_id)));
+    CloudConversationData::Oz(Box::new(conversation))
 }
 
 fn start_parent_conversation(
@@ -598,6 +660,90 @@ fn test_restored_remote_hidden_child_pane_enters_existing_ambient_session() {
     });
 }
 
+#[test]
+fn test_ambient_transcript_restore_creates_cloud_mode_pane_when_handoff_enabled() {
+    let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+    let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+    let _setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+    let _handoff = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let pane_group = mock_pane_group(&mut app, Default::default());
+        let task_id = new_ambient_agent_task_id();
+
+        pane_group.update(&mut app, |panes, ctx| {
+            panes.load_data_into_conversation_transcript_viewer(
+                cloud_conversation_with_ambient_task(task_id),
+                Some(task_id),
+                ctx,
+            );
+        });
+
+        pane_group.read(&app, |panes, ctx| {
+            let terminal_view = panes
+                .active_session_view(ctx)
+                .expect("restored pane should have an active terminal view");
+            let view = terminal_view.as_ref(ctx);
+            let ambient_model = view
+                .ambient_agent_view_model()
+                .expect("ambient restore should create a Cloud Mode view")
+                .as_ref(ctx);
+
+            assert_eq!(ambient_model.task_id(), Some(task_id));
+            assert!(ambient_model.is_agent_running());
+            assert_eq!(
+                view.ambient_agent_task_id_for_details_panel(ctx),
+                Some(task_id)
+            );
+            assert!(view.active_conversation_id(ctx).is_some());
+
+            let model = view.model.lock();
+            assert!(!model.is_conversation_transcript_viewer());
+            assert!(!model.is_read_only());
+            assert!(matches!(
+                model.shared_session_status(),
+                SharedSessionStatus::NotShared
+            ));
+        });
+    });
+}
+
+#[test]
+fn test_ambient_transcript_restore_uses_generic_viewer_when_handoff_disabled() {
+    let _handoff = FeatureFlag::HandoffCloudCloud.override_enabled(false);
+    let _setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let pane_group = mock_pane_group(&mut app, Default::default());
+        let task_id = new_ambient_agent_task_id();
+
+        pane_group.update(&mut app, |panes, ctx| {
+            panes.load_data_into_conversation_transcript_viewer(
+                cloud_conversation_with_ambient_task(task_id),
+                Some(task_id),
+                ctx,
+            );
+        });
+
+        pane_group.read(&app, |panes, ctx| {
+            let terminal_view = panes
+                .active_session_view(ctx)
+                .expect("fallback viewer should have an active terminal view");
+            let view = terminal_view.as_ref(ctx);
+            assert!(view.ambient_agent_view_model().is_none());
+
+            let model = view.model.lock();
+            assert!(model.is_conversation_transcript_viewer());
+            assert!(model.is_read_only());
+            assert_eq!(
+                model.conversation_transcript_viewer_status(),
+                Some(&ConversationTranscriptViewerStatus::ViewingAmbientConversation(task_id))
+            );
+        });
+    });
+}
 #[test]
 fn test_active_session_id_reset_on_last_pane_close() {
     App::test((), |mut app| async move {

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -13,7 +13,10 @@ use crate::{
         },
         agent_conversations_model::AgentConversationsModel,
         ambient_agents::github_auth_notifier::GitHubAuthNotifier,
-        ambient_agents::AmbientAgentTaskId,
+        ambient_agents::{
+            task::TaskCreatorInfo, AgentSource, AmbientAgentTask, AmbientAgentTaskId,
+            AmbientAgentTaskState,
+        },
         blocklist::{
             orchestration_event_streamer::OrchestrationEventStreamer,
             orchestration_events::OrchestrationEventService,
@@ -32,7 +35,7 @@ use crate::{
         skills::SkillManager,
         AIRequestUsageModel,
     },
-    auth::auth_manager::AuthManager,
+    auth::{auth_manager::AuthManager, user::TEST_USER_UID},
     changelog_model::ChangelogModel,
     cloud_object::model::persistence::CloudModel,
     cloud_object::{Owner, Revision, ServerMetadata, ServerPermissions},
@@ -258,6 +261,36 @@ fn new_notebook(ctx: &mut ViewContext<PaneGroup>) -> ViewHandle<NotebookView> {
 
 fn new_ambient_agent_task_id() -> AmbientAgentTaskId {
     Uuid::new_v4().to_string().parse().unwrap()
+}
+
+fn ambient_agent_task_for_current_user(task_id: AmbientAgentTaskId) -> AmbientAgentTask {
+    let now = Utc::now();
+    AmbientAgentTask {
+        task_id,
+        parent_run_id: None,
+        title: "Owned task".to_string(),
+        state: AmbientAgentTaskState::Succeeded,
+        prompt: "test".to_string(),
+        created_at: now,
+        started_at: Some(now),
+        updated_at: now,
+        status_message: None,
+        source: Some(AgentSource::CloudMode),
+        session_id: None,
+        session_link: None,
+        creator: Some(TaskCreatorInfo {
+            creator_type: "USER".to_string(),
+            uid: TEST_USER_UID.to_string(),
+            display_name: None,
+        }),
+        conversation_id: None,
+        request_usage: None,
+        is_sandbox_running: false,
+        agent_config_snapshot: None,
+        artifacts: vec![],
+        last_event_sequence: None,
+        children: vec![],
+    }
 }
 
 fn mock_server_metadata() -> ServerMetadata {
@@ -673,6 +706,9 @@ fn test_ambient_transcript_restore_creates_cloud_mode_pane_when_handoff_enabled(
         let task_id = new_ambient_agent_task_id();
 
         pane_group.update(&mut app, |panes, ctx| {
+            AgentConversationsModel::handle(ctx).update(ctx, |model, _| {
+                model.insert_task_for_test(ambient_agent_task_for_current_user(task_id));
+            });
             panes.load_data_into_conversation_transcript_viewer(
                 cloud_conversation_with_ambient_task(task_id),
                 Some(task_id),

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -452,6 +452,14 @@ impl PaneContent for TerminalPane {
                 conversation_ids_to_restore: vec![],
                 active_conversation_id: None,
             })
+        } else if let Some(task_id) = view
+            .ambient_agent_view_model()
+            .and_then(|ambient_model| ambient_model.as_ref(app).task_id())
+        {
+            LeafContents::AmbientAgent(AmbientAgentPaneSnapshot {
+                uuid: self.uuid.clone(),
+                task_id: Some(task_id),
+            })
         } else if view.model.lock().is_conversation_transcript_viewer() {
             // Conversation transcript viewers (opened from the conversation list)
             // can be restored via the ambient agent task if one exists.

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -8,7 +8,6 @@ use crate::features::FeatureFlag;
 use crate::launch_configs::launch_config::LaunchConfig;
 use crate::menu::{MenuAction, MenuItem, MenuItemFields};
 use crate::pane_group::{PaneGroup, PaneId};
-use crate::terminal::model::terminal_model::ConversationTranscriptViewerStatus;
 use settings::Setting as _;
 use std::sync::Arc;
 use std::time::Duration;
@@ -790,14 +789,19 @@ impl<'a> TabComponent<'a> {
         let active_pane_is_ambient_agent_session = tab
             .pane_group
             .as_ref(ctx)
-            .active_session_terminal_model(ctx)
-            .map(|model| {
-                let model = model.lock();
-                model.is_shared_ambient_agent_session()
-                    || matches!(
-                        model.conversation_transcript_viewer_status(),
-                        Some(ConversationTranscriptViewerStatus::ViewingAmbientConversation(_))
-                    )
+            .active_session_view(ctx)
+            .map(|view| {
+                let view = view.as_ref(ctx);
+                view.is_ambient_agent_session(ctx) || {
+                    let model = view.model.lock();
+                    model.is_shared_ambient_agent_session()
+                        || matches!(
+                            model.conversation_transcript_viewer_status(),
+                            Some(
+                                crate::terminal::model::terminal_model::ConversationTranscriptViewerStatus::ViewingAmbientConversation(_)
+                            )
+                        )
+                }
             })
             .unwrap_or(false);
         let active_pane_has_unsaved_code_changes = tab

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -1010,6 +1010,10 @@ pub enum Event {
         prompt: String,
         attachments: Vec<AgentAttachment>,
     },
+    /// A disconnected Cloud Mode pane is requesting to submit a cloud follow-up.
+    SubmitCloudFollowup {
+        prompt: String,
+    },
     /// A viewer in a shared session is requesting to cancel the active agent conversation.
     CancelSharedSessionConversation {
         server_conversation_token: ServerConversationToken,
@@ -12479,6 +12483,19 @@ impl Input {
                 suggestions.confirm(ctx);
             });
         } else if self.should_block_cloud_mode_setup_submission(ctx) {
+            return;
+        } else if FeatureFlag::HandoffCloudCloud.is_enabled()
+            && self
+                .ambient_agent_view_model()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model
+                        .as_ref(ctx)
+                        .is_ready_for_cloud_followup_prompt()
+                })
+        {
+            ctx.emit(Event::SubmitCloudFollowup {
+                prompt: command.trim().to_owned(),
+            });
             return;
         } else if FeatureFlag::AgentMode.is_enabled()
             && AISettings::as_ref(ctx).is_any_ai_enabled(ctx)

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -1222,7 +1222,7 @@ impl TerminalModel {
         is_inverted: bool,
         obfuscate_secrets: ObfuscateSecrets,
     ) -> Self {
-        let mut me = Self::new_for_shared_session_viewer_internal(
+        let mut me = Self::new_for_dummy_cloud_mode_session(
             sizes,
             colors,
             event_proxy,
@@ -1231,7 +1231,6 @@ impl TerminalModel {
             honor_ps1,
             is_inverted,
             obfuscate_secrets,
-            true,
         );
         if FeatureFlag::CloudModeSetupV2.is_enabled() {
             me.block_list_mut()
@@ -1250,7 +1249,6 @@ impl TerminalModel {
         honor_ps1: bool,
         is_inverted: bool,
         obfuscate_secrets: ObfuscateSecrets,
-        is_dummy_cloud_mode_session: bool,
     ) -> Self {
         Self::new_internal(
             None,
@@ -1273,7 +1271,43 @@ impl TerminalModel {
                 shell_type: ShellType::Zsh,
             },
             SharedSessionStatus::ViewPending,
-            is_dummy_cloud_mode_session,
+            false,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_for_dummy_cloud_mode_session(
+        sizes: BlockSize,
+        colors: color::List,
+        event_proxy: ChannelEventListener,
+        background_executor: Arc<Background>,
+        show_memory_stats: bool,
+        honor_ps1: bool,
+        is_inverted: bool,
+        obfuscate_secrets: ObfuscateSecrets,
+    ) -> Self {
+        Self::new_internal(
+            None,
+            sizes,
+            colors,
+            event_proxy,
+            background_executor,
+            false,
+            false,
+            show_memory_stats,
+            honor_ps1,
+            is_inverted,
+            obfuscate_secrets,
+            false,
+            None,
+            // TODO: use the same shell type as the sharer
+            ShellLaunchState::ShellSpawned {
+                available_shell: None,
+                display_name: ShellName::blank(),
+                shell_type: ShellType::Zsh,
+            },
+            SharedSessionStatus::NotShared,
+            true,
         )
     }
 
@@ -1298,7 +1332,6 @@ impl TerminalModel {
             honor_ps1,
             is_inverted,
             obfuscate_secrets,
-            false,
         )
     }
 

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -1222,15 +1222,28 @@ impl TerminalModel {
         is_inverted: bool,
         obfuscate_secrets: ObfuscateSecrets,
     ) -> Self {
-        let mut me = Self::new_for_dummy_cloud_mode_session(
+        let mut me = Self::new_internal(
+            None,
             sizes,
             colors,
             event_proxy,
             background_executor,
+            false,
+            false,
             show_memory_stats,
             honor_ps1,
             is_inverted,
             obfuscate_secrets,
+            false,
+            None,
+            // TODO: use the same shell type as the sharer
+            ShellLaunchState::ShellSpawned {
+                available_shell: None,
+                display_name: ShellName::blank(),
+                shell_type: ShellType::Zsh,
+            },
+            SharedSessionStatus::ViewPending,
+            true,
         );
         if FeatureFlag::CloudModeSetupV2.is_enabled() {
             me.block_list_mut()
@@ -1272,42 +1285,6 @@ impl TerminalModel {
             },
             SharedSessionStatus::ViewPending,
             false,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn new_for_dummy_cloud_mode_session(
-        sizes: BlockSize,
-        colors: color::List,
-        event_proxy: ChannelEventListener,
-        background_executor: Arc<Background>,
-        show_memory_stats: bool,
-        honor_ps1: bool,
-        is_inverted: bool,
-        obfuscate_secrets: ObfuscateSecrets,
-    ) -> Self {
-        Self::new_internal(
-            None,
-            sizes,
-            colors,
-            event_proxy,
-            background_executor,
-            false,
-            false,
-            show_memory_stats,
-            honor_ps1,
-            is_inverted,
-            obfuscate_secrets,
-            false,
-            None,
-            // TODO: use the same shell type as the sharer
-            ShellLaunchState::ShellSpawned {
-                available_shell: None,
-                display_name: ShellName::blank(),
-                shell_type: ShellType::Zsh,
-            },
-            SharedSessionStatus::NotShared,
-            true,
         )
     }
 

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -49,7 +49,7 @@ fn create_default_serialized_block() -> SerializedBlock {
 }
 
 #[test]
-fn cloud_mode_deferred_terminal_model_starts_not_shared() {
+fn cloud_mode_deferred_terminal_model_starts_view_pending() {
     let model = TerminalModel::new_for_cloud_mode_shared_session_viewer(
         block_size(),
         color::List::from(&color::Colors::default()),
@@ -63,9 +63,10 @@ fn cloud_mode_deferred_terminal_model_starts_not_shared() {
 
     assert!(matches!(
         model.shared_session_status(),
-        SharedSessionStatus::NotShared
+        SharedSessionStatus::ViewPending
     ));
-    assert!(!model.shared_session_status().is_viewer());
+    assert!(model.shared_session_status().is_viewer());
+    assert!(model.is_dummy_cloud_mode_session());
 }
 
 #[test]

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -1,14 +1,20 @@
 use super::*;
+use crate::terminal::color;
 use crate::terminal::model::ansi::{Handler, Processor};
 use crate::terminal::model::block::BlockId;
 use crate::terminal::model::bootstrap::BootstrapStage;
 use crate::terminal::model::grid::Dimensions as _;
 use crate::terminal::model::index::Side;
 use crate::terminal::model::selection::ExpandedSelectionRange;
+use crate::terminal::model::test_utils::block_size;
+use crate::terminal::model::ObfuscateSecrets;
+use crate::terminal::{event_listener::ChannelEventListener, shared_session::SharedSessionStatus};
 use chrono::{DateTime, Local};
+use std::sync::Arc;
 use vec1::vec1;
 use warp_core::command::ExitCode;
 use warp_terminal::model::ansi::ClearMode;
+use warpui::r#async::executor::Background;
 use warpui::text::str_to_byte_vec;
 use warpui::text::SelectionType;
 
@@ -40,6 +46,46 @@ fn create_default_serialized_block() -> SerializedBlock {
         is_local: None,
         agent_view_visibility: None,
     }
+}
+
+#[test]
+fn cloud_mode_deferred_terminal_model_starts_not_shared() {
+    let model = TerminalModel::new_for_cloud_mode_shared_session_viewer(
+        block_size(),
+        color::List::from(&color::Colors::default()),
+        ChannelEventListener::new_for_test(),
+        Arc::new(Background::default()),
+        false,
+        false,
+        false,
+        ObfuscateSecrets::No,
+    );
+
+    assert!(matches!(
+        model.shared_session_status(),
+        SharedSessionStatus::NotShared
+    ));
+    assert!(!model.shared_session_status().is_viewer());
+}
+
+#[test]
+fn generic_shared_session_viewer_model_starts_view_pending() {
+    let model = TerminalModel::new_for_shared_session_viewer(
+        block_size(),
+        color::List::from(&color::Colors::default()),
+        ChannelEventListener::new_for_test(),
+        Arc::new(Background::default()),
+        false,
+        false,
+        false,
+        ObfuscateSecrets::No,
+    );
+
+    assert!(matches!(
+        model.shared_session_status(),
+        SharedSessionStatus::ViewPending
+    ));
+    assert!(model.shared_session_status().is_viewer());
 }
 
 // Ensures that an ssh session successfully bootstraps even if the block list is empty.

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -1587,6 +1587,16 @@ impl TerminalManager {
             .clear_write_to_pty_events_for_shared_session_tx();
         if FeatureFlag::HandoffCloudCloud.is_enabled() {
             terminal_view.update(ctx, |terminal_view, ctx| {
+                // Owned ambient tasks remain editable Cloud Mode panes after their live shared
+                // session ends; non-owners are still read-only viewers of a finished session.
+                let owns_ambient_task = terminal_view.owned_ambient_agent_task_id(ctx).is_some();
+                model
+                    .lock()
+                    .set_shared_session_status(if owns_ambient_task {
+                        SharedSessionStatus::NotShared
+                    } else {
+                        SharedSessionStatus::FinishedViewer
+                    });
                 if let Some(ambient_agent_view_model) =
                     terminal_view.ambient_agent_view_model().cloned()
                 {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -20194,16 +20194,19 @@ impl TerminalView {
                 prompt,
                 attachments,
             } => {
-                if FeatureFlag::HandoffCloudCloud.is_enabled()
-                    && self.try_submit_pending_cloud_followup(prompt.clone(), ctx)
-                {
-                    return;
-                }
                 ctx.emit(Event::SendAgentPrompt {
                     server_conversation_token: *server_conversation_token,
                     prompt: prompt.clone(),
                     attachments: attachments.clone(),
                 });
+            }
+            InputEvent::SubmitCloudFollowup { prompt } => {
+                if FeatureFlag::HandoffCloudCloud.is_enabled()
+                    && self.try_submit_pending_cloud_followup(prompt.clone(), ctx)
+                {
+                    return;
+                }
+                self.show_error_toast("Couldn't continue this cloud task.".to_string(), ctx);
             }
             InputEvent::CancelSharedSessionConversation {
                 server_conversation_token,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7128,6 +7128,9 @@ impl TerminalView {
         if model.is_read_only() {
             return false;
         }
+        if self.conversation_ended_tombstone_view_id.is_some() {
+            return false;
+        }
         if self.has_active_cli_agent_input_session(app) {
             return true;
         }

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -762,6 +762,19 @@ impl AmbientAgentViewModel {
         matches!(self.status, Status::AgentRunning)
     }
 
+    /// Returns true when an existing ambient task can accept a follow-up prompt.
+    ///
+    /// `AgentRunning` means this pane has moved past setup/composition into an ambient task view;
+    /// `active_execution_session_id` is the live-session signal. After a Cloud Mode execution ends,
+    /// the status stays `AgentRunning` while the active session is cleared, which is the editable
+    /// post-run state where follow-ups are allowed.
+    pub fn is_ready_for_cloud_followup_prompt(&self) -> bool {
+        self.task_id.is_some()
+            && self.active_execution_session_id.is_none()
+            && self.pending_followup_prompt.is_none()
+            && matches!(self.status, Status::AgentRunning)
+    }
+
     /// Whether or not we should show a status footer (loading, error, auth, or cancelled).
     pub fn should_show_status_footer(&self) -> bool {
         if FeatureFlag::CloudModeSetupV2.is_enabled() {

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -25,7 +25,6 @@ use crate::settings::app_installation_detection::{
     UserAppInstallDetectionSettings, UserAppInstallStatus,
 };
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
-use crate::terminal::model::terminal_model::ConversationTranscriptViewerStatus;
 use crate::terminal::shared_session::participant_avatar_view::render_participants_and_role_elements;
 use crate::terminal::shared_session::render_util::shared_session_indicator_color;
 use crate::terminal::shared_session::SharedSessionActionSource;
@@ -297,14 +296,9 @@ impl TerminalView {
             ClipConfig::start()
         };
 
-        let should_render_ambient_agent_indicator = {
-            let model = self.model.lock();
-            model.is_shared_ambient_agent_session()
-                || matches!(
-                    model.conversation_transcript_viewer_status(),
-                    Some(ConversationTranscriptViewerStatus::ViewingAmbientConversation(_))
-                )
-        };
+        let should_render_ambient_agent_indicator =
+            self.ambient_agent_task_id_for_details_panel(app).is_some()
+                || self.model.lock().is_shared_ambient_agent_session();
         let theme = appearance.theme();
         let render_agent_circle = |variant| {
             render_icon_with_status(

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -122,7 +122,7 @@ impl TerminalView {
         )
     }
 
-    pub(in crate::terminal) fn owned_ambient_agent_task_id(
+    pub(crate) fn owned_ambient_agent_task_id(
         &self,
         ctx: &AppContext,
     ) -> Option<AmbientAgentTaskId> {

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -122,11 +122,11 @@ impl TerminalView {
         )
     }
 
-    pub(in crate::terminal::view) fn owned_ambient_agent_task_id(
+    pub(in crate::terminal) fn owned_ambient_agent_task_id(
         &self,
         ctx: &AppContext,
     ) -> Option<AmbientAgentTaskId> {
-        let task_id = self.model.lock().ambient_agent_task_id()?;
+        let task_id = self.ambient_agent_task_id_for_details_panel(ctx)?;
         self.is_current_user_creator_of_ambient_task(task_id, ctx)
             .then_some(task_id)
     }
@@ -1668,7 +1668,7 @@ impl TerminalView {
         if self.conversation_ended_tombstone_view_id.is_some() {
             self.remove_conversation_ended_tombstone(ctx);
         }
-        let task_id = self.model.lock().ambient_agent_task_id();
+        let task_id = self.ambient_agent_task_id_for_details_panel(ctx);
         let terminal_view_id = self.id();
 
         let tombstone_view_handle = ctx.add_typed_action_view(|ctx| {

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -1,7 +1,10 @@
 use pathfinder_geometry::vector::vec2f;
 use session_sharing_protocol::sharer::SessionSourceType;
+use std::collections::HashMap;
+use warp_multi_agent_api::{self as api, client_action as api_client_action};
 
 use crate::ai::agent::conversation::ConversationStatus;
+use crate::ai::agent::AIAgentInput;
 use crate::ai::agent_conversations_model::{AgentConversationsModel, AgentRunDisplayStatus};
 use crate::ai::ambient_agents::task::TaskCreatorInfo;
 use crate::ai::ambient_agents::{AgentSource, AmbientAgentTask, AmbientAgentTaskState};
@@ -696,6 +699,53 @@ fn test_on_ambient_agent_execution_ended_enables_followup_input_without_tombston
 }
 
 #[test]
+fn test_restored_owned_tombstone_hides_input_until_continue() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = cloud_mode_terminal_for_test(&mut app);
+        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task_id = task.task_id;
+
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(task);
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            let mut model = view.model.lock();
+            model.set_shared_session_source_type(SessionSourceType::AmbientAgent {
+                task_id: Some(task_id.to_string()),
+            });
+            model.set_shared_session_status(SharedSessionStatus::NotShared);
+            drop(model);
+
+            let ambient_agent_view_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .clone();
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.enter_viewing_existing_session(task_id, ctx);
+            });
+
+            view.insert_conversation_ended_tombstone(ctx);
+            assert!(view.conversation_ended_tombstone_view_id.is_some());
+            {
+                let model = view.model.lock();
+                assert!(!view.is_input_box_visible(&model, ctx));
+            }
+
+            view.start_cloud_followup_from_tombstone(task_id, ctx);
+            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert_eq!(view.pending_cloud_followup_task_id, Some(task_id));
+            {
+                let model = view.model.lock();
+                assert!(view.is_input_box_visible(&model, ctx));
+            }
+        });
+    });
+}
+#[test]
 fn test_on_ambient_agent_execution_ended_keeps_live_owned_session_on_session_sharing_path() {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
     let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
@@ -773,6 +823,115 @@ fn test_try_submit_pending_cloud_followup_allows_repeat_submission_for_owned_tas
                     .pending_followup_prompt(),
                 Some("second follow up")
             );
+        });
+    });
+}
+#[test]
+fn test_shared_followup_on_existing_conversation_converts_user_query_input() {
+    App::test((), |mut app| async move {
+        let terminal = cloud_mode_terminal_for_test(&mut app);
+        let terminal_view_id = terminal.id();
+        let conversation_token = "restored-conversation-token";
+        let request_id = "new-followup-request";
+        let root_task_id = "root-task";
+        let followup_query = "follow up";
+
+        let conversation_id =
+            BlocklistAIHistoryModel::handle(&app).update(&mut app, |model, ctx| {
+                let conversation_id =
+                    model.start_new_conversation(terminal_view_id, false, false, ctx);
+                model.set_server_conversation_token_for_conversation(
+                    conversation_id,
+                    conversation_token.to_string(),
+                );
+                conversation_id
+            });
+
+        terminal.update(&mut app, |view, ctx| {
+            let init_event = api::ResponseEvent {
+                r#type: Some(api::response_event::Type::Init(
+                    api::response_event::StreamInit {
+                        request_id: request_id.to_string(),
+                        conversation_id: conversation_token.to_string(),
+                        run_id: String::new(),
+                    },
+                )),
+            };
+            view.ai_controller.update(ctx, |controller, ctx| {
+                controller.handle_shared_session_response_event(init_event, ctx);
+            });
+
+            let create_root_task_event = api::ResponseEvent {
+                r#type: Some(api::response_event::Type::ClientActions(
+                    api::response_event::ClientActions {
+                        actions: vec![api::ClientAction {
+                            action: Some(api_client_action::Action::CreateTask(
+                                api_client_action::CreateTask {
+                                    task: Some(api::Task {
+                                        id: root_task_id.to_string(),
+                                        messages: vec![],
+                                        dependencies: None,
+                                        description: String::new(),
+                                        summary: String::new(),
+                                        server_data: String::new(),
+                                    }),
+                                },
+                            )),
+                        }],
+                    },
+                )),
+            };
+            view.ai_controller.update(ctx, |controller, ctx| {
+                controller.handle_shared_session_response_event(create_root_task_event, ctx);
+            });
+
+            let add_user_query_event = api::ResponseEvent {
+                r#type: Some(api::response_event::Type::ClientActions(
+                    api::response_event::ClientActions {
+                        actions: vec![api::ClientAction {
+                            action: Some(api_client_action::Action::AddMessagesToTask(
+                                api_client_action::AddMessagesToTask {
+                                    task_id: root_task_id.to_string(),
+                                    messages: vec![api::Message {
+                                        id: "user-message".to_string(),
+                                        task_id: root_task_id.to_string(),
+                                        server_message_data: String::new(),
+                                        citations: vec![],
+                                        message: Some(api::message::Message::UserQuery(
+                                            api::message::UserQuery {
+                                                query: followup_query.to_string(),
+                                                context: None,
+                                                referenced_attachments: HashMap::new(),
+                                                mode: None,
+                                                intended_agent: Default::default(),
+                                            },
+                                        )),
+                                        request_id: request_id.to_string(),
+                                        timestamp: None,
+                                    }],
+                                },
+                            )),
+                        }],
+                    },
+                )),
+            };
+            view.ai_controller.update(ctx, |controller, ctx| {
+                controller.handle_shared_session_response_event(add_user_query_event, ctx);
+            });
+        });
+
+        BlocklistAIHistoryModel::handle(&app).read(&app, |model, _| {
+            let conversation = model
+                .conversation(&conversation_id)
+                .expect("conversation should exist");
+            assert!(conversation.is_viewing_shared_session());
+
+            let input = conversation
+                .latest_exchange()
+                .and_then(|exchange| exchange.input.first())
+                .expect("shared-session replay should reconstruct the user query input");
+            assert!(matches!(input, AIAgentInput::UserQuery { .. }));
+            assert_eq!(input.user_query().as_deref(), Some(followup_query));
         });
     });
 }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -52,6 +52,7 @@ use crate::terminal::model::blocks::{insert_block, TotalIndex};
 use crate::terminal::model::grid::Dimensions as _;
 use crate::terminal::model::terminal_model::WithinBlock;
 use crate::terminal::session_settings::AgentToolbarChipSelection;
+use crate::terminal::shared_session::SharedSessionStatus;
 use crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent;
 use crate::terminal::CLIAgent;
 
@@ -645,8 +646,6 @@ fn root_cloud_mode_pane_sets_root_cloud_mode_context_key() {
 
 #[test]
 fn set_input_mode_agent_does_not_enter_local_agent_from_root_cloud_mode_pane() {
-    use crate::terminal::shared_session::SharedSessionStatus;
-
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         FeatureFlag::AgentView.set_enabled(true);
@@ -745,6 +744,52 @@ fn cloud_mode_v2_agent_prefixed_query_spawns_cloud_agent() {
             assert_eq!(request.prompt, "/agent fix the tests");
             assert_eq!(request.mode, UserQueryMode::Normal);
             assert!(input.as_ref(ctx).buffer_text(ctx).is_empty());
+        });
+    });
+}
+
+#[test]
+fn cloud_mode_followup_input_uses_explicit_submit_event_even_when_view_pending() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _agent_mode = FeatureFlag::AgentMode.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _handoff = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+        let _setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        let task_id = AmbientAgentTaskId::from_str("123e4567-e89b-12d3-a456-426614174000")
+            .expect("valid task id");
+
+        let ambient_agent_view_model = terminal.update(&mut app, |view, ctx| {
+            view.model
+                .lock()
+                .set_shared_session_status(SharedSessionStatus::ViewPending);
+            view.pending_cloud_followup_task_id = Some(task_id);
+            let ambient_agent_view_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .clone();
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.enter_viewing_existing_session(task_id, ctx);
+            });
+
+            view.input().update(ctx, |input, ctx| {
+                input.set_input_mode_agent(true, ctx);
+                input.replace_buffer_content("follow up", ctx);
+                input.input_enter(ctx);
+            });
+            ambient_agent_view_model
+        });
+
+        terminal.read(&app, |_view, ctx| {
+            assert_eq!(
+                ambient_agent_view_model
+                    .as_ref(ctx)
+                    .pending_followup_prompt(),
+                Some("follow up")
+            );
         });
     });
 }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -749,6 +749,29 @@ fn cloud_mode_v2_agent_prefixed_query_spawns_cloud_agent() {
 }
 
 #[test]
+fn fresh_cloud_mode_setup_enters_agent_view_when_view_pending() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+
+        terminal.update(&mut app, |view, ctx| {
+            view.model
+                .lock()
+                .set_shared_session_status(SharedSessionStatus::ViewPending);
+
+            assert!(!view.agent_view_controller().as_ref(ctx).is_active());
+            view.enter_ambient_agent_setup(Some("write the tests".to_string()), ctx);
+
+            assert!(view.agent_view_controller().as_ref(ctx).is_active());
+            assert_eq!(view.input().as_ref(ctx).buffer_text(ctx), "write the tests");
+        });
+    });
+}
+
+#[test]
 fn cloud_mode_followup_input_uses_explicit_submit_event_even_when_view_pending() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3999,7 +3999,7 @@ impl Workspace {
         let history = BlocklistAIHistoryModel::as_ref(ctx);
         let Some(conversation_id) = history.find_conversation_id_by_server_token(&server_token)
         else {
-            self.load_cloud_conversation_into_new_transcript_viewer(server_token, ctx);
+            self.load_cloud_conversation_into_new_transcript_viewer(server_token, None, ctx);
             return;
         };
 
@@ -4020,7 +4020,7 @@ impl Workspace {
         };
 
         if !conversation_is_owned_by_current_user {
-            self.load_cloud_conversation_into_new_transcript_viewer(server_token, ctx);
+            self.load_cloud_conversation_into_new_transcript_viewer(server_token, None, ctx);
             return;
         }
 
@@ -4031,7 +4031,7 @@ impl Workspace {
         ) {
             ctx.dispatch_typed_action_deferred(action);
         } else {
-            self.load_cloud_conversation_into_new_transcript_viewer(server_token, ctx);
+            self.load_cloud_conversation_into_new_transcript_viewer(server_token, None, ctx);
         }
     }
 
@@ -4039,6 +4039,7 @@ impl Workspace {
     pub fn load_cloud_conversation_into_new_transcript_viewer(
         &mut self,
         conversation_id: ServerConversationToken,
+        ambient_agent_task_id: Option<AmbientAgentTaskId>,
         ctx: &mut ViewContext<Self>,
     ) {
         // Create the tab immediately with a loading state
@@ -4085,8 +4086,11 @@ impl Workspace {
 
                 // Update the pane group with the loaded conversation
                 new_pane_group.update(ctx, |pane_group, ctx| {
-                    pane_group
-                        .load_data_into_conversation_transcript_viewer(cloud_conversation, ctx);
+                    pane_group.load_data_into_conversation_transcript_viewer(
+                        cloud_conversation,
+                        ambient_agent_task_id,
+                        ctx,
+                    );
                 });
 
                 // Open the transcript details panel by default on WASM (unless on mobile)
@@ -4108,9 +4112,8 @@ impl Workspace {
                         .as_ref(ctx)
                         .active_session_view(ctx)
                         .map(|view| view.id());
-                    let ambient_agent_task_id = me
-                        .get_active_session_terminal_model(ctx)
-                        .and_then(|model| model.lock().ambient_agent_task_id());
+                    let ambient_agent_task_id =
+                        me.ambient_agent_task_id_for_focused_terminal_view(ctx);
                     me.notify_terminal_focus_change(
                         focused_terminal_view_id,
                         ambient_agent_task_id,
@@ -4870,8 +4873,8 @@ impl Workspace {
                         if active_terminal_view_id == Some(tv.id()) {
                             return true;
                         }
-                        // Fall back to checking the terminal model directly
-                        tv.as_ref(ctx).model.lock().ambient_agent_task_id() == Some(task_id)
+                        // Fall back to checking the terminal view directly.
+                        tv.as_ref(ctx).ambient_agent_task_id_for_details_panel(ctx) == Some(task_id)
                     })
             });
             has_task.then_some(index)
@@ -4965,6 +4968,21 @@ impl Workspace {
     }
 
     /// Notifies the agent views model and notifications model that a terminal view gained focus.
+    fn ambient_agent_task_id_for_focused_terminal_view(
+        &self,
+        ctx: &AppContext,
+    ) -> Option<AmbientAgentTaskId> {
+        let pane_group = self.active_tab_pane_group().as_ref(ctx);
+        let focused_pane_id = pane_group.focused_pane_id(ctx);
+        pane_group
+            .terminal_view_from_pane_id(focused_pane_id, ctx)
+            .and_then(|view| {
+                view.as_ref(ctx)
+                    .ambient_agent_task_id_for_details_panel(ctx)
+            })
+    }
+
+    /// Notifies the agent views model and notifications model that a terminal view gained focus.
     fn notify_terminal_focus_change(
         &self,
         focused_terminal_view_id: Option<EntityId>,
@@ -5046,9 +5064,7 @@ impl Workspace {
             .as_ref(ctx)
             .terminal_view_from_pane_id(pane_group.as_ref(ctx).focused_pane_id(ctx), ctx)
             .map(|tv| tv.id());
-        let ambient_agent_task_id = self
-            .get_active_session_terminal_model(ctx)
-            .and_then(|model| model.lock().ambient_agent_task_id());
+        let ambient_agent_task_id = self.ambient_agent_task_id_for_focused_terminal_view(ctx);
         self.notify_terminal_focus_change(focused_terminal_view_id, ambient_agent_task_id, ctx);
 
         self.update_active_session(ctx);
@@ -13887,9 +13903,8 @@ impl Workspace {
                         .terminal_view_from_pane_id(pane_group.focused_pane_id(ctx), ctx)
                         .map(|tv| tv.id())
                 };
-                let ambient_agent_task_id = self
-                    .get_active_session_terminal_model(ctx)
-                    .and_then(|model| model.lock().ambient_agent_task_id());
+                let ambient_agent_task_id =
+                    self.ambient_agent_task_id_for_focused_terminal_view(ctx);
                 self.notify_terminal_focus_change(
                     focused_terminal_view_id,
                     ambient_agent_task_id,
@@ -21829,6 +21844,7 @@ impl TypedActionView for Workspace {
                 }
                 self.load_cloud_conversation_into_new_transcript_viewer(
                     conversation_id.clone(),
+                    *ambient_agent_task_id,
                     ctx,
                 );
             }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -951,6 +951,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::DragTabsToWindows,
     FeatureFlag::NamedAgents,
     FeatureFlag::GitCredentialRefresh,
+    FeatureFlag::HandoffCloudCloud,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).

--- a/specs/APP-4319/handoff-cloud-cloud-resumable-transcripts/PRODUCT.md
+++ b/specs/APP-4319/handoff-cloud-cloud-resumable-transcripts/PRODUCT.md
@@ -1,0 +1,39 @@
+# Cloud-to-cloud handoff resumable completed conversations
+## Summary
+Completed cloud agent conversations should be resumable in cloud mode when cloud-to-cloud handoff is available. Opening a completed cloud task should restore a Cloud Mode pane seeded with the prior conversation history, preserving the familiar completed transcript/tombstone experience while allowing the user to submit a follow-up prompt that starts a new cloud execution in the same conversation.
+## Problem
+Before cloud-to-cloud handoff, a cloud task with no active execution was permanently complete from the client’s perspective, so the transcript viewer and “Continue locally” affordance were sufficient. With multi-execution cloud runs, the same visual state can now be a pause between executions. Users should not hit a dead-end toast when the product offers a cloud Continue action.
+## Figma
+Figma: none provided. The current failure state is represented by the screenshot attached to the request.
+## Behavior
+1. When a user opens a cloud agent conversation that has no active execution and cloud-to-cloud continuation is available, Warp opens a Cloud Mode pane seeded with the completed conversation history instead of starting a new blank task.
+2. The restored Cloud Mode pane preserves the existing completed-conversation presentation:
+   - The prior conversation output remains visible.
+   - The completed task tombstone remains visible at the end of the transcript.
+   - Existing metadata, artifacts, error status, runtime, credits, source, skill, and working-directory details remain available wherever they are already shown.
+3. For a resumable cloud task, the tombstone shows a primary `Continue` action for continuing in cloud mode.
+4. The existing `Continue locally` action remains available where it is supported today. Adding cloud continuation must not remove the local fork path.
+5. If the task cannot be continued in cloud mode, Warp does not show a cloud `Continue` action. Users should not be offered an action that can only produce a generic “couldn't continue” failure.
+6. Clicking cloud `Continue` does not immediately create a new execution. It prepares the same Cloud Mode pane for a follow-up prompt and focuses the existing terminal input.
+7. While the pane is waiting for a follow-up prompt, the user can type, edit, or abandon the prompt using the normal terminal input behavior.
+8. Submitting a non-empty follow-up prompt starts a new execution for the same cloud task/run, not a new user-visible conversation.
+9. Submitting an empty follow-up prompt does not start a new execution. The pane stays usable and focused so the user can type a real prompt or leave the view.
+10. After the follow-up prompt is submitted, the restored pane transitions into Cloud Mode setup/progress UI in the same pane.
+11. During follow-up setup, the user sees their submitted prompt represented optimistically so the pane does not appear to ignore the input while the new cloud execution is starting.
+12. When the new execution starts, Warp attaches to the new cloud session in the same pane. It does not open a separate tab, split, or replacement conversation unless the user separately chooses another navigation action.
+13. The same logical conversation/run identity is preserved across the original transcript and every follow-up execution.
+14. New output from the follow-up appears after the existing transcript content in chronological order.
+15. Returning to the conversation list, agent management view, details panel, or another navigation surface should focus the already-open pane for this task while it is open.
+16. If a follow-up execution finishes, the pane returns to a completed-between-executions state and can offer cloud `Continue` again when the task is still resumable.
+17. Repeated follow-ups are allowed. A second or later follow-up should behave the same as the first: prompt input, setup/progress, same-pane session attachment, and preserved conversation identity.
+18. A failed, blocked, cancelled, timed-out, unauthorized, or quota-limited follow-up attempt surfaces through the same user-facing Cloud Mode error/auth/capacity/credits states used by cloud task startup.
+19. If the follow-up request fails before the prompt is accepted, the user’s prompt is restored in the input so they can edit or retry.
+20. If the follow-up request is accepted but the new execution fails before a session is available, the pane shows the appropriate failure state and does not silently discard the completed conversation history.
+21. Closing the pane while a follow-up execution is starting stops only the local viewing/waiting experience. It must not imply that the remote cloud run is cancelled unless the user explicitly invokes a cancel action.
+22. Opening a completed local agent conversation still uses the existing local transcript behavior. Cloud continuation is only for cloud/ambient agent conversations that are resumable in cloud mode.
+23. Opening a non-owned or otherwise non-resumable cloud transcript still works as a read-only transcript. It must not incorrectly expose cloud continuation.
+24. If the cloud-to-cloud continuation feature is unavailable or disabled, completed cloud conversations continue to use the existing transcript/tombstone behavior.
+25. Existing transcript share/open behavior should continue to work while the view is idle between cloud executions.
+26. Keyboard focus should move to the prompt input after cloud `Continue` is clicked. Users should not need to click the input manually before typing the follow-up prompt.
+27. The UI should avoid stacking confusing duplicate tombstones for the same between-executions state. After a follow-up starts, the old tombstone should not remain as an actionable end marker above the active setup/progress state.
+28. The generic “Couldn't continue this cloud task.” toast is only acceptable for genuinely unexpected inconsistencies. It should not be part of the normal completed-cloud-task continuation flow.

--- a/specs/APP-4319/handoff-cloud-cloud-resumable-transcripts/TECH.md
+++ b/specs/APP-4319/handoff-cloud-cloud-resumable-transcripts/TECH.md
@@ -1,0 +1,91 @@
+# Cloud-to-cloud handoff resumable completed cloud panes
+## Context
+`PRODUCT.md` defines the target behavior: completed cloud conversations should restore into Cloud Mode panes seeded with prior conversation history, keep the completed transcript/tombstone presentation, and become resumable in cloud mode when cloud-to-cloud handoff is available.
+The follow-up execution path mostly exists. `ConversationEndedTombstoneView` creates a cloud `Continue` action when it has an ambient task id and `FeatureFlag::HandoffCloudCloud` is enabled in `app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs (202-235)`, then emits `ConversationEndedTombstoneEvent::ContinueInCloud` from `app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs (631-640)`. `TerminalView::start_cloud_followup_from_tombstone` sets `pending_cloud_followup_task_id` and focuses the existing input in `app/src/terminal/view/shared_session/view_impl.rs (810-842)`. `TerminalView::try_submit_pending_cloud_followup` routes the next prompt through `AmbientAgentViewModel::submit_cloud_followup` in `app/src/terminal/view.rs (19979-20075)`. The ambient model emits `FollowupSessionReady` after polling for a fresh session in `app/src/terminal/view/ambient_agent/model.rs (686-744)`, and the deferred Cloud Mode manager attaches it through `TerminalManager::attach_followup_session` in `app/src/terminal/view/ambient_agent/mod.rs (60-118)` and `app/src/terminal/shared_session/viewer/terminal_manager.rs (310-384)`.
+The follow-up submit trigger should be explicit Cloud Mode behavior, not a side effect of shared-session viewer submission. Fresh Cloud Mode prompts already bypass `Input::submit_ai_query` while the ambient model is in `Composing` and call `AmbientAgentViewModel::spawn_agent` directly. Follow-up prompts should follow the same pattern: before generic AI submission and before generic shared-session viewer permission checks, `Input` should detect a disconnected Cloud Mode follow-up composer and emit a dedicated Cloud follow-up event handled by `TerminalView::try_submit_pending_cloud_followup`. Both cases must use this same path: a pane whose initial cloud execution just ended, and a pane restored from ambient conversation history.
+Disconnected Cloud Mode panes should also stop representing themselves as shared-session viewers. `SharedSessionStatus::ViewPending`, `ActiveViewer`, and `FinishedViewer` should mean a live or ended collaborative viewer state with shared-session permission semantics. A fresh, restored, or between-executions Cloud Mode pane that has no attached session should instead use `SharedSessionStatus::NotShared` plus the existing Cloud Mode/ambient model state. `connect_session` and `attach_followup_session` should transition into `ViewPending` only when a real shared-session id is available.
+The broken path is pane construction. `TerminalView::new` creates `ambient_agent_view_model` only when `is_cloud_mode` is true in `app/src/terminal/view.rs (3003-3030)`. Historical transcript panes are currently created through `MockTerminalManager::create_model` in `app/src/pane_group/mod.rs (5675-5728)` and loaded through `PaneGroup::load_data_into_transcript_viewer` in `app/src/pane_group/mod.rs (3825-3928)`. Those panes can have `ConversationTranscriptViewerStatus::ViewingAmbientConversation(task_id)`, but that is a workaround for treating a generic transcript viewer like an ambient session. It still does not give the pane the ambient model or deferred viewer manager needed to submit and attach a cloud follow-up.
+`WorkspaceAction::OpenConversationTranscriptViewer` already carries `ambient_agent_task_id`, but the action handler discards it and calls `load_cloud_conversation_into_new_transcript_viewer(conversation_id, ctx)` in `app/src/workspace/view.rs (21677-21698)`. The loader then creates a generic transcript-loading tab in `app/src/workspace/view.rs (3998-4054)`. By the time cloud conversation data is loaded, `PaneGroup` can recover an ambient task id from metadata, but it still mutates a non-cloud transcript viewer rather than creating a resumable cloud viewer.
+The desired invariant is that viewing any ambient agent conversation, including a restored completed one, puts the user in a Cloud Mode pane. The fetched conversation history is seeded UI state for scrollback and completed-tombstone presentation, not the server-side agent context for the next follow-up request. Generic transcript-viewer state should remain only for non-ambient conversations and loading/fallback paths.
+## Proposed changes
+### Preserve ambient task identity through restore loading
+Change `Workspace::load_cloud_conversation_into_new_transcript_viewer` to accept `ambient_agent_task_id: Option<AmbientAgentTaskId>`, and pass the action’s task id through from `WorkspaceAction::OpenConversationTranscriptViewer`.
+When `load_conversation_from_server` returns `CloudConversationData`, resolve the effective task id as:
+1. the task id from the action, if present;
+2. the task id from cloud conversation metadata, if present;
+3. `None`.
+Use the effective task id to choose the pane construction path, seed the ambient model, register active ambient views, and decide whether the tombstone can offer cloud `Continue`.
+### Route ambient restores into Cloud Mode pane construction
+Add a PaneGroup helper that creates a restored ambient Cloud Mode pane when all of these are true:
+- `FeatureFlag::HandoffCloudCloud` is enabled;
+- an effective ambient task id exists;
+- the loaded conversation is a cloud/ambient conversation, not a purely local transcript.
+A concrete shape:
+- `PaneGroup::create_restored_ambient_cloud_mode_pane(conversation, task_id, resources, initial_size, ctx)`
+- `PaneGroup::replace_loading_pane_with_restored_ambient_cloud_mode_pane(loading_pane_id, cloud_conversation, task_id, ctx)`
+- or a branch in the cloud-conversation loading callback that replaces the loading pane with a Cloud Mode pane instead of calling the generic transcript restoration path.
+The helper should use `terminal::view::ambient_agent::create_cloud_mode_view` or the existing `PaneGroup::create_cloud_mode_terminal` wrapper, then restore the fetched conversation history into that view. This gives the view `ambient_agent_view_model`, the `FollowupSessionReady` subscription, and a deferred viewer manager that can later call `attach_followup_session`.
+Do not create a `MockTerminalManager` transcript viewer and then retrofit Cloud Mode behavior onto it. Also do not set `ConversationTranscriptViewerStatus::ViewingAmbientConversation(task_id)` for the new path. The pane should be ambient because it is a Cloud Mode pane, not because a transcript-viewer marker carries a task id.
+### Seed the Cloud Mode pane with historical UI state
+After creating the restored Cloud Mode pane:
+- restore the fetched conversation into the terminal view so prior blocks and rich content render as historical UI state;
+- insert the completed-conversation tombstone at the end of the restored history;
+- call `AmbientAgentViewModel::enter_viewing_existing_session(task_id, ctx)` so the model stores the stable task id and fetches run config metadata;
+- if the loaded conversation has a local `AIConversationId`, call `set_conversation_id(Some(id))`;
+- register `ActiveAgentViewsModel::register_ambient_session(terminal_view.id(), task_id, ctx)`;
+- enter the same agent-view/header/details state as a normal Cloud Mode pane for that task.
+This should mirror existing remote-child restoration in `app/src/pane_group/mod.rs (3161-3258)` and the existing ambient Cloud Mode construction path in `app/src/pane_group/mod.rs (3249-3276)`. The restored history is only the pane’s initial UI state. `submit_cloud_followup` should still send the follow-up prompt and task/session identity through the existing cloud-to-cloud follow-up API rather than replaying the transcript as prompt context.
+If the current `AmbientAgentViewModel::Status::AgentRunning` is too strong for a completed task with no live session, introduce or reuse a between-executions state that represents “viewing an existing ambient task with no active session.” The important behavior is that the pane looks like the completed Cloud Mode state produced after a fresh Cloud Mode execution ends and the VM/session is no longer active.
+When an ambient shared session ends, owner panes should transition back to this disconnected Cloud Mode follow-up composer state and use `SharedSessionStatus::NotShared`. Non-owner panes should remain read-only ended viewer surfaces and must not expose editable Cloud follow-up input.
+### Use one Cloud follow-up submission path
+Do not maintain separate follow-up submission paths based on whether the pane was previously attached to a shared session. The post-session-ended case and restored-from-history case should converge before submission:
+- the pane is in disconnected Cloud Mode state;
+- it has an ambient task id in `AmbientAgentViewModel`;
+- the next non-empty prompt is submitted through `TerminalView::try_submit_pending_cloud_followup`;
+- `try_submit_pending_cloud_followup` calls `AmbientAgentViewModel::submit_cloud_followup`;
+- the ambient model emits `FollowupDispatched` and later `FollowupSessionReady`;
+- the deferred Cloud Mode manager attaches the fresh shared session through `attach_followup_session`.
+`Input::submit_ai_query` should no longer be the mechanism that routes follow-up prompts through `submit_viewer_ai_query` and `InputEvent::SendAgentPrompt`. That path is still appropriate for a true live shared-session viewer sending a prompt to the sharer, but it is not the semantic model for starting a new cloud follow-up execution.
+### Stop using ambient transcript-viewer status as an ambient identity source
+Remove `ConversationTranscriptViewerStatus::ViewingAmbientConversation` from the new design. If the variant can be deleted cleanly, replace its call sites with Cloud Mode predicates:
+- `TerminalModel::ambient_agent_task_id` should derive ambient identity from `shared_session_source_type` and/or the `AmbientAgentViewModel`, not from transcript-viewer status.
+- `TerminalPane::snapshot` should snapshot restored ambient panes as `LeafContents::AmbientAgent`, because they are Cloud Mode panes.
+- tab and pane-header ambient indicators should use `is_shared_ambient_agent_session`, `TerminalView::ambient_agent_view_model`, or another explicit Cloud Mode ambient predicate instead of checking transcript-viewer status.
+- transcript share-link behavior should remain on true transcript viewers; restored ambient panes should use the Cloud Mode/shared-session share/open behavior available while idle between executions.
+It is acceptable to keep `ConversationTranscriptViewerStatus::Loading` and `ViewingLocalConversation` for generic local/non-ambient transcript viewers. The key invariant is that ambient restored conversations do not become read-only because they are marked as transcript viewers.
+### Keep generic transcript behavior as the fallback
+Continue using the current `MockTerminalManager` transcript path when:
+- `HandoffCloudCloud` is disabled;
+- no effective task id exists;
+- the conversation data is not cloud/ambient;
+- the pane is opened on a platform or flow that cannot continue cloud runs.
+This preserves `PRODUCT.md` invariants 22-24 and keeps the fix scoped to resumable cloud tasks.
+### Align tombstone capability with pane capability
+`ConversationEndedTombstoneView::new` currently infers cloud Continue eligibility from task id plus feature flag. Prefer adding a capability argument from `TerminalView::insert_conversation_ended_tombstone`, for example `CloudContinueCapability::Available(AmbientAgentTaskId)` vs `Unavailable`, so the button reflects whether the surrounding view can actually submit a cloud follow-up.
+If restored ambient panes are always Cloud Mode panes with an ambient model, the first implementation can keep the existing constructor logic and add a regression test. The capability argument is safer because it prevents a stale task id on a generic transcript viewer from showing a cloud `Continue` action that can only fall back to the generic toast.
+## Testing and validation
+Map tests to `PRODUCT.md` behavior invariants instead of duplicating product requirements:
+- Invariants 1-5 and 22-24: add PaneGroup/workspace tests that opening a completed cloud task with `HandoffCloudCloud` enabled creates a Cloud Mode pane with an `AmbientAgentViewModel` and no ambient transcript-viewer status, while disabled/no-task/local cases use the existing transcript path.
+- Invariants 6-12 and 26-28: add terminal/shared-session tests that tombstone Continue in a restored ambient Cloud Mode pane sets `pending_cloud_followup_task_id`, focuses input, submits through `AmbientAgentViewModel`, and does not hit the generic toast path.
+- Add an input/terminal test that a disconnected Cloud Mode follow-up prompt emits the dedicated Cloud follow-up event before generic shared-session viewer gating. Cover both restored panes and panes whose initial shared session just ended so they share the same submission path.
+- Add a state test that fresh/restored/between-executions Cloud Mode panes with no live session use `SharedSessionStatus::NotShared`, then transition to `ViewPending` only when `connect_session` or `attach_followup_session` starts joining a real session.
+- Invariants 13-17 and 25: add tests that the view remains registered for the same ambient task, repeated `FollowupSessionReady` attaches through the deferred manager, and follow-up completion returns the pane to a between-executions Cloud Mode tombstone state.
+- Invariants 18-21: extend existing follow-up error tests to cover transcript-originated follow-ups, including prompt restoration before request acceptance and Cloud Mode error state after accepted-but-failed startup.
+Targeted checks:
+- `cargo nextest run -p warp terminal::view::shared_session::view_impl_test terminal::view_test`
+- `cargo nextest run -p warp pane_group::mod_tests ai::agent_conversations_model_tests`
+- `cargo check -p warp --features handoff_cloud_cloud`
+Use the repo-standard formatting command when preparing the PR; do not run `cargo fmt --all` or file-specific `cargo fmt`.
+## Risks and mitigations
+### Duplicate transcript restoration
+Creating a Cloud Mode view and then loading historical blocks could duplicate content if a follow-up session replays prior blocks. Keep follow-up joins on `SharedSessionInitialLoadMode::AppendFollowupScrollback` and rely on the existing block-id dedupe in `TerminalModel::append_followup_shared_session_scrollback`.
+### Completed Cloud Mode state does not currently have a precise model status
+`AmbientAgentViewModel::enter_viewing_existing_session` currently sets `Status::AgentRunning`, which may not accurately describe a completed task with no live session. If this causes incorrect setup/progress/footer behavior, add a between-executions/viewing-existing status instead of falling back to transcript-viewer state.
+### Read-only transcript state blocks input
+`TerminalModel::is_read_only` returns true when `conversation_transcript_viewer_status` is set in `app/src/terminal/model/terminal_model.rs (1534-1554)`. Restored ambient panes should avoid setting transcript-viewer status entirely so cloud follow-up input is not blocked. Generic transcript viewers can keep the existing read-only behavior.
+### Manager/view mismatch
+Retrofitting a `MockTerminalManager` transcript viewer with cloud follow-up subscriptions would duplicate Cloud Mode setup logic. Replace the loading pane with a deferred shared-session viewer manager for restored ambient conversations instead.
+### Authorization and stale task state
+The client may think a task is resumable when the server rejects follow-up creation or returns stale no-execution data. Treat the follow-up API as authoritative and surface errors through existing Cloud Mode error/auth/capacity/credits states.
+## Parallelization
+This fix is small enough to implement sequentially because the key change is one coherent pane-construction path. If split, one agent can own workspace/pane-group creation and restore behavior while another owns tombstone/input/read-only tests. They converge at the restored ambient Cloud Mode pane helper and should avoid simultaneous edits to the same `PaneGroup` creation functions.


### PR DESCRIPTION
## Description

Restore inactive ambient agent conversations into panes set up for cloud mode, as opposed for just conversation transcript viewing.  This makes it possible to continue cloud agent conversations.