### PR TITLE
fix: preserve Windows Explorer new tab directory

### DIFF
--- a/app/src/app_services/windows/mod.rs
+++ b/app/src/app_services/windows/mod.rs
@@ -43,18 +43,22 @@ pub fn pass_startup_args_to_existing_instance(
         if args.urls.is_empty() {
             // If there are no URLs on the command line, send one to open a new
             // window using the same current working directory as this process.
-            let mut open_new_url = format!("{}://action/new_window", ChannelState::url_scheme());
+            let mut open_new_url = Url::parse(&format!(
+                "{}://action/new_window",
+                ChannelState::url_scheme()
+            ))?;
             if let Ok(current_dir) = std::env::current_dir() {
                 match current_dir.into_os_string().into_string() {
-                    Ok(current_dir) => open_new_url.push_str(&format!("?path={}", current_dir)),
+                    Ok(current_dir) => {
+                        open_new_url.query_pairs_mut().append_pair("path", &current_dir);
+                    }
                     Err(os_string) => {
                         log::error!("Failed to convert OsString {os_string:?} to ");
                     }
                 }
             }
 
-            let url = Url::parse(&open_new_url)?;
-            forward_uri_to_sole_running_instance(vec![url]).await?
+            forward_uri_to_sole_running_instance(vec![open_new_url]).await?
         } else {
             forward_uri_to_sole_running_instance(args.urls.clone()).await?
         }

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -716,7 +716,24 @@ fn find_matching_config_name<'a>(
 /// user's home directory.
 fn parse_tab_path(url: &Url) -> Option<PathBuf> {
     let raw = url.query_pairs().find(|(k, _)| k == "path")?.1;
-    Some(PathBuf::from(shellexpand::tilde(&raw).into_owned()))
+    parse_tab_path_value(&raw)
+}
+
+fn parse_tab_path_value(raw: &str) -> Option<PathBuf> {
+    let trimmed = raw.trim();
+    let path = trimmed
+        .strip_prefix('"')
+        .and_then(|path| path.strip_suffix('"'))
+        .unwrap_or(trimmed);
+
+    if let Ok(file_url) = Url::parse(path)
+        && file_url.scheme() == "file"
+        && let Ok(file_path) = file_url.to_file_path()
+    {
+        return Some(file_path);
+    }
+
+    Some(PathBuf::from(shellexpand::tilde(path).into_owned()))
 }
 
 #[derive(Debug)]

--- a/app/src/uri/uri_tests.rs
+++ b/app/src/uri/uri_tests.rs
@@ -574,6 +574,39 @@ fn test_parse_tab_path_bare_tilde() {
     assert_eq!(parse_tab_path(&url), Some(home));
 }
 
+#[test]
+fn test_parse_tab_path_trims_shell_quotes() {
+    assert_eq!(
+        parse_tab_path_value(r#""/tmp/warp project""#),
+        Some(PathBuf::from("/tmp/warp project"))
+    );
+}
+
+#[test]
+fn test_parse_tab_path_file_url() {
+    let expected = if cfg!(windows) {
+        PathBuf::from(r"C:\Projects\my-app")
+    } else {
+        PathBuf::from("/tmp/warp-project")
+    };
+    let file_url = if cfg!(windows) {
+        "file:///C:/Projects/my-app"
+    } else {
+        "file:///tmp/warp-project"
+    };
+
+    assert_eq!(parse_tab_path_value(file_url), Some(expected));
+}
+
+#[test]
+#[cfg(windows)]
+fn test_parse_tab_path_trims_quoted_windows_path() {
+    assert_eq!(
+        parse_tab_path_value(r#""C:\Projects\my-app""#),
+        Some(PathBuf::from(r"C:\Projects\my-app"))
+    );
+}
+
 // Regression coverage for issue #9005: shell scripts opened via `file://` should run,
 // not open in the editor. Exercised through the pure routing helper to avoid standing
 // up a full `AppContext`.

--- a/script/windows/windows-installer.iss
+++ b/script/windows/windows-installer.iss
@@ -115,11 +115,11 @@ Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#MyAppName}"; F
 ; Add "Open Warp in new tab" to directory context menu
 Root: HKA; Subkey: "Software\Classes\Directory\shell\{#MyAppName}Tab"; ValueType: string; ValueName: ""; ValueData: "Open {#MyAppName} in new tab"; Flags: uninsdeletekey
 Root: HKA; Subkey: "Software\Classes\Directory\shell\{#MyAppName}Tab"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\icon.ico"
-Root: HKA; Subkey: "Software\Classes\Directory\shell\{#MyAppName}Tab\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""{#MyAppName}://action/new_tab?path=%1"""
+Root: HKA; Subkey: "Software\Classes\Directory\shell\{#MyAppName}Tab\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""file:///%1"""
 ; Add "Open Warp in new tab" to directory background context menu
 Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#MyAppName}Tab"; ValueType: string; ValueName: ""; ValueData: "Open {#MyAppName} in new tab"; Flags: uninsdeletekey
 Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#MyAppName}Tab"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\icon.ico"
-Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#MyAppName}Tab\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""{#MyAppName}://action/new_tab?path=%V"""
+Root: HKA; Subkey: "Software\Classes\Directory\Background\shell\{#MyAppName}Tab\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""file:///%V"""
 ; Add "Open Warp in new window" to directory context menu
 Root: HKA; Subkey: "Software\Classes\Directory\shell\{#MyAppName}Window"; ValueType: string; ValueName: ""; ValueData: "Open {#MyAppName} in new window"; Flags: uninsdeletekey
 Root: HKA; Subkey: "Software\Classes\Directory\shell\{#MyAppName}Window"; ValueType: string; ValueName: "Icon"; ValueData: "{app}\icon.ico"


### PR DESCRIPTION
﻿## Description

Fixes #9844.

Windows Explorer's `Open Warp in new tab` registry entries now pass the selected folder/background folder as a `file:///...` URI, which routes through Warp's existing file URI handling and preserves the target directory when creating the session.

This also hardens the custom `action/new_tab?path=...` parser so it can handle shell-quoted paths and `file://` path values, and updates Windows single-instance forwarding to append the current directory through `Url::query_pairs_mut()` instead of concatenating an unescaped query string.

## Visual Evidence

The review requested end-to-end proof for both Explorer flows. These artifacts show Warp opening in the expected directory and `pwd` confirming the working directory.

### Selected-folder flow

![Selected-folder screenshot](https://raw.githubusercontent.com/lllakshit/warp-pr-10464-evidence/main/folder-flow.png)

Recording: https://raw.githubusercontent.com/lllakshit/warp-pr-10464-evidence/main/folder-flow.mp4

### Folder-background flow

![Folder-background screenshot](https://raw.githubusercontent.com/lllakshit/warp-pr-10464-evidence/main/background-flow.png)

Recording: https://raw.githubusercontent.com/lllakshit/warp-pr-10464-evidence/main/background-flow.mp4

## Linked Issue

- [x] The linked issue is labeled `ready-to-implement`.
- Fixes #9844

## Testing

- `git diff --check`
- Added unit coverage for quoted tab paths and `file://` tab path values.

Not run locally because this Windows machine does not currently have the required developer tools available on PATH:

- `cargo`
- `rustfmt`
- Inno Setup `iscc`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Codex CLI.

CHANGELOG-BUG-FIX: Fixed Windows Explorer's `Open Warp in new tab` context menu action losing the selected folder and opening at the home directory.
