### PR TITLE
Add typed InstallFailureCategory classifier for remote server install errors

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -11848,8 +11848,12 @@ impl TerminalView {
         }
 
         let error = error.to_owned();
-        let banner = ctx
-            .add_typed_action_view(|_| SshRemoteServerFailedBanner::new(session_id, kind, error));
+        let failure_category = Some(
+            remote_server::setup::ClassifiedInstallFailure::from_error_string(&error).category,
+        );
+        let banner = ctx.add_typed_action_view(|_| {
+            SshRemoteServerFailedBanner::new(session_id, kind, failure_category, error)
+        });
 
         ctx.subscribe_to_view(&banner, move |me, _, event, ctx| match event {
             SshRemoteServerFailedBannerEvent::Dismissed => {

--- a/app/src/terminal/view/ssh_remote_server_failed_banner.rs
+++ b/app/src/terminal/view/ssh_remote_server_failed_banner.rs
@@ -12,6 +12,8 @@ use warpui::{
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext,
 };
 
+use remote_server::setup::InstallFailureCategory;
+
 use crate::{terminal::model::session::SessionId, ui_components::icons::Icon, Appearance};
 
 const BANNER_BODY: &str =
@@ -60,15 +62,25 @@ impl SshRemoteServerFailureKind {
 pub struct SshRemoteServerFailedBanner {
     session_id: SessionId,
     kind: SshRemoteServerFailureKind,
+    /// Typed failure category from the classifier, when available.
+    /// Used to override the generic phase-based title/description
+    /// with a more specific message.
+    failure_category: Option<InstallFailureCategory>,
     error: String,
     close_mouse_state: MouseStateHandle,
 }
 
 impl SshRemoteServerFailedBanner {
-    pub fn new(session_id: SessionId, kind: SshRemoteServerFailureKind, error: String) -> Self {
+    pub fn new(
+        session_id: SessionId,
+        kind: SshRemoteServerFailureKind,
+        failure_category: Option<InstallFailureCategory>,
+        error: String,
+    ) -> Self {
         Self {
             session_id,
             kind,
+            failure_category,
             error,
             close_mouse_state: MouseStateHandle::default(),
         }
@@ -76,6 +88,23 @@ impl SshRemoteServerFailedBanner {
 
     pub fn session_id(&self) -> SessionId {
         self.session_id
+    }
+
+    /// Returns the most specific title available: the typed category
+    /// title if classified, otherwise the phase-based kind title.
+    fn effective_title(&self) -> &str {
+        self.failure_category
+            .as_ref()
+            .map(|c| c.title())
+            .unwrap_or_else(|| self.kind.title())
+    }
+
+    /// Returns the most specific description available.
+    fn effective_description(&self) -> &str {
+        self.failure_category
+            .as_ref()
+            .map(|c| c.description())
+            .unwrap_or_else(|| self.kind.description())
     }
 }
 
@@ -106,11 +135,11 @@ impl View for SshRemoteServerFailedBanner {
         .with_margin_right(8.)
         .finish();
 
-        let title = Text::new(self.kind.title(), appearance.ui_font_family(), font_size)
+        let title = Text::new(self.effective_title(), appearance.ui_font_family(), font_size)
             .with_color(fg_color)
             .finish();
 
-        let body_text = format!("{} {BANNER_BODY}", self.kind.description());
+        let body_text = format!("{} {BANNER_BODY}", self.effective_description());
         let body = Text::new(body_text, appearance.ui_font_family(), small_font_size)
             .soft_wrap(true)
             .with_color(muted_color)

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -19,6 +19,8 @@ use crate::setup::RemotePlatform;
 use crate::setup::RemoteServerSetupState;
 use crate::setup::UnsupportedReason;
 #[cfg(not(target_family = "wasm"))]
+use crate::setup::{classify_install_failure, ClassifiedInstallFailure};
+#[cfg(not(target_family = "wasm"))]
 use crate::transport::Connection;
 use crate::transport::RemoteTransport;
 use crate::HostId;
@@ -589,10 +591,14 @@ impl RemoteServerManager {
                                 me.session_platforms.insert(session_id, p.clone());
                             }
                             if let Err(error) = &check_result {
+                                let failure_category = Some(
+                                    classify_install_failure(error, None),
+                                );
                                 ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
                                     session_id,
                                     state: RemoteServerSetupState::Failed {
                                         error: error.clone(),
+                                        failure_category,
                                     },
                                 });
                             }
@@ -683,10 +689,13 @@ impl RemoteServerManager {
                     let _ = spawner
                         .spawn(move |_me, ctx| {
                             if let Err(error) = &result {
+                                let classified =
+                                    ClassifiedInstallFailure::from_error_string(error);
                                 ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
                                     session_id,
                                     state: RemoteServerSetupState::Failed {
                                         error: error.clone(),
+                                        failure_category: Some(classified.category),
                                     },
                                 });
                             }
@@ -784,10 +793,14 @@ impl RemoteServerManager {
                             let error = format!("{e}");
                             let _ = spawner
                                 .spawn(move |me, ctx| {
+                                    let failure_category = Some(
+                                        classify_install_failure(&error, None),
+                                    );
                                     ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
                                         session_id,
                                         state: RemoteServerSetupState::Failed {
                                             error: error.clone(),
+                                            failure_category,
                                         },
                                     });
                                     ctx.emit(RemoteServerManagerEvent::SessionConnectionFailed {

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -1,6 +1,10 @@
 mod glibc;
+mod install_failure;
 
 pub use glibc::{GlibcVersion, RemoteLibc};
+pub use install_failure::{
+    classify_install_failure, ClassifiedInstallFailure, InstallFailureCategory,
+};
 
 use std::time::Duration;
 
@@ -23,7 +27,14 @@ pub enum RemoteServerSetupState {
     /// Handshake complete. Ready.
     Ready,
     /// Something failed. Fall back to ControlMaster.
-    Failed { error: String },
+    Failed {
+        error: String,
+        /// Typed classification of the failure, when one could be
+        /// determined from the raw error text. `None` for failures
+        /// that predate the classifier or where classification was
+        /// not attempted.
+        failure_category: Option<InstallFailureCategory>,
+    },
     /// Preinstall check classified the host as incompatible with the
     /// prebuilt remote-server binary. The controller treats this as a
     /// clean fall-back to the legacy ControlMaster-backed SSH flow,

--- a/crates/remote_server/src/setup/install_failure.rs
+++ b/crates/remote_server/src/setup/install_failure.rs
@@ -1,0 +1,564 @@
+/// Typed classification of remote-server install/setup failures.
+///
+/// Each variant maps to one or more families from the production error CSV.
+/// The classifier preserves the raw stderr for diagnostics and telemetry,
+/// but exposes a typed category with human-readable title and description
+/// for the UI banner and telemetry event fields.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InstallFailureCategory {
+    /// Install or download exceeded the configured timeout.
+    Timeout,
+    /// `curl` is not installed on the remote host (but `wget` may be).
+    MissingCurl,
+    /// `wget` is not installed on the remote host (but `curl` may be).
+    MissingWget,
+    /// Neither `curl` nor `wget` is available on the remote host.
+    /// This is the category that triggers the SCP fallback.
+    MissingHttpClient,
+    /// `tar` is not installed on the remote host.
+    MissingTar,
+    /// `bash` is not available on the remote host (script interpreter).
+    MissingBash,
+    /// The remote host's CPU architecture is not supported.
+    UnsupportedArchitecture,
+    /// The remote host's OS is not supported.
+    UnsupportedOs,
+    /// DNS resolution failed for the download endpoint.
+    DnsFailure,
+    /// TCP connection to the download endpoint was refused.
+    ConnectionRefused,
+    /// The download endpoint is unreachable (network/routing failure).
+    ConnectionUnreachable,
+    /// TLS/SSL certificate verification failed.
+    TlsCaFailure,
+    /// HTTP 403 Forbidden from the download endpoint.
+    HttpForbidden,
+    /// HTTP 502 Bad Gateway from the download endpoint.
+    HttpBadGateway,
+    /// Other HTTP error from the download endpoint.
+    HttpError,
+    /// Download was interrupted or incomplete (partial transfer).
+    PartialDownload,
+    /// Could not write the downloaded file to disk.
+    DownloadWriteFailure,
+    /// Permission denied when creating the install directory or
+    /// writing the binary.
+    InstallDirPermissionDenied,
+    /// No space left on the remote filesystem.
+    NoSpaceLeft,
+    /// The remote filesystem is mounted read-only.
+    ReadOnlyFilesystem,
+    /// `tar` extraction failed (corrupt archive, format error).
+    TarExtractionFailure,
+    /// `tar` extraction failed due to permission/ownership errors.
+    TarPermissionFailure,
+    /// The remote user's password has expired; SSH commands requiring
+    /// a TTY prompt fail.
+    ExpiredPassword,
+    /// Permission denied when accessing shell startup files
+    /// (e.g. `.bashrc`, `.profile`).
+    StartupFilePermissionDenied,
+    /// SSH connection was forcibly closed (exit code 255) or the
+    /// remote end sent a disconnect.
+    SshDisconnect,
+    /// The install script exited with a non-zero code that doesn't
+    /// match any recognized pattern.
+    ScriptError,
+    /// The failure could not be classified from the available stderr
+    /// and exit code.
+    Unknown,
+}
+
+impl InstallFailureCategory {
+    /// Short, human-readable title for the UI banner header.
+    pub fn title(&self) -> &'static str {
+        match self {
+            Self::Timeout => "Installation timed out",
+            Self::MissingCurl => "curl is not installed",
+            Self::MissingWget => "wget is not installed",
+            Self::MissingHttpClient => "No HTTP client available",
+            Self::MissingTar => "tar is not installed",
+            Self::MissingBash => "bash is not available",
+            Self::UnsupportedArchitecture => "Unsupported CPU architecture",
+            Self::UnsupportedOs => "Unsupported operating system",
+            Self::DnsFailure => "DNS resolution failed",
+            Self::ConnectionRefused => "Connection refused",
+            Self::ConnectionUnreachable => "Host unreachable",
+            Self::TlsCaFailure => "TLS certificate error",
+            Self::HttpForbidden => "Download forbidden (HTTP 403)",
+            Self::HttpBadGateway => "Download server error (HTTP 502)",
+            Self::HttpError => "Download failed (HTTP error)",
+            Self::PartialDownload => "Download incomplete",
+            Self::DownloadWriteFailure => "Could not save download",
+            Self::InstallDirPermissionDenied => "Permission denied",
+            Self::NoSpaceLeft => "No space left on device",
+            Self::ReadOnlyFilesystem => "Read-only filesystem",
+            Self::TarExtractionFailure => "Archive extraction failed",
+            Self::TarPermissionFailure => "Extraction permission error",
+            Self::ExpiredPassword => "Password expired",
+            Self::StartupFilePermissionDenied => "Startup file permission error",
+            Self::SshDisconnect => "SSH connection lost",
+            Self::ScriptError => "Install script failed",
+            Self::Unknown => "Installation failed",
+        }
+    }
+
+    /// Longer description for the UI banner body text.
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Timeout => {
+                "The installation timed out before completing. \
+                 The remote host may have a slow network connection."
+            }
+            Self::MissingCurl => {
+                "curl is not installed on the remote host. \
+                 Install curl or ensure wget is available."
+            }
+            Self::MissingWget => {
+                "wget is not installed on the remote host. \
+                 Install wget or ensure curl is available."
+            }
+            Self::MissingHttpClient => {
+                "Neither curl nor wget is available on the remote host. \
+                 Install one of these HTTP clients to enable direct download."
+            }
+            Self::MissingTar => {
+                "tar is not installed on the remote host. \
+                 The archive cannot be extracted without tar."
+            }
+            Self::MissingBash => {
+                "bash is not available on the remote host. \
+                 The install script requires bash to run."
+            }
+            Self::UnsupportedArchitecture => {
+                "The remote host's CPU architecture is not supported by \
+                 the prebuilt binary."
+            }
+            Self::UnsupportedOs => {
+                "The remote host's operating system is not supported by \
+                 the prebuilt binary."
+            }
+            Self::DnsFailure => {
+                "Could not resolve the download server's hostname. \
+                 Check the remote host's DNS configuration."
+            }
+            Self::ConnectionRefused => {
+                "The download server actively refused the connection. \
+                 A firewall or proxy may be blocking outbound HTTPS."
+            }
+            Self::ConnectionUnreachable => {
+                "The download server is unreachable from the remote host. \
+                 Check the network configuration and firewall rules."
+            }
+            Self::TlsCaFailure => {
+                "TLS certificate verification failed. The remote host's \
+                 CA certificates may be missing or outdated."
+            }
+            Self::HttpForbidden => {
+                "The download server returned HTTP 403 Forbidden. \
+                 The download URL may have expired or be restricted."
+            }
+            Self::HttpBadGateway => {
+                "The download server returned HTTP 502 Bad Gateway. \
+                 This is usually a transient server-side issue."
+            }
+            Self::HttpError => {
+                "The download failed with an HTTP error. \
+                 The server may be temporarily unavailable."
+            }
+            Self::PartialDownload => {
+                "The download was interrupted before completing. \
+                 The network connection may be unstable."
+            }
+            Self::DownloadWriteFailure => {
+                "Could not write the downloaded file to disk. \
+                 Check disk space and directory permissions."
+            }
+            Self::InstallDirPermissionDenied => {
+                "Permission denied when writing to the install directory. \
+                 Check that the remote user has write access to the home directory."
+            }
+            Self::NoSpaceLeft => {
+                "The remote filesystem has no space left. \
+                 Free up disk space and try again."
+            }
+            Self::ReadOnlyFilesystem => {
+                "The remote filesystem is mounted read-only. \
+                 The binary cannot be installed on a read-only filesystem."
+            }
+            Self::TarExtractionFailure => {
+                "The downloaded archive could not be extracted. \
+                 The file may be corrupt or in an unexpected format."
+            }
+            Self::TarPermissionFailure => {
+                "Archive extraction failed due to a permission error. \
+                 tar could not set file ownership or permissions."
+            }
+            Self::ExpiredPassword => {
+                "The remote user's password has expired. \
+                 Update the password on the remote host and reconnect."
+            }
+            Self::StartupFilePermissionDenied => {
+                "A shell startup file (e.g. .bashrc, .profile) could not be read. \
+                 Check file permissions on the remote host."
+            }
+            Self::SshDisconnect => {
+                "The SSH connection was lost during installation. \
+                 The remote host may have disconnected or the network dropped."
+            }
+            Self::ScriptError => {
+                "The install script exited with an error. \
+                 Check the error details below for more information."
+            }
+            Self::Unknown => {
+                "The installation failed for an unknown reason. \
+                 Check the error details below for more information."
+            }
+        }
+    }
+
+    /// Stable snake_case identifier for telemetry and serialization.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::MissingCurl => "missing_curl",
+            Self::MissingWget => "missing_wget",
+            Self::MissingHttpClient => "missing_http_client",
+            Self::MissingTar => "missing_tar",
+            Self::MissingBash => "missing_bash",
+            Self::UnsupportedArchitecture => "unsupported_architecture",
+            Self::UnsupportedOs => "unsupported_os",
+            Self::DnsFailure => "dns_failure",
+            Self::ConnectionRefused => "connection_refused",
+            Self::ConnectionUnreachable => "connection_unreachable",
+            Self::TlsCaFailure => "tls_ca_failure",
+            Self::HttpForbidden => "http_forbidden",
+            Self::HttpBadGateway => "http_bad_gateway",
+            Self::HttpError => "http_error",
+            Self::PartialDownload => "partial_download",
+            Self::DownloadWriteFailure => "download_write_failure",
+            Self::InstallDirPermissionDenied => "install_dir_permission_denied",
+            Self::NoSpaceLeft => "no_space_left",
+            Self::ReadOnlyFilesystem => "read_only_filesystem",
+            Self::TarExtractionFailure => "tar_extraction_failure",
+            Self::TarPermissionFailure => "tar_permission_failure",
+            Self::ExpiredPassword => "expired_password",
+            Self::StartupFilePermissionDenied => "startup_file_permission_denied",
+            Self::SshDisconnect => "ssh_disconnect",
+            Self::ScriptError => "script_error",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for InstallFailureCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Classifies a raw install/setup failure into a typed
+/// [`InstallFailureCategory`].
+///
+/// The classifier inspects both the stderr text and the process exit code
+/// to determine the most specific category. Pattern matching is done
+/// case-insensitively against known error signatures from `curl`, `wget`,
+/// `tar`, `bash`, `ssh`, and common shell/OS error messages.
+///
+/// When multiple patterns match, the first (most specific) match wins.
+pub fn classify_install_failure(
+    stderr: &str,
+    exit_code: Option<i32>,
+) -> InstallFailureCategory {
+    let lower = stderr.to_ascii_lowercase();
+
+    // --- SSH-level failures (exit 255 or explicit disconnect) ---
+    if exit_code == Some(255) {
+        return InstallFailureCategory::SshDisconnect;
+    }
+    if lower.contains("connection reset by peer")
+        || lower.contains("broken pipe")
+        || lower.contains("ssh_exchange_identification")
+        || lower.contains("packet_write_wait")
+        || lower.contains("connection closed by remote host")
+        || lower.contains("client_loop: send disconnect")
+    {
+        return InstallFailureCategory::SshDisconnect;
+    }
+
+    // --- Timeout ---
+    if lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("operation timed out")
+        || lower.contains("connection timed out")
+    {
+        return InstallFailureCategory::Timeout;
+    }
+
+    // --- Password/auth failures ---
+    if lower.contains("password has expired")
+        || lower.contains("password expired")
+        || lower.contains("your password has expired")
+        || lower.contains("you are required to change your password")
+    {
+        return InstallFailureCategory::ExpiredPassword;
+    }
+
+    // --- Missing tools (exit code 127 = command not found) ---
+    if lower.contains("neither curl nor wget")
+        || lower.contains("error: neither curl nor wget is available")
+    {
+        return InstallFailureCategory::MissingHttpClient;
+    }
+    // The install script uses a specific exit code for no HTTP client.
+    if exit_code == Some(super::NO_HTTP_CLIENT_EXIT_CODE) {
+        return InstallFailureCategory::MissingHttpClient;
+    }
+    if (lower.contains("curl") || lower.contains("curl:"))
+        && (lower.contains("not found") || lower.contains("command not found"))
+    {
+        return InstallFailureCategory::MissingCurl;
+    }
+    if (lower.contains("wget") || lower.contains("wget:"))
+        && (lower.contains("not found") || lower.contains("command not found"))
+    {
+        return InstallFailureCategory::MissingWget;
+    }
+    if lower.contains("tar:") && lower.contains("not found")
+        || lower.contains("tar: command not found")
+    {
+        return InstallFailureCategory::MissingTar;
+    }
+    if lower.contains("bash") && lower.contains("not found")
+        || lower.contains("bash: command not found")
+        || lower.contains("bash: no such file or directory")
+    {
+        return InstallFailureCategory::MissingBash;
+    }
+
+    // --- Unsupported arch/OS (from the install script's stderr) ---
+    if lower.contains("unsupported arch") {
+        return InstallFailureCategory::UnsupportedArchitecture;
+    }
+    if lower.contains("unsupported os") {
+        return InstallFailureCategory::UnsupportedOs;
+    }
+
+    // --- DNS failure ---
+    if lower.contains("could not resolve host")
+        || lower.contains("could not resolve")
+        || lower.contains("name or service not known")
+        || lower.contains("temporary failure in name resolution")
+        || lower.contains("unable to resolve host")
+        || lower.contains("dns_error")
+    {
+        return InstallFailureCategory::DnsFailure;
+    }
+
+    // --- Connection refused ---
+    if lower.contains("connection refused") {
+        return InstallFailureCategory::ConnectionRefused;
+    }
+
+    // --- Connection unreachable ---
+    if lower.contains("no route to host")
+        || lower.contains("network is unreachable")
+        || lower.contains("host is unreachable")
+        || lower.contains("network unreachable")
+    {
+        return InstallFailureCategory::ConnectionUnreachable;
+    }
+
+    // --- TLS/CA failures ---
+    if lower.contains("ssl certificate problem")
+        || lower.contains("certificate verify failed")
+        || lower.contains("ssl_error")
+        || lower.contains("unable to get local issuer certificate")
+        || lower.contains("ca certificate")
+        || lower.contains("self signed certificate")
+        || lower.contains("certificate is not trusted")
+        || lower.contains("unable to locally verify")
+        || lower.contains("ssl handshake")
+    {
+        return InstallFailureCategory::TlsCaFailure;
+    }
+
+    // --- HTTP status codes ---
+    // curl with -f emits "The requested URL returned error: 403" or
+    // "curl: (22) The requested URL returned error: 403 Forbidden"
+    if lower.contains("403 forbidden") || lower.contains("returned error: 403") {
+        return InstallFailureCategory::HttpForbidden;
+    }
+    if lower.contains("502 bad gateway") || lower.contains("returned error: 502") {
+        return InstallFailureCategory::HttpBadGateway;
+    }
+    // Generic HTTP error from curl -f (exit code 22)
+    if lower.contains("the requested url returned error")
+        || (exit_code == Some(22) && lower.contains("curl"))
+    {
+        return InstallFailureCategory::HttpError;
+    }
+    // wget HTTP errors
+    if lower.contains("error 4") && lower.contains("wget") {
+        return InstallFailureCategory::HttpError;
+    }
+
+    // --- Partial download ---
+    if lower.contains("partial file")
+        || lower.contains("transfer closed with")
+        || lower.contains("curl: (18)")
+        || lower.contains("connection was reset")
+        || lower.contains("incomplete download")
+    {
+        return InstallFailureCategory::PartialDownload;
+    }
+
+    // --- Read-only filesystem (check before general permission denied) ---
+    if lower.contains("read-only file system") || lower.contains("erofs") {
+        return InstallFailureCategory::ReadOnlyFilesystem;
+    }
+
+    // --- No space left ---
+    if lower.contains("no space left on device")
+        || lower.contains("disk quota exceeded")
+        || lower.contains("enospc")
+    {
+        return InstallFailureCategory::NoSpaceLeft;
+    }
+
+    // --- Download write failure ---
+    // Exclude lines that are clearly tar errors ("tar:" prefix), but
+    // allow filenames like "oz.tar.gz" in curl error messages.
+    if (lower.contains("failed writing body")
+        || lower.contains("write error")
+        || lower.contains("failed to create file")
+        || lower.contains("curl: (23)"))
+        && !lower.contains("tar:")
+    {
+        return InstallFailureCategory::DownloadWriteFailure;
+    }
+
+    // --- Tar permission/ownership failure ---
+    if lower.contains("tar:")
+        && (lower.contains("cannot change ownership")
+            || lower.contains("operation not permitted")
+            || lower.contains("cannot open: permission denied"))
+    {
+        return InstallFailureCategory::TarPermissionFailure;
+    }
+
+    // --- Tar extraction failure ---
+    if lower.contains("tar:")
+        && (lower.contains("error is not recoverable")
+            || lower.contains("not in gzip format")
+            || lower.contains("unexpected eof")
+            || lower.contains("invalid tar")
+            || lower.contains("damaged")
+            || lower.contains("truncated")
+            || lower.contains("corrupted"))
+    {
+        return InstallFailureCategory::TarExtractionFailure;
+    }
+    // Generic tar failure
+    if lower.contains("tar:") && lower.contains("exiting with failure") {
+        return InstallFailureCategory::TarExtractionFailure;
+    }
+
+    // --- Install dir permission denied ---
+    if lower.contains("permission denied") && lower.contains("mkdir") {
+        return InstallFailureCategory::InstallDirPermissionDenied;
+    }
+    if lower.contains("permission denied") && lower.contains("mv ") {
+        return InstallFailureCategory::InstallDirPermissionDenied;
+    }
+    if lower.contains("permission denied") && lower.contains("chmod") {
+        return InstallFailureCategory::InstallDirPermissionDenied;
+    }
+
+    // --- Startup file permission denied ---
+    if lower.contains("permission denied")
+        && (lower.contains(".bashrc")
+            || lower.contains(".bash_profile")
+            || lower.contains(".profile")
+            || lower.contains(".zshrc")
+            || lower.contains(".zprofile")
+            || lower.contains("startup"))
+    {
+        return InstallFailureCategory::StartupFilePermissionDenied;
+    }
+
+    // --- Generic permission denied (after more specific checks) ---
+    if lower.contains("permission denied") {
+        return InstallFailureCategory::InstallDirPermissionDenied;
+    }
+
+    // --- Script error (non-zero exit but no matching pattern) ---
+    if let Some(code) = exit_code {
+        if code != 0 {
+            return InstallFailureCategory::ScriptError;
+        }
+    }
+
+    InstallFailureCategory::Unknown
+}
+
+/// A classified install failure bundling the typed category with the
+/// raw stderr for diagnostics.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClassifiedInstallFailure {
+    /// The typed failure category.
+    pub category: InstallFailureCategory,
+    /// The original raw stderr text, preserved for diagnostics and
+    /// detailed error display.
+    pub raw_stderr: String,
+    /// The original process exit code, if available.
+    pub exit_code: Option<i32>,
+}
+
+impl ClassifiedInstallFailure {
+    /// Classify a raw failure.
+    pub fn from_raw(stderr: &str, exit_code: Option<i32>) -> Self {
+        let category = classify_install_failure(stderr, exit_code);
+        Self {
+            category,
+            raw_stderr: stderr.to_owned(),
+            exit_code,
+        }
+    }
+
+    /// Classify from a combined error string like
+    /// `"install script failed (exit 1): <stderr>"`.
+    pub fn from_error_string(error: &str) -> Self {
+        let (exit_code, stderr) = parse_error_string(error);
+        Self::from_raw(stderr, exit_code)
+    }
+}
+
+/// Parses an error string of the form
+/// `"install script failed (exit <code>): <stderr>"` or
+/// `"<anything> (exit <code>): <stderr>"` into its exit code and stderr
+/// components. Falls back to treating the whole string as stderr with
+/// no exit code.
+fn parse_error_string(error: &str) -> (Option<i32>, &str) {
+    // Try to find "(exit <N>): " pattern.
+    if let Some(exit_start) = error.find("(exit ") {
+        let after_exit = &error[exit_start + 6..];
+        if let Some(paren_end) = after_exit.find(')') {
+            let code_str = &after_exit[..paren_end];
+            let exit_code = code_str.trim().parse::<i32>().ok();
+            // The stderr follows "): "
+            let stderr_start = exit_start + 6 + paren_end + 1;
+            let stderr = if stderr_start < error.len() {
+                error[stderr_start..].trim_start_matches(": ").trim()
+            } else {
+                ""
+            };
+            return (exit_code, stderr);
+        }
+    }
+    (None, error)
+}
+
+#[cfg(test)]
+#[path = "install_failure_tests.rs"]
+mod tests;

--- a/crates/remote_server/src/setup/install_failure_tests.rs
+++ b/crates/remote_server/src/setup/install_failure_tests.rs
@@ -1,0 +1,697 @@
+use super::*;
+
+// ===== SSH disconnect / exit 255 =====
+
+#[test]
+fn ssh_disconnect_exit_255() {
+    let cat = classify_install_failure("", Some(255));
+    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+}
+
+#[test]
+fn ssh_disconnect_connection_reset() {
+    let cat = classify_install_failure(
+        "ssh: Connection reset by peer",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+}
+
+#[test]
+fn ssh_disconnect_broken_pipe() {
+    let cat = classify_install_failure(
+        "write failed: Broken pipe",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+}
+
+#[test]
+fn ssh_disconnect_packet_write_wait() {
+    let cat = classify_install_failure(
+        "packet_write_wait: Connection to 10.0.0.1 port 22: Broken pipe",
+        Some(255),
+    );
+    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+}
+
+#[test]
+fn ssh_disconnect_client_loop() {
+    let cat = classify_install_failure(
+        "client_loop: send disconnect: Broken pipe",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+}
+
+#[test]
+fn ssh_disconnect_connection_closed_by_remote() {
+    let cat = classify_install_failure(
+        "Connection closed by remote host",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::SshDisconnect);
+}
+
+// ===== Timeout =====
+
+#[test]
+fn timeout_operation_timed_out() {
+    let cat = classify_install_failure(
+        "curl: (28) Operation timed out after 60001 milliseconds",
+        Some(28),
+    );
+    assert_eq!(cat, InstallFailureCategory::Timeout);
+}
+
+#[test]
+fn timeout_connection_timed_out() {
+    let cat = classify_install_failure(
+        "curl: (28) Connection timed out after 15000 milliseconds",
+        Some(28),
+    );
+    assert_eq!(cat, InstallFailureCategory::Timeout);
+}
+
+#[test]
+fn timeout_generic() {
+    let cat = classify_install_failure("command timeout reached", Some(124));
+    assert_eq!(cat, InstallFailureCategory::Timeout);
+}
+
+// ===== Expired password =====
+
+#[test]
+fn expired_password_your_password_has_expired() {
+    let cat = classify_install_failure(
+        "WARNING: Your password has expired.\nPassword change required but no TTY available.",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::ExpiredPassword);
+}
+
+#[test]
+fn expired_password_required_to_change() {
+    let cat = classify_install_failure(
+        "You are required to change your password immediately (administrator enforced)",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::ExpiredPassword);
+}
+
+// ===== Missing HTTP clients =====
+
+#[test]
+fn missing_http_client_neither() {
+    let cat = classify_install_failure(
+        "error: neither curl nor wget is available",
+        Some(3),
+    );
+    assert_eq!(cat, InstallFailureCategory::MissingHttpClient);
+}
+
+#[test]
+fn missing_http_client_exit_code_only() {
+    let cat = classify_install_failure("", Some(3));
+    assert_eq!(cat, InstallFailureCategory::MissingHttpClient);
+}
+
+#[test]
+fn missing_curl_command_not_found() {
+    let cat = classify_install_failure(
+        "bash: curl: command not found",
+        Some(127),
+    );
+    assert_eq!(cat, InstallFailureCategory::MissingCurl);
+}
+
+#[test]
+fn missing_wget_command_not_found() {
+    let cat = classify_install_failure(
+        "bash: wget: command not found",
+        Some(127),
+    );
+    assert_eq!(cat, InstallFailureCategory::MissingWget);
+}
+
+// ===== Missing tar =====
+
+#[test]
+fn missing_tar_not_found() {
+    let cat = classify_install_failure(
+        "tar: command not found",
+        Some(127),
+    );
+    assert_eq!(cat, InstallFailureCategory::MissingTar);
+}
+
+#[test]
+fn missing_tar_colon_not_found() {
+    let cat = classify_install_failure(
+        "bash: tar: not found",
+        Some(127),
+    );
+    assert_eq!(cat, InstallFailureCategory::MissingTar);
+}
+
+// ===== Missing bash =====
+
+#[test]
+fn missing_bash_not_found() {
+    let cat = classify_install_failure(
+        "bash: command not found",
+        Some(127),
+    );
+    assert_eq!(cat, InstallFailureCategory::MissingBash);
+}
+
+#[test]
+fn missing_bash_no_such_file() {
+    let cat = classify_install_failure(
+        "bash: No such file or directory",
+        Some(127),
+    );
+    assert_eq!(cat, InstallFailureCategory::MissingBash);
+}
+
+// ===== Unsupported arch/OS =====
+
+#[test]
+fn unsupported_architecture() {
+    let cat = classify_install_failure(
+        "unsupported arch: mips",
+        Some(2),
+    );
+    assert_eq!(cat, InstallFailureCategory::UnsupportedArchitecture);
+}
+
+#[test]
+fn unsupported_os() {
+    let cat = classify_install_failure(
+        "unsupported OS: FreeBSD",
+        Some(2),
+    );
+    assert_eq!(cat, InstallFailureCategory::UnsupportedOs);
+}
+
+// ===== DNS failure =====
+
+#[test]
+fn dns_could_not_resolve_host() {
+    let cat = classify_install_failure(
+        "curl: (6) Could not resolve host: app.warp.dev",
+        Some(6),
+    );
+    assert_eq!(cat, InstallFailureCategory::DnsFailure);
+}
+
+#[test]
+fn dns_name_or_service_not_known() {
+    let cat = classify_install_failure(
+        "wget: unable to resolve host address 'app.warp.dev'\nName or service not known",
+        Some(4),
+    );
+    assert_eq!(cat, InstallFailureCategory::DnsFailure);
+}
+
+#[test]
+fn dns_temporary_failure() {
+    let cat = classify_install_failure(
+        "Temporary failure in name resolution",
+        Some(6),
+    );
+    assert_eq!(cat, InstallFailureCategory::DnsFailure);
+}
+
+// ===== Connection refused =====
+
+#[test]
+fn connection_refused() {
+    let cat = classify_install_failure(
+        "curl: (7) Failed to connect to app.warp.dev port 443: Connection refused",
+        Some(7),
+    );
+    assert_eq!(cat, InstallFailureCategory::ConnectionRefused);
+}
+
+// ===== Connection unreachable =====
+
+#[test]
+fn connection_unreachable_no_route() {
+    let cat = classify_install_failure(
+        "curl: (7) Failed to connect to app.warp.dev port 443: No route to host",
+        Some(7),
+    );
+    assert_eq!(cat, InstallFailureCategory::ConnectionUnreachable);
+}
+
+#[test]
+fn connection_unreachable_network() {
+    let cat = classify_install_failure(
+        "curl: (7) Network is unreachable",
+        Some(7),
+    );
+    assert_eq!(cat, InstallFailureCategory::ConnectionUnreachable);
+}
+
+// ===== TLS/CA failures =====
+
+#[test]
+fn tls_ssl_certificate_problem() {
+    let cat = classify_install_failure(
+        "curl: (60) SSL certificate problem: unable to get local issuer certificate",
+        Some(60),
+    );
+    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
+}
+
+#[test]
+fn tls_certificate_verify_failed() {
+    let cat = classify_install_failure(
+        "OpenSSL: error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
+}
+
+#[test]
+fn tls_self_signed() {
+    let cat = classify_install_failure(
+        "curl: (60) SSL certificate problem: self signed certificate in chain",
+        Some(60),
+    );
+    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
+}
+
+// ===== HTTP errors =====
+
+#[test]
+fn http_403_forbidden() {
+    let cat = classify_install_failure(
+        "curl: (22) The requested URL returned error: 403 Forbidden",
+        Some(22),
+    );
+    assert_eq!(cat, InstallFailureCategory::HttpForbidden);
+}
+
+#[test]
+fn http_502_bad_gateway() {
+    let cat = classify_install_failure(
+        "curl: (22) The requested URL returned error: 502 Bad Gateway",
+        Some(22),
+    );
+    assert_eq!(cat, InstallFailureCategory::HttpBadGateway);
+}
+
+#[test]
+fn http_generic_error() {
+    let cat = classify_install_failure(
+        "curl: (22) The requested URL returned error: 500 Internal Server Error",
+        Some(22),
+    );
+    assert_eq!(cat, InstallFailureCategory::HttpError);
+}
+
+#[test]
+fn http_wget_error() {
+    let cat = classify_install_failure(
+        "wget: ERROR 4 (NETWORK_FAILURE)",
+        Some(4),
+    );
+    assert_eq!(cat, InstallFailureCategory::HttpError);
+}
+
+// ===== Partial download =====
+
+#[test]
+fn partial_download_curl_18() {
+    let cat = classify_install_failure(
+        "curl: (18) transfer closed with 12345 bytes remaining",
+        Some(18),
+    );
+    assert_eq!(cat, InstallFailureCategory::PartialDownload);
+}
+
+#[test]
+fn partial_download_partial_file() {
+    let cat = classify_install_failure(
+        "curl: (18) Partial file. Only 1024 of 5242880 bytes were received.",
+        Some(18),
+    );
+    assert_eq!(cat, InstallFailureCategory::PartialDownload);
+}
+
+#[test]
+fn partial_download_transfer_closed() {
+    let cat = classify_install_failure(
+        "transfer closed with outstanding read data remaining",
+        Some(18),
+    );
+    assert_eq!(cat, InstallFailureCategory::PartialDownload);
+}
+
+// ===== Read-only filesystem =====
+
+#[test]
+fn read_only_filesystem() {
+    let cat = classify_install_failure(
+        "mkdir: cannot create directory '/home/user/.warp': Read-only file system",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::ReadOnlyFilesystem);
+}
+
+#[test]
+fn read_only_filesystem_erofs() {
+    let cat = classify_install_failure(
+        "open failed: EROFS (Read-only file system)",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::ReadOnlyFilesystem);
+}
+
+// ===== No space left =====
+
+#[test]
+fn no_space_left() {
+    let cat = classify_install_failure(
+        "write error: No space left on device",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::NoSpaceLeft);
+}
+
+#[test]
+fn disk_quota_exceeded() {
+    let cat = classify_install_failure(
+        "write: Disk quota exceeded",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::NoSpaceLeft);
+}
+
+// ===== Download write failure =====
+
+#[test]
+fn download_write_failure_curl_23() {
+    let cat = classify_install_failure(
+        "curl: (23) Failed writing body (0 != 16384)",
+        Some(23),
+    );
+    assert_eq!(cat, InstallFailureCategory::DownloadWriteFailure);
+}
+
+#[test]
+fn download_write_failure_failed_to_create() {
+    let cat = classify_install_failure(
+        "curl: failed to create file '/tmp/install.XXXX/oz.tar.gz'",
+        Some(23),
+    );
+    assert_eq!(cat, InstallFailureCategory::DownloadWriteFailure);
+}
+
+// ===== Tar permission failure =====
+
+#[test]
+fn tar_permission_cannot_change_ownership() {
+    let cat = classify_install_failure(
+        "tar: oz: Cannot change ownership to uid 1000, gid 1000: Operation not permitted\ntar: Exiting with failure status due to previous errors",
+        Some(2),
+    );
+    assert_eq!(cat, InstallFailureCategory::TarPermissionFailure);
+}
+
+#[test]
+fn tar_permission_cannot_open() {
+    let cat = classify_install_failure(
+        "tar: ./oz: Cannot open: Permission denied",
+        Some(2),
+    );
+    assert_eq!(cat, InstallFailureCategory::TarPermissionFailure);
+}
+
+// ===== Tar extraction failure =====
+
+#[test]
+fn tar_extraction_not_gzip() {
+    let cat = classify_install_failure(
+        "tar: (stdin): not in gzip format\ntar: Error is not recoverable: exiting now",
+        Some(2),
+    );
+    assert_eq!(cat, InstallFailureCategory::TarExtractionFailure);
+}
+
+#[test]
+fn tar_extraction_unexpected_eof() {
+    let cat = classify_install_failure(
+        "tar: Unexpected EOF in archive\ntar: Error is not recoverable: exiting now",
+        Some(2),
+    );
+    assert_eq!(cat, InstallFailureCategory::TarExtractionFailure);
+}
+
+#[test]
+fn tar_extraction_corrupted() {
+    let cat = classify_install_failure(
+        "tar: Archive is corrupted",
+        Some(2),
+    );
+    assert_eq!(cat, InstallFailureCategory::TarExtractionFailure);
+}
+
+// ===== Install dir permission denied =====
+
+#[test]
+fn install_dir_permission_denied_mkdir() {
+    let cat = classify_install_failure(
+        "mkdir: cannot create directory '/home/user/.warp': Permission denied",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::InstallDirPermissionDenied);
+}
+
+#[test]
+fn install_dir_permission_denied_mv() {
+    let cat = classify_install_failure(
+        "mv: cannot move '/tmp/.install.XXXX/oz' to '/home/user/.warp/remote-server/oz': Permission denied",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::InstallDirPermissionDenied);
+}
+
+#[test]
+fn install_dir_permission_denied_chmod() {
+    let cat = classify_install_failure(
+        "chmod: changing permissions of '/home/user/.warp/remote-server/oz': Permission denied",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::InstallDirPermissionDenied);
+}
+
+#[test]
+fn install_dir_generic_permission_denied() {
+    let cat = classify_install_failure(
+        "/home/user/.warp/remote-server: Permission denied",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::InstallDirPermissionDenied);
+}
+
+// ===== Startup file permission denied =====
+
+#[test]
+fn startup_file_bashrc_permission_denied() {
+    let cat = classify_install_failure(
+        "/home/user/.bashrc: Permission denied",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::StartupFilePermissionDenied);
+}
+
+#[test]
+fn startup_file_profile_permission_denied() {
+    let cat = classify_install_failure(
+        "bash: /home/user/.profile: Permission denied",
+        Some(1),
+    );
+    assert_eq!(cat, InstallFailureCategory::StartupFilePermissionDenied);
+}
+
+// ===== Script error (generic) =====
+
+#[test]
+fn script_error_unknown_exit_code() {
+    let cat = classify_install_failure(
+        "some unknown error happened",
+        Some(42),
+    );
+    assert_eq!(cat, InstallFailureCategory::ScriptError);
+}
+
+// ===== Unknown =====
+
+#[test]
+fn unknown_no_exit_code_no_pattern() {
+    let cat = classify_install_failure("", None);
+    assert_eq!(cat, InstallFailureCategory::Unknown);
+}
+
+#[test]
+fn unknown_exit_zero_no_pattern() {
+    let cat = classify_install_failure("all good but still reported as failure", Some(0));
+    assert_eq!(cat, InstallFailureCategory::Unknown);
+}
+
+// ===== as_str / title / description completeness =====
+
+#[test]
+fn all_variants_have_non_empty_title_and_description() {
+    let variants = [
+        InstallFailureCategory::Timeout,
+        InstallFailureCategory::MissingCurl,
+        InstallFailureCategory::MissingWget,
+        InstallFailureCategory::MissingHttpClient,
+        InstallFailureCategory::MissingTar,
+        InstallFailureCategory::MissingBash,
+        InstallFailureCategory::UnsupportedArchitecture,
+        InstallFailureCategory::UnsupportedOs,
+        InstallFailureCategory::DnsFailure,
+        InstallFailureCategory::ConnectionRefused,
+        InstallFailureCategory::ConnectionUnreachable,
+        InstallFailureCategory::TlsCaFailure,
+        InstallFailureCategory::HttpForbidden,
+        InstallFailureCategory::HttpBadGateway,
+        InstallFailureCategory::HttpError,
+        InstallFailureCategory::PartialDownload,
+        InstallFailureCategory::DownloadWriteFailure,
+        InstallFailureCategory::InstallDirPermissionDenied,
+        InstallFailureCategory::NoSpaceLeft,
+        InstallFailureCategory::ReadOnlyFilesystem,
+        InstallFailureCategory::TarExtractionFailure,
+        InstallFailureCategory::TarPermissionFailure,
+        InstallFailureCategory::ExpiredPassword,
+        InstallFailureCategory::StartupFilePermissionDenied,
+        InstallFailureCategory::SshDisconnect,
+        InstallFailureCategory::ScriptError,
+        InstallFailureCategory::Unknown,
+    ];
+    for v in &variants {
+        assert!(!v.title().is_empty(), "empty title for {v:?}");
+        assert!(!v.description().is_empty(), "empty description for {v:?}");
+        assert!(!v.as_str().is_empty(), "empty as_str for {v:?}");
+        // as_str should be snake_case (lowercase, underscores only)
+        assert!(
+            v.as_str().chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+            "as_str '{}' is not snake_case for {v:?}",
+            v.as_str()
+        );
+    }
+}
+
+// ===== Display trait =====
+
+#[test]
+fn display_matches_as_str() {
+    let cat = InstallFailureCategory::TlsCaFailure;
+    assert_eq!(format!("{cat}"), cat.as_str());
+}
+
+// ===== ClassifiedInstallFailure =====
+
+#[test]
+fn classified_from_raw() {
+    let f = ClassifiedInstallFailure::from_raw(
+        "curl: (28) Operation timed out",
+        Some(28),
+    );
+    assert_eq!(f.category, InstallFailureCategory::Timeout);
+    assert_eq!(f.raw_stderr, "curl: (28) Operation timed out");
+    assert_eq!(f.exit_code, Some(28));
+}
+
+#[test]
+fn classified_from_error_string() {
+    let f = ClassifiedInstallFailure::from_error_string(
+        "install script failed (exit 6): curl: (6) Could not resolve host: app.warp.dev",
+    );
+    assert_eq!(f.category, InstallFailureCategory::DnsFailure);
+    assert_eq!(f.exit_code, Some(6));
+    assert!(f.raw_stderr.contains("Could not resolve host"));
+}
+
+#[test]
+fn classified_from_error_string_no_exit_pattern() {
+    let f = ClassifiedInstallFailure::from_error_string(
+        "some random error without exit code pattern",
+    );
+    assert_eq!(f.category, InstallFailureCategory::Unknown);
+    assert_eq!(f.exit_code, None);
+}
+
+#[test]
+fn classified_from_error_string_ssh_exit_255() {
+    let f = ClassifiedInstallFailure::from_error_string(
+        "install script failed (exit 255): Connection closed by remote host",
+    );
+    assert_eq!(f.category, InstallFailureCategory::SshDisconnect);
+    assert_eq!(f.exit_code, Some(255));
+}
+
+// ===== parse_error_string =====
+
+#[test]
+fn parse_error_string_standard_format() {
+    let (code, stderr) = parse_error_string(
+        "install script failed (exit 1): mkdir: Permission denied",
+    );
+    assert_eq!(code, Some(1));
+    assert_eq!(stderr, "mkdir: Permission denied");
+}
+
+#[test]
+fn parse_error_string_no_pattern() {
+    let (code, stderr) = parse_error_string("just some error text");
+    assert_eq!(code, None);
+    assert_eq!(stderr, "just some error text");
+}
+
+#[test]
+fn parse_error_string_negative_exit_code() {
+    let (code, stderr) = parse_error_string(
+        "install script failed (exit -1): terminated by signal",
+    );
+    assert_eq!(code, Some(-1));
+    assert_eq!(stderr, "terminated by signal");
+}
+
+// ===== Edge cases =====
+
+#[test]
+fn case_insensitive_matching() {
+    let cat = classify_install_failure(
+        "CURL: (60) SSL CERTIFICATE PROBLEM: UNABLE TO GET LOCAL ISSUER CERTIFICATE",
+        Some(60),
+    );
+    assert_eq!(cat, InstallFailureCategory::TlsCaFailure);
+}
+
+#[test]
+fn mixed_case_unsupported_arch() {
+    let cat = classify_install_failure(
+        "Unsupported Arch: ppc64le",
+        Some(2),
+    );
+    assert_eq!(cat, InstallFailureCategory::UnsupportedArchitecture);
+}
+
+#[test]
+fn multiline_stderr_with_tar_and_permission() {
+    // When tar stderr contains both ownership and exiting errors,
+    // the more specific TarPermissionFailure should match.
+    let cat = classify_install_failure(
+        "tar: oz-dev: Cannot change ownership to uid 0, gid 0: Operation not permitted\n\
+         tar: Exiting with failure status due to previous errors",
+        Some(2),
+    );
+    assert_eq!(cat, InstallFailureCategory::TarPermissionFailure);
+}

--- a/crates/remote_server/src/setup_tests.rs
+++ b/crates/remote_server/src/setup_tests.rs
@@ -86,7 +86,8 @@ fn state_is_ready() {
 #[test]
 fn state_is_failed() {
     assert!(RemoteServerSetupState::Failed {
-        error: "test".into()
+        error: "test".into(),
+        failure_category: None,
     }
     .is_failed());
     assert!(!RemoteServerSetupState::Ready.is_failed());
@@ -96,7 +97,8 @@ fn state_is_failed() {
 fn state_is_terminal() {
     assert!(RemoteServerSetupState::Ready.is_terminal());
     assert!(RemoteServerSetupState::Failed {
-        error: "test".into()
+        error: "test".into(),
+        failure_category: None,
     }
     .is_terminal());
     assert!(RemoteServerSetupState::Unsupported {


### PR DESCRIPTION
## Problem
When remote-server installation failed, the app mostly had raw stderr and generic setup failure state. That made the UI and telemetry hard to interpret: users saw broad install failures even when the underlying problem was a known category such as DNS, missing tools, unsupported architecture, no space, permission denied, TLS, or SSH disconnect.

## Solution
- Add a typed install-failure classification layer for remote-server setup errors.
- Thread the classified category through setup/manager state so callers and UI can preserve both the stable category and the raw stderr.
- Update user-facing failure handling to show a clearer category/title while retaining technical details.
- Add tests for category parsing, metadata, and priority ordering across the observed install failure families.

## Proof / validation
No screenshots are applicable because this PR changes failure classification/copy rather than a visual layout. Proof is unit-test and integration output:

- The classifier test suite covers the CSV-derived install failure families and priority ordering.
- In the integrated validation run, `cargo test -p remote_server` passed with 136 tests.
- The Docker SSH harness produced category-preserving evidence after integration, including HTTP 403 and TLS failures exiting the download sentinel path while preserving the underlying stderr needed for typed classification.

Co-Authored-By: Oz <oz-agent@warp.dev>
