### PR TITLE
Hide command for third-party harness cloud agents.

### DIFF
--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -2512,129 +2512,136 @@ impl BlockListElement {
             Self::draw_border_between_blocks(border_origin, block_grid_params, ctx);
         }
 
-        let prompt_height_offset = cell_size_height * block.padding_top().as_f64() as f32;
-
-        *grid_origin += vec2f(0., prompt_height_offset);
-
-        let prompt_origin = snackbar_header
-            .and_then(|header| header.header_rect())
-            .map_or(*grid_origin, |r| {
-                let y = r.origin().y() + prompt_height_offset + block_banner_height;
-                vec2f(grid_origin.x(), y)
-            });
-
         let cursor_visible = block.is_mode_set(TermMode::SHOW_CURSOR);
-        // Draw prompt
-        if let Some(label_element) = label_element {
-            label_element.paint(prompt_origin, ctx, app);
-        } else {
-            let size_info = &block_grid_params.grid_render_params.size_info;
-            if block.should_display_rprompt(size_info) {
-                let rprompt_origin = prompt_origin + block.rprompt_render_offset(size_info);
-                block.rprompt_grid().draw(
-                    rprompt_origin,
-                    element_origin,
-                    glyphs,
-                    COMMAND_ALPHA,
-                    None,
-                    None,
-                    hovered_secret,
-                    None::<std::iter::Empty<&RangeInclusive<IndexPoint>>>,
-                    None,
-                    Properties::default(),
-                    block_grid_params,
-                    None,
-                    image_metadata,
+        let command_origin = if !block.should_hide_command_grid() {
+            let prompt_height_offset = cell_size_height * block.padding_top().as_f64() as f32;
+
+            *grid_origin += vec2f(0., prompt_height_offset);
+
+            let prompt_origin = snackbar_header
+                .and_then(|header| header.header_rect())
+                .map_or(*grid_origin, |r| {
+                    let y = r.origin().y() + prompt_height_offset + block_banner_height;
+                    vec2f(grid_origin.x(), y)
+                });
+
+            // Draw prompt
+            if let Some(label_element) = label_element {
+                label_element.paint(prompt_origin, ctx, app);
+            } else {
+                let size_info = &block_grid_params.grid_render_params.size_info;
+                if block.should_display_rprompt(size_info) {
+                    let rprompt_origin = prompt_origin + block.rprompt_render_offset(size_info);
+                    block.rprompt_grid().draw(
+                        rprompt_origin,
+                        element_origin,
+                        glyphs,
+                        COMMAND_ALPHA,
+                        None,
+                        None,
+                        hovered_secret,
+                        None::<std::iter::Empty<&RangeInclusive<IndexPoint>>>,
+                        None,
+                        Properties::default(),
+                        block_grid_params,
+                        None,
+                        image_metadata,
+                        ctx,
+                        app,
+                    );
+                }
+            }
+
+            // If Warp prompt (non-PS1) is being used, the command is drawn below the prompt,
+            // hence we account for the prompt's vertical offset.
+            let prompt_vertical_offset_px = if !block.honor_ps1() {
+                cell_size_height
+                    * (block.command_padding_top() + block.prompt_height()).as_f64() as f32
+            } else {
+                // Otherwise, the prompt/command are drawn together, in a single grid. Hence, we haven't
+                // drawn the prompt above and we do not account for the offset.
+                0.0
+            };
+
+            *grid_origin += vec2f(0.0, prompt_vertical_offset_px);
+
+            // Determine command_origin based on snackbar_header.
+            let command_origin = if snackbar_header.is_some() {
+                prompt_origin + vec2f(0.0, prompt_vertical_offset_px)
+            } else {
+                *grid_origin
+            };
+
+            // Update grid_origin and draw command.
+            let command_grid_properties = Properties::default();
+            block.prompt_and_command_grid().draw(
+                command_origin,
+                element_origin,
+                glyphs,
+                COMMAND_ALPHA,
+                highlighted_url
+                    .filter(|url| url.is_in_command_content() && url.block_index == block_index)
+                    .map(|url| &url.inner),
+                link_tool_tip
+                    .filter(|url| url.is_in_command_content() && url.block_index == block_index)
+                    .map(|url| &url.inner),
+                hovered_secret,
+                block_list_find_run
+                    .map(|run| run.matches_for_block_grid(block_index, GridType::PromptAndCommand)),
+                block_list_find_run
+                    .and_then(|run| run.focused_match())
+                    .and_then(|focused_match| match focused_match {
+                        BlockListMatch::CommandBlock(m)
+                            if m.block_index == block_index
+                                && m.grid_type == GridType::PromptAndCommand =>
+                        {
+                            Some(&m.range)
+                        }
+                        _ => None,
+                    }),
+                command_grid_properties,
+                block_grid_params,
+                cursor_visible.then(|| block.prompt_and_command_grid().cursor_style().shape),
+                image_metadata,
+                ctx,
+                app,
+            );
+
+            // Only render the cursor in the command grid if the command grid is active and if it's
+            // long running. This is to avoid jitter where a cursor just flickers while the pty is
+            // initializing.
+            if block.is_active_and_long_running()
+                && block.is_command_grid_active()
+                // Check if the "hide cursor" escape sequence is present.
+                && block.is_mode_set(TermMode::SHOW_CURSOR)
+            {
+                block.prompt_and_command_grid().draw_cursor(
+                    command_origin,
+                    &block_grid_params.grid_render_params,
                     ctx,
+                    terminal_view_id,
+                    None,
+                    block_grid_params
+                        .grid_render_params
+                        .warp_theme
+                        .cursor()
+                        .into(),
                     app,
                 );
             }
-        }
 
-        // If Warp prompt (non-PS1) is being used, the command is drawn below the prompt,
-        // hence we account for the prompt's vertical offset.
-        let prompt_vertical_offset_px = if !block.honor_ps1() {
-            cell_size_height * (block.command_padding_top() + block.prompt_height()).as_f64() as f32
-        } else {
-            // Otherwise, the prompt/command are drawn together, in a single grid. Hence, we haven't
-            // drawn the prompt above and we do not account for the offset.
-            0.0
-        };
+            // Update grid_origin & draw output
+            *grid_origin += vec2f(
+                0.,
+                cell_size_height
+                    * (block.padding_middle() + block.prompt_and_command_grid().len().into_lines())
+                        .as_f64() as f32,
+            );
 
-        *grid_origin += vec2f(0.0, prompt_vertical_offset_px);
-
-        // Determine command_origin based on snackbar_header.
-        let command_origin = if snackbar_header.is_some() {
-            prompt_origin + vec2f(0.0, prompt_vertical_offset_px)
+            command_origin
         } else {
             *grid_origin
         };
-
-        // Update grid_origin and draw command.
-        let command_grid_properties = Properties::default();
-        block.prompt_and_command_grid().draw(
-            command_origin,
-            element_origin,
-            glyphs,
-            COMMAND_ALPHA,
-            highlighted_url
-                .filter(|url| url.is_in_command_content() && url.block_index == block_index)
-                .map(|url| &url.inner),
-            link_tool_tip
-                .filter(|url| url.is_in_command_content() && url.block_index == block_index)
-                .map(|url| &url.inner),
-            hovered_secret,
-            block_list_find_run
-                .map(|run| run.matches_for_block_grid(block_index, GridType::PromptAndCommand)),
-            block_list_find_run
-                .and_then(|run| run.focused_match())
-                .and_then(|focused_match| match focused_match {
-                    BlockListMatch::CommandBlock(m)
-                        if m.block_index == block_index
-                            && m.grid_type == GridType::PromptAndCommand =>
-                    {
-                        Some(&m.range)
-                    }
-                    _ => None,
-                }),
-            command_grid_properties,
-            block_grid_params,
-            cursor_visible.then(|| block.prompt_and_command_grid().cursor_style().shape),
-            image_metadata,
-            ctx,
-            app,
-        );
-
-        // Only render the cursor in the command grid if the command grid is active and if it's
-        // long running. This is to avoid jitter where a cursor just flickers while the pty is
-        // initializing.
-        if block.is_active_and_long_running()
-            && block.is_command_grid_active()
-            // Check if the "hide cursor" escape sequence is present.
-            && block.is_mode_set(TermMode::SHOW_CURSOR)
-        {
-            block.prompt_and_command_grid().draw_cursor(
-                command_origin,
-                &block_grid_params.grid_render_params,
-                ctx,
-                terminal_view_id,
-                None,
-                block_grid_params
-                    .grid_render_params
-                    .warp_theme
-                    .cursor()
-                    .into(),
-                app,
-            );
-        }
-
-        // Update grid_origin & draw output
-        *grid_origin += vec2f(
-            0.,
-            cell_size_height
-                * (block.padding_middle() + block.prompt_and_command_grid().len().into_lines())
-                    .as_f64() as f32,
-        );
 
         let block_middle_lines =
             block.padding_middle() + block.prompt_and_command_number_of_rows().into_lines();
@@ -4346,7 +4353,11 @@ impl Element for BlockListElement {
                         }
                     }
 
-                    draw_border_above_block = true;
+                    // Don't draw a border below session headers (i.e. above the next block).
+                    draw_border_above_block = !matches!(
+                        self.rich_content_metadata.get(view_id),
+                        Some(RichContentMetadata::HarnessSessionHeader)
+                    );
 
                     grid_origin += vec2f(0., *height_px);
                 }

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -1527,9 +1527,11 @@ impl Block {
             Lines::zero()
         } else {
             self.block_banner_height()
-                + self.padding_top()
-                + self.prompt_and_command_height()
-                + self.padding_middle()
+                + if self.should_hide_command_grid {
+                    Lines::zero()
+                } else {
+                    self.padding_top() + self.prompt_and_command_height() + self.padding_middle()
+                }
                 + if self.should_hide_output_grid {
                     Lines::zero()
                 } else {

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -399,6 +399,9 @@ pub struct Block {
     /// If `true`, the output grid should not be rendered.
     should_hide_output_grid: bool,
 
+    /// If `true`, the prompt+command grid should not be rendered.
+    should_hide_command_grid: bool,
+
     /// [`Self::linefeed`] may discard some linefeeds at the beginning of the prompt. Doing so will
     /// alter the row numbers for [`Self::goto`] and [`Self::goto_line`] when ConPTY is involved. We
     /// track the count of discarded newlines here in order to correct the row number.
@@ -1007,6 +1010,7 @@ impl Block {
             has_received_user_input: false,
             hidden: false,
             should_hide_output_grid: false,
+            should_hide_command_grid: false,
             leading_linefeeds_ignored: 0,
             is_ai_ugc_telemetry_enabled,
             restored_block_was_local: None,
@@ -1489,6 +1493,14 @@ impl Block {
         self.should_hide_output_grid = should_hide;
     }
 
+    pub fn should_hide_command_grid(&self) -> bool {
+        self.should_hide_command_grid
+    }
+
+    pub fn set_should_hide_command_grid(&mut self, should_hide: bool) {
+        self.should_hide_command_grid = should_hide;
+    }
+
     /// Returns true iff this block should be used as a scrollback block
     /// in a shared session context. Note the active block is included in scrollback to get the active prompt.
     pub fn is_scrollback_block_for_shared_session(
@@ -1940,7 +1952,7 @@ impl Block {
     /// In the case of combined grid: for Warp prompt, this includes the height of both the Warp prompt
     /// AND combined grid; for PS1, this is just the combined grid (PS1 is included there).
     pub fn prompt_and_command_height(&self) -> Lines {
-        if !self.ready_to_render() {
+        if !self.ready_to_render() || self.should_hide_command_grid {
             Lines::zero()
         } else if self.header_grid.honor_ps1 {
             // No padding between prompt and command in the case of PS1 (combined grid).

--- a/app/src/terminal/view/ambient_agent/block.rs
+++ b/app/src/terminal/view/ambient_agent/block.rs
@@ -1,8 +1,10 @@
 mod entry;
+mod harness_session_header;
 mod setup_command;
 mod setup_command_text;
 
 pub use entry::*;
+pub use harness_session_header::*;
 pub use setup_command::*;
 pub use setup_command_text::*;
 

--- a/app/src/terminal/view/ambient_agent/block/harness_session_header.rs
+++ b/app/src/terminal/view/ambient_agent/block/harness_session_header.rs
@@ -1,0 +1,144 @@
+use warp_core::ui::appearance::Appearance;
+use warp_terminal::model::BlockId;
+use warpui::{
+    elements::{
+        ConstrainedBox, CrossAxisAlignment, Flex, Hoverable, MainAxisSize, ParentElement,
+        Shrinkable, Text,
+    },
+    platform::Cursor,
+    prelude::{Container, MouseStateHandle},
+    text_layout::ClipConfig,
+    AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext,
+};
+
+use crate::{
+    terminal::{view::PADDING_LEFT, CLIAgent},
+    ui_components::icons::Icon,
+};
+
+const CHEVRON_SIZE: f32 = 14.;
+const COLLAPSED_BOTTOM_PADDING: f32 = 8.;
+
+pub struct HarnessSessionHeader {
+    block_id: BlockId,
+    cli_name: String,
+    is_expanded: bool,
+    mouse_state: MouseStateHandle,
+}
+
+#[derive(Debug, Clone)]
+pub enum HarnessSessionHeaderEvent {
+    ToggleCommandGridVisibility(BlockId),
+}
+
+impl HarnessSessionHeader {
+    pub fn new(block_id: BlockId, cli_agent: Option<CLIAgent>) -> Self {
+        let cli_name = cli_agent
+            .map(|agent| agent.display_name().to_owned())
+            .unwrap_or_else(|| "Agent".to_owned());
+
+        Self {
+            block_id,
+            cli_name,
+            is_expanded: false,
+            mouse_state: Default::default(),
+        }
+    }
+}
+
+impl Entity for HarnessSessionHeader {
+    type Event = HarnessSessionHeaderEvent;
+}
+
+impl View for HarnessSessionHeader {
+    fn ui_name() -> &'static str {
+        "HarnessSessionHeader"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let text_color = theme.main_text_color(theme.background()).into_solid();
+
+        let chevron_icon = if self.is_expanded {
+            Icon::ChevronDown
+        } else {
+            Icon::ChevronRight
+        };
+
+        let label = format!("Running {}...", self.cli_name);
+
+        let row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_child(
+                Shrinkable::new(
+                    1.,
+                    Text::new(
+                        label,
+                        appearance.ai_font_family(),
+                        appearance.monospace_font_size(),
+                    )
+                    .with_color(text_color)
+                    .soft_wrap(false)
+                    .with_clip(ClipConfig::ellipsis())
+                    .finish(),
+                )
+                .finish(),
+            )
+            .with_child(
+                Container::new(
+                    ConstrainedBox::new(
+                        chevron_icon
+                            .to_warpui_icon(theme.sub_text_color(theme.background()))
+                            .finish(),
+                    )
+                    .with_width(CHEVRON_SIZE)
+                    .with_height(CHEVRON_SIZE)
+                    .finish(),
+                )
+                .finish(),
+            );
+
+        let bottom_padding = if self.is_expanded {
+            0.
+        } else {
+            COLLAPSED_BOTTOM_PADDING
+        };
+
+        Hoverable::new(self.mouse_state.clone(), move |_| {
+            Container::new(row.finish())
+                .with_margin_left(*PADDING_LEFT)
+                .with_margin_right(*PADDING_LEFT)
+                .with_padding_top(4.)
+                .with_padding_bottom(bottom_padding)
+                .finish()
+        })
+        .with_cursor(Cursor::PointingHand)
+        .on_click(move |ctx, _, _| {
+            ctx.dispatch_typed_action(HarnessSessionHeaderAction::ToggleCommandGridVisibility)
+        })
+        .finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum HarnessSessionHeaderAction {
+    ToggleCommandGridVisibility,
+}
+
+impl TypedActionView for HarnessSessionHeader {
+    type Action = HarnessSessionHeaderAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            HarnessSessionHeaderAction::ToggleCommandGridVisibility => {
+                self.is_expanded = !self.is_expanded;
+                ctx.emit(HarnessSessionHeaderEvent::ToggleCommandGridVisibility(
+                    self.block_id.clone(),
+                ));
+                ctx.notify();
+            }
+        }
+    }
+}

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -326,6 +326,44 @@ impl TerminalView {
                     model.finish_setup_command_group(group_id, ctx);
                     model.set_setup_command_visibility(false, ctx);
                 });
+
+                // Hide the command for the CLI agent block.
+                if FeatureFlag::HarnessSessionHeader.is_enabled() {
+                    let cli_agent = ambient_agent_view_model
+                        .as_ref(ctx)
+                        .selected_third_party_cli_agent();
+                    let block_index = {
+                        let mut model = self.model.lock();
+                        if let Some(block) = model.block_list_mut().mut_block_from_id(block_id) {
+                            block.set_should_hide_command_grid(true);
+                        }
+                        model.block_list().block_index_for_id(block_id)
+                    };
+                    if let Some(block_index) = block_index {
+                        let header_view = ctx.add_typed_action_view(|_| {
+                            super::HarnessSessionHeader::new(block_id.clone(), cli_agent)
+                        });
+                        ctx.subscribe_to_view(&header_view, |me, _, event, _| {
+                            let super::HarnessSessionHeaderEvent::ToggleCommandGridVisibility(
+                                block_id,
+                            ) = event;
+                            let mut model = me.model.lock();
+                            if let Some(block) = model.block_list_mut().mut_block_from_id(block_id)
+                            {
+                                let hidden = block.should_hide_command_grid();
+                                block.set_should_hide_command_grid(!hidden);
+                            }
+                        });
+                        self.insert_rich_content(
+                            None,
+                            header_view,
+                            Some(RichContentMetadata::HarnessSessionHeader),
+                            RichContentInsertionPosition::BeforeBlockIndex(block_index),
+                            ctx,
+                        );
+                    }
+                }
+
                 // Force a fresh viewer size report to the sharer so the harness CLI (e.g.
                 // the claude TUI) starts at our terminal's actual dimensions instead of
                 // whatever the sandbox PTY was sized to during setup.

--- a/app/src/terminal/view/rich_content.rs
+++ b/app/src/terminal/view/rich_content.rs
@@ -272,6 +272,7 @@ pub enum RichContentMetadata {
     TerminalViewZeroState,
     PluginInstructionsBlock,
     PendingUserQuery,
+    HarnessSessionHeader,
 }
 
 impl TerminalView {

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -869,6 +869,9 @@ pub enum FeatureFlag {
     /// (`~/.git-credentials`, `~/.config/gh/hosts.yaml`) and runs the
     /// background refresh loop that keeps them fresh during a task run.
     GitCredentialRefresh,
+
+    /// Replaces the raw harness CLI command with a styled header showing CLI name + status icon.
+    HarnessSessionHeader,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -952,6 +955,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::NamedAgents,
     FeatureFlag::GitCredentialRefresh,
     FeatureFlag::HandoffCloudCloud,
+    FeatureFlag::HarnessSessionHeader,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
First stab at an alternative UI for hiding third-party harness cloud agent commands. Significant inspiration taken from
 how we're showing setup commands.

Currently gated behind a separate feature flag, and only touches the cloud agent path for block rendering--this should not impact other block-rendering codepaths.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end. 

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up. 
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->
Loom: https://www.loom.com/share/2e61d8636b4f46ef91351ab5c8cacca3

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

