### PR TITLE
Add custom/third-party API endpoint support for AI providers

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -4,7 +4,7 @@ mod convert_to;
 mod r#impl;
 
 pub use ai::agent::convert::ConvertToAPITypeError;
-use ai::api_keys::ApiKeyManager;
+use ai::api_keys::{ApiKeyManager, CustomApiEndpoint};
 pub use convert_from::{
     user_inputs_from_messages, ConversionParams, ConvertAPIMessageToClientOutputMessage,
     MaybeAIAgentOutputMessage, MessageToAIAgentOutputMessageError,
@@ -117,6 +117,9 @@ pub struct RequestParams {
 
     /// User-provided API keys for AI providers (BYO API Key).
     pub api_keys: Option<warp_multi_agent_api::request::settings::ApiKeys>,
+    /// Custom/third-party API endpoints configured by the user.
+    /// These are used when a model from a custom endpoint is selected.
+    pub custom_endpoints: Vec<CustomApiEndpoint>,
     pub allow_use_of_warp_credits_with_byok: bool,
     pub autonomy_level: warp_multi_agent_api::AutonomyLevel,
     pub isolation_level: warp_multi_agent_api::IsolationLevel,
@@ -239,6 +242,10 @@ impl RequestParams {
             user_workspaces.is_byo_api_key_enabled(),
             user_workspaces.is_aws_bedrock_credentials_enabled(app),
         );
+        // Get custom endpoints for custom endpoint support.
+        // TODO(CORE-2300): When warp_multi_agent_api adds support for custom endpoints
+        // in the ApiKeys struct, this should be included there instead.
+        let custom_endpoints = ApiKeyManager::as_ref(app).custom_endpoints_for_request();
         let allow_use_of_warp_credits_with_byok =
             *AISettings::as_ref(app).can_use_warp_credits_with_byok;
 
@@ -321,6 +328,7 @@ impl RequestParams {
             planning_enabled: true,
             should_redact_secrets,
             api_keys,
+            custom_endpoints,
             allow_use_of_warp_credits_with_byok,
             autonomy_level,
             isolation_level,

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -56,6 +56,11 @@ pub async fn generate_multi_agent_output(
         api_keys.allow_use_of_warp_credits = params.allow_use_of_warp_credits_with_byok;
     }
 
+    // TODO(CORE-2300): Once warp_multi_agent_api adds support for custom endpoints
+    // in the request::Settings struct, pass params.custom_endpoints through.
+    // Until then, custom endpoints are stored in RequestParams but not yet forwarded
+    // to the multi-agent API server.
+
     let request = api::Request {
         task_context: Some(api::request::TaskContext {
             tasks: params.tasks,

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -37,16 +37,18 @@ use crate::settings::{
 };
 use crate::terminal::session_settings::{SessionSettings, SessionSettingsChangedEvent};
 use crate::terminal::CLIAgent;
+use crate::ui_components::buttons::{icon_button, text_button};
 use crate::view_components::{
     action_button::{ActionButton, ButtonSize, SecondaryTheme},
     FilterableDropdown, SubmittableTextInput, SubmittableTextInputEvent,
 };
 use crate::workspaces::user_workspaces::UserWorkspacesEvent;
-use ::ai::api_keys::{ApiKeyManager, ApiKeys};
+use ::ai::api_keys::{ApiKeyManager, ApiKeys, CustomApiEndpoint, ProviderType};
 use enum_iterator::all;
 use itertools::Itertools;
 use regex::Regex;
 use settings::{Setting, ToggleableSetting};
+use std::borrow::Cow;
 use strum::IntoEnumIterator;
 use warp_core::channel::ChannelState;
 use warp_core::context_flag::ContextFlag;
@@ -62,7 +64,8 @@ use warpui::keymap::ContextPredicate;
 use warpui::ui_components::slider::SliderStateHandle;
 use warpui::{
     elements::{
-        Container, Flex, FormattedTextElement, HighlightedHyperlink, HyperlinkUrl, ParentElement,
+        Container, Flex, FormattedTextElement, HighlightedHyperlink, HyperlinkUrl, Padding,
+        ParentElement,
     },
     ui_components::{
         button::ButtonVariant,
@@ -135,7 +138,6 @@ use crate::{
 use crate::{report_error, report_if_error, send_telemetry_from_ctx};
 use crate::{TelemetryEvent, UserWorkspaces};
 use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
-use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ops::Not;
@@ -451,6 +453,10 @@ pub struct AISettingsPageView {
     thinking_display_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     #[cfg(feature = "local_fs")]
     conversation_layout_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
+
+    // Custom endpoint form state
+    custom_endpoint_form_visible: bool,
+    custom_endpoint_provider_type: ProviderType,
 
     // Profile views
     profile_views: Vec<ViewHandle<ExecutionProfileView>>,
@@ -1433,6 +1439,8 @@ impl AISettingsPageView {
             conversation_layout_dropdown,
             profile_views,
             add_profile_button,
+            custom_endpoint_form_visible: false,
+            custom_endpoint_provider_type: ProviderType::OpenAI,
         }
     }
 
@@ -1510,6 +1518,7 @@ impl AISettingsPageView {
                 }
                 widgets.push(Box::new(CLIAgentWidget::default()));
                 widgets.push(Box::new(ApiKeysWidget::new(ctx)));
+                widgets.push(Box::new(CustomEndpointsWidget::new(ctx)));
                 widgets.push(Box::new(AwsBedrockWidget::new(ctx)));
                 widgets.push(Box::new(AgentAttributionWidget::default()));
                 widgets.push(Box::new(OtherAIWidget::default()));
@@ -1550,6 +1559,7 @@ impl AISettingsPageView {
                     widgets.push(Box::new(VoiceWidget::default()));
                 }
                 widgets.push(Box::new(ApiKeysWidget::new(ctx)));
+                widgets.push(Box::new(CustomEndpointsWidget::new(ctx)));
                 widgets.push(Box::new(AwsBedrockWidget::new(ctx)));
                 widgets.push(Box::new(AgentAttributionWidget::default()));
                 widgets.push(Box::new(OtherAIWidget::default()));
@@ -2278,6 +2288,10 @@ pub enum AISettingsPageAction {
         pattern: String,
         agent: Option<CLIAgent>,
     },
+    DeleteCustomEndpoint(String),
+    ToggleCustomEndpointForm,
+    SaveCustomEndpoint(CustomApiEndpoint),
+    SetCustomEndpointProviderType(ProviderType),
 }
 
 impl From<&AISettingsPageAction> for LoginGatedFeature {
@@ -3025,6 +3039,29 @@ impl TypedActionView for AISettingsPageView {
                         .agent_attribution_enabled
                         .toggle_and_save_value(ctx));
                 });
+                ctx.notify();
+            }
+            AISettingsPageAction::DeleteCustomEndpoint(id) => {
+                ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                    manager.remove_custom_endpoint(id, ctx);
+                });
+                ctx.notify();
+            }
+            AISettingsPageAction::SaveCustomEndpoint(endpoint) => {
+                ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                    manager.add_custom_endpoint(endpoint.clone(), ctx);
+                });
+                // Reset form state
+                self.custom_endpoint_form_visible = false;
+                self.custom_endpoint_provider_type = ProviderType::OpenAI;
+                ctx.notify();
+            }
+            AISettingsPageAction::ToggleCustomEndpointForm => {
+                self.custom_endpoint_form_visible = !self.custom_endpoint_form_visible;
+                ctx.notify();
+            }
+            AISettingsPageAction::SetCustomEndpointProviderType(ptype) => {
+                self.custom_endpoint_provider_type = ptype.clone();
                 ctx.notify();
             }
         }
@@ -6636,6 +6673,425 @@ impl SettingsWidget for ApiKeysWidget {
                     .finish(),
             );
         }
+
+        Container::new(column.finish())
+            .with_margin_bottom(HEADER_PADDING)
+            .finish()
+    }
+}
+
+/// Widget for managing custom/third-party API endpoints.
+/// Allows users to configure self-hosted or third-party LLM endpoints
+/// that are compatible with OpenAI or Anthropic APIs.
+struct CustomEndpointsWidget {
+    name_editor: ViewHandle<EditorView>,
+    url_editor: ViewHandle<EditorView>,
+    api_key_editor: ViewHandle<EditorView>,
+    models_editor: ViewHandle<EditorView>,
+    add_button: ViewHandle<ActionButton>,
+    /// Mouse state handles for interactive elements
+    save_button_mouse_state: MouseStateHandle,
+    provider_type_mouse_states: [MouseStateHandle; 3],
+}
+
+impl CustomEndpointsWidget {
+    fn new(ctx: &mut ViewContext<<Self as SettingsWidget>::View>) -> Self {
+        let mut create_editor = |placeholder: &str, is_password: bool| {
+            ctx.add_typed_action_view(move |ctx| {
+                let appearance = Appearance::as_ref(ctx);
+                let options = SingleLineEditorOptions {
+                    is_password,
+                    text: TextOptions {
+                        font_size_override: Some(appearance.ui_font_size()),
+                        font_family_override: Some(appearance.ui_font_family()),
+                        text_colors_override: Some(TextColors {
+                            default_color: appearance.theme().active_ui_text_color(),
+                            disabled_color: appearance.theme().disabled_ui_text_color(),
+                            hint_color: appearance.theme().disabled_ui_text_color(),
+                        }),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                };
+                let mut editor = EditorView::single_line(options, ctx);
+                editor.set_placeholder_text(placeholder, ctx);
+                editor
+            })
+        };
+
+        let name_editor = create_editor("Endpoint Name", false);
+        let url_editor = create_editor("https://api.example.com/v1", false);
+        let api_key_editor = create_editor("API Key", true);
+        let models_editor = create_editor("model-1, model-2 (comma separated, optional)", false);
+
+        let add_button = ctx.add_typed_action_view(|_ctx| {
+            ActionButton::new("+ Add Custom Endpoint", SecondaryTheme).on_click(|ctx| {
+                ctx.dispatch_typed_action(AISettingsPageAction::ToggleCustomEndpointForm);
+            })
+        });
+
+        Self {
+            name_editor,
+            url_editor,
+            api_key_editor,
+            models_editor,
+            add_button,
+            save_button_mouse_state: MouseStateHandle::default(),
+            provider_type_mouse_states: [
+                MouseStateHandle::default(),
+                MouseStateHandle::default(),
+                MouseStateHandle::default(),
+            ],
+        }
+    }
+
+    fn delete_endpoint(&self, id: &str, ctx: &mut ViewContext<AISettingsPageView>) {
+        ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+            manager.remove_custom_endpoint(id, ctx);
+        });
+    }
+
+    fn render_endpoints_list(
+        &self,
+        appearance: &Appearance,
+        app: &AppContext,
+        is_enabled: bool,
+    ) -> Box<dyn Element> {
+        let api_key_manager = ApiKeyManager::as_ref(app);
+        let endpoints = api_key_manager.custom_endpoints();
+
+        let mut column = Flex::column().with_spacing(8.);
+
+        if endpoints.is_empty() {
+            column.add_child(
+                Container::new(
+                    Text::new(
+                        "No custom endpoints configured. Add one to use your own API endpoint.",
+                        appearance.ui_font_family(),
+                        CONTENT_FONT_SIZE,
+                    )
+                    .with_color(
+                        if is_enabled {
+                            appearance
+                                .theme()
+                                .sub_text_color(appearance.theme().surface_2())
+                        } else {
+                            appearance.theme().disabled_ui_text_color()
+                        }
+                        .into(),
+                    )
+                    .finish(),
+                )
+                .with_padding(Padding::uniform(16.))
+                .with_background(appearance.theme().surface_2())
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+                .finish(),
+            );
+        } else {
+            for endpoint in endpoints {
+                let endpoint_card =
+                    self.render_endpoint_card(appearance, app, endpoint, is_enabled);
+                column.add_child(endpoint_card);
+            }
+        }
+
+        column.finish()
+    }
+
+    fn render_endpoint_card(
+        &self,
+        appearance: &Appearance,
+        app: &AppContext,
+        endpoint: &CustomApiEndpoint,
+        is_enabled: bool,
+    ) -> Box<dyn Element> {
+        let provider_type_text = match endpoint.provider_type {
+            ProviderType::OpenAI => "OpenAI Compatible",
+            ProviderType::Anthropic => "Anthropic Compatible",
+            ProviderType::Custom => "Custom",
+        };
+
+        let delete_endpoint = endpoint.clone();
+        let delete_button = icon_button(appearance, Icon::X, false, MouseStateHandle::default())
+            .build()
+            .on_click(move |ctx, _, _| {
+                let id = delete_endpoint.id.clone();
+                let action = AISettingsPageAction::DeleteCustomEndpoint(id);
+                ctx.dispatch_typed_action(action);
+            })
+            .finish();
+
+        let mut header_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center);
+
+        header_row.add_child(
+            Expanded::new(
+                1.,
+                Text::new(
+                    &endpoint.name,
+                    appearance.ui_font_family(),
+                    CONTENT_FONT_SIZE,
+                )
+                .with_color(styles::header_font_color(is_enabled, app).into())
+                .finish(),
+            )
+            .finish(),
+        );
+
+        header_row.add_child(delete_button);
+
+        let mut info_column = Flex::column().with_spacing(4.);
+        info_column.add_child(header_row.finish());
+
+        info_column.add_child(
+            Text::new(
+                format!("{} • {}", endpoint.url, provider_type_text),
+                appearance.ui_font_family(),
+                CONTENT_FONT_SIZE,
+            )
+            .with_color(
+                appearance
+                    .theme()
+                    .sub_text_color(appearance.theme().surface_2())
+                    .into(),
+            )
+            .finish(),
+        );
+
+        if !endpoint.models.is_empty() {
+            let models_text = if endpoint.models.len() > 3 {
+                format!("{} models", endpoint.models.len())
+            } else {
+                endpoint.models.join(", ")
+            };
+            info_column.add_child(
+                Text::new(models_text, appearance.ui_font_family(), CONTENT_FONT_SIZE)
+                    .with_color(
+                        appearance
+                            .theme()
+                            .sub_text_color(appearance.theme().surface_2())
+                            .into(),
+                    )
+                    .finish(),
+            );
+        }
+
+        Container::new(info_column.finish())
+            .with_padding(Padding::uniform(12.))
+            .with_background(appearance.theme().surface_2())
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+            .finish()
+    }
+
+    fn render_add_form(
+        &self,
+        appearance: &Appearance,
+        app: &AppContext,
+        current_provider_type: &ProviderType,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let header_font_color = theme.active_ui_text_color();
+
+        let provider_types = [
+            (ProviderType::OpenAI, "OpenAI", 0usize),
+            (ProviderType::Anthropic, "Anthropic", 1usize),
+            (ProviderType::Custom, "Custom", 2usize),
+        ];
+
+        let mut provider_row = Flex::row()
+            .with_spacing(8.)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center);
+
+        for (ptype, label, idx) in provider_types {
+            let is_selected = current_provider_type == &ptype;
+            let mouse_state = self.provider_type_mouse_states[idx].clone();
+            let bg_color = if is_selected {
+                theme.accent()
+            } else {
+                theme.surface_2()
+            };
+            let text_color = if is_selected {
+                theme.active_ui_text_color()
+            } else {
+                theme.sub_text_color(theme.surface_2())
+            };
+
+            let button = text_button(appearance, label, mouse_state).with_style(
+                UiComponentStyles::default()
+                    .set_background(bg_color.into())
+                    .set_font_color(text_color.into())
+                    .set_border_radius(CornerRadius::with_all(Radius::Pixels(6.)))
+                    .set_border_width(1.)
+                    .set_border_color(theme.outline().into()),
+            );
+
+            let selected_type = ptype;
+            let provider_button = button.build().on_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(AISettingsPageAction::SetCustomEndpointProviderType(
+                    selected_type.clone(),
+                ));
+            });
+
+            provider_row.add_child(Box::new(provider_button));
+        }
+
+        let render_field = |label: &str, editor: &ViewHandle<EditorView>| {
+            let mut col = Flex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Start)
+                .with_spacing(4.);
+
+            col.add_child(
+                Text::new(label, appearance.ui_font_family(), CONTENT_FONT_SIZE)
+                    .with_color(header_font_color.into())
+                    .finish(),
+            );
+
+            col.add_child(ChildView::new(editor).finish());
+
+            col.finish()
+        };
+
+        // Create save button that reads editor values and dispatches action
+        let name_editor = self.name_editor.clone();
+        let url_editor = self.url_editor.clone();
+        let api_key_editor = self.api_key_editor.clone();
+        let models_editor = self.models_editor.clone();
+        let provider_type = current_provider_type.clone();
+
+        let save_button = text_button(
+            appearance,
+            "Save Endpoint",
+            self.save_button_mouse_state.clone(),
+        )
+        .with_style(
+            UiComponentStyles::default()
+                .set_background(theme.accent().into())
+                .set_font_color(theme.active_ui_text_color().into())
+                .set_border_radius(CornerRadius::with_all(Radius::Pixels(6.)))
+                .set_border_width(1.)
+                .set_border_color(theme.outline().into()),
+        );
+
+        let save_btn = save_button.build().on_click(move |ctx, app, _| {
+            let name = name_editor.as_ref(app).buffer_text(app);
+            let url = url_editor.as_ref(app).buffer_text(app);
+            let api_key = api_key_editor.as_ref(app).buffer_text(app);
+            let models_text = models_editor.as_ref(app).buffer_text(app);
+
+            let models: Vec<String> = models_text
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+
+            let endpoint = CustomApiEndpoint {
+                id: uuid::Uuid::new_v4().to_string(),
+                name,
+                url,
+                api_key: if api_key.is_empty() {
+                    None
+                } else {
+                    Some(api_key)
+                },
+                provider_type: provider_type.clone(),
+                models,
+            };
+
+            ctx.dispatch_typed_action(AISettingsPageAction::SaveCustomEndpoint(endpoint));
+        });
+
+        let mut form = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(12.);
+
+        form.add_child(provider_row.finish());
+        form.add_child(render_field("Name", &self.name_editor));
+        form.add_child(render_field("URL", &self.url_editor));
+        form.add_child(render_field("API Key", &self.api_key_editor));
+        form.add_child(render_field("Models", &self.models_editor));
+
+        form.add_child(
+            Container::new(Box::new(save_btn))
+                .with_margin_top(8.)
+                .finish(),
+        );
+
+        Container::new(form.finish())
+            .with_padding(Padding::uniform(16.))
+            .with_background(theme.surface_2())
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+            .with_border(Border::all(1.).with_border_fill(theme.outline()))
+            .finish()
+    }
+}
+
+impl SettingsWidget for CustomEndpointsWidget {
+    type View = AISettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "custom api endpoint third party self hosted llm openai anthropic provider"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        // Only show this widget if the feature flag is enabled
+        if !FeatureFlag::CustomApiEndpoints.is_enabled() {
+            return Container::new(Flex::column().finish()).finish();
+        }
+
+        let ai_settings = AISettings::as_ref(app);
+        let is_any_ai_enabled = ai_settings.is_any_ai_enabled(app);
+        let is_byo_enabled = UserWorkspaces::as_ref(app).is_byo_api_key_enabled();
+        let is_enabled = is_any_ai_enabled && is_byo_enabled;
+
+        let mut column = Flex::column()
+            .with_child(render_separator(appearance))
+            .with_child(
+                build_sub_header(
+                    appearance,
+                    "Custom API Endpoints",
+                    Some(styles::header_font_color(is_enabled, app)),
+                )
+                .with_padding_bottom(HEADER_PADDING)
+                .finish(),
+            )
+            .with_child(
+                Container::new(
+                    render_ai_setting_description(
+                        "Configure custom LLM endpoints (OpenAI or Anthropic compatible) with your own API keys. These endpoints are stored locally and never synced to the cloud.",
+                        is_enabled,
+                        app,
+                    ),
+                )
+                .with_margin_bottom(16.)
+                .finish(),
+            )
+            .with_child(self.render_endpoints_list(appearance, app, is_enabled));
+
+        if view.custom_endpoint_form_visible {
+            column.add_child(
+                Container::new(self.render_add_form(
+                    appearance,
+                    app,
+                    &view.custom_endpoint_provider_type,
+                ))
+                .with_margin_top(16.)
+                .finish(),
+            );
+        }
+
+        // Add button: toggles the add form
+        let button = self.add_button.clone();
+        column.add_child(
+            Container::new(button.as_ref(app).render(app))
+                .with_margin_top(16.)
+                .finish(),
+        );
 
         Container::new(column.finish())
             .with_margin_bottom(HEADER_PADDING)

--- a/app/src/ui_components/buttons.rs
+++ b/app/src/ui_components/buttons.rs
@@ -248,3 +248,43 @@ pub fn highlight(button: Button, appearance: &Appearance) -> Button {
                 .set_font_color(appearance.theme().foreground().into()),
         )
 }
+
+/// Creates a simple text button with hover and click states.
+pub fn text_button(
+    appearance: &Appearance,
+    label: &str,
+    mouse_state_handle: MouseStateHandle,
+) -> Button {
+    let theme = appearance.theme();
+
+    let default_styles = UiComponentStyles::default()
+        .set_font_color(theme.foreground().into())
+        .set_padding(Coords::uniform(8.))
+        .set_border_radius(CornerRadius::with_all(Radius::Pixels(BORDER_RADIUS)));
+
+    let hovered_styles = UiComponentStyles::default()
+        .set_background(theme.surface_2().into())
+        .set_font_color(theme.foreground().into())
+        .set_padding(Coords::uniform(8.))
+        .set_border_radius(CornerRadius::with_all(Radius::Pixels(BORDER_RADIUS)));
+
+    let clicked_styles = UiComponentStyles::default()
+        .set_background(theme.surface_3().into())
+        .set_font_color(theme.foreground().into())
+        .set_padding(Coords::uniform(8.))
+        .set_border_radius(CornerRadius::with_all(Radius::Pixels(BORDER_RADIUS)));
+
+    let disabled_styles = UiComponentStyles::default()
+        .set_font_color(theme.disabled_ui_text_color().into())
+        .set_padding(Coords::uniform(8.))
+        .set_border_radius(CornerRadius::with_all(Radius::Pixels(BORDER_RADIUS)));
+
+    Button::new(
+        mouse_state_handle,
+        default_styles,
+        Some(hovered_styles),
+        Some(clicked_styles),
+        Some(disabled_styles),
+    )
+    .with_text_label(label.to_string())
+}

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -12,6 +12,40 @@ pub enum ApiKeyManagerEvent {
     KeysUpdated,
 }
 
+/// Provider type for custom API endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProviderType {
+    OpenAI,
+    Anthropic,
+    Custom,
+}
+
+impl Default for ProviderType {
+    fn default() -> Self {
+        ProviderType::OpenAI
+    }
+}
+
+/// Configuration for a custom/third-party API endpoint.
+///
+/// This allows users to use self-hosted or third-party LLM endpoints
+/// that are compatible with OpenAI or Anthropic APIs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CustomApiEndpoint {
+    /// Unique identifier for this endpoint
+    pub id: String,
+    /// Display name for this endpoint
+    pub name: String,
+    /// API base URL (e.g., "https://api.example.com/v1")
+    pub url: String,
+    /// API key for authentication
+    pub api_key: Option<String>,
+    /// Provider type for API compatibility
+    pub provider_type: ProviderType,
+    /// List of available models from this endpoint
+    pub models: Vec<String>,
+}
+
 /// User-provided API keys for AI providers.
 ///
 /// These are used for "Bring Your Own API Key" functionality, allowing
@@ -22,6 +56,8 @@ pub struct ApiKeys {
     pub anthropic: Option<String>,
     pub openai: Option<String>,
     pub open_router: Option<String>,
+    #[serde(default)]
+    pub custom_endpoints: Vec<CustomApiEndpoint>,
 }
 
 impl ApiKeys {
@@ -30,6 +66,7 @@ impl ApiKeys {
             || self.anthropic.is_some()
             || self.google.is_some()
             || self.open_router.is_some()
+            || !self.custom_endpoints.is_empty()
     }
 }
 
@@ -93,6 +130,48 @@ impl ApiKeyManager {
         self.write_keys_to_secure_storage(ctx);
     }
 
+    /// Returns the list of custom API endpoints.
+    pub fn custom_endpoints(&self) -> &[CustomApiEndpoint] {
+        &self.keys.custom_endpoints
+    }
+
+    /// Adds a new custom API endpoint.
+    pub fn add_custom_endpoint(
+        &mut self,
+        endpoint: CustomApiEndpoint,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.keys.custom_endpoints.push(endpoint);
+        ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+        self.write_keys_to_secure_storage(ctx);
+    }
+
+    /// Updates an existing custom API endpoint by ID.
+    pub fn update_custom_endpoint(
+        &mut self,
+        id: &str,
+        endpoint: CustomApiEndpoint,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if let Some(idx) = self.keys.custom_endpoints.iter().position(|e| e.id == id) {
+            self.keys.custom_endpoints[idx] = endpoint;
+            ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+            self.write_keys_to_secure_storage(ctx);
+        }
+    }
+
+    /// Removes a custom API endpoint by ID.
+    pub fn remove_custom_endpoint(&mut self, id: &str, ctx: &mut ModelContext<Self>) {
+        self.keys.custom_endpoints.retain(|e| e.id != id);
+        ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+        self.write_keys_to_secure_storage(ctx);
+    }
+
+    /// Returns a custom endpoint by ID, if it exists.
+    pub fn get_custom_endpoint(&self, id: &str) -> Option<&CustomApiEndpoint> {
+        self.keys.custom_endpoints.iter().find(|e| e.id == id)
+    }
+
     pub fn set_aws_credentials_state(
         &mut self,
         state: AwsCredentialsState,
@@ -154,14 +233,20 @@ impl ApiKeyManager {
             })
             .flatten();
 
+        let has_custom_endpoints = include_byo_keys && !self.keys.custom_endpoints.is_empty();
+
         if anthropic.is_empty()
             && openai.is_empty()
             && google.is_empty()
             && open_router.is_empty()
             && aws_credentials.is_none()
+            && !has_custom_endpoints
         {
             None
         } else {
+            // TODO(CORE-2300): Once warp_multi_agent_api::request::settings::ApiKeys is updated
+            // to include a custom_endpoints field, include them here. Until then, custom endpoints
+            // are passed separately via RequestParams.custom_endpoints.
             Some(api::request::settings::ApiKeys {
                 anthropic,
                 openai,
@@ -171,6 +256,11 @@ impl ApiKeyManager {
                 aws_credentials,
             })
         }
+    }
+
+    /// Returns a snapshot of the custom endpoints for use in API requests.
+    pub fn custom_endpoints_for_request(&self) -> Vec<CustomApiEndpoint> {
+        self.keys.custom_endpoints.clone()
     }
 
     fn load_keys_from_secure_storage(ctx: &mut ModelContext<Self>) -> ApiKeys {
@@ -217,3 +307,7 @@ impl Entity for ApiKeyManager {
 }
 
 impl SingletonEntity for ApiKeyManager {}
+
+#[cfg(test)]
+#[path = "api_keys_tests.rs"]
+mod tests;

--- a/crates/ai/src/api_keys_tests.rs
+++ b/crates/ai/src/api_keys_tests.rs
@@ -1,0 +1,146 @@
+use crate::api_keys::{ApiKeys, CustomApiEndpoint, ProviderType};
+
+fn create_test_endpoint(id: &str, name: &str, url: &str) -> CustomApiEndpoint {
+    CustomApiEndpoint {
+        id: id.to_string(),
+        name: name.to_string(),
+        url: url.to_string(),
+        api_key: Some("test-key".to_string()),
+        provider_type: ProviderType::OpenAI,
+        models: vec!["gpt-4".to_string()],
+    }
+}
+
+#[test]
+fn test_custom_endpoint_creation() {
+    let endpoint = create_test_endpoint("test-id", "Test Endpoint", "https://api.test.com/v1");
+
+    assert_eq!(endpoint.id, "test-id");
+    assert_eq!(endpoint.name, "Test Endpoint");
+    assert_eq!(endpoint.url, "https://api.test.com/v1");
+    assert_eq!(endpoint.provider_type, ProviderType::OpenAI);
+    assert!(endpoint.api_key.is_some());
+    assert_eq!(endpoint.models.len(), 1);
+}
+
+#[test]
+fn test_provider_type_default() {
+    let provider_type = ProviderType::default();
+    assert_eq!(provider_type, ProviderType::OpenAI);
+}
+
+#[test]
+fn test_api_keys_empty_custom_endpoints() {
+    let keys = ApiKeys::default();
+    assert!(keys.custom_endpoints.is_empty());
+}
+
+#[test]
+fn test_api_keys_with_custom_endpoints() {
+    let endpoint1 = create_test_endpoint("id1", "Endpoint 1", "https://api1.com/v1");
+    let endpoint2 = create_test_endpoint("id2", "Endpoint 2", "https://api2.com/v1");
+
+    let keys = ApiKeys {
+        google: None,
+        anthropic: None,
+        openai: Some("openai-key".to_string()),
+        open_router: None,
+        custom_endpoints: vec![endpoint1, endpoint2],
+    };
+
+    assert!(keys.has_any_key());
+    assert_eq!(keys.custom_endpoints.len(), 2);
+}
+
+#[test]
+fn test_api_keys_has_any_key_with_custom_endpoint_only() {
+    let endpoint = create_test_endpoint("id1", "Endpoint 1", "https://api1.com/v1");
+
+    let keys = ApiKeys {
+        google: None,
+        anthropic: None,
+        openai: None,
+        open_router: None,
+        custom_endpoints: vec![endpoint],
+    };
+
+    assert!(keys.has_any_key());
+}
+
+#[test]
+fn test_api_keys_serialization_roundtrip() {
+    let endpoint = create_test_endpoint("id1", "Test Endpoint", "https://api.test.com/v1");
+
+    let keys = ApiKeys {
+        google: Some("google-key".to_string()),
+        anthropic: Some("anthropic-key".to_string()),
+        openai: Some("openai-key".to_string()),
+        open_router: None,
+        custom_endpoints: vec![endpoint],
+    };
+
+    let json = serde_json::to_string(&keys).expect("Failed to serialize");
+    let deserialized: ApiKeys = serde_json::from_str(&json).expect("Failed to deserialize");
+
+    assert_eq!(keys, deserialized);
+}
+
+#[test]
+fn test_api_keys_backward_compatibility_missing_custom_endpoints() {
+    // Old format without custom_endpoints field should deserialize with empty vec
+    let old_json = r#"{
+        "google": null,
+        "anthropic": "anthropic-key",
+        "openai": null,
+        "open_router": null
+    }"#;
+
+    let keys: ApiKeys = serde_json::from_str(old_json).expect("Failed to deserialize old format");
+
+    assert!(keys.custom_endpoints.is_empty());
+    assert_eq!(keys.anthropic, Some("anthropic-key".to_string()));
+}
+
+#[test]
+fn test_custom_endpoint_provider_type_serialization() {
+    let endpoint_openai = CustomApiEndpoint {
+        id: "1".to_string(),
+        name: "OpenAI Endpoint".to_string(),
+        url: "https://api.openai.com/v1".to_string(),
+        api_key: None,
+        provider_type: ProviderType::OpenAI,
+        models: vec![],
+    };
+
+    let endpoint_anthropic = CustomApiEndpoint {
+        id: "2".to_string(),
+        name: "Anthropic Endpoint".to_string(),
+        url: "https://api.anthropic.com/v1".to_string(),
+        api_key: None,
+        provider_type: ProviderType::Anthropic,
+        models: vec![],
+    };
+
+    let endpoint_custom = CustomApiEndpoint {
+        id: "3".to_string(),
+        name: "Custom Endpoint".to_string(),
+        url: "https://custom.llm.com/v1".to_string(),
+        api_key: None,
+        provider_type: ProviderType::Custom,
+        models: vec![],
+    };
+
+    // Test serialization
+    let json_openai = serde_json::to_string(&endpoint_openai.provider_type).unwrap();
+    assert_eq!(json_openai, "\"OpenAI\"");
+
+    let json_anthropic = serde_json::to_string(&endpoint_anthropic.provider_type).unwrap();
+    assert_eq!(json_anthropic, "\"Anthropic\"");
+
+    let json_custom = serde_json::to_string(&endpoint_custom.provider_type).unwrap();
+    assert_eq!(json_custom, "\"Custom\"");
+
+    // Test deserialization
+    let deserialized: ProviderType = serde_json::from_str(&json_openai).unwrap();
+    assert_eq!(deserialized, ProviderType::OpenAI);
+}

--- a/crates/ai/src/lib.rs
+++ b/crates/ai/src/lib.rs
@@ -3,6 +3,7 @@ pub mod api_keys;
 pub mod aws_credentials;
 pub mod llm_id;
 
+pub use api_keys::{CustomApiEndpoint, ProviderType};
 pub use llm_id::LLMId;
 pub mod diff_validation;
 pub mod document;

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -864,6 +864,11 @@ pub enum FeatureFlag {
     /// (`~/.git-credentials`, `~/.config/gh/hosts.yaml`) and runs the
     /// background refresh loop that keeps them fresh during a task run.
     GitCredentialRefresh,
+
+    /// Enables support for custom/third-party API endpoint configuration.
+    /// Users can add their own LLM endpoints (OpenAI-compatible, Anthropic-compatible,
+    /// or custom) with API keys and model lists for use with Agent Mode.
+    CustomApiEndpoints,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =


### PR DESCRIPTION
This feature allows users to configure self-hosted or third-party LLM endpoints (vLLM, Ollama, LocalAI, OpenAI-compatible proxies). Changes include: new CustomApiEndpoint data model, CustomApiEndpoints feature flag, settings UI widget, and unit tests with backward compatibility. Note: Full server-side integration requires CORE-2300 upstream changes.