### PR TITLE
Improve CLI agent pane summary labels

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -335,7 +335,7 @@ use crate::terminal::view::ambient_agent::{
 };
 #[cfg(feature = "local_tty")]
 use crate::terminal::view::docker_sandbox::DEFAULT_DOCKER_SANDBOX_BASE_IMAGE;
-use crate::terminal::{self, SizeInfo, TerminalView};
+use crate::terminal::{self, CLIAgent, SizeInfo, TerminalView};
 #[cfg(target_os = "macos")]
 use crate::workspace::cli_install;
 use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -1076,6 +1076,18 @@ pub struct Workspace {
     tab_config_action_sidecar_item: Option<SidecarItemKind>,
     tab_config_action_sidecar_mouse_states: crate::tab_configs::action_sidecar::SidecarMouseStates,
     remove_tab_config_confirmation_dialog: ViewHandle<RemoveTabConfigConfirmationDialog>,
+}
+
+fn pane_name_menu_labels(
+    is_cli_agent_pane: bool,
+    is_active_pane_target: bool,
+) -> (&'static str, &'static str) {
+    match (is_cli_agent_pane, is_active_pane_target) {
+        (true, true) => ("Edit active agent summary", "Reset active agent summary"),
+        (true, false) => ("Edit agent summary", "Reset agent summary"),
+        (false, true) => ("Rename active pane", "Reset active pane name"),
+        (false, false) => ("Rename pane", "Reset pane name"),
+    }
 }
 
 impl Workspace {
@@ -6614,17 +6626,34 @@ impl Workspace {
             return;
         }
 
+        let is_cli_agent_pane = tab
+            .pane_group
+            .as_ref(ctx)
+            .terminal_view_from_pane_id(pane.pane_id, ctx)
+            .and_then(|terminal_view| {
+                CLIAgentSessionsModel::as_ref(ctx)
+                    .session(terminal_view.id())
+                    .map(|session| session.agent)
+            })
+            .is_some_and(|agent| !matches!(agent, CLIAgent::Unknown));
+
         let pane_name_target = match target {
-            VerticalTabsPaneContextMenuTarget::ClickedPane(locator) => PaneNameMenuTarget {
-                locator,
-                rename_label: "Rename pane",
-                reset_label: "Reset pane name",
-            },
-            VerticalTabsPaneContextMenuTarget::ActivePane(locator) => PaneNameMenuTarget {
-                locator,
-                rename_label: "Rename active pane",
-                reset_label: "Reset active pane name",
-            },
+            VerticalTabsPaneContextMenuTarget::ClickedPane(locator) => {
+                let (rename_label, reset_label) = pane_name_menu_labels(is_cli_agent_pane, false);
+                PaneNameMenuTarget {
+                    locator,
+                    rename_label,
+                    reset_label,
+                }
+            }
+            VerticalTabsPaneContextMenuTarget::ActivePane(locator) => {
+                let (rename_label, reset_label) = pane_name_menu_labels(is_cli_agent_pane, true);
+                PaneNameMenuTarget {
+                    locator,
+                    rename_label,
+                    reset_label,
+                }
+            }
         };
         let menu_items = tab.menu_items_with_pane_name_target(
             tab_index,

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -85,6 +85,30 @@ use warp_editor::editor::NavigationKey;
 use warpui::AddSingletonModel;
 use warpui::{platform::WindowStyle, App, ViewHandle};
 
+#[test]
+fn pane_name_menu_labels_use_summary_copy_for_cli_agent_panes() {
+    assert_eq!(
+        pane_name_menu_labels(true, false),
+        ("Edit agent summary", "Reset agent summary")
+    );
+    assert_eq!(
+        pane_name_menu_labels(true, true),
+        ("Edit active agent summary", "Reset active agent summary")
+    );
+}
+
+#[test]
+fn pane_name_menu_labels_keep_rename_copy_for_regular_panes() {
+    assert_eq!(
+        pane_name_menu_labels(false, false),
+        ("Rename pane", "Reset pane name")
+    );
+    assert_eq!(
+        pane_name_menu_labels(false, true),
+        ("Rename active pane", "Reset active pane name")
+    );
+}
+
 fn initialize_app(app: &mut App) {
     initialize_settings_for_tests(app);
 


### PR DESCRIPTION
## Summary
- Detect when the vertical-tabs context menu target is a known CLI agent pane.
- Label the existing custom pane-title action as "Edit agent summary" for CLI agent panes, with matching reset copy.
- Keep the existing "Rename pane" labels for regular terminal panes.

## Why
When several CLI agent panes are open in the same Warp window, it is hard to tell which pane is doing what. Autogenerated agent pane labels can be stale or unavailable depending on the agent integration; Codex currently only provides coarse notification/status events, so it often falls back to showing the working directory. Warp already persists a custom vertical-tabs title per pane, so this makes that existing override more discoverable for agent panes without changing storage or agent protocol behavior.

## Testing
- rustfmt app/src/workspace/view.rs app/src/workspace/view_tests.rs
- git diff --check
- cargo test -p warp pane_name_menu_labels --lib *(blocked locally: warpui build requires the Metal Toolchain; build.rs reports `cannot execute tool metal` and suggests `xcodebuild -downloadComponent MetalToolchain`)*