### PR TITLE
Fix zsh tab-completion dropping basename for nested file paths (#10358)

### DIFF
--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1242,23 +1242,25 @@ esac
     # descriptions in $__dscr!
 
     # display all matches
-    local dsuf dscr
+    local dsuf dscr full
     for i in {1..$#__hits}; do
-        # add a dir suffix?
-        (( dirsuf )) && [[ -d $__hits[$i] ]] && dsuf=/ || dsuf=
+        # Reconstruct the full insertion text. $IPREFIX is zsh's accumulated
+        # "consumed" prefix from recursive completion (e.g. _path_files walking
+        # nested directories) and ${hpre[2]} is the value of compadd's -p
+        # hidden-prefix flag. Without this, completing e.g. `git add
+        # some/nested/dir/` would only emit `file1.txt`, which the Rust filter
+        # then drops because it does not prefix-match the slashy query token.
+        # See issue #10358. Both expand to empty when not set, so plain
+        # command/option completion is unaffected.
+        full="$IPREFIX${hpre[2]}$__hits[$i]"
+        # add a dir suffix? Test against the prefixed path so nested directory
+        # candidates keep their trailing `/` (the bare basename may not exist
+        # relative to the current working directory).
+        (( dirsuf )) && [[ -d $full ]] && dsuf=/ || dsuf=
         # description to be displayed afterwards
         (( $#__dscr >= $i )) && dscr="${${__dscr[$i]}##$__hits[$i] #}" || dscr=""
 
-        # Prepend $IPREFIX (zsh's accumulated "consumed" prefix from recursive
-        # completion such as _path_files walking nested directories) and
-        # ${hpre[2]} (the value of compadd's -p hidden-prefix flag) so the
-        # emitted match is the full insertion text rather than just the bare
-        # basename. Without this, completing e.g. `git add some/nested/dir/`
-        # would only emit `file1.txt`, which the Rust filter then drops because
-        # it does not prefix-match the slashy query token. See issue #10358.
-        # When neither IPREFIX nor -p is set both expand to empty strings, so
-        # plain command/option completion is unaffected.
-        local match="$IPREFIX${hpre[2]}$__hits[$i]$dsuf"
+        local match="$full$dsuf"
 
         print -n "\e]9280;C"$OSC_PARAM_SEPARATOR$match$OSC_END
         print -n "\e]9280;D?description"$OSC_PARAM_SEPARATOR$dscr$OSC_END

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1246,13 +1246,16 @@ esac
     for i in {1..$#__hits}; do
         # Reconstruct the full insertion text. $IPREFIX is zsh's accumulated
         # "consumed" prefix from recursive completion (e.g. _path_files walking
-        # nested directories) and ${hpre[2]} is the value of compadd's -p
-        # hidden-prefix flag. Without this, completing e.g. `git add
-        # some/nested/dir/` would only emit `file1.txt`, which the Rust filter
-        # then drops because it does not prefix-match the slashy query token.
-        # See issue #10358. Both expand to empty when not set, so plain
-        # command/option completion is unaffected.
-        full="$IPREFIX${hpre[2]}$__hits[$i]"
+        # nested directories) and ${hpre[-p]} is the value of compadd's -p
+        # hidden-prefix flag. `hpre` is declared with `typeset -A` above, so
+        # `zparseopts ... p:=hpre` stores the -p argument under the literal
+        # `-p` key (not numeric index 2 — that form only applies to plain
+        # arrays). Without this, completing e.g. `git add some/nested/dir/`
+        # would only emit `file1.txt`, which the Rust filter then drops
+        # because it does not prefix-match the slashy query token. See issue
+        # #10358. Both expand to empty when not set, so plain command/option
+        # completion is unaffected.
+        full="$IPREFIX${hpre[-p]}$__hits[$i]"
         # add a dir suffix? Test against the prefixed path so nested directory
         # candidates keep their trailing `/` (the bare basename may not exist
         # relative to the current working directory).

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1249,7 +1249,16 @@ esac
         # description to be displayed afterwards
         (( $#__dscr >= $i )) && dscr="${${__dscr[$i]}##$__hits[$i] #}" || dscr=""
 
-        local match="$__hits[$i]$dsuf"
+        # Prepend $IPREFIX (zsh's accumulated "consumed" prefix from recursive
+        # completion such as _path_files walking nested directories) and
+        # ${hpre[2]} (the value of compadd's -p hidden-prefix flag) so the
+        # emitted match is the full insertion text rather than just the bare
+        # basename. Without this, completing e.g. `git add some/nested/dir/`
+        # would only emit `file1.txt`, which the Rust filter then drops because
+        # it does not prefix-match the slashy query token. See issue #10358.
+        # When neither IPREFIX nor -p is set both expand to empty strings, so
+        # plain command/option completion is unaffected.
+        local match="$IPREFIX${hpre[2]}$__hits[$i]$dsuf"
 
         print -n "\e]9280;C"$OSC_PARAM_SEPARATOR$match$OSC_END
         print -n "\e]9280;D?description"$OSC_PARAM_SEPARATOR$dscr$OSC_END

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1250,23 +1250,25 @@ esac
     # descriptions in $__dscr!
 
     # display all matches
-    local dsuf dscr
+    local dsuf dscr full
     for i in {1..$#__hits}; do
-        # add a dir suffix?
-        (( dirsuf )) && [[ -d $__hits[$i] ]] && dsuf=/ || dsuf=
+        # Reconstruct the full insertion text. $IPREFIX is zsh's accumulated
+        # "consumed" prefix from recursive completion (e.g. _path_files walking
+        # nested directories) and ${hpre[2]} is the value of compadd's -p
+        # hidden-prefix flag. Without this, completing e.g. `git add
+        # some/nested/dir/` would only emit `file1.txt`, which the Rust filter
+        # then drops because it does not prefix-match the slashy query token.
+        # See issue #10358. Both expand to empty when not set, so plain
+        # command/option completion is unaffected.
+        full="$IPREFIX${hpre[2]}$__hits[$i]"
+        # add a dir suffix? Test against the prefixed path so nested directory
+        # candidates keep their trailing `/` (the bare basename may not exist
+        # relative to the current working directory).
+        (( dirsuf )) && [[ -d $full ]] && dsuf=/ || dsuf=
         # description to be displayed afterwards
         (( $#__dscr >= $i )) && dscr="${${__dscr[$i]}##$__hits[$i] #}" || dscr=""
 
-        # Prepend $IPREFIX (zsh's accumulated "consumed" prefix from recursive
-        # completion such as _path_files walking nested directories) and
-        # ${hpre[2]} (the value of compadd's -p hidden-prefix flag) so the
-        # emitted match is the full insertion text rather than just the bare
-        # basename. Without this, completing e.g. `git add some/nested/dir/`
-        # would only emit `file1.txt`, which the Rust filter then drops because
-        # it does not prefix-match the slashy query token. See issue #10358.
-        # When neither IPREFIX nor -p is set both expand to empty strings, so
-        # plain command/option completion is unaffected.
-        local match="$IPREFIX${hpre[2]}$__hits[$i]$dsuf"
+        local match="$full$dsuf"
 
         print -n "\e]9280;C"$OSC_PARAM_SEPARATOR$match$OSC_END
         print -n "\e]9280;D?description"$OSC_PARAM_SEPARATOR$dscr$OSC_END

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1257,7 +1257,16 @@ esac
         # description to be displayed afterwards
         (( $#__dscr >= $i )) && dscr="${${__dscr[$i]}##$__hits[$i] #}" || dscr=""
 
-        local match="$__hits[$i]$dsuf"
+        # Prepend $IPREFIX (zsh's accumulated "consumed" prefix from recursive
+        # completion such as _path_files walking nested directories) and
+        # ${hpre[2]} (the value of compadd's -p hidden-prefix flag) so the
+        # emitted match is the full insertion text rather than just the bare
+        # basename. Without this, completing e.g. `git add some/nested/dir/`
+        # would only emit `file1.txt`, which the Rust filter then drops because
+        # it does not prefix-match the slashy query token. See issue #10358.
+        # When neither IPREFIX nor -p is set both expand to empty strings, so
+        # plain command/option completion is unaffected.
+        local match="$IPREFIX${hpre[2]}$__hits[$i]$dsuf"
 
         print -n "\e]9280;C"$OSC_PARAM_SEPARATOR$match$OSC_END
         print -n "\e]9280;D?description"$OSC_PARAM_SEPARATOR$dscr$OSC_END

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1254,13 +1254,16 @@ esac
     for i in {1..$#__hits}; do
         # Reconstruct the full insertion text. $IPREFIX is zsh's accumulated
         # "consumed" prefix from recursive completion (e.g. _path_files walking
-        # nested directories) and ${hpre[2]} is the value of compadd's -p
-        # hidden-prefix flag. Without this, completing e.g. `git add
-        # some/nested/dir/` would only emit `file1.txt`, which the Rust filter
-        # then drops because it does not prefix-match the slashy query token.
-        # See issue #10358. Both expand to empty when not set, so plain
-        # command/option completion is unaffected.
-        full="$IPREFIX${hpre[2]}$__hits[$i]"
+        # nested directories) and ${hpre[-p]} is the value of compadd's -p
+        # hidden-prefix flag. `hpre` is declared with `typeset -A` above, so
+        # `zparseopts ... p:=hpre` stores the -p argument under the literal
+        # `-p` key (not numeric index 2 — that form only applies to plain
+        # arrays). Without this, completing e.g. `git add some/nested/dir/`
+        # would only emit `file1.txt`, which the Rust filter then drops
+        # because it does not prefix-match the slashy query token. See issue
+        # #10358. Both expand to empty when not set, so plain command/option
+        # completion is unaffected.
+        full="$IPREFIX${hpre[-p]}$__hits[$i]"
         # add a dir suffix? Test against the prefixed path so nested directory
         # candidates keep their trailing `/` (the bare basename may not exist
         # relative to the current working directory).

--- a/crates/warp_completer/src/completer/suggest/test.rs
+++ b/crates/warp_completer/src/completer/suggest/test.rs
@@ -2035,32 +2035,25 @@ fn test_matching_indices_nested_file_paths() {
 
 /// Filter-contract regression test for issue #10358 (zsh nested-path completion).
 ///
-/// This test does NOT exercise the OSC ingestion path that the zsh fix actually
-/// modifies — `ShellCompletion` is constructed in `app/src/terminal/model/`
-/// against the `app` crate, which we don't depend on here. Instead, this test
-/// pins the contract that `filter_by_query` relies on: once the shell-side fix
-/// emits the full path as the replacement, the filter must retain it for a
-/// directory-prefix query, and a bare-basename replacement (the pre-fix OSC
-/// payload) must be dropped. If a future change to `filter_by_query` broke
-/// either invariant, the user-visible regression in #10358 would silently
-/// return.
+/// Mirrors the actual `ShellCompletion` ingestion shape: the OSC `9280;C`
+/// payload is fed through `Suggestion::with_same_display_and_replacement`, so
+/// display == replacement and `file_type` is `None`. Pins the contract that
+/// `filter_by_query` relies on: once the shell-side fix emits the full path
+/// as the replacement, the filter must retain it for a directory-prefix
+/// query, and a bare-basename replacement (the pre-fix OSC payload) must be
+/// dropped. If a future change to `filter_by_query` broke either invariant,
+/// the user-visible regression in #10358 would silently return.
 #[test]
 fn test_filter_by_query_retains_file_with_full_path_replacement_after_iprefix_fix() {
     use super::{MatchedSuggestion, Suggestion, SuggestionResults};
     use crate::completer::matchers::Match;
-    use crate::completer::EngineFileType;
 
-    let suggestion = Suggestion {
-        display: "file1.txt".into(),
-        replacement: "some/nested/folder1/file1.txt".into(),
-        description: None,
-        suggestion_type: SuggestionType::Argument,
-        override_icon: None,
-        priority: super::Priority::default(),
-        is_hidden: false,
-        file_type: Some(EngineFileType::File),
-        is_abbreviation: false,
-    };
+    let suggestion = Suggestion::with_same_display_and_replacement(
+        "some/nested/folder1/file1.txt",
+        None,
+        SuggestionType::Argument,
+        super::Priority::default(),
+    );
 
     let results = SuggestionResults {
         replacement_span: crate::meta::Span::new(0, 0),
@@ -2084,24 +2077,19 @@ fn test_filter_by_query_retains_file_with_full_path_replacement_after_iprefix_fi
 
     assert_eq!(
         retained,
-        vec![String::from("file1.txt")],
+        vec![String::from("some/nested/folder1/file1.txt")],
         "file suggestion with full-path replacement must be retained when query \
          is the directory prefix (regression for issue #10358)"
     );
 
     // Also verify that a bare-basename replacement (the pre-fix OSC payload) is
     // correctly dropped so the test documents both sides of the regression.
-    let bare_suggestion = Suggestion {
-        display: "file1.txt".into(),
-        replacement: "file1.txt".into(), // pre-fix: no IPREFIX prepended
-        description: None,
-        suggestion_type: SuggestionType::Argument,
-        override_icon: None,
-        priority: super::Priority::default(),
-        is_hidden: false,
-        file_type: Some(EngineFileType::File),
-        is_abbreviation: false,
-    };
+    let bare_suggestion = Suggestion::with_same_display_and_replacement(
+        "file1.txt", // pre-fix: no IPREFIX prepended
+        None,
+        SuggestionType::Argument,
+        super::Priority::default(),
+    );
 
     let bare_results = SuggestionResults {
         replacement_span: crate::meta::Span::new(0, 0),

--- a/crates/warp_completer/src/completer/suggest/test.rs
+++ b/crates/warp_completer/src/completer/suggest/test.rs
@@ -2033,6 +2033,100 @@ fn test_matching_indices_nested_file_paths() {
     );
 }
 
+/// Filter-contract regression test for issue #10358 (zsh nested-path completion).
+///
+/// This test does NOT exercise the OSC ingestion path that the zsh fix actually
+/// modifies — `ShellCompletion` is constructed in `app/src/terminal/model/`
+/// against the `app` crate, which we don't depend on here. Instead, this test
+/// pins the contract that `filter_by_query` relies on: once the shell-side fix
+/// emits the full path as the replacement, the filter must retain it for a
+/// directory-prefix query, and a bare-basename replacement (the pre-fix OSC
+/// payload) must be dropped. If a future change to `filter_by_query` broke
+/// either invariant, the user-visible regression in #10358 would silently
+/// return.
+#[test]
+fn test_filter_by_query_retains_file_with_full_path_replacement_after_iprefix_fix() {
+    use super::{MatchedSuggestion, Suggestion, SuggestionResults};
+    use crate::completer::matchers::Match;
+    use crate::completer::EngineFileType;
+
+    let suggestion = Suggestion {
+        display: "file1.txt".into(),
+        replacement: "some/nested/folder1/file1.txt".into(),
+        description: None,
+        suggestion_type: SuggestionType::Argument,
+        override_icon: None,
+        priority: super::Priority::default(),
+        is_hidden: false,
+        file_type: Some(EngineFileType::File),
+        is_abbreviation: false,
+    };
+
+    let results = SuggestionResults {
+        replacement_span: crate::meta::Span::new(0, 0),
+        suggestions: vec![MatchedSuggestion::new(
+            suggestion,
+            Match::Prefix {
+                is_case_sensitive: true,
+            },
+        )],
+        match_strategy: MatchStrategy::CaseSensitive,
+    };
+
+    // The query ends with '/' — this is what Warp receives when the user has
+    // typed a directory path and zsh's _path_files sets IPREFIX to the prefix.
+    // With the fix applied the replacement starts with the query, so the
+    // candidate must NOT be filtered out.
+    let retained: Vec<String> = results
+        .filter_by_query("some/nested/folder1/", &['/'])
+        .map(|s| s.suggestion.display.to_string())
+        .collect();
+
+    assert_eq!(
+        retained,
+        vec![String::from("file1.txt")],
+        "file suggestion with full-path replacement must be retained when query \
+         is the directory prefix (regression for issue #10358)"
+    );
+
+    // Also verify that a bare-basename replacement (the pre-fix OSC payload) is
+    // correctly dropped so the test documents both sides of the regression.
+    let bare_suggestion = Suggestion {
+        display: "file1.txt".into(),
+        replacement: "file1.txt".into(), // pre-fix: no IPREFIX prepended
+        description: None,
+        suggestion_type: SuggestionType::Argument,
+        override_icon: None,
+        priority: super::Priority::default(),
+        is_hidden: false,
+        file_type: Some(EngineFileType::File),
+        is_abbreviation: false,
+    };
+
+    let bare_results = SuggestionResults {
+        replacement_span: crate::meta::Span::new(0, 0),
+        suggestions: vec![MatchedSuggestion::new(
+            bare_suggestion,
+            Match::Prefix {
+                is_case_sensitive: true,
+            },
+        )],
+        match_strategy: MatchStrategy::CaseSensitive,
+    };
+
+    let dropped: Vec<String> = bare_results
+        .filter_by_query("some/nested/folder1/", &['/'])
+        .map(|s| s.suggestion.display.to_string())
+        .collect();
+
+    assert!(
+        dropped.is_empty(),
+        "bare-basename replacement must be dropped when query contains path prefix \
+         (documents pre-fix behavior — once OSC always emits full path this check \
+         can be removed)"
+    );
+}
+
 #[test]
 fn test_matching_indices_for_git_branches() {
     let registry = create_test_command_registry([git_signature()]);


### PR DESCRIPTION
## Description

Fixes #10358. On macOS zsh, completing nested file paths silently fails: typing `git add some/nested/folder1/<TAB>` does not insert `file1.txt` even when it's the only file.

`app/assets/bundled/bootstrap/zsh_body.sh` overrides `compadd` to capture completion candidates and emit them via OSC `9280;C`. zsh's `_path_files` walks nested directories, accumulates the consumed prefix into `$IPREFIX`, and ends up calling `compadd file1.txt` (basename only). The override emitted only the basename, so the OSC payload was `file1.txt` while the user-typed token was `some/nested/folder1/`. The Rust suggestion filter could not prefix-match the basename against the slashy query and silently dropped the candidate.

The override already parsed compadd's `-p` hidden-prefix flag into `hpre` (line 1233) but never used it.

Fix: prepend `$IPREFIX` and `${hpre[-p]}` to the emitted match. Both expand to empty when not set, so plain command/option completion is unaffected.

```diff
-        local match="$__hits[$i]$dsuf"
+        local match="$IPREFIX${hpre[-p]}$__hits[$i]$dsuf"
```

Note on the `[-p]` key: `hpre` is declared with `typeset -A` (associative array), so `zparseopts ... p:=hpre` stores the `-p` argument under the literal `-p` key — not the numeric index `2` (that form only applies to plain arrays). An earlier revision of this PR used `${hpre[2]}`, which silently expanded to empty; the nested-path repro happened to work only because it routes through `$IPREFIX`. Any completion path relying on `compadd -p` would still have dropped the hidden prefix.

### Known trade-off

The OSC `C;` payload is currently mapped to both `display` and `replacement` (`Suggestion::with_same_display_and_replacement`), so the dropdown will now show the full path (e.g. `some/nested/folder1/file1.txt`) instead of just the basename. Functionality is restored; cleaner UX (basename in dropdown, full path on accept) would require sending display and replacement separately and is left as a follow-up.

## Linked Issue

Fixes #10358 (label: `ready-to-implement`).

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

Added a regression test in `crates/warp_completer/src/completer/suggest/test.rs` (`test_filter_by_query_retains_file_with_full_path_replacement_after_iprefix_fix`). It exercises `filter_by_query` with both the post-fix OSC payload (full path → retained) and the pre-fix payload (bare basename → dropped), pinning the filter contract that the shell-side fix relies on. Doc comment is explicit that this is a contract-level regression test, not E2E (the `ShellCompletion` ingestion path lives in the `app` crate).

```
$ cargo fmt -- --check                                            # clean
$ cargo clippy -p warp_completer --all-targets --tests -- -D warnings   # clean
$ cargo test -p warp_completer --lib suggest                      # 60 passed (incl. new test)
```

The 11 pre-existing `FeatureFlag::CloudEnvironments` panics in `crates/warp_features/src/lib.rs:988` reproduce on `master` and are unrelated to this change.

- [x] I have manually tested my changes locally with a local build (`ForceNativeShellCompletions=true`).

### Manual end-to-end verification

Built locally from this branch with `ForceNativeShellCompletions=true` (the native completion path the bootstrap fix lives in) and reproduced issue #10358 directly: in `/tmp/test10358`, typing `git add some/nested/folder1/<TAB>` now inserts the full path `some/nested/folder1/file1.txt` and the resulting block executes correctly.

https://github.com/user-attachments/assets/2086d4f0-3a5a-4ae5-b6cc-483a4406e93d

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fix zsh tab-completion failing to insert filenames inside nested directory paths


