### PR TITLE
[REMOTE-1544] Apply slash command enablement checks on execution

### DIFF
--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -177,7 +177,8 @@ pub static MOVE_TO_CLOUD: LazyLock<StaticCommand> = LazyLock::new(|| StaticComma
     icon_path: "bundled/svg/upload-cloud-01.svg",
     availability: Availability::AGENT_VIEW
         | Availability::ACTIVE_CONVERSATION
-        | Availability::AI_ENABLED,
+        | Availability::AI_ENABLED
+        | Availability::NOT_CLOUD_AGENT,
     auto_enter_ai_mode: false,
     argument: Some(
         Argument::optional()

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -1619,6 +1619,7 @@ pub struct Input {
     inline_slash_commands_view: ViewHandle<InlineSlashCommandView>,
     cloud_mode_v2_slash_commands_view: Option<ViewHandle<CloudModeV2SlashCommandView>>,
     slash_command_data_source: ModelHandle<SlashCommandDataSource>,
+    cloud_mode_composer_slash_command_data_source: Option<ModelHandle<SlashCommandDataSource>>,
 
     /// Inline conversation menu for selecting AI conversations.
     inline_conversation_menu_view: ViewHandle<InlineConversationMenuView>,
@@ -3121,21 +3122,24 @@ impl Input {
                 agent_view_controller: agent_view_controller.clone(),
                 cli_subagent_controller: cli_subagent_controller.clone(),
                 terminal_view_id,
+                ambient_agent_view_model: ambient_agent_view_model.clone(),
             };
             SlashCommandDataSource::new(args, ctx)
         });
 
-        let v2_slash_command_data_source = if FeatureFlag::CloudModeInputV2.is_enabled() {
-            let args = slash_commands::DataSourceArgs {
-                active_session: active_session.clone(),
-                agent_view_controller: agent_view_controller.clone(),
-                cli_subagent_controller: cli_subagent_controller.clone(),
-                terminal_view_id,
+        let cloud_mode_composer_slash_command_data_source =
+            if FeatureFlag::CloudModeInputV2.is_enabled() {
+                let args = slash_commands::DataSourceArgs {
+                    active_session: active_session.clone(),
+                    agent_view_controller: agent_view_controller.clone(),
+                    cli_subagent_controller: cli_subagent_controller.clone(),
+                    terminal_view_id,
+                    ambient_agent_view_model: ambient_agent_view_model.clone(),
+                };
+                Some(ctx.add_model(|ctx| SlashCommandDataSource::for_cloud_mode_v2(args, ctx)))
+            } else {
+                None
             };
-            Some(ctx.add_model(|ctx| SlashCommandDataSource::for_cloud_mode_v2(args, ctx)))
-        } else {
-            None
-        };
         let slash_command_model = ctx.add_model(|ctx| {
             SlashCommandModel::new(
                 &buffer_model,
@@ -3298,7 +3302,7 @@ impl Input {
         });
 
         let cloud_mode_v2_slash_commands_view =
-            if let Some(v2_data_source) = v2_slash_command_data_source {
+            if let Some(v2_data_source) = cloud_mode_composer_slash_command_data_source.clone() {
                 let view = ctx.add_typed_action_view(|ctx| {
                     CloudModeV2SlashCommandView::new(
                         &slash_command_model,
@@ -3476,6 +3480,7 @@ impl Input {
             agent_shortcut_view_model,
             ambient_agent_view_state,
             slash_command_data_source,
+            cloud_mode_composer_slash_command_data_source,
             ephemeral_message_model,
             input_contents_before_prompt_chip_command: None,
         };
@@ -13855,10 +13860,17 @@ impl Input {
             footer.set_current_repo_path(repo_path.clone(), footer_ctx);
         });
 
-        self.slash_command_data_source
-            .update(ctx, |data_source, ctx| {
+        self.slash_command_data_source.update(ctx, {
+            let repo_path = repo_path.clone();
+            |data_source, ctx| {
+                data_source.set_active_repo_root(repo_path, ctx);
+            }
+        });
+        if let Some(data_source) = self.cloud_mode_composer_slash_command_data_source.as_ref() {
+            data_source.update(ctx, |data_source, ctx| {
                 data_source.set_active_repo_root(repo_path, ctx);
             });
+        }
     }
 
     fn active_session_path_if_local(&self, ctx: &ViewContext<Self>) -> Option<&Path> {

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -26,6 +26,7 @@ use crate::terminal::cli_agent_sessions::{
     CLIAgentInputState, CLIAgentSessionsModel, CLIAgentSessionsModelEvent,
 };
 use crate::terminal::model::session::SessionType;
+use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
 #[cfg(not(target_family = "wasm"))]
 use warp_cli::agent::Harness;
 use warp_core::ui::Icon as WarpIcon;
@@ -54,6 +55,18 @@ pub struct DataSourceArgs {
     pub agent_view_controller: ModelHandle<AgentViewController>,
     pub cli_subagent_controller: ModelHandle<CLISubagentController>,
     pub terminal_view_id: EntityId,
+    pub ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
+}
+
+/// Context needed to decide which slash commands are enabled.
+struct ActiveCommandsContext {
+    session_context: Availability,
+    is_orchestration_enabled: bool,
+    is_feedback_skill_available: bool,
+    #[cfg(not(target_family = "wasm"))]
+    active_conversation_is_cloud_oz: bool,
+    has_default_host: bool,
+    is_cli_agent_input: bool,
 }
 
 pub struct SlashCommandDataSource {
@@ -63,16 +76,17 @@ pub struct SlashCommandDataSource {
     terminal_view_id: EntityId,
     active_commands_by_id: HashMap<SlashCommandId, StaticCommand>,
     active_repo_root: Option<PathBuf>,
+    ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
     is_cloud_mode_v2: bool,
 }
 
 impl SlashCommandDataSource {
     pub fn new(args: DataSourceArgs, ctx: &mut ModelContext<Self>) -> Self {
-        Self::build(args, false, ctx)
+        Self::build(args, /* is_cloud_mode_v2 */ false, ctx)
     }
 
     pub fn for_cloud_mode_v2(args: DataSourceArgs, ctx: &mut ModelContext<Self>) -> Self {
-        Self::build(args, true, ctx)
+        Self::build(args, /* is_cloud_mode_v2 */ true, ctx)
     }
 
     fn build(args: DataSourceArgs, is_cloud_mode_v2: bool, ctx: &mut ModelContext<Self>) -> Self {
@@ -81,6 +95,7 @@ impl SlashCommandDataSource {
             agent_view_controller,
             cli_subagent_controller,
             terminal_view_id,
+            ambient_agent_view_model,
         } = args;
         ctx.subscribe_to_model(&active_session, |me, event, ctx| match event {
             ActiveSessionEvent::UpdatedPwd | ActiveSessionEvent::Bootstrapped => {
@@ -172,6 +187,7 @@ impl SlashCommandDataSource {
             terminal_view_id,
             active_commands_by_id: Default::default(),
             active_repo_root: None,
+            ambient_agent_view_model,
             is_cloud_mode_v2,
         };
         me.recompute_active_commands(ctx);
@@ -183,7 +199,38 @@ impl SlashCommandDataSource {
     /// for a running CLI agent (Claude Code, Codex, etc.).
     const CLI_AGENT_INPUT_ALLOWED_COMMANDS: &[&str] = &["/prompts", "/skills"];
 
+    fn is_cloud_mode(&self, ctx: &AppContext) -> bool {
+        self.is_cloud_mode_v2
+            || (FeatureFlag::CloudMode.is_enabled()
+                && self
+                    .ambient_agent_view_model
+                    .as_ref()
+                    .is_some_and(|model| model.as_ref(ctx).is_ambient_agent()))
+    }
+
     fn recompute_active_commands(&mut self, ctx: &mut ModelContext<Self>) {
+        let active_commands_context = self.active_commands_context(ctx);
+
+        let old_active_command_count = self.active_commands_by_id.len();
+        self.active_commands_by_id = HashMap::from_iter(
+            COMMAND_REGISTRY
+                .all_commands_by_id()
+                .filter(|(_, command)| {
+                    self.command_is_active_in_context(command, &active_commands_context)
+                })
+                .map(|(id, command)| (id, command.clone())),
+        );
+
+        // This is an imperfect heuristic, but better than re-firing unnecessarily.
+        //
+        // If it actually matters, we can update it.
+        if self.active_commands_by_id.len() != old_active_command_count {
+            ctx.emit(UpdatedActiveCommands);
+        }
+    }
+
+    /// Gather the context needed to check slash command availability.
+    fn active_commands_context(&self, ctx: &AppContext) -> ActiveCommandsContext {
         let is_cli_agent_input = self.is_cli_agent_input_open(ctx);
 
         let mut session_context = Availability::empty();
@@ -244,11 +291,10 @@ impl SlashCommandDataSource {
         if self.is_cloud_mode_v2 && FeatureFlag::CloudModeInputV2.is_enabled() {
             session_context |= Availability::CLOUD_AGENT_V2;
         }
-        if !self.is_cloud_mode_v2 {
+
+        if !self.is_cloud_mode(ctx) {
             session_context |= Availability::NOT_CLOUD_AGENT;
         }
-
-        let is_orchestration_enabled = AISettings::as_ref(ctx).is_orchestration_enabled(ctx);
 
         // Hide /host when no default host is configured (env var or workspace setting).
         let has_default_host = std::env::var("WARP_CLOUD_MODE_DEFAULT_HOST")
@@ -257,55 +303,60 @@ impl SlashCommandDataSource {
             .is_some()
             || UserWorkspaces::as_ref(ctx).default_host_slug().is_some();
 
-        #[cfg(not(target_family = "wasm"))]
-        let active_conversation_is_cloud_oz = self.active_conversation_is_cloud_oz(ctx);
-
-        let old_active_command_count = self.active_commands_by_id.len();
-        self.active_commands_by_id = HashMap::from_iter(
-            COMMAND_REGISTRY
-                .all_commands_by_id()
-                .filter(|(_, command)| command.is_active(session_context))
-                .filter(|(_, command)| {
-                    command.name != commands::ORCHESTRATE_NAME || is_orchestration_enabled
-                })
-                // The static `/feedback` command is an AI-off fallback for the richer bundled
-                // `feedback` skill. Hide it whenever the bundled skill will actually take over,
-                // matching the precedence used by `Workspace::send_feedback`.
-                .filter(|(_, command)| {
-                    command.name != commands::FEEDBACK.name
-                        || !crate::workspace::is_feedback_skill_available(ctx)
-                })
-                // /continue-locally only applies to cloud Oz conversations. Local conversations
-                // and non-Oz cloud runs (Claude, Gemini) are filtered out so the slash menu
-                // doesn't surface a no-op command.
-                .filter(|(_, command)| {
-                    #[cfg(not(target_family = "wasm"))]
-                    {
-                        command.name != commands::CONTINUE_LOCALLY.name
-                            || active_conversation_is_cloud_oz
-                    }
-                    #[cfg(target_family = "wasm")]
-                    {
-                        let _ = command;
-                        true
-                    }
-                })
-                // /host is only useful when a default self-hosted host is configured.
-                .filter(|(_, command)| command.name != commands::HOST.name || has_default_host)
-                // When CLI agent input is open, restrict to the explicit allowlist.
-                .filter(|(_, command)| {
-                    !is_cli_agent_input
-                        || Self::CLI_AGENT_INPUT_ALLOWED_COMMANDS.contains(&command.name)
-                })
-                .map(|(id, command)| (id, command.clone())),
-        );
-
-        // This is an imperfect heuristic, but better than re-firing unnecessarily.
-        //
-        // If it actually matters, we can update it.
-        if self.active_commands_by_id.len() != old_active_command_count {
-            ctx.emit(UpdatedActiveCommands);
+        ActiveCommandsContext {
+            session_context,
+            is_orchestration_enabled: AISettings::as_ref(ctx).is_orchestration_enabled(ctx),
+            is_feedback_skill_available: crate::workspace::is_feedback_skill_available(ctx),
+            #[cfg(not(target_family = "wasm"))]
+            active_conversation_is_cloud_oz: self.active_conversation_is_cloud_oz(ctx),
+            has_default_host,
+            is_cli_agent_input,
         }
+    }
+
+    fn command_is_active_in_context(
+        &self,
+        command: &StaticCommand,
+        context: &ActiveCommandsContext,
+    ) -> bool {
+        if !command.is_active(context.session_context) {
+            return false;
+        }
+        if command.name == commands::ORCHESTRATE_NAME && !context.is_orchestration_enabled {
+            return false;
+        }
+        // The static `/feedback` command is an AI-off fallback for the richer bundled
+        // `feedback` skill. Hide it whenever the bundled skill will actually take over,
+        // matching the precedence used by `Workspace::send_feedback`.
+        if command.name == commands::FEEDBACK.name && context.is_feedback_skill_available {
+            return false;
+        }
+        // /continue-locally only applies to cloud Oz conversations. Local conversations
+        // and non-Oz cloud runs (Claude, Gemini) are filtered out so the slash menu
+        // doesn't surface a no-op command.
+        #[cfg(not(target_family = "wasm"))]
+        if command.name == commands::CONTINUE_LOCALLY.name
+            && !context.active_conversation_is_cloud_oz
+        {
+            return false;
+        }
+        // /host is only useful when a default self-hosted host is configured.
+        if command.name == commands::HOST.name && !context.has_default_host {
+            return false;
+        }
+        // When CLI agent input is open, restrict to the explicit allowlist.
+        if context.is_cli_agent_input
+            && !Self::CLI_AGENT_INPUT_ALLOWED_COMMANDS.contains(&command.name)
+        {
+            return false;
+        }
+
+        true
+    }
+
+    pub(crate) fn command_is_active(&self, command: &StaticCommand, ctx: &AppContext) -> bool {
+        let active_commands_context = self.active_commands_context(ctx);
+        self.command_is_active_in_context(command, &active_commands_context)
     }
 
     /// Update the active repository root for this terminal. Called by the parent when

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -18,7 +18,7 @@ use warp_core::ui::theme::AnsiColorIdentifier;
 #[cfg(feature = "local_fs")]
 use warp_util::path::{CleanPathResult, LineAndColumnArg};
 use warpui::clipboard::ClipboardContent;
-use warpui::{SingletonEntity, ViewContext};
+use warpui::{AppContext, SingletonEntity, ViewContext};
 
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::agent::conversation::AIConversationId;
@@ -58,8 +58,6 @@ use crate::workspace::{ForkedConversationDestination, ToastStack, WorkspaceActio
 use crate::TelemetryEvent;
 #[cfg(not(target_family = "wasm"))]
 use warp_cli::agent::Harness;
-#[cfg(not(target_family = "wasm"))]
-use warpui::AppContext;
 
 #[derive(Debug, Clone)]
 pub enum AcceptSlashCommandOrSavedPrompt {
@@ -144,12 +142,30 @@ fn open_file_command_path(
 }
 
 impl Input {
+    fn is_slash_command_available(&self, command: &StaticCommand, ctx: &AppContext) -> bool {
+        let slash_command_data_source = if self.is_cloud_mode_input_v2_composing(ctx) {
+            let Some(data_source) = self.cloud_mode_composer_slash_command_data_source.as_ref()
+            else {
+                return false;
+            };
+            data_source
+        } else {
+            &self.slash_command_data_source
+        };
+        slash_command_data_source
+            .as_ref(ctx)
+            .command_is_active(command, ctx)
+    }
+
     pub(super) fn select_slash_command(
         &mut self,
         command: &StaticCommand,
         trigger: SlashCommandTrigger,
         ctx: &mut ViewContext<Self>,
     ) {
+        if !self.is_slash_command_available(command, ctx) {
+            return;
+        }
         if command.argument.as_ref().is_none() {
             self.execute_slash_command(
                 command, None, trigger, /*is_queued_prompt*/ false, ctx,
@@ -1134,6 +1150,9 @@ impl Input {
             SlashCommandEntryState::SlashCommand(detected_command) => {
                 let command = detected_command.command.clone();
                 let argument = detected_command.argument.clone();
+                if !self.is_slash_command_available(&command, ctx) {
+                    return false;
+                }
                 self.execute_slash_command(
                     &command,
                     argument.as_ref(),
@@ -1232,6 +1251,9 @@ impl Input {
             SlashCommandEntryState::SlashCommand(detected_command) => {
                 let command = detected_command.command.clone();
                 let argument = detected_command.argument.clone();
+                if !self.is_slash_command_available(&command, ctx) {
+                    return false;
+                }
                 self.execute_slash_command(
                     &command,
                     argument.as_ref(),
@@ -1255,68 +1277,6 @@ impl Input {
             SlashCommandEntryState::None
             | SlashCommandEntryState::Composing { .. }
             | SlashCommandEntryState::DisabledUntilEmptyBuffer => false,
-        }
-    }
-}
-
-#[cfg(all(test, feature = "local_fs", windows))]
-mod tests {
-    use super::*;
-    use std::sync::Arc;
-
-    use crate::terminal::model::session::command_executor::testing::TestCommandExecutor;
-    use crate::terminal::model::session::SessionInfo;
-    use crate::terminal::shell::ShellType;
-    use crate::terminal::ShellLaunchData;
-
-    fn wsl_session() -> Session {
-        Session::new(
-            SessionInfo::new_for_test().with_shell_type(ShellType::Bash),
-            Arc::new(TestCommandExecutor::default()),
-        )
-        .with_shell_launch_data(ShellLaunchData::WSL {
-            distro: "Ubuntu".to_owned(),
-        })
-    }
-
-    #[test]
-    fn open_file_command_converts_wsl_paths_to_host_paths() {
-        let session = wsl_session();
-        let cases = [
-            (
-                "/home/ubuntu",
-                "subdir/test.txt",
-                r"\\WSL$\Ubuntu\home\ubuntu\subdir\test.txt",
-                None,
-            ),
-            (
-                "/home/ubuntu/project",
-                "../test.txt",
-                r"\\WSL$\Ubuntu\home\ubuntu\test.txt",
-                None,
-            ),
-            (
-                "/home/ubuntu",
-                "subdir/file\\ name.txt",
-                r"\\WSL$\Ubuntu\home\ubuntu\subdir\file name.txt",
-                None,
-            ),
-            (
-                "/home/ubuntu",
-                "subdir/test.txt:4:2",
-                r"\\WSL$\Ubuntu\home\ubuntu\subdir\test.txt",
-                Some(LineAndColumnArg {
-                    line_num: 4,
-                    column_num: Some(2),
-                }),
-            ),
-        ];
-
-        for (current_dir, raw_arg, expected_path, expected_line_col) in cases {
-            let (path, line_col) = open_file_command_path(&session, current_dir, raw_arg);
-
-            assert_eq!(path, PathBuf::from(expected_path));
-            assert_eq!(line_col, expected_line_col);
         }
     }
 }
@@ -1353,3 +1313,7 @@ fn conversation_is_cloud_oz_for_slash_command(
         None => true,
     }
 }
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/app/src/terminal/input/slash_commands/mod_tests.rs
+++ b/app/src/terminal/input/slash_commands/mod_tests.rs
@@ -1,0 +1,97 @@
+use crate::features::FeatureFlag;
+use crate::search::slash_command_menu::static_commands::commands;
+use crate::search::slash_command_menu::static_commands::Availability;
+const BASELINE_AVAILABILITY: Availability = Availability::AGENT_VIEW
+    .union(Availability::AI_ENABLED)
+    .union(Availability::NO_LRC_CONTROL);
+
+#[test]
+fn not_cloud_agent_commands_are_only_active_outside_cloud_mode() {
+    let local_context = BASELINE_AVAILABILITY | Availability::NOT_CLOUD_AGENT;
+    assert!(commands::AGENT.is_active(local_context));
+    assert!(commands::NEW.is_active(local_context));
+
+    let cloud_context = BASELINE_AVAILABILITY;
+    assert!(!commands::AGENT.is_active(cloud_context));
+    assert!(!commands::NEW.is_active(cloud_context));
+
+    let _cloud_mode_input_v2 = FeatureFlag::CloudModeInputV2.override_enabled(true);
+    let cloud_mode_v2_context = BASELINE_AVAILABILITY | Availability::CLOUD_AGENT_V2;
+    assert!(!commands::AGENT.is_active(cloud_mode_v2_context));
+    assert!(!commands::NEW.is_active(cloud_mode_v2_context));
+}
+
+#[test]
+fn cloud_mode_v2_commands_are_active_only_in_cloud_mode_v2_context() {
+    let cloud_context = BASELINE_AVAILABILITY;
+    assert!(!commands::HARNESS.is_active(cloud_context));
+
+    let _cloud_mode_input_v2 = FeatureFlag::CloudModeInputV2.override_enabled(true);
+    let cloud_mode_v2_context = BASELINE_AVAILABILITY | Availability::CLOUD_AGENT_V2;
+    assert!(commands::PLAN.is_active(cloud_mode_v2_context));
+    assert!(commands::MODEL.is_active(cloud_mode_v2_context));
+    assert!(commands::HARNESS.is_active(cloud_mode_v2_context));
+}
+
+#[cfg(all(feature = "local_fs", windows))]
+mod windows {
+    use std::sync::Arc;
+
+    use crate::terminal::model::session::command_executor::testing::TestCommandExecutor;
+    use crate::terminal::model::session::SessionInfo;
+    use crate::terminal::shell::ShellType;
+    use crate::terminal::ShellLaunchData;
+
+    use super::super::*;
+
+    fn wsl_session() -> Session {
+        Session::new(
+            SessionInfo::new_for_test().with_shell_type(ShellType::Bash),
+            Arc::new(TestCommandExecutor::default()),
+        )
+        .with_shell_launch_data(ShellLaunchData::WSL {
+            distro: "Ubuntu".to_owned(),
+        })
+    }
+
+    #[test]
+    fn open_file_command_converts_wsl_paths_to_host_paths() {
+        let session = wsl_session();
+        let cases = [
+            (
+                "/home/ubuntu",
+                "subdir/test.txt",
+                r"\\WSL$\Ubuntu\home\ubuntu\subdir\test.txt",
+                None,
+            ),
+            (
+                "/home/ubuntu/project",
+                "../test.txt",
+                r"\\WSL$\Ubuntu\home\ubuntu\test.txt",
+                None,
+            ),
+            (
+                "/home/ubuntu",
+                "subdir/file\\ name.txt",
+                r"\\WSL$\Ubuntu\home\ubuntu\subdir\file name.txt",
+                None,
+            ),
+            (
+                "/home/ubuntu",
+                "subdir/test.txt:4:2",
+                r"\\WSL$\Ubuntu\home\ubuntu\subdir\test.txt",
+                Some(LineAndColumnArg {
+                    line_num: 4,
+                    column_num: Some(2),
+                }),
+            ),
+        ];
+
+        for (current_dir, raw_arg, expected_path, expected_line_col) in cases {
+            let (path, line_col) = open_file_command_path(&session, current_dir, raw_arg);
+
+            assert_eq!(path, PathBuf::from(expected_path));
+            assert_eq!(line_col, expected_line_col);
+        }
+    }
+}

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -44,7 +44,7 @@ use crate::settings_view::keybindings::KeybindingChangedNotifier;
 use crate::system::SystemInfo;
 use crate::system::SystemStats;
 use crate::terminal::alt_screen_reporting::AltScreenReporting;
-use crate::terminal::event::BootstrappedEvent;
+use crate::terminal::event::{BlockMetadataReceivedEvent, BootstrappedEvent};
 use crate::terminal::keys::TerminalKeybindings;
 use crate::terminal::local_shell::LocalShellState;
 use crate::terminal::shared_session::permissions_manager::SessionPermissionsManager;
@@ -61,6 +61,7 @@ use crate::terminal::model::grid::Dimensions as _;
 use crate::terminal::model::index::Side;
 use crate::terminal::model::session::{BootstrapSessionType, SessionInfo};
 use crate::terminal::model::terminal_model::BlockIndex;
+use crate::terminal::model_events::ModelEvent;
 use ai::index::full_source_code_embedding::manager::CodebaseIndexManager;
 use chrono::Local;
 use warpui::text::SelectionType;
@@ -336,20 +337,37 @@ pub fn simulate_directory_for_completion<A, S>(
 {
     let directory = directory.into();
     terminal.update(app, |terminal, ctx| {
-        terminal.model.lock().block_list_mut().precmd(PrecmdValue {
-            pwd: Some(directory.clone()),
-            session_id: Some(session_id.into()),
-            ..Default::default()
-        });
+        let block_metadata = BlockMetadata::new(Some(session_id), Some(directory.clone()));
+        let block_index = {
+            let mut model = terminal.model.lock();
+            model.block_list_mut().precmd(PrecmdValue {
+                pwd: Some(directory.clone()),
+                session_id: Some(session_id.into()),
+                ..Default::default()
+            });
+            model.block_list().active_block_index()
+        };
 
         // Normally, the precmd message should be sufficient to also set this block metadata.
-        // However, in unit tests the foreground executor does not relay the event.
+        // However, in unit tests the foreground executor does not relay the event, so notify
+        // the dispatcher directly for models that observe active-session metadata.
+        terminal
+            .model_event_dispatcher()
+            .update(ctx, |dispatcher, ctx| {
+                dispatcher.set_active_session_id(session_id);
+                ctx.emit(ModelEvent::BlockMetadataReceived(
+                    BlockMetadataReceivedEvent {
+                        block_metadata: block_metadata.clone(),
+                        block_index,
+                        is_after_in_band_command: false,
+                        is_done_bootstrapping: true,
+                    },
+                ));
+            });
+
+        // Keep the input's block metadata in sync with the active-session metadata above.
         terminal.input().update(ctx, |input, ctx| {
-            input.set_active_block_metadata(
-                BlockMetadata::new(Some(session_id), Some(directory)),
-                false,
-                ctx,
-            );
+            input.set_active_block_metadata(block_metadata, false, ctx);
         });
     });
 }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -674,6 +674,82 @@ fn set_input_mode_agent_does_not_enter_local_agent_from_root_cloud_mode_pane() {
 }
 
 #[test]
+fn cloud_mode_v1_agent_prefixed_query_spawns_cloud_agent() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_mode = FeatureFlag::AgentMode.override_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _cloud_mode_input_v2 = FeatureFlag::CloudModeInputV2.override_enabled(false);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        let input = terminal.read(&app, |view, _| view.input.clone());
+
+        input.update(&mut app, |input, ctx| {
+            input.ai_input_model().update(ctx, |ai_input, ctx| {
+                ai_input.set_input_config(
+                    InputConfig {
+                        input_type: InputType::AI,
+                        is_locked: false,
+                    },
+                    true,
+                    ctx,
+                );
+            });
+            assert!(!input.is_cloud_mode_input_v2_composing(ctx));
+            input.replace_buffer_content("/agent fix the tests", ctx);
+            input.input_enter(ctx);
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let ambient_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .as_ref(ctx);
+            let request = ambient_model
+                .request()
+                .expect("enter should submit through the cloud agent spawn path");
+            assert_eq!(request.prompt, "/agent fix the tests");
+            assert_eq!(request.mode, UserQueryMode::Normal);
+            assert!(input.as_ref(ctx).buffer_text(ctx).is_empty());
+        });
+    });
+}
+
+#[test]
+fn cloud_mode_v2_agent_prefixed_query_spawns_cloud_agent() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_mode = FeatureFlag::AgentMode.override_enabled(true);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _cloud_mode_input_v2 = FeatureFlag::CloudModeInputV2.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        let input = terminal.read(&app, |view, _| view.input.clone());
+
+        input.update(&mut app, |input, ctx| {
+            assert!(input.is_cloud_mode_input_v2_composing(ctx));
+            input.replace_buffer_content("/agent fix the tests", ctx);
+            input.input_enter(ctx);
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let ambient_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .as_ref(ctx);
+            let request = ambient_model
+                .request()
+                .expect("enter should submit through the cloud agent spawn path");
+            assert_eq!(request.prompt, "/agent fix the tests");
+            assert_eq!(request.mode, UserQueryMode::Normal);
+            assert!(input.as_ref(ctx).buffer_text(ctx).is_empty());
+        });
+    });
+}
+
+#[test]
 fn pending_cloud_followup_without_ambient_model_restores_prompt() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);


### PR DESCRIPTION
## Description

This fixes a bug where executing `/agent <some query>` in the Cloud Mode composer would result in a broken session.

The root issue was that we check slash command availability when constructing the menu, but _not_ when actually executing a slash command. To fix this, we adjust `SlashCommandDataSource` to support checking if a specific command is available, and use this to gate execution in the `Input` view. This protects against a user typing or pasting `/invalid-command` and bypassing the menu.

For this fix to be effective, we also need to check against the proper set of slash commands - namely, the v2 Cloud Mode composer uses a separate data source, and we have to check against _that_ data source rather than the generic one. The `Input` view now receives handles to both `SlashCommandDataSource`s, and chooses the appropriate one based on its current state.

## Linked Issue

https://linear.app/warpdotdev/issue/REMOTE-1544/sending-a-slash-command-skill-in-the-old-cloud-mode-ui-and-current-ui

## Testing

- [x] Added unit tests for slash command enablement
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

https://www.loom.com/share/db71b808547149f8a2f0b2921d75c87d

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
