### PR TITLE
Hide "sharer's" cursor in cloud agent sessions

### DIFF
--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -1476,19 +1476,23 @@ impl TerminalManager {
 
                 // Flush the initial input operations that the sharer performed
                 // in the latest buffer before the share was started.
-                let init_input_ops: Vec<CrdtOperation> = terminal_view
-                    .as_ref(ctx)
-                    .input()
-                    .as_ref(ctx)
-                    .latest_buffer_operations()
-                    .cloned()
-                    .collect();
-                network.update(ctx, |network, _ctx| {
-                    network.send_input_update(
-                        model.lock().block_list().active_block_id(),
-                        init_input_ops.iter(),
-                    );
-                });
+                // Skip for ambient agent sessions — the sharer is a headless
+                // worker whose input ops would cause a phantom cursor.
+                if !model.lock().is_shared_ambient_agent_session() {
+                    let init_input_ops: Vec<CrdtOperation> = terminal_view
+                        .as_ref(ctx)
+                        .input()
+                        .as_ref(ctx)
+                        .latest_buffer_operations()
+                        .cloned()
+                        .collect();
+                    network.update(ctx, |network, _ctx| {
+                        network.send_input_update(
+                            model.lock().block_list().active_block_id(),
+                            init_input_ops.iter(),
+                        );
+                    });
+                }
 
                 // Stream historical agent conversations so viewers have conversation and task context.
                 if FeatureFlag::AgentSharedSessions.is_enabled() {
@@ -2316,6 +2320,14 @@ impl TerminalManager {
                 // If the block ID has become stale by the time we get here,
                 // we don't need to send this update to the server.
                 if model.lock().block_list().active_block_id() != block_id {
+                    return;
+                }
+
+                // In cloud agent sessions the sharer is a headless worker
+                // that never interactively types in the rich input. Sending
+                // its CRDT selection ops would cause a phantom cursor to
+                // render on the viewer side.
+                if model.lock().is_shared_ambient_agent_session() {
                     return;
                 }
 

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -128,6 +128,13 @@ type RemoteServerController =
 
 const ACL_UPDATE_FAILURE_RESPONSE: &str = "Something went wrong. Please try again.";
 
+/// Whether the given CRDT operation is a selection-only update. In ambient
+/// agent sessions the sharer is a headless worker — forwarding its selection
+/// ops would produce a phantom cursor on the viewer side.
+fn is_sharer_selection_op(op: &CrdtOperation) -> bool {
+    matches!(op, CrdtOperation::UpdateSelections(_))
+}
+
 /// The TerminalManager is responsible for
 /// - creating the terminal model
 /// - starting the local PTY
@@ -1476,16 +1483,18 @@ impl TerminalManager {
 
                 // Flush the initial input operations that the sharer performed
                 // in the latest buffer before the share was started.
-                // Skip for ambient agent sessions — the sharer is a headless
-                // worker whose input ops would cause a phantom cursor.
-                if !model.lock().is_shared_ambient_agent_session() {
-                    let init_input_ops: Vec<CrdtOperation> = terminal_view
-                        .as_ref(ctx)
-                        .input()
-                        .as_ref(ctx)
-                        .latest_buffer_operations()
-                        .cloned()
-                        .collect();
+                // For ambient agent sessions, filter out selection ops to
+                // avoid a phantom cursor from the headless worker.
+                let is_ambient = model.lock().is_shared_ambient_agent_session();
+                let init_input_ops: Vec<CrdtOperation> = terminal_view
+                    .as_ref(ctx)
+                    .input()
+                    .as_ref(ctx)
+                    .latest_buffer_operations()
+                    .filter(|op| !is_ambient || !is_sharer_selection_op(op))
+                    .cloned()
+                    .collect();
+                if !init_input_ops.is_empty() {
                     network.update(ctx, |network, _ctx| {
                         network.send_input_update(
                             model.lock().block_list().active_block_id(),
@@ -2323,18 +2332,29 @@ impl TerminalManager {
                     return;
                 }
 
-                // In cloud agent sessions the sharer is a headless worker
-                // that never interactively types in the rich input. Sending
-                // its CRDT selection ops would cause a phantom cursor to
-                // render on the viewer side.
-                if model.lock().is_shared_ambient_agent_session() {
-                    return;
-                }
-
-                if let Some(network) = session_sharer.borrow().as_ref() {
-                    network.update(ctx, |network, _| {
-                        network.send_input_update(block_id, operations.iter());
-                    });
+                // In ambient agent sessions the sharer is a headless worker;
+                // filter out selection ops to avoid a phantom cursor on the
+                // viewer side, but keep content ops so the buffer stays in sync.
+                let is_ambient = model.lock().is_shared_ambient_agent_session();
+                if is_ambient {
+                    let filtered: Vec<_> = operations
+                        .iter()
+                        .filter(|op| !is_sharer_selection_op(op))
+                        .collect();
+                    if filtered.is_empty() {
+                        return;
+                    }
+                    if let Some(network) = session_sharer.borrow().as_ref() {
+                        network.update(ctx, |network, _| {
+                            network.send_input_update(block_id, filtered.into_iter());
+                        });
+                    }
+                } else {
+                    if let Some(network) = session_sharer.borrow().as_ref() {
+                        network.update(ctx, |network, _| {
+                            network.send_input_update(block_id, operations.iter());
+                        });
+                    }
                 }
             }
             TerminalViewEvent::UpdateSessionLinkPermissions { role } => {

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -128,11 +128,13 @@ type RemoteServerController =
 
 const ACL_UPDATE_FAILURE_RESPONSE: &str = "Something went wrong. Please try again.";
 
-/// Whether the given CRDT operation is a selection-only update. In ambient
-/// agent sessions the sharer is a headless worker — forwarding its selection
-/// ops would produce a phantom cursor on the viewer side.
-fn is_sharer_selection_op(op: &CrdtOperation) -> bool {
-    matches!(op, CrdtOperation::UpdateSelections(_))
+/// Whether the given CRDT operation should be dropped when broadcasting
+/// sharer input to viewers. In ambient agent sessions the sharer is a
+/// headless worker — forwarding its selection ops would produce a phantom
+/// cursor on the viewer side. Content ops (Edit / Undo) are kept so the
+/// buffer stays in sync.
+fn should_skip_sharer_op(is_ambient_session: bool, op: &CrdtOperation) -> bool {
+    is_ambient_session && matches!(op, CrdtOperation::UpdateSelections(_))
 }
 
 /// The TerminalManager is responsible for
@@ -1483,15 +1485,13 @@ impl TerminalManager {
 
                 // Flush the initial input operations that the sharer performed
                 // in the latest buffer before the share was started.
-                // For ambient agent sessions, filter out selection ops to
-                // avoid a phantom cursor from the headless worker.
                 let is_ambient = model.lock().is_shared_ambient_agent_session();
                 let init_input_ops: Vec<CrdtOperation> = terminal_view
                     .as_ref(ctx)
                     .input()
                     .as_ref(ctx)
                     .latest_buffer_operations()
-                    .filter(|op| !is_ambient || !is_sharer_selection_op(op))
+                    .filter(|op| !should_skip_sharer_op(is_ambient, op))
                     .cloned()
                     .collect();
                 if !init_input_ops.is_empty() {
@@ -2332,29 +2332,18 @@ impl TerminalManager {
                     return;
                 }
 
-                // In ambient agent sessions the sharer is a headless worker;
-                // filter out selection ops to avoid a phantom cursor on the
-                // viewer side, but keep content ops so the buffer stays in sync.
                 let is_ambient = model.lock().is_shared_ambient_agent_session();
-                if is_ambient {
-                    let filtered: Vec<_> = operations
-                        .iter()
-                        .filter(|op| !is_sharer_selection_op(op))
-                        .collect();
-                    if filtered.is_empty() {
-                        return;
-                    }
-                    if let Some(network) = session_sharer.borrow().as_ref() {
-                        network.update(ctx, |network, _| {
-                            network.send_input_update(block_id, filtered.into_iter());
-                        });
-                    }
-                } else {
-                    if let Some(network) = session_sharer.borrow().as_ref() {
-                        network.update(ctx, |network, _| {
-                            network.send_input_update(block_id, operations.iter());
-                        });
-                    }
+                let filtered: Vec<_> = operations
+                    .iter()
+                    .filter(|op| !should_skip_sharer_op(is_ambient, op))
+                    .collect();
+                if filtered.is_empty() {
+                    return;
+                }
+                if let Some(network) = session_sharer.borrow().as_ref() {
+                    network.update(ctx, |network, _| {
+                        network.send_input_update(block_id, filtered.into_iter());
+                    });
                 }
             }
             TerminalViewEvent::UpdateSessionLinkPermissions { role } => {

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -59,7 +59,7 @@
       "source": "warpdotdev/common-skills",
       "sourceType": "github",
       "skillPath": ".agents/skills/write-tech-spec/SKILL.md",
-      "computedHash": "702924ae98de5466f452eba2effbd004de5edd91617097372c4725a5b5035919"
+      "computedHash": "3b5eb4ef021112d473984eca28412d372e87d9337ad5d9754f3ad3e01f94d39b"
     }
   }
 }

--- a/specs/REMOTE-1590/TECH.md
+++ b/specs/REMOTE-1590/TECH.md
@@ -1,0 +1,50 @@
+# REMOTE-1590: Hide sharer's input cursor in cloud agent sessions
+
+## Context
+When viewing a cloud agent session running a third-party CLI agent (e.g. Claude Code), the viewer sees a phantom remote cursor in the rich input — rendered with the sharer's avatar — even though the sharer is a headless agent worker that never interactively types in the input.
+
+### How remote input cursors work
+The input editor is a CRDT-backed collaborative buffer. For a remote cursor to render, two conditions must be met:
+1. The participant is **registered as a remote peer** in the editor's buffer (`view_impl.rs:1150-1157` for the sharer, `view_impl.rs:1122-1129` for viewers).
+2. The buffer has **remote selection data** for that peer's replica ID, populated by `UpdateSelections` CRDT operations received from the sharer.
+
+Condition 1 is always met: `handle_presence_manager_event` unconditionally registers the sharer as a remote peer when a viewer joins any shared session (`view_impl.rs:1132-1158`).
+
+Condition 2 was historically never met for cloud agent sessions because the worker's input buffer was inert — no code path on the worker ever called `edit()` on the rich input buffer.
+
+### What changed
+The CLI agent rich input feature introduced lifecycle events (`InputSessionChanged::Open` / `Closed`) that call `clear_buffer_and_reset_undo_stack` on the worker's input (`input.rs:2477`, `2492`). Unlike `reinitialize_buffer` (which creates a fresh buffer without emitting CRDT operations), `clear_buffer_and_reset_undo_stack` goes through the full `edit()` → `end_batch()` → `UpdatePeers` path, emitting CRDT selection operations. These operations are transmitted to the viewer via session sharing (`local_tty/terminal_manager.rs:2312-2326`), satisfying condition 2.
+
+This does not affect the Oz harness because it does not use the CLI agent rich input — its buffer clears go through `reinitialize_buffer` during block completion (`input.rs:13448-13449`), which creates a fresh buffer without emitting CRDT operations.
+
+### Why the cursor draws
+`input_data_for_participant` (`presence_manager.rs:726`) sets `should_draw_cursors: true` when the participant has `Selection::None` in its presence data. The cloud agent worker — running a CLI agent in the alt screen with no block or text selected — satisfies this.
+
+## Proposed changes
+Gate the **emission** of sharer input CRDT operations for ambient agent sessions. The sharer is a headless worker that never types in the rich input; sending its CRDT selection ops would cause a phantom cursor on the viewer side. Gating at the source (rather than filtering on the receiver) avoids needing to guard every downstream call site that touches registered peers.
+
+### `local_tty/terminal_manager.rs` — `InputEditorUpdated` handler
+Early-return when `model.lock().is_shared_ambient_agent_session()` so the sharer's real-time input CRDT ops are never sent to the server.
+
+### `local_tty/terminal_manager.rs` — initial input flush
+Wrap the initial `send_input_update` call (inside `SharedSessionCreatedSuccessfully`) in the same `is_shared_ambient_agent_session()` check so pre-share buffer ops are not flushed either.
+
+### Why this gate is safe
+The only code path that emits `InputEditorUpdated` on the sharer side in ambient agent sessions is the CLI agent input lifecycle (`clear_buffer_and_reset_undo_stack` on open/close). All other input-adjacent flows bypass the rich input editor entirely:
+- **Long-running command write-to-PTY** (`WriteToPtyRequested` / `WriteAgentInputToPty`): writes directly to the PTY event loop, never touches the editor.
+- **Viewer submits a terminal command** (`CommandExecutionRequested`): the sharer executes via `try_execute_command_on_behalf_of_shared_session_participant` → PTY. Buffer is cleared by `handle_block_completed_event` → `reinitialize_buffer` (no CRDT ops).
+- **Sharer executes its own commands**: same path — PTY + `reinitialize_buffer`.
+- **Viewer submits a CLI agent prompt** (`AgentPromptRequested`): for CLI agents, `submit_text_to_cli_agent_pty` writes to the PTY. The viewer's own buffer ops go through the viewer's `InputEditorUpdated` handler (`viewer/terminal_manager.rs:1374`), a completely separate code path.
+
+### What stays the same
+- The sharer is still registered as a remote peer on the viewer side — presence avatars, `set_remote_peer_selection_data`, and `refresh_input_data_for_participants` all continue to work without warnings.
+- The viewer's input CRDT operations still flow to the sharer (gated by executor role on the viewer side, unchanged).
+- Normal (human-to-human) shared sessions are unaffected: the check is specific to ambient agent sessions.
+
+## Testing and validation
+- Manual: start a cloud agent run with a third-party harness (e.g. Claude Code), open the session as a viewer, and confirm no phantom cursor appears in the rich input.
+- Manual: start a normal (non-cloud) shared session between two users and confirm remote cursors still appear in the input.
+- Existing `presence_manager_tests` continue to pass unchanged.
+
+## Parallelization
+Not beneficial — this is a single-file, two-line change.

--- a/specs/REMOTE-1590/TECH.md
+++ b/specs/REMOTE-1590/TECH.md
@@ -21,20 +21,15 @@ This does not affect the Oz harness because it does not use the CLI agent rich i
 `input_data_for_participant` (`presence_manager.rs:726`) sets `should_draw_cursors: true` when the participant has `Selection::None` in its presence data. The cloud agent worker — running a CLI agent in the alt screen with no block or text selected — satisfies this.
 
 ## Proposed changes
-Gate the **emission** of sharer input CRDT operations for ambient agent sessions. The sharer is a headless worker that never types in the rich input; sending its CRDT selection ops would cause a phantom cursor on the viewer side. Gating at the source (rather than filtering on the receiver) avoids needing to guard every downstream call site that touches registered peers.
+Filter **selection-only** CRDT operations (`UpdateSelections`) from the sharer's input broadcasts in ambient agent sessions. The sharer is a headless worker that never types in the rich input; its selection ops would render a phantom cursor on the viewer side. Content operations (`Edit` / `Undo`) are still forwarded so the viewer's buffer stays in sync if the sharer ever writes to the input. Filtering at the source (rather than on the receiver) avoids needing to guard every downstream call site that touches registered peers.
+
+A predicate helper `is_sharer_selection_op` (`local_tty/terminal_manager.rs`) encapsulates the check for `CrdtOperation::UpdateSelections`.
 
 ### `local_tty/terminal_manager.rs` — `InputEditorUpdated` handler
-Early-return when `model.lock().is_shared_ambient_agent_session()` so the sharer's real-time input CRDT ops are never sent to the server.
+For ambient agent sessions, filter the operations through `is_sharer_selection_op` so only content ops are sent. Non-ambient sessions pass operations through unchanged with no allocation.
 
 ### `local_tty/terminal_manager.rs` — initial input flush
-Wrap the initial `send_input_update` call (inside `SharedSessionCreatedSuccessfully`) in the same `is_shared_ambient_agent_session()` check so pre-share buffer ops are not flushed either.
-
-### Why this gate is safe
-The only code path that emits `InputEditorUpdated` on the sharer side in ambient agent sessions is the CLI agent input lifecycle (`clear_buffer_and_reset_undo_stack` on open/close). All other input-adjacent flows bypass the rich input editor entirely:
-- **Long-running command write-to-PTY** (`WriteToPtyRequested` / `WriteAgentInputToPty`): writes directly to the PTY event loop, never touches the editor.
-- **Viewer submits a terminal command** (`CommandExecutionRequested`): the sharer executes via `try_execute_command_on_behalf_of_shared_session_participant` → PTY. Buffer is cleared by `handle_block_completed_event` → `reinitialize_buffer` (no CRDT ops).
-- **Sharer executes its own commands**: same path — PTY + `reinitialize_buffer`.
-- **Viewer submits a CLI agent prompt** (`AgentPromptRequested`): for CLI agents, `submit_text_to_cli_agent_pty` writes to the PTY. The viewer's own buffer ops go through the viewer's `InputEditorUpdated` handler (`viewer/terminal_manager.rs:1374`), a completely separate code path.
+Filter the initial `latest_buffer_operations()` iterator through the same predicate before cloning, so selection ops from the pre-share buffer are excluded while content ops are still flushed.
 
 ### What stays the same
 - The sharer is still registered as a remote peer on the viewer side — presence avatars, `set_remote_peer_selection_data`, and `refresh_input_data_for_participants` all continue to work without warnings.


### PR DESCRIPTION
## Summary

There was a bug in cloud mode for 3rd party agents where the viewer's cursor was being rendered at the beginning of the input. See the tech spec below for why this never surfaced before (the agent did some gnarly debugging to figure this out), but regardless, the headless cloud-agent runner should not be sending these kinds of events (the viewer doesn't/shouldn't care about where the "sharer's" cursor is for example when the sharer is a cloud agent runner).

## demo

https://www.loom.com/share/b687e1e5d661438d8f400c0130e94acc

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._
