### PR TITLE
fix: Able to run 'open .command' file

### DIFF
--- a/app/src/uri/uri_tests.rs
+++ b/app/src/uri/uri_tests.rs
@@ -608,7 +608,7 @@ fn test_open_file_non_executable_sh_routes_to_editor() {
 fn test_open_file_executable_bash_zsh_fish_route_to_execute() {
     use std::os::unix::fs::PermissionsExt;
     let dir = tempfile::tempdir().unwrap();
-    for name in ["run.bash", "run.zsh", "run.fish"] {
+    for name in ["run.bash", "run.zsh", "run.fish", "run.command"] {
         let p = dir.path().join(name);
         std::fs::write(&p, b"#!/bin/sh\n:\n").unwrap();
         std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();

--- a/app/src/util/openable_file_type.rs
+++ b/app/src/util/openable_file_type.rs
@@ -119,7 +119,7 @@ pub fn is_runnable_shell_script(path: &Path) -> bool {
         .and_then(|e| e.to_str())
         .map(|e| e.to_ascii_lowercase());
     if let Some(ext) = ext.as_deref() {
-        return matches!(ext, "sh" | "bash" | "zsh" | "fish" | "ksh");
+        return matches!(ext, "sh" | "bash" | "zsh" | "fish" | "ksh" | "command");
     }
     starts_with_shebang(path)
 }
@@ -445,7 +445,7 @@ mod tests {
     fn test_is_runnable_shell_script_other_shell_extensions() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();
-        for name in ["run.bash", "run.zsh", "run.fish", "run.ksh"] {
+        for name in ["run.bash", "run.zsh", "run.fish", "run.ksh", "run.command"] {
             let p = dir.path().join(name);
             std::fs::write(&p, b"#!/bin/sh\n:\n").unwrap();
             std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();


### PR DESCRIPTION
## Description

Allow `.command` files to be executed directly via the `open` command, matching macOS default behavior. Previously, double-clicking or opening a `.command` file in Warp routed to the editor instead of executing it.

This change adds `"command"` to the list of extensions recognized by `is_runnable_shell_script` so executable `.command` files are properly run as shell scripts.

## Linked Issue

Fixes #9213

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Updated the existing unit tests in `openable_file_type.rs` and URI routing tests in `uri_tests.rs` to cover `.command` files alongside the other shell extensions (`bash`, `zsh`, `fish`, `ksh`). The new cases verify that an executable `.command` file is detected as a runnable shell script and routed to execution rather than the editor.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

N/A — no UI changes.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed `.command` files not being executed when opened via the `open` command.
-->