### PR TITLE
Label cloud tab config as Cloud Agent behind harness flag

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6114,10 +6114,16 @@ impl Workspace {
         });
     }
 
-    /// Builds the unified new-session menu items
-    /// tab bar chevron and the vertical tab bar `+` button.
-    ///
-    /// Order: Agent → Terminal (sidecar) → Cloud Oz → [tab configs] → separator → New worktree config (sidecar) → New tab config → separator → Reopen closed session.
+    fn cloud_agent_new_session_label() -> &'static str {
+        if FeatureFlag::AgentHarness.is_enabled() {
+            "Cloud Agent"
+        } else {
+            "Cloud Oz"
+        }
+    }
+
+    /// Builds the unified new-session menu items used by the tab bar chevron
+    /// and the vertical tab bar `+` button.
     fn unified_new_session_menu_items(
         &self,
         ctx: &mut ViewContext<Self>,
@@ -6199,12 +6205,12 @@ impl Workspace {
             }
         }
 
-        // 3. Cloud Oz (if flags enabled)
+        // 3. Cloud agent entry (if flags enabled)
         if is_any_ai_enabled
             && FeatureFlag::AgentView.is_enabled()
             && FeatureFlag::CloudMode.is_enabled()
         {
-            let mut cloud_item = MenuItemFields::new("Cloud Oz")
+            let mut cloud_item = MenuItemFields::new(Self::cloud_agent_new_session_label())
                 .with_on_select_action(WorkspaceAction::AddAmbientAgentTab)
                 .with_icon(icons::Icon::LayoutAlt01);
             if effective_default == DefaultSessionMode::CloudAgent {

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -697,6 +697,25 @@ fn reopen_closed_session_menu_item(
     }
 }
 
+fn cloud_agent_new_session_menu_item(
+    menu_items: &[MenuItem<WorkspaceAction>],
+) -> &MenuItemFields<WorkspaceAction> {
+    menu_items
+        .iter()
+        .find_map(|item| {
+            if let MenuItem::Item(fields) = item {
+                if matches!(
+                    fields.on_select_action(),
+                    Some(WorkspaceAction::AddAmbientAgentTab)
+                ) {
+                    return Some(fields);
+                }
+            }
+            None
+        })
+        .expect("expected a cloud agent menu item")
+}
+
 #[test]
 fn test_reward_modal_no_overlap() {
     App::test((), |mut app| async move {
@@ -2698,6 +2717,45 @@ fn test_unified_new_session_menu_uses_new_worktree_config_label_and_order() {
     });
 }
 
+#[test]
+fn test_unified_new_session_menu_uses_cloud_agent_label_when_agent_harness_enabled() {
+    let _agent_view_guard = FeatureFlag::AgentView.override_enabled(true);
+    let _cloud_mode_guard = FeatureFlag::CloudMode.override_enabled(true);
+    let _agent_harness_guard = FeatureFlag::AgentHarness.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            let menu_items = workspace.unified_new_session_menu_items(ctx);
+            let cloud_item = cloud_agent_new_session_menu_item(&menu_items);
+
+            assert_eq!(cloud_item.label(), "Cloud Agent");
+        });
+    });
+}
+
+#[test]
+fn test_unified_new_session_menu_uses_cloud_oz_label_when_agent_harness_disabled() {
+    let _agent_view_guard = FeatureFlag::AgentView.override_enabled(true);
+    let _cloud_mode_guard = FeatureFlag::CloudMode.override_enabled(true);
+    let _agent_harness_guard = FeatureFlag::AgentHarness.override_enabled(false);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            let menu_items = workspace.unified_new_session_menu_items(ctx);
+            let cloud_item = cloud_agent_new_session_menu_item(&menu_items);
+
+            assert_eq!(cloud_item.label(), "Cloud Oz");
+        });
+    });
+}
 #[test]
 fn test_unified_new_session_menu_includes_reopen_closed_session() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Summary
- Rename the new-session cloud entry from "Cloud Oz" to "Cloud Agent" when `FeatureFlag::AgentHarness` is enabled.
- Keep the existing "Cloud Oz" label when the flag is disabled.
- Add focused workspace view tests for both feature flag states.

## Validation
- `CARGO_BUILD_JOBS=1 cargo nextest run --manifest-path /workspace/warp/Cargo.toml -E 'test(test_unified_new_session_menu_uses_cloud)'`
- `CARGO_BUILD_JOBS=1 cargo build --manifest-path /workspace/warp/Cargo.toml --bin warp`
- Computer use verified the new-session menu row and sidecar both show `Cloud Agent`, with no visible `Cloud Oz` in that menu path.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/7c7da8e4-5085-432e-ac23-e8311b5d06da_
_Run: https://oz.staging.warp.dev/runs/019e095d-97ab-7448-8e3b-7c8a7307318a_
_This PR was generated with [Oz](https://warp.dev/oz)._
