### PR TITLE
feat: harness-specific model selection in orchestration config (QUALITY-643)

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -817,6 +817,7 @@ impl AIConversation {
     pub fn set_agent_name(&mut self, name: String) {
         self.agent_name = Some(name);
     }
+
     pub fn orchestration_harness_type(&self) -> Option<&str> {
         self.orchestration_harness_type.as_deref()
     }
@@ -2533,6 +2534,29 @@ impl AIConversation {
                 message: Some(message),
                 mask: Some(mask),
             }) => {
+                // Process OrchestrationConfigSnapshot if the updated
+                // message carries one (e.g. create_orchestration_config
+                // tool call result updating a single message in place).
+                if let Some(api::message::Message::OrchestrationConfigSnapshot(snapshot)) =
+                    &message.message
+                {
+                    let config = snapshot
+                        .config
+                        .as_ref()
+                        .map(OrchestrationConfig::from_proto);
+                    let status = OrchestrationConfigStatus::from_proto(snapshot.status.as_ref());
+                    let plan_id = if snapshot.plan_id.is_empty() {
+                        None
+                    } else {
+                        Some(snapshot.plan_id.clone())
+                    };
+                    if self.set_orchestration_config(config, status, plan_id) {
+                        ctx.emit(BlocklistAIHistoryEvent::OrchestrationConfigUpdated {
+                            conversation_id: self.id,
+                        });
+                    }
+                }
+
                 let task_id = TaskId::new(task_id);
                 let exchange_id = self
                     .added_exchanges_by_response
@@ -3440,6 +3464,7 @@ fn parse_orchestration_harness_type(value: &str) -> Harness {
         .or_else(|| Harness::parse_orchestration_harness(value))
         .unwrap_or(Harness::Unknown)
 }
+
 pub(super) fn update_todo_list_from_todo_op(
     todo_lists: &mut Vec<AIAgentTodoList>,
     op: api::message::update_todos::Operation,

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -664,6 +664,9 @@ fn set_codex_model(doc: &mut toml_edit::DocumentMut, third_party_harness_model_i
     let Some(model_id) =
         third_party_harness_model_id.filter(|id| !id.is_empty() && *id != "default")
     else {
+        // No model specified or "default" selected — remove any pre-existing
+        // key so Codex uses its own default.
+        doc.remove(CODEX_MODEL_KEY);
         return;
     };
     doc[CODEX_MODEL_KEY] = toml_edit::value(model_id);

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -202,13 +202,15 @@ fn prepare_codex_config_toml_preserves_unrelated_keys() {
     )
     .unwrap();
 
-    // Pass `None` for the model id so the helper preserves the user's existing `model = ...`.
+    // Pass `None` — the `model` key is intentionally removed (managed
+    // key), but unrelated keys like existing project entries are kept.
     prepare_codex_config_toml(&config_path, &working_dir, &HashMap::new(), None).unwrap();
 
     let canonical = working_dir.canonicalize().unwrap();
     let key = canonical.to_string_lossy().into_owned();
     let cfg = read_codex_config(&config_path);
-    assert_eq!(cfg["model"].as_str(), Some("gpt-5"));
+    // `model` is a managed key — removed when no override is provided.
+    assert!(!cfg.contains_key("model"));
     assert_eq!(
         cfg["projects"]["/other/path"]["trust_level"].as_str(),
         Some("trusted")

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -10,6 +10,7 @@ use ai::agent::action::RunAgentsExecutionMode;
 use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationExecutionMode};
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::{vec2f, Vector2F};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use warpui::elements::{
     ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty, Expanded, Flex,
@@ -32,8 +33,8 @@ use warp_core::ui::theme::Fill;
 
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::execution_profiles::model_menu_items::available_model_menu_items;
+use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::harness_display;
-use crate::ai::llms::LLMProvider;
 use crate::appearance::Appearance;
 use crate::menu::{MenuItem, MenuItemFields};
 use crate::ui_components::blended_colors;
@@ -51,6 +52,8 @@ pub const ORCHESTRATION_PICKER_BORDER_WIDTH: f32 = 1.;
 pub const ORCHESTRATION_PICKER_FONT_SIZE: f32 = 14.;
 pub const ORCHESTRATION_PICKER_RADIUS: f32 = 4.;
 pub const ORCHESTRATION_PICKER_MAX_WIDTH: f32 = 205.;
+
+const DEFAULT_MODEL_LABEL: &str = "Default model";
 
 // ── Action trait ────────────────────────────────────────────────────
 
@@ -159,6 +162,23 @@ impl OrchestrationEditState {
                 )
             }
             RunAgentsExecutionMode::Local | RunAgentsExecutionMode::Remote { .. } => None,
+        }
+    }
+
+    /// Fills in empty fields from the approved orchestration config.
+    /// When the LLM omits harness/model/execution_mode to inherit from
+    /// the active config, the raw request arrives with defaults (empty
+    /// harness, empty model, Local mode). This resolves those to the
+    /// config values so the UI shows the intended settings.
+    pub fn resolve_from_config(&mut self, config: &OrchestrationConfig) {
+        if self.harness_type.is_empty() && !config.harness_type.is_empty() {
+            self.harness_type = config.harness_type.clone();
+        }
+        if self.model_id.is_empty() && !config.model_id.is_empty() {
+            self.model_id = config.model_id.clone();
+        }
+        if !self.execution_mode.is_remote() && config.execution_mode.is_remote() {
+            self.execution_mode = Self::from_orchestration_config(config).execution_mode;
         }
     }
 
@@ -292,66 +312,102 @@ pub fn new_standard_picker_dropdown<A: OrchestrationControlAction, V: View>(
     })
 }
 
-/// Populates the model picker with all available models (no harness filter).
-pub fn populate_model_picker<A: OrchestrationControlAction, V: View>(
-    dropdown: &ViewHandle<Dropdown<A>>,
-    initial_model_id: &str,
-    ctx: &mut ViewContext<V>,
-) {
-    populate_model_picker_for_harness(dropdown, initial_model_id, "", ctx);
-}
-
-/// Returns whether the given LLM matches the harness filter.
-/// Claude → Anthropic only, Codex → OpenAI only, Oz/empty → all.
-fn matches_harness_filter(harness: Option<Harness>, provider: &LLMProvider) -> bool {
-    match harness {
-        Some(Harness::Claude) => matches!(provider, LLMProvider::Anthropic),
-        Some(Harness::Codex) => matches!(provider, LLMProvider::OpenAI),
-        Some(Harness::Oz)
-        | Some(Harness::Gemini)
-        | Some(Harness::OpenCode)
-        | Some(Harness::Unknown)
-        | None => true,
-    }
-}
-
-/// Populates the model picker, filtering choices by harness.
-/// Claude → Anthropic models only, Codex → OpenAI models only,
-/// Oz/empty → all models.
+/// Populates the model picker based on the active harness.
+///
+/// - **Oz / empty**: shows the Warp LLM catalog (existing behavior).
+/// - **Local Codex**: shows only a "Default model" entry (no model delivery
+///   possible for local Codex children).
+/// - **Other non-Oz harnesses**: shows "Default model" at the top, followed
+///   by the server-provided harness model catalog from
+///   `HarnessAvailabilityModel::models_for()`.
 pub fn populate_model_picker_for_harness<A: OrchestrationControlAction, V: View>(
     dropdown: &ViewHandle<Dropdown<A>>,
     initial_model_id: &str,
     harness_type: &str,
+    is_local: bool,
     ctx: &mut ViewContext<V>,
 ) {
     let initial_model_id = initial_model_id.to_string();
     let harness_type = harness_type.to_string();
     dropdown.update(ctx, |dropdown, ctx_dropdown| {
-        let llm_prefs = LLMPreferences::as_ref(ctx_dropdown);
-        let all_choices: Vec<_> = llm_prefs.get_base_llm_choices_for_agent_mode().collect();
         let harness = Harness::parse_orchestration_harness(&harness_type);
-        let choices: Vec<_> = all_choices
-            .into_iter()
-            .filter(|llm| matches_harness_filter(harness, &llm.provider))
-            .collect();
-        let selected_display_name = choices
-            .iter()
-            .find(|llm| llm.id.to_string() == initial_model_id)
-            .map(|llm| llm.menu_display_name());
-        let items = available_model_menu_items(
-            choices,
-            move |llm| DropdownAction::SelectActionAndClose(A::model_changed(llm.id.to_string())),
-            None,
-            None,
-            false,
-            false,
-            ctx_dropdown,
-        );
-        dropdown.set_rich_items(items, ctx_dropdown);
-        if let Some(name) = &selected_display_name {
-            dropdown.set_selected_by_name(name, ctx_dropdown);
+        match harness {
+            Some(Harness::Oz) | None => {
+                // Oz / unset: current behavior — Warp LLM catalog.
+                let llm_prefs = LLMPreferences::as_ref(ctx_dropdown);
+                let choices: Vec<_> = llm_prefs.get_base_llm_choices_for_agent_mode().collect();
+                let selected_display_name = choices
+                    .iter()
+                    .find(|llm| llm.id.to_string() == initial_model_id)
+                    .map(|llm| llm.menu_display_name());
+                let items = available_model_menu_items(
+                    choices,
+                    move |llm| {
+                        DropdownAction::SelectActionAndClose(A::model_changed(llm.id.to_string()))
+                    },
+                    None,
+                    None,
+                    false,
+                    false,
+                    ctx_dropdown,
+                );
+                dropdown.set_rich_items(items, ctx_dropdown);
+                if let Some(name) = &selected_display_name {
+                    dropdown.set_selected_by_name(name, ctx_dropdown);
+                }
+            }
+            Some(Harness::Codex) if is_local => {
+                // Local Codex: only "Default model" entry.
+                let items = vec![default_model_menu_item::<A>()];
+                dropdown.set_rich_items(items, ctx_dropdown);
+                dropdown.set_selected_by_name(DEFAULT_MODEL_LABEL, ctx_dropdown);
+            }
+            Some(harness) => {
+                // Non-Oz harness: "Default model" at top, then server-provided
+                // harness models.
+                let mut items: Vec<MenuItem<DropdownAction<A>>> =
+                    vec![default_model_menu_item::<A>()];
+                let availability = HarnessAvailabilityModel::as_ref(ctx_dropdown);
+                if let Some(models) = availability.models_for(harness) {
+                    for model in models {
+                        let model_id = model.id.clone();
+                        let fields = MenuItemFields::new(&model.display_name)
+                            .with_on_select_action(DropdownAction::SelectActionAndClose(
+                                A::model_changed(model_id),
+                            ));
+                        items.push(MenuItem::Item(fields));
+                    }
+                }
+                // Find display name before set_rich_items borrows ctx_dropdown mutably.
+                let selected_display_name = if initial_model_id.is_empty() {
+                    Some(DEFAULT_MODEL_LABEL.to_string())
+                } else {
+                    availability
+                        .models_for(harness)
+                        .and_then(|models| {
+                            models
+                                .iter()
+                                .find(|m| m.id == initial_model_id)
+                                .map(|m| m.display_name.clone())
+                        })
+                        .or_else(|| Some(DEFAULT_MODEL_LABEL.to_string()))
+                };
+                dropdown.set_rich_items(items, ctx_dropdown);
+                if let Some(name) = &selected_display_name {
+                    dropdown.set_selected_by_name(name, ctx_dropdown);
+                }
+            }
         }
     });
+}
+
+/// Creates a "Default model" menu item that emits an empty model_id.
+fn default_model_menu_item<A: OrchestrationControlAction>() -> MenuItem<DropdownAction<A>> {
+    MenuItem::Item(
+        MenuItemFields::new(DEFAULT_MODEL_LABEL).with_on_select_action(
+            DropdownAction::SelectActionAndClose(A::model_changed(String::new())),
+        ),
+    )
 }
 
 /// Returns whether the given model_id is present in the harness-filtered
@@ -360,28 +416,50 @@ pub fn populate_model_picker_for_harness<A: OrchestrationControlAction, V: View>
 pub fn is_model_in_filtered_choices<V: View>(
     model_id: &str,
     harness_type: &str,
+    is_local: bool,
     ctx: &mut ViewContext<V>,
 ) -> bool {
-    let llm_prefs = LLMPreferences::as_ref(ctx);
     let harness = Harness::parse_orchestration_harness(harness_type);
-    llm_prefs
-        .get_base_llm_choices_for_agent_mode()
-        .filter(|llm| matches_harness_filter(harness, &llm.provider))
-        .any(|llm| llm.id.to_string() == model_id)
+    match harness {
+        Some(Harness::Oz) | None => {
+            let llm_prefs = LLMPreferences::as_ref(ctx);
+            llm_prefs
+                .get_base_llm_choices_for_agent_mode()
+                .any(|llm| llm.id.to_string() == model_id)
+        }
+        Some(Harness::Codex) if is_local => model_id.is_empty(),
+        Some(harness) => {
+            // Empty string is always valid (the "Default model" entry).
+            if model_id.is_empty() {
+                return true;
+            }
+            let availability = HarnessAvailabilityModel::as_ref(ctx);
+            availability
+                .models_for(harness)
+                .is_some_and(|models| models.iter().any(|m| m.id == model_id))
+        }
+    }
 }
 
-/// Returns the model_id of the first model in the harness-filtered set,
-/// or `None` if the filtered set is empty.
+/// Returns the default model_id for the given harness.
+///
+/// For Oz this is the first Warp LLM; for non-Oz harnesses it is an empty
+/// string (the "Default model" entry).
 pub fn first_filtered_model_id<V: View>(
     harness_type: &str,
     ctx: &mut ViewContext<V>,
 ) -> Option<String> {
-    let llm_prefs = LLMPreferences::as_ref(ctx);
     let harness = Harness::parse_orchestration_harness(harness_type);
-    llm_prefs
-        .get_base_llm_choices_for_agent_mode()
-        .find(|llm| matches_harness_filter(harness, &llm.provider))
-        .map(|llm| llm.id.to_string())
+    match harness {
+        Some(Harness::Oz) | None => {
+            let llm_prefs = LLMPreferences::as_ref(ctx);
+            llm_prefs
+                .get_base_llm_choices_for_agent_mode()
+                .next()
+                .map(|llm| llm.id.to_string())
+        }
+        Some(_) => Some(String::new()),
+    }
 }
 
 pub fn populate_harness_picker<A: OrchestrationControlAction, V: View>(
@@ -391,26 +469,57 @@ pub fn populate_harness_picker<A: OrchestrationControlAction, V: View>(
 ) {
     let initial_harness = initial_harness.to_string();
     dropdown.update(ctx, |dropdown, ctx_dropdown| {
+        let availability = HarnessAvailabilityModel::as_ref(ctx_dropdown);
+        let harnesses = availability.available_harnesses();
+
+        // Sort enabled harnesses before disabled ones, preserving
+        // relative order within each group.
+        // Filter out Gemini — it is not yet supported as a multi-agent
+        // harness and causes an infinite "Spawning agents" hang.
+        let mut sorted: Vec<_> = harnesses
+            .iter()
+            .filter(|entry| entry.harness != Harness::Gemini)
+            .collect();
+        sorted.sort_by_key(|entry| !entry.enabled);
+
+        // Resolve the target harness so we can match by enum variant
+        // even when the `initial_harness` string is "claude" but the
+        // cached entry.harness deserialized as Unknown.
+        let target_harness = Harness::parse_orchestration_harness(&initial_harness);
+
         let mut items: Vec<MenuItem<DropdownAction<A>>> = Vec::new();
         let mut selected_idx = None;
-        // TODO: Re-enable Harness::Gemini once it is supported as
-        // a multi-agent harness (currently causes an infinite
-        // "Spawning agents" hang).
-        for (idx, harness) in [Harness::Oz, Harness::Claude, Harness::Codex]
-            .into_iter()
-            .enumerate()
-        {
-            let mut fields = MenuItemFields::new(harness_display::display_name(harness))
+        for (idx, entry) in sorted.iter().enumerate() {
+            let harness = entry.harness;
+            // Use the server-provided display_name for the label so stale
+            // cache entries (where harness deserializes as Unknown) still
+            // show the correct name.
+            let mut fields = MenuItemFields::new(&entry.display_name)
                 .with_icon(harness_display::icon_for(harness));
             if let Some(color) = harness_display::brand_color(harness) {
                 fields = fields.with_override_icon_color(Fill::from(color));
             }
             let harness_str = harness.to_string();
-            fields = fields.with_on_select_action(DropdownAction::SelectActionAndClose(
-                A::harness_changed(harness_str.clone()),
-            ));
+            if entry.enabled {
+                fields = fields.with_on_select_action(DropdownAction::SelectActionAndClose(
+                    A::harness_changed(harness_str.clone()),
+                ));
+            } else {
+                fields = fields.with_disabled(true);
+            }
+            // Match by harness string first, then fall back to matching
+            // the display_name against the client-side name for the target
+            // harness. This handles stale cache entries where entry.harness
+            // is Unknown but entry.display_name is still correct.
             if harness_str.eq_ignore_ascii_case(&initial_harness) {
                 selected_idx = Some(idx);
+            } else if selected_idx.is_none() {
+                if let Some(target) = target_harness {
+                    let target_display = harness_display::display_name(target);
+                    if entry.display_name == target_display {
+                        selected_idx = Some(idx);
+                    }
+                }
             }
             items.push(MenuItem::Item(fields));
         }
@@ -510,7 +619,127 @@ pub fn populate_host_picker<A: OrchestrationControlAction, V: View>(
     });
 }
 
-// ── Picker selection sync ───────────────────────────────────────────
+/// Normalizes a harness_type string for use as a HashMap key in
+/// per-harness model memory. Empty string (the wire representation
+/// of Oz) is mapped to "oz" so saves and lookups are consistent.
+pub fn harness_save_key(harness_type: &str) -> &str {
+    if harness_type.is_empty() {
+        "oz"
+    } else {
+        harness_type
+    }
+}
+
+// ── Shared action helpers ───────────────────────────────────────────
+
+/// Handles a harness change for both card views: saves the current
+/// model for the old harness, restores a previously saved model for
+/// the new harness (if still valid), falls back to a caller-provided
+/// base model id or the first available model, and repopulates the
+/// model picker.
+///
+/// Does NOT call `sync_picker_selections` — the harness picker
+/// dispatched this action and must not be re-entered.
+pub fn apply_harness_change<A: OrchestrationControlAction, V: View>(
+    state: &mut OrchestrationEditState,
+    memory: &mut HashMap<String, String>,
+    handles: &OrchestrationPickerHandles<A>,
+    new_harness_type: &str,
+    fallback_base_model_id: impl FnOnce(&mut ViewContext<V>) -> Option<String>,
+    ctx: &mut ViewContext<V>,
+) {
+    // Save current model for the old harness.
+    let old_key = harness_save_key(&state.harness_type).to_string();
+    memory.insert(old_key, state.model_id.clone());
+    state.harness_type = new_harness_type.to_string();
+
+    let is_local = !state.execution_mode.is_remote();
+    // Try to restore a previously saved model for this harness.
+    let new_key = harness_save_key(new_harness_type);
+    let restored = memory
+        .get(new_key)
+        .filter(|id| is_model_in_filtered_choices(id, new_harness_type, is_local, ctx))
+        .cloned();
+    if let Some(saved_id) = restored {
+        state.model_id = saved_id;
+    } else if !is_model_in_filtered_choices(&state.model_id, new_harness_type, is_local, ctx) {
+        // No saved model — fall back to conversation base model
+        // for Oz, or default for non-Oz.
+        let reset_id = fallback_base_model_id(ctx)
+            .filter(|id| is_model_in_filtered_choices(id, new_harness_type, is_local, ctx))
+            .or_else(|| first_filtered_model_id(new_harness_type, ctx))
+            .unwrap_or_default();
+        state.model_id = reset_id;
+    }
+    if let Some(handle) = &handles.model_picker {
+        populate_model_picker_for_harness(handle, &state.model_id, new_harness_type, is_local, ctx);
+    }
+}
+
+/// Handles an execution-mode toggle for both card views: toggles the
+/// mode, revalidates/resets the model_id if invalid for the new mode,
+/// repopulates the model picker, and syncs all picker selections.
+pub fn apply_execution_mode_change<A: OrchestrationControlAction, V: View>(
+    state: &mut OrchestrationEditState,
+    handles: &OrchestrationPickerHandles<A>,
+    is_remote: bool,
+    fallback_base_model_id: impl FnOnce(&mut ViewContext<V>) -> Option<String>,
+    ctx: &mut ViewContext<V>,
+) {
+    state.toggle_execution_mode_to_remote(is_remote);
+    let is_local = !state.execution_mode.is_remote();
+    if !is_model_in_filtered_choices(&state.model_id, &state.harness_type, is_local, ctx) {
+        let reset_id = fallback_base_model_id(ctx)
+            .filter(|id| is_model_in_filtered_choices(id, &state.harness_type, is_local, ctx))
+            .or_else(|| first_filtered_model_id(&state.harness_type, ctx))
+            .unwrap_or_default();
+        state.model_id = reset_id;
+    }
+    if let Some(handle) = &handles.model_picker {
+        populate_model_picker_for_harness(
+            handle,
+            &state.model_id,
+            &state.harness_type,
+            is_local,
+            ctx,
+        );
+    }
+    sync_picker_selections(state, handles, ctx);
+}
+
+// ── Picker repopulation + selection sync ──
+
+/// Repopulates both the harness and model pickers from the current
+/// server-provided data, revalidates `state.model_id` against the
+/// updated catalog (resetting to default if the model disappeared),
+/// then re-syncs dropdown selections.
+pub fn repopulate_all_pickers<A: OrchestrationControlAction, V: View>(
+    state: &mut OrchestrationEditState,
+    handles: &OrchestrationPickerHandles<A>,
+    ctx: &mut ViewContext<V>,
+) {
+    if let Some(handle) = &handles.harness_picker {
+        populate_harness_picker(handle, &state.harness_type, ctx);
+    }
+    // Revalidate model_id: if the previously selected model is no longer
+    // in the catalog (e.g. server removed it), reset to default.
+    let is_local = !state.execution_mode.is_remote();
+    if !is_model_in_filtered_choices(&state.model_id, &state.harness_type, is_local, ctx) {
+        if let Some(first_id) = first_filtered_model_id(&state.harness_type, ctx) {
+            state.model_id = first_id;
+        }
+    }
+    if let Some(handle) = &handles.model_picker {
+        populate_model_picker_for_harness(
+            handle,
+            &state.model_id,
+            &state.harness_type,
+            is_local,
+            ctx,
+        );
+    }
+    sync_picker_selections(state, handles, ctx);
+}
 
 pub fn sync_picker_selections<A: OrchestrationControlAction, V: View>(
     state: &OrchestrationEditState,
@@ -519,13 +748,30 @@ pub fn sync_picker_selections<A: OrchestrationControlAction, V: View>(
 ) {
     if let Some(model_picker) = handles.model_picker.clone() {
         let target_model_id = state.model_id.clone();
+        let harness_type = state.harness_type.clone();
         model_picker.update(ctx, |dropdown, ctx_dropdown| {
-            let display_name = {
-                let llm_prefs = LLMPreferences::as_ref(ctx_dropdown);
-                llm_prefs
-                    .get_base_llm_choices_for_agent_mode()
-                    .find(|llm| llm.id.to_string() == target_model_id)
-                    .map(|llm| llm.menu_display_name())
+            let harness = Harness::parse_orchestration_harness(&harness_type);
+            let display_name = match harness {
+                Some(Harness::Oz) | None => {
+                    let llm_prefs = LLMPreferences::as_ref(ctx_dropdown);
+                    llm_prefs
+                        .get_base_llm_choices_for_agent_mode()
+                        .find(|llm| llm.id.to_string() == target_model_id)
+                        .map(|llm| llm.menu_display_name())
+                }
+                Some(harness) => {
+                    if target_model_id.is_empty() {
+                        Some(DEFAULT_MODEL_LABEL.to_string())
+                    } else {
+                        let availability = HarnessAvailabilityModel::as_ref(ctx_dropdown);
+                        availability.models_for(harness).and_then(|models| {
+                            models
+                                .iter()
+                                .find(|m| m.id == target_model_id)
+                                .map(|m| m.display_name.clone())
+                        })
+                    }
+                }
             };
             if let Some(name) = &display_name {
                 dropdown.set_selected_by_name(name, ctx_dropdown);
@@ -533,10 +779,14 @@ pub fn sync_picker_selections<A: OrchestrationControlAction, V: View>(
         });
     }
     if let Some(harness_picker) = handles.harness_picker.clone() {
-        let target =
-            Harness::parse_orchestration_harness(&state.harness_type).unwrap_or(Harness::Oz);
-        let display = harness_display::display_name(target).to_string();
+        let harness_type = state.harness_type.clone();
         harness_picker.update(ctx, |dropdown, ctx_dropdown| {
+            let target = Harness::parse_orchestration_harness(&harness_type).unwrap_or(Harness::Oz);
+            // Use the server-provided display_name from HarnessAvailabilityModel
+            // so the selection matches the labels (which also use display_name).
+            let display = HarnessAvailabilityModel::as_ref(ctx_dropdown)
+                .display_name_for(target)
+                .to_string();
             dropdown.set_selected_by_name(&display, ctx_dropdown);
         });
     }

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -3,6 +3,8 @@
 //! Each card is a `View` keyed by `AIAgentActionId`, embedded by
 //! `AIBlock` via `ChildView`. Keybindings and Accept dispatch live on
 //! the view; only `RejectRequested` flows back to the parent.
+use std::collections::HashMap;
+
 use ai::agent::action::{RunAgentsAgentRunConfig, RunAgentsExecutionMode, RunAgentsRequest};
 use ai::agent::action_result::{RunAgentsAgentOutcomeKind, RunAgentsResult};
 use ai::agent::orchestration_config::{
@@ -39,6 +41,7 @@ use crate::ai::blocklist::inline_action::orchestration_controls::{
 use crate::ai::blocklist::inline_action::requested_action::{
     render_requested_action_row_for_text, CTRL_C_KEYSTROKE, ENTER_KEYSTROKE,
 };
+use crate::ai::harness_availability::{HarnessAvailabilityEvent, HarnessAvailabilityModel};
 use crate::ai::llms::{LLMPreferences, LLMPreferencesEvent};
 use crate::appearance::Appearance;
 use crate::menu::{Event as MenuEvent, Menu, MenuItemFields, MenuVariant};
@@ -184,6 +187,9 @@ pub struct RunAgentsCardView {
 
     action_model: ModelHandle<BlocklistAIActionModel>,
     block_model: Rc<dyn AIBlockModel<View = AIBlock>>,
+    /// UI-only per-harness model memory so switching harnesses preserves
+    /// the user's previous model selection for each harness.
+    saved_model_per_harness: HashMap<String, String>,
 }
 
 /// Returns `true` when the conditions for auto-launching are met.
@@ -264,7 +270,27 @@ impl RunAgentsCardView {
         // once the action becomes blocked.
         let is_denied = compute_is_denied(is_denied, &active_config);
 
-        let state = RunAgentsEditState::from_request(request);
+        let mut state = RunAgentsEditState::from_request(request);
+        // When the LLM omits harness/model to inherit from the active
+        // config, resolve empty fields so the card shows the intended
+        // settings rather than defaults.
+        if let Some((config, status)) = &active_config {
+            if status.is_approved() {
+                state.orch.resolve_from_config(config);
+            }
+        }
+        // For Oz (or empty harness), default to the conversation's base
+        // model so the picker shows e.g. "auto (genius)" instead of the
+        // system default.
+        if state.orch.model_id.is_empty() {
+            let harness =
+                warp_cli::agent::Harness::parse_orchestration_harness(&state.orch.harness_type);
+            if matches!(harness, Some(warp_cli::agent::Harness::Oz) | None) {
+                if let Some(base) = block_model.base_model(ctx).map(|id| id.to_string()) {
+                    state.orch.model_id = base;
+                }
+            }
+        }
         let auto_launched = should_auto_launch(false, is_denied, false, &state, &active_config);
 
         let reject_keystroke = CTRL_C_KEYSTROKE.clone();
@@ -370,42 +396,42 @@ impl RunAgentsCardView {
             _ => {}
         });
 
-        // Repopulate the model picker when available LLMs change.
-        // LLMPreferences loads asynchronously from the server; the
-        // picker may have been created before models arrived.
+        // Repopulate the model picker when available Warp LLMs change.
+        // Only relevant for Oz harness — non-Oz harnesses get their
+        // model catalog from HarnessAvailabilityModel, not LLMPreferences.
         ctx.subscribe_to_model(&LLMPreferences::handle(ctx), |me, _, event, ctx| {
             if let LLMPreferencesEvent::UpdatedAvailableLLMs = event {
                 if let Some(handle) = &me.handles.pickers.model_picker {
-                    // Re-validate model_id against the updated choices.
-                    // This handles the case where harness was changed while
-                    // models hadn't loaded yet.
-                    if !oc::is_model_in_filtered_choices(
-                        &me.state.orch.model_id,
-                        &me.state.orch.harness_type,
-                        ctx,
-                    ) {
-                        if let Some(first_id) =
-                            oc::first_filtered_model_id(&me.state.orch.harness_type, ctx)
-                        {
-                            me.state.orch.model_id = first_id;
-                        }
-                    }
+                    let is_local = !me.state.orch.execution_mode.is_remote();
                     oc::populate_model_picker_for_harness(
                         handle,
                         &me.state.orch.model_id,
                         &me.state.orch.harness_type,
+                        is_local,
                         ctx,
                     );
                 }
             }
         });
 
+        // Repopulate harness and model pickers when the server-provided
+        // harness list or harness model catalogs change.
+        ctx.subscribe_to_model(
+            &HarnessAvailabilityModel::handle(ctx),
+            |me, _, event, ctx| {
+                if let HarnessAvailabilityEvent::Changed = event {
+                    oc::repopulate_all_pickers(&mut me.state.orch, &me.handles.pickers, ctx);
+                    ctx.notify();
+                }
+            },
+        );
+
         // When auto_launched is true, execution is deferred to the
         // ActionBlockedOnUserConfirmation subscription above — the action
         // hasn't been queued in pending_actions yet at construction time.
         let mut view = Self {
             action_id,
-            state: RunAgentsEditState::from_request(request),
+            state,
             handles: RunAgentsCardHandles {
                 reject_button: Some(reject_button),
                 accept_button: Some(accept_button),
@@ -420,6 +446,7 @@ impl RunAgentsCardView {
             position_id_prefix,
             action_model,
             block_model,
+            saved_model_per_harness: HashMap::new(),
         };
 
         // Eagerly create picker views so the editor section is always
@@ -434,9 +461,34 @@ impl RunAgentsCardView {
         if self.spawning.is_some() || self.auto_launched || self.is_denied {
             return;
         }
-        let new_state = RunAgentsEditState::from_request(request);
+        let mut new_state = RunAgentsEditState::from_request(request);
+        // Resolve empty fields from the active config (same as in new()).
+        if let Some((config, status)) = &self.active_config {
+            if status.is_approved() {
+                new_state.orch.resolve_from_config(config);
+            }
+        }
+        if new_state.orch.model_id.is_empty() {
+            let harness =
+                warp_cli::agent::Harness::parse_orchestration_harness(&new_state.orch.harness_type);
+            if matches!(harness, Some(warp_cli::agent::Harness::Oz) | None) {
+                if let Some(base) = self.block_model.base_model(ctx).map(|id| id.to_string()) {
+                    new_state.orch.model_id = base;
+                }
+            }
+        }
         if self.state != new_state {
+            let harness_or_model_changed = self.state.orch.harness_type
+                != new_state.orch.harness_type
+                || self.state.orch.model_id != new_state.orch.model_id
+                || self.state.orch.execution_mode != new_state.orch.execution_mode;
             self.state = new_state;
+            // When harness_type, model_id, or execution_mode arrive via
+            // streaming (they may be empty in early chunks), repopulate
+            // and re-sync the pickers so the UI matches the final state.
+            if harness_or_model_changed {
+                oc::repopulate_all_pickers(&mut self.state.orch, &self.handles.pickers, ctx);
+            }
             ctx.notify();
         }
     }
@@ -502,12 +554,14 @@ impl RunAgentsCardView {
             } else {
                 state.orch.model_id.clone()
             };
+            let is_local = !state.orch.execution_mode.is_remote();
             let handle = oc::new_standard_picker_dropdown(&colors, ctx);
             Self::set_upward_menu_position(&handle, ctx);
             oc::populate_model_picker_for_harness(
                 &handle,
                 &initial_model_id,
                 &state.orch.harness_type,
+                is_local,
                 ctx,
             );
             Self::subscribe_picker_close(&handle, ctx);
@@ -741,8 +795,14 @@ impl TypedActionView for RunAgentsCardView {
                 ctx.emit(RunAgentsCardViewEvent::RejectRequested);
             }
             RunAgentsCardViewAction::ExecutionModeToggled { is_remote } => {
-                self.state.orch.toggle_execution_mode_to_remote(*is_remote);
-                self.sync_picker_selections(ctx);
+                let block_model = self.block_model.clone();
+                oc::apply_execution_mode_change(
+                    &mut self.state.orch,
+                    &self.handles.pickers,
+                    *is_remote,
+                    |ctx| block_model.base_model(ctx).map(|id| id.to_string()),
+                    ctx,
+                );
                 ctx.notify();
             }
             RunAgentsCardViewAction::ModelChanged { model_id } => {
@@ -750,33 +810,15 @@ impl TypedActionView for RunAgentsCardView {
                 ctx.notify();
             }
             RunAgentsCardViewAction::HarnessChanged { harness_type } => {
-                self.state.orch.harness_type = harness_type.clone();
-                // Re-populate model picker with harness-filtered choices.
-                // Reset to the first available model if the current selection
-                // is no longer in the filtered set.
-                if let Some(handle) = &self.handles.pickers.model_picker {
-                    oc::populate_model_picker_for_harness(
-                        handle,
-                        &self.state.orch.model_id,
-                        harness_type,
-                        ctx,
-                    );
-                    if !oc::is_model_in_filtered_choices(
-                        &self.state.orch.model_id,
-                        harness_type,
-                        ctx,
-                    ) {
-                        if let Some(first_id) = oc::first_filtered_model_id(harness_type, ctx) {
-                            self.state.orch.model_id = first_id;
-                        }
-                        oc::populate_model_picker_for_harness(
-                            handle,
-                            &self.state.orch.model_id,
-                            harness_type,
-                            ctx,
-                        );
-                    }
-                }
+                let block_model = self.block_model.clone();
+                oc::apply_harness_change(
+                    &mut self.state.orch,
+                    &mut self.saved_model_per_harness,
+                    &self.handles.pickers,
+                    harness_type,
+                    |ctx| block_model.base_model(ctx).map(|id| id.to_string()),
+                    ctx,
+                );
                 ctx.notify();
             }
             RunAgentsCardViewAction::EnvironmentChanged { environment_id } => {

--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -5,6 +5,7 @@
 use ai::agent::action::RunAgentsExecutionMode;
 use ai::agent::orchestration_config::OrchestrationConfigStatus;
 use pathfinder_color::ColorU;
+use std::collections::HashMap;
 use warpui::elements::{
     ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty, Flex, Hoverable,
     MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement, Radius, Text,
@@ -19,6 +20,7 @@ use crate::ai::blocklist::inline_action::orchestration_controls::{
 };
 use crate::ai::blocklist::BlocklistAIHistoryEvent;
 use crate::ai::document::ai_document_model::AIDocumentModel;
+use crate::ai::harness_availability::{HarnessAvailabilityEvent, HarnessAvailabilityModel};
 use crate::ai::llms::{LLMPreferences, LLMPreferencesEvent};
 use crate::appearance::Appearance;
 use crate::ui_components::blended_colors;
@@ -115,6 +117,9 @@ pub struct OrchestrationConfigBlockView {
     pickers_initialized: bool,
     toggle_mouse_state: MouseStateHandle,
     details_mouse_state: MouseStateHandle,
+    /// UI-only per-harness model memory so switching harnesses preserves
+    /// the user's previous model selection for each harness.
+    saved_model_per_harness: HashMap<String, String>,
 }
 
 impl OrchestrationConfigBlockView {
@@ -158,16 +163,37 @@ impl OrchestrationConfigBlockView {
             },
         );
 
-        // Repopulate the model picker when available LLMs change.
-        // LLMPreferences loads asynchronously from the server; the
-        // picker may have been created before models arrived.
+        // Repopulate the model picker when available LLMs change (Oz
+        // harness only — non-Oz harnesses get their catalog from
+        // HarnessAvailabilityModel, not LLMPreferences).
         ctx.subscribe_to_model(&LLMPreferences::handle(ctx), |me, _, event, ctx| {
             if let LLMPreferencesEvent::UpdatedAvailableLLMs = event {
                 if let Some(handle) = &me.pickers.model_picker {
-                    oc::populate_model_picker(handle, &me.edit_state.model_id, ctx);
+                    let is_local = !me.edit_state.execution_mode.is_remote();
+                    oc::populate_model_picker_for_harness(
+                        handle,
+                        &me.edit_state.model_id,
+                        &me.edit_state.harness_type,
+                        is_local,
+                        ctx,
+                    );
                 }
             }
         });
+
+        // Repopulate harness and model pickers when the server-provided
+        // harness list or harness model catalogs change.
+        ctx.subscribe_to_model(
+            &HarnessAvailabilityModel::handle(ctx),
+            |me, _, event, ctx| {
+                if let HarnessAvailabilityEvent::Changed = event {
+                    if me.pickers_initialized {
+                        oc::repopulate_all_pickers(&mut me.edit_state, &me.pickers, ctx);
+                    }
+                    ctx.notify();
+                }
+            },
+        );
 
         let mut view = Self {
             conversation_id,
@@ -178,6 +204,7 @@ impl OrchestrationConfigBlockView {
             pickers_initialized: false,
             toggle_mouse_state: MouseStateHandle::default(),
             details_mouse_state: MouseStateHandle::default(),
+            saved_model_per_harness: HashMap::new(),
         };
         if view.is_approved {
             view.ensure_pickers(ctx);
@@ -192,7 +219,7 @@ impl OrchestrationConfigBlockView {
                 self.edit_state = OrchestrationEditState::from_orchestration_config(config);
                 self.is_approved = conv.orchestration_status().is_approved();
                 if self.pickers_initialized {
-                    oc::sync_picker_selections(&self.edit_state, &self.pickers, ctx);
+                    oc::repopulate_all_pickers(&mut self.edit_state, &self.pickers, ctx);
                 }
                 ctx.notify();
             }
@@ -218,9 +245,16 @@ impl OrchestrationConfigBlockView {
         } else {
             self.edit_state.model_id.clone()
         };
+        let is_local = !self.edit_state.execution_mode.is_remote();
         let model_handle = oc::new_standard_picker_dropdown(&colors, ctx);
         model_handle.update(ctx, |d, c| d.set_use_overlay_layer(true, c));
-        oc::populate_model_picker(&model_handle, &display_model_id, ctx);
+        oc::populate_model_picker_for_harness(
+            &model_handle,
+            &display_model_id,
+            &self.edit_state.harness_type,
+            is_local,
+            ctx,
+        );
         self.pickers.model_picker = Some(model_handle);
 
         let harness_handle = oc::new_standard_picker_dropdown(&colors, ctx);
@@ -462,8 +496,19 @@ impl TypedActionView for OrchestrationConfigBlockView {
                 ctx.notify();
             }
             OrchestrationConfigBlockAction::ExecutionModeToggled { is_remote } => {
-                self.edit_state.toggle_execution_mode_to_remote(*is_remote);
-                oc::sync_picker_selections(&self.edit_state, &self.pickers, ctx);
+                let conversation_id = self.conversation_id;
+                oc::apply_execution_mode_change(
+                    &mut self.edit_state,
+                    &self.pickers,
+                    *is_remote,
+                    |ctx| {
+                        BlocklistAIHistoryModel::as_ref(ctx)
+                            .conversation(&conversation_id)
+                            .and_then(|conv| conv.latest_exchange())
+                            .map(|ex| ex.model_id.to_string())
+                    },
+                    ctx,
+                );
                 self.apply_field_change(ctx);
                 ctx.notify();
             }
@@ -473,7 +518,20 @@ impl TypedActionView for OrchestrationConfigBlockView {
                 ctx.notify();
             }
             OrchestrationConfigBlockAction::HarnessChanged { harness_type } => {
-                self.edit_state.harness_type = harness_type.clone();
+                let conversation_id = self.conversation_id;
+                oc::apply_harness_change(
+                    &mut self.edit_state,
+                    &mut self.saved_model_per_harness,
+                    &self.pickers,
+                    harness_type,
+                    |ctx| {
+                        BlocklistAIHistoryModel::as_ref(ctx)
+                            .conversation(&conversation_id)
+                            .and_then(|conv| conv.latest_exchange())
+                            .map(|ex| ex.model_id.to_string())
+                    },
+                    ctx,
+                );
                 self.apply_field_change(ctx);
                 ctx.notify();
             }

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -3,7 +3,10 @@ use std::{collections::HashMap, ffi::OsString, path::PathBuf, sync::Arc};
 use crate::ai::{
     agent_sdk::{
         driver::{
-            harness::{claude_code::prepare_claude_environment_config, harness_kind, HarnessKind},
+            harness::{
+                claude_code::prepare_claude_environment_config, harness_kind,
+                harness_model_env_vars, HarnessKind,
+            },
             AgentDriverError,
         },
         task_env_vars, validate_cli_installed,
@@ -77,6 +80,7 @@ fn local_child_task_config(harness: Harness) -> Option<AgentConfigSnapshot> {
 pub(super) async fn prepare_local_harness_child_launch(
     prompt: String,
     harness_type: String,
+    model_id: Option<String>,
     parent_run_id: Option<String>,
     shell_type: Option<ShellType>,
     startup_directory: Option<PathBuf>,
@@ -169,9 +173,15 @@ pub(super) async fn prepare_local_harness_child_launch(
             )
         })?;
 
+    let mut env_vars = task_env_vars(Some(&task_id), parent_run_id.as_deref(), harness);
+    // Propagate the selected model to Claude Code via ANTHROPIC_MODEL.
+    // Codex local children never receive a model override — the UI
+    // ensures model_id is empty for local Codex.
+    env_vars.extend(harness_model_env_vars(harness, model_id.as_deref()));
+
     Ok(PreparedLocalHarnessLaunch {
         command,
-        env_vars: task_env_vars(Some(&task_id), parent_run_id.as_deref(), harness),
+        env_vars,
         run_id: task_id.to_string(),
         task_id,
     })

--- a/app/src/pane_group/pane/local_harness_launch_tests.rs
+++ b/app/src/pane_group/pane/local_harness_launch_tests.rs
@@ -179,6 +179,7 @@ async fn prepare_local_codex_child_launch_does_not_rewrite_global_codex_state() 
     let prepared = prepare_local_harness_child_launch(
         "hello world".to_string(),
         "codex".to_string(),
+        None,
         Some("parent-run".to_string()),
         Some(ShellType::Zsh),
         Some(working_dir),
@@ -192,4 +193,75 @@ async fn prepare_local_codex_child_launch_does_not_rewrite_global_codex_state() 
         "codex --dangerously-bypass-approvals-and-sandbox 'hello world'"
     );
     assert!(!fake_home.path().join(".codex").exists());
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn prepare_local_claude_child_merges_anthropic_model_env_var() {
+    let fake_home = TempDir::new().unwrap();
+    let fake_bin_dir = TempDir::new().unwrap();
+    let working_dir = fake_home.path().join("workspace");
+    fs::create_dir_all(&working_dir).unwrap();
+    write_fake_cli(fake_bin_dir.path(), "claude");
+
+    let _home = EnvVarGuard::set("HOME", fake_home.path().as_os_str().to_os_string());
+    let _path = EnvVarGuard::set("PATH", fake_bin_dir.path().as_os_str().to_os_string());
+
+    let mut ai_client = MockAIClient::new();
+    ai_client
+        .expect_create_agent_task()
+        .times(1)
+        .returning(|_, _, _, _| Ok("550e8400-e29b-41d4-a716-446655440000".parse().unwrap()));
+
+    let prepared = prepare_local_harness_child_launch(
+        "hello world".to_string(),
+        "claude".to_string(),
+        Some("opus".to_string()),
+        Some("parent-run".to_string()),
+        Some(ShellType::Zsh),
+        Some(working_dir),
+        Arc::new(ai_client),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        prepared.env_vars.get(&OsString::from("ANTHROPIC_MODEL")),
+        Some(&OsString::from("opus"))
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn prepare_local_claude_child_no_anthropic_model_when_empty() {
+    let fake_home = TempDir::new().unwrap();
+    let fake_bin_dir = TempDir::new().unwrap();
+    let working_dir = fake_home.path().join("workspace");
+    fs::create_dir_all(&working_dir).unwrap();
+    write_fake_cli(fake_bin_dir.path(), "claude");
+
+    let _home = EnvVarGuard::set("HOME", fake_home.path().as_os_str().to_os_string());
+    let _path = EnvVarGuard::set("PATH", fake_bin_dir.path().as_os_str().to_os_string());
+
+    let mut ai_client = MockAIClient::new();
+    ai_client
+        .expect_create_agent_task()
+        .times(1)
+        .returning(|_, _, _, _| Ok("550e8400-e29b-41d4-a716-446655440000".parse().unwrap()));
+
+    let prepared = prepare_local_harness_child_launch(
+        "hello world".to_string(),
+        "claude".to_string(),
+        None,
+        Some("parent-run".to_string()),
+        Some(ShellType::Zsh),
+        Some(working_dir),
+        Arc::new(ai_client),
+    )
+    .await
+    .unwrap();
+
+    assert!(!prepared
+        .env_vars
+        .contains_key(&OsString::from("ANTHROPIC_MODEL")));
 }

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1334,11 +1334,13 @@ fn launch_local_harness_child(
         .terminal_view_from_pane_id(parent_pane_id, ctx)
         .and_then(|terminal_view| terminal_view.as_ref(ctx).active_session_shell_type(ctx));
 
+    let model_id_for_harness_env = model_id.clone();
     let _ = ctx.spawn(
         async move {
             prepare_local_harness_child_launch(
                 prompt,
                 harness_type,
+                model_id_for_harness_env,
                 parent_run_id,
                 shell_type,
                 startup_directory,

--- a/specs/QUALITY-643/PRODUCT.md
+++ b/specs/QUALITY-643/PRODUCT.md
@@ -1,0 +1,79 @@
+# Harness-Specific Model Selection in Orchestration Config
+
+Linear: [QUALITY-643](https://linear.app/warpdotdev/issue/QUALITY-643)
+
+## Summary
+
+When a user selects a non-Oz harness (Claude Code, Codex) in the orchestration config UI, the model picker should show models that the selected harness actually supports, and the chosen model should reach the harness process. Today the model picker always shows Warp's internal model catalog regardless of harness, and those IDs are not recognized by third-party harness CLIs.
+
+Figma: none provided — changes are behavioral within existing orchestration config UI chrome (plan card and run_agents confirmation card).
+
+## Behavior
+
+### Harness picker content
+
+1. The harness picker populates from the server-provided `availableHarnesses` list (via `HarnessAvailabilityModel`), not from a hardcoded client-side list. This ensures the desktop matches the web UI and respects admin-configured harness availability.
+
+2. Each harness entry displays its `display_name` from the server with the corresponding brand icon (Warp logo for Oz, Claude logo for Claude Code, OpenAI logo for Codex, Gemini logo for Gemini CLI).
+
+3. Enabled harnesses are selectable. Disabled harnesses (admin-disabled via org settings) appear in the list with a visual indicator (e.g. greyed text or a "disabled" badge) but cannot be selected.
+
+4. Enabled harnesses appear before disabled harnesses in the list.
+
+5. If the currently-selected harness becomes disabled (e.g. after a server refresh), the picker retains the selection but the UI should indicate the issue.
+
+### Model picker content by harness
+
+6. When the harness picker is set to **Oz** (or is empty/unset), the model picker shows the Warp LLM catalog — the same models shown in single-agent mode. This is the current behavior and must not regress.
+
+7. When the harness picker is set to **Claude Code**, the model picker shows:
+   - A **"Default model"** entry at the top (value: empty string) meaning "don't override — let the harness use its own default."
+   - The server-provided Claude Code model catalog (e.g. `best`, `opus`, `sonnet`, `haiku`, `opus (1M context)`, `sonnet (1M context)`, pinned versions like `opus 4.7`, `sonnet 4.6`).
+   This matches the Oz web UI's harness model selector.
+
+8. When the harness picker is set to **Codex** and the execution mode is **Cloud**, the model picker shows:
+   - A **"Default model"** entry at the top (value: empty string), same as Claude Code.
+   - The server-provided Codex model catalog (e.g. `default`, `GPT-5.5`, `GPT-5.4`, `GPT-5.4 mini`). The `default` entry from the server explicitly skips writing the model key to config, which has the same practical effect as the "Default model" entry but is Codex-specific.
+   This matches the Oz web UI's Codex model selector.
+
+   When the execution mode is **Local**, the model picker shows only the **"Default model"** entry. The Codex CLI reads its model from `~/.codex/config.toml`, which is shared global state — writing to it from a child agent would clobber the user's existing config and race with parallel agents. Local Codex children inherit whatever model the user has configured.
+
+9. When the harness picker is set to **Gemini** (currently disabled for orchestration), the model picker follows the same pattern: "Default model" at top, then server-provided Gemini models if any exist.
+
+10. Each model entry displays its `display_name` from the server catalog. The raw `id` (e.g. `"opus"`, `"gpt-5.4"`) is the value stored as the selected model_id and passed to the harness process. No provider icons or model spec sidecars are shown for harness models (they lack that metadata).
+
+### Defaults when no model is specified
+
+11. When the orchestration config is created (via `create_orchestration_config`) or the harness changes and no model_id is specified (empty string), the model picker defaults to:
+   - **Oz**: the orchestrator's current model (the model the parent agent is using).
+   - **Non-Oz harnesses** (Claude Code, Codex, Gemini): the "Default model" entry (empty string), meaning the harness uses its own default.
+
+### Model reset on harness change
+
+12. When the user changes the harness, the model_id resets because each harness has its own disjoint model catalog. The reset target is "Default model" (empty string) for non-Oz harnesses, or the first available Warp LLM for Oz. The only exception is the empty string itself ("Default model"), which can persist across non-Oz harness changes.
+
+### Loading and empty states
+
+13. If the harness model catalog has not yet been fetched from the server when the user switches to a non-Oz harness, the model picker shows only the "Default model" entry. Once the catalog arrives, the picker repopulates with the full list, keeping "Default model" selected.
+
+14. If the server returns an empty model list for a harness, the model picker shows only the "Default model" entry. The model_id remains empty.
+
+### Consistency across UI surfaces
+
+15. The orchestration config block (plan card) and the run_agents confirmation card must show the same harness-specific models, using the same server catalog, and behave identically when the harness changes.
+
+16. The `sync_picker_selections` logic (which syncs picker UI state to the edit state) must correctly match harness-specific model IDs against the harness model list, not against Warp's internal LLM catalog, when a non-Oz harness is active.
+
+### Model ID delivery to harness processes
+
+17. When the user selects a model for **Claude Code** and agents are launched, the selected model_id (e.g. `"opus"`) must reach the Claude Code CLI process as the `ANTHROPIC_MODEL` environment variable. This applies to both local child agents and remote agents.
+
+18. When the user selects a model for **Codex** and agents are launched in **Cloud** mode, the selected model_id (e.g. `"gpt-5.4"`) must be written to `~/.codex/config.toml` as the top-level `model` key before the Codex CLI starts. If the selected model is `"default"`, the `model` key must NOT be written (or must be removed if previously present), allowing Codex to use its own default. In **Local** mode, no model override is written — the user's existing `~/.codex/config.toml` is used as-is.
+
+19. When the user selects a model for **Oz**, the existing model_id propagation behavior (Warp internal LLM preference) must not change.
+
+20. When the "Default model" entry is selected (empty model_id) for any non-Oz harness, no model override is injected — the harness process uses its own default.
+
+### Auto-launch behavior
+
+21. The `matches_active_config` check (which determines whether a run_agents call auto-launches without user confirmation) must treat harness-specific model_ids the same as Warp model_ids: an exact string match between the request's model_id and the config's model_id.

--- a/specs/QUALITY-643/TECH.md
+++ b/specs/QUALITY-643/TECH.md
@@ -1,0 +1,189 @@
+# Harness-Specific Model Selection — Tech Spec
+
+Linear: [QUALITY-643](https://linear.app/warpdotdev/issue/QUALITY-643)
+
+Companion product spec: `specs/QUALITY-643/PRODUCT.md`
+
+## Context
+
+The orchestration config UI (plan card and run_agents confirmation card) lets users pick a harness and model for child agents. Both cards share picker logic in `orchestration_controls.rs`. Two problems exist today:
+
+1. **Harness picker** is hardcoded to `[Oz, Claude, Codex]` — it doesn't read from the server's `availableHarnesses` list, doesn't include Gemini, and doesn't respect admin enabled/disabled state.
+2. **Model picker** always shows Warp's internal LLM catalog filtered by provider (Anthropic for Claude, OpenAI for Codex). Those IDs (e.g. `claude-4-6-opus-high`) are not recognized by third-party harness CLIs. The server maintains separate harness-specific model catalogs that the desktop client already fetches and caches in `HarnessAvailabilityModel`, but the orchestration UI doesn't use them.
+
+Additionally, model_id is not delivered to local child harness processes: Claude Code doesn't receive `ANTHROPIC_MODEL`. Codex model delivery uses `~/.codex/config.toml`, which is only safe in cloud/remote environments where the filesystem is isolated — local children must not touch it (see `local_harness_launch.rs:143` comment).
+
+### Relevant files
+
+**Shared picker logic (model/harness dropdowns)**
+- `app/src/ai/blocklist/inline_action/orchestration_controls.rs` — `populate_harness_picker()` (line 380), `populate_model_picker_for_harness()` (line 314), `is_model_in_filtered_choices()` (line 353), `first_filtered_model_id()` (line 368), `sync_picker_selections()` (line 508), `matches_harness_filter()` (line 299)
+
+**UI card views that consume the shared pickers**
+- `app/src/ai/document/orchestration_config_block.rs` — plan card; subscribes to `LLMPreferencesEvent` for model refresh
+- `app/src/ai/blocklist/inline_action/run_agents_card_view.rs` — confirmation card; `HarnessChanged` handler (line 752) resets model on harness change
+
+**Harness availability and model data (already fetched and cached)**
+- `app/src/ai/harness_availability.rs` — `HarnessAvailabilityModel` singleton with:
+  - `available_harnesses()` → `&[HarnessAvailability]` (harness, display_name, enabled, available_models)
+  - `models_for(harness)` → `Option<&[HarnessModelInfo]>` (id, display_name)
+  - `is_harness_enabled(harness)` → `bool`
+  - Emits `HarnessAvailabilityEvent::Changed`
+
+**Harness display metadata**
+- `app/src/ai/harness_display.rs` — `display_name()`, `icon_for()`, `brand_color()` per `Harness` variant
+
+**Model ID delivery to harness processes**
+- `app/src/ai/agent_sdk/driver/harness/mod.rs` — `harness_model_env_vars()` (line 373): sets `ANTHROPIC_MODEL` for Claude, no-op for Codex
+- `app/src/pane_group/pane/local_harness_launch.rs` — `prepare_local_harness_child_launch()` (line 77): builds child env_vars but does not include model_id
+- `app/src/pane_group/pane/terminal_pane.rs` — `launch_local_harness_child()` (line 1302): passes `model_id` to `apply_child_model_id_override` which only sets Oz LLM preference
+- `app/src/ai/agent_sdk/driver/harness/codex.rs` — `prepare_codex_config_toml()` (line 573): writes `~/.codex/config.toml` but does not write a `model` key; top-level key name is `"model"` (confirmed by test at `codex_tests.rs:201`)
+
+## Proposed changes
+
+### 1. Populate harness picker from `HarnessAvailabilityModel`
+
+**File**: `orchestration_controls.rs` — `populate_harness_picker()`
+
+Replace the hardcoded `[Harness::Oz, Harness::Claude, Harness::Codex]` iteration (line 392) with a read from `HarnessAvailabilityModel::as_ref(ctx).available_harnesses()`.
+
+For each `HarnessAvailability` entry:
+- Use `harness_display::icon_for()` and `harness_display::brand_color()` for icons (these already cover all variants including Gemini).
+- Use `harness_display::display_name()` for the label (the server's `display_name` field could also be used, but the client-side names already match and are guaranteed non-empty before the server responds).
+- If `!entry.enabled`: render as disabled (non-selectable, greyed text). The `MenuItemFields` API supports `.with_disabled(true)` or equivalent — check the existing `MenuItem` disabled patterns in the codebase.
+- Sort enabled entries before disabled entries.
+
+Also subscribe both card views to `HarnessAvailabilityEvent::Changed` to repopulate the harness picker when the server list updates.
+
+Addresses PRODUCT.md behaviors 1–5.
+
+### 2. Switch model picker to harness-specific models with "Default model" entry
+
+**File**: `orchestration_controls.rs` — `populate_model_picker_for_harness()`
+
+Add an `is_local: bool` parameter (or pass the current `RunAgentsExecutionMode`) so the picker can be execution-mode-aware. Replace the current provider-filtered `LLMPreferences` logic with harness-aware branching:
+
+```
+let harness = Harness::parse_orchestration_harness(harness_type);
+match harness {
+    Some(Harness::Oz) | None => {
+        // Current behavior: LLMPreferences filtered by provider
+    }
+    Some(Harness::Codex) if is_local => {
+        // Local Codex: only "Default model" entry (no model delivery possible)
+    }
+    Some(harness) => {
+        // 1. Always add a "Default model" entry first (value: empty string)
+        // 2. Read HarnessAvailabilityModel::as_ref(ctx).models_for(harness)
+        // 3. If Some(models): append each HarnessModelInfo as a menu item
+        //    with display_name as label and id as the model_changed action value
+        // 4. If None: only "Default model" is shown (loading/empty state)
+    }
+}
+```
+
+The "Default model" entry should use label `"Default model"` and emit `A::model_changed(String::new())` (empty string). This matches the web UI which adds this entry with value `""`.
+
+When execution mode toggles between Local and Cloud, the `HarnessChanged` / `ExecutionModeToggled` handlers must repopulate the model picker since Codex's available models depend on the mode.
+
+Apply the same Oz-vs-non-Oz branching to:
+- `is_model_in_filtered_choices()` — for non-Oz, check model_id against `HarnessAvailabilityModel::models_for()` OR accept empty string (the "Default model" entry). For local Codex, only empty string is valid.
+- `first_filtered_model_id()` — for non-Oz, return `Some(String::new())` (the "Default model" entry) as the default.
+- `sync_picker_selections()` — for non-Oz, find display_name from `HarnessAvailabilityModel::models_for()` instead of `LLMPreferences`. Map empty model_id to the "Default model" label.
+
+Addresses behaviors 6–10, 11–14, 15–16.
+
+### 3. Subscribe both card views to `HarnessAvailabilityEvent::Changed`
+
+**Files**: `orchestration_config_block.rs`, `run_agents_card_view.rs`
+
+Both views already subscribe to `LLMPreferencesEvent::UpdatedAvailableLLMs`. Add an analogous subscription to `HarnessAvailabilityModel`:
+- Repopulate the **harness picker** when the harness list changes (behaviors 1–5).
+- Repopulate the **model picker** when harness models arrive, but only when the current harness is non-Oz (behavior 15).
+
+Addresses behaviors 1–5, 15.
+
+### 4. Propagate model_id to local child harness processes (Claude Code only)
+
+**File**: `local_harness_launch.rs`
+
+Add `model_id: Option<String>` parameter to `prepare_local_harness_child_launch()`. After building `env_vars` from `task_env_vars()`:
+- For Claude: merge `harness_model_env_vars(harness, model_id.as_deref())` into env_vars. This sets `ANTHROPIC_MODEL` when model_id is non-empty.
+- For Codex: no model delivery for local children. The UI ensures model_id is empty for local Codex (behavior 8), so no action is needed here. The existing code already skips `prepare_codex_environment_config()` for local children (`local_harness_launch.rs:143`) and this spec preserves that constraint.
+
+**File**: `terminal_pane.rs`
+
+Update the call to `prepare_local_harness_child_launch()` in `launch_local_harness_child()` (line 1325) to pass the `model_id` value.
+
+Addresses behaviors 17, 20.
+
+### 5. Write Codex model to config.toml (cloud/remote path only)
+
+**File**: `codex.rs`
+
+Add `model_id: Option<&str>` parameter to `prepare_codex_environment_config()` and `prepare_codex_config_toml()`.
+
+In `prepare_codex_config_toml()`, after `set_codex_openai_base_url()`:
+- If `model_id` is `Some(id)` where `id` is non-empty and not `"default"`: `doc["model"] = toml_edit::value(id)`.
+- Otherwise: `doc.remove("model")` to clear any pre-existing key.
+
+Add constant `CODEX_MODEL_KEY: &str = "model"`.
+
+The existing test at `codex_tests.rs:201` verifies a pre-existing `model` key is preserved — update it to verify the new write/remove behavior.
+
+Update the caller of `prepare_codex_environment_config()` in `codex.rs` `build_runner()` to pass `model_id`. No changes needed in `local_harness_launch.rs` — local Codex children don't call this function and don't receive model overrides.
+
+Addresses behavior 18.
+
+### 6. No changes needed for remote launch path
+
+The remote launch path already passes `model_id` to the server via `StartAgentExecutionMode::Remote { model_id }` in `run_agents_to_start_agent_mode()`. With the UI now storing harness-native IDs (or empty for "Default model"), the server receives the correct value without translation.
+
+Addresses behaviors 17 (remote), 18 (remote).
+
+## Testing and validation
+
+### Unit tests
+
+**orchestration_controls tests** — new tests:
+- Harness picker populated from `HarnessAvailabilityModel`; disabled harnesses shown but not selectable. (Behaviors 1–4)
+- `populate_model_picker_for_harness` with harness="claude": "Default model" entry at top, then harness-specific models from `HarnessAvailabilityModel`. (Behavior 7)
+- `populate_model_picker_for_harness` with harness="codex", cloud mode: "Default model" entry at top, then Codex models. (Behavior 8)
+- `populate_model_picker_for_harness` with harness="codex", local mode: only "Default model" entry. (Behavior 8)
+- `populate_model_picker_for_harness` with harness="oz": Warp LLM catalog (existing behavior). (Behavior 6)
+- `is_model_in_filtered_choices` returns false for Warp IDs when harness is non-Oz, true for empty string ("Default model"). (Behavior 12)
+- `first_filtered_model_id` returns empty string for non-Oz harness. (Behavior 11)
+- Harness change from Claude (model="opus") to Oz: model resets to first Warp LLM. (Behavior 12)
+
+**local_harness_launch tests** — new/updated tests:
+- `prepare_local_harness_child_launch` merges `ANTHROPIC_MODEL` into env_vars when harness is Claude and model_id is provided. (Behavior 17)
+- `prepare_local_harness_child_launch` does NOT set `ANTHROPIC_MODEL` when model_id is None or empty. (Behavior 20)
+
+**codex config.toml tests** — update existing tests in `codex_tests.rs`:
+- `prepare_codex_config_toml` writes `model = "gpt-5.4"` when model_id is `Some("gpt-5.4")`. (Behavior 18)
+- `prepare_codex_config_toml` removes existing `model` key when model_id is `Some("default")`. (Behavior 18)
+- `prepare_codex_config_toml` removes existing `model` key when model_id is `None`. (Behavior 20)
+- Pre-existing non-model keys (openai_base_url, projects, mcp_servers) are preserved in all cases.
+
+**orchestration_config_tests** — existing tests must continue to pass. (Behavior 21)
+
+### Presubmit
+
+Run `cargo fmt`, `cargo clippy`, and `./script/presubmit` before PR.
+
+### Manual validation
+
+- Open orchestration config on a plan card → harness picker shows Oz, Claude Code, Codex (and Gemini if server returns it, possibly disabled).
+- Select Claude Code → model picker shows "Default model" at top, then `best`, `opus`, `sonnet`, etc.
+- Select Codex (Cloud mode) → model picker shows "Default model" at top, then `default`, `GPT-5.5`, `GPT-5.4`, etc.
+- Select Codex (Local mode) → model picker shows only "Default model".
+- Toggle Local → Cloud with Codex selected → model picker repopulates with full Codex catalog.
+- Select Oz → model picker returns to Warp LLM catalog.
+- Change harness from Claude (with "opus" selected) to Oz → model resets.
+- Launch local agents with Claude Code + "opus" → verify `ANTHROPIC_MODEL=opus` in child env.
+- Launch local agents with Claude Code + "Default model" → verify no `ANTHROPIC_MODEL` in child env.
+- Launch cloud agents with Codex + "gpt-5.4" → verify `model = "gpt-5.4"` in `~/.codex/config.toml` inside the cloud env.
+- Launch cloud agents with Codex + "default" → verify no `model` key in `~/.codex/config.toml`.
+
+## Parallelization
+
+Not recommended. The changes are tightly coupled — the harness picker (change 1) and model picker (change 2) share state in `orchestration_controls.rs`, the card view subscriptions (change 3) depend on both pickers, and the launch-side changes (4–5) depend on the correct model_id format flowing from the picker. Total scope is ~7 files with moderate changes each, well suited for sequential execution by a single agent.


### PR DESCRIPTION
## Description

Replace the hardcoded harness list and provider-filtered model picker in the orchestration config UI with server-provided harness availability data and harness-specific model catalogs. The selected model_id is delivered to harness processes (ANTHROPIC_MODEL for Claude Code, config.toml model key for Codex).

Key changes across 12 files:
- **Harness picker** reads from `HarnessAvailabilityModel` instead of hardcoded list; disabled harnesses shown but non-selectable
- **Model picker** shows harness-specific models with "Default model" entry for non-Oz harnesses; local Codex shows only "Default model"
- **Event subscriptions** on both card views for `HarnessAvailabilityEvent::Changed` to refresh pickers
- **Model delivery**: Claude Code gets `ANTHROPIC_MODEL` env var; Codex gets `model` key in `~/.codex/config.toml`
- **`build_runner` trait** accepts explicit `model_id` parameter (replaces env var smuggling)
- **Streaming support**: `update_request()` re-syncs pickers when harness/model changes arrive via streaming

Specs: `specs/QUALITY-643/PRODUCT.md`, `specs/QUALITY-643/TECH.md`

[Agent conversation](https://staging.warp.dev/conversation/75d9ba5c-7a6f-4ea4-a15f-d1c57d44937f)

## Linked Issue

https://linear.app/warpdotdev/issue/QUALITY-643

## Testing

- Added 6 new codex config.toml tests (model write/remove/preserve)
- Added 2 new local_harness_launch tests (ANTHROPIC_MODEL env var)
- All 115 relevant tests pass; existing orchestration_config tests unchanged
- Renamed `preserves_unrelated_keys` → `preserves_non_model_keys` to reflect model is now a managed key

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Demo

https://www.loom.com/share/6dcff3f5f9d64b99880f678c999e7909