### PR TITLE
Support `--conversation` for the `run-cloud` CLI command

### DIFF
--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -491,7 +491,7 @@ impl AmbientAgentRunner {
                 parent_run_id: None,
                 runtime_skills: vec![],
                 referenced_attachments: vec![],
-                conversation_id: None,
+                conversation_id: args.conversation,
                 initial_snapshot_token: None,
             };
 

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -1602,6 +1602,32 @@ fn harness_parse_local_child_harness_accepts_codex() {
 }
 
 #[test]
+fn agent_run_cloud_accepts_conversation_flag() {
+    let args = Args::try_parse_from([
+        "warp",
+        "agent",
+        "run-cloud",
+        "--prompt",
+        "hello",
+        "--conversation",
+        "92b8aa0f-1525-4813-9990-62db7afe9c12",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp agent run-cloud` command");
+    };
+    let CliCommand::Agent(AgentCommand::RunCloud(run_args)) = boxed_cmd.as_ref() else {
+        panic!("Expected `warp agent run-cloud` command");
+    };
+
+    assert_eq!(
+        run_args.conversation.as_deref(),
+        Some("92b8aa0f-1525-4813-9990-62db7afe9c12")
+    );
+}
+
+#[test]
 fn agent_run_cloud_accepts_claude_auth_secret_with_harness() {
     let args = Args::try_parse_from([
         "warp",

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -1602,32 +1602,6 @@ fn harness_parse_local_child_harness_accepts_codex() {
 }
 
 #[test]
-fn agent_run_cloud_accepts_conversation_flag() {
-    let args = Args::try_parse_from([
-        "warp",
-        "agent",
-        "run-cloud",
-        "--prompt",
-        "hello",
-        "--conversation",
-        "92b8aa0f-1525-4813-9990-62db7afe9c12",
-    ])
-    .unwrap();
-
-    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
-        panic!("Expected `warp agent run-cloud` command");
-    };
-    let CliCommand::Agent(AgentCommand::RunCloud(run_args)) = boxed_cmd.as_ref() else {
-        panic!("Expected `warp agent run-cloud` command");
-    };
-
-    assert_eq!(
-        run_args.conversation.as_deref(),
-        Some("92b8aa0f-1525-4813-9990-62db7afe9c12")
-    );
-}
-
-#[test]
 fn agent_run_cloud_accepts_claude_auth_secret_with_harness() {
     let args = Args::try_parse_from([
         "warp",


### PR DESCRIPTION
## Description
The `--conversation` flag on `agent run-cloud` was parsed but never propagated to the `SpawnAgentRequest`. The `conversation_id` field was hardcoded to `None` in `ambient.rs`, so the server never received the conversation context.

## Linked Issue
- [REMOTE-1633](https://linear.app/warpdotdev/issue/REMOTE-1633)

## Testing
Ran Andy's command locally, and observed that we do indeed pick up the conversation correctly https://oz.staging.warp.dev/runs/019e1587-0dc1-7611-bb63-9b5ab8f7ea38

```bash
./script/run -- agent run-cloud --environment <env> --conversation <convo> --prompt "<prompt>"
```

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/02bfb4e3-783a-4ded-bb6a-52792364f74c_
_Run: https://oz.staging.warp.dev/runs/019e09ad-52e8-774e-afb0-0a561b8aa219_
_This PR was generated with [Oz](https://warp.dev/oz)._
