### PR TITLE
fix(file-tree): add Refresh to directory right-click menu

### DIFF
--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -136,6 +136,9 @@ pub enum FileTreeAction {
     CDToDirectory {
         id: FileTreeIdentifier,
     },
+    RefreshDirectory {
+        id: FileTreeIdentifier,
+    },
     DismissEditor,
     ItemDroppedOnInput {
         id: FileTreeIdentifier,
@@ -2370,6 +2373,13 @@ impl FileTreeView {
                             .with_on_select_action(FileTreeAction::OpenInNewTab { id: id.clone() })
                             .into_item(),
                     );
+                    items.push(
+                        MenuItemFields::new("Refresh")
+                            .with_on_select_action(FileTreeAction::RefreshDirectory {
+                                id: id.clone(),
+                            })
+                            .into_item(),
+                    );
                 }
             };
 
@@ -2535,6 +2545,43 @@ impl FileTreeView {
 
         ctx.emit(FileTreeEvent::CDToDirectory { path });
     }
+
+    /// Re-reads the right-clicked directory's contents from disk and updates the tree.
+    /// Surgical: only the targeted directory is re-scanned (one level deep, matching lazy-load behavior).
+    /// Bypasses watcher staleness from dropped FSEvents or lazy-load mutation drops.
+    #[cfg(feature = "local_fs")]
+    fn refresh_directory(&mut self, id: &FileTreeIdentifier, ctx: &mut ViewContext<Self>) {
+        let Some(root_dir) = self.root_directories.get(&id.root) else {
+            return;
+        };
+        let Some(item) = root_dir.items.get(id.index) else {
+            return;
+        };
+        let FileTreeItem::DirectoryHeader { .. } = item else {
+            return;
+        };
+        let dir_path = item.path().clone();
+        let local_path = dir_path.to_local_path_lossy();
+        // The displayed file-tree root (id.root) can be a subdirectory of the
+        // indexed repository (cwd-inside-repo case), in which case it is not a
+        // valid repo_root key for load_directory and the call would return
+        // RepoNotFound. Look up the actual indexed repository root that contains
+        // dir_path, falling back to the displayed root for standalone lazy-loaded
+        // paths where they coincide.
+        let repo_root = self
+            .repository_metadata_model
+            .as_ref(ctx)
+            .find_repository_for_path(&local_path, ctx)
+            .unwrap_or_else(|| id.root.clone());
+        self.repository_metadata_model.update(ctx, |model, ctx| {
+            if let Err(err) = model.load_directory(&repo_root, &dir_path, ctx) {
+                log::warn!("Refresh failed for {dir_path:?}: {err:?}");
+            }
+        });
+    }
+
+    #[cfg(not(feature = "local_fs"))]
+    fn refresh_directory(&mut self, _id: &FileTreeIdentifier, _ctx: &mut ViewContext<Self>) {}
 
     fn rename_item(&mut self, id: &FileTreeIdentifier, ctx: &mut ViewContext<Self>) {
         let exists = self
@@ -3099,6 +3146,12 @@ impl TypedActionView for FileTreeView {
             FileTreeAction::CDToDirectory { id } => {
                 if !self.is_remote_item(id) {
                     self.cd_to_directory(id, ctx);
+                }
+                self.context_menu_state.take();
+            }
+            FileTreeAction::RefreshDirectory { id } => {
+                if !self.is_remote_item(id) {
+                    self.refresh_directory(id, ctx);
                 }
                 self.context_menu_state.take();
             }

--- a/crates/repo_metadata/src/file_tree_store/file_tree_state.rs
+++ b/crates/repo_metadata/src/file_tree_store/file_tree_state.rs
@@ -196,6 +196,12 @@ impl FileTreeMapStore {
         });
 
         entry.load(gitignores)?;
+        // Clear any stale state for this path before re-inserting. Without this,
+        // `insert_entry_at_path` only `extend`s the maps, so entries for files
+        // that were deleted on disk between loads remain in the tree. Safe for
+        // first-time-expand callers because the path's previous value is just an
+        // unloaded placeholder with no descendants in the maps.
+        self.remove(path);
         self.insert_entry_at_path(child_path, entry);
         Ok(())
     }


### PR DESCRIPTION
## Summary

Adds a `Refresh` menu item under directory headers in the file tree right-click context menu. Re-reads the clicked directory's contents from disk (one level deep, matching lazy-load behavior) via the existing `LocalRepoMetadataModel::load_directory` path.

## Why

Long-standing open issues report Project Explorer / file tree failing to reflect filesystem changes after the initial scan:

- #10205 — newly created files/folders don't appear
- #9190 — only quitting and reopening Warp updates the tree
- #9890 — refresh too slow on macOS

Source-level: in `apply_file_tree_mutations` (`crates/repo_metadata/src/local_model.rs`), three branches do `if lazy_load && !is_parent_loaded_in_entry { continue }`, silently dropping watcher mutations when a parent directory is not loaded. Combined with FSEvents itself being best-effort, the in-memory tree drifts from disk and there is currently no API or UI to reconcile.

## What this PR does

- New `FileTreeAction::RefreshDirectory { id }` variant
- Right-click menu on any directory header now shows `Refresh` after `Open in new tab`
- Dispatch handler calls a new `refresh_directory` helper
- Helper resolves the target directory and calls the existing wrapper `RepoMetadataModel::load_directory(repo_root, dir_path, ctx)`, which delegates to `LocalRepoMetadataModel::load_directory` → `Entry::load` → `Entry::build_tree` (force-reads from disk)

Surgical scope: only the targeted subtree is re-scanned. No watcher churn, no full root re-index. `FileTreeItem::File` does not get the option since files don't have contents to refresh.

## What this PR does NOT do (intentionally scoped out)

- **Does not fix the underlying watcher event drop** — the lazy_load `continue` paths in `apply_file_tree_mutations` still silently skip mutations. That is a separate, deeper architectural fix (would need observability + force-rescan + reconciliation hooks layered on top, see analysis in #10205).
- **Does not implement the Command Palette action requested in #10003** — that is tracked separately by spec PR #10025. This PR adds the right-click entry only; a Command Palette / keybinding entry can be a follow-up that calls the same `refresh_directory` helper.
- **Single-level rescan only** — recursive deep refresh is out of scope for v1.

## Files

- `app/src/code/file_tree/view.rs` — +42 lines, 0 deletions

## Verification

- `cargo check -p warp --bin warp-oss` clean
- `cargo clippy -p warp --bin warp-oss --no-deps` no new warnings
- Manually verified on a self-built `warp-oss` bundle: right-click any directory header → `Refresh` appears after `Open in new tab`; selecting it reconciles a drifted subtree

Closes #10205