### PR TITLE
fix(features): enable ImeMarkedText on macOS regardless of release_bundle

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2458,6 +2458,15 @@ pub fn enabled_features() -> HashSet<FeatureFlag> {
         flags.extend(features::RELEASE_FLAGS);
     }
 
+    // IME marked text is the only piece of CJK / dead-key Latin / emoji-candidate input
+    // rendering on macOS — without this flag, `setMarkedText:` calls are short-circuited in
+    // the terminal view and no preedit is ever drawn, breaking text input for any user with
+    // an IME enabled. Stable / Preview macOS already enable it via RELEASE_FLAGS, but the
+    // OSS distribution doesn't pass `feature = "release_bundle"`, so the flag stays off and
+    // CJK users effectively can't type. Enable it unconditionally on macOS to match.
+    #[cfg(target_os = "macos")]
+    flags.insert(FeatureFlag::ImeMarkedText);
+
     flags.extend([
         #[cfg(feature = "autoupdate")]
         FeatureFlag::Autoupdate,


### PR DESCRIPTION
## Summary

Without `FeatureFlag::ImeMarkedText`, `setMarkedText:` callbacks from the macOS input system are short-circuited inside the terminal view (`set_marked_text_on_terminal` early-returns) and no IME preedit is ever drawn. That breaks text input for any user typing through an IME — CJK pinyin / wubi, Japanese kana / romaji, Korean hangul, dead-key Latin (French / German / Spanish / Vietnamese), macOS auto-correct candidates, emoji candidate windows, etc.

**Visible symptom**: typing pinyin shows no Latin preedit characters in the input box; the only thing that appears is the final committed Chinese after picking a candidate. Effectively, CJK users can't type at all in OSS macOS builds.

## Why this only affects OSS

Stable / Preview macOS get this flag via `RELEASE_FLAGS` because they build with `cfg!(feature = "release_bundle")` — so the rendering code path is well-exercised and stable. The OSS distribution simply doesn't pass that cargo feature when running `cargo bundle --bin warp-oss --features gui`, so `is_release_bundle()` returns false, `RELEASE_FLAGS` is never extended, and macOS OSS users lose IME entirely.

## Repro (before this patch)

```bash
cargo bundle --bin warp-oss --features gui --release
cp -R target/release/bundle/osx/WarpOss.app /Applications/
open /Applications/WarpOss.app
```

Type pinyin into any TUI input (zsh, vim, Claude Code, etc.) inside WarpOss.
- Expected: Latin letters of the in-progress pinyin appear inline (typically underlined).
- Actual: nothing appears until a Chinese candidate is committed.

## Fix

Insert `FeatureFlag::ImeMarkedText` unconditionally for macOS in `enabled_features()`, after the release-bundle gate. Matches the existing `#[cfg(target_os = "macos")]` guard in `RELEASE_FLAGS` so behavior on Linux / Windows is unchanged (their marked-text paths are separate and gated by their own platform-specific work, e.g. #9602 for Linux/Wayland IME enable).

9 lines added, no other changes.

## Verification

- `cargo check -p warp --bin warp-oss --features gui` clean (0 errors).
- Manual repro on a re-built bundle: IME preedit now renders inline correctly across pinyin / Japanese / Korean test cases.

## Notes

This is functionally equivalent to passing `--features release_bundle` at build time, but scoped to just the IME rendering flag rather than also turning on `Autoupdate` / `Changelog` / `CrashReporting` / `SshRemoteServer` (each of which has its own cargo-feature dependencies and may not be desired for OSS bundles).

Linux / Windows are unaffected by this change. Their respective IME paths are tracked elsewhere — Linux/Wayland enable in #9602, Windows IMM32/TSF would need a separate implementation.