### PR TITLE
Hook `DiffStateModel` to remote server

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -202,6 +202,7 @@ use warp_util::{
     content_version::ContentVersion,
     file::{FileLoadError, FileSaveError},
     path::LineAndColumnArg,
+    standardized_path::StandardizedPath,
 };
 
 pub struct CodeReviewHeaderFields {
@@ -5573,7 +5574,10 @@ impl CodeReviewView {
                 .unwrap_or(GitFileStatus::Modified),
             _ => GitFileStatus::Modified,
         };
-        FileStatusInfo { path, status }
+        FileStatusInfo {
+            path: StandardizedPath::from_local_absolute_unchecked(&path),
+            status,
+        }
     }
 
     fn discard_file(&mut self, path: &Path, should_stash: bool, ctx: &mut ViewContext<Self>) {

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -533,8 +533,13 @@ impl LocalDiffStateModel {
                         DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(repo_path, ctx)
                     {
                         me.set_active_repository(repo_handle, ctx);
+                        return;
                     }
                 }
+                // Repo detection completed but found no repository.
+                // Emit so subscribers (e.g. the server model) can drain
+                // pending responses with the NotInRepository state.
+                ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
             });
         }
         model
@@ -563,6 +568,11 @@ impl LocalDiffStateModel {
                 Err(err) => DiffState::Error(err.clone()),
             },
         }
+    }
+
+    /// Returns the current diff metadata, if available.
+    pub fn metadata(&self) -> Option<&DiffMetadata> {
+        self.metadata.as_ref()
     }
 
     pub fn diff_mode(&self) -> DiffMode {
@@ -1536,6 +1546,19 @@ impl LocalDiffStateModel {
     ) -> Option<GitDiffData> {
         let diffs = Self::load_diffs_for_repo(repo_path, mode, false).await;
         diffs.changes.ok().map(|diff| diff.into())
+    }
+
+    /// Load diff data with `content_at_head` for a given mode without
+    /// requiring an existing model instance. Used by the remote server to
+    /// serve late-joining subscribers that need `content_at_head` for editor
+    /// rendering, without disturbing the model's state.
+    #[cfg(feature = "local_fs")]
+    pub async fn load_diffs_with_content_for_mode(
+        mode: DiffMode,
+        repo_path: PathBuf,
+    ) -> Option<GitDiffWithBaseContent> {
+        let diffs = Self::load_diffs_for_repo(repo_path, mode, false).await;
+        diffs.changes.ok()
     }
 
     async fn load_diffs_for_repo(

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -12,6 +12,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use warp_util::standardized_path::StandardizedPath;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
@@ -97,7 +98,7 @@ impl GitFileStatus {
 
 #[derive(Clone, Debug)]
 pub struct FileStatusInfo {
-    pub path: PathBuf,
+    pub path: StandardizedPath,
     pub status: GitFileStatus,
 }
 
@@ -924,11 +925,15 @@ impl LocalDiffStateModel {
     /// Removes files based on the operation type
     #[cfg(feature = "local_fs")]
     async fn discard_files_impl(
-        repo_path: &Path,
+        repo_sp: &StandardizedPath,
         file_infos: Vec<FileStatusInfo>,
         should_stash: bool,
         branch: &str,
     ) -> Result<()> {
+        let Some(repo_path) = repo_sp.to_local_path() else {
+            anyhow::bail!("discard_files_impl called with non-local path: {repo_sp}");
+        };
+
         let mut renamed_file_infos = Vec::new();
         let mut other_file_infos = Vec::new();
 
@@ -945,12 +950,14 @@ impl LocalDiffStateModel {
             if branch == "HEAD" && should_stash {
                 let renamed_paths: Vec<String> = renamed_file_infos
                     .iter()
-                    .map(|info| match info.path.strip_prefix(repo_path) {
-                        Ok(rel_path) => rel_path.to_string_lossy().to_string(),
-                        Err(_) => info.path.to_string_lossy().to_string(),
+                    .map(|info| {
+                        info.path
+                            .strip_prefix(repo_sp)
+                            .unwrap_or(info.path.as_str())
+                            .to_string()
                     })
                     .collect();
-                Self::stash_uncommitted_changes(repo_path, &renamed_paths).await?;
+                Self::stash_uncommitted_changes(&repo_path, &renamed_paths).await?;
 
                 for info in &renamed_file_infos {
                     if let GitFileStatus::Renamed { old_path } = &info.status {
@@ -958,7 +965,7 @@ impl LocalDiffStateModel {
                             "[GIT OPERATION] local.rs discard_files_impl git restore --staged --worktree -- {old_path}"
                         );
                         let _ = run_git_command(
-                            repo_path,
+                            &repo_path,
                             &["restore", "--staged", "--worktree", "--", old_path],
                         )
                         .await;
@@ -967,17 +974,18 @@ impl LocalDiffStateModel {
             } else {
                 for info in renamed_file_infos {
                     if let GitFileStatus::Renamed { old_path } = &info.status {
-                        let relative_new_path = match info.path.strip_prefix(repo_path) {
-                            Ok(rel) => rel.to_string_lossy().to_string(),
-                            Err(_) => info.path.to_string_lossy().to_string(),
-                        };
+                        let relative_new_path = info
+                            .path
+                            .strip_prefix(repo_sp)
+                            .unwrap_or(info.path.as_str())
+                            .to_string();
 
                         // Remove the new file
                         log::debug!(
                             "[GIT OPERATION] local.rs discard_files_impl git rm -f -- {relative_new_path}"
                         );
                         if let Err(e) =
-                            run_git_command(repo_path, &["rm", "-f", "--", &relative_new_path])
+                            run_git_command(&repo_path, &["rm", "-f", "--", &relative_new_path])
                                 .await
                         {
                             log::warn!("Failed to remove renamed file '{relative_new_path}': {e}");
@@ -990,7 +998,7 @@ impl LocalDiffStateModel {
                             "[GIT OPERATION] local.rs discard_files_impl git checkout {branch} -- {old_path}"
                         );
                         if let Err(e) =
-                            run_git_command(repo_path, &["checkout", branch, "--", old_path]).await
+                            run_git_command(&repo_path, &["checkout", branch, "--", old_path]).await
                         {
                             log::error!(
                                 "Failed to restore old file '{old_path}' from branch '{branch}': {e}"
@@ -1005,16 +1013,18 @@ impl LocalDiffStateModel {
         if !other_file_infos.is_empty() {
             let relative_paths: Vec<String> = other_file_infos
                 .iter()
-                .map(|info| match info.path.strip_prefix(repo_path) {
-                    Ok(rel_path) => rel_path.to_string_lossy().to_string(),
-                    Err(_) => info.path.to_string_lossy().to_string(),
+                .map(|info| {
+                    info.path
+                        .strip_prefix(repo_sp)
+                        .unwrap_or(info.path.as_str())
+                        .to_string()
                 })
                 .collect();
 
             if branch == "HEAD" && should_stash {
-                Self::stash_uncommitted_changes(repo_path, &relative_paths).await?;
+                Self::stash_uncommitted_changes(&repo_path, &relative_paths).await?;
             } else {
-                Self::git_restore_and_clean(repo_path, &relative_paths, branch).await?;
+                Self::git_restore_and_clean(&repo_path, &relative_paths, branch).await?;
             }
         }
         Ok(())
@@ -1032,10 +1042,7 @@ impl LocalDiffStateModel {
         let Some(current_repository) = &self.repository else {
             return;
         };
-        let current_repository_path = current_repository
-            .as_ref(ctx)
-            .root_dir()
-            .to_local_path_lossy();
+        let current_repository_path = current_repository.as_ref(ctx).root_dir().clone();
 
         let branch = branch_name.unwrap_or_else(|| "HEAD".to_string());
         ctx.spawn(

--- a/app/src/remote_server/diff_state_proto.rs
+++ b/app/src/remote_server/diff_state_proto.rs
@@ -19,6 +19,21 @@ use crate::util::git::{Commit, PrInfo};
 
 // ── Proto → Rust (for incoming client messages) ────────────────────
 
+/// Rejects empty, absolute, and parent-traversal (`..`) paths.
+fn validate_relative_path(path: &str) -> Result<(), String> {
+    let p = Path::new(path);
+    if p.as_os_str().is_empty()
+        || p.is_absolute()
+        || p.components().any(|c| c == std::path::Component::ParentDir)
+    {
+        return Err(format!(
+            "rejecting path with traversal or absolute component: {}",
+            p.display()
+        ));
+    }
+    Ok(())
+}
+
 impl From<&proto::DiffMode> for DiffMode {
     fn from(proto_mode: &proto::DiffMode) -> Self {
         match &proto_mode.mode {
@@ -55,27 +70,26 @@ impl TryFrom<&proto::FileStatusInfo> for FileStatusInfo {
     type Error = String;
 
     fn try_from(proto_info: &proto::FileStatusInfo) -> Result<Self, Self::Error> {
-        let path = PathBuf::from(&proto_info.path);
-        // Reject empty, absolute paths and path traversal (".." components)
-        // to prevent destructive operations outside the repo root.
-        if path.as_os_str().is_empty()
-            || path.is_absolute()
-            || path
-                .components()
-                .any(|c| c == std::path::Component::ParentDir)
-        {
-            return Err(format!(
-                "rejecting path with traversal or absolute component: {}",
-                path.display()
-            ));
+        validate_relative_path(&proto_info.path)?;
+
+        let status: GitFileStatus = proto_info
+            .status
+            .as_ref()
+            .map(GitFileStatus::from)
+            .unwrap_or(GitFileStatus::Modified);
+
+        // Validate old_path in Renamed/Copied variants — these also flow
+        // into git restore/checkout commands during discard.
+        match &status {
+            GitFileStatus::Renamed { old_path } | GitFileStatus::Copied { old_path } => {
+                validate_relative_path(old_path)?;
+            }
+            _ => {}
         }
+
         Ok(FileStatusInfo {
-            path,
-            status: proto_info
-                .status
-                .as_ref()
-                .map(GitFileStatus::from)
-                .unwrap_or(GitFileStatus::Modified),
+            path: PathBuf::from(&proto_info.path),
+            status,
         })
     }
 }

--- a/app/src/remote_server/diff_state_proto.rs
+++ b/app/src/remote_server/diff_state_proto.rs
@@ -1,0 +1,342 @@
+//! Conversion between diff state Rust types and proto-generated types.
+//!
+//! Rust types are canonical, proto types are the wire format.
+//! Only the directions needed by the server are implemented here.
+//!
+//! This module lives in `app/` (rather than in the `remote_server` crate alongside
+//! `repo_metadata_proto`) because it depends on app-level types
+//! (`code_review::diff_state`, `util::git`) that are not available in the crate.
+use std::path::{Path, PathBuf};
+
+use super::proto;
+
+use crate::code_review::diff_size_limits::DiffSize;
+use crate::code_review::diff_state::{
+    DiffHunk, DiffLine, DiffLineType, DiffMetadata, DiffMetadataAgainstBase, DiffMode, DiffState,
+    DiffStats, FileDiff, FileDiffAndContent, FileStatusInfo, GitDiffWithBaseContent, GitFileStatus,
+};
+use crate::util::git::{Commit, PrInfo};
+
+// ── Proto → Rust (for incoming client messages) ────────────────────
+
+impl From<&proto::DiffMode> for DiffMode {
+    fn from(proto_mode: &proto::DiffMode) -> Self {
+        match &proto_mode.mode {
+            Some(proto::diff_mode::Mode::Head(_)) | None => DiffMode::Head,
+            Some(proto::diff_mode::Mode::MainBranch(_)) => DiffMode::MainBranch,
+            Some(proto::diff_mode::Mode::OtherBranch(ob)) => {
+                DiffMode::OtherBranch(ob.branch_name.clone())
+            }
+        }
+    }
+}
+
+impl From<&proto::GitFileStatus> for GitFileStatus {
+    fn from(proto_status: &proto::GitFileStatus) -> Self {
+        match &proto_status.status {
+            Some(proto::git_file_status::Status::NewFile(_)) => GitFileStatus::New,
+            Some(proto::git_file_status::Status::Modified(_)) => GitFileStatus::Modified,
+            Some(proto::git_file_status::Status::Deleted(_)) => GitFileStatus::Deleted,
+            Some(proto::git_file_status::Status::Renamed(r)) => GitFileStatus::Renamed {
+                old_path: r.old_path.clone(),
+            },
+            Some(proto::git_file_status::Status::Copied(c)) => GitFileStatus::Copied {
+                old_path: c.old_path.clone(),
+            },
+            Some(proto::git_file_status::Status::Untracked(_)) => GitFileStatus::Untracked,
+            Some(proto::git_file_status::Status::Conflicted(_)) => GitFileStatus::Conflicted,
+            // Default to Modified for unrecognized/missing status.
+            None => GitFileStatus::Modified,
+        }
+    }
+}
+
+impl TryFrom<&proto::FileStatusInfo> for FileStatusInfo {
+    type Error = String;
+
+    fn try_from(proto_info: &proto::FileStatusInfo) -> Result<Self, Self::Error> {
+        let path = PathBuf::from(&proto_info.path);
+        // Reject empty, absolute paths and path traversal (".." components)
+        // to prevent destructive operations outside the repo root.
+        if path.as_os_str().is_empty()
+            || path.is_absolute()
+            || path
+                .components()
+                .any(|c| c == std::path::Component::ParentDir)
+        {
+            return Err(format!(
+                "rejecting path with traversal or absolute component: {}",
+                path.display()
+            ));
+        }
+        Ok(FileStatusInfo {
+            path,
+            status: proto_info
+                .status
+                .as_ref()
+                .map(GitFileStatus::from)
+                .unwrap_or(GitFileStatus::Modified),
+        })
+    }
+}
+
+// ── Rust → Proto (for server pushes) ────────────────────────────────
+
+impl From<&DiffMode> for proto::DiffMode {
+    fn from(mode: &DiffMode) -> Self {
+        let mode_oneof = match mode {
+            DiffMode::Head => proto::diff_mode::Mode::Head(proto::DiffModeHead {}),
+            DiffMode::MainBranch => {
+                proto::diff_mode::Mode::MainBranch(proto::DiffModeMainBranch {})
+            }
+            DiffMode::OtherBranch(branch) => {
+                proto::diff_mode::Mode::OtherBranch(proto::DiffModeOtherBranch {
+                    branch_name: branch.clone(),
+                })
+            }
+        };
+        proto::DiffMode {
+            mode: Some(mode_oneof),
+        }
+    }
+}
+
+impl From<&DiffStats> for proto::DiffStats {
+    fn from(stats: &DiffStats) -> Self {
+        proto::DiffStats {
+            files_changed: stats.files_changed as u64,
+            total_additions: stats.total_additions as u64,
+            total_deletions: stats.total_deletions as u64,
+        }
+    }
+}
+
+impl From<&DiffMetadataAgainstBase> for proto::DiffMetadataAgainstBase {
+    fn from(m: &DiffMetadataAgainstBase) -> Self {
+        proto::DiffMetadataAgainstBase {
+            aggregate_stats: Some((&m.aggregate_stats).into()),
+        }
+    }
+}
+
+impl From<&Commit> for proto::Commit {
+    fn from(c: &Commit) -> Self {
+        proto::Commit {
+            hash: c.hash.clone(),
+            subject: c.subject.clone(),
+            files_changed: c.files_changed as u64,
+            additions: c.additions as u64,
+            deletions: c.deletions as u64,
+        }
+    }
+}
+
+impl From<&PrInfo> for proto::PrInfo {
+    fn from(p: &PrInfo) -> Self {
+        proto::PrInfo {
+            number: p.number,
+            url: p.url.clone(),
+        }
+    }
+}
+
+impl From<&DiffMetadata> for proto::DiffMetadata {
+    fn from(m: &DiffMetadata) -> Self {
+        proto::DiffMetadata {
+            main_branch_name: m.main_branch_name.clone(),
+            current_branch_name: m.current_branch_name.clone(),
+            against_head: Some((&m.against_head).into()),
+            against_base_branch: m.against_base_branch.as_ref().map(|b| b.into()),
+            has_head_commit: m.has_head_commit,
+            unpushed_commits: m.unpushed_commits.iter().map(proto::Commit::from).collect(),
+            upstream_ref: m.upstream_ref.clone(),
+            pr_info: m.pr_info.as_ref().map(proto::PrInfo::from),
+        }
+    }
+}
+
+impl From<&GitFileStatus> for proto::GitFileStatus {
+    fn from(s: &GitFileStatus) -> Self {
+        let status = match s {
+            GitFileStatus::New => {
+                proto::git_file_status::Status::NewFile(proto::GitFileStatusNew {})
+            }
+            GitFileStatus::Modified => {
+                proto::git_file_status::Status::Modified(proto::GitFileStatusModified {})
+            }
+            GitFileStatus::Deleted => {
+                proto::git_file_status::Status::Deleted(proto::GitFileStatusDeleted {})
+            }
+            GitFileStatus::Renamed { old_path } => {
+                proto::git_file_status::Status::Renamed(proto::GitFileStatusRenamed {
+                    old_path: old_path.clone(),
+                })
+            }
+            GitFileStatus::Copied { old_path } => {
+                proto::git_file_status::Status::Copied(proto::GitFileStatusCopied {
+                    old_path: old_path.clone(),
+                })
+            }
+            GitFileStatus::Untracked => {
+                proto::git_file_status::Status::Untracked(proto::GitFileStatusUntracked {})
+            }
+            GitFileStatus::Conflicted => {
+                proto::git_file_status::Status::Conflicted(proto::GitFileStatusConflicted {})
+            }
+        };
+        proto::GitFileStatus {
+            status: Some(status),
+        }
+    }
+}
+
+impl From<&DiffLineType> for proto::DiffLineType {
+    fn from(t: &DiffLineType) -> Self {
+        match t {
+            DiffLineType::Context => proto::DiffLineType::Context,
+            DiffLineType::Add => proto::DiffLineType::Add,
+            DiffLineType::Delete => proto::DiffLineType::Delete,
+            DiffLineType::HunkHeader => proto::DiffLineType::HunkHeader,
+        }
+    }
+}
+
+impl From<&DiffLine> for proto::DiffLine {
+    fn from(l: &DiffLine) -> Self {
+        proto::DiffLine {
+            line_type: proto::DiffLineType::from(&l.line_type).into(),
+            old_line_number: l.old_line_number.map(|n| n as u64),
+            new_line_number: l.new_line_number.map(|n| n as u64),
+            text: l.text.clone(),
+            no_trailing_newline: l.no_trailing_newline,
+        }
+    }
+}
+
+impl From<&DiffHunk> for proto::DiffHunk {
+    fn from(h: &DiffHunk) -> Self {
+        proto::DiffHunk {
+            old_start_line: h.old_start_line as u64,
+            old_line_count: h.old_line_count as u64,
+            new_start_line: h.new_start_line as u64,
+            new_line_count: h.new_line_count as u64,
+            lines: h.lines.iter().map(proto::DiffLine::from).collect(),
+            unified_diff_start: h.unified_diff_start as u64,
+            unified_diff_end: h.unified_diff_end as u64,
+        }
+    }
+}
+
+impl From<&DiffSize> for proto::DiffSize {
+    fn from(s: &DiffSize) -> Self {
+        match s {
+            DiffSize::Normal => proto::DiffSize::Normal,
+            DiffSize::Large => proto::DiffSize::Large,
+            DiffSize::Unrenderable => proto::DiffSize::Unrenderable,
+        }
+    }
+}
+
+impl From<&DiffState> for proto::DiffState {
+    fn from(state: &DiffState) -> Self {
+        let state_oneof = match state {
+            DiffState::NotInRepository => {
+                proto::diff_state::State::NotInRepository(proto::DiffStateNotInRepository {})
+            }
+            DiffState::Loading => proto::diff_state::State::Loading(proto::DiffStateLoading {}),
+            DiffState::Error(msg) => proto::diff_state::State::Error(proto::DiffStateErrorValue {
+                message: msg.clone(),
+            }),
+            DiffState::Loaded => proto::diff_state::State::Loaded(proto::DiffStateLoaded {}),
+        };
+        proto::DiffState {
+            state: Some(state_oneof),
+        }
+    }
+}
+
+/// Converts a `FileDiff` to proto with an optional `content_at_base`.
+/// Cannot be a `From` impl because of the extra parameter.
+pub fn file_diff_to_proto(f: &FileDiff, content_at_base: Option<&str>) -> proto::FileDiff {
+    proto::FileDiff {
+        file_path: f.file_path.to_string_lossy().to_string(),
+        status: Some((&f.status).into()),
+        hunks: f.hunks.iter().map(proto::DiffHunk::from).collect(),
+        is_binary: f.is_binary,
+        is_autogenerated: f.is_autogenerated,
+        max_line_number: f.max_line_number as u64,
+        has_hidden_bidi_chars: f.has_hidden_bidi_chars,
+        size: proto::DiffSize::from(&f.size).into(),
+        content_at_base: content_at_base.map(|s| s.to_string()),
+    }
+}
+
+impl From<&FileDiffAndContent> for proto::FileDiff {
+    fn from(f: &FileDiffAndContent) -> Self {
+        file_diff_to_proto(&f.file_diff, f.content_at_head.as_deref())
+    }
+}
+
+impl From<&GitDiffWithBaseContent> for proto::GitDiffData {
+    fn from(d: &GitDiffWithBaseContent) -> Self {
+        proto::GitDiffData {
+            files: d.files.iter().map(proto::FileDiff::from).collect(),
+            total_additions: d.total_additions as u64,
+            total_deletions: d.total_deletions as u64,
+            files_changed: d.files_changed as u64,
+        }
+    }
+}
+
+// ── Higher-level message builders ───────────────────────────────────
+
+/// Builds a `DiffStateSnapshot` proto message.
+///
+/// Accepts an optional `GitDiffWithBaseContent` and converts it to proto
+/// internally. Pass `None` for terminal states (Error, NotInRepository)
+/// or when diffs are not yet available.
+pub fn build_diff_state_snapshot(
+    repo_path: &str,
+    mode: &DiffMode,
+    metadata: Option<&DiffMetadata>,
+    state: &DiffState,
+    diffs: Option<&GitDiffWithBaseContent>,
+) -> proto::DiffStateSnapshot {
+    proto::DiffStateSnapshot {
+        repo_path: repo_path.to_string(),
+        mode: Some(mode.into()),
+        metadata: metadata.map(proto::DiffMetadata::from),
+        state: Some(state.into()),
+        diffs: diffs.map(proto::GitDiffData::from),
+    }
+}
+
+/// Builds a `DiffStateMetadataUpdate` proto message.
+pub fn build_diff_state_metadata_update(
+    repo_path: &str,
+    mode: &DiffMode,
+    metadata: &DiffMetadata,
+) -> proto::DiffStateMetadataUpdate {
+    proto::DiffStateMetadataUpdate {
+        repo_path: repo_path.to_string(),
+        mode: Some(mode.into()),
+        metadata: Some(metadata.into()),
+    }
+}
+
+/// Builds a `DiffStateFileDelta` proto message.
+pub fn build_diff_state_file_delta(
+    repo_path: &str,
+    mode: &DiffMode,
+    file_path: &Path,
+    diff: Option<&FileDiffAndContent>,
+    metadata: Option<&DiffMetadata>,
+) -> proto::DiffStateFileDelta {
+    proto::DiffStateFileDelta {
+        repo_path: repo_path.to_string(),
+        mode: Some(mode.into()),
+        file_path: file_path.to_string_lossy().to_string(),
+        diff: diff.map(proto::FileDiff::from),
+        metadata: metadata.map(proto::DiffMetadata::from),
+    }
+}

--- a/app/src/remote_server/diff_state_proto.rs
+++ b/app/src/remote_server/diff_state_proto.rs
@@ -8,6 +8,8 @@
 //! (`code_review::diff_state`, `util::git`) that are not available in the crate.
 use std::path::{Path, PathBuf};
 
+use typed_path::TypedPath;
+
 use super::proto;
 
 use crate::code_review::diff_size_limits::DiffSize;
@@ -20,10 +22,14 @@ use crate::util::git::{Commit, PrInfo};
 // ── Proto → Rust (for incoming client messages) ────────────────────
 
 /// Rejects empty, absolute, and parent-traversal (`..`) paths.
+///
+/// Uses `typed_path` for platform-agnostic detection so that Unix-style
+/// absolute paths (e.g. `/etc/passwd`) are rejected even on Windows.
 fn validate_relative_path(path: &str) -> Result<(), String> {
     let p = Path::new(path);
+    let typed = TypedPath::derive(path);
     if p.as_os_str().is_empty()
-        || p.is_absolute()
+        || typed.is_absolute()
         || p.components().any(|c| c == std::path::Component::ParentDir)
     {
         return Err(format!(

--- a/app/src/remote_server/diff_state_proto.rs
+++ b/app/src/remote_server/diff_state_proto.rs
@@ -340,3 +340,7 @@ pub fn build_diff_state_file_delta(
         metadata: metadata.map(proto::DiffMetadata::from),
     }
 }
+
+#[cfg(test)]
+#[path = "diff_state_proto_tests.rs"]
+mod tests;

--- a/app/src/remote_server/diff_state_proto.rs
+++ b/app/src/remote_server/diff_state_proto.rs
@@ -6,11 +6,10 @@
 //! This module lives in `app/` (rather than in the `remote_server` crate alongside
 //! `repo_metadata_proto`) because it depends on app-level types
 //! (`code_review::diff_state`, `util::git`) that are not available in the crate.
-use std::path::{Path, PathBuf};
-
-use typed_path::TypedPath;
+use std::path::Path;
 
 use super::proto;
+use warp_util::standardized_path::StandardizedPath;
 
 use crate::code_review::diff_size_limits::DiffSize;
 use crate::code_review::diff_state::{
@@ -20,25 +19,6 @@ use crate::code_review::diff_state::{
 use crate::util::git::{Commit, PrInfo};
 
 // ── Proto → Rust (for incoming client messages) ────────────────────
-
-/// Rejects empty, absolute, and parent-traversal (`..`) paths.
-///
-/// Uses `typed_path` for platform-agnostic detection so that Unix-style
-/// absolute paths (e.g. `/etc/passwd`) are rejected even on Windows.
-fn validate_relative_path(path: &str) -> Result<(), String> {
-    let p = Path::new(path);
-    let typed = TypedPath::derive(path);
-    if p.as_os_str().is_empty()
-        || typed.is_absolute()
-        || p.components().any(|c| c == std::path::Component::ParentDir)
-    {
-        return Err(format!(
-            "rejecting path with traversal or absolute component: {}",
-            p.display()
-        ));
-    }
-    Ok(())
-}
 
 impl From<&proto::DiffMode> for DiffMode {
     fn from(proto_mode: &proto::DiffMode) -> Self {
@@ -52,22 +32,23 @@ impl From<&proto::DiffMode> for DiffMode {
     }
 }
 
-impl From<&proto::GitFileStatus> for GitFileStatus {
-    fn from(proto_status: &proto::GitFileStatus) -> Self {
+impl TryFrom<&proto::GitFileStatus> for GitFileStatus {
+    type Error = String;
+
+    fn try_from(proto_status: &proto::GitFileStatus) -> Result<Self, Self::Error> {
         match &proto_status.status {
-            Some(proto::git_file_status::Status::NewFile(_)) => GitFileStatus::New,
-            Some(proto::git_file_status::Status::Modified(_)) => GitFileStatus::Modified,
-            Some(proto::git_file_status::Status::Deleted(_)) => GitFileStatus::Deleted,
-            Some(proto::git_file_status::Status::Renamed(r)) => GitFileStatus::Renamed {
+            Some(proto::git_file_status::Status::NewFile(_)) => Ok(GitFileStatus::New),
+            Some(proto::git_file_status::Status::Modified(_)) => Ok(GitFileStatus::Modified),
+            Some(proto::git_file_status::Status::Deleted(_)) => Ok(GitFileStatus::Deleted),
+            Some(proto::git_file_status::Status::Renamed(r)) => Ok(GitFileStatus::Renamed {
                 old_path: r.old_path.clone(),
-            },
-            Some(proto::git_file_status::Status::Copied(c)) => GitFileStatus::Copied {
+            }),
+            Some(proto::git_file_status::Status::Copied(c)) => Ok(GitFileStatus::Copied {
                 old_path: c.old_path.clone(),
-            },
-            Some(proto::git_file_status::Status::Untracked(_)) => GitFileStatus::Untracked,
-            Some(proto::git_file_status::Status::Conflicted(_)) => GitFileStatus::Conflicted,
-            // Default to Modified for unrecognized/missing status.
-            None => GitFileStatus::Modified,
+            }),
+            Some(proto::git_file_status::Status::Untracked(_)) => Ok(GitFileStatus::Untracked),
+            Some(proto::git_file_status::Status::Conflicted(_)) => Ok(GitFileStatus::Conflicted),
+            None => Err("missing status variant in GitFileStatus".to_string()),
         }
     }
 }
@@ -76,27 +57,24 @@ impl TryFrom<&proto::FileStatusInfo> for FileStatusInfo {
     type Error = String;
 
     fn try_from(proto_info: &proto::FileStatusInfo) -> Result<Self, Self::Error> {
-        validate_relative_path(&proto_info.path)?;
+        let path = StandardizedPath::try_new(&proto_info.path).map_err(|e| e.to_string())?;
 
         let status: GitFileStatus = proto_info
             .status
             .as_ref()
-            .map(GitFileStatus::from)
-            .unwrap_or(GitFileStatus::Modified);
+            .ok_or_else(|| "missing status in FileStatusInfo".to_string())
+            .and_then(GitFileStatus::try_from)?;
 
         // Validate old_path in Renamed/Copied variants — these also flow
         // into git restore/checkout commands during discard.
         match &status {
             GitFileStatus::Renamed { old_path } | GitFileStatus::Copied { old_path } => {
-                validate_relative_path(old_path)?;
+                StandardizedPath::try_new(old_path).map_err(|e| e.to_string())?;
             }
             _ => {}
         }
 
-        Ok(FileStatusInfo {
-            path: PathBuf::from(&proto_info.path),
-            status,
-        })
+        Ok(FileStatusInfo { path, status })
     }
 }
 

--- a/app/src/remote_server/diff_state_proto_tests.rs
+++ b/app/src/remote_server/diff_state_proto_tests.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+
+use super::super::proto;
+use crate::code_review::diff_state::{FileStatusInfo, GitFileStatus};
+
+// ── FileStatusInfo path validation (TryFrom) ────────────────────────
+
+#[test]
+fn file_status_info_valid_relative_path() {
+    let proto_info = proto::FileStatusInfo {
+        path: "src/main.rs".into(),
+        status: Some(proto::GitFileStatus {
+            status: Some(proto::git_file_status::Status::NewFile(
+                proto::GitFileStatusNew {},
+            )),
+        }),
+    };
+
+    let info = FileStatusInfo::try_from(&proto_info).unwrap();
+    assert_eq!(info.path, PathBuf::from("src/main.rs"));
+    assert_eq!(info.status, GitFileStatus::New);
+}
+
+#[test]
+fn file_status_info_missing_status_defaults_to_modified() {
+    let proto_info = proto::FileStatusInfo {
+        path: "file.rs".into(),
+        status: None,
+    };
+
+    let info = FileStatusInfo::try_from(&proto_info).unwrap();
+    assert_eq!(info.status, GitFileStatus::Modified);
+}
+
+#[test]
+fn file_status_info_rejects_absolute_path() {
+    let proto_info = proto::FileStatusInfo {
+        path: "/etc/passwd".into(),
+        status: None,
+    };
+
+    assert!(FileStatusInfo::try_from(&proto_info).is_err());
+}
+
+#[test]
+fn file_status_info_rejects_path_traversal() {
+    let proto_info = proto::FileStatusInfo {
+        path: "../outside/secret.txt".into(),
+        status: None,
+    };
+
+    assert!(FileStatusInfo::try_from(&proto_info).is_err());
+}
+
+#[test]
+fn file_status_info_rejects_empty_path() {
+    let proto_info = proto::FileStatusInfo {
+        path: "".into(),
+        status: None,
+    };
+
+    assert!(FileStatusInfo::try_from(&proto_info).is_err());
+}

--- a/app/src/remote_server/diff_state_proto_tests.rs
+++ b/app/src/remote_server/diff_state_proto_tests.rs
@@ -1,14 +1,13 @@
-use std::path::PathBuf;
-
 use super::super::proto;
 use crate::code_review::diff_state::{FileStatusInfo, GitFileStatus};
+use warp_util::standardized_path::StandardizedPath;
 
-// ── FileStatusInfo path validation (TryFrom) ────────────────────────
+// ── FileStatusInfo path validation (TryFrom) ────────────────────
 
 #[test]
-fn file_status_info_valid_relative_path() {
+fn file_status_info_valid_absolute_path() {
     let proto_info = proto::FileStatusInfo {
-        path: "src/main.rs".into(),
+        path: "/repo/src/main.rs".into(),
         status: Some(proto::GitFileStatus {
             status: Some(proto::git_file_status::Status::NewFile(
                 proto::GitFileStatusNew {},
@@ -17,25 +16,17 @@ fn file_status_info_valid_relative_path() {
     };
 
     let info = FileStatusInfo::try_from(&proto_info).unwrap();
-    assert_eq!(info.path, PathBuf::from("src/main.rs"));
+    assert_eq!(
+        info.path,
+        StandardizedPath::try_new("/repo/src/main.rs").unwrap()
+    );
     assert_eq!(info.status, GitFileStatus::New);
 }
 
 #[test]
-fn file_status_info_missing_status_defaults_to_modified() {
+fn file_status_info_missing_status_is_error() {
     let proto_info = proto::FileStatusInfo {
-        path: "file.rs".into(),
-        status: None,
-    };
-
-    let info = FileStatusInfo::try_from(&proto_info).unwrap();
-    assert_eq!(info.status, GitFileStatus::Modified);
-}
-
-#[test]
-fn file_status_info_rejects_absolute_path() {
-    let proto_info = proto::FileStatusInfo {
-        path: "/etc/passwd".into(),
+        path: "/repo/file.rs".into(),
         status: None,
     };
 
@@ -43,21 +34,28 @@ fn file_status_info_rejects_absolute_path() {
 }
 
 #[test]
-fn file_status_info_rejects_path_traversal() {
+fn file_status_info_missing_status_variant_is_error() {
     let proto_info = proto::FileStatusInfo {
-        path: "../outside/secret.txt".into(),
-        status: None,
+        path: "/repo/file.rs".into(),
+        status: Some(proto::GitFileStatus { status: None }),
     };
 
     assert!(FileStatusInfo::try_from(&proto_info).is_err());
 }
 
 #[test]
-fn file_status_info_rejects_empty_path() {
+fn file_status_info_validates_renamed_old_path() {
     let proto_info = proto::FileStatusInfo {
-        path: "".into(),
-        status: None,
+        path: "/repo/new_name.rs".into(),
+        status: Some(proto::GitFileStatus {
+            status: Some(proto::git_file_status::Status::Renamed(
+                proto::GitFileStatusRenamed {
+                    old_path: "relative/old.rs".into(),
+                },
+            )),
+        }),
     };
 
+    // old_path is relative — should fail validation.
     assert!(FileStatusInfo::try_from(&proto_info).is_err());
 }

--- a/app/src/remote_server/diff_state_tracker.rs
+++ b/app/src/remote_server/diff_state_tracker.rs
@@ -1,0 +1,171 @@
+//! Server-side diff state management.
+//!
+//! [`GlobalDiffStateModel`] manages per-(repo, mode) `LocalDiffStateModel` instances
+//! and tracks which connections are subscribed to each. It is stored as a plain
+//! struct on `ServerModel` (like `ServerBufferTracker` / `PendingFileOps`).
+
+use std::collections::{HashMap, HashSet};
+
+use itertools::Itertools;
+use warp_util::standardized_path::StandardizedPath;
+use warpui::{AppContext, ModelHandle};
+
+use crate::code_review::diff_state::{DiffMetadata, DiffMode, DiffState, LocalDiffStateModel};
+
+use super::protocol::RequestId;
+use super::server_model::ConnectionId;
+
+// ── Key type ────────────────────────────────────────────────────────
+
+/// Composite key: each (repo, mode) gets its own `LocalDiffStateModel`.
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+pub(super) struct DiffModelKey {
+    pub repo_path: StandardizedPath,
+    pub mode: DiffMode,
+}
+
+// ── Pending response tracker ────────────────────────────────────────
+
+/// Tracks a `GetDiffState` request that arrived while the model was still loading.
+/// The response is sent once `NewDiffsComputed` fires.
+pub(super) struct PendingDiffStateResponse {
+    pub request_id: RequestId,
+    pub conn_id: ConnectionId,
+}
+
+// ── GlobalDiffStateModel ────────────────────────────────────────────
+
+/// Manages the lifecycle of server-side `LocalDiffStateModel` instances and
+/// per-connection subscription tracking.
+///
+/// A model is created when the first `GetDiffState` arrives for a given key
+/// and dropped when the last connection unsubscribes (or disconnects).
+pub(super) struct GlobalDiffStateModel {
+    /// One model per (repo, mode). Mode is immutable — pinned at construction.
+    states: HashMap<DiffModelKey, ModelHandle<LocalDiffStateModel>>,
+    /// Per-key set of subscribed connections.
+    key_to_connections: HashMap<DiffModelKey, HashSet<ConnectionId>>,
+    /// Pending `GetDiffState` responses waiting for the model to finish loading.
+    pending_responses: HashMap<DiffModelKey, Vec<PendingDiffStateResponse>>,
+}
+
+impl GlobalDiffStateModel {
+    pub fn new() -> Self {
+        Self {
+            states: HashMap::new(),
+            key_to_connections: HashMap::new(),
+            pending_responses: HashMap::new(),
+        }
+    }
+
+    // ── Model CRUD ──────────────────────────────────────────────────
+
+    pub fn get_model(&self, key: &DiffModelKey) -> Option<&ModelHandle<LocalDiffStateModel>> {
+        self.states.get(key)
+    }
+
+    pub fn insert_model(&mut self, key: DiffModelKey, model: ModelHandle<LocalDiffStateModel>) {
+        self.states.insert(key, model);
+    }
+
+    pub fn remove_model(&mut self, key: &DiffModelKey) {
+        self.states.remove(key);
+        self.pending_responses.remove(key);
+        self.key_to_connections.remove(key);
+    }
+
+    /// Reads the current `DiffState` and cloned `DiffMetadata` from the model
+    /// for `key`. Returns `fallback` values when the model is absent.
+    pub fn read_state_and_metadata(
+        &self,
+        key: &DiffModelKey,
+        fallback_state: DiffState,
+        app: &AppContext,
+    ) -> (DiffState, Option<DiffMetadata>) {
+        self.states
+            .get(key)
+            .map(|model| {
+                let m = model.as_ref(app);
+                (m.get(), m.metadata().cloned())
+            })
+            .unwrap_or((fallback_state, None))
+    }
+
+    // ── Connection subscription tracking ────────────────────────────
+
+    /// Records that `conn_id` is subscribed to `key`.
+    pub fn subscribe_connection(&mut self, key: DiffModelKey, conn_id: ConnectionId) {
+        self.key_to_connections
+            .entry(key)
+            .or_default()
+            .insert(conn_id);
+    }
+
+    /// Removes `conn_id`'s subscription for `key`.
+    /// If the key has zero remaining subscribers the model is dropped inline.
+    pub fn unsubscribe_connection(&mut self, key: &DiffModelKey, conn_id: ConnectionId) {
+        if let Some(pending) = self.pending_responses.get_mut(key) {
+            pending.retain(|p| p.conn_id != conn_id);
+        }
+
+        if let Some(connections) = self.key_to_connections.get_mut(key) {
+            connections.remove(&conn_id);
+            if connections.is_empty() {
+                self.remove_model(key);
+            }
+        }
+    }
+
+    /// Removes all subscriptions for a disconnected connection.
+    /// Orphaned models (no remaining subscribers) are dropped inline.
+    pub fn remove_connection(&mut self, conn_id: ConnectionId) {
+        let keys = self
+            .key_to_connections
+            .iter()
+            .filter(|(_, conns)| conns.contains(&conn_id))
+            .map(|(key, _)| key.clone())
+            .collect_vec();
+
+        for key in keys {
+            self.unsubscribe_connection(&key, conn_id);
+        }
+    }
+
+    /// Returns the connection IDs subscribed to `key`.
+    pub fn subscribed_connections(&self, key: &DiffModelKey) -> Vec<ConnectionId> {
+        self.key_to_connections
+            .get(key)
+            .map(|conns| conns.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    // ── Pending response tracking ───────────────────────────────────
+
+    /// Returns `true` if there are pending responses queued for `key`.
+    pub fn has_pending_responses(&self, key: &DiffModelKey) -> bool {
+        self.pending_responses
+            .get(key)
+            .is_some_and(|v| !v.is_empty())
+    }
+
+    /// Registers a pending `GetDiffState` response to be sent once the model loads.
+    pub fn add_pending_response(
+        &mut self,
+        key: DiffModelKey,
+        request_id: RequestId,
+        conn_id: ConnectionId,
+    ) {
+        self.pending_responses
+            .entry(key)
+            .or_default()
+            .push(PendingDiffStateResponse {
+                request_id,
+                conn_id,
+            });
+    }
+
+    /// Drains all pending responses for `key`.
+    pub fn drain_pending_responses(&mut self, key: &DiffModelKey) -> Vec<PendingDiffStateResponse> {
+        self.pending_responses.remove(key).unwrap_or_default()
+    }
+}

--- a/app/src/remote_server/diff_state_tracker.rs
+++ b/app/src/remote_server/diff_state_tracker.rs
@@ -1,16 +1,24 @@
 //! Server-side diff state management.
 //!
-//! [`GlobalDiffStateModel`] manages per-(repo, mode) `LocalDiffStateModel` instances
-//! and tracks which connections are subscribed to each. It is stored as a plain
-//! struct on `ServerModel` (like `ServerBufferTracker` / `PendingFileOps`).
+//! [`RemoteDiffStateManager`] is an entity that manages per-(repo, mode)
+//! `LocalDiffStateModel` instances and tracks which connections are subscribed
+//! to each. It owns model creation, event subscriptions, and content reload
+//! spawning. `ServerModel` subscribes to its `DiffStateUpdate` events to
+//! handle proto conversion and wire delivery.
 
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use itertools::Itertools;
 use warp_util::standardized_path::StandardizedPath;
-use warpui::{AppContext, ModelHandle};
+use warpui::r#async::SpawnedFutureHandle;
+use warpui::{AppContext, Entity, ModelContext, ModelHandle};
 
-use crate::code_review::diff_state::{DiffMetadata, DiffMode, DiffState, LocalDiffStateModel};
+use crate::code_review::diff_state::{
+    DiffMetadata, DiffMode, DiffState, DiffStateModelEvent, FileDiffAndContent,
+    GitDiffWithBaseContent, LocalDiffStateModel,
+};
 
 use super::protocol::RequestId;
 use super::server_model::ConnectionId;
@@ -33,28 +41,87 @@ pub(super) struct PendingDiffStateResponse {
     pub conn_id: ConnectionId,
 }
 
-// ── GlobalDiffStateModel ────────────────────────────────────────────
+// ── Action / outcome types ─────────────────────────────────────
+
+/// Outcome of [`RemoteDiffStateManager::subscribe`].
+#[allow(clippy::large_enum_variant)]
+pub(super) enum SubscribeOutcome {
+    /// Respond with this snapshot immediately.
+    RespondWithSnapshot {
+        key: DiffModelKey,
+        state: DiffState,
+        metadata: Option<DiffMetadata>,
+    },
+    /// An async operation is in flight (content reload or model loading).
+    /// The manager tracks spawned handles internally.
+    Async,
+}
+
+/// Domain-level dispatch action returned by event processing and content
+/// reload completion. Proto conversion is handled by `ServerModel` at
+/// dispatch time.
+pub(super) enum DiffStateUpdate {
+    /// Build and send a snapshot to subscribers. Entries with a `request_id`
+    /// receive a `GetDiffStateResponse`; entries without receive a
+    /// server-initiated push `DiffStateSnapshot`.
+    Snapshot {
+        repo_path: String,
+        mode: DiffMode,
+        state: DiffState,
+        metadata: Option<DiffMetadata>,
+        diffs: Option<Arc<GitDiffWithBaseContent>>,
+        /// Each subscriber is a connection plus an optional request ID.
+        /// `Some(request_id)` → pending `GetDiffState` response (sent with request_id).
+        /// `None` → already-subscribed connection that receives a server-initiated push.
+        subscribers: Vec<(ConnectionId, Option<RequestId>)>,
+    },
+    /// Build and send a metadata update to all subscribers.
+    MetadataUpdate {
+        repo_path: StandardizedPath,
+        mode: DiffMode,
+        metadata: DiffMetadata,
+        subscribers: Vec<ConnectionId>,
+    },
+    /// Build and send a single-file delta to all subscribers.
+    FileDelta {
+        repo_path: StandardizedPath,
+        mode: DiffMode,
+        path: PathBuf,
+        diff: Option<Arc<FileDiffAndContent>>,
+        metadata: Option<DiffMetadata>,
+        subscribers: Vec<ConnectionId>,
+    },
+}
+
+// ── RemoteDiffStateManager ────────────────────────────────────────
 
 /// Manages the lifecycle of server-side `LocalDiffStateModel` instances and
 /// per-connection subscription tracking.
 ///
 /// A model is created when the first `GetDiffState` arrives for a given key
 /// and dropped when the last connection unsubscribes (or disconnects).
-pub(super) struct GlobalDiffStateModel {
+pub(super) struct RemoteDiffStateManager {
     /// One model per (repo, mode). Mode is immutable — pinned at construction.
     states: HashMap<DiffModelKey, ModelHandle<LocalDiffStateModel>>,
     /// Per-key set of subscribed connections.
     key_to_connections: HashMap<DiffModelKey, HashSet<ConnectionId>>,
     /// Pending `GetDiffState` responses waiting for the model to finish loading.
     pending_responses: HashMap<DiffModelKey, Vec<PendingDiffStateResponse>>,
+    /// In-progress content reload handles, keyed by request ID.
+    in_progress: HashMap<RequestId, SpawnedFutureHandle>,
 }
 
-impl GlobalDiffStateModel {
+impl Entity for RemoteDiffStateManager {
+    type Event = DiffStateUpdate;
+}
+
+impl RemoteDiffStateManager {
     pub fn new() -> Self {
         Self {
             states: HashMap::new(),
             key_to_connections: HashMap::new(),
             pending_responses: HashMap::new(),
+            in_progress: HashMap::new(),
         }
     }
 
@@ -75,20 +142,16 @@ impl GlobalDiffStateModel {
     }
 
     /// Reads the current `DiffState` and cloned `DiffMetadata` from the model
-    /// for `key`. Returns `fallback` values when the model is absent.
+    /// for `key`. Returns `None` when the model is absent.
     pub fn read_state_and_metadata(
         &self,
         key: &DiffModelKey,
-        fallback_state: DiffState,
         app: &AppContext,
-    ) -> (DiffState, Option<DiffMetadata>) {
-        self.states
-            .get(key)
-            .map(|model| {
-                let m = model.as_ref(app);
-                (m.get(), m.metadata().cloned())
-            })
-            .unwrap_or((fallback_state, None))
+    ) -> Option<(DiffState, Option<DiffMetadata>)> {
+        self.states.get(key).map(|model| {
+            let m = model.as_ref(app);
+            (m.get(), m.metadata().cloned())
+        })
     }
 
     // ── Connection subscription tracking ────────────────────────────
@@ -167,6 +230,214 @@ impl GlobalDiffStateModel {
     /// Drains all pending responses for `key`.
     pub fn drain_pending_responses(&mut self, key: &DiffModelKey) -> Vec<PendingDiffStateResponse> {
         self.pending_responses.remove(key).unwrap_or_default()
+    }
+
+    // ── High-level operations ────────────────────────────────────
+
+    /// Handles a `GetDiffState` subscription request.
+    ///
+    /// Subscribes the connection, looks up or creates the model, and returns
+    /// an outcome describing the result. When a content reload is needed it
+    /// is spawned internally; when a new model is created the event
+    /// subscription is wired up internally.
+    pub fn subscribe(
+        &mut self,
+        repo_path: StandardizedPath,
+        mode: DiffMode,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> SubscribeOutcome {
+        let key = DiffModelKey { repo_path, mode };
+        self.subscribe_connection(key.clone(), conn_id);
+
+        if let Some(model) = self.get_model(&key) {
+            let model_ref = model.as_ref(ctx);
+            let state = model_ref.get();
+            match state {
+                DiffState::Loaded => {
+                    let already_in_flight = self.has_pending_responses(&key);
+                    self.add_pending_response(key.clone(), request_id.clone(), conn_id);
+                    if !already_in_flight {
+                        self.spawn_content_reload(key, request_id, ctx);
+                    }
+                    SubscribeOutcome::Async
+                }
+                DiffState::Error(_) | DiffState::NotInRepository => {
+                    SubscribeOutcome::RespondWithSnapshot {
+                        key,
+                        state,
+                        metadata: model_ref.metadata().cloned(),
+                    }
+                }
+                DiffState::Loading => {
+                    self.add_pending_response(key, request_id.clone(), conn_id);
+                    SubscribeOutcome::Async
+                }
+            }
+        } else {
+            // Model doesn't exist — create it and wire up event subscription.
+            let repo_path_str = key.repo_path.to_string();
+            let mode = key.mode.clone();
+            let model = ctx.add_model(|ctx| {
+                let mut m = LocalDiffStateModel::new(Some(repo_path_str), ctx);
+                m.set_diff_mode(mode, false, ctx);
+                m.set_code_review_metadata_refresh_enabled(true, ctx);
+                m
+            });
+            self.insert_model(key.clone(), model.clone());
+            self.add_pending_response(key.clone(), request_id.clone(), conn_id);
+
+            let key_for_sub = key;
+            ctx.subscribe_to_model(&model, move |me, event, ctx| {
+                me.handle_model_event(&key_for_sub, event, ctx);
+            });
+
+            SubscribeOutcome::Async
+        }
+    }
+
+    /// Processes a `DiffStateModelEvent`, builds domain-level dispatch
+    /// actions, and emits them as entity events for `ServerModel` to handle.
+    fn handle_model_event(
+        &mut self,
+        key: &DiffModelKey,
+        event: &DiffStateModelEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match event {
+            DiffStateModelEvent::NewDiffsComputed(diffs) => {
+                let Some((state, metadata)) = self.read_state_and_metadata(key, ctx) else {
+                    log::warn!("NewDiffsComputed for absent model key={key:?}");
+                    return;
+                };
+
+                let pending = self.drain_pending_responses(key);
+                let responded_conns: HashSet<ConnectionId> =
+                    pending.iter().map(|p| p.conn_id).collect();
+                let mut subscribers: Vec<(ConnectionId, Option<RequestId>)> = pending
+                    .into_iter()
+                    .map(|p| (p.conn_id, Some(p.request_id)))
+                    .collect();
+                subscribers.extend(
+                    self.subscribed_connections(key)
+                        .into_iter()
+                        .filter(|c| !responded_conns.contains(c))
+                        .map(|c| (c, None)),
+                );
+
+                ctx.emit(DiffStateUpdate::Snapshot {
+                    repo_path: key.repo_path.to_string(),
+                    mode: key.mode.clone(),
+                    state,
+                    metadata,
+                    diffs: diffs.clone(),
+                    subscribers,
+                });
+            }
+            DiffStateModelEvent::MetadataRefreshed(metadata) => {
+                ctx.emit(DiffStateUpdate::MetadataUpdate {
+                    repo_path: key.repo_path.clone(),
+                    mode: key.mode.clone(),
+                    metadata: metadata.clone(),
+                    subscribers: self.subscribed_connections(key),
+                });
+            }
+            DiffStateModelEvent::CurrentBranchChanged => {
+                let Some(model) = self.get_model(key) else {
+                    return;
+                };
+                let Some(metadata) = model.as_ref(ctx).metadata() else {
+                    return;
+                };
+                ctx.emit(DiffStateUpdate::MetadataUpdate {
+                    repo_path: key.repo_path.clone(),
+                    mode: key.mode.clone(),
+                    metadata: metadata.clone(),
+                    subscribers: self.subscribed_connections(key),
+                });
+            }
+            DiffStateModelEvent::SingleFileUpdated { path, diff } => {
+                let metadata = self
+                    .get_model(key)
+                    .and_then(|m| m.as_ref(ctx).metadata().cloned());
+                ctx.emit(DiffStateUpdate::FileDelta {
+                    repo_path: key.repo_path.clone(),
+                    mode: key.mode.clone(),
+                    path: path.clone(),
+                    diff: diff.clone(),
+                    metadata,
+                    subscribers: self.subscribed_connections(key),
+                });
+            }
+        }
+    }
+
+    /// Reads model state, drains pending responses, and emits a `Snapshot`
+    /// dispatch so `ServerModel` can deliver the results to waiting clients.
+    fn resolve_pending_responses(
+        &mut self,
+        key: &DiffModelKey,
+        diffs: Option<GitDiffWithBaseContent>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some((state, metadata)) = self.read_state_and_metadata(key, ctx) else {
+            log::warn!("Content reload completed for absent model key={key:?}");
+            return;
+        };
+        let diffs_arc = diffs.map(Arc::new);
+        let subscribers = self
+            .drain_pending_responses(key)
+            .into_iter()
+            .map(|p| (p.conn_id, Some(p.request_id)))
+            .collect();
+
+        ctx.emit(DiffStateUpdate::Snapshot {
+            repo_path: key.repo_path.to_string(),
+            mode: key.mode.clone(),
+            state,
+            metadata,
+            diffs: diffs_arc,
+            subscribers,
+        });
+    }
+
+    /// Spawns an async diff reload with `content_at_base` for late-joining subscribers.
+    fn spawn_content_reload(
+        &mut self,
+        key: DiffModelKey,
+        request_id: &RequestId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let diff_mode = key.mode.clone();
+        let repo_path = PathBuf::from(key.repo_path.as_str());
+        let resolve_id = request_id.clone();
+        let abort_id = request_id.clone();
+        let handle = ctx.spawn_abortable(
+            async move {
+                LocalDiffStateModel::load_diffs_with_content_for_mode(diff_mode, repo_path).await
+            },
+            move |me, diffs, ctx| {
+                me.in_progress.remove(&resolve_id);
+                me.resolve_pending_responses(&key, diffs, ctx);
+            },
+            move |me, _ctx| {
+                log::info!("Request cancelled (request_id={abort_id})");
+                me.in_progress.remove(&abort_id);
+            },
+        );
+        self.in_progress.insert(request_id.clone(), handle);
+    }
+
+    /// Cancels an in-progress content reload, if one exists for this request.
+    /// Returns `true` if a request was found and aborted.
+    pub fn abort_request(&mut self, request_id: &RequestId) -> bool {
+        if let Some(handle) = self.in_progress.remove(request_id) {
+            handle.abort();
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/app/src/remote_server/diff_state_tracker.rs
+++ b/app/src/remote_server/diff_state_tracker.rs
@@ -169,3 +169,7 @@ impl GlobalDiffStateModel {
         self.pending_responses.remove(key).unwrap_or_default()
     }
 }
+
+#[cfg(test)]
+#[path = "diff_state_tracker_tests.rs"]
+mod tests;

--- a/app/src/remote_server/diff_state_tracker_tests.rs
+++ b/app/src/remote_server/diff_state_tracker_tests.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use warp_util::standardized_path::StandardizedPath;
 
 use crate::code_review::diff_state::DiffMode;
@@ -8,9 +6,11 @@ use super::super::protocol::RequestId;
 use super::super::server_model::ConnectionId;
 use super::{DiffModelKey, GlobalDiffStateModel};
 
+/// Uses `try_new` instead of `try_from_local` so that Unix-style paths
+/// like `/repo` are recognised as absolute on all platforms (including Windows).
 fn test_key(repo: &str, mode: DiffMode) -> DiffModelKey {
     DiffModelKey {
-        repo_path: StandardizedPath::try_from_local(Path::new(repo)).unwrap(),
+        repo_path: StandardizedPath::try_new(repo).unwrap(),
         mode,
     }
 }

--- a/app/src/remote_server/diff_state_tracker_tests.rs
+++ b/app/src/remote_server/diff_state_tracker_tests.rs
@@ -4,7 +4,7 @@ use crate::code_review::diff_state::DiffMode;
 
 use super::super::protocol::RequestId;
 use super::super::server_model::ConnectionId;
-use super::{DiffModelKey, GlobalDiffStateModel};
+use super::{DiffModelKey, RemoteDiffStateManager};
 
 /// Uses `try_new` instead of `try_from_local` so that Unix-style paths
 /// like `/repo` are recognised as absolute on all platforms (including Windows).
@@ -23,7 +23,7 @@ fn new_conn() -> ConnectionId {
 
 #[test]
 fn subscribe_registers_connection() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
     let conn = new_conn();
 
@@ -34,7 +34,7 @@ fn subscribe_registers_connection() {
 
 #[test]
 fn subscribe_multiple_connections_to_same_key() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
     let conn_a = new_conn();
     let conn_b = new_conn();
@@ -50,7 +50,7 @@ fn subscribe_multiple_connections_to_same_key() {
 
 #[test]
 fn subscribe_same_connection_to_different_keys() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key_head = test_key("/repo", DiffMode::Head);
     let key_main = test_key("/repo", DiffMode::MainBranch);
     let conn = new_conn();
@@ -64,7 +64,7 @@ fn subscribe_same_connection_to_different_keys() {
 
 #[test]
 fn subscribed_connections_returns_empty_for_unknown_key() {
-    let model = GlobalDiffStateModel::new();
+    let model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
 
     assert!(model.subscribed_connections(&key).is_empty());
@@ -74,7 +74,7 @@ fn subscribed_connections_returns_empty_for_unknown_key() {
 
 #[test]
 fn unsubscribe_last_connection_removes_model() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
     let conn = new_conn();
 
@@ -94,7 +94,7 @@ fn unsubscribe_last_connection_removes_model() {
 
 #[test]
 fn unsubscribe_one_of_two_keeps_model() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
     let conn_a = new_conn();
     let conn_b = new_conn();
@@ -115,7 +115,7 @@ fn unsubscribe_one_of_two_keeps_model() {
 
 #[test]
 fn unsubscribe_clears_pending_responses_for_that_connection() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
     let conn_a = new_conn();
     let conn_b = new_conn();
@@ -142,7 +142,7 @@ fn unsubscribe_clears_pending_responses_for_that_connection() {
 
 #[test]
 fn remove_connection_unsubscribes_from_all_keys() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key_head = test_key("/repo", DiffMode::Head);
     let key_main = test_key("/repo", DiffMode::MainBranch);
     let conn = new_conn();
@@ -167,7 +167,7 @@ fn remove_connection_unsubscribes_from_all_keys() {
 
 #[test]
 fn remove_connection_keeps_models_with_other_subscribers() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
     let conn_a = new_conn();
     let conn_b = new_conn();
@@ -188,7 +188,7 @@ fn remove_connection_keeps_models_with_other_subscribers() {
 
 #[test]
 fn remove_connection_clears_pending_responses() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
     let conn = new_conn();
 
@@ -210,7 +210,7 @@ fn remove_connection_clears_pending_responses() {
 
 #[test]
 fn has_pending_responses_false_when_empty() {
-    let model = GlobalDiffStateModel::new();
+    let model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
 
     assert!(!model.has_pending_responses(&key));
@@ -218,7 +218,7 @@ fn has_pending_responses_false_when_empty() {
 
 #[test]
 fn add_and_drain_pending_responses() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
     let conn = new_conn();
     let rid = RequestId::new();
@@ -237,7 +237,7 @@ fn add_and_drain_pending_responses() {
 
 #[test]
 fn drain_pending_responses_returns_empty_for_unknown_key() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
 
     assert!(model.drain_pending_responses(&key).is_empty());
@@ -245,7 +245,7 @@ fn drain_pending_responses_returns_empty_for_unknown_key() {
 
 #[test]
 fn multiple_pending_responses_for_same_key() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
     let conn_a = new_conn();
     let conn_b = new_conn();
@@ -263,7 +263,7 @@ fn multiple_pending_responses_for_same_key() {
 
 #[test]
 fn get_model_returns_none_when_empty() {
-    let model = GlobalDiffStateModel::new();
+    let model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
 
     assert!(model.get_model(&key).is_none());
@@ -271,7 +271,7 @@ fn get_model_returns_none_when_empty() {
 
 #[test]
 fn insert_and_get_model() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
 
     warpui::App::test((), |mut app| async move {
@@ -285,7 +285,7 @@ fn insert_and_get_model() {
 
 #[test]
 fn remove_model_clears_pending_and_subscriptions() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key = test_key("/repo", DiffMode::Head);
     let conn = new_conn();
 
@@ -308,7 +308,7 @@ fn remove_model_clears_pending_and_subscriptions() {
 
 #[test]
 fn different_modes_are_different_keys() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key_head = test_key("/repo", DiffMode::Head);
     let key_main = test_key("/repo", DiffMode::MainBranch);
     let conn = new_conn();
@@ -321,7 +321,7 @@ fn different_modes_are_different_keys() {
 
 #[test]
 fn different_repos_are_different_keys() {
-    let mut model = GlobalDiffStateModel::new();
+    let mut model = RemoteDiffStateManager::new();
     let key_a = test_key("/repo-a", DiffMode::Head);
     let key_b = test_key("/repo-b", DiffMode::Head);
     let conn = new_conn();

--- a/app/src/remote_server/diff_state_tracker_tests.rs
+++ b/app/src/remote_server/diff_state_tracker_tests.rs
@@ -1,0 +1,333 @@
+use std::path::Path;
+
+use warp_util::standardized_path::StandardizedPath;
+
+use crate::code_review::diff_state::DiffMode;
+
+use super::super::protocol::RequestId;
+use super::super::server_model::ConnectionId;
+use super::{DiffModelKey, GlobalDiffStateModel};
+
+fn test_key(repo: &str, mode: DiffMode) -> DiffModelKey {
+    DiffModelKey {
+        repo_path: StandardizedPath::try_from_local(Path::new(repo)).unwrap(),
+        mode,
+    }
+}
+
+fn new_conn() -> ConnectionId {
+    uuid::Uuid::new_v4()
+}
+
+// ── Subscription tracking ───────────────────────────────────────────
+
+#[test]
+fn subscribe_registers_connection() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+    let conn = new_conn();
+
+    model.subscribe_connection(key.clone(), conn);
+
+    assert_eq!(model.subscribed_connections(&key), vec![conn]);
+}
+
+#[test]
+fn subscribe_multiple_connections_to_same_key() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+    let conn_a = new_conn();
+    let conn_b = new_conn();
+
+    model.subscribe_connection(key.clone(), conn_a);
+    model.subscribe_connection(key.clone(), conn_b);
+
+    let subs = model.subscribed_connections(&key);
+    assert_eq!(subs.len(), 2);
+    assert!(subs.contains(&conn_a));
+    assert!(subs.contains(&conn_b));
+}
+
+#[test]
+fn subscribe_same_connection_to_different_keys() {
+    let mut model = GlobalDiffStateModel::new();
+    let key_head = test_key("/repo", DiffMode::Head);
+    let key_main = test_key("/repo", DiffMode::MainBranch);
+    let conn = new_conn();
+
+    model.subscribe_connection(key_head.clone(), conn);
+    model.subscribe_connection(key_main.clone(), conn);
+
+    assert_eq!(model.subscribed_connections(&key_head), vec![conn]);
+    assert_eq!(model.subscribed_connections(&key_main), vec![conn]);
+}
+
+#[test]
+fn subscribed_connections_returns_empty_for_unknown_key() {
+    let model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+
+    assert!(model.subscribed_connections(&key).is_empty());
+}
+
+// ── Unsubscribe ─────────────────────────────────────────────────────
+
+#[test]
+fn unsubscribe_last_connection_removes_model() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+    let conn = new_conn();
+
+    // Simulate model insertion + subscription (what handle_get_diff_state does).
+    warpui::App::test((), |mut app| async move {
+        let handle = app
+            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        model.insert_model(key.clone(), handle);
+        model.subscribe_connection(key.clone(), conn);
+
+        model.unsubscribe_connection(&key, conn);
+
+        assert!(model.get_model(&key).is_none());
+        assert!(model.subscribed_connections(&key).is_empty());
+    });
+}
+
+#[test]
+fn unsubscribe_one_of_two_keeps_model() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+    let conn_a = new_conn();
+    let conn_b = new_conn();
+
+    warpui::App::test((), |mut app| async move {
+        let handle = app
+            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        model.insert_model(key.clone(), handle);
+        model.subscribe_connection(key.clone(), conn_a);
+        model.subscribe_connection(key.clone(), conn_b);
+
+        model.unsubscribe_connection(&key, conn_a);
+
+        assert!(model.get_model(&key).is_some());
+        assert_eq!(model.subscribed_connections(&key), vec![conn_b]);
+    });
+}
+
+#[test]
+fn unsubscribe_clears_pending_responses_for_that_connection() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+    let conn_a = new_conn();
+    let conn_b = new_conn();
+
+    warpui::App::test((), |mut app| async move {
+        let handle = app
+            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        model.insert_model(key.clone(), handle);
+        model.subscribe_connection(key.clone(), conn_a);
+        model.subscribe_connection(key.clone(), conn_b);
+        model.add_pending_response(key.clone(), RequestId::new(), conn_a);
+        model.add_pending_response(key.clone(), RequestId::new(), conn_b);
+
+        model.unsubscribe_connection(&key, conn_a);
+
+        // Only conn_b's pending response should remain.
+        let pending = model.drain_pending_responses(&key);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].conn_id, conn_b);
+    });
+}
+
+// ── remove_connection ───────────────────────────────────────────────
+
+#[test]
+fn remove_connection_unsubscribes_from_all_keys() {
+    let mut model = GlobalDiffStateModel::new();
+    let key_head = test_key("/repo", DiffMode::Head);
+    let key_main = test_key("/repo", DiffMode::MainBranch);
+    let conn = new_conn();
+
+    warpui::App::test((), |mut app| async move {
+        let h1 = app
+            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        let h2 = app
+            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        model.insert_model(key_head.clone(), h1);
+        model.insert_model(key_main.clone(), h2);
+        model.subscribe_connection(key_head.clone(), conn);
+        model.subscribe_connection(key_main.clone(), conn);
+
+        model.remove_connection(conn);
+
+        // Both models dropped because conn was the sole subscriber.
+        assert!(model.get_model(&key_head).is_none());
+        assert!(model.get_model(&key_main).is_none());
+    });
+}
+
+#[test]
+fn remove_connection_keeps_models_with_other_subscribers() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+    let conn_a = new_conn();
+    let conn_b = new_conn();
+
+    warpui::App::test((), |mut app| async move {
+        let handle = app
+            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        model.insert_model(key.clone(), handle);
+        model.subscribe_connection(key.clone(), conn_a);
+        model.subscribe_connection(key.clone(), conn_b);
+
+        model.remove_connection(conn_a);
+
+        assert!(model.get_model(&key).is_some());
+        assert_eq!(model.subscribed_connections(&key), vec![conn_b]);
+    });
+}
+
+#[test]
+fn remove_connection_clears_pending_responses() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+    let conn = new_conn();
+
+    warpui::App::test((), |mut app| async move {
+        let handle = app
+            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        model.insert_model(key.clone(), handle);
+        model.subscribe_connection(key.clone(), conn);
+        model.add_pending_response(key.clone(), RequestId::new(), conn);
+
+        model.remove_connection(conn);
+
+        // Model removed, so pending responses should be gone too.
+        assert!(!model.has_pending_responses(&key));
+    });
+}
+
+// ── Pending response tracking ───────────────────────────────────────
+
+#[test]
+fn has_pending_responses_false_when_empty() {
+    let model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+
+    assert!(!model.has_pending_responses(&key));
+}
+
+#[test]
+fn add_and_drain_pending_responses() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+    let conn = new_conn();
+    let rid = RequestId::new();
+
+    model.add_pending_response(key.clone(), rid, conn);
+
+    assert!(model.has_pending_responses(&key));
+
+    let drained = model.drain_pending_responses(&key);
+    assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].conn_id, conn);
+
+    // After drain, no pending responses remain.
+    assert!(!model.has_pending_responses(&key));
+}
+
+#[test]
+fn drain_pending_responses_returns_empty_for_unknown_key() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+
+    assert!(model.drain_pending_responses(&key).is_empty());
+}
+
+#[test]
+fn multiple_pending_responses_for_same_key() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+    let conn_a = new_conn();
+    let conn_b = new_conn();
+
+    model.add_pending_response(key.clone(), RequestId::new(), conn_a);
+    model.add_pending_response(key.clone(), RequestId::new(), conn_b);
+
+    let drained = model.drain_pending_responses(&key);
+    assert_eq!(drained.len(), 2);
+    assert_eq!(drained[0].conn_id, conn_a);
+    assert_eq!(drained[1].conn_id, conn_b);
+}
+
+// ── Model CRUD ──────────────────────────────────────────────────────
+
+#[test]
+fn get_model_returns_none_when_empty() {
+    let model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+
+    assert!(model.get_model(&key).is_none());
+}
+
+#[test]
+fn insert_and_get_model() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+
+    warpui::App::test((), |mut app| async move {
+        let handle = app
+            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        model.insert_model(key.clone(), handle);
+
+        assert!(model.get_model(&key).is_some());
+    });
+}
+
+#[test]
+fn remove_model_clears_pending_and_subscriptions() {
+    let mut model = GlobalDiffStateModel::new();
+    let key = test_key("/repo", DiffMode::Head);
+    let conn = new_conn();
+
+    warpui::App::test((), |mut app| async move {
+        let handle = app
+            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        model.insert_model(key.clone(), handle);
+        model.subscribe_connection(key.clone(), conn);
+        model.add_pending_response(key.clone(), RequestId::new(), conn);
+
+        model.remove_model(&key);
+
+        assert!(model.get_model(&key).is_none());
+        assert!(!model.has_pending_responses(&key));
+        assert!(model.subscribed_connections(&key).is_empty());
+    });
+}
+
+// ── Key equality ────────────────────────────────────────────────────
+
+#[test]
+fn different_modes_are_different_keys() {
+    let mut model = GlobalDiffStateModel::new();
+    let key_head = test_key("/repo", DiffMode::Head);
+    let key_main = test_key("/repo", DiffMode::MainBranch);
+    let conn = new_conn();
+
+    model.subscribe_connection(key_head.clone(), conn);
+
+    assert_eq!(model.subscribed_connections(&key_head).len(), 1);
+    assert!(model.subscribed_connections(&key_main).is_empty());
+}
+
+#[test]
+fn different_repos_are_different_keys() {
+    let mut model = GlobalDiffStateModel::new();
+    let key_a = test_key("/repo-a", DiffMode::Head);
+    let key_b = test_key("/repo-b", DiffMode::Head);
+    let conn = new_conn();
+
+    model.subscribe_connection(key_a.clone(), conn);
+
+    assert_eq!(model.subscribed_connections(&key_a).len(), 1);
+    assert!(model.subscribed_connections(&key_b).is_empty());
+}

--- a/app/src/remote_server/mod.rs
+++ b/app/src/remote_server/mod.rs
@@ -11,6 +11,10 @@ pub use remote_server::*;
 #[cfg(not(target_family = "wasm"))]
 pub mod auth_context;
 #[cfg(not(target_family = "wasm"))]
+pub mod diff_state_proto;
+#[cfg(not(target_family = "wasm"))]
+pub mod diff_state_tracker;
+#[cfg(not(target_family = "wasm"))]
 pub mod server_buffer_tracker;
 #[cfg(not(target_family = "wasm"))]
 pub mod server_model;

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -19,19 +19,26 @@ use warp_files::{FileModel, FileModelEvent};
 use warp_util::content_version::ContentVersion;
 use warp_util::file::FileId;
 
+use super::diff_state_proto;
+use super::diff_state_tracker::{DiffModelKey, GlobalDiffStateModel};
 use super::proto::{
-    client_message, delete_file_response, resolve_conflict_response, run_command_response,
-    save_buffer_response, server_message, write_file_response, Abort, Authenticate, BufferEdit,
-    BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexStatusesSnapshot, DeleteFile,
-    DeleteFileResponse, DeleteFileSuccess, ErrorCode, ErrorResponse, FailedFileRead,
-    FileContextProto, FileOperationError, Initialize, InitializeResponse, NavigatedToDirectory,
-    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextResponse,
-    ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess, RunCommandError,
-    RunCommandErrorCode, RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer,
-    SaveBufferResponse, SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, WriteFile,
-    WriteFileResponse, WriteFileSuccess,
+    client_message, delete_file_response, discard_files_response, get_diff_state_response,
+    resolve_conflict_response, run_command_response, save_buffer_response, server_message,
+    write_file_response, Abort, Authenticate, BufferEdit, BufferUpdatedPush, ClientMessage,
+    CloseBuffer, CodebaseIndexStatusesSnapshot, DeleteFile, DeleteFileResponse, DeleteFileSuccess,
+    DiscardFilesError, DiscardFilesResponse, DiscardFilesSuccess, ErrorCode, ErrorResponse,
+    FailedFileRead, FileContextProto, FileOperationError, GetDiffStateResponse, Initialize,
+    InitializeResponse, NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer,
+    OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
+    ResolveConflictSuccess, RunCommandError, RunCommandErrorCode, RunCommandRequest,
+    RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess,
+    ServerMessage, SessionBootstrapped, TextEdit, WriteFile, WriteFileResponse, WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
+
+use crate::code_review::diff_state::{
+    DiffState, DiffStateModelEvent, FileStatusInfo, LocalDiffStateModel,
+};
 
 /// How long the daemon waits with no connections before exiting.
 pub const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10 * 60);
@@ -178,6 +185,8 @@ pub struct ServerModel {
     /// Tracks open buffers, per-buffer connection sets, and pending async
     /// buffer requests (OpenBuffer, SaveBuffer).
     buffers: ServerBufferTracker,
+    /// Manages per-(repo, mode) diff state models and per-connection subscriptions.
+    diff_states: GlobalDiffStateModel,
 }
 
 impl Entity for ServerModel {
@@ -204,6 +213,7 @@ impl ServerModel {
             pending_file_ops: PendingFileOps::new(),
             auth_state: AuthStateProvider::as_ref(ctx).get().clone(),
             buffers: ServerBufferTracker::new(),
+            diff_states: GlobalDiffStateModel::new(),
         };
         // Subscribe to FileModel and RepoMetadataModel events
         // file operation results and repo metadata pushes are forwarded to all
@@ -553,6 +563,10 @@ impl ServerModel {
         // Orphaned buffers (no connections left) are deallocated automatically.
         self.buffers.remove_connection(conn_id, ctx);
 
+        // Remove this connection from diff state subscriptions.
+        // Orphaned models (no subscribers) are dropped automatically.
+        self.diff_states.remove_connection(conn_id);
+
         let remaining = self.connection_senders.len();
         log::info!("Daemon: connection {conn_id} deregistered — {remaining} active remaining");
         if remaining == 0 {
@@ -653,10 +667,16 @@ impl ServerModel {
             Some(client_message::Message::ResolveConflict(msg)) => {
                 self.handle_resolve_conflict(msg, &request_id, conn_id, ctx)
             }
-            // TODO: implement diff state handlers
-            Some(client_message::Message::GetDiffState(_)) => return,
-            Some(client_message::Message::UnsubscribeDiffState(_)) => return,
-            Some(client_message::Message::DiscardFiles(_)) => return,
+            Some(client_message::Message::GetDiffState(msg)) => {
+                self.handle_get_diff_state(msg, &request_id, conn_id, ctx)
+            }
+            Some(client_message::Message::UnsubscribeDiffState(msg)) => {
+                self.handle_unsubscribe_diff_state(msg, conn_id);
+                return; // fire-and-forget notification
+            }
+            Some(client_message::Message::DiscardFiles(msg)) => {
+                self.handle_discard_files(msg, &request_id, ctx)
+            }
             None => {
                 log::warn!(
                     "Received ClientMessage with no message variant (request_id={request_id})"
@@ -1646,6 +1666,417 @@ impl ServerModel {
     ) {
         log::info!("Handling CloseBuffer path={} conn={conn_id}", msg.path);
         self.buffers.close_buffer(&msg.path, conn_id, ctx);
+    }
+
+    /// Handles `GetDiffState` — subscribe to a (repo, mode) pair.
+    /// Creates a `LocalDiffStateModel` if one doesn't exist, subscribes the
+    /// connection, and responds with the current state (sync) or defers the
+    /// response until the model finishes loading (async).
+    fn handle_get_diff_state(
+        &mut self,
+        msg: super::proto::GetDiffState,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        let Some(mode_proto) = &msg.mode else {
+            return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                code: ErrorCode::InvalidRequest.into(),
+                message: "Missing mode in GetDiffState".to_string(),
+            }));
+        };
+
+        let std_path = match StandardizedPath::from_local_canonicalized(Path::new(&msg.repo_path)) {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!("Invalid repo_path for GetDiffState: {e}");
+                return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                    code: ErrorCode::InvalidRequest.into(),
+                    message: format!("Invalid repo_path: {e}"),
+                }));
+            }
+        };
+
+        let key = DiffModelKey {
+            repo_path: std_path,
+            mode: mode_proto.into(),
+        };
+
+        log::info!(
+            "Handling GetDiffState repo={} mode={:?} (request_id={request_id})",
+            msg.repo_path,
+            key.mode
+        );
+
+        // Subscribe this connection.
+        self.diff_states.subscribe_connection(key.clone(), conn_id);
+
+        // Look up or create the model.
+        if let Some(model) = self.diff_states.get_model(&key) {
+            let model_ref = model.as_ref(ctx);
+            let state = model_ref.get();
+            match state {
+                DiffState::Loaded => self.spawn_content_reload_for_subscriber(
+                    key,
+                    msg.repo_path.clone(),
+                    request_id,
+                    conn_id,
+                    ctx,
+                ),
+                DiffState::Error(_) | DiffState::NotInRepository => {
+                    // Terminal state with no diffs — respond immediately.
+                    let repo_path_str = key.repo_path.to_string();
+                    let snapshot = diff_state_proto::build_diff_state_snapshot(
+                        &repo_path_str,
+                        &key.mode,
+                        model_ref.metadata(),
+                        &state,
+                        None,
+                    );
+                    HandlerOutcome::Sync(server_message::Message::GetDiffStateResponse(
+                        GetDiffStateResponse {
+                            result: Some(get_diff_state_response::Result::Snapshot(snapshot)),
+                        },
+                    ))
+                }
+                DiffState::Loading => {
+                    // Model is still loading — defer response.
+                    self.diff_states
+                        .add_pending_response(key, request_id.clone(), conn_id);
+                    HandlerOutcome::Async(None)
+                }
+            }
+        } else {
+            // Model doesn't exist — create it.
+            let repo_path_str = msg.repo_path.clone();
+            let model = ctx.add_model(|ctx| {
+                let mut m = LocalDiffStateModel::new(Some(repo_path_str), ctx);
+                m.set_diff_mode(key.mode.clone(), false, ctx);
+                m.set_code_review_metadata_refresh_enabled(true, ctx);
+                m
+            });
+
+            // Subscribe to events from this model.
+            let key_for_sub = key.clone();
+            ctx.subscribe_to_model(&model, move |me, event, ctx| {
+                me.handle_diff_state_model_event(&key_for_sub, event, ctx);
+            });
+
+            self.diff_states.insert_model(key.clone(), model);
+            self.diff_states
+                .add_pending_response(key, request_id.clone(), conn_id);
+            HandlerOutcome::Async(None)
+        }
+    }
+
+    /// Handles `UnsubscribeDiffState` — notification (fire-and-forget).
+    fn handle_unsubscribe_diff_state(
+        &mut self,
+        msg: super::proto::UnsubscribeDiffState,
+        conn_id: ConnectionId,
+    ) {
+        let Some(mode_proto) = &msg.mode else {
+            log::warn!("UnsubscribeDiffState from conn={conn_id}: missing mode");
+            return;
+        };
+        let Ok(std_path) = StandardizedPath::from_local_canonicalized(Path::new(&msg.repo_path))
+        else {
+            log::warn!(
+                "UnsubscribeDiffState from conn={conn_id}: invalid repo_path={}",
+                msg.repo_path
+            );
+            return;
+        };
+
+        let key = DiffModelKey {
+            repo_path: std_path,
+            mode: mode_proto.into(),
+        };
+
+        log::info!(
+            "Handling UnsubscribeDiffState repo={} mode={:?} conn={conn_id}",
+            msg.repo_path,
+            key.mode
+        );
+
+        self.diff_states.unsubscribe_connection(&key, conn_id);
+    }
+
+    /// Dispatches a `DiffStateModelEvent` from a `LocalDiffStateModel` to the
+    /// appropriate proto message and sends it to subscribed connections.
+    fn handle_diff_state_model_event(
+        &mut self,
+        key: &DiffModelKey,
+        event: &DiffStateModelEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let repo_path_str = key.repo_path.to_string();
+
+        match event {
+            DiffStateModelEvent::NewDiffsComputed(diffs) => {
+                // Read current state + metadata from the model for the snapshot.
+                let (state, metadata) =
+                    self.diff_states
+                        .read_state_and_metadata(key, DiffState::Loading, ctx);
+
+                let snapshot = diff_state_proto::build_diff_state_snapshot(
+                    &repo_path_str,
+                    &key.mode,
+                    metadata.as_ref(),
+                    &state,
+                    diffs.as_ref().map(|d| d.as_ref()),
+                );
+
+                // Drain pending GetDiffState responses.
+                // These connections receive their initial snapshot as a GetDiffStateResponse
+                // and are excluded from the broadcast push to avoid sending duplicate data.
+                let responded_conns: HashSet<ConnectionId> = self
+                    .diff_states
+                    .drain_pending_responses(key)
+                    .into_iter()
+                    .map(|pending| {
+                        self.send_server_message(
+                            Some(pending.conn_id),
+                            Some(&pending.request_id),
+                            server_message::Message::GetDiffStateResponse(GetDiffStateResponse {
+                                result: Some(get_diff_state_response::Result::Snapshot(
+                                    snapshot.clone(),
+                                )),
+                            }),
+                        );
+                        pending.conn_id
+                    })
+                    .collect();
+
+                // Push to subscribers that didn't already get a response.
+                for conn_id in self.diff_states.subscribed_connections(key) {
+                    if !responded_conns.contains(&conn_id) {
+                        self.send_server_message(
+                            Some(conn_id),
+                            None,
+                            server_message::Message::DiffStateSnapshot(snapshot.clone()),
+                        );
+                    }
+                }
+            }
+            DiffStateModelEvent::MetadataRefreshed(metadata) => {
+                let update = diff_state_proto::build_diff_state_metadata_update(
+                    &repo_path_str,
+                    &key.mode,
+                    metadata,
+                );
+                self.send_to_diff_state_subscribers(
+                    key,
+                    server_message::Message::DiffStateMetadataUpdate(update),
+                );
+            }
+            DiffStateModelEvent::CurrentBranchChanged => {
+                // Push metadata only as the new branch hasn't been loaded yet.
+                // NewDiffsComputed will follow with the actual diffs.
+                if let Some(model) = self.diff_states.get_model(key) {
+                    if let Some(metadata) = model.as_ref(ctx).metadata() {
+                        let update = diff_state_proto::build_diff_state_metadata_update(
+                            &repo_path_str,
+                            &key.mode,
+                            metadata,
+                        );
+                        self.send_to_diff_state_subscribers(
+                            key,
+                            server_message::Message::DiffStateMetadataUpdate(update),
+                        );
+                    }
+                }
+            }
+            DiffStateModelEvent::SingleFileUpdated { path, diff } => {
+                let diff_ref = diff.as_ref().map(|d| d.as_ref());
+                let metadata = self
+                    .diff_states
+                    .get_model(key)
+                    .and_then(|m| m.as_ref(ctx).metadata().cloned());
+                let delta = diff_state_proto::build_diff_state_file_delta(
+                    &repo_path_str,
+                    &key.mode,
+                    path,
+                    diff_ref,
+                    metadata.as_ref(),
+                );
+                self.send_to_diff_state_subscribers(
+                    key,
+                    server_message::Message::DiffStateFileDelta(delta),
+                );
+            }
+        }
+    }
+
+    /// Spawns an async diff reload with `content_at_base` for late-joining
+    /// subscribers. Used when the model is already `Loaded` but the expensive
+    /// content data was shed after the initial `NewDiffsComputed` event.
+    fn spawn_content_reload_for_subscriber(
+        &mut self,
+        key: DiffModelKey,
+        repo_path: String,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        if self.diff_states.has_pending_responses(&key) {
+            // A reload is already in-flight — piggyback on it.
+            self.diff_states
+                .add_pending_response(key, request_id.clone(), conn_id);
+            return HandlerOutcome::Async(None);
+        }
+
+        let diff_mode = key.mode.clone();
+        let diff_model_key = key.clone();
+
+        self.diff_states
+            .add_pending_response(key, request_id.clone(), conn_id);
+
+        let handle = self.spawn_request_handler(
+            request_id.clone(),
+            async move {
+                LocalDiffStateModel::load_diffs_with_content_for_mode(
+                    diff_mode,
+                    PathBuf::from(repo_path),
+                )
+                .await
+            },
+            move |me, diffs, ctx| {
+                let (state, metadata) =
+                    me.diff_states
+                        .read_state_and_metadata(&diff_model_key, DiffState::Loaded, ctx);
+
+                let snapshot = diff_state_proto::build_diff_state_snapshot(
+                    &diff_model_key.repo_path.to_string(),
+                    &diff_model_key.mode,
+                    metadata.as_ref(),
+                    &state,
+                    diffs.as_ref(),
+                );
+
+                for pending in me.diff_states.drain_pending_responses(&diff_model_key) {
+                    me.send_server_message(
+                        Some(pending.conn_id),
+                        Some(&pending.request_id),
+                        server_message::Message::GetDiffStateResponse(GetDiffStateResponse {
+                            result: Some(get_diff_state_response::Result::Snapshot(
+                                snapshot.clone(),
+                            )),
+                        }),
+                    );
+                }
+            },
+            ctx,
+        );
+        HandlerOutcome::Async(Some(handle))
+    }
+
+    /// Handles `DiscardFilesRequest` — request/response.
+    ///
+    /// Runs git restore/stash on the remote filesystem for the specified files.
+    /// The model's `discard_files` spawns async git operations internally.
+    /// On success it reloads diffs, which triggers `NewDiffsComputed` pushes
+    /// to subscribed connections. On failure it logs the error.
+    ///
+    /// We respond with success synchronously after delegating to the model,
+    /// since `discard_files` does not surface completion status to the caller.
+    fn handle_discard_files(
+        &mut self,
+        msg: super::proto::DiscardFilesRequest,
+        request_id: &RequestId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        log::info!(
+            "Handling DiscardFiles repo={} files={} (request_id={request_id})",
+            msg.repo_path,
+            msg.files.len()
+        );
+
+        let std_path = match StandardizedPath::from_local_canonicalized(Path::new(&msg.repo_path)) {
+            Ok(p) => p,
+            Err(e) => {
+                return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                    code: ErrorCode::InvalidRequest.into(),
+                    message: format!("Invalid repo_path: {e}"),
+                }));
+            }
+        };
+
+        let Some(mode_proto) = &msg.mode else {
+            return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                code: ErrorCode::InvalidRequest.into(),
+                message: "Missing mode in DiscardFiles".to_string(),
+            }));
+        };
+
+        let key = DiffModelKey {
+            repo_path: std_path,
+            mode: mode_proto.into(),
+        };
+
+        let Some(model) = self.diff_states.get_model(&key).cloned() else {
+            return HandlerOutcome::Sync(server_message::Message::DiscardFilesResponse(
+                DiscardFilesResponse {
+                    result: Some(discard_files_response::Result::Error(DiscardFilesError {
+                        message: format!(
+                            "No active diff state model for repo={} mode={:?}",
+                            msg.repo_path, key.mode
+                        ),
+                    })),
+                },
+            ));
+        };
+
+        if msg.files.is_empty() {
+            return HandlerOutcome::Sync(server_message::Message::DiscardFilesResponse(
+                DiscardFilesResponse {
+                    result: Some(discard_files_response::Result::Error(DiscardFilesError {
+                        message: "No files specified in DiscardFilesRequest".to_string(),
+                    })),
+                },
+            ));
+        }
+
+        let file_infos: Vec<_> = msg
+            .files
+            .iter()
+            .filter_map(|f| match FileStatusInfo::try_from(f) {
+                Ok(info) => Some(info),
+                Err(e) => {
+                    log::warn!("DiscardFiles: {e}");
+                    None
+                }
+            })
+            .collect();
+
+        if file_infos.is_empty() {
+            return HandlerOutcome::Sync(server_message::Message::DiscardFilesResponse(
+                DiscardFilesResponse {
+                    result: Some(discard_files_response::Result::Error(DiscardFilesError {
+                        message: "No valid files after path validation".to_string(),
+                    })),
+                },
+            ));
+        }
+
+        model.update(ctx, |m, ctx| {
+            m.discard_files(file_infos, msg.should_stash, msg.branch_name, ctx);
+        });
+
+        HandlerOutcome::Sync(server_message::Message::DiscardFilesResponse(
+            DiscardFilesResponse {
+                result: Some(discard_files_response::Result::Success(
+                    DiscardFilesSuccess {},
+                )),
+            },
+        ))
+    }
+
+    /// Sends a push message to all connections subscribed to the given diff state key.
+    fn send_to_diff_state_subscribers(&self, key: &DiffModelKey, message: server_message::Message) {
+        for conn_id in self.diff_states.subscribed_connections(key) {
+            self.send_server_message(Some(conn_id), None, message.clone());
+        }
     }
 }
 

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -12,7 +12,7 @@ use warp_core::SessionId;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::platform::TerminationMode;
 use warpui::r#async::{Spawnable, SpawnableOutput, SpawnedFutureHandle};
-use warpui::{Entity, ModelContext, SingletonEntity};
+use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity};
 
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
 use warp_files::{FileModel, FileModelEvent};
@@ -20,7 +20,9 @@ use warp_util::content_version::ContentVersion;
 use warp_util::file::FileId;
 
 use super::diff_state_proto;
-use super::diff_state_tracker::{DiffModelKey, GlobalDiffStateModel};
+use super::diff_state_tracker::{
+    DiffModelKey, DiffStateUpdate, RemoteDiffStateManager, SubscribeOutcome,
+};
 use super::proto::{
     client_message, delete_file_response, discard_files_response, get_diff_state_response,
     resolve_conflict_response, run_command_response, save_buffer_response, server_message,
@@ -36,9 +38,7 @@ use super::proto::{
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 
-use crate::code_review::diff_state::{
-    DiffState, DiffStateModelEvent, FileStatusInfo, LocalDiffStateModel,
-};
+use crate::code_review::diff_state::{DiffMode, FileStatusInfo};
 
 /// How long the daemon waits with no connections before exiting.
 pub const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10 * 60);
@@ -186,7 +186,7 @@ pub struct ServerModel {
     /// buffer requests (OpenBuffer, SaveBuffer).
     buffers: ServerBufferTracker,
     /// Manages per-(repo, mode) diff state models and per-connection subscriptions.
-    diff_states: GlobalDiffStateModel,
+    diff_states: ModelHandle<RemoteDiffStateManager>,
 }
 
 impl Entity for ServerModel {
@@ -213,7 +213,7 @@ impl ServerModel {
             pending_file_ops: PendingFileOps::new(),
             auth_state: AuthStateProvider::as_ref(ctx).get().clone(),
             buffers: ServerBufferTracker::new(),
-            diff_states: GlobalDiffStateModel::new(),
+            diff_states: ctx.add_model(|_| RemoteDiffStateManager::new()),
         };
         // Subscribe to FileModel and RepoMetadataModel events
         // file operation results and repo metadata pushes are forwarded to all
@@ -517,6 +517,14 @@ impl ServerModel {
                 }
             });
         }
+        // Subscribe to diff state manager events — convert domain dispatches
+        // to proto messages and send them to connected clients.
+        {
+            let diff_states = model.diff_states.clone();
+            ctx.subscribe_to_model(&diff_states, |me, dispatch, _ctx| {
+                me.handle_diff_state_update(dispatch);
+            });
+        }
         // Start the grace timer immediately so the daemon exits if no proxy
         // connects within GRACE_PERIOD. In practice the spawning proxy connects
         // within milliseconds, so the risk of premature shutdown is negligible;
@@ -565,7 +573,8 @@ impl ServerModel {
 
         // Remove this connection from diff state subscriptions.
         // Orphaned models (no subscribers) are dropped automatically.
-        self.diff_states.remove_connection(conn_id);
+        self.diff_states
+            .update(ctx, |mgr, _| mgr.remove_connection(conn_id));
 
         let remaining = self.connection_senders.len();
         log::info!("Daemon: connection {conn_id} deregistered — {remaining} active remaining");
@@ -629,7 +638,7 @@ impl ServerModel {
                 return;
             }
             Some(client_message::Message::Abort(abort)) => {
-                self.handle_abort(abort, &request_id);
+                self.handle_abort(abort, &request_id, ctx);
                 return;
             }
             Some(client_message::Message::RunCommand(req)) => {
@@ -671,7 +680,7 @@ impl ServerModel {
                 self.handle_get_diff_state(msg, &request_id, conn_id, ctx)
             }
             Some(client_message::Message::UnsubscribeDiffState(msg)) => {
-                self.handle_unsubscribe_diff_state(msg, conn_id);
+                self.handle_unsubscribe_diff_state(msg, conn_id, ctx);
                 return; // fire-and-forget notification
             }
             Some(client_message::Message::DiscardFiles(msg)) => {
@@ -890,8 +899,10 @@ impl ServerModel {
     }
 
     /// Handles `Abort` by cancelling the in-progress request it targets.
+    /// Checks `ServerModel`'s own in-progress map first, then delegates to
+    /// the diff state manager for content reload requests.
     /// This is a notification — no response is sent.
-    fn handle_abort(&mut self, abort: Abort, request_id: &RequestId) {
+    fn handle_abort(&mut self, abort: Abort, request_id: &RequestId, ctx: &mut ModelContext<Self>) {
         let target_id = RequestId::from(abort.request_id_to_abort);
         if let Some(handle) = self.in_progress.remove(&target_id) {
             log::info!(
@@ -900,10 +911,15 @@ impl ServerModel {
             );
             handle.abort();
         } else {
-            log::info!(
-                "Abort for unknown/completed request (request_id={target_id}, \
-                 abort_request_id={request_id})"
-            );
+            let found = self
+                .diff_states
+                .update(ctx, |mgr, _| mgr.abort_request(&target_id));
+            if !found {
+                log::info!(
+                    "Abort for unknown/completed request (request_id={target_id}, \
+                     abort_request_id={request_id})"
+                );
+            }
         }
     }
 
@@ -1669,9 +1685,6 @@ impl ServerModel {
     }
 
     /// Handles `GetDiffState` — subscribe to a (repo, mode) pair.
-    /// Creates a `LocalDiffStateModel` if one doesn't exist, subscribes the
-    /// connection, and responds with the current state (sync) or defers the
-    /// response until the model finishes loading (async).
     fn handle_get_diff_state(
         &mut self,
         msg: super::proto::GetDiffState,
@@ -1679,6 +1692,8 @@ impl ServerModel {
         conn_id: ConnectionId,
         ctx: &mut ModelContext<Self>,
     ) -> HandlerOutcome {
+        // Proto3 message fields are always optional on the wire, so `mode`
+        // cannot be made required at the schema level — validate at runtime.
         let Some(mode_proto) = &msg.mode else {
             return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
                 code: ErrorCode::InvalidRequest.into(),
@@ -1697,75 +1712,37 @@ impl ServerModel {
             }
         };
 
-        let key = DiffModelKey {
-            repo_path: std_path,
-            mode: mode_proto.into(),
-        };
+        let mode: DiffMode = mode_proto.into();
 
         log::info!(
-            "Handling GetDiffState repo={} mode={:?} (request_id={request_id})",
+            "Handling GetDiffState repo={} mode={mode:?} (request_id={request_id})",
             msg.repo_path,
-            key.mode
         );
 
-        // Subscribe this connection.
-        self.diff_states.subscribe_connection(key.clone(), conn_id);
+        let outcome = self.diff_states.update(ctx, |mgr, ctx| {
+            mgr.subscribe(std_path, mode, request_id, conn_id, ctx)
+        });
 
-        // Look up or create the model.
-        if let Some(model) = self.diff_states.get_model(&key) {
-            let model_ref = model.as_ref(ctx);
-            let state = model_ref.get();
-            match state {
-                DiffState::Loaded => self.spawn_content_reload_for_subscriber(
-                    key,
-                    msg.repo_path.clone(),
-                    request_id,
-                    conn_id,
-                    ctx,
-                ),
-                DiffState::Error(_) | DiffState::NotInRepository => {
-                    // Terminal state with no diffs — respond immediately.
-                    let repo_path_str = key.repo_path.to_string();
-                    let snapshot = diff_state_proto::build_diff_state_snapshot(
-                        &repo_path_str,
-                        &key.mode,
-                        model_ref.metadata(),
-                        &state,
-                        None,
-                    );
-                    HandlerOutcome::Sync(server_message::Message::GetDiffStateResponse(
-                        GetDiffStateResponse {
-                            result: Some(get_diff_state_response::Result::Snapshot(snapshot)),
-                        },
-                    ))
-                }
-                DiffState::Loading => {
-                    // Model is still loading — defer response.
-                    self.diff_states
-                        .add_pending_response(key, request_id.clone(), conn_id);
-                    HandlerOutcome::Async(None)
-                }
+        match outcome {
+            SubscribeOutcome::RespondWithSnapshot {
+                key,
+                state,
+                metadata,
+            } => {
+                let snapshot = diff_state_proto::build_diff_state_snapshot(
+                    key.repo_path.as_str(),
+                    &key.mode,
+                    metadata.as_ref(),
+                    &state,
+                    None,
+                );
+                HandlerOutcome::Sync(server_message::Message::GetDiffStateResponse(
+                    GetDiffStateResponse {
+                        result: Some(get_diff_state_response::Result::Snapshot(snapshot)),
+                    },
+                ))
             }
-        } else {
-            // Model doesn't exist — create it.
-            let repo_path_str = msg.repo_path.clone();
-            let model = ctx.add_model(|ctx| {
-                let mut m = LocalDiffStateModel::new(Some(repo_path_str), ctx);
-                m.set_diff_mode(key.mode.clone(), false, ctx);
-                m.set_code_review_metadata_refresh_enabled(true, ctx);
-                m
-            });
-
-            // Subscribe to events from this model.
-            let key_for_sub = key.clone();
-            ctx.subscribe_to_model(&model, move |me, event, ctx| {
-                me.handle_diff_state_model_event(&key_for_sub, event, ctx);
-            });
-
-            self.diff_states.insert_model(key.clone(), model);
-            self.diff_states
-                .add_pending_response(key, request_id.clone(), conn_id);
-            HandlerOutcome::Async(None)
+            SubscribeOutcome::Async => HandlerOutcome::Async(None),
         }
     }
 
@@ -1774,6 +1751,7 @@ impl ServerModel {
         &mut self,
         msg: super::proto::UnsubscribeDiffState,
         conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
     ) {
         let Some(mode_proto) = &msg.mode else {
             log::warn!("UnsubscribeDiffState from conn={conn_id}: missing mode");
@@ -1799,176 +1777,92 @@ impl ServerModel {
             key.mode
         );
 
-        self.diff_states.unsubscribe_connection(&key, conn_id);
+        self.diff_states
+            .update(ctx, |mgr, _| mgr.unsubscribe_connection(&key, conn_id));
     }
 
-    /// Dispatches a `DiffStateModelEvent` from a `LocalDiffStateModel` to the
-    /// appropriate proto message and sends it to subscribed connections.
-    fn handle_diff_state_model_event(
-        &mut self,
-        key: &DiffModelKey,
-        event: &DiffStateModelEvent,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let repo_path_str = key.repo_path.to_string();
-
-        match event {
-            DiffStateModelEvent::NewDiffsComputed(diffs) => {
-                // Read current state + metadata from the model for the snapshot.
-                let (state, metadata) =
-                    self.diff_states
-                        .read_state_and_metadata(key, DiffState::Loading, ctx);
-
+    /// Converts a domain-level diff state dispatch to proto messages
+    /// and sends them to the appropriate connections.
+    fn handle_diff_state_update(&self, update: &DiffStateUpdate) {
+        match update {
+            DiffStateUpdate::Snapshot {
+                repo_path,
+                mode,
+                state,
+                metadata,
+                diffs,
+                subscribers,
+            } => {
                 let snapshot = diff_state_proto::build_diff_state_snapshot(
-                    &repo_path_str,
-                    &key.mode,
+                    repo_path,
+                    mode,
                     metadata.as_ref(),
-                    &state,
-                    diffs.as_ref().map(|d| d.as_ref()),
+                    state,
+                    diffs.as_deref(),
                 );
-
-                // Drain pending GetDiffState responses.
-                // These connections receive their initial snapshot as a GetDiffStateResponse
-                // and are excluded from the broadcast push to avoid sending duplicate data.
-                let responded_conns: HashSet<ConnectionId> = self
-                    .diff_states
-                    .drain_pending_responses(key)
-                    .into_iter()
-                    .map(|pending| {
+                for (conn_id, request_id) in subscribers {
+                    if let Some(request_id) = request_id {
                         self.send_server_message(
-                            Some(pending.conn_id),
-                            Some(&pending.request_id),
+                            Some(*conn_id),
+                            Some(request_id),
                             server_message::Message::GetDiffStateResponse(GetDiffStateResponse {
                                 result: Some(get_diff_state_response::Result::Snapshot(
                                     snapshot.clone(),
                                 )),
                             }),
                         );
-                        pending.conn_id
-                    })
-                    .collect();
-
-                // Push to subscribers that didn't already get a response.
-                for conn_id in self.diff_states.subscribed_connections(key) {
-                    if !responded_conns.contains(&conn_id) {
+                    } else {
                         self.send_server_message(
-                            Some(conn_id),
+                            Some(*conn_id),
                             None,
                             server_message::Message::DiffStateSnapshot(snapshot.clone()),
                         );
                     }
                 }
             }
-            DiffStateModelEvent::MetadataRefreshed(metadata) => {
+            DiffStateUpdate::MetadataUpdate {
+                repo_path,
+                mode,
+                metadata,
+                subscribers,
+            } => {
                 let update = diff_state_proto::build_diff_state_metadata_update(
-                    &repo_path_str,
-                    &key.mode,
+                    repo_path.as_str(),
+                    mode,
                     metadata,
                 );
-                self.send_to_diff_state_subscribers(
-                    key,
-                    server_message::Message::DiffStateMetadataUpdate(update),
-                );
-            }
-            DiffStateModelEvent::CurrentBranchChanged => {
-                // Push metadata only as the new branch hasn't been loaded yet.
-                // NewDiffsComputed will follow with the actual diffs.
-                if let Some(model) = self.diff_states.get_model(key) {
-                    if let Some(metadata) = model.as_ref(ctx).metadata() {
-                        let update = diff_state_proto::build_diff_state_metadata_update(
-                            &repo_path_str,
-                            &key.mode,
-                            metadata,
-                        );
-                        self.send_to_diff_state_subscribers(
-                            key,
-                            server_message::Message::DiffStateMetadataUpdate(update),
-                        );
-                    }
-                }
-            }
-            DiffStateModelEvent::SingleFileUpdated { path, diff } => {
-                let diff_ref = diff.as_ref().map(|d| d.as_ref());
-                let metadata = self
-                    .diff_states
-                    .get_model(key)
-                    .and_then(|m| m.as_ref(ctx).metadata().cloned());
-                let delta = diff_state_proto::build_diff_state_file_delta(
-                    &repo_path_str,
-                    &key.mode,
-                    path,
-                    diff_ref,
-                    metadata.as_ref(),
-                );
-                self.send_to_diff_state_subscribers(
-                    key,
-                    server_message::Message::DiffStateFileDelta(delta),
-                );
-            }
-        }
-    }
-
-    /// Spawns an async diff reload with `content_at_base` for late-joining
-    /// subscribers. Used when the model is already `Loaded` but the expensive
-    /// content data was shed after the initial `NewDiffsComputed` event.
-    fn spawn_content_reload_for_subscriber(
-        &mut self,
-        key: DiffModelKey,
-        repo_path: String,
-        request_id: &RequestId,
-        conn_id: ConnectionId,
-        ctx: &mut ModelContext<Self>,
-    ) -> HandlerOutcome {
-        if self.diff_states.has_pending_responses(&key) {
-            // A reload is already in-flight — piggyback on it.
-            self.diff_states
-                .add_pending_response(key, request_id.clone(), conn_id);
-            return HandlerOutcome::Async(None);
-        }
-
-        let diff_mode = key.mode.clone();
-        let diff_model_key = key.clone();
-
-        self.diff_states
-            .add_pending_response(key, request_id.clone(), conn_id);
-
-        let handle = self.spawn_request_handler(
-            request_id.clone(),
-            async move {
-                LocalDiffStateModel::load_diffs_with_content_for_mode(
-                    diff_mode,
-                    PathBuf::from(repo_path),
-                )
-                .await
-            },
-            move |me, diffs, ctx| {
-                let (state, metadata) =
-                    me.diff_states
-                        .read_state_and_metadata(&diff_model_key, DiffState::Loaded, ctx);
-
-                let snapshot = diff_state_proto::build_diff_state_snapshot(
-                    &diff_model_key.repo_path.to_string(),
-                    &diff_model_key.mode,
-                    metadata.as_ref(),
-                    &state,
-                    diffs.as_ref(),
-                );
-
-                for pending in me.diff_states.drain_pending_responses(&diff_model_key) {
-                    me.send_server_message(
-                        Some(pending.conn_id),
-                        Some(&pending.request_id),
-                        server_message::Message::GetDiffStateResponse(GetDiffStateResponse {
-                            result: Some(get_diff_state_response::Result::Snapshot(
-                                snapshot.clone(),
-                            )),
-                        }),
+                for conn_id in subscribers {
+                    self.send_server_message(
+                        Some(*conn_id),
+                        None,
+                        server_message::Message::DiffStateMetadataUpdate(update.clone()),
                     );
                 }
-            },
-            ctx,
-        );
-        HandlerOutcome::Async(Some(handle))
+            }
+            DiffStateUpdate::FileDelta {
+                repo_path,
+                mode,
+                path,
+                diff,
+                metadata,
+                subscribers,
+            } => {
+                let delta = diff_state_proto::build_diff_state_file_delta(
+                    repo_path.as_str(),
+                    mode,
+                    path,
+                    diff.as_deref(),
+                    metadata.as_ref(),
+                );
+                for conn_id in subscribers {
+                    self.send_server_message(
+                        Some(*conn_id),
+                        None,
+                        server_message::Message::DiffStateFileDelta(delta.clone()),
+                    );
+                }
+            }
+        }
     }
 
     /// Handles `DiscardFilesRequest` — request/response.
@@ -2014,7 +1908,10 @@ impl ServerModel {
             mode: mode_proto.into(),
         };
 
-        let Some(model) = self.diff_states.get_model(&key).cloned() else {
+        let model = self
+            .diff_states
+            .update(ctx, |mgr, _| mgr.get_model(&key).cloned());
+        let Some(model) = model else {
             return HandlerOutcome::Sync(server_message::Message::DiscardFilesResponse(
                 DiscardFilesResponse {
                     result: Some(discard_files_response::Result::Error(DiscardFilesError {
@@ -2070,13 +1967,6 @@ impl ServerModel {
                 )),
             },
         ))
-    }
-
-    /// Sends a push message to all connections subscribed to the given diff state key.
-    fn send_to_diff_state_subscribers(&self, key: &DiffModelKey, message: server_message::Message) {
-        for conn_id in self.diff_states.subscribed_connections(key) {
-            self.send_server_message(Some(conn_id), None, message.clone());
-        }
     }
 }
 

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -2,6 +2,7 @@ use crate::auth::auth_state::AuthState;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use super::super::diff_state_tracker::GlobalDiffStateModel;
 use super::super::proto::{Authenticate, Initialize};
 use super::super::server_buffer_tracker::ServerBufferTracker;
 use super::{PendingFileOps, ServerModel};
@@ -17,6 +18,7 @@ fn test_model() -> ServerModel {
         pending_file_ops: PendingFileOps::new(),
         auth_state: Arc::new(AuthState::new_logged_out_for_test()),
         buffers: ServerBufferTracker::new(),
+        diff_states: GlobalDiffStateModel::new(),
     }
 }
 

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -1,13 +1,14 @@
 use crate::auth::auth_state::AuthState;
 use std::collections::HashMap;
 use std::sync::Arc;
+use warpui::App;
 
-use super::super::diff_state_tracker::GlobalDiffStateModel;
+use super::super::diff_state_tracker::RemoteDiffStateManager;
 use super::super::proto::{Authenticate, Initialize};
 use super::super::server_buffer_tracker::ServerBufferTracker;
 use super::{PendingFileOps, ServerModel};
 
-fn test_model() -> ServerModel {
+fn test_model(app: &mut App) -> ServerModel {
     ServerModel {
         connection_senders: HashMap::new(),
         snapshot_sent_roots_by_connection: HashMap::new(),
@@ -18,93 +19,103 @@ fn test_model() -> ServerModel {
         pending_file_ops: PendingFileOps::new(),
         auth_state: Arc::new(AuthState::new_logged_out_for_test()),
         buffers: ServerBufferTracker::new(),
-        diff_states: GlobalDiffStateModel::new(),
+        diff_states: app.add_model(|_| RemoteDiffStateManager::new()),
     }
 }
 
 #[test]
 fn fresh_model_starts_without_auth_token() {
-    let model = test_model();
+    App::test((), |mut app| async move {
+        let model = test_model(&mut app);
 
-    assert_eq!(model.auth_token().as_deref(), None);
-    assert_eq!(model.auth_state.user_id(), None);
-    assert_eq!(model.auth_state.user_email(), None);
+        assert_eq!(model.auth_token().as_deref(), None);
+        assert_eq!(model.auth_state.user_id(), None);
+        assert_eq!(model.auth_state.user_email(), None);
+    });
 }
 
 #[test]
 fn initialize_with_auth_token_stores_token() {
-    let mut model = test_model();
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
 
-    model.apply_initialize_auth(&Initialize {
-        auth_token: "initial-token".to_string(),
-        user_id: "test-user-id".to_string(),
-        user_email: "test@example.com".to_string(),
-        crash_reporting_enabled: true,
+        model.apply_initialize_auth(&Initialize {
+            auth_token: "initial-token".to_string(),
+            user_id: "test-user-id".to_string(),
+            user_email: "test@example.com".to_string(),
+            crash_reporting_enabled: true,
+        });
+
+        assert_eq!(model.auth_token().as_deref(), Some("initial-token"));
+        assert_eq!(
+            model.auth_state.user_id().unwrap().as_string(),
+            "test-user-id"
+        );
+        assert_eq!(
+            model.auth_state.user_email().as_deref(),
+            Some("test@example.com")
+        );
     });
-
-    assert_eq!(model.auth_token().as_deref(), Some("initial-token"));
-    assert_eq!(
-        model.auth_state.user_id().unwrap().as_string(),
-        "test-user-id"
-    );
-    assert_eq!(
-        model.auth_state.user_email().as_deref(),
-        Some("test@example.com")
-    );
 }
 
 #[test]
 fn empty_initialize_clears_auth_context() {
-    let mut model = test_model();
-    model.apply_initialize_auth(&Initialize {
-        auth_token: "initial-token".to_string(),
-        user_id: "test-user-id".to_string(),
-        user_email: "test@example.com".to_string(),
-        crash_reporting_enabled: true,
-    });
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        model.apply_initialize_auth(&Initialize {
+            auth_token: "initial-token".to_string(),
+            user_id: "test-user-id".to_string(),
+            user_email: "test@example.com".to_string(),
+            crash_reporting_enabled: true,
+        });
 
-    model.apply_initialize_auth(&Initialize {
-        auth_token: String::new(),
-        user_id: String::new(),
-        user_email: String::new(),
-        crash_reporting_enabled: true,
-    });
+        model.apply_initialize_auth(&Initialize {
+            auth_token: String::new(),
+            user_id: String::new(),
+            user_email: String::new(),
+            crash_reporting_enabled: true,
+        });
 
-    assert_eq!(model.auth_token().as_deref(), None);
-    assert_eq!(model.auth_state.user_id(), None);
-    assert_eq!(model.auth_state.user_email(), None);
+        assert_eq!(model.auth_token().as_deref(), None);
+        assert_eq!(model.auth_state.user_id(), None);
+        assert_eq!(model.auth_state.user_email(), None);
+    });
 }
 
 #[test]
 fn authenticate_with_auth_token_replaces_auth_token() {
-    let mut model = test_model();
-    model.apply_initialize_auth(&Initialize {
-        auth_token: "initial-token".to_string(),
-        user_id: String::new(),
-        user_email: String::new(),
-        crash_reporting_enabled: true,
-    });
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        model.apply_initialize_auth(&Initialize {
+            auth_token: "initial-token".to_string(),
+            user_id: String::new(),
+            user_email: String::new(),
+            crash_reporting_enabled: true,
+        });
 
-    model.handle_authenticate(Authenticate {
-        auth_token: "rotated-token".to_string(),
-    });
+        model.handle_authenticate(Authenticate {
+            auth_token: "rotated-token".to_string(),
+        });
 
-    assert_eq!(model.auth_token().as_deref(), Some("rotated-token"));
+        assert_eq!(model.auth_token().as_deref(), Some("rotated-token"));
+    });
 }
 
 #[test]
 fn empty_authenticate_clears_auth_token() {
-    let mut model = test_model();
-    model.apply_initialize_auth(&Initialize {
-        auth_token: "initial-token".to_string(),
-        user_id: String::new(),
-        user_email: String::new(),
-        crash_reporting_enabled: true,
-    });
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        model.apply_initialize_auth(&Initialize {
+            auth_token: "initial-token".to_string(),
+            user_id: String::new(),
+            user_email: String::new(),
+            crash_reporting_enabled: true,
+        });
 
-    model.handle_authenticate(Authenticate {
-        auth_token: String::new(),
-    });
+        model.handle_authenticate(Authenticate {
+            auth_token: String::new(),
+        });
 
-    assert_eq!(model.auth_token().as_deref(), None);
+        assert_eq!(model.auth_token().as_deref(), None);
+    });
 }

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -183,7 +183,10 @@ impl Sessions {
                 | RemoteServerManagerEvent::BinaryCheckComplete { .. }
                 | RemoteServerManagerEvent::BinaryInstallComplete { .. }
                 | RemoteServerManagerEvent::ClientRequestFailed { .. }
-                | RemoteServerManagerEvent::ServerMessageDecodingError { .. } => {}
+                | RemoteServerManagerEvent::ServerMessageDecodingError { .. }
+                | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
+                | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
+                | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. } => {}
                 RemoteServerManagerEvent::SessionReconnected {
                     session_id: sid,
                     client,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4530,7 +4530,10 @@ impl TerminalView {
                     | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
                     | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
                     | RemoteServerManagerEvent::BufferUpdated { .. }
-                    | RemoteServerManagerEvent::BufferConflictDetected { .. } => {}
+                    | RemoteServerManagerEvent::BufferConflictDetected { .. }
+                    | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
+                    | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
+                    | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. } => {}
                 }
             });
         }

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -150,7 +150,10 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::ClientRequestFailed { .. }
             | RemoteServerManagerEvent::ServerMessageDecodingError { .. }
             | RemoteServerManagerEvent::BufferUpdated { .. }
-            | RemoteServerManagerEvent::BufferConflictDetected { .. } => {}
+            | RemoteServerManagerEvent::BufferConflictDetected { .. }
+            | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
+            | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
+            | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. } => {}
         });
 
         Self {

--- a/crates/remote_server/proto/diff_state.proto
+++ b/crates/remote_server/proto/diff_state.proto
@@ -200,6 +200,8 @@ message DiscardFilesRequest {
   bool should_stash = 3;
   // Branch to restore against. Absent means HEAD.
   optional string branch_name = 4;
+  // The diff mode identifying which DiffStateModel to use.
+  DiffMode mode = 5;
 }
 
 // ── Diff state server → client ────────────────────────────────────

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -15,7 +15,8 @@ use warpui::r#async::{executor, FutureExt as _};
 
 use crate::proto::{
     client_message, server_message, Abort, Authenticate, BufferEdit, ClientMessage, CloseBuffer,
-    DeleteFile, ErrorCode, Initialize, InitializeResponse, LoadRepoMetadataDirectoryResponse,
+    DeleteFile, DiffStateFileDelta, DiffStateMetadataUpdate, DiffStateSnapshot, ErrorCode,
+    Initialize, InitializeResponse, LoadRepoMetadataDirectoryResponse,
     NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextRequest,
     ReadFileContextResponse, RunCommandRequest, RunCommandResponse, SaveBuffer, ServerMessage,
     SessionBootstrapped, TextEdit, WriteFile,
@@ -91,7 +92,15 @@ pub enum ClientEvent {
     /// The server did NOT apply the change; the client should show a
     /// conflict resolution banner.
     BufferConflictDetected { path: String },
+    /// A full diff state snapshot was pushed by the server (NewDiffsComputed).
+    DiffStateSnapshotReceived { snapshot: DiffStateSnapshot },
+    /// A metadata-only diff state update was pushed by the server
+    /// (MetadataRefreshed or CurrentBranchChanged).
+    DiffStateMetadataUpdateReceived { update: DiffStateMetadataUpdate },
+    /// A single-file diff delta was pushed by the server (SingleFileUpdated).
+    DiffStateFileDeltaReceived { delta: DiffStateFileDelta },
 }
+
 /// Parameters for the `Initialize` handshake, sent to the daemon at
 /// connection time.
 pub struct InitializeParams {
@@ -535,6 +544,15 @@ impl RemoteServerClient {
             }),
             server_message::Message::BufferConflictDetected(push) => {
                 Some(ClientEvent::BufferConflictDetected { path: push.path })
+            }
+            server_message::Message::DiffStateSnapshot(snapshot) => {
+                Some(ClientEvent::DiffStateSnapshotReceived { snapshot })
+            }
+            server_message::Message::DiffStateMetadataUpdate(update) => {
+                Some(ClientEvent::DiffStateMetadataUpdateReceived { update })
+            }
+            server_message::Message::DiffStateFileDelta(delta) => {
+                Some(ClientEvent::DiffStateFileDeltaReceived { delta })
             }
             other => {
                 safe_warn!(

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -12,6 +12,7 @@ use crate::client::ClientEvent;
 use crate::client::InitializeParams;
 use crate::client::RemoteServerClient;
 use crate::codebase_index_proto::RemoteCodebaseIndexStatus;
+use crate::proto::{DiffStateFileDelta, DiffStateMetadataUpdate, DiffStateSnapshot};
 use crate::setup::PreinstallCheckResult;
 #[cfg(not(target_family = "wasm"))]
 use crate::setup::RemoteOs;
@@ -174,6 +175,9 @@ fn client_event_kind(event: &ClientEvent) -> &'static str {
         ClientEvent::CodebaseIndexStatusUpdated { .. } => "codebase_index_status_updated",
         ClientEvent::BufferUpdated { .. } => "buffer_updated",
         ClientEvent::BufferConflictDetected { .. } => "buffer_conflict_detected",
+        ClientEvent::DiffStateSnapshotReceived { .. } => "diff_state_snapshot",
+        ClientEvent::DiffStateMetadataUpdateReceived { .. } => "diff_state_metadata_update",
+        ClientEvent::DiffStateFileDeltaReceived { .. } => "diff_state_file_delta",
         ClientEvent::MessageDecodingError => "message_decoding_error",
     }
 }
@@ -369,6 +373,23 @@ pub enum RemoteServerManagerEvent {
     /// conflict resolution banner.
     BufferConflictDetected { host_id: HostId, path: String },
 
+    // --- Diff state events (forwarded from ClientEvent push channel) ---
+    /// A full diff state snapshot was pushed by the server (NewDiffsComputed).
+    DiffStateSnapshotReceived {
+        host_id: HostId,
+        snapshot: DiffStateSnapshot,
+    },
+    /// A metadata-only diff state update was pushed by the server.
+    DiffStateMetadataUpdateReceived {
+        host_id: HostId,
+        update: DiffStateMetadataUpdate,
+    },
+    /// A single-file diff delta was pushed by the server.
+    DiffStateFileDeltaReceived {
+        host_id: HostId,
+        delta: DiffStateFileDelta,
+    },
+
     // --- Setup events ---
     /// Intermediate state change during the binary check/install flow.
     SetupStateChanged {
@@ -449,7 +470,10 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
             | RemoteServerManagerEvent::BufferUpdated { .. }
-            | RemoteServerManagerEvent::BufferConflictDetected { .. } => None,
+            | RemoteServerManagerEvent::BufferConflictDetected { .. }
+            | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
+            | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
+            | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. } => None,
         }
     }
 }
@@ -1391,6 +1415,18 @@ impl RemoteServerManager {
             }
             ClientEvent::BufferConflictDetected { path } => {
                 ctx.emit(RemoteServerManagerEvent::BufferConflictDetected { host_id, path });
+            }
+            ClientEvent::DiffStateSnapshotReceived { snapshot } => {
+                ctx.emit(RemoteServerManagerEvent::DiffStateSnapshotReceived { host_id, snapshot });
+            }
+            ClientEvent::DiffStateMetadataUpdateReceived { update } => {
+                ctx.emit(RemoteServerManagerEvent::DiffStateMetadataUpdateReceived {
+                    host_id,
+                    update,
+                });
+            }
+            ClientEvent::DiffStateFileDeltaReceived { delta } => {
+                ctx.emit(RemoteServerManagerEvent::DiffStateFileDeltaReceived { host_id, delta });
             }
             ClientEvent::Disconnected => {
                 // Handled by the drain loop's completion callback.

--- a/specs/APP-4351/TECH.md
+++ b/specs/APP-4351/TECH.md
@@ -36,7 +36,7 @@ Add to `crates/remote_server/proto/remote_server.proto`.
 **Client → Server:**
 - `GetDiffState { repo_path, mode }` — request/response. The server responds with a `GetDiffStateResponse` (snapshot or error), then pushes subsequent changes. Follows the `NavigatedToDirectory` → `NavigatedToDirectoryResponse` + `RepoMetadataSnapshot` pattern.
 - `UnsubscribeDiffState { repo_path, mode }` — notification (fire-and-forget). Tells the server the client no longer needs updates for this (repo, mode).
-- `DiscardFilesRequest { repo_path, files, should_stash, branch_name? }` — request/response. Runs `git restore`/`git stash`/`git rm` on the remote filesystem for the specified files. `files` is a list of `FileStatusInfo { path, status }`. `should_stash` controls whether changes are stashed (recoverable) or discarded. `branch_name` specifies the branch to restore against (absent means HEAD).
+- `DiscardFilesRequest { repo_path, files, should_stash, branch_name?, mode }` — request/response. Runs `git restore`/`git stash`/`git rm` on the remote filesystem for the specified files. `files` is a list of `FileStatusInfo { path, status }`. `should_stash` controls whether changes are stashed (recoverable) or discarded. `branch_name` specifies the branch to restore against (absent means HEAD). `mode` identifies which `(repo, mode)` diff state model the server should use — the server looks up the exact model via `DiffModelKey` rather than picking an arbitrary model for the repo.
 
 **Server → Client:**
 - `GetDiffStateResponse` — `oneof result { DiffStateSnapshot snapshot, DiffStateError error }`. Matches the `WriteFileResponse`/`RunCommandResponse` pattern.
@@ -81,33 +81,31 @@ No new state enum — the existing `DiffState` has the right variants (`NotInRep
 
 ### 3. Server-side GlobalDiffStateModel
 
-New file: `app/src/remote_server/diff_state_server.rs`.
+New file: `app/src/remote_server/diff_state_tracker.rs`.
 
 ```rust path=null start=null
 #[derive(Hash, Eq, PartialEq, Clone)]
-struct ServerDiffStateKey {
+struct DiffModelKey {
     repo_path: StandardizedPath,
     mode: DiffMode,
 }
 
 pub struct GlobalDiffStateModel {
-    states: HashMap<ServerDiffStateKey, ModelHandle<LocalDiffStateModel>>,
-    /// connection → keys: used to clean up all subscriptions on connection drop.
-    keys_by_connection: HashMap<ConnectionId, HashSet<ServerDiffStateKey>>,
-    /// key → connections: used to fan out repo events to subscribers.
-    connections_by_key: HashMap<ServerDiffStateKey, HashSet<ConnectionId>>,
+    states: HashMap<DiffModelKey, ModelHandle<LocalDiffStateModel>>,
+    /// key → connections: used for push fan-out and orphan detection.
+    key_to_connections: HashMap<DiffModelKey, HashSet<ConnectionId>>,
 }
 ```
 
-`ServerDiffStateKey` uses `StandardizedPath` (not `RepositoryIdentifier`) because the server daemon only manages local-to-the-remote-host repositories — the `Remote` variant of `RepositoryIdentifier` is never used on the server side. This matches the existing `ServerModel` convention where per-connection state is keyed on `StandardizedPath` (e.g. `snapshot_sent_roots_by_connection`).
+`DiffModelKey` uses `StandardizedPath` (not `RepositoryIdentifier`) because the server daemon only manages local-to-the-remote-host repositories — the `Remote` variant of `RepositoryIdentifier` is never used on the server side. This matches the existing `ServerModel` convention where per-connection state is keyed on `StandardizedPath` (e.g. `snapshot_sent_roots_by_connection`).
 
 **Per-(repo, mode) models with immutable mode.** The server keys models on `(repo_path, mode)`.
 
 **Lifecycle:**
 1. `GetDiffState` arrives as a request. `GlobalDiffStateModel` looks up or creates a `LocalDiffStateModel` for the key. If already loaded, responds immediately. If loading, uses `ctx.spawn` to respond once `NewDiffsComputed` fires. Reuses `Repository` handles from `DetectedRepositories` (already detected by prior `NavigatedToDirectory`). If no repository has been detected yet (e.g. `GetDiffState` arrives before `NavigatedToDirectory`), responds with `DiffStateError` — the client retries after `NavigatedToDirectory` completes.
 2. After responding, subsequent model events are pushed to subscribed connections only via `send_to_diff_state_subscribers(key, msg)`, which looks up `connections_by_key[key]`. Targeted sends avoid broadcasting large diff payloads (~500KB–2MB).
-3. `UnsubscribeDiffState` removes the key from both maps. If no connection subscribes to the key, the model is dropped.
-4. `deregister_connection(conn_id)` removes the connection from `keys_by_connection` and from every corresponding entry in `connections_by_key`, dropping orphaned models.
+3. `UnsubscribeDiffState` calls `unsubscribe_connection` for the specific key. If no subscribers remain, the model is dropped.
+4. `remove_connection(conn_id)` iterates `key_to_connections` to find all keys the connection belongs to and calls `unsubscribe_connection` for each, dropping orphaned models.
 
 **Event → push mapping:**
 - `NewDiffsComputed` → full `DiffStateSnapshot`


### PR DESCRIPTION
## Description
* Built on https://github.com/warpdotdev/warp/pull/10428 
* Adds the server-side changes to support `DiffStateModel` and git states on remote environments  
  * Adds type conversions
  * Adds a `GlobalDiffStateModel` to track each `LocalDiffStateModel` per `repo_path`, `diff_mode`
  * Adds subscription to repositories to send server messages
  * Adds handlers for client messages

## Linked Issue
[APP-4355](https://linear.app/warpdotdev/issue/APP-4355/hook-up-diffstatemodel-to-remote-server)

## Testing
No-op 

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
