### PR TITLE
Add context field to third party harnesses

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1489,12 +1489,13 @@ impl AgentDriver {
             .map_err(|_| AgentDriverError::InvalidRuntimeState)
             .flatten()?;
 
-        let (prompt_text, system_prompt, resumption_prompt): (
+        let (prompt_text, system_prompt, resumption_prompt, server_context): (
             Cow<'_, str>,
             Option<String>,
             Option<String>,
+            Option<String>,
         ) = match prompt {
-            AgentRunPrompt::Local(text) => (Cow::Borrowed(text), None, None),
+            AgentRunPrompt::Local(text) => (Cow::Borrowed(text), None, None, None),
             AgentRunPrompt::ServerSide {
                 skill,
                 attachments_dir,
@@ -1518,6 +1519,7 @@ impl AgentDriver {
                     Cow::Owned(resolved.prompt),
                     resolved.system_prompt,
                     resolved.resumption_prompt,
+                    resolved.context,
                 )
             }
         };
@@ -1544,6 +1546,7 @@ impl AgentDriver {
                 prompt_text.as_ref(),
                 system_prompt.as_deref(),
                 resumption_prompt.as_deref(),
+                server_context.as_deref(),
                 &working_dir,
                 task_id,
                 server_api,

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -109,6 +109,7 @@ impl ThirdPartyHarness for ClaudeHarness {
         prompt: &str,
         system_prompt: Option<&str>,
         resumption_prompt: Option<&str>,
+        context: Option<&str>,
         working_dir: &Path,
         task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
@@ -118,11 +119,21 @@ impl ThirdPartyHarness for ClaudeHarness {
         // The ResumePayload shouldn't contain non-Claude information, error if it does.
         let claude_resume = resume.map(ClaudeResumeInfo::try_from).transpose()?;
         // Claude treats the user-turn message as immediate intent, so the resumption preamble
-        // is most reliable when prepended directly to the prompt that gets piped into the CLI.
-        let owned_prompt = match resumption_prompt {
-            Some(preamble) if !preamble.is_empty() => format!("{preamble}\n\n{prompt}"),
-            _ => prompt.to_string(),
-        };
+        // and server context are most reliable when prepended directly to the prompt that gets
+        // piped into the CLI. Order: resumption_prompt → context → prompt
+        let mut parts: Vec<&str> = Vec::new();
+        if let Some(preamble) = resumption_prompt {
+            if !preamble.is_empty() {
+                parts.push(preamble);
+            }
+        }
+        if let Some(ctx) = context {
+            if !ctx.is_empty() {
+                parts.push(ctx);
+            }
+        }
+        parts.push(prompt);
+        let owned_prompt = parts.join("\n\n");
         Ok(Box::new(ClaudeHarnessRunner::new(
             self.cli_agent().command_prefix(),
             &owned_prompt,

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -91,6 +91,7 @@ impl ThirdPartyHarness for CodexHarness {
         prompt: &str,
         system_prompt: Option<&str>,
         resumption_prompt: Option<&str>,
+        context: Option<&str>,
         working_dir: &Path,
         _task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
@@ -100,12 +101,22 @@ impl ThirdPartyHarness for CodexHarness {
         // The ResumePayload shouldn't contain non-Codex information, error if it does.
         let codex_resume = resume.map(CodexResumeInfo::try_from).transpose()?;
 
-        // Mirror Claude harness behavior: prepend the resumption preamble to
-        // the user-turn prompt so codex treats it as immediate intent.
-        let owned_prompt = match resumption_prompt {
-            Some(preamble) if !preamble.is_empty() => format!("{preamble}\n\n{prompt}"),
-            _ => prompt.to_string(),
-        };
+        // Mirror Claude harness behavior: prepend the resumption preamble and server context
+        // to the user-turn prompt so codex treats it as immediate intent.
+        // Order: resumption_prompt → context → prompt
+        let mut parts: Vec<&str> = Vec::new();
+        if let Some(preamble) = resumption_prompt {
+            if !preamble.is_empty() {
+                parts.push(preamble);
+            }
+        }
+        if let Some(ctx) = context {
+            if !ctx.is_empty() {
+                parts.push(ctx);
+            }
+        }
+        parts.push(prompt);
+        let owned_prompt = parts.join("\n\n");
         let client: Arc<dyn HarnessSupportClient> = server_api;
         Ok(Box::new(CodexHarnessRunner::new(
             self.cli_agent().command_prefix(),

--- a/app/src/ai/agent_sdk/driver/harness/gemini.rs
+++ b/app/src/ai/agent_sdk/driver/harness/gemini.rs
@@ -68,6 +68,7 @@ impl ThirdPartyHarness for GeminiHarness {
         prompt: &str,
         system_prompt: Option<&str>,
         _resumption_prompt: Option<&str>,
+        context: Option<&str>,
         working_dir: &Path,
         _task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,
@@ -77,10 +78,15 @@ impl ThirdPartyHarness for GeminiHarness {
         // Gemini does not support conversation resume yet. When it does, it will add its
         // own `ResumePayload::Gemini(..)` variant and override `fetch_resume_payload`,
         // and decide how to surface the user-turn resumption preamble.
+        // Prepend server context to the prompt if available.
+        let effective_prompt = match context {
+            Some(ctx) if !ctx.is_empty() => format!("{ctx}\n\n{prompt}"),
+            _ => prompt.to_string(),
+        };
         let client: Arc<dyn HarnessSupportClient> = server_api;
         Ok(Box::new(GeminiHarnessRunner::new(
             self.cli_agent().command_prefix(),
-            prompt,
+            &effective_prompt,
             system_prompt,
             working_dir,
             client,

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -185,6 +185,7 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
         prompt: &str,
         system_prompt: Option<&str>,
         resumption_prompt: Option<&str>,
+        context: Option<&str>,
         working_dir: &Path,
         task_id: Option<AmbientAgentTaskId>,
         server_api: Arc<ServerApi>,

--- a/app/src/server/server_api/harness_support.rs
+++ b/app/src/server/server_api/harness_support.rs
@@ -94,6 +94,11 @@ pub struct ResolvedHarnessPrompt {
     /// system context. Empty when no resumption is in effect.
     #[serde(default)]
     pub resumption_prompt: Option<String>,
+    /// Optional server-retrieved context relevant to the task prompt. Each harness
+    /// decides how to inject this — typically by prepending it to the user-turn prompt
+    /// after any resumption preamble.
+    #[serde(default)]
+    pub context: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Add support for a `context` field when resolving the prompt that we send to third-party harnesses. Since third party harnesses only allow us to send a single prompt, we prepend the context string to the user query for each harness.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?
-->
Tested locally, demo in associated server PR.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode