### PR TITLE
cli: reject --computer-use alongside --harness in run-cloud

### DIFF
--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -75,11 +75,11 @@ impl PromptArg {
 #[derive(Debug, Clone, Args, Default)]
 pub struct ComputerUseArgs {
     /// Enable computer use capabilities for this agent run.
-    #[arg(long = "computer-use", conflicts_with = "no_computer_use")]
+    #[arg(long = "computer-use", conflicts_with_all = ["no_computer_use", "harness"])]
     pub computer_use: bool,
 
     /// Disable computer use capabilities for this agent run.
-    #[arg(long = "no-computer-use", conflicts_with = "computer_use")]
+    #[arg(long = "no-computer-use", conflicts_with_all = ["computer_use", "harness"])]
     pub no_computer_use: bool,
 }
 

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -1512,6 +1512,38 @@ fn agent_run_cloud_rejects_both_computer_use_flags() {
 }
 
 #[test]
+fn agent_run_cloud_rejects_computer_use_with_harness() {
+    let result = Args::try_parse_from([
+        "warp",
+        "agent",
+        "run-cloud",
+        "--prompt",
+        "hello",
+        "--computer-use",
+        "--harness",
+        "claude",
+    ]);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn agent_run_cloud_rejects_no_computer_use_with_harness() {
+    let result = Args::try_parse_from([
+        "warp",
+        "agent",
+        "run-cloud",
+        "--prompt",
+        "hello",
+        "--no-computer-use",
+        "--harness",
+        "claude",
+    ]);
+
+    assert!(result.is_err());
+}
+
+#[test]
 fn agent_run_cloud_defaults_to_no_computer_use_override() {
     let args = Args::try_parse_from(["warp", "agent", "run-cloud", "--prompt", "hello"]).unwrap();
 


### PR DESCRIPTION
## Summary
- `--computer-use` and `--no-computer-use` are now mutually exclusive with `--harness` in the `run-cloud` command at the clap parse layer
- Changed `conflicts_with` to `conflicts_with_all` on both fields in `ComputerUseArgs` to include `"harness"` alongside the existing `"no_computer_use"` / `"computer_use"` conflict
- Added two new tests: `agent_run_cloud_rejects_computer_use_with_harness` and `agent_run_cloud_rejects_no_computer_use_with_harness`

## Test plan
- [ ] `cargo test -p warp_cli -- agent_run_cloud_rejects` — all 3 rejection tests pass
- [ ] Running `warp agent run-cloud --prompt foo --computer-use --harness claude` produces a clap parse error

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._