### PR TITLE
feat(ui): add pane header tab actions

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -147,8 +147,8 @@ pub struct TabData {
     pub detached: bool,
 }
 
-const TAB_COLOR_ICON_PATH: &str = "bundled/svg/ellipse.svg";
-const TAB_NO_COLOR_ICON_PATH: &str = "bundled/svg/no_color_ellipse.svg";
+pub(crate) const TAB_COLOR_ICON_PATH: &str = "bundled/svg/ellipse.svg";
+pub(crate) const TAB_NO_COLOR_ICON_PATH: &str = "bundled/svg/no_color_ellipse.svg";
 
 impl TabData {
     pub fn new(pane_group: ViewHandle<PaneGroup>) -> Self {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -24952,6 +24952,18 @@ impl TypedActionView for TerminalView {
             | KillAgentConversation { .. }
             | ToggleCLIAgentRichInput
             | ToggleSessionRecording => Empty,
+            RenamePane(_) => Custom(AccessibilityContent::new_without_help(
+                "Rename pane",
+                WarpA11yRole::UserAction,
+            )),
+            RenameActiveTabWithFallbackTitle(_) => Custom(AccessibilityContent::new_without_help(
+                "Rename tab",
+                WarpA11yRole::UserAction,
+            )),
+            SetActiveTabColor(_) => Custom(AccessibilityContent::new_without_help(
+                "Set tab color",
+                WarpA11yRole::UserAction,
+            )),
         }
     }
 
@@ -25183,6 +25195,17 @@ impl TypedActionView for TerminalView {
                 ctx.emit(Event::Pane(PaneEvent::SplitUp(chosen_shell.to_owned())))
             }
             ToggleMaximizePane => ctx.emit(Event::Pane(PaneEvent::ToggleMaximized)),
+            RenamePane(pane_id) => {
+                ctx.dispatch_typed_action(&WorkspaceAction::RenamePaneById(*pane_id));
+            }
+            RenameActiveTabWithFallbackTitle(fallback_title) => {
+                ctx.dispatch_typed_action(&WorkspaceAction::RenameActiveTabWithFallbackTitle(
+                    fallback_title.clone(),
+                ));
+            }
+            SetActiveTabColor(color) => {
+                ctx.dispatch_typed_action(&WorkspaceAction::SetActiveTabColor(*color));
+            }
             PromptContextMenu {
                 position_offset_from_prompt,
             } => self.show_prompt_context_menu(*position_offset_from_prompt, ctx),

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -25196,15 +25196,15 @@ impl TypedActionView for TerminalView {
             }
             ToggleMaximizePane => ctx.emit(Event::Pane(PaneEvent::ToggleMaximized)),
             RenamePane(pane_id) => {
-                ctx.dispatch_typed_action(&WorkspaceAction::RenamePaneById(*pane_id));
+                ctx.dispatch_typed_action_deferred(WorkspaceAction::RenamePaneById(*pane_id));
             }
             RenameActiveTabWithFallbackTitle(fallback_title) => {
-                ctx.dispatch_typed_action(&WorkspaceAction::RenameActiveTabWithFallbackTitle(
-                    fallback_title.clone(),
-                ));
+                ctx.dispatch_typed_action_deferred(
+                    WorkspaceAction::RenameActiveTabWithFallbackTitle(fallback_title.clone()),
+                );
             }
             SetActiveTabColor(color) => {
-                ctx.dispatch_typed_action(&WorkspaceAction::SetActiveTabColor(*color));
+                ctx.dispatch_typed_action_deferred(WorkspaceAction::SetActiveTabColor(*color));
             }
             PromptContextMenu {
                 position_offset_from_prompt,

--- a/app/src/terminal/view/action.rs
+++ b/app/src/terminal/view/action.rs
@@ -18,7 +18,9 @@ use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::AIAgentExchangeId;
 use crate::ai::blocklist::codebase_index_speedbump_banner::CodebaseIndexSpeedbumpBannerAction;
 use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
+use crate::pane_group::PaneId;
 use crate::server::telemetry::{AgentModeRewindEntrypoint, PaletteSource, ToggleBlockFilterSource};
+use crate::tab::SelectedTabColor;
 use crate::terminal::available_shells::AvailableShell;
 use crate::terminal::model::completions::ShellCompletion;
 use crate::terminal::shared_session::SharedSessionActionSource;
@@ -209,6 +211,9 @@ pub enum TerminalAction {
     ClearSelectionsWhenShellMode,
     Close,
     ToggleMaximizePane,
+    RenamePane(PaneId),
+    RenameActiveTabWithFallbackTitle(String),
+    SetActiveTabColor(SelectedTabColor),
     SplitRight(Option<AvailableShell>),
     SplitLeft(Option<AvailableShell>),
     SplitDown(Option<AvailableShell>),
@@ -565,6 +570,9 @@ impl fmt::Debug for TerminalAction {
             SplitDown(_) => f.write_str("SplitDown"),
             SplitUp(_) => f.write_str("SplitUp"),
             ToggleMaximizePane => f.write_str("ToggleMaximizeActivePane"),
+            RenamePane(_) => f.write_str("RenamePane"),
+            RenameActiveTabWithFallbackTitle(_) => f.write_str("RenameActiveTabWithFallbackTitle"),
+            SetActiveTabColor(color) => write!(f, "SetActiveTabColor({color:?})"),
             PromptContextMenu {
                 position_offset_from_prompt,
             } => write!(

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -24,6 +24,7 @@ use crate::pane_group::{pane::view, pane::view::PaneHeaderAction, BackingView, S
 use crate::settings::app_installation_detection::{
     UserAppInstallDetectionSettings, UserAppInstallStatus,
 };
+use crate::tab::{SelectedTabColor, TAB_COLOR_ICON_PATH, TAB_NO_COLOR_ICON_PATH};
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::terminal::shared_session::participant_avatar_view::render_participants_and_role_elements;
 use crate::terminal::shared_session::render_util::shared_session_indicator_color;
@@ -33,6 +34,7 @@ use crate::terminal::TerminalView;
 use crate::ui_components::agent_icon::terminal_view_agent_icon_variant;
 use crate::ui_components::blended_colors;
 use crate::ui_components::buttons::icon_button_with_color;
+use crate::ui_components::color_dot::TAB_COLOR_OPTIONS;
 use crate::ui_components::icon_with_status::render_icon_with_status;
 use crate::ui_components::icons;
 use crate::workspace::tab_settings::TabSettings;
@@ -644,15 +646,64 @@ impl BackingView for TerminalView {
         ctx: &AppContext,
     ) -> Vec<MenuItem<Self::PaneHeaderOverflowMenuAction>> {
         let model = self.model.lock();
+        let appearance = Appearance::as_ref(ctx);
+        let terminal_colors = appearance.theme().terminal_colors().normal;
+        let rename_tab_fallback_title = self
+            .pane_configuration
+            .as_ref(ctx)
+            .title()
+            .trim()
+            .to_owned();
         let mut items = vec![];
+        if let Some(focus_handle) = self.focus_handle() {
+            items.push(
+                MenuItemFields::new("Rename pane")
+                    .with_on_select_action(TerminalAction::RenamePane(focus_handle.pane_id()))
+                    .into_item(),
+            );
+        }
+        items.extend([
+            MenuItemFields::new("Rename tab")
+                .with_on_select_action(TerminalAction::RenameActiveTabWithFallbackTitle(
+                    rename_tab_fallback_title,
+                ))
+                .into_item(),
+            MenuItem::ItemsRow {
+                items: std::iter::once(
+                    MenuItemFields::new_with_icon(
+                        TAB_NO_COLOR_ICON_PATH,
+                        appearance.theme().foreground(),
+                        "None".to_owned(),
+                    )
+                    .no_highlight_on_hover()
+                    .with_on_select_action(TerminalAction::SetActiveTabColor(
+                        SelectedTabColor::Cleared,
+                    )),
+                )
+                .chain(TAB_COLOR_OPTIONS.iter().map(|color_option| {
+                    let color = color_option.to_ansi_color(&terminal_colors);
+                    MenuItemFields::new_with_icon(
+                        TAB_COLOR_ICON_PATH,
+                        color.into(),
+                        color_option.to_string(),
+                    )
+                    .no_highlight_on_hover()
+                    .with_on_select_action(TerminalAction::SetActiveTabColor(
+                        SelectedTabColor::Color(*color_option),
+                    ))
+                }))
+                .collect(),
+            },
+        ]);
         let source = SharedSessionActionSource::PaneHeader;
 
         // Shared-session related items.
+        let mut shared_session_items = vec![];
         let shared_session_status = model.shared_session_status();
         let is_ambient_agent = self.is_ambient_agent_session(ctx);
         if shared_session_status.is_sharer_or_viewer() {
             if !is_ambient_agent {
-                items.push(
+                shared_session_items.push(
                     MenuItemFields::new("Copy link")
                         .with_on_select_action(TerminalAction::CopySharedSessionLink { source })
                         .into_item(),
@@ -660,7 +711,7 @@ impl BackingView for TerminalView {
             }
 
             if shared_session_status.is_sharer() {
-                items.push(
+                shared_session_items.push(
                     MenuItemFields::new("Stop sharing session")
                         .with_on_select_action(TerminalAction::StopSharingCurrentSession { source })
                         .into_item(),
@@ -672,7 +723,7 @@ impl BackingView for TerminalView {
                     .value()
                     == UserAppInstallStatus::Detected
             {
-                items.push(
+                shared_session_items.push(
                     MenuItemFields::new("Open on Desktop")
                         .with_on_select_action(TerminalAction::OpenSharedSessionOnDesktop {
                             source,
@@ -683,11 +734,15 @@ impl BackingView for TerminalView {
         } else if FeatureFlag::CreatingSharedSessions.is_enabled()
             && ContextFlag::CreateSharedSession.is_enabled()
         {
-            items.push(
+            shared_session_items.push(
                 MenuItemFields::new("Share session")
                     .with_on_select_action(TerminalAction::OpenShareSessionModal { source })
                     .into_item(),
             );
+        }
+        if !shared_session_items.is_empty() {
+            items.push(MenuItem::Separator);
+            items.extend(shared_session_items);
         }
 
         // Split-pane related items.

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -29,11 +29,13 @@ use crate::ai::llms::LLMId;
 use crate::context_chips::prompt::Prompt;
 use crate::editor::{AutosuggestionLocation, AutosuggestionType};
 use crate::features::FeatureFlag;
+use crate::menu::MenuItem;
 use crate::pane_group::focus_state::PaneGroupFocusState;
 use crate::pane_group::{pane::PaneStack, BackingView, TerminalPaneId};
 use crate::server::server_api::ai::SpawnAgentRequest;
 use crate::settings::import::model::ImportedConfigModel;
 use crate::settings::{AISettings, AppEditorSettings, WarpPromptSeparator};
+use crate::tab::SelectedTabColor;
 use crate::terminal::alt_screen::should_intercept_mouse;
 use crate::terminal::block_list_element::{SnackbarPoint, SnackbarTranslationMode};
 use crate::terminal::block_list_viewport::{ClampingMode, ScrollLines};
@@ -60,6 +62,7 @@ use crate::terminal::{MockTerminalManager, TerminalManager, TerminalModel};
 use crate::test_util::terminal::add_window_with_id_and_terminal;
 use crate::test_util::terminal::initialize_app_for_terminal_view;
 use crate::test_util::{add_window_with_terminal, assert_eventually};
+use crate::themes::theme::AnsiColorIdentifier;
 use crate::view_components::find::FindWithinBlockState;
 use crate::workspace::ToastStack;
 
@@ -80,6 +83,87 @@ fn has_pending_user_query_block(view: &TerminalView) -> bool {
     view.rich_content_views.iter().any(|rich_content| {
         rich_content.view_id() == view_id && rich_content.is_pending_user_query()
     })
+}
+
+#[test]
+fn pane_header_overflow_menu_includes_tab_identification_actions() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let terminal_pane_id = TerminalPaneId::dummy_terminal_pane_id();
+        let expected_pane_id = terminal_pane_id.into();
+
+        terminal.update(&mut app, |view, ctx| {
+            let focus_state = ctx.add_model(|_| {
+                PaneGroupFocusState::new(expected_pane_id, Some(terminal_pane_id), false)
+            });
+            let focus_handle = PaneFocusHandle::new(expected_pane_id, focus_state);
+            view.set_focus_handle(focus_handle, ctx);
+        });
+
+        terminal.read(&app, |terminal, ctx| {
+            let items = terminal.pane_header_overflow_menu_items(ctx);
+
+            let item_labels = items
+                .iter()
+                .filter_map(|item| match item {
+                    MenuItem::Item(fields) => Some(fields.label()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+
+            assert!(matches!(
+                items.first(),
+                Some(MenuItem::Item(fields))
+                    if fields.label() == "Rename pane"
+                        && matches!(
+                            fields.on_select_action(),
+                            Some(TerminalAction::RenamePane(action_pane_id))
+                                if *action_pane_id == expected_pane_id
+                        )
+            ));
+            assert!(matches!(
+                items.get(1),
+                Some(MenuItem::Item(fields))
+                    if fields.label() == "Rename tab"
+                        && matches!(
+                            fields.on_select_action(),
+                            Some(TerminalAction::RenameActiveTabWithFallbackTitle(_))
+                        )
+            ));
+            assert!(item_labels.contains(&"Rename pane"));
+            assert!(item_labels.contains(&"Rename tab"));
+
+            let color_actions = items
+                .iter()
+                .find_map(|item| match item {
+                    MenuItem::ItemsRow { items } => Some(
+                        items
+                            .iter()
+                            .filter_map(|fields| match fields.on_select_action() {
+                                Some(TerminalAction::SetActiveTabColor(color)) => Some(*color),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>(),
+                    ),
+                    _ => None,
+                })
+                .expect("expected a tab color row");
+
+            assert_eq!(
+                color_actions,
+                vec![
+                    SelectedTabColor::Cleared,
+                    SelectedTabColor::Color(AnsiColorIdentifier::Red),
+                    SelectedTabColor::Color(AnsiColorIdentifier::Green),
+                    SelectedTabColor::Color(AnsiColorIdentifier::Yellow),
+                    SelectedTabColor::Color(AnsiColorIdentifier::Blue),
+                    SelectedTabColor::Color(AnsiColorIdentifier::Magenta),
+                    SelectedTabColor::Color(AnsiColorIdentifier::Cyan),
+                ]
+            );
+        });
+    });
 }
 
 fn exchange_with_inputs(inputs: Vec<AIAgentInput>) -> AIAgentExchange {

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -13,7 +13,7 @@ use crate::auth::auth_manager::LoginGatedFeature;
 use crate::drive::items::WarpDriveItemId;
 use crate::drive::CloudObjectTypeAndId;
 use crate::palette::PaletteMode;
-use crate::pane_group::PaneGroup;
+use crate::pane_group::{PaneGroup, PaneId};
 use crate::prompt::editor_modal::OpenSource as PromptEditorOpenSource;
 use crate::search;
 use crate::server::ids::SyncId;
@@ -110,8 +110,10 @@ pub enum WorkspaceAction {
     RenameTab(usize),
     ResetTabName(usize),
     RenamePane(PaneViewLocator),
+    RenamePaneById(PaneId),
     ResetPaneName(PaneViewLocator),
     RenameActiveTab,
+    RenameActiveTabWithFallbackTitle(String),
     /// Renames the focused pane in the active tab. Mirrors `RenameActiveTab`
     /// so the action is reachable from the binding registry / Command Palette
     /// (see #9351). The context-menu path keeps using `RenamePane(locator)`.
@@ -734,8 +736,10 @@ impl WorkspaceAction {
             | RenameTab(_)
             | ResetTabName(_)
             | RenamePane(_)
+            | RenamePaneById(_)
             | ResetPaneName(_)
             | RenameActiveTab
+            | RenameActiveTabWithFallbackTitle(_)
             | RenameActivePane
             | SetActiveTabName(_)
             | SetActiveTabColor(_)

--- a/app/src/workspace/action_tests.rs
+++ b/app/src/workspace/action_tests.rs
@@ -73,9 +73,14 @@ fn pane_name_actions_save_workspace_state() {
     };
 
     assert!(WorkspaceAction::RenamePane(locator).should_save_app_state_on_action());
+    assert!(WorkspaceAction::RenamePaneById(locator.pane_id).should_save_app_state_on_action());
     assert!(WorkspaceAction::ResetPaneName(locator).should_save_app_state_on_action());
     // GH-9351: the keyboard-bindable variant must persist app state on the
     // same conditions as the locator-based one, since both ultimately drive
     // `rename_pane` which mutates `pane_configuration`.
     assert!(WorkspaceAction::RenameActivePane.should_save_app_state_on_action());
+    assert!(
+        WorkspaceAction::RenameActiveTabWithFallbackTitle("pane title".to_string())
+            .should_save_app_state_on_action()
+    );
 }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5127,6 +5127,28 @@ impl Workspace {
         );
     }
 
+    pub fn rename_active_tab_with_fallback_title(
+        &mut self,
+        fallback_title: &str,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(tab) = self.tabs.get(self.active_tab_index) else {
+            log::warn!("Tried to rename active tab but active tab index was out of range");
+            return;
+        };
+        let title = tab
+            .pane_group
+            .as_ref(ctx)
+            .custom_title(ctx)
+            .unwrap_or_else(|| fallback_title.to_string());
+
+        self.rename_tab_internal(self.active_tab_index, &title, ctx);
+        send_telemetry_from_ctx!(
+            TelemetryEvent::TabRenamed(TabRenameEvent::OpenedEditor),
+            ctx
+        );
+    }
+
     fn set_active_tab_name(&mut self, title: &str, ctx: &mut ViewContext<Self>) {
         let Some(pane_group) = self
             .tabs
@@ -5312,6 +5334,21 @@ impl Workspace {
         });
         ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
+    }
+
+    pub fn rename_pane_by_id(&mut self, pane_id: PaneId, ctx: &mut ViewContext<Self>) {
+        let Some(locator) = self.tabs.iter().find_map(|tab| {
+            let pane_group = tab.pane_group.as_ref(ctx);
+            pane_group.pane_by_id(pane_id).map(|_| PaneViewLocator {
+                pane_group_id: tab.pane_group.id(),
+                pane_id,
+            })
+        }) else {
+            log::warn!("Tried to rename a missing pane");
+            return;
+        };
+
+        self.rename_pane(locator, ctx);
     }
 
     pub fn rename_pane(&mut self, locator: PaneViewLocator, ctx: &mut ViewContext<Self>) {
@@ -20384,8 +20421,12 @@ impl TypedActionView for Workspace {
             RenameTab(index) => self.rename_tab(*index, ctx),
             ResetTabName(index) => self.clear_tab_name(*index, ctx),
             RenamePane(locator) => self.rename_pane(*locator, ctx),
+            RenamePaneById(pane_id) => self.rename_pane_by_id(*pane_id, ctx),
             ResetPaneName(locator) => self.clear_pane_name(*locator, ctx),
             RenameActiveTab => self.rename_tab(self.active_tab_index, ctx),
+            RenameActiveTabWithFallbackTitle(fallback_title) => {
+                self.rename_active_tab_with_fallback_title(fallback_title, ctx)
+            }
             RenameActivePane => {
                 let pane_group = self.active_tab_pane_group().clone();
                 let pane_group_id = pane_group.id();

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -850,6 +850,45 @@ fn test_set_active_tab_name() {
 }
 
 #[test]
+fn test_rename_active_tab_with_fallback_title() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.handle_action(
+                &WorkspaceAction::RenameActiveTabWithFallbackTitle("Pane title".to_string()),
+                ctx,
+            );
+            assert_eq!(
+                workspace
+                    .tab_rename_editor
+                    .read(ctx, |editor, ctx| editor.selected_text(ctx)),
+                "Pane title"
+            );
+
+            workspace.handle_action(
+                &WorkspaceAction::SetActiveTabName("Custom tab title".to_string()),
+                ctx,
+            );
+            workspace.handle_action(
+                &WorkspaceAction::RenameActiveTabWithFallbackTitle(
+                    "Different pane title".to_string(),
+                ),
+                ctx,
+            );
+            assert_eq!(
+                workspace
+                    .tab_rename_editor
+                    .read(ctx, |editor, ctx| editor.selected_text(ctx)),
+                "Custom tab title"
+            );
+        });
+    });
+}
+
+#[test]
 fn test_set_active_tab_name_clears_active_rename_editor_state() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);


### PR DESCRIPTION
## Description

Adds tab and pane identification actions to the pane header overflow menu:

- `Rename pane`
- `Rename tab`
- The existing tab color choices, including clearing the color

This reuses the existing tab rename/color behavior and keeps the existing pane header actions (`Share session`, `Maximize pane`) in place. The pane rename action carries the pane id from the opened header menu so split-pane layouts rename the intended pane, not whichever pane happens to be focused later.

During local GUI validation, the first implementation exposed a circular view reference when `Rename tab` was selected from the pane header menu. The final version avoids that by passing the pane title as a fallback from the terminal view and opening the workspace tab rename editor without re-reading the focused pane view title.

## Linked Issue

Closes #10580.

Related broader requests:

- #2743
- #6897
- #7002

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
  - #10580 was opened for this narrow pane-header menu improvement. This PR is draft again until maintainers confirm the issue scope and apply `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).
  - Manual GUI validation was completed locally. The available GitHub CLI/API workflow cannot directly upload binary screenshot or video attachments, so the visual evidence is recorded below with exact observed UI state.

## Testing

- [x] Added unit coverage for the pane header overflow menu action list.
- [x] `cargo fmt -- --check`
- [x] `git diff --check`
- [x] `cargo test -p warp pane_header_overflow_menu_includes_tab_identification_actions`
- [x] `cargo test -p warp test_rename_active_tab_with_fallback_title`
- [x] `cargo test -p warp test_set_active_tab`
- [x] `cargo test -p warp pane_name_actions_save_workspace_state`
- [x] `cargo clippy -p warp --all-targets --tests -- -D warnings`
- [x] `cargo build -p warp --bin warp-oss`
- [x] Manual local GUI validation with `target/debug/warp-oss`
  - Opened a split-pane layout.
  - Opened the pane header overflow menu.
  - Confirmed the menu shows `Rename pane`, `Rename tab`, the tab color row with clear-color control, `Share session`, and `Maximize pane`.
  - Confirmed selecting a tab color dispatches `WorkspaceAction::SetActiveTabColor`.
  - Re-tested `Rename tab` after `c1b7576a`; selecting it opens the tab rename flow and no longer crashes the `warp-oss` process.

- [ ] I have manually tested my changes locally with `./script/run`
  - Manual testing used the locally built `target/debug/warp-oss` binary instead. `./script/run --dont-open` rebuilt the binary, but the post-build bundler step still exits with the known `Term(ColorOutOfRange)` panic.

### Screenshots / Videos

Visual validation was performed with a locally captured screenshot of the pane header overflow menu. I cannot attach the PNG directly from this CLI/API-only environment, so the reproducible visual state is described here instead.

The local screenshot shows the menu opened from a split-pane layout and includes:

- `Rename pane`
- `Rename tab`
- The tab color row and clear-color control
- `Share session`
- `Maximize pane`

Local screenshot files captured during validation:

- `/private/tmp/warp-10577-pane-menu.png`
- `/private/tmp/warp-10577-pane-menu-focused.png`

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add pane header menu actions for renaming panes, renaming tabs, and setting tab color.
