### PR TITLE
Add Ask-User-Question autonomy speedbump

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -111,6 +111,7 @@ use crate::util::openable_file_type::{is_supported_image_file, FileTarget};
 use crate::view_components::action_button::ActionButton;
 use crate::view_components::action_button::ButtonSize;
 use crate::view_components::action_button::KeystrokeSource;
+use crate::view_components::dropdown::{Dropdown, DropdownItem};
 use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::Appearance;
 use crate::LLMPreferences;
@@ -132,7 +133,7 @@ use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::button::TextAndIcon;
 use warpui::ui_components::button::TextAndIconAlignment;
 use warpui::ui_components::components::UiComponent;
-use warpui::ui_components::components::UiComponentStyles;
+use warpui::ui_components::components::{Coords, UiComponentStyles};
 
 use crate::util::link_detection::*;
 use chrono::Duration;
@@ -171,6 +172,8 @@ use crate::ai::blocklist::permissions::{
 };
 use crate::ai::blocklist::suggestion_chip_view::{SuggestedChipViewEvent, SuggestionChipView};
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel, AIDocumentVersion};
+use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use crate::ai::execution_profiles::AskUserQuestionPermission;
 use crate::ai::get_relevant_files::controller::{
     GetRelevantFilesController, GetRelevantFilesControllerEvent,
 };
@@ -409,6 +412,8 @@ pub(super) struct AIBlockStateHandles {
     codebase_search_speedbump_radio_button_handle: RadioButtonStateHandle,
     manage_autonomy_settings_link_handle: MouseStateHandle,
 
+    ask_user_question_speedbump_settings_link_handle: MouseStateHandle,
+
     /// Mouse state handles for rating the AI block.
     thumbs_up_handle: MouseStateHandle,
     thumbs_down_handle: MouseStateHandle,
@@ -507,6 +512,28 @@ pub enum AutonomySettingSpeedbump {
         /// Set at render-time.
         shown: Arc<Mutex<bool>>,
     },
+    /// Show a one-shot dropdown-based speedbump for ask-user-question permission.
+    ShouldShowForAskUserQuestion {
+        /// Which action this corresponds to.
+        action_id: AIAgentActionId,
+        /// Whether or not the speedbump is actually shown.
+        ///
+        /// Set at render-time.
+        shown: Arc<Mutex<bool>>,
+    },
+}
+
+#[derive(Clone)]
+pub(crate) struct AskUserQuestionSpeedbumpFooter {
+    pub dropdown: ViewHandle<Dropdown<AIBlockAction>>,
+    pub settings_link_handle: MouseStateHandle,
+}
+
+fn first_ask_user_question_action_id(output: &AIAgentOutput) -> Option<AIAgentActionId> {
+    output.actions().find_map(|action| {
+        matches!(action.action, AIAgentActionType::AskUserQuestion { .. })
+            .then(|| action.id.clone())
+    })
 }
 
 /// State for the todo list preview element in the AI block.
@@ -965,6 +992,9 @@ pub struct AIBlock {
     terminal_view_handle: WeakViewHandle<TerminalView>,
 
     ask_user_question_view: Option<ViewHandle<AskUserQuestionView>>,
+
+    /// Kept on the block so the dropdown's event subscription survives re-renders.
+    ask_user_question_speedbump_dropdown: Option<ViewHandle<Dropdown<AIBlockAction>>>,
 }
 
 struct EmbeddedCodeEditorView {
@@ -1072,6 +1102,10 @@ impl AIBlock {
         let safe_mode_settings = SafeModeSettings::handle(ctx);
         ctx.subscribe_to_model(&safe_mode_settings, |me, _, event, ctx| {
             me.handle_safe_mode_settings_changed_event(event, ctx)
+        });
+
+        ctx.subscribe_to_model(&AIExecutionProfilesModel::handle(ctx), |me, _, _, ctx| {
+            me.refresh_ask_user_question_speedbump_dropdown_selection(ctx);
         });
 
         let detected_links_state: DetectedLinksState = Default::default();
@@ -1393,6 +1427,7 @@ impl AIBlock {
             resolved_blocklist_image_sources: Default::default(),
             terminal_view_handle,
             ask_user_question_view: None,
+            ask_user_question_speedbump_dropdown: None,
         };
         me.run_secret_redaction_on_user_query(me.client_ids.conversation_id, ctx);
         me.spawn_link_detection(ctx);
@@ -2564,6 +2599,25 @@ impl AIBlock {
             }
         }
 
+        // One-shot flag is consumed only after the footer is attached, so restored
+        // blocks and views that haven't arrived yet don't burn the flag.
+        if !self.model.is_restored()
+            && FeatureFlag::AskUserQuestion.is_enabled()
+            && is_agent_mode_autonomy_allowed(ctx)
+            && *AISettings::as_ref(ctx).should_show_agent_mode_ask_user_question_speedbump
+        {
+            if let Some(action_id) = first_ask_user_question_action_id(output) {
+                self.autonomy_setting_speedbump =
+                    AutonomySettingSpeedbump::ShouldShowForAskUserQuestion {
+                        action_id: action_id.clone(),
+                        shown: Arc::new(Mutex::new(false)),
+                    };
+                if self.sync_ask_user_question_speedbump_footer(ctx) {
+                    Self::mark_ask_user_question_speedbump_as_shown(ctx);
+                }
+            }
+        }
+
         // Run secret detection at the end of the stream to catch any secrets we might've missed while streaming,
         // due to secret patterns that may include whitespace within them (we delimit on whitespace with the optimized
         // secret detection approach).
@@ -2789,6 +2843,17 @@ impl AIBlock {
                 );
             });
         }
+    }
+
+    fn mark_ask_user_question_speedbump_as_shown(ctx: &mut ViewContext<Self>) {
+        AISettings::handle(ctx).update(ctx, |ai_settings, ctx| {
+            if let Err(err) = ai_settings
+                .should_show_agent_mode_ask_user_question_speedbump
+                .set_value(false, ctx)
+            {
+                log::warn!("Could not mark ask-user-question speedbump as shown: {err}");
+            }
+        });
     }
 
     fn handle_requested_edit_complete(
@@ -3369,7 +3434,111 @@ impl AIBlock {
         {
             ctx.focus(&view);
         }
+        if self.sync_ask_user_question_speedbump_footer(ctx)
+            && *AISettings::as_ref(ctx).should_show_agent_mode_ask_user_question_speedbump
+        {
+            Self::mark_ask_user_question_speedbump_as_shown(ctx);
+        }
         ctx.notify();
+    }
+
+    fn ensure_ask_user_question_speedbump_dropdown(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<Dropdown<AIBlockAction>> {
+        if let Some(view) = self.ask_user_question_speedbump_dropdown.as_ref() {
+            return view.clone();
+        }
+        let view = ctx.add_typed_action_view(|ctx| {
+            let dropdown_font_size = Appearance::as_ref(ctx).monospace_font_size() - 1.;
+            let mut dropdown = Dropdown::new(ctx);
+            dropdown.set_font_size(dropdown_font_size, ctx);
+            dropdown.set_padding(
+                Coords {
+                    top: 2.,
+                    bottom: 2.,
+                    left: 8.,
+                    right: 8.,
+                },
+                ctx,
+            );
+            dropdown.set_vertical_margin(0., ctx);
+            dropdown.set_top_bar_height(24., ctx);
+            let permissions = [
+                AskUserQuestionPermission::Never,
+                AskUserQuestionPermission::AskExceptInAutoApprove,
+                AskUserQuestionPermission::AlwaysAsk,
+            ];
+            dropdown.set_items(
+                permissions
+                    .into_iter()
+                    .map(|p| {
+                        DropdownItem::new(
+                            p.label(),
+                            AIBlockAction::SetAskUserQuestionSpeedbumpPermission(p),
+                        )
+                    })
+                    .collect(),
+                ctx,
+            );
+            dropdown
+        });
+        self.ask_user_question_speedbump_dropdown = Some(view.clone());
+        self.refresh_ask_user_question_speedbump_dropdown_selection(ctx);
+        view
+    }
+
+    fn refresh_ask_user_question_speedbump_dropdown_selection(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(dropdown) = self.ask_user_question_speedbump_dropdown.clone() else {
+            return;
+        };
+        let permission = AIExecutionProfilesModel::as_ref(ctx)
+            .active_profile(Some(self.terminal_view_id), ctx)
+            .data()
+            .ask_user_question;
+        dropdown.update(ctx, |dropdown, ctx| {
+            dropdown.set_selected_by_name(permission.label(), ctx);
+        });
+    }
+
+    /// Attaches the footer to the view if the speedbump variant matches. Called from
+    /// both the variant-seeding and view-creation paths.
+    fn sync_ask_user_question_speedbump_footer(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        let Some(view) = self.ask_user_question_view.clone() else {
+            return false;
+        };
+        let speedbump_matches = matches!(
+            &self.autonomy_setting_speedbump,
+            AutonomySettingSpeedbump::ShouldShowForAskUserQuestion { action_id, .. }
+                if action_id == view.as_ref(ctx).action_id()
+        );
+        if speedbump_matches {
+            let dropdown = self.ensure_ask_user_question_speedbump_dropdown(ctx);
+            let settings_link_handle = self
+                .state_handles
+                .ask_user_question_speedbump_settings_link_handle
+                .clone();
+            if let AutonomySettingSpeedbump::ShouldShowForAskUserQuestion { shown, .. } =
+                &self.autonomy_setting_speedbump
+            {
+                *shown.lock() = true;
+            }
+            view.update(ctx, |view, ctx| {
+                view.set_speedbump_footer(
+                    Some(AskUserQuestionSpeedbumpFooter {
+                        dropdown,
+                        settings_link_handle,
+                    }),
+                    ctx,
+                );
+            });
+            true
+        } else {
+            false
+        }
     }
 
     fn handle_ask_user_question_view_event(
@@ -5712,6 +5881,7 @@ pub enum AIBlockAction {
     ToggleAutoreadFilesSpeedbumpCheckbox,
     ToggleAwsBedrockAutoLogin,
     ToggleCodebaseSearchSpeedbump(Option<usize>),
+    SetAskUserQuestionSpeedbumpPermission(AskUserQuestionPermission),
     StartNewConversationButtonClicked {
         action_id: AIAgentActionId,
         server_output_id: Option<ServerOutputId>,
@@ -6112,6 +6282,25 @@ impl TypedActionView for AIBlock {
                         }
                     });
                 }
+            }
+            AIBlockAction::SetAskUserQuestionSpeedbumpPermission(permission) => {
+                let permission = *permission;
+                let profile_id = *AIExecutionProfilesModel::as_ref(ctx)
+                    .active_profile(Some(self.terminal_view_id), ctx)
+                    .id();
+                AIExecutionProfilesModel::handle(ctx).update(ctx, |model, ctx| {
+                    model.set_ask_user_question(profile_id, permission, ctx);
+                });
+                send_telemetry_from_ctx!(
+                    TelemetryEvent::ChangedAgentModeAskUserQuestionPermission {
+                        src: AutonomySettingToggleSource::Speedbump,
+                        new: permission,
+                    },
+                    ctx
+                );
+                Self::mark_ask_user_question_speedbump_as_shown(ctx);
+                self.autonomy_setting_speedbump = AutonomySettingSpeedbump::None;
+                ctx.notify();
             }
             AIBlockAction::StartNewConversationButtonClicked {
                 action_id,

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -111,7 +111,6 @@ use crate::util::openable_file_type::{is_supported_image_file, FileTarget};
 use crate::view_components::action_button::ActionButton;
 use crate::view_components::action_button::ButtonSize;
 use crate::view_components::action_button::KeystrokeSource;
-use crate::view_components::dropdown::{Dropdown, DropdownItem};
 use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::Appearance;
 use crate::LLMPreferences;
@@ -133,7 +132,7 @@ use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::button::TextAndIcon;
 use warpui::ui_components::button::TextAndIconAlignment;
 use warpui::ui_components::components::UiComponent;
-use warpui::ui_components::components::{Coords, UiComponentStyles};
+use warpui::ui_components::components::UiComponentStyles;
 
 use crate::util::link_detection::*;
 use chrono::Duration;
@@ -173,7 +172,6 @@ use crate::ai::blocklist::permissions::{
 use crate::ai::blocklist::suggestion_chip_view::{SuggestedChipViewEvent, SuggestionChipView};
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel, AIDocumentVersion};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
-use crate::ai::execution_profiles::AskUserQuestionPermission;
 use crate::ai::get_relevant_files::controller::{
     GetRelevantFilesController, GetRelevantFilesControllerEvent,
 };
@@ -521,19 +519,6 @@ pub enum AutonomySettingSpeedbump {
         /// Set at render-time.
         shown: Arc<Mutex<bool>>,
     },
-}
-
-#[derive(Clone)]
-pub(crate) struct AskUserQuestionSpeedbumpFooter {
-    pub dropdown: ViewHandle<Dropdown<AIBlockAction>>,
-    pub settings_link_handle: MouseStateHandle,
-}
-
-fn first_ask_user_question_action_id(output: &AIAgentOutput) -> Option<AIAgentActionId> {
-    output.actions().find_map(|action| {
-        matches!(action.action, AIAgentActionType::AskUserQuestion { .. })
-            .then(|| action.id.clone())
-    })
 }
 
 /// State for the todo list preview element in the AI block.
@@ -992,9 +977,6 @@ pub struct AIBlock {
     terminal_view_handle: WeakViewHandle<TerminalView>,
 
     ask_user_question_view: Option<ViewHandle<AskUserQuestionView>>,
-
-    /// Kept on the block so the dropdown's event subscription survives re-renders.
-    ask_user_question_speedbump_dropdown: Option<ViewHandle<Dropdown<AIBlockAction>>>,
 }
 
 struct EmbeddedCodeEditorView {
@@ -1105,7 +1087,12 @@ impl AIBlock {
         });
 
         ctx.subscribe_to_model(&AIExecutionProfilesModel::handle(ctx), |me, _, _, ctx| {
-            me.refresh_ask_user_question_speedbump_dropdown_selection(ctx);
+            let terminal_view_id = me.terminal_view_id;
+            if let Some(view) = me.ask_user_question_view.clone() {
+                view.update(ctx, |v, ctx| {
+                    v.refresh_speedbump_dropdown_selection(terminal_view_id, ctx);
+                });
+            }
         });
 
         let detected_links_state: DetectedLinksState = Default::default();
@@ -1427,7 +1414,6 @@ impl AIBlock {
             resolved_blocklist_image_sources: Default::default(),
             terminal_view_handle,
             ask_user_question_view: None,
-            ask_user_question_speedbump_dropdown: None,
         };
         me.run_secret_redaction_on_user_query(me.client_ids.conversation_id, ctx);
         me.spawn_link_detection(ctx);
@@ -2571,45 +2557,44 @@ impl AIBlock {
             }
         }
 
-        for action_id in output.actions().filter_map(|action| {
-            let should_show_file_access_speedbump =
-                action.is_get_specific_files() || action.is_grep() || action.is_file_glob();
-            should_show_file_access_speedbump.then_some(&action.id)
-        }) {
-            if is_agent_mode_autonomy_allowed(ctx)
-                && *AISettings::as_ref(ctx).should_show_agent_mode_autoread_files_speedbump
-            {
-                // Try to show the speedbump for autoread files setting
-                // if we haven't shown it enough before.
-                self.autonomy_setting_speedbump =
-                    AutonomySettingSpeedbump::ShouldShowForFileAccess {
-                        action_id: action_id.clone(),
-                        checked: true,
-                        shown: Arc::new(Mutex::new(false)),
-                    };
-                // Mark the speedbump as shown in settings so that we do not render it again.
-                AISettings::handle(ctx).update(ctx, |ai_settings, ctx| {
-                    if let Err(err) = ai_settings
-                        .should_show_agent_mode_autoread_files_speedbump
-                        .set_value(false, ctx)
-                    {
-                        log::warn!("Error with marking autoread files speedbump as shown {err}");
-                    }
-                })
-            }
-        }
-
         // One-shot flag is consumed only after the footer is attached, so restored
         // blocks and views that haven't arrived yet don't burn the flag.
-        if !self.model.is_restored()
-            && FeatureFlag::AskUserQuestion.is_enabled()
-            && is_agent_mode_autonomy_allowed(ctx)
-            && *AISettings::as_ref(ctx).should_show_agent_mode_ask_user_question_speedbump
-        {
-            if let Some(action_id) = first_ask_user_question_action_id(output) {
+        for action in output.actions() {
+            let is_file_access =
+                action.is_get_specific_files() || action.is_grep() || action.is_file_glob();
+            if is_file_access {
+                if is_agent_mode_autonomy_allowed(ctx)
+                    && *AISettings::as_ref(ctx).should_show_agent_mode_autoread_files_speedbump
+                {
+                    // Try to show the speedbump for autoread files setting
+                    // if we haven't shown it enough before.
+                    self.autonomy_setting_speedbump =
+                        AutonomySettingSpeedbump::ShouldShowForFileAccess {
+                            action_id: action.id.clone(),
+                            checked: true,
+                            shown: Arc::new(Mutex::new(false)),
+                        };
+                    // Mark the speedbump as shown in settings so that we do not render it again.
+                    AISettings::handle(ctx).update(ctx, |ai_settings, ctx| {
+                        if let Err(err) = ai_settings
+                            .should_show_agent_mode_autoread_files_speedbump
+                            .set_value(false, ctx)
+                        {
+                            log::warn!(
+                                "Error with marking autoread files speedbump as shown {err}"
+                            );
+                        }
+                    })
+                }
+            } else if matches!(action.action, AIAgentActionType::AskUserQuestion { .. })
+                && !self.model.is_restored()
+                && FeatureFlag::AskUserQuestion.is_enabled()
+                && is_agent_mode_autonomy_allowed(ctx)
+                && *AISettings::as_ref(ctx).should_show_agent_mode_ask_user_question_speedbump
+            {
                 self.autonomy_setting_speedbump =
                     AutonomySettingSpeedbump::ShouldShowForAskUserQuestion {
-                        action_id: action_id.clone(),
+                        action_id: action.id.clone(),
                         shown: Arc::new(Mutex::new(false)),
                     };
                 if self.sync_ask_user_question_speedbump_footer(ctx) {
@@ -3442,68 +3427,6 @@ impl AIBlock {
         ctx.notify();
     }
 
-    fn ensure_ask_user_question_speedbump_dropdown(
-        &mut self,
-        ctx: &mut ViewContext<Self>,
-    ) -> ViewHandle<Dropdown<AIBlockAction>> {
-        if let Some(view) = self.ask_user_question_speedbump_dropdown.as_ref() {
-            return view.clone();
-        }
-        let view = ctx.add_typed_action_view(|ctx| {
-            let dropdown_font_size = Appearance::as_ref(ctx).monospace_font_size() - 1.;
-            let mut dropdown = Dropdown::new(ctx);
-            dropdown.set_font_size(dropdown_font_size, ctx);
-            dropdown.set_padding(
-                Coords {
-                    top: 2.,
-                    bottom: 2.,
-                    left: 8.,
-                    right: 8.,
-                },
-                ctx,
-            );
-            dropdown.set_vertical_margin(0., ctx);
-            dropdown.set_top_bar_height(24., ctx);
-            let permissions = [
-                AskUserQuestionPermission::Never,
-                AskUserQuestionPermission::AskExceptInAutoApprove,
-                AskUserQuestionPermission::AlwaysAsk,
-            ];
-            dropdown.set_items(
-                permissions
-                    .into_iter()
-                    .map(|p| {
-                        DropdownItem::new(
-                            p.label(),
-                            AIBlockAction::SetAskUserQuestionSpeedbumpPermission(p),
-                        )
-                    })
-                    .collect(),
-                ctx,
-            );
-            dropdown
-        });
-        self.ask_user_question_speedbump_dropdown = Some(view.clone());
-        self.refresh_ask_user_question_speedbump_dropdown_selection(ctx);
-        view
-    }
-
-    fn refresh_ask_user_question_speedbump_dropdown_selection(
-        &mut self,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        let Some(dropdown) = self.ask_user_question_speedbump_dropdown.clone() else {
-            return;
-        };
-        let permission = AIExecutionProfilesModel::as_ref(ctx)
-            .active_profile(Some(self.terminal_view_id), ctx)
-            .data()
-            .ask_user_question;
-        dropdown.update(ctx, |dropdown, ctx| {
-            dropdown.set_selected_by_name(permission.label(), ctx);
-        });
-    }
-
     /// Attaches the footer to the view if the speedbump variant matches. Called from
     /// both the variant-seeding and view-creation paths.
     fn sync_ask_user_question_speedbump_footer(&mut self, ctx: &mut ViewContext<Self>) -> bool {
@@ -3516,7 +3439,6 @@ impl AIBlock {
                 if action_id == view.as_ref(ctx).action_id()
         );
         if speedbump_matches {
-            let dropdown = self.ensure_ask_user_question_speedbump_dropdown(ctx);
             let settings_link_handle = self
                 .state_handles
                 .ask_user_question_speedbump_settings_link_handle
@@ -3526,14 +3448,11 @@ impl AIBlock {
             {
                 *shown.lock() = true;
             }
+            let terminal_view_id = self.terminal_view_id;
             view.update(ctx, |view, ctx| {
-                view.set_speedbump_footer(
-                    Some(AskUserQuestionSpeedbumpFooter {
-                        dropdown,
-                        settings_link_handle,
-                    }),
-                    ctx,
-                );
+                view.set_speedbump_settings_link(Some(settings_link_handle), ctx);
+                view.init_speedbump_dropdown(ctx);
+                view.refresh_speedbump_dropdown_selection(terminal_view_id, ctx);
             });
             true
         } else {
@@ -3557,6 +3476,25 @@ impl AIBlock {
 
         match event {
             AskUserQuestionViewEvent::Updated => {
+                ctx.notify();
+            }
+            AskUserQuestionViewEvent::SpeedbumpPermissionChanged(permission) => {
+                let permission = *permission;
+                let profile_id = *AIExecutionProfilesModel::as_ref(ctx)
+                    .active_profile(Some(self.terminal_view_id), ctx)
+                    .id();
+                AIExecutionProfilesModel::handle(ctx).update(ctx, |model, ctx| {
+                    model.set_ask_user_question(profile_id, permission, ctx);
+                });
+                send_telemetry_from_ctx!(
+                    TelemetryEvent::ChangedAgentModeAskUserQuestionPermission {
+                        src: AutonomySettingToggleSource::Speedbump,
+                        new: permission,
+                    },
+                    ctx
+                );
+                Self::mark_ask_user_question_speedbump_as_shown(ctx);
+                self.autonomy_setting_speedbump = AutonomySettingSpeedbump::None;
                 ctx.notify();
             }
         }
@@ -5881,7 +5819,6 @@ pub enum AIBlockAction {
     ToggleAutoreadFilesSpeedbumpCheckbox,
     ToggleAwsBedrockAutoLogin,
     ToggleCodebaseSearchSpeedbump(Option<usize>),
-    SetAskUserQuestionSpeedbumpPermission(AskUserQuestionPermission),
     StartNewConversationButtonClicked {
         action_id: AIAgentActionId,
         server_output_id: Option<ServerOutputId>,
@@ -6282,25 +6219,6 @@ impl TypedActionView for AIBlock {
                         }
                     });
                 }
-            }
-            AIBlockAction::SetAskUserQuestionSpeedbumpPermission(permission) => {
-                let permission = *permission;
-                let profile_id = *AIExecutionProfilesModel::as_ref(ctx)
-                    .active_profile(Some(self.terminal_view_id), ctx)
-                    .id();
-                AIExecutionProfilesModel::handle(ctx).update(ctx, |model, ctx| {
-                    model.set_ask_user_question(profile_id, permission, ctx);
-                });
-                send_telemetry_from_ctx!(
-                    TelemetryEvent::ChangedAgentModeAskUserQuestionPermission {
-                        src: AutonomySettingToggleSource::Speedbump,
-                        new: permission,
-                    },
-                    ctx
-                );
-                Self::mark_ask_user_question_speedbump_as_shown(ctx);
-                self.autonomy_setting_speedbump = AutonomySettingSpeedbump::None;
-                ctx.notify();
             }
             AIBlockAction::StartNewConversationButtonClicked {
                 action_id,

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -727,6 +727,66 @@ pub fn render_citation(
     )
 }
 
+/// Renders the Ask-User-Question speedbump footer: a short description label, a
+/// dropdown for the `ask_user_question` permission, and a right-aligned
+/// "Manage AI Autonomy permissions" link. Matches the visual rhythm of
+/// [`render_autonomy_checkbox_setting_speedbump_footer`].
+pub fn render_autonomy_dropdown_setting_speedbump_footer(
+    description: &'static str,
+    dropdown: &warpui::ViewHandle<crate::view_components::dropdown::Dropdown<super::AIBlockAction>>,
+    settings_link_handle: MouseStateHandle,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+    Flex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_child(
+            Container::new(
+                Text::new(
+                    description,
+                    appearance.ui_font_family(),
+                    appearance.monospace_font_size() - 1.,
+                )
+                .with_color(blended_colors::text_sub(theme, theme.surface_1()))
+                .with_selectable(false)
+                .finish(),
+            )
+            .with_margin_right(8.)
+            .finish(),
+        )
+        .with_child(warpui::elements::ChildView::new(dropdown).finish())
+        .with_child(
+            Expanded::new(
+                1.,
+                Align::new(
+                    appearance
+                        .ui_builder()
+                        .link(
+                            "Manage AI Autonomy permissions".into(),
+                            None,
+                            Some(Box::new(move |ctx| {
+                                ctx.dispatch_typed_action(
+                                    WorkspaceAction::ShowSettingsPageWithSearch {
+                                        search_query: "Autonomy".to_string(),
+                                        section: Some(SettingsSection::AI),
+                                    },
+                                );
+                            })),
+                            settings_link_handle,
+                        )
+                        .build()
+                        .finish(),
+                )
+                .right()
+                .finish(),
+            )
+            .finish(),
+        )
+        .finish()
+}
+
 /// TODO: All AIBlock footer-related rendering logic should probably be put into its own View.
 /// This function is needed both above (i.e. `block.rs`) and below (i.e. `output.rs`), and as such
 /// cannot reside in `output.rs` because we don't want to make `mod output` public.

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -731,12 +731,15 @@ pub fn render_citation(
 /// dropdown for the `ask_user_question` permission, and a right-aligned
 /// "Manage AI Autonomy permissions" link. Matches the visual rhythm of
 /// [`render_autonomy_checkbox_setting_speedbump_footer`].
-pub fn render_autonomy_dropdown_setting_speedbump_footer(
+pub fn render_autonomy_dropdown_setting_speedbump_footer<A>(
     description: &'static str,
-    dropdown: &warpui::ViewHandle<crate::view_components::dropdown::Dropdown<super::AIBlockAction>>,
+    dropdown: &warpui::ViewHandle<crate::view_components::dropdown::Dropdown<A>>,
     settings_link_handle: MouseStateHandle,
     app: &AppContext,
-) -> Box<dyn Element> {
+) -> Box<dyn Element>
+where
+    A: warpui::Action + Clone,
+{
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
     Flex::row()

--- a/app/src/ai/blocklist/block_tests.rs
+++ b/app/src/ai/blocklist/block_tests.rs
@@ -1,5 +1,10 @@
+use super::first_ask_user_question_action_id;
 use super::{received_message_collapsible_id, CollapsibleElementState, CollapsibleExpansionState};
-use crate::ai::agent::StartAgentExecutionMode;
+use crate::ai::agent::task::TaskId;
+use crate::ai::agent::{
+    AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentOutput, AIAgentOutputMessage,
+    AIAgentOutputMessageType, MessageId, StartAgentExecutionMode,
+};
 use crate::ai::blocklist::action_model::{
     compose_run_agents_child_prompt, run_agents_to_start_agent_mode,
 };
@@ -10,6 +15,23 @@ use ai::skills::SkillReference;
 use settings::Setting;
 use std::path::PathBuf;
 use warpui::{App, SingletonEntity};
+
+fn test_action(action_id: &str, action: AIAgentActionType) -> AIAgentAction {
+    AIAgentAction {
+        id: AIAgentActionId::from(action_id.to_string()),
+        action,
+        task_id: TaskId::new(format!("task-{action_id}")),
+        requires_result: false,
+    }
+}
+
+fn action_message(message_id: &str, action: AIAgentAction) -> AIAgentOutputMessage {
+    AIAgentOutputMessage {
+        id: MessageId::new(message_id.to_string()),
+        message: AIAgentOutputMessageType::Action(action),
+        citations: vec![],
+    }
+}
 
 #[test]
 fn reasoning_auto_collapses_when_user_has_not_manually_toggled() {
@@ -218,4 +240,75 @@ fn remote_arm_rejects_opencode() {
     )
     .expect_err("Remote+opencode must be rejected");
     assert!(err.to_lowercase().contains("opencode"));
+}
+
+#[test]
+fn first_ask_user_question_action_id_returns_first_ask_action() {
+    let output = AIAgentOutput {
+        messages: vec![
+            action_message(
+                "init-project",
+                test_action("init-project", AIAgentActionType::InitProject),
+            ),
+            action_message(
+                "ask-1",
+                test_action(
+                    "ask-1",
+                    AIAgentActionType::AskUserQuestion { questions: vec![] },
+                ),
+            ),
+            action_message(
+                "ask-2",
+                test_action(
+                    "ask-2",
+                    AIAgentActionType::AskUserQuestion { questions: vec![] },
+                ),
+            ),
+        ],
+        ..Default::default()
+    };
+
+    assert_eq!(
+        first_ask_user_question_action_id(&output),
+        Some(AIAgentActionId::from("ask-1".to_string()))
+    );
+}
+
+#[test]
+fn first_ask_user_question_action_id_returns_none_without_ask_action() {
+    let output = AIAgentOutput {
+        messages: vec![action_message(
+            "init-project",
+            test_action("init-project", AIAgentActionType::InitProject),
+        )],
+        ..Default::default()
+    };
+
+    assert_eq!(first_ask_user_question_action_id(&output), None);
+}
+
+#[test]
+fn should_show_agent_mode_ask_user_question_speedbump_defaults_to_true() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        AISettings::handle(&app).read(&app, |settings, _ctx| {
+            assert!(*settings.should_show_agent_mode_ask_user_question_speedbump);
+        });
+    });
+}
+
+#[test]
+fn should_show_agent_mode_ask_user_question_speedbump_round_trips_to_false() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        AISettings::handle(&app).update(&mut app, |settings, ctx| {
+            settings
+                .should_show_agent_mode_ask_user_question_speedbump
+                .set_value(false, ctx)
+                .unwrap();
+        });
+        AISettings::handle(&app).read(&app, |settings, _ctx| {
+            assert!(!*settings.should_show_agent_mode_ask_user_question_speedbump);
+        });
+    });
 }

--- a/app/src/ai/blocklist/block_tests.rs
+++ b/app/src/ai/blocklist/block_tests.rs
@@ -1,10 +1,5 @@
-use super::first_ask_user_question_action_id;
 use super::{received_message_collapsible_id, CollapsibleElementState, CollapsibleExpansionState};
-use crate::ai::agent::task::TaskId;
-use crate::ai::agent::{
-    AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentOutput, AIAgentOutputMessage,
-    AIAgentOutputMessageType, MessageId, StartAgentExecutionMode,
-};
+use crate::ai::agent::StartAgentExecutionMode;
 use crate::ai::blocklist::action_model::{
     compose_run_agents_child_prompt, run_agents_to_start_agent_mode,
 };
@@ -15,23 +10,6 @@ use ai::skills::SkillReference;
 use settings::Setting;
 use std::path::PathBuf;
 use warpui::{App, SingletonEntity};
-
-fn test_action(action_id: &str, action: AIAgentActionType) -> AIAgentAction {
-    AIAgentAction {
-        id: AIAgentActionId::from(action_id.to_string()),
-        action,
-        task_id: TaskId::new(format!("task-{action_id}")),
-        requires_result: false,
-    }
-}
-
-fn action_message(message_id: &str, action: AIAgentAction) -> AIAgentOutputMessage {
-    AIAgentOutputMessage {
-        id: MessageId::new(message_id.to_string()),
-        message: AIAgentOutputMessageType::Action(action),
-        citations: vec![],
-    }
-}
 
 #[test]
 fn reasoning_auto_collapses_when_user_has_not_manually_toggled() {
@@ -240,51 +218,6 @@ fn remote_arm_rejects_opencode() {
     )
     .expect_err("Remote+opencode must be rejected");
     assert!(err.to_lowercase().contains("opencode"));
-}
-
-#[test]
-fn first_ask_user_question_action_id_returns_first_ask_action() {
-    let output = AIAgentOutput {
-        messages: vec![
-            action_message(
-                "init-project",
-                test_action("init-project", AIAgentActionType::InitProject),
-            ),
-            action_message(
-                "ask-1",
-                test_action(
-                    "ask-1",
-                    AIAgentActionType::AskUserQuestion { questions: vec![] },
-                ),
-            ),
-            action_message(
-                "ask-2",
-                test_action(
-                    "ask-2",
-                    AIAgentActionType::AskUserQuestion { questions: vec![] },
-                ),
-            ),
-        ],
-        ..Default::default()
-    };
-
-    assert_eq!(
-        first_ask_user_question_action_id(&output),
-        Some(AIAgentActionId::from("ask-1".to_string()))
-    );
-}
-
-#[test]
-fn first_ask_user_question_action_id_returns_none_without_ask_action() {
-    let output = AIAgentOutput {
-        messages: vec![action_message(
-            "init-project",
-            test_action("init-project", AIAgentActionType::InitProject),
-        )],
-        ..Default::default()
-    };
-
-    assert_eq!(first_ask_user_question_action_id(&output), None);
 }
 
 #[test]

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -34,7 +34,10 @@ use crate::{
                     self, NumberShortcutButtonBuilder, NumberShortcutButtons,
                     NumberShortcutButtonsConfig,
                 },
-                view_impl::{CONTENT_HORIZONTAL_PADDING, CONTENT_ITEM_VERTICAL_MARGIN},
+                view_impl::{
+                    render_autonomy_dropdown_setting_speedbump_footer, CONTENT_HORIZONTAL_PADDING,
+                    CONTENT_ITEM_VERTICAL_MARGIN,
+                },
             },
             inline_action::{
                 inline_action_header::{
@@ -732,6 +735,9 @@ pub(crate) struct AskUserQuestionView {
     toggle_mouse_state: MouseStateHandle,
     skip_button: CompactibleActionButton,
     next_button: CompactibleActionButton,
+    /// Opt-in speedbump footer installed by `AIBlock` when the Ask-User-Question
+    /// autonomy speedbump is seeded for this action. Read only by `render_completed`.
+    speedbump_footer: Option<crate::ai::blocklist::block::AskUserQuestionSpeedbumpFooter>,
 }
 
 impl AskUserQuestionView {
@@ -791,6 +797,7 @@ impl AskUserQuestionView {
             toggle_mouse_state: MouseStateHandle::default(),
             skip_button,
             next_button,
+            speedbump_footer: None,
         };
 
         ctx.subscribe_to_model(&action_model, |me, _, event, ctx| {
@@ -816,6 +823,17 @@ impl AskUserQuestionView {
 
     pub fn is_editing(&self) -> bool {
         self.session.is_editing()
+    }
+
+    /// Installs or clears the Ask-User-Question autonomy speedbump footer. The
+    /// footer is only actually drawn during the completed/finished render paths.
+    pub fn set_speedbump_footer(
+        &mut self,
+        footer: Option<crate::ai::blocklist::block::AskUserQuestionSpeedbumpFooter>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.speedbump_footer = footer;
+        ctx.notify();
     }
 
     /// Recover completed/cancelled status even if the live action entry is gone, so restored
@@ -1309,24 +1327,75 @@ impl AskUserQuestionView {
         appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
-        let header = HeaderConfig::new(label, app)
+        let speedbump_footer = self
+            .speedbump_footer
+            .as_ref()
+            .map(|footer| self.render_speedbump_footer(footer, appearance, app));
+        let has_speedbump_footer = speedbump_footer.is_some();
+
+        let mut header_config = HeaderConfig::new(label, app)
             .with_icon(status_icon)
             .with_interaction_mode(InteractionMode::ManuallyExpandable(
                 ExpandedConfig::new(self.is_expanded, self.toggle_mouse_state.clone())
                     .with_toggle_callback(|ctx| {
                         ctx.dispatch_typed_action(AskUserQuestionViewAction::ToggleExpanded);
                     }),
-            ))
-            .render(app);
+            ));
+        if has_speedbump_footer {
+            header_config = header_config
+                .with_corner_radius_override(CornerRadius::with_top(Radius::Pixels(8.)));
+        }
+        let header = header_config.render(app);
+
+        // Collapsed state: just the header — but still draw the speedbump footer if it's
+        // present, since the autonomy nudge must stay visible even if the user collapses
+        // their answers.
         if !self.is_expanded {
+            if let Some(footer) = speedbump_footer {
+                let mut wrapper =
+                    Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+                wrapper.add_child(header);
+                wrapper.add_child(footer);
+                return wrap_with_agent_output_item_spacing(wrapper.finish(), app).finish();
+            }
             return wrap_with_agent_output_item_spacing(header, app).finish();
         }
 
         let mut wrapper = Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
         wrapper.add_child(header);
-        wrapper.add_child(render_answers(questions, answers, appearance));
+        wrapper.add_child(render_answers(
+            questions,
+            answers,
+            appearance,
+            has_speedbump_footer,
+        ));
+        if let Some(footer) = speedbump_footer {
+            wrapper.add_child(footer);
+            return wrap_with_agent_output_item_spacing(wrapper.finish(), app).finish();
+        }
         wrap_with_agent_output_item_spacing(wrapper.finish(), app)
             .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+            .finish()
+    }
+
+    fn render_speedbump_footer(
+        &self,
+        footer: &crate::ai::blocklist::block::AskUserQuestionSpeedbumpFooter,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let row = render_autonomy_dropdown_setting_speedbump_footer(
+            "Ask questions",
+            &footer.dropdown,
+            footer.settings_link_handle.clone(),
+            app,
+        );
+        Container::new(row)
+            .with_horizontal_padding(INLINE_ACTION_HORIZONTAL_PADDING)
+            .with_vertical_padding(4.)
+            .with_background(theme.surface_1())
+            .with_corner_radius(CornerRadius::with_bottom(Radius::Pixels(8.)))
             .finish()
     }
 
@@ -1616,6 +1685,7 @@ fn render_answers(
     questions: &[AskUserQuestionItem],
     answers: Option<&[AskUserQuestionAnswerItem]>,
     appearance: &Appearance,
+    flatten_bottom: bool,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
     let font_size = appearance.monospace_font_size();
@@ -1651,10 +1721,11 @@ fn render_answers(
         content.add_child(item_container.finish());
     }
 
-    Container::new(content.finish())
-        .with_background(theme.surface_2())
-        .with_corner_radius(CornerRadius::with_bottom(Radius::Pixels(8.)))
-        .finish()
+    let mut container = Container::new(content.finish()).with_background(theme.surface_2());
+    if !flatten_bottom {
+        container = container.with_corner_radius(CornerRadius::with_bottom(Radius::Pixels(8.)));
+    }
+    container.finish()
 }
 
 fn wrap_with_content_item_spacing(element: Box<dyn Element>) -> Container {

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -15,9 +15,10 @@ use warpui::{
     },
     keymap::{FixedBinding, Keystroke},
     r#async::{SpawnedFutureHandle, Timer},
+    ui_components::components::Coords,
     units::Pixels,
-    AppContext, Element, Entity, FocusContext, ModelHandle, SingletonEntity, TypedActionView, View,
-    ViewContext, ViewHandle,
+    AppContext, Element, Entity, EntityId, FocusContext, ModelHandle, SingletonEntity,
+    TypedActionView, View, ViewContext, ViewHandle,
 };
 
 use crate::{
@@ -49,12 +50,14 @@ use crate::{
             },
             BlocklistAIHistoryModel,
         },
+        execution_profiles::{profiles::AIExecutionProfilesModel, AskUserQuestionPermission},
     },
     terminal::input::message_bar::{
         common::{render_standard_message, standard_message_bar_height, styles},
         Message, MessageItem,
     },
     ui_components::{blended_colors, icons::Icon},
+    view_components::dropdown::{Dropdown, DropdownItem},
     view_components::{
         action_button::{ButtonSize, KeystrokeSource, NakedTheme, PrimaryTheme},
         compactible_action_button::CompactibleActionButton,
@@ -159,12 +162,15 @@ pub enum AskUserQuestionViewAction {
     NavigatePrev,
     ToggleExpanded,
     EnterPressed,
+    SetPermission(AskUserQuestionPermission),
 }
 
 /// Emitted when local questionnaire state changes and the parent needs to refresh.
 #[derive(Clone, Debug)]
 pub enum AskUserQuestionViewEvent {
     Updated,
+    /// Fired when the user selects a new permission from the speedbump dropdown.
+    SpeedbumpPermissionChanged(AskUserQuestionPermission),
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -735,9 +741,12 @@ pub(crate) struct AskUserQuestionView {
     toggle_mouse_state: MouseStateHandle,
     skip_button: CompactibleActionButton,
     next_button: CompactibleActionButton,
-    /// Opt-in speedbump footer installed by `AIBlock` when the Ask-User-Question
-    /// autonomy speedbump is seeded for this action. Read only by `render_completed`.
-    speedbump_footer: Option<crate::ai::blocklist::block::AskUserQuestionSpeedbumpFooter>,
+    /// Settings link handle for the Ask-User-Question autonomy speedbump footer,
+    /// set by `AIBlock` when the speedbump is seeded for this action.
+    speedbump_settings_link_handle: Option<MouseStateHandle>,
+    /// Lazily created dropdown for the speedbump footer; owned here so the
+    /// view handle (and its event subscription) survives re-renders.
+    speedbump_dropdown: Option<ViewHandle<Dropdown<AskUserQuestionViewAction>>>,
 }
 
 impl AskUserQuestionView {
@@ -797,7 +806,8 @@ impl AskUserQuestionView {
             toggle_mouse_state: MouseStateHandle::default(),
             skip_button,
             next_button,
-            speedbump_footer: None,
+            speedbump_settings_link_handle: None,
+            speedbump_dropdown: None,
         };
 
         ctx.subscribe_to_model(&action_model, |me, _, event, ctx| {
@@ -825,15 +835,72 @@ impl AskUserQuestionView {
         self.session.is_editing()
     }
 
-    /// Installs or clears the Ask-User-Question autonomy speedbump footer. The
-    /// footer is only actually drawn during the completed/finished render paths.
-    pub fn set_speedbump_footer(
+    /// Sets the settings-link mouse handle used in the speedbump footer.
+    /// The footer is only actually drawn during the completed/finished render paths.
+    pub fn set_speedbump_settings_link(
         &mut self,
-        footer: Option<crate::ai::blocklist::block::AskUserQuestionSpeedbumpFooter>,
+        settings_link_handle: Option<MouseStateHandle>,
         ctx: &mut ViewContext<Self>,
     ) {
-        self.speedbump_footer = footer;
+        self.speedbump_settings_link_handle = settings_link_handle;
         ctx.notify();
+    }
+
+    /// Creates the dropdown view for the speedbump footer. No-op if already initialized.
+    pub fn init_speedbump_dropdown(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.speedbump_dropdown.is_some() {
+            return;
+        }
+        let view = ctx.add_typed_action_view(|ctx| {
+            let dropdown_font_size = Appearance::as_ref(ctx).monospace_font_size() - 1.;
+            let mut dropdown = Dropdown::new(ctx);
+            dropdown.set_font_size(dropdown_font_size, ctx);
+            dropdown.set_padding(
+                Coords {
+                    top: 2.,
+                    bottom: 2.,
+                    left: 8.,
+                    right: 8.,
+                },
+                ctx,
+            );
+            dropdown.set_vertical_margin(0., ctx);
+            dropdown.set_top_bar_height(24., ctx);
+            let permissions = [
+                AskUserQuestionPermission::Never,
+                AskUserQuestionPermission::AskExceptInAutoApprove,
+                AskUserQuestionPermission::AlwaysAsk,
+            ];
+            dropdown.set_items(
+                permissions
+                    .into_iter()
+                    .map(|p| {
+                        DropdownItem::new(p.label(), AskUserQuestionViewAction::SetPermission(p))
+                    })
+                    .collect(),
+                ctx,
+            );
+            dropdown
+        });
+        self.speedbump_dropdown = Some(view);
+    }
+
+    /// Updates the dropdown's selected item to match the active execution profile.
+    pub fn refresh_speedbump_dropdown_selection(
+        &mut self,
+        terminal_view_id: EntityId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(dropdown) = self.speedbump_dropdown.clone() else {
+            return;
+        };
+        let permission = AIExecutionProfilesModel::as_ref(ctx)
+            .active_profile(Some(terminal_view_id), ctx)
+            .data()
+            .ask_user_question;
+        dropdown.update(ctx, |dropdown, ctx| {
+            dropdown.set_selected_by_name(permission.label(), ctx);
+        });
     }
 
     /// Recover completed/cancelled status even if the live action entry is gone, so restored
@@ -1328,9 +1395,10 @@ impl AskUserQuestionView {
         app: &AppContext,
     ) -> Box<dyn Element> {
         let speedbump_footer = self
-            .speedbump_footer
-            .as_ref()
-            .map(|footer| self.render_speedbump_footer(footer, appearance, app));
+            .speedbump_settings_link_handle
+            .clone()
+            .filter(|_| self.speedbump_dropdown.is_some())
+            .and_then(|handle| self.render_speedbump_footer(handle, appearance, app));
         let has_speedbump_footer = speedbump_footer.is_some();
 
         let mut header_config = HeaderConfig::new(label, app)
@@ -1380,23 +1448,26 @@ impl AskUserQuestionView {
 
     fn render_speedbump_footer(
         &self,
-        footer: &crate::ai::blocklist::block::AskUserQuestionSpeedbumpFooter,
+        settings_link_handle: MouseStateHandle,
         appearance: &Appearance,
         app: &AppContext,
-    ) -> Box<dyn Element> {
+    ) -> Option<Box<dyn Element>> {
         let theme = appearance.theme();
+        let dropdown = self.speedbump_dropdown.as_ref()?;
         let row = render_autonomy_dropdown_setting_speedbump_footer(
-            "Ask questions",
-            &footer.dropdown,
-            footer.settings_link_handle.clone(),
+            "Allow the agent to ask questions:",
+            dropdown,
+            settings_link_handle,
             app,
         );
-        Container::new(row)
-            .with_horizontal_padding(INLINE_ACTION_HORIZONTAL_PADDING)
-            .with_vertical_padding(4.)
-            .with_background(theme.surface_1())
-            .with_corner_radius(CornerRadius::with_bottom(Radius::Pixels(8.)))
-            .finish()
+        Some(
+            Container::new(row)
+                .with_horizontal_padding(INLINE_ACTION_HORIZONTAL_PADDING)
+                .with_vertical_padding(4.)
+                .with_background(theme.surface_1())
+                .with_corner_radius(CornerRadius::with_bottom(Radius::Pixels(8.)))
+                .finish(),
+        )
     }
 
     fn render_question_text(
@@ -1575,11 +1646,13 @@ impl TypedActionView for AskUserQuestionView {
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         // Editing actions only run while this inline block is still the active user blocker. The
-        // completion summary stays interactive via ToggleExpanded after completion.
-        if !matches!(action, AskUserQuestionViewAction::ToggleExpanded)
-            && (!self.session.is_editing()
-                || !self.is_waiting_on_user_answers(ctx)
-                || self.session.current().is_none())
+        // completion summary stays interactive via ToggleExpanded and SetPermission after completion.
+        if !matches!(
+            action,
+            AskUserQuestionViewAction::ToggleExpanded | AskUserQuestionViewAction::SetPermission(_)
+        ) && (!self.session.is_editing()
+            || !self.is_waiting_on_user_answers(ctx)
+            || self.session.current().is_none())
         {
             return;
         }
@@ -1629,6 +1702,11 @@ impl TypedActionView for AskUserQuestionView {
             }
             AskUserQuestionViewAction::ToggleExpanded => {
                 self.is_expanded = !self.is_expanded;
+            }
+            AskUserQuestionViewAction::SetPermission(permission) => {
+                ctx.emit(AskUserQuestionViewEvent::SpeedbumpPermissionChanged(
+                    *permission,
+                ));
             }
             AskUserQuestionViewAction::EnterPressed => {
                 self.abort_auto_advance();

--- a/app/src/ai/execution_profiles/mod.rs
+++ b/app/src/ai/execution_profiles/mod.rs
@@ -183,9 +183,9 @@ pub enum AskUserQuestionPermission {
     /// Never pause; skip questions and continue with best judgment.
     Never,
     /// Pause and wait for the user, unless auto-approve mode is enabled.
-    #[default]
     AskExceptInAutoApprove,
     /// Always pause and wait for the user to answer before continuing, even in auto-approve mode.
+    #[default]
     AlwaysAsk,
 
     // This is intended to catch deserialization errors whenever we add new variants to this enum.
@@ -194,6 +194,16 @@ pub enum AskUserQuestionPermission {
 }
 
 impl AskUserQuestionPermission {
+    pub fn label(&self) -> &'static str {
+        match self {
+            AskUserQuestionPermission::Never => "Never ask",
+            AskUserQuestionPermission::AskExceptInAutoApprove => "Ask unless auto-approve",
+            AskUserQuestionPermission::AlwaysAsk | AskUserQuestionPermission::Unknown => {
+                "Always ask"
+            }
+        }
+    }
+
     pub fn description(&self) -> &'static str {
         match self {
             AskUserQuestionPermission::AskExceptInAutoApprove
@@ -267,7 +277,7 @@ impl Default for AIExecutionProfile {
             execute_commands: ActionPermission::AlwaysAsk,
             write_to_pty: WriteToPtyPermission::AlwaysAsk,
             mcp_permissions: ActionPermission::AgentDecides,
-            ask_user_question: AskUserQuestionPermission::AskExceptInAutoApprove,
+            ask_user_question: AskUserQuestionPermission::AlwaysAsk,
             command_denylist: DEFAULT_COMMAND_EXECUTION_DENYLIST.clone(),
             command_allowlist: Vec::new(),
             directory_allowlist: Vec::new(),

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -35,6 +35,7 @@ use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::ai::blocklist::AIBlockResponseRating;
 use crate::ai::blocklist::CommandExecutionPermissionAllowedReason;
 use crate::ai::blocklist::InputType;
+use crate::ai::execution_profiles::AskUserQuestionPermission;
 use crate::ai::mcp::TemplateVariable;
 use crate::ai::predict::generate_ai_input_suggestions::GenerateAIInputSuggestionsRequest;
 use crate::ai::predict::generate_ai_input_suggestions::GenerateAIInputSuggestionsResponseV2;
@@ -2278,6 +2279,10 @@ pub enum TelemetryEvent {
         src: AutonomySettingToggleSource,
         new: AgentModeCodingPermissionsType,
     },
+    ChangedAgentModeAskUserQuestionPermission {
+        src: AutonomySettingToggleSource,
+        new: AskUserQuestionPermission,
+    },
     FullEmbedCodebaseContextSearchSuccess {
         action_id: AIAgentActionId,
         total_search_duration: Duration,
@@ -3840,6 +3845,10 @@ impl TelemetryEvent {
                 "source": src,
                 "new": new,
             })),
+            TelemetryEvent::ChangedAgentModeAskUserQuestionPermission { src, new } => Some(json!({
+                "source": src,
+                "new": new,
+            })),
             TelemetryEvent::FullEmbedCodebaseContextSearchSuccess {
                 action_id,
                 total_search_duration,
@@ -4919,6 +4928,7 @@ impl TelemetryEvent {
             | TelemetryEvent::WorkflowAliasArgumentEdited { .. }
             | TelemetryEvent::ToggledAgentModeAutoexecuteReadonlyCommandsSetting { .. }
             | TelemetryEvent::ChangedAgentModeCodingPermissions { .. }
+            | TelemetryEvent::ChangedAgentModeAskUserQuestionPermission { .. }
             | TelemetryEvent::RepoOutlineConstructionSuccess { .. }
             | TelemetryEvent::RepoOutlineConstructionFailed { .. }
             | TelemetryEvent::AutoexecutedAgentModeRequestedCommand { .. }
@@ -5494,6 +5504,7 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             }
             Self::ToggledAgentModeAutoexecuteReadonlyCommandsSetting
             | Self::ChangedAgentModeCodingPermissions
+            | Self::ChangedAgentModeAskUserQuestionPermission
             | Self::AutoexecutedAgentModeRequestedCommand => EnablementState::Always,
             Self::AttachedImagesToAgentModeQuery => {
                 EnablementState::Flag(FeatureFlag::ImageAsContext)
@@ -6009,6 +6020,9 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             }
             Self::ChangedAgentModeCodingPermissions => {
                 "AIAutonomy.ChangedAgentModeCodingPermissions"
+            }
+            Self::ChangedAgentModeAskUserQuestionPermission => {
+                "AIAutonomy.ChangedAgentModeAskUserQuestionPermission"
             }
             Self::AutoexecutedAgentModeRequestedCommand => {
                 "AIAutonomy.AutoexecutedRequestedCommand"
@@ -6826,6 +6840,9 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             }
             Self::ChangedAgentModeCodingPermissions => {
                 "Changed Agent Mode permissions for coding tasks"
+            }
+            Self::ChangedAgentModeAskUserQuestionPermission => {
+                "Changed Agent Mode permission for asking user questions"
             }
             Self::AutoexecutedAgentModeRequestedCommand => {
                 "Autoexecuted an Agent Mode requested command"

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1007,6 +1007,19 @@ define_settings_group!(AISettings, settings: [
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
         private: true,
     }
+    // Whether or not we should show the one-shot speedbump on Ask-User-Question cards.
+    //
+    // Not a user-visible setting - we model it as a setting so we can track state.
+    // Intentionally NOT cloud-synced: we want users to see the first-time nudge on
+    // each fresh device, and we avoid a cloud-sync race that would make the flag
+    // silently stay `false` on new devices after being consumed once elsewhere.
+    should_show_agent_mode_ask_user_question_speedbump: ShouldShowAgentModeAskUserQuestionSpeedbump {
+        type: bool,
+        default: true,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Never,
+        private: true,
+    }
     // Whether to use locally loaded AWS credentials for Bedrock-enabled requests.
     aws_bedrock_credentials_enabled: AwsBedrockCredentialsEnabled {
         type: bool,

--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -4445,7 +4445,29 @@ impl Element for BlockListElement {
             event.raw_event()
         } else {
             let Some(e) = event.at_z_index(z_index, ctx) else {
-                // Only proceed if there's a relevant event at this z-index.
+                // The event is behind an overlay. Still dispatch interactive
+                // events to rich content views so overlay children (e.g.
+                // ask-user-question speedbump dropdowns) can handle them.
+                if matches!(
+                    event.raw_event(),
+                    Event::ScrollWheel { .. }
+                        | Event::LeftMouseDown { .. }
+                        | Event::LeftMouseUp { .. }
+                        | Event::LeftMouseDragged { .. }
+                        | Event::MiddleMouseDown { .. }
+                        | Event::RightMouseDown { .. }
+                        | Event::BackMouseDown { .. }
+                        | Event::ForwardMouseDown { .. }
+                ) && self.pane_state.is_focused()
+                {
+                    let mut handled = false;
+                    for view_id in self.visible_rich_content_views() {
+                        if let Some(rich_content) = self.rich_content_elements.get_mut(&view_id) {
+                            handled |= rich_content.dispatch_event(event, ctx, app);
+                        }
+                    }
+                    return handled;
+                }
                 return false;
             };
             e

--- a/crates/warpui_core/src/elements/dismiss.rs
+++ b/crates/warpui_core/src/elements/dismiss.rs
@@ -91,20 +91,37 @@ impl Element for Dismiss {
 
         let z_index = self.z_index().unwrap();
 
-        match (
-            self.dismiss_handler.as_mut(),
-            event.at_z_index(z_index, ctx),
-        ) {
+        let event_at_z_index = event.at_z_index(z_index, ctx);
+        match (self.dismiss_handler.as_mut(), event_at_z_index) {
             // If the event is available at the root z-index, that means it isn't covered by the
             // child element, which means the user is clicking outside of the child element
             (Some(handler), Some(Event::LeftMouseDown { .. })) => {
                 handler(ctx, app);
+                return self.prevent_interaction_with_other_elements;
             }
             (None, Some(Event::LeftMouseDown { .. })) => {
                 log::warn!("Dismiss underlay was clicked but no handler was set!");
+                return self.prevent_interaction_with_other_elements;
             }
             _ => {}
         };
+
+        if self.prevent_interaction_with_other_elements
+            && event_at_z_index.is_some()
+            && matches!(
+                event.raw_event(),
+                Event::ScrollWheel { .. }
+                    | Event::LeftMouseUp { .. }
+                    | Event::LeftMouseDragged { .. }
+                    | Event::MiddleMouseDown { .. }
+                    | Event::RightMouseDown { .. }
+                    | Event::BackMouseDown { .. }
+                    | Event::ForwardMouseDown { .. }
+                    | Event::MouseMoved { .. }
+            )
+        {
+            return true;
+        }
 
         false
     }

--- a/crates/warpui_core/src/elements/selectable_area.rs
+++ b/crates/warpui_core/src/elements/selectable_area.rs
@@ -672,6 +672,15 @@ impl Element for SelectableArea {
                 return true;
             }
         }
+        if matches!(
+            event.raw_event(),
+            Event::LeftMouseDown { .. } | Event::RightMouseDown { .. }
+        ) && self
+            .z_index()
+            .is_some_and(|z_index| event.at_z_index(z_index, ctx).is_none())
+        {
+            return false;
+        }
 
         match event.raw_event() {
             Event::LeftMouseDown {

--- a/specs/QUALITY-512-ask-user-question-speedbump/PRODUCT.md
+++ b/specs/QUALITY-512-ask-user-question-speedbump/PRODUCT.md
@@ -1,0 +1,80 @@
+# Ask-User-Question Autonomy Speedbump
+
+Linear: [QUALITY-512](https://linear.app/warpdotdev/issue/QUALITY-512/add-ask-user-question-permission-speedbump)
+
+## 1. Summary
+When Agent Mode first uses the Ask Question tool on a local client, show a compact inline footer on the Ask-User-Question card that lets the user adjust the active execution profile's Ask Question permission. The footer uses a dropdown with the existing three permission values and links to the AI Autonomy settings page.
+## 2. Problem
+Users can control how often Agent Mode pauses to ask them questions, but that control is buried in settings. Ask Question is also most noticeable at the moment the agent pauses, so the relevant permission should be surfaced in context the first time the user encounters it. Existing autonomy speedbumps already teach file-read and command execution permissions in context; Ask Question should follow the same pattern.
+## 3. Goals
+- Surface Ask Question autonomy controls at the moment the tool first appears.
+- Let the user update the active execution profile without leaving the conversation.
+- Link to the AI Autonomy settings page for users who want the full settings UI.
+- Show the nudge only once per local client install/profile state so it does not become noisy.
+- Support both normal Ask Question cards and first-use auto-approve skipped Ask Question cases.
+- Match the compact visual rhythm of existing autonomy speedbump footers.
+## 4. Non-goals
+- No new Ask Question permission values.
+- No changes to the AI settings page layout.
+- No changes to the active Ask-User-Question answer/skip flow.
+- No per-conversation or per-repository overrides.
+- No global reset UI for speedbumps.
+## 5. User experience
+### Trigger
+The speedbump is seeded when all of the following are true:
+- `FeatureFlag::AskUserQuestion` is enabled.
+- Agent Mode autonomy is allowed for the workspace.
+- The local one-shot setting `should_show_agent_mode_ask_user_question_speedbump` is `true`.
+- The completed agent output contains an Ask-User-Question action.
+
+The trigger intentionally includes auto-approve conversations. If Ask Question is skipped because auto-approve is active, the first skipped Ask Question card can still show the footer so the user can discover and adjust the setting.
+### One-shot semantics
+The one-shot flag is local-only and is not synced through Warp Drive. The flag is consumed once the footer is successfully attached to an Ask-User-Question view. If the agent output is processed before the view exists, the flag remains `true` and is consumed later when the matching view is created and the footer can actually be installed.
+
+The flag is consumed even if the user does not interact with the footer. This keeps the behavior to a single first-use display: if the user notices it and changes the setting, great; if they ignore it, the nudge is still considered displayed and will not reappear on future cards.
+### Card placement and layout
+- The footer renders as the bottom strip of the Ask-User-Question card.
+- The footer is compact, with reduced vertical padding and a smaller dropdown so it feels similar to existing read-file/checkmark speedbumps.
+- When the footer is present, the main Ask-User-Question card content does not keep rounded bottom corners; the footer owns the bottom radius so the combined card reads as one attached surface.
+- The footer appears for both collapsed and expanded completed cards.
+### Footer content
+- Left side: short explanatory text and a dropdown.
+- Right side: `Manage AI Autonomy permissions` link.
+- The settings link opens the AI settings page scoped to the Autonomy section.
+### Dropdown behavior
+The dropdown options match the settings page order:
+- `Never ask` → `AskUserQuestionPermission::Never`
+- `Ask unless auto-approve` → `AskUserQuestionPermission::AskExceptInAutoApprove`
+- `Always ask` → `AskUserQuestionPermission::AlwaysAsk`
+
+The selected value reflects the active execution profile's current `ask_user_question` permission. Selecting an option immediately updates the active profile, emits telemetry, hides the footer on the current card, and leaves the local one-shot flag consumed.
+### Overlay behavior
+The dropdown menu renders above surrounding block content. Its options are clickable even when the card is embedded in terminal rich content, and clicking the dropdown underlay dismisses the menu without terminal text selection intercepting the interaction.
+## 6. Success criteria
+- First normal Ask Question invocation on a local client shows the footer on the resulting card.
+- First auto-approve skipped Ask Question invocation also shows the footer on the resulting card.
+- The local one-shot flag is not consumed if no matching view exists yet.
+- The local one-shot flag is consumed once the footer is attached to the matching view.
+- Ignoring the footer does not cause it to reappear on future Ask Question cards.
+- Selecting any dropdown option updates the active profile immediately and hides the footer on the current card.
+- The dropdown selection stays in sync with external active-profile changes while the footer exists.
+- The settings link opens AI settings at the Autonomy section.
+- Dropdown options can be clicked and dismissed reliably above terminal/block content.
+- Collapsed and expanded cards with the footer render as one attached card with no double-rounded seam.
+## 7. Validation
+Automated validation:
+- `cargo check -p warp`
+- `cargo check --all-targets -p warp`
+- `cargo nextest run --no-fail-fast -p warp ask_user_question`
+- `cargo fmt --all`
+- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
+- `git --no-pager diff --check`
+## 8. Manual QA checklist
+- Reset `ShouldShowAgentModeAskUserQuestionSpeedbump` locally to `true`.
+- Trigger Ask Question in a normal conversation and confirm the compact footer appears on the card.
+- Trigger Ask Question in auto-approve mode and confirm the skipped card can show the same footer on first display.
+- Re-trigger Ask Question after ignoring the footer and confirm the footer does not reappear once the flag has been consumed.
+- Select each dropdown option and confirm the active profile's setting changes in AI settings.
+- Confirm selecting a dropdown option hides the footer.
+- Open the dropdown near other rich content and confirm its menu appears above other content, options are clickable, Escape/outside click dismisses it, and terminal selection does not intercept clicks.
+- Confirm collapsed and expanded cards have flattened attached corners with the footer present.

--- a/specs/QUALITY-512-ask-user-question-speedbump/TECH.md
+++ b/specs/QUALITY-512-ask-user-question-speedbump/TECH.md
@@ -1,0 +1,86 @@
+# Ask-User-Question Autonomy Speedbump — Technical Notes
+
+Linear: [QUALITY-512](https://linear.app/warpdotdev/issue/QUALITY-512/add-ask-user-question-permission-speedbump)
+Product spec: `specs/QUALITY-512-ask-user-question-speedbump/PRODUCT.md`
+
+## 1. Overview
+This change adds a one-shot Ask-User-Question autonomy speedbump to the existing `AIBlock` speedbump infrastructure. The speedbump installs a compact footer into `AskUserQuestionView`, backed by a `Dropdown<AIBlockAction>` that updates the active execution profile's `ask_user_question` permission.
+## 2. Key files
+- `app/src/settings/ai.rs` — defines `should_show_agent_mode_ask_user_question_speedbump` as a private local-only setting with `SyncToCloud::Never`.
+- `app/src/ai/blocklist/block.rs` — seeds the new speedbump variant, owns the dropdown view, syncs the footer into `AskUserQuestionView`, handles dropdown actions, and consumes the one-shot flag after successful footer installation.
+- `app/src/ai/blocklist/block/view_impl.rs` — renders the shared dropdown speedbump footer row.
+- `app/src/ai/blocklist/inline_action/ask_user_question_view.rs` — owns the Ask-User-Question card chrome and renders the attached footer in completed/collapsed states.
+- `app/src/server/telemetry/events.rs` — adds `ChangedAgentModeAskUserQuestionPermission`.
+- `app/src/terminal/block_list_element.rs` — forwards covered mouse events to visible rich-content overlays so dropdown menus remain interactive.
+- `crates/warpui_core/src/elements/dismiss.rs` — consumes underlay clicks for dismissable overlays that prevent interaction with other elements.
+- `crates/warpui_core/src/elements/selectable_area.rs` — avoids starting terminal selection for mouse down events covered by higher-z-index overlays.
+- `app/src/ai/blocklist/block_tests.rs` — covers permission index mapping, first Ask-User-Question action detection, and setting defaults/round-trip.
+## 3. Setting
+The new setting is intentionally local-only:
+- Name: `should_show_agent_mode_ask_user_question_speedbump`
+- Default: `true`
+- Private: `true`
+- Sync: `SyncToCloud::Never`
+
+This keeps the speedbump display tied to the local client state. It also avoids cross-device races where one device could consume the onboarding display for another device.
+## 4. Speedbump state
+`AutonomySettingSpeedbump` now has:
+- `ShouldShowForAskUserQuestion { action_id, shown }`
+
+The `action_id` pins the footer to the Ask-User-Question action that triggered it. The `shown` field is set when the footer is attached, matching the broader speedbump pattern and making the attachment state explicit.
+## 5. Trigger and one-shot consumption
+`AIBlock::handle_complete_output` uses `first_ask_user_question_action_id(output)` to find the first Ask-User-Question action in the completed agent output. It seeds the speedbump when the feature flag is enabled, autonomy is allowed, and the local one-shot setting is still `true`.
+
+Unlike the original design, auto-approve is not excluded. Auto-approve skipped Ask Question actions can seed the same first-use footer.
+
+The local one-shot flag is not consumed at seed time. `sync_ask_user_question_speedbump_footer` returns `true` only after it finds a matching `AskUserQuestionView` and installs the footer. Callers then invoke `mark_ask_user_question_speedbump_as_shown` only on that successful path. If output completion happens before the view exists, the flag remains `true`; `handle_ask_user_question_stream_update` calls the same sync helper after creating/replacing the view and consumes the flag when installation succeeds.
+## 6. Dropdown ownership and action flow
+`AIBlock` owns `ask_user_question_speedbump_dropdown: Option<ViewHandle<Dropdown<AIBlockAction>>>`. The dropdown is created lazily and reused for the block lifetime.
+
+Dropdown items dispatch `AIBlockAction::SetAskUserQuestionSpeedbumpPermission(permission)`. The handler:
+- Resolves the active execution profile for the terminal view.
+- Calls `AIExecutionProfilesModel::set_ask_user_question`.
+- Emits `ChangedAgentModeAskUserQuestionPermission` with source `Speedbump`.
+- Marks the local one-shot setting false idempotently.
+- Clears the speedbump state and footer from the current Ask-User-Question view.
+- Notifies the block so the footer hides immediately.
+
+Profile model events refresh the dropdown selected index so external settings changes are reflected while the footer exists.
+## 7. Footer rendering
+The footer is threaded into `AskUserQuestionView` rather than wrapping the child view externally. This keeps the Ask-User-Question card in charge of its own border, radius, and layout.
+
+`AskUserQuestionView` renders the footer as an attached bottom strip:
+- Reduced vertical padding for a compressed speedbump height.
+- Compact dropdown sizing.
+- Bottom radius applied to the footer strip.
+- Main card/header radius flattened at the bottom when a footer is present.
+- Footer support for collapsed and expanded completed states.
+
+This avoids a double-rounded seam between the card body and the speedbump footer.
+## 8. Overlay event routing
+The dropdown menu is rendered through WarpUI overlay infrastructure. A covered mouse event previously could be rejected by `BlockListElement` before the rich-content overlay received it, allowing terminal selection or surrounding content to intercept dropdown clicks.
+
+The fix has three parts:
+- `BlockListElement` forwards covered mouse events to visible rich-content views before returning.
+- `SelectableArea` does not start a selection when a mouse down event is covered at its z-index.
+- `Dismiss::prevent_interaction_with_other_elements` consumes mouse events that hit its underlay.
+
+Together these keep dropdown options clickable and make outside-click dismissal reliable.
+## 9. Telemetry
+The new telemetry event is `ChangedAgentModeAskUserQuestionPermission` with fields:
+- `src: AutonomySettingToggleSource`
+- `new: AskUserQuestionPermission`
+
+The speedbump path emits the event with `src = Speedbump` whenever the user selects a dropdown option.
+## 10. Validation
+Local validation:
+- `cargo check -p warp`
+- `cargo check --all-targets -p warp`
+- `cargo nextest run --no-fail-fast -p warp ask_user_question`
+- `cargo fmt --all`
+- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
+- `git --no-pager diff --check`
+## 11. Follow-ups
+- Add deeper regression coverage for overlay routing if a convenient harness exists for rich-content overlays.
+- Consider a shared compact dropdown speedbump component if future autonomy speedbumps need dropdowns.
+- Consider an internal reset affordance for local-only onboarding speedbumps to simplify QA.


### PR DESCRIPTION
## Description
Add a one-shot dropdown-based speedbump footer on Ask-User-Question cards that lets users adjust the `ask_user_question` default permission (Never / Ask except in auto-approve / Always ask) without leaving the conversation. The footer includes a link to the full autonomy settings page and fires telemetry when the permission is changed.

Key changes:
- New `AskUserQuestionPermission` enum and `label()` method in execution profiles
- New `ShouldShowForAskUserQuestion` variant in `AutonomySettingSpeedbump`
- `AskUserQuestionSpeedbumpFooter` struct with dropdown and settings link
- Speedbump dropdown creation, selection sync, and footer attachment logic in `AIBlock`
- Telemetry event for permission changes via the speedbump
- New `should_show_agent_mode_ask_user_question_speedbump` AI setting (one-shot flag)
- Overlay event routing for the dropdown through `BlockListElement` and `dismiss.rs`

[Warp conversation](https://staging.warp.dev/conversation/18f9d432-c579-484f-a86c-cc7c4ed2fdb4)

[Demo](https://www.loom.com/share/3b5683daf73847b78a0fd4660ea99a48)

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
<!-- TODO: Add screenshots/video of the speedbump dropdown -->

## Testing
- Presubmit (`./script/presubmit`) passes
- Manually verified `cargo check` compiles cleanly
- Unit test for `AskUserQuestionPermission::label()` coverage

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Added a one-shot speedbump on Ask-User-Question cards to adjust the default permission setting inline
-->