### PR TITLE
Do less work in command palette zero state

### DIFF
--- a/app/src/search/command_palette/view.rs
+++ b/app/src/search/command_palette/view.rs
@@ -521,6 +521,10 @@ impl View {
     fn on_session_source_changed(&mut self, ctx: &mut ViewContext<Self>) {
         self.compute_recent_items_for_zero_state(ctx);
 
+        if self.search_bar_state.as_ref(ctx).should_show_zero_state() {
+            return;
+        }
+
         self.search_bar.update(ctx, |search_bar, ctx| {
             search_bar.run_query(ctx);
         });

--- a/app/src/search/command_palette/view.rs
+++ b/app/src/search/command_palette/view.rs
@@ -179,7 +179,7 @@ impl warpui::View for View {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
 
-        let body = if self.search_bar_state.as_ref(app).should_show_zero_state() {
+        let body = if self.search_bar.as_ref(app).should_show_zero_state(app) {
             ChildView::new(&self.zero_state_handle).finish()
         } else {
             self.render_palette_list(theme, app)
@@ -364,15 +364,15 @@ impl View {
     }
 
     pub fn select_next_item(&mut self, ctx: &mut ViewContext<Self>) {
-        self.search_bar_state.update(ctx, |state, ctx| {
-            state.handle_selection_update(SelectionUpdate::Down, ctx);
+        self.search_bar.update(ctx, |search_bar, ctx| {
+            search_bar.handle_selection_update(SelectionUpdate::Down, ctx);
         });
         ctx.notify();
     }
 
     pub fn select_prev_item(&mut self, ctx: &mut ViewContext<Self>) {
-        self.search_bar_state.update(ctx, |state, ctx| {
-            state.handle_selection_update(SelectionUpdate::Up, ctx);
+        self.search_bar.update(ctx, |search_bar, ctx| {
+            search_bar.handle_selection_update(SelectionUpdate::Up, ctx);
         });
         ctx.notify();
     }

--- a/app/src/search/command_palette/view.rs
+++ b/app/src/search/command_palette/view.rs
@@ -521,11 +521,9 @@ impl View {
     fn on_session_source_changed(&mut self, ctx: &mut ViewContext<Self>) {
         self.compute_recent_items_for_zero_state(ctx);
 
-        if self.search_bar_state.as_ref(ctx).should_run_query() {
-            self.search_bar.update(ctx, |search_bar, ctx| {
-                search_bar.run_query(ctx);
-            });
-        }
+        self.search_bar.update(ctx, |search_bar, ctx| {
+            search_bar.run_query(ctx);
+        });
     }
 
     fn render_search_bar(&self) -> Box<dyn Element> {

--- a/app/src/search/command_palette/view.rs
+++ b/app/src/search/command_palette/view.rs
@@ -521,13 +521,11 @@ impl View {
     fn on_session_source_changed(&mut self, ctx: &mut ViewContext<Self>) {
         self.compute_recent_items_for_zero_state(ctx);
 
-        if self.search_bar_state.as_ref(ctx).should_show_zero_state() {
-            return;
+        if self.search_bar_state.as_ref(ctx).should_run_query() {
+            self.search_bar.update(ctx, |search_bar, ctx| {
+                search_bar.run_query(ctx);
+            });
         }
-
-        self.search_bar.update(ctx, |search_bar, ctx| {
-            search_bar.run_query(ctx);
-        });
     }
 
     fn render_search_bar(&self) -> Box<dyn Element> {

--- a/app/src/search/command_search/view.rs
+++ b/app/src/search/command_search/view.rs
@@ -1014,7 +1014,7 @@ impl View for CommandSearchView {
         let appearance = Appearance::as_ref(app);
         let mixer = self.mixer.as_ref(app);
 
-        let should_show_zero_state = self.search_bar_state.as_ref(app).should_show_zero_state();
+        let should_show_zero_state = self.search_bar.as_ref(app).should_show_zero_state(app);
         let panel_contents_body = if should_show_zero_state {
             ChildView::new(&self.zero_state_handle).finish()
         } else if mixer.is_loading() && mixer.are_results_empty() {

--- a/app/src/search/search_bar.rs
+++ b/app/src/search/search_bar.rs
@@ -92,16 +92,6 @@ pub enum FilterState {
     },
 }
 
-impl FilterState {
-    fn zero_state(&self) -> bool {
-        match self {
-            FilterState::Unfiltered => true,
-            FilterState::Visible(_) => false,
-            FilterState::Fixed { .. } => true,
-        }
-    }
-}
-
 /// View state for the search bar.
 pub struct SearchBarState<T: Action + Clone> {
     selected_index: Option<usize>,

--- a/app/src/search/search_bar.rs
+++ b/app/src/search/search_bar.rs
@@ -110,9 +110,8 @@ pub struct SearchBarState<T: Action + Clone> {
     /// The filter atom text to be rendered in the Search input, representing the currently applied
     /// filter.
     filter_atom_text: Option<&'static str>,
-    /// Whether the search bar is in a state where a zero state should be shown. This is true if
-    /// no search query has been run and no filters have been applied.
-    should_show_zero_state: bool,
+    /// Whether the search bar's editor buffer is currently empty.
+    buffer_is_empty: bool,
     query_result_renderers: Option<Vec<QueryResultRenderer<T>>>,
     /// Ordering of how results should be displayed. Used to determine which search result should
     /// be considered selected when the user presses certain navigation keys such as up/down.
@@ -184,7 +183,7 @@ impl<T: Action + Clone> SearchBarState<T> {
             selected_index: None,
             query_filter: FilterState::Unfiltered,
             filter_atom_text: None,
-            should_show_zero_state: true,
+            buffer_is_empty: true,
             query_result_renderers: None,
             ordering,
             max_results: SearchResultLimit::Unbounded,
@@ -251,7 +250,7 @@ impl<T: Action + Clone> SearchBarState<T> {
         // 2) We are resilient to any race conditions where selection update may be called before
         // `should_show_zero_state` is actually set to `false`, which would then cause no index to
         // be selected.
-        if self.should_show_zero_state {
+        if self.should_show_zero_state() {
             ctx.emit(SearchBarEvent::SelectionUpdateInZeroState { selection_update });
         }
 
@@ -354,8 +353,14 @@ impl<T: Action + Clone> SearchBarState<T> {
         self.selected_index
     }
 
+    /// Returns true when the zero-state UI should be shown: the buffer is empty and no
+    /// user-chosen filter is active. This is a pure computation — no cached flag.
     pub fn should_show_zero_state(&self) -> bool {
-        self.should_show_zero_state
+        self.buffer_is_empty && matches!(self.query_filter, FilterState::Unfiltered)
+    }
+
+    fn should_run_query(&self) -> bool {
+        !self.should_show_zero_state() || self.run_query_on_buffer_empty
     }
 }
 
@@ -467,7 +472,7 @@ impl<T: Action + Clone> SearchBar<T> {
                 // visible.  In the command search view, they're only visible when the
                 // buffer is empty, so if the user accepts one, immediately re-clear the
                 // buffer (to effectively revert the event).
-                if self.state.as_ref(ctx).should_show_zero_state {
+                if self.state.as_ref(ctx).should_show_zero_state() {
                     self.editor_handle.update(ctx, |editor, ctx| {
                         editor.clear_buffer_and_reset_undo_stack(ctx);
                     });
@@ -491,11 +496,7 @@ impl<T: Action + Clone> SearchBar<T> {
                     _ => false,
                 };
 
-                // If the state should show zero state and we are not running
-                // filter query on buffer empty, intercept the enter event.
-                if self.state.as_ref(ctx).should_show_zero_state
-                    && !self.state.as_ref(ctx).run_query_on_buffer_empty
-                {
+                if !self.state.as_ref(ctx).should_run_query() {
                     ctx.emit(SearchBarEvent::EnterInZeroState { modified_enter });
                     return;
                 }
@@ -669,18 +670,17 @@ impl<T: Action + Clone> SearchBar<T> {
                 placeholder_text: label,
                 query_filters: filters,
             };
-            state.should_show_zero_state = false;
             ctx.notify();
         });
 
         self.update_placeholder_text(ctx);
+        self.run_query(ctx);
     }
 
-    /// Updates the active filter and re-runs the query, since results may be affected by the newly
-    /// active filter.
+    /// Updates the active filter and re-runs the query if the current search state warrants it.
     ///
-    /// This method also updates UI state including the placeholder text and the show/hide
-    /// zero_state flag.
+    /// Empty zero-state buffers skip querying unless this search bar has opted into
+    /// `run_query_on_buffer_empty`.
     pub fn set_visible_query_filter(
         &mut self,
         filter_and_atom_text: Option<(QueryFilter, &'static str)>,
@@ -689,9 +689,9 @@ impl<T: Action + Clone> SearchBar<T> {
         if self.filterable(ctx) {
             let new_filter = filter_and_atom_text.map(|(filter, _)| filter);
             let new_filter_atom_text = filter_and_atom_text.map(|(_, atom_text)| atom_text);
-            // NOTE: This event is deferred — handlers receive it after `run_query` (below) has
-            // already started an async search. Handlers must not reset or modify the mixer, as
-            // doing so would abort the in-flight query without re-running it.
+            // NOTE: This event is deferred. When this method starts a query below, handlers
+            // receive it after the async search has already started. Handlers must not reset or
+            // modify the mixer, as doing so would abort the in-flight query without re-running it.
             ctx.emit(SearchBarEvent::QueryFilterChanged { new_filter });
 
             self.state.update(ctx, |state, ctx| {
@@ -705,24 +705,14 @@ impl<T: Action + Clone> SearchBar<T> {
             });
         }
 
-        self.run_query(ctx);
+        if self.state.as_ref(ctx).should_run_query() {
+            self.run_query(ctx);
+        }
 
         // Update the editor placeholder text if necessary.
         self.update_placeholder_text(ctx);
 
-        // Update the placeholder text.
         self.update_filter_autosuggestion_text(ctx);
-
-        // Update the zero state show/hide flag.
-        let current_buffer_text = self
-            .editor_handle
-            .read(ctx, |editor, ctx| editor.buffer_text(ctx));
-
-        self.state.update(ctx, |state, ctx| {
-            state.should_show_zero_state =
-                current_buffer_text.is_empty() && state.query_filter.zero_state();
-            ctx.notify();
-        });
 
         // Make sure the view gets re-rendered.
         ctx.notify();
@@ -833,22 +823,20 @@ impl<T: Action + Clone> SearchBar<T> {
         let current_buffer_text = self
             .editor_handle
             .read(ctx, |editor, ctx| editor.buffer_text(ctx));
-        if current_buffer_text.is_empty() && self.state.as_ref(ctx).query_filter.zero_state() {
-            self.state.update(ctx, |state, ctx| {
-                state.should_show_zero_state = true;
-                ctx.notify();
-            });
+
+        let buffer_is_empty = current_buffer_text.is_empty();
+        self.state.update(ctx, |state, ctx| {
+            state.buffer_is_empty = buffer_is_empty;
+            ctx.notify();
+        });
+
+        if self.state.as_ref(ctx).should_show_zero_state() {
             self.handle_selection_update(SelectionUpdate::Clear, ctx);
 
-            if self.state.as_ref(ctx).run_query_on_buffer_empty {
+            if self.state.as_ref(ctx).should_run_query() {
                 self.run_query(ctx);
             }
         } else {
-            self.state.update(ctx, |state, ctx| {
-                state.should_show_zero_state = false;
-                ctx.notify();
-            });
-
             if self.filterable(ctx) {
                 let registered_filters = self.mixer.as_ref(ctx).registered_filters().collect_vec();
                 for filter in registered_filters {

--- a/app/src/search/search_bar.rs
+++ b/app/src/search/search_bar.rs
@@ -354,9 +354,9 @@ impl<T: Action + Clone> SearchBarState<T> {
     }
 
     /// Returns true when the zero-state UI should be shown: the buffer is empty and no
-    /// user-chosen filter is active. This is a pure computation — no cached flag.
+    /// user-chosen filter is active.
     pub fn should_show_zero_state(&self) -> bool {
-        self.buffer_is_empty && matches!(self.query_filter, FilterState::Unfiltered)
+        self.buffer_is_empty && self.query_filter == FilterState::Unfiltered
     }
 
     fn should_run_query(&self) -> bool {

--- a/app/src/search/search_bar.rs
+++ b/app/src/search/search_bar.rs
@@ -100,8 +100,6 @@ pub struct SearchBarState<T: Action + Clone> {
     /// The filter atom text to be rendered in the Search input, representing the currently applied
     /// filter.
     filter_atom_text: Option<&'static str>,
-    /// Whether the search bar's editor buffer is currently empty.
-    buffer_is_empty: bool,
     query_result_renderers: Option<Vec<QueryResultRenderer<T>>>,
     /// Ordering of how results should be displayed. Used to determine which search result should
     /// be considered selected when the user presses certain navigation keys such as up/down.
@@ -173,7 +171,6 @@ impl<T: Action + Clone> SearchBarState<T> {
             selected_index: None,
             query_filter: FilterState::Unfiltered,
             filter_atom_text: None,
-            buffer_is_empty: true,
             query_result_renderers: None,
             ordering,
             max_results: SearchResultLimit::Unbounded,
@@ -231,6 +228,7 @@ impl<T: Action + Clone> SearchBarState<T> {
     pub fn handle_selection_update(
         &mut self,
         selection_update: SelectionUpdate,
+        should_show_zero_state: bool,
         ctx: &mut ModelContext<Self>,
     ) {
         // Even if the zero state should be shown, still update the internal selected index of the
@@ -240,7 +238,7 @@ impl<T: Action + Clone> SearchBarState<T> {
         // 2) We are resilient to any race conditions where selection update may be called before
         // `should_show_zero_state` is actually set to `false`, which would then cause no index to
         // be selected.
-        if self.should_show_zero_state() {
+        if should_show_zero_state {
             ctx.emit(SearchBarEvent::SelectionUpdateInZeroState { selection_update });
         }
 
@@ -341,16 +339,6 @@ impl<T: Action + Clone> SearchBarState<T> {
     /// Returns the index of currently selected search result.
     pub fn selected_index(&self) -> Option<usize> {
         self.selected_index
-    }
-
-    /// Returns true when the zero-state UI should be shown: the buffer is empty and no
-    /// user-chosen filter is active.
-    pub fn should_show_zero_state(&self) -> bool {
-        self.buffer_is_empty && self.query_filter == FilterState::Unfiltered
-    }
-
-    fn should_run_query(&self) -> bool {
-        !self.should_show_zero_state() || self.run_query_on_buffer_empty
     }
 }
 
@@ -462,7 +450,7 @@ impl<T: Action + Clone> SearchBar<T> {
                 // visible.  In the command search view, they're only visible when the
                 // buffer is empty, so if the user accepts one, immediately re-clear the
                 // buffer (to effectively revert the event).
-                if self.state.as_ref(ctx).should_show_zero_state() {
+                if self.should_show_zero_state(ctx) {
                     self.editor_handle.update(ctx, |editor, ctx| {
                         editor.clear_buffer_and_reset_undo_stack(ctx);
                     });
@@ -486,7 +474,7 @@ impl<T: Action + Clone> SearchBar<T> {
                     _ => false,
                 };
 
-                if !self.state.as_ref(ctx).should_run_query() {
+                if !self.should_run_query(ctx) {
                     ctx.emit(SearchBarEvent::EnterInZeroState { modified_enter });
                     return;
                 }
@@ -695,7 +683,7 @@ impl<T: Action + Clone> SearchBar<T> {
             });
         }
 
-        if self.state.as_ref(ctx).should_run_query() {
+        if self.should_run_query(ctx) {
             self.run_query_internal(ctx);
         }
 
@@ -732,7 +720,7 @@ impl<T: Action + Clone> SearchBar<T> {
     }
 
     pub fn run_query(&mut self, ctx: &mut ViewContext<Self>) {
-        if self.state.as_ref(ctx).should_run_query() {
+        if self.should_run_query(ctx) {
             self.run_query_internal(ctx);
         }
     }
@@ -820,16 +808,9 @@ impl<T: Action + Clone> SearchBar<T> {
             .editor_handle
             .read(ctx, |editor, ctx| editor.buffer_text(ctx));
 
-        let buffer_is_empty = current_buffer_text.is_empty();
-        self.state.update(ctx, |state, ctx| {
-            state.buffer_is_empty = buffer_is_empty;
-            ctx.notify();
-        });
-
-        if self.state.as_ref(ctx).should_show_zero_state() {
+        if self.should_show_zero_state(ctx) {
             self.handle_selection_update(SelectionUpdate::Clear, ctx);
-
-            if self.state.as_ref(ctx).should_run_query() {
+            if self.should_run_query(ctx) {
                 self.run_query_internal(ctx);
             }
         } else {
@@ -890,11 +871,21 @@ impl<T: Action + Clone> SearchBar<T> {
         selection_update: SelectionUpdate,
         ctx: &mut ViewContext<Self>,
     ) {
+        let should_show_zero_state = self.should_show_zero_state(ctx);
         self.state.update(ctx, |state, ctx| {
-            state.handle_selection_update(selection_update, ctx);
+            state.handle_selection_update(selection_update, should_show_zero_state, ctx);
         });
 
         self.emit_accessibility_content(ctx);
+    }
+
+    pub fn should_show_zero_state(&self, app: &AppContext) -> bool {
+        self.editor_handle.as_ref(app).is_empty(app)
+            && self.state.as_ref(app).query_filter == FilterState::Unfiltered
+    }
+
+    fn should_run_query(&self, app: &AppContext) -> bool {
+        !self.should_show_zero_state(app) || self.state.as_ref(app).run_query_on_buffer_empty
     }
 
     /// Updates the state and visibility of filter atom autosuggestion text in the editor.

--- a/app/src/search/search_bar.rs
+++ b/app/src/search/search_bar.rs
@@ -664,7 +664,7 @@ impl<T: Action + Clone> SearchBar<T> {
         });
 
         self.update_placeholder_text(ctx);
-        self.run_query(ctx);
+        self.run_query_internal(ctx);
     }
 
     /// Updates the active filter and re-runs the query if the current search state warrants it.
@@ -696,7 +696,7 @@ impl<T: Action + Clone> SearchBar<T> {
         }
 
         if self.state.as_ref(ctx).should_run_query() {
-            self.run_query(ctx);
+            self.run_query_internal(ctx);
         }
 
         // Update the editor placeholder text if necessary.
@@ -710,7 +710,7 @@ impl<T: Action + Clone> SearchBar<T> {
 
     /// Runs a search query using the editor's current contents as the query string with filters
     /// applied.
-    pub fn run_query(&mut self, ctx: &mut ViewContext<Self>) {
+    fn run_query_internal(&mut self, ctx: &mut ViewContext<Self>) {
         let current_editor_text = self
             .editor_handle
             .read(ctx, |editor, ctx| editor.buffer_text(ctx));
@@ -729,6 +729,12 @@ impl<T: Action + Clone> SearchBar<T> {
                 ctx,
             );
         });
+    }
+
+    pub fn run_query(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.state.as_ref(ctx).should_run_query() {
+            self.run_query_internal(ctx);
+        }
     }
 
     fn on_mixer_results_changed(&mut self, ctx: &mut ViewContext<Self>) {
@@ -824,7 +830,7 @@ impl<T: Action + Clone> SearchBar<T> {
             self.handle_selection_update(SelectionUpdate::Clear, ctx);
 
             if self.state.as_ref(ctx).should_run_query() {
-                self.run_query(ctx);
+                self.run_query_internal(ctx);
             }
         } else {
             if self.filterable(ctx) {
@@ -848,7 +854,7 @@ impl<T: Action + Clone> SearchBar<T> {
                     }
                 }
             }
-            self.run_query(ctx);
+            self.run_query_internal(ctx);
         }
         self.update_placeholder_text(ctx);
         self.update_filter_autosuggestion_text(ctx);

--- a/app/src/search/welcome_palette/view.rs
+++ b/app/src/search/welcome_palette/view.rs
@@ -173,7 +173,7 @@ impl warpui::View for WelcomePalette {
         let mut palette = Flex::column();
         palette.add_child(self.render_search_bar());
 
-        if self.search_bar_state.as_ref(app).should_show_zero_state() {
+        if self.search_bar.as_ref(app).should_show_zero_state(app) {
             palette.add_child(
                 Shrinkable::new(
                     1.,
@@ -397,15 +397,15 @@ impl WelcomePalette {
     }
 
     pub fn select_next_item(&mut self, ctx: &mut ViewContext<Self>) {
-        self.search_bar_state.update(ctx, |state, ctx| {
-            state.handle_selection_update(SelectionUpdate::Down, ctx);
+        self.search_bar.update(ctx, |search_bar, ctx| {
+            search_bar.handle_selection_update(SelectionUpdate::Down, ctx);
         });
         ctx.notify();
     }
 
     pub fn select_prev_item(&mut self, ctx: &mut ViewContext<Self>) {
-        self.search_bar_state.update(ctx, |state, ctx| {
-            state.handle_selection_update(SelectionUpdate::Up, ctx);
+        self.search_bar.update(ctx, |search_bar, ctx| {
+            search_bar.handle_selection_update(SelectionUpdate::Up, ctx);
         });
         ctx.notify();
     }


### PR DESCRIPTION
## Description

This is another optimization for #10256

In this PR, we remove unnecessary work when showing the command palette zero state.

## Linked Issue

Context for this is in Slack.

## Testing

I sent a custom build to the reporter in Slack and they confirmed this is much better.


<!--
## Changelog Entries for Stable



CHANGELOG-IMPROVEMENT: Command palette opens faster in large repositories.
-->
