### PR TITLE
feat: add Anthropic proxy URL (Meridian / Claude Max) to BYOK settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,8 +306,8 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "3dd0cd81eae83b4ce09c7805c8ef12599798aa26" }
-wasm-bindgen = "0.2.89"
+warp_multi_agent_api = { git = "https://github.com/simonmeacham/warp-proto-apis.git", rev = "153c5671949dc37a4bfc2041066cbad1be02e7dc" }
+# warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [
   "Blob",

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -6309,6 +6309,7 @@ impl SettingsWidget for CloudAgentComputerUseWidget {
 struct ApiKeysWidget {
     openai_api_key_editor: ViewHandle<EditorView>,
     anthropic_api_key_editor: ViewHandle<EditorView>,
+    anthropic_base_url_editor: ViewHandle<EditorView>,
     google_api_key_editor: ViewHandle<EditorView>,
 
     can_use_warp_credits_with_byok: SwitchStateHandle,
@@ -6326,6 +6327,7 @@ impl ApiKeysWidget {
             openai: openai_key,
             anthropic: anthropic_key,
             google: google_key,
+            anthropic_base_url: anthropic_base_url_value,
             ..
         } = ApiKeyManager::as_ref(ctx).keys().clone();
 
@@ -6414,9 +6416,75 @@ impl ApiKeysWidget {
             "AIzaSy..."
         );
 
+        // Meridian proxy URL editor — plain text (not a password field).
+        let anthropic_base_url_editor = ctx.add_typed_action_view(move |ctx| {
+            let appearance = Appearance::handle(ctx).as_ref(ctx);
+            let options = SingleLineEditorOptions {
+                is_password: false,
+                text: TextOptions {
+                    font_size_override: Some(appearance.ui_font_size()),
+                    font_family_override: Some(appearance.monospace_font_family()),
+                    text_colors_override: Some(TextColors {
+                        default_color: appearance.theme().active_ui_text_color(),
+                        disabled_color: appearance.theme().disabled_ui_text_color(),
+                        hint_color: appearance.theme().disabled_ui_text_color(),
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let mut editor = EditorView::single_line(options, ctx);
+            editor.set_placeholder_text("http://localhost:3456", ctx);
+            if let Some(url) = &anthropic_base_url_value {
+                editor.set_buffer_text(url, ctx);
+            }
+            editor
+        });
+        AISettingsPageView::update_editor_interaction_state(
+            anthropic_base_url_editor.clone(),
+            is_any_ai_enabled && is_byo_enabled,
+            ctx,
+        );
+        ctx.subscribe_to_view(&anthropic_base_url_editor, |_, editor, event, ctx| {
+            if matches!(event, EditorEvent::Blurred | EditorEvent::Enter) {
+                let buffer_text = editor.as_ref(ctx).buffer_text(ctx);
+                let url = buffer_text.is_empty().not().then_some(buffer_text);
+                ApiKeyManager::handle(ctx).update(ctx, |model, ctx| {
+                    model.set_anthropic_base_url(url, ctx);
+                });
+            }
+        });
+        let base_url_editor_clone = anthropic_base_url_editor.clone();
+        ctx.subscribe_to_model(&workspace_handle, move |_, workspace, event, ctx| {
+            if let UserWorkspacesEvent::TeamsChanged = event {
+                let is_any_ai_enabled =
+                    AISettings::handle(ctx).as_ref(ctx).is_any_ai_enabled(ctx);
+                let is_byo_enabled = workspace.as_ref(ctx).is_byo_api_key_enabled();
+                let is_enabled = is_any_ai_enabled && is_byo_enabled;
+                let has_url = !base_url_editor_clone.as_ref(ctx).is_empty(ctx);
+
+                if !is_byo_enabled && has_url {
+                    base_url_editor_clone.update(ctx, |editor, ctx| {
+                        editor.set_buffer_text("", ctx);
+                    });
+                    ApiKeyManager::handle(ctx).update(ctx, |model, ctx| {
+                        model.set_anthropic_base_url(None, ctx);
+                    });
+                }
+
+                AISettingsPageView::update_editor_interaction_state(
+                    base_url_editor_clone.clone(),
+                    is_enabled,
+                    ctx,
+                );
+                ctx.notify();
+            }
+        });
+
         Self {
             openai_api_key_editor,
             anthropic_api_key_editor,
+            anthropic_base_url_editor,
             google_api_key_editor,
 
             can_use_warp_credits_with_byok: Default::default(),
@@ -6497,6 +6565,13 @@ impl ApiKeysWidget {
             appearance,
             "Anthropic API Key",
             self.anthropic_api_key_editor.clone(),
+            is_enabled,
+            app,
+        ));
+        column.add_child(render_api_key_input(
+            appearance,
+            "Anthropic Proxy URL (Meridian / Claude Max)",
+            self.anthropic_base_url_editor.clone(),
             is_enabled,
             app,
         ));
@@ -6603,7 +6678,7 @@ impl SettingsWidget for ApiKeysWidget {
     type View = AISettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "api keys bring your own byo openai anthropic google claude gemini gpt"
+        "api keys bring your own byo openai anthropic google claude gemini gpt meridian proxy claude max local"
     }
 
     fn render(

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -22,6 +22,16 @@ pub struct ApiKeys {
     pub anthropic: Option<String>,
     pub openai: Option<String>,
     pub open_router: Option<String>,
+    /// Optional base URL override for the Anthropic API endpoint.
+    ///
+    /// When set, requests to Anthropic are routed through this URL instead
+    /// of the default `api.anthropic.com`. Intended for use with a locally
+    /// running Anthropic-compatible proxy such as Meridian, which bridges
+    /// the Claude Code SDK to the standard Anthropic API and allows use of
+    /// a Claude Max subscription with Warp's agent.
+    ///
+    /// Example: `http://localhost:3456`
+    pub anthropic_base_url: Option<String>,
 }
 
 impl ApiKeys {
@@ -30,6 +40,7 @@ impl ApiKeys {
             || self.anthropic.is_some()
             || self.google.is_some()
             || self.open_router.is_some()
+            || self.anthropic_base_url.is_some()
     }
 }
 
@@ -89,6 +100,16 @@ impl ApiKeyManager {
 
     pub fn set_open_router_key(&mut self, key: Option<String>, ctx: &mut ModelContext<Self>) {
         self.keys.open_router = key;
+        ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+        self.write_keys_to_secure_storage(ctx);
+    }
+
+    pub fn set_anthropic_base_url(
+        &mut self,
+        url: Option<String>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.keys.anthropic_base_url = url;
         ctx.emit(ApiKeyManagerEvent::KeysUpdated);
         self.write_keys_to_secure_storage(ctx);
     }
@@ -154,11 +175,17 @@ impl ApiKeyManager {
             })
             .flatten();
 
+        let anthropic_base_url = include_byo_keys
+            .then(|| self.keys.anthropic_base_url.clone())
+            .flatten()
+            .unwrap_or_default();
+
         if anthropic.is_empty()
             && openai.is_empty()
             && google.is_empty()
             && open_router.is_empty()
             && aws_credentials.is_none()
+            && anthropic_base_url.is_empty()
         {
             None
         } else {
@@ -169,6 +196,7 @@ impl ApiKeyManager {
                 open_router,
                 allow_use_of_warp_credits: false,
                 aws_credentials,
+                anthropic_base_url,
             })
         }
     }


### PR DESCRIPTION
## Summary

Adds an optional **Anthropic Proxy URL** field to the API Keys settings page, allowing users to route Anthropic API calls through a local Anthropic-compatible proxy server such as [Meridian](https://github.com/rynfar/meridian).

Meridian bridges the Claude Code SDK to the standard Anthropic API, enabling users with a Claude Max subscription to use Warp's AI agent without consuming Warp credits.

## Changes

### `warp-proto-apis` (companion PR: [simonmeacham/warp-proto-apis](https://github.com/simonmeacham/warp-proto-apis/tree/feature/meridian-proxy))
- Added `string anthropic_base_url = 7` to the `ApiKeys` message in `request.proto`
- When set, Warp's server routes Anthropic API calls to this URL instead of `api.anthropic.com`

### `crates/ai/src/api_keys.rs`
- Added `anthropic_base_url: Option<String>` field to the `ApiKeys` struct (serialized to secure storage alongside other keys)
- Added `set_anthropic_base_url()` setter on `ApiKeyManager`
- `api_keys_for_request()` now includes `anthropic_base_url` in the proto payload when BYOK is enabled

### `app/src/settings_view/ai_page.rs`
- New **"Anthropic Proxy URL (Meridian / Claude Max)"** plain-text input field rendered below the existing Anthropic API Key field
- Follows the same enable/disable lifecycle as other BYOK fields (respects the BYO plan gating and global AI toggle)
- Persisted via `ApiKeyManager` on blur/enter
- Added `meridian proxy claude max local` to search terms so users can find it by searching for "meridian" in settings

### `Cargo.toml`
- Points `warp_multi_agent_api` at the fork containing the new proto field

## How to test

1. Install [Meridian](https://github.com/rynfar/meridian): `npm install -g @rynfar/meridian`
2. Authenticate: `claude login`
3. Start the proxy: `meridian` (runs on `http://localhost:3456`)
4. In Warp Settings → search `API keys` → set **Anthropic Proxy URL** to `http://localhost:3456`
5. Set **Anthropic API Key** to any non-empty value (e.g. `x`) — the proxy ignores it
6. Select a Claude model with a key icon in the model picker
7. Agent requests should now route through Meridian → Claude Max, with 0 Warp credits consumed

## Notes

- This requires server-side support to honour the `anthropic_base_url` field — the proto change and client plumbing are complete; the server-side routing is the remaining piece
- The proxy URL is stored locally in secure storage and never synced to the cloud, consistent with other BYOK keys

---

_Generated with [Warp](https://app.warp.dev/conversation/42a57dc9-3ef1-4813-baef-af3145fb5f62)_

Co-Authored-By: Oz <oz-agent@warp.dev>