### PR TITLE
feat: add jq syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ dependencies = [
  "arborium-html",
  "arborium-java",
  "arborium-javascript",
+ "arborium-jq",
  "arborium-json",
  "arborium-kotlin",
  "arborium-lua",
@@ -772,6 +773,17 @@ name = "arborium-javascript"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3b04390f79e704f411fec9f11acd1ee7e6bc3c4e1941ca6af41d31efad78582"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-jq"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdce2ce4dabcff7626fb09fcb2a6915ce4714d2f6a190dc8c54dac1bd2072da"
 dependencies = [
  "arborium-sysroot",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,6 +281,7 @@ arborium = { version = "2", default-features = false, features = [
   "lang-css",
   "lang-c",
   "lang-json",
+  "lang-jq",
   "lang-hcl",
   "lang-lua",
   "lang-ruby",

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -738,6 +738,7 @@ impl ProgrammingLanguage {
                 "css" => Some("css"),
                 "c" => Some("c"),
                 "json" => Some("json"),
+                "jq" => Some("jq"),
                 "hcl" | "terraform" | "tf" => Some("hcl"),
                 "lua" => Some("lua"),
                 "ruby" | "rb" => Some("rb"),

--- a/crates/languages/grammars/jq/config.yaml
+++ b/crates/languages/grammars/jq/config.yaml
@@ -1,0 +1,13 @@
+display_name: "jq"
+indent_unit:
+  space: 2
+comment_prefix: "#"
+brackets:
+  - start: "{"
+    end: "}"
+  - start: "("
+    end: ")"
+  - start: "["
+    end: "]"
+  - start: "\""
+    end: "\""

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -19,7 +19,7 @@ lazy_static! {
     static ref LANGUAGE_REGISTRY: LanguageRegistry = LanguageRegistry::new();
 }
 
-pub const SUPPORTED_LANGUAGES: [&str; 32] = [
+pub const SUPPORTED_LANGUAGES: [&str; 33] = [
     "rust",
     "golang",
     "yaml",
@@ -36,6 +36,7 @@ pub const SUPPORTED_LANGUAGES: [&str; 32] = [
     "css",
     "c",
     "json",
+    "jq",
     "hcl",
     "lua",
     "ruby",
@@ -159,6 +160,7 @@ pub fn language_by_filename(path: &Path) -> Option<Arc<Language>> {
         "css" => language_by_name("css"),
         "c" => language_by_name("c"),
         "json" => language_by_name("json"),
+        "jq" => language_by_name("jq"),
         "tf" | "hcl" | "tfvars" => language_by_name("hcl"),
         "lua" => language_by_name("lua"),
         "rb" => language_by_name("ruby"),
@@ -254,6 +256,7 @@ fn get_arborium_highlight_query(lang: &str) -> Option<&str> {
         "css" => Some(arborium::lang_css::HIGHLIGHTS_QUERY),
         "c" => Some(arborium::lang_c::HIGHLIGHTS_QUERY),
         "json" => Some(arborium::lang_json::HIGHLIGHTS_QUERY),
+        "jq" => Some(arborium::lang_jq::HIGHLIGHTS_QUERY),
         "hcl" => Some(arborium::lang_hcl::HIGHLIGHTS_QUERY),
         "lua" => Some(arborium::lang_lua::HIGHLIGHTS_QUERY),
         "ruby" => Some(arborium::lang_ruby::HIGHLIGHTS_QUERY),

--- a/crates/warp_util/src/file_type.rs
+++ b/crates/warp_util/src/file_type.rs
@@ -226,7 +226,7 @@ fn is_development_text_extension(extension: &str) -> bool {
         "svelte" | "astro" | "blade" | "twig" | "mustache" | "hbs" |
         "handlebars" | "ejs" | "pug" | "jade" | "erb" | "haml" |
         // Configuration and data formats
-        "toml" | "yaml" | "yml" | "json" | "jsonc" | "json5" |
+        "toml" | "yaml" | "yml" | "json" | "jsonc" | "json5" | "jq" |
         "xml" | "ini" | "cfg" | "conf" | "config" | "properties" |
         "env" | "dotenv" | "editorconfig" | "gitignore" | "gitattributes" |
         // Documentation


### PR DESCRIPTION
## Description
Adds jq to the list of syntax-highlighted languages by enabling the `lang-jq` feature on arborium and registering `jq` in `crates/languages/src/lib.rs` (`SUPPORTED_LANGUAGES`, extension mapping, highlight-query lookup). Adds `crates/languages/grammars/jq/config.yaml` with display name, 2-space indent, `#` comment prefix, and standard brackets — uses arborium's bundled highlights, so no `.scm` files are needed. Also keeps the two parallel "kept-in-sync" language lists current: `ProgrammingLanguage::to_extension` in the AI agent, and `is_development_text_extension` in `warp_util/file_type.rs`.

## Testing
- [x] I have manually tested my changes locally with `./script/run`

Automated coverage:
- `cargo test -p languages` — `all_supported_languages_load_successfully` confirms the grammar + bundled highlight query parse cleanly
- `cargo clippy --workspace --exclude warp_completer --exclude command-signatures-v2 --all-targets --tests -- -D warnings` — clean
- `cargo nextest run --workspace --exclude command-signatures-v2` — only failures are pre-existing on master (5 SSH integration tests + 1 settings-migration test that depends on absent `~/.warp-oss/settings.toml`); verified by re-running with my changes stashed

### Screenshots / Videos
<img width="1357" height="737" alt="Screenshot 2026-05-08 at 8 36 05 PM" src="https://github.com/user-attachments/assets/8a635b24-ba36-453e-9898-ed1104a1e355" />

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Used claude code


CHANGELOG-IMPROVEMENT: jq syntax highlighting for code blocks and `.jq` files
