### PR TITLE
Fix WSL log tail commands

### DIFF
--- a/app/src/settings_view/mcp_servers/list_page.rs
+++ b/app/src/settings_view/mcp_servers/list_page.rs
@@ -635,7 +635,7 @@ impl MCPServersListPageView {
 
             terminal_view_handle.update(ctx, |terminal, ctx| {
                 let shell_family = terminal.shell_family(ctx);
-                let shell_launch_data = terminal.active_session_shell(ctx);
+                let shell_launch_data = terminal.active_or_pending_shell_launch_data(ctx);
                 let tail_command =
                     tail_command_for_shell(shell_family, log_file_path, shell_launch_data.as_ref());
                 terminal.set_pending_command(&tail_command, ctx);

--- a/app/src/settings_view/mcp_servers/list_page.rs
+++ b/app/src/settings_view/mcp_servers/list_page.rs
@@ -635,7 +635,9 @@ impl MCPServersListPageView {
 
             terminal_view_handle.update(ctx, |terminal, ctx| {
                 let shell_family = terminal.shell_family(ctx);
-                let tail_command = tail_command_for_shell(shell_family, log_file_path);
+                let shell_launch_data = terminal.active_session_shell(ctx);
+                let tail_command =
+                    tail_command_for_shell(shell_family, log_file_path, shell_launch_data.as_ref());
                 terminal.set_pending_command(&tail_command, ctx);
             });
         })

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6808,6 +6808,16 @@ impl TerminalView {
         })
     }
 
+    /// Returns the active session's launch shell if bootstrap has completed, otherwise falls
+    /// back to the terminal model's active shell launch data captured before bootstrap.
+    pub fn active_or_pending_shell_launch_data<C: ModelAsRef>(
+        &self,
+        ctx: &C,
+    ) -> Option<ShellLaunchData> {
+        self.active_session_shell(ctx)
+            .or_else(|| self.model.lock().active_shell_launch_data().cloned())
+    }
+
     /// Returns the active session's WSL distribution information, if it exists.
     /// Returns None if there is no active session or if the current session is
     /// not a WSL session.

--- a/app/src/workflows/local_workflows.rs
+++ b/app/src/workflows/local_workflows.rs
@@ -12,7 +12,10 @@ use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
 #[cfg(feature = "local_fs")]
 use crate::user_config::load_workflows;
-use crate::{terminal::model::session::Session, user_config::WarpConfig};
+use crate::{
+    terminal::{model::session::Session, ShellLaunchData},
+    user_config::WarpConfig,
+};
 
 use super::{workflow::Workflow, WorkflowSource};
 
@@ -193,17 +196,39 @@ pub(super) fn load_project_workflows(path: &Path) -> Vec<Workflow> {
 
 /// Runs `tail` or equivalent command on the given path.
 /// Note: On Windows this may cause a lossy conversion if the path is not valid UTF-8.
-pub fn tail_command_for_shell(shell_family: ShellFamily, path: &PathBuf) -> String {
+pub fn tail_command_for_shell(
+    shell_family: ShellFamily,
+    path: &PathBuf,
+    shell_launch_data: Option<&ShellLaunchData>,
+) -> String {
+    let display_path = shell_launch_data
+        .and_then(|shell_launch_data| {
+            path.to_str().map(|path| match shell_launch_data {
+                ShellLaunchData::WSL { .. } => warp_util::path::convert_windows_path_to_wsl(path),
+                ShellLaunchData::MSYS2 { .. } => {
+                    warp_util::path::convert_windows_path_to_msys2(path)
+                }
+                ShellLaunchData::Executable { .. } | ShellLaunchData::DockerSandbox { .. } => {
+                    path.to_owned()
+                }
+            })
+        })
+        .map(PathBuf::from)
+        .unwrap_or_else(|| path.clone());
+
     match shell_family {
         // Use debug formatting for `PathBuf` so that any non-Unicode components of the path get
         // escaped.  This will also add quotes around the path, so there's no need to add them in
         // the format string.
-        ShellFamily::Posix => format!("tail -f {path:?}"),
+        ShellFamily::Posix => format!("tail -f {display_path:?}"),
         // We avoid the debug formatting here so that backslashes don't get escaped, which is not
         // desirable for PowerShell.  Note that this may be lossy conversion if the path is not
         // valid UTF-8.
         ShellFamily::PowerShell => {
-            format!("Get-Content -Wait -Tail 10 -Path \"{}\"", path.display())
+            format!(
+                "Get-Content -Wait -Tail 10 -Path \"{}\"",
+                display_path.display()
+            )
         }
     }
 }
@@ -216,7 +241,7 @@ pub fn prompt_chip_logging_workflow(shell_family: ShellFamily) -> Option<Workflo
     let log_file_path = crate::context_chips::logging::log_file_path().ok()?;
     Some(Workflow::Command {
         name: "Tail prompt chip log".into(),
-        command: tail_command_for_shell(shell_family, &log_file_path),
+        command: tail_command_for_shell(shell_family, &log_file_path, None),
         tags: vec!["warp".into(), "debug".into()],
         description: Some(
             "Shows the diagnostic log of shell commands run by prompt context chips (dogfood only)"

--- a/app/src/workflows/local_workflows_tests.rs
+++ b/app/src/workflows/local_workflows_tests.rs
@@ -1,4 +1,7 @@
+use std::path::PathBuf;
 use std::sync::Arc;
+use warp_terminal::shell::{ShellLaunchData, ShellType};
+use warp_util::path::ShellFamily;
 use warpui::App;
 
 use super::*;
@@ -53,4 +56,55 @@ fn test_workflow_by_command_name() {
             assert_eq!(workflow_source, WorkflowSource::Global);
         });
     });
+}
+
+#[test]
+fn tail_command_for_shell_converts_windows_log_paths_for_wsl_sessions() {
+    let shell_launch_data = ShellLaunchData::WSL {
+        distro: "Ubuntu".to_owned(),
+    };
+
+    let command = tail_command_for_shell(
+        ShellFamily::Posix,
+        &PathBuf::from(r"C:\Users\test\AppData\Roaming\Warp\logs\mcp\server.log"),
+        Some(&shell_launch_data),
+    );
+
+    assert_eq!(
+        command,
+        r#"tail -f "/mnt/c/Users/test/AppData/Roaming/Warp/logs/mcp/server.log""#
+    );
+}
+
+#[test]
+fn tail_command_for_shell_converts_windows_log_paths_for_msys2_sessions() {
+    let shell_launch_data = ShellLaunchData::MSYS2 {
+        executable_path: PathBuf::from(r"C:\msys64\usr\bin\bash.exe"),
+        shell_type: ShellType::Bash,
+    };
+
+    let command = tail_command_for_shell(
+        ShellFamily::Posix,
+        &PathBuf::from(r"C:\Users\test\AppData\Roaming\Warp\logs\mcp\server.log"),
+        Some(&shell_launch_data),
+    );
+
+    assert_eq!(
+        command,
+        r#"tail -f "/c/Users/test/AppData/Roaming/Warp/logs/mcp/server.log""#
+    );
+}
+
+#[test]
+fn tail_command_for_shell_leaves_windows_log_paths_for_powershell_sessions() {
+    let command = tail_command_for_shell(
+        ShellFamily::PowerShell,
+        &PathBuf::from(r"C:\Users\test\AppData\Roaming\Warp\logs\mcp\server.log"),
+        None,
+    );
+
+    assert_eq!(
+        command,
+        r#"Get-Content -Wait -Tail 10 -Path "C:\Users\test\AppData\Roaming\Warp\logs\mcp\server.log""#
+    );
 }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -15172,7 +15172,9 @@ impl Workspace {
 
         terminal_view_handle.update(ctx, |terminal, ctx| {
             let shell_family = terminal.shell_family(ctx);
-            let tail_command = tail_command_for_shell(shell_family, log_path);
+            let shell_launch_data = terminal.active_session_shell(ctx);
+            let tail_command =
+                tail_command_for_shell(shell_family, log_path, shell_launch_data.as_ref());
             terminal.set_pending_command(&tail_command, ctx);
         });
     }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -15172,7 +15172,7 @@ impl Workspace {
 
         terminal_view_handle.update(ctx, |terminal, ctx| {
             let shell_family = terminal.shell_family(ctx);
-            let shell_launch_data = terminal.active_session_shell(ctx);
+            let shell_launch_data = terminal.active_or_pending_shell_launch_data(ctx);
             let tail_command =
                 tail_command_for_shell(shell_family, log_path, shell_launch_data.as_ref());
             terminal.set_pending_command(&tail_command, ctx);


### PR DESCRIPTION
## Summary
- convert Windows host log paths to session-native paths before building tail commands
- apply the same session-aware tail command flow to MCP logs and LSP logs
- add coverage for WSL path conversion and PowerShell behavior

Closes #10169.