### PR TITLE
GH8642: rename agent conversations (custom title on agent-panel cards)

### DIFF
--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -87,6 +87,9 @@ pub fn convert_conversation_data_to_ai_conversation(
             run_id: None,
             autoexecute_override: None,
             last_event_sequence: None,
+            // user_set_title is local-only and never synced to the server. Forks always start
+            // with no override. See `specs/GH8642/`.
+            user_set_title: None,
         },
         RestorationMode::Continue => AgentConversationData {
             server_conversation_token: Some(
@@ -108,6 +111,10 @@ pub fn convert_conversation_data_to_ai_conversation(
             run_id: None,
             autoexecute_override: None,
             last_event_sequence: None,
+            // user_set_title is local-only and not synced. The local DB row's stored value (if
+            // any) is read by `convert_persisted_conversation_to_ai_conversation_with_metadata`,
+            // not this cloud path. See `specs/GH8642/`.
+            user_set_title: None,
         },
     };
 

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -209,6 +209,12 @@ pub struct AIConversation {
     /// Fallback title used when no task description or initial query exists.
     fallback_display_title: Option<String>,
 
+    /// User-supplied custom title for this conversation. When set, takes precedence over the
+    /// auto-generated `task.description()` / `initial_query()` / `fallback_display_title` chain in
+    /// `title()`. Set via [`Self::set_user_title`] (or cleared by passing `None`).
+    /// Local-only in this iteration; not synced to the server. See `specs/GH8642/`.
+    user_set_title: Option<String>,
+
     /// Artifacts created during this conversation (plans, PRs, etc.).
     artifacts: Vec<Artifact>,
 
@@ -282,6 +288,7 @@ impl AIConversation {
             total_request_cost: RequestCost::new(0.),
             total_token_usage_by_model: Default::default(),
             fallback_display_title: None,
+            user_set_title: None,
             artifacts: Vec::new(),
             parent_agent_id: None,
             agent_name: None,
@@ -374,6 +381,7 @@ impl AIConversation {
             run_id,
             autoexecute_override,
             last_event_sequence,
+            user_set_title,
         ) = if let Some(data) = conversation_data {
             let server_conversation_token = data
                 .server_conversation_token
@@ -407,6 +415,7 @@ impl AIConversation {
                 AIConversationAutoexecuteMode::default()
             };
             let last_event_sequence = data.last_event_sequence;
+            let user_set_title = data.user_set_title;
 
             (
                 server_conversation_token,
@@ -422,6 +431,7 @@ impl AIConversation {
                 run_id,
                 autoexecute_override,
                 last_event_sequence,
+                user_set_title,
             )
         } else {
             (
@@ -437,6 +447,7 @@ impl AIConversation {
                 false,
                 None,
                 AIConversationAutoexecuteMode::default(),
+                None,
                 None,
             )
         };
@@ -475,6 +486,7 @@ impl AIConversation {
             total_token_usage_by_model: Default::default(),
             optimistic_cli_subagent_subtask_id: None,
             fallback_display_title: None,
+            user_set_title,
             artifacts,
             parent_agent_id,
             agent_name,
@@ -1209,11 +1221,20 @@ impl AIConversation {
         self.task_store.latest_skills()
     }
 
-    /// Get the auto-generated title of the given conversation
-    /// (falling back to the first query if the title is empty).
     /// Get the title of the given conversation.
-    /// Priority: auto-generated task description > initial query > fallback_display_title.
+    /// Priority: user-set title > auto-generated task description > initial query > fallback_display_title.
     pub fn title(&self) -> Option<String> {
+        if let Some(title) = self.user_set_title.as_deref() {
+            return Some(title.to_owned());
+        }
+        self.auto_generated_title_for_display()
+    }
+
+    /// Returns the title that would be displayed if the user had not set a custom title.
+    /// Used by the rename UI to seed the editor with the auto-generated title when the user
+    /// clears their custom override, and to compute the placeholder shown when the editor input
+    /// is empty.
+    pub fn auto_generated_title_for_display(&self) -> Option<String> {
         self.task_store
             .root_task()
             .and_then(|task| {
@@ -1224,6 +1245,50 @@ impl AIConversation {
                 }
             })
             .or_else(|| self.fallback_display_title.clone())
+    }
+
+    /// Returns the user-supplied title for this conversation, if any.
+    pub fn user_set_title(&self) -> Option<&str> {
+        self.user_set_title.as_deref()
+    }
+
+    /// Normalizes a candidate user-set title: trims surrounding whitespace, treats empty /
+    /// whitespace-only input as `None`, and caps length at [`Self::USER_SET_TITLE_MAX_CHARS`]
+    /// characters.
+    pub fn normalize_user_title(title: Option<String>) -> Option<String> {
+        title
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .map(|t| t.chars().take(Self::USER_SET_TITLE_MAX_CHARS).collect())
+    }
+
+    /// Maximum length for a user-supplied conversation title (in chars). See `specs/GH8642/`
+    /// product spec invariant 5.
+    pub const USER_SET_TITLE_MAX_CHARS: usize = 200;
+
+    /// Sets a user-supplied custom title for this conversation. Passing `None` (or a string that
+    /// normalizes to empty) clears the override and reverts to the auto-generated chain.
+    ///
+    /// Returns `true` if the persisted value changed (so the caller can decide whether to
+    /// announce success), `false` if the call was a no-op.
+    pub fn set_user_title(
+        &mut self,
+        title: Option<String>,
+        terminal_view_id: EntityId,
+        ctx: &mut ModelContext<BlocklistAIHistoryModel>,
+    ) -> bool {
+        let normalized = Self::normalize_user_title(title);
+        if normalized == self.user_set_title {
+            return false;
+        }
+        self.user_set_title = normalized.clone();
+        self.write_updated_conversation_state(ctx);
+        ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationTitle {
+            terminal_view_id,
+            conversation_id: self.id,
+            title: normalized,
+        });
+        true
     }
 
     /// Set a fallback title used when no task description or initial query exists.
@@ -2972,6 +3037,7 @@ impl AIConversation {
                 run_id: self.task_id.map(|id| id.to_string()),
                 autoexecute_override: Some(self.autoexecute_override.into()),
                 last_event_sequence: self.last_event_sequence,
+                user_set_title: self.user_set_title.clone(),
             },
         };
         ctx.spawn(

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -232,3 +232,102 @@ fn fork_artifacts_adds_file_artifacts_to_conversation() {
         })
     );
 }
+
+// ---------------------------------------------------------------------------
+// User-set conversation title (specs/GH8642/)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn restored_conversation_picks_up_persisted_user_set_title() {
+    let conversation_data: AgentConversationData = serde_json::from_str(
+        r#"{"server_conversation_token":null,"user_set_title":"My custom title"}"#,
+    )
+    .unwrap();
+
+    let conversation = restored_conversation(Some(conversation_data));
+
+    assert_eq!(conversation.user_set_title(), Some("My custom title"));
+}
+
+#[test]
+fn title_prefers_user_set_title_over_auto_description() {
+    // Build a conversation with a non-empty initial query that title() would
+    // normally surface, then layer a user-set title on top via persisted data.
+    // The user-set title must win.
+    let conversation_data: AgentConversationData = serde_json::from_str(
+        r#"{"server_conversation_token":null,"user_set_title":"Pinned name"}"#,
+    )
+    .unwrap();
+
+    let mut conversation = restored_conversation(Some(conversation_data));
+
+    assert_eq!(
+        conversation.title().as_deref(),
+        Some("Pinned name"),
+        "user-set title should take precedence over the auto chain"
+    );
+
+    // The auto-only accessor should still return what `title()` would have
+    // returned without the override (here: None, since this fixture has no
+    // task description, no initial query, and no fallback display title).
+    assert_eq!(conversation.auto_generated_title_for_display(), None);
+
+    // Direct field manipulation models the post-set state without needing
+    // a ModelContext. Clearing the override must fall through to the auto
+    // chain.
+    conversation.user_set_title = None;
+    assert_eq!(conversation.title(), None);
+}
+
+#[test]
+fn normalize_user_title_trims_and_treats_empty_as_none() {
+    use crate::ai::agent::conversation::AIConversation;
+
+    assert_eq!(AIConversation::normalize_user_title(None), None);
+    assert_eq!(
+        AIConversation::normalize_user_title(Some(String::new())),
+        None
+    );
+    assert_eq!(
+        AIConversation::normalize_user_title(Some("   ".to_string())),
+        None
+    );
+    assert_eq!(
+        AIConversation::normalize_user_title(Some("  hello  ".to_string())),
+        Some("hello".to_string())
+    );
+}
+
+#[test]
+fn normalize_user_title_caps_length_at_max_chars() {
+    use crate::ai::agent::conversation::AIConversation;
+
+    let max = AIConversation::USER_SET_TITLE_MAX_CHARS;
+    let too_long: String = "a".repeat(max + 50);
+
+    let normalized = AIConversation::normalize_user_title(Some(too_long))
+        .expect("non-empty input should normalize to Some");
+    assert_eq!(
+        normalized.chars().count(),
+        max,
+        "normalize_user_title must cap output to USER_SET_TITLE_MAX_CHARS chars"
+    );
+}
+
+#[test]
+fn normalize_user_title_counts_chars_not_bytes() {
+    use crate::ai::agent::conversation::AIConversation;
+
+    // Build a string of exactly max+1 multi-byte chars and verify the cap is
+    // applied in chars, not bytes.
+    let max = AIConversation::USER_SET_TITLE_MAX_CHARS;
+    let multibyte: String = "🦀".repeat(max + 1);
+
+    let normalized = AIConversation::normalize_user_title(Some(multibyte))
+        .expect("non-empty input should normalize to Some");
+    assert_eq!(
+        normalized.chars().count(),
+        max,
+        "cap must apply to char count rather than byte count"
+    );
+}

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -1339,6 +1339,15 @@ impl AgentConversationsModel {
                 ctx.emit(AgentConversationsModelEvent::ConversationUpdated { kind });
             }
 
+            // User-set title changes — re-render so the conversation row reflects the new title.
+            // The conversation list reads `conversation.title()` on every render, which already
+            // picks up the override; we just need to nudge the view to redraw.
+            BlocklistAIHistoryEvent::UpdatedConversationTitle { .. } => {
+                ctx.emit(AgentConversationsModelEvent::ConversationUpdated {
+                    kind: ConversationUpdateKind::MetadataChanged,
+                });
+            }
+
             // Artifact changes - sync live artifacts into the cached task and notify.
             BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
                 conversation_id, ..

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -262,6 +262,7 @@ fn test_display_status_uses_matching_conversation_for_in_progress_task() {
                 run_id: Some(task_id.clone()),
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -317,6 +318,7 @@ fn test_display_status_uses_active_execution_over_previous_conversation_status()
                 run_id: Some(task_id.clone()),
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -379,6 +381,7 @@ fn test_display_status_updates_when_blocked_conversation_resumes() {
                 run_id: Some(task_id.clone()),
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -457,6 +460,7 @@ fn test_display_status_terminal_task_state_overrides_matching_conversation() {
                 run_id: Some(task_id.clone()),
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -511,6 +515,7 @@ fn test_status_filter_uses_display_status_for_task_backed_conversations() {
                 run_id: Some(task_id.clone()),
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -597,6 +602,7 @@ fn create_test_conversation_metadata(
             is_in_active_pane: false,
             is_closed: false,
             server_conversation_token: None,
+            has_user_set_title: false,
         },
     }
 }
@@ -801,6 +807,7 @@ fn test_get_entries_merges_task_and_local_conversation_by_run_id() {
                 run_id: Some(task_id.clone()),
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -854,6 +861,7 @@ fn test_get_entries_merges_task_and_local_conversation_by_server_token() {
                 run_id: None,
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -1022,6 +1030,7 @@ fn test_resolve_open_action_falls_back_to_local_conversation_for_invalid_session
                 run_id: Some(task_id.clone()),
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -1312,6 +1321,7 @@ fn test_server_token_assignment_updates_copy_link_resolution() {
                 run_id: None,
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -1407,6 +1417,7 @@ fn test_resolve_copy_link_uses_attached_synced_conversation_for_task_without_tok
                 run_id: Some(task_id.clone()),
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -1732,6 +1743,7 @@ fn test_get_entries_prefers_task_when_task_id_matches_conversation_run_id() {
                 run_id: Some(task_id.clone()),
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -1791,6 +1803,7 @@ fn test_get_entries_prefers_task_when_server_token_matches() {
                 run_id: None,
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2049,7 +2049,10 @@ impl AgentDriver {
                 | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
                 | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
                 | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-                | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => (),
+                | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+                // SDK output streams don't include the title; renames are display-only and
+                // don't gate run-exit / idle-timeout decisions.
+                | BlocklistAIHistoryEvent::UpdatedConversationTitle { .. } => (),
             }
         });
 

--- a/app/src/ai/blocklist/action_model/execute/start_agent.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent.rs
@@ -262,7 +262,11 @@ impl StartAgentExecutor {
             | BlocklistAIHistoryEvent::RestoredConversations { .. }
             | BlocklistAIHistoryEvent::UpdatedConversationMetadata { .. }
             | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
-            | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. } => {}
+            | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
+            // The start_agent executor only cares about lifecycle/identity events for the
+            // pending child conversation. Title renames are user-driven display state and
+            // do not affect the pending decision.
+            | BlocklistAIHistoryEvent::UpdatedConversationTitle { .. } => {}
             BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => {}
         }
     }

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -96,6 +96,12 @@ pub struct AIConversationMetadata {
     /// Full server metadata for cloud conversations, including permissions.
     /// Used by the sharing dialog to display permissions when the full conversation isn't loaded.
     pub server_conversation_metadata: Option<ServerAIConversationMetadata>,
+
+    /// User-set title override for this conversation, if any. Local-only — not synced to the
+    /// server. When `Some`, this is the effective title for `AIConversationMetadata.title` and
+    /// the source of truth for whether `Reset conversation name` should be shown in menus.
+    /// See `specs/GH8642/`.
+    pub user_set_title: Option<String>,
 }
 
 impl From<&AIConversation> for AIConversationMetadata {
@@ -120,6 +126,7 @@ impl From<&AIConversation> for AIConversationMetadata {
             has_cloud_data: conversation.server_metadata().is_some(),
             artifacts: conversation.artifacts().to_vec(),
             server_conversation_metadata: conversation.server_metadata().cloned(),
+            user_set_title: conversation.user_set_title().map(|s| s.to_string()),
         }
     }
 }
@@ -160,6 +167,8 @@ impl AIConversationMetadata {
             has_cloud_data: true, // Server metadata implies cloud data exists
             artifacts,
             server_conversation_metadata: Some(server_conversation_metadata),
+            // User-set titles are local-only; server metadata never carries one.
+            user_set_title: None,
         }
     }
 
@@ -178,6 +187,34 @@ pub enum UpdateHistoryError {
     Conversation(#[from] UpdateConversationError),
     #[error("Failed to find conversation with ID {0:?}")]
     ConversationNotFound(AIConversationId),
+}
+
+/// Reasons a conversation rename request can fail. Returned from
+/// [`BlocklistAIHistoryModel::set_conversation_user_title`] so the UI can disable / ignore
+/// rename actions for non-renamable rows up front instead of failing silently after dispatch.
+/// See `specs/GH8642/` (PR #9746) tech spec, History-model API.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum RenameConversationError {
+    /// No metadata or loaded conversation exists for this ID. Treat as a transient
+    /// inconsistency: the row was rendered but is gone by the time the rename action ran.
+    #[error("Conversation {0:?} not found")]
+    NotFound(AIConversationId),
+    /// Cloud-only or task-only row with no local conversation data; cannot be renamed locally
+    /// in this iteration. Surfaced to the UI as a disabled menu item with a tooltip.
+    #[error("Conversation {0:?} has no local data and cannot be renamed")]
+    NoLocalData(AIConversationId),
+    /// Shared-session viewer mode does not own the conversation; rename is hidden in the UI
+    /// and rejected here as a defense in depth.
+    #[error("Cannot rename conversation {0:?} from shared-session viewer mode")]
+    SharedSessionViewer(AIConversationId),
+    /// The conversation has local data on disk but could not be materialized into memory.
+    /// In practice this happens when the on-disk SQLite record is missing/corrupted or the
+    /// read-only DB connection is unavailable (notably on WASM where `local_fs` is off).
+    /// Successful renames against metadata-only rows go through a synchronous load via
+    /// [`BlocklistAIHistoryModel::load_conversation_from_db`]; this error is the fallback
+    /// path when that load returns `None`.
+    #[error("Conversation {0:?} is not loaded in memory and could not be loaded from disk")]
+    NotLoaded(AIConversationId),
 }
 
 /// Responsible for managing the history of user and AI exchanges.
@@ -1166,6 +1203,9 @@ impl BlocklistAIHistoryModel {
             run_id: None,
             autoexecute_override: Some(source_conversation.autoexecute_override().into()),
             last_event_sequence: None,
+            // Forked conversations start with no user-set title; the user can rename the fork
+            // independently. See `specs/GH8642/` product spec invariant 9.
+            user_set_title: None,
         };
         let forked_conversation_id = AIConversationId::new();
         if let Err(e) = sqlite_sender.send(ModelEvent::UpdateMultiAgentConversation {
@@ -1323,6 +1363,8 @@ impl BlocklistAIHistoryModel {
             run_id: None,
             autoexecute_override: Some(conversation.autoexecute_override().into()),
             last_event_sequence: None,
+            // Forked conversations start with no user-set title. See `specs/GH8642/`.
+            user_set_title: None,
         };
 
         let forked_conversation_id = AIConversationId::new();
@@ -1918,6 +1960,120 @@ impl BlocklistAIHistoryModel {
         ctx.emit(BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { terminal_view_id });
     }
 
+    /// Sets (or clears) the user-supplied display title for the given conversation. Passing
+    /// `Some("")` or `Some("   ")` is treated as a reset and clears the override (same effect
+    /// as passing `None`).
+    ///
+    /// Returns `Ok(true)` if the persisted value changed, `Ok(false)` if the call was a no-op
+    /// (idempotent re-set with the same normalized value), or one of the
+    /// [`RenameConversationError`] variants for non-renamable rows. See `specs/GH8642/` for
+    /// behavior.
+    ///
+    /// Mirrors any successful change onto `all_conversations_metadata` so historical and
+    /// not-currently-active rows reflect the rename without needing a reload.
+    pub fn set_conversation_user_title(
+        &mut self,
+        conversation_id: AIConversationId,
+        title: Option<String>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Result<bool, RenameConversationError> {
+        // Locate the loaded conversation, or distinguish between historical-but-unloaded
+        // (which has metadata + local data on disk: load it synchronously and proceed),
+        // cloud-only / task-only (which we can't rename locally in this iteration), and
+        // truly missing.
+        //
+        // The two-step `contains_key` then `get_mut` dance below is to satisfy the borrow
+        // checker: `load_conversation_from_db` and the `all_conversations_metadata` peek
+        // both need `&self` in the same scope as the eventual `&mut self.conversations_by_id`.
+        let conversation = if self.conversations_by_id.contains_key(&conversation_id) {
+            self.conversations_by_id
+                .get_mut(&conversation_id)
+                .expect("just contains_key'd")
+        } else {
+            let has_local_data = match self.all_conversations_metadata.get(&conversation_id) {
+                Some(metadata) => metadata.has_local_data,
+                None => return Err(RenameConversationError::NotFound(conversation_id)),
+            };
+            if !has_local_data {
+                return Err(RenameConversationError::NoLocalData(conversation_id));
+            }
+            // Conversation row was rendered from history metadata without the full payload
+            // loaded into memory; pull it from SQLite and insert before mutating. On WASM
+            // (`local_fs` disabled) or if the row is missing/corrupted in the DB this returns
+            // `None`, in which case the caller sees `NotLoaded` and can decide how to retry.
+            let Some(loaded) = self.load_conversation_from_db(&conversation_id) else {
+                return Err(RenameConversationError::NotLoaded(conversation_id));
+            };
+            self.conversations_by_id.insert(conversation_id, loaded);
+            self.conversations_by_id
+                .get_mut(&conversation_id)
+                .expect("just inserted")
+        };
+
+        // Defense in depth: shared-session viewer mode never owns the conversation. The UI
+        // hides the rename affordance, but a stray dispatch from a stale menu state must not
+        // mutate or persist anything.
+        if conversation.is_viewing_shared_session() {
+            return Err(RenameConversationError::SharedSessionViewer(
+                conversation_id,
+            ));
+        }
+
+        // Find the terminal view that owns this conversation so the emitted event has a
+        // meaningful `terminal_view_id`. Conversations that were closed but kept around for
+        // up-arrow history are tracked in `cleared_conversation_ids_for_terminal_view`.
+        // Historical-but-loaded conversations may not be tracked under any terminal view; in
+        // that case fall back to a synthetic sentinel id (`from_usize(0)`). Per-view event
+        // consumers correctly no-op when the id doesn't match a real terminal view; global
+        // listeners (e.g. agent_conversations_model) still receive the rename and refresh.
+        let terminal_view_id = self
+            .live_conversation_ids_for_terminal_view
+            .iter()
+            .find_map(|(view_id, ids)| ids.contains(&conversation_id).then_some(*view_id))
+            .or_else(|| {
+                self.cleared_conversation_ids_for_terminal_view
+                    .iter()
+                    .find_map(|(view_id, ids)| ids.contains(&conversation_id).then_some(*view_id))
+            })
+            .unwrap_or_else(|| EntityId::from_usize(0));
+
+        let changed = conversation.set_user_title(title, terminal_view_id, ctx);
+        if changed {
+            // Mirror onto cached metadata so historical / not-currently-active rows reflect
+            // the rename for the conversation list, command palette, etc. The conversation's
+            // own `set_user_title` already updated its in-memory field.
+            let conversation_ref = self.conversations_by_id.get(&conversation_id);
+            let new_user_title =
+                conversation_ref.and_then(|c| c.user_set_title().map(|s| s.to_string()));
+            // On reset we recompute `metadata.title` from the derived chain (root task
+            // description -> initial query -> fallback) so cached historical surfaces revert
+            // immediately. Computing this up front keeps the mutable borrow below scoped to a
+            // single `get_mut` call.
+            let derived_title_on_reset = if new_user_title.is_none() {
+                conversation_ref.and_then(|c| c.auto_generated_title_for_display())
+            } else {
+                None
+            };
+            if let Some(metadata) = self.all_conversations_metadata.get_mut(&conversation_id) {
+                metadata.user_set_title = new_user_title.clone();
+                match new_user_title {
+                    Some(t) => metadata.title = t,
+                    None => {
+                        // Reset path: prefer the derived title if we could compute one. When
+                        // no derived title is available (no exchanges yet, no initial query,
+                        // no fallback), we leave `metadata.title` at its last value rather
+                        // than blanking it -- a blank row in the conversation list would be
+                        // a worse UX than a stale label until next reload.
+                        if let Some(derived) = derived_title_on_reset {
+                            metadata.title = derived;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(changed)
+    }
+
     /// Truncates a conversation from the given exchange ID, removing all exchanges
     /// from that exchange onwards (inclusive). This is a lossy operation.
     ///
@@ -2320,6 +2476,16 @@ pub enum BlocklistAIHistoryEvent {
     OrchestrationConfigUpdated {
         conversation_id: AIConversationId,
     },
+
+    /// Emitted when a conversation's user-set title changes (set, updated, or cleared).
+    /// Subscribers should re-render any surface that displays the conversation title.
+    /// `title` carries the new value; `None` means the override was cleared and the
+    /// auto-generated title is now in effect. See `specs/GH8642/`.
+    UpdatedConversationTitle {
+        terminal_view_id: EntityId,
+        conversation_id: AIConversationId,
+        title: Option<String>,
+    },
 }
 
 impl BlocklistAIHistoryEvent {
@@ -2384,6 +2550,9 @@ impl BlocklistAIHistoryEvent {
                 terminal_view_id, ..
             }
             | BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
+                terminal_view_id, ..
+            }
+            | BlocklistAIHistoryEvent::UpdatedConversationTitle {
                 terminal_view_id, ..
             } => Some(*terminal_view_id),
             // UpdatedConversationMetadata can have None when updating historical-only conversations

--- a/app/src/ai/blocklist/history_model/conversation_loader.rs
+++ b/app/src/ai/blocklist/history_model/conversation_loader.rs
@@ -542,11 +542,18 @@ impl BlocklistAIHistoryModel {
                 }
 
                 // We derive the title from the description of the root task,
-                // falling back to initial_query if the description is empty
-                let title = root_task
+                // falling back to initial_query if the description is empty.
+                // A user-set title (from `specs/GH8642/`) overrides both — it's local-only
+                // metadata stored in `AgentConversationData.user_set_title` and is read here so
+                // historical rows render the override before the full conversation is loaded.
+                let user_set_title = conversation_data
+                    .as_ref()
+                    .and_then(|data| data.user_set_title.clone());
+                let derived_title = root_task
                     .map(|task| task.description.clone())
                     .filter(|desc| !desc.is_empty())
                     .unwrap_or_else(|| initial_query.clone());
+                let title = user_set_title.clone().unwrap_or(derived_title);
 
                 // Extract working directory from the first UserQuery message in the tasks
                 // TODO: search tasks in correct order once we've implemented task ordering.
@@ -578,6 +585,7 @@ impl BlocklistAIHistoryModel {
                     artifacts,
                     // Only populated when loading from server, not from local DB
                     server_conversation_metadata: None,
+                    user_set_title,
                 }))
             })
             .collect();

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -20,6 +20,7 @@ use crate::{
     },
     cloud_object::{Owner, Revision, ServerMetadata, ServerPermissions},
     input_suggestions::HistoryInputSuggestion,
+    pane_group::PaneConfiguration,
     persistence::{model::PersistedAutoexecuteMode, ModelEvent},
     server::ids::ServerId,
     terminal::model::session::SessionId,
@@ -29,7 +30,7 @@ use crate::{
 
 use super::{
     AIConversationMetadata, AIQueryHistoryOutputStatus, BlocklistAIHistoryModel, PersistedAIInput,
-    PersistedAIInputType,
+    PersistedAIInputType, RenameConversationError,
 };
 
 /// Helper function to create a PersistedAIInput for testing
@@ -1252,6 +1253,7 @@ fn test_find_by_token_after_insert_forked_conversation_from_tasks() {
             run_id: None,
             autoexecute_override: None,
             last_event_sequence: None,
+            user_set_title: None,
         };
         let tasks = vec![warp_multi_agent_api::Task {
             id: "root-task".to_string(),
@@ -1444,6 +1446,7 @@ fn test_fork_then_bind_handoff_token_resolves_to_forked_conversation() {
                 run_id: None,
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             }),
         )
         .expect("restored source conversation should build");
@@ -1541,6 +1544,7 @@ fn test_fork_conversation_preserves_task_ids_when_requested() {
                 run_id: None,
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             }),
         )
         .expect("restored source conversation should build");
@@ -1627,6 +1631,7 @@ fn test_fork_conversation_title_override_replaces_prefix() {
                 run_id: None,
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             }),
         )
         .expect("restored source conversation should build");
@@ -1650,6 +1655,490 @@ fn test_fork_conversation_title_override_replaces_prefix() {
             assert_eq!(
                 forked_root.description, "Custom title",
                 "title_override must replace the prefix+description",
+            );
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// GH8642: set_conversation_user_title tests
+// See `specs/GH8642/` (PR #9746) for behavior. Tests cover:
+//   - loaded conversation rename + reset
+//   - idempotency (no-op on identical re-set)
+//   - metadata mirror after rename
+//   - error variants for non-renamable rows (NotFound, NoLocalData,
+//     SharedSessionViewer, NotLoaded)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_set_conversation_user_title_renames_loaded_conversation_and_mirrors_metadata() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        // set_user_title calls write_updated_conversation_state, which needs a model_event_sender.
+        let (sender, _receiver) = std::sync::mpsc::sync_channel(1);
+        let mut handles = GlobalResourceHandles::mock(&mut app);
+        handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(handles));
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let terminal_view_id = EntityId::new();
+
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, ctx)
+        });
+
+        // Seed metadata so we can verify the mirror onto `all_conversations_metadata`.
+        history_model.update(&mut app, |model, _| {
+            let metadata =
+                AIConversationMetadata::from(model.conversation(&conversation_id).unwrap());
+            model
+                .all_conversations_metadata
+                .insert(conversation_id, metadata);
+        });
+
+        // Initial rename succeeds and reports a change.
+        let result = history_model.update(&mut app, |model, ctx| {
+            model.set_conversation_user_title(
+                conversation_id,
+                Some("My Custom Title".to_string()),
+                ctx,
+            )
+        });
+        assert_eq!(result, Ok(true));
+
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .unwrap()
+                    .user_set_title(),
+                Some("My Custom Title"),
+            );
+            let metadata = model.get_conversation_metadata(&conversation_id).unwrap();
+            assert_eq!(metadata.user_set_title.as_deref(), Some("My Custom Title"));
+            assert_eq!(metadata.title, "My Custom Title");
+        });
+    });
+}
+
+#[test]
+fn test_set_conversation_user_title_is_idempotent_on_repeat_set() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel(2);
+        let mut handles = GlobalResourceHandles::mock(&mut app);
+        handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(handles));
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let terminal_view_id = EntityId::new();
+
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, ctx)
+        });
+
+        // First set: changes and returns Ok(true).
+        let first = history_model.update(&mut app, |model, ctx| {
+            model.set_conversation_user_title(conversation_id, Some("Hello".to_string()), ctx)
+        });
+        assert_eq!(first, Ok(true));
+
+        // Re-setting the normalized-equivalent value is a no-op.
+        let same = history_model.update(&mut app, |model, ctx| {
+            model.set_conversation_user_title(
+                conversation_id,
+                Some("  Hello  ".to_string()), // whitespace trim normalizes to same value
+                ctx,
+            )
+        });
+        assert_eq!(same, Ok(false));
+    });
+}
+
+#[test]
+fn test_set_conversation_user_title_reset_clears_override() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel(4);
+        let mut handles = GlobalResourceHandles::mock(&mut app);
+        handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(handles));
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let terminal_view_id = EntityId::new();
+
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, ctx)
+        });
+        history_model.update(&mut app, |model, _| {
+            let metadata =
+                AIConversationMetadata::from(model.conversation(&conversation_id).unwrap());
+            model
+                .all_conversations_metadata
+                .insert(conversation_id, metadata);
+        });
+
+        // Set, then reset (Some("") and None both clear).
+        history_model
+            .update(&mut app, |model, ctx| {
+                model.set_conversation_user_title(conversation_id, Some("Custom".into()), ctx)
+            })
+            .unwrap();
+
+        let reset = history_model.update(&mut app, |model, ctx| {
+            model.set_conversation_user_title(conversation_id, None, ctx)
+        });
+        assert_eq!(reset, Ok(true));
+
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .unwrap()
+                    .user_set_title(),
+                None,
+            );
+            let metadata = model.get_conversation_metadata(&conversation_id).unwrap();
+            assert_eq!(metadata.user_set_title, None);
+        });
+
+        // Whitespace-only also clears.
+        history_model
+            .update(&mut app, |model, ctx| {
+                model.set_conversation_user_title(conversation_id, Some("x".into()), ctx)
+            })
+            .unwrap();
+        let reset_via_whitespace = history_model.update(&mut app, |model, ctx| {
+            model.set_conversation_user_title(conversation_id, Some("   ".into()), ctx)
+        });
+        assert_eq!(reset_via_whitespace, Ok(true));
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .unwrap()
+                    .user_set_title(),
+                None,
+            );
+        });
+    });
+}
+
+#[test]
+fn test_set_conversation_user_title_returns_not_found_for_unknown_id() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let unknown_id = AIConversationId::new();
+
+        let result = history_model.update(&mut app, |model, ctx| {
+            model.set_conversation_user_title(unknown_id, Some("X".into()), ctx)
+        });
+        assert_eq!(result, Err(RenameConversationError::NotFound(unknown_id)));
+    });
+}
+
+#[test]
+fn test_set_conversation_user_title_returns_no_local_data_for_cloud_only_metadata() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let cloud_only_id = AIConversationId::new();
+
+        // Insert metadata that has no local data (`from_server_metadata` sets has_local_data=false).
+        history_model.update(&mut app, |model, _| {
+            let metadata = AIConversationMetadata::from_server_metadata(
+                cloud_only_id,
+                create_server_metadata("Cloud-only", "token-cloud-only", 1.0, None),
+            );
+            model
+                .all_conversations_metadata
+                .insert(cloud_only_id, metadata);
+        });
+
+        let result = history_model.update(&mut app, |model, ctx| {
+            model.set_conversation_user_title(cloud_only_id, Some("X".into()), ctx)
+        });
+        assert_eq!(
+            result,
+            Err(RenameConversationError::NoLocalData(cloud_only_id)),
+        );
+    });
+}
+
+// GH8642 review fix #1 (Oz review on PR #10553): metadata-only rows with
+// has_local_data=true previously returned `NotLoaded` and dropped the user's
+// rename on the floor. The new behavior is to attempt a synchronous SQLite
+// load via `load_conversation_from_db` and proceed on success. In the unit-test
+// harness the model has no `db_connection` (it's set up only when a real DB
+// file exists at `database_file_path()`), so the load returns `None` and we
+// fall through to `NotLoaded` -- but now `NotLoaded` exclusively means "we
+// tried to load and couldn't", not "this code path is a stub". A real DB-backed
+// integration test is required to cover the success path end-to-end.
+#[test]
+fn test_set_conversation_user_title_returns_not_loaded_only_when_db_load_fails() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let metadata_only_id = AIConversationId::new();
+
+        // Seed a metadata-only entry that claims has_local_data=true. There's no
+        // matching AIConversation in conversations_by_id and no DB record to load,
+        // so the new code path will attempt the load and fall back to NotLoaded.
+        history_model.update(&mut app, |model, _| {
+            let mut metadata = AIConversationMetadata::from_server_metadata(
+                metadata_only_id,
+                create_server_metadata("Has local data", "token-historical", 1.0, None),
+            );
+            metadata.has_local_data = true;
+            model
+                .all_conversations_metadata
+                .insert(metadata_only_id, metadata);
+        });
+
+        let result = history_model.update(&mut app, |model, ctx| {
+            model.set_conversation_user_title(metadata_only_id, Some("X".into()), ctx)
+        });
+        assert_eq!(
+            result,
+            Err(RenameConversationError::NotLoaded(metadata_only_id)),
+        );
+
+        // Sanity check: the conversation was NOT silently inserted into memory
+        // by a partial load. The model is in the same shape it was before.
+        history_model.read(&app, |model, _| {
+            assert!(model.conversation(&metadata_only_id).is_none());
+        });
+    });
+}
+
+// GH8642 review fix #2 (Oz review on PR #10553): after a user resets a custom
+// title, `metadata.title` previously stayed at the old custom value until the
+// next reload, so cached historical surfaces (conversation list, command
+// palette) kept showing the cleared name. The fix recomputes `metadata.title`
+// from `AIConversation::auto_generated_title_for_display` on reset.
+#[test]
+fn test_set_conversation_user_title_reset_recomputes_metadata_title_from_derived_chain() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel(4);
+        let mut handles = GlobalResourceHandles::mock(&mut app);
+        handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(handles));
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let terminal_view_id = EntityId::new();
+
+        // Build a conversation with a stable derived title via the fallback chain
+        // (no exchanges yet -> root task description empty -> no initial query ->
+        // fallback_display_title wins).
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            let id = model.start_new_conversation(terminal_view_id, false, false, ctx);
+            model
+                .conversation_mut(&id)
+                .expect("just created")
+                .set_fallback_display_title("Derived Title".to_string());
+            id
+        });
+        history_model.update(&mut app, |model, _| {
+            let metadata =
+                AIConversationMetadata::from(model.conversation(&conversation_id).unwrap());
+            model
+                .all_conversations_metadata
+                .insert(conversation_id, metadata);
+        });
+
+        // Sanity check: AIConversationMetadata::from picks up the derived title.
+        history_model.read(&app, |model, _| {
+            let m = model.get_conversation_metadata(&conversation_id).unwrap();
+            assert_eq!(m.title, "Derived Title");
+            assert_eq!(m.user_set_title, None);
+        });
+
+        // Set a custom override -- both fields mirror the custom value.
+        history_model
+            .update(&mut app, |model, ctx| {
+                model.set_conversation_user_title(
+                    conversation_id,
+                    Some("Custom Override".to_string()),
+                    ctx,
+                )
+            })
+            .unwrap();
+        history_model.read(&app, |model, _| {
+            let m = model.get_conversation_metadata(&conversation_id).unwrap();
+            assert_eq!(m.title, "Custom Override");
+            assert_eq!(m.user_set_title.as_deref(), Some("Custom Override"));
+        });
+
+        // Reset -- regression assertion: metadata.title must revert to the derived
+        // value immediately, not linger as "Custom Override" until next restart.
+        history_model
+            .update(&mut app, |model, ctx| {
+                model.set_conversation_user_title(conversation_id, None, ctx)
+            })
+            .unwrap();
+        history_model.read(&app, |model, _| {
+            let m = model.get_conversation_metadata(&conversation_id).unwrap();
+            assert_eq!(m.user_set_title, None, "reset must clear the override flag",);
+            assert_eq!(
+                m.title, "Derived Title",
+                "reset must recompute metadata.title from the derived chain so the \
+                 conversation list and command palette refresh immediately",
+            );
+        });
+    });
+}
+
+#[test]
+fn test_set_conversation_user_title_rejects_shared_session_viewer() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let terminal_view_id = EntityId::new();
+
+        // Conversation starts in viewer mode — the start_new_conversation third arg is
+        // `is_viewing_shared_session`.
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, true, ctx)
+        });
+
+        let result = history_model.update(&mut app, |model, ctx| {
+            model.set_conversation_user_title(conversation_id, Some("X".into()), ctx)
+        });
+        assert_eq!(
+            result,
+            Err(RenameConversationError::SharedSessionViewer(
+                conversation_id
+            )),
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// GH8642: persistence-layer comparison test
+//
+// Demonstrates the divergence between the pre-existing "Rename pane"
+// (`PaneConfiguration::set_custom_vertical_tabs_title`) and the new "Rename
+// conversation" (`BlocklistAIHistoryModel::set_conversation_user_title`):
+//
+//   - Pane title is keyed on the `PaneConfiguration` *entity* — i.e. on the
+//     pane (`pane_group_id`, `pane_id`) the workspace happens to be hosting
+//     the conversation in. A different pane hosting the same conversation
+//     does NOT inherit a previously-set pane title.
+//   - Conversation title is keyed on the *conversation id* and lives on the
+//     `AIConversation` itself plus the cached `AIConversationMetadata` mirror,
+//     so it is reachable regardless of which pane is currently rendering the
+//     conversation.
+//
+// This test is the ground-truth answer to "do Rename pane and Rename
+// conversation actually do the same thing?" — they don't; they write to
+// different layers with different lifetimes. The pane label is a workspace
+// layout decoration that dies with the pane; the conversation title is
+// metadata of the conversation itself and survives pane lifecycle, the
+// conversation list, the command palette, and (after persistence) restart.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pane_title_is_pane_scoped_while_conversation_title_is_conversation_scoped() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        // set_user_title -> write_updated_conversation_state needs a model_event_sender.
+        let (sender, _receiver) = std::sync::mpsc::sync_channel(2);
+        let mut handles = GlobalResourceHandles::mock(&mut app);
+        handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(handles));
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let terminal_view_id = EntityId::new();
+
+        // One conversation, two distinct PaneConfiguration entities. Models the
+        // user flow: rename pane in pane A; close pane A; reopen the same
+        // conversation in a brand-new pane B. The conversation id is stable
+        // across that flow; the pane ids are not.
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, ctx)
+        });
+        history_model.update(&mut app, |model, _| {
+            let metadata =
+                AIConversationMetadata::from(model.conversation(&conversation_id).unwrap());
+            model
+                .all_conversations_metadata
+                .insert(conversation_id, metadata);
+        });
+
+        let pane_a = app.add_model(|_| PaneConfiguration::new("auto-derived A"));
+        let pane_b = app.add_model(|_| PaneConfiguration::new("auto-derived B"));
+
+        // ---- Rename pane (pre-existing path) -------------------------------
+        // Same call site as `Workspace::set_custom_pane_name` uses inside
+        // `finish_pane_rename`: write the title onto pane A's PaneConfiguration.
+        pane_a.update(&mut app, |config, ctx| {
+            config.set_custom_vertical_tabs_title("Foo", ctx);
+        });
+        pane_a.read(&app, |config, _| {
+            assert_eq!(
+                config.custom_vertical_tabs_title(),
+                Some("Foo"),
+                "rename pane writes the title onto the PaneConfiguration entity",
+            );
+        });
+        pane_b.read(&app, |config, _| {
+            assert_eq!(
+                config.custom_vertical_tabs_title(),
+                None,
+                "pane title is pane-scoped: a different pane hosting the same \
+                 conversation must NOT inherit pane A's custom title",
+            );
+        });
+
+        // ---- Rename conversation (this PR) ---------------------------------
+        // Same call site `Workspace::finish_conversation_rename` uses:
+        // BlocklistAIHistoryModel::set_conversation_user_title.
+        let result = history_model.update(&mut app, |model, ctx| {
+            model.set_conversation_user_title(conversation_id, Some("Bar".to_string()), ctx)
+        });
+        assert_eq!(result, Ok(true));
+
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .unwrap()
+                    .user_set_title(),
+                Some("Bar"),
+                "rename conversation writes user_set_title onto the AIConversation \
+                 itself, recoverable by conversation_id without going through any pane",
+            );
+            let metadata = model.get_conversation_metadata(&conversation_id).unwrap();
+            assert_eq!(
+                metadata.user_set_title.as_deref(),
+                Some("Bar"),
+                "rename conversation also mirrors onto AIConversationMetadata, \
+                 which is what the conversation list / command palette reads",
+            );
+            assert_eq!(metadata.title, "Bar");
+        });
+
+        // ---- The decisive divergence ---------------------------------------
+        // After both renames, pane B (the "new pane same conversation" case)
+        // still has no pane title, and the conversation's user-set title is
+        // still recoverable from its id without consulting any pane. The two
+        // features write to different layers — they are not interchangeable.
+        pane_b.read(&app, |config, _| {
+            assert_eq!(
+                config.custom_vertical_tabs_title(),
+                None,
+                "pane B is unaffected by either rename: it never had a pane \
+                 title and the conversation rename does not propagate into \
+                 PaneConfiguration",
+            );
+        });
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .unwrap()
+                    .user_set_title(),
+                Some("Bar"),
+                "conversation-scoped title persists in the history model — \
+                 this is what makes it survive pane lifecycle, conversation \
+                 list rendering, and (after persistence) restart",
             );
         });
     });

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -375,7 +375,10 @@ impl OrchestrationEventStreamer {
             | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
             | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
             | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => {}
+            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+            // Title renames don't affect orchestration eligibility, watched run ids, or the
+            // SSE connection state.
+            | BlocklistAIHistoryEvent::UpdatedConversationTitle { .. } => {}
         }
     }
 

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -147,6 +147,7 @@ fn ai_conversation_new_restored_preserves_last_event_sequence() {
         run_id: None,
         autoexecute_override: None,
         last_event_sequence: Some(42),
+        user_set_title: None,
     };
     let conversation =
         AIConversation::new_restored(AIConversationId::new(), vec![task], Some(data))

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -136,6 +136,7 @@ fn test_from_task_includes_linked_directory_when_run_id_matches() {
                 run_id: Some(task_id.to_string()),
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 
@@ -276,6 +277,7 @@ fn test_from_conversation_populates_local_conversation_fields() {
                 run_id: None,
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
                 is_remote_child: false,
             },
         );
@@ -349,6 +351,7 @@ fn test_from_task_includes_linked_directory_when_server_token_matches() {
                 run_id: None,
                 autoexecute_override: None,
                 last_event_sequence: None,
+                user_set_title: None,
             },
         );
 

--- a/app/src/ai/conversation_navigation/mod.rs
+++ b/app/src/ai/conversation_navigation/mod.rs
@@ -34,6 +34,10 @@ pub struct ConversationNavigationData {
     pub is_closed: bool,
     /// The server-generated conversation token, used to reference this conversation in context tags.
     pub server_conversation_token: Option<ServerConversationToken>,
+    /// Whether the user has set a custom title for this conversation. Used by menu rendering
+    /// to show / hide the conditional `Reset conversation name` item without requiring the
+    /// caller to load the full conversation. See `specs/GH8642/`.
+    pub has_user_set_title: bool,
 }
 
 impl PartialOrd for ConversationNavigationData {
@@ -95,6 +99,7 @@ impl ConversationNavigationData {
             is_in_active_pane,
             is_closed,
             server_conversation_token: conversation.server_conversation_token().cloned(),
+            has_user_set_title: conversation.user_set_title().is_some(),
         }
     }
 
@@ -113,6 +118,7 @@ impl ConversationNavigationData {
             is_in_active_pane: false,
             is_closed: false,
             server_conversation_token: metadata.server_conversation_token.clone(),
+            has_user_set_title: metadata.user_set_title.is_some(),
         }
     }
 

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1818,6 +1818,9 @@ fn handle_ai_history_event(
         | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
         | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
         | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-        | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => (),
+        | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+        // Title renames persist via `AIConversation::set_user_title` writing through
+        // `write_updated_conversation_state`; no separate SQL persistence needed here.
+        | BlocklistAIHistoryEvent::UpdatedConversationTitle { .. } => (),
     }
 }

--- a/app/src/search/command_palette/conversations/search_tests.rs
+++ b/app/src/search/command_palette/conversations/search_tests.rs
@@ -24,6 +24,7 @@ fn test_conversation_navigation_data_ordering() {
         is_closed: false,
         server_conversation_token: None,
         is_in_active_pane: true,
+        has_user_set_title: false,
     };
 
     let active_old = ConversationNavigationData {
@@ -40,6 +41,7 @@ fn test_conversation_navigation_data_ordering() {
         is_closed: false,
         server_conversation_token: None,
         is_in_active_pane: true,
+        has_user_set_title: false,
     };
 
     let inactive_recent = ConversationNavigationData {
@@ -56,6 +58,7 @@ fn test_conversation_navigation_data_ordering() {
         is_closed: false,
         server_conversation_token: None,
         is_in_active_pane: false,
+        has_user_set_title: false,
     };
 
     let inactive_old = ConversationNavigationData {
@@ -72,6 +75,7 @@ fn test_conversation_navigation_data_ordering() {
         is_closed: false,
         server_conversation_token: None,
         is_in_active_pane: false,
+        has_user_set_title: false,
     };
 
     let historical_recent = ConversationNavigationData {
@@ -88,6 +92,7 @@ fn test_conversation_navigation_data_ordering() {
         is_closed: false,
         server_conversation_token: None,
         is_in_active_pane: false,
+        has_user_set_title: false,
     };
 
     let historical_old = ConversationNavigationData {
@@ -104,6 +109,7 @@ fn test_conversation_navigation_data_ordering() {
         is_closed: false,
         server_conversation_token: None,
         is_in_active_pane: false,
+        has_user_set_title: false,
     };
 
     // Test sorting a vector

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -1,4 +1,4 @@
-use crate::ai::agent::conversation::ConversationStatus;
+use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
 use crate::ai::conversation_status_ui::{render_status_element, STATUS_ELEMENT_PADDING};
 use crate::appearance::Appearance;
 /// Tab module contains structures related to Tabs (such as TabData or TabComponent) that simplify
@@ -125,6 +125,17 @@ pub struct PaneNameMenuTarget {
     pub reset_label: &'static str,
 }
 
+/// GH8642: target for the conversation rename/reset entries in the
+/// vertical-tabs pane context menu. Resolved by the workspace before
+/// building the menu — [`PaneConversationMenuTarget::has_user_set_title`]
+/// gates the "Reset conversation name" item the same way `PaneNameMenuTarget`
+/// gates "Reset pane name".
+#[derive(Clone, Copy)]
+pub struct PaneConversationMenuTarget {
+    pub conversation_id: AIConversationId,
+    pub has_user_set_title: bool,
+}
+
 /// TabData struct holds the state of the given tab. It includes the pane group and mouse states
 /// used for closing the tab or tracking the mouse over the rendered tab.
 /// It has to be "stored" by some View to persist its state.
@@ -187,6 +198,22 @@ impl TabData {
         pane_name_target: Option<PaneNameMenuTarget>,
         ctx: &AppContext,
     ) -> Vec<MenuItem<WorkspaceAction>> {
+        self.menu_items_with_pane_targets(index, tabs_len, pane_name_target, None, ctx)
+    }
+
+    /// GH8642: variant that additionally accepts a `PaneConversationMenuTarget`
+    /// so the vertical-tabs pane context menu can offer Rename / Reset for the
+    /// chrome conversation hosted in the right-clicked pane. The conversation
+    /// items are inserted alongside the pane-name items so all rename actions
+    /// for the pane are grouped together visually.
+    pub fn menu_items_with_pane_targets(
+        &self,
+        index: usize,
+        tabs_len: usize,
+        pane_name_target: Option<PaneNameMenuTarget>,
+        pane_conversation_target: Option<PaneConversationMenuTarget>,
+        ctx: &AppContext,
+    ) -> Vec<MenuItem<WorkspaceAction>> {
         let appearance = Appearance::as_ref(ctx);
         let terminal_colors = appearance.theme().terminal_colors().normal;
         let mut menu_items = vec![];
@@ -194,7 +221,13 @@ impl TabData {
         for section_items in [
             self.session_sharing_menu_items(index, ctx),
             self.copy_metadata_menu_items(pane_name_target, ctx),
-            self.modify_tab_menu_items(index, tabs_len, pane_name_target, ctx),
+            self.modify_tab_menu_items(
+                index,
+                tabs_len,
+                pane_name_target,
+                pane_conversation_target,
+                ctx,
+            ),
             self.close_tab_menu_items(index, tabs_len, ctx),
             Self::save_config_menu_items(index),
             self.color_option_menu_items(index, terminal_colors),
@@ -398,6 +431,7 @@ impl TabData {
         index: usize,
         tabs_len: usize,
         pane_name_target: Option<PaneNameMenuTarget>,
+        pane_conversation_target: Option<PaneConversationMenuTarget>,
         ctx: &AppContext,
     ) -> Vec<MenuItem<WorkspaceAction>> {
         let mut menu_items = vec![];
@@ -420,6 +454,12 @@ impl TabData {
         }
         if let Some(pane_name_target) = pane_name_target {
             menu_items.extend(self.pane_name_menu_items(pane_name_target, ctx));
+        }
+        // GH8642: Rename / Reset conversation items live next to the pane
+        // rename items so they're visually grouped under the same "rename
+        // things in this pane" affordance.
+        if let Some(target) = pane_conversation_target {
+            menu_items.extend(Self::pane_conversation_menu_items(target));
         }
         // Don't show options that aren't relevant (moving end tabs, closing
         // other tabs when you don't have any others to close)
@@ -444,6 +484,30 @@ impl TabData {
                 })
                 .with_on_select_action(WorkspaceAction::MoveTabLeft(index))
                 .into_item(),
+            );
+        }
+        menu_items
+    }
+
+    /// GH8642: build the Rename / Reset Conversation menu items for the
+    /// vertical-tabs pane context menu. Reset is included only when the
+    /// conversation already has a user-set title; this matches
+    /// [`Self::pane_name_menu_items`].
+    fn pane_conversation_menu_items(
+        target: PaneConversationMenuTarget,
+    ) -> Vec<MenuItem<WorkspaceAction>> {
+        let mut menu_items = vec![MenuItemFields::new("Rename conversation")
+            .with_on_select_action(WorkspaceAction::RenameConversation {
+                conversation_id: target.conversation_id,
+            })
+            .into_item()];
+        if target.has_user_set_title {
+            menu_items.push(
+                MenuItemFields::new("Reset conversation name")
+                    .with_on_select_action(WorkspaceAction::ResetConversationName {
+                        conversation_id: target.conversation_id,
+                    })
+                    .into_item(),
             );
         }
         menu_items

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5276,7 +5276,9 @@ impl TerminalView {
             | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
             | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
             | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => None,
+            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+            // Title renames are display-only; no per-view ownership routing needed.
+            | BlocklistAIHistoryEvent::UpdatedConversationTitle { .. } => None,
         }
     }
 
@@ -5735,6 +5737,12 @@ impl TerminalView {
                     self.rich_content_views
                         .retain(|view| view.view_id() != view_id_to_remove);
                 }
+            }
+            BlocklistAIHistoryEvent::UpdatedConversationTitle { .. } => {
+                // Refresh the pane header so it reflects the new title. The pane title is
+                // derived from `selected_conversation_display_title()`, which reads through
+                // `AIConversation::title()` and now picks up the user-set override.
+                self.update_pane_configuration(ctx);
             }
             BlocklistAIHistoryEvent::CreatedSubtask { .. }
             | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. }

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -1025,6 +1025,9 @@ impl TerminalView {
             run_id: None,
             autoexecute_override: None,
             last_event_sequence: None,
+            // user_set_title is local-only and never synced to the server. Fresh ad-hoc loads
+            // (e.g. from cloud task data) start with no override. See `specs/GH8642/`.
+            user_set_title: None,
         };
 
         match AIConversation::new_restored(conversation_id, tasks, Some(conversation_data)) {

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -4,7 +4,7 @@ use super::ambient_agent::is_cloud_agent_pre_first_exchange;
 use super::shared_session::adapter::Kind as SharedSessionKind;
 use super::{Event, PaneConfiguration, TerminalAction, TerminalViewState, Viewer};
 use crate::ai::agent::conversation::{
-    AIConversation, ConversationStatus, ServerAIConversationMetadata,
+    AIConversation, AIConversationId, ConversationStatus, ServerAIConversationMetadata,
 };
 use crate::ai::blocklist::agent_view::agent_view_bg_fill;
 use crate::ai::blocklist::agent_view::orchestration_conversation_links::parent_conversation_navigation_card;
@@ -1039,6 +1039,29 @@ impl TerminalView {
     ) -> Option<String> {
         self.selected_conversation_for_user_facing_chrome(ctx)
             .and_then(AIConversation::latest_user_query)
+    }
+
+    /// GH8642: returns the [`AIConversationId`] of the currently-selected conversation, if it is
+    /// the conversation we'd render in the tab/pane chrome (passive conversations and unnamed
+    /// non-AgentView conversations are filtered out by
+    /// [`Self::selected_conversation_for_user_facing_chrome`], matching how the rest of the
+    /// chrome already resolves "the conversation behind this terminal view"). Used by the
+    /// vertical-tabs rename surface to dispatch [`crate::workspace::WorkspaceAction::RenameConversation`]
+    /// for the right id without requiring callers to re-derive the filter.
+    pub fn selected_conversation_id_for_chrome(
+        &self,
+        ctx: &AppContext,
+    ) -> Option<AIConversationId> {
+        self.selected_conversation_for_user_facing_chrome(ctx)
+            .map(AIConversation::id)
+    }
+
+    /// GH8642: whether the currently-selected chrome conversation has a user-set title. Threaded
+    /// through the vertical-tabs title-preference helper so a user-set title can never be
+    /// overridden by the latest-prompt setting (the spec's primary risk mitigation in PR #9746).
+    pub fn selected_conversation_has_user_set_title(&self, ctx: &AppContext) -> bool {
+        self.selected_conversation_for_user_facing_chrome(ctx)
+            .is_some_and(|conversation| conversation.user_set_title().is_some())
     }
 
     fn selected_cli_agent_title_for_chrome(&self, ctx: &AppContext) -> Option<String> {

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -117,6 +117,30 @@ pub enum WorkspaceAction {
     /// (see #9351). The context-menu path keeps using `RenamePane(locator)`.
     RenameActivePane,
     SetActiveTabName(String),
+    /// Begin renaming the given conversation: opens an inline editor seeded with the
+    /// conversation's effective title (user-set if any, else the auto-generated title).
+    /// Dispatched from a double-click on the agent-card title in vertical tabs or from a
+    /// `Rename conversation` menu item. The editor's Enter handler dispatches
+    /// [`Self::SetConversationUserTitle`] to commit; Escape clears editor state without
+    /// dispatching. The editor lives at the workspace level (alongside `tab_rename_editor`
+    /// / `pane_rename_editor`) and is wired up in phase 2d. See `specs/GH8642/`.
+    RenameConversation {
+        conversation_id: AIConversationId,
+    },
+    /// Clears the conversation's user-set title override and reverts to the auto-generated
+    /// title chain. Dispatched from a `Reset conversation name` menu item (only shown when
+    /// the conversation already has a user-set title). See `specs/GH8642/`.
+    ResetConversationName {
+        conversation_id: AIConversationId,
+    },
+    /// Persists a new user-set title for the conversation (or clears it when `title` is
+    /// `None` / whitespace-only). Dispatched on Enter / blur from the inline rename editor,
+    /// and is the single entry point both surfaces (vertical tabs and the conversation list)
+    /// converge on for actually committing a rename. See `specs/GH8642/`.
+    SetConversationUserTitle {
+        conversation_id: AIConversationId,
+        title: Option<String>,
+    },
     /// Sets the manual color override for the active tab.
     ///
     /// - `Color(_)` — apply that color.
@@ -744,6 +768,12 @@ impl WorkspaceAction {
             | RenameActiveTab
             | RenameActivePane
             | SetActiveTabName(_)
+            // GH8642: conversation rename mutates the conversation's persisted user-set title
+            // (via `BlocklistAIHistoryModel::set_conversation_user_title`), so it should be
+            // reflected in saved app state on the next checkpoint.
+            | RenameConversation { .. }
+            | ResetConversationName { .. }
+            | SetConversationUserTitle { .. }
             | SetActiveTabColor(_)
             | CloseTab(_)
             | CloseActiveTab

--- a/app/src/workspace/util.rs
+++ b/app/src/workspace/util.rs
@@ -4,7 +4,12 @@ use warpui::{
     WindowId,
 };
 
+#[cfg(test)]
+#[path = "util_tests.rs"]
+mod tests;
+
 use super::OneTimeModalModel;
+use crate::ai::agent::conversation::AIConversationId;
 use crate::window_settings::WindowSettings;
 use crate::{
     appearance::Appearance, pane_group::PaneId, terminal::TerminalView, workspace::Workspace,
@@ -129,6 +134,12 @@ pub struct WorkspaceState {
     pub is_transcript_details_panel_open: bool,
     tab_being_renamed: Option<usize>, // The index of the tab being renamed
     pane_being_renamed: Option<PaneViewLocator>,
+    /// GH8642: id of the conversation currently being renamed via the
+    /// workspace-level inline editor (`Workspace::conversation_rename_editor`),
+    /// or `None` when no conversation rename is in progress. Mutually
+    /// exclusive with `tab_being_renamed` and `pane_being_renamed` — entering
+    /// any rename mode clears the others (see `set_*` setters below).
+    conversation_being_renamed: Option<AIConversationId>,
 }
 
 impl WorkspaceState {
@@ -146,6 +157,7 @@ impl WorkspaceState {
             || self.is_changelog_modal_open
             || self.tab_being_renamed.is_some()
             || self.pane_being_renamed.is_some()
+            || self.conversation_being_renamed.is_some()
             || self.is_reward_modal_open
             || self.is_launch_config_save_modal_open
             || self.is_command_search_open
@@ -187,6 +199,7 @@ impl WorkspaceState {
         self.is_changelog_modal_open = false;
         self.tab_being_renamed = None;
         self.pane_being_renamed = None;
+        self.conversation_being_renamed = None;
         self.is_reward_modal_open = false;
         self.is_launch_config_save_modal_open = false;
         self.is_command_search_open = false;
@@ -230,6 +243,7 @@ impl WorkspaceState {
     pub fn set_tab_being_renamed(&mut self, index: usize) {
         self.tab_being_renamed = Some(index);
         self.pane_being_renamed = None;
+        self.conversation_being_renamed = None;
     }
 
     pub fn clear_tab_being_renamed(&mut self) {
@@ -251,6 +265,7 @@ impl WorkspaceState {
     pub fn set_pane_being_renamed(&mut self, pane: PaneViewLocator) {
         self.pane_being_renamed = Some(pane);
         self.tab_being_renamed = None;
+        self.conversation_being_renamed = None;
     }
 
     pub fn clear_pane_being_renamed(&mut self) {
@@ -259,6 +274,36 @@ impl WorkspaceState {
 
     pub fn pane_being_renamed(&self) -> Option<PaneViewLocator> {
         self.pane_being_renamed
+    }
+
+    /// GH8642: returns `true` when the given conversation id is currently in
+    /// inline-rename mode at the workspace level (vertical-tabs surface).
+    pub fn is_conversation_being_renamed(&self, conversation_id: AIConversationId) -> bool {
+        self.conversation_being_renamed == Some(conversation_id)
+    }
+
+    /// GH8642: returns `true` when any conversation is in inline-rename mode.
+    /// Used by render code that suppresses chrome (kebab/tooltip overlays)
+    /// regardless of which row owns the rename.
+    pub fn is_any_conversation_being_renamed(&self) -> bool {
+        self.conversation_being_renamed.is_some()
+    }
+
+    /// GH8642: enter conversation-rename mode for the given id. Mutually
+    /// exclusive with tab/pane rename — those are cleared so the workspace
+    /// rename editor is always owned by exactly one rename surface.
+    pub fn set_conversation_being_renamed(&mut self, conversation_id: AIConversationId) {
+        self.conversation_being_renamed = Some(conversation_id);
+        self.tab_being_renamed = None;
+        self.pane_being_renamed = None;
+    }
+
+    pub fn clear_conversation_being_renamed(&mut self) {
+        self.conversation_being_renamed = None;
+    }
+
+    pub fn conversation_being_renamed(&self) -> Option<AIConversationId> {
+        self.conversation_being_renamed
     }
 }
 

--- a/app/src/workspace/util_tests.rs
+++ b/app/src/workspace/util_tests.rs
@@ -1,0 +1,85 @@
+//! Unit tests for [`super::util`].
+//!
+//! These tests focus on the small, pure pieces of [`WorkspaceState`] that
+//! don't need a workspace view or app context — currently the
+//! tab/pane/conversation rename state machine. Heavier scenarios that need a
+//! live `Workspace` view live in `view_test.rs` / integration tests.
+use super::{PaneViewLocator, WorkspaceState};
+use crate::ai::agent::conversation::AIConversationId;
+use crate::pane_group::TerminalPaneId;
+use warpui::EntityId;
+
+fn pane_locator() -> PaneViewLocator {
+    PaneViewLocator {
+        pane_group_id: EntityId::new(),
+        pane_id: TerminalPaneId::dummy_terminal_pane_id().into(),
+    }
+}
+
+#[test]
+fn workspace_state_starts_with_no_rename_in_progress() {
+    let state = WorkspaceState::default();
+    assert!(!state.is_tab_being_renamed());
+    assert!(!state.is_any_pane_being_renamed());
+    assert!(!state.is_any_conversation_being_renamed());
+    assert_eq!(state.tab_being_renamed(), None);
+    assert_eq!(state.pane_being_renamed(), None);
+    assert_eq!(state.conversation_being_renamed(), None);
+}
+
+/// GH8642 invariant: only one rename surface (tab / pane / conversation) can
+/// be active at a time. Setting any one of the three must clear the others
+/// so the workspace-level inline editor is always owned by exactly one
+/// rename source.
+#[test]
+fn workspace_state_rename_modes_are_mutually_exclusive() {
+    let mut state = WorkspaceState::default();
+    let conversation_id = AIConversationId::new();
+    let pane = pane_locator();
+
+    // Start with a tab rename, then enter pane rename: tab clears.
+    state.set_tab_being_renamed(7);
+    assert_eq!(state.tab_being_renamed(), Some(7));
+    state.set_pane_being_renamed(pane);
+    assert_eq!(state.tab_being_renamed(), None);
+    assert!(state.is_pane_being_renamed(pane));
+
+    // Now enter conversation rename: pane clears.
+    state.set_conversation_being_renamed(conversation_id);
+    assert!(!state.is_any_pane_being_renamed());
+    assert!(state.is_any_conversation_being_renamed());
+    assert_eq!(state.conversation_being_renamed(), Some(conversation_id));
+    assert!(state.is_conversation_being_renamed(conversation_id));
+
+    // Round-trip back to tab: conversation clears.
+    state.set_tab_being_renamed(2);
+    assert_eq!(state.tab_being_renamed(), Some(2));
+    assert!(!state.is_any_conversation_being_renamed());
+    assert_eq!(state.conversation_being_renamed(), None);
+}
+
+#[test]
+fn workspace_state_clear_conversation_being_renamed_idempotent() {
+    let mut state = WorkspaceState::default();
+    let conversation_id = AIConversationId::new();
+
+    state.set_conversation_being_renamed(conversation_id);
+    assert!(state.is_any_conversation_being_renamed());
+    state.clear_conversation_being_renamed();
+    assert!(!state.is_any_conversation_being_renamed());
+    // Calling clear again is a no-op (regression: don't panic on double-clear).
+    state.clear_conversation_being_renamed();
+    assert_eq!(state.conversation_being_renamed(), None);
+}
+
+#[test]
+fn workspace_state_is_conversation_being_renamed_only_matches_active_id() {
+    let mut state = WorkspaceState::default();
+    let active = AIConversationId::new();
+    let other = AIConversationId::new();
+    assert_ne!(active, other);
+
+    state.set_conversation_being_renamed(active);
+    assert!(state.is_conversation_being_renamed(active));
+    assert!(!state.is_conversation_being_renamed(other));
+}

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -488,8 +488,9 @@ use crate::palette::PaletteMode;
 use crate::search::command_palette::view::{Event as CommandPaletteEvent, View as CommandPalette};
 use crate::server::telemetry::{NotificationsTurnedOnSource, PaletteSource, TabRenameEvent};
 use crate::tab::{
-    tab_position_id, uses_vertical_tabs, NewSessionMenuItem, PaneNameMenuTarget, SelectedTabColor,
-    TabBarState, TabComponent, TabData, TabTelemetryAction, TAB_BAR_BORDER_HEIGHT,
+    tab_position_id, uses_vertical_tabs, NewSessionMenuItem, PaneConversationMenuTarget,
+    PaneNameMenuTarget, SelectedTabColor, TabBarState, TabComponent, TabData, TabTelemetryAction,
+    TAB_BAR_BORDER_HEIGHT,
 };
 use crate::terminal::view::ssh_file_upload::FileUploadId;
 use crate::ui_components::icons;
@@ -933,6 +934,13 @@ pub struct Workspace {
     traffic_light_mouse_states: TrafficLightMouseStates,
     tab_rename_editor: ViewHandle<EditorView>,
     pane_rename_editor: ViewHandle<EditorView>,
+    /// GH8642: shared single-line editor used to rename the conversation whose
+    /// id is currently in [`WorkspaceState::conversation_being_renamed`]. Lives
+    /// at the workspace level so any pane in any tab can drive the rename, and
+    /// so the rename survives tab/pane focus changes the same way `tab_rename_editor`
+    /// does. Mirrors the tab/pane pattern — built once in `Workspace::new` and
+    /// re-seeded each time rename starts.
+    pub(crate) conversation_rename_editor: ViewHandle<EditorView>,
     vertical_tabs_search_input: ViewHandle<EditorView>,
     tips_completed: ModelHandle<TipsCompleted>,
     user_default_shell_unsupported_banner_model_handle: ModelHandle<BannerState>,
@@ -1312,6 +1320,25 @@ impl Workspace {
         editor
     }
 
+    /// GH8642: builder for the workspace-level conversation rename editor used
+    /// by the vertical-tabs surface. Mirrors [`Self::pane_rename_editor`] — a
+    /// single-line editor at 12pt, subscribed to events that route
+    /// Enter/Blurred -> commit and Escape -> cancel.
+    fn conversation_rename_editor(ctx: &mut ViewContext<Self>) -> ViewHandle<EditorView> {
+        let editor = ctx.add_typed_action_view(|ctx| {
+            let appearance = Appearance::as_ref(ctx);
+            let options = SingleLineEditorOptions {
+                text: TextOptions::ui_text(Some(12.), appearance),
+                ..Default::default()
+            };
+            EditorView::single_line(options, ctx)
+        });
+        ctx.subscribe_to_view(&editor, move |me, _, event, ctx| {
+            me.handle_conversation_rename_editor_event(event, ctx);
+        });
+        editor
+    }
+
     pub fn handle_tab_rename_editor_event(
         &mut self,
         event: &EditorEvent,
@@ -1342,6 +1369,29 @@ impl Workspace {
                 }
                 EditorEvent::Escape => {
                     self.cancel_pane_rename(ctx);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// GH8642: handle commit/cancel for the workspace-level conversation rename
+    /// editor. Mirrors [`Self::handle_pane_rename_editor_event`].
+    pub fn handle_conversation_rename_editor_event(
+        &mut self,
+        event: &EditorEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self
+            .current_workspace_state
+            .is_any_conversation_being_renamed()
+        {
+            match event {
+                EditorEvent::Blurred | EditorEvent::Enter => {
+                    self.finish_conversation_rename(ctx);
+                }
+                EditorEvent::Escape => {
+                    self.cancel_conversation_rename(ctx);
                 }
                 _ => {}
             }
@@ -1400,6 +1450,61 @@ impl Workspace {
             self.focus_pane(locator, ctx);
             ctx.notify();
         }
+    }
+
+    fn clear_conversation_rename_editor(&mut self, ctx: &mut ViewContext<Self>) {
+        self.conversation_rename_editor.update(ctx, |editor, ctx| {
+            editor.clear_buffer_and_reset_undo_stack(ctx);
+        });
+    }
+
+    /// GH8642: commit the in-progress conversation rename (Enter / blur path).
+    /// Reads the editor buffer, dispatches
+    /// [`WorkspaceAction::SetConversationUserTitle`] (whitespace-only input is
+    /// treated as `None`, clearing the override), clears editor + state, and
+    /// returns focus to the active tab.
+    fn finish_conversation_rename(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(conversation_id) = self.current_workspace_state.conversation_being_renamed()
+        else {
+            return;
+        };
+
+        self.current_workspace_state
+            .clear_conversation_being_renamed();
+
+        let raw = self.conversation_rename_editor.as_ref(ctx).buffer_text(ctx);
+        let trimmed = raw.trim();
+        let title = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+
+        ctx.dispatch_typed_action(&WorkspaceAction::SetConversationUserTitle {
+            conversation_id,
+            title,
+        });
+
+        self.clear_conversation_rename_editor(ctx);
+        self.focus_active_tab(ctx);
+        ctx.notify();
+    }
+
+    /// GH8642: cancel the in-progress conversation rename (Escape path) without
+    /// dispatching. Clears editor + state and refocuses the active tab.
+    fn cancel_conversation_rename(&mut self, ctx: &mut ViewContext<Self>) {
+        if self
+            .current_workspace_state
+            .conversation_being_renamed()
+            .is_none()
+        {
+            return;
+        }
+        self.current_workspace_state
+            .clear_conversation_being_renamed();
+        self.clear_conversation_rename_editor(ctx);
+        self.focus_active_tab(ctx);
+        ctx.notify();
     }
 
     fn build_import_modal(ctx: &mut ViewContext<Self>) -> ViewHandle<ImportModal> {
@@ -3099,6 +3204,7 @@ impl Workspace {
             traffic_light_mouse_states: Default::default(),
             tab_rename_editor: Self::tab_rename_editor(ctx),
             pane_rename_editor: Self::pane_rename_editor(ctx),
+            conversation_rename_editor: Self::conversation_rename_editor(ctx),
             vertical_tabs_search_input: Self::vertical_tabs_search_input(ctx),
             tips_completed,
             user_default_shell_unsupported_banner_model_handle,
@@ -5286,6 +5392,104 @@ impl Workspace {
         ctx.notify();
     }
 
+    /// GH8642: begin renaming the given conversation by opening the
+    /// workspace-level inline editor. Mirrors [`Self::rename_tab_internal`] —
+    /// records the renaming conversation id on `WorkspaceState`, seeds the
+    /// editor with the conversation's effective title (live `title()` →
+    /// historical metadata `title` → "Untitled conversation" placeholder), and
+    /// focuses the editor so the next render replaces the vertical-tab title
+    /// text with the inline editor.
+    ///
+    /// Shared-session viewers do not own the conversation, so the rename API
+    /// would reject the commit anyway — short-circuit before touching state
+    /// to avoid a no-op editor session.
+    pub fn rename_conversation(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let history_model = BlocklistAIHistoryModel::as_ref(ctx);
+        if history_model
+            .conversation(&conversation_id)
+            .is_some_and(|c| c.is_viewing_shared_session())
+        {
+            log::debug!(
+                "rename_conversation: refusing to rename {conversation_id} \
+                 (shared-session viewer)"
+            );
+            return;
+        }
+
+        let seed_title = history_model
+            .conversation(&conversation_id)
+            .and_then(|c| c.title())
+            .or_else(|| {
+                history_model
+                    .get_conversation_metadata(&conversation_id)
+                    .map(|m| m.title.clone())
+            })
+            .unwrap_or_else(|| "Untitled conversation".to_string());
+
+        self.current_workspace_state
+            .set_conversation_being_renamed(conversation_id);
+
+        // Reset and re-seed the editor every time so a previous rename's text
+        // (committed or cancelled) doesn't leak into the new session.
+        self.conversation_rename_editor.update(ctx, |editor, ctx| {
+            editor.clear_buffer_and_reset_undo_stack(ctx);
+            editor.insert_selected_text(&seed_title, ctx);
+        });
+        ctx.focus(&self.conversation_rename_editor);
+        ctx.notify();
+    }
+
+    /// Clears the user-set title override for the given conversation, reverting to the
+    /// auto-generated title chain. Wraps the history-model API and translates errors into
+    /// log warnings (no toast yet — phase 2c will add UI surfaces for these errors).
+    pub fn reset_conversation_name(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let history_model = BlocklistAIHistoryModel::handle(ctx);
+        let result = history_model.update(ctx, |model, ctx| {
+            model.set_conversation_user_title(conversation_id, None, ctx)
+        });
+        match result {
+            Ok(true) => {}
+            Ok(false) => {
+                log::debug!(
+                    "reset_conversation_name: {conversation_id} had no user-set title; no-op"
+                );
+            }
+            Err(err) => {
+                log::warn!("reset_conversation_name failed for {conversation_id}: {err}");
+            }
+        }
+    }
+
+    /// Persists a user-set title for the given conversation. `title = None` (or a string
+    /// that normalizes to empty) clears the override, identical to
+    /// [`Self::reset_conversation_name`]. This is the single commit entry point both
+    /// rename surfaces (vertical tabs and the conversation list) converge on.
+    pub fn set_conversation_user_title(
+        &mut self,
+        conversation_id: AIConversationId,
+        title: Option<String>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let history_model = BlocklistAIHistoryModel::handle(ctx);
+        let result = history_model.update(ctx, |model, ctx| {
+            model.set_conversation_user_title(conversation_id, title, ctx)
+        });
+        match result {
+            Ok(_) => {}
+            Err(err) => {
+                log::warn!("set_conversation_user_title failed for {conversation_id}: {err}");
+            }
+        }
+    }
+
     fn set_custom_pane_name(
         &mut self,
         locator: PaneViewLocator,
@@ -6639,10 +6843,38 @@ impl Workspace {
                 reset_label: "Reset active pane name",
             },
         };
-        let menu_items = tab.menu_items_with_pane_name_target(
+        // GH8642: resolve the conversation rename target by looking up the
+        // chrome conversation behind the right-clicked pane. Skip the menu
+        // entries entirely when the pane is a shared-session viewer (since
+        // the rename API would reject the commit anyway).
+        let pane_conversation_target = tab
+            .pane_group
+            .as_ref(ctx)
+            .terminal_view_from_pane_id(pane.pane_id, ctx)
+            .and_then(|terminal_view| {
+                terminal_view
+                    .as_ref(ctx)
+                    .selected_conversation_id_for_chrome(ctx)
+            })
+            .filter(|conversation_id| {
+                !BlocklistAIHistoryModel::as_ref(ctx)
+                    .conversation(conversation_id)
+                    .is_some_and(|c| c.is_viewing_shared_session())
+            })
+            .map(|conversation_id| {
+                let has_user_set_title = BlocklistAIHistoryModel::as_ref(ctx)
+                    .conversation(&conversation_id)
+                    .is_some_and(|c| c.user_set_title().is_some());
+                PaneConversationMenuTarget {
+                    conversation_id,
+                    has_user_set_title,
+                }
+            });
+        let menu_items = tab.menu_items_with_pane_targets(
             tab_index,
             self.tabs.len(),
             Some(pane_name_target),
+            pane_conversation_target,
             ctx,
         );
 
@@ -20443,6 +20675,16 @@ impl TypedActionView for Workspace {
                 );
             }
             SetActiveTabName(name) => self.set_active_tab_name(name, ctx),
+            RenameConversation { conversation_id } => {
+                self.rename_conversation(*conversation_id, ctx)
+            }
+            ResetConversationName { conversation_id } => {
+                self.reset_conversation_name(*conversation_id, ctx)
+            }
+            SetConversationUserTitle {
+                conversation_id,
+                title,
+            } => self.set_conversation_user_title(*conversation_id, title.clone(), ctx),
             SetActiveTabColor(color) => self.set_tab_color(self.active_tab_index, *color, ctx),
             ToggleTabRightClickMenu { tab_index, anchor } => {
                 self.toggle_tab_right_click_menu(*tab_index, *anchor, ctx)

--- a/app/src/workspace/view/conversation_list/item.rs
+++ b/app/src/workspace/view/conversation_list/item.rs
@@ -5,6 +5,7 @@ use crate::ai::agent_conversations_model::{
 use crate::ai::conversation_status_ui::STATUS_ELEMENT_PADDING;
 use crate::appearance::Appearance;
 use crate::drive::sharing::dialog::SharingDialog;
+use crate::editor::EditorView;
 use crate::menu::Menu;
 use crate::ui_components::agent_icon::agent_conversation_entry_icon_variant;
 use crate::ui_components::icon_with_status::render_icon_with_status;
@@ -19,15 +20,17 @@ use warp_core::ui::theme::color::internal_colors;
 use warp_util::path::user_friendly_path;
 use warpui::elements::{
     AnchorPair, ChildAnchor, ChildView, ConstrainedBox, Container, CornerRadius,
-    CrossAxisAlignment, DispatchEventResult, Element, EventHandler, Flex, Highlight, Hoverable,
-    MainAxisAlignment, MainAxisSize, MouseInBehavior, MouseStateHandle, OffsetPositioning,
-    OffsetType, ParentAnchor, ParentElement, ParentOffsetBounds, PositionedElementOffsetBounds,
-    PositioningAxis, Radius, SavePosition, Shrinkable, Stack, Text, XAxisAnchor, YAxisAnchor,
+    CrossAxisAlignment, DispatchEventResult, Element, EventHandler, Fill, Flex, Highlight,
+    Hoverable, MainAxisAlignment, MainAxisSize, MouseInBehavior, MouseStateHandle,
+    OffsetPositioning, OffsetType, ParentAnchor, ParentElement, ParentOffsetBounds,
+    PositionedElementOffsetBounds, PositioningAxis, Radius, SavePosition, Shrinkable, Stack, Text,
+    XAxisAnchor, YAxisAnchor,
 };
 use warpui::fonts::{Properties, Weight};
 use warpui::platform::Cursor;
 use warpui::text_layout::TextStyle;
 use warpui::ui_components::components::{UiComponent, UiComponentStyles};
+use warpui::ui_components::text_input::TextInput;
 use warpui::{AppContext, SingletonEntity, ViewHandle};
 
 /// Maximum length for tooltip text before truncation
@@ -93,6 +96,18 @@ pub struct ItemProps<'a> {
     pub is_share_dialog_open: bool,
     pub list_position_id: &'a str,
     pub tooltip_opens_right: bool,
+    /// GH8642: when `true`, this row is currently in inline-rename mode and the
+    /// title `Text` is replaced by [`Self::rename_editor`]. Click-to-open and
+    /// the kebab/tooltip overlays are suppressed while renaming so the editor
+    /// owns the row's interaction.
+    pub is_renaming: bool,
+    /// GH8642: shared single-line editor used to rename the conversation when
+    /// `is_renaming` is `true`. Only one row can be renaming at a time, and
+    /// its commit/cancel logic lives in `ConversationListView` (see
+    /// `handle_rename_editor_event`). The handle is always passed in (never
+    /// `Option`) so the editor's `MouseStateHandle`s and event subscriptions
+    /// stay stable across the renaming-state flip.
+    pub rename_editor: &'a ViewHandle<EditorView>,
 }
 
 pub struct StaticItemProps<'a> {
@@ -182,6 +197,8 @@ pub fn render_item(props: ItemProps<'_>, app: &AppContext) -> Box<dyn Element> {
         is_share_dialog_open,
         list_position_id,
         tooltip_opens_right,
+        is_renaming,
+        rename_editor,
     } = props;
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
@@ -190,27 +207,45 @@ pub fn render_item(props: ItemProps<'_>, app: &AppContext) -> Box<dyn Element> {
     let font_size = appearance.ui_font_size();
 
     let title_font_size = font_size + 2.;
-    let mut title_text = Text::new_inline(
-        conversation.display.title.clone(),
-        font_family,
-        title_font_size,
-    )
-    .with_color(theme.main_text_color(theme.background()).into());
 
-    if let Some(indices) = highlight_indices {
-        if !indices.is_empty() {
-            let highlight = Highlight::new()
-                .with_properties(Properties::default().weight(Weight::Bold))
-                .with_text_style(
-                    TextStyle::new()
-                        .with_foreground_color(theme.main_text_color(theme.background()).into())
-                        .with_background_color(
-                            internal_colors::accent_overlay_3(theme).into_solid(),
-                        ),
-                );
-            title_text = title_text.with_single_highlight(highlight, indices.clone());
+    // GH8642: when the row is renaming, swap the title `Text` for a
+    // `TextInput` wrapping the shared rename editor. We keep the same icon +
+    // bottom row (subtext / timestamp) so the layout doesn't reflow during the
+    // state flip; only the title slot changes.
+    let title_slot: Box<dyn Element> = if is_renaming {
+        TextInput::new(
+            rename_editor.clone(),
+            UiComponentStyles::default()
+                .set_background(Fill::None)
+                .set_border_radius(CornerRadius::with_all(Radius::Pixels(0.)))
+                .set_border_width(0.),
+        )
+        .build()
+        .finish()
+    } else {
+        let mut title_text = Text::new_inline(
+            conversation.display.title.clone(),
+            font_family,
+            title_font_size,
+        )
+        .with_color(theme.main_text_color(theme.background()).into());
+
+        if let Some(indices) = highlight_indices {
+            if !indices.is_empty() {
+                let highlight = Highlight::new()
+                    .with_properties(Properties::default().weight(Weight::Bold))
+                    .with_text_style(
+                        TextStyle::new()
+                            .with_foreground_color(theme.main_text_color(theme.background()).into())
+                            .with_background_color(
+                                internal_colors::accent_overlay_3(theme).into_solid(),
+                            ),
+                    );
+                title_text = title_text.with_single_highlight(highlight, indices.clone());
+            }
         }
-    }
+        title_text.finish()
+    };
 
     let status_element_size = font_size + STATUS_ELEMENT_PADDING * 2.;
     let icon_element = render_icon_with_status(
@@ -227,7 +262,7 @@ pub fn render_item(props: ItemProps<'_>, app: &AppContext) -> Box<dyn Element> {
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_spacing(ICON_SPACING)
             .with_child(icon_element)
-            .with_child(Shrinkable::new(1.0, title_text.finish()).finish())
+            .with_child(Shrinkable::new(1.0, title_slot).finish())
             .finish(),
     )
     .finish();
@@ -282,6 +317,10 @@ pub fn render_item(props: ItemProps<'_>, app: &AppContext) -> Box<dyn Element> {
     let can_open = conversation.capabilities.can_open;
     let tooltip_text = truncate_from_end(&conversation.display.title, MAX_TOOLTIP_LENGTH);
     let overflow_button_state = state.overflow_button_state.clone();
+    // GH8642: while a row is renaming we suppress the kebab + tooltip overlays
+    // so the editor isn't covered by floating chrome. Captured up-front so the
+    // closure can `move` it without re-borrowing `is_renaming`.
+    let suppress_overlays = is_renaming;
     let hoverable = Hoverable::new(state.mouse_state.clone(), move |_| {
         let container = Container::new(row)
             .with_horizontal_padding(12.)
@@ -298,7 +337,9 @@ pub fn render_item(props: ItemProps<'_>, app: &AppContext) -> Box<dyn Element> {
         let mut stack = Stack::new().with_child(container.finish());
 
         // We show the overflow menu button when the item is selected, or the overflow menu is already open.
-        if is_selected || !matches!(overflow_menu_display, OverflowMenuDisplay::Closed) {
+        if !suppress_overlays
+            && (is_selected || !matches!(overflow_menu_display, OverflowMenuDisplay::Closed))
+        {
             let button_style = UiComponentStyles::default()
                 .set_background(theme.surface_2().into())
                 .set_border_color(theme.surface_3().into());
@@ -337,7 +378,10 @@ pub fn render_item(props: ItemProps<'_>, app: &AppContext) -> Box<dyn Element> {
         }
 
         // Hide the tooltip when the overflow menu is being shown so that they don't overlap.
-        if is_selected && matches!(overflow_menu_display, OverflowMenuDisplay::Closed) {
+        if !suppress_overlays
+            && is_selected
+            && matches!(overflow_menu_display, OverflowMenuDisplay::Closed)
+        {
             let tooltip = ui_builder.tool_tip(tooltip_text).build().finish();
             let (parent_anchor, child_anchor, offset_x) = if tooltip_opens_right {
                 (ParentAnchor::MiddleRight, ChildAnchor::MiddleLeft, 4.)
@@ -371,7 +415,33 @@ pub fn render_item(props: ItemProps<'_>, app: &AppContext) -> Box<dyn Element> {
     })
     .with_defer_events_to_children();
 
-    let hoverable_element = if can_open {
+    // GH8642: double-click on the row title region begins inline rename, but
+    // only for non-task, non-shared-viewer rows. Tasks are filtered out below
+    // by checking the id variant. Shared-viewer state is enforced view-side in
+    // `ConversationListView::start_rename` (defense in depth).
+    let allow_rename = matches!(conversation_id, AgentConversationEntryId::Conversation(_));
+    let rename_dispatch_id = match conversation_id {
+        AgentConversationEntryId::Conversation(id) => Some(id),
+        AgentConversationEntryId::AmbientRun(_) => None,
+    };
+    let hoverable = if allow_rename && !is_renaming {
+        if let Some(ai_conversation_id) = rename_dispatch_id {
+            hoverable.on_double_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(ConversationListViewAction::RenameConversation {
+                    conversation_id: ai_conversation_id,
+                });
+            })
+        } else {
+            hoverable
+        }
+    } else {
+        hoverable
+    };
+
+    // While renaming, the row's primary affordance is the editor itself.
+    // Suppress the row-wide click-to-open so a stray click in the editor's
+    // bounds doesn't navigate away mid-edit.
+    let hoverable_element = if can_open && !is_renaming {
         hoverable
             .with_cursor(Cursor::PointingHand)
             .on_click(move |ctx, _, _| {

--- a/app/src/workspace/view/conversation_list/view.rs
+++ b/app/src/workspace/view/conversation_list/view.rs
@@ -141,6 +141,22 @@ pub enum ConversationListViewAction {
         conversation_id: AgentConversationEntryId,
         destination: ForkedConversationDestination,
     },
+    /// GH8642: begin renaming the given conversation by opening the inline editor
+    /// in place of the row's title. Dispatched from a double-click on the row's
+    /// title region or from the overflow menu's `Rename conversation` item.
+    /// The editor commits on Enter / blur (dispatches `WorkspaceAction::SetConversationUserTitle`)
+    /// and cancels on Escape (clears editor state without dispatching).
+    /// See `specs/GH8642/`.
+    RenameConversation {
+        conversation_id: AIConversationId,
+    },
+    /// GH8642: clears the user-set title override, reverting to the auto-generated
+    /// title chain. Dispatched from the overflow menu's `Reset conversation name`
+    /// item, which is only shown when the conversation already has a user-set
+    /// title. Forwards to `WorkspaceAction::ResetConversationName`. See `specs/GH8642/`.
+    ResetConversationName {
+        conversation_id: AIConversationId,
+    },
 }
 
 pub enum Event {
@@ -176,6 +192,16 @@ pub struct ConversationListView {
     /// (we use this to decide whether or not to show the view all button).
     total_past_items: usize,
     state_handles: StateHandles,
+    /// GH8642: shared single-line editor used to rename the conversation row whose
+    /// id is currently in [`Self::renaming_conversation_id`]. The editor is built
+    /// once in [`Self::new`] and re-seeded with the row's effective title every
+    /// time rename starts. Mirrors the workspace-level `tab_rename_editor`.
+    rename_editor: ViewHandle<EditorView>,
+    /// GH8642: id of the conversation whose row is currently in inline-rename
+    /// mode, or `None` when the list is in normal display mode. Only ever set to
+    /// the id of an [`AIConversation`] (never an ambient task) since rename is
+    /// not supported for tasks.
+    renaming_conversation_id: Option<AIConversationId>,
 }
 
 pub fn register_conversation_list_view_bindings(app: &mut AppContext) {
@@ -268,6 +294,8 @@ impl ConversationListView {
             ctx.notify();
         });
 
+        let rename_editor = Self::build_rename_editor(ctx);
+
         let mut view = Self {
             window_id: ctx.window_id(),
             view_id: ctx.view_id(),
@@ -284,9 +312,139 @@ impl ConversationListView {
             view_all: false,
             total_past_items: 0,
             state_handles: StateHandles::default(),
+            rename_editor,
+            renaming_conversation_id: None,
         };
         view.sync_list_items(ctx);
         view
+    }
+
+    /// Builds the inline-rename editor used by both rename surfaces in this view
+    /// (double-click on the title region and the overflow menu's `Rename
+    /// conversation` item). Mirrors the workspace `tab_rename_editor`: 14pt UI
+    /// font, select-all on focus, and propagate vertical navigation keys so the
+    /// editor doesn't swallow Up/Down (which the list still uses to move
+    /// selection between rows).
+    ///
+    /// Subscribes to the editor's events so:
+    /// * `Enter` / `Blurred` → commit the current buffer via
+    ///   [`Self::commit_rename`] (dispatches
+    ///   [`WorkspaceAction::SetConversationUserTitle`]).
+    /// * `Escape` → cancel via [`Self::cancel_rename`] without dispatching.
+    fn build_rename_editor(ctx: &mut ViewContext<Self>) -> ViewHandle<EditorView> {
+        let editor = ctx.add_typed_action_view(|ctx| {
+            let appearance = Appearance::as_ref(ctx);
+            EditorView::single_line(
+                SingleLineEditorOptions {
+                    text: TextOptions::ui_text(Some(appearance.ui_font_size() + 2.), appearance),
+                    select_all_on_focus: true,
+                    clear_selections_on_blur: true,
+                    propagate_and_no_op_vertical_navigation_keys:
+                        PropagateAndNoOpNavigationKeys::Always,
+                    ..Default::default()
+                },
+                ctx,
+            )
+        });
+        ctx.subscribe_to_view(&editor, |me, _handle, event, ctx| {
+            me.handle_rename_editor_event(event, ctx);
+        });
+        editor
+    }
+
+    fn handle_rename_editor_event(&mut self, event: &EditorEvent, ctx: &mut ViewContext<Self>) {
+        if self.renaming_conversation_id.is_none() {
+            return;
+        }
+        match event {
+            EditorEvent::Enter | EditorEvent::Blurred => self.commit_rename(ctx),
+            EditorEvent::Escape => self.cancel_rename(ctx),
+            _ => {}
+        }
+    }
+
+    /// Begin renaming the given conversation: seed the inline editor with the
+    /// row's currently-displayed title and focus the editor. The next render
+    /// pass swaps the row's title text for the editor.
+    fn start_rename(&mut self, conversation_id: AIConversationId, ctx: &mut ViewContext<Self>) {
+        // Defense in depth: shared-session viewer mode does not own the
+        // conversation, so the rename API would reject the commit anyway.
+        // Hide the affordance up front to avoid a no-op editor session.
+        let history_model = BlocklistAIHistoryModel::as_ref(ctx);
+        if history_model
+            .conversation(&conversation_id)
+            .is_some_and(|c| c.is_viewing_shared_session())
+        {
+            log::debug!(
+                "start_rename: refusing to rename {conversation_id} \
+                 (shared-session viewer)"
+            );
+            return;
+        }
+
+        // Resolve the seed title: prefer the live conversation's `title()` (so
+        // an in-flight rename in another surface is reflected), fall back to
+        // the cached metadata title (historical / not-currently-loaded rows),
+        // and finally to the placeholder used elsewhere in this view.
+        let seed_title = history_model
+            .conversation(&conversation_id)
+            .and_then(|c| c.title())
+            .or_else(|| {
+                history_model
+                    .get_conversation_metadata(&conversation_id)
+                    .map(|m| m.title.clone())
+            })
+            .unwrap_or_else(|| "Untitled conversation".to_string());
+
+        self.renaming_conversation_id = Some(conversation_id);
+
+        // Reset and re-seed the editor every time so a previous rename's text
+        // (committed or cancelled) doesn't leak into the new session.
+        self.rename_editor.update(ctx, |editor, ctx| {
+            editor.clear_buffer_and_reset_undo_stack(ctx);
+            editor.insert_selected_text(&seed_title, ctx);
+        });
+        ctx.focus(&self.rename_editor);
+        ctx.notify();
+    }
+
+    /// Commit the in-progress rename by dispatching
+    /// [`WorkspaceAction::SetConversationUserTitle`] with the editor's current
+    /// buffer (or `None` for whitespace-only input, which clears the override).
+    fn commit_rename(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(conversation_id) = self.renaming_conversation_id.take() else {
+            return;
+        };
+
+        let raw = self.rename_editor.as_ref(ctx).buffer_text(ctx);
+        let trimmed = raw.trim();
+        let title = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+
+        ctx.dispatch_typed_action(&WorkspaceAction::SetConversationUserTitle {
+            conversation_id,
+            title,
+        });
+
+        self.rename_editor.update(ctx, |editor, ctx| {
+            editor.clear_buffer_and_reset_undo_stack(ctx);
+        });
+        ctx.notify();
+    }
+
+    /// Cancel the in-progress rename without dispatching: clear editor state
+    /// and return the next render to displaying the title text again.
+    fn cancel_rename(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.renaming_conversation_id.take().is_none() {
+            return;
+        }
+        self.rename_editor.update(ctx, |editor, ctx| {
+            editor.clear_buffer_and_reset_undo_stack(ctx);
+        });
+        ctx.notify();
     }
 
     /// Rebuilds the flat list of items based on sections and collapse state.
@@ -975,10 +1133,63 @@ impl TypedActionView for ConversationListView {
                             None
                         };
 
+                    // GH8642: rename / reset items appear between Share and Fork. Rename is
+                    // available for any non-task, non-shared-viewer conversation. Reset is
+                    // available only when the conversation already has a user-set title (read
+                    // from `nav_data.has_user_set_title`, which is populated for both live and
+                    // historical metadata rows).
+                    let rename_items: Vec<MenuItem<ConversationListViewAction>> =
+                        match conversation_id {
+                            AgentConversationEntryId::Conversation(ai_conversation_id) => {
+                                let history_model = BlocklistAIHistoryModel::as_ref(ctx);
+                                let is_shared_viewer = history_model
+                                    .conversation(&ai_conversation_id)
+                                    .is_some_and(|c| c.is_viewing_shared_session());
+                                if is_shared_viewer {
+                                    Vec::new()
+                                } else {
+                                    // GH8642: the Reset entry is only available when the
+                                    // conversation currently has a user-set title override. Read
+                                    // through the history model so live + historical metadata
+                                    // rows agree on this answer.
+                                    let has_user_set_title = history_model
+                                        .conversation(&ai_conversation_id)
+                                        .and_then(|c| c.user_set_title().map(|_| ()))
+                                        .is_some()
+                                        || history_model
+                                            .get_conversation_metadata(&ai_conversation_id)
+                                            .and_then(|m| m.user_set_title.as_ref())
+                                            .is_some();
+                                    let mut entries =
+                                        vec![MenuItemFields::new("Rename conversation")
+                                            .with_on_select_action(
+                                                ConversationListViewAction::RenameConversation {
+                                                    conversation_id: ai_conversation_id,
+                                                },
+                                            )
+                                            .into_item()];
+                                    if has_user_set_title {
+                                        entries.push(
+                                            MenuItemFields::new("Reset conversation name")
+                                                .with_on_select_action(
+                                                    ConversationListViewAction::ResetConversationName {
+                                                        conversation_id: ai_conversation_id,
+                                                    },
+                                                )
+                                                .into_item(),
+                                        );
+                                    }
+                                    entries
+                                }
+                            }
+                            AgentConversationEntryId::AmbientRun(_) => Vec::new(),
+                        };
+
                     let mut items = Vec::new();
                     if let Some(share_item) = share_item {
                         items.push(share_item);
                     }
+                    items.extend(rename_items);
                     if let Some(fork_items) = fork_items {
                         items.extend(fork_items);
                     }
@@ -1152,6 +1363,18 @@ impl TypedActionView for ConversationListView {
                     destination: *destination,
                 });
             }
+            ConversationListViewAction::RenameConversation { conversation_id } => {
+                // Close the overflow menu (if open for this row) before starting
+                // rename so the inline editor isn't covered by a stale menu.
+                self.overflow_menu_state = None;
+                self.start_rename(*conversation_id, ctx);
+            }
+            ConversationListViewAction::ResetConversationName { conversation_id } => {
+                self.overflow_menu_state = None;
+                ctx.dispatch_typed_action(&WorkspaceAction::ResetConversationName {
+                    conversation_id: *conversation_id,
+                });
+            }
         }
     }
 }
@@ -1208,6 +1431,10 @@ impl View for ConversationListView {
             let sharing_dialog = self.sharing_dialog.clone();
             let share_dialog_open_for = self.share_dialog_open_for;
             let list_position_id = self.get_position_id();
+            // GH8642: capture rename state outside the closure so each rendered
+            // row can decide whether to show the inline editor in its title slot.
+            let renaming_conversation_id = self.renaming_conversation_id;
+            let rename_editor = self.rename_editor.clone();
             let tooltip_opens_right = TabSettings::as_ref(app)
                 .header_toolbar_chip_selection
                 .left_items()
@@ -1275,6 +1502,12 @@ impl View for ConversationListView {
                                     };
                                     let is_share_dialog_open =
                                         share_dialog_open_for == Some(entry.id);
+                                    let is_renaming = match entry.id {
+                                        AgentConversationEntryId::Conversation(id) => {
+                                            renaming_conversation_id == Some(id)
+                                        }
+                                        AgentConversationEntryId::AmbientRun(_) => false,
+                                    };
                                     Some(render_item(
                                         ItemProps {
                                             conversation: &conversation,
@@ -1290,6 +1523,8 @@ impl View for ConversationListView {
                                             is_share_dialog_open,
                                             list_position_id: &list_position_id,
                                             tooltip_opens_right,
+                                            is_renaming,
+                                            rename_editor: &rename_editor,
                                         },
                                         app,
                                     ))

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1,6 +1,6 @@
 pub mod telemetry;
 
-use crate::ai::agent::conversation::{ConversationStatus, StatusColorStyle};
+use crate::ai::agent::conversation::{AIConversationId, ConversationStatus, StatusColorStyle};
 use crate::ai::agent_management::AgentNotificationsModel;
 use crate::ai::conversation_status_ui::render_status_element;
 use crate::code::editor::{add_color, remove_color};
@@ -121,6 +121,55 @@ const VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE: f32 = 10.;
 
 fn vtab_pane_row_position_id(pane_group_id: EntityId, pane_id: PaneId) -> String {
     format!("vertical_tabs:pane_row:{pane_group_id:?}:{pane_id}")
+}
+
+/// GH8642: resolves the conversation-rename triple for a single pane row in
+/// the vertical tabs panel.
+///
+/// Returns:
+/// * `conversation_id` — the chrome conversation behind this pane (terminal
+///   panes only; `None` for non-terminal panes and any conversation that
+///   matches the shared-session-viewer guard so we never offer rename to a
+///   user who can't commit).
+/// * `is_conversation_being_renamed` — whether the workspace-level rename
+///   editor is currently bound to that conversation.
+/// * `conversation_rename_editor` — the workspace editor handle, but only
+///   forwarded when this pane currently owns the rename, matching the
+///   pane-rename pattern of keeping the inline editor's mount point unique.
+fn pane_conversation_rename_props(
+    workspace: &Workspace,
+    pane_group: &PaneGroup,
+    pane_id: PaneId,
+    app: &AppContext,
+) -> (
+    Option<AIConversationId>,
+    bool,
+    Option<ViewHandle<EditorView>>,
+) {
+    let conversation_id = pane_group
+        .terminal_view_from_pane_id(pane_id, app)
+        .and_then(|terminal_view| {
+            terminal_view
+                .as_ref(app)
+                .selected_conversation_id_for_chrome(app)
+        })
+        .filter(|conversation_id| {
+            !crate::BlocklistAIHistoryModel::as_ref(app)
+                .conversation(conversation_id)
+                .is_some_and(|c| c.is_viewing_shared_session())
+        });
+    let is_conversation_being_renamed = conversation_id.is_some_and(|id| {
+        workspace
+            .current_workspace_state
+            .is_conversation_being_renamed(id)
+    });
+    let conversation_rename_editor =
+        is_conversation_being_renamed.then(|| workspace.conversation_rename_editor.clone());
+    (
+        conversation_id,
+        is_conversation_being_renamed,
+        conversation_rename_editor,
+    )
 }
 
 fn terminal_title_fallback_font(agent_text: &TerminalAgentText) -> TerminalPrimaryLineFont {
@@ -330,6 +379,9 @@ fn render_pane_row_element(
         rename_editor: _,
         is_pane_being_renamed,
         pane_rename_editor: _,
+        conversation_id: _,
+        is_conversation_being_renamed: _,
+        conversation_rename_editor: _,
     } = props;
     let is_selected = is_active_tab && is_focused;
     let mut row = Hoverable::new(mouse_state, move |state| {
@@ -692,6 +744,20 @@ struct PaneProps<'a> {
     rename_editor: Option<ViewHandle<EditorView>>,
     is_pane_being_renamed: bool,
     pane_rename_editor: Option<ViewHandle<EditorView>>,
+    /// GH8642: id of the chrome conversation behind this pane (terminal panes
+    /// only; `None` for non-terminal panes and shared-session viewers). Used
+    /// to drive the conversation-rename inline editor and to flip the
+    /// title-region double-click target from `RenamePane` to
+    /// `RenameConversation`.
+    conversation_id: Option<AIConversationId>,
+    /// GH8642: when true, the workspace-level conversation rename editor is
+    /// active for [`Self::conversation_id`]. Causes the title slot to render
+    /// the inline editor instead of the conversation title text.
+    is_conversation_being_renamed: bool,
+    /// GH8642: workspace-level conversation rename editor; only forwarded by
+    /// the call site when the pane currently owns the rename, to keep the
+    /// editor mount-point unique across re-renders.
+    conversation_rename_editor: Option<ViewHandle<EditorView>>,
 }
 
 struct PaneRowState {
@@ -1082,6 +1148,9 @@ impl VerticalTabsPanelState {
                                 None,
                                 None,
                                 false,
+                                None,
+                                false,
+                                None,
                                 None,
                                 false,
                                 None,
@@ -1635,6 +1704,9 @@ fn render_groups(
                                     None,
                                     false,
                                     None,
+                                    None,
+                                    false,
+                                    None,
                                     app,
                                 )
                                 .is_some_and(|props| {
@@ -1659,6 +1731,9 @@ fn render_groups(
                                 None,
                                 None,
                                 false,
+                                None,
+                                false,
+                                None,
                                 None,
                                 false,
                                 None,
@@ -1901,6 +1976,8 @@ fn render_tab_group_internal(
                     .entry(*pane_id)
                     .or_default()
                     .clone();
+                let (conversation_id, is_conversation_being_renamed, conversation_rename_editor) =
+                    pane_conversation_rename_props(workspace, pane_group, *pane_id, app);
                 let Some(pane_props) = PaneProps::new(
                     pane_group,
                     *pane_id,
@@ -1922,6 +1999,9 @@ fn render_tab_group_internal(
                     (!uses_outer_group_container).then_some(rename_editor.clone()),
                     false,
                     None,
+                    conversation_id,
+                    is_conversation_being_renamed,
+                    conversation_rename_editor,
                     app,
                 ) else {
                     return Empty::new().finish();
@@ -1954,6 +2034,8 @@ fn render_tab_group_internal(
                 let is_pane_being_renamed = workspace
                     .current_workspace_state
                     .is_pane_being_renamed(locator);
+                let (conversation_id, is_conversation_being_renamed, conversation_rename_editor) =
+                    pane_conversation_rename_props(workspace, pane_group, *pane_id, app);
                 let Some(pane_props) = PaneProps::new(
                     pane_group,
                     *pane_id,
@@ -1975,6 +2057,9 @@ fn render_tab_group_internal(
                     (!uses_outer_group_container).then_some(rename_editor.clone()),
                     is_pane_being_renamed,
                     is_pane_being_renamed.then_some(workspace.pane_rename_editor.clone()),
+                    conversation_id,
+                    is_conversation_being_renamed,
+                    conversation_rename_editor,
                     app,
                 ) else {
                     continue;
@@ -2848,6 +2933,9 @@ impl<'a> PaneProps<'a> {
         rename_editor: Option<ViewHandle<EditorView>>,
         is_pane_being_renamed: bool,
         pane_rename_editor: Option<ViewHandle<EditorView>>,
+        conversation_id: Option<AIConversationId>,
+        is_conversation_being_renamed: bool,
+        conversation_rename_editor: Option<ViewHandle<EditorView>>,
         app: &AppContext,
     ) -> Option<Self> {
         let pane = pane_group.pane_by_id(pane_id)?;
@@ -2897,6 +2985,9 @@ impl<'a> PaneProps<'a> {
             rename_editor,
             is_pane_being_renamed,
             pane_rename_editor,
+            conversation_id,
+            is_conversation_being_renamed,
+            conversation_rename_editor,
         })
     }
 
@@ -2916,6 +3007,7 @@ impl<'a> PaneProps<'a> {
     fn shows_inline_tab_rename_editor(&self) -> bool {
         (self.is_tab_being_renamed && self.rename_editor.is_some())
             || (self.is_pane_being_renamed && self.pane_rename_editor.is_some())
+            || (self.is_conversation_being_renamed && self.conversation_rename_editor.is_some())
     }
 
     fn rendered_search_text_fragments(&self, app: &AppContext) -> Vec<String> {
@@ -3125,6 +3217,19 @@ struct TerminalAgentText {
     cli_agent_latest_user_prompt: Option<String>,
     is_oz_agent: bool,
     cli_agent: Option<CLIAgent>,
+    /// GH8642: id of the chrome conversation behind this terminal view, when one
+    /// exists. Carried alongside the title text so the vertical-tabs rename
+    /// dispatch (`WorkspaceAction::RenameConversation { conversation_id }`) can
+    /// route to the correct conversation without re-deriving the filter from
+    /// `TerminalView::selected_conversation_for_user_facing_chrome`.
+    conversation_id: Option<AIConversationId>,
+    /// GH8642: whether [`Self::conversation_id`] currently has a user-set title
+    /// override (i.e. `AIConversation::user_set_title().is_some()`). When true,
+    /// `preferred_agent_tab_titles` short-circuits and always returns
+    /// `conversation_display_title`, never the latest user prompt — user-set
+    /// titles must beat the `use_latest_user_prompt_as_conversation_title_in_tab_names`
+    /// setting. See spec PR #9746 "risks".
+    has_user_set_title: bool,
 }
 
 fn agent_tab_text_preference(app: &AppContext) -> AgentTabTextPreference {
@@ -3139,7 +3244,19 @@ fn preferred_agent_tab_titles(
     agent_text: &TerminalAgentText,
     preference: AgentTabTextPreference,
 ) -> (Option<String>, Option<String>) {
-    let conversation_title = match preference {
+    // GH8642: a user-set conversation title takes priority over
+    // `use_latest_user_prompt_as_conversation_title_in_tab_names`. Without this
+    // short-circuit, a user who renames a conversation can have their rename
+    // silently overridden whenever they toggle the latest-prompt setting (or
+    // ship a new exchange); see PR #9746 "risks". CLI-agent titles aren't
+    // affected because CLI agents don't expose a user-set-title API today.
+    let effective_preference = if agent_text.has_user_set_title {
+        AgentTabTextPreference::ConversationTitle
+    } else {
+        preference
+    };
+
+    let conversation_title = match effective_preference {
         AgentTabTextPreference::ConversationTitle => agent_text
             .conversation_display_title
             .clone()
@@ -3180,6 +3297,11 @@ fn terminal_agent_text(terminal_view: &TerminalView, app: &AppContext) -> Termin
         terminal_view.selected_conversation_latest_user_prompt_for_tab_name(app);
     agent_text.is_oz_agent =
         agent_text.conversation_display_title.is_some() || agent_text.is_oz_agent;
+    // GH8642: thread the conversation id + user-set-title flag through so the
+    // rename surface can dispatch to the right conversation and the title
+    // preference can never override a user-set title.
+    agent_text.conversation_id = terminal_view.selected_conversation_id_for_chrome(app);
+    agent_text.has_user_set_title = terminal_view.selected_conversation_has_user_set_title(app);
 
     if let Some(session) = cli_agent_session {
         agent_text.cli_agent_title = session.session_context.title_like_text();
@@ -3520,6 +3642,13 @@ fn render_title_override(
             .as_ref()
             .map(|rename_editor| render_inline_tab_rename_editor(rename_editor, appearance, app));
     }
+    // GH8642: conversation rename takes the same title slot as tab/pane rename.
+    if props.is_conversation_being_renamed {
+        return props
+            .conversation_rename_editor
+            .as_ref()
+            .map(|rename_editor| render_inline_tab_rename_editor(rename_editor, appearance, app));
+    }
 
     props
         .custom_vertical_tabs_title
@@ -3560,9 +3689,16 @@ fn render_pane_title_slot(
         pane_group_id: props.pane_group_id,
         pane_id: props.pane_id,
     };
+    // GH8642: when the pane has a chrome conversation, double-click renames
+    // the conversation; otherwise it falls through to pane rename.
+    let conversation_id = props.conversation_id;
     Hoverable::new(title_mouse_state, move |_| title)
         .on_double_click(move |ctx, _, _| {
-            ctx.dispatch_typed_action(WorkspaceAction::RenamePane(locator));
+            if let Some(conversation_id) = conversation_id {
+                ctx.dispatch_typed_action(WorkspaceAction::RenameConversation { conversation_id });
+            } else {
+                ctx.dispatch_typed_action(WorkspaceAction::RenamePane(locator));
+            }
         })
         .with_cursor(Cursor::PointingHand)
         .finish()
@@ -5582,6 +5718,9 @@ fn detail_pane_props<'a>(
         None,
         None,
         false,
+        None,
+        false,
+        None,
         None,
         false,
         None,

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -158,6 +158,8 @@ fn preferred_agent_tab_titles_default_to_title_like_text() {
         cli_agent_latest_user_prompt: Some("Latest CLI prompt".to_string()),
         is_oz_agent: true,
         cli_agent: Some(CLIAgent::Claude),
+        conversation_id: None,
+        has_user_set_title: false,
     };
 
     assert_eq!(
@@ -178,6 +180,8 @@ fn preferred_agent_tab_titles_do_not_use_cli_prompt_when_disabled() {
         cli_agent_latest_user_prompt: Some("Latest CLI prompt".to_string()),
         is_oz_agent: false,
         cli_agent: Some(CLIAgent::Claude),
+        conversation_id: None,
+        has_user_set_title: false,
     };
 
     assert_eq!(
@@ -195,6 +199,8 @@ fn terminal_primary_line_uses_terminal_title_when_disabled_cli_has_only_prompt()
         cli_agent_latest_user_prompt: Some("Latest CLI prompt".to_string()),
         is_oz_agent: false,
         cli_agent: Some(CLIAgent::Claude),
+        conversation_id: None,
+        has_user_set_title: false,
     };
     let (conversation_title, cli_title) =
         preferred_agent_tab_titles(&agent_text, AgentTabTextPreference::ConversationTitle);
@@ -228,6 +234,8 @@ fn preferred_agent_tab_titles_use_latest_prompt_when_enabled() {
         cli_agent_latest_user_prompt: Some("Latest CLI prompt".to_string()),
         is_oz_agent: true,
         cli_agent: Some(CLIAgent::Claude),
+        conversation_id: None,
+        has_user_set_title: false,
     };
 
     assert_eq!(
@@ -248,6 +256,8 @@ fn terminal_primary_line_uses_cli_prompt_when_enabled_cli_has_prompt() {
         cli_agent_latest_user_prompt: Some("Latest CLI prompt".to_string()),
         is_oz_agent: false,
         cli_agent: Some(CLIAgent::Claude),
+        conversation_id: None,
+        has_user_set_title: false,
     };
     let (conversation_title, cli_title) =
         preferred_agent_tab_titles(&agent_text, AgentTabTextPreference::LatestUserPrompt);
@@ -274,6 +284,8 @@ fn terminal_primary_line_uses_cli_prompt_when_enabled_cli_is_long_running() {
         cli_agent_latest_user_prompt: Some("Latest CLI prompt".to_string()),
         is_oz_agent: false,
         cli_agent: Some(CLIAgent::Claude),
+        conversation_id: None,
+        has_user_set_title: false,
     };
     let (conversation_title, cli_title) =
         preferred_agent_tab_titles(&agent_text, AgentTabTextPreference::LatestUserPrompt);
@@ -300,6 +312,8 @@ fn preferred_agent_tab_titles_fall_back_when_preferred_text_is_missing() {
         cli_agent_latest_user_prompt: Some("Latest CLI prompt".to_string()),
         is_oz_agent: true,
         cli_agent: Some(CLIAgent::Claude),
+        conversation_id: None,
+        has_user_set_title: false,
     };
 
     assert_eq!(
@@ -308,6 +322,59 @@ fn preferred_agent_tab_titles_fall_back_when_preferred_text_is_missing() {
             Some("Generated Oz title".to_string()),
             Some("Latest CLI prompt".to_string())
         )
+    );
+}
+
+/// GH8642 risk mitigation: when the conversation has a user-set title, the title-preference
+/// helper must short-circuit to the display title even when the user has
+/// `use_latest_user_prompt_as_conversation_title_in_tab_names` enabled. Without this, a user
+/// who renames their conversation can have the rename silently overridden whenever they
+/// toggle the latest-prompt setting (or ship a new exchange). See PR #9746 "risks".
+#[test]
+fn preferred_agent_tab_titles_user_set_title_beats_latest_prompt_preference() {
+    let agent_text = TerminalAgentText {
+        conversation_display_title: Some("My custom title".to_string()),
+        conversation_latest_user_prompt: Some("Latest Oz prompt that should NOT win".to_string()),
+        cli_agent_title: None,
+        cli_agent_latest_user_prompt: None,
+        is_oz_agent: true,
+        cli_agent: None,
+        conversation_id: None,
+        has_user_set_title: true,
+    };
+
+    // With LatestUserPrompt preference + has_user_set_title: still returns the display title.
+    assert_eq!(
+        preferred_agent_tab_titles(&agent_text, AgentTabTextPreference::LatestUserPrompt),
+        (Some("My custom title".to_string()), None)
+    );
+
+    // And of course also returns the display title under the default preference.
+    assert_eq!(
+        preferred_agent_tab_titles(&agent_text, AgentTabTextPreference::ConversationTitle),
+        (Some("My custom title".to_string()), None)
+    );
+}
+
+/// Sanity check: when there's no user-set title, the helper still honors the latest-prompt
+/// preference. This is the inverse of the regression test above and ensures the short-circuit
+/// only fires when needed (so we don't silently break the existing latest-prompt feature).
+#[test]
+fn preferred_agent_tab_titles_honor_preference_when_no_user_set_title() {
+    let agent_text = TerminalAgentText {
+        conversation_display_title: Some("Auto-generated title".to_string()),
+        conversation_latest_user_prompt: Some("Latest Oz prompt".to_string()),
+        cli_agent_title: None,
+        cli_agent_latest_user_prompt: None,
+        is_oz_agent: true,
+        cli_agent: None,
+        conversation_id: None,
+        has_user_set_title: false,
+    };
+
+    assert_eq!(
+        preferred_agent_tab_titles(&agent_text, AgentTabTextPreference::LatestUserPrompt),
+        (Some("Latest Oz prompt".to_string()), None)
     );
 }
 

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1056,6 +1056,11 @@ pub struct AgentConversationData {
     /// delivery without re-delivering already-processed events.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_event_sequence: Option<i64>,
+    /// User-supplied custom title for this conversation. When set, takes precedence over the
+    /// auto-generated title in the UI. Local-only — not synced to the server. See
+    /// `specs/GH8642/`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_set_title: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -1367,6 +1372,7 @@ mod tests {
             run_id: None,
             autoexecute_override: None,
             last_event_sequence: Some(42),
+            user_set_title: None,
         };
         let json = serde_json::to_string(&data).expect("serialize");
         let roundtripped: AgentConversationData = serde_json::from_str(&json).expect("deserialize");
@@ -1402,6 +1408,7 @@ mod tests {
             run_id: None,
             autoexecute_override: None,
             last_event_sequence: None,
+            user_set_title: None,
         };
         let json = serde_json::to_string(&data).expect("serialize");
         let roundtripped: AgentConversationData = serde_json::from_str(&json).expect("deserialize");
@@ -1418,6 +1425,7 @@ mod tests {
         assert_eq!(data.last_event_sequence, None);
         assert_eq!(data.orchestration_harness_type, None);
         assert!(!data.is_remote_child);
+        assert_eq!(data.user_set_title, None);
     }
 
     #[test]
@@ -1436,10 +1444,62 @@ mod tests {
             run_id: None,
             autoexecute_override: None,
             last_event_sequence: None,
+            user_set_title: None,
         };
         let json = serde_json::to_string(&data).expect("serialize");
         assert!(
             !json.contains("last_event_sequence"),
+            "None should be skipped in serialized output: {json}"
+        );
+    }
+
+    #[test]
+    fn agent_conversation_data_roundtrips_user_set_title() {
+        let data = AgentConversationData {
+            server_conversation_token: None,
+            conversation_usage_metadata: None,
+            reverted_action_ids: None,
+            forked_from_server_conversation_token: None,
+            artifacts_json: None,
+            parent_agent_id: None,
+            agent_name: None,
+            parent_conversation_id: None,
+            is_remote_child: false,
+            run_id: None,
+            autoexecute_override: None,
+            last_event_sequence: None,
+            user_set_title: Some("My custom title".to_string()),
+        };
+        let json = serde_json::to_string(&data).expect("serialize");
+        let roundtripped: AgentConversationData = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            roundtripped.user_set_title.as_deref(),
+            Some("My custom title")
+        );
+    }
+
+    #[test]
+    fn agent_conversation_data_skips_serializing_none_user_set_title() {
+        // When no user-set title is present, the field should not appear in the on-disk JSON
+        // payload. This keeps the persisted blob small and avoids polluting legacy rows.
+        let data = AgentConversationData {
+            server_conversation_token: None,
+            conversation_usage_metadata: None,
+            reverted_action_ids: None,
+            forked_from_server_conversation_token: None,
+            artifacts_json: None,
+            parent_agent_id: None,
+            agent_name: None,
+            parent_conversation_id: None,
+            is_remote_child: false,
+            run_id: None,
+            autoexecute_override: None,
+            last_event_sequence: None,
+            user_set_title: None,
+        };
+        let json = serde_json::to_string(&data).expect("serialize");
+        assert!(
+            !json.contains("user_set_title"),
             "None should be skipped in serialized output: {json}"
         );
     }


### PR DESCRIPTION
## Description

Implements GH-8642: allow users to rename an agent conversation (custom title on agent-panel cards). Adds an end-to-end "user-set conversation title" feature that propagates from the data model through persistence, the conversation list, and the vertical-tabs panel.

User-visible surfaces:
- **Conversation list** (left panel): inline rename editor with overflow-menu items "Rename conversation" and "Reset conversation name" (Reset shows only when a user-set title exists). Double-click the row title to start a rename. Enter / blur commits, Escape cancels.
- **Vertical tabs**: double-clicking the title region of a pane that hosts a chrome conversation now starts a workspace-level inline rename for that conversation; the inline editor renders in the same title slot the existing tab/pane editors use. The pane right-click context menu offers "Rename conversation" / "Reset conversation name" alongside the existing pane-name items.
- **Title preference**: a user-set title always wins over the `use_latest_user_prompt_as_conversation_title_in_tab_names` setting — we never silently overwrite a user's rename when they toggle the setting or ship a new exchange.

Implementation outline (commit-by-commit):
- `29d4694` — `user_set_title: Option<String>` on `AIConversation` and `AgentConversationData`; new `BlocklistAIHistoryEvent::UpdatedConversationTitle` variant. Persisted via existing conversation save path.
- `722337a` — exhaustive-match cleanup for the new event variant across the codebase.
- `9a04857` — `BlocklistAIHistoryModel::set_conversation_user_title` returning `Result<bool, RenameConversationError>` with shared-session-viewer guard, metadata mirroring, and a `has_user_set_title` flag on `ConversationNavigationData`. Conversation loader parses `user_set_title` from the persisted JSON.
- `94b17c1` — three new `WorkspaceAction` variants: `RenameConversation`, `ResetConversationName`, `SetConversationUserTitle`; all participate in app-state save.
- `90d8647` — conversation-list rename UX (editor, menu items, double-click handler, ItemProps swap).
- `3a9ab80` — title-preference safety net: `TerminalAgentText::has_user_set_title` short-circuits `preferred_agent_tab_titles` so the user-set title can't be overridden by the latest-prompt setting.
- `505a96e` — workspace-level `conversation_rename_editor`, `WorkspaceState::conversation_being_renamed` (mutually exclusive with tab/pane rename), real `Workspace::rename_conversation` / `finish_conversation_rename` / `cancel_conversation_rename`.
- `f09ccf8` — vertical-tabs UX wiring: `PaneProps` extended with `conversation_id` / `is_conversation_being_renamed` / `conversation_rename_editor`; `render_title_override` adds a third branch; `render_pane_title_slot` flips its double-click target; new `pane_conversation_rename_props` helper resolves the triple per pane row with the shared-session-viewer guard. `tab.rs` gains `PaneConversationMenuTarget` + `pane_conversation_menu_items` + `menu_items_with_pane_targets`; the workspace's pane context menu builder resolves the target from the right-clicked pane's terminal view.
- `13cf01f` — sibling tests for the rename state machine and clippy cleanup.

## Linked Issue

Closes #8642.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Screenshots / Videos

No screenshots attached in this PR yet — the surfaces are functional and styled to match the existing tab/pane rename editors (12pt single-line UI font, same inline mount point). Happy to capture a short video of the conversation-list and vertical-tabs flows on request.

## Testing

Automated:
- New unit tests in `app/src/workspace/util_tests.rs` (4 tests) exercise the `WorkspaceState` rename state machine: starts empty, mutual exclusivity between tab / pane / conversation rename, idempotent clear, identity check on `is_conversation_being_renamed`.
- New regression test in `app/src/workspace/view/vertical_tabs_tests.rs`: `preferred_agent_tab_titles_user_set_title_beats_latest_prompt_preference` ensures the user-set title beats the latest-prompt setting (the spec PR #9746 "risks" mitigation).
- `app/src/ai/agent/conversation_tests.rs` covers `restored_conversation_picks_up_persisted_user_set_title`, `title_prefers_user_set_title_over_auto_description`, `normalize_user_title_*` (trimming, empty-as-None, char-cap, multi-byte char counting).

Local validations:
- `cargo check -p warp --lib` clean at every step of the staged commits.
- `cargo clippy -p warp --lib --tests --all-features -- -D warnings` clean.
- All new tests pass; the broader warp lib suite has only pre-existing unrelated flakiness (terminal/server/codex tests that pass in isolation on master too).

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: You can now rename an agent conversation from the conversation list and vertical-tabs panel; the custom title is preserved across exchanges and setting toggles.
-->

---

Generated with Warp Agent Mode.

- Conversation: https://app.warp.dev/conversation/1d5461bb-8989-42e6-961e-d3bf5832f380
- Plan (overall feature): https://app.warp.dev/drive/notebook/ab1ckX49jSErFX1GUSPzBY
- Plan (Phase 3): https://app.warp.dev/drive/notebook/x1b8x0IUQcwF14zX79zmjb

Co-Authored-By: Oz <oz-agent@warp.dev>
