### PR TITLE
Snapshot changes for handoff, even when the conversation is empty

### DIFF
--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -129,7 +129,8 @@ impl SnapshotUploadStatus {
 pub(crate) struct PendingHandoff {
     /// Forked conversation id minted by `POST /agent/conversations/{conversation_id}/fork`.
     /// Sent under `conversation_id` on the subsequent `POST /agent/runs` request.
-    pub(crate) forked_conversation_id: String,
+    /// `None` for fresh cloud launches that have no source conversation to fork.
+    pub(crate) forked_conversation_id: Option<String>,
     /// Title override for the cloud run (e.g. "<title> (Moved to cloud)").
     pub(crate) title: Option<String>,
     /// `None` until `derive_touched_workspace` completes.
@@ -592,7 +593,7 @@ impl AmbientAgentViewModel {
         &self,
         prompt: String,
         attachments: Vec<AttachmentInput>,
-        forked_conversation_id: String,
+        forked_conversation_id: Option<String>,
         initial_snapshot_token: Option<InitialSnapshotToken>,
         ctx: &AppContext,
     ) -> SpawnAgentRequest {
@@ -610,7 +611,7 @@ impl AmbientAgentViewModel {
             parent_run_id: None,
             runtime_skills: vec![],
             referenced_attachments: vec![],
-            conversation_id: Some(forked_conversation_id),
+            conversation_id: forked_conversation_id,
             initial_snapshot_token,
             agent_identity_uid: None,
         }

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -24,7 +24,7 @@ fn pending_launch() -> PendingCloudLaunch {
 
 fn pending_handoff() -> PendingHandoff {
     PendingHandoff {
-        forked_conversation_id: "forked-conversation".to_owned(),
+        forked_conversation_id: Some("forked-conversation".to_owned()),
         title: None,
         touched_workspace: None,
         snapshot_upload: SnapshotUploadStatus::Pending,

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -34,6 +34,17 @@ fn pending_handoff() -> PendingHandoff {
     }
 }
 
+fn pending_handoff_fresh_launch() -> PendingHandoff {
+    PendingHandoff {
+        forked_conversation_id: None,
+        touched_workspace: None,
+        snapshot_upload: SnapshotUploadStatus::Pending,
+        submission_state: HandoffSubmissionState::Idle,
+        auto_submit: Some(pending_launch()),
+        explicit_environment_id: None,
+    }
+}
+
 fn add_model(app: &mut App) -> warpui::ModelHandle<AmbientAgentViewModel> {
     app.add_model(|ctx| AmbientAgentViewModel::new(EntityId::new(), ctx))
 }
@@ -102,6 +113,54 @@ fn maybe_auto_submit_handoff_waits_for_workspace_and_snapshot_then_consumes_laun
             let launch = model
                 .maybe_auto_submit_handoff(ctx)
                 .expect("ready handoff should auto-submit");
+            assert_eq!(launch.prompt, "fix tests");
+            assert!(model.maybe_auto_submit_handoff(ctx).is_none());
+        });
+    });
+}
+
+#[test]
+fn fresh_launch_queues_handoff_with_no_conversation_id() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let model = add_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.set_pending_handoff(Some(pending_handoff_fresh_launch()), ctx);
+        });
+
+        let queued = model.update(&mut app, |model, ctx| model.queue_handoff_auto_submit(ctx));
+
+        assert!(queued);
+        model.read(&app, |model, _| {
+            let request = model.request().expect("request should be populated");
+            assert_eq!(request.prompt, "fix tests");
+            assert!(request.conversation_id.is_none());
+            assert_eq!(request.attachments.len(), 1);
+        });
+    });
+}
+
+#[test]
+fn fresh_launch_auto_submits_after_snapshot_settles() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let model = add_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.set_pending_handoff(Some(pending_handoff_fresh_launch()), ctx);
+            assert!(model.maybe_auto_submit_handoff(ctx).is_none());
+
+            model.set_pending_handoff_workspace(TouchedWorkspace::default(), ctx);
+            assert!(model.maybe_auto_submit_handoff(ctx).is_none());
+
+            model.set_pending_handoff_snapshot_upload(
+                SnapshotUploadStatus::SkippedEmptyWorkspace,
+                ctx,
+            );
+            let launch = model
+                .maybe_auto_submit_handoff(ctx)
+                .expect("ready fresh-launch handoff should auto-submit");
             assert_eq!(launch.prompt, "fix tests");
             assert!(model.maybe_auto_submit_handoff(ctx).is_none());
         });

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -37,6 +37,7 @@ fn pending_handoff() -> PendingHandoff {
 fn pending_handoff_fresh_launch() -> PendingHandoff {
     PendingHandoff {
         forked_conversation_id: None,
+        title: None,
         touched_workspace: None,
         snapshot_upload: SnapshotUploadStatus::Pending,
         submission_state: HandoffSubmissionState::Idle,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13153,6 +13153,74 @@ impl Workspace {
         });
     }
 
+    /// Spawns the async snapshot upload pipeline for a handoff pane. Derives the
+    /// touched workspace from `paths`, uploads repo patches + orphan files, sets
+    /// environment overlap, and settles the snapshot status on the model. Shared
+    /// by both the conversation-fork and fresh-launch handoff paths.
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+    fn spawn_handoff_snapshot_upload(
+        paths: Vec<PathBuf>,
+        pane_view: ViewHandle<TerminalView>,
+        model_handle: ModelHandle<AmbientAgentViewModel>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let server_api_provider = ServerApiProvider::as_ref(ctx);
+        let ai_client = server_api_provider.get_ai_client();
+        let http = server_api_provider.get_http_client();
+        ctx.spawn(
+            async move {
+                let workspace = derive_touched_workspace(paths).await;
+                let repo_paths: Vec<_> =
+                    workspace.repos.iter().map(|r| r.git_root.clone()).collect();
+                let upload_result = upload_snapshot_for_handoff(
+                    repo_paths,
+                    workspace.orphan_files.clone(),
+                    ai_client,
+                    http.as_ref(),
+                )
+                .await;
+                (workspace, upload_result)
+            },
+            move |_workspace, (derived_workspace, upload_result), ctx| {
+                model_handle.update(ctx, |model, model_ctx| {
+                    if !model.is_local_to_cloud_handoff() {
+                        return;
+                    }
+                    if !model.pending_handoff_has_explicit_environment() {
+                        let mut envs = CloudAmbientAgentEnvironment::get_all(model_ctx);
+                        sort_environments_by_recency(&mut envs);
+                        if let Some(overlap_env) =
+                            pick_handoff_overlap_env(&derived_workspace, envs)
+                        {
+                            model.set_environment_id(Some(overlap_env), model_ctx);
+                        }
+                    }
+                    model.set_pending_handoff_workspace(derived_workspace, model_ctx);
+                    match upload_result {
+                        Ok(Some(initial_snapshot_token)) => {
+                            model.set_pending_handoff_snapshot_upload(
+                                SnapshotUploadStatus::Uploaded(initial_snapshot_token),
+                                model_ctx,
+                            );
+                        }
+                        Ok(None) => {
+                            model.set_pending_handoff_snapshot_upload(
+                                SnapshotUploadStatus::SkippedEmptyWorkspace,
+                                model_ctx,
+                            );
+                        }
+                        Err(err) => {
+                            log::warn!("Handoff snapshot upload failed: {err:#}");
+                            model
+                                .record_handoff_snapshot_upload_failed(format!("{err}"), model_ctx);
+                        }
+                    }
+                });
+                Self::maybe_auto_submit_handoff(&pane_view, &model_handle, ctx);
+            },
+        );
+    }
+
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn show_handoff_success_toast(ctx: &mut ViewContext<Self>) {
         let window_id = ctx.window_id();
@@ -13168,6 +13236,8 @@ impl Workspace {
     }
 
     /// Opens a cloud pane without forking when there is no local conversation to hand off.
+    /// Still snapshots the source pane's pwd so the cloud agent receives the local repo's
+    /// branch info and uncommitted diffs.
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn start_fresh_cloud_launch(
         &mut self,
@@ -13177,7 +13247,7 @@ impl Workspace {
         ctx: &mut ViewContext<Self>,
     ) {
         // Push a cloud-mode pane for the fresh launch.
-        let Some((_new_pane_view, model_handle)) = source_view.update(ctx, |view, view_ctx| {
+        let Some((new_pane_view, model_handle)) = source_view.update(ctx, |view, view_ctx| {
             view.start_local_to_cloud_handoff_pane(view_ctx)
         }) else {
             log::warn!("start_local_to_cloud_handoff: failed to push fresh cloud-mode pane");
@@ -13186,18 +13256,31 @@ impl Workspace {
             return;
         };
 
-        if let Some(environment_id) = explicit_environment_id {
+        if let Some(env_id) = explicit_environment_id {
             model_handle.update(ctx, |model, ctx| {
-                model.set_environment_id(Some(environment_id), ctx);
+                model.set_environment_id(Some(env_id), ctx);
             });
         }
         Self::show_handoff_success_toast(ctx);
 
-        if let Some(launch) = launch {
-            model_handle.update(ctx, |model, ctx| {
-                model.spawn_agent(launch.prompt, launch.attachments.request_attachments, ctx);
-            });
-        }
+        let pending = PendingHandoff {
+            forked_conversation_id: None,
+            touched_workspace: None,
+            snapshot_upload: SnapshotUploadStatus::Pending,
+            submission_state: HandoffSubmissionState::Idle,
+            auto_submit: launch,
+            explicit_environment_id,
+        };
+        model_handle.update(ctx, |model, model_ctx| {
+            model.set_pending_handoff(Some(pending), model_ctx);
+        });
+        model_handle.update(ctx, |model, ctx| {
+            model.queue_handoff_auto_submit(ctx);
+        });
+
+        let source_pwd = source_view.as_ref(ctx).active_session_path_if_local(ctx);
+        let paths: Vec<PathBuf> = source_pwd.into_iter().collect();
+        Self::spawn_handoff_snapshot_upload(paths, new_pane_view, model_handle, ctx);
     }
 
     /// Opens a local-to-cloud handoff pane in place over the active local pane.
@@ -13376,7 +13459,7 @@ impl Workspace {
 
         // Keep handoff state on the cloud model until snapshot prep and submit finish.
         let pending = PendingHandoff {
-            forked_conversation_id: forked_conversation_id.clone(),
+            forked_conversation_id: Some(forked_conversation_id.clone()),
             title: title_override,
             touched_workspace: None,
             snapshot_upload: SnapshotUploadStatus::Pending,
@@ -13393,65 +13476,18 @@ impl Workspace {
             model.queue_handoff_auto_submit(ctx);
         });
 
-        let async_pane_view = new_pane_view.clone();
-        let async_model_handle = model_handle.clone();
-        let server_api_provider = ServerApiProvider::as_ref(ctx);
-        let ai_client = server_api_provider.get_ai_client();
-        let http = server_api_provider.get_http_client();
+        let source_pwd = source_view.as_ref(ctx).active_session_path_if_local(ctx);
         // Derive touched repos and upload the initial snapshot off the UI thread.
-        ctx.spawn(
-            async move {
-                let paths = extract_paths_from_conversation(&source_conversation);
-                let workspace = derive_touched_workspace(paths).await;
-                let repo_paths: Vec<_> =
-                    workspace.repos.iter().map(|r| r.git_root.clone()).collect();
-                let upload_result = upload_snapshot_for_handoff(
-                    repo_paths,
-                    workspace.orphan_files.clone(),
-                    ai_client,
-                    http.as_ref(),
-                )
-                .await;
-                (workspace, upload_result)
-            },
-            move |_workspace, (derived_workspace, upload_result), ctx| {
-                async_model_handle.update(ctx, |model, model_ctx| {
-                    if !model.is_local_to_cloud_handoff() {
-                        return;
-                    }
-                    if !model.pending_handoff_has_explicit_environment() {
-                        let mut envs = CloudAmbientAgentEnvironment::get_all(model_ctx);
-                        sort_environments_by_recency(&mut envs);
-                        if let Some(overlap_env) =
-                            pick_handoff_overlap_env(&derived_workspace, envs)
-                        {
-                            model.set_environment_id(Some(overlap_env), model_ctx);
-                        }
-                    }
-                    model.set_pending_handoff_workspace(derived_workspace, model_ctx);
-                    match upload_result {
-                        Ok(Some(initial_snapshot_token)) => {
-                            model.set_pending_handoff_snapshot_upload(
-                                SnapshotUploadStatus::Uploaded(initial_snapshot_token),
-                                model_ctx,
-                            );
-                        }
-                        Ok(None) => {
-                            model.set_pending_handoff_snapshot_upload(
-                                SnapshotUploadStatus::SkippedEmptyWorkspace,
-                                model_ctx,
-                            );
-                        }
-                        Err(err) => {
-                            log::warn!("Handoff snapshot upload failed: {err:#}");
-                            model
-                                .record_handoff_snapshot_upload_failed(format!("{err}"), model_ctx);
-                        }
-                    }
-                });
-                Self::maybe_auto_submit_handoff(&async_pane_view, &async_model_handle, ctx);
-            },
-        );
+        // The paths list is built from the conversation's write actions plus the
+        // source pane's pwd (so the current repo is always captured).
+        let paths = {
+            let mut p = extract_paths_from_conversation(&source_conversation);
+            if let Some(pwd) = source_pwd {
+                p.push(pwd);
+            }
+            p
+        };
+        Self::spawn_handoff_snapshot_upload(paths, new_pane_view, model_handle, ctx);
     }
 
     pub(crate) fn handle_file_tree_event(

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13265,6 +13265,7 @@ impl Workspace {
 
         let pending = PendingHandoff {
             forked_conversation_id: None,
+            title: None,
             touched_workspace: None,
             snapshot_upload: SnapshotUploadStatus::Pending,
             submission_state: HandoffSubmissionState::Idle,


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

ZL ran into a case where changes weren't snapshotted for local -> cloud handoff and he wasn't sure why. The issue was that he was doing handoff from an empty conversation, which we were effectively treating as just kicking off a regular cloud run. However, even in the empty conversation case for local -> cloud handoff, we should be snapshotting the user's changes and restoring them on-start.

Luckily, snapshotting and conversation-resuming are sufficiently decoupled that we can easily do this by just attaching snapshots in either case.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/1c3dc27b080842669368814eb8039651

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
