### PR TITLE
[APP-4267] Show Mermaid render failure callout

### DIFF
--- a/app/src/notebooks/editor/view.rs
+++ b/app/src/notebooks/editor/view.rs
@@ -1338,8 +1338,9 @@ impl RichTextEditorView {
                     ctx.spawn(future, move |me, (), ctx| {
                         me.pending_layout_affecting_asset_loads.remove(&handle);
                         me.model.update(ctx, |model, ctx| {
-                            if matches!(model.interaction_state(ctx), InteractionState::Selectable)
-                            {
+                            if Self::should_rebuild_layout_after_layout_affecting_asset_load(
+                                model.interaction_state(ctx),
+                            ) {
                                 model.rebuild_layout(ctx);
                             }
                         });
@@ -1350,6 +1351,15 @@ impl RichTextEditorView {
                 }
             }
         }
+    }
+
+    fn should_rebuild_layout_after_layout_affecting_asset_load(state: InteractionState) -> bool {
+        matches!(
+            state,
+            InteractionState::Selectable
+                | InteractionState::Editable
+                | InteractionState::EditableWithInvalidSelection
+        )
     }
 
     /// Handles changes to the lifecycle state.

--- a/app/src/notebooks/editor/view_tests.rs
+++ b/app/src/notebooks/editor/view_tests.rs
@@ -181,6 +181,25 @@ fn rendered_mermaid_block_range(
 }
 
 #[test]
+fn layout_affecting_asset_loads_rebuild_selectable_and_editable_layouts() {
+    assert!(
+        RichTextEditorView::should_rebuild_layout_after_layout_affecting_asset_load(
+            InteractionState::Selectable,
+        )
+    );
+    assert!(
+        RichTextEditorView::should_rebuild_layout_after_layout_affecting_asset_load(
+            InteractionState::Editable,
+        )
+    );
+    assert!(
+        RichTextEditorView::should_rebuild_layout_after_layout_affecting_asset_load(
+            InteractionState::EditableWithInvalidSelection,
+        )
+    );
+}
+
+#[test]
 fn test_focus() {
     App::test((), |mut app| async move {
         let (window, editor_view, test_view) = initialize_editor(&mut app);

--- a/crates/editor/src/content/mermaid_diagram.rs
+++ b/crates/editor/src/content/mermaid_diagram.rs
@@ -18,6 +18,7 @@ use crate::render::{
 };
 
 const DEFAULT_MERMAID_HEIGHT_LINE_MULTIPLIER: f32 = 10.0;
+const FAILED_MERMAID_HEIGHT_LINE_MULTIPLIER: f32 = 2.0;
 
 struct MermaidDiagramAsset;
 
@@ -50,22 +51,42 @@ pub fn mermaid_diagram_layout(
     app: &AppContext,
 ) -> (AssetSource, ImageBlockConfig) {
     let asset_source = mermaid_asset_source(source);
-    let max_width = layout.max_width() - spacing.x_axis_offset();
-    let default_height = layout.rich_text_styles().base_line_height()
-        * DEFAULT_MERMAID_HEIGHT_LINE_MULTIPLIER.into_pixels();
-    let (width, height) =
-        mermaid_diagram_size(&asset_source, max_width, app).unwrap_or((max_width, default_height));
+    let config = mermaid_diagram_config(&asset_source, layout, spacing, app);
 
-    (
-        asset_source,
-        ImageBlockConfig {
-            width,
-            height,
-            spacing,
-        },
-    )
+    (asset_source, config)
 }
 
+fn mermaid_diagram_config(
+    asset_source: &AssetSource,
+    layout: &TextLayout,
+    spacing: BlockSpacing,
+    app: &AppContext,
+) -> ImageBlockConfig {
+    let max_width = layout.max_width() - spacing.x_axis_offset();
+    let (width, height) = mermaid_diagram_size(asset_source, max_width, app).unwrap_or_else(|| {
+        let height = layout.rich_text_styles().base_line_height()
+            * mermaid_diagram_fallback_height_line_multiplier(asset_source, app).into_pixels();
+        (max_width, height)
+    });
+    ImageBlockConfig {
+        width,
+        height,
+        spacing,
+    }
+}
+
+fn mermaid_diagram_fallback_height_line_multiplier(
+    asset_source: &AssetSource,
+    app: &AppContext,
+) -> f32 {
+    let asset_cache = AssetCache::as_ref(app);
+    match asset_cache.load_asset::<ImageType>(asset_source.clone()) {
+        AssetState::FailedToLoad(_) => FAILED_MERMAID_HEIGHT_LINE_MULTIPLIER,
+        AssetState::Loading { .. } | AssetState::Loaded { .. } | AssetState::Evicted => {
+            DEFAULT_MERMAID_HEIGHT_LINE_MULTIPLIER
+        }
+    }
+}
 fn mermaid_diagram_size(
     asset_source: &AssetSource,
     max_width: Pixels,
@@ -89,3 +110,7 @@ fn mermaid_diagram_size(
     let height = Pixels::new(width.as_f32() * intrinsic_height / intrinsic_width);
     Some((width, height))
 }
+
+#[cfg(test)]
+#[path = "mermaid_diagram_tests.rs"]
+mod tests;

--- a/crates/editor/src/content/mermaid_diagram_tests.rs
+++ b/crates/editor/src/content/mermaid_diagram_tests.rs
@@ -1,0 +1,68 @@
+use super::*;
+use crate::render::{layout::TextLayout, model::test_utils::TEST_STYLES};
+use warpui::{
+    App, SingletonEntity,
+    assets::asset_cache::{AssetCache, AssetSource, AssetState},
+    image_cache::ImageType,
+    text_layout::LayoutCache,
+};
+
+fn mermaid_block_spacing() -> BlockSpacing {
+    TEST_STYLES.block_spacings.from_block_style(
+        &crate::content::text::BufferBlockStyle::CodeBlock {
+            code_block_type: crate::content::text::CodeBlockType::Mermaid,
+        },
+    )
+}
+
+#[test]
+fn loading_mermaid_layout_uses_default_height() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let source = "graph TD\nA[Start] --> B[Finish]\n";
+            let layout_cache = LayoutCache::new();
+            let text_layout = TextLayout::new(
+                &layout_cache,
+                ctx.font_cache().text_layout_system(),
+                &TEST_STYLES,
+                800.,
+            );
+            let (_asset_source, config) =
+                mermaid_diagram_layout(source, &text_layout, mermaid_block_spacing(), ctx);
+            let expected_height = TEST_STYLES.base_line_height()
+                * DEFAULT_MERMAID_HEIGHT_LINE_MULTIPLIER.into_pixels();
+
+            assert!((config.height.as_f32() - expected_height.as_f32()).abs() < 0.5);
+        });
+    })
+}
+
+#[test]
+fn failed_mermaid_layout_uses_compact_height() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let asset_source = AssetSource::Raw {
+                id: "missing-mermaid-test-asset".to_string(),
+            };
+            let asset_cache = AssetCache::as_ref(ctx);
+            assert!(matches!(
+                asset_cache.load_asset::<ImageType>(asset_source.clone()),
+                AssetState::FailedToLoad(_)
+            ));
+
+            let layout_cache = LayoutCache::new();
+            let text_layout = TextLayout::new(
+                &layout_cache,
+                ctx.font_cache().text_layout_system(),
+                &TEST_STYLES,
+                800.,
+            );
+            let config =
+                mermaid_diagram_config(&asset_source, &text_layout, mermaid_block_spacing(), ctx);
+            let expected_height = TEST_STYLES.base_line_height()
+                * FAILED_MERMAID_HEIGHT_LINE_MULTIPLIER.into_pixels();
+
+            assert!((config.height.as_f32() - expected_height.as_f32()).abs() < 0.5);
+        });
+    })
+}

--- a/crates/editor/src/render/element/mermaid.rs
+++ b/crates/editor/src/render/element/mermaid.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use warpui::{
     AppContext, Element, SizeConstraint,
     elements::{Align, CacheOption, CornerRadius, Image, Radius, Text},
@@ -13,6 +15,7 @@ use crate::{
 };
 
 use super::{CursorDisplayType, RenderContext, RenderableBlock};
+const MERMAID_RENDER_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct RenderableMermaidDiagram {
     viewport_item: ViewportItem,
@@ -42,13 +45,38 @@ impl RenderableBlock for RenderableMermaidDiagram {
         );
 
         let code_text = model.styles().code_text;
+        let placeholder_color = model.styles().placeholder_color;
         let placeholder = Align::new(
             Text::new(
                 "Rendering Mermaid diagram…",
                 code_text.font_family,
                 code_text.font_size,
             )
-            .with_color(model.styles().placeholder_color)
+            .with_color(placeholder_color)
+            .with_line_height_ratio(code_text.line_height_ratio)
+            .soft_wrap(false)
+            .finish(),
+        )
+        .finish();
+        let failure_notice = Align::new(
+            Text::new(
+                "Failed to render Mermaid diagram",
+                code_text.font_family,
+                code_text.font_size,
+            )
+            .with_color(placeholder_color)
+            .with_line_height_ratio(code_text.line_height_ratio)
+            .soft_wrap(false)
+            .finish(),
+        )
+        .finish();
+        let timeout_notice = Align::new(
+            Text::new(
+                "Failed to render Mermaid diagram",
+                code_text.font_family,
+                code_text.font_size,
+            )
+            .with_color(placeholder_color)
             .with_line_height_ratio(code_text.line_height_ratio)
             .soft_wrap(false)
             .finish(),
@@ -58,7 +86,9 @@ impl RenderableBlock for RenderableMermaidDiagram {
         let size = vec2f(config.width.as_f32(), config.height.as_f32());
         let mut image = Image::new(asset_source, CacheOption::BySize)
             .contain()
-            .before_load(placeholder);
+            .before_load(placeholder)
+            .on_load_failure(failure_notice)
+            .on_load_timeout(MERMAID_RENDER_TIMEOUT, timeout_notice);
         image.layout(SizeConstraint::strict(size), ctx, app);
 
         self.image_element = Some(Box::new(image));

--- a/crates/warpui_core/src/elements/image.rs
+++ b/crates/warpui_core/src/elements/image.rs
@@ -9,10 +9,32 @@ use crate::{
 
 pub use crate::image_cache::CacheOption;
 use instant::Instant;
+use lazy_static::lazy_static;
+use parking_lot::Mutex;
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::{vec2f, Vector2F, Vector2I};
-use std::sync::Arc;
 use std::time::Duration;
+use std::{
+    collections::HashMap,
+    hash::{DefaultHasher, Hash, Hasher},
+    sync::Arc,
+};
+
+lazy_static! {
+    static ref IMAGE_LOAD_TIMEOUT_STARTED_AT: Mutex<HashMap<u64, Instant>> =
+        Mutex::new(HashMap::new());
+}
+struct LoadTimeout {
+    timeout: Duration,
+    element: Box<dyn Element>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BackupElementKind {
+    BeforeLoad,
+    FailedToLoad,
+    LoadTimeout,
+}
 
 pub struct Image {
     source: AssetSource,
@@ -31,6 +53,8 @@ pub struct Image {
     /// This could be None in two situations: (1) the caller does not provide a before_load_element
     /// or (2) the caller provided one but it's no longer needed due to the image having loaded.
     before_load_element: Option<Box<dyn Element>>,
+    failed_to_load_element: Option<Box<dyn Element>>,
+    load_timeout: Option<LoadTimeout>,
 
     /// To avoid duplicating delayed repaint, we store whether or not we've requested a
     /// repaint on behalf of this element.
@@ -65,6 +89,8 @@ impl Image {
             top_aligned: false,
             right_aligned: false,
             before_load_element: None,
+            failed_to_load_element: None,
+            load_timeout: None,
             requested_repaint_after_load: false,
             #[cfg(debug_assertions)]
             constructor_location: Some(std::panic::Location::caller()),
@@ -133,6 +159,96 @@ impl Image {
     pub fn before_load(mut self, element: Box<dyn Element>) -> Self {
         self.before_load_element = Some(element);
         self
+    }
+    pub fn on_load_failure(mut self, element: Box<dyn Element>) -> Self {
+        self.failed_to_load_element = Some(element);
+        self
+    }
+
+    pub fn on_load_timeout(mut self, timeout: Duration, element: Box<dyn Element>) -> Self {
+        self.load_timeout = Some(LoadTimeout { timeout, element });
+        self
+    }
+
+    fn load_timeout_key(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.source.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn load_started_at(&self, now: Instant) -> Instant {
+        *IMAGE_LOAD_TIMEOUT_STARTED_AT
+            .lock()
+            .entry(self.load_timeout_key())
+            .or_insert(now)
+    }
+
+    fn clear_load_timeout_started_at(&self) {
+        IMAGE_LOAD_TIMEOUT_STARTED_AT
+            .lock()
+            .remove(&self.load_timeout_key());
+    }
+
+    fn loading_backup_element_kind(
+        &mut self,
+        now: Instant,
+    ) -> (Option<BackupElementKind>, Option<Duration>) {
+        let Some(load_timeout) = self.load_timeout.as_ref() else {
+            return (
+                self.before_load_element
+                    .as_ref()
+                    .map(|_| BackupElementKind::BeforeLoad),
+                None,
+            );
+        };
+        let started_at = self.load_started_at(now);
+        let elapsed = now.duration_since(started_at);
+        if elapsed >= load_timeout.timeout {
+            return (Some(BackupElementKind::LoadTimeout), None);
+        }
+
+        (
+            self.before_load_element
+                .as_ref()
+                .map(|_| BackupElementKind::BeforeLoad),
+            Some(load_timeout.timeout - elapsed),
+        )
+    }
+
+    fn failed_to_load_backup_element_kind(&self) -> Option<BackupElementKind> {
+        if self.failed_to_load_element.is_some() {
+            Some(BackupElementKind::FailedToLoad)
+        } else if self.before_load_element.is_some() {
+            Some(BackupElementKind::BeforeLoad)
+        } else {
+            None
+        }
+    }
+
+    fn paint_backup_element(
+        &mut self,
+        kind: BackupElementKind,
+        origin: Vector2F,
+        ctx: &mut PaintContext,
+        app: &AppContext,
+    ) {
+        match kind {
+            BackupElementKind::BeforeLoad => {
+                if let Some(before_load_element) = self.before_load_element.as_mut() {
+                    before_load_element.paint(origin, ctx, app);
+                }
+            }
+            BackupElementKind::FailedToLoad => {
+                if let Some(failed_to_load_element) = self.failed_to_load_element.as_mut() {
+                    failed_to_load_element.paint(origin, ctx, app);
+                }
+            }
+            BackupElementKind::LoadTimeout => {
+                if let Some(load_timeout) = self.load_timeout.as_mut() {
+                    load_timeout.element.paint(origin, ctx, app);
+                }
+            }
+        }
     }
 
     fn paint_static_image(
@@ -284,6 +400,12 @@ impl Element for Image {
         if let Some(before_load_element) = self.before_load_element.as_mut() {
             before_load_element.layout(constraint, ctx, app);
         }
+        if let Some(failed_to_load_element) = self.failed_to_load_element.as_mut() {
+            failed_to_load_element.layout(constraint, ctx, app);
+        }
+        if let Some(load_timeout) = self.load_timeout.as_mut() {
+            load_timeout.element.layout(constraint, ctx, app);
+        }
 
         size
     }
@@ -291,6 +413,12 @@ impl Element for Image {
     fn after_layout(&mut self, ctx: &mut AfterLayoutContext, app: &AppContext) {
         if let Some(before_load_element) = self.before_load_element.as_mut() {
             before_load_element.after_layout(ctx, app);
+        }
+        if let Some(failed_to_load_element) = self.failed_to_load_element.as_mut() {
+            failed_to_load_element.after_layout(ctx, app);
+        }
+        if let Some(load_timeout) = self.load_timeout.as_mut() {
+            load_timeout.element.after_layout(ctx, app);
         }
     }
 
@@ -335,25 +463,34 @@ impl Element for Image {
                     ctx.repaint_after_load(handle);
                     self.requested_repaint_after_load = true;
                 }
-
-                if let Some(before_load_element) = self.before_load_element.as_mut() {
-                    before_load_element.paint(origin, ctx, app);
+                let (backup_element_kind, repaint_after) =
+                    self.loading_backup_element_kind(Instant::now());
+                if let Some(repaint_after) = repaint_after {
+                    ctx.repaint_after(repaint_after);
+                }
+                if let Some(kind) = backup_element_kind {
+                    self.paint_backup_element(kind, origin, ctx, app);
                 }
             }
             AssetState::Evicted => {
+                self.clear_load_timeout_started_at();
                 if let Some(before_load_element) = self.before_load_element.as_mut() {
                     before_load_element.paint(origin, ctx, app);
                 }
             }
             AssetState::FailedToLoad(_) => {
-                if let Some(before_load_element) = self.before_load_element.as_mut() {
-                    before_load_element.paint(origin, ctx, app);
+                self.clear_load_timeout_started_at();
+                if let Some(kind) = self.failed_to_load_backup_element_kind() {
+                    self.paint_backup_element(kind, origin, ctx, app);
                 }
             }
             AssetState::Loaded { data } => {
                 // Don't waste time calling layout() and after_layout() on the backup element once the main
                 // one has loaded.
+                self.clear_load_timeout_started_at();
                 self.before_load_element = None;
+                self.failed_to_load_element = None;
+                self.load_timeout = None;
 
                 match data.as_ref() {
                     crate::image_cache::Image::Static(static_image) => {

--- a/crates/warpui_core/src/elements/image_tests.rs
+++ b/crates/warpui_core/src/elements/image_tests.rs
@@ -1,5 +1,52 @@
 use super::*;
 
+struct TestElement;
+
+impl Element for TestElement {
+    fn layout(
+        &mut self,
+        constraint: SizeConstraint,
+        _: &mut LayoutContext,
+        _: &AppContext,
+    ) -> Vector2F {
+        constraint.max
+    }
+
+    fn after_layout(&mut self, _: &mut AfterLayoutContext, _: &AppContext) {}
+
+    fn paint(&mut self, _: Vector2F, _: &mut PaintContext, _: &AppContext) {}
+
+    fn size(&self) -> Option<Vector2F> {
+        None
+    }
+
+    fn origin(&self) -> Option<Point> {
+        None
+    }
+
+    fn dispatch_event(
+        &mut self,
+        _: &DispatchedEvent,
+        _: &mut EventContext,
+        _: &AppContext,
+    ) -> bool {
+        false
+    }
+}
+
+fn test_element() -> Box<dyn Element> {
+    Box::new(TestElement)
+}
+
+fn test_image() -> Image {
+    Image::new(
+        AssetSource::Raw {
+            id: "test".to_string(),
+        },
+        CacheOption::BySize,
+    )
+}
+
 #[test]
 fn image_rect_returns_none_for_nan_origin() {
     assert!(image_rect(
@@ -10,4 +57,64 @@ fn image_rect_returns_none_for_nan_origin() {
         false,
     )
     .is_none());
+}
+
+#[test]
+fn failed_to_load_prefers_failure_element_when_provided() {
+    let image = test_image()
+        .before_load(test_element())
+        .on_load_failure(test_element());
+
+    assert_eq!(
+        image.failed_to_load_backup_element_kind(),
+        Some(BackupElementKind::FailedToLoad)
+    );
+}
+
+#[test]
+fn failed_to_load_falls_back_to_before_load_element() {
+    let image = test_image().before_load(test_element());
+
+    assert_eq!(
+        image.failed_to_load_backup_element_kind(),
+        Some(BackupElementKind::BeforeLoad)
+    );
+}
+
+#[test]
+fn loading_image_switches_to_timeout_element_after_timeout() {
+    let mut image = test_image()
+        .before_load(test_element())
+        .on_load_timeout(Duration::from_secs(10), test_element());
+    image.clear_load_timeout_started_at();
+    let now = Instant::now();
+
+    let (initial_kind, initial_repaint_after) = image.loading_backup_element_kind(now);
+    assert_eq!(initial_kind, Some(BackupElementKind::BeforeLoad));
+    assert_eq!(initial_repaint_after, Some(Duration::from_secs(10)));
+
+    let (timed_out_kind, timed_out_repaint_after) =
+        image.loading_backup_element_kind(now + Duration::from_secs(11));
+    assert_eq!(timed_out_kind, Some(BackupElementKind::LoadTimeout));
+    assert_eq!(timed_out_repaint_after, None);
+}
+
+#[test]
+fn loading_timeout_survives_image_rebuild_for_same_source() {
+    let mut image = test_image()
+        .before_load(test_element())
+        .on_load_timeout(Duration::from_secs(10), test_element());
+    image.clear_load_timeout_started_at();
+    let now = Instant::now();
+
+    let (initial_kind, _initial_repaint_after) = image.loading_backup_element_kind(now);
+    assert_eq!(initial_kind, Some(BackupElementKind::BeforeLoad));
+
+    let mut rebuilt_image = test_image()
+        .before_load(test_element())
+        .on_load_timeout(Duration::from_secs(10), test_element());
+    let (timed_out_kind, timed_out_repaint_after) =
+        rebuilt_image.loading_backup_element_kind(now + Duration::from_secs(11));
+    assert_eq!(timed_out_kind, Some(BackupElementKind::LoadTimeout));
+    assert_eq!(timed_out_repaint_after, None);
 }

--- a/specs/APP-4267/PRODUCT.md
+++ b/specs/APP-4267/PRODUCT.md
@@ -1,0 +1,35 @@
+# APP-4267: Mermaid render failures show an explicit callout
+## Summary
+Mermaid diagrams in rendered markdown surfaces should never leave users staring at an indefinite “Rendering Mermaid diagram…” placeholder. When rendering fails or remains pending too long, Warp replaces the loading state with a clear failure callout while preserving the underlying markdown source.
+## Problem
+The markdown viewer can show a large Mermaid placeholder that remains stuck on “Rendering Mermaid diagram…” indefinitely. Users cannot tell whether the diagram is still rendering, failed due to invalid Mermaid syntax, failed during SVG/image conversion, or hit an internal renderer hang.
+## Goals
+- Show an explicit, readable failure state for Mermaid diagrams that fail or time out.
+- Preserve successful Mermaid rendering behavior.
+- Preserve the authored Mermaid markdown for editing, copying, storage, and export.
+- Keep the first iteration lightweight by reusing existing markdown/code-block styling.
+## Non-goals
+- Adding a dedicated Mermaid source editor.
+- Adding retry, “copy raw,” or “open raw source” controls in this iteration.
+- Changing Mermaid syntax support, diagram theme, layout algorithm, or rendered SVG fidelity.
+- Changing ordinary image loading behavior outside the explicit implementation surface needed for Mermaid failures.
+## Figma
+Figma: none provided (use existing markdown/code block styling).
+## Behavior
+1. When a rendered markdown surface contains a fenced Mermaid code block and Mermaid rendering is enabled, Warp initially shows the existing pending state: “Rendering Mermaid diagram…”.
+2. The pending state is temporary. A Mermaid render attempt enters the failure state if:
+   - Mermaid-to-SVG rendering returns an error.
+   - The SVG/image conversion pipeline returns an error.
+   - The diagram remains unresolved for longer than the Mermaid render timeout, initially 10 seconds.
+3. When a Mermaid render attempt enters the failure state, Warp replaces “Rendering Mermaid diagram…” with a visible callout that says “Failed to render Mermaid diagram”.
+4. The failure callout appears inside the same diagram/code-block container where the rendered diagram or loading placeholder would have appeared. It uses theme-derived text, border, and background colors consistent with existing rendered code/markdown blocks.
+5. The failure callout is compact enough that a failed diagram does not reserve the large default placeholder height when Warp can determine the render has permanently failed. If the failure is only a UI timeout while the underlying render is still unresolved, the callout must still be visible in the existing placeholder area.
+6. A successfully rendered Mermaid diagram continues to display as the rendered SVG, not as a callout.
+7. If a render attempt times out but later resolves successfully, Warp replaces the timeout callout with the successfully rendered diagram. Warp must not switch back to the loading placeholder for the same unresolved render attempt.
+8. If the underlying Mermaid source changes, Warp treats the new source as a new render attempt: the previous success, failure, or timeout state does not permanently carry over to the changed diagram.
+9. Multiple Mermaid diagrams in the same markdown document are independent. A failure in one diagram does not change the rendering, loading, or failure state of any other diagram.
+10. The authored Mermaid markdown remains the source of truth. Copying, storing, exporting, sharing, undo/redo, and editing behavior continue to operate on the original fenced Mermaid markdown, not on the failure callout text.
+11. When Mermaid rendering is disabled or the surface is intentionally showing raw code blocks, existing raw Mermaid code block behavior is unchanged.
+12. The callout has no interactive controls in this iteration, so it does not add keyboard focus stops. It must still be readable by text-based accessibility surfaces as ordinary visible text.
+13. Selection behavior around the failed diagram remains consistent with rendered Mermaid diagrams today: users should not accidentally select or copy the failure message instead of the authored Mermaid markdown when operating on the block as markdown content.
+14. The failure state should not log a user-visible toast or modal. The error is localized to the diagram block so the rest of the document remains readable.

--- a/specs/APP-4267/TECH.md
+++ b/specs/APP-4267/TECH.md
@@ -1,0 +1,94 @@
+# APP-4267: Mermaid render failures show an explicit callout — Tech Spec
+Product spec: `specs/APP-4267/PRODUCT.md`
+Linear issue: https://linear.app/warpdotdev/issue/APP-4267/show-failure-callout-when-mermaid-diagram-rendering-gets-stuck
+## Context
+Mermaid rendering is implemented as an async image asset layered on top of the rich-text markdown renderer.
+- `crates/editor/src/content/text.rs (721-729)` classifies fenced Mermaid blocks as `CodeBlockType::Mermaid` when `FeatureFlag::MarkdownMermaid` is enabled.
+- `crates/editor/src/content/edit.rs (671-726)` converts styled Mermaid code blocks into `LayoutTask::MermaidDiagram` and calls `mermaid_diagram_layout`.
+- `crates/editor/src/content/edit.rs (1031-1067)` converts that layout task into `BlockItem::MermaidDiagram` while preserving the source block content length.
+- `crates/editor/src/content/mermaid_diagram.rs:20` defines the current default pending height as 10 line-heights.
+- `crates/editor/src/content/mermaid_diagram.rs (28-44)` creates an `AssetSource::Async` whose fetch future calls `mermaid_to_svg::render_mermaid_to_svg`.
+- `crates/editor/src/content/mermaid_diagram.rs (47-66)` computes Mermaid block dimensions from the loaded SVG and falls back to the default placeholder height while the asset is not loaded.
+- `crates/editor/src/render/element/mermaid.rs (33-66)` renders a Mermaid block by wrapping `Image::new(...).contain().before_load(...)` with the “Rendering Mermaid diagram…” placeholder.
+- `crates/editor/src/render/element/mermaid.rs (68-112)` paints the code-block-like rounded background/border and then paints the image element into the content rect.
+- `crates/warpui_core/src/elements/image.rs (316-358)` currently paints `before_load_element` for `Loading`, `Evicted`, and `FailedToLoad`; the shared image element has no separate failed-state element.
+- `crates/warpui_core/src/assets/asset_cache.rs (284-330)` stores new async assets as `Loading` and spawns the fetch future once per async asset ID.
+- `crates/warpui_core/src/assets/asset_cache.rs (415-486)` promotes async assets to `Loaded` or `FailedToLoad` only when the background future resolves.
+There is already an attached implementation branch, `origin/oz-agent/APP-4267/mermaid-failure-callout`, that adds an `Image::on_load_failure` element and a compact Mermaid failure notice for `AssetState::FailedToLoad`. That direction fits the current architecture, but it should be tightened to cover the product-level timeout behavior: a truly stuck render can remain `AssetState::Loading` forever because the asset cache only transitions when the fetch future resolves.
+## Proposed changes
+### 1. Add a Mermaid-specific failed height
+In `crates/editor/src/content/mermaid_diagram.rs`, add a compact failed-height multiplier next to the existing pending-height multiplier:
+- `DEFAULT_MERMAID_HEIGHT_LINE_MULTIPLIER` remains the pending/success fallback height.
+- `FAILED_MERMAID_HEIGHT_LINE_MULTIPLIER` should be 2 line-heights for known permanent failures.
+Update `mermaid_diagram_layout` so it distinguishes:
+- `Loaded` SVG asset: use intrinsic SVG aspect ratio, as today.
+- `FailedToLoad`: use `max_width` and `base_line_height * FAILED_MERMAID_HEIGHT_LINE_MULTIPLIER`.
+- `Loading` or `Evicted`: keep the existing default pending height.
+Keep the helper focused on layout sizing; do not add render-element state to the content model.
+### 2. Add explicit failed-load rendering to `Image`
+In `crates/warpui_core/src/elements/image.rs`, add an optional failed-state element to `Image`:
+- Store `failed_to_load_element: Option<Box<dyn Element>>`.
+- Add `pub fn on_load_failure(mut self, element: Box<dyn Element>) -> Self`.
+- During `layout` and `after_layout`, lay out both the before-load element and failed-load element when present.
+- During `paint`, render `failed_to_load_element` for `AssetState::FailedToLoad(_)`; if none is provided, preserve current behavior by falling back to `before_load_element`.
+This keeps all existing image callers behavior-compatible while allowing Mermaid to provide a distinct error UI.
+### 3. Add a loading-timeout path for Mermaid
+`AssetState::FailedToLoad` only covers futures that resolve with an error. To satisfy `PRODUCT.md` Behavior 2 for stuck renders, add a Mermaid render timeout without making every image in Warp time out.
+Preferred shape:
+- Add an optional timeout API to `Image`, for example `pub fn on_load_timeout(mut self, timeout: Duration, element: Box<dyn Element>) -> Self`.
+- Track load start time by stable asset-source key inside the image element module. Do not reuse the existing animation `started_at`, and do not store the timeout start only on a single `Image` instance because rich-text layout can rebuild the element before the timeout fires.
+- When `paint` sees `AssetState::Loading`, initialize `load_started_at` if needed, schedule a repaint for the timeout deadline, and paint the before-load element until the timeout expires.
+- Once the timeout expires, paint the timeout element instead of the before-load element while the asset remains `Loading`.
+- If the asset later becomes `Loaded`, paint the image normally and clear backup elements as the existing loaded path does.
+- If the asset later becomes `FailedToLoad`, prefer the failed-load element.
+If a generic `Image` timeout API feels too broad during implementation, keep the timeout state in `RenderableMermaidDiagram` instead. The important invariant is user-visible: Mermaid cannot show the loading text indefinitely. Avoid wrapping `render_mermaid_to_svg` with `warpui::r#async::FutureExt::with_timeout` as the only timeout mechanism; that helper only times out while the wrapped future yields, and Mermaid rendering is currently a synchronous call inside the async fetch body.
+### 4. Wire the Mermaid failure and timeout callouts
+In `crates/editor/src/render/element/mermaid.rs`:
+- Build the existing loading placeholder as today, using `model.styles().placeholder_color`.
+- Build a failure callout text element with the exact string `Failed to render Mermaid diagram`, the code text font family, font size, line-height ratio, and theme-derived placeholder or secondary text color.
+- Create the `Image` with:
+  - `.contain()`
+  - `.before_load(loading_placeholder)`
+  - `.on_load_failure(failure_callout)`
+  - the Mermaid timeout API from §3, using a 10 second timeout and the same visible failure callout text.
+Keep the existing rounded background, border, selection overlay, and cursor painting in `RenderableMermaidDiagram::paint`.
+### 5. Preserve source and selection semantics
+Do not change `BlockItem::MermaidDiagram` content length, markdown serialization, copy behavior, hidden block handling, or editor selection semantics. The failure callout is a render-state presentation for the diagram block, not new document content.
+### 6. Logging
+Do not add new user-visible toasts. Existing `AssetCache` warning logs for fetch/conversion failures are sufficient for actual failed loads. If timeout logging is added, use at most a debug-level log so a pathological document with many invalid diagrams does not create noisy client logs.
+## Testing and validation
+Use `cargo nextest run --no-fail-fast --workspace <test identifier>` for focused Rust tests in this repo.
+### Unit tests
+- Add `crates/editor/src/content/mermaid_diagram_tests.rs` and import it from `mermaid_diagram.rs` with a `#[cfg(test)]` path module. Test that a failed Mermaid asset uses the compact failed height while loading still uses the default pending height.
+- Extend or add `crates/warpui_core/src/elements/image_tests.rs` coverage for:
+  - `AssetState::FailedToLoad` renders the failed-load element when one is provided.
+  - `AssetState::FailedToLoad` falls back to `before_load_element` when no failed-load element is provided.
+  - A loading image switches from before-load element to timeout element after the configured timeout.
+  - Timeout start time survives rebuilding an `Image` element for the same asset source.
+- Keep the existing `test_layout_mermaid_block_uses_loaded_svg_aspect_ratio` coverage in `crates/editor/src/content/edit_tests.rs` passing for successful diagrams.
+### Integration/manual validation
+- In a markdown viewer or editable plan, render a valid Mermaid diagram and confirm it still becomes an SVG.
+- Render invalid Mermaid syntax and confirm the block shows `Failed to render Mermaid diagram` instead of staying on the loading placeholder.
+- Simulate a stuck Mermaid render by using a test-only async asset source that never resolves, or a temporary local patch in `mermaid_asset_source`, and confirm the loading text is replaced after 10 seconds.
+- Confirm editing the Mermaid source creates a new render attempt and does not permanently preserve the previous failure state.
+- Confirm two Mermaid diagrams in the same document can independently show success and failure states.
+- Confirm selecting/copying/exporting the document still preserves the authored fenced Mermaid markdown, not the failure callout text.
+### Commands
+- Focused editor tests: `cargo nextest run --no-fail-fast --workspace mermaid`
+- Focused image tests: `cargo nextest run --no-fail-fast --workspace image`
+- Compile check after implementation: `cargo check`
+## Risks and mitigations
+### Timeout does not cancel underlying work
+A UI-level timeout prevents an indefinite placeholder, but it does not necessarily cancel a synchronous Mermaid render already running on the background executor. Keep the timeout scoped to presentation for this issue. If stuck renders consume executor capacity in practice, follow up with renderer-level cancellation or process isolation.
+### Shared `Image` behavior regresses other callers
+The new failure and timeout behavior must be opt-in. Existing callers without `on_load_failure` or timeout configuration should behave exactly as they do today.
+### Layout height for timed-out loading assets
+Known `FailedToLoad` assets can use compact layout on the next layout pass. A UI timeout while the asset remains `Loading` may still occupy the pending placeholder height unless implementation adds model-level timeout state and requests relayout. The first iteration prioritizes replacing the indefinite loading text; compact timeout layout can be a follow-up if needed.
+## Parallelization
+- One agent can implement the shared `Image` failed-load and timeout behavior plus unit tests.
+- Another agent can wire Mermaid-specific layout and render behavior plus Mermaid-focused tests.
+- Manual UI validation should wait until both code paths are integrated.
+## Follow-ups
+- Add a retry affordance for failed diagrams if users need to retry the same source without editing or reopening the document.
+- Add a “copy Mermaid source” affordance if the failure state needs an explicit raw-source escape hatch.
+- Investigate renderer-level cancellation or isolation if stuck Mermaid renders are confirmed to consume background executor capacity.


### PR DESCRIPTION
## Description
Adds an explicit failure state for Mermaid diagrams so rendered markdown surfaces no longer leave users on an indefinite “Rendering Mermaid diagram…” placeholder when rendering fails or stays unresolved too long.

This PR:
- Adds compact failed-layout sizing for Mermaid render failures while preserving the existing pending height for loading diagrams.
- Extends the shared `Image` element with opt-in failed-load and load-timeout backup elements, preserving existing behavior for callers that do not opt in.
- Wires Mermaid rendering to show `Failed to render Mermaid diagram` for permanent load failures and after the Mermaid render timeout.
- Keeps Mermaid source, selection, copying, and markdown serialization semantics unchanged.
- Adds PRODUCT and TECH specs for APP-4267.

Agent conversation: https://staging.warp.dev/conversation/2a1dc8f7-5ddb-4b22-bdea-384e2281624a

## Linked Issue
https://linear.app/warpdotdev/issue/APP-4267/show-failure-callout-when-mermaid-diagram-rendering-gets-stuck

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Automated validation:
- `cargo fmt --manifest-path /Users/zach/Projects/warp_3/Cargo.toml --all --check`
- `PATH=/tmp/warp-corepack-bin:$PATH cargo nextest run --manifest-path /Users/zach/Projects/warp_3/Cargo.toml --no-fail-fast --workspace mermaid image`
  - 121 tests passed, including the focused Mermaid/image tests and matching integration tests selected by those filters.
- `PATH=/tmp/warp-corepack-bin:$PATH cargo clippy --manifest-path /Users/zach/Projects/warp_3/Cargo.toml --workspace --all-targets --all-features --tests -- -D warnings`

New/updated test coverage includes:
- Mermaid layout uses the existing default height while loading.
- Failed Mermaid assets use a compact failed-callout height.
- `Image` prefers a provided failed-load element for failed assets.
- `Image` falls back to the before-load element for failed assets when no failed-load element is provided.
- Loading images switch to a timeout element after the configured timeout.
- Timeout start state survives rebuilding an `Image` element for the same asset source.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Mermaid render failure callout captured from the PR branch with a forced Mermaid asset-load failure:

![Mermaid render failure callout](https://files.catbox.moe/w7dwwm.png)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed Mermaid diagrams showing an indefinite rendering placeholder when rendering fails or times out.

Co-Authored-By: Oz <oz-agent@warp.dev>

