### PR TITLE
Fix ambient agent session re-entry from management and list view.

### DIFF
--- a/app/src/ai/active_agent_views_model.rs
+++ b/app/src/ai/active_agent_views_model.rs
@@ -349,6 +349,8 @@ impl ActiveAgentViewsModel {
         task_id: AmbientAgentTaskId,
         ctx: &mut ModelContext<Self>,
     ) {
+        self.ambient_sessions
+            .retain(|view_id, id| *view_id == terminal_view_id || *id != task_id);
         let existing = self.ambient_sessions.insert(terminal_view_id, task_id);
         if existing != Some(task_id) {
             self.last_opened_times
@@ -365,9 +367,11 @@ impl ActiveAgentViewsModel {
         ctx: &mut ModelContext<Self>,
     ) {
         if let Some(task_id) = self.ambient_sessions.remove(&terminal_view_id) {
-            self.last_opened_times
-                .remove(&ConversationOrTaskId::TaskId(task_id));
-            ctx.emit(ActiveAgentViewsEvent::AmbientSessionClosed { task_id });
+            if !self.ambient_sessions.values().any(|id| *id == task_id) {
+                self.last_opened_times
+                    .remove(&ConversationOrTaskId::TaskId(task_id));
+                ctx.emit(ActiveAgentViewsEvent::AmbientSessionClosed { task_id });
+            }
         }
     }
 

--- a/app/src/ai/active_agent_views_model_tests.rs
+++ b/app/src/ai/active_agent_views_model_tests.rs
@@ -145,6 +145,72 @@ fn focus_change_without_task_id_has_no_conversation() {
 }
 
 #[test]
+fn ambient_session_registration_replaces_stale_terminal_for_same_task() {
+    App::test((), |mut app| async move {
+        let model = setup_model(&mut app);
+        let terminal_a = EntityId::new();
+        let terminal_b = EntityId::new();
+        let task = new_task_id();
+
+        model.update(&mut app, |model, ctx| {
+            model.register_ambient_session(terminal_a, task, ctx);
+            model.register_ambient_session(terminal_b, task, ctx);
+        });
+
+        model.read(&app, |model, _| {
+            assert_eq!(
+                model.get_terminal_view_id_for_ambient_task(task),
+                Some(terminal_b)
+            );
+            assert_eq!(model.ambient_sessions.len(), 1);
+        });
+    });
+}
+
+#[test]
+fn ambient_session_unregister_keeps_task_open_until_last_terminal_is_removed() {
+    App::test((), |mut app| async move {
+        let model = setup_model(&mut app);
+        let terminal_a = EntityId::new();
+        let terminal_b = EntityId::new();
+        let task = new_task_id();
+
+        model.update(&mut app, |model, _| {
+            model.ambient_sessions.insert(terminal_a, task);
+            model.ambient_sessions.insert(terminal_b, task);
+            model
+                .last_opened_times
+                .insert(ConversationOrTaskId::TaskId(task), Utc::now());
+        });
+
+        model.update(&mut app, |model, ctx| {
+            model.unregister_ambient_session(terminal_a, ctx);
+        });
+
+        model.read(&app, |model, _| {
+            assert_eq!(
+                model.get_terminal_view_id_for_ambient_task(task),
+                Some(terminal_b)
+            );
+            assert!(model
+                .last_opened_times
+                .contains_key(&ConversationOrTaskId::TaskId(task)));
+        });
+
+        model.update(&mut app, |model, ctx| {
+            model.unregister_ambient_session(terminal_b, ctx);
+        });
+
+        model.read(&app, |model, _| {
+            assert_eq!(model.get_terminal_view_id_for_ambient_task(task), None);
+            assert!(!model
+                .last_opened_times
+                .contains_key(&ConversationOrTaskId::TaskId(task)));
+        });
+    });
+}
+
+#[test]
 fn remove_focused_state_for_window_cleans_up() {
     App::test((), |mut app| async move {
         let model = setup_model(&mut app);

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -1382,6 +1382,70 @@ fn test_server_token_assignment_updates_copy_link_resolution() {
 }
 
 #[test]
+fn test_resolve_open_action_reopens_ambient_session_after_terminal_unregister() {
+    App::test((), |mut app| async move {
+        add_entry_projection_test_models(&mut app);
+
+        let now = Utc::now();
+        let session_id = make_uuid(8205);
+        let mut task = create_test_task(&make_uuid(8206), "user-a", now);
+        task.state = AmbientAgentTaskState::InProgress;
+        task.session_id = Some(session_id.clone());
+        task.session_link = Some("https://example.com/session".to_string());
+        task.is_sandbox_running = true;
+        let task_id = task.task_id;
+        let terminal_view_id = EntityId::new();
+
+        app.add_singleton_model(|_| {
+            let mut model = create_test_model();
+            model.tasks.insert(task_id, task);
+            model
+        });
+        ActiveAgentViewsModel::handle(&app).update(&mut app, |model, ctx| {
+            model.register_ambient_session(terminal_view_id, task_id, ctx);
+        });
+
+        app.update(|ctx| {
+            let action = AgentConversationsModel::resolve_open_action(
+                AgentConversationNavigationSubject::Entry(AgentConversationEntryId::AmbientRun(
+                    task_id,
+                )),
+                None,
+                ctx,
+            );
+
+            assert!(matches!(
+                action,
+                Some(WorkspaceAction::FocusTerminalViewInWorkspace { terminal_view_id: id })
+                    if id == terminal_view_id
+            ));
+        });
+
+        ActiveAgentViewsModel::handle(&app).update(&mut app, |model, ctx| {
+            model.unregister_ambient_session(terminal_view_id, ctx);
+        });
+
+        app.update(|ctx| {
+            let action = AgentConversationsModel::resolve_open_action(
+                AgentConversationNavigationSubject::Entry(AgentConversationEntryId::AmbientRun(
+                    task_id,
+                )),
+                None,
+                ctx,
+            );
+
+            assert!(matches!(
+                action,
+                Some(WorkspaceAction::OpenAmbientAgentSession {
+                    session_id: resolved_session_id,
+                    task_id: resolved_task_id,
+                }) if resolved_session_id.to_string() == session_id && resolved_task_id == task_id
+            ));
+        });
+    });
+}
+
+#[test]
 fn test_resolve_copy_link_uses_attached_synced_conversation_for_task_without_token() {
     App::test((), |mut app| async move {
         let _orchestration_v2_guard = FeatureFlag::OrchestrationV2.override_enabled(true);

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -5570,6 +5570,7 @@ impl PaneGroup {
                     self.cleanup_closed_pane(pane_id, ctx);
                     return false;
                 }
+                self.restore_missing_child_agent_panes_for_terminal_pane_if_needed(pane_id, ctx);
 
                 self.focus_pane_and_record_in_history(pane_id, ctx);
 

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -5570,7 +5570,6 @@ impl PaneGroup {
                     self.cleanup_closed_pane(pane_id, ctx);
                     return false;
                 }
-                self.restore_missing_child_agent_panes_for_terminal_pane_if_needed(pane_id, ctx);
 
                 self.focus_pane_and_record_in_history(pane_id, ctx);
 

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -373,6 +373,17 @@ impl PaneContent for TerminalPane {
             }
         });
         let active_session = terminal_view.as_ref(ctx).active_session().clone();
+        let ambient_session_registrations = pane_stack
+            .as_ref(ctx)
+            .entries()
+            .iter()
+            .filter_map(|(_, terminal_view)| {
+                terminal_view
+                    .as_ref(ctx)
+                    .ambient_agent_task_id_for_details_panel(ctx)
+                    .map(|task_id| (terminal_view.id(), task_id))
+            })
+            .collect::<Vec<_>>();
         ActiveAgentViewsModel::handle(ctx).update(ctx, |model, ctx| {
             model.register_agent_view_controller(
                 &agent_view_controller,
@@ -380,6 +391,9 @@ impl PaneContent for TerminalPane {
                 terminal_view_id,
                 ctx,
             );
+            for (terminal_view_id, task_id) in ambient_session_registrations {
+                model.register_ambient_session(terminal_view_id, task_id, ctx);
+            }
         });
     }
 
@@ -402,6 +416,10 @@ impl PaneContent for TerminalPane {
         // Unsubscribe from all views in the pane stack.
         let pane_stack = self.view.as_ref(ctx).pane_stack().clone();
         let contents = pane_stack.as_ref(ctx).entries().to_vec();
+        let terminal_view_ids = contents
+            .iter()
+            .map(|(_, view)| view.id())
+            .collect::<Vec<_>>();
         for (manager, view) in contents {
             // Notify the view that it's being detached so it can react appropriately
             // (e.g. the shared-session viewer tears down its network only when the detach
@@ -418,7 +436,10 @@ impl PaneContent for TerminalPane {
         // restored, so this is safe to run unconditionally.
         let terminal_view_id = self.terminal_view(ctx).id();
         ActiveAgentViewsModel::handle(ctx).update(ctx, |model, ctx| {
-            model.unregister_agent_view_controller(terminal_view_id, ctx);
+            for terminal_view_id in terminal_view_ids {
+                model.unregister_agent_view_controller(terminal_view_id, ctx);
+                model.unregister_ambient_session(terminal_view_id, ctx);
+            }
         });
 
         // Clean up any active CLI agent session so its notification is removed.

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -373,17 +373,11 @@ impl PaneContent for TerminalPane {
             }
         });
         let active_session = terminal_view.as_ref(ctx).active_session().clone();
-        let ambient_session_registrations = pane_stack
+        let active_stack_view = pane_stack.as_ref(ctx).active_view().clone();
+        let active_ambient_session_registration = active_stack_view
             .as_ref(ctx)
-            .entries()
-            .iter()
-            .filter_map(|(_, terminal_view)| {
-                terminal_view
-                    .as_ref(ctx)
-                    .ambient_agent_task_id_for_details_panel(ctx)
-                    .map(|task_id| (terminal_view.id(), task_id))
-            })
-            .collect::<Vec<_>>();
+            .ambient_agent_task_id_for_details_panel(ctx)
+            .map(|task_id| (active_stack_view.id(), task_id));
         ActiveAgentViewsModel::handle(ctx).update(ctx, |model, ctx| {
             model.register_agent_view_controller(
                 &agent_view_controller,
@@ -391,7 +385,7 @@ impl PaneContent for TerminalPane {
                 terminal_view_id,
                 ctx,
             );
-            for (terminal_view_id, task_id) in ambient_session_registrations {
+            if let Some((terminal_view_id, task_id)) = active_ambient_session_registration {
                 model.register_ambient_session(terminal_view_id, task_id, ctx);
             }
         });

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -4878,7 +4878,7 @@ impl Workspace {
 
         self.tabs.iter().enumerate().find_map(|(index, tab)| {
             let pane_group = tab.pane_group.as_ref(ctx);
-            let has_task = pane_group.terminal_pane_ids().into_iter().any(|pane_id| {
+            let has_task = pane_group.visible_pane_ids().into_iter().any(|pane_id| {
                 pane_group
                     .terminal_view_from_pane_id(pane_id, ctx)
                     .is_some_and(|tv| {


### PR DESCRIPTION
## Summary
- Unregister ambient session mappings for every terminal view in a pane stack when a pane detaches, and re-register them when it reattaches.
- Replace stale ambient task mappings when the same task is registered for a newer terminal view.
- Ignore hidden panes when looking for an already-open ambient agent conversation.

[Demo](https://www.loom.com/share/7e4fa35108124ef7832b06208cbd36b5)

## Tests
- `CARGO_BUILD_JOBS=1 cargo nextest run --manifest-path /workspace/warp/Cargo.toml -p warp -E 'test(ambient_session_registration_replaces_stale_terminal_for_same_task) | test(ambient_session_unregister_keeps_task_open_until_last_terminal_is_removed) | test(test_resolve_open_action_reopens_ambient_session_after_terminal_unregister)'`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/cea617fb-5ea0-4e0b-8f27-6078accad759_
_Run: https://oz.staging.warp.dev/runs/019e0919-5caa-7ec5-acd6-160481714093_
_This PR was generated with [Oz](https://warp.dev/oz)._
