### PR TITLE
Pin Ubuntu LTS used for the internal dev image

### DIFF
--- a/docker/agent-dev/Dockerfile
+++ b/docker/agent-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo


### PR DESCRIPTION
## Description

The latest Ubuntu release includes a Python3 version that's too new for the `gcloud` package. As a quick fix, we can pin to the current Ubuntu LTS.

## Testing

I used this to build a new version of the dev image.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

