### PR TITLE
Use unified agent icon-with-status in management panel

### DIFF
--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -108,7 +108,7 @@ const CARD_MARGIN_BOTTOM: f32 = 8.;
 
 const BUTTON_SIZE: f32 = 20.;
 /// Total size of the agent icon-with-status component rendered in each card's header row.
-const CARD_AGENT_ICON_SIZE: f32 = 20.;
+const CARD_AGENT_ICON_SIZE: f32 = 24.;
 const CREATOR_AVATAR_FONT_SIZE: f32 = 10.;
 
 const SESSION_EXPIRED_TEXT: &str = "Sessions expire after one week and cannot be opened.";

--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -35,7 +35,6 @@ use crate::ai::blocklist::format_credits;
 use crate::ai::conversation_details_panel::{
     ConversationDetailsData, ConversationDetailsPanel, ConversationDetailsPanelEvent,
 };
-use crate::ai::conversation_status_ui::render_status_element;
 use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::harness_display;
 use crate::app_state::PersistedAgentManagementFilters;
@@ -107,7 +106,6 @@ const CARD_CONTENT_PADDING: f32 = 12.;
 const CARD_BORDER_RADIUS: f32 = 4.;
 const CARD_MARGIN_BOTTOM: f32 = 8.;
 
-const STATUS_ICON_SIZE: f32 = 12.;
 const BUTTON_SIZE: f32 = 20.;
 /// Total size of the agent icon-with-status component rendered in each card's header row.
 const CARD_AGENT_ICON_SIZE: f32 = 20.;
@@ -1723,16 +1721,13 @@ impl AgentManagementView {
 
         let title_text = Text::new_inline(entry.display.title.clone(), font_family, font_size)
             .with_color(theme.active_ui_text_color().into());
-        let status_icon: Box<dyn Element> = match agent_conversation_entry_icon_variant(entry) {
-            Some(variant) => render_icon_with_status(
-                variant,
-                CARD_AGENT_ICON_SIZE,
-                0.,
-                theme,
-                internal_colors::fg_overlay_1(theme),
-            ),
-            None => render_status_element(&entry.display.status, STATUS_ICON_SIZE, appearance),
-        };
+        let status_icon = render_icon_with_status(
+            agent_conversation_entry_icon_variant(entry),
+            CARD_AGENT_ICON_SIZE,
+            0.,
+            theme,
+            internal_colors::fg_overlay_1(theme),
+        );
         let time_str = format_approx_duration_from_now_utc(entry.display.last_updated);
         let time_text = Text::new_inline(time_str, font_family, font_size)
             .with_color(theme.nonactive_ui_text_color().into());

--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -48,7 +48,9 @@ use crate::editor::{
 use crate::menu::{MenuItem, MenuItemFields};
 use crate::notebooks::NotebookId;
 use crate::settings::ai::AISettings;
+use crate::ui_components::agent_icon::agent_conversation_entry_icon_variant;
 use crate::ui_components::avatar::{Avatar, AvatarContent};
+use crate::ui_components::icon_with_status::render_icon_with_status;
 use crate::util::time_format::format_approx_duration_from_now_utc;
 use crate::view_components::action_button::{
     ActionButton, ButtonSize, NakedTheme, PrimaryTheme, SecondaryTheme,
@@ -107,6 +109,8 @@ const CARD_MARGIN_BOTTOM: f32 = 8.;
 
 const STATUS_ICON_SIZE: f32 = 12.;
 const BUTTON_SIZE: f32 = 20.;
+/// Total size of the agent icon-with-status component rendered in each card's header row.
+const CARD_AGENT_ICON_SIZE: f32 = 20.;
 const CREATOR_AVATAR_FONT_SIZE: f32 = 10.;
 
 const SESSION_EXPIRED_TEXT: &str = "Sessions expire after one week and cannot be opened.";
@@ -1719,8 +1723,16 @@ impl AgentManagementView {
 
         let title_text = Text::new_inline(entry.display.title.clone(), font_family, font_size)
             .with_color(theme.active_ui_text_color().into());
-        let status_icon =
-            render_status_element(&entry.display.status, STATUS_ICON_SIZE, appearance);
+        let status_icon: Box<dyn Element> = match agent_conversation_entry_icon_variant(entry) {
+            Some(variant) => render_icon_with_status(
+                variant,
+                CARD_AGENT_ICON_SIZE,
+                0.,
+                theme,
+                internal_colors::fg_overlay_1(theme),
+            ),
+            None => render_status_element(&entry.display.status, STATUS_ICON_SIZE, appearance),
+        };
         let time_str = format_approx_duration_from_now_utc(entry.display.last_updated);
         let time_text = Text::new_inline(time_str, font_family, font_size)
             .with_color(theme.nonactive_ui_text_color().into());

--- a/app/src/ui_components/agent_icon.rs
+++ b/app/src/ui_components/agent_icon.rs
@@ -88,16 +88,16 @@ pub(crate) fn terminal_view_agent_icon_variant(
 
 pub(crate) fn agent_conversation_entry_icon_variant(
     entry: &AgentConversationEntry,
-) -> Option<IconWithStatusVariant> {
+) -> IconWithStatusVariant {
     let status = entry.display.status.to_conversation_status();
     let is_ambient = matches!(entry.provenance, AgentConversationProvenance::AmbientRun)
         || entry.backing.has_ambient_run
         || entry.identity.ambient_agent_task_id.is_some();
-    Some(agent_icon_variant_for_run(
+    agent_icon_variant_for_run(
         entry.display.harness.unwrap_or(Harness::Oz),
         status,
         is_ambient,
-    ))
+    )
 }
 
 /// Primitive inputs to the terminal-view waterfall, gathered once from the live

--- a/app/src/ui_components/agent_icon_tests.rs
+++ b/app/src/ui_components/agent_icon_tests.rs
@@ -426,7 +426,7 @@ fn non_ambient_entry_uses_display_harness() {
         },
     };
 
-    let variant = agent_conversation_entry_icon_variant(&entry).unwrap();
+    let variant = agent_conversation_entry_icon_variant(&entry);
     assert_eq!(
         AgentIconFields::from_variant(&variant).unwrap(),
         AgentIconFields {

--- a/app/src/workspace/view/conversation_list/item.rs
+++ b/app/src/workspace/view/conversation_list/item.rs
@@ -2,7 +2,7 @@ use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent_conversations_model::{
     AgentConversationEntry, AgentConversationEntryId, AgentConversationProvenance,
 };
-use crate::ai::conversation_status_ui::{render_status_element, STATUS_ELEMENT_PADDING};
+use crate::ai::conversation_status_ui::STATUS_ELEMENT_PADDING;
 use crate::appearance::Appearance;
 use crate::drive::sharing::dialog::SharingDialog;
 use crate::menu::Menu;
@@ -213,24 +213,13 @@ pub fn render_item(props: ItemProps<'_>, app: &AppContext) -> Box<dyn Element> {
     }
 
     let status_element_size = font_size + STATUS_ELEMENT_PADDING * 2.;
-    // Prefer the unified agent icon-with-status circle (brand color + cloud lobe for
-    // ambient runs) so the row matches the vertical tab / pane header. Fall back to the
-    // plain status-only icon when the helper can't produce an agent variant (never today,
-    // but keeps the surface future-proof).
-    let icon_element: Box<dyn Element> = match agent_conversation_entry_icon_variant(conversation) {
-        Some(variant) => render_icon_with_status(
-            variant,
-            LIST_ITEM_AGENT_SIZE,
-            LIST_ITEM_OVERLAY_EXTRA_OVERHANG,
-            theme,
-            theme.background(),
-        ),
-        None => render_status_element(
-            &conversation.display.status.to_conversation_status(),
-            font_size,
-            appearance,
-        ),
-    };
+    let icon_element = render_icon_with_status(
+        agent_conversation_entry_icon_variant(conversation),
+        LIST_ITEM_AGENT_SIZE,
+        LIST_ITEM_OVERLAY_EXTRA_OVERHANG,
+        theme,
+        theme.background(),
+    );
 
     let icon_and_title_row = Shrinkable::new(
         1.0,


### PR DESCRIPTION
## Description

We want to re-use the agent + icon combo in the agent management panel that we already use in the conversation list, vertical tabs, etc. This unifies status rendering across all surfaces.

## Demo

![image.png](https://app.graphite.com/user-attachments/assets/8467468e-f7ab-424a-9c09-8979ca3bd844.png)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/328da37b-7f3d-4c63-9aaa-8f9acaba2669_
_Run: https://oz.staging.warp.dev/runs/019e0962-c201-7e58-802b-736b69251d5e_
_This PR was generated with [Oz](https://warp.dev/oz)._
