### PR TITLE
feat: expose pane UUID as WARP_SESSION_ID env var (closes #8611)

### DIFF
--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -1,4 +1,4 @@
-# Note that WARP_SESSION_ID is expected to have been set when executing commands to
+# Note that _WARP_BOOT_ID is expected to have been set when executing commands to
 # emit the InitShell payload, which includes the session ID.
 #
 # Throughout, command -p is used to call external binaries. command -p resolves the
@@ -99,9 +99,9 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
     # callable the moment the trap is registered.
     if [[ "$WARP_IS_SSH" == "1" ]]; then
         __warp_emit_exit_shell() {
-            if [[ -n "$WARP_SESSION_ID" ]]; then
+            if [[ -n "$_WARP_BOOT_ID" ]]; then
                 warp_send_json_message \
-                    "{\"hook\": \"ExitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID}}"
+                    "{\"hook\": \"ExitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID}}"
             fi
         }
         # Bash allows only one handler per signal, so compose with the
@@ -437,10 +437,10 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
         if [ "$WARP_IN_MSYS2" = true ]; then
           warp_send_hook_via_kv_pairs_start "CommandFinished"
           warp_send_hook_kv_pair "exit_code" "$exit_code"
-          warp_send_hook_kv_pair "next_block_id" "precmd-$WARP_SESSION_ID-$((block_id++))"
+          warp_send_hook_kv_pair "next_block_id" "precmd-$_WARP_BOOT_ID-$((block_id++))"
           warp_send_hook_via_kv_pairs_end
         else
-          warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"precmd-$WARP_SESSION_ID-$((block_id++))\"}}"
+          warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"precmd-$_WARP_BOOT_ID-$((block_id++))\"}}"
         fi
 
         warp_maybe_send_reset_grid_osc
@@ -470,7 +470,7 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
             \"virtual_env\": \"\",
             \"conda_env\": \"\",
             \"node_version\": \"\",
-            \"session_id\": $WARP_SESSION_ID,
+            \"session_id\": $_WARP_BOOT_ID,
             \"is_after_in_band_command\": true
             }}"
             return 0
@@ -634,7 +634,7 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
         # as JS string literals of the form \uHEX, and will include
         # ctrl characters (like ESC) in the json, which will cause a JSON
         # parse error.
-        # Note WARP_SESSION_ID doesn't need to be escaped since it's a number
+        # Note _WARP_BOOT_ID doesn't need to be escaped since it's a number
         # We also pass the shell's notion of `honor_ps1` to ensure it's synced correctly on the Warp-side for prompt handling.
         # This is passed as a "real boolean" via the JSON payload (string interpolated into JSON string below).
         local honor_ps1
@@ -658,7 +658,7 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
           warp_send_hook_kv_pair "virtual_env" "$VIRTUAL_ENV"
           warp_send_hook_kv_pair "conda_env" "$CONDA_DEFAULT_ENV"
           warp_send_hook_kv_pair "node_version" "$node_version"
-          warp_send_hook_kv_pair "session_id" "$WARP_SESSION_ID"
+          warp_send_hook_kv_pair "session_id" "$_WARP_BOOT_ID"
           warp_send_hook_via_kv_pairs_end
         else
           local escaped_json="{\"hook\": \"Precmd\", \"value\": {
@@ -671,7 +671,7 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
           \"virtual_env\": \"$escaped_virtual_env\",
           \"conda_env\": \"$escaped_conda_env\",
           \"node_version\": \"$escaped_node_version\",
-          \"session_id\": $WARP_SESSION_ID
+          \"session_id\": $_WARP_BOOT_ID
           }}"
           warp_send_json_message "$escaped_json"
         fi
@@ -976,7 +976,7 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
             # Hex-encode the ZSH environment script we use to bootstrap remote zsh b/c it contains control characters
             # We decode on the SSH server using xxd if its available, otherwise fall back to a for-loop over each byte
             # and use printf to convert back to plaintext
-            local zsh_env_script=$(printf '%s' 'unsetopt ZLE; unset RCS; unset GLOBAL_RCS; WARP_SESSION_ID="$(command -p date +%s)$RANDOM"; WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@; WARP_HONOR_PS1='$WARP_HONOR_PS1'; _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n); _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER); _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d '"'"' \n'"'"'); printf '"'"'\e]9278;d;%s\x07'"'"' $_msg; unset _hostname _user _msg' | command -p od -An -v -tx1 | command -p tr -d ' \n')
+            local zsh_env_script=$(printf '%s' 'unsetopt ZLE; unset RCS; unset GLOBAL_RCS; _WARP_BOOT_ID="$(command -p date +%s)$RANDOM"; WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@; WARP_HONOR_PS1='$WARP_HONOR_PS1'; _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n); _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER); _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d '"'"' \n'"'"'); printf '"'"'\e]9278;d;%s\x07'"'"' $_msg; unset _hostname _user _msg' | command -p od -An -v -tx1 | command -p tr -d ' \n')
 
             # Keep remote commands up-to-date with shell.rs & bash.sh.
             # Note that in this command, we're passing a string to the remote shell. Any variable expansions need to be
@@ -985,7 +985,7 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
             # determine what shell is the login shell on the remote machine.  We perform a preliminary check to see if
             # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
             # support.
-            command ssh -o ControlMaster=yes -o ControlPath=$SSH_SOCKET_DIR/$WARP_SESSION_ID \
+            command ssh -o ControlMaster=yes -o ControlPath=$SSH_SOCKET_DIR/$_WARP_BOOT_ID \
             -t "${@:1}" \
 "
 export TERM_PROGRAM='WarpTerminal'
@@ -997,7 +997,7 @@ test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSI
 # Only forward the protocol version if it was set locally (i.e. the HOANotifications feature flag is on).
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
 
-hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$SSH_SOCKET_DIR/$WARP_SESSION_ID'\", \"remote_shell\": \"%s\"}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
+hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$SSH_SOCKET_DIR/$_WARP_BOOT_ID'\", \"remote_shell\": \"%s\"}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
 printf '$OSC_START$DCS_JSON_MARKER$OSC_PARAM_SEPARATOR%s$OSC_END' "'$hook'"
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then
@@ -1032,11 +1032,11 @@ case "'${SHELL##*/}'" in
       command -p stty raw
       HISTCONTROL=ignorespace
       HISTIGNORE=" *"
-      WARP_SESSION_ID="$(command -p date +%s)$RANDOM"
+      _WARP_BOOT_ID="$(command -p date +%s)$RANDOM"
       WARP_HONOR_PS1="'$WARP_HONOR_PS1'"
       _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n)
       _user=$(command -v whoami >/dev/null 2>&1 && command whoami 2>/dev/null || echo $USER)
-      _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"bash\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
+      _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"bash\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
       WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@
       if [[ "'$OS'" == Windows_NT ]]; then WARP_IN_MSYS2=true; else WARP_IN_MSYS2=false; fi
       printf '\''"'\e]9278;d;%s\x07'"'\'' \""'$_msg'"\"')
@@ -1312,7 +1312,7 @@ esac
         if [ "$WARP_IN_MSYS2" = true ]; then
           warp_send_hook_via_kv_pairs_start "Bootstrapped"
           warp_send_hook_kv_pair "histfile" "$HISTFILE"
-          warp_send_hook_kv_pair "session_id" "$WARP_SESSION_ID"
+          warp_send_hook_kv_pair "session_id" "$_WARP_BOOT_ID"
           warp_send_hook_kv_pair "shell" "bash"
           warp_send_hook_kv_pair "home_dir" "$HOME"
           warp_send_hook_kv_pair "user" "$_user"
@@ -1338,7 +1338,7 @@ esac
         else
           local escaped_editor="$(warp_escape_json "$EDITOR")"
           local escaped_shell_path="$(warp_escape_json "$BASH")"
-          local escaped_json="{\"hook\": \"Bootstrapped\", \"value\": {\"histfile\": \"$escaped_histfile\", \"session_id\": $WARP_SESSION_ID, \"shell\": \"bash\",  \"home_dir\": \"$HOME\", \"user\":\"$_user\", \"host\":\"$_hostname\", \"path\": \"$escaped_path\", \"editor\": \"$escaped_editor\", \"env_var_names\": \"$escaped_env_var_names\", \"abbreviations\": \"$escaped_abbrs\", \"aliases\": \"$escaped_aliases\", \"function_names\": \"$escaped_function_names\", \"builtins\": \"$escaped_builtins\", \"keywords\": \"$escaped_keywords\", \"shell_version\": \"$BASH_VERSION\", \"shell_options\": \"$escaped_shell_options\", \"rcfiles_start_time\": \"$rcfiles_start_time\", \"rcfiles_end_time\": \"$rcfiles_end_time\", \"vi_mode_enabled\": \"$vi_mode_enabled\", \"os_category\": \"$os_category\", \"linux_distribution\": \"$linux_distribution\", \"wsl_name\": \"$WSL_DISTRO_NAME\", \"shell_path\": \"$escaped_shell_path\"}}"
+          local escaped_json="{\"hook\": \"Bootstrapped\", \"value\": {\"histfile\": \"$escaped_histfile\", \"session_id\": $_WARP_BOOT_ID, \"shell\": \"bash\",  \"home_dir\": \"$HOME\", \"user\":\"$_user\", \"host\":\"$_hostname\", \"path\": \"$escaped_path\", \"editor\": \"$escaped_editor\", \"env_var_names\": \"$escaped_env_var_names\", \"abbreviations\": \"$escaped_abbrs\", \"aliases\": \"$escaped_aliases\", \"function_names\": \"$escaped_function_names\", \"builtins\": \"$escaped_builtins\", \"keywords\": \"$escaped_keywords\", \"shell_version\": \"$BASH_VERSION\", \"shell_options\": \"$escaped_shell_options\", \"rcfiles_start_time\": \"$rcfiles_start_time\", \"rcfiles_end_time\": \"$rcfiles_end_time\", \"vi_mode_enabled\": \"$vi_mode_enabled\", \"os_category\": \"$os_category\", \"linux_distribution\": \"$linux_distribution\", \"wsl_name\": \"$WSL_DISTRO_NAME\", \"shell_path\": \"$escaped_shell_path\"}}"
           warp_send_json_message "$escaped_json"
         fi
     }

--- a/app/assets/bundled/bootstrap/bash_init_shell.sh
+++ b/app/assets/bundled/bootstrap/bash_init_shell.sh
@@ -3,12 +3,12 @@
 command -p stty raw
 HISTCONTROL=ignorespace
 HISTIGNORE=" *"
-WARP_SESSION_ID="$(command -p date +%s)$RANDOM"
+_WARP_BOOT_ID="$(command -p date +%s)$RANDOM"
 _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n)
 _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER)
 if [[ "$OS" == Windows_NT ]]; then WARP_IN_MSYS2=true; else WARP_IN_MSYS2=false; fi
 # If we're in MSYS2, we want to send the hook via key-value pairs.
-if [ "$WARP_IN_MSYS2" = true ]; then _msg="\e]9278;k;A;InitShell\a\e]9278;k;B;session_id;$WARP_SESSION_ID\a\e]9278;k;B;shell;bash\a\e]9278;k;B;user;$_user\a\e]9278;k;B;hostname;$_hostname\a\e]9278;k;C\a"; else _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"bash\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n"); fi
+if [ "$WARP_IN_MSYS2" = true ]; then _msg="\e]9278;k;A;InitShell\a\e]9278;k;B;session_id;$_WARP_BOOT_ID\a\e]9278;k;B;shell;bash\a\e]9278;k;B;user;$_user\a\e]9278;k;B;hostname;$_hostname\a\e]9278;k;C\a"; else _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"bash\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n"); fi
 WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@
 # We send the InitShell hook via OSCs when on Windows and via DCSs otherwise.
 if [ "$WARP_USING_WINDOWS_CON_PTY" = true ]; then if [ "$WARP_IN_MSYS2" = true ]; then printf "$_msg"; else printf '\e]9278;d;%s\x07' "$_msg"; fi; else printf '\e\x50\x24\x64%s\x9c' "$_msg"; fi

--- a/app/assets/bundled/bootstrap/bash_init_subshell.sh
+++ b/app/assets/bundled/bootstrap/bash_init_subshell.sh
@@ -5,10 +5,10 @@ unset PROMPT_COMMAND
 HISTCONTROL=ignorespace
 HISTIGNORE=" *"
 WARP_IS_SUBSHELL=1
-WARP_SESSION_ID="$(command -p date +%s)$RANDOM"
+_WARP_BOOT_ID="$(command -p date +%s)$RANDOM"
 _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n)
 _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER)
-_msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"bash\", \"user\": \"%s\", \"hostname\": \"%s\", \"is_subshell\": true}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")
+_msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"bash\", \"user\": \"%s\", \"hostname\": \"%s\", \"is_subshell\": true}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")
 if [[ "$OS" == Windows_NT ]]; then WARP_IN_MSYS2=true; else WARP_IN_MSYS2=false; fi
 WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@
 if [ "$WARP_USING_WINDOWS_CON_PTY" = true ]; then printf '\e]9278;d;%s\x07' "$_msg"; else printf '\e\x50\x24\x64%s\x9c' "$_msg"; fi

--- a/app/assets/bundled/bootstrap/fish.sh
+++ b/app/assets/bundled/bootstrap/fish.sh
@@ -1,4 +1,4 @@
-# Note that WARP_SESSION_ID is expected to have been set when executing commands to
+# Note that _WARP_BOOT_ID is expected to have been set when executing commands to
 # emit the InitShell payload, which includes the session ID.
 begin
 # We wrap ourselves in a begin block because these are effectively injected
@@ -278,7 +278,7 @@ function warp_precmd --on-event fish_prompt --on-event fish_posterror
         set exit_code 1
     end
 
-    warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"precmd-$WARP_SESSION_ID-$block_id\"}}"
+    warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"precmd-$_WARP_BOOT_ID-$block_id\"}}"
     warp_maybe_send_reset_grid_osc
 
     set block_id (math $block_id + 1)
@@ -293,7 +293,7 @@ function warp_precmd --on-event fish_prompt --on-event fish_posterror
         \"virtual_env\": \"\",
         \"conda_env\": \"\",
         \"node_version\": \"\",
-        \"session_id\": $WARP_SESSION_ID,
+        \"session_id\": $_WARP_BOOT_ID,
         \"is_after_in_band_command\": true
         }}"
         warp_send_json_message $escaped_json
@@ -422,7 +422,7 @@ function warp_precmd --on-event fish_prompt --on-event fish_posterror
       \"virtual_env\": \"$escaped_virtual_env\",
       \"conda_env\": \"$escaped_conda_env\",
       \"node_version\": \"$escaped_node_version\",
-      \"session_id\": $WARP_SESSION_ID
+      \"session_id\": $_WARP_BOOT_ID
       }}"
     else
       # We send an lprompt to use for prompt preview purposes only (we still use prompt markers for active prompts).
@@ -435,7 +435,7 @@ function warp_precmd --on-event fish_prompt --on-event fish_posterror
       \"virtual_env\": \"$escaped_virtual_env\",
       \"conda_env\": \"$escaped_conda_env\",
       \"node_version\": \"$escaped_node_version\",
-      \"session_id\": $WARP_SESSION_ID
+      \"session_id\": $_WARP_BOOT_ID
       }}"
     end
     warp_send_json_message $escaped_json
@@ -601,7 +601,7 @@ if test "$WARP_IS_LOCAL_SHELL_SESSION" = "1"
         # Hex-encode the ZSH environment script we use to bootstrap remote zsh b/c it contains control characters
         # We decode on the SSH server using xxd if its available, otherwise fall back to a for-loop over each byte
         # and use printf to convert back to plaintext
-        set -l zsh_env_script (printf '%s' 'unsetopt ZLE; unset RCS; unset GLOBAL_RCS; WARP_SESSION_ID="$(command -p date +%s)$RANDOM"; WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@; WARP_HONOR_PS1='$WARP_HONOR_PS1'; _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || uname -n); _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER); _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n"); printf '"'"'\x1b\x50\x24\x64%s\x9c'"'"' $_msg; unset _hostname _user _msg' | command od -An -v -tx1 | command tr -d ' \n')
+        set -l zsh_env_script (printf '%s' 'unsetopt ZLE; unset RCS; unset GLOBAL_RCS; _WARP_BOOT_ID="$(command -p date +%s)$RANDOM"; WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@; WARP_HONOR_PS1='$WARP_HONOR_PS1'; _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || uname -n); _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER); _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n"); printf '"'"'\x1b\x50\x24\x64%s\x9c'"'"' $_msg; unset _hostname _user _msg' | command od -An -v -tx1 | command tr -d ' \n')
 
         # Note that in this command, we're passing a string to the remote shell. Any variable expansions need to be
         # escaped with "''" to avoid the local shell from expanding them before they're passed to the remote shell.
@@ -609,14 +609,14 @@ if test "$WARP_IS_LOCAL_SHELL_SESSION" = "1"
         # determine what shell is the login shell on the remote machine.  We perform a preliminary check to see if
         # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
         # support.
-        command ssh -o ControlMaster=yes -o ControlPath=$SSH_SOCKET_DIR/$WARP_SESSION_ID \
+        command ssh -o ControlMaster=yes -o ControlPath=$SSH_SOCKET_DIR/$_WARP_BOOT_ID \
         -t $argv \
 "
 export TERM_PROGRAM='WarpTerminal'
 test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSION'
 # Only forward the protocol version if it was set locally (i.e. the HOANotifications feature flag is on).
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
-hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$SSH_SOCKET_DIR/$WARP_SESSION_ID'\", \"remote_shell\": \"%s\"}}" "${SHELL##*/}" | command od -An -v -tx1 | command tr -d " \n")'"
+hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$SSH_SOCKET_DIR/$_WARP_BOOT_ID'\", \"remote_shell\": \"%s\"}}" "${SHELL##*/}" | command od -An -v -tx1 | command tr -d " \n")'"
 printf '$DCS_START$DCS_JSON_MARKER%s$DCS_END' "'$hook'"
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then
@@ -651,11 +651,11 @@ bash)
       stty raw
       HISTCONTROL=ignorespace
       HISTIGNORE=" *"
-      WARP_SESSION_ID="$(command -p date +%s)$RANDOM"
+      _WARP_BOOT_ID="$(command -p date +%s)$RANDOM"
       WARP_HONOR_PS1="'$WARP_HONOR_PS1'"
       _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || uname -n)
       _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER)
-      _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"bash\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
+      _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"bash\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
       WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@
       if [[ "'$OS'" == Windows_NT ]]; then WARP_IN_MSYS2=true; else WARP_IN_MSYS2=false; fi
       printf '\''"'\eP$d%s\x9c'"'\'' \""'$_msg'"\"'

--- a/app/assets/bundled/bootstrap/fish_init_shell.sh
+++ b/app/assets/bundled/bootstrap/fish_init_shell.sh
@@ -1,8 +1,8 @@
-set -g WARP_SESSION_ID (random)
+set -g _WARP_BOOT_ID (random)
 set _hostname (command -v hostname >/dev/null 2>&1 && command hostname 2>/dev/null || uname -n)
 set _user (command -v whoami >/dev/null 2>&1 && command whoami 2>/dev/null || echo $USER)
 set -g WARP_IN_MSYS2 (test "$OS" = Windows_NT; and echo true; or echo false)
-if test "$WARP_IN_MSYS2" = true; set _msg "\e]9278;k;A;InitShell\a\e]9278;k;B;session_id;$WARP_SESSION_ID\a\e]9278;k;B;shell;fish\a\e]9278;k;B;user;$_user\a\e]9278;k;B;hostname;$_hostname\a\e]9278;k;C\a"; else; set _msg (printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"fish\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command od -An -v -tx1 | command tr -d " \n"); end
+if test "$WARP_IN_MSYS2" = true; set _msg "\e]9278;k;A;InitShell\a\e]9278;k;B;session_id;$_WARP_BOOT_ID\a\e]9278;k;B;shell;fish\a\e]9278;k;B;user;$_user\a\e]9278;k;B;hostname;$_hostname\a\e]9278;k;C\a"; else; set _msg (printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"fish\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command od -An -v -tx1 | command tr -d " \n"); end
 set WARP_USING_WINDOWS_CON_PTY @@USING_CON_PTY_BOOLEAN@@
 # We send the InitShell hook via OSCs when on Windows and via DCSs otherwise.
 if test "$WARP_USING_WINDOWS_CON_PTY" = true; if test "$WARP_IN_MSYS2" = true; printf "$_msg"; else; printf '\e]9278;d;%s\x07' "$_msg"; end; else; printf '\e\x50\x24\x64%s\x9c' "$_msg"; end

--- a/app/assets/bundled/bootstrap/fish_init_subshell.sh
+++ b/app/assets/bundled/bootstrap/fish_init_subshell.sh
@@ -1,8 +1,8 @@
-set -g WARP_SESSION_ID (random)
+set -g _WARP_BOOT_ID (random)
 set _hostname (command -v hostname >/dev/null 2>&1 && command hostname 2>/dev/null || uname -n)
 set _user (command -v whoami >/dev/null 2>&1 && command whoami 2>/dev/null || echo $USER)
 set -g WARP_IN_MSYS2 (test "$OS" = Windows_NT; and echo true; or echo false)
-if test "$WARP_IN_MSYS2" = true; set _msg "\e]9278;k;A;InitShell\a\e]9278;k;B;session_id;$WARP_SESSION_ID\a\e]9278;k;B;shell;fish\a\e]9278;k;B;user;$_user\a\e]9278;k;B;hostname;$_hostname\a\e]9278;k;B;is_subshell;true\a\e]9278;k;C\a"; else; set _msg (printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"user\": \"%s\", \"hostname\": \"%s\", \"shell\": \"fish\", \"is_subshell\": true, \"wsl_name\": \"$WSL_DISTRO_NAME\"}}" "$_user" "$_hostname" | command od -An -v -tx1 | command tr -d " \n"); end
+if test "$WARP_IN_MSYS2" = true; set _msg "\e]9278;k;A;InitShell\a\e]9278;k;B;session_id;$_WARP_BOOT_ID\a\e]9278;k;B;shell;fish\a\e]9278;k;B;user;$_user\a\e]9278;k;B;hostname;$_hostname\a\e]9278;k;B;is_subshell;true\a\e]9278;k;C\a"; else; set _msg (printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"user\": \"%s\", \"hostname\": \"%s\", \"shell\": \"fish\", \"is_subshell\": true, \"wsl_name\": \"$WSL_DISTRO_NAME\"}}" "$_user" "$_hostname" | command od -An -v -tx1 | command tr -d " \n"); end
 set WARP_USING_WINDOWS_CON_PTY @@USING_CON_PTY_BOOLEAN@@
 if test "$WARP_USING_WINDOWS_CON_PTY" = true; if test "$WARP_IN_MSYS2" = true; printf "$_msg"; else; printf '\e]9278;d;%s\x07' "$_msg"; end; else; printf '\e\x50\x24\x64%s\x9c' "$_msg"; end
 set -e _hostname _user _msg

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1,4 +1,4 @@
-# Note that WARP_SESSION_ID is expected to have been set when executing commands to
+# Note that _WARP_BOOT_ID is expected to have been set when executing commands to
 # emit the InitShell payload, which includes the session ID.
 #
 # Throughout, command -p is used to call external binaries. command -p resolves the
@@ -108,9 +108,9 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
   # callable the moment the hook is registered.
   if [[ "$WARP_IS_SSH" == "1" ]]; then
       __warp_emit_exit_shell() {
-          if [[ -n "$WARP_SESSION_ID" ]]; then
+          if [[ -n "$_WARP_BOOT_ID" ]]; then
               warp_send_json_message \
-                  "{\"hook\": \"ExitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID}}"
+                  "{\"hook\": \"ExitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID}}"
           fi
       }
       # zshexit_functions is zsh's idiomatic exit-hook mechanism. We prefer
@@ -307,7 +307,7 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       # in this function below).
       local exit_code=$?
 
-      warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"precmd-$WARP_SESSION_ID-$((block_id++))\"}}"
+      warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"precmd-$_WARP_BOOT_ID-$((block_id++))\"}}"
       warp_maybe_send_reset_grid_osc
 
       # If this is being called for a generator command, short circuit and send an unpopulated
@@ -327,7 +327,7 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
         \"virtual_env\": \"\",
         \"conda_env\": \"\",
         \"node_version\": \"\",
-        \"session_id\": $WARP_SESSION_ID,
+        \"session_id\": $_WARP_BOOT_ID,
         \"is_after_in_band_command\": true
         }}"
         return 0
@@ -471,7 +471,7 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       \"conda_env\": \"$escaped_conda_env\",
       \"node_version\": \"$escaped_node_version\",
       \"kube_config\": \"$escaped_kube_config\",
-      \"session_id\": $WARP_SESSION_ID
+      \"session_id\": $_WARP_BOOT_ID
       }}"
       warp_send_json_message "$escaped_json"
   }
@@ -867,7 +867,7 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
           # Hex-encode the ZSH environment script we use to bootstrap remote zsh b/c it contains control characters
           # We decode on the SSH server using xxd if its available, otherwise fall back to a for-loop over each byte
           # and use printf to convert back to plaintext
-          local zsh_env_script=$(printf '%s' 'unsetopt ZLE; unset RCS; unset GLOBAL_RCS; WARP_SESSION_ID="$(command -p date +%s)$RANDOM"; WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@; _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n); _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER); _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d '"'"' \n'"'"'); printf '"'"'\e]9278;d;%s\x07'"'"' $_msg; unset _hostname _user _msg' | command -p od -An -v -tx1 | command -p tr -d ' \n')
+          local zsh_env_script=$(printf '%s' 'unsetopt ZLE; unset RCS; unset GLOBAL_RCS; _WARP_BOOT_ID="$(command -p date +%s)$RANDOM"; WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@; _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n); _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER); _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d '"'"' \n'"'"'); printf '"'"'\e]9278;d;%s\x07'"'"' $_msg; unset _hostname _user _msg' | command -p od -An -v -tx1 | command -p tr -d ' \n')
 
           # Keep remote commands up-to-date with shell.rs & bash.sh.
           # Note that in this command, we're passing a string to the remote shell. Any variable expansions need to be
@@ -876,7 +876,7 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
           # determine what shell is the login shell on the remote machine.  We perform a preliminary check to see if
           # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
           # support.
-          command ssh -o ControlMaster=yes -o ControlPath=$SSH_SOCKET_DIR/$WARP_SESSION_ID \
+          command ssh -o ControlMaster=yes -o ControlPath=$SSH_SOCKET_DIR/$_WARP_BOOT_ID \
           -t "${@:1}" \
 "
 export TERM_PROGRAM='WarpTerminal'
@@ -887,7 +887,7 @@ export WARP_IS_SSH='1'
 test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSION'
 # Only forward the protocol version if it was set locally (i.e. the HOANotifications feature flag is on).
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
-hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$SSH_SOCKET_DIR/$WARP_SESSION_ID'\", \"remote_shell\": \"%s\"}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
+hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$SSH_SOCKET_DIR/$_WARP_BOOT_ID'\", \"remote_shell\": \"%s\"}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
 printf '$OSC_START$DCS_JSON_MARKER$OSC_PARAM_SEPARATOR%s$OSC_END' "'$hook'"
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then
@@ -922,11 +922,11 @@ case "'${SHELL##*/}'" in
       command -p stty raw
       HISTCONTROL=ignorespace
       HISTIGNORE=" *"
-      WARP_SESSION_ID="$(command -p date +%s)$RANDOM"
+      _WARP_BOOT_ID="$(command -p date +%s)$RANDOM"
       WARP_HONOR_PS1="'$WARP_HONOR_PS1'"
       _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n)
       _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER)
-      _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"bash\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
+      _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"bash\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
       WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@
       if [[ "'$OS'" == Windows_NT ]]; then WARP_IN_MSYS2=true; else WARP_IN_MSYS2=false; fi
       printf '\''"'\e]9278;d;%s\x07'"'\'' \""'$_msg'"\"'

--- a/app/assets/bundled/bootstrap/zsh_init_shell.sh
+++ b/app/assets/bundled/bootstrap/zsh_init_shell.sh
@@ -3,10 +3,10 @@
 # command -p resolves the given command with the system default PATH, ensuring the shell
 # can find them even if the user has a clobbered PATH value.
  unsetopt ZLE
- WARP_SESSION_ID="$(command -p date +%s)$RANDOM"
+ _WARP_BOOT_ID="$(command -p date +%s)$RANDOM"
  _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n)
  _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER)
- _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")
+ _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")
  WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@
  # We send the InitShell hook via OSCs when on Windows and via DCSs otherwise.
  if [ "$WARP_USING_WINDOWS_CON_PTY" = true ]; then printf '\e]9278;d;%s\x07' "$_msg"; else printf '\e\x50\x24\x64%s\x9c' "$_msg"; fi

--- a/app/assets/bundled/bootstrap/zsh_init_subshell.sh
+++ b/app/assets/bundled/bootstrap/zsh_init_subshell.sh
@@ -7,10 +7,10 @@
 setopt hist_ignore_space
  unsetopt ZLE
  WARP_IS_SUBSHELL=1
- WARP_SESSION_ID="$(command -p date +%s)$RANDOM"
+ _WARP_BOOT_ID="$(command -p date +%s)$RANDOM"
  _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n)
  _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER)
- _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\", \"is_subshell\": true, \"wsl_name\": \"$WSL_DISTRO_NAME\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")
+ _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $_WARP_BOOT_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\", \"is_subshell\": true, \"wsl_name\": \"$WSL_DISTRO_NAME\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n")
  WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@
  if [ "$WARP_USING_WINDOWS_CON_PTY" = true ]; then printf '\e]9278;d;%s\x07' "$_msg"; else printf '\e\x50\x24\x64%s\x9c' "$_msg"; fi
  unset _hostname _user _msg

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -1333,6 +1333,7 @@ impl PaneGroup {
                         Self::create_ambient_agent_terminal(resources, view_size, ctx)
                     }
                     PaneMode::Terminal | PaneMode::Agent => PaneGroup::create_session(
+                        uuid,
                         // Use cwd from the template iff such path exists, otherwise None
                         // TODO(CORE-3187): On Windows, support WSL directory restoration.
                         Some(cwd).filter(|p| p.exists()),
@@ -1627,6 +1628,7 @@ impl PaneGroup {
                         },
                     );
                 let (terminal_view, terminal_manager) = PaneGroup::create_session(
+                    Uuid::from_slice(&uuid.0).unwrap_or_else(|_| Uuid::new_v4()),
                     startup_directory,
                     HashMap::new(),
                     IsSharedSessionCreator::No,
@@ -3527,7 +3529,9 @@ impl PaneGroup {
         pane_history: &mut Vec<PaneId>,
         ctx: &mut ViewContext<Self>,
     ) -> (PaneData, InitialFocus) {
+        let uuid = Uuid::new_v4();
         let (view, terminal_manager) = PaneGroup::create_session(
+            uuid,
             options.initial_directory,
             options.env_vars,
             options.is_shared_session_creator,
@@ -3541,7 +3545,6 @@ impl PaneGroup {
             None,
             ctx,
         );
-        let uuid = Uuid::new_v4();
 
         let pane_data = TerminalPane::new(
             uuid.as_bytes().to_vec(),
@@ -5856,8 +5859,9 @@ impl PaneGroup {
     // and do not completely replace it.
     #[allow(clippy::too_many_arguments, unused_variables)]
     fn create_session(
+        pane_uuid: Uuid,
         startup_directory: Option<PathBuf>,
-        env_vars: HashMap<OsString, OsString>,
+        mut env_vars: HashMap<OsString, OsString>,
         is_shared_session: IsSharedSessionCreator,
         resources: TerminalViewResources,
         restored_blocks: Option<&Vec<SerializedBlockListItem>>,
@@ -5872,6 +5876,12 @@ impl PaneGroup {
         ViewHandle<TerminalView>,
         ModelHandle<Box<dyn TerminalManager>>,
     ) {
+        // Expose the persistent pane UUID to the spawned shell so external tools can
+        // identify (and deep-link to) this pane via `warp://session/<uuid>`.
+        // See warpdotdev/Warp#8611. Caller-supplied overrides win (`entry().or_insert_with`).
+        env_vars
+            .entry(OsString::from("WARP_SESSION_ID"))
+            .or_insert_with(|| OsString::from(pane_uuid.as_hyphenated().to_string()));
         cfg_if::cfg_if! {
             if #[cfg(feature = "remote_tty")] {
                 let terminal_manager: ModelHandle<Box<dyn TerminalManager>> = crate::terminal::remote_tty::TerminalManager::create_model(
@@ -6166,6 +6176,7 @@ impl PaneGroup {
 
         let view_bounds = Self::estimated_view_bounds(ctx);
         let (view, terminal_manager) = PaneGroup::create_session(
+            uuid,
             startup_directory,
             HashMap::new(),
             IsSharedSessionCreator::No,
@@ -6292,6 +6303,7 @@ impl PaneGroup {
 
         let view_bounds = Self::estimated_view_bounds(ctx);
         let (view, terminal_manager) = PaneGroup::create_session(
+            uuid,
             startup_directory,
             env_vars,
             IsSharedSessionCreator::No,

--- a/app/src/terminal/local_tty/windows/environment.rs
+++ b/app/src/terminal/local_tty/windows/environment.rs
@@ -27,6 +27,7 @@ const SSH_SOCKET_DIR: &str = "SSH_SOCKET_DIR";
 const PATH_APPEND_NAME: &str = "WARP_PATH_APPEND";
 const CLIENT_VERSION_NAME: &str = "WARP_CLIENT_VERSION";
 const CLI_AGENT_PROTOCOL_VERSION_NAME: &str = "WARP_CLI_AGENT_PROTOCOL_VERSION";
+const SESSION_ID_NAME: &str = "WARP_SESSION_ID";
 const WSLENV: &str = "WSLENV";
 const HISTIGNORE: &str = "HISTIGNORE";
 
@@ -199,6 +200,7 @@ fn wsl_env_allowlist(include_initial_working_dir: bool) -> OsString {
         format!("{IS_LOCAL_SESSION_NAME}/u"),
         format!("{SSH_SOCKET_DIR}/u"),
         format!("{CLIENT_VERSION_NAME}/u"),
+        format!("{SESSION_ID_NAME}/u"),
     ];
 
     if FeatureFlag::HOANotifications.is_enabled() {
@@ -383,6 +385,7 @@ mod tests {
                 format!("{IS_LOCAL_SESSION_NAME}/u"),
                 format!("{SSH_SOCKET_DIR}/u"),
                 format!("{CLIENT_VERSION_NAME}/u"),
+                format!("{SESSION_ID_NAME}/u"),
             ],
         );
     }
@@ -403,6 +406,7 @@ mod tests {
                 format!("{IS_LOCAL_SESSION_NAME}/u"),
                 format!("{SSH_SOCKET_DIR}/u"),
                 format!("{CLIENT_VERSION_NAME}/u"),
+                format!("{SESSION_ID_NAME}/u"),
                 format!("{CLI_AGENT_PROTOCOL_VERSION_NAME}/u"),
                 format!("{INITIAL_WORKING_DIR_NAME}/pu"),
             ],

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -36,6 +36,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use url::Url;
+use uuid::Uuid;
 use warpui::notification::UserNotification;
 use warpui::{platform::TerminationMode, SingletonEntity as _, TypedActionView};
 
@@ -457,17 +458,17 @@ impl UriHost {
                 }
             },
             UriHost::Session => {
-                let uuid_hex = url
+                let raw_uuid = url
                     .path_segments()
                     .into_iter()
                     .flatten()
                     .last()
                     .unwrap_or("");
 
-                let Some(uuid_bytes) = decode_uuid_hex(uuid_hex) else {
+                let Some(uuid_bytes) = decode_session_uuid(raw_uuid) else {
                     log::warn!(
-                        "session deep link received invalid UUID hex (safe: len={})",
-                        uuid_hex.len()
+                        "session deep link received invalid UUID (safe: len={})",
+                        raw_uuid.len()
                     );
                     return;
                 };
@@ -1431,19 +1432,15 @@ fn safe_url_log_fields(url: &Url) -> String {
     )
 }
 
-fn decode_uuid_hex(hex: &str) -> Option<Vec<u8>> {
-    let hex = hex.as_bytes();
-    if hex.len() != 32 {
-        return None;
-    }
-
-    hex.chunks_exact(2)
-        .map(|pair| {
-            let high = (pair[0] as char).to_digit(16)?;
-            let low = (pair[1] as char).to_digit(16)?;
-            Some(((high << 4) | low) as u8)
-        })
-        .collect()
+/// Decode the `<id>` portion of a `warp://session/<id>` URL into raw UUID bytes.
+///
+/// Accepts both forms:
+/// - 36-character hyphenated UUIDs (`550e8400-e29b-41d4-a716-446655440000`) —
+///   the value `WARP_SESSION_ID` exposes to shells (matches the `Uuid` Display impl).
+/// - 32-character unhyphenated hex (`550e8400e29b41d4a716446655440000`) — preserved
+///   so links written before this format was settled keep working.
+fn decode_session_uuid(raw: &str) -> Option<Vec<u8>> {
+    Uuid::parse_str(raw).ok().map(|u| u.as_bytes().to_vec())
 }
 
 #[cfg(test)]

--- a/app/src/uri/uri_tests.rs
+++ b/app/src/uri/uri_tests.rs
@@ -699,20 +699,35 @@ fn test_session_uri_invalid_hex_does_not_panic() {
 fn test_session_uri_case_insensitive_hex() {
     let upper = "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4";
     let lower = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4";
-    let upper_bytes = super::decode_uuid_hex(upper).expect("upper hex should decode");
-    let lower_bytes = super::decode_uuid_hex(lower).expect("lower hex should decode");
+    let upper_bytes = super::decode_session_uuid(upper).expect("upper hex should decode");
+    let lower_bytes = super::decode_session_uuid(lower).expect("lower hex should decode");
     assert_eq!(upper_bytes, lower_bytes);
     assert_eq!(upper_bytes.len(), 16);
 }
 
 #[test]
-fn test_decode_uuid_hex_rejects_wrong_length() {
-    assert!(super::decode_uuid_hex("ABCD").is_none());
-    assert!(super::decode_uuid_hex("").is_none());
-    assert!(super::decode_uuid_hex("A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4FF").is_none());
+fn test_decode_session_uuid_accepts_hyphenated_form() {
+    // Hyphenated form is what the Uuid Display impl produces and what
+    // `WARP_SESSION_ID` exposes to shells, so external tools can pass the
+    // value verbatim into `warp://session/<id>`.
+    let hyphenated = "a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4";
+    let unhyphenated = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4";
+    let hyphenated_bytes =
+        super::decode_session_uuid(hyphenated).expect("hyphenated should decode");
+    let unhyphenated_bytes =
+        super::decode_session_uuid(unhyphenated).expect("unhyphenated should decode");
+    assert_eq!(hyphenated_bytes, unhyphenated_bytes);
+    assert_eq!(hyphenated_bytes.len(), 16);
 }
 
 #[test]
-fn test_decode_uuid_hex_rejects_invalid_chars() {
-    assert!(super::decode_uuid_hex("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ").is_none());
+fn test_decode_session_uuid_rejects_wrong_length() {
+    assert!(super::decode_session_uuid("ABCD").is_none());
+    assert!(super::decode_session_uuid("").is_none());
+    assert!(super::decode_session_uuid("A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4FF").is_none());
+}
+
+#[test]
+fn test_decode_session_uuid_rejects_invalid_chars() {
+    assert!(super::decode_session_uuid("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ").is_none());
 }


### PR DESCRIPTION
## Description

Reconciles the bootstrap-internal session id with the persistent pane UUID so a process running inside a Warp shell can identify (and deep-link to) its own pane via `warp://session/<uuid>` (`warposs://` on the OSS channel).

The `warp://session/<uuid>` deep link itself landed in #9655. This PR ships the env-var half of #8611: an exported `WARP_SESSION_ID` whose value is the same UUID the deep link expects, so `open "warp://session/$WARP_SESSION_ID"` from inside the shell focuses the calling pane.

### Changes
- `PaneGroup::create_session` now takes the pane UUID and injects `WARP_SESSION_ID = <uuid hyphenated>` into the spawned process env via `entry().or_insert_with`, so caller-supplied overrides still win. All five call sites pass the UUID they were already generating.
- The Windows `wsl_env_allowlist()` adds `WARP_SESSION_ID/u` so `wsl.exe` forwards the variable into WSL distros when Warp launches `wsl.exe` directly as a tab shell.
- `decode_uuid_hex` is replaced by `decode_session_uuid` using `Uuid::parse_str`, which accepts both the 36-character hyphenated form (what `WARP_SESSION_ID` exposes, matches the `Uuid` Display impl) and the existing 32-character unhyphenated hex.
- The bootstrap scripts' internal `WARP_SESSION_ID` shell variable is renamed to `_WARP_BOOT_ID` across bash/zsh/fish init/init_subshell/body files. The OSC payload's `session_id` JSON field is unchanged (still a u64); the block-ID format `precmd-$_WARP_BOOT_ID-N` keeps its semantics. This frees the user-facing `WARP_SESSION_ID` name to mean "this pane's persistent UUID".

## Linked Issue

Closes #8611

- [x] The linked issue is labeled `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

### Automated
- 3 new unit tests for `decode_session_uuid` (hyphenated, unhyphenated, length / invalid-char rejection).
- The two existing `wsl_env_allowlist` tests updated to assert `WARP_SESSION_ID/u` is present with and without the `HOANotifications` flag.
- `cargo fmt --check`, `cargo clippy -p warp --all-targets --tests -- -D warnings`, and the full pane_group test set (54 tests) pass locally on Windows.

### Manual (Windows, debug build with `--features release_bundle`)

Read PEB of three `pwsh.exe` children of `warp-oss.exe` to confirm per-pane WARP_SESSION_ID injection without disturbing the running session:

```
PID 101028 (pwsh.exe) WARP_SESSION_ID = 3347c049-db8e-4c5d-9e17-bb0ff705987a
PID 121400 (pwsh.exe) WARP_SESSION_ID = 6572f6bf-ad94-4437-88d2-d818bf5cd6a0
PID 116324 (pwsh.exe) WARP_SESSION_ID = 914e0105-07e8-4ff4-a8fb-4023278611f7
```

Three distinct hyphenated UUIDs, one per pane.

Cycled `warposs://session/<uuid>` deep links across the three tabs:

```
warp-oss processes before: 2
[1] focusing PID 101028 / UUID 3347c049-... (hyphenated)
[2] focusing PID 121400 / UUID 6572f6bf-...
[3] focusing PID 116324 / UUID 914e0105-... (hyphenated)
[4] focusing PID 101028 / UUID 3347c049db8e4c5d9e17bb0ff705987a (UNHYPHENATED 32-hex)
warp-oss processes after: 2 (delta = 0)
```

Each invocation shifted focus to the matching pane and stayed a single instance (named-pipe URI forwarding via `SingleInstanceManager`). Both UUID forms decoded to the same target.

WSL propagation via `WSLENV` is covered by unit tests; native-WSL-tab end-to-end was not exercised locally on this build (a `pwsh` tab where the user types `wsl` is a different code path that doesn't get `WSLENV` injected by Warp — out of scope for this PR).

- [x] I have manually tested my changes locally.

## Agent Mode

- [ ] Warp Agent Mode — this PR was co-authored with Claude Code (Anthropic). Manually verified end-to-end on Windows.

CHANGELOG-NEW-FEATURE: External tools can read WARP_SESSION_ID (a UUID) from any Warp shell to deep-link to that pane via warp://session/<uuid>.