### PR TITLE
fix: refresh IME cursor area after redraw

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -1020,7 +1020,12 @@ impl EventLoop {
         })();
 
         match render_result {
-            Ok(_) => self.callbacks.for_window(window).frame_drawn(),
+            Ok(_) => {
+                self.callbacks.for_window(window).frame_drawn();
+                if self.ime_enabled {
+                    self.update_ime_position();
+                }
+            }
             Err(err) => {
                 log::warn!("Failed to render frame: {err:#}");
                 self.callbacks.for_window(window).frame_failed_to_draw();

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -1020,12 +1020,7 @@ impl EventLoop {
         })();
 
         match render_result {
-            Ok(_) => {
-                self.callbacks.for_window(window).frame_drawn();
-                if self.ime_enabled {
-                    self.update_ime_position();
-                }
-            }
+            Ok(_) => self.callbacks.for_window(window).frame_drawn(),
             Err(err) => {
                 log::warn!("Failed to render frame: {err:#}");
                 self.callbacks.for_window(window).frame_failed_to_draw();

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -1008,7 +1008,12 @@ impl EventLoop {
         })();
 
         match render_result {
-            Ok(_) => self.callbacks.for_window(window).frame_drawn(),
+            Ok(_) => {
+                self.callbacks.for_window(window).frame_drawn();
+                if self.ime_enabled {
+                    self.update_ime_position();
+                }
+            }
             Err(err) => {
                 log::warn!("Failed to render frame: {err:#}");
                 self.callbacks.for_window(window).frame_failed_to_draw();

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -1008,12 +1008,7 @@ impl EventLoop {
         })();
 
         match render_result {
-            Ok(_) => {
-                self.callbacks.for_window(window).frame_drawn();
-                if self.ime_enabled {
-                    self.update_ime_position();
-                }
-            }
+            Ok(_) => self.callbacks.for_window(window).frame_drawn(),
             Err(err) => {
                 log::warn!("Failed to render frame: {err:#}");
                 self.callbacks.for_window(window).frame_failed_to_draw();

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -592,6 +592,9 @@ pub struct AppContext {
     /// is the fastest commonly-used hasher for this type.
     singleton_models: FxHashMap<TypeId, AnyModelHandle>,
     last_frame_position_cache: HashMap<WindowId, crate::presenter::PositionCache>,
+    /// Last cursor position observed after scene layout, used to notify platform IME code only
+    /// when layout moves the active cursor.
+    last_observed_active_cursor_positions: HashMap<WindowId, Option<CursorInfo>>,
     pub(super) windows: HashMap<WindowId, Window>,
     pub(super) ref_counts: Arc<Mutex<RefCounts>>,
     pub(super) platform_delegate: Box<dyn platform::Delegate>,
@@ -765,6 +768,7 @@ impl AppContext {
             windows: Default::default(),
             ref_counts: Arc::new(Mutex::new(RefCounts::default())),
             last_frame_position_cache: Default::default(),
+            last_observed_active_cursor_positions: Default::default(),
             platform_delegate,
             // AppContext fields
             actions: Default::default(),
@@ -930,6 +934,22 @@ impl AppContext {
 
     pub fn report_active_cursor_position_update(&self) {
         self.windows().active_cursor_position_updated();
+    }
+
+    /// Notifies the platform when a scene rebuild changes the active cursor position.
+    pub fn report_active_cursor_position_update_if_changed(&mut self, window_id: WindowId) {
+        let active_cursor_position = self.active_cursor_position(window_id);
+        let did_change = match self.last_observed_active_cursor_positions.get(&window_id) {
+            Some(previous_position) => previous_position != &active_cursor_position,
+            None => active_cursor_position.is_some(),
+        };
+
+        self.last_observed_active_cursor_positions
+            .insert(window_id, active_cursor_position);
+
+        if did_change && self.windows().active_window() == Some(window_id) {
+            self.report_active_cursor_position_update();
+        }
     }
 
     pub fn rendering_config(&self) -> rendering::Config {
@@ -2566,6 +2586,8 @@ impl AppContext {
         self.presenters.remove(&window_id);
         self.invalidation_callbacks.remove(&window_id);
         self.window_invalidations.remove(&window_id);
+        self.last_observed_active_cursor_positions
+            .remove(&window_id);
         autotracking::close_window(window_id);
 
         let mut subscriptions = HashMap::new();
@@ -2777,6 +2799,8 @@ impl AppContext {
                 self.handle_window_event(event, window_id, presenter.clone());
             }
         }
+
+        self.report_active_cursor_position_update_if_changed(window_id);
 
         scene
     }

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -579,6 +579,9 @@ pub struct AppContext {
     /// is the fastest commonly-used hasher for this type.
     singleton_models: FxHashMap<TypeId, AnyModelHandle>,
     last_frame_position_cache: HashMap<WindowId, crate::presenter::PositionCache>,
+    /// Last cursor position observed after scene layout, used to notify platform IME code only
+    /// when layout moves the active cursor.
+    last_observed_active_cursor_positions: HashMap<WindowId, Option<CursorInfo>>,
     pub(super) windows: HashMap<WindowId, Window>,
     pub(super) ref_counts: Arc<Mutex<RefCounts>>,
     pub(super) platform_delegate: Box<dyn platform::Delegate>,
@@ -752,6 +755,7 @@ impl AppContext {
             windows: Default::default(),
             ref_counts: Arc::new(Mutex::new(RefCounts::default())),
             last_frame_position_cache: Default::default(),
+            last_observed_active_cursor_positions: Default::default(),
             platform_delegate,
             // AppContext fields
             actions: Default::default(),
@@ -917,6 +921,22 @@ impl AppContext {
 
     pub fn report_active_cursor_position_update(&self) {
         self.windows().active_cursor_position_updated();
+    }
+
+    /// Notifies the platform when a scene rebuild changes the active cursor position.
+    pub fn report_active_cursor_position_update_if_changed(&mut self, window_id: WindowId) {
+        let active_cursor_position = self.active_cursor_position(window_id);
+        let did_change = match self.last_observed_active_cursor_positions.get(&window_id) {
+            Some(previous_position) => previous_position != &active_cursor_position,
+            None => active_cursor_position.is_some(),
+        };
+
+        self.last_observed_active_cursor_positions
+            .insert(window_id, active_cursor_position);
+
+        if did_change && self.windows().active_window() == Some(window_id) {
+            self.report_active_cursor_position_update();
+        }
     }
 
     pub fn rendering_config(&self) -> rendering::Config {
@@ -2553,6 +2573,8 @@ impl AppContext {
         self.presenters.remove(&window_id);
         self.invalidation_callbacks.remove(&window_id);
         self.window_invalidations.remove(&window_id);
+        self.last_observed_active_cursor_positions
+            .remove(&window_id);
         autotracking::close_window(window_id);
 
         let mut subscriptions = HashMap::new();
@@ -2764,6 +2786,8 @@ impl AppContext {
                 self.handle_window_event(event, window_id, presenter.clone());
             }
         }
+
+        self.report_active_cursor_position_update_if_changed(window_id);
 
         scene
     }

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -96,7 +96,7 @@ impl fmt::Display for DisplayIdx {
 }
 
 /// Information to display the IME editor near the active cursor.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct CursorInfo {
     /// Position of the active cursor.
     pub position: RectF,

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -94,7 +94,7 @@ impl fmt::Display for DisplayIdx {
 }
 
 /// Information to display the IME editor near the active cursor.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct CursorInfo {
     /// Position of the active cursor.
     pub position: RectF,


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
This change refreshes the IME cursor area after a successful redraw when IME is enabled.

That keeps the IME preedit/candidate UI aligned with the terminal cursor during redraw-heavy terminal apps.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end. 

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up. 
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

Before this PR:
<img width="2593" height="1670" alt="Screenshot1" src="https://github.com/user-attachments/assets/9d3c4971-1eb2-4e02-9ee6-6d98b133e740" />
After this PR:
<img width="2572" height="1608" alt="Screenshot2" src="https://github.com/user-attachments/assets/3b9a6c7b-43c7-4efc-8b70-9174e61df170" />

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->
