### PR TITLE
spec(GH9908): resolve clickable filenames in listing-command output against listed directory

### DIFF
--- a/specs/GH9908/product.md
+++ b/specs/GH9908/product.md
@@ -1,0 +1,76 @@
+# Product Spec: Resolve clickable filenames in listing-command output against the listed directory
+
+**Issue:** [warpdotdev/warp#9908](https://github.com/warpdotdev/warp/issues/9908)
+
+## Summary
+
+When a user runs `ls DIR/` (or `eza DIR/`, `lsd DIR/`, etc.), the terminal output contains bare filenames relative to `DIR`, not to the block's working directory. Clicking these filenames currently resolves them against `pwd`, which silently opens wrong files (if a same-named file exists in `pwd`) or fails to resolve at all.
+
+This spec defines the behavior for resolving clickable filenames against the listed directory when the block's command is a recognized directory-listing command.
+
+## Problem
+
+Warp's file-link detection scans terminal output for path-like strings and resolves them against the block's `pwd`. This works for most commands, but breaks for listing commands with a directory argument:
+
+- `ls ~/projects/` outputs `README.md`, `src/`, etc. — these are relative to `~/projects/`, not `pwd`.
+- If `pwd` also contains a `README.md`, clicking opens the wrong file with no indication of the error.
+- If `pwd` does not contain the file, the link simply doesn't resolve — a false negative.
+
+This is the most common case of file-link misresolution because `ls DIR/` is one of the most frequent terminal commands.
+
+## Goals
+
+- Bare filenames in listing-command output resolve against the listed directory, not just `pwd`.
+- Existing resolution behavior is preserved for all non-listing commands.
+- The feature works with common aliases (`ll`, `la`, `l`) via Warp's existing alias resolution.
+- The set of recognized listing commands is extensible (future: user setting).
+
+## Non-goals
+
+- Recursive listing (`ls -R DIR/`) — output interleaves multiple subdirectory headers; per-section tracking is a separate feature.
+- Multi-operand listing (`ls DIR1/ DIR2/`) — output sections are not reliably separable without parsing column headers.
+- Piped output (`ls DIR/ | grep foo`) — Warp cannot determine which command produced the output in a pipeline.
+- `tree` output — blocked on box-drawing character tokenization (#9909).
+- Shell variable expansion in arguments (`ls $MYDIR`) — the terminal sees the expanded command string, so this works if the shell expands before execution; unexpanded variables are out of scope.
+
+## Behavior Invariants
+
+1. **Single directory operand:** When a listing command has exactly one positional argument that resolves to an existing directory, bare filenames in the output resolve against that directory first, then fall back to `pwd`.
+2. **No directory operand:** When a listing command has no positional arguments (e.g. bare `ls`), resolution uses `pwd` only (unchanged behavior).
+3. **Multiple positional arguments:** When a listing command has more than one positional argument, resolution uses `pwd` only (unchanged behavior — we cannot determine which section a filename belongs to).
+4. **`-d` / `--directory` flag:** When present, the listing command lists the directory entry itself, not its contents. Resolution uses `pwd` only (the output names the operand, not entries inside it).
+5. **Alias resolution:** Shell aliases are resolved via `Block::top_level_command`. If `ll` resolves to `ls`, the feature activates. Aliases with baked-in positional arguments (e.g. `alias lt='ls /tmp'`) are not expanded — only the alias-to-command mapping is used.
+6. **Fallback to pwd:** If a filename does not resolve against the listed directory, resolution falls back to `pwd`. This ensures no currently-working links are broken.
+7. **Non-listing commands:** Commands not in the recognized set are completely unaffected.
+8. **Recognized commands:** `ls`, `eza`, `exa`, `lsd` (configurable in future).
+9. **Flag-argument consumption:** Flags that take arguments (e.g. `--color=auto`, `-I PATTERN`) do not consume the directory operand. Argument classification uses the existing command-signatures infrastructure.
+10. **Env-var prefixes:** Leading `KEY=VALUE` assignments (e.g. `LANG=C ls DIR/`) are stripped before command identification (existing parser behavior).
+
+## Edge Cases
+
+| Input | Behavior |
+|---|---|
+| `ls` | No directory arg → pwd-only resolution (unchanged) |
+| `ls -la ~/projects/` | Single dir arg → resolve against `~/projects/` |
+| `ls file1.txt file2.txt` | Multiple positional args, none are dirs → pwd-only (unchanged) |
+| `ls ~/projects/ ~/other/` | Multiple dir args → pwd-only (cannot attribute output lines) |
+| `ls -d ~/projects/` | `-d` flag present → pwd-only (output names the operand itself) |
+| `ll ~/projects/` | `ll` resolves to `ls` via alias → feature activates |
+| `PAGER=cat ls ~/projects/` | Env prefix stripped → `ls` identified → feature activates |
+| `ls "path with spaces/"` | Quoted arg handled by parser → resolves correctly |
+| `ls $(echo dir)` | Subshell in arg → cannot statically resolve → pwd-only fallback |
+
+## Success Criteria
+
+1. `ls ~/projects/` → clicking `README.md` in output opens `~/projects/README.md`.
+2. `ls -la ~/projects/` → same behavior (flags don't interfere).
+3. `ll ~/projects/` (where `ll` is aliased to `ls -l`) → feature activates.
+4. `ls` (no args) → behavior unchanged from today.
+5. `ls -d ~/projects/` → clicking `projects` resolves against `pwd` (not `~/projects/`).
+6. `ls ~/a/ ~/b/` → behavior unchanged (multi-dir fallback to pwd).
+7. No regression: commands that are not listing commands behave exactly as before.
+
+## Open Questions
+
+1. **Should this be a user-configurable setting?** zachlloyd suggested making the command list configurable. Recommendation: ship with a hardcoded list first, add a setting if there's demand.
+2. **Should multi-operand be attempted?** If both args are dirs, we could try each. Risk: false positives if dirs share filenames. Recommendation: defer to follow-up.

--- a/specs/GH9908/tech.md
+++ b/specs/GH9908/tech.md
@@ -1,0 +1,172 @@
+# Tech Spec: Resolve clickable filenames in listing-command output against the listed directory
+
+**Issue:** [warpdotdev/warp#9908](https://github.com/warpdotdev/warp/issues/9908)
+
+## Context
+
+### Current system
+
+File-link detection lives in `app/src/terminal/view/link_detection.rs`. The `scan_for_file_path` method:
+
+1. Extracts the block's `pwd`, `command_to_string()`, and `top_level_command(sessions)` (lines 463–477).
+2. Calls `possible_file_paths_at_point` to get candidate path strings from the terminal grid.
+3. Resolves each candidate against `pwd` using `std::fs::metadata` on a background thread.
+
+`Block::top_level_command` delegates to `warp_completer::parsers::simple::top_level_command`, which strips env-var prefixes and returns the first literal token. It also resolves shell aliases via the session's alias table.
+
+### Existing parser infrastructure
+
+- **`warp_completer::parsers::simple::top_level_command`** — Extracts the command name from a command string, stripping env-var prefixes and handling quoting/subshells.
+- **`warp_completer::parsers::classify_command`** — Full argument classification using `CommandRegistry`. Separates env vars, flags (with their consumed arguments), and positional arguments. Handles `--flag=value` syntax, short flag stacking, and variadic flag arguments.
+- **`CommandRegistry`** — Loaded from the [command-signatures](https://github.com/warpdotdev/command-signatures) repository. Contains typed signatures for common commands including `ls` (with options like `-a`, `--color`, `-d` and a variadic `filepaths` positional argument).
+- **`warp_completer::parsers::simple::parse_for_completions`** — Produces a `LiteCommand` from a string, handling the lexer/parser pipeline.
+
+### Relevant files
+
+| File | Role |
+|---|---|
+| `app/src/terminal/view/link_detection.rs:445–510` | `scan_for_file_path` — entry point for file-link resolution |
+| `crates/warp_completer/src/parsers/simple/mod.rs:44` | `top_level_command` — command name extraction |
+| `crates/warp_completer/src/parsers/mod.rs:117` | `classify_command` — full arg classification |
+| `crates/warp_completer/src/signatures/` | `CommandRegistry` and signature loading |
+| `crates/warp_util/src/listing_command.rs` | Current PR's custom parser (to be replaced) |
+
+## Proposed Changes
+
+### Architecture
+
+Replace the custom `shlex`-based parser in `listing_command.rs` with a thin adapter over `classify_command` + `CommandRegistry`. The adapter:
+
+1. Receives the block's command string and resolved alias name.
+2. Uses `parse_for_completions` to produce a `LiteCommand`.
+3. Calls `classify_command` with the `CommandRegistry` to get a `ClassifiedCommand`.
+4. Inspects the classified result: extracts positional arguments and checks for the `-d`/`--directory` flag.
+5. Returns `Option<PathBuf>` — the single directory argument if conditions are met.
+
+### Module: `crates/warp_completer/src/listing_dir.rs` (new)
+
+```rust
+/// Given a classified command, determines if it is a single-directory listing
+/// command and returns the directory path to resolve filenames against.
+pub fn listing_directory_from_classified(
+    command_str: &str,
+    resolved_command_name: Option<&str>,
+    pwd: &Path,
+    command_registry: &CommandRegistry,
+    listing_commands: &[&str],
+) -> Option<PathBuf>
+```
+
+**Logic:**
+
+1. Parse `command_str` via `simple::parse_for_completions` → `LiteCommand`.
+2. Tokenize into `Vec<&str>` for `classify_command`.
+3. Call `classify_command(lite_command, &mut tokens, command_registry, case_sensitivity)`.
+4. Check if the resolved command name (or first token) is in `listing_commands`.
+5. If classified: inspect `command.flags` for `-d`/`--directory` → if present, return `None`.
+6. Extract positional arguments from `ClassifiedCommand`.
+7. If exactly one positional: resolve it against `pwd`, check `is_dir()` → return `Some(resolved_path)`.
+8. Otherwise (zero or multiple positionals): return `None`.
+
+### Wire-up: `app/src/terminal/view/link_detection.rs`
+
+Replace the current call to `listing_command_argument_dir` (from `warp_util`) with a call to `listing_directory_from_classified` (from `warp_completer`). The `CommandRegistry` is already available in the app context (used by the completion engine).
+
+### Changes to `crates/warp_util/`
+
+Remove `listing_command.rs` and `listing_command_test.rs` — the custom parser is no longer needed. The `shlex` dependency can also be removed from `warp_util/Cargo.toml`.
+
+### Data flow
+
+```
+Block command string + alias resolution
+    ↓
+parse_for_completions (simple parser)
+    ↓
+LiteCommand
+    ↓
+classify_command (with CommandRegistry)
+    ↓
+ClassifiedCommand { env_vars, command, error }
+    ↓
+Check: is listing command? has -d? exactly 1 positional dir?
+    ↓
+Option<PathBuf> (the directory to resolve against)
+```
+
+### Handling lucieleblanc's concerns
+
+| Concern | Resolution |
+|---|---|
+| Multi-arg exclusion drops currently-resolved entries | Invariant 3 + Invariant 6: multi-arg falls back to pwd-only, which is today's behavior. No regression. |
+| `-d` exclusion unclear | Invariant 4: `ls -d DIR` lists the directory entry itself (name, permissions), not its contents. Output is the operand name, not children. Resolving against `DIR` would be incorrect. |
+| Aliases with positional args | Invariant 5: We use `Block::top_level_command` for alias→command mapping only. Baked-in positional args in aliases are not expanded (would require shell-level alias expansion, which Warp doesn't do). The resolved command name triggers the feature; the positional arg comes from the actual command string. |
+| Reuse existing parsers | This spec replaces the custom `shlex` parser with `classify_command` + `CommandRegistry`. Full reuse of existing infrastructure. |
+| Leverage command-signatures | `classify_command` uses the `ls` signature from command-signatures to properly separate `-d`, `--color=auto`, `-I PATTERN` (flag args) from the directory positional. |
+
+### Types
+
+No new public types. The function signature is:
+
+```rust
+pub fn listing_directory_from_classified(
+    command_str: &str,
+    resolved_command_name: Option<&str>,
+    pwd: &Path,
+    command_registry: &CommandRegistry,
+    listing_commands: &[&str],
+) -> Option<PathBuf>
+```
+
+### Tradeoffs
+
+- **Pro:** Full reuse of battle-tested parser infrastructure. Correct handling of quoting, subshells, env-var prefixes, and flag-argument consumption.
+- **Pro:** Access to command-signatures means we correctly handle flags like `--color=auto` (which takes an argument) vs `-l` (which doesn't).
+- **Con:** Requires `CommandRegistry` access at the call site. The registry is already loaded for completions, so this is available but adds a dependency from link-detection to the completer crate.
+- **Con:** Commands not in the registry fall back to unclassified parsing (positionals only, no flag-arg consumption). For `ls`/`eza`/`lsd` this is fine — they're all in the registry.
+
+## Testing and Validation
+
+### Unit tests (in `crates/warp_completer/src/listing_dir.rs`)
+
+| Test | Invariant |
+|---|---|
+| `ls DIR/` with existing dir → returns `Some(DIR)` | 1 |
+| `ls` (no args) → returns `None` | 2 |
+| `ls DIR1/ DIR2/` → returns `None` | 3 |
+| `ls -d DIR/` → returns `None` | 4 |
+| `ls --directory DIR/` → returns `None` | 4 |
+| `ls -la DIR/` → returns `Some(DIR)` | 1, 9 |
+| `ls --color=auto DIR/` → returns `Some(DIR)` | 9 |
+| `LANG=C ls DIR/` → returns `Some(DIR)` | 10 |
+| `ls "path with spaces/"` → returns `Some(path with spaces)` | 1 |
+| `ls $(echo dir)` → returns `None` (subshell) | edge case |
+| Resolved alias `ll` → `ls`: `ll DIR/` → returns `Some(DIR)` | 5 |
+| `ls nonexistent/` → returns `None` (not a dir) | 1 |
+| `ls file.txt` → returns `None` (not a dir) | 1 |
+
+### Integration test (in `app/src/terminal/view/`)
+
+- Verify that `scan_for_file_path` resolves a filename from `ls DIR/` output against `DIR`, not `pwd`.
+
+### Manual validation
+
+1. `ls ~/some-project/` → hover over a filename → tooltip shows path under `~/some-project/`.
+2. Click → opens the correct file.
+3. `ls` (no args) → behavior unchanged.
+4. `ll ~/some-project/` → same as (1) if `ll` is aliased to `ls`.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `CommandRegistry` not available at link-detection call site | Registry is already loaded for completions; thread through from app context. |
+| Performance: `classify_command` on every hover | Called once per block (cached by block index), not per hover pixel. Same cost as current `top_level_command` call. |
+| Unclassified commands (not in registry) | Fall back to `None` — same as today's behavior. No regression. |
+
+## Follow-ups
+
+- User-configurable listing command list (setting).
+- Multi-operand heuristic (try each dir, accept if unambiguous).
+- `ls -R` recursive listing with per-section directory headers.
+- `tree` support (blocked on #9909 / #10004).


### PR DESCRIPTION
## Summary

Spec for #9908 — resolving clickable filenames in listing-command output (`ls DIR/`, `eza DIR/`, etc.) against the listed directory instead of the block's pwd.

This addresses the review feedback on #9974 from @lucieleblanc requesting a spec PR before code, and specifically:

- **Reuses existing parser infrastructure** (`warp_completer::parsers::classify_command` + `CommandRegistry`) instead of introducing a parallel custom parser
- **Leverages command-signatures** for proper flag-argument classification (e.g. `--color=auto` doesn't consume the directory positional, `-d` is properly detected)
- **Addresses product concerns:** multi-arg exclusion (falls back to pwd — no regression), `-d` handling (lists the entry itself, not contents), alias resolution (uses existing `Block::top_level_command`)

## Scope

This is the **V1 spec** covering the single-directory-operand case, which is the majority use case. A V2 follow-up (multi-directory + recursive with section-header parsing from output) is planned but not included here.

## What's in the spec

- `specs/GH9908/product.md` — 10 testable behavior invariants, edge cases, success criteria
- `specs/GH9908/tech.md` — implementation plan grounded in existing codebase with file references, proposed module, data flow, testing plan

## Related

- Issue: #9908
- Current code PR: #9974 (will be superseded by implementation based on this spec)
- zachlloyd comment on product direction: https://github.com/warpdotdev/warp/issues/9908#issuecomment-4362487383