### PR TITLE
Top align slash command menu sidecar with selected item in CloudModeV2.

### DIFF
--- a/app/src/terminal/input/slash_commands/cloud_mode_v2_view.rs
+++ b/app/src/terminal/input/slash_commands/cloud_mode_v2_view.rs
@@ -1143,8 +1143,8 @@ impl View for CloudModeV2SlashCommandView {
                 row_position_id,
                 vec2f(SIDECAR_GAP, 0.),
                 PositionedElementOffsetBounds::WindowByPosition,
-                PositionedElementAnchor::BottomRight,
-                ChildAnchor::BottomLeft,
+                PositionedElementAnchor::TopRight,
+                ChildAnchor::TopLeft,
             ),
         );
         stack.finish()


### PR DESCRIPTION
## Description

![image.png](https://app.graphite.com/user-attachments/assets/413dc751-d15a-4ee0-89fb-b4c48e9d163e.png)

as opposed to

![image.png](https://app.graphite.com/user-attachments/assets/db3097cd-4a5b-425c-8ba7-cec7bab6e893.png)

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->