### PR TITLE
Add typed install error classification and exhaustive test matrix for all CSV failure families

### DIFF
--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -1,6 +1,8 @@
 mod glibc;
+pub mod install_error;
 
 pub use glibc::{GlibcVersion, RemoteLibc};
+pub use install_error::{classify_install_failure, InstallFailureCategory};
 
 use std::time::Duration;
 

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -2,7 +2,9 @@ mod glibc;
 pub mod install_error;
 
 pub use glibc::{GlibcVersion, RemoteLibc};
-pub use install_error::{classify_install_failure, InstallFailureCategory};
+pub use install_error::{
+    classify_install_failure, classify_install_failure_with_timeout, InstallFailureCategory,
+};
 
 use std::time::Duration;
 

--- a/crates/remote_server/src/setup/install_error.rs
+++ b/crates/remote_server/src/setup/install_error.rs
@@ -23,38 +23,57 @@ const UNSUPPORTED_ARCH_OR_OS_EXIT_CODE: i32 = 2;
 /// Each variant corresponds to one of the CSV failure families observed
 /// in production.  The ordering roughly follows the install script's
 /// execution flow: platform checks → download → extraction → placement.
+///
+/// Aligned with the coordinated API shape so that
+/// `RemoteServerSetupState::Failed` can carry an
+/// `Option<InstallFailureCategory>` alongside the raw stderr, and
+/// telemetry / UI can switch on the category.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InstallFailureCategory {
+    // ── Timeout ─────────────────────────────────────────────────────
+    /// The install script timed out (SSH-level timeout fired before
+    /// the script exited).
+    Timeout,
+
     // ── Platform / environment ──────────────────────────────────────
-    /// `uname -m` reported an architecture we don't ship a binary for.
-    UnsupportedArch { arch: String },
-    /// `uname -s` reported an OS we don't support (e.g. FreeBSD).
-    UnsupportedOs { os: String },
+    /// `curl` is specifically missing (detected from stderr). In
+    /// practice the install script falls through to wget, so this is
+    /// rarely seen in isolation; the script emits [`MissingHttpClient`]
+    /// when *both* are absent.
+    MissingCurl,
+    /// `wget` is specifically missing (detected from stderr). Same
+    /// caveat as [`MissingCurl`].
+    MissingWget,
     /// Neither `curl` nor `wget` is available.  This is the trigger for
-    /// the SCP upload fallback in the SSH transport.
-    NoHttpClient,
+    /// the SCP upload fallback in the SSH transport (exit code 3).
+    MissingHttpClient,
     /// `tar` is not available on the remote host.
     MissingTar,
     /// `bash` is not available (script is piped into `bash -s`).
     MissingBash,
+    /// `uname -m` reported an architecture we don't ship a binary for.
+    UnsupportedArchitecture,
+    /// `uname -s` reported an OS we don't support (e.g. FreeBSD).
+    UnsupportedOs,
 
     // ── Network / download ──────────────────────────────────────────
     /// DNS resolution failed.
     DnsFailure,
-    /// TCP connection was refused or the host was unreachable.
+    /// TCP connection was refused by the remote endpoint.
     ConnectionRefused,
+    /// Host or network is unreachable (no route, network down).
+    ConnectionUnreachable,
     /// TLS handshake failed (certificate validation, expired cert, etc.).
     TlsCaFailure,
     /// HTTP 403 Forbidden from the download endpoint.
     HttpForbidden,
-    /// HTTP 502 Bad Gateway (or similar server error) from the CDN.
-    HttpServerError { status_code: u16 },
+    /// HTTP 502 Bad Gateway from the CDN.
+    HttpBadGateway,
+    /// Any other HTTP error (e.g. 500, 503, generic curl -f exit 22).
+    HttpError,
     /// The download started but was truncated (curl exit 18 / wget
     /// partial content).
     PartialDownload,
-    /// The install script timed out (SSH-level timeout fired before
-    /// the script exited).
-    InstallTimeout,
 
     // ── Filesystem / extraction ─────────────────────────────────────
     /// Writing the downloaded tarball to disk failed (e.g. broken pipe
@@ -63,16 +82,19 @@ pub enum InstallFailureCategory {
     /// `mkdir -p` or `mv` on the install directory failed with EACCES.
     InstallDirPermissionDenied,
     /// No space left on device (ENOSPC) or disk quota exceeded.
-    NoSpaceOrQuota,
+    NoSpaceLeft,
     /// The filesystem (or mount) is read-only.
     ReadOnlyFilesystem,
+    /// `tar -xzf` failed for a non-permission reason (corrupt archive,
+    /// unsupported format, etc.).
+    TarExtractionFailure,
     /// `tar -xzf` failed due to ownership or permission errors.
     TarPermissionFailure,
 
     // ── SSH / auth ──────────────────────────────────────────────────
     /// The remote requires a password change or has no TTY for
     /// interactive auth prompts.
-    ExpiredPasswordOrNoTty,
+    ExpiredPassword,
     /// Permission denied writing to a startup file (e.g. ~/.bashrc is
     /// read-only or owned by root).
     StartupFilePermissionDenied,
@@ -80,12 +102,124 @@ pub enum InstallFailureCategory {
     /// pipe, or connection reset.
     SshDisconnect,
 
+    // ── Script-level ────────────────────────────────────────────────
+    /// The install script exited with a non-zero code that doesn't match
+    /// any sentinel, and stderr doesn't match a known pattern — but the
+    /// script clearly ran (non-signal exit). Distinguished from
+    /// [`Unknown`] for telemetry bucketing.
+    ScriptError,
+
     // ── Catch-all ───────────────────────────────────────────────────
     /// The error didn't match any known pattern.
     Unknown,
 }
 
 impl InstallFailureCategory {
+    /// Short human-readable title for UI banners and error summaries.
+    pub fn title(&self) -> &'static str {
+        match self {
+            Self::Timeout => "Install Timeout",
+            Self::MissingCurl => "curl Not Found",
+            Self::MissingWget => "wget Not Found",
+            Self::MissingHttpClient => "No HTTP Client",
+            Self::MissingTar => "tar Not Found",
+            Self::MissingBash => "bash Not Found",
+            Self::UnsupportedArchitecture => "Unsupported Architecture",
+            Self::UnsupportedOs => "Unsupported OS",
+            Self::DnsFailure => "DNS Resolution Failed",
+            Self::ConnectionRefused => "Connection Refused",
+            Self::ConnectionUnreachable => "Host Unreachable",
+            Self::TlsCaFailure => "TLS/Certificate Error",
+            Self::HttpForbidden => "HTTP 403 Forbidden",
+            Self::HttpBadGateway => "HTTP 502 Bad Gateway",
+            Self::HttpError => "HTTP Error",
+            Self::PartialDownload => "Incomplete Download",
+            Self::DownloadWriteFailure => "Download Write Error",
+            Self::InstallDirPermissionDenied => "Permission Denied",
+            Self::NoSpaceLeft => "No Space Left",
+            Self::ReadOnlyFilesystem => "Read-Only Filesystem",
+            Self::TarExtractionFailure => "Extraction Failed",
+            Self::TarPermissionFailure => "Extraction Permission Error",
+            Self::ExpiredPassword => "Password Expired",
+            Self::StartupFilePermissionDenied => "Startup File Permission Denied",
+            Self::SshDisconnect => "SSH Disconnected",
+            Self::ScriptError => "Install Script Error",
+            Self::Unknown => "Install Failed",
+        }
+    }
+
+    /// Longer description suitable for error detail panels and telemetry.
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Timeout => "The install script timed out before completing.",
+            Self::MissingCurl => "curl is not installed on the remote host.",
+            Self::MissingWget => "wget is not installed on the remote host.",
+            Self::MissingHttpClient => "Neither curl nor wget is available on the remote host.",
+            Self::MissingTar => "tar is not installed on the remote host.",
+            Self::MissingBash => "bash is not available on the remote host.",
+            Self::UnsupportedArchitecture => "The remote host's CPU architecture is not supported.",
+            Self::UnsupportedOs => "The remote host's operating system is not supported.",
+            Self::DnsFailure => "Failed to resolve the download server hostname.",
+            Self::ConnectionRefused => "The download server refused the connection.",
+            Self::ConnectionUnreachable => {
+                "The download server is unreachable (no route or network down)."
+            }
+            Self::TlsCaFailure => "TLS certificate verification failed.",
+            Self::HttpForbidden => "The download server returned HTTP 403 Forbidden.",
+            Self::HttpBadGateway => "The download server returned HTTP 502 Bad Gateway.",
+            Self::HttpError => "The download server returned an HTTP error.",
+            Self::PartialDownload => "The download was truncated or incomplete.",
+            Self::DownloadWriteFailure => "Failed to write the downloaded file to disk.",
+            Self::InstallDirPermissionDenied => {
+                "Permission denied creating or writing to the install directory."
+            }
+            Self::NoSpaceLeft => "No space left on device or disk quota exceeded.",
+            Self::ReadOnlyFilesystem => "The filesystem is mounted read-only.",
+            Self::TarExtractionFailure => "Failed to extract the downloaded archive.",
+            Self::TarPermissionFailure => "Archive extraction failed due to a permission error.",
+            Self::ExpiredPassword => "The remote account's password has expired or requires a TTY.",
+            Self::StartupFilePermissionDenied => {
+                "Permission denied writing to a shell startup file."
+            }
+            Self::SshDisconnect => "The SSH connection was forcibly closed (exit 255).",
+            Self::ScriptError => "The install script exited with an error.",
+            Self::Unknown => "An unknown error occurred during installation.",
+        }
+    }
+
+    /// Short, stable string tag suitable for telemetry and serialization.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::MissingCurl => "missing_curl",
+            Self::MissingWget => "missing_wget",
+            Self::MissingHttpClient => "missing_http_client",
+            Self::MissingTar => "missing_tar",
+            Self::MissingBash => "missing_bash",
+            Self::UnsupportedArchitecture => "unsupported_architecture",
+            Self::UnsupportedOs => "unsupported_os",
+            Self::DnsFailure => "dns_failure",
+            Self::ConnectionRefused => "connection_refused",
+            Self::ConnectionUnreachable => "connection_unreachable",
+            Self::TlsCaFailure => "tls_ca_failure",
+            Self::HttpForbidden => "http_forbidden",
+            Self::HttpBadGateway => "http_bad_gateway",
+            Self::HttpError => "http_error",
+            Self::PartialDownload => "partial_download",
+            Self::DownloadWriteFailure => "download_write_failure",
+            Self::InstallDirPermissionDenied => "install_dir_permission_denied",
+            Self::NoSpaceLeft => "no_space_left",
+            Self::ReadOnlyFilesystem => "read_only_filesystem",
+            Self::TarExtractionFailure => "tar_extraction_failure",
+            Self::TarPermissionFailure => "tar_permission_failure",
+            Self::ExpiredPassword => "expired_password",
+            Self::StartupFilePermissionDenied => "startup_file_permission_denied",
+            Self::SshDisconnect => "ssh_disconnect",
+            Self::ScriptError => "script_error",
+            Self::Unknown => "unknown",
+        }
+    }
+
     /// Whether this failure category is potentially retriable.
     ///
     /// Categories caused by transient conditions (network hiccups,
@@ -95,91 +229,42 @@ impl InstallFailureCategory {
     pub fn is_retriable(&self) -> bool {
         match self {
             // Transient / network
-            Self::DnsFailure
+            Self::Timeout
+            | Self::DnsFailure
             | Self::ConnectionRefused
+            | Self::ConnectionUnreachable
             | Self::TlsCaFailure
-            | Self::HttpServerError { .. }
-            | Self::PartialDownload
-            | Self::InstallTimeout => true,
+            | Self::HttpBadGateway
+            | Self::HttpError
+            | Self::PartialDownload => true,
 
             // Permanent host condition — do NOT retry
-            Self::UnsupportedArch { .. }
-            | Self::UnsupportedOs { .. }
-            | Self::NoHttpClient
+            Self::MissingCurl
+            | Self::MissingWget
+            | Self::MissingHttpClient
             | Self::MissingTar
             | Self::MissingBash
+            | Self::UnsupportedArchitecture
+            | Self::UnsupportedOs
             | Self::HttpForbidden
             | Self::DownloadWriteFailure
             | Self::InstallDirPermissionDenied
-            | Self::NoSpaceOrQuota
+            | Self::NoSpaceLeft
             | Self::ReadOnlyFilesystem
+            | Self::TarExtractionFailure
             | Self::TarPermissionFailure
-            | Self::ExpiredPasswordOrNoTty
+            | Self::ExpiredPassword
             | Self::StartupFilePermissionDenied
             | Self::SshDisconnect
+            | Self::ScriptError
             | Self::Unknown => false,
-        }
-    }
-
-    /// Returns a short, stable string tag suitable for telemetry.
-    pub fn telemetry_tag(&self) -> &'static str {
-        match self {
-            Self::UnsupportedArch { .. } => "unsupported_arch",
-            Self::UnsupportedOs { .. } => "unsupported_os",
-            Self::NoHttpClient => "no_http_client",
-            Self::MissingTar => "missing_tar",
-            Self::MissingBash => "missing_bash",
-            Self::DnsFailure => "dns_failure",
-            Self::ConnectionRefused => "connection_refused",
-            Self::TlsCaFailure => "tls_ca_failure",
-            Self::HttpForbidden => "http_forbidden",
-            Self::HttpServerError { .. } => "http_server_error",
-            Self::PartialDownload => "partial_download",
-            Self::InstallTimeout => "install_timeout",
-            Self::DownloadWriteFailure => "download_write_failure",
-            Self::InstallDirPermissionDenied => "install_dir_permission_denied",
-            Self::NoSpaceOrQuota => "no_space_or_quota",
-            Self::ReadOnlyFilesystem => "read_only_filesystem",
-            Self::TarPermissionFailure => "tar_permission_failure",
-            Self::ExpiredPasswordOrNoTty => "expired_password_or_no_tty",
-            Self::StartupFilePermissionDenied => "startup_file_permission_denied",
-            Self::SshDisconnect => "ssh_disconnect",
-            Self::Unknown => "unknown",
         }
     }
 }
 
 impl fmt::Display for InstallFailureCategory {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::UnsupportedArch { arch } => write!(f, "unsupported architecture: {arch}"),
-            Self::UnsupportedOs { os } => write!(f, "unsupported OS: {os}"),
-            Self::NoHttpClient => write!(f, "neither curl nor wget is available"),
-            Self::MissingTar => write!(f, "tar is not installed on the remote host"),
-            Self::MissingBash => write!(f, "bash is not available on the remote host"),
-            Self::DnsFailure => write!(f, "DNS resolution failed"),
-            Self::ConnectionRefused => write!(f, "connection refused or host unreachable"),
-            Self::TlsCaFailure => write!(f, "TLS/certificate verification failed"),
-            Self::HttpForbidden => write!(f, "HTTP 403 Forbidden"),
-            Self::HttpServerError { status_code } => write!(f, "HTTP server error ({status_code})"),
-            Self::PartialDownload => write!(f, "download was truncated or incomplete"),
-            Self::InstallTimeout => write!(f, "install timed out"),
-            Self::DownloadWriteFailure => write!(f, "failed to write downloaded file"),
-            Self::InstallDirPermissionDenied => {
-                write!(f, "permission denied on install directory")
-            }
-            Self::NoSpaceOrQuota => write!(f, "no space left on device or quota exceeded"),
-            Self::ReadOnlyFilesystem => write!(f, "read-only filesystem"),
-            Self::TarPermissionFailure => write!(f, "tar extraction failed (permission error)"),
-            Self::ExpiredPasswordOrNoTty => {
-                write!(f, "expired password or no TTY for interactive auth")
-            }
-            Self::StartupFilePermissionDenied => {
-                write!(f, "permission denied writing startup file")
-            }
-            Self::SshDisconnect => write!(f, "SSH connection was forcibly closed (exit 255)"),
-            Self::Unknown => write!(f, "unknown install failure"),
-        }
+        write!(f, "{}", self.description())
     }
 }
 
@@ -188,21 +273,35 @@ impl fmt::Display for InstallFailureCategory {
 ///
 /// # Arguments
 ///
-/// * `exit_code` — The process exit code, if available. `None` when the
-///   process was killed by a signal or the exit code wasn't captured.
 /// * `stderr` — Combined stderr output from the install script / SSH
 ///   command.
-/// * `is_timeout` — `true` when the failure was caused by the
-///   SSH-level timeout firing before the script exited (the async
-///   runtime kills the child and returns a timeout error).
-pub fn classify_install_failure(
-    exit_code: Option<i32>,
+/// * `exit_code` — The process exit code, if available. `None` when the
+///   process was killed by a signal or the exit code wasn't captured.
+pub fn classify_install_failure(stderr: &str, exit_code: Option<i32>) -> InstallFailureCategory {
+    classify_install_failure_inner(stderr, exit_code, false)
+}
+
+/// Like [`classify_install_failure`] but accepts an explicit timeout flag.
+///
+/// `is_timeout` should be `true` when the failure was caused by the
+/// SSH-level timeout firing before the script exited (the async runtime
+/// kills the child and returns a timeout error).
+pub fn classify_install_failure_with_timeout(
     stderr: &str,
+    exit_code: Option<i32>,
+    is_timeout: bool,
+) -> InstallFailureCategory {
+    classify_install_failure_inner(stderr, exit_code, is_timeout)
+}
+
+fn classify_install_failure_inner(
+    stderr: &str,
+    exit_code: Option<i32>,
     is_timeout: bool,
 ) -> InstallFailureCategory {
     // Timeout is unambiguous — the script didn't finish in time.
     if is_timeout {
-        return InstallFailureCategory::InstallTimeout;
+        return InstallFailureCategory::Timeout;
     }
 
     // SSH exit 255 → forced disconnect / broken pipe.
@@ -212,21 +311,19 @@ pub fn classify_install_failure(
 
     // Script exit 3 → no HTTP client (sentinel from install script).
     if exit_code == Some(super::NO_HTTP_CLIENT_EXIT_CODE) {
-        return InstallFailureCategory::NoHttpClient;
+        return InstallFailureCategory::MissingHttpClient;
     }
 
     // Script exit 2 → unsupported arch or OS.
     if exit_code == Some(UNSUPPORTED_ARCH_OR_OS_EXIT_CODE) {
-        if let Some(arch) = extract_unsupported_arch(stderr) {
-            return InstallFailureCategory::UnsupportedArch { arch };
+        if stderr_contains_unsupported_arch(stderr) {
+            return InstallFailureCategory::UnsupportedArchitecture;
         }
-        if let Some(os) = extract_unsupported_os(stderr) {
-            return InstallFailureCategory::UnsupportedOs { os };
+        if stderr_contains_unsupported_os(stderr) {
+            return InstallFailureCategory::UnsupportedOs;
         }
         // Exit 2 but no parseable arch/os — still treat as unsupported.
-        return InstallFailureCategory::UnsupportedArch {
-            arch: "unknown".to_string(),
-        };
+        return InstallFailureCategory::UnsupportedArchitecture;
     }
 
     let lower = stderr.to_lowercase();
@@ -258,15 +355,19 @@ pub fn classify_install_failure(
         return InstallFailureCategory::DnsFailure;
     }
 
-    // ── Connection refused / unreachable ────────────────────────────
-    if lower.contains("connection refused")
-        || lower.contains("no route to host")
-        || lower.contains("network is unreachable")
-        || lower.contains("connection timed out")
-            && !lower.contains("ssl")
-            && !lower.contains("tls")
-    {
+    // ── Connection refused ──────────────────────────────────────────
+    if lower.contains("connection refused") {
         return InstallFailureCategory::ConnectionRefused;
+    }
+
+    // ── Connection unreachable ──────────────────────────────────────
+    if lower.contains("no route to host")
+        || lower.contains("network is unreachable")
+        || (lower.contains("connection timed out")
+            && !lower.contains("ssl")
+            && !lower.contains("tls"))
+    {
+        return InstallFailureCategory::ConnectionUnreachable;
     }
 
     // ── TLS / CA failures ───────────────────────────────────────────
@@ -291,22 +392,20 @@ pub fn classify_install_failure(
         || lower.contains("http/1.1 502")
         || lower.contains("http/2 502")
     {
-        return InstallFailureCategory::HttpServerError { status_code: 502 };
-    }
-    if lower.contains("503 service unavailable") || lower.contains("http/1.1 503") {
-        return InstallFailureCategory::HttpServerError { status_code: 503 };
+        return InstallFailureCategory::HttpBadGateway;
     }
     // curl exit 22 = HTTP error ≥ 400 (with -f flag)
     if exit_code == Some(22) && lower.contains("403") {
         return InstallFailureCategory::HttpForbidden;
     }
     if exit_code == Some(22) {
-        // Generic HTTP server error from curl -f
-        return InstallFailureCategory::HttpServerError { status_code: 0 };
+        return InstallFailureCategory::HttpError;
+    }
+    if lower.contains("503 service unavailable") || lower.contains("http/1.1 503") {
+        return InstallFailureCategory::HttpError;
     }
 
     // ── Partial download ────────────────────────────────────────────
-    // curl exit 18 = transfer closed with outstanding read data remaining
     if exit_code == Some(18)
         || lower.contains("partial file")
         || lower.contains("transfer closed with outstanding read data")
@@ -317,8 +416,6 @@ pub fn classify_install_failure(
     }
 
     // ── Download write failure ──────────────────────────────────────
-    // curl exit 23 = write error (e.g. broken pipe, I/O error on
-    // the temp file)
     if exit_code == Some(23)
         || (lower.contains("write error") && lower.contains("download"))
         || lower.contains("failed writing body")
@@ -326,10 +423,7 @@ pub fn classify_install_failure(
         return InstallFailureCategory::DownloadWriteFailure;
     }
 
-    // ── tar extraction failures ─────────────────────────────────────
-    // Check tar-specific patterns *before* the generic "permission
-    // denied" rule so that `tar: Cannot open: Permission denied` is
-    // classified as a tar failure, not a generic install-dir EACCES.
+    // ── tar extraction failures (permission) ────────────────────────
     if (lower.contains("tar") || lower.contains("extract"))
         && (lower.contains("cannot open")
             || lower.contains("operation not permitted")
@@ -339,9 +433,18 @@ pub fn classify_install_failure(
         return InstallFailureCategory::TarPermissionFailure;
     }
 
-    // ── Filesystem: permission denied ───────────────────────────────────
+    // ── tar extraction failures (non-permission) ────────────────────
+    if (lower.contains("tar") || lower.contains("extract"))
+        && (lower.contains("not in gzip format")
+            || lower.contains("unexpected eof")
+            || lower.contains("invalid tar")
+            || lower.contains("corrupted"))
+    {
+        return InstallFailureCategory::TarExtractionFailure;
+    }
+
+    // ── Filesystem: permission denied ───────────────────────────────
     if lower.contains("permission denied") {
-        // Distinguish install-dir EACCES from startup-file EACCES.
         if lower.contains(".bashrc")
             || lower.contains(".bash_profile")
             || lower.contains(".profile")
@@ -357,7 +460,7 @@ pub fn classify_install_failure(
         || lower.contains("disk quota exceeded")
         || lower.contains("enospc")
     {
-        return InstallFailureCategory::NoSpaceOrQuota;
+        return InstallFailureCategory::NoSpaceLeft;
     }
 
     // ── Filesystem: read-only ───────────────────────────────────────
@@ -371,38 +474,31 @@ pub fn classify_install_failure(
         || lower.contains("no tty present")
         || lower.contains("password change required")
     {
-        return InstallFailureCategory::ExpiredPasswordOrNoTty;
+        return InstallFailureCategory::ExpiredPassword;
+    }
+
+    // ── Script error: non-zero exit with no recognized pattern ──────
+    if let Some(code) = exit_code {
+        if code != 0 {
+            return InstallFailureCategory::ScriptError;
+        }
     }
 
     InstallFailureCategory::Unknown
 }
 
-/// Extracts the architecture name from an "unsupported arch: XYZ" stderr line.
-fn extract_unsupported_arch(stderr: &str) -> Option<String> {
-    for line in stderr.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("unsupported arch:") {
-            let arch = rest.trim().to_string();
-            if !arch.is_empty() {
-                return Some(arch);
-            }
-        }
-    }
-    None
+/// Checks if stderr contains the install script's "unsupported arch:" message.
+fn stderr_contains_unsupported_arch(stderr: &str) -> bool {
+    stderr
+        .lines()
+        .any(|l| l.trim().starts_with("unsupported arch:"))
 }
 
-/// Extracts the OS name from an "unsupported OS: XYZ" stderr line.
-fn extract_unsupported_os(stderr: &str) -> Option<String> {
-    for line in stderr.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("unsupported OS:") {
-            let os = rest.trim().to_string();
-            if !os.is_empty() {
-                return Some(os);
-            }
-        }
-    }
-    None
+/// Checks if stderr contains the install script's "unsupported OS:" message.
+fn stderr_contains_unsupported_os(stderr: &str) -> bool {
+    stderr
+        .lines()
+        .any(|l| l.trim().starts_with("unsupported OS:"))
 }
 
 #[cfg(test)]

--- a/crates/remote_server/src/setup/install_error.rs
+++ b/crates/remote_server/src/setup/install_error.rs
@@ -1,0 +1,410 @@
+//! Typed classification of remote-server install failures.
+//!
+//! Production install errors arrive as raw exit codes + stderr strings
+//! from the install script or SSH transport layer.  This module converts
+//! them into a [`InstallFailureCategory`] enum so that:
+//!
+//! 1. Telemetry gets a stable, enumerated tag instead of a free-form string.
+//! 2. The retry/fallback logic can match on categories instead of fragile
+//!    substring tests.
+//! 3. UI can render targeted user-facing messages.
+//!
+//! The classifier is intentionally conservative: if the stderr doesn't
+//! match any known pattern, it falls through to [`InstallFailureCategory::Unknown`].
+
+use std::fmt;
+
+/// Exit code the install script uses when the detected architecture is
+/// unsupported (e.g. `mips`, `ppc64le`).
+const UNSUPPORTED_ARCH_OR_OS_EXIT_CODE: i32 = 2;
+
+/// Typed classification of a remote-server install failure.
+///
+/// Each variant corresponds to one of the CSV failure families observed
+/// in production.  The ordering roughly follows the install script's
+/// execution flow: platform checks → download → extraction → placement.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InstallFailureCategory {
+    // ── Platform / environment ──────────────────────────────────────
+    /// `uname -m` reported an architecture we don't ship a binary for.
+    UnsupportedArch { arch: String },
+    /// `uname -s` reported an OS we don't support (e.g. FreeBSD).
+    UnsupportedOs { os: String },
+    /// Neither `curl` nor `wget` is available.  This is the trigger for
+    /// the SCP upload fallback in the SSH transport.
+    NoHttpClient,
+    /// `tar` is not available on the remote host.
+    MissingTar,
+    /// `bash` is not available (script is piped into `bash -s`).
+    MissingBash,
+
+    // ── Network / download ──────────────────────────────────────────
+    /// DNS resolution failed.
+    DnsFailure,
+    /// TCP connection was refused or the host was unreachable.
+    ConnectionRefused,
+    /// TLS handshake failed (certificate validation, expired cert, etc.).
+    TlsCaFailure,
+    /// HTTP 403 Forbidden from the download endpoint.
+    HttpForbidden,
+    /// HTTP 502 Bad Gateway (or similar server error) from the CDN.
+    HttpServerError { status_code: u16 },
+    /// The download started but was truncated (curl exit 18 / wget
+    /// partial content).
+    PartialDownload,
+    /// The install script timed out (SSH-level timeout fired before
+    /// the script exited).
+    InstallTimeout,
+
+    // ── Filesystem / extraction ─────────────────────────────────────
+    /// Writing the downloaded tarball to disk failed (e.g. broken pipe
+    /// to the temp file, I/O error).
+    DownloadWriteFailure,
+    /// `mkdir -p` or `mv` on the install directory failed with EACCES.
+    InstallDirPermissionDenied,
+    /// No space left on device (ENOSPC) or disk quota exceeded.
+    NoSpaceOrQuota,
+    /// The filesystem (or mount) is read-only.
+    ReadOnlyFilesystem,
+    /// `tar -xzf` failed due to ownership or permission errors.
+    TarPermissionFailure,
+
+    // ── SSH / auth ──────────────────────────────────────────────────
+    /// The remote requires a password change or has no TTY for
+    /// interactive auth prompts.
+    ExpiredPasswordOrNoTty,
+    /// Permission denied writing to a startup file (e.g. ~/.bashrc is
+    /// read-only or owned by root).
+    StartupFilePermissionDenied,
+    /// SSH exited with code 255, indicating a forced disconnect, broken
+    /// pipe, or connection reset.
+    SshDisconnect,
+
+    // ── Catch-all ───────────────────────────────────────────────────
+    /// The error didn't match any known pattern.
+    Unknown,
+}
+
+impl InstallFailureCategory {
+    /// Whether this failure category is potentially retriable.
+    ///
+    /// Categories caused by transient conditions (network hiccups,
+    /// timeouts, server errors) return `true`.  Permanent host
+    /// conditions (permissions, disk, auth, architecture) return
+    /// `false` to prevent wasteful blind retries.
+    pub fn is_retriable(&self) -> bool {
+        match self {
+            // Transient / network
+            Self::DnsFailure
+            | Self::ConnectionRefused
+            | Self::TlsCaFailure
+            | Self::HttpServerError { .. }
+            | Self::PartialDownload
+            | Self::InstallTimeout => true,
+
+            // Permanent host condition — do NOT retry
+            Self::UnsupportedArch { .. }
+            | Self::UnsupportedOs { .. }
+            | Self::NoHttpClient
+            | Self::MissingTar
+            | Self::MissingBash
+            | Self::HttpForbidden
+            | Self::DownloadWriteFailure
+            | Self::InstallDirPermissionDenied
+            | Self::NoSpaceOrQuota
+            | Self::ReadOnlyFilesystem
+            | Self::TarPermissionFailure
+            | Self::ExpiredPasswordOrNoTty
+            | Self::StartupFilePermissionDenied
+            | Self::SshDisconnect
+            | Self::Unknown => false,
+        }
+    }
+
+    /// Returns a short, stable string tag suitable for telemetry.
+    pub fn telemetry_tag(&self) -> &'static str {
+        match self {
+            Self::UnsupportedArch { .. } => "unsupported_arch",
+            Self::UnsupportedOs { .. } => "unsupported_os",
+            Self::NoHttpClient => "no_http_client",
+            Self::MissingTar => "missing_tar",
+            Self::MissingBash => "missing_bash",
+            Self::DnsFailure => "dns_failure",
+            Self::ConnectionRefused => "connection_refused",
+            Self::TlsCaFailure => "tls_ca_failure",
+            Self::HttpForbidden => "http_forbidden",
+            Self::HttpServerError { .. } => "http_server_error",
+            Self::PartialDownload => "partial_download",
+            Self::InstallTimeout => "install_timeout",
+            Self::DownloadWriteFailure => "download_write_failure",
+            Self::InstallDirPermissionDenied => "install_dir_permission_denied",
+            Self::NoSpaceOrQuota => "no_space_or_quota",
+            Self::ReadOnlyFilesystem => "read_only_filesystem",
+            Self::TarPermissionFailure => "tar_permission_failure",
+            Self::ExpiredPasswordOrNoTty => "expired_password_or_no_tty",
+            Self::StartupFilePermissionDenied => "startup_file_permission_denied",
+            Self::SshDisconnect => "ssh_disconnect",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl fmt::Display for InstallFailureCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedArch { arch } => write!(f, "unsupported architecture: {arch}"),
+            Self::UnsupportedOs { os } => write!(f, "unsupported OS: {os}"),
+            Self::NoHttpClient => write!(f, "neither curl nor wget is available"),
+            Self::MissingTar => write!(f, "tar is not installed on the remote host"),
+            Self::MissingBash => write!(f, "bash is not available on the remote host"),
+            Self::DnsFailure => write!(f, "DNS resolution failed"),
+            Self::ConnectionRefused => write!(f, "connection refused or host unreachable"),
+            Self::TlsCaFailure => write!(f, "TLS/certificate verification failed"),
+            Self::HttpForbidden => write!(f, "HTTP 403 Forbidden"),
+            Self::HttpServerError { status_code } => write!(f, "HTTP server error ({status_code})"),
+            Self::PartialDownload => write!(f, "download was truncated or incomplete"),
+            Self::InstallTimeout => write!(f, "install timed out"),
+            Self::DownloadWriteFailure => write!(f, "failed to write downloaded file"),
+            Self::InstallDirPermissionDenied => {
+                write!(f, "permission denied on install directory")
+            }
+            Self::NoSpaceOrQuota => write!(f, "no space left on device or quota exceeded"),
+            Self::ReadOnlyFilesystem => write!(f, "read-only filesystem"),
+            Self::TarPermissionFailure => write!(f, "tar extraction failed (permission error)"),
+            Self::ExpiredPasswordOrNoTty => {
+                write!(f, "expired password or no TTY for interactive auth")
+            }
+            Self::StartupFilePermissionDenied => {
+                write!(f, "permission denied writing startup file")
+            }
+            Self::SshDisconnect => write!(f, "SSH connection was forcibly closed (exit 255)"),
+            Self::Unknown => write!(f, "unknown install failure"),
+        }
+    }
+}
+
+/// Classify a raw install failure from the install script or SSH transport
+/// into a typed [`InstallFailureCategory`].
+///
+/// # Arguments
+///
+/// * `exit_code` — The process exit code, if available. `None` when the
+///   process was killed by a signal or the exit code wasn't captured.
+/// * `stderr` — Combined stderr output from the install script / SSH
+///   command.
+/// * `is_timeout` — `true` when the failure was caused by the
+///   SSH-level timeout firing before the script exited (the async
+///   runtime kills the child and returns a timeout error).
+pub fn classify_install_failure(
+    exit_code: Option<i32>,
+    stderr: &str,
+    is_timeout: bool,
+) -> InstallFailureCategory {
+    // Timeout is unambiguous — the script didn't finish in time.
+    if is_timeout {
+        return InstallFailureCategory::InstallTimeout;
+    }
+
+    // SSH exit 255 → forced disconnect / broken pipe.
+    if exit_code == Some(255) {
+        return InstallFailureCategory::SshDisconnect;
+    }
+
+    // Script exit 3 → no HTTP client (sentinel from install script).
+    if exit_code == Some(super::NO_HTTP_CLIENT_EXIT_CODE) {
+        return InstallFailureCategory::NoHttpClient;
+    }
+
+    // Script exit 2 → unsupported arch or OS.
+    if exit_code == Some(UNSUPPORTED_ARCH_OR_OS_EXIT_CODE) {
+        if let Some(arch) = extract_unsupported_arch(stderr) {
+            return InstallFailureCategory::UnsupportedArch { arch };
+        }
+        if let Some(os) = extract_unsupported_os(stderr) {
+            return InstallFailureCategory::UnsupportedOs { os };
+        }
+        // Exit 2 but no parseable arch/os — still treat as unsupported.
+        return InstallFailureCategory::UnsupportedArch {
+            arch: "unknown".to_string(),
+        };
+    }
+
+    let lower = stderr.to_lowercase();
+
+    // ── Bash / shell availability ───────────────────────────────────
+    if lower.contains("bash: not found")
+        || lower.contains("bash: command not found")
+        || lower.contains("no such file or directory: bash")
+        || lower.contains("cannot execute binary file") && lower.contains("bash")
+    {
+        return InstallFailureCategory::MissingBash;
+    }
+
+    // ── tar availability ────────────────────────────────────────────
+    if lower.contains("tar: not found")
+        || lower.contains("tar: command not found")
+        || (lower.contains("no such file") && lower.contains("tar"))
+    {
+        return InstallFailureCategory::MissingTar;
+    }
+
+    // ── DNS failure ─────────────────────────────────────────────────
+    if lower.contains("could not resolve host")
+        || lower.contains("name or service not known")
+        || lower.contains("temporary failure in name resolution")
+        || lower.contains("unable to resolve host")
+        || lower.contains("dns_error")
+    {
+        return InstallFailureCategory::DnsFailure;
+    }
+
+    // ── Connection refused / unreachable ────────────────────────────
+    if lower.contains("connection refused")
+        || lower.contains("no route to host")
+        || lower.contains("network is unreachable")
+        || lower.contains("connection timed out")
+            && !lower.contains("ssl")
+            && !lower.contains("tls")
+    {
+        return InstallFailureCategory::ConnectionRefused;
+    }
+
+    // ── TLS / CA failures ───────────────────────────────────────────
+    if lower.contains("ssl")
+        || lower.contains("certificate")
+        || lower.contains("tls")
+        || lower.contains("ca-bundle")
+        || lower.contains("unable to get local issuer certificate")
+        || lower.contains("verify failed")
+    {
+        return InstallFailureCategory::TlsCaFailure;
+    }
+
+    // ── HTTP status codes ───────────────────────────────────────────
+    if lower.contains("403 forbidden")
+        || lower.contains("http/1.1 403")
+        || lower.contains("http/2 403")
+    {
+        return InstallFailureCategory::HttpForbidden;
+    }
+    if lower.contains("502 bad gateway")
+        || lower.contains("http/1.1 502")
+        || lower.contains("http/2 502")
+    {
+        return InstallFailureCategory::HttpServerError { status_code: 502 };
+    }
+    if lower.contains("503 service unavailable") || lower.contains("http/1.1 503") {
+        return InstallFailureCategory::HttpServerError { status_code: 503 };
+    }
+    // curl exit 22 = HTTP error ≥ 400 (with -f flag)
+    if exit_code == Some(22) && lower.contains("403") {
+        return InstallFailureCategory::HttpForbidden;
+    }
+    if exit_code == Some(22) {
+        // Generic HTTP server error from curl -f
+        return InstallFailureCategory::HttpServerError { status_code: 0 };
+    }
+
+    // ── Partial download ────────────────────────────────────────────
+    // curl exit 18 = transfer closed with outstanding read data remaining
+    if exit_code == Some(18)
+        || lower.contains("partial file")
+        || lower.contains("transfer closed with outstanding read data")
+        || lower.contains("incomplete download")
+        || (lower.contains("unexpected end") && lower.contains("gz"))
+    {
+        return InstallFailureCategory::PartialDownload;
+    }
+
+    // ── Download write failure ──────────────────────────────────────
+    // curl exit 23 = write error (e.g. broken pipe, I/O error on
+    // the temp file)
+    if exit_code == Some(23)
+        || (lower.contains("write error") && lower.contains("download"))
+        || lower.contains("failed writing body")
+    {
+        return InstallFailureCategory::DownloadWriteFailure;
+    }
+
+    // ── tar extraction failures ─────────────────────────────────────
+    // Check tar-specific patterns *before* the generic "permission
+    // denied" rule so that `tar: Cannot open: Permission denied` is
+    // classified as a tar failure, not a generic install-dir EACCES.
+    if (lower.contains("tar") || lower.contains("extract"))
+        && (lower.contains("cannot open")
+            || lower.contains("operation not permitted")
+            || lower.contains("cannot change ownership")
+            || lower.contains("permission denied"))
+    {
+        return InstallFailureCategory::TarPermissionFailure;
+    }
+
+    // ── Filesystem: permission denied ───────────────────────────────────
+    if lower.contains("permission denied") {
+        // Distinguish install-dir EACCES from startup-file EACCES.
+        if lower.contains(".bashrc")
+            || lower.contains(".bash_profile")
+            || lower.contains(".profile")
+            || lower.contains(".zshrc")
+        {
+            return InstallFailureCategory::StartupFilePermissionDenied;
+        }
+        return InstallFailureCategory::InstallDirPermissionDenied;
+    }
+
+    // ── Filesystem: no space / quota ────────────────────────────────
+    if lower.contains("no space left on device")
+        || lower.contains("disk quota exceeded")
+        || lower.contains("enospc")
+    {
+        return InstallFailureCategory::NoSpaceOrQuota;
+    }
+
+    // ── Filesystem: read-only ───────────────────────────────────────
+    if lower.contains("read-only file system") || lower.contains("erofs") {
+        return InstallFailureCategory::ReadOnlyFilesystem;
+    }
+
+    // ── Expired password / no TTY ───────────────────────────────────
+    if lower.contains("password has expired")
+        || lower.contains("you must change your password")
+        || lower.contains("no tty present")
+        || lower.contains("password change required")
+    {
+        return InstallFailureCategory::ExpiredPasswordOrNoTty;
+    }
+
+    InstallFailureCategory::Unknown
+}
+
+/// Extracts the architecture name from an "unsupported arch: XYZ" stderr line.
+fn extract_unsupported_arch(stderr: &str) -> Option<String> {
+    for line in stderr.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("unsupported arch:") {
+            let arch = rest.trim().to_string();
+            if !arch.is_empty() {
+                return Some(arch);
+            }
+        }
+    }
+    None
+}
+
+/// Extracts the OS name from an "unsupported OS: XYZ" stderr line.
+fn extract_unsupported_os(stderr: &str) -> Option<String> {
+    for line in stderr.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("unsupported OS:") {
+            let os = rest.trim().to_string();
+            if !os.is_empty() {
+                return Some(os);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "install_error_tests.rs"]
+mod tests;

--- a/crates/remote_server/src/setup/install_error_tests.rs
+++ b/crates/remote_server/src/setup/install_error_tests.rs
@@ -1,0 +1,917 @@
+use super::*;
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 1  Classifier coverage for every CSV failure family
+// ═══════════════════════════════════════════════════════════════════════
+
+// ── Install timeout ─────────────────────────────────────────────────
+
+#[test]
+fn classify_timeout_from_flag() {
+    let cat = classify_install_failure(None, "", true);
+    assert_eq!(cat, InstallFailureCategory::InstallTimeout);
+}
+
+#[test]
+fn classify_timeout_overrides_stderr() {
+    // Even if stderr contains other patterns, the timeout flag wins.
+    let cat = classify_install_failure(Some(1), "Permission denied", true);
+    assert_eq!(cat, InstallFailureCategory::InstallTimeout);
+}
+
+// ── Missing curl (no HTTP client) ───────────────────────────────────
+
+#[test]
+fn classify_no_http_client_exit_code() {
+    let cat = classify_install_failure(Some(3), "error: neither curl nor wget is available", false);
+    assert_eq!(cat, InstallFailureCategory::NoHttpClient);
+}
+
+#[test]
+fn classify_no_http_client_exit_code_only() {
+    // Exit code alone is sufficient — the script prints the message to
+    // stderr but the sentinel is the exit code.
+    let cat = classify_install_failure(Some(3), "", false);
+    assert_eq!(cat, InstallFailureCategory::NoHttpClient);
+}
+
+// ── Missing wget / both HTTP clients ────────────────────────────────
+// The install script falls through curl → wget → exit 3. Whether only
+// wget is missing doesn't matter; the sentinel covers both.
+
+#[test]
+fn classify_no_http_client_when_both_missing() {
+    let cat = classify_install_failure(
+        Some(3),
+        "error: neither curl nor wget is available\n",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::NoHttpClient);
+}
+
+// ── Missing tar ─────────────────────────────────────────────────────
+
+#[test]
+fn classify_missing_tar_not_found() {
+    let cat = classify_install_failure(Some(127), "tar: not found", false);
+    assert_eq!(cat, InstallFailureCategory::MissingTar);
+}
+
+#[test]
+fn classify_missing_tar_command_not_found() {
+    let cat = classify_install_failure(Some(127), "bash: tar: command not found", false);
+    assert_eq!(cat, InstallFailureCategory::MissingTar);
+}
+
+#[test]
+fn classify_missing_tar_no_such_file() {
+    let cat = classify_install_failure(Some(127), "/usr/bin/tar: No such file or directory", false);
+    assert_eq!(cat, InstallFailureCategory::MissingTar);
+}
+
+// ── Missing bash ────────────────────────────────────────────────────
+
+#[test]
+fn classify_missing_bash_not_found() {
+    let cat = classify_install_failure(Some(127), "bash: not found", false);
+    assert_eq!(cat, InstallFailureCategory::MissingBash);
+}
+
+#[test]
+fn classify_missing_bash_command_not_found() {
+    let cat = classify_install_failure(Some(127), "bash: command not found", false);
+    assert_eq!(cat, InstallFailureCategory::MissingBash);
+}
+
+#[test]
+fn classify_missing_bash_no_such_file() {
+    let cat = classify_install_failure(Some(127), "No such file or directory: bash", false);
+    assert_eq!(cat, InstallFailureCategory::MissingBash);
+}
+
+// ── Unsupported arch ────────────────────────────────────────────────
+
+#[test]
+fn classify_unsupported_arch_mips() {
+    let cat = classify_install_failure(Some(2), "unsupported arch: mips\n", false);
+    assert_eq!(
+        cat,
+        InstallFailureCategory::UnsupportedArch {
+            arch: "mips".to_string()
+        }
+    );
+}
+
+#[test]
+fn classify_unsupported_arch_ppc64le() {
+    let cat = classify_install_failure(Some(2), "unsupported arch: ppc64le\n", false);
+    assert_eq!(
+        cat,
+        InstallFailureCategory::UnsupportedArch {
+            arch: "ppc64le".to_string()
+        }
+    );
+}
+
+#[test]
+fn classify_unsupported_arch_s390x() {
+    let cat = classify_install_failure(Some(2), "unsupported arch: s390x\n", false);
+    assert_eq!(
+        cat,
+        InstallFailureCategory::UnsupportedArch {
+            arch: "s390x".to_string()
+        }
+    );
+}
+
+#[test]
+fn classify_unsupported_arch_exit2_no_message() {
+    // Exit code 2 but no parseable arch → falls back to "unknown".
+    let cat = classify_install_failure(Some(2), "", false);
+    assert_eq!(
+        cat,
+        InstallFailureCategory::UnsupportedArch {
+            arch: "unknown".to_string()
+        }
+    );
+}
+
+#[test]
+fn classify_unsupported_os_freebsd() {
+    let cat = classify_install_failure(Some(2), "unsupported OS: FreeBSD\n", false);
+    assert_eq!(
+        cat,
+        InstallFailureCategory::UnsupportedOs {
+            os: "FreeBSD".to_string()
+        }
+    );
+}
+
+// ── DNS failure ─────────────────────────────────────────────────────
+
+#[test]
+fn classify_dns_could_not_resolve() {
+    let cat = classify_install_failure(
+        Some(6),
+        "curl: (6) Could not resolve host: app.warp.dev",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::DnsFailure);
+}
+
+#[test]
+fn classify_dns_name_or_service() {
+    let cat = classify_install_failure(
+        Some(6),
+        "wget: unable to resolve host address 'app.warp.dev': Name or service not known",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::DnsFailure);
+}
+
+#[test]
+fn classify_dns_temporary_failure() {
+    let cat = classify_install_failure(Some(6), "Temporary failure in name resolution", false);
+    assert_eq!(cat, InstallFailureCategory::DnsFailure);
+}
+
+// ── Connection refused / unreachable ────────────────────────────────
+
+#[test]
+fn classify_connection_refused() {
+    let cat = classify_install_failure(
+        Some(7),
+        "curl: (7) Failed to connect to app.warp.dev port 443: Connection refused",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::ConnectionRefused);
+}
+
+#[test]
+fn classify_no_route_to_host() {
+    let cat = classify_install_failure(
+        Some(7),
+        "curl: (7) Failed to connect: No route to host",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::ConnectionRefused);
+}
+
+#[test]
+fn classify_network_unreachable() {
+    let cat = classify_install_failure(Some(7), "curl: (7) Network is unreachable", false);
+    assert_eq!(cat, InstallFailureCategory::ConnectionRefused);
+}
+
+// ── TLS / CA failure ────────────────────────────────────────────────
+
+#[test]
+fn classify_tls_ssl_connect_error() {
+    let cat = classify_install_failure(Some(35), "curl: (35) SSL connect error", false);
+    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
+}
+
+#[test]
+fn classify_tls_certificate_verify() {
+    let cat = classify_install_failure(
+        Some(60),
+        "curl: (60) SSL certificate problem: unable to get local issuer certificate",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
+}
+
+#[test]
+fn classify_tls_ca_bundle() {
+    let cat = classify_install_failure(
+        Some(77),
+        "curl: (77) error setting certificate verify locations: CA-bundle",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
+}
+
+#[test]
+fn classify_tls_verify_failed() {
+    let cat = classify_install_failure(
+        Some(1),
+        "ERROR: certificate verify failed (OpenSSL::SSL::SSLError)",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
+}
+
+// ── HTTP 403 ────────────────────────────────────────────────────────
+
+#[test]
+fn classify_http_403_forbidden_stderr() {
+    let cat = classify_install_failure(
+        Some(22),
+        "The requested URL returned error: 403 Forbidden",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::HttpForbidden);
+}
+
+#[test]
+fn classify_http_403_curl_exit_22() {
+    let cat = classify_install_failure(Some(22), "403", false);
+    assert_eq!(cat, InstallFailureCategory::HttpForbidden);
+}
+
+// ── HTTP 502 ────────────────────────────────────────────────────────
+
+#[test]
+fn classify_http_502_bad_gateway() {
+    let cat = classify_install_failure(Some(22), "502 Bad Gateway", false);
+    assert_eq!(
+        cat,
+        InstallFailureCategory::HttpServerError { status_code: 502 }
+    );
+}
+
+#[test]
+fn classify_http_503_service_unavailable() {
+    let cat = classify_install_failure(Some(22), "503 Service Unavailable", false);
+    assert_eq!(
+        cat,
+        InstallFailureCategory::HttpServerError { status_code: 503 }
+    );
+}
+
+#[test]
+fn classify_curl_exit_22_generic() {
+    // curl -f exit 22 with no recognizable status → generic server error.
+    let cat = classify_install_failure(Some(22), "The requested URL returned error: 500", false);
+    assert_eq!(
+        cat,
+        InstallFailureCategory::HttpServerError { status_code: 0 }
+    );
+}
+
+// ── Partial download ────────────────────────────────────────────────
+
+#[test]
+fn classify_partial_download_curl_exit_18() {
+    let cat = classify_install_failure(
+        Some(18),
+        "curl: (18) transfer closed with 12345 bytes remaining",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::PartialDownload);
+}
+
+#[test]
+fn classify_partial_download_stderr_partial_file() {
+    let cat = classify_install_failure(Some(1), "Partial file received", false);
+    assert_eq!(cat, InstallFailureCategory::PartialDownload);
+}
+
+#[test]
+fn classify_partial_download_unexpected_end_gz() {
+    let cat = classify_install_failure(
+        Some(1),
+        "gzip: stdin: unexpected end of file\ntar: Child returned status 1\ntar: Error: oz.tar.gz",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::PartialDownload);
+}
+
+// ── Download write failure ──────────────────────────────────────────
+
+#[test]
+fn classify_download_write_failure_curl_exit_23() {
+    let cat = classify_install_failure(Some(23), "Failed writing body (0 != 1234)", false);
+    assert_eq!(cat, InstallFailureCategory::DownloadWriteFailure);
+}
+
+#[test]
+fn classify_download_write_failure_failed_writing_body() {
+    let cat = classify_install_failure(Some(1), "curl: Failed writing body", false);
+    assert_eq!(cat, InstallFailureCategory::DownloadWriteFailure);
+}
+
+// ── Install dir permission denied ───────────────────────────────────
+
+#[test]
+fn classify_install_dir_permission_denied() {
+    let cat = classify_install_failure(
+        Some(1),
+        "mkdir: cannot create directory '/root/.warp/remote-server': Permission denied",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::InstallDirPermissionDenied);
+}
+
+#[test]
+fn classify_install_dir_mv_permission_denied() {
+    let cat = classify_install_failure(
+        Some(1),
+        "mv: cannot move 'oz' to '/opt/warp/remote-server/oz': Permission denied",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::InstallDirPermissionDenied);
+}
+
+// ── No space / quota ────────────────────────────────────────────────
+
+#[test]
+fn classify_no_space_left() {
+    let cat = classify_install_failure(Some(1), "write error: No space left on device", false);
+    assert_eq!(cat, InstallFailureCategory::NoSpaceOrQuota);
+}
+
+#[test]
+fn classify_disk_quota_exceeded() {
+    let cat = classify_install_failure(Some(1), "Disk quota exceeded", false);
+    assert_eq!(cat, InstallFailureCategory::NoSpaceOrQuota);
+}
+
+#[test]
+fn classify_enospc() {
+    let cat = classify_install_failure(Some(1), "ENOSPC: no space left on device", false);
+    assert_eq!(cat, InstallFailureCategory::NoSpaceOrQuota);
+}
+
+// ── Read-only filesystem ────────────────────────────────────────────
+
+#[test]
+fn classify_read_only_filesystem() {
+    let cat = classify_install_failure(
+        Some(1),
+        "mkdir: cannot create directory: Read-only file system",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::ReadOnlyFilesystem);
+}
+
+#[test]
+fn classify_erofs() {
+    let cat = classify_install_failure(
+        Some(1),
+        "mv: cannot move file: EROFS: read-only file system",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::ReadOnlyFilesystem);
+}
+
+// ── Tar ownership / permission failure ──────────────────────────────
+
+#[test]
+fn classify_tar_cannot_change_ownership() {
+    let cat = classify_install_failure(
+        Some(1),
+        "tar: oz: Cannot change ownership to uid 1000, gid 1000: Operation not permitted",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::TarPermissionFailure);
+}
+
+#[test]
+fn classify_tar_cannot_open_exit_2_is_unsupported_sentinel() {
+    // Exit 2 is the script's sentinel for unsupported arch/OS and is
+    // handled before stderr matching, so even tar errors with exit 2
+    // classify as UnsupportedArch.
+    let cat = classify_install_failure(
+        Some(2),
+        "tar: oz.tar.gz: Cannot open: Permission denied\ntar: Error is not recoverable",
+        false,
+    );
+    assert_eq!(
+        cat,
+        InstallFailureCategory::UnsupportedArch {
+            arch: "unknown".to_string()
+        }
+    );
+}
+
+#[test]
+fn classify_tar_cannot_open_non_sentinel_exit() {
+    // With a non-sentinel exit code, the tar-specific pattern wins
+    // over the generic "permission denied" rule.
+    let cat = classify_install_failure(
+        Some(1),
+        "tar: oz.tar.gz: Cannot open: Permission denied\ntar: Error is not recoverable",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::TarPermissionFailure);
+}
+
+#[test]
+fn classify_extract_operation_not_permitted() {
+    let cat = classify_install_failure(
+        Some(1),
+        "extract: Operation not permitted while extracting archive",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::TarPermissionFailure);
+}
+
+// ── Expired password / no TTY ───────────────────────────────────────
+
+#[test]
+fn classify_expired_password() {
+    let cat = classify_install_failure(
+        Some(1),
+        "WARNING: Your password has expired.\nPassword change required but no TTY available.",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::ExpiredPasswordOrNoTty);
+}
+
+#[test]
+fn classify_must_change_password() {
+    let cat = classify_install_failure(
+        Some(1),
+        "You must change your password before continuing",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::ExpiredPasswordOrNoTty);
+}
+
+#[test]
+fn classify_no_tty_present() {
+    let cat = classify_install_failure(
+        Some(1),
+        "sudo: no tty present and no askpass program specified",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::ExpiredPasswordOrNoTty);
+}
+
+// ── Startup-file permission denied ──────────────────────────────────
+
+#[test]
+fn classify_startup_file_bashrc_permission_denied() {
+    let cat = classify_install_failure(
+        Some(1),
+        "bash: /home/user/.bashrc: Permission denied",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::StartupFilePermissionDenied);
+}
+
+#[test]
+fn classify_startup_file_profile_permission_denied() {
+    let cat = classify_install_failure(
+        Some(1),
+        "bash: /home/user/.profile: Permission denied",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::StartupFilePermissionDenied);
+}
+
+#[test]
+fn classify_startup_file_zshrc_permission_denied() {
+    let cat = classify_install_failure(Some(1), "zsh: permission denied: /home/user/.zshrc", false);
+    assert_eq!(cat, InstallFailureCategory::StartupFilePermissionDenied);
+}
+
+// ── SSH disconnect / exit 255 ───────────────────────────────────────
+
+#[test]
+fn classify_ssh_disconnect_exit_255() {
+    let cat = classify_install_failure(
+        Some(255),
+        "ssh: connect to host example.com: Connection reset by peer",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+}
+
+#[test]
+fn classify_ssh_disconnect_exit_255_no_stderr() {
+    let cat = classify_install_failure(Some(255), "", false);
+    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+}
+
+// ── Unknown / catch-all ─────────────────────────────────────────────
+
+#[test]
+fn classify_unknown_for_unrecognized_error() {
+    let cat = classify_install_failure(Some(42), "some totally unexpected error output", false);
+    assert_eq!(cat, InstallFailureCategory::Unknown);
+}
+
+#[test]
+fn classify_unknown_for_empty_stderr() {
+    let cat = classify_install_failure(Some(1), "", false);
+    assert_eq!(cat, InstallFailureCategory::Unknown);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 2  is_retriable – no blind retry for permanent conditions
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn retriable_categories() {
+    let retriable = [
+        InstallFailureCategory::DnsFailure,
+        InstallFailureCategory::ConnectionRefused,
+        InstallFailureCategory::TlsCaFailure,
+        InstallFailureCategory::HttpServerError { status_code: 502 },
+        InstallFailureCategory::PartialDownload,
+        InstallFailureCategory::InstallTimeout,
+    ];
+    for cat in &retriable {
+        assert!(cat.is_retriable(), "{cat:?} should be retriable");
+    }
+}
+
+#[test]
+fn non_retriable_permanent_conditions() {
+    let non_retriable = [
+        InstallFailureCategory::UnsupportedArch {
+            arch: "mips".to_string(),
+        },
+        InstallFailureCategory::UnsupportedOs {
+            os: "FreeBSD".to_string(),
+        },
+        InstallFailureCategory::NoHttpClient,
+        InstallFailureCategory::MissingTar,
+        InstallFailureCategory::MissingBash,
+        InstallFailureCategory::HttpForbidden,
+        InstallFailureCategory::DownloadWriteFailure,
+        InstallFailureCategory::InstallDirPermissionDenied,
+        InstallFailureCategory::NoSpaceOrQuota,
+        InstallFailureCategory::ReadOnlyFilesystem,
+        InstallFailureCategory::TarPermissionFailure,
+        InstallFailureCategory::ExpiredPasswordOrNoTty,
+        InstallFailureCategory::StartupFilePermissionDenied,
+        InstallFailureCategory::SshDisconnect,
+        InstallFailureCategory::Unknown,
+    ];
+    for cat in &non_retriable {
+        assert!(!cat.is_retriable(), "{cat:?} should NOT be retriable");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 3  telemetry_tag stability
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn telemetry_tags_are_unique_and_non_empty() {
+    let all_categories = [
+        InstallFailureCategory::UnsupportedArch {
+            arch: "mips".to_string(),
+        },
+        InstallFailureCategory::UnsupportedOs {
+            os: "FreeBSD".to_string(),
+        },
+        InstallFailureCategory::NoHttpClient,
+        InstallFailureCategory::MissingTar,
+        InstallFailureCategory::MissingBash,
+        InstallFailureCategory::DnsFailure,
+        InstallFailureCategory::ConnectionRefused,
+        InstallFailureCategory::TlsCaFailure,
+        InstallFailureCategory::HttpForbidden,
+        InstallFailureCategory::HttpServerError { status_code: 502 },
+        InstallFailureCategory::PartialDownload,
+        InstallFailureCategory::InstallTimeout,
+        InstallFailureCategory::DownloadWriteFailure,
+        InstallFailureCategory::InstallDirPermissionDenied,
+        InstallFailureCategory::NoSpaceOrQuota,
+        InstallFailureCategory::ReadOnlyFilesystem,
+        InstallFailureCategory::TarPermissionFailure,
+        InstallFailureCategory::ExpiredPasswordOrNoTty,
+        InstallFailureCategory::StartupFilePermissionDenied,
+        InstallFailureCategory::SshDisconnect,
+        InstallFailureCategory::Unknown,
+    ];
+
+    let mut seen = std::collections::HashSet::new();
+    for cat in &all_categories {
+        let tag = cat.telemetry_tag();
+        assert!(!tag.is_empty(), "{cat:?} has empty telemetry tag");
+        assert!(
+            seen.insert(tag),
+            "duplicate telemetry tag {tag:?} for {cat:?}"
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 4  Display is non-empty for all variants
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn display_is_non_empty() {
+    let all_categories = [
+        InstallFailureCategory::UnsupportedArch {
+            arch: "mips".to_string(),
+        },
+        InstallFailureCategory::UnsupportedOs {
+            os: "FreeBSD".to_string(),
+        },
+        InstallFailureCategory::NoHttpClient,
+        InstallFailureCategory::MissingTar,
+        InstallFailureCategory::MissingBash,
+        InstallFailureCategory::DnsFailure,
+        InstallFailureCategory::ConnectionRefused,
+        InstallFailureCategory::TlsCaFailure,
+        InstallFailureCategory::HttpForbidden,
+        InstallFailureCategory::HttpServerError { status_code: 502 },
+        InstallFailureCategory::PartialDownload,
+        InstallFailureCategory::InstallTimeout,
+        InstallFailureCategory::DownloadWriteFailure,
+        InstallFailureCategory::InstallDirPermissionDenied,
+        InstallFailureCategory::NoSpaceOrQuota,
+        InstallFailureCategory::ReadOnlyFilesystem,
+        InstallFailureCategory::TarPermissionFailure,
+        InstallFailureCategory::ExpiredPasswordOrNoTty,
+        InstallFailureCategory::StartupFilePermissionDenied,
+        InstallFailureCategory::SshDisconnect,
+        InstallFailureCategory::Unknown,
+    ];
+
+    for cat in &all_categories {
+        let display = format!("{cat}");
+        assert!(!display.is_empty(), "{cat:?} has empty Display output");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 5  Edge cases and production stderr samples
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Real-world production sample: curl with MOTD noise before the error.
+#[test]
+fn classify_dns_failure_with_motd_noise() {
+    let stderr = "\
+Welcome to Ubuntu 22.04 LTS
+Last login: Mon Apr 7 10:00:00 2025
+curl: (6) Could not resolve host: app.warp.dev\n";
+    let cat = classify_install_failure(Some(6), stderr, false);
+    assert_eq!(cat, InstallFailureCategory::DnsFailure);
+}
+
+/// Real-world: wget variant of DNS failure.
+#[test]
+fn classify_dns_failure_wget() {
+    let cat = classify_install_failure(
+        Some(4),
+        "wget: unable to resolve host address 'app.warp.dev'\n",
+        false,
+    );
+    assert_eq!(cat, InstallFailureCategory::DnsFailure);
+}
+
+/// Real-world: gzip truncation from partial download.
+#[test]
+fn classify_partial_download_gzip_unexpected_eof() {
+    let stderr = "\
+gzip: stdin: unexpected end of file
+tar: Child returned status 1
+tar: Error is not recoverable: exiting now\n";
+    // Note: "unexpected end" + "gz" pattern
+    let cat = classify_install_failure(Some(1), stderr, false);
+    assert_eq!(cat, InstallFailureCategory::PartialDownload);
+}
+
+/// Classifier priority: timeout > exit code > stderr.
+#[test]
+fn timeout_takes_priority_over_exit_code() {
+    let cat = classify_install_failure(Some(255), "connection reset", true);
+    assert_eq!(cat, InstallFailureCategory::InstallTimeout);
+}
+
+/// Exit 255 takes priority over stderr patterns.
+#[test]
+fn exit_255_takes_priority_over_stderr() {
+    let cat = classify_install_failure(Some(255), "Permission denied", false);
+    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+}
+
+/// Exit 3 (no HTTP client) takes priority over stderr.
+#[test]
+fn exit_3_takes_priority_over_stderr() {
+    let cat = classify_install_failure(Some(3), "Permission denied", false);
+    assert_eq!(cat, InstallFailureCategory::NoHttpClient);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 6  Script constant alignment
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Verify our exit code constant matches the one in setup.rs.
+#[test]
+fn no_http_client_exit_code_matches_setup() {
+    assert_eq!(super::super::NO_HTTP_CLIENT_EXIT_CODE, 3);
+}
+
+/// The unsupported arch/os exit code matches the script's `exit 2`.
+#[test]
+fn unsupported_exit_code_is_2() {
+    assert_eq!(UNSUPPORTED_ARCH_OR_OS_EXIT_CODE, 2);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 7  Script probe: architecture mapping and sh compatibility
+// ═══════════════════════════════════════════════════════════════════════
+
+/// The install script's `case "$arch"` must recognise the same arch
+/// strings that [`parse_uname_output`] does.
+#[test]
+fn install_script_arch_case_covers_known_architectures() {
+    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
+    // The script has a `case "$arch" in` block.
+    assert!(
+        template.contains("x86_64)"),
+        "install script must handle x86_64"
+    );
+    assert!(
+        template.contains("aarch64|arm64)"),
+        "install script must handle aarch64 and arm64"
+    );
+    // Unsupported arches fall through to `*) ... exit 2`.
+    assert!(
+        template.contains("*) echo \"unsupported arch:"),
+        "install script must have an unsupported-arch catch-all"
+    );
+}
+
+/// The install script's `case "$os_kernel"` must match what
+/// [`parse_uname_output`] recognises.
+#[test]
+fn install_script_os_case_covers_known_os() {
+    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
+    assert!(
+        template.contains("Darwin) os_name=macos"),
+        "install script must handle Darwin/macOS"
+    );
+    assert!(
+        template.contains("Linux)  os_name=linux") || template.contains("Linux) os_name=linux"),
+        "install script must handle Linux"
+    );
+}
+
+/// The install script uses `set -e` so any failing command propagates.
+#[test]
+fn install_script_has_set_e() {
+    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
+    assert!(
+        template.contains("set -e"),
+        "install script must use `set -e`"
+    );
+}
+
+/// The no-HTTP-client exit code placeholder is present in the template.
+#[test]
+fn install_script_has_no_http_client_exit_code_placeholder() {
+    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
+    assert!(
+        template.contains("{no_http_client_exit_code}"),
+        "install script must reference the no_http_client_exit_code placeholder"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 8  HTTP client selection / fallback in install script
+// ═══════════════════════════════════════════════════════════════════════
+
+/// The script must try curl first, then wget, then emit the sentinel.
+#[test]
+fn install_script_tries_curl_before_wget() {
+    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
+    let curl_pos = template
+        .find("command -v curl")
+        .expect("script must check for curl");
+    let wget_pos = template
+        .find("command -v wget")
+        .expect("script must check for wget");
+    assert!(
+        curl_pos < wget_pos,
+        "script must try curl before wget (curl at {curl_pos}, wget at {wget_pos})"
+    );
+}
+
+/// The sentinel exit for no HTTP client must appear after both client checks.
+#[test]
+fn install_script_no_http_client_sentinel_after_checks() {
+    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
+    let wget_pos = template
+        .find("command -v wget")
+        .expect("script must check for wget");
+    let sentinel_pos = template
+        .find("exit {no_http_client_exit_code}")
+        .expect("script must have the no-HTTP-client sentinel exit");
+    assert!(
+        sentinel_pos > wget_pos,
+        "no-HTTP-client sentinel must come after the wget check"
+    );
+}
+
+/// When `staging_tarball_path` is non-empty, the script skips download.
+#[test]
+fn install_script_staging_tarball_skips_download() {
+    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
+    assert!(
+        template.contains("if [ -n \"$staging_tarball_path\" ]"),
+        "script must check for staging_tarball_path"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 9  SCP fallback trigger alignment
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Verify that `NO_HTTP_CLIENT_EXIT_CODE` is the only exit code that
+/// triggers the SCP fallback in the SSH transport. This is a structural
+/// test to prevent introducing new fallback triggers accidentally.
+#[test]
+fn scp_fallback_triggered_only_by_no_http_client() {
+    // The SCP fallback is triggered in ssh_transport.rs when
+    // `output.status.code() == Some(NO_HTTP_CLIENT_EXIT_CODE)`.
+    // We verify the constant is 3 and that the classifier agrees.
+    assert_eq!(super::super::NO_HTTP_CLIENT_EXIT_CODE, 3);
+    let cat = classify_install_failure(Some(3), "", false);
+    assert_eq!(cat, InstallFailureCategory::NoHttpClient);
+
+    // Other exit codes should NOT classify as NoHttpClient.
+    for code in [0, 1, 2, 4, 18, 22, 23, 42, 127, 255] {
+        let cat = classify_install_failure(Some(code), "", false);
+        assert_ne!(
+            cat,
+            InstallFailureCategory::NoHttpClient,
+            "exit code {code} should not classify as NoHttpClient"
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 10  Architecture mapping alignment between script and Rust
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Verify that every arch string that `parse_uname_output` recognises
+/// would also be accepted by the install script's case statement.
+#[test]
+fn rust_arch_mapping_consistent_with_script() {
+    use super::super::{parse_uname_output, RemoteArch};
+
+    let cases = [
+        ("Linux x86_64", RemoteArch::X86_64),
+        ("Linux aarch64", RemoteArch::Aarch64),
+        ("Darwin arm64", RemoteArch::Aarch64),
+        ("Linux armv8l", RemoteArch::Aarch64),
+        ("Darwin x86_64", RemoteArch::X86_64),
+    ];
+
+    for (input, expected_arch) in &cases {
+        let platform = parse_uname_output(input).expect(input);
+        assert_eq!(&platform.arch, expected_arch, "arch mismatch for {input}");
+    }
+
+    // Unsupported arches should error.
+    for bad in [
+        "Linux mips",
+        "Linux ppc64le",
+        "Linux s390x",
+        "Linux riscv64",
+    ] {
+        assert!(
+            parse_uname_output(bad).is_err(),
+            "{bad} should not be a supported arch"
+        );
+    }
+}

--- a/crates/remote_server/src/setup/install_error_tests.rs
+++ b/crates/remote_server/src/setup/install_error_tests.rs
@@ -1,542 +1,524 @@
 use super::*;
 
+// Helper: classify via the timeout-aware overload.
+fn classify(stderr: &str, exit_code: Option<i32>) -> InstallFailureCategory {
+    classify_install_failure(stderr, exit_code)
+}
+
+fn classify_timeout(stderr: &str, exit_code: Option<i32>) -> InstallFailureCategory {
+    classify_install_failure_with_timeout(stderr, exit_code, true)
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // § 1  Classifier coverage for every CSV failure family
 // ═══════════════════════════════════════════════════════════════════════
 
-// ── Install timeout ─────────────────────────────────────────────────
+// ── Timeout ─────────────────────────────────────────────────────────
 
 #[test]
 fn classify_timeout_from_flag() {
-    let cat = classify_install_failure(None, "", true);
-    assert_eq!(cat, InstallFailureCategory::InstallTimeout);
+    assert_eq!(classify_timeout("", None), InstallFailureCategory::Timeout);
 }
 
 #[test]
 fn classify_timeout_overrides_stderr() {
-    // Even if stderr contains other patterns, the timeout flag wins.
-    let cat = classify_install_failure(Some(1), "Permission denied", true);
-    assert_eq!(cat, InstallFailureCategory::InstallTimeout);
-}
-
-// ── Missing curl (no HTTP client) ───────────────────────────────────
-
-#[test]
-fn classify_no_http_client_exit_code() {
-    let cat = classify_install_failure(Some(3), "error: neither curl nor wget is available", false);
-    assert_eq!(cat, InstallFailureCategory::NoHttpClient);
-}
-
-#[test]
-fn classify_no_http_client_exit_code_only() {
-    // Exit code alone is sufficient — the script prints the message to
-    // stderr but the sentinel is the exit code.
-    let cat = classify_install_failure(Some(3), "", false);
-    assert_eq!(cat, InstallFailureCategory::NoHttpClient);
-}
-
-// ── Missing wget / both HTTP clients ────────────────────────────────
-// The install script falls through curl → wget → exit 3. Whether only
-// wget is missing doesn't matter; the sentinel covers both.
-
-#[test]
-fn classify_no_http_client_when_both_missing() {
-    let cat = classify_install_failure(
-        Some(3),
-        "error: neither curl nor wget is available\n",
-        false,
+    assert_eq!(
+        classify_timeout("Permission denied", Some(1)),
+        InstallFailureCategory::Timeout
     );
-    assert_eq!(cat, InstallFailureCategory::NoHttpClient);
 }
 
-// ── Missing tar ─────────────────────────────────────────────────────
+// ── MissingHttpClient (no curl, no wget — exit 3) ───────────────────
+
+#[test]
+fn classify_missing_http_client_exit_code() {
+    assert_eq!(
+        classify("error: neither curl nor wget is available", Some(3)),
+        InstallFailureCategory::MissingHttpClient
+    );
+}
+
+#[test]
+fn classify_missing_http_client_exit_code_only() {
+    assert_eq!(
+        classify("", Some(3)),
+        InstallFailureCategory::MissingHttpClient
+    );
+}
+
+#[test]
+fn classify_missing_http_client_when_both_absent() {
+    assert_eq!(
+        classify("error: neither curl nor wget is available\n", Some(3)),
+        InstallFailureCategory::MissingHttpClient
+    );
+}
+
+// ── MissingTar ──────────────────────────────────────────────────────
 
 #[test]
 fn classify_missing_tar_not_found() {
-    let cat = classify_install_failure(Some(127), "tar: not found", false);
-    assert_eq!(cat, InstallFailureCategory::MissingTar);
+    assert_eq!(
+        classify("tar: not found", Some(127)),
+        InstallFailureCategory::MissingTar
+    );
 }
 
 #[test]
 fn classify_missing_tar_command_not_found() {
-    let cat = classify_install_failure(Some(127), "bash: tar: command not found", false);
-    assert_eq!(cat, InstallFailureCategory::MissingTar);
+    assert_eq!(
+        classify("bash: tar: command not found", Some(127)),
+        InstallFailureCategory::MissingTar
+    );
 }
 
 #[test]
 fn classify_missing_tar_no_such_file() {
-    let cat = classify_install_failure(Some(127), "/usr/bin/tar: No such file or directory", false);
-    assert_eq!(cat, InstallFailureCategory::MissingTar);
+    assert_eq!(
+        classify("/usr/bin/tar: No such file or directory", Some(127)),
+        InstallFailureCategory::MissingTar
+    );
 }
 
-// ── Missing bash ────────────────────────────────────────────────────
+// ── MissingBash ─────────────────────────────────────────────────────
 
 #[test]
 fn classify_missing_bash_not_found() {
-    let cat = classify_install_failure(Some(127), "bash: not found", false);
-    assert_eq!(cat, InstallFailureCategory::MissingBash);
+    assert_eq!(
+        classify("bash: not found", Some(127)),
+        InstallFailureCategory::MissingBash
+    );
 }
 
 #[test]
 fn classify_missing_bash_command_not_found() {
-    let cat = classify_install_failure(Some(127), "bash: command not found", false);
-    assert_eq!(cat, InstallFailureCategory::MissingBash);
+    assert_eq!(
+        classify("bash: command not found", Some(127)),
+        InstallFailureCategory::MissingBash
+    );
 }
 
 #[test]
 fn classify_missing_bash_no_such_file() {
-    let cat = classify_install_failure(Some(127), "No such file or directory: bash", false);
-    assert_eq!(cat, InstallFailureCategory::MissingBash);
+    assert_eq!(
+        classify("No such file or directory: bash", Some(127)),
+        InstallFailureCategory::MissingBash
+    );
 }
 
-// ── Unsupported arch ────────────────────────────────────────────────
+// ── UnsupportedArchitecture ─────────────────────────────────────────
 
 #[test]
 fn classify_unsupported_arch_mips() {
-    let cat = classify_install_failure(Some(2), "unsupported arch: mips\n", false);
     assert_eq!(
-        cat,
-        InstallFailureCategory::UnsupportedArch {
-            arch: "mips".to_string()
-        }
+        classify("unsupported arch: mips\n", Some(2)),
+        InstallFailureCategory::UnsupportedArchitecture
     );
 }
 
 #[test]
 fn classify_unsupported_arch_ppc64le() {
-    let cat = classify_install_failure(Some(2), "unsupported arch: ppc64le\n", false);
     assert_eq!(
-        cat,
-        InstallFailureCategory::UnsupportedArch {
-            arch: "ppc64le".to_string()
-        }
-    );
-}
-
-#[test]
-fn classify_unsupported_arch_s390x() {
-    let cat = classify_install_failure(Some(2), "unsupported arch: s390x\n", false);
-    assert_eq!(
-        cat,
-        InstallFailureCategory::UnsupportedArch {
-            arch: "s390x".to_string()
-        }
+        classify("unsupported arch: ppc64le\n", Some(2)),
+        InstallFailureCategory::UnsupportedArchitecture
     );
 }
 
 #[test]
 fn classify_unsupported_arch_exit2_no_message() {
-    // Exit code 2 but no parseable arch → falls back to "unknown".
-    let cat = classify_install_failure(Some(2), "", false);
     assert_eq!(
-        cat,
-        InstallFailureCategory::UnsupportedArch {
-            arch: "unknown".to_string()
-        }
+        classify("", Some(2)),
+        InstallFailureCategory::UnsupportedArchitecture
     );
 }
+
+// ── UnsupportedOs ───────────────────────────────────────────────────
 
 #[test]
 fn classify_unsupported_os_freebsd() {
-    let cat = classify_install_failure(Some(2), "unsupported OS: FreeBSD\n", false);
     assert_eq!(
-        cat,
-        InstallFailureCategory::UnsupportedOs {
-            os: "FreeBSD".to_string()
-        }
+        classify("unsupported OS: FreeBSD\n", Some(2)),
+        InstallFailureCategory::UnsupportedOs
     );
 }
 
-// ── DNS failure ─────────────────────────────────────────────────────
+// ── DnsFailure ──────────────────────────────────────────────────────
 
 #[test]
 fn classify_dns_could_not_resolve() {
-    let cat = classify_install_failure(
-        Some(6),
-        "curl: (6) Could not resolve host: app.warp.dev",
-        false,
+    assert_eq!(
+        classify("curl: (6) Could not resolve host: app.warp.dev", Some(6)),
+        InstallFailureCategory::DnsFailure
     );
-    assert_eq!(cat, InstallFailureCategory::DnsFailure);
 }
 
 #[test]
 fn classify_dns_name_or_service() {
-    let cat = classify_install_failure(
-        Some(6),
-        "wget: unable to resolve host address 'app.warp.dev': Name or service not known",
-        false,
+    assert_eq!(
+        classify(
+            "wget: unable to resolve host address 'app.warp.dev': Name or service not known",
+            Some(6)
+        ),
+        InstallFailureCategory::DnsFailure
     );
-    assert_eq!(cat, InstallFailureCategory::DnsFailure);
 }
 
 #[test]
 fn classify_dns_temporary_failure() {
-    let cat = classify_install_failure(Some(6), "Temporary failure in name resolution", false);
-    assert_eq!(cat, InstallFailureCategory::DnsFailure);
+    assert_eq!(
+        classify("Temporary failure in name resolution", Some(6)),
+        InstallFailureCategory::DnsFailure
+    );
 }
 
-// ── Connection refused / unreachable ────────────────────────────────
+// ── ConnectionRefused ───────────────────────────────────────────────
 
 #[test]
 fn classify_connection_refused() {
-    let cat = classify_install_failure(
-        Some(7),
-        "curl: (7) Failed to connect to app.warp.dev port 443: Connection refused",
-        false,
+    assert_eq!(
+        classify(
+            "curl: (7) Failed to connect to app.warp.dev port 443: Connection refused",
+            Some(7)
+        ),
+        InstallFailureCategory::ConnectionRefused
     );
-    assert_eq!(cat, InstallFailureCategory::ConnectionRefused);
 }
+
+// ── ConnectionUnreachable ───────────────────────────────────────────
 
 #[test]
 fn classify_no_route_to_host() {
-    let cat = classify_install_failure(
-        Some(7),
-        "curl: (7) Failed to connect: No route to host",
-        false,
+    assert_eq!(
+        classify("curl: (7) Failed to connect: No route to host", Some(7)),
+        InstallFailureCategory::ConnectionUnreachable
     );
-    assert_eq!(cat, InstallFailureCategory::ConnectionRefused);
 }
 
 #[test]
 fn classify_network_unreachable() {
-    let cat = classify_install_failure(Some(7), "curl: (7) Network is unreachable", false);
-    assert_eq!(cat, InstallFailureCategory::ConnectionRefused);
+    assert_eq!(
+        classify("curl: (7) Network is unreachable", Some(7)),
+        InstallFailureCategory::ConnectionUnreachable
+    );
 }
 
-// ── TLS / CA failure ────────────────────────────────────────────────
+// ── TlsCaFailure ────────────────────────────────────────────────────
 
 #[test]
 fn classify_tls_ssl_connect_error() {
-    let cat = classify_install_failure(Some(35), "curl: (35) SSL connect error", false);
-    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
+    assert_eq!(
+        classify("curl: (35) SSL connect error", Some(35)),
+        InstallFailureCategory::TlsCaFailure
+    );
 }
 
 #[test]
 fn classify_tls_certificate_verify() {
-    let cat = classify_install_failure(
-        Some(60),
-        "curl: (60) SSL certificate problem: unable to get local issuer certificate",
-        false,
+    assert_eq!(
+        classify(
+            "curl: (60) SSL certificate problem: unable to get local issuer certificate",
+            Some(60)
+        ),
+        InstallFailureCategory::TlsCaFailure
     );
-    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
 }
 
 #[test]
 fn classify_tls_ca_bundle() {
-    let cat = classify_install_failure(
-        Some(77),
-        "curl: (77) error setting certificate verify locations: CA-bundle",
-        false,
+    assert_eq!(
+        classify(
+            "curl: (77) error setting certificate verify locations: CA-bundle",
+            Some(77)
+        ),
+        InstallFailureCategory::TlsCaFailure
     );
-    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
 }
 
-#[test]
-fn classify_tls_verify_failed() {
-    let cat = classify_install_failure(
-        Some(1),
-        "ERROR: certificate verify failed (OpenSSL::SSL::SSLError)",
-        false,
-    );
-    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
-}
-
-// ── HTTP 403 ────────────────────────────────────────────────────────
+// ── HttpForbidden ───────────────────────────────────────────────────
 
 #[test]
 fn classify_http_403_forbidden_stderr() {
-    let cat = classify_install_failure(
-        Some(22),
-        "The requested URL returned error: 403 Forbidden",
-        false,
+    assert_eq!(
+        classify("The requested URL returned error: 403 Forbidden", Some(22)),
+        InstallFailureCategory::HttpForbidden
     );
-    assert_eq!(cat, InstallFailureCategory::HttpForbidden);
 }
 
 #[test]
 fn classify_http_403_curl_exit_22() {
-    let cat = classify_install_failure(Some(22), "403", false);
-    assert_eq!(cat, InstallFailureCategory::HttpForbidden);
-}
-
-// ── HTTP 502 ────────────────────────────────────────────────────────
-
-#[test]
-fn classify_http_502_bad_gateway() {
-    let cat = classify_install_failure(Some(22), "502 Bad Gateway", false);
     assert_eq!(
-        cat,
-        InstallFailureCategory::HttpServerError { status_code: 502 }
+        classify("403", Some(22)),
+        InstallFailureCategory::HttpForbidden
     );
 }
 
+// ── HttpBadGateway ──────────────────────────────────────────────────
+
+#[test]
+fn classify_http_502_bad_gateway() {
+    assert_eq!(
+        classify("502 Bad Gateway", Some(22)),
+        InstallFailureCategory::HttpBadGateway
+    );
+}
+
+// ── HttpError ───────────────────────────────────────────────────────
+
 #[test]
 fn classify_http_503_service_unavailable() {
-    let cat = classify_install_failure(Some(22), "503 Service Unavailable", false);
     assert_eq!(
-        cat,
-        InstallFailureCategory::HttpServerError { status_code: 503 }
+        classify("503 Service Unavailable", Some(1)),
+        InstallFailureCategory::HttpError
     );
 }
 
 #[test]
 fn classify_curl_exit_22_generic() {
-    // curl -f exit 22 with no recognizable status → generic server error.
-    let cat = classify_install_failure(Some(22), "The requested URL returned error: 500", false);
     assert_eq!(
-        cat,
-        InstallFailureCategory::HttpServerError { status_code: 0 }
+        classify("The requested URL returned error: 500", Some(22)),
+        InstallFailureCategory::HttpError
     );
 }
 
-// ── Partial download ────────────────────────────────────────────────
+// ── PartialDownload ─────────────────────────────────────────────────
 
 #[test]
 fn classify_partial_download_curl_exit_18() {
-    let cat = classify_install_failure(
-        Some(18),
-        "curl: (18) transfer closed with 12345 bytes remaining",
-        false,
+    assert_eq!(
+        classify(
+            "curl: (18) transfer closed with 12345 bytes remaining",
+            Some(18)
+        ),
+        InstallFailureCategory::PartialDownload
     );
-    assert_eq!(cat, InstallFailureCategory::PartialDownload);
 }
 
 #[test]
 fn classify_partial_download_stderr_partial_file() {
-    let cat = classify_install_failure(Some(1), "Partial file received", false);
-    assert_eq!(cat, InstallFailureCategory::PartialDownload);
+    assert_eq!(
+        classify("Partial file received", Some(1)),
+        InstallFailureCategory::PartialDownload
+    );
 }
 
 #[test]
 fn classify_partial_download_unexpected_end_gz() {
-    let cat = classify_install_failure(
-        Some(1),
-        "gzip: stdin: unexpected end of file\ntar: Child returned status 1\ntar: Error: oz.tar.gz",
-        false,
+    let stderr =
+        "gzip: stdin: unexpected end of file\ntar: Child returned status 1\ntar: Error: oz.tar.gz";
+    assert_eq!(
+        classify(stderr, Some(1)),
+        InstallFailureCategory::PartialDownload
     );
-    assert_eq!(cat, InstallFailureCategory::PartialDownload);
 }
 
-// ── Download write failure ──────────────────────────────────────────
+// ── DownloadWriteFailure ────────────────────────────────────────────
 
 #[test]
 fn classify_download_write_failure_curl_exit_23() {
-    let cat = classify_install_failure(Some(23), "Failed writing body (0 != 1234)", false);
-    assert_eq!(cat, InstallFailureCategory::DownloadWriteFailure);
+    assert_eq!(
+        classify("Failed writing body (0 != 1234)", Some(23)),
+        InstallFailureCategory::DownloadWriteFailure
+    );
 }
 
 #[test]
 fn classify_download_write_failure_failed_writing_body() {
-    let cat = classify_install_failure(Some(1), "curl: Failed writing body", false);
-    assert_eq!(cat, InstallFailureCategory::DownloadWriteFailure);
+    assert_eq!(
+        classify("curl: Failed writing body", Some(1)),
+        InstallFailureCategory::DownloadWriteFailure
+    );
 }
 
-// ── Install dir permission denied ───────────────────────────────────
+// ── InstallDirPermissionDenied ──────────────────────────────────────
 
 #[test]
 fn classify_install_dir_permission_denied() {
-    let cat = classify_install_failure(
-        Some(1),
-        "mkdir: cannot create directory '/root/.warp/remote-server': Permission denied",
-        false,
+    assert_eq!(
+        classify(
+            "mkdir: cannot create directory '/root/.warp/remote-server': Permission denied",
+            Some(1)
+        ),
+        InstallFailureCategory::InstallDirPermissionDenied
     );
-    assert_eq!(cat, InstallFailureCategory::InstallDirPermissionDenied);
 }
 
-#[test]
-fn classify_install_dir_mv_permission_denied() {
-    let cat = classify_install_failure(
-        Some(1),
-        "mv: cannot move 'oz' to '/opt/warp/remote-server/oz': Permission denied",
-        false,
-    );
-    assert_eq!(cat, InstallFailureCategory::InstallDirPermissionDenied);
-}
-
-// ── No space / quota ────────────────────────────────────────────────
+// ── NoSpaceLeft ─────────────────────────────────────────────────────
 
 #[test]
 fn classify_no_space_left() {
-    let cat = classify_install_failure(Some(1), "write error: No space left on device", false);
-    assert_eq!(cat, InstallFailureCategory::NoSpaceOrQuota);
+    assert_eq!(
+        classify("write error: No space left on device", Some(1)),
+        InstallFailureCategory::NoSpaceLeft
+    );
 }
 
 #[test]
 fn classify_disk_quota_exceeded() {
-    let cat = classify_install_failure(Some(1), "Disk quota exceeded", false);
-    assert_eq!(cat, InstallFailureCategory::NoSpaceOrQuota);
+    assert_eq!(
+        classify("Disk quota exceeded", Some(1)),
+        InstallFailureCategory::NoSpaceLeft
+    );
 }
 
-#[test]
-fn classify_enospc() {
-    let cat = classify_install_failure(Some(1), "ENOSPC: no space left on device", false);
-    assert_eq!(cat, InstallFailureCategory::NoSpaceOrQuota);
-}
-
-// ── Read-only filesystem ────────────────────────────────────────────
+// ── ReadOnlyFilesystem ──────────────────────────────────────────────
 
 #[test]
 fn classify_read_only_filesystem() {
-    let cat = classify_install_failure(
-        Some(1),
-        "mkdir: cannot create directory: Read-only file system",
-        false,
+    assert_eq!(
+        classify(
+            "mkdir: cannot create directory: Read-only file system",
+            Some(1)
+        ),
+        InstallFailureCategory::ReadOnlyFilesystem
     );
-    assert_eq!(cat, InstallFailureCategory::ReadOnlyFilesystem);
 }
 
 #[test]
 fn classify_erofs() {
-    let cat = classify_install_failure(
-        Some(1),
-        "mv: cannot move file: EROFS: read-only file system",
-        false,
+    assert_eq!(
+        classify(
+            "mv: cannot move file: EROFS: read-only file system",
+            Some(1)
+        ),
+        InstallFailureCategory::ReadOnlyFilesystem
     );
-    assert_eq!(cat, InstallFailureCategory::ReadOnlyFilesystem);
 }
 
-// ── Tar ownership / permission failure ──────────────────────────────
+// ── TarPermissionFailure ────────────────────────────────────────────
 
 #[test]
 fn classify_tar_cannot_change_ownership() {
-    let cat = classify_install_failure(
-        Some(1),
-        "tar: oz: Cannot change ownership to uid 1000, gid 1000: Operation not permitted",
-        false,
-    );
-    assert_eq!(cat, InstallFailureCategory::TarPermissionFailure);
-}
-
-#[test]
-fn classify_tar_cannot_open_exit_2_is_unsupported_sentinel() {
-    // Exit 2 is the script's sentinel for unsupported arch/OS and is
-    // handled before stderr matching, so even tar errors with exit 2
-    // classify as UnsupportedArch.
-    let cat = classify_install_failure(
-        Some(2),
-        "tar: oz.tar.gz: Cannot open: Permission denied\ntar: Error is not recoverable",
-        false,
-    );
     assert_eq!(
-        cat,
-        InstallFailureCategory::UnsupportedArch {
-            arch: "unknown".to_string()
-        }
+        classify(
+            "tar: oz: Cannot change ownership to uid 1000, gid 1000: Operation not permitted",
+            Some(1)
+        ),
+        InstallFailureCategory::TarPermissionFailure
     );
 }
 
 #[test]
 fn classify_tar_cannot_open_non_sentinel_exit() {
-    // With a non-sentinel exit code, the tar-specific pattern wins
-    // over the generic "permission denied" rule.
-    let cat = classify_install_failure(
-        Some(1),
-        "tar: oz.tar.gz: Cannot open: Permission denied\ntar: Error is not recoverable",
-        false,
+    assert_eq!(
+        classify(
+            "tar: oz.tar.gz: Cannot open: Permission denied\ntar: Error is not recoverable",
+            Some(1)
+        ),
+        InstallFailureCategory::TarPermissionFailure
     );
-    assert_eq!(cat, InstallFailureCategory::TarPermissionFailure);
+}
+
+// ── TarExtractionFailure ────────────────────────────────────────────
+
+#[test]
+fn classify_tar_not_gzip() {
+    assert_eq!(
+        classify(
+            "tar: This does not look like a tar archive\ngzip: stdin: not in gzip format",
+            Some(1)
+        ),
+        InstallFailureCategory::TarExtractionFailure
+    );
 }
 
 #[test]
-fn classify_extract_operation_not_permitted() {
-    let cat = classify_install_failure(
-        Some(1),
-        "extract: Operation not permitted while extracting archive",
-        false,
+fn classify_tar_corrupted() {
+    assert_eq!(
+        classify("tar: Archive is corrupted", Some(1)),
+        InstallFailureCategory::TarExtractionFailure
     );
-    assert_eq!(cat, InstallFailureCategory::TarPermissionFailure);
 }
 
-// ── Expired password / no TTY ───────────────────────────────────────
+// ── ExpiredPassword ─────────────────────────────────────────────────
 
 #[test]
 fn classify_expired_password() {
-    let cat = classify_install_failure(
-        Some(1),
-        "WARNING: Your password has expired.\nPassword change required but no TTY available.",
-        false,
+    assert_eq!(
+        classify(
+            "WARNING: Your password has expired.\nPassword change required but no TTY available.",
+            Some(1)
+        ),
+        InstallFailureCategory::ExpiredPassword
     );
-    assert_eq!(cat, InstallFailureCategory::ExpiredPasswordOrNoTty);
-}
-
-#[test]
-fn classify_must_change_password() {
-    let cat = classify_install_failure(
-        Some(1),
-        "You must change your password before continuing",
-        false,
-    );
-    assert_eq!(cat, InstallFailureCategory::ExpiredPasswordOrNoTty);
 }
 
 #[test]
 fn classify_no_tty_present() {
-    let cat = classify_install_failure(
-        Some(1),
-        "sudo: no tty present and no askpass program specified",
-        false,
+    assert_eq!(
+        classify(
+            "sudo: no tty present and no askpass program specified",
+            Some(1)
+        ),
+        InstallFailureCategory::ExpiredPassword
     );
-    assert_eq!(cat, InstallFailureCategory::ExpiredPasswordOrNoTty);
 }
 
-// ── Startup-file permission denied ──────────────────────────────────
+// ── StartupFilePermissionDenied ─────────────────────────────────────
 
 #[test]
 fn classify_startup_file_bashrc_permission_denied() {
-    let cat = classify_install_failure(
-        Some(1),
-        "bash: /home/user/.bashrc: Permission denied",
-        false,
+    assert_eq!(
+        classify("bash: /home/user/.bashrc: Permission denied", Some(1)),
+        InstallFailureCategory::StartupFilePermissionDenied
     );
-    assert_eq!(cat, InstallFailureCategory::StartupFilePermissionDenied);
-}
-
-#[test]
-fn classify_startup_file_profile_permission_denied() {
-    let cat = classify_install_failure(
-        Some(1),
-        "bash: /home/user/.profile: Permission denied",
-        false,
-    );
-    assert_eq!(cat, InstallFailureCategory::StartupFilePermissionDenied);
 }
 
 #[test]
 fn classify_startup_file_zshrc_permission_denied() {
-    let cat = classify_install_failure(Some(1), "zsh: permission denied: /home/user/.zshrc", false);
-    assert_eq!(cat, InstallFailureCategory::StartupFilePermissionDenied);
+    assert_eq!(
+        classify("zsh: permission denied: /home/user/.zshrc", Some(1)),
+        InstallFailureCategory::StartupFilePermissionDenied
+    );
 }
 
-// ── SSH disconnect / exit 255 ───────────────────────────────────────
+// ── SshDisconnect ───────────────────────────────────────────────────
 
 #[test]
 fn classify_ssh_disconnect_exit_255() {
-    let cat = classify_install_failure(
-        Some(255),
-        "ssh: connect to host example.com: Connection reset by peer",
-        false,
+    assert_eq!(
+        classify(
+            "ssh: connect to host example.com: Connection reset by peer",
+            Some(255)
+        ),
+        InstallFailureCategory::SshDisconnect
     );
-    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
 }
 
 #[test]
 fn classify_ssh_disconnect_exit_255_no_stderr() {
-    let cat = classify_install_failure(Some(255), "", false);
-    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+    assert_eq!(
+        classify("", Some(255)),
+        InstallFailureCategory::SshDisconnect
+    );
 }
 
-// ── Unknown / catch-all ─────────────────────────────────────────────
+// ── ScriptError ─────────────────────────────────────────────────────
 
 #[test]
-fn classify_unknown_for_unrecognized_error() {
-    let cat = classify_install_failure(Some(42), "some totally unexpected error output", false);
-    assert_eq!(cat, InstallFailureCategory::Unknown);
+fn classify_script_error_unrecognized_nonzero() {
+    assert_eq!(
+        classify("some totally unexpected error output", Some(42)),
+        InstallFailureCategory::ScriptError
+    );
 }
 
 #[test]
-fn classify_unknown_for_empty_stderr() {
-    let cat = classify_install_failure(Some(1), "", false);
-    assert_eq!(cat, InstallFailureCategory::Unknown);
+fn classify_script_error_empty_stderr_nonzero() {
+    assert_eq!(classify("", Some(1)), InstallFailureCategory::ScriptError);
+}
+
+// ── Unknown ─────────────────────────────────────────────────────────
+
+#[test]
+fn classify_unknown_for_exit_zero() {
+    // exit 0 should not be classified as a failure; if the caller asks
+    // anyway the fallback is Unknown.
+    assert_eq!(classify("", Some(0)), InstallFailureCategory::Unknown);
+}
+
+#[test]
+fn classify_unknown_for_signal_kill() {
+    assert_eq!(classify("", None), InstallFailureCategory::Unknown);
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -546,12 +528,14 @@ fn classify_unknown_for_empty_stderr() {
 #[test]
 fn retriable_categories() {
     let retriable = [
+        InstallFailureCategory::Timeout,
         InstallFailureCategory::DnsFailure,
         InstallFailureCategory::ConnectionRefused,
+        InstallFailureCategory::ConnectionUnreachable,
         InstallFailureCategory::TlsCaFailure,
-        InstallFailureCategory::HttpServerError { status_code: 502 },
+        InstallFailureCategory::HttpBadGateway,
+        InstallFailureCategory::HttpError,
         InstallFailureCategory::PartialDownload,
-        InstallFailureCategory::InstallTimeout,
     ];
     for cat in &retriable {
         assert!(cat.is_retriable(), "{cat:?} should be retriable");
@@ -561,24 +545,24 @@ fn retriable_categories() {
 #[test]
 fn non_retriable_permanent_conditions() {
     let non_retriable = [
-        InstallFailureCategory::UnsupportedArch {
-            arch: "mips".to_string(),
-        },
-        InstallFailureCategory::UnsupportedOs {
-            os: "FreeBSD".to_string(),
-        },
-        InstallFailureCategory::NoHttpClient,
+        InstallFailureCategory::MissingCurl,
+        InstallFailureCategory::MissingWget,
+        InstallFailureCategory::MissingHttpClient,
         InstallFailureCategory::MissingTar,
         InstallFailureCategory::MissingBash,
+        InstallFailureCategory::UnsupportedArchitecture,
+        InstallFailureCategory::UnsupportedOs,
         InstallFailureCategory::HttpForbidden,
         InstallFailureCategory::DownloadWriteFailure,
         InstallFailureCategory::InstallDirPermissionDenied,
-        InstallFailureCategory::NoSpaceOrQuota,
+        InstallFailureCategory::NoSpaceLeft,
         InstallFailureCategory::ReadOnlyFilesystem,
+        InstallFailureCategory::TarExtractionFailure,
         InstallFailureCategory::TarPermissionFailure,
-        InstallFailureCategory::ExpiredPasswordOrNoTty,
+        InstallFailureCategory::ExpiredPassword,
         InstallFailureCategory::StartupFilePermissionDenied,
         InstallFailureCategory::SshDisconnect,
+        InstallFailureCategory::ScriptError,
         InstallFailureCategory::Unknown,
     ];
     for cat in &non_retriable {
@@ -587,230 +571,108 @@ fn non_retriable_permanent_conditions() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// § 3  telemetry_tag stability
+// § 3  as_str / title / description stability
 // ═══════════════════════════════════════════════════════════════════════
 
 #[test]
-fn telemetry_tags_are_unique_and_non_empty() {
-    let all_categories = [
-        InstallFailureCategory::UnsupportedArch {
-            arch: "mips".to_string(),
-        },
-        InstallFailureCategory::UnsupportedOs {
-            os: "FreeBSD".to_string(),
-        },
-        InstallFailureCategory::NoHttpClient,
-        InstallFailureCategory::MissingTar,
-        InstallFailureCategory::MissingBash,
-        InstallFailureCategory::DnsFailure,
-        InstallFailureCategory::ConnectionRefused,
-        InstallFailureCategory::TlsCaFailure,
-        InstallFailureCategory::HttpForbidden,
-        InstallFailureCategory::HttpServerError { status_code: 502 },
-        InstallFailureCategory::PartialDownload,
-        InstallFailureCategory::InstallTimeout,
-        InstallFailureCategory::DownloadWriteFailure,
-        InstallFailureCategory::InstallDirPermissionDenied,
-        InstallFailureCategory::NoSpaceOrQuota,
-        InstallFailureCategory::ReadOnlyFilesystem,
-        InstallFailureCategory::TarPermissionFailure,
-        InstallFailureCategory::ExpiredPasswordOrNoTty,
-        InstallFailureCategory::StartupFilePermissionDenied,
-        InstallFailureCategory::SshDisconnect,
-        InstallFailureCategory::Unknown,
-    ];
-
+fn as_str_tags_are_unique_and_non_empty() {
+    let all = all_categories();
     let mut seen = std::collections::HashSet::new();
-    for cat in &all_categories {
-        let tag = cat.telemetry_tag();
-        assert!(!tag.is_empty(), "{cat:?} has empty telemetry tag");
+    for cat in &all {
+        let tag = cat.as_str();
+        assert!(!tag.is_empty(), "{cat:?} has empty as_str tag");
+        assert!(seen.insert(tag), "duplicate as_str tag {tag:?} for {cat:?}");
+    }
+}
+
+#[test]
+fn title_is_non_empty() {
+    for cat in &all_categories() {
+        assert!(!cat.title().is_empty(), "{cat:?} has empty title");
+    }
+}
+
+#[test]
+fn description_is_non_empty() {
+    for cat in &all_categories() {
         assert!(
-            seen.insert(tag),
-            "duplicate telemetry tag {tag:?} for {cat:?}"
+            !cat.description().is_empty(),
+            "{cat:?} has empty description"
         );
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════════
-// § 4  Display is non-empty for all variants
-// ═══════════════════════════════════════════════════════════════════════
-
 #[test]
-fn display_is_non_empty() {
-    let all_categories = [
-        InstallFailureCategory::UnsupportedArch {
-            arch: "mips".to_string(),
-        },
-        InstallFailureCategory::UnsupportedOs {
-            os: "FreeBSD".to_string(),
-        },
-        InstallFailureCategory::NoHttpClient,
-        InstallFailureCategory::MissingTar,
-        InstallFailureCategory::MissingBash,
-        InstallFailureCategory::DnsFailure,
-        InstallFailureCategory::ConnectionRefused,
-        InstallFailureCategory::TlsCaFailure,
-        InstallFailureCategory::HttpForbidden,
-        InstallFailureCategory::HttpServerError { status_code: 502 },
-        InstallFailureCategory::PartialDownload,
-        InstallFailureCategory::InstallTimeout,
-        InstallFailureCategory::DownloadWriteFailure,
-        InstallFailureCategory::InstallDirPermissionDenied,
-        InstallFailureCategory::NoSpaceOrQuota,
-        InstallFailureCategory::ReadOnlyFilesystem,
-        InstallFailureCategory::TarPermissionFailure,
-        InstallFailureCategory::ExpiredPasswordOrNoTty,
-        InstallFailureCategory::StartupFilePermissionDenied,
-        InstallFailureCategory::SshDisconnect,
-        InstallFailureCategory::Unknown,
-    ];
-
-    for cat in &all_categories {
-        let display = format!("{cat}");
-        assert!(!display.is_empty(), "{cat:?} has empty Display output");
+fn display_matches_description() {
+    for cat in &all_categories() {
+        assert_eq!(format!("{cat}"), cat.description());
     }
 }
 
+fn all_categories() -> Vec<InstallFailureCategory> {
+    vec![
+        InstallFailureCategory::Timeout,
+        InstallFailureCategory::MissingCurl,
+        InstallFailureCategory::MissingWget,
+        InstallFailureCategory::MissingHttpClient,
+        InstallFailureCategory::MissingTar,
+        InstallFailureCategory::MissingBash,
+        InstallFailureCategory::UnsupportedArchitecture,
+        InstallFailureCategory::UnsupportedOs,
+        InstallFailureCategory::DnsFailure,
+        InstallFailureCategory::ConnectionRefused,
+        InstallFailureCategory::ConnectionUnreachable,
+        InstallFailureCategory::TlsCaFailure,
+        InstallFailureCategory::HttpForbidden,
+        InstallFailureCategory::HttpBadGateway,
+        InstallFailureCategory::HttpError,
+        InstallFailureCategory::PartialDownload,
+        InstallFailureCategory::DownloadWriteFailure,
+        InstallFailureCategory::InstallDirPermissionDenied,
+        InstallFailureCategory::NoSpaceLeft,
+        InstallFailureCategory::ReadOnlyFilesystem,
+        InstallFailureCategory::TarExtractionFailure,
+        InstallFailureCategory::TarPermissionFailure,
+        InstallFailureCategory::ExpiredPassword,
+        InstallFailureCategory::StartupFilePermissionDenied,
+        InstallFailureCategory::SshDisconnect,
+        InstallFailureCategory::ScriptError,
+        InstallFailureCategory::Unknown,
+    ]
+}
+
 // ═══════════════════════════════════════════════════════════════════════
-// § 5  Edge cases and production stderr samples
+// § 4  Priority ordering
 // ═══════════════════════════════════════════════════════════════════════
 
-/// Real-world production sample: curl with MOTD noise before the error.
-#[test]
-fn classify_dns_failure_with_motd_noise() {
-    let stderr = "\
-Welcome to Ubuntu 22.04 LTS
-Last login: Mon Apr 7 10:00:00 2025
-curl: (6) Could not resolve host: app.warp.dev\n";
-    let cat = classify_install_failure(Some(6), stderr, false);
-    assert_eq!(cat, InstallFailureCategory::DnsFailure);
-}
-
-/// Real-world: wget variant of DNS failure.
-#[test]
-fn classify_dns_failure_wget() {
-    let cat = classify_install_failure(
-        Some(4),
-        "wget: unable to resolve host address 'app.warp.dev'\n",
-        false,
-    );
-    assert_eq!(cat, InstallFailureCategory::DnsFailure);
-}
-
-/// Real-world: gzip truncation from partial download.
-#[test]
-fn classify_partial_download_gzip_unexpected_eof() {
-    let stderr = "\
-gzip: stdin: unexpected end of file
-tar: Child returned status 1
-tar: Error is not recoverable: exiting now\n";
-    // Note: "unexpected end" + "gz" pattern
-    let cat = classify_install_failure(Some(1), stderr, false);
-    assert_eq!(cat, InstallFailureCategory::PartialDownload);
-}
-
-/// Classifier priority: timeout > exit code > stderr.
 #[test]
 fn timeout_takes_priority_over_exit_code() {
-    let cat = classify_install_failure(Some(255), "connection reset", true);
-    assert_eq!(cat, InstallFailureCategory::InstallTimeout);
+    assert_eq!(
+        classify_install_failure_with_timeout("connection reset", Some(255), true),
+        InstallFailureCategory::Timeout
+    );
 }
 
-/// Exit 255 takes priority over stderr patterns.
 #[test]
 fn exit_255_takes_priority_over_stderr() {
-    let cat = classify_install_failure(Some(255), "Permission denied", false);
-    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+    assert_eq!(
+        classify("Permission denied", Some(255)),
+        InstallFailureCategory::SshDisconnect
+    );
 }
 
-/// Exit 3 (no HTTP client) takes priority over stderr.
 #[test]
 fn exit_3_takes_priority_over_stderr() {
-    let cat = classify_install_failure(Some(3), "Permission denied", false);
-    assert_eq!(cat, InstallFailureCategory::NoHttpClient);
-}
-
-// ═══════════════════════════════════════════════════════════════════════
-// § 6  Script constant alignment
-// ═══════════════════════════════════════════════════════════════════════
-
-/// Verify our exit code constant matches the one in setup.rs.
-#[test]
-fn no_http_client_exit_code_matches_setup() {
-    assert_eq!(super::super::NO_HTTP_CLIENT_EXIT_CODE, 3);
-}
-
-/// The unsupported arch/os exit code matches the script's `exit 2`.
-#[test]
-fn unsupported_exit_code_is_2() {
-    assert_eq!(UNSUPPORTED_ARCH_OR_OS_EXIT_CODE, 2);
-}
-
-// ═══════════════════════════════════════════════════════════════════════
-// § 7  Script probe: architecture mapping and sh compatibility
-// ═══════════════════════════════════════════════════════════════════════
-
-/// The install script's `case "$arch"` must recognise the same arch
-/// strings that [`parse_uname_output`] does.
-#[test]
-fn install_script_arch_case_covers_known_architectures() {
-    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
-    // The script has a `case "$arch" in` block.
-    assert!(
-        template.contains("x86_64)"),
-        "install script must handle x86_64"
-    );
-    assert!(
-        template.contains("aarch64|arm64)"),
-        "install script must handle aarch64 and arm64"
-    );
-    // Unsupported arches fall through to `*) ... exit 2`.
-    assert!(
-        template.contains("*) echo \"unsupported arch:"),
-        "install script must have an unsupported-arch catch-all"
-    );
-}
-
-/// The install script's `case "$os_kernel"` must match what
-/// [`parse_uname_output`] recognises.
-#[test]
-fn install_script_os_case_covers_known_os() {
-    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
-    assert!(
-        template.contains("Darwin) os_name=macos"),
-        "install script must handle Darwin/macOS"
-    );
-    assert!(
-        template.contains("Linux)  os_name=linux") || template.contains("Linux) os_name=linux"),
-        "install script must handle Linux"
-    );
-}
-
-/// The install script uses `set -e` so any failing command propagates.
-#[test]
-fn install_script_has_set_e() {
-    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
-    assert!(
-        template.contains("set -e"),
-        "install script must use `set -e`"
-    );
-}
-
-/// The no-HTTP-client exit code placeholder is present in the template.
-#[test]
-fn install_script_has_no_http_client_exit_code_placeholder() {
-    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
-    assert!(
-        template.contains("{no_http_client_exit_code}"),
-        "install script must reference the no_http_client_exit_code placeholder"
+    assert_eq!(
+        classify("Permission denied", Some(3)),
+        InstallFailureCategory::MissingHttpClient
     );
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// § 8  HTTP client selection / fallback in install script
+// § 5  Script structural probes
 // ═══════════════════════════════════════════════════════════════════════
 
-/// The script must try curl first, then wget, then emit the sentinel.
 #[test]
 fn install_script_tries_curl_before_wget() {
     let template = super::super::INSTALL_SCRIPT_TEMPLATE;
@@ -820,71 +682,71 @@ fn install_script_tries_curl_before_wget() {
     let wget_pos = template
         .find("command -v wget")
         .expect("script must check for wget");
-    assert!(
-        curl_pos < wget_pos,
-        "script must try curl before wget (curl at {curl_pos}, wget at {wget_pos})"
-    );
+    assert!(curl_pos < wget_pos);
 }
 
-/// The sentinel exit for no HTTP client must appear after both client checks.
 #[test]
 fn install_script_no_http_client_sentinel_after_checks() {
     let template = super::super::INSTALL_SCRIPT_TEMPLATE;
-    let wget_pos = template
-        .find("command -v wget")
-        .expect("script must check for wget");
+    let wget_pos = template.find("command -v wget").expect("must check wget");
     let sentinel_pos = template
         .find("exit {no_http_client_exit_code}")
-        .expect("script must have the no-HTTP-client sentinel exit");
+        .expect("must have sentinel");
+    assert!(sentinel_pos > wget_pos);
+}
+
+#[test]
+fn install_script_arch_case_covers_known_architectures() {
+    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
+    assert!(template.contains("x86_64)"));
+    assert!(template.contains("aarch64|arm64)"));
+    assert!(template.contains("*) echo \"unsupported arch:"));
+}
+
+#[test]
+fn install_script_os_case_covers_known_os() {
+    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
+    assert!(template.contains("Darwin) os_name=macos"));
     assert!(
-        sentinel_pos > wget_pos,
-        "no-HTTP-client sentinel must come after the wget check"
+        template.contains("Linux)  os_name=linux") || template.contains("Linux) os_name=linux")
     );
 }
 
-/// When `staging_tarball_path` is non-empty, the script skips download.
+#[test]
+fn install_script_has_set_e() {
+    assert!(super::super::INSTALL_SCRIPT_TEMPLATE.contains("set -e"));
+}
+
 #[test]
 fn install_script_staging_tarball_skips_download() {
-    let template = super::super::INSTALL_SCRIPT_TEMPLATE;
-    assert!(
-        template.contains("if [ -n \"$staging_tarball_path\" ]"),
-        "script must check for staging_tarball_path"
-    );
+    assert!(super::super::INSTALL_SCRIPT_TEMPLATE.contains("if [ -n \"$staging_tarball_path\" ]"));
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// § 9  SCP fallback trigger alignment
+// § 6  SCP fallback trigger alignment
 // ═══════════════════════════════════════════════════════════════════════
 
-/// Verify that `NO_HTTP_CLIENT_EXIT_CODE` is the only exit code that
-/// triggers the SCP fallback in the SSH transport. This is a structural
-/// test to prevent introducing new fallback triggers accidentally.
 #[test]
-fn scp_fallback_triggered_only_by_no_http_client() {
-    // The SCP fallback is triggered in ssh_transport.rs when
-    // `output.status.code() == Some(NO_HTTP_CLIENT_EXIT_CODE)`.
-    // We verify the constant is 3 and that the classifier agrees.
+fn scp_fallback_triggered_only_by_missing_http_client() {
     assert_eq!(super::super::NO_HTTP_CLIENT_EXIT_CODE, 3);
-    let cat = classify_install_failure(Some(3), "", false);
-    assert_eq!(cat, InstallFailureCategory::NoHttpClient);
+    assert_eq!(
+        classify("", Some(3)),
+        InstallFailureCategory::MissingHttpClient
+    );
 
-    // Other exit codes should NOT classify as NoHttpClient.
     for code in [0, 1, 2, 4, 18, 22, 23, 42, 127, 255] {
-        let cat = classify_install_failure(Some(code), "", false);
         assert_ne!(
-            cat,
-            InstallFailureCategory::NoHttpClient,
-            "exit code {code} should not classify as NoHttpClient"
+            classify("", Some(code)),
+            InstallFailureCategory::MissingHttpClient,
+            "exit code {code} should not classify as MissingHttpClient"
         );
     }
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// § 10  Architecture mapping alignment between script and Rust
+// § 7  Architecture mapping consistency
 // ═══════════════════════════════════════════════════════════════════════
 
-/// Verify that every arch string that `parse_uname_output` recognises
-/// would also be accepted by the install script's case statement.
 #[test]
 fn rust_arch_mapping_consistent_with_script() {
     use super::super::{parse_uname_output, RemoteArch};
@@ -902,7 +764,6 @@ fn rust_arch_mapping_consistent_with_script() {
         assert_eq!(&platform.arch, expected_arch, "arch mismatch for {input}");
     }
 
-    // Unsupported arches should error.
     for bad in [
         "Linux mips",
         "Linux ppc64le",
@@ -911,7 +772,43 @@ fn rust_arch_mapping_consistent_with_script() {
     ] {
         assert!(
             parse_uname_output(bad).is_err(),
-            "{bad} should not be a supported arch"
+            "{bad} should not be supported"
         );
     }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// § 8  Production stderr edge cases
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn classify_dns_failure_with_motd_noise() {
+    let stderr =
+        "Welcome to Ubuntu 22.04 LTS\nLast login: Mon Apr 7 10:00:00 2025\ncurl: (6) Could not resolve host: app.warp.dev\n";
+    assert_eq!(
+        classify(stderr, Some(6)),
+        InstallFailureCategory::DnsFailure
+    );
+}
+
+#[test]
+fn classify_partial_download_gzip_unexpected_eof() {
+    let stderr =
+        "gzip: stdin: unexpected end of file\ntar: Child returned status 1\ntar: Error is not recoverable: exiting now\n";
+    assert_eq!(
+        classify(stderr, Some(1)),
+        InstallFailureCategory::PartialDownload
+    );
+}
+
+#[test]
+fn classify_exit2_tar_error_is_unsupported_sentinel() {
+    // Exit 2 is the script's sentinel and takes priority over stderr.
+    assert_eq!(
+        classify(
+            "tar: oz.tar.gz: Cannot open: Permission denied\ntar: Error is not recoverable",
+            Some(2)
+        ),
+        InstallFailureCategory::UnsupportedArchitecture
+    );
 }


### PR DESCRIPTION
## Problem
Remote-server install failures were arriving as raw exit codes and stderr strings. The CSV contained many distinct failure families, but without a typed classifier it was difficult to tell which failures were transient, which should be routed to fallback logic, and which represented permanent host conditions. This also made regressions likely because the failure-family coverage was not encoded in tests.

## Solution
- Add a typed `InstallFailureCategory` enum for the observed install failure families.
- Add classifier helpers for raw stderr, exit codes, and explicit timeout failures.
- Encode retryability by category so fallback logic can distinguish retriable network/download failures from permanent host failures.
- Add an exhaustive unit-test matrix for the CSV-derived families, category metadata, priority ordering, script sentinels, and architecture mapping consistency.

## Proof / validation
No screenshots are applicable because this is classifier/test infrastructure. Proof is the test matrix itself and command output:

- `cargo test -p remote_server` passed in the integrated validation run: 136 tests passed.
- The tests cover timeout, missing curl/wget/no HTTP client, missing tar/bash, unsupported OS/arch, DNS/connectivity/TLS/HTTP failures, partial downloads, write failures, permissions, no-space/quota, read-only filesystems, extraction failures, expired password, startup-file permission issues, SSH disconnects, and unknown script errors.
- The Docker SSH harness produced classifier-aligned sentinels after integration, including DNS/HTTP/TLS/download failures exiting `4`, no HTTP client exiting `3`, and missing tar exiting `5`.

Co-Authored-By: Oz <oz-agent@warp.dev>
