### PR TITLE
Surface requested cloud provider setup failures

### DIFF
--- a/app/src/ai/agent_sdk/driver/cloud_provider.rs
+++ b/app/src/ai/agent_sdk/driver/cloud_provider.rs
@@ -54,14 +54,33 @@ pub(crate) trait CloudProvider: Send {
 pub(crate) fn load_providers(
     providers: &ProvidersConfig,
     run_id: &str,
+    identity_federation_enabled: bool,
 ) -> Result<Vec<Box<dyn CloudProvider>>> {
     let mut result: Vec<Box<dyn CloudProvider>> = Vec::new();
 
     if let Some(aws) = &providers.aws {
+        log::info!("Detected AWS cloud provider configuration");
+        if !identity_federation_enabled {
+            return Err(CloudProviderSetupError::new(
+                aws::AwsCloudProvider::PROVIDER_NAME,
+                anyhow::anyhow!(
+                    "AWS cloud provider auth was requested, but Oz identity federation is disabled"
+                ),
+            ));
+        }
         result.push(Box::new(aws::AwsCloudProvider::new(aws, run_id)?));
     }
 
     if let Some(gcp) = &providers.gcp {
+        log::info!("Detected GCP cloud provider configuration");
+        if !identity_federation_enabled {
+            return Err(CloudProviderSetupError::new(
+                gcp::GcpCloudProvider::PROVIDER_NAME,
+                anyhow::anyhow!(
+                    "GCP cloud provider auth was requested, but Oz identity federation is disabled"
+                ),
+            ));
+        }
         result.push(Box::new(gcp::GcpCloudProvider::new(gcp, run_id)?));
     }
 

--- a/app/src/ai/agent_sdk/driver/cloud_provider/aws.rs
+++ b/app/src/ai/agent_sdk/driver/cloud_provider/aws.rs
@@ -31,7 +31,7 @@ pub(crate) struct AwsCloudProvider {
 }
 
 impl AwsCloudProvider {
-    const PROVIDER_NAME: &'static str = "aws";
+    pub(super) const PROVIDER_NAME: &'static str = "aws";
 
     pub fn new(config: &AwsProviderConfig, run_id: &str) -> Result<Self> {
         // The `tempfile` crate defaults to creating temporary files with user-only permissions.

--- a/app/src/ai/agent_sdk/driver/cloud_provider/gcp.rs
+++ b/app/src/ai/agent_sdk/driver/cloud_provider/gcp.rs
@@ -21,7 +21,7 @@ pub(crate) struct GcpCloudProvider {
 }
 
 impl GcpCloudProvider {
-    const PROVIDER_NAME: &'static str = "gcp";
+    pub(super) const PROVIDER_NAME: &'static str = "gcp";
 
     pub fn new(config: &GcpProviderConfig, run_id: &str) -> Result<Self> {
         let federation_config = GcpFederationConfig {

--- a/app/src/ai/agent_sdk/driver/cloud_provider_tests.rs
+++ b/app/src/ai/agent_sdk/driver/cloud_provider_tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ffi::OsString, path::PathBuf};
+use std::{collections::HashMap, error::Error as _, ffi::OsString, path::PathBuf};
 
 use crate::ai::cloud_environments::{AwsProviderConfig, GcpProviderConfig, ProvidersConfig};
 
@@ -37,7 +37,7 @@ fn extract_cloud_providers_empty_when_no_providers() {
         gcp: None,
         aws: None,
     };
-    let providers = load_providers(&config, "run-1").unwrap();
+    let providers = load_providers(&config, "run-1", false).unwrap();
     assert!(providers.is_empty());
 }
 
@@ -49,7 +49,7 @@ fn extract_cloud_providers_creates_aws_provider() {
             role_arn: "arn:aws:iam::111111111111:role/TestRole".to_string(),
         }),
     };
-    let providers = load_providers(&config, "run-42").unwrap();
+    let providers = load_providers(&config, "run-42", true).unwrap();
     assert_eq!(providers.len(), 1);
 
     let vars = providers[0].env_vars().unwrap();
@@ -92,7 +92,7 @@ fn extract_cloud_providers_creates_gcp_provider() {
         }),
         aws: None,
     };
-    let providers = load_providers(&config, "run-1").unwrap();
+    let providers = load_providers(&config, "run-1", true).unwrap();
     assert_eq!(providers.len(), 1);
 
     let vars = providers[0].env_vars().unwrap();
@@ -112,7 +112,7 @@ fn collect_provider_env_vars_merges_all_providers() {
             role_arn: "arn:aws:iam::999:role/R".to_string(),
         }),
     };
-    let providers = load_providers(&config, "id-7").unwrap();
+    let providers = load_providers(&config, "id-7", true).unwrap();
     assert_eq!(providers.len(), 2);
 
     let mut vars = HashMap::new();
@@ -123,4 +123,24 @@ fn collect_provider_env_vars_merges_all_providers() {
     assert!(vars.contains_key(&OsString::from("AWS_ROLE_SESSION_NAME")));
     // GCP variables.
     assert!(vars.contains_key(&OsString::from("GOOGLE_APPLICATION_CREDENTIALS")));
+}
+
+#[test]
+fn load_providers_errors_when_requested_but_identity_federation_disabled() {
+    let config = ProvidersConfig {
+        gcp: None,
+        aws: Some(AwsProviderConfig {
+            role_arn: "arn:aws:iam::111111111111:role/TestRole".to_string(),
+        }),
+    };
+
+    let err = match load_providers(&config, "run-42", false) {
+        Ok(_) => panic!("requested provider should fail when federation is disabled"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("aws setup failed"));
+    assert!(err.source().is_some_and(|source| source
+        .to_string()
+        .contains("Oz identity federation is disabled")));
 }

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1295,14 +1295,17 @@ impl AgentDriverRunner {
             })
             .await??;
 
-        if FeatureFlag::OzIdentityFederation.is_enabled() {
+        if !environment.providers.is_empty() {
             let run_id = driver_options
                 .task_id
                 .map(|id| id.to_string())
                 .unwrap_or_else(|| "local".to_string());
-            driver_options.cloud_providers =
-                driver::cloud_provider::load_providers(&environment.providers, &run_id)
-                    .map_err(AgentDriverError::CloudProviderSetupFailed)?;
+            driver_options.cloud_providers = driver::cloud_provider::load_providers(
+                &environment.providers,
+                &run_id,
+                FeatureFlag::OzIdentityFederation.is_enabled(),
+            )
+            .map_err(AgentDriverError::CloudProviderSetupFailed)?;
         }
 
         driver_options.environment = Some(environment);


### PR DESCRIPTION
## Summary
- Load cloud providers whenever an environment requests them, instead of skipping provider setup when identity federation is disabled.
- Return a cloud-provider setup error when requested AWS/GCP auth cannot be configured because federation is unavailable.
- Log each detected AWS/GCP provider in `load_providers`.

## Testing
- `cargo test -p warp ai::agent_sdk::driver::cloud_provider::tests --lib`

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._
