### PR TITLE
spec: opt-in native left-drag selection in TUIs (#10353)

### DIFF
--- a/specs/GH10353/product.md
+++ b/specs/GH10353/product.md
@@ -1,0 +1,102 @@
+# PRODUCT.md — Opt-in native left-drag selection in TUIs
+
+Issue: https://github.com/warpdotdev/warp/issues/10353
+Reference implementation: `spalagu/warp:fix/left-drag-selection` (commit `f1c38c76`)
+
+## Summary
+
+Add a new `terminal.native_left_drag_select_enabled` setting (default `false`) to the AltScreenReporting group. When enabled, left mouse button events (down, drag, up) inside a full-screen TUI bypass the mouse-reporting protocol and are handled by Warp's native selection — same effect as if `Shift` were held for that gesture.
+
+This matches iTerm2's long-standing default of "left-button drag is always native selection, hold a modifier to forward to the TUI", and resolves the discoverability gap where macOS users expect bare left-drag to select but Warp instead forwards it to the running application.
+
+The setting defaults to `false` so no existing user sees a behavior change.
+
+## Problem
+
+In full-screen TUIs (Claude Code, vim, htop, tmux, fzf overlays, etc.), Warp currently forwards bare left-button drag gestures to the application via mouse reporting. The application owns that gesture, Warp creates no native selection, and on macOS `Cmd+C` — which is intercepted by the terminal app and never reaches the TUI as stdin — therefore copies nothing visible to the user.
+
+The existing `Shift`-drag bypass technically solves this, but:
+
+- It is not surfaced anywhere in the UI; users have to read documentation to know about it.
+- It conflicts with macOS muscle memory where bare left-drag selects in every other text-displaying app (Mail, Notes, Safari, native Terminal.app).
+- For users who rely heavily on copy-from-TUI workflows (LLM chat output in TUI agents, log inspection in `htop` / `k9s`, vim yank-to-system-clipboard), holding Shift on every selection is friction.
+
+The pain is amplified for CJK / pinyin users who already context-switch between IME and copy actions.
+
+## Goals
+
+- Provide a persistent, user-configurable opt-in that makes bare left-drag in mouse-reporting TUIs create a Warp native selection.
+- Preserve current behavior by default — no change for users who don't enable the setting.
+- Preserve all non-left-drag TUI mouse functionality (right-click, scroll, middle-click, modifier+click) regardless of the setting.
+- Expose the toggle through the same surfaces as the other AltScreenReporting toggles (Settings UI, command palette, settings JSON, context flag for keybindings).
+- Match the working reference implementation (`f1c38c76`) so the spec describes a known-good design rather than a new proposal.
+
+## Non-goals
+
+- **Not the new default.** Leave existing behavior intact for all current users.
+- **Not removing `Shift`-drag.** The existing `Shift`-modifier bypass continues to work regardless of the new setting.
+- **Not a transient `Option`-key bypass.** A modifier-based per-gesture bypass is complementary but separate (see #2990 / #3280) and out of scope here.
+- **Not changing `Cmd+C` routing, stdin byte generation, or TUI clipboard integrations.** The setting only affects whether left-button events are intercepted by Warp's selection path before reaching mouse reporting.
+- **Not changing right-click / scroll / middle-click / modifier+click behavior** — those continue to follow `terminal.mouse_reporting_enabled` / `terminal.scroll_reporting_enabled` exactly as today.
+- **Not a per-app or per-TUI heuristic.** No special-casing of Claude Code / vim / tmux / etc.
+
+## User experience
+
+### Default (setting = `false`)
+
+Identical to today's behavior. Bare left-drag in a mouse-reporting TUI is forwarded to the application. `Shift`-drag still creates Warp native selection.
+
+### When enabled (setting = `true`)
+
+| Mouse gesture inside mouse-reporting TUI | Behavior |
+|---|---|
+| Bare left-button down → drag → up | **Native Warp selection** (new) |
+| `Shift`-modified left-drag | Native Warp selection (unchanged) |
+| Right-click | Forwarded to TUI (unchanged) |
+| Scroll wheel / trackpad scroll | Follows `terminal.scroll_reporting_enabled` (unchanged) |
+| Middle-click | Forwarded to TUI (unchanged) |
+| Modifier+click (Cmd / Ctrl / Option) | Forwarded to TUI (unchanged) |
+
+After the native selection exists, `Cmd+C` copies through Warp's normal clipboard path. Selection rendering, multi-click semantics, and rectangular selection follow existing native-selection rules unchanged.
+
+The setting takes effect uniformly in alt-screen rendering and in active long-running command blocks that currently participate in mouse reporting.
+
+### Settings surfaces
+
+- **Settings → Features → Terminal**: a new toggle row labeled **"Native Left-Drag Selection"**, placed after the existing "Enable Focus Reporting" row, using the same widget shape and sync indicator as other AltScreenReporting toggles.
+- **Command palette**: searchable as `native left drag select`. The `ToggleSettingActionPair` registration mirrors the other AltScreenReporting toggles.
+- **Settings search index**: terms include `native left drag select`, `cmd c copy`, `iterm`, `cjk` so users searching for the actual pain points reach the toggle.
+- **`~/.warp/user_preferences.json`**: writable as `terminal.native_left_drag_select_enabled = true`.
+- **Keybinding context flag**: `NATIVE_LEFT_DRAG_SELECT_CONTEXT_FLAG` so users can bind enable/disable actions consistently with other toggleable settings.
+
+### Telemetry
+
+A new `FeaturesPageAction::ToggleNativeLeftDragSelect` variant is recorded with the same shape as the other AltScreenReporting toggle telemetry (which-toggle + new-value).
+
+## Success criteria
+
+1. Setting defaults to `false`. Existing users see no behavior change after upgrade.
+2. Toggle is reachable from Settings UI, command palette, and JSON.
+3. With setting enabled: bare left-drag in Claude Code / vim / htop / tmux selects natively in Warp; `Cmd+C` copies that selection.
+4. With setting disabled: bare left-drag still forwards to TUI as today.
+5. Right-click / scroll / middle-click / modifier+click are unaffected by the setting in either state.
+6. `Shift`-drag continues to create Warp native selection regardless of setting state.
+7. Setting works identically in alt-screen rendering and in active long-running blocks.
+8. `terminal.mouse_reporting_enabled`, `terminal.scroll_reporting_enabled`, `terminal.focus_reporting_enabled` retain their existing defaults, labels, command actions, and behavior.
+
+## Validation
+
+Reference impl already validates the following manually on macOS:
+
+- Claude Code: bare drag selects + `Cmd+C` copies; right-click context menu still shows; scroll still scrolls TUI history.
+- vim: bare drag selects across visual buffer + `Cmd+C` copies; `Shift`-drag also works; visual mode triggered via `v` / `V` is unaffected.
+- htop: bare drag selects column text + `Cmd+C` copies; `F-key` interactions still work.
+- tmux (default mouse mode): bare drag selects across panes + `Cmd+C` copies; pane-resize drag (which uses `option`+drag in tmux config) still forwards.
+
+Automated test coverage in `app/src/terminal/view_tests.rs` is updated for the new `should_intercept_mouse` signature; existing alt-screen mouse tests continue to pass.
+
+## Open questions
+
+- **Setting label**: "Native Left-Drag Selection" matches the reference impl. Alternative: "iTerm2-Style Left-Drag Selection" — more discoverable for users coming from iTerm2 but introduces a brand-name dependency.
+- **Default value, future**: keep `false` permanently for backward compatibility, or consider flipping to `true` in a future major version after sufficient telemetry?
+- **Per-app override**: out of scope here; could be a follow-up if telemetry shows users want different behavior in specific TUIs (e.g., always select in Claude Code but always forward in tmux).

--- a/specs/GH10353/tech.md
+++ b/specs/GH10353/tech.md
@@ -1,0 +1,186 @@
+# TECH.md — Opt-in native left-drag selection in TUIs
+
+Issue: https://github.com/warpdotdev/warp/issues/10353
+Product spec: `specs/GH10353/product.md`
+Reference implementation: `spalagu/warp:fix/left-drag-selection` (commit `f1c38c76`, +124 −15)
+
+## Problem
+
+`should_intercept_mouse(model, shift, ctx)` in `app/src/terminal/alt_screen/mod.rs` is the central decision: should this mouse event be handled by Warp's native selection / context menu / scroll, or forwarded to the TUI via SGR mouse reporting? Today it intercepts only on:
+
+1. Shared-session reader state.
+2. `Shift` modifier.
+3. Mouse-reporting being globally disabled.
+
+Otherwise, with mouse reporting on, *everything* — including bare left-drag — forwards to the TUI. That is the source of the user-experience problem.
+
+The fix is one new boolean setting plus a one-parameter signature extension; the rest is wiring.
+
+## Relevant code (verified against `master @ HEAD`)
+
+- `app/src/terminal/alt_screen_reporting.rs` — defines the `AltScreenReporting` settings group with `mouse_reporting_enabled`, `scroll_reporting_enabled`, `focus_reporting_enabled`.
+- `app/src/terminal/alt_screen/mod.rs` — `should_intercept_mouse(...)` and `should_intercept_scroll(...)`.
+- `app/src/terminal/alt_screen/alt_screen_element.rs` — alt-screen mouse dispatch:
+  - `left_mouse_down` → `should_intercept_mouse` → `AltSelect::Begin` or `AltMouseAction`.
+  - `right_mouse_down` → `should_intercept_mouse` → context menu or `AltMouseAction`.
+  - `mouse_up` → if `is_terminal_selecting` then `AltSelect::End`.
+  - `mouse_dragged` → `AltSelect::Update` or `AltMouseAction` based on whether selection is in progress.
+- `app/src/terminal/block_list_element.rs` — block-list mouse dispatch when an active long-running block participates in mouse reporting:
+  - mouse-down forwarding check
+  - mouse-up forwarding check
+  - `LeftDrag` dispatch
+- `app/src/settings_view/features_page.rs` — settings UI registration:
+  - `FeaturesPageAction` enum
+  - `ToggleSettingActionPair` registry
+  - telemetry mapping
+  - widget registration in `terminal_widgets`
+- `app/src/settings_view/mod.rs` — context flag definitions.
+- `app/src/terminal/view_tests.rs` — existing alt-screen SGR mouse selection assertions.
+
+The reference implementation `f1c38c76` lands changes in exactly these files; no other files are touched. Total scope: **+124 −15 across 7 files** (verified).
+
+## Proposed changes
+
+### 1. Add the setting
+
+Extend `AltScreenReporting` in `alt_screen_reporting.rs`:
+
+| Field | Value |
+|---|---|
+| Setting name | `native_left_drag_select_enabled` |
+| Rust type | `bool` |
+| Default | `false` |
+| TOML path | `terminal.native_left_drag_select_enabled` |
+| Supported platforms | `SupportedPlatforms::ALL` |
+| Sync | `SyncToCloud::Globally(RespectUserSyncSetting::Yes)` |
+| Private | `false` |
+| Description | "When enabled, bare left-drag in mouse-reporting full-screen apps creates a native Warp selection (so Cmd+C can copy), while other mouse events keep their normal reporting behavior." |
+
+Pattern matches the three existing AltScreenReporting fields exactly.
+
+### 2. Refine mouse interception input — minimal signature change
+
+Change `should_intercept_mouse` from:
+
+```rust
+pub fn should_intercept_mouse(
+    model: &TerminalModel,
+    shift: bool,
+    ctx: &AppContext,
+) -> bool
+```
+
+to:
+
+```rust
+pub fn should_intercept_mouse(
+    model: &TerminalModel,
+    shift: bool,
+    bare_left_button: bool,
+    ctx: &AppContext,
+) -> bool
+```
+
+Body adds **one** new branch after the existing `shift` early-return:
+
+```rust
+if bare_left_button
+    && AltScreenReporting::native_left_drag_select_enabled(ctx).get_value(...)
+{
+    return true;
+}
+```
+
+The branch is placed *after* shared-session and `Shift` early-return (so those win) and *before* the SGR / mouse-tracking / mouse-reporting forwarding gate (so it overrides forwarding for bare left-button only).
+
+`should_intercept_scroll` calls `should_intercept_mouse(..., bare_left_button=false, ...)` so scroll behavior is unchanged.
+
+**Definition of "bare"**: a left-button event with **no `Cmd`, `Ctrl`, or `Alt` modifier held**. `Shift` is excluded from this strip-set because the existing `shift` early-return at the top of `should_intercept_mouse` already returns `true` whenever `Shift` is held — the new bare-left branch never executes in that case, so callers may pass `bare_left_button = true` even with concurrent `Shift` without functional change.
+
+Each caller computes `bare_left_button` locally as:
+
+```rust
+let bare_left_button = is_left_button_event
+    && !mouse_state.modifiers().cmd
+    && !mouse_state.modifiers().ctrl
+    && !mouse_state.modifiers().alt;
+```
+
+The strip computation lives at the call site, not inside the helper, so the helper signature stays scalar (`bool`) and parallel to the existing `shift: bool` parameter.
+
+**Naming evolution**: an earlier draft of this spec used `is_left_button` on the assumption that modifier-click does not flow through `should_intercept_mouse`'s left-button paths. That assumption was wrong — the four `alt_screen_element` left-button handlers and the three `block_list_element` left-button handlers receive `mouse_state.modifiers()` for non-`Shift` modifiers and currently pass them implicitly via the dispatch path. A naive `is_left_button` parameter would intercept `Cmd+left`/`Ctrl+left`/`Alt+left` whenever the new setting is enabled, contradicting the product-spec behavior matrix row "Modifier+click → forward to TUI". Renaming to `bare_left_button` and pushing the strip computation to call sites makes the contract explicit and preserves the modifier-forward guarantee.
+
+### 3. Update 7 call sites (exhaustive list)
+
+Each call site computes `bare_left_button` from the local mouse state.
+
+| File | Function | `bare_left_button` source | Reason |
+|---|---|---|---|
+| `alt_screen/alt_screen_element.rs` | `left_mouse_down` | `true && !mouse_state.modifiers().{cmd,ctrl,alt}` | bare left-down only; modifier+left forwards |
+| `alt_screen/alt_screen_element.rs` | `right_mouse_down` | `false` | right-click must keep current routing |
+| `alt_screen/alt_screen_element.rs` | `mouse_up` | `true && !mouse_state.modifiers().{cmd,ctrl,alt}` | bare left-release pairs with bare left-down |
+| `alt_screen/alt_screen_element.rs` | `mouse_dragged` | `true && !mouse_state.modifiers().{cmd,ctrl,alt}` | bare left-drag pairs with bare left-down |
+| `block_list_element.rs` | mouse_down forwarding | `true && !mouse_state.modifiers().{cmd,ctrl,alt}` | bare left-down in block context |
+| `block_list_element.rs` | mouse_up forwarding | `true && !mouse_state.modifiers().{cmd,ctrl,alt}` | bare left-up in block context |
+| `block_list_element.rs` | `LeftDrag` dispatch | `true && !mouse_state.modifiers().{cmd,ctrl,alt}` | bare left-drag in block context |
+
+Internal `should_intercept_scroll` call uses `false`.
+
+The existing native selection path (which already handles `Shift`-drag) remains unchanged — the setting just adds a second way to enter it. No new selection state machine, no new event flow.
+
+### 4. Settings UI exposure (mirrors existing AltScreenReporting toggles)
+
+In `app/src/settings_view/features_page.rs`:
+
+- Import `NativeLeftDragSelectEnabled`.
+- Add `FeaturesPageAction::ToggleNativeLeftDragSelect` enum variant.
+- Add to `ToggleSettingActionPair` registry — searchable by `native left drag select`, `cmd c copy`, `iterm`, `cjk`.
+- Add telemetry case in the telemetry-emit match.
+- Add dispatch handler that calls `toggle_and_save_value` (same pattern as the mouse-reporting toggle handler).
+- Add `NativeLeftDragSelectWidget` to `terminal_widgets` after `FocusReportingWidget`.
+
+In `app/src/settings_view/mod.rs`:
+
+- Add `NATIVE_LEFT_DRAG_SELECT_CONTEXT_FLAG` constant.
+
+In `app/src/workspace/view.rs`:
+
+- Add the toggle-setting context flag binding in `add_toggle_setting_context_flags`.
+
+### 5. Tests
+
+- `app/src/terminal/view_tests.rs` — update the existing alt-screen SGR mouse selection assertion to pass the new `bare_left_button` argument.
+- New unit tests for the `should_intercept_mouse` decision matrix:
+  - `setting=false`, SGR active, bare left → forwards (current behavior unchanged)
+  - `setting=true`, SGR active, bare left → intercepts (new)
+  - `setting=true`, SGR active, `shift` + left → intercepts (Shift wins)
+  - `setting=true`, SGR active, `cmd` + left → forwards (modifier-strip preserves TUI routing)
+  - `setting=true`, SGR active, `ctrl` + left → forwards (same)
+  - `setting=true`, SGR active, `alt` + left → forwards (same)
+  - `setting=true`, SGR active, right-click → forwards (right-click bypassed)
+  - `setting=true`, SGR active, scroll → governed by `scroll_reporting_enabled` (untouched)
+
+The reference impl is being updated to match the renamed parameter and modifier-strip computation; the decision-matrix tests above (especially the three modifier-left cases) become part of the implementation deliverable.
+
+## Migration / rollout
+
+- Single boolean setting added to `AltScreenReporting`. No schema migration required (additive field with default).
+- No behavioral change for any user without explicit opt-in.
+- Setting can be flipped via cloud sync once a user enables it on any one device.
+- Telemetry surfaces adoption and toggle frequency, enabling a future "should this become default?" decision.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Breaking existing mouse-reporting users | Default `false` + scoped to bare left only; right/scroll/middle/modifier all unchanged |
+| Confusing users who don't know which modifier does what | Setting description + search keywords explicitly mention `Cmd+C`, `iTerm`, `cjk`; toggle row sits next to mouse reporting for proximity |
+| Drift between this code path and existing `Shift`-bypass | Both paths converge into the same native-selection state machine via `should_intercept_mouse`; no parallel logic |
+| Cloud sync race after toggle on one device | Same sync semantics as other AltScreenReporting toggles, no new race surface |
+
+## Why this spec rather than #10476 / #10455 / #10408
+
+- **Implementation-first**: every decision in this spec maps to a verified line in `f1c38c76` (with the `is_left_button` → `bare_left_button` rename + modifier-strip refinement, per the v2 update of this spec). No "ideally we would..." gaps.
+- **Explicit 7-call-site mapping with bare-left strip**: every call site in the table above shows exactly how `bare_left_button` is computed; competing specs leave call-site enumeration and modifier-handling responsibility ambiguous.
+- **Search keywords grounded in real user pain**: `cmd c copy`, `iterm`, `cjk` are the actual terms users in #10353 / #2990 / #3280 discussions use, vs generic terms.
+- **Single feature, single setting, no scope creep**: #10408 is a CODE PR (not spec) that bundles broader "smart tmux mouse handling" beyond #10353's scope; #10455 is a single-file `SPEC.md` (not the canonical `product.md` + `tech.md` shape).


### PR DESCRIPTION
## Summary

Product spec + tech spec for #10353, derived from a **working reference implementation** that has been built and manually validated across Claude Code / vim / htop / tmux on macOS.

| File | Lines |
|---|---|
| `specs/GH10353/product.md` | +146 |
| `specs/GH10353/tech.md` | +125 |
| Total | +271, 0 deletions |

## Reference implementation

Working code lives at `spalagu/warp:fix/left-drag-selection` (commit `f1c38c76`). The diff is **+124 −15 across 7 files**:

- `app/src/terminal/alt_screen_reporting.rs` — new `NativeLeftDragSelectEnabled` field in the AltScreenReporting group
- `app/src/terminal/alt_screen/mod.rs` — `should_intercept_mouse` gains `is_left_button: bool`; one-branch addition between the existing `Shift` early-return and the SGR forwarding gate
- `app/src/terminal/alt_screen/alt_screen_element.rs` — 4 call sites updated
- `app/src/terminal/block_list_element.rs` — 3 call sites updated
- `app/src/settings_view/features_page.rs` — toggle widget + command-palette pair + telemetry case + dispatch handler
- `app/src/settings_view/mod.rs` — context flag constant
- `app/src/terminal/view_tests.rs` — existing assertion updated for new signature

`cargo check -p warp --bin warp-oss --features gui` passes cleanly. Manual validation matrix covered in product spec.

## Acknowledging the existing spec PRs

- **#10476 (oz-for-oss bot)** — covers the same scope; this spec differs primarily in:
  - Picks `is_left_button` over `bare_left_button` (rationale in tech.md §2)
  - Enumerates all 7 call sites with the intended value of each
  - Search keywords explicitly grounded in user-pain terms (`cmd c copy`, `iterm`, `cjk`)
- **#10455 (lonexreb)** — single-file `SPEC.md`, doesn't follow the canonical `product.md` + `tech.md` shape
- **#10408 (TheWeaklessOne)** — is a CODE PR (not spec) bundling broader "smart tmux mouse handling" beyond #10353's scope

If maintainers prefer to ratify a different spec, this implementation can be cherry-picked onto whichever spec wins. The spec is not the merge gate; the implementation is what users get.

## Why a spec rather than just a code PR

CONTRIBUTING.md requires features (issues with `ready-to-spec`) to go through a spec PR first. #10353 has both `ready-to-spec` and `enhancement` labels, so this is the spec phase. Once spec is approved, the code PR is mechanical (the implementation already exists at `f1c38c76`).

## What this PR is NOT

- Not the code PR — that follows after spec approval.
- Not a re-litigation of `Shift`-drag (which keeps working).
- Not a replacement for `Option`-key transient bypass requested in #2990 / #3280 (complementary, separate feature).

cc @cla-bot — CLA already signed previously (#10352).