### PR TITLE
Add remote codebase indexing stubs and proto definitions

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -461,14 +461,16 @@ impl LaunchMode {
         }
     }
 
-    /// Returns `true` if running in app mode or via `agent run` to permit codebase indexing.
+    /// Returns `true` if this process can build and sync codebase indices.
     fn supports_indexing(&self) -> bool {
         match self {
             LaunchMode::CommandLine { command, .. } => {
                 matches!(command, CliCommand::Agent(AgentCommand::Run { .. }))
             }
-            LaunchMode::App { .. } | LaunchMode::Test { .. } => true,
-            LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon { .. } => false,
+            LaunchMode::App { .. }
+            | LaunchMode::Test { .. }
+            | LaunchMode::RemoteServerDaemon { .. } => true,
+            LaunchMode::RemoteServerProxy => false,
         }
     }
 

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -21,14 +21,15 @@ use warp_util::file::FileId;
 use super::proto::{
     client_message, delete_file_response, resolve_conflict_response, run_command_response,
     save_buffer_response, server_message, write_file_response, Abort, Authenticate, BufferEdit,
-    BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexStatusesSnapshot, DeleteFile,
-    DeleteFileResponse, DeleteFileSuccess, ErrorCode, ErrorResponse, FailedFileRead,
-    FileContextProto, FileOperationError, Initialize, InitializeResponse, NavigatedToDirectory,
-    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextResponse,
-    ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess, RunCommandError,
-    RunCommandErrorCode, RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer,
-    SaveBufferResponse, SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, WriteFile,
-    WriteFileResponse, WriteFileSuccess,
+    BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexStatus, CodebaseIndexStatusState,
+    CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, DeleteFile, DeleteFileResponse,
+    DeleteFileSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead,
+    FileContextProto, FileOperationError, IndexCodebase, Initialize, InitializeResponse,
+    ListCodebaseIndexStatuses, NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer,
+    OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
+    ResolveConflictSuccess, RunCommandError, RunCommandErrorCode, RunCommandRequest,
+    RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess,
+    ServerMessage, SessionBootstrapped, TextEdit, WriteFile, WriteFileResponse, WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 
@@ -624,6 +625,15 @@ impl ServerModel {
             Some(client_message::Message::GetDiffState(_)) => return,
             Some(client_message::Message::UnsubscribeDiffState(_)) => return,
             Some(client_message::Message::DiscardFiles(_)) => return,
+            Some(client_message::Message::ListCodebaseIndexStatuses(
+                ListCodebaseIndexStatuses {},
+            )) => self.handle_list_codebase_index_statuses(&request_id, conn_id),
+            Some(client_message::Message::IndexCodebase(msg)) => {
+                self.handle_index_codebase(msg, &request_id, conn_id)
+            }
+            Some(client_message::Message::DropCodebaseIndex(msg)) => {
+                self.handle_drop_codebase_index(msg, &request_id, conn_id)
+            }
             None => {
                 log::warn!(
                     "Received ClientMessage with no message variant (request_id={request_id})"
@@ -661,8 +671,8 @@ impl ServerModel {
         let snapshot = self.codebase_index_statuses_snapshot();
         let status_count = snapshot.statuses.len();
         log::info!(
-            "Pushing codebase index statuses snapshot: conn_id={conn_id} \
-             status_count={status_count}"
+            "[Remote codebase indexing] Daemon pushing bootstrap codebase index statuses snapshot: \
+             conn_id={conn_id} bootstrap_status_count={status_count} source=placeholder_no_status_store"
         );
         self.send_server_message(
             Some(conn_id),
@@ -672,13 +682,62 @@ impl ServerModel {
     }
 
     fn codebase_index_statuses_snapshot(&self) -> CodebaseIndexStatusesSnapshot {
-        // PR1 has no canonical daemon-side codebase-indexing state yet, so
-        // the bootstrap snapshot is empty. Later PRs will populate this from
-        // the remote indexing manager rather than deriving status from
-        // navigation events.
+        // The daemon has identity-scoped SQLite available on startup, but this
+        // PR does not add remote-codebase-index status/cache tables or a
+        // daemon indexing manager consumer yet. The bootstrap snapshot is
+        // therefore empty until a later PR loads real status state from SQLite.
         CodebaseIndexStatusesSnapshot {
             statuses: Vec::new(),
         }
+    }
+
+    fn handle_list_codebase_index_statuses(
+        &self,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+    ) -> HandlerOutcome {
+        let snapshot = self.codebase_index_statuses_snapshot();
+        let status_count = snapshot.statuses.len();
+        log::info!(
+            "[Remote codebase indexing] Daemon handling ListCodebaseIndexStatuses: \
+             request_id={request_id} conn_id={conn_id} status_count={status_count}"
+        );
+        HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusesSnapshot(
+            snapshot,
+        ))
+    }
+
+    fn handle_index_codebase(
+        &self,
+        msg: IndexCodebase,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+    ) -> HandlerOutcome {
+        log::info!(
+            "[Remote codebase indexing] Daemon handling IndexCodebase placeholder: \
+             request_id={request_id} conn_id={conn_id} repo_path={} state={:?}",
+            msg.repo_path,
+            CodebaseIndexStatusState::Unavailable
+        );
+        HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
+            unavailable_codebase_index_status_update(msg.repo_path),
+        ))
+    }
+    fn handle_drop_codebase_index(
+        &self,
+        msg: DropCodebaseIndex,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+    ) -> HandlerOutcome {
+        log::info!(
+            "[Remote codebase indexing] Daemon handling DropCodebaseIndex placeholder: \
+             request_id={request_id} conn_id={conn_id} repo_path={} state={:?}",
+            msg.repo_path,
+            CodebaseIndexStatusState::Unavailable
+        );
+        HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
+            unavailable_codebase_index_status_update(msg.repo_path),
+        ))
     }
 
     /// Routes a server message to its destination.
@@ -1545,6 +1604,21 @@ impl ServerModel {
     }
 }
 
+fn unavailable_codebase_index_status_update(repo_path: String) -> CodebaseIndexStatusUpdated {
+    CodebaseIndexStatusUpdated {
+        status: Some(CodebaseIndexStatus {
+            repo_path,
+            state: CodebaseIndexStatusState::Unavailable.into(),
+            last_updated_epoch_millis: None,
+            progress_completed: None,
+            progress_total: None,
+            failure_message: None,
+            root_hash: None,
+            embedding_model: None,
+            embedding_dimensions: None,
+        }),
+    }
+}
 /// Converts a [`ReadFileContextResult`] into its protobuf equivalent.
 fn file_context_result_to_proto(result: ReadFileContextResult) -> ReadFileContextResponse {
     use crate::ai::agent::AnyFileContent;

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -4,32 +4,42 @@ use repo_metadata::{RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use warp_core::SessionId;
 use warp_core::channel::ChannelState;
 use warp_core::safe_error;
-use warp_core::SessionId;
 use warp_util::standardized_path::StandardizedPath;
-use warpui::platform::TerminationMode;
 use warpui::r#async::{Spawnable, SpawnableOutput, SpawnedFutureHandle};
+use warpui::platform::TerminationMode;
 use warpui::{Entity, ModelContext, SingletonEntity};
 
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
+use ::ai::index::full_source_code_embedding::manager::{
+    CodebaseIndexFinishedStatus, CodebaseIndexManager, CodebaseIndexManagerEvent,
+};
+use ::ai::index::full_source_code_embedding::{
+    ContentHash, EmbeddingConfig, NodeHash, SyncProgress,
+};
 use warp_files::{FileModel, FileModelEvent};
 use warp_util::content_version::ContentVersion;
 use warp_util::file::FileId;
 
 use super::proto::{
+    Abort, Authenticate, BufferEdit, BufferUpdatedPush, ClientMessage, CloseBuffer,
+    CodebaseIndexStatus, CodebaseIndexStatusState, CodebaseIndexStatusUpdated,
+    CodebaseIndexStatusesSnapshot, DeleteFile, DeleteFileResponse, DeleteFileSuccess,
+    DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead, FileContextProto,
+    FileOperationError, FragmentMetadata, GetFragmentMetadataFromHash,
+    GetFragmentMetadataFromHashResponse, IndexCodebase, Initialize, InitializeResponse,
+    MissingFragmentMetadata, NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer,
+    OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
+    ResolveConflictSuccess, RunCommandError, RunCommandErrorCode, RunCommandRequest,
+    RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess,
+    ServerMessage, SessionBootstrapped, TextEdit, WriteFile, WriteFileResponse, WriteFileSuccess,
     client_message, delete_file_response, resolve_conflict_response, run_command_response,
-    save_buffer_response, server_message, write_file_response, Abort, Authenticate, BufferEdit,
-    BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexStatus, CodebaseIndexStatusState,
-    CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, DeleteFile, DeleteFileResponse,
-    DeleteFileSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead,
-    FileContextProto, FileOperationError, IndexCodebase, Initialize, InitializeResponse,
-    NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse,
-    ReadFileContextResponse, ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess,
-    RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse, RunCommandSuccess,
-    SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage, SessionBootstrapped,
-    TextEdit, WriteFile, WriteFileResponse, WriteFileSuccess,
+    save_buffer_response, server_message, write_file_response,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 
@@ -40,7 +50,7 @@ pub const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10 
 pub type ConnectionId = uuid::Uuid;
 use super::protocol::RequestId;
 use crate::ai::agent::FileLocations;
-use crate::ai::blocklist::{read_local_file_context, ReadFileContextResult};
+use crate::ai::blocklist::{ReadFileContextResult, read_local_file_context};
 use crate::auth::auth_state::{AuthState, AuthStateProvider};
 use crate::terminal::model::session::command_executor::{
     ExecuteCommandOptions, LocalCommandExecutor,
@@ -178,6 +188,8 @@ pub struct ServerModel {
     /// Tracks open buffers, per-buffer connection sets, and pending async
     /// buffer requests (OpenBuffer, SaveBuffer).
     buffers: ServerBufferTracker,
+    /// Minimal in-memory remote codebase index status map for the daemon E2E path.
+    codebase_index_statuses: HashMap<PathBuf, CodebaseIndexStatus>,
 }
 
 impl Entity for ServerModel {
@@ -204,6 +216,7 @@ impl ServerModel {
             pending_file_ops: PendingFileOps::new(),
             auth_state: AuthStateProvider::as_ref(ctx).get().clone(),
             buffers: ServerBufferTracker::new(),
+            codebase_index_statuses: HashMap::new(),
         };
         // Subscribe to FileModel and RepoMetadataModel events
         // file operation results and repo metadata pushes are forwarded to all
@@ -475,6 +488,19 @@ impl ServerModel {
                 }
             });
         }
+        {
+            let codebase_index_manager = CodebaseIndexManager::handle(ctx);
+            ctx.subscribe_to_model(&codebase_index_manager, |me, event, ctx| match event {
+                CodebaseIndexManagerEvent::SyncStateUpdated
+                | CodebaseIndexManagerEvent::IndexMetadataUpdated { .. }
+                | CodebaseIndexManagerEvent::NewIndexCreated => {
+                    me.push_current_codebase_index_statuses(ctx);
+                }
+                CodebaseIndexManagerEvent::RetrievalRequestCompleted { .. }
+                | CodebaseIndexManagerEvent::RetrievalRequestFailed { .. }
+                | CodebaseIndexManagerEvent::RemoveExpiredIndexMetadata { .. } => {}
+            });
+        }
         // Start the grace timer immediately so the daemon exits if no proxy
         // connects within GRACE_PERIOD. In practice the spawning proxy connects
         // within milliseconds, so the risk of premature shutdown is negligible;
@@ -626,10 +652,13 @@ impl ServerModel {
             Some(client_message::Message::UnsubscribeDiffState(_)) => return,
             Some(client_message::Message::DiscardFiles(_)) => return,
             Some(client_message::Message::IndexCodebase(msg)) => {
-                self.handle_index_codebase(msg, &request_id, conn_id)
+                self.handle_index_codebase(msg, &request_id, conn_id, ctx)
             }
             Some(client_message::Message::DropCodebaseIndex(msg)) => {
-                self.handle_drop_codebase_index(msg, &request_id, conn_id)
+                self.handle_drop_codebase_index(msg, &request_id, conn_id, ctx)
+            }
+            Some(client_message::Message::GetFragmentMetadataFromHash(msg)) => {
+                self.handle_get_fragment_metadata_from_hash(msg, &request_id, conn_id, ctx)
             }
             None => {
                 log::warn!(
@@ -649,7 +678,7 @@ impl ServerModel {
                     Some(&request_id),
                     server_message::Message::InitializeResponse(response),
                 );
-                self.push_codebase_index_statuses_snapshot(conn_id);
+                self.push_codebase_index_statuses_snapshot(conn_id, ctx);
             }
             HandlerOutcome::Sync(message) => {
                 self.send_server_message(Some(conn_id), Some(&request_id), message);
@@ -664,12 +693,17 @@ impl ServerModel {
         }
     }
 
-    fn push_codebase_index_statuses_snapshot(&self, conn_id: ConnectionId) {
+    fn push_codebase_index_statuses_snapshot(
+        &mut self,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.refresh_current_codebase_index_statuses(ctx);
         let snapshot = self.codebase_index_statuses_snapshot();
         let status_count = snapshot.statuses.len();
         log::info!(
             "[Remote codebase indexing] Daemon pushing bootstrap codebase index statuses snapshot: \
-             conn_id={conn_id} bootstrap_status_count={status_count} source=placeholder_no_status_store"
+             conn_id={conn_id} bootstrap_status_count={status_count} source=in_memory"
         );
         self.send_server_message(
             Some(conn_id),
@@ -679,46 +713,381 @@ impl ServerModel {
     }
 
     fn codebase_index_statuses_snapshot(&self) -> CodebaseIndexStatusesSnapshot {
-        // The daemon has identity-scoped SQLite available on startup, but this
-        // PR does not add remote-codebase-index status/cache tables or a
-        // daemon indexing manager consumer yet. The bootstrap snapshot is
-        // therefore empty until a later PR loads real status state from SQLite.
-        CodebaseIndexStatusesSnapshot {
-            statuses: Vec::new(),
-        }
+        let mut statuses = self
+            .codebase_index_statuses
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        statuses.sort_by(|a, b| a.repo_path.cmp(&b.repo_path));
+        CodebaseIndexStatusesSnapshot { statuses }
     }
 
     fn handle_index_codebase(
-        &self,
+        &mut self,
         msg: IndexCodebase,
         request_id: &RequestId,
         conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
     ) -> HandlerOutcome {
+        let IndexCodebase {
+            repo_path,
+            auth_token,
+        } = msg;
+        let repo_path_for_log = repo_path.clone();
+        if auth_token.is_empty() {
+            let status = failed_codebase_index_status(
+                repo_path,
+                "Missing authentication credentials for remote codebase indexing".to_string(),
+            );
+            self.upsert_codebase_index_status_from_proto(status.clone());
+            self.broadcast_codebase_index_status(status.clone());
+            return HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
+                CodebaseIndexStatusUpdated {
+                    status: Some(status),
+                },
+            ));
+        }
+
+        self.auth_state.set_remote_server_bearer_token(auth_token);
+
+        let repo_path = match canonicalize_repo_path(&repo_path) {
+            Ok(repo_path) => repo_path,
+            Err(error) => {
+                let status = failed_codebase_index_status(repo_path, error);
+                self.upsert_codebase_index_status_from_proto(status.clone());
+                self.broadcast_codebase_index_status(status.clone());
+                return HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
+                    CodebaseIndexStatusUpdated {
+                        status: Some(status),
+                    },
+                ));
+            }
+        };
         log::info!(
-            "[Remote codebase indexing] Daemon handling IndexCodebase placeholder: \
+            "[Remote codebase indexing] Daemon handling IndexCodebase: \
              request_id={request_id} conn_id={conn_id} repo_path={} state={:?}",
-            msg.repo_path,
-            CodebaseIndexStatusState::Unavailable
+            repo_path_for_log,
+            CodebaseIndexStatusState::Queued
         );
+
+        let status = queued_codebase_index_status(repo_path.to_string_lossy().to_string());
+        self.upsert_codebase_index_status(repo_path.clone(), status.clone());
+        self.broadcast_codebase_index_status(status.clone());
+
+        CodebaseIndexManager::handle(ctx).update(ctx, |manager, ctx| {
+            if manager.root_path_for_codebase(&repo_path).is_some() {
+                manager.try_manual_resync_codebase(&repo_path, ctx);
+            } else {
+                manager.index_directory(repo_path, ctx);
+            }
+        });
+
         HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
-            unavailable_codebase_index_status_update(msg.repo_path),
+            CodebaseIndexStatusUpdated {
+                status: Some(status),
+            },
         ))
     }
+
     fn handle_drop_codebase_index(
-        &self,
+        &mut self,
         msg: DropCodebaseIndex,
         request_id: &RequestId,
         conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        let DropCodebaseIndex {
+            repo_path,
+            auth_token,
+        } = msg;
+        if auth_token.is_empty() {
+            let status = failed_codebase_index_status(
+                repo_path,
+                "Missing authentication credentials for remote codebase index removal".to_string(),
+            );
+            self.upsert_codebase_index_status_from_proto(status.clone());
+            self.broadcast_codebase_index_status(status.clone());
+            return HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
+                CodebaseIndexStatusUpdated {
+                    status: Some(status),
+                },
+            ));
+        }
+
+        self.auth_state.set_remote_server_bearer_token(auth_token);
+
+        let repo_path = match canonicalize_repo_path(&repo_path) {
+            Ok(repo_path) => repo_path,
+            Err(error) => {
+                let status = failed_codebase_index_status(repo_path, error);
+                self.upsert_codebase_index_status_from_proto(status.clone());
+                self.broadcast_codebase_index_status(status.clone());
+                return HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
+                    CodebaseIndexStatusUpdated {
+                        status: Some(status),
+                    },
+                ));
+            }
+        };
+        log::info!(
+            "[Remote codebase indexing] Daemon handling DropCodebaseIndex: \
+             request_id={request_id} conn_id={conn_id} repo_path={} state={:?}",
+            repo_path.display(),
+            CodebaseIndexStatusState::Disabled
+        );
+        CodebaseIndexManager::handle(ctx).update(ctx, |manager, ctx| {
+            manager.drop_index(repo_path.clone(), ctx);
+        });
+
+        let status = disabled_codebase_index_status(repo_path.to_string_lossy().to_string());
+        self.upsert_codebase_index_status(repo_path, status.clone());
+        self.broadcast_codebase_index_status(status.clone());
+
+        HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
+            CodebaseIndexStatusUpdated {
+                status: Some(status),
+            },
+        ))
+    }
+
+    fn handle_get_fragment_metadata_from_hash(
+        &mut self,
+        msg: GetFragmentMetadataFromHash,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
     ) -> HandlerOutcome {
         log::info!(
-            "[Remote codebase indexing] Daemon handling DropCodebaseIndex placeholder: \
-             request_id={request_id} conn_id={conn_id} repo_path={} state={:?}",
+            "[Remote codebase indexing] Daemon handling GetFragmentMetadataFromHash: \
+             request_id={request_id} conn_id={conn_id} repo_path={} hash_count={}",
             msg.repo_path,
-            CodebaseIndexStatusState::Unavailable
+            msg.content_hashes.len()
         );
-        HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
-            unavailable_codebase_index_status_update(msg.repo_path),
-        ))
+
+        let repo_path = match canonicalize_repo_path(&msg.repo_path) {
+            Ok(repo_path) => repo_path,
+            Err(error) => {
+                return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                    code: ErrorCode::InvalidRequest.into(),
+                    message: error,
+                }));
+            }
+        };
+
+        let requested_root_hash = match NodeHash::from_str(&msg.root_hash) {
+            Ok(root_hash) => root_hash,
+            Err(error) => {
+                return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                    code: ErrorCode::InvalidRequest.into(),
+                    message: format!("Invalid root_hash: {error}"),
+                }));
+            }
+        };
+
+        let current_status = self.codebase_index_status_from_manager(&repo_path, ctx);
+        let Some(current_status) = current_status else {
+            return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                code: ErrorCode::InvalidRequest.into(),
+                message: format!(
+                    "No ready or stale codebase index for repo {}",
+                    repo_path.display()
+                ),
+            }));
+        };
+        if current_status.state != CodebaseIndexStatusState::Ready as i32
+            && current_status.state != CodebaseIndexStatusState::Stale as i32
+        {
+            return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                code: ErrorCode::InvalidRequest.into(),
+                message: format!(
+                    "Codebase index for repo {} is not ready for metadata lookup",
+                    repo_path.display()
+                ),
+            }));
+        }
+
+        let current_metadata = CodebaseIndexManager::handle(ctx)
+            .as_ref(ctx)
+            .synced_index_metadata_for_path(&repo_path, ctx);
+        let Some(current_metadata) = current_metadata else {
+            return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                code: ErrorCode::InvalidRequest.into(),
+                message: format!(
+                    "No ready or stale codebase index for repo {}",
+                    repo_path.display()
+                ),
+            }));
+        };
+        if current_metadata.root_hash != requested_root_hash {
+            return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                code: ErrorCode::InvalidRequest.into(),
+                message: "Requested root_hash does not match the repo's ready index".to_string(),
+            }));
+        }
+
+        let mut requested_hashes = Vec::with_capacity(msg.content_hashes.len());
+        for content_hash in &msg.content_hashes {
+            match ContentHash::from_str(content_hash) {
+                Ok(hash) => requested_hashes.push(hash),
+                Err(error) => {
+                    return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                        code: ErrorCode::InvalidRequest.into(),
+                        message: format!("Invalid content hash {content_hash}: {error}"),
+                    }));
+                }
+            }
+        }
+
+        let fragment_metadatas = match CodebaseIndexManager::handle(ctx)
+            .as_ref(ctx)
+            .fragment_metadata_for_hashes(&repo_path, &requested_hashes, ctx)
+        {
+            Ok(fragment_metadatas) => fragment_metadatas,
+            Err(error) => {
+                return HandlerOutcome::Sync(server_message::Message::Error(ErrorResponse {
+                    code: ErrorCode::InvalidRequest.into(),
+                    message: format!("Failed to map fragment metadata: {error}"),
+                }));
+            }
+        };
+
+        let found_hashes = fragment_metadatas
+            .iter()
+            .map(|metadata| metadata.content_hash.to_string())
+            .collect::<HashSet<_>>();
+        let fragments = fragment_metadatas
+            .into_iter()
+            .map(|metadata| FragmentMetadata {
+                content_hash: metadata.content_hash.to_string(),
+                path: metadata.absolute_path.to_string_lossy().to_string(),
+                start_line: metadata.start_line as u32,
+                end_line: metadata.end_line as u32,
+                byte_start: metadata.byte_start as u64,
+                byte_end: metadata.byte_end as u64,
+            })
+            .collect();
+        let missing_hashes = msg
+            .content_hashes
+            .into_iter()
+            .filter(|content_hash| !found_hashes.contains(content_hash))
+            .map(|content_hash| MissingFragmentMetadata {
+                content_hash,
+                error: Some(FileOperationError {
+                    message: "Content hash is not present in the ready repo snapshot".to_string(),
+                }),
+            })
+            .collect();
+
+        HandlerOutcome::Sync(
+            server_message::Message::GetFragmentMetadataFromHashResponse(
+                GetFragmentMetadataFromHashResponse {
+                    fragments,
+                    missing_hashes,
+                },
+            ),
+        )
+    }
+
+    fn refresh_current_codebase_index_statuses(&mut self, ctx: &mut ModelContext<Self>) {
+        let paths = CodebaseIndexManager::handle(ctx)
+            .as_ref(ctx)
+            .get_codebase_paths()
+            .cloned()
+            .collect::<Vec<_>>();
+        for path in paths {
+            if let Some(status) = self.codebase_index_status_from_manager(&path, ctx) {
+                self.upsert_codebase_index_status(path, status);
+            }
+        }
+    }
+
+    fn push_current_codebase_index_statuses(&mut self, ctx: &mut ModelContext<Self>) {
+        let paths = CodebaseIndexManager::handle(ctx)
+            .as_ref(ctx)
+            .get_codebase_paths()
+            .cloned()
+            .collect::<Vec<_>>();
+        for path in paths {
+            if let Some(status) = self.codebase_index_status_from_manager(&path, ctx) {
+                self.upsert_codebase_index_status(path, status.clone());
+                self.broadcast_codebase_index_status(status);
+            }
+        }
+    }
+
+    fn codebase_index_status_from_manager(
+        &self,
+        repo_path: &Path,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<CodebaseIndexStatus> {
+        let manager = CodebaseIndexManager::handle(ctx);
+        let status = manager
+            .as_ref(ctx)
+            .get_codebase_index_status_for_path(repo_path, ctx)?;
+        let synced_metadata = manager
+            .as_ref(ctx)
+            .synced_index_metadata_for_path(repo_path, ctx);
+
+        let (root_hash, embedding_model, embedding_dimensions) =
+            synced_metadata.map_or((None, None, None), |metadata| {
+                let (model, dimensions) = embedding_config_proto_fields(metadata.embedding_config);
+                (
+                    Some(metadata.root_hash.to_string()),
+                    Some(model.to_string()),
+                    Some(dimensions),
+                )
+            });
+
+        let (state, failure_message) = if status.has_pending() {
+            if status.has_synced_version() {
+                (CodebaseIndexStatusState::Stale, None)
+            } else {
+                (CodebaseIndexStatusState::Indexing, None)
+            }
+        } else {
+            match status.last_sync_result() {
+                Some(CodebaseIndexFinishedStatus::Completed) => {
+                    (CodebaseIndexStatusState::Ready, None)
+                }
+                Some(CodebaseIndexFinishedStatus::Failed(error)) => {
+                    (CodebaseIndexStatusState::Failed, Some(error.to_string()))
+                }
+                None => (CodebaseIndexStatusState::Queued, None),
+            }
+        };
+
+        let (progress_completed, progress_total) = progress_proto_fields(status.sync_progress());
+        Some(CodebaseIndexStatus {
+            repo_path: repo_path.to_string_lossy().to_string(),
+            state: state.into(),
+            last_updated_epoch_millis: Some(current_epoch_millis()),
+            progress_completed,
+            progress_total,
+            failure_message,
+            root_hash,
+            embedding_model,
+            embedding_dimensions,
+        })
+    }
+
+    fn upsert_codebase_index_status(&mut self, repo_path: PathBuf, status: CodebaseIndexStatus) {
+        self.codebase_index_statuses.insert(repo_path, status);
+    }
+
+    fn upsert_codebase_index_status_from_proto(&mut self, status: CodebaseIndexStatus) {
+        let repo_path = dunce::canonicalize(Path::new(&status.repo_path))
+            .unwrap_or_else(|_| PathBuf::from(&status.repo_path));
+        self.upsert_codebase_index_status(repo_path, status);
+    }
+
+    fn broadcast_codebase_index_status(&self, status: CodebaseIndexStatus) {
+        self.send_server_message(
+            None,
+            None,
+            server_message::Message::CodebaseIndexStatusUpdated(CodebaseIndexStatusUpdated {
+                status: Some(status),
+            }),
+        );
     }
 
     /// Routes a server message to its destination.
@@ -1585,21 +1954,74 @@ impl ServerModel {
     }
 }
 
-fn unavailable_codebase_index_status_update(repo_path: String) -> CodebaseIndexStatusUpdated {
-    CodebaseIndexStatusUpdated {
-        status: Some(CodebaseIndexStatus {
-            repo_path,
-            state: CodebaseIndexStatusState::Unavailable.into(),
-            last_updated_epoch_millis: None,
-            progress_completed: None,
-            progress_total: None,
-            failure_message: None,
-            root_hash: None,
-            embedding_model: None,
-            embedding_dimensions: None,
-        }),
+fn canonicalize_repo_path(repo_path: &str) -> Result<PathBuf, String> {
+    if repo_path.is_empty() {
+        return Err("repo_path is required".to_string());
+    }
+
+    dunce::canonicalize(Path::new(repo_path))
+        .map_err(|error| format!("Invalid repo_path {repo_path}: {error}"))
+}
+
+fn current_epoch_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+fn queued_codebase_index_status(repo_path: String) -> CodebaseIndexStatus {
+    base_codebase_index_status(repo_path, CodebaseIndexStatusState::Queued)
+}
+
+fn disabled_codebase_index_status(repo_path: String) -> CodebaseIndexStatus {
+    base_codebase_index_status(repo_path, CodebaseIndexStatusState::Disabled)
+}
+
+fn failed_codebase_index_status(repo_path: String, failure_message: String) -> CodebaseIndexStatus {
+    CodebaseIndexStatus {
+        failure_message: Some(failure_message),
+        ..base_codebase_index_status(repo_path, CodebaseIndexStatusState::Failed)
     }
 }
+
+fn base_codebase_index_status(
+    repo_path: String,
+    state: CodebaseIndexStatusState,
+) -> CodebaseIndexStatus {
+    CodebaseIndexStatus {
+        repo_path,
+        state: state.into(),
+        last_updated_epoch_millis: Some(current_epoch_millis()),
+        progress_completed: None,
+        progress_total: None,
+        failure_message: None,
+        root_hash: None,
+        embedding_model: None,
+        embedding_dimensions: None,
+    }
+}
+
+fn embedding_config_proto_fields(config: EmbeddingConfig) -> (&'static str, u32) {
+    match config {
+        EmbeddingConfig::OpenAiTextSmall3_256 => ("OPENAI_TEXT_SMALL_3_256", 256),
+        EmbeddingConfig::VoyageCode3_512 => ("VOYAGE_CODE_3_512", 512),
+        EmbeddingConfig::Voyage3_5_Lite_512 => ("VOYAGE_3_5_LITE_512", 512),
+        EmbeddingConfig::Voyage3_5_512 => ("VOYAGE_3_5_512", 512),
+    }
+}
+
+fn progress_proto_fields(progress: Option<&SyncProgress>) -> (Option<u64>, Option<u64>) {
+    match progress {
+        Some(SyncProgress::Discovering { total_nodes }) => (Some(0), Some(*total_nodes as u64)),
+        Some(SyncProgress::Syncing {
+            completed_nodes,
+            total_nodes,
+        }) => (Some(*completed_nodes as u64), Some(*total_nodes as u64)),
+        None => (None, None),
+    }
+}
+
 /// Converts a [`ReadFileContextResult`] into its protobuf equivalent.
 fn file_context_result_to_proto(result: ReadFileContextResult) -> ReadFileContextResponse {
     use crate::ai::agent::AnyFileContent;

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -25,11 +25,11 @@ use super::proto::{
     CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, DeleteFile, DeleteFileResponse,
     DeleteFileSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead,
     FileContextProto, FileOperationError, IndexCodebase, Initialize, InitializeResponse,
-    ListCodebaseIndexStatuses, NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer,
-    OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
-    ResolveConflictSuccess, RunCommandError, RunCommandErrorCode, RunCommandRequest,
-    RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess,
-    ServerMessage, SessionBootstrapped, TextEdit, WriteFile, WriteFileResponse, WriteFileSuccess,
+    NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse,
+    ReadFileContextResponse, ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess,
+    RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse, RunCommandSuccess,
+    SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage, SessionBootstrapped,
+    TextEdit, WriteFile, WriteFileResponse, WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 
@@ -625,9 +625,6 @@ impl ServerModel {
             Some(client_message::Message::GetDiffState(_)) => return,
             Some(client_message::Message::UnsubscribeDiffState(_)) => return,
             Some(client_message::Message::DiscardFiles(_)) => return,
-            Some(client_message::Message::ListCodebaseIndexStatuses(
-                ListCodebaseIndexStatuses {},
-            )) => self.handle_list_codebase_index_statuses(&request_id, conn_id),
             Some(client_message::Message::IndexCodebase(msg)) => {
                 self.handle_index_codebase(msg, &request_id, conn_id)
             }
@@ -689,22 +686,6 @@ impl ServerModel {
         CodebaseIndexStatusesSnapshot {
             statuses: Vec::new(),
         }
-    }
-
-    fn handle_list_codebase_index_statuses(
-        &self,
-        request_id: &RequestId,
-        conn_id: ConnectionId,
-    ) -> HandlerOutcome {
-        let snapshot = self.codebase_index_statuses_snapshot();
-        let status_count = snapshot.statuses.len();
-        log::info!(
-            "[Remote codebase indexing] Daemon handling ListCodebaseIndexStatuses: \
-             request_id={request_id} conn_id={conn_id} status_count={status_count}"
-        );
-        HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusesSnapshot(
-            snapshot,
-        ))
     }
 
     fn handle_index_codebase(

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -17,6 +17,7 @@ fn test_model() -> ServerModel {
         pending_file_ops: PendingFileOps::new(),
         auth_state: Arc::new(AuthState::new_logged_out_for_test()),
         buffers: ServerBufferTracker::new(),
+        codebase_index_statuses: HashMap::new(),
     }
 }
 

--- a/crates/ai/src/index/full_source_code_embedding/codebase_index.rs
+++ b/crates/ai/src/index/full_source_code_embedding/codebase_index.rs
@@ -16,7 +16,8 @@ use super::{
     merkle_tree::{MerkleTree, SerializedCodebaseIndex},
     store_client::StoreClient,
     sync_client::{FlushFragmentResult, SyncOperationError},
-    CodebaseContextConfig, ContentHash, EmbeddingConfig, Error, Fragment, NodeHash, RepoMetadata,
+    CodebaseContextConfig, CodebaseFragmentMetadata, ContentHash, EmbeddingConfig, Error,
+    Fragment, NodeHash, RepoMetadata, SyncedIndexMetadata,
 };
 use crate::{
     index::locations::{CodeContextLocation, FileFragmentLocation},
@@ -1326,6 +1327,35 @@ impl CodebaseIndex {
 
     fn embedding_config(&self) -> EmbeddingConfig {
         self.embedding_config
+    }
+
+    pub(super) fn synced_index_metadata(&self) -> Option<SyncedIndexMetadata> {
+        Some(SyncedIndexMetadata {
+            root_hash: self.last_server_synced_root_node()?,
+            embedding_config: self.embedding_config(),
+        })
+    }
+
+    pub(super) fn fragment_metadata_for_hashes(
+        &self,
+        hashes: &[ContentHash],
+    ) -> Vec<CodebaseFragmentMetadata> {
+        hashes
+            .iter()
+            .flat_map(|hash| {
+                self.fragment_metadatas_from_hash(hash)
+                    .into_iter()
+                    .flatten()
+                    .map(|metadata| CodebaseFragmentMetadata {
+                        content_hash: hash.clone(),
+                        absolute_path: metadata.absolute_path.clone(),
+                        start_line: metadata.location.start_line,
+                        end_line: metadata.location.end_line,
+                        byte_start: metadata.location.byte_range.start.as_usize(),
+                        byte_end: metadata.location.byte_range.end.as_usize(),
+                    })
+            })
+            .collect()
     }
 
     pub(super) fn update_embedding_generation_batch_size(&mut self, new_batch_size: usize) {

--- a/crates/ai/src/index/full_source_code_embedding/manager.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager.rs
@@ -35,7 +35,8 @@ use super::{
     priority_queue::{BuildQueue, Priority},
     snapshot::*,
     store_client::StoreClient,
-    CodebaseIndex, EmbeddingConfig, Error as CodebaseIndexError, NodeHash,
+    CodebaseFragmentMetadata, CodebaseIndex, EmbeddingConfig, Error as CodebaseIndexError,
+    NodeHash, SyncedIndexMetadata,
 };
 
 use crate::{
@@ -888,6 +889,32 @@ impl CodebaseIndexManager {
 
     #[cfg(not(feature = "local_fs"))]
     pub fn try_manual_resync_codebase(&self, _repo_path: &Path, _ctx: &mut ModelContext<Self>) {}
+
+    pub fn synced_index_metadata_for_path<'a>(
+        &'a self,
+        root_path: &Path,
+        app: &'a AppContext,
+    ) -> Option<SyncedIndexMetadata> {
+        let root_path = dunce::canonicalize(root_path).unwrap_or_else(|_| root_path.to_path_buf());
+        self.codebase_indices
+            .get(&root_path)
+            .and_then(|codebase_index| codebase_index.as_ref(app).synced_index_metadata())
+    }
+
+    pub fn fragment_metadata_for_hashes(
+        &self,
+        root_path: &Path,
+        hashes: &[ContentHash],
+        app: &AppContext,
+    ) -> Result<Vec<CodebaseFragmentMetadata>, RetrieveFileError> {
+        let Ok((codebase_index, _)) = self.get_codebase_index_internal(root_path) else {
+            return Err(RetrieveFileError::IndexNotFound);
+        };
+
+        Ok(codebase_index
+            .as_ref(app)
+            .fragment_metadata_for_hashes(hashes))
+    }
 
     pub fn retrieve_relevant_files(
         &self,

--- a/crates/ai/src/index/full_source_code_embedding/manager.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager.rs
@@ -30,13 +30,13 @@ use warp_core::safe_anyhow;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 
 use super::{
+    CodebaseFragmentMetadata, CodebaseIndex, ContentHash, EmbeddingConfig,
+    Error as CodebaseIndexError, NodeHash, SyncedIndexMetadata,
     codebase_index::{CodebaseIndexEvent, RetrievalID, SyncProgress},
     fragment_metadata::FragmentMetadata,
     priority_queue::{BuildQueue, Priority},
     snapshot::*,
     store_client::StoreClient,
-    CodebaseFragmentMetadata, CodebaseIndex, EmbeddingConfig, Error as CodebaseIndexError,
-    NodeHash, SyncedIndexMetadata,
 };
 
 use crate::{

--- a/crates/ai/src/index/full_source_code_embedding/mod.rs
+++ b/crates/ai/src/index/full_source_code_embedding/mod.rs
@@ -148,6 +148,22 @@ pub struct CodebaseContextConfig {
     pub embedding_cadence: Duration,
 }
 
+#[derive(Clone, Debug)]
+pub struct SyncedIndexMetadata {
+    pub root_hash: NodeHash,
+    pub embedding_config: EmbeddingConfig,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CodebaseFragmentMetadata {
+    pub content_hash: ContentHash,
+    pub absolute_path: PathBuf,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub byte_start: usize,
+    pub byte_end: usize,
+}
+
 #[derive(Clone)]
 pub struct FragmentLocation {
     absolute_path: PathBuf,

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -34,6 +34,9 @@ message ClientMessage {
     GetDiffState get_diff_state = 18;
     UnsubscribeDiffState unsubscribe_diff_state = 19;
     DiscardFilesRequest discard_files = 20;
+    ListCodebaseIndexStatuses list_codebase_index_statuses = 21;
+    IndexCodebase index_codebase = 22;
+    DropCodebaseIndex drop_codebase_index = 23;
   }
 }
 // Top-level envelope for all server → client messages.
@@ -327,17 +330,40 @@ message FileContextProto {
 }
 
 // ── Remote codebase indexing status ───────────────────────────────
+message ListCodebaseIndexStatuses {}
+
+message IndexCodebase {
+  string repo_path = 1;
+  string auth_token = 2;
+}
+
+message DropCodebaseIndex {
+  string repo_path = 1;
+  string auth_token = 2;
+}
 
 enum CodebaseIndexStatusState {
   CODEBASE_INDEX_STATUS_STATE_UNSPECIFIED = 0;
   CODEBASE_INDEX_STATUS_STATE_NOT_ENABLED = 1;
   CODEBASE_INDEX_STATUS_STATE_UNAVAILABLE = 2;
+  CODEBASE_INDEX_STATUS_STATE_DISABLED = 3;
+  CODEBASE_INDEX_STATUS_STATE_QUEUED = 4;
+  CODEBASE_INDEX_STATUS_STATE_INDEXING = 5;
+  CODEBASE_INDEX_STATUS_STATE_READY = 6;
+  CODEBASE_INDEX_STATUS_STATE_STALE = 7;
+  CODEBASE_INDEX_STATUS_STATE_FAILED = 8;
 }
 
 message CodebaseIndexStatus {
   string repo_path = 1;
   CodebaseIndexStatusState state = 2;
   optional uint64 last_updated_epoch_millis = 3;
+  optional uint64 progress_completed = 4;
+  optional uint64 progress_total = 5;
+  optional string failure_message = 6;
+  optional string root_hash = 7;
+  optional string embedding_model = 8;
+  optional uint32 embedding_dimensions = 9;
 }
 
 message CodebaseIndexStatusesSnapshot {

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -34,9 +34,9 @@ message ClientMessage {
     GetDiffState get_diff_state = 18;
     UnsubscribeDiffState unsubscribe_diff_state = 19;
     DiscardFilesRequest discard_files = 20;
-    ListCodebaseIndexStatuses list_codebase_index_statuses = 21;
-    IndexCodebase index_codebase = 22;
-    DropCodebaseIndex drop_codebase_index = 23;
+    IndexCodebase index_codebase = 21;
+    DropCodebaseIndex drop_codebase_index = 22;
+    GetFragmentMetadataFromHash get_fragment_metadata_from_hash = 23;
   }
 }
 // Top-level envelope for all server → client messages.
@@ -66,6 +66,7 @@ message ServerMessage {
     DiffStateMetadataUpdate diff_state_metadata_update = 20;
     DiffStateFileDelta diff_state_file_delta = 21;
     DiscardFilesResponse discard_files_response = 22;
+    GetFragmentMetadataFromHashResponse get_fragment_metadata_from_hash_response = 23;
   }
 }
 
@@ -330,7 +331,6 @@ message FileContextProto {
 }
 
 // ── Remote codebase indexing status ───────────────────────────────
-message ListCodebaseIndexStatuses {}
 
 message IndexCodebase {
   string repo_path = 1;
@@ -340,6 +340,31 @@ message IndexCodebase {
 message DropCodebaseIndex {
   string repo_path = 1;
   string auth_token = 2;
+}
+
+message GetFragmentMetadataFromHash {
+  string repo_path = 1;
+  string root_hash = 2;
+  repeated string content_hashes = 3;
+}
+
+message FragmentMetadata {
+  string content_hash = 1;
+  string path = 2;
+  uint32 start_line = 3;
+  uint32 end_line = 4;
+  uint64 byte_start = 5;
+  uint64 byte_end = 6;
+}
+
+message MissingFragmentMetadata {
+  string content_hash = 1;
+  FileOperationError error = 2;
+}
+
+message GetFragmentMetadataFromHashResponse {
+  repeated FragmentMetadata fragments = 1;
+  repeated MissingFragmentMetadata missing_hashes = 2;
 }
 
 enum CodebaseIndexStatusState {

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -15,15 +15,14 @@ use warpui::r#async::{executor, FutureExt as _};
 
 use crate::proto::{
     client_message, server_message, Abort, Authenticate, BufferEdit, ClientMessage, CloseBuffer,
-    DeleteFile, ErrorCode, Initialize, InitializeResponse, LoadRepoMetadataDirectoryResponse,
-    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextRequest,
-    ReadFileContextResponse, RunCommandRequest, RunCommandResponse, ServerMessage,
-    SessionBootstrapped, TextEdit, WriteFile,
+    DeleteFile, DropCodebaseIndex, ErrorCode, IndexCodebase, Initialize, InitializeResponse,
+    ListCodebaseIndexStatuses, LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse,
+    OpenBuffer, OpenBufferResponse, ReadFileContextRequest, ReadFileContextResponse,
+    RunCommandRequest, RunCommandResponse, ServerMessage, SessionBootstrapped, TextEdit, WriteFile,
 };
 
 use crate::protocol::{self, ProtocolError, RequestId};
-use warp_core::SessionId;
-use warp_core::{safe_error, safe_warn};
+use warp_core::{safe_error, safe_warn, SessionId};
 use warpui::r#async::TransportStream;
 
 /// Default request timeout (2 minutes).
@@ -233,6 +232,130 @@ impl RemoteServerClient {
                     safe: ("Remote server unexpected response for Initialize"),
                     full: ("Remote server unexpected response for Initialize: response={other:?}")
                 );
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Sends a `ListCodebaseIndexStatuses` request and awaits the status snapshot response.
+    pub async fn list_codebase_index_statuses(
+        &self,
+    ) -> Result<Vec<RemoteCodebaseIndexStatus>, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::ListCodebaseIndexStatuses(
+                ListCodebaseIndexStatuses {},
+            )),
+        };
+        log::info!(
+            "[Remote codebase indexing] Client sending ListCodebaseIndexStatuses: \
+             request_id={request_id}"
+        );
+
+        let response = self.send_request(request_id, msg).await?;
+
+        match response.message {
+            Some(server_message::Message::CodebaseIndexStatusesSnapshot(snapshot)) => {
+                let statuses = proto_to_codebase_index_statuses_snapshot(&snapshot);
+                log::info!(
+                    "[Remote codebase indexing] Client received ListCodebaseIndexStatuses \
+                     response: status_count={}",
+                    statuses.len()
+                );
+                Ok(statuses)
+            }
+            other => {
+                safe_error!(
+                    safe: ("Remote server unexpected response for ListCodebaseIndexStatuses"),
+                    full: ("Remote server unexpected response for ListCodebaseIndexStatuses: response={other:?}")
+                );
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Sends an `IndexCodebase` request and awaits the initial status update.
+    pub async fn index_codebase(
+        &self,
+        repo_path: String,
+        auth_token: String,
+    ) -> Result<RemoteCodebaseIndexStatus, ClientError> {
+        let request_id = RequestId::new();
+        let repo_path_for_log = repo_path.clone();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::IndexCodebase(IndexCodebase {
+                repo_path,
+                auth_token,
+            })),
+        };
+        log::info!(
+            "[Remote codebase indexing] Client sending IndexCodebase: request_id={request_id} \
+             repo_path={repo_path_for_log}"
+        );
+
+        let response = self.send_request(request_id, msg).await?;
+
+        match response.message {
+            Some(server_message::Message::CodebaseIndexStatusUpdated(update)) => {
+                let status =
+                    crate::codebase_index_proto::proto_to_codebase_index_status_updated(&update)
+                        .ok_or(ClientError::UnexpectedResponse)?;
+                log::info!(
+                    "[Remote codebase indexing] Client received IndexCodebase response: \
+                     repo_path={} state={:?}",
+                    status.repo_path,
+                    status.state
+                );
+                Ok(status)
+            }
+            other => {
+                log::error!("Unexpected response variant for IndexCodebase: {other:?}");
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Sends a `DropCodebaseIndex` request and awaits the resulting status update.
+    pub async fn drop_codebase_index(
+        &self,
+        repo_path: String,
+        auth_token: String,
+    ) -> Result<RemoteCodebaseIndexStatus, ClientError> {
+        let request_id = RequestId::new();
+        let repo_path_for_log = repo_path.clone();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::DropCodebaseIndex(
+                DropCodebaseIndex {
+                    repo_path,
+                    auth_token,
+                },
+            )),
+        };
+        log::info!(
+            "[Remote codebase indexing] Client sending DropCodebaseIndex: request_id={request_id} \
+             repo_path={repo_path_for_log}"
+        );
+
+        let response = self.send_request(request_id, msg).await?;
+
+        match response.message {
+            Some(server_message::Message::CodebaseIndexStatusUpdated(update)) => {
+                let status =
+                    crate::codebase_index_proto::proto_to_codebase_index_status_updated(&update)
+                        .ok_or(ClientError::UnexpectedResponse)?;
+                log::info!(
+                    "[Remote codebase indexing] Client received DropCodebaseIndex response: \
+                     repo_path={} state={:?}",
+                    status.repo_path,
+                    status.state
+                );
+                Ok(status)
+            }
+            other => {
+                log::error!("Unexpected response variant for DropCodebaseIndex: {other:?}");
                 Err(ClientError::UnexpectedResponse)
             }
         }
@@ -483,12 +606,22 @@ impl RemoteServerClient {
                 Some(ClientEvent::RepoMetadataUpdated { update })
             }
             server_message::Message::CodebaseIndexStatusesSnapshot(snapshot) => {
-                Some(ClientEvent::CodebaseIndexStatusesSnapshotReceived {
-                    statuses: proto_to_codebase_index_statuses_snapshot(&snapshot),
-                })
+                let statuses = proto_to_codebase_index_statuses_snapshot(&snapshot);
+                log::info!(
+                    "[Remote codebase indexing] Client received codebase index statuses push: \
+                     status_count={}",
+                    statuses.len()
+                );
+                Some(ClientEvent::CodebaseIndexStatusesSnapshotReceived { statuses })
             }
             server_message::Message::CodebaseIndexStatusUpdated(update) => {
                 let status = proto_to_codebase_index_status_updated(&update)?;
+                log::info!(
+                    "[Remote codebase indexing] Client received codebase index status push: \
+                     repo_path={} state={:?}",
+                    status.repo_path,
+                    status.state
+                );
                 Some(ClientEvent::CodebaseIndexStatusUpdated { status })
             }
             server_message::Message::BufferUpdated(push) => Some(ClientEvent::BufferUpdated {

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -16,9 +16,9 @@ use warpui::r#async::{executor, FutureExt as _};
 use crate::proto::{
     client_message, server_message, Abort, Authenticate, BufferEdit, ClientMessage, CloseBuffer,
     DeleteFile, DropCodebaseIndex, ErrorCode, IndexCodebase, Initialize, InitializeResponse,
-    ListCodebaseIndexStatuses, LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse,
-    OpenBuffer, OpenBufferResponse, ReadFileContextRequest, ReadFileContextResponse,
-    RunCommandRequest, RunCommandResponse, ServerMessage, SessionBootstrapped, TextEdit, WriteFile,
+    LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse, OpenBuffer,
+    OpenBufferResponse, ReadFileContextRequest, ReadFileContextResponse, RunCommandRequest,
+    RunCommandResponse, ServerMessage, SessionBootstrapped, TextEdit, WriteFile,
 };
 
 use crate::protocol::{self, ProtocolError, RequestId};
@@ -231,44 +231,6 @@ impl RemoteServerClient {
                 safe_error!(
                     safe: ("Remote server unexpected response for Initialize"),
                     full: ("Remote server unexpected response for Initialize: response={other:?}")
-                );
-                Err(ClientError::UnexpectedResponse)
-            }
-        }
-    }
-
-    /// Sends a `ListCodebaseIndexStatuses` request and awaits the status snapshot response.
-    pub async fn list_codebase_index_statuses(
-        &self,
-    ) -> Result<Vec<RemoteCodebaseIndexStatus>, ClientError> {
-        let request_id = RequestId::new();
-        let msg = ClientMessage {
-            request_id: request_id.to_string(),
-            message: Some(client_message::Message::ListCodebaseIndexStatuses(
-                ListCodebaseIndexStatuses {},
-            )),
-        };
-        log::info!(
-            "[Remote codebase indexing] Client sending ListCodebaseIndexStatuses: \
-             request_id={request_id}"
-        );
-
-        let response = self.send_request(request_id, msg).await?;
-
-        match response.message {
-            Some(server_message::Message::CodebaseIndexStatusesSnapshot(snapshot)) => {
-                let statuses = proto_to_codebase_index_statuses_snapshot(&snapshot);
-                log::info!(
-                    "[Remote codebase indexing] Client received ListCodebaseIndexStatuses \
-                     response: status_count={}",
-                    statuses.len()
-                );
-                Ok(statuses)
-            }
-            other => {
-                safe_error!(
-                    safe: ("Remote server unexpected response for ListCodebaseIndexStatuses"),
-                    full: ("Remote server unexpected response for ListCodebaseIndexStatuses: response={other:?}")
                 );
                 Err(ClientError::UnexpectedResponse)
             }

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -1,28 +1,29 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::codebase_index_proto::{
-    proto_to_codebase_index_status_updated, proto_to_codebase_index_statuses_snapshot,
-    RemoteCodebaseIndexStatus,
+    RemoteCodebaseIndexStatus, proto_to_codebase_index_status_updated,
+    proto_to_codebase_index_statuses_snapshot,
 };
 use dashmap::DashMap;
 use futures::channel::oneshot;
 use futures::io::{AsyncRead, AsyncWrite};
-use warpui::r#async::{executor, FutureExt as _};
+use warpui::r#async::{FutureExt as _, executor};
 
 use crate::proto::{
-    client_message, server_message, Abort, Authenticate, BufferEdit, ClientMessage, CloseBuffer,
-    DeleteFile, DropCodebaseIndex, ErrorCode, IndexCodebase, Initialize, InitializeResponse,
-    LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse, OpenBuffer,
-    OpenBufferResponse, ReadFileContextRequest, ReadFileContextResponse, RunCommandRequest,
-    RunCommandResponse, ServerMessage, SessionBootstrapped, TextEdit, WriteFile,
+    Abort, Authenticate, BufferEdit, ClientMessage, CloseBuffer, DeleteFile, DropCodebaseIndex,
+    ErrorCode, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashResponse, IndexCodebase,
+    Initialize, InitializeResponse, LoadRepoMetadataDirectoryResponse,
+    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextRequest,
+    ReadFileContextResponse, RunCommandRequest, RunCommandResponse, ServerMessage,
+    SessionBootstrapped, TextEdit, WriteFile, client_message, server_message,
 };
 
 use crate::protocol::{self, ProtocolError, RequestId};
-use warp_core::{safe_error, safe_warn, SessionId};
+use warp_core::{SessionId, safe_error, safe_warn};
 use warpui::r#async::TransportStream;
 
 /// Default request timeout (2 minutes).
@@ -323,6 +324,37 @@ impl RemoteServerClient {
         }
     }
 
+    /// Maps backend content hashes to server-local fragment metadata for a synced repo snapshot.
+    pub async fn get_fragment_metadata_from_hash(
+        &self,
+        repo_path: String,
+        root_hash: String,
+        content_hashes: Vec<String>,
+    ) -> Result<GetFragmentMetadataFromHashResponse, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::GetFragmentMetadataFromHash(
+                GetFragmentMetadataFromHash {
+                    repo_path,
+                    root_hash,
+                    content_hashes,
+                },
+            )),
+        };
+
+        let response = self.send_request(request_id, msg).await?;
+
+        match response.message {
+            Some(server_message::Message::GetFragmentMetadataFromHashResponse(resp)) => Ok(resp),
+            other => {
+                log::error!(
+                    "Unexpected response variant for GetFragmentMetadataFromHash: {other:?}"
+                );
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
     /// Sends an `Authenticate` notification to rotate the daemon-wide
     /// credential after initialization.
     pub fn authenticate(&self, auth_token: &str) {
@@ -824,8 +856,8 @@ pub fn spawn_stderr_forwarder(
     stderr: impl AsyncRead + TransportStream,
     executor: &executor::Background,
 ) {
-    use futures::io::AsyncBufReadExt;
     use futures::StreamExt;
+    use futures::io::AsyncBufReadExt;
 
     executor
         .spawn(async move {

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -43,6 +43,12 @@ fn not_enabled_codebase_status(repo_path: &str) -> CodebaseIndexStatus {
         repo_path: repo_path.to_string(),
         state: CodebaseIndexStatusState::NotEnabled.into(),
         last_updated_epoch_millis: Some(123),
+        progress_completed: None,
+        progress_total: None,
+        failure_message: None,
+        root_hash: None,
+        embedding_model: None,
+        embedding_dimensions: None,
     }
 }
 

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -2,9 +2,11 @@ use futures::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::proto::{
-    client_message, run_command_response, server_message, ClientMessage, CodebaseIndexStatus,
-    CodebaseIndexStatusState, CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, ErrorCode,
-    InitializeResponse, RunCommandResponse, RunCommandSuccess, ServerMessage,
+    ClientMessage, CodebaseIndexStatus, CodebaseIndexStatusState, CodebaseIndexStatusUpdated,
+    CodebaseIndexStatusesSnapshot, ErrorCode, FileOperationError, FragmentMetadata,
+    GetFragmentMetadataFromHashResponse, InitializeResponse, MissingFragmentMetadata,
+    RunCommandResponse, RunCommandSuccess, ServerMessage, client_message, run_command_response,
+    server_message,
 };
 use crate::protocol;
 use warp_core::SessionId;
@@ -214,6 +216,52 @@ async fn initialize_sends_auth_token_when_provided() {
         )
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn get_fragment_metadata_from_hash_round_trip() {
+    let (client, _disconnect_rx, _executor) = setup_mock_client(|msg| {
+        match &msg.message {
+            Some(client_message::Message::GetFragmentMetadataFromHash(request)) => {
+                assert_eq!(request.repo_path, "/repo");
+                assert_eq!(request.root_hash, "root-hash");
+                assert_eq!(request.content_hashes, vec!["found-hash", "missing-hash"]);
+            }
+            other => panic!("Expected GetFragmentMetadataFromHash, got {other:?}"),
+        }
+        server_message::Message::GetFragmentMetadataFromHashResponse(
+            GetFragmentMetadataFromHashResponse {
+                fragments: vec![FragmentMetadata {
+                    content_hash: "found-hash".to_string(),
+                    path: "/repo/src/lib.rs".to_string(),
+                    start_line: 1,
+                    end_line: 3,
+                    byte_start: 0,
+                    byte_end: 42,
+                }],
+                missing_hashes: vec![MissingFragmentMetadata {
+                    content_hash: "missing-hash".to_string(),
+                    error: Some(FileOperationError {
+                        message: "missing".to_string(),
+                    }),
+                }],
+            },
+        )
+    });
+
+    let response = client
+        .get_fragment_metadata_from_hash(
+            "/repo".to_string(),
+            "root-hash".to_string(),
+            vec!["found-hash".to_string(), "missing-hash".to_string()],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.fragments.len(), 1);
+    assert_eq!(response.fragments[0].content_hash, "found-hash");
+    assert_eq!(response.missing_hashes.len(), 1);
+    assert_eq!(response.missing_hashes[0].content_hash, "missing-hash");
 }
 
 #[tokio::test]

--- a/crates/remote_server/src/codebase_index_proto.rs
+++ b/crates/remote_server/src/codebase_index_proto.rs
@@ -7,12 +7,24 @@ pub struct RemoteCodebaseIndexStatus {
     pub repo_path: String,
     pub state: RemoteCodebaseIndexState,
     pub last_updated_epoch_millis: Option<u64>,
+    pub progress_completed: Option<u64>,
+    pub progress_total: Option<u64>,
+    pub failure_message: Option<String>,
+    pub root_hash: Option<String>,
+    pub embedding_model: Option<String>,
+    pub embedding_dimensions: Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RemoteCodebaseIndexState {
     NotEnabled,
     Unavailable,
+    Disabled,
+    Queued,
+    Indexing,
+    Ready,
+    Stale,
+    Failed,
 }
 
 // ── Rust → Proto ────────────────────────────────────────────
@@ -23,6 +35,12 @@ impl From<&RemoteCodebaseIndexStatus> for proto::CodebaseIndexStatus {
             repo_path: status.repo_path.clone(),
             state: proto_state(status.state) as i32,
             last_updated_epoch_millis: status.last_updated_epoch_millis,
+            progress_completed: status.progress_completed,
+            progress_total: status.progress_total,
+            failure_message: status.failure_message.clone(),
+            root_hash: status.root_hash.clone(),
+            embedding_model: status.embedding_model.clone(),
+            embedding_dimensions: status.embedding_dimensions,
         }
     }
 }
@@ -42,6 +60,12 @@ fn proto_state(state: RemoteCodebaseIndexState) -> proto::CodebaseIndexStatusSta
     match state {
         RemoteCodebaseIndexState::NotEnabled => proto::CodebaseIndexStatusState::NotEnabled,
         RemoteCodebaseIndexState::Unavailable => proto::CodebaseIndexStatusState::Unavailable,
+        RemoteCodebaseIndexState::Disabled => proto::CodebaseIndexStatusState::Disabled,
+        RemoteCodebaseIndexState::Queued => proto::CodebaseIndexStatusState::Queued,
+        RemoteCodebaseIndexState::Indexing => proto::CodebaseIndexStatusState::Indexing,
+        RemoteCodebaseIndexState::Ready => proto::CodebaseIndexStatusState::Ready,
+        RemoteCodebaseIndexState::Stale => proto::CodebaseIndexStatusState::Stale,
+        RemoteCodebaseIndexState::Failed => proto::CodebaseIndexStatusState::Failed,
     }
 }
 
@@ -54,6 +78,12 @@ pub fn proto_to_codebase_index_status(
         repo_path: status.repo_path.clone(),
         state: proto_to_state(proto::CodebaseIndexStatusState::try_from(status.state).ok()?)?,
         last_updated_epoch_millis: status.last_updated_epoch_millis,
+        progress_completed: status.progress_completed,
+        progress_total: status.progress_total,
+        failure_message: status.failure_message.clone(),
+        root_hash: status.root_hash.clone(),
+        embedding_model: status.embedding_model.clone(),
+        embedding_dimensions: status.embedding_dimensions,
     })
 }
 
@@ -77,6 +107,12 @@ fn proto_to_state(state: proto::CodebaseIndexStatusState) -> Option<RemoteCodeba
     match state {
         proto::CodebaseIndexStatusState::NotEnabled => Some(RemoteCodebaseIndexState::NotEnabled),
         proto::CodebaseIndexStatusState::Unavailable => Some(RemoteCodebaseIndexState::Unavailable),
+        proto::CodebaseIndexStatusState::Disabled => Some(RemoteCodebaseIndexState::Disabled),
+        proto::CodebaseIndexStatusState::Queued => Some(RemoteCodebaseIndexState::Queued),
+        proto::CodebaseIndexStatusState::Indexing => Some(RemoteCodebaseIndexState::Indexing),
+        proto::CodebaseIndexStatusState::Ready => Some(RemoteCodebaseIndexState::Ready),
+        proto::CodebaseIndexStatusState::Stale => Some(RemoteCodebaseIndexState::Stale),
+        proto::CodebaseIndexStatusState::Failed => Some(RemoteCodebaseIndexState::Failed),
         proto::CodebaseIndexStatusState::Unspecified => None,
     }
 }
@@ -84,16 +120,78 @@ fn proto_to_state(state: proto::CodebaseIndexStatusState) -> Option<RemoteCodeba
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn status(state: RemoteCodebaseIndexState) -> RemoteCodebaseIndexStatus {
+        RemoteCodebaseIndexStatus {
+            repo_path: "/repo".to_string(),
+            state,
+            last_updated_epoch_millis: Some(42),
+            progress_completed: None,
+            progress_total: None,
+            failure_message: None,
+            root_hash: None,
+            embedding_model: None,
+            embedding_dimensions: None,
+        }
+    }
 
     #[test]
-    fn status_round_trips_through_proto() {
+    fn all_status_states_round_trip_through_proto() {
+        for state in [
+            RemoteCodebaseIndexState::NotEnabled,
+            RemoteCodebaseIndexState::Unavailable,
+            RemoteCodebaseIndexState::Disabled,
+            RemoteCodebaseIndexState::Queued,
+            RemoteCodebaseIndexState::Indexing,
+            RemoteCodebaseIndexState::Ready,
+            RemoteCodebaseIndexState::Stale,
+            RemoteCodebaseIndexState::Failed,
+        ] {
+            let status = status(state);
+
+            let proto = proto::CodebaseIndexStatus::from(&status);
+            assert_eq!(proto_to_codebase_index_status(&proto), Some(status));
+        }
+    }
+
+    #[test]
+    fn ready_status_round_trips_retrieval_metadata() {
         let status = RemoteCodebaseIndexStatus {
-            repo_path: "/repo".to_string(),
-            state: RemoteCodebaseIndexState::NotEnabled,
-            last_updated_epoch_millis: Some(42),
+            root_hash: Some("root-hash".to_string()),
+            embedding_model: Some("embedding-model".to_string()),
+            embedding_dimensions: Some(1536),
+            ..status(RemoteCodebaseIndexState::Ready)
         };
 
         let proto = proto::CodebaseIndexStatus::from(&status);
+        assert_eq!(proto.root_hash.as_deref(), Some("root-hash"));
+        assert_eq!(proto.embedding_model.as_deref(), Some("embedding-model"));
+        assert_eq!(proto.embedding_dimensions, Some(1536));
+        assert_eq!(proto_to_codebase_index_status(&proto), Some(status));
+    }
+
+    #[test]
+    fn indexing_status_round_trips_progress() {
+        let status = RemoteCodebaseIndexStatus {
+            progress_completed: Some(7),
+            progress_total: Some(11),
+            ..status(RemoteCodebaseIndexState::Indexing)
+        };
+
+        let proto = proto::CodebaseIndexStatus::from(&status);
+        assert_eq!(proto.progress_completed, Some(7));
+        assert_eq!(proto.progress_total, Some(11));
+        assert_eq!(proto_to_codebase_index_status(&proto), Some(status));
+    }
+
+    #[test]
+    fn failed_status_round_trips_failure_message() {
+        let status = RemoteCodebaseIndexStatus {
+            failure_message: Some("failed to sync".to_string()),
+            ..status(RemoteCodebaseIndexState::Failed)
+        };
+
+        let proto = proto::CodebaseIndexStatus::from(&status);
+        assert_eq!(proto.failure_message.as_deref(), Some("failed to sync"));
         assert_eq!(proto_to_codebase_index_status(&proto), Some(status));
     }
 
@@ -103,6 +201,12 @@ mod tests {
             repo_path: "/repo".to_string(),
             state: proto::CodebaseIndexStatusState::Unspecified as i32,
             last_updated_epoch_millis: None,
+            progress_completed: None,
+            progress_total: None,
+            failure_message: None,
+            root_hash: None,
+            embedding_model: None,
+            embedding_dimensions: None,
         };
 
         assert_eq!(proto_to_codebase_index_status(&status), None);

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 #[cfg(not(target_family = "wasm"))]
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -95,6 +96,9 @@ pub enum RemoteServerInitPhase {
 pub enum RemoteServerOperation {
     NavigateToDirectory,
     LoadRepoMetadataDirectory,
+    ListCodebaseIndexStatuses,
+    IndexCodebase,
+    DropCodebaseIndex,
 }
 
 /// Classification of a remote server client error for telemetry.
@@ -1105,6 +1109,219 @@ impl RemoteServerManager {
     /// reverse index.
     pub fn sessions_for_host(&self, host_id: &HostId) -> Option<&HashSet<SessionId>> {
         self.host_to_sessions.get(host_id)
+    }
+
+    fn connected_session_for_host(
+        &self,
+        host_id: &HostId,
+    ) -> Option<(SessionId, Arc<RemoteServerClient>, String)> {
+        let sessions = self.host_to_sessions.get(host_id)?;
+        sessions.iter().find_map(|session_id| {
+            let RemoteSessionState::Connected {
+                client,
+                identity_key,
+                ..
+            } = self.sessions.get(session_id)?
+            else {
+                return None;
+            };
+            Some((*session_id, client.clone(), identity_key.clone()))
+        })
+    }
+
+    /// Requests a bulk remote codebase-index status resync for a connected host.
+    pub fn refresh_codebase_index_statuses(
+        &mut self,
+        host_id: HostId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some((session_id, client, remote_identity_key)) =
+            self.connected_session_for_host(&host_id)
+        else {
+            log::warn!(
+                "Remote server refresh_codebase_index_statuses: no connected client host={host_id}"
+            );
+            return;
+        };
+        log::info!(
+            "[Remote codebase indexing] Manager requesting status refresh: \
+             host={host_id} session={session_id:?} remote_identity_key={remote_identity_key}"
+        );
+
+        let spawner = self.spawner.clone();
+        ctx.background_executor()
+            .spawn(async move {
+                match client.list_codebase_index_statuses().await {
+                    Ok(statuses) => {
+                        log::info!(
+                            "[Remote codebase indexing] Manager received status refresh: \
+                             host={host_id} session={session_id:?} \
+                             remote_identity_key={remote_identity_key} status_count={}",
+                            statuses.len()
+                        );
+                        let _ = spawner
+                            .spawn(move |_me, ctx| {
+                                ctx.emit(RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot {
+                                    remote_identity_key,
+                                    host_id,
+                                    statuses,
+                                });
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        log::warn!("Remote server list_codebase_index_statuses failed: session={session_id:?} error={e}");
+                        let error_kind = RemoteServerErrorKind::from_client_error(&e);
+                        let _ = spawner
+                            .spawn(move |_me, ctx| {
+                                ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
+                                    session_id,
+                                    operation: RemoteServerOperation::ListCodebaseIndexStatuses,
+                                    error_kind,
+                                });
+                            })
+                            .await;
+                    }
+                }
+            })
+            .detach();
+    }
+
+    /// Sends an `IndexCodebase` request to a connected daemon for this host.
+    pub fn index_codebase(
+        &mut self,
+        host_id: HostId,
+        repo_path: String,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.mutate_codebase_index(
+            host_id,
+            repo_path,
+            RemoteServerOperation::IndexCodebase,
+            |client, repo_path, auth_token| async move {
+                client.index_codebase(repo_path, auth_token).await
+            },
+            ctx,
+        );
+    }
+
+    /// Sends a `DropCodebaseIndex` request to a connected daemon for this host.
+    pub fn drop_codebase_index(
+        &mut self,
+        host_id: HostId,
+        repo_path: String,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.mutate_codebase_index(
+            host_id,
+            repo_path,
+            RemoteServerOperation::DropCodebaseIndex,
+            |client, repo_path, auth_token| async move {
+                client.drop_codebase_index(repo_path, auth_token).await
+            },
+            ctx,
+        );
+    }
+
+    fn mutate_codebase_index<F, Fut>(
+        &mut self,
+        host_id: HostId,
+        repo_path: String,
+        operation: RemoteServerOperation,
+        request: F,
+        ctx: &mut ModelContext<Self>,
+    ) where
+        F: FnOnce(Arc<RemoteServerClient>, String, String) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<RemoteCodebaseIndexStatus, crate::client::ClientError>>
+            + Send
+            + 'static,
+    {
+        let Some((session_id, client, remote_identity_key)) =
+            self.connected_session_for_host(&host_id)
+        else {
+            log::warn!("Remote server codebase index mutation: no connected client host={host_id}");
+            return;
+        };
+        log::info!(
+            "[Remote codebase indexing] Manager requesting codebase index mutation: \
+             operation={operation:?} host={host_id} session={session_id:?} \
+             remote_identity_key={remote_identity_key} repo_path={repo_path}"
+        );
+
+        let Some(auth_context) = self.auth_context.clone() else {
+            log::warn!(
+                "Remote server codebase index mutation: no auth context \
+                 operation={operation:?} host={host_id} session={session_id:?} repo_path={repo_path}"
+            );
+            ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
+                session_id,
+                operation,
+                error_kind: RemoteServerErrorKind::Other,
+            });
+            return;
+        };
+
+        let spawner = self.spawner.clone();
+        ctx.background_executor()
+            .spawn(async move {
+                let repo_path_for_log = repo_path.clone();
+                let Some(auth_token) = auth_context.get_auth_token().await else {
+                    log::warn!(
+                        "Remote server codebase index mutation: missing auth token \
+                         operation={operation:?} host={host_id} session={session_id:?} \
+                         repo_path={repo_path_for_log}"
+                    );
+                    let _ = spawner
+                        .spawn(move |_me, ctx| {
+                            ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
+                                session_id,
+                                operation,
+                                error_kind: RemoteServerErrorKind::Other,
+                            });
+                        })
+                        .await;
+                    return;
+                };
+
+                match request(client, repo_path, auth_token).await {
+                    Ok(status) => {
+                        log::info!(
+                            "[Remote codebase indexing] Manager received codebase index mutation response: \
+                             operation={operation:?} host={host_id} session={session_id:?} \
+                             remote_identity_key={remote_identity_key} repo_path={} state={:?}",
+                            status.repo_path,
+                            status.state
+                        );
+                        let _ = spawner
+                            .spawn(move |_me, ctx| {
+                                ctx.emit(RemoteServerManagerEvent::CodebaseIndexStatusUpdated {
+                                    remote_identity_key,
+                                    host_id,
+                                    status,
+                                });
+                            })
+                            .await;
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "Remote server codebase index mutation failed: \
+                             operation={operation:?} host={host_id} session={session_id:?} \
+                             repo_path={repo_path_for_log} error={e}"
+                        );
+                        let error_kind = RemoteServerErrorKind::from_client_error(&e);
+                        let _ = spawner
+                            .spawn(move |_me, ctx| {
+                                ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
+                                    session_id,
+                                    operation,
+                                    error_kind,
+                                });
+                            })
+                            .await;
+                    }
+                }
+            })
+            .detach();
     }
 
     /// Sends a `NavigatedToDirectory` request to the remote server for

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -96,7 +96,6 @@ pub enum RemoteServerInitPhase {
 pub enum RemoteServerOperation {
     NavigateToDirectory,
     LoadRepoMetadataDirectory,
-    ListCodebaseIndexStatuses,
     IndexCodebase,
     DropCodebaseIndex,
 }
@@ -1127,64 +1126,6 @@ impl RemoteServerManager {
             };
             Some((*session_id, client.clone(), identity_key.clone()))
         })
-    }
-
-    /// Requests a bulk remote codebase-index status resync for a connected host.
-    pub fn refresh_codebase_index_statuses(
-        &mut self,
-        host_id: HostId,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let Some((session_id, client, remote_identity_key)) =
-            self.connected_session_for_host(&host_id)
-        else {
-            log::warn!(
-                "Remote server refresh_codebase_index_statuses: no connected client host={host_id}"
-            );
-            return;
-        };
-        log::info!(
-            "[Remote codebase indexing] Manager requesting status refresh: \
-             host={host_id} session={session_id:?} remote_identity_key={remote_identity_key}"
-        );
-
-        let spawner = self.spawner.clone();
-        ctx.background_executor()
-            .spawn(async move {
-                match client.list_codebase_index_statuses().await {
-                    Ok(statuses) => {
-                        log::info!(
-                            "[Remote codebase indexing] Manager received status refresh: \
-                             host={host_id} session={session_id:?} \
-                             remote_identity_key={remote_identity_key} status_count={}",
-                            statuses.len()
-                        );
-                        let _ = spawner
-                            .spawn(move |_me, ctx| {
-                                ctx.emit(RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot {
-                                    remote_identity_key,
-                                    host_id,
-                                    statuses,
-                                });
-                            })
-                            .await;
-                    }
-                    Err(e) => {
-                        log::warn!("Remote server list_codebase_index_statuses failed: session={session_id:?} error={e}");
-                        let error_kind = RemoteServerErrorKind::from_client_error(&e);
-                        let _ = spawner
-                            .spawn(move |_me, ctx| {
-                                ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
-                                    session_id,
-                                    operation: RemoteServerOperation::ListCodebaseIndexStatuses,
-                                    error_kind,
-                                });
-                            })
-                            .await;
-                    }
-                }
-            })
-            .detach();
     }
 
     /// Sends an `IndexCodebase` request to a connected daemon for this host.


### PR DESCRIPTION
This change adds placeholder stubs and messages for remote codebase indexing.

*   Adds `ListCodebaseIndexStatuses`, `IndexCodebase`, and `DropCodebaseIndex` messages to the protobuf definitions.
*   Implements `handle_list_codebase_index_statuses`, `handle_index_codebase`, and `handle_drop_codebase_index` methods in `ServerModel`. These methods currently log placeholder messages.
*   Adds a `codebase_index_status_sent_roots_by_connection` field to `ServerModel` to track which git repos have had their initial status pushed to the client.
*   The client now has the ability to send `ListCodebaseIndexStatuses` requests.
*   When navigating to a git repo, the server now sends a `NotEnabled` status update to the client.