### PR TITLE
docs(crates): fix grammar issues in documentation comments

### DIFF
--- a/crates/ai/src/agent/action/mod.rs
+++ b/crates/ai/src/agent/action/mod.rs
@@ -48,7 +48,7 @@ pub enum AIAgentActionType {
         /// result instead.
         wait_until_completion: bool,
 
-        /// [`Some(true)`] iff the LLM thinks that the `command` might invoke pager.
+        /// [`Some(true)`] iff the LLM thinks that the `command` might invoke a pager.
         uses_pager: Option<bool>,
 
         /// The AI's rationale for requesting a command.

--- a/crates/ai/src/index/full_source_code_embedding/snapshot.rs
+++ b/crates/ai/src/index/full_source_code_embedding/snapshot.rs
@@ -188,7 +188,7 @@ pub(super) fn snapshot_dir() -> Option<PathBuf> {
 
 /// Constructs a snapshot path given a base directory and the codebase index's root path.
 pub(super) fn snapshot_path(snapshot_dir: &Path, repo_path: &Path) -> PathBuf {
-    // Use a hash the repo_path to create a unique filename
+    // Use a hash of the repo_path to create a unique filename
     let mut hasher = DefaultHasher::new();
     repo_path.hash(&mut hasher);
     let snapshot_file_name = format!("snapshot_{}", hasher.finish());

--- a/crates/settings/src/macros.rs
+++ b/crates/settings/src/macros.rs
@@ -39,7 +39,7 @@
 //! ```
 //!
 //! The macro also generates an `Event` type that is passed to subscribers of the
-//! setting group model. The name of the type is created by appended 'ChangedEvent'
+//! setting group model. The name of the type is created by appending 'ChangedEvent'
 //! to the name of the setting group:
 //!
 //! ```


### PR DESCRIPTION
## Description

Fixes a few minor grammar and wording issues in crate documentation comments.

### Changes

* Added missing article in pager comment
* Fixed wording in repo_path hash comment
* Corrected "appended" → "appending" in settings macro docs

## Testing

* [x] Verified the documentation comment changes locally
* [x] No functional code changes
