### PR TITLE
Fix remote file tree not updating with local file changes

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1464,8 +1464,7 @@ pub(crate) fn initialize_app(
             });
         }
 
-        let emit_incremental_updates =
-            matches!(launch_mode, LaunchMode::RemoteServerDaemon { .. });
+        let emit_incremental_updates = matches!(launch_mode, LaunchMode::RemoteServerDaemon { .. });
         ctx.add_singleton_model(|ctx| {
             let model = if emit_incremental_updates {
                 RepoMetadataModel::new_with_incremental_updates(ctx)

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1464,8 +1464,14 @@ pub(crate) fn initialize_app(
             });
         }
 
+        let emit_incremental_updates =
+            matches!(launch_mode, LaunchMode::RemoteServerDaemon { .. });
         ctx.add_singleton_model(|ctx| {
-            let model = RepoMetadataModel::new(ctx);
+            let model = if emit_incremental_updates {
+                RepoMetadataModel::new_with_incremental_updates(ctx)
+            } else {
+                RepoMetadataModel::new(ctx)
+            };
 
             // Subscribe to RemoteServerManager push events so that remote repo
             // metadata snapshots and incremental updates populate the remote


### PR DESCRIPTION
## Problem
The file tree in remote SSH sessions does not update when files change on the server. Cd-ing in and out of the directory restores the correct state.

## Root Cause
The daemon process creates its `RepoMetadataModel` with `emit_incremental_updates = false`.

`initialize_app()` calls `RepoMetadataModel::new(ctx)` for **all** launch modes, including `RemoteServerDaemon`. The `new()` constructor leaves `emit_incremental_updates` disabled on the local sub-model. When the file system watcher detects changes and `apply_file_tree_mutations` runs, it returns `None` instead of a `RepoMetadataUpdate`, so `IncrementalUpdateReady` is never emitted.

The `ServerModel` subscribes to `IncrementalUpdateReady` events to push them to clients, but they never arrive.

Cd-ing fixes the issue because `NavigatedToDirectory` triggers a full snapshot push (via `RepositoryUpdated` or directly in the handler), which replaces the entire client-side tree.

This has been broken since the initial commit — the `new_with_incremental_updates` constructor existed but was never wired into the daemon initialization path.

## Fix
In `initialize_app()`, use `RepoMetadataModel::new_with_incremental_updates(ctx)` when the launch mode is `RemoteServerDaemon`.

---
[Oz conversation](https://staging.warp.dev/conversation/c0f4ca93-e310-48aa-afd1-0ccc6b8e384d) | [Plan](https://staging.warp.dev/drive/notebook/ehhdaoqpILmQhzyNRukMbl)