### PR TITLE
fix cloud background + status styling for cloud conversations

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -3767,6 +3767,14 @@ impl From<AIConversationAutoexecuteMode> for PersistedAutoexecuteMode {
     }
 }
 
+#[derive(Clone, Copy)]
+pub enum StatusColorStyle {
+    /// Foreground-blend colors (`ansi_fg`) used by the regular status badge.
+    Standard,
+    /// Background-blend colors (`ansi_bg`) used by the cloud overlay badge.
+    Cloud,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ConversationStatus {
     /// Agent is running.
@@ -3808,13 +3816,41 @@ impl ConversationStatus {
         }
     }
 
-    pub fn status_icon_and_color(&self, theme: &WarpTheme) -> (Icon, ColorU) {
+    pub fn status_icon_and_color(
+        &self,
+        theme: &WarpTheme,
+        color_style: StatusColorStyle,
+    ) -> (Icon, ColorU) {
         match self {
-            ConversationStatus::InProgress => (Icon::ClockLoader, theme.ansi_fg_magenta()),
-            ConversationStatus::Success => (Icon::Check, theme.ansi_fg_green()),
-            ConversationStatus::Error => (Icon::Triangle, theme.ansi_fg_red()),
+            ConversationStatus::InProgress => (
+                Icon::ClockLoader,
+                match color_style {
+                    StatusColorStyle::Standard => theme.ansi_fg_magenta(),
+                    StatusColorStyle::Cloud => theme.ansi_bg_magenta(),
+                },
+            ),
+            ConversationStatus::Success => (
+                Icon::Check,
+                match color_style {
+                    StatusColorStyle::Standard => theme.ansi_fg_green(),
+                    StatusColorStyle::Cloud => theme.ansi_bg_green(),
+                },
+            ),
+            ConversationStatus::Error => (
+                Icon::Triangle,
+                match color_style {
+                    StatusColorStyle::Standard => theme.ansi_fg_red(),
+                    StatusColorStyle::Cloud => theme.ansi_bg_red(),
+                },
+            ),
             ConversationStatus::Cancelled => (Icon::StopFilled, internal_colors::neutral_5(theme)),
-            ConversationStatus::Blocked { .. } => (Icon::StopFilled, theme.ansi_fg_yellow()),
+            ConversationStatus::Blocked { .. } => (
+                Icon::StopFilled,
+                match color_style {
+                    StatusColorStyle::Standard => theme.ansi_fg_yellow(),
+                    StatusColorStyle::Cloud => theme.ansi_bg_yellow(),
+                },
+            ),
         }
     }
 

--- a/app/src/ai/blocklist/agent_view/child_agent_status_card.rs
+++ b/app/src/ai/blocklist/agent_view/child_agent_status_card.rs
@@ -8,7 +8,7 @@ use warpui::{
     AppContext, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
 };
 
-use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
+use crate::ai::agent::conversation::{AIConversationId, ConversationStatus, StatusColorStyle};
 use crate::ai::blocklist::agent_view::orchestration_conversation_links::conversation_navigation_card_with_icon;
 use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
 use crate::ai::blocklist::BlocklistAIHistoryEvent;
@@ -196,7 +196,9 @@ impl View for ChildAgentStatusCard {
 
             let agent_name = child.agent_name().unwrap_or("Agent").to_string();
             let title = child.title().unwrap_or_else(|| "Untitled".to_string());
-            let status_icon = child.status().status_icon_and_color(appearance.theme());
+            let status_icon = child
+                .status()
+                .status_icon_and_color(appearance.theme(), StatusColorStyle::Standard);
 
             let Some(mouse_state) = self.mouse_states.get(&conversation_id).cloned() else {
                 log::error!(

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -29,7 +29,9 @@ use warpui::{
     ViewHandle,
 };
 
-use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
+use crate::ai::agent::conversation::{
+    AIConversation, AIConversationId, ConversationStatus, StatusColorStyle,
+};
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::agent_view::orchestration_conversation_links::parent_conversation_id;
 use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
@@ -1132,7 +1134,7 @@ fn render_status_badge(
     theme: &WarpTheme,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
-    let (icon, color) = status.status_icon_and_color(theme);
+    let (icon, color) = status.status_icon_and_color(theme, StatusColorStyle::Standard);
     let icon_el = ConstrainedBox::new(icon.to_warpui_icon(color.into()).finish())
         .with_width(12.)
         .with_height(12.)

--- a/app/src/ai/blocklist/block/view_impl/orchestration.rs
+++ b/app/src/ai/blocklist/block/view_impl/orchestration.rs
@@ -11,7 +11,9 @@ use warpui::{AppContext, Element, SingletonEntity};
 use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
 use warpui::elements::FormattedTextElement;
 
-use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
+use crate::ai::agent::conversation::{
+    AIConversation, AIConversationId, ConversationStatus, StatusColorStyle,
+};
 use crate::ai::agent::{
     AIAgentActionId, AIAgentActionResultType, MessageId, ReceivedMessageDisplay,
     SendMessageToAgentResult, StartAgentExecutionMode, StartAgentResult,
@@ -554,7 +556,9 @@ pub(super) fn render_start_agent(
                     );
                     MouseStateHandle::default()
                 });
-            let status_icon = card_data.status.status_icon_and_color(theme);
+            let status_icon = card_data
+                .status
+                .status_icon_and_color(theme, StatusColorStyle::Standard);
             column.add_child(render_conversation_navigation_card_row(
                 &card_data.agent_name,
                 Some(&card_data.title),

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -28,7 +28,7 @@ use warpui::{
 
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::AIConversation;
-use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
+use crate::ai::agent::conversation::{AIConversationId, ConversationStatus, StatusColorStyle};
 use crate::ai::agent_conversations_model::{AgentConversationEntry, AgentRunDisplayStatus};
 use crate::ai::agent_management::details_action_buttons::{
     ActionButtonsConfig, AgentDetailsButtonEvent, ConversationActionButtonsRow,
@@ -1036,7 +1036,7 @@ impl ConversationDetailsPanel {
             }
             PanelMode::Conversation { status, .. } => {
                 let status = status.as_ref()?;
-                let (icon, color) = status.status_icon_and_color(theme);
+                let (icon, color) = status.status_icon_and_color(theme, StatusColorStyle::Standard);
                 (icon, color, status.to_string())
             }
         };

--- a/app/src/ai/conversation_status_ui.rs
+++ b/app/src/ai/conversation_status_ui.rs
@@ -5,7 +5,7 @@ use warpui::color::ColorU;
 use warpui::elements::{ConstrainedBox, Container, CornerRadius, Radius};
 use warpui::Element;
 
-use crate::ai::agent::conversation::ConversationStatus;
+use crate::ai::agent::conversation::{ConversationStatus, StatusColorStyle};
 use crate::ai::agent_conversations_model::AgentRunDisplayStatus;
 use crate::ui_components::icons::Icon;
 
@@ -18,7 +18,7 @@ pub trait StatusElementStyle {
 
 impl StatusElementStyle for ConversationStatus {
     fn status_icon_and_color(&self, theme: &WarpTheme) -> (Icon, ColorU) {
-        ConversationStatus::status_icon_and_color(self, theme)
+        ConversationStatus::status_icon_and_color(self, theme, StatusColorStyle::Standard)
     }
 }
 

--- a/app/src/ui_components/icon_with_status.rs
+++ b/app/src/ui_components/icon_with_status.rs
@@ -8,7 +8,7 @@ use warpui::elements::{
     ParentElement, ParentOffsetBounds, Radius, Stack,
 };
 
-use crate::ai::agent::conversation::ConversationStatus;
+use crate::ai::agent::conversation::{ConversationStatus, StatusColorStyle};
 use crate::terminal::CLIAgent;
 use crate::themes::theme::Fill as ThemeFill;
 
@@ -277,7 +277,6 @@ fn attach_status_overlay(
             total_size,
             overlay_extra_overhang_ratio,
             theme,
-            status_container_background,
         )
     } else {
         render_with_optional_status_badge(
@@ -299,12 +298,11 @@ fn render_with_cloud_status_badge(
     total_size: f32,
     overlay_extra_overhang_ratio: f32,
     theme: &WarpTheme,
-    status_container_background: WarpThemeFill,
 ) -> Box<dyn Element> {
     let cloud_diameter = cloud_icon_size(total_size);
     let cloud = ConstrainedBox::new(
         WarpIcon::CloudFilled
-            .to_warpui_icon(status_container_background)
+            .to_warpui_icon(theme.foreground())
             .finish(),
     )
     .with_width(cloud_diameter)
@@ -313,7 +311,7 @@ fn render_with_cloud_status_badge(
 
     let cloud_with_status: Box<dyn Element> = match status {
         Some(status) => {
-            let (icon, color) = status.status_icon_and_color(theme);
+            let (icon, color) = status.status_icon_and_color(theme, StatusColorStyle::Cloud);
             let inner = status_in_cloud_size(total_size);
             let status_icon =
                 ConstrainedBox::new(icon.to_warpui_icon(WarpThemeFill::Solid(color)).finish())
@@ -379,7 +377,7 @@ fn render_with_optional_status_badge(
             .with_height(total_size)
             .finish();
     };
-    let (icon, color) = status.status_icon_and_color(theme);
+    let (icon, color) = status.status_icon_and_color(theme, StatusColorStyle::Standard);
     let badge_icon_diameter = badge_icon_size(total_size);
     let pad = badge_padding(total_size);
     let badge_icon = ConstrainedBox::new(icon.to_warpui_icon(WarpThemeFill::Solid(color)).finish())

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1,6 +1,6 @@
 pub mod telemetry;
 
-use crate::ai::agent::conversation::ConversationStatus;
+use crate::ai::agent::conversation::{ConversationStatus, StatusColorStyle};
 use crate::ai::agent_management::AgentNotificationsModel;
 use crate::ai::conversation_status_ui::render_status_element;
 use crate::code::editor::{add_color, remove_color};
@@ -5488,7 +5488,7 @@ fn render_detail_status_pill(
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
-    let (icon, color) = status.status_icon_and_color(theme);
+    let (icon, color) = status.status_icon_and_color(theme, StatusColorStyle::Standard);
     Container::new(
         Flex::row()
             .with_main_axis_size(MainAxisSize::Min)

--- a/crates/warp_core/src/ui/theme/color.rs
+++ b/crates/warp_core/src/ui/theme/color.rs
@@ -409,8 +409,16 @@ impl WarpTheme {
         self.ansi_fg(AnsiColorIdentifier::Yellow.to_ansi_color(&self.terminal_colors().normal))
     }
 
+    pub fn ansi_bg_magenta(&self) -> ColorU {
+        self.ansi_bg(AnsiColorIdentifier::Magenta.to_ansi_color(&self.terminal_colors().normal))
+    }
+
     pub fn ansi_fg_magenta(&self) -> ColorU {
         self.ansi_fg(AnsiColorIdentifier::Magenta.to_ansi_color(&self.terminal_colors().normal))
+    }
+
+    pub fn ansi_bg_yellow(&self) -> ColorU {
+        self.ansi_bg(AnsiColorIdentifier::Yellow.to_ansi_color(&self.terminal_colors().normal))
     }
 
     pub fn ansi_fg_cyan(&self) -> ColorU {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

WISOTT. The original figma called for the cloud to have `foreground` color, but the status icon wasn't standing out against that color at all times. To fix this, we're changing it so that the cloud bg is `foreground` but the status colors (just in the cloud case) use `ansi_bg_<color>` instead of the base ansi color (the bg variants are made to stand out against the foreground).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/8c5668b9293d4ae4a0adf08a763a530b

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode