### PR TITLE
specs(GH10207): file tree degraded-mode handling

### DIFF
--- a/specs/gh-10207/TECH.md
+++ b/specs/gh-10207/TECH.md
@@ -1,4 +1,4 @@
-# gh-10207 — File tree handling for repos exceeding `MAX_FILES_PER_REPO`
+# gh-10207 — File tree falls back to lazy loading on `ExceededMaxFileLimit`
 
 ## Context
 
@@ -14,227 +14,156 @@ Root cause:
   `MAX_TREE_DEPTH=200` and a 100k-file global quota
   (`crates/repo_metadata/src/local_model.rs:60`).
 - On `ExceededMaxFileLimit` (`crates/repo_metadata/src/entry.rs:14-28`,
-  raised in `entry.rs:157-220`), the spawn callback marked the repo
+  raised in `entry.rs:157-220`), the spawn callback marks the repo
   `IndexedRepoState::Failed`. The view (`app/src/code/file_tree/view.rs:1584-1586`)
   swaps a `Failed` state for an empty `FileTreeEntry`.
 - Lazy per-directory expansion already exists (`Entry::load`,
   `entry.rs:257-284`, with `LAZY_LOAD_FILE_LIMIT=5000`) but is unreachable
   when the root is `Failed`.
 
-Current PR ([#10234](https://github.com/warpdotdev/warp/pull/10234)) — reactive
-fallback:
-
-- On `ExceededMaxFileLimit`, retry `build_tree` with `max_depth=1` and the
-  same 100k file quota so the root is `Indexed` with unloaded subdirectories.
-  Lazy-load handles expansion.
-- **Edge case the current PR doesn't cover:** if the repo has >100k files
-  *directly* at the root (not in subdirectories), the depth-1 retry hits
-  `ExceededMaxFileLimit` again because the file quota is consumed at depth=1
-  for direct-child files (`entry.rs:214-220`). The repo lands back in
-  `IndexedRepoState::Failed` and the tree is empty — the original bug. This
-  is rare in practice (most repos spread files across subdirectories) but
-  the fix should remove it.
-- New `RepositoryIndexedWithLimit` event surfaces a transient toast in the
-  file tree.
-- Skill watcher gains a `find_top_level_skill_directories_in_filesystem`
-  fallback (gitignore-aware) so repo-local skills aren't lost; same probe is
-  reused by the synchronous cloud-environment path
-  (`SkillWatcher::read_skills_for_repos`).
-
-@moirahuang's review asked three open questions before merging. This spec
-evaluates the alternatives and recommends a path.
+Scope agreed with @moirahuang and @alokedesai
+([comment](https://github.com/warpdotdev/warp/pull/10490#issuecomment-4423492563)):
+**make the file tree use lazy loading when indexing hits the maximum, and
+otherwise leave the user experience unchanged.** No toast, no indicator —
+the visible result should be "the folder expands" rather than "the folder
+expands plus a banner." A broader "always-lazy file tree" exploration is
+tracked internally as a follow-up.
 
 Out of scope but worth flagging: `ai::project_context::model`
-(`crates/ai/src/project_context/model.rs:298`),
-`warp::ai::outline::native`, and
-`ai::index::full_source_code_embedding` each call `Entry::build_tree`
+(`crates/ai/src/project_context/model.rs:298`), `warp::ai::outline::native`,
+and `ai::index::full_source_code_embedding` each call `Entry::build_tree`
 independently and hit the same hard limit. They are tracked separately and
 this spec does not change their behavior.
 
 ## Proposed changes
 
-### Q1 — Pre-detect "too many files" or always lazy-load?
+### File tree fallback (load-bearing)
 
-**Three options considered:**
+In the `index_repository` spawn callback (`local_model.rs:892-1030`), on
+`Err(BuildTreeError::ExceededMaxFileLimit)`, retry `Entry::build_tree` once
+with:
 
-1. **Pre-detect, then choose mode.** Cheaply count files first (e.g.
-   `git ls-files --cached | wc -l` for git repos) and skip the full walk
-   when over budget.
-2. **Always lazy-load.** Drop full-depth indexing; treat every repo as
-   degraded.
-3. **Reactive fallback (current PR).** Try full, fall back on the limit error.
+- `max_depth = 1` so the root is loaded with unloaded subdirectory entries
+  (`entry.rs:142-150`).
+- `remaining_file_quota = None`. Direct-child files at depth=1 consume the
+  quota (`entry.rs:214-220`), so reusing `MAX_FILES_PER_REPO` would
+  re-trigger `ExceededMaxFileLimit` on the rare repo with >100k files
+  *directly* under the root and reproduce the empty-tree bug. Cost is
+  bounded by root-entry count since subdirectories return as unloaded
+  immediately at depth=1; only top-level files allocate `FileMetadata`.
 
-**Recommendation: keep reactive fallback (option 3), do not add pre-detection
-in this spec.**
+On retry success, install the repo as `IndexedRepoState::Indexed` via the
+existing `add_repository_internal`, which emits the usual
+`RepositoryUpdated` event. The view's existing handlers refresh the tree;
+the existing per-directory lazy-load path (`view.rs:1410-1431`,
+`LAZY_LOAD_FILE_LIMIT=5000`) handles expansion from there.
 
-- **Option 1** only helps git repos (the user's repro is git-tracked, but
-  `IgnoredPathStrategy::IncludeLazy` in `local_model.rs:899` means we walk
-  more than just tracked files anyway). It adds a separate code path, an
-  external `git` invocation, and a latency floor to every open. The savings
-  are bounded to the wasted partial walk before the quota trips, which on
-  the reporter's 153k repo is ~15s of background work — perceptible in
-  logs, not perceptible in the UI thanks to `ctx.spawn` (`local_model.rs:892`).
-- **Option 2** regresses small/medium repos. Full-depth indexing is what
-  feeds AI context, file search, and project rules; making everything lazy
-  would either silently break those features for normal-size repos or push
-  the same problem into other consumers. Not worth it.
-- **Option 3** already handles git, non-git, partial-clone, submodule, and
-  deeply-nested cases uniformly. The only cost is the partial walk on huge
-  repos, paid once per session.
+On retry failure (e.g. `IOError` reading the root directory), keep the
+existing `mark_repository_failed` path. This is the same outcome users
+already get for unreadable repo roots and is outside the scope of #10207.
 
-**One refinement to land with this spec:** the depth-1 retry should pass
-`None` for `remaining_file_quota` (`entry.rs:94`) instead of reusing
-`MAX_FILES_PER_REPO`. Cost is bounded by the count of root-level entries
-(directories return as unloaded immediately at depth=1; only direct-child
-files consume memory). For a hypothetical 1M-file root that's ~1M
-`FileMetadata` allocations (~100 bytes each → ~100 MB) — order of magnitude
-more than the typical case but still cheaper than the `Failed → empty tree`
-status quo, and it ensures every repo can at least show its top level.
-With this change, the only path that still fails is `read_dir` itself
-returning an error, which already maps to `BuildTreeError::IOError`.
+No new event, no new state on `FileTreeState`, no UI plumbing in the view.
 
-**Followup (not this PR):** add a telemetry counter on the persistent
-`indexed_with_limit` transition (and reuse the existing
-`RepoMetadataTelemetryEvent::BuildTreeFailed { error: "ExceededMaxFileLimit" }`
-already emitted at `local_model.rs:1001`) plus the time spent in the failed
-full-depth `build_tree`. If the partial-walk latency turns out to matter,
-revisit option 1 (pre-detection) as an optimization layered on top.
+### Skill discovery in degraded mode
 
-### Q2 — Is the toast necessary?
+The skill watcher (`app/src/ai/skills/file_watchers/skill_watcher.rs`)
+discovers repo-local skills (`<repo>/.agents/skills/...`,
+`<repo>/.claude/skills/...`, etc.) by querying the metadata tree for
+directories ending in known skill provider paths
+(`find_skill_directories_in_tree`, `app/src/ai/skills/file_watchers/utils.rs:20-56`).
+In degraded mode the tree only knows about depth-1 entries, so
+`<provider>/skills` (two levels under the repo root) is invisible and the
+skills are silently dropped — visible in the AI panel, not the file tree,
+but still a user-facing regression in our repro.
 
-The toast was added to satisfy the issue's expected behavior (b) — "show a
-clear, user-visible message that indexing was limited." But:
+Fix: add a sibling probe `find_top_level_skill_directories_in_filesystem`
+(`utils.rs`) that walks `SKILL_PROVIDER_DEFINITIONS` and returns
+`<repo>/<provider.skills_path>` for the entries that exist on disk,
+honoring `gitignores_for_directory(repo_path)` + `matches_gitignores` so it
+matches the tree-based path's gitignore semantics (the tree uses
+`get_repo_contents` with `include_ignored = false`).
 
-- Degraded mode is persistent for the session, while the toast is transient
-  (`add_ephemeral_toast`, `view.rs:1614-1623`). During testing the reporter
-  missed it and we needed to relaunch.
-- The same user opens the same repo every day; a daily toast becomes noise.
-- Other features (AI codebase indexing) already render a persistent
-  "Codebase too large" status (`settings_view/code_page.rs:1520-1539`), so a
-  parallel persistent indicator in the file tree fits an existing pattern.
+Wire it via the existing two skill-discovery entry points:
 
-**Recommendation: replace the transient toast with a persistent, dismissible
-inline indicator in the file tree header for the affected root.**
+- Async: `SkillWatcher::new_internal`'s `RepositoryUpdated` handler. Change
+  `scan_repository_for_skills` (`skill_watcher.rs:259-268`) to combine the
+  tree-based result with the filesystem probe and dedupe via a
+  `HashSet<PathBuf>` before passing to `spawn_read_skills_from_directories`.
+  Works for both normal and degraded repos.
+- Sync: `SkillWatcher::read_skills_for_repos` (`skill_watcher.rs:77-94`,
+  cloud-environment entry point) does the same combine-and-dedupe.
 
-- New per-root state on `RootDirectory` (`view.rs:251`): `indexed_with_limit:
-  bool` plus a per-view `dismissed_indexed_with_limit: HashSet<StandardizedPath>`.
-- The indicator renders inline next to the root header (small warning glyph
-  with hover tooltip "Repository is too large to fully index. Subfolders
-  load when expanded."). Clicking dismisses it for the session.
-- Drop `RepositoryMetadataEvent::RepositoryIndexedWithLimit` and the
-  forwarding plumbing; carry the flag on `FileTreeState` instead
-  (`crates/repo_metadata/src/file_tree_store.rs:353`). State-on-the-model
-  beats one-shot event because it survives view-mount-after-indexing
-  (the cause of the toast-missed bug we hit during manual testing) and
-  workspace reopens within the same session.
-- View checks the flag in two places: when handling `RepositoryUpdated` and
-  when registering a root via `register_and_refresh_lazy_loaded_directory`
-  (`view.rs:1532-1589`).
-
-If the team prefers no UI signal at all, drop the indicator entirely and
-just keep the existing `safe_warn!` log line. The folder visibly expanding
-arguably is the signal — in degraded mode the user mostly cannot tell
-unless they look for AI rules / search results that are missing.
-
-### Q3 — Performance implications of lazy load
-
-`Entry::load` (`entry.rs:257-284`) runs synchronously on the main thread via
-`load_directory_from_model` (`view.rs:1410-1431`). Each expand:
-
-- Reads one directory (one `read_dir` syscall + one `is_symlink/is_dir` per
-  child).
-- Up to `LAZY_LOAD_FILE_LIMIT=5000` entries are loaded; over that, the
-  existing per-folder error toast fires (`view.rs:1421`).
-- Walks gitignore matchers (`matches_gitignores` per child).
-
-For the reporter's repo (153k files, 1500+ top-level subdirs of 100 files
-each), each expand is bounded and fast. For real monorepos a single
-subdirectory may exceed 5,000 (`node_modules`, `vendor`, generated
-`.pb.go`s) and the user gets a toast with no contents — the existing
-behavior. Subjectively still better than the silent-empty-tree this PR
-fixes.
-
-**Recommendations:**
-
-- **Instrument**, don't tune. Add a one-time telemetry event on lazy-load
-  with `entry_count` and `duration_ms`. Decide later whether to raise
-  `LAZY_LOAD_FILE_LIMIT` based on real distributions; raising it without
-  data risks main-thread stalls on giant subdirectories.
-- **Consider moving lazy-load off the main thread** as a follow-up
-  (`ctx.spawn` mirroring the initial-build pattern). Out of scope for this
-  PR — the existing 5k cap keeps each call short enough that the UI doesn't
-  visibly stall in our manual testing.
-- The recursive watcher registered by `add_repository_internal`
-  (`local_model.rs:382`) already covers the whole repo regardless of which
-  subtrees are loaded, so file-change notifications are not affected by
-  lazy mode.
+Nested provider paths (`<repo>/sub/.agents/skills`) under unloaded
+subtrees are still picked up later by the repository file watcher when the
+user expands `sub`, so the probe intentionally only covers top-level
+provider paths.
 
 ## Testing and validation
 
-- Unit: extend `crates/repo_metadata/src/local_model_test.rs` with a test
-  that drives `Entry::build_tree` past the quota (parameterize
-  `MAX_FILES_PER_REPO` via a test-only override or a constructor argument
-  on the model) and asserts the resulting `FileTreeState.indexed_with_limit
-  == true` with depth-1 children only. Also assert
-  `RepositoryUpdated` fires (and `UpdatingRepositoryFailed` does not).
-- Unit (regression for the depth-1 quota gap noted in Context): a fixture
-  with `MAX_FILES_PER_REPO + 1` files placed *directly under the repo
-  root* (i.e. no intermediate directories). Without the unquoted retry the
-  fallback reproduces the original bug; with `remaining_file_quota = None`
-  on the depth-1 retry the test asserts `IndexedRepoState::Indexed` with
-  `indexed_with_limit == true` and the root entry containing all top-level
-  files.
-- Unit: `find_top_level_skill_directories_in_filesystem` honors gitignore.
-  Add a fixture with a `.gitignore` excluding `.claude/skills` and a
-  populated `.claude/skills/foo/SKILL.md`; assert the probe returns empty.
-- Unit: `read_skills_for_repos` deduplicates between the tree-based and
-  filesystem-probed paths.
-- View: a layout test for the inline degraded indicator (one for visible,
-  one for dismissed).
-- Manual: use the fixture at `~/code-fixtures/warp-10207-large-repo`
-  (150,001 files + `.agents/skills/example-skill/SKILL.md`). Build with
+- Unit (regression for the original empty-tree bug): drive
+  `Entry::build_tree` past `MAX_FILES_PER_REPO` (parameterized via a
+  test-only constructor on the model or by lowering the constant under
+  `#[cfg(test)]`) and assert the resulting `IndexedRepoState::Indexed`
+  with the root containing depth-1 unloaded subdirectory entries. Assert
+  `RepositoryUpdated` fires and `UpdatingRepositoryFailed` does not.
+- Unit (regression for the depth-1 quota gap, requires the `None` quota
+  fix): fixture with `MAX_FILES_PER_REPO + 1` files placed *directly under
+  the repo root*. Without the unquoted retry the fallback reproduces the
+  original bug. With `remaining_file_quota = None` the test asserts
+  `Indexed` with all top-level files present.
+- Unit (skill probe gitignore): `.gitignore` excluding `.claude/skills`
+  plus a populated `.claude/skills/foo/SKILL.md`; assert the probe
+  returns empty.
+- Unit (skill probe dedupe): `read_skills_for_repos` and
+  `scan_repository_for_skills` produce the same skills regardless of
+  whether the tree already contained the provider path.
+- Manual: use the existing fixture at
+  `~/code-fixtures/warp-10207-large-repo` (150,001 files +
+  `.agents/skills/example-skill/SKILL.md`). Build with
   `./script/run --dont-open` and `open -a target/debug/bundle/osx/WarpOss.app
   ~/code-fixtures/warp-10207-large-repo`. Verify:
-  1. `~/Library/Logs/warp-oss.log` contains `Repository exceeded max file
-     limit; indexed in degraded mode`.
+  1. `~/Library/Logs/warp-oss.log` contains the "indexed in degraded
+     mode" warn line (or whatever the implementation logs — non-empty,
+     non-error).
   2. `.agents`, `src`, etc. expand and show their contents.
-  3. The persistent inline indicator is visible on the root header.
-  4. The agent panel lists `example-skill` (proves the filesystem probe
-     ran).
-  5. Subfolders within `LAZY_LOAD_FILE_LIMIT` expand without the per-folder
-     toast.
+  3. **No toast, no banner.** UI should look like any other repo.
+  4. The agent panel lists `example-skill`.
 
 ## Risks and mitigations
 
-- **Carrying `indexed_with_limit` on `FileTreeState`** is observable from
-  many crates that pattern-match the struct. We avoid breakage by adding a
-  `bool` field with a `Default` value of `false` and updating the two
-  constructors (`new`, `new_lazy_loaded`); existing call sites compile
-  unchanged.
 - **Watcher pressure on 153k-file repos.** The recursive `register_path`
-  call already happens today for any indexed repo; this PR doesn't change
-  the watcher footprint. If users report watcher CPU/memory issues, a
-  follow-up could prune the watch to actually-loaded subtrees, but that's
-  a larger change.
+  call already happens today for any indexed repo; this PR does not
+  change the watcher footprint. If users report watcher CPU/memory
+  issues, a follow-up could prune the watch to actually-loaded subtrees.
 - **Discovery for nested provider paths in degraded repos.** The
-  filesystem probe only checks `<repo>/<provider>/skills`; a nested
-  `<repo>/sub/.agents/skills` is missed until the watcher reports an
-  add or until the user expands `sub`. Acceptable: the watcher catches
-  later additions, and root-level provider paths are the predominant
-  layout.
+  filesystem probe only checks `<repo>/<provider>/skills`. Nested
+  occurrences (`<repo>/sub/.agents/skills`) are picked up later by the
+  repository file watcher when their subtrees are loaded. Acceptable: the
+  watcher catches later additions, and root-level provider paths are the
+  predominant layout.
+- **Silent degradation.** The team's explicit position is that the file
+  tree experience should not change, so there is no UI signal that the
+  repo is in degraded mode. This means AI features that depend on the
+  tree (project rules, outline, codebase index) may behave as if the
+  repo is smaller than it is. Those consumers each handle the limit on
+  their own and are out of scope here; their own status surfaces (e.g.
+  the "Codebase too large" status in AI settings,
+  `settings_view/code_page.rs:1520-1539`) remain the place where users
+  see the codebase-level signal.
 
 ## Follow-ups
 
+- Always-lazy file tree (tracked internally by @moirahuang /
+  @alokedesai): if the file tree is moved to lazy loading by default,
+  the special-case fallback in this spec collapses into the default
+  path and `MAX_FILES_PER_REPO` can be dropped from the file-tree
+  pipeline.
+- Telemetry: a counter on the depth-1 fallback so we can see how often
+  it fires in the wild. The existing
+  `RepoMetadataTelemetryEvent::BuildTreeFailed { error: "ExceededMaxFileLimit" }`
+  at `local_model.rs:1001` already covers the trigger side; pair it with
+  a success counter on the fallback retry.
 - Apply the same fallback / probe pattern to `ai::project_context::model`,
   `ai::outline::native`, and `ai::index::full_source_code_embedding`, or
-  surface the "codebase too large" status alongside the file-tree
-  indicator so users see one consistent message.
-- Telemetry: counter on the `FileTreeState.indexed_with_limit` transition
-  (the existing `BuildTreeFailed { error: "ExceededMaxFileLimit" }`
-  telemetry at `local_model.rs:1001` already covers the trigger; add a
-  paired success counter for the depth-1 retry); histogram for lazy-load
-  entry-count and duration. Inform whether to raise `LAZY_LOAD_FILE_LIMIT`
-  or move lazy-load off the main thread.
-- Make `MAX_FILES_PER_REPO` configurable per-user (settings) so power
-  users on large monorepos can opt into a higher limit at the cost of
-  memory.
+  let the existing "Codebase too large" status remain the one place users
+  see degraded-mode messaging.

--- a/specs/gh-10207/TECH.md
+++ b/specs/gh-10207/TECH.md
@@ -1,0 +1,209 @@
+# gh-10207 — File tree handling for repos exceeding `MAX_FILES_PER_REPO`
+
+## Context
+
+[Issue #10207](https://github.com/warpdotdev/warp/issues/10207): Project Explorer
+silently shows populated folders (e.g. `.agents`) as empty when a repo exceeds
+`MAX_FILES_PER_REPO` (100,000) during initial indexing. The reporter has
+~153k tracked files in `~/code` and sees `Failed to build file tree for
+repository: ExceededMaxFileLimit` in the log.
+
+Root cause:
+
+- `crates/repo_metadata/src/local_model.rs:892` runs `Entry::build_tree` with
+  `MAX_TREE_DEPTH=200` and a 100k-file global quota
+  (`crates/repo_metadata/src/local_model.rs:60`).
+- On `ExceededMaxFileLimit` (`crates/repo_metadata/src/entry.rs:14-28`,
+  raised in `entry.rs:157-220`), the spawn callback marked the repo
+  `IndexedRepoState::Failed`. The view (`app/src/code/file_tree/view.rs:1584-1586`)
+  swaps a `Failed` state for an empty `FileTreeEntry`.
+- Lazy per-directory expansion already exists (`Entry::load`,
+  `entry.rs:257-284`, with `LAZY_LOAD_FILE_LIMIT=5000`) but is unreachable
+  when the root is `Failed`.
+
+Current PR ([#10234](https://github.com/warpdotdev/warp/pull/10234)) — reactive
+fallback:
+
+- On `ExceededMaxFileLimit`, retry `build_tree` with `max_depth=1` so the root
+  is `Indexed` with unloaded subdirectories. Lazy-load handles expansion.
+- New `RepositoryIndexedWithLimit` event surfaces a transient toast in the
+  file tree.
+- Skill watcher gains a `find_top_level_skill_directories_in_filesystem`
+  fallback (gitignore-aware) so repo-local skills aren't lost; same probe is
+  reused by the synchronous cloud-environment path
+  (`SkillWatcher::read_skills_for_repos`).
+
+@moirahuang's review asked three open questions before merging. This spec
+evaluates the alternatives and recommends a path.
+
+Out of scope but worth flagging: `ai::project_context::model`
+(`crates/ai/src/project_context/model.rs:298`),
+`warp::ai::outline::native`, and
+`ai::index::full_source_code_embedding` each call `Entry::build_tree`
+independently and hit the same hard limit. They are tracked separately and
+this spec does not change their behavior.
+
+## Proposed changes
+
+### Q1 — Pre-detect "too many files" or always lazy-load?
+
+**Three options considered:**
+
+1. **Pre-detect, then choose mode.** Cheaply count files first (e.g.
+   `git ls-files --cached | wc -l` for git repos) and skip the full walk
+   when over budget.
+2. **Always lazy-load.** Drop full-depth indexing; treat every repo as
+   degraded.
+3. **Reactive fallback (current PR).** Try full, fall back on the limit error.
+
+**Recommendation: keep reactive fallback (option 3), do not add pre-detection
+in this spec.**
+
+- **Option 1** only helps git repos (the user's repro is git-tracked, but
+  `IgnoredPathStrategy::IncludeLazy` in `local_model.rs:899` means we walk
+  more than just tracked files anyway). It adds a separate code path, an
+  external `git` invocation, and a latency floor to every open. The savings
+  are bounded to the wasted partial walk before the quota trips, which on
+  the reporter's 153k repo is ~15s of background work — perceptible in
+  logs, not perceptible in the UI thanks to `ctx.spawn` (`local_model.rs:892`).
+- **Option 2** regresses small/medium repos. Full-depth indexing is what
+  feeds AI context, file search, and project rules; making everything lazy
+  would either silently break those features for normal-size repos or push
+  the same problem into other consumers. Not worth it.
+- **Option 3** already handles git, non-git, partial-clone, submodule, and
+  deeply-nested cases uniformly. The only cost is the partial walk on huge
+  repos, paid once per session.
+
+**Followup (not this PR):** add a telemetry counter for
+`RepositoryIndexedWithLimit` events plus the time spent in the failed
+`build_tree`. If the partial-walk latency turns out to matter, revisit
+option 1 as an optimization layered on top.
+
+### Q2 — Is the toast necessary?
+
+The toast was added to satisfy the issue's expected behavior (b) — "show a
+clear, user-visible message that indexing was limited." But:
+
+- Degraded mode is persistent for the session, while the toast is transient
+  (`add_ephemeral_toast`, `view.rs:1614-1623`). During testing the reporter
+  missed it and we needed to relaunch.
+- The same user opens the same repo every day; a daily toast becomes noise.
+- Other features (AI codebase indexing) already render a persistent
+  "Codebase too large" status (`settings_view/code_page.rs:1520-1539`), so a
+  parallel persistent indicator in the file tree fits an existing pattern.
+
+**Recommendation: replace the transient toast with a persistent, dismissible
+inline indicator in the file tree header for the affected root.**
+
+- New per-root state on `RootDirectory` (`view.rs:251`): `indexed_with_limit:
+  bool` plus a per-view `dismissed_indexed_with_limit: HashSet<StandardizedPath>`.
+- The indicator renders inline next to the root header (small warning glyph
+  with hover tooltip "Repository is too large to fully index. Subfolders
+  load when expanded."). Clicking dismisses it for the session.
+- Drop `RepositoryMetadataEvent::RepositoryIndexedWithLimit` and the
+  forwarding plumbing; carry the flag on `FileTreeState` instead
+  (`crates/repo_metadata/src/file_tree_store.rs:353`). State-on-the-model
+  beats one-shot event because it survives view-mount-after-indexing
+  (the cause of the toast-missed bug we hit during manual testing) and
+  workspace reopens within the same session.
+- View checks the flag in two places: when handling `RepositoryUpdated` and
+  when registering a root via `register_and_refresh_lazy_loaded_directory`
+  (`view.rs:1532-1589`).
+
+If the team prefers no UI signal at all, drop the indicator entirely and
+just keep the existing `safe_warn!` log line. The folder visibly expanding
+arguably is the signal — in degraded mode the user mostly cannot tell
+unless they look for AI rules / search results that are missing.
+
+### Q3 — Performance implications of lazy load
+
+`Entry::load` (`entry.rs:257-284`) runs synchronously on the main thread via
+`load_directory_from_model` (`view.rs:1410-1431`). Each expand:
+
+- Reads one directory (one `read_dir` syscall + one `is_symlink/is_dir` per
+  child).
+- Up to `LAZY_LOAD_FILE_LIMIT=5000` entries are loaded; over that, the
+  existing per-folder error toast fires (`view.rs:1421`).
+- Walks gitignore matchers (`matches_gitignores` per child).
+
+For the reporter's repo (153k files, 1500+ top-level subdirs of 100 files
+each), each expand is bounded and fast. For real monorepos a single
+subdirectory may exceed 5,000 (`node_modules`, `vendor`, generated
+`.pb.go`s) and the user gets a toast with no contents — the existing
+behavior. Subjectively still better than the silent-empty-tree this PR
+fixes.
+
+**Recommendations:**
+
+- **Instrument**, don't tune. Add a one-time telemetry event on lazy-load
+  with `entry_count` and `duration_ms`. Decide later whether to raise
+  `LAZY_LOAD_FILE_LIMIT` based on real distributions; raising it without
+  data risks main-thread stalls on giant subdirectories.
+- **Consider moving lazy-load off the main thread** as a follow-up
+  (`ctx.spawn` mirroring the initial-build pattern). Out of scope for this
+  PR — the existing 5k cap keeps each call short enough that the UI doesn't
+  visibly stall in our manual testing.
+- The recursive watcher registered by `add_repository_internal`
+  (`local_model.rs:382`) already covers the whole repo regardless of which
+  subtrees are loaded, so file-change notifications are not affected by
+  lazy mode.
+
+## Testing and validation
+
+- Unit: extend `crates/repo_metadata/src/local_model_test.rs` with a test
+  that drives `Entry::build_tree` past the quota (parameterize
+  `MAX_FILES_PER_REPO` via a test-only override or a constructor argument
+  on the model) and asserts the resulting `FileTreeState.indexed_with_limit
+  == true` with depth-1 children only. Also assert
+  `RepositoryUpdated` fires (and `UpdatingRepositoryFailed` does not).
+- Unit: `find_top_level_skill_directories_in_filesystem` honors gitignore.
+  Add a fixture with a `.gitignore` excluding `.claude/skills` and a
+  populated `.claude/skills/foo/SKILL.md`; assert the probe returns empty.
+- Unit: `read_skills_for_repos` deduplicates between the tree-based and
+  filesystem-probed paths.
+- View: a layout test for the inline degraded indicator (one for visible,
+  one for dismissed).
+- Manual: use the fixture at `~/code-fixtures/warp-10207-large-repo`
+  (150,001 files + `.agents/skills/example-skill/SKILL.md`). Build with
+  `./script/run --dont-open` and `open -a target/debug/bundle/osx/WarpOss.app
+  ~/code-fixtures/warp-10207-large-repo`. Verify:
+  1. `~/Library/Logs/warp-oss.log` contains `Repository exceeded max file
+     limit; indexed in degraded mode`.
+  2. `.agents`, `src`, etc. expand and show their contents.
+  3. The persistent inline indicator is visible on the root header.
+  4. The agent panel lists `example-skill` (proves the filesystem probe
+     ran).
+  5. Subfolders within `LAZY_LOAD_FILE_LIMIT` expand without the per-folder
+     toast.
+
+## Risks and mitigations
+
+- **Carrying `indexed_with_limit` on `FileTreeState`** is observable from
+  many crates that pattern-match the struct. We avoid breakage by adding a
+  `bool` field with a `Default` value of `false` and updating the two
+  constructors (`new`, `new_lazy_loaded`); existing call sites compile
+  unchanged.
+- **Watcher pressure on 153k-file repos.** The recursive `register_path`
+  call already happens today for any indexed repo; this PR doesn't change
+  the watcher footprint. If users report watcher CPU/memory issues, a
+  follow-up could prune the watch to actually-loaded subtrees, but that's
+  a larger change.
+- **Discovery for nested provider paths in degraded repos.** The
+  filesystem probe only checks `<repo>/<provider>/skills`; a nested
+  `<repo>/sub/.agents/skills` is missed until the watcher reports an
+  add or until the user expands `sub`. Acceptable: the watcher catches
+  later additions, and root-level provider paths are the predominant
+  layout.
+
+## Follow-ups
+
+- Apply the same fallback / probe pattern to `ai::project_context::model`,
+  `ai::outline::native`, and `ai::index::full_source_code_embedding`, or
+  surface the "codebase too large" status alongside the file-tree
+  indicator so users see one consistent message.
+- Telemetry: counter for `RepositoryIndexedWithLimit`; histogram for
+  lazy-load entry-count and duration. Inform whether to raise
+  `LAZY_LOAD_FILE_LIMIT` or move lazy-load off the main thread.
+- Make `MAX_FILES_PER_REPO` configurable per-user (settings) so power
+  users on large monorepos can opt into a higher limit at the cost of
+  memory.

--- a/specs/gh-10207/TECH.md
+++ b/specs/gh-10207/TECH.md
@@ -24,8 +24,16 @@ Root cause:
 Current PR ([#10234](https://github.com/warpdotdev/warp/pull/10234)) — reactive
 fallback:
 
-- On `ExceededMaxFileLimit`, retry `build_tree` with `max_depth=1` so the root
-  is `Indexed` with unloaded subdirectories. Lazy-load handles expansion.
+- On `ExceededMaxFileLimit`, retry `build_tree` with `max_depth=1` and the
+  same 100k file quota so the root is `Indexed` with unloaded subdirectories.
+  Lazy-load handles expansion.
+- **Edge case the current PR doesn't cover:** if the repo has >100k files
+  *directly* at the root (not in subdirectories), the depth-1 retry hits
+  `ExceededMaxFileLimit` again because the file quota is consumed at depth=1
+  for direct-child files (`entry.rs:214-220`). The repo lands back in
+  `IndexedRepoState::Failed` and the tree is empty — the original bug. This
+  is rare in practice (most repos spread files across subdirectories) but
+  the fix should remove it.
 - New `RepositoryIndexedWithLimit` event surfaces a transient toast in the
   file tree.
 - Skill watcher gains a `find_top_level_skill_directories_in_filesystem`
@@ -74,10 +82,23 @@ in this spec.**
   deeply-nested cases uniformly. The only cost is the partial walk on huge
   repos, paid once per session.
 
-**Followup (not this PR):** add a telemetry counter for
-`RepositoryIndexedWithLimit` events plus the time spent in the failed
-`build_tree`. If the partial-walk latency turns out to matter, revisit
-option 1 as an optimization layered on top.
+**One refinement to land with this spec:** the depth-1 retry should pass
+`None` for `remaining_file_quota` (`entry.rs:94`) instead of reusing
+`MAX_FILES_PER_REPO`. Cost is bounded by the count of root-level entries
+(directories return as unloaded immediately at depth=1; only direct-child
+files consume memory). For a hypothetical 1M-file root that's ~1M
+`FileMetadata` allocations (~100 bytes each → ~100 MB) — order of magnitude
+more than the typical case but still cheaper than the `Failed → empty tree`
+status quo, and it ensures every repo can at least show its top level.
+With this change, the only path that still fails is `read_dir` itself
+returning an error, which already maps to `BuildTreeError::IOError`.
+
+**Followup (not this PR):** add a telemetry counter on the persistent
+`indexed_with_limit` transition (and reuse the existing
+`RepoMetadataTelemetryEvent::BuildTreeFailed { error: "ExceededMaxFileLimit" }`
+already emitted at `local_model.rs:1001`) plus the time spent in the failed
+full-depth `build_tree`. If the partial-walk latency turns out to matter,
+revisit option 1 (pre-detection) as an optimization layered on top.
 
 ### Q2 — Is the toast necessary?
 
@@ -156,6 +177,13 @@ fixes.
   on the model) and asserts the resulting `FileTreeState.indexed_with_limit
   == true` with depth-1 children only. Also assert
   `RepositoryUpdated` fires (and `UpdatingRepositoryFailed` does not).
+- Unit (regression for the depth-1 quota gap noted in Context): a fixture
+  with `MAX_FILES_PER_REPO + 1` files placed *directly under the repo
+  root* (i.e. no intermediate directories). Without the unquoted retry the
+  fallback reproduces the original bug; with `remaining_file_quota = None`
+  on the depth-1 retry the test asserts `IndexedRepoState::Indexed` with
+  `indexed_with_limit == true` and the root entry containing all top-level
+  files.
 - Unit: `find_top_level_skill_directories_in_filesystem` honors gitignore.
   Add a fixture with a `.gitignore` excluding `.claude/skills` and a
   populated `.claude/skills/foo/SKILL.md`; assert the probe returns empty.
@@ -201,9 +229,12 @@ fixes.
   `ai::outline::native`, and `ai::index::full_source_code_embedding`, or
   surface the "codebase too large" status alongside the file-tree
   indicator so users see one consistent message.
-- Telemetry: counter for `RepositoryIndexedWithLimit`; histogram for
-  lazy-load entry-count and duration. Inform whether to raise
-  `LAZY_LOAD_FILE_LIMIT` or move lazy-load off the main thread.
+- Telemetry: counter on the `FileTreeState.indexed_with_limit` transition
+  (the existing `BuildTreeFailed { error: "ExceededMaxFileLimit" }`
+  telemetry at `local_model.rs:1001` already covers the trigger; add a
+  paired success counter for the depth-1 retry); histogram for lazy-load
+  entry-count and duration. Inform whether to raise `LAZY_LOAD_FILE_LIMIT`
+  or move lazy-load off the main thread.
 - Make `MAX_FILES_PER_REPO` configurable per-user (settings) so power
   users on large monorepos can opt into a higher limit at the cost of
   memory.

--- a/specs/gh-10207/TECH.md
+++ b/specs/gh-10207/TECH.md
@@ -29,11 +29,15 @@ the visible result should be "the folder expands" rather than "the folder
 expands plus a banner." A broader "always-lazy file tree" exploration is
 tracked internally as a follow-up.
 
-Out of scope but worth flagging: `ai::project_context::model`
+Out of scope: repo-local skill discovery
+(`app/src/ai/skills/file_watchers/`) silently drops skills in degraded
+mode because it queries the metadata tree, and `ai::project_context::model`
 (`crates/ai/src/project_context/model.rs:298`), `warp::ai::outline::native`,
 and `ai::index::full_source_code_embedding` each call `Entry::build_tree`
-independently and hit the same hard limit. They are tracked separately and
-this spec does not change their behavior.
+independently and hit the same hard limit. Per @moirahuang
+([comment](https://github.com/warpdotdev/warp/pull/10490#issuecomment-4427103160)),
+those surfaces will be addressed holistically in follow-up work; this
+spec is strictly scoped to the file tree.
 
 ## Proposed changes
 
@@ -64,40 +68,6 @@ already get for unreadable repo roots and is outside the scope of #10207.
 
 No new event, no new state on `FileTreeState`, no UI plumbing in the view.
 
-### Skill discovery in degraded mode
-
-The skill watcher (`app/src/ai/skills/file_watchers/skill_watcher.rs`)
-discovers repo-local skills (`<repo>/.agents/skills/...`,
-`<repo>/.claude/skills/...`, etc.) by querying the metadata tree for
-directories ending in known skill provider paths
-(`find_skill_directories_in_tree`, `app/src/ai/skills/file_watchers/utils.rs:20-56`).
-In degraded mode the tree only knows about depth-1 entries, so
-`<provider>/skills` (two levels under the repo root) is invisible and the
-skills are silently dropped — visible in the AI panel, not the file tree,
-but still a user-facing regression in our repro.
-
-Fix: add a sibling probe `find_top_level_skill_directories_in_filesystem`
-(`utils.rs`) that walks `SKILL_PROVIDER_DEFINITIONS` and returns
-`<repo>/<provider.skills_path>` for the entries that exist on disk,
-honoring `gitignores_for_directory(repo_path)` + `matches_gitignores` so it
-matches the tree-based path's gitignore semantics (the tree uses
-`get_repo_contents` with `include_ignored = false`).
-
-Wire it via the existing two skill-discovery entry points:
-
-- Async: `SkillWatcher::new_internal`'s `RepositoryUpdated` handler. Change
-  `scan_repository_for_skills` (`skill_watcher.rs:259-268`) to combine the
-  tree-based result with the filesystem probe and dedupe via a
-  `HashSet<PathBuf>` before passing to `spawn_read_skills_from_directories`.
-  Works for both normal and degraded repos.
-- Sync: `SkillWatcher::read_skills_for_repos` (`skill_watcher.rs:77-94`,
-  cloud-environment entry point) does the same combine-and-dedupe.
-
-Nested provider paths (`<repo>/sub/.agents/skills`) under unloaded
-subtrees are still picked up later by the repository file watcher when the
-user expands `sub`, so the probe intentionally only covers top-level
-provider paths.
-
 ## Testing and validation
 
 - Unit (regression for the original empty-tree bug): drive
@@ -111,15 +81,8 @@ provider paths.
   the repo root*. Without the unquoted retry the fallback reproduces the
   original bug. With `remaining_file_quota = None` the test asserts
   `Indexed` with all top-level files present.
-- Unit (skill probe gitignore): `.gitignore` excluding `.claude/skills`
-  plus a populated `.claude/skills/foo/SKILL.md`; assert the probe
-  returns empty.
-- Unit (skill probe dedupe): `read_skills_for_repos` and
-  `scan_repository_for_skills` produce the same skills regardless of
-  whether the tree already contained the provider path.
 - Manual: use the existing fixture at
-  `~/code-fixtures/warp-10207-large-repo` (150,001 files +
-  `.agents/skills/example-skill/SKILL.md`). Build with
+  `~/code-fixtures/warp-10207-large-repo` (150,001 files). Build with
   `./script/run --dont-open` and `open -a target/debug/bundle/osx/WarpOss.app
   ~/code-fixtures/warp-10207-large-repo`. Verify:
   1. `~/Library/Logs/warp-oss.log` contains the "indexed in degraded
@@ -127,7 +90,6 @@ provider paths.
      non-error).
   2. `.agents`, `src`, etc. expand and show their contents.
   3. **No toast, no banner.** UI should look like any other repo.
-  4. The agent panel lists `example-skill`.
 
 ## Risks and mitigations
 
@@ -135,21 +97,13 @@ provider paths.
   call already happens today for any indexed repo; this PR does not
   change the watcher footprint. If users report watcher CPU/memory
   issues, a follow-up could prune the watch to actually-loaded subtrees.
-- **Discovery for nested provider paths in degraded repos.** The
-  filesystem probe only checks `<repo>/<provider>/skills`. Nested
-  occurrences (`<repo>/sub/.agents/skills`) are picked up later by the
-  repository file watcher when their subtrees are loaded. Acceptable: the
-  watcher catches later additions, and root-level provider paths are the
-  predominant layout.
-- **Silent degradation.** The team's explicit position is that the file
-  tree experience should not change, so there is no UI signal that the
-  repo is in degraded mode. This means AI features that depend on the
-  tree (project rules, outline, codebase index) may behave as if the
-  repo is smaller than it is. Those consumers each handle the limit on
-  their own and are out of scope here; their own status surfaces (e.g.
-  the "Codebase too large" status in AI settings,
-  `settings_view/code_page.rs:1520-1539`) remain the place where users
-  see the codebase-level signal.
+- **Silent degradation for non-file-tree surfaces.** The team's explicit
+  position is that the file tree experience should not change, so there
+  is no UI signal here that the repo is in degraded mode. Repo-local
+  skill discovery, project rules, outline, and codebase indexing each
+  hit the same limit on their own and will go silent or partially
+  silent in degraded mode. They are explicitly out of scope for this
+  spec and will be addressed holistically in follow-up work.
 
 ## Follow-ups
 
@@ -163,7 +117,7 @@ provider paths.
   `RepoMetadataTelemetryEvent::BuildTreeFailed { error: "ExceededMaxFileLimit" }`
   at `local_model.rs:1001` already covers the trigger side; pair it with
   a success counter on the fallback retry.
-- Apply the same fallback / probe pattern to `ai::project_context::model`,
-  `ai::outline::native`, and `ai::index::full_source_code_embedding`, or
-  let the existing "Codebase too large" status remain the one place users
-  see degraded-mode messaging.
+- Holistic handling of degraded-mode behavior for repo-local skill
+  discovery, `ai::project_context::model`, `ai::outline::native`, and
+  `ai::index::full_source_code_embedding`. Tracked separately by
+  @moirahuang.


### PR DESCRIPTION
## Description

Tech spec for [issue #10207](https://github.com/warpdotdev/warp/issues/10207) (Project Explorer fails to expand populated folders in large repos after `ExceededMaxFileLimit`).

Splitting this out from PR #10234 (which carries a conservative reactive fallback already) so the design questions @moirahuang raised can be debated independently of the existing code review.

The spec evaluates three open questions:

1. **Pre-detect "too many files" or always lazy-load?** — recommends keeping the reactive fallback as the load-bearing mechanism. Pre-detection only helps git repos cheaply (via `git ls-files | wc -l`) and the savings are bounded to a partial walk in a `ctx.spawn` background task. Worth revisiting later as an optimization once telemetry tells us whether it matters.
2. **Should we show a toast?** — recommends replacing the transient toast with a persistent dismissible inline indicator on the affected root header, carried via an `indexed_with_limit` flag on `FileTreeState` (mirrors the existing "Codebase too large" pattern in AI settings). The transient toast was easy to miss during manual testing.
3. **Performance of lazy load** — keep the existing 5k cap; instrument lazy-load latency before tuning; consider moving lazy-load off the main thread as a follow-up.

Also flags the parallel `ExceededMaxFileLimit` consumers in `ai::project_context::model`, `ai::outline::native`, and `ai::index::full_source_code_embedding` that this PR (and #10234) do not change.

## Linked Issue

[#10207](https://github.com/warpdotdev/warp/issues/10207)

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Screenshots / Videos

N/A — spec-only change.

## Testing

N/A — documentation. The validation plan for the implementation lives in the `Testing and validation` section of `TECH.md`.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode