### PR TITLE
docs: add DeepWiki README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
   ·
   <a href="https://docs.warp.dev">Docs</a>
   ·
+  <a href="https://deepwiki.com/warpdotdev/warp">DeepWiki</a>
+  ·
   <a href="https://www.warp.dev/blog/how-warp-works">How Warp Works</a>
 </p>
 


### PR DESCRIPTION
## Description

Adds a DeepWiki link to the README resource navigation, next to the existing Docs and How Warp Works links.

This makes the generated codebase wiki easier to find from the repository landing page without changing any product behavior or code.

## Linked Issue

No linked issue; this is a small docs-only README navigation update.

## Testing

Not run; this is a docs-only README link change.

<!--
No stable changelog entry; docs-only README change.
-->
