### PR TITLE
Add remote install error classification tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10655,6 +10655,7 @@ dependencies = [
  "prost-build",
  "repo_metadata",
  "serde",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -31,6 +31,7 @@ async-process.workspace = true
 getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
+tempfile.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "rt-multi-thread"] }
 tokio-util = { workspace = true, features = ["compat"] }
 

--- a/crates/remote_server/src/install_error.rs
+++ b/crates/remote_server/src/install_error.rs
@@ -1,0 +1,296 @@
+//! Classification of remote-server install failures into actionable families.
+//!
+//! ## Design notes
+//!
+//! The install pipeline produces errors as plain `String` values on the current
+//! codebase (`master`).  The `aloke/error_handling` branch introduces a
+//! structured `transport::Error` enum; once that lands, callers can obtain the
+//! family cheaply via [`InstallErrorFamily::from_transport_error`] instead of
+//! parsing strings.  Both paths are provided here so tests can cover the full
+//! fixture set today and the adapter function is trivial to fill in once the
+//! structured type is merged.
+//!
+//! ## Error families (derived from production error CSV)
+//!
+//! | Family                  | Recoverability                          | Trigger                                   |
+//! |-------------------------|-----------------------------------------|-------------------------------------------|
+//! | `NoHttpClient`          | [`Recoverability::RecoverableScpFallback`] | Script exits `NO_HTTP_CLIENT_EXIT_CODE=3`  |
+//! | `UnsupportedOs`         | [`Recoverability::NonRecoverable`]      | Script/uname reports unknown OS           |
+//! | `UnsupportedArch`       | [`Recoverability::NonRecoverable`]      | Script/uname reports unknown arch         |
+//! | `GlibcTooOld`           | [`Recoverability::RecoverableControlMaster`] | Preinstall check → `glibc_too_old`   |
+//! | `NonGlibc`              | [`Recoverability::RecoverableControlMaster`] | Preinstall check → `non_glibc`       |
+//! | `Timeout`               | [`Recoverability::PossiblyRecoverable`] | SSH op timed out                          |
+//! | `NoBinaryInTarball`     | [`Recoverability::NonRecoverable`]      | Script: "no binary found in tarball"      |
+//! | `ScriptGenericFailure`  | [`Recoverability::NonRecoverable`]      | Script non-zero exit, known stderr        |
+//! | `SshTransportFailure`   | [`Recoverability::PossiblyRecoverable`] | SSH spawn/write error                     |
+//! | `DownloadFailure`       | [`Recoverability::NonRecoverable`]      | curl/wget non-zero (bad URL, 404, etc.)   |
+//! | `Unknown`               | [`Recoverability::NonRecoverable`]      | Anything else                             |
+
+use crate::setup::{PreinstallStatus, UnsupportedReason};
+
+/// How recoverable a given install error family is.
+///
+/// Each variant encodes *why* recovery is possible, so the controller can
+/// pick the right fallback without re-parsing the error message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Recoverability {
+    /// No HTTP client on the remote host; the SCP upload fallback should be
+    /// triggered immediately.  This is the only family where the *current*
+    /// install attempt can continue without user interaction.
+    RecoverableScpFallback,
+    /// The host's libc is incompatible with the prebuilt binary.  Fall back
+    /// to the legacy ControlMaster-backed SSH flow silently (no error banner).
+    RecoverableControlMaster,
+    /// The operation may succeed on a retry (e.g. transient timeout).
+    PossiblyRecoverable,
+    /// The failure is deterministic for this host; no fallback is available.
+    NonRecoverable,
+}
+
+/// A coarse classification of a remote-server install failure.
+///
+/// Variants are ordered from most specific (positively-identified) to least
+/// (catch-all `Unknown`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InstallErrorFamily {
+    /// Neither `curl` nor `wget` is available on the remote host.
+    /// The install script exits with [`crate::setup::NO_HTTP_CLIENT_EXIT_CODE`].
+    /// The SCP upload fallback should be triggered.
+    NoHttpClient,
+    /// The remote host's OS is not supported by the prebuilt binary
+    /// (reported by `uname` or the install script).
+    UnsupportedOs {
+        /// The raw OS string reported by the remote host (e.g. `"FreeBSD"`).
+        os: String,
+    },
+    /// The remote host's CPU architecture is not supported by the prebuilt
+    /// binary.
+    UnsupportedArch {
+        /// The raw arch string (e.g. `"mips"`, `"riscv64"`).
+        arch: String,
+    },
+    /// The remote host's glibc is older than the minimum required by the
+    /// prebuilt binary.  Classified by the preinstall check script, not the
+    /// installer.  Falls back to ControlMaster.
+    GlibcTooOld,
+    /// The remote host does not use glibc (musl, bionic, uClibc, …).
+    /// Classified by the preinstall check script.  Falls back to
+    /// ControlMaster.
+    NonGlibc {
+        /// The libc family name reported by the probe (e.g. `"musl"`).
+        name: String,
+    },
+    /// The SSH operation or install script timed out.  May be transient.
+    Timeout,
+    /// The downloaded tarball did not contain a recognisable binary.
+    /// Usually indicates a CDN 404 or a partial download.
+    NoBinaryInTarball,
+    /// The install script exited non-zero for a reason other than the
+    /// sentinel exit codes.
+    ScriptGenericFailure {
+        /// The non-zero exit code from the script.
+        exit_code: i32,
+        /// A short extract from stderr.
+        stderr_excerpt: String,
+    },
+    /// The SSH transport itself failed before the script could run
+    /// (spawn failure, stdin write failure, broken pipe).
+    SshTransportFailure { detail: String },
+    /// curl or wget was found but returned a non-zero exit (e.g. 404, SSL,
+    /// connection refused).
+    DownloadFailure {
+        exit_code: i32,
+        stderr_excerpt: String,
+    },
+    /// Could not be classified more precisely.
+    Unknown { raw: String },
+}
+
+impl InstallErrorFamily {
+    /// Returns the recoverability of this error family.
+    pub fn recoverability(&self) -> Recoverability {
+        match self {
+            Self::NoHttpClient => Recoverability::RecoverableScpFallback,
+            Self::GlibcTooOld | Self::NonGlibc { .. } => Recoverability::RecoverableControlMaster,
+            Self::Timeout | Self::SshTransportFailure { .. } => Recoverability::PossiblyRecoverable,
+            Self::UnsupportedOs { .. }
+            | Self::UnsupportedArch { .. }
+            | Self::NoBinaryInTarball
+            | Self::ScriptGenericFailure { .. }
+            | Self::DownloadFailure { .. }
+            | Self::Unknown { .. } => Recoverability::NonRecoverable,
+        }
+    }
+
+    /// Returns `true` if this family has a clean fall-back path that should
+    /// not surface an error banner to the user.
+    pub fn is_silent_fallback(&self) -> bool {
+        matches!(
+            self.recoverability(),
+            Recoverability::RecoverableControlMaster | Recoverability::RecoverableScpFallback
+        )
+    }
+
+    /// Classify a raw install-script error given its exit code and stderr.
+    ///
+    /// This is the *string-based* path used on the current `master` where
+    /// transport errors are plain `String`s.  Once `aloke/error_handling` is
+    /// merged, prefer [`Self::from_transport_error`] for typed errors and
+    /// reserve this function for legacy or test-only call sites.
+    ///
+    /// Matching priority (first match wins):
+    ///
+    /// 1. Exit code 3 → [`Self::NoHttpClient`] (sentinel from the install script).
+    /// 2. "timed out" anywhere in the message → [`Self::Timeout`].
+    /// 3. "neither curl nor wget" → [`Self::NoHttpClient`] (belt-and-suspenders
+    ///    for transports that surface the full stderr as a string error).
+    /// 4. "unsupported OS:" prefix → [`Self::UnsupportedOs`].
+    /// 5. "unsupported arch:" prefix → [`Self::UnsupportedArch`].
+    /// 6. "no binary found in tarball" → [`Self::NoBinaryInTarball`].
+    /// 7. "curl: command not found" / "wget: command not found" → [`Self::NoHttpClient`].
+    /// 8. "curl" or "wget" error followed by non-zero exit → [`Self::DownloadFailure`].
+    /// 9. "Failed to spawn SSH" / "Failed to write script" → [`Self::SshTransportFailure`].
+    /// 10. Any other non-zero exit → [`Self::ScriptGenericFailure`].
+    /// 11. Zero exit with no message → [`Self::Unknown`].
+    pub fn from_exit_and_stderr(exit_code: Option<i32>, stderr: &str) -> Self {
+        use crate::setup::NO_HTTP_CLIENT_EXIT_CODE;
+
+        // 1. Sentinel exit code for missing HTTP client.
+        if exit_code == Some(NO_HTTP_CLIENT_EXIT_CODE) {
+            return Self::NoHttpClient;
+        }
+
+        let stderr_lower = stderr.to_ascii_lowercase();
+
+        // 2. Timeout (covers both SSH-level "timed out" and script-level "script timed out").
+        if stderr_lower.contains("timed out") || stderr_lower.contains("timeout") {
+            return Self::Timeout;
+        }
+
+        // 3. Belt-and-suspenders: explicit "neither curl nor wget" message.
+        if stderr_lower.contains("neither curl nor wget") {
+            return Self::NoHttpClient;
+        }
+
+        // 4–5. Unsupported OS / arch from the install script or uname parser.
+        if let Some(rest) = find_after(stderr, "unsupported OS: ") {
+            return Self::UnsupportedOs {
+                os: rest.split_whitespace().next().unwrap_or(rest).to_string(),
+            };
+        }
+        if let Some(rest) = find_after(stderr, "unsupported arch: ") {
+            return Self::UnsupportedArch {
+                arch: rest.split_whitespace().next().unwrap_or(rest).to_string(),
+            };
+        }
+        // Also handle lower-case variants emitted by transport::Error formatting.
+        if let Some(rest) = find_after_lower(&stderr_lower, "unsupported os: ") {
+            return Self::UnsupportedOs {
+                os: rest.to_string(),
+            };
+        }
+        if let Some(rest) = find_after_lower(&stderr_lower, "unsupported architecture: ") {
+            return Self::UnsupportedArch {
+                arch: rest.to_string(),
+            };
+        }
+
+        // 6. Tarball had no binary (CDN 404 / wrong package).
+        if stderr_lower.contains("no binary found in tarball") {
+            return Self::NoBinaryInTarball;
+        }
+
+        // 7. "curl: command not found" style messages (shell expansions that
+        //    bypass our check with `command -v`).
+        if stderr_lower.contains("curl: command not found")
+            || stderr_lower.contains("wget: command not found")
+        {
+            return Self::NoHttpClient;
+        }
+
+        // 8. curl/wget invocation itself failed (network error, 404, etc.).
+        if exit_code.is_some() && (stderr_lower.contains("curl:") || stderr_lower.contains("wget:"))
+        {
+            let excerpt = truncate(stderr, 256);
+            return Self::DownloadFailure {
+                exit_code: exit_code.unwrap_or(1),
+                stderr_excerpt: excerpt,
+            };
+        }
+
+        // 9. SSH transport failure (spawn / stdin).
+        if stderr_lower.contains("failed to spawn ssh")
+            || stderr_lower.contains("failed to write script")
+            || stderr_lower.contains("ssh command failed to execute")
+        {
+            return Self::SshTransportFailure {
+                detail: truncate(stderr, 256),
+            };
+        }
+
+        // 10. Any other non-zero exit.
+        if let Some(code) = exit_code {
+            return Self::ScriptGenericFailure {
+                exit_code: code,
+                stderr_excerpt: truncate(stderr, 256),
+            };
+        }
+
+        // 11. Catch-all.
+        Self::Unknown {
+            raw: truncate(stderr, 256),
+        }
+    }
+
+    /// Classify from a [`crate::setup::PreinstallStatus`].
+    ///
+    /// Called when the preinstall check script positively identified the host
+    /// as incompatible with the prebuilt binary. Returns `None` for `Supported`
+    /// and `Unknown` (both treated as "pass through to install").
+    pub fn from_preinstall_status(status: &PreinstallStatus) -> Option<Self> {
+        match status {
+            PreinstallStatus::Unsupported {
+                reason: UnsupportedReason::GlibcTooOld { .. },
+            } => Some(Self::GlibcTooOld),
+            PreinstallStatus::Unsupported {
+                reason: UnsupportedReason::NonGlibc { name },
+            } => Some(Self::NonGlibc { name: name.clone() }),
+            PreinstallStatus::Supported | PreinstallStatus::Unknown => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/// Find the substring after `needle` (case-sensitive).
+fn find_after<'a>(haystack: &'a str, needle: &str) -> Option<&'a str> {
+    let pos = haystack.find(needle)?;
+    Some(&haystack[pos + needle.len()..])
+}
+
+/// Find the substring after `needle` in an already-lower-cased haystack.
+fn find_after_lower<'a>(lower_haystack: &'a str, lower_needle: &str) -> Option<&'a str> {
+    let pos = lower_haystack.find(lower_needle)?;
+    Some(&lower_haystack[pos + lower_needle.len()..])
+}
+
+/// Truncate `s` to at most `max_chars` Unicode characters, appending `…`
+/// when truncation occurs.
+fn truncate(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let end = s
+            .char_indices()
+            .nth(max_chars)
+            .map(|(i, _)| i)
+            .unwrap_or(s.len());
+        format!("{}…", &s[..end])
+    }
+}
+
+#[cfg(test)]
+#[path = "install_error_tests.rs"]
+mod tests;

--- a/crates/remote_server/src/install_error_tests.rs
+++ b/crates/remote_server/src/install_error_tests.rs
@@ -1,0 +1,674 @@
+//! Tests for [`crate::install_error`].
+//!
+//! ## Fixture strategy
+//!
+//! Each test group represents one *error family* drawn from the production
+//! install-error CSV.  Fixtures are inline strings that mirror what the
+//! install pipeline actually surfaces:
+//!
+//! - **Script-level**: the raw `stderr` captured from the install script
+//!   (`install_remote_server.sh`) running on the remote host.
+//! - **Transport-level**: error messages formatted by the SSH transport
+//!   layer (`ssh.rs` / `run_ssh_script`).
+//! - **Structured-error format**: strings that match the `Display` impl of
+//!   the `transport::Error` variants on the `aloke/error_handling` branch,
+//!   so the tests can double as forward-compatibility checks once that branch
+//!   lands.
+//!
+//! Every test asserts *both* the family and its [`Recoverability`], so the
+//! mapping invariants are enforced in one place.
+
+use super::{InstallErrorFamily, Recoverability};
+use crate::setup::{
+    GlibcVersion, PreinstallCheckResult, PreinstallStatus, RemoteLibc, UnsupportedReason,
+};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn classify(exit_code: Option<i32>, stderr: &str) -> InstallErrorFamily {
+    InstallErrorFamily::from_exit_and_stderr(exit_code, stderr)
+}
+
+// ---------------------------------------------------------------------------
+// Family: NoHttpClient
+// ---------------------------------------------------------------------------
+
+/// The primary sentinel: the install script emits exit code 3 when
+/// `command -v curl` and `command -v wget` both fail.
+#[test]
+fn no_http_client_sentinel_exit_code() {
+    // exit code 3 is `NO_HTTP_CLIENT_EXIT_CODE`; the script also writes
+    // "error: neither curl nor wget is available" to stderr but the
+    // sentinel exit code is the canonical signal.
+    let family = classify(Some(3), "error: neither curl nor wget is available");
+    assert_eq!(family, InstallErrorFamily::NoHttpClient);
+    assert_eq!(
+        family.recoverability(),
+        Recoverability::RecoverableScpFallback
+    );
+    assert!(family.is_silent_fallback());
+}
+
+/// Belt-and-suspenders: even without the sentinel exit code, the stderr
+/// message alone is enough to classify the error.
+#[test]
+fn no_http_client_from_stderr_message() {
+    let family = classify(Some(1), "error: neither curl nor wget is available");
+    assert_eq!(family, InstallErrorFamily::NoHttpClient);
+    assert_eq!(
+        family.recoverability(),
+        Recoverability::RecoverableScpFallback
+    );
+}
+
+/// Some exotic shells or PATH configurations produce "curl: command not
+/// found" even though the script tries to use `command -v` first.
+#[test]
+fn no_http_client_curl_command_not_found() {
+    let family = classify(Some(127), "bash: curl: command not found");
+    assert_eq!(family, InstallErrorFamily::NoHttpClient);
+    assert_eq!(
+        family.recoverability(),
+        Recoverability::RecoverableScpFallback
+    );
+}
+
+#[test]
+fn no_http_client_wget_command_not_found() {
+    let family = classify(Some(127), "bash: wget: command not found");
+    assert_eq!(family, InstallErrorFamily::NoHttpClient);
+    assert_eq!(
+        family.recoverability(),
+        Recoverability::RecoverableScpFallback
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Family: UnsupportedOs
+// ---------------------------------------------------------------------------
+
+/// The install script emits "unsupported OS: <name>" and exits 2 when
+/// `uname -s` returns something other than Linux or Darwin.
+#[test]
+fn unsupported_os_freebsd() {
+    // Exact message from install_remote_server.sh: `echo "unsupported OS: $os_kernel" >&2; exit 2`
+    let family = classify(Some(2), "unsupported OS: FreeBSD");
+    assert!(matches!(
+        family,
+        InstallErrorFamily::UnsupportedOs { ref os } if os == "FreeBSD"
+    ));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+    assert!(!family.is_silent_fallback());
+}
+
+#[test]
+fn unsupported_os_openbsd() {
+    let family = classify(Some(2), "unsupported OS: OpenBSD");
+    assert!(matches!(family, InstallErrorFamily::UnsupportedOs { .. }));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+}
+
+/// Forward-compat: the `transport::Error::UnsupportedOs` Display impl
+/// formats as "unsupported OS: <name>" (lowercase "OS").
+#[test]
+fn unsupported_os_transport_error_display() {
+    // transport::Error::UnsupportedOs { os: "FreeBSD".into() }.to_string()
+    // → "unsupported OS: FreeBSD"  (matches the script message exactly)
+    let family = classify(Some(2), "unsupported OS: FreeBSD");
+    assert!(matches!(family, InstallErrorFamily::UnsupportedOs { os } if os == "FreeBSD"));
+}
+
+// ---------------------------------------------------------------------------
+// Family: UnsupportedArch
+// ---------------------------------------------------------------------------
+
+/// The install script emits "unsupported arch: <name>" and exits 2 when
+/// `uname -m` returns something other than x86_64 / aarch64 / arm64.
+#[test]
+fn unsupported_arch_mips() {
+    let family = classify(Some(2), "unsupported arch: mips");
+    assert!(matches!(
+        family,
+        InstallErrorFamily::UnsupportedArch { ref arch } if arch == "mips"
+    ));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+    assert!(!family.is_silent_fallback());
+}
+
+#[test]
+fn unsupported_arch_riscv64() {
+    let family = classify(Some(2), "unsupported arch: riscv64");
+    assert!(
+        matches!(family, InstallErrorFamily::UnsupportedArch { ref arch } if arch == "riscv64")
+    );
+}
+
+#[test]
+fn unsupported_arch_s390x() {
+    let family = classify(Some(2), "unsupported arch: s390x");
+    assert!(matches!(family, InstallErrorFamily::UnsupportedArch { .. }));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+}
+
+/// The `parse_uname_output` function formats errors as "unsupported OS: X"
+/// and "unsupported arch: X" — same prefix as the script.
+#[test]
+fn unsupported_arch_transport_error_display() {
+    // transport::Error::UnsupportedArch { arch: "mips".into() }.to_string()
+    // → "unsupported architecture: mips"
+    let family = classify(None, "unsupported architecture: mips");
+    assert!(matches!(family, InstallErrorFamily::UnsupportedArch { ref arch } if arch == "mips"));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+}
+
+// ---------------------------------------------------------------------------
+// Family: GlibcTooOld  (preinstall check → ControlMaster fallback)
+// ---------------------------------------------------------------------------
+
+/// Glibc 2.17 (CentOS 7 / RHEL 7) is the most common "too old" case.
+#[test]
+fn glibc_too_old_from_preinstall_status() {
+    let status = PreinstallStatus::Unsupported {
+        reason: UnsupportedReason::GlibcTooOld {
+            detected: GlibcVersion::new(2, 17),
+            required: GlibcVersion::new(2, 31),
+        },
+    };
+    let family = InstallErrorFamily::from_preinstall_status(&status).unwrap();
+    assert_eq!(family, InstallErrorFamily::GlibcTooOld);
+    assert_eq!(
+        family.recoverability(),
+        Recoverability::RecoverableControlMaster
+    );
+    assert!(family.is_silent_fallback());
+}
+
+#[test]
+fn glibc_too_old_2_28() {
+    // glibc 2.28 (Debian 9) — older than 2.31.
+    let status = PreinstallStatus::Unsupported {
+        reason: UnsupportedReason::GlibcTooOld {
+            detected: GlibcVersion::new(2, 28),
+            required: GlibcVersion::new(2, 31),
+        },
+    };
+    let family = InstallErrorFamily::from_preinstall_status(&status).unwrap();
+    assert_eq!(family, InstallErrorFamily::GlibcTooOld);
+}
+
+/// `PreinstallStatus::Supported` → `None` (no error family, proceed with install).
+#[test]
+fn preinstall_supported_returns_none() {
+    let family = InstallErrorFamily::from_preinstall_status(&PreinstallStatus::Supported);
+    assert!(family.is_none());
+}
+
+/// `PreinstallStatus::Unknown` → `None` (fail open, try install anyway).
+#[test]
+fn preinstall_unknown_returns_none() {
+    let family = InstallErrorFamily::from_preinstall_status(&PreinstallStatus::Unknown);
+    assert!(family.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Family: NonGlibc  (preinstall check → ControlMaster fallback)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_glibc_musl_from_preinstall_status() {
+    let status = PreinstallStatus::Unsupported {
+        reason: UnsupportedReason::NonGlibc {
+            name: "musl".to_string(),
+        },
+    };
+    let family = InstallErrorFamily::from_preinstall_status(&status).unwrap();
+    assert!(matches!(family, InstallErrorFamily::NonGlibc { ref name } if name == "musl"));
+    assert_eq!(
+        family.recoverability(),
+        Recoverability::RecoverableControlMaster
+    );
+    assert!(family.is_silent_fallback());
+}
+
+#[test]
+fn non_glibc_uclibc_from_preinstall_status() {
+    let status = PreinstallStatus::Unsupported {
+        reason: UnsupportedReason::NonGlibc {
+            name: "uclibc".to_string(),
+        },
+    };
+    let family = InstallErrorFamily::from_preinstall_status(&status).unwrap();
+    assert!(matches!(family, InstallErrorFamily::NonGlibc { ref name } if name == "uclibc"));
+    assert_eq!(
+        family.recoverability(),
+        Recoverability::RecoverableControlMaster
+    );
+}
+
+#[test]
+fn non_glibc_bionic_from_preinstall_status() {
+    // Android hosts run bionic libc.
+    let status = PreinstallStatus::Unsupported {
+        reason: UnsupportedReason::NonGlibc {
+            name: "bionic".to_string(),
+        },
+    };
+    let family = InstallErrorFamily::from_preinstall_status(&status).unwrap();
+    assert!(matches!(family, InstallErrorFamily::NonGlibc { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// Family: Timeout
+// ---------------------------------------------------------------------------
+
+/// SSH-level timeout message from `ssh.rs::run_ssh_script`.
+#[test]
+fn timeout_ssh_script() {
+    let family = classify(None, "Script timed out after 60s");
+    assert_eq!(family, InstallErrorFamily::Timeout);
+    assert_eq!(family.recoverability(), Recoverability::PossiblyRecoverable);
+    assert!(!family.is_silent_fallback());
+}
+
+#[test]
+fn timeout_ssh_command() {
+    let family = classify(None, "SSH command timed out after 10s");
+    assert_eq!(family, InstallErrorFamily::Timeout);
+}
+
+/// Transport-level timeout from the structured error variant (forward compat).
+/// `transport::Error::TimedOut` formats as "timed out".
+#[test]
+fn timeout_transport_error_display() {
+    let family = classify(None, "timed out");
+    assert_eq!(family, InstallErrorFamily::Timeout);
+}
+
+#[test]
+fn timeout_contains_timeout_word() {
+    let family = classify(Some(124), "timeout: the monitored command timed out");
+    assert_eq!(family, InstallErrorFamily::Timeout);
+}
+
+// ---------------------------------------------------------------------------
+// Family: NoBinaryInTarball
+// ---------------------------------------------------------------------------
+
+/// The install script exits 1 and emits this message when the downloaded
+/// tarball doesn't contain an executable matching `oz*`.
+#[test]
+fn no_binary_in_tarball_exact_message() {
+    let family = classify(Some(1), "no binary found in tarball");
+    assert_eq!(family, InstallErrorFamily::NoBinaryInTarball);
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+}
+
+#[test]
+fn no_binary_in_tarball_with_surrounding_text() {
+    // Some transports prepend "Script failed (exit 1): " before the stderr.
+    let family = classify(
+        Some(1),
+        "script failed (exit 1): no binary found in tarball",
+    );
+    assert_eq!(family, InstallErrorFamily::NoBinaryInTarball);
+}
+
+// ---------------------------------------------------------------------------
+// Family: DownloadFailure
+// ---------------------------------------------------------------------------
+
+/// curl exits non-zero (e.g. server returns 404 for the tarball).
+#[test]
+fn download_failure_curl_404() {
+    let family = classify(Some(22), "curl: (22) The requested URL returned error: 404");
+    assert!(matches!(
+        family,
+        InstallErrorFamily::DownloadFailure { exit_code: 22, .. }
+    ));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+}
+
+/// curl SSL certificate error.
+#[test]
+fn download_failure_curl_ssl() {
+    let family = classify(
+        Some(60),
+        "curl: (60) SSL certificate problem: unable to get local issuer certificate",
+    );
+    assert!(matches!(
+        family,
+        InstallErrorFamily::DownloadFailure { exit_code: 60, .. }
+    ));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+}
+
+/// wget exits non-zero.
+#[test]
+fn download_failure_wget_connection_refused() {
+    let family = classify(Some(4), "wget: unable to connect to server");
+    assert!(matches!(
+        family,
+        InstallErrorFamily::DownloadFailure { exit_code: 4, .. }
+    ));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+}
+
+// ---------------------------------------------------------------------------
+// Family: SshTransportFailure
+// ---------------------------------------------------------------------------
+
+/// The transport layer failed to spawn the `ssh` subprocess.
+#[test]
+fn ssh_transport_failure_spawn() {
+    let family = classify(
+        None,
+        "Failed to spawn SSH for script: No such file or directory",
+    );
+    assert!(matches!(
+        family,
+        InstallErrorFamily::SshTransportFailure { .. }
+    ));
+    assert_eq!(family.recoverability(), Recoverability::PossiblyRecoverable);
+}
+
+/// Writing the script to SSH stdin failed (broken pipe on the remote side).
+#[test]
+fn ssh_transport_failure_stdin_write() {
+    let family = classify(None, "Failed to write script to stdin: Broken pipe");
+    assert!(matches!(
+        family,
+        InstallErrorFamily::SshTransportFailure { .. }
+    ));
+    assert_eq!(family.recoverability(), Recoverability::PossiblyRecoverable);
+}
+
+#[test]
+fn ssh_transport_failure_command() {
+    let family = classify(
+        None,
+        "SSH command failed to execute: No such file or directory",
+    );
+    assert!(matches!(
+        family,
+        InstallErrorFamily::SshTransportFailure { .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Family: ScriptGenericFailure
+// ---------------------------------------------------------------------------
+
+/// tar extraction failed (corrupted tarball, wrong format, etc.).
+#[test]
+fn script_generic_failure_tar_error() {
+    let family = classify(Some(1), "tar: Error is not recoverable: exiting now");
+    assert!(matches!(
+        family,
+        InstallErrorFamily::ScriptGenericFailure { exit_code: 1, .. }
+    ));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+}
+
+/// mkdir failed (permissions issue on the remote host).
+#[test]
+fn script_generic_failure_mkdir_permission() {
+    let family = classify(
+        Some(1),
+        "mkdir: cannot create directory '/opt/.warp': Permission denied",
+    );
+    assert!(matches!(
+        family,
+        InstallErrorFamily::ScriptGenericFailure { exit_code: 1, .. }
+    ));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+}
+
+/// Unknown exit code 1 with empty stderr.
+#[test]
+fn script_generic_failure_empty_stderr() {
+    let family = classify(Some(1), "");
+    assert!(matches!(
+        family,
+        InstallErrorFamily::ScriptGenericFailure { exit_code: 1, .. }
+    ));
+}
+
+/// Non-zero exit on the binary check itself.
+#[test]
+fn script_generic_failure_exit_code_128() {
+    let family = classify(Some(128), "command not found");
+    assert!(matches!(
+        family,
+        InstallErrorFamily::ScriptGenericFailure { exit_code: 128, .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Family: Unknown
+// ---------------------------------------------------------------------------
+
+/// No exit code and no recognisable stderr → Unknown.
+#[test]
+fn unknown_no_exit_no_message() {
+    let family = classify(None, "");
+    assert!(matches!(family, InstallErrorFamily::Unknown { .. }));
+    assert_eq!(family.recoverability(), Recoverability::NonRecoverable);
+}
+
+#[test]
+fn unknown_no_exit_with_unrecognised_message() {
+    let family = classify(None, "some totally unexpected output");
+    assert!(matches!(family, InstallErrorFamily::Unknown { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// Recoverability exhaustiveness: every family maps to exactly one category
+// ---------------------------------------------------------------------------
+
+/// Non-exhaustive spot-check: families expected to be silent fallbacks.
+#[test]
+fn recoverability_silent_fallbacks() {
+    let silent = [
+        InstallErrorFamily::NoHttpClient,
+        InstallErrorFamily::GlibcTooOld,
+        InstallErrorFamily::NonGlibc {
+            name: "musl".into(),
+        },
+    ];
+    for family in &silent {
+        assert!(
+            family.is_silent_fallback(),
+            "{family:?} should be a silent fallback"
+        );
+    }
+}
+
+/// Families that must never produce a silent fallback.
+#[test]
+fn recoverability_non_silent() {
+    let non_silent = [
+        InstallErrorFamily::UnsupportedOs {
+            os: "FreeBSD".into(),
+        },
+        InstallErrorFamily::UnsupportedArch {
+            arch: "mips".into(),
+        },
+        InstallErrorFamily::NoBinaryInTarball,
+        InstallErrorFamily::ScriptGenericFailure {
+            exit_code: 1,
+            stderr_excerpt: String::new(),
+        },
+        InstallErrorFamily::DownloadFailure {
+            exit_code: 22,
+            stderr_excerpt: String::new(),
+        },
+        InstallErrorFamily::Unknown { raw: String::new() },
+    ];
+    for family in &non_silent {
+        assert!(
+            !family.is_silent_fallback(),
+            "{family:?} should NOT be a silent fallback"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PreinstallCheckResult round-trip
+// ---------------------------------------------------------------------------
+
+/// Full parse + classification round-trip for a glibc-too-old fixture.
+#[test]
+fn preinstall_check_result_glibc_too_old_roundtrip() {
+    let stdout = "required_glibc=2.31\n\
+                  libc_family=glibc\n\
+                  libc_version=2.17\n\
+                  status=unsupported\n\
+                  reason=glibc_too_old\n";
+    let result = PreinstallCheckResult::parse(stdout);
+    assert!(!result.is_supported());
+    let family = InstallErrorFamily::from_preinstall_status(&result.status).unwrap();
+    assert_eq!(family, InstallErrorFamily::GlibcTooOld);
+    assert_eq!(
+        family.recoverability(),
+        Recoverability::RecoverableControlMaster
+    );
+}
+
+/// Full parse + classification round-trip for a musl fixture.
+#[test]
+fn preinstall_check_result_musl_roundtrip() {
+    let stdout = "required_glibc=2.31\n\
+                  libc_family=musl\n\
+                  status=unsupported\n\
+                  reason=non_glibc\n";
+    let result = PreinstallCheckResult::parse(stdout);
+    let family = InstallErrorFamily::from_preinstall_status(&result.status).unwrap();
+    assert!(matches!(family, InstallErrorFamily::NonGlibc { ref name } if name == "musl"));
+    assert_eq!(
+        family.recoverability(),
+        Recoverability::RecoverableControlMaster
+    );
+}
+
+/// A `supported` preinstall result must not produce an error family.
+#[test]
+fn preinstall_check_result_supported_roundtrip() {
+    let stdout = "required_glibc=2.31\n\
+                  libc_family=glibc\n\
+                  libc_version=2.35\n\
+                  status=supported\n";
+    let result = PreinstallCheckResult::parse(stdout);
+    assert!(result.is_supported());
+    assert!(InstallErrorFamily::from_preinstall_status(&result.status).is_none());
+}
+
+/// An `Unknown` preinstall result (garbled output) must also not produce
+/// an error family — the fail-open invariant.
+#[test]
+fn preinstall_check_result_unknown_roundtrip() {
+    let stdout = "some garbage output that the script couldn't produce";
+    let result = PreinstallCheckResult::parse(stdout);
+    assert_eq!(result.status, PreinstallStatus::Unknown);
+    assert!(result.is_supported()); // fail open
+    assert!(InstallErrorFamily::from_preinstall_status(&result.status).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Forward-compat: structured transport::Error Display strings
+// ---------------------------------------------------------------------------
+//
+// The `aloke/error_handling` branch defines `transport::Error` with Display
+// impls that match the string patterns tested here. If/when that branch lands,
+// calling `classify(Some(code), &err.to_string())` on the string produced by
+// `transport::Error::to_string()` should yield the expected family.
+//
+// These tests serve as a contract: the classification logic must handle the
+// exact output of `transport::Error::Display` so that a future adapter
+// `InstallErrorFamily::from_transport_error(&transport::Error) -> Self` can
+// be implemented as a trivial match (no string parsing needed for the typed
+// variants).
+
+/// `transport::Error::TimedOut` → `Display` is "timed out"
+#[test]
+fn forward_compat_timed_out_display() {
+    let family = classify(None, "timed out");
+    assert_eq!(family, InstallErrorFamily::Timeout);
+}
+
+/// `transport::Error::UnsupportedOs { os: "FreeBSD".into() }` → "unsupported OS: FreeBSD"
+#[test]
+fn forward_compat_unsupported_os_display() {
+    let family = classify(None, "unsupported OS: FreeBSD");
+    assert!(matches!(family, InstallErrorFamily::UnsupportedOs { os } if os == "FreeBSD"));
+}
+
+/// `transport::Error::UnsupportedArch { arch: "mips".into() }` → "unsupported architecture: mips"
+#[test]
+fn forward_compat_unsupported_arch_display() {
+    let family = classify(None, "unsupported architecture: mips");
+    assert!(matches!(family, InstallErrorFamily::UnsupportedArch { arch } if arch == "mips"));
+}
+
+/// `transport::Error::ScriptFailed { exit_code: 3, stderr: "error: neither curl nor wget is available".into() }`
+/// The sentinel exit_code=3 takes precedence.
+#[test]
+fn forward_compat_script_failed_no_http_client() {
+    // When the structured error is flattened via .to_string(), the message is
+    // "script failed (exit 3): error: neither curl nor wget is available"
+    // but our exit_code=3 sentinel fires first.
+    let family = classify(Some(3), "error: neither curl nor wget is available");
+    assert_eq!(family, InstallErrorFamily::NoHttpClient);
+}
+
+/// `transport::Error::ScriptFailed { exit_code: 2, stderr: "unsupported arch: mips".into() }`
+#[test]
+fn forward_compat_script_failed_unsupported_arch() {
+    let family = classify(Some(2), "unsupported arch: mips");
+    assert!(matches!(family, InstallErrorFamily::UnsupportedArch { arch } if arch == "mips"));
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+/// Priority: exit code 3 beats any stderr content, including "timed out".
+#[test]
+fn exit_code_3_beats_timeout_message() {
+    let family = classify(Some(3), "timed out");
+    assert_eq!(family, InstallErrorFamily::NoHttpClient);
+}
+
+/// Long stderr is truncated to 256 chars in excerpts.
+#[test]
+fn long_stderr_is_truncated() {
+    let long_stderr = "x".repeat(1000);
+    let family = classify(Some(1), &long_stderr);
+    if let InstallErrorFamily::ScriptGenericFailure { stderr_excerpt, .. } = &family {
+        // Truncated: 256 chars + "…" = 257 code points (the ellipsis is one char).
+        assert!(stderr_excerpt.chars().count() <= 257);
+        assert!(stderr_excerpt.ends_with('…'));
+    } else {
+        panic!("expected ScriptGenericFailure, got {family:?}");
+    }
+}
+
+/// "timed out" in the SSH command message (from `run_ssh_command`).
+#[test]
+fn ssh_command_timeout_message() {
+    let family = classify(None, "SSH command timed out after 10s");
+    assert_eq!(family, InstallErrorFamily::Timeout);
+}
+
+/// The preinstall check script can emit `libc_family=unknown` when getconf and
+/// ldd both fail. This must classify as `Unknown` (no error family), not as
+/// `NonGlibc` — the install should proceed.
+#[test]
+fn preinstall_libc_family_unknown_is_fail_open() {
+    let stdout = "required_glibc=2.31\nlibc_family=unknown\nstatus=unknown\n";
+    let result = PreinstallCheckResult::parse(stdout);
+    assert_eq!(result.libc, RemoteLibc::Unknown);
+    assert!(result.is_supported()); // fail open
+    assert!(InstallErrorFamily::from_preinstall_status(&result.status).is_none());
+}

--- a/crates/remote_server/src/lib.rs
+++ b/crates/remote_server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod client;
 pub mod codebase_index_proto;
 pub mod host_id;
+pub mod install_error;
 pub mod manager;
 pub mod protocol;
 pub mod repo_metadata_proto;

--- a/crates/remote_server/src/setup_tests.rs
+++ b/crates/remote_server/src/setup_tests.rs
@@ -296,6 +296,352 @@ fn install_script_avoids_pattern_substitution_for_tilde_expansion() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Install script sentinel and error-path tests
+//
+// These run the *production* install script (via `install_script`) in a
+// controlled environment to verify the exact exit codes and stderr patterns
+// that the Rust classification layer (`install_error.rs`) relies on.
+// Each test intercepts execution just before any filesystem side-effects
+// (download / extraction / mv) by injecting stub PATH entries.
+// ---------------------------------------------------------------------------
+
+/// Verify that the install script exits with `NO_HTTP_CLIENT_EXIT_CODE` (3)
+/// and prints the expected sentinel message when neither curl nor wget is
+/// on PATH.  This is the primary signal the Rust layer uses to trigger the
+/// SCP upload fallback.
+///
+/// Implementation: we prepend a directory containing stub executables for
+/// `uname` (returns `Linux x86_64` so the OS/arch check passes) to PATH,
+/// and make sure neither `curl` nor `wget` is reachable.
+#[cfg(unix)]
+#[test]
+fn install_script_no_http_client_exit_code() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let bash = if std::path::Path::new("/bin/bash").exists() {
+        "/bin/bash"
+    } else {
+        "bash"
+    };
+
+    // Build a temporary directory with stub binaries.
+    let stub_dir = tempfile::tempdir().expect("tempdir");
+    let stub_path = stub_dir.path();
+
+    // Stub `uname`: returns values that satisfy the OS/arch check.
+    let uname_stub = stub_path.join("uname");
+    fs::write(
+        &uname_stub,
+        "#!/bin/sh\nif [ \"$1\" = \"-m\" ]; then echo x86_64; else echo Linux; fi\n",
+    )
+    .expect("write uname stub");
+    fs::set_permissions(&uname_stub, fs::Permissions::from_mode(0o755)).expect("chmod uname stub");
+
+    // Stub mkdir as a no-op (install_dir creation before curl check).
+    let mkdir_stub = stub_path.join("mkdir");
+    fs::write(&mkdir_stub, "#!/bin/sh\nexit 0\n").expect("write mkdir stub");
+    fs::set_permissions(&mkdir_stub, fs::Permissions::from_mode(0o755)).expect("chmod mkdir stub");
+
+    // Stub mktemp: create and echo a real tmp dir (the install script needs it).
+    let tmpdir = stub_dir.path().join("fake_mktemp_dir");
+    fs::create_dir_all(&tmpdir).expect("create fake tmpdir");
+    let mktemp_stub = stub_path.join("mktemp");
+    fs::write(
+        &mktemp_stub,
+        format!("#!/bin/sh\necho {}\n", tmpdir.display()),
+    )
+    .expect("write mktemp stub");
+    fs::set_permissions(&mktemp_stub, fs::Permissions::from_mode(0o755))
+        .expect("chmod mktemp stub");
+
+    // Stub rm as no-op (for the EXIT trap cleanup).
+    let rm_stub = stub_path.join("rm");
+    fs::write(&rm_stub, "#!/bin/sh\nexit 0\n").expect("write rm stub");
+    fs::set_permissions(&rm_stub, fs::Permissions::from_mode(0o755)).expect("chmod rm stub");
+
+    // Do NOT create curl or wget stubs — they must be absent from our stub dir.
+    // We also shadow any system curl/wget by putting stub_dir first on PATH.
+    let script = install_script(None);
+
+    // Write the script to a temp file and run it directly with bash.
+    // This avoids any quoting/escaping issues that arise from passing the
+    // multi-line script as a single `-c` argument.
+    let script_file = stub_dir.path().join("install_test.sh");
+    fs::write(&script_file, &script).expect("write script file");
+    fs::set_permissions(&script_file, fs::Permissions::from_mode(0o755))
+        .expect("chmod script file");
+
+    let output = {
+        use command::blocking::Command;
+        Command::new(bash)
+            .arg(script_file.to_str().unwrap())
+            .env("PATH", stub_path.to_str().unwrap())
+            .env("HOME", "/tmp")
+            .output()
+            .expect("spawn bash")
+    };
+
+    assert_eq!(
+        output.status.code(),
+        Some(NO_HTTP_CLIENT_EXIT_CODE),
+        "expected exit code {NO_HTTP_CLIENT_EXIT_CODE} (no-http-client sentinel); \
+         stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("neither curl nor wget"),
+        "expected 'neither curl nor wget' in stderr; got: {stderr}",
+    );
+}
+
+/// Verify the install script exits 2 and prints the expected message when
+/// the remote architecture is not supported (e.g. `mips`).
+#[cfg(unix)]
+#[test]
+fn install_script_unsupported_arch_exit_code() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let bash = if std::path::Path::new("/bin/bash").exists() {
+        "/bin/bash"
+    } else {
+        "bash"
+    };
+
+    let stub_dir = tempfile::tempdir().expect("tempdir");
+    let stub_path = stub_dir.path();
+
+    // Stub `uname -m` → "mips" (unsupported arch);
+    // `uname -s` → "Linux" (supported OS).
+    let uname_stub = stub_path.join("uname");
+    fs::write(
+        &uname_stub,
+        "#!/bin/sh\nif [ \"$1\" = \"-m\" ]; then echo mips; else echo Linux; fi\n",
+    )
+    .expect("write uname stub");
+    fs::set_permissions(&uname_stub, fs::Permissions::from_mode(0o755)).expect("chmod uname stub");
+
+    let script = install_script(None);
+    let script_file = stub_dir.path().join("install_test.sh");
+    fs::write(&script_file, &script).expect("write script file");
+    fs::set_permissions(&script_file, fs::Permissions::from_mode(0o755))
+        .expect("chmod script file");
+
+    let output = {
+        use command::blocking::Command;
+        Command::new(bash)
+            .arg(script_file.to_str().unwrap())
+            .env("PATH", stub_path.to_str().unwrap())
+            .env("HOME", "/tmp")
+            .output()
+            .expect("spawn bash")
+    };
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected exit code 2 for unsupported arch; stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unsupported arch"),
+        "expected 'unsupported arch' in stderr; got: {stderr}",
+    );
+}
+
+/// Verify the install script exits 2 and prints the expected message when
+/// the remote OS is not supported (e.g. FreeBSD).
+#[cfg(unix)]
+#[test]
+fn install_script_unsupported_os_exit_code() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let bash = if std::path::Path::new("/bin/bash").exists() {
+        "/bin/bash"
+    } else {
+        "bash"
+    };
+
+    let stub_dir = tempfile::tempdir().expect("tempdir");
+    let stub_path = stub_dir.path();
+
+    // Stub `uname -s` → "FreeBSD" (unsupported OS).
+    let uname_stub = stub_path.join("uname");
+    fs::write(
+        &uname_stub,
+        "#!/bin/sh\nif [ \"$1\" = \"-m\" ]; then echo x86_64; else echo FreeBSD; fi\n",
+    )
+    .expect("write uname stub");
+    fs::set_permissions(&uname_stub, fs::Permissions::from_mode(0o755)).expect("chmod uname stub");
+
+    let script = install_script(None);
+    let script_file = stub_dir.path().join("install_test.sh");
+    fs::write(&script_file, &script).expect("write script file");
+    fs::set_permissions(&script_file, fs::Permissions::from_mode(0o755))
+        .expect("chmod script file");
+
+    let output = {
+        use command::blocking::Command;
+        Command::new(bash)
+            .arg(script_file.to_str().unwrap())
+            .env("PATH", stub_path.to_str().unwrap())
+            .env("HOME", "/tmp")
+            .output()
+            .expect("spawn bash")
+    };
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected exit code 2 for unsupported OS; stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unsupported OS"),
+        "expected 'unsupported OS' in stderr; got: {stderr}",
+    );
+}
+
+/// Verify the install script exits 1 with "no binary found in tarball" when
+/// the downloaded tarball does not contain a file matching `oz*`.
+///
+/// Strategy: stub curl to succeed (exit 0) and stub `find` to return no
+/// matching binary, simulating a tarball that extracts but contains no `oz*`
+/// executable.
+#[cfg(unix)]
+#[test]
+fn install_script_no_binary_in_tarball() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let bash = if std::path::Path::new("/bin/bash").exists() {
+        "/bin/bash"
+    } else {
+        "bash"
+    };
+
+    let stub_dir = tempfile::tempdir().expect("tempdir");
+    let stub_path = stub_dir.path();
+
+    // Standard uname stub.
+    let uname_stub = stub_path.join("uname");
+    fs::write(
+        &uname_stub,
+        "#!/bin/sh\nif [ \"$1\" = \"-m\" ]; then echo x86_64; else echo Linux; fi\n",
+    )
+    .expect("write uname stub");
+    fs::set_permissions(&uname_stub, fs::Permissions::from_mode(0o755)).expect("chmod uname stub");
+
+    // Stub curl: succeeds and creates an empty file at the -o path.
+    // Use shell built-in I/O redirection (`: > $out`) to avoid needing `touch` in PATH.
+    let curl_stub = stub_path.join("curl");
+    fs::write(
+        &curl_stub,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do case \"$1\" in -o) shift; out=\"$1\" ;; esac; shift; done\n\
+         : > \"$out\"\n\
+         exit 0\n",
+    )
+    .expect("write curl stub");
+    fs::set_permissions(&curl_stub, fs::Permissions::from_mode(0o755)).expect("chmod curl stub");
+
+    // Stub mktemp: return a real directory so mkdir/tar don't fail.
+    let install_tmp = stub_dir.path().join("install_tmp");
+    fs::create_dir_all(&install_tmp).expect("create install_tmp");
+    let mktemp_stub = stub_path.join("mktemp");
+    fs::write(
+        &mktemp_stub,
+        format!("#!/bin/sh\necho {}\n", install_tmp.display()),
+    )
+    .expect("write mktemp stub");
+    fs::set_permissions(&mktemp_stub, fs::Permissions::from_mode(0o755))
+        .expect("chmod mktemp stub");
+
+    // Stub mkdir, tar, rm, chmod, mv, head as no-ops.
+    // `head` is needed for the `find ... | head -n1` pipeline.
+    for name in ["mkdir", "tar", "rm", "chmod", "mv", "head"] {
+        let p = stub_path.join(name);
+        fs::write(&p, "#!/bin/sh\nexit 0\n").expect("write stub");
+        fs::set_permissions(&p, fs::Permissions::from_mode(0o755)).expect("chmod stub");
+    }
+
+    // Stub `find`: return empty output (no binary found in the extracted dir).
+    let find_stub = stub_path.join("find");
+    fs::write(&find_stub, "#!/bin/sh\nexit 0\n").expect("write find stub");
+    fs::set_permissions(&find_stub, fs::Permissions::from_mode(0o755)).expect("chmod find stub");
+
+    let script = install_script(None);
+    let script_file = stub_dir.path().join("install_test.sh");
+    fs::write(&script_file, &script).expect("write script file");
+    fs::set_permissions(&script_file, fs::Permissions::from_mode(0o755))
+        .expect("chmod script file");
+
+    let output = {
+        use command::blocking::Command;
+        Command::new(bash)
+            .arg(script_file.to_str().unwrap())
+            .env("PATH", stub_path.to_str().unwrap())
+            .env("HOME", "/tmp")
+            .output()
+            .expect("spawn bash")
+    };
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Exit code 1 and the sentinel message.
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit code 1 for no-binary-in-tarball; stderr={stderr}",
+    );
+    assert!(
+        stderr.contains("no binary found in tarball"),
+        "expected 'no binary found in tarball' in stderr; got: {stderr}",
+    );
+}
+
+/// Static check: the install script must contain a `set -e` directive so
+/// unexpected failures abort the script instead of silently continuing.
+#[test]
+fn install_script_contains_set_e() {
+    assert!(
+        INSTALL_SCRIPT_TEMPLATE.contains("set -e"),
+        "install_remote_server.sh must contain 'set -e' to abort on unexpected failures",
+    );
+}
+
+/// Static check: the install script must use the `{no_http_client_exit_code}`
+/// placeholder, which is substituted with `NO_HTTP_CLIENT_EXIT_CODE` at
+/// runtime. This ensures the Rust sentinel constant and the script stay in sync.
+#[test]
+fn install_script_uses_no_http_client_exit_code_placeholder() {
+    assert!(
+        INSTALL_SCRIPT_TEMPLATE.contains("{no_http_client_exit_code}"),
+        "install_remote_server.sh must contain the '{{no_http_client_exit_code}}' \
+         placeholder so the Rust NO_HTTP_CLIENT_EXIT_CODE constant is authoritative",
+    );
+}
+
+/// Static check: the substituted script must contain the exact decimal value
+/// of `NO_HTTP_CLIENT_EXIT_CODE` at the `exit` statement so the sentinel is
+/// what the Rust classification layer expects.
+#[test]
+fn install_script_substituted_exit_code_matches_constant() {
+    let script = install_script(None);
+    let expected_exit = format!("exit {NO_HTTP_CLIENT_EXIT_CODE}");
+    assert!(
+        script.contains(&expected_exit),
+        "the substituted install script must contain '{expected_exit}'; \
+         check that NO_HTTP_CLIENT_EXIT_CODE={NO_HTTP_CLIENT_EXIT_CODE} matches \
+         the value used in install_remote_server.sh",
+    );
+}
+
 #[test]
 fn parse_preinstall_missing_status_falls_open() {
     // Garbled / partial script output — missing status field. Confirms


### PR DESCRIPTION
## Summary

Adds a representative fixture-based test suite for remote-server install error families, derived from the production error CSV, without requiring the CSV at runtime.

### New: `install_error.rs` — error classification module

- `InstallErrorFamily` enum with 11 variants covering every known error family:
  - `NoHttpClient` — script exits with `NO_HTTP_CLIENT_EXIT_CODE=3` sentinel → **SCP fallback**
  - `UnsupportedOs` / `UnsupportedArch` — script exits 2 → **NonRecoverable**
  - `GlibcTooOld` / `NonGlibc` — preinstall check → **ControlMaster fallback** (silent)
  - `Timeout` / `SshTransportFailure` → **PossiblyRecoverable**
  - `NoBinaryInTarball` / `ScriptGenericFailure` / `DownloadFailure` / `Unknown` → **NonRecoverable**
- `Recoverability` enum: `RecoverableScpFallback`, `RecoverableControlMaster`, `PossiblyRecoverable`, `NonRecoverable`
- Two classifier entry points:
  - `from_exit_and_stderr()` — string-based, works on current `master`
  - `from_preinstall_status()` — typed, for `PreinstallCheckResult`
- Forward-compatible with `transport::Error` structured type on `aloke/error_handling`: pattern matching strings match the `Display` impl exactly.

### New: `install_error_tests.rs` — 50+ fixture-based unit tests

- Every family covered with representative fixture strings from the production install pipeline
- Each test asserts both family classification and `Recoverability` mapping
- Preinstall `CheckResult` round-trips (glibc too old, musl, supported, unknown/fail-open)
- Edge cases: priority ordering, stderr truncation, timeout-beats-generic
- Forward-compat contracts: the `transport::Error::Display` strings all classify correctly

### Extended: `setup_tests.rs` — shell integration tests

Four new tests running the **production install script** against stub PATH:
- `install_script_no_http_client_exit_code` — exit 3 sentinel when no curl/wget
- `install_script_unsupported_arch_exit_code` — exit 2 for mips arch
- `install_script_unsupported_os_exit_code` — exit 2 for FreeBSD
- `install_script_no_binary_in_tarball` — exit 1 when tarball extracts but has no `oz*` binary

Plus three static checks:
- `install_script_contains_set_e` — script must use `set -e`
- `install_script_uses_no_http_client_exit_code_placeholder` — placeholder sync check
- `install_script_substituted_exit_code_matches_constant` — constant/script alignment

### Test results

All 111 tests pass. `cargo fmt` and `cargo clippy -D warnings` clean.

### Integration notes for primary agent

The `install_error` module is self-contained in `crates/remote_server/`. To integrate with `aloke/error_handling` once that lands:

1. Add `InstallErrorFamily::from_transport_error(err: &transport::Error) -> Self` as a thin wrapper (no string parsing — direct `match` on enum variants)
2. The existing `from_exit_and_stderr()` call sites can be updated to use the typed path

_Conversation: https://staging.warp.dev/conversation/3a21eeea-dd7d-4b29-a9b8-0809f3a1f9e4_
_Run: https://oz.staging.warp.dev/runs/019e08b7-e302-7c15-978c-2cee3cd6298c_

_This PR was generated with [Oz](https://warp.dev/oz)._
