### PR TITLE
fix soft-wrapped lines glyph indices cosmic text

### DIFF
--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -586,17 +586,20 @@ impl TextLayoutSystem {
             );
             total_height += line.height();
 
-            // We add 1 to the last caret position here to skip the newline character.
-            // Since we're working with separate lines within a text frame, there is guaranteed
-            // to be a newline to skip at the end of each iteration of the loop.
-            // The only exception is on the last iteration; in that case, we don't use this
-            // value later anyway.
-            line_glyph_start_index = line
-                .caret_positions
-                .last()
-                .map(|position| position.last_offset)
-                .unwrap_or(line_glyph_start_index)
-                + 1;
+            // Only update line_glyph_start_index at paragraph boundaries (when there's a trailing
+            // newline). For soft-wrapped lines within the same paragraph, glyph.start values from
+            // cosmic-text are always byte offsets relative to the paragraph start, so
+            // line_glyph_start_index must stay at the paragraph's starting byte offset in the full
+            // text.
+            if has_trailing_newline {
+                // Convert the last caret's char index back to a byte index, then advance past the
+                // newline separator to get the next paragraph's byte offset.
+                line_glyph_start_index = line
+                    .caret_positions
+                    .last()
+                    .and_then(|position| str_index_map.byte_index(position.last_offset + 1))
+                    .unwrap_or(line_glyph_start_index);
+            }
 
             // TODO(alokedesai): Properly clip multi-line text using the same strategy we use on mac.
             // See https://github.com/warpdotdev/warp-internal/blob/91dfe429074c6129a6b5c1c57c55c1daf6d274a9/ui/src/platform/mac/text_layout.rs#L318-L359.

--- a/crates/warpui/src/windowing/winit/text_layout_tests.rs
+++ b/crates/warpui/src/windowing/winit/text_layout_tests.rs
@@ -592,3 +592,146 @@ fn all_lines_bounded(frame: &TextFrame, frame_width: f32) -> bool {
         all_bounded && current_bounded
     })
 }
+
+#[test]
+fn test_softwrap_caret_positions_are_contiguous() -> Result<()> {
+    let (font_db, font_family) = init_fonts();
+
+    // A single paragraph (no newlines) long enough to soft-wrap at 200px.
+    let text = "The quick brown fox jumps over the lazy dog and then keeps running onward";
+    let frame = font_db.text_layout_system().layout_text(
+        text,
+        LineStyle {
+            font_size: FONT_SIZE,
+            line_height_ratio: DEFAULT_UI_LINE_HEIGHT_RATIO,
+            baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+            fixed_width_tab_size: None,
+        },
+        &[(
+            0..text.chars().count(),
+            StyleAndFont::new(font_family, Properties::default(), TextStyle::new()),
+        )],
+        200.,
+        f32::MAX,
+        TextAlignment::Left,
+        None,
+    );
+
+    // Should wrap onto multiple lines.
+    assert!(
+        frame.lines().len() >= 2,
+        "Expected at least 2 lines but got {}",
+        frame.lines().len()
+    );
+
+    // Collect all caret position start_offsets across all lines.
+    let all_caret_starts: Vec<usize> = frame
+        .lines()
+        .iter()
+        .flat_map(|line| line.caret_positions.iter().map(|c| c.start_offset))
+        .collect();
+
+    // The caret positions should be monotonically non-decreasing across all lines.
+    // Before the fix, the second/third wrapped line's carets would reset to 0.
+    for window in all_caret_starts.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "Caret positions are not monotonically non-decreasing: {} > {} (all: {:?})",
+            window[0],
+            window[1],
+            all_caret_starts
+        );
+    }
+
+    // The first caret should start at 0 and the last should correspond to near the end of the text.
+    assert_eq!(
+        *all_caret_starts.first().unwrap(),
+        0,
+        "First caret should start at 0"
+    );
+    let last_caret = frame
+        .lines()
+        .last()
+        .unwrap()
+        .caret_positions
+        .last()
+        .unwrap();
+    assert!(
+        last_caret.last_offset > 0,
+        "Last caret offset should be > 0"
+    );
+
+    // Each wrapped line's first caret should pick up where the previous line left off.
+    for i in 1..frame.lines().len() {
+        let prev_line = &frame.lines()[i - 1];
+        let curr_line = &frame.lines()[i];
+        if let (Some(prev_last), Some(curr_first)) = (
+            prev_line.caret_positions.last(),
+            curr_line.caret_positions.first(),
+        ) {
+            assert!(
+                curr_first.start_offset > prev_last.start_offset,
+                "Line {}'s first caret ({}) should be after line {}'s last caret ({})",
+                i,
+                curr_first.start_offset,
+                i - 1,
+                prev_last.start_offset
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_softwrap_caret_positions_multi_paragraph() -> Result<()> {
+    let (font_db, font_family) = init_fonts();
+
+    // Two paragraphs, each long enough to soft-wrap.
+    let text = "The quick brown fox jumps over the lazy dog repeatedly\nAnother paragraph that \
+        also wraps around when narrow";
+    let frame = font_db.text_layout_system().layout_text(
+        text,
+        LineStyle {
+            font_size: FONT_SIZE,
+            line_height_ratio: DEFAULT_UI_LINE_HEIGHT_RATIO,
+            baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+            fixed_width_tab_size: None,
+        },
+        &[(
+            0..text.chars().count(),
+            StyleAndFont::new(font_family, Properties::default(), TextStyle::new()),
+        )],
+        200.,
+        f32::MAX,
+        TextAlignment::Left,
+        None,
+    );
+
+    // Should have multiple lines from wrapping.
+    assert!(
+        frame.lines().len() >= 3,
+        "Expected at least 3 lines but got {}",
+        frame.lines().len()
+    );
+
+    // Caret positions should be monotonically non-decreasing across ALL lines (including across
+    // the paragraph boundary).
+    let all_caret_starts: Vec<usize> = frame
+        .lines()
+        .iter()
+        .flat_map(|line| line.caret_positions.iter().map(|c| c.start_offset))
+        .collect();
+
+    for window in all_caret_starts.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "Caret positions are not monotonically non-decreasing across paragraphs: {} > {} (all: {:?})",
+            window[0],
+            window[1],
+            all_caret_starts
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

This PR fixes selecting text after a soft-wrap on Windows/Linux for agent conversations.

The problem is that glyph indices were resetting after a soft-wrap when they should only be resetting after a hard-wrap.

## Linked Issue

This PR fixes #9805

UPDATE: I think this will also fix #9994

## Testing

Unit tests added. Also, selection on soft-wrapped lines works in agent conversations.


https://github.com/user-attachments/assets/486f674d-c4eb-4949-8ade-750bd69d9936


## Changelog Entries for Stable

CHANGELOG-BUG-FIX: [Windows/Linux] Text selection on soft-wrapped lines fixed.

