### PR TITLE
feat: support fzf ctrl-r history search in Warp

### DIFF
--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -1270,6 +1270,35 @@ esac
 
     shell_plugins=()
 
+    # Detect if fzf's ctrl-r history search is bound. If so, register a wrapper
+    # function that invokes __fzf_history__ and then reports READLINE_LINE back
+    # to Warp via the InputBuffer hook.
+    warp_has_fzf_ctrl_r=""
+    if ((BASH_VERSINFO[0] >= 4)); then
+        # On bash >= 4, fzf uses `bind -x` to bind __fzf_history__ to \C-r.
+        # Check if that binding exists.
+        if bind -x '"\C-r"' 2>/dev/null | command -p grep -q '__fzf_history__' 2>/dev/null; then
+            warp_has_fzf_ctrl_r="1"
+
+            __warp_fzf_history__() {
+                __fzf_history__
+                # Report the resulting READLINE_LINE back to Warp.
+                local escaped_input="$(warp_escape_json "$READLINE_LINE")"
+                warp_send_json_message "{ \"hook\": \"InputBuffer\", \"value\": { \"buffer\": \"$escaped_input\" } }"
+            }
+            bind -m emacs-standard -x '"\C-r": __warp_fzf_history__'
+            bind -m vi-command -x '"\C-r": __warp_fzf_history__'
+            bind -m vi-insert -x '"\C-r": __warp_fzf_history__'
+        fi
+    else
+        # On bash < 4, fzf uses macro-style bind. Check if \C-r contains __fzf_history__.
+        if bind -p 2>/dev/null | command -p grep -q '__fzf_history__' 2>/dev/null; then
+            warp_has_fzf_ctrl_r="1"
+            # We can't easily wrap macro-style bindings, so just flag it for detection.
+            # The user will get fzf's native behavior without buffer reporting.
+        fi
+    fi
+
     function warp_bootstrapped () {
         local aliases="`alias`"
         local env_var_names="`compgen -e`"
@@ -1293,6 +1322,11 @@ esac
         # real bash options.
         if [[ -n $USER_HISTCONTROL ]]; then
             shell_options="$shell_options \n !histcontrol_$USER_HISTCONTROL"
+        fi
+
+        # If fzf's ctrl-r is detected, append our custom flag.
+        if [[ -n "$warp_has_fzf_ctrl_r" ]]; then
+            shell_options="$shell_options \n fzf_ctrl_r"
         fi
 
         # Check if Starship is active for Bash. Note that another prompt could still be overriding Starship, however,

--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -1274,12 +1274,16 @@ esac
     # function that invokes __fzf_history__ and then reports READLINE_LINE back
     # to Warp via the InputBuffer hook.
     warp_has_fzf_ctrl_r=""
-    if ((BASH_VERSINFO[0] >= 4)); then
-        # On bash >= 4, fzf uses `bind -x` to bind __fzf_history__ to \C-r.
-        # Check if that binding exists.
-        if bind -x '"\C-r"' 2>/dev/null | command -p grep -q '__fzf_history__' 2>/dev/null; then
-            warp_has_fzf_ctrl_r="1"
+    # Detect fzf's ctrl-r by checking if the __fzf_history__ function exists.
+    # We use `declare -f` instead of inspecting bind output because `bind -X`
+    # only works in the current interactive shell — pipes and subshells lose
+    # readline state, making bind-based detection unreliable.
+    if declare -f __fzf_history__ >/dev/null 2>&1; then
+        warp_has_fzf_ctrl_r="1"
 
+        if ((BASH_VERSINFO[0] >= 4)); then
+            # On bash >= 4, fzf uses `bind -x` so we can wrap the binding with
+            # a function that reports READLINE_LINE back to Warp.
             __warp_fzf_history__() {
                 __fzf_history__
                 # Report the resulting READLINE_LINE back to Warp.
@@ -1290,13 +1294,8 @@ esac
             bind -m vi-command -x '"\C-r": __warp_fzf_history__'
             bind -m vi-insert -x '"\C-r": __warp_fzf_history__'
         fi
-    else
-        # On bash < 4, fzf uses macro-style bind. Check if \C-r contains __fzf_history__.
-        if bind -p 2>/dev/null | command -p grep -q '__fzf_history__' 2>/dev/null; then
-            warp_has_fzf_ctrl_r="1"
-            # We can't easily wrap macro-style bindings, so just flag it for detection.
-            # The user will get fzf's native behavior without buffer reporting.
-        fi
+        # On bash < 4, fzf uses macro-style bindings which we can't easily wrap,
+        # but we still flag it so Warp delegates ctrl-r to the shell.
     fi
 
     function warp_bootstrapped () {

--- a/app/assets/bundled/bootstrap/fish.sh
+++ b/app/assets/bundled/bootstrap/fish.sh
@@ -511,9 +511,27 @@ function warp_bootstrapped
   set -l escaped_builtins (warp_escape_json (builtin -n))
   # Note "keywords" is set to an empty string since fish includes keywords as a
   # part of its builtins (e.g. "for", "while", etc.).
+  # Detect if fzf's ctrl-r history widget is bound.
+  set -l warp_shell_options ""
+  if bind \cr 2>/dev/null | string match -q '*fzf-history-widget*'
+    set warp_shell_options "fzf_ctrl_r"
+
+    # Register a wrapper function that invokes fzf-history-widget and then
+    # reports the resulting commandline back to Warp via the InputBuffer hook.
+    function warp_fzf_history_widget
+      fzf-history-widget
+      # Report the resulting commandline back to Warp.
+      set -l escaped_input (warp_escape_json (commandline))
+      warp_send_json_message "{ \"hook\": \"InputBuffer\", \"value\": { \"buffer\": \"$escaped_input\" } }"
+    end
+    bind \cr warp_fzf_history_widget
+    bind -M insert \cr warp_fzf_history_widget
+  end
+
+  set -l escaped_shell_options (warp_escape_json "$warp_shell_options")
   set -l escaped_editor (warp_escape_json "$EDITOR")
   set -l escaped_shell_path (warp_escape_json (status fish-path))
-  set -l escaped_json "{\"hook\": \"Bootstrapped\", \"value\": {\"histfile\": \"$escaped_histfile\", \"shell\": \"fish\", \"home_dir\": \"$HOME\", \"path\": \"$PATH\", \"editor\": \"$escaped_editor\", \"abbreviations\": \"$escaped_abbr\", \"aliases\": \"$escaped_aliases\", \"function_names\": \"$function_names\", \"env_var_names\": \"$env_var_names\", \"builtins\": \"$escaped_builtins\", \"keywords\": \"\", \"shell_version\": \"$FISH_VERSION\", \"vi_mode_enabled\": \"$vi_mode_enabled\", \"os_category\": \"$os_category\", \"linux_distribution\": \"$linux_distribution\", \"wsl_name\": \"$WSL_DISTRO_NAME\", \"shell_path\": \"$escaped_shell_path\"}}"
+  set -l escaped_json "{\"hook\": \"Bootstrapped\", \"value\": {\"histfile\": \"$escaped_histfile\", \"shell\": \"fish\", \"home_dir\": \"$HOME\", \"path\": \"$PATH\", \"editor\": \"$escaped_editor\", \"abbreviations\": \"$escaped_abbr\", \"aliases\": \"$escaped_aliases\", \"function_names\": \"$function_names\", \"env_var_names\": \"$env_var_names\", \"builtins\": \"$escaped_builtins\", \"keywords\": \"\", \"shell_version\": \"$FISH_VERSION\", \"shell_options\": \"$escaped_shell_options\", \"vi_mode_enabled\": \"$vi_mode_enabled\", \"os_category\": \"$os_category\", \"linux_distribution\": \"$linux_distribution\", \"wsl_name\": \"$WSL_DISTRO_NAME\", \"shell_path\": \"$escaped_shell_path\"}}"
   warp_send_json_message $escaped_json
 end
 

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1374,6 +1374,30 @@ esac
   zstyle ':completion:warp_complete_via_compadd_override:*' list-separator ''
 
 
+  # Detect if fzf's ctrl-r history widget is bound. If so, register a wrapper
+  # widget that invokes fzf-history-widget and then reports the resulting buffer
+  # back to Warp via the InputBuffer hook so Warp can populate its input editor.
+  local warp_has_fzf_ctrl_r=""
+  if [[ "$(bindkey '^R' 2>/dev/null)" == *"fzf-history-widget"* ]]; then
+    warp_has_fzf_ctrl_r="1"
+
+    function warp_fzf_history_widget () {
+      # Invoke the real fzf history widget.
+      zle fzf-history-widget
+      local ret=$?
+
+      # Report the resulting buffer back to Warp so it can populate the input editor.
+      # Unlike warp_report_input, we do NOT clear the buffer here — the user wants
+      # the selected command to remain in the ZLE buffer for the prompt redraw.
+      local escaped_input="$(warp_escape_json "$BUFFER")"
+      warp_send_json_message "{ \"hook\": \"InputBuffer\", \"value\": { \"buffer\": \"$escaped_input\" } }"
+
+      return $ret
+    }
+    zle -N warp_fzf_history_widget
+    bindkey '^R' warp_fzf_history_widget
+  fi
+
   function warp_bootstrapped () {
     # Note that for now we don't support dynamically changing HISTFILE within a session.
     local escaped_histfile="$(warp_escape_json $HISTFILE)"
@@ -1391,7 +1415,11 @@ esac
     local escaped_shell_plugins="$(warp_escape_json "`builtin print -l -- ${shell_plugins}`")"
 
     # The list of options enabled for the current shell.
+    # If fzf's ctrl-r is detected, append our custom fzf_ctrl_r flag.
     local shell_options="$(warp_escape_json "`setopt`")"
+    if [[ -n "$warp_has_fzf_ctrl_r" ]]; then
+      shell_options="$shell_options fzf_ctrl_r"
+    fi
 
     local escaped_editor="$(warp_escape_json "$EDITOR")"
     local escaped_shell_path="$(warp_escape_json "${commands[zsh]}")"

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -963,6 +963,10 @@ pub enum Event {
     SyncInput(SyncInputType),
     ShowCommandSearch(CommandSearchOptions),
     CtrlD,
+    /// Emitted when the user presses ctrl-r and fzf's history widget is available.
+    /// The terminal view should write the raw ctrl-r byte (\x12) to the PTY so the
+    /// shell's line editor invokes fzf.
+    FzfCtrlR,
     CtrlC {
         // The number of chars cleared from the buffer, if the ctrl-c triggered a buffer clear.
         cleared_buffer_len: usize,
@@ -10469,7 +10473,19 @@ impl Input {
                     input_suggestions.select_prev(ctx);
                 });
         } else if !self.ai_input_model.as_ref(ctx).is_ai_input_enabled() {
-            self.fuzzy_history_search(ctx);
+            // If fzf's ctrl-r history widget is available, delegate to the shell's
+            // line editor instead of opening Warp's command search. The shell's
+            // wrapper widget will invoke fzf and report the selected command back
+            // via the InputBuffer hook.
+            let has_fzf = self
+                .active_session(ctx)
+                .map(|session| session.shell().has_fzf_ctrl_r())
+                .unwrap_or(false);
+            if has_fzf {
+                ctx.emit(Event::FzfCtrlR);
+            } else {
+                self.fuzzy_history_search(ctx);
+            }
         }
     }
 

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -10464,6 +10464,24 @@ impl Input {
         ctx.emit(Event::CtrlD);
     }
 
+    /// Check whether fzf ctrl-r is available and, if so, emit the FzfCtrlR
+    /// event so the terminal view writes the raw ctrl-r byte to the PTY.
+    /// Returns `true` when fzf was detected and the event was emitted;
+    /// `false` otherwise (caller should fall back to Warp's command search).
+    pub fn try_emit_fzf_ctrl_r(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        if self.ai_input_model.as_ref(ctx).is_ai_input_enabled() {
+            return false;
+        }
+        let has_fzf = self
+            .active_session(ctx)
+            .map(|session| session.shell().has_fzf_ctrl_r())
+            .unwrap_or(false);
+        if has_fzf {
+            ctx.emit(Event::FzfCtrlR);
+        }
+        has_fzf
+    }
+
     fn ctrl_r(&mut self, ctx: &mut ViewContext<Self>) {
         if self.suggestions_mode_model.as_ref(ctx).is_history_up() {
             // Iterate through menu if we're already in history substring mode and
@@ -10472,20 +10490,8 @@ impl Input {
                 .update(ctx, |input_suggestions, ctx| {
                     input_suggestions.select_prev(ctx);
                 });
-        } else if !self.ai_input_model.as_ref(ctx).is_ai_input_enabled() {
-            // If fzf's ctrl-r history widget is available, delegate to the shell's
-            // line editor instead of opening Warp's command search. The shell's
-            // wrapper widget will invoke fzf and report the selected command back
-            // via the InputBuffer hook.
-            let has_fzf = self
-                .active_session(ctx)
-                .map(|session| session.shell().has_fzf_ctrl_r())
-                .unwrap_or(false);
-            if has_fzf {
-                ctx.emit(Event::FzfCtrlR);
-            } else {
-                self.fuzzy_history_search(ctx);
-            }
+        } else if !self.try_emit_fzf_ctrl_r(ctx) {
+            self.fuzzy_history_search(ctx);
         }
     }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2854,6 +2854,11 @@ pub struct TerminalView {
     /// State handle for the shimmering text animation in the remote server loading footer.
     /// Persisted across renders so the animation doesn't restart.
     remote_server_shimmer_handle: ShimmeringTextStateHandle,
+
+    /// When `true`, keystrokes are forwarded to the PTY instead of the input
+    /// editor. Set when fzf's ctrl-r history widget is invoked and cleared when
+    /// fzf completes (detected via the InputBuffer hook / typeahead event).
+    fzf_passthrough_active: bool,
 }
 
 /// Parameters stashed when a code review pane open is requested with
@@ -4256,6 +4261,7 @@ impl TerminalView {
             pty_recorder: ctx
                 .add_model(|ctx| PtyRecorder::new(inactive_pty_reads_rx, window_id, ctx)),
             active_viewer_driven_size: None,
+            fzf_passthrough_active: false,
         };
         terminal_view.register_subscriptions_for_use_agent_footer(ctx);
 
@@ -7118,6 +7124,11 @@ impl TerminalView {
         if model.is_read_only() {
             return false;
         }
+        // Hide the input box while fzf's TUI is active so keystrokes route
+        // directly to the PTY.
+        if self.fzf_passthrough_active {
+            return false;
+        }
         if self.has_active_cli_agent_input_session(app) {
             return true;
         }
@@ -7346,6 +7357,15 @@ impl TerminalView {
         cleared_buffer_len: usize,
         ctx: &mut ViewContext<Self>,
     ) {
+        // When fzf passthrough is active, send ctrl-c directly to the PTY to
+        // cancel fzf and exit passthrough mode.
+        if self.fzf_passthrough_active {
+            self.fzf_passthrough_active = false;
+            self.user_write_ctrl_c_to_pty(ctx);
+            ctx.notify();
+            return;
+        }
+
         let did_resolve_prompt_suggestion = self
             .resolve_passive_suggestion(PromptSuggestionResolution::Reject { ctrl_c: true }, ctx);
         if did_resolve_prompt_suggestion {
@@ -7659,6 +7679,14 @@ impl TerminalView {
             && !model.is_read_only()
     }
 
+    /// Returns `true` when keystrokes should be routed directly to the PTY
+    /// rather than to the input editor. This is the case when a long-running
+    /// command is active **or** when an fzf passthrough session is in progress
+    /// (e.g. fzf's ctrl-r history widget running inside readline via `bind -x`).
+    fn is_pty_passthrough_active(&self) -> bool {
+        self.fzf_passthrough_active || self.is_long_running()
+    }
+
     /// Returns `true` when an interactive SSH command has been detected at
     /// preexec and the SSH block is still running (long-running). Used by
     /// the workspace to derive `PendingRemoteSession` without storing
@@ -7707,7 +7735,7 @@ impl TerminalView {
     }
 
     fn control_sequence_on_terminal(&mut self, bytes: &[u8], ctx: &mut ViewContext<Self>) {
-        if self.is_long_running() {
+        if self.is_pty_passthrough_active() {
             self.on_ssh_warpification_key_event(Some(SshKeyEvent::from_bytes(bytes)), ctx);
             self.write_user_bytes_to_pty(bytes.to_owned(), ctx);
         } else {
@@ -7776,7 +7804,7 @@ impl TerminalView {
     /// Receiving the warpui::Event::KeyDown event from a child element.
     /// Generally, this should be control characters rather than printable characters.
     fn keydown_on_terminal(&mut self, characters: &str, ctx: &mut ViewContext<Self>) {
-        if self.is_long_running() {
+        if self.is_pty_passthrough_active() {
             self.on_ssh_warpification_key_event(Some(SshKeyEvent::from_chars(characters)), ctx);
             self.highlighted_link.invalidate();
             self.report_possible_typeahead(characters);
@@ -7823,7 +7851,7 @@ impl TerminalView {
     fn typed_characters_on_terminal(&mut self, characters: &str, ctx: &mut ViewContext<Self>) {
         self.on_ssh_warpification_key_event(Some(SshKeyEvent::from_chars(characters)), ctx);
 
-        if self.should_write_typed_chars_to_pty(ctx) {
+        if self.fzf_passthrough_active || self.should_write_typed_chars_to_pty(ctx) {
             self.highlighted_link.invalidate();
             self.report_possible_typeahead(characters);
             self.write_user_bytes_to_pty(characters.as_bytes().to_vec(), ctx);
@@ -8146,6 +8174,14 @@ impl TerminalView {
     }
 
     fn handle_typeahead_event(&mut self, ctx: &mut ViewContext<Self>) {
+        // If fzf passthrough was active, the InputBuffer hook from our wrapper
+        // function signals that fzf has completed. Clear the passthrough flag
+        // so keystrokes return to the input editor.
+        if self.fzf_passthrough_active {
+            self.fzf_passthrough_active = false;
+            ctx.notify();
+        }
+
         let mut model = self.model.lock();
         let completed_block_idx = model.block_list().prev_matching_block_from_index(
             BlockFilter {
@@ -20477,7 +20513,9 @@ impl TerminalView {
                 // Write the raw ctrl-r byte to the PTY so the shell's line editor
                 // invokes fzf's history widget. The wrapper widget in the bootstrap
                 // script will report the selected command back via InputBuffer.
+                self.fzf_passthrough_active = true;
                 self.write_to_pty(vec![0x12], ctx);
+                ctx.notify();
             }
             InputEvent::CtrlC { cleared_buffer_len } => {
                 self.handle_ctrl_c_input_event(*cleared_buffer_len, ctx);
@@ -21120,7 +21158,7 @@ impl TerminalView {
                     );
                 }
             }
-        } else if self.is_long_running() {
+        } else if self.is_pty_passthrough_active() {
             self.on_ssh_warpification_key_event(None, ctx);
             let sequence =
                 EscCodes::build_escape_sequence(self.model.lock().deref(), &[EscCodes::ARROW_UP]);
@@ -21201,7 +21239,7 @@ impl TerminalView {
                     self.select_less_recent_block(false /* is_cmd_down */, ctx);
                 }
             }
-        } else if self.is_long_running() {
+        } else if self.is_pty_passthrough_active() {
             let sequence =
                 EscCodes::build_escape_sequence(self.model.lock().deref(), &[EscCodes::ARROW_DOWN]);
             self.write_user_bytes_to_pty(sequence, ctx);
@@ -21209,7 +21247,7 @@ impl TerminalView {
     }
 
     fn page_up(&mut self, ctx: &mut ViewContext<Self>) {
-        if self.is_long_running() {
+        if self.is_pty_passthrough_active() {
             // Note: We explicitly use the CSI prefix, as the terminal we are impersonating
             // (`xterm-256color`) has the escape sequence for page up defined with that prefix
             let sequence = EscCodes::build_escape_sequence_with_c1(C1::CSI, EscCodes::PAGE_UP);
@@ -21220,7 +21258,7 @@ impl TerminalView {
     }
 
     fn page_down(&mut self, ctx: &mut ViewContext<Self>) {
-        if self.is_long_running() {
+        if self.is_pty_passthrough_active() {
             // Note: We explicitly use the CSI prefix, as the terminal we are impersonating
             // (`xterm-256color`) has the escape sequence for page down defined with that prefix
             let sequence = EscCodes::build_escape_sequence_with_c1(C1::CSI, EscCodes::PAGE_DOWN);
@@ -21231,7 +21269,7 @@ impl TerminalView {
     }
 
     fn move_home(&mut self, ctx: &mut ViewContext<Self>) {
-        if self.is_long_running() {
+        if self.is_pty_passthrough_active() {
             let sequence = EscCodes::build_escape_sequence(self.model.lock().deref(), b"H");
             self.write_user_bytes_to_pty(sequence, ctx);
         } else {
@@ -21240,7 +21278,7 @@ impl TerminalView {
     }
 
     fn move_end(&mut self, ctx: &mut ViewContext<Self>) {
-        if self.is_long_running() {
+        if self.is_pty_passthrough_active() {
             let sequence = EscCodes::build_escape_sequence(self.model.lock().deref(), b"F");
             self.write_user_bytes_to_pty(sequence, ctx);
         } else {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -20473,6 +20473,12 @@ impl TerminalView {
             InputEvent::CtrlD => {
                 ctx.emit(Event::CtrlD);
             }
+            InputEvent::FzfCtrlR => {
+                // Write the raw ctrl-r byte to the PTY so the shell's line editor
+                // invokes fzf's history widget. The wrapper widget in the bootstrap
+                // script will report the selected command back via InputBuffer.
+                self.write_to_pty(vec![0x12], ctx);
+            }
             InputEvent::CtrlC { cleared_buffer_len } => {
                 self.handle_ctrl_c_input_event(*cleared_buffer_len, ctx);
             }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -14585,6 +14585,22 @@ impl Workspace {
             return;
         }
 
+        // When the search is triggered without an explicit filter (the ctrl-r
+        // keybinding path) and the active terminal has fzf's ctrl-r widget,
+        // delegate to the shell instead of opening the Command Search dialog.
+        if query_filter.is_none() {
+            if let Some(terminal_view_handle) = self.active_session_view(ctx) {
+                let has_fzf = terminal_view_handle.update(ctx, |tv, ctx| {
+                    tv.input().update(ctx, |input, ctx| {
+                        input.try_emit_fzf_ctrl_r(ctx)
+                    })
+                });
+                if has_fzf {
+                    return;
+                }
+            }
+        }
+
         // Close all overlays including chip menus before opening command search
         self.close_all_overlays(ctx);
 

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -143,6 +143,14 @@ impl Shell {
         self.shell_type.supports_native_shell_completions()
     }
 
+    /// Returns true if fzf's ctrl-r history widget is bound in the shell.
+    /// Detected during bootstrap by inspecting shell key bindings.
+    pub fn has_fzf_ctrl_r(&self) -> bool {
+        self.options
+            .as_ref()
+            .is_some_and(|opts| opts.contains("fzf_ctrl_r"))
+    }
+
     /// Whether the shell supports "autocd" (`cd`ing into a directory without specifying
     /// `cd`).
     pub fn supports_autocd(&self) -> bool {


### PR DESCRIPTION
## Summary

Support fzf's ctrl-r history search in Warp by detecting fzf at bootstrap time, delegating ctrl-r to the shell when fzf is available, and entering a PTY passthrough mode so fzf's TUI can receive keystrokes.

## Problem

When pressing ctrl-r with fzf installed, the fzf TUI would appear but the Warp input editor remained active — keystrokes went to the editor instead of fzf, making the search unusable. This happened because fzf runs within readline's `bind -x` context, which doesn't trigger preexec, so the terminal never entered "long-running command" mode.

## Changes

### Shell bootstrap (bash, zsh, fish)
- Detect fzf's ctrl-r binding during shell bootstrap
- Register wrapper functions that invoke fzf then report the selected command back to Warp via the `InputBuffer` hook
- Append `fzf_ctrl_r` to shell options for Rust-side detection

### Rust-side keystroke routing
- Added `fzf_passthrough_active` flag to `TerminalView`
- Added `is_pty_passthrough_active()` helper (checks both `is_long_running()` and `fzf_passthrough_active`)
- When `FzfCtrlR` event fires: set passthrough, write ctrl-r byte to PTY, hide input box
- Routes all keystroke types to PTY during passthrough: keydown, typed chars, control sequences, arrows, page up/down, home/end, ctrl-c
- Flag is cleared when fzf completes (InputBuffer/typeahead event) or ctrl-c cancels

### Workspace-level routing
- `show_command_search()` checks for fzf before opening Command Search dialog
- `Input::ctrl_r()` delegates to fzf when detected instead of fuzzy history search

---

_Conversation: https://staging.warp.dev/conversation/5e966d0f-d7b4-4c3e-99bf-2d724621128c_
_Run: https://oz.staging.warp.dev/runs/019e0988-f786-7ace-9a4d-241954a19eeb_

_This PR was generated with [Oz](https://warp.dev/oz)._
