### PR TITLE
spec(GH9908): resolve clickable filenames in listing-command output against listed directory

### DIFF
--- a/specs/GH9908/product-v2.md
+++ b/specs/GH9908/product-v2.md
@@ -1,0 +1,75 @@
+# Product Spec: Section-aware file-link resolution for multi-directory and recursive listings
+
+**Issue:** [warpdotdev/warp#9908](https://github.com/warpdotdev/warp/issues/9908) (follow-up to V1 spec)
+**Depends on:** V1 spec (single-directory listing resolution)
+
+## Summary
+
+V1 resolves clickable filenames against a single listed directory. V2 extends this to multi-directory (`ls DIR1/ DIR2/`) and recursive (`ls -R DIR/`) listings by parsing section headers from the command output to determine which directory each filename belongs to.
+
+## Problem
+
+After V1 ships, two common listing patterns still fall back to pwd-only resolution:
+
+1. **Multi-directory:** `ls ~/projects/ ~/downloads/` outputs files from both directories, separated by `dirname:` headers.
+2. **Recursive:** `ls -R ~/projects/` outputs files from the root and all subdirectories, each preceded by a `./subdir:` header.
+
+Both produce structured output with clear section boundaries. Users expect clicking any filename to open the correct file regardless of which section it appears in.
+
+## Goals
+
+- Filenames in multi-directory and recursive listing output resolve against their section's directory.
+- Section detection uses the standard `ls` header format (`path:` on its own line, followed by entries).
+- V1's single-directory behavior is preserved as a fast path (no output scanning needed).
+- Performance: output scanning is bounded and lazy (scan backward from hovered line only).
+
+## Non-goals
+
+- Custom/non-standard output formats (e.g. `ls --format=commas` where entries aren't one-per-line).
+- `tree` output (different header format, blocked on #9909/#10004).
+- Piped output (`ls -R | grep foo`) — cannot attribute lines to the listing command.
+
+## Behavior Invariants
+
+1. **Section header detection:** A line matching the pattern `<path>:` (path followed by colon, with no other content after ANSI stripping) immediately preceding one or more filename lines is treated as a section header.
+2. **Multi-directory resolution:** For `ls DIR1/ DIR2/`, each section's filenames resolve against that section's header path (joined with the block's pwd if relative).
+3. **Recursive resolution:** For `ls -R DIR/`, section headers like `./subdir:` resolve relative to the listing root (the directory argument from the command). Filenames resolve against the fully-resolved section path.
+4. **Backward scan:** When the user hovers a filename, the system scans backward from that line to find the nearest section header. If no header is found, resolution falls back to V1 behavior (single-dir or pwd).
+5. **Empty line separator:** `ls` separates sections with a blank line before the header. The scanner treats blank lines as potential section boundaries but does not require them.
+6. **V1 fast path preserved:** If the command has exactly one positional directory arg and no `-R` flag, V1's direct resolution is used (no output scanning).
+7. **Ambiguous headers:** If a line looks like a section header but the path doesn't resolve to a directory, it's not treated as a header (fall through to V1/pwd resolution).
+8. **Relative headers:** Resolution base depends on the listing mode:
+   - **Recursive (`ls -R DIR/`):** Headers like `./src:` or `subdir:` resolve relative to the listing root (the `-R` directory argument). If no directory argument, resolve relative to pwd.
+   - **Multi-directory (`ls DIR1/ DIR2/`):** Headers like `DIR2/:` or `~/b/:` are already rooted paths as printed by `ls`. Resolve against pwd directly (they contain the full relative or absolute path).
+9. **No regression:** If section parsing fails or produces no match, the system falls back to V1 -> pwd, in that order. No currently-working links break.
+10. **Scope gate:** Section-aware resolution only activates when the command is a recognized listing command AND has either multiple directory positionals OR the `-R`/`--recursive` flag.
+
+## Edge Cases
+
+| Input | Behavior |
+|---|---|
+| `ls -R ~/projects/` with `./src:` header | Filenames under `./src:` resolve against `~/projects/src/` |
+| `ls -R` (no dir arg, recursive from pwd) | Headers like `./src:` resolve against pwd |
+| `ls ~/a/ ~/b/` where both contain `README.md` | Each `README.md` resolves against its own section's directory |
+| `ls -R ~/projects/` with deeply nested `./a/b/c:` | Resolves against `~/projects/a/b/c/` |
+| Header-like line in file content (e.g. `config:`) | Ambiguity check: `config` is not a directory -> not treated as header -> falls back |
+| `ls --color=auto -R DIR/` | ANSI codes stripped before header matching |
+| Very long output (10000+ lines) | Backward scan bounded (max 500 lines back) to avoid perf issues |
+
+## Success Criteria
+
+1. `ls -R ~/projects/` -> clicking `main.rs` under `./src:` header opens `~/projects/src/main.rs`.
+2. `ls ~/a/ ~/b/` -> clicking `file.txt` under `~/b/:` header opens `~/b/file.txt`.
+3. `ls -R` (no arg) -> clicking `helper.rs` under `./utils:` opens `$PWD/utils/helper.rs`.
+4. V1 single-dir case still works without output scanning (fast path).
+5. No performance regression on hover for non-listing commands.
+6. Fallback chain: section-dir -> V1-dir -> pwd. No broken links.
+
+## Resolved Questions
+
+1. **`eza`/`lsd` header format:** Confirmed — all three tools (`ls`, `eza -R`, `lsd -R`) use the same `path:` section header format for recursive and multi-directory output. No regex variants needed. `eza -T`/`--tree` uses tree-drawing characters (different format, out of scope — blocked on #9909/#10004).
+
+## Open Questions
+
+1. **Scan depth limit:** How far back should we scan for a header? 500 lines? Configurable? Recommendation: 500 lines, hardcoded initially.
+2. **Should V2 ship with V1 or as a follow-up PR?** Recommendation: follow-up PR. V1 establishes infrastructure, V2 adds output parsing on top.

--- a/specs/GH9908/product.md
+++ b/specs/GH9908/product.md
@@ -1,0 +1,76 @@
+# Product Spec: Resolve clickable filenames in listing-command output against the listed directory
+
+**Issue:** [warpdotdev/warp#9908](https://github.com/warpdotdev/warp/issues/9908)
+
+## Summary
+
+When a user runs `ls DIR/` (or `eza DIR/`, `lsd DIR/`, etc.), the terminal output contains bare filenames relative to `DIR`, not to the block's working directory. Clicking these filenames currently resolves them against `pwd`, which silently opens wrong files (if a same-named file exists in `pwd`) or fails to resolve at all.
+
+This spec defines the behavior for resolving clickable filenames against the listed directory when the block's command is a recognized directory-listing command.
+
+## Problem
+
+Warp's file-link detection scans terminal output for path-like strings and resolves them against the block's `pwd`. This works for most commands, but breaks for listing commands with a directory argument:
+
+- `ls ~/projects/` outputs `README.md`, `src/`, etc. — these are relative to `~/projects/`, not `pwd`.
+- If `pwd` also contains a `README.md`, clicking opens the wrong file with no indication of the error.
+- If `pwd` does not contain the file, the link simply doesn't resolve — a false negative.
+
+This is the most common case of file-link misresolution because `ls DIR/` is one of the most frequent terminal commands.
+
+## Goals
+
+- Bare filenames in listing-command output resolve against the listed directory, not just `pwd`.
+- Existing resolution behavior is preserved for all non-listing commands.
+- The feature works with common aliases (`ll`, `la`, `l`) via Warp's existing alias resolution.
+- The set of recognized listing commands is extensible (future: user setting).
+
+## Non-goals
+
+- Recursive listing (`ls -R DIR/`) — output interleaves multiple subdirectory headers; per-section tracking is a separate feature.
+- Multi-operand listing (`ls DIR1/ DIR2/`) — output sections are not reliably separable without parsing column headers.
+- Piped output (`ls DIR/ | grep foo`) — Warp cannot determine which command produced the output in a pipeline.
+- `tree` output — blocked on box-drawing character tokenization (#9909).
+- Shell variable expansion in arguments (`ls $MYDIR`) — the terminal sees the expanded command string, so this works if the shell expands before execution; unexpanded variables are out of scope.
+
+## Behavior Invariants
+
+1. **Single directory operand:** When a listing command has exactly one positional argument that resolves to an existing directory, bare filenames in the output resolve against that directory first, then fall back to `pwd`.
+2. **No directory operand:** When a listing command has no positional arguments (e.g. bare `ls`), resolution uses `pwd` only (unchanged behavior).
+3. **Multiple positional arguments:** When a listing command has more than one positional argument, resolution uses `pwd` only (unchanged behavior — we cannot determine which section a filename belongs to).
+4. **`-d` / `--directory` flag:** When present, the listing command lists the directory entry itself, not its contents. Resolution uses `pwd` only (the output names the operand, not entries inside it).
+5. **Alias resolution:** Shell aliases are resolved via `Block::top_level_command`. If `ll` resolves to `ls`, the feature activates. Aliases with baked-in positional arguments (e.g. `alias lt='ls /tmp'`) are not expanded — only the alias-to-command mapping is used.
+6. **Fallback to pwd:** If a filename does not resolve against the listed directory, resolution falls back to `pwd`. This ensures no currently-working links are broken.
+7. **Non-listing commands:** Commands not in the recognized set are completely unaffected.
+8. **Recognized commands:** `ls`, `eza`, `exa`, `lsd` (configurable in future).
+9. **Flag-argument consumption:** Flags that take arguments (e.g. `--color=auto`, `-I PATTERN`) do not consume the directory operand. Argument classification uses the existing command-signatures infrastructure.
+10. **Env-var prefixes:** Leading `KEY=VALUE` assignments (e.g. `LANG=C ls DIR/`) are stripped before command identification (existing parser behavior).
+
+## Edge Cases
+
+| Input | Behavior |
+|---|---|
+| `ls` | No directory arg → pwd-only resolution (unchanged) |
+| `ls -la ~/projects/` | Single dir arg → resolve against `~/projects/` |
+| `ls file1.txt file2.txt` | Multiple positional args, none are dirs → pwd-only (unchanged) |
+| `ls ~/projects/ ~/other/` | Multiple dir args → pwd-only (cannot attribute output lines) |
+| `ls -d ~/projects/` | `-d` flag present → pwd-only (output names the operand itself) |
+| `ll ~/projects/` | `ll` resolves to `ls` via alias → feature activates |
+| `PAGER=cat ls ~/projects/` | Env prefix stripped → `ls` identified → feature activates |
+| `ls "path with spaces/"` | Quoted arg handled by parser → resolves correctly |
+| `ls $(echo dir)` | Subshell in arg → cannot statically resolve → pwd-only fallback |
+
+## Success Criteria
+
+1. `ls ~/projects/` → clicking `README.md` in output opens `~/projects/README.md`.
+2. `ls -la ~/projects/` → same behavior (flags don't interfere).
+3. `ll ~/projects/` (where `ll` is aliased to `ls -l`) → feature activates.
+4. `ls` (no args) → behavior unchanged from today.
+5. `ls -d ~/projects/` → clicking `projects` resolves against `pwd` (not `~/projects/`).
+6. `ls ~/a/ ~/b/` → behavior unchanged (multi-dir fallback to pwd).
+7. No regression: commands that are not listing commands behave exactly as before.
+
+## Open Questions
+
+1. **Should this be a user-configurable setting?** zachlloyd suggested making the command list configurable. Recommendation: ship with a hardcoded list first, add a setting if there's demand.
+2. **Should multi-operand be attempted?** If both args are dirs, we could try each. Risk: false positives if dirs share filenames. Recommendation: defer to follow-up.

--- a/specs/GH9908/tech-v2.md
+++ b/specs/GH9908/tech-v2.md
@@ -1,0 +1,227 @@
+# Tech Spec: Section-aware file-link resolution for multi-directory and recursive listings
+
+**Issue:** [warpdotdev/warp#9908](https://github.com/warpdotdev/warp/issues/9908) (follow-up to V1 spec)
+**Depends on:** V1 tech spec (classify_command + CommandRegistry integration)
+
+## Context
+
+### Current system (after V1)
+
+V1 introduces `listing_directory_from_classified` in `crates/warp_completer/src/listing_dir.rs`. It uses `classify_command` + `CommandRegistry` to extract the single directory positional from a listing command. When the command has multiple positional directories or the `-R`/`--recursive` flag, V1 returns `None` and resolution falls back to pwd.
+
+V2 adds output-aware resolution for these cases by scanning the block's terminal grid for section headers.
+
+### Relevant files
+
+| File | Role |
+|---|---|
+| `app/src/terminal/view/link_detection.rs:445-510` | `scan_for_file_path` — entry point, calls V1's listing_directory_from_classified |
+| `app/src/terminal/model/grid/grid_handler.rs:848` | `line_to_string` — extracts text content from any grid row |
+| `app/src/terminal/model/grid/grid_handler.rs:1097` | `possible_file_paths_at_point` — provides hovered row context |
+| `crates/warp_completer/src/listing_dir.rs` | V1's command classification (new in V1) |
+
+### ls output format
+
+Multi-directory (`ls ~/a/ ~/b/`):
+```
+~/a/:
+file1.txt
+file2.txt
+
+~/b/:
+fileA.txt
+fileB.txt
+```
+
+Recursive (`ls -R ~/projects/`):
+```
+~/projects/:
+README.md
+src
+
+~/projects/src:
+main.rs
+lib.rs
+
+~/projects/src/utils:
+helpers.rs
+```
+
+Header format: `<path>:` on its own line (possibly with ANSI color codes), followed by entries, separated by blank lines between sections.
+
+## Proposed Changes
+
+### New module: `app/src/terminal/view/listing_section_scanner.rs`
+
+```rust
+use std::path::{Path, PathBuf};
+
+/// Scans backward from `hovered_row` in the block's output grid to find the
+/// nearest section header (`path:` line). Returns the resolved directory path
+/// if a valid header is found.
+///
+/// `listing_root` is the primary directory argument from the command (if any),
+/// used to resolve relative headers like `./src:`. If None, relative headers
+/// resolve against `pwd`.
+pub fn resolve_via_section_header(
+    grid: &GridHandler,
+    hovered_row: usize,
+    listing_root: Option<&Path>,
+    pwd: &Path,
+    max_scan_depth: usize,
+) -> Option<PathBuf>
+```
+
+**Logic:**
+
+1. Starting at `hovered_row - 1`, scan backward up to `max_scan_depth` rows.
+2. For each row, call `grid.row_text(row)` to get the plain text content.
+   - **Note:** `GridHandler::line_to_string` is currently `pub(super)` (private to the grid module). A new public accessor is needed:
+   ```rust
+   /// Returns the plain text content of a single row.
+   pub fn row_text(&self, row: usize) -> Option<String> {
+       self.line_to_string(row, 0..self.columns(), false, false, RespectObfuscatedSecrets::No, false)
+   }
+   ```
+   This is minimal API surface and generally useful beyond this feature.
+3. Strip ANSI escape sequences from the line.
+4. Trim whitespace. If the line matches `^(.+):$` (non-empty path followed by colon, nothing else):
+   a. Extract the path portion (everything before the trailing colon).
+   b. Resolve the path — avoiding double-prefix:
+      - If absolute or starts with `~/`: expand directly.
+      - If starts with `./`: strip the `./` prefix, then join with `listing_root` (or `pwd` if no listing root). This handles `ls -R ./src` which emits `./src:`, `./src/utils:` headers.
+      - Otherwise (bare relative like `src` or `src/subdir`): resolve against `pwd` directly. This handles `ls -R src` which emits `src:`, `src/subdir:` headers — these are already pwd-relative and must NOT be joined with listing_root (that would produce `src/src/...`).
+   c. Check `resolved_path.is_dir()`. If true, return `Some(resolved_path)`.
+   d. If not a directory, continue scanning (it's not a real header).
+5. If scan exhausts `max_scan_depth` or reaches row 0 with no valid header, return `None`.
+
+### Wire-up in `link_detection.rs`
+
+In `scan_for_file_path`, after the V1 call:
+
+```rust
+let listing_dir = pwd.as_deref().and_then(|pwd_str| {
+    listing_directory_from_classified(/* V1 args */)
+});
+
+// V2: if V1 returned None and command is a multi-dir or recursive listing,
+// try section-header scanning.
+//
+// listing_root semantics differ by case:
+// - Recursive (ls -R DIR/): headers like ./src: are relative to DIR.
+//   Pass DIR as listing_root.
+// - Multi-directory (ls DIR1/ DIR2/): headers like DIR2/: are already
+//   rooted paths (relative to pwd or absolute). Pass None — resolve
+//   all headers against pwd directly.
+let effective_dir = listing_dir.or_else(|| {
+    if is_multi_dir_or_recursive_listing(&classified_command) {
+        let listing_root = if is_recursive(&classified_command) {
+            first_dir_positional.as_deref() // ./subdir: resolves relative to this
+        } else {
+            None // multi-dir headers are already rooted paths
+        };
+        resolve_via_section_header(
+            &grid_handler,
+            hovered_point.row,
+            listing_root,
+            Path::new(pwd_str),
+            500, // max scan depth
+        )
+    } else {
+        None
+    }
+});
+```
+
+### Helper: ANSI stripping
+
+Use the existing `strip_ansi_escapes` crate (already a dependency in the workspace) or a simple regex `\x1b\[[0-9;]*m` to strip color codes before header matching.
+
+### Constants
+
+```rust
+const MAX_SECTION_SCAN_DEPTH: usize = 500;
+const SECTION_HEADER_REGEX: &str = r"^(.+):$";
+```
+
+## Data Flow
+
+```
+Hover event on filename in block output
+  |
+  v
+V1: classify_command -> single dir? -> resolve against it (fast path)
+  |
+  | (V1 returns None: multi-dir or -R case)
+  v
+V2: is_multi_dir_or_recursive?
+  |
+  | yes
+  v
+Scan backward from hovered_row in grid
+  |
+  v
+Find line matching `path:` pattern
+  |
+  v
+Strip ANSI, extract path, resolve (relative to listing_root or pwd)
+  |
+  v
+is_dir()? -> return Some(resolved_dir)
+  |
+  | (no valid header found)
+  v
+Fall back to pwd (existing behavior)
+```
+
+## Resolution Priority (complete V1+V2 system)
+
+```
+1. Section header directory (V2 — multi-dir/recursive only, output scanning)
+2. Single listing directory (V1 — single-dir fast path, command parsing only)
+3. Block pwd (existing behavior — all other commands)
+```
+
+## Testing and Validation
+
+### Unit tests (in `app/src/terminal/view/listing_section_scanner.rs`)
+
+| Test | Invariant |
+|---|---|
+| Grid with `./src:` header + listing_root=project -> resolves to project/src | 1, 3 |
+| Grid with `src:` header from `ls -R src` -> resolves against pwd (not listing_root) | double-prefix prevention |
+| Grid with `src/subdir:` header from `ls -R src` -> resolves against pwd as pwd/src/subdir | double-prefix prevention |
+| Grid with `./src/utils:` header + listing_root -> strips ./ and joins with listing_root | 3 |
+| Grid with no header lines -> returns None | 4 |
+| Grid with `~/absolute/path:` header -> resolves absolutely | 8 |
+| Grid with `config:` where config is not a dir -> skips, returns None | 7 |
+| Grid with ANSI-colored header `\x1b[1m./src:\x1b[0m` -> strips and matches | edge |
+| Scan stops at max_scan_depth -> returns None | perf |
+| Multiple headers: returns nearest one above hovered row | 4 |
+| Blank line between sections doesn't break scanning | 5 |
+
+### Integration tests
+
+- Create a mock block with multi-section ls output, verify hover on different sections resolves to different directories.
+- Verify V1 fast path still works (single-dir, no output scanning triggered).
+
+### Manual validation
+
+1. `ls -R ~/some-project/` -> hover filenames in different sections -> each resolves correctly.
+2. `ls ~/dir1/ ~/dir2/` -> hover in each section -> correct resolution.
+3. `ls ~/single-dir/` -> still uses V1 fast path (no output scanning).
+4. Non-listing command -> completely unaffected.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Performance: scanning 500 rows on every hover | Only triggered for multi-dir/recursive listings (scope gate). Single-dir and non-listing commands skip entirely. Could cache result per (block_id, hovered_row). |
+| False positive headers | `is_dir()` check eliminates most. Lines like `error:` or `warning:` won't match because those paths don't exist as directories. |
+| Grid row access during model lock | `line_to_string` is already called in the same code path for `possible_file_paths_at_point`. No new locking concerns. |
+
+## Follow-ups
+
+- Cache section header lookups per block (avoid re-scanning on adjacent row hovers).
+- User-configurable scan depth.
+- `tree` output support (different header format: indented with box-drawing chars, blocked on #10004).

--- a/specs/GH9908/tech.md
+++ b/specs/GH9908/tech.md
@@ -1,0 +1,178 @@
+# Tech Spec: Resolve clickable filenames in listing-command output against the listed directory
+
+**Issue:** [warpdotdev/warp#9908](https://github.com/warpdotdev/warp/issues/9908)
+
+## Context
+
+### Current system
+
+File-link detection lives in `app/src/terminal/view/link_detection.rs`. The `scan_for_file_path` method:
+
+1. Extracts the block's `pwd`, `command_to_string()`, and `top_level_command(sessions)` (lines 463–477).
+2. Calls `possible_file_paths_at_point` to get candidate path strings from the terminal grid.
+3. Resolves each candidate against `pwd` using `std::fs::metadata` on a background thread.
+
+`Block::top_level_command` delegates to `warp_completer::parsers::simple::top_level_command`, which strips env-var prefixes and returns the first literal token. It also resolves shell aliases via the session's alias table.
+
+### Existing parser infrastructure
+
+- **`warp_completer::parsers::simple::top_level_command`** — Extracts the command name from a command string, stripping env-var prefixes and handling quoting/subshells.
+- **`warp_completer::parsers::classify_command`** — Full argument classification using `CommandRegistry`. Separates env vars, flags (with their consumed arguments), and positional arguments. Handles `--flag=value` syntax, short flag stacking, and variadic flag arguments.
+- **`CommandRegistry`** — Loaded from the [command-signatures](https://github.com/warpdotdev/command-signatures) repository. Contains typed signatures for common commands including `ls` (with options like `-a`, `--color`, `-d` and a variadic `filepaths` positional argument).
+- **`warp_completer::parsers::simple::parse_for_completions`** — Produces a `LiteCommand` from a string, handling the lexer/parser pipeline.
+
+### Relevant files
+
+| File | Role |
+|---|---|
+| `app/src/terminal/view/link_detection.rs:445–510` | `scan_for_file_path` — entry point for file-link resolution |
+| `crates/warp_completer/src/parsers/simple/mod.rs:44` | `top_level_command` — command name extraction |
+| `crates/warp_completer/src/parsers/mod.rs:117` | `classify_command` — full arg classification |
+| `crates/warp_completer/src/signatures/` | `CommandRegistry` and signature loading |
+| `crates/warp_util/src/listing_command.rs` | Current PR's custom parser (to be replaced) |
+
+## Proposed Changes
+
+### Architecture
+
+Replace the custom `shlex`-based parser in `listing_command.rs` with a thin adapter over `classify_command` + `CommandRegistry`. The adapter:
+
+1. Receives the block's command string and resolved alias name.
+2. Uses `parse_for_completions` to produce a `LiteCommand`.
+3. Calls `classify_command` with the `CommandRegistry` to get a `ClassifiedCommand`.
+4. Inspects the classified result: extracts positional arguments and checks for the `-d`/`--directory` flag.
+5. Returns `Option<PathBuf>` — the single directory argument if conditions are met.
+
+### Module: `crates/warp_completer/src/listing_dir.rs` (new)
+
+```rust
+/// Given a classified command, determines if it is a single-directory listing
+/// command and returns the directory path to resolve filenames against.
+pub fn listing_directory_from_classified(
+    command_str: &str,
+    resolved_command_name: Option<&str>,
+    pwd: &Path,
+    command_registry: &CommandRegistry,
+    listing_commands: &[&str],
+) -> Option<PathBuf>
+```
+
+**Logic:**
+
+1. Parse `command_str` via `simple::parse_for_completions` → `LiteCommand`.
+1b. **Pipeline rejection:** Use `decompose_command(command_str, escape_char)` to check if the command contains a pipeline. If more than one top-level command is present, return `None`. This prevents `ls DIR/ | grep foo` from misclassifying `grep`'s arguments — `parse_for_completions` returns the last unclosed command, which would be `grep`, not `ls`.
+2. Tokenize into `Vec<&str>` for `classify_command`.
+3. Call `classify_command(lite_command, &mut tokens, command_registry, case_sensitivity)`.
+4. Check if the resolved command name (or first token) is in `listing_commands`.
+5. If the command was classified (signature found in registry): inspect `command.flags` for `-d`/`--directory` → if present, return `None`.
+6. Extract positional arguments from `ClassifiedCommand`.
+7. If exactly one positional: resolve it against `pwd`, check `is_dir()` → return `Some(resolved_path)`.
+8. Otherwise (zero or multiple positionals): return `None`.
+
+**Alias handling note:** `classify_command` looks up signatures by the literal first token. If the user typed `ll` (aliased to `ls`), the registry won't have a signature for `ll`, so the command is returned as unclassified. In this case:
+- The feature still activates (step 4 uses `resolved_command_name` from `Block::top_level_command`).
+- Flag-argument classification is best-effort: without a signature, all non-flag-looking tokens are treated as positionals. This means `ll --color=auto DIR/` works (flag with `=` is self-contained), but `ll -I PATTERN DIR/` may miscount positionals (the `-I` argument `PATTERN` looks like a positional).
+- This is acceptable for V1. If reviewers require full alias support, the enhancement is to substitute the resolved command name into the first token of the `LiteCommand` before calling `classify_command`, giving it access to the `ls` signature.
+
+### Wire-up: `app/src/terminal/view/link_detection.rs`
+
+Replace the current call to `listing_command_argument_dir` (from `warp_util`) with a call to `listing_directory_from_classified` (from `warp_completer`). The `CommandRegistry` is already available in the app context (used by the completion engine).
+
+### Changes to `crates/warp_util/`
+
+Remove `listing_command.rs` and `listing_command_test.rs` — the custom parser is no longer needed. The `shlex` dependency can also be removed from `warp_util/Cargo.toml`.
+
+### Data flow
+
+```
+Block command string + alias resolution
+    ↓
+parse_for_completions (simple parser)
+    ↓
+LiteCommand
+    ↓
+classify_command (with CommandRegistry)
+    ↓
+ClassifiedCommand { env_vars, command, error }
+    ↓
+Check: is listing command? has -d? exactly 1 positional dir?
+    ↓
+Option<PathBuf> (the directory to resolve against)
+```
+
+### Handling lucieleblanc's concerns
+
+| Concern | Resolution |
+|---|---|
+| Multi-arg exclusion drops currently-resolved entries | Invariant 3 + Invariant 6: multi-arg falls back to pwd-only, which is today's behavior. No regression. |
+| `-d` exclusion unclear | Invariant 4: `ls -d DIR` lists the directory entry itself (name, permissions), not its contents. Output is the operand name, not children. Resolving against `DIR` would be incorrect. |
+| Aliases with positional args | Invariant 5: We use `Block::top_level_command` for alias→command mapping only. Baked-in positional args in aliases are not expanded (would require shell-level alias expansion, which Warp doesn't do). The resolved command name triggers the feature; the positional arg comes from the actual command string. |
+| Reuse existing parsers | This spec replaces the custom `shlex` parser with `classify_command` + `CommandRegistry`. Full reuse of existing infrastructure. |
+| Leverage command-signatures | `classify_command` uses the `ls` signature from command-signatures to properly separate `-d`, `--color=auto`, `-I PATTERN` (flag args) from the directory positional. |
+
+### Types
+
+No new public types. The function signature is:
+
+```rust
+pub fn listing_directory_from_classified(
+    command_str: &str,
+    resolved_command_name: Option<&str>,
+    pwd: &Path,
+    command_registry: &CommandRegistry,
+    listing_commands: &[&str],
+) -> Option<PathBuf>
+```
+
+### Tradeoffs
+
+- **Pro:** Full reuse of battle-tested parser infrastructure. Correct handling of quoting, subshells, env-var prefixes, and flag-argument consumption.
+- **Pro:** Access to command-signatures means we correctly handle flags like `--color=auto` (which takes an argument) vs `-l` (which doesn't).
+- **Con:** Requires `CommandRegistry` access at the call site. The registry is already loaded for completions, so this is available but adds a dependency from link-detection to the completer crate.
+- **Con:** Commands not in the registry fall back to unclassified parsing (positionals only, no flag-arg consumption). For `ls`/`eza`/`lsd` this is fine — they're all in the registry.
+
+## Testing and Validation
+
+### Unit tests (in `crates/warp_completer/src/listing_dir.rs`)
+
+| Test | Invariant |
+|---|---|
+| `ls DIR/` with existing dir → returns `Some(DIR)` | 1 |
+| `ls` (no args) → returns `None` | 2 |
+| `ls DIR1/ DIR2/` → returns `None` | 3 |
+| `ls -d DIR/` → returns `None` | 4 |
+| `ls --directory DIR/` → returns `None` | 4 |
+| `ls -la DIR/` → returns `Some(DIR)` | 1, 9 |
+| `ls --color=auto DIR/` → returns `Some(DIR)` | 9 |
+| `LANG=C ls DIR/` → returns `Some(DIR)` | 10 |
+| `ls "path with spaces/"` → returns `Some(path with spaces)` | 1 |
+| `ls $(echo dir)` → returns `None` (subshell) | edge case |
+| Resolved alias `ll` → `ls`: `ll DIR/` → returns `Some(DIR)` | 5 |
+| `ls nonexistent/` → returns `None` (not a dir) | 1 |
+| `ls file.txt` → returns `None` (not a dir) | 1 |
+
+### Integration test (in `app/src/terminal/view/`)
+
+- Verify that `scan_for_file_path` resolves a filename from `ls DIR/` output against `DIR`, not `pwd`.
+
+### Manual validation
+
+1. `ls ~/some-project/` → hover over a filename → tooltip shows path under `~/some-project/`.
+2. Click → opens the correct file.
+3. `ls` (no args) → behavior unchanged.
+4. `ll ~/some-project/` → same as (1) if `ll` is aliased to `ls`.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `CommandRegistry` not available at link-detection call site | Registry is already loaded for completions; thread through from app context. |
+| Performance: `classify_command` on every hover | Acceptable per-hover cost: pure string parse, no I/O, bounded by command length (typically <100 chars), runs on the background thread. Same call site as existing `top_level_command` which already parses the command string on each hover. No cache needed for V1 — if profiling shows otherwise, a `(block_id, command_hash) -> Option<PathBuf>` cache can be added without API changes. |
+| Unclassified commands (not in registry) | Fall back to `None` — same as today's behavior. No regression. |
+
+## Follow-ups
+
+- User-configurable listing command list (setting).
+- Multi-operand heuristic (try each dir, accept if unambiguous).
+- `ls -R` recursive listing with per-section directory headers.
+- `tree` support (blocked on #9909 / #10004).


### PR DESCRIPTION
## Summary

Spec for #9908 — resolving clickable filenames in listing-command output (`ls DIR/`, `eza DIR/`, etc.) against the listed directory instead of the block's pwd.

This addresses the review feedback on #9974 from @lucieleblanc requesting a spec PR before code, and specifically:

- **Reuses existing parser infrastructure** (`warp_completer::parsers::classify_command` + `CommandRegistry`) instead of introducing a parallel custom parser
- **Leverages command-signatures** for proper flag-argument classification (e.g. `--color=auto` does not consume the directory positional, `-d` is properly detected)
- **Addresses product concerns:** multi-arg exclusion (falls back to pwd — no regression), `-d` handling (lists the entry itself, not contents), alias resolution (uses existing `Block::top_level_command`)

## Specs included

**V1 — Single-directory operand** (primary deliverable):
- `specs/GH9908/product.md` — 10 testable behavior invariants, edge cases, success criteria
- `specs/GH9908/tech.md` — implementation plan with file references, proposed module, data flow, testing plan

**V2 — Multi-directory + recursive** (planned follow-up):
- `specs/GH9908/product-v2.md` — section-header parsing from output, backward scan, scope gate
- `specs/GH9908/tech-v2.md` — `listing_section_scanner` module, grid row access, resolution priority chain

V2 builds on V1 infrastructure. Both `ls -R DIR/` and `ls DIR1/ DIR2/` use the same `path:` section header format (confirmed for ls, eza, and lsd).

## Resolution priority (complete system)

```
1. Section header directory (V2 — multi-dir/recursive, output scanning)
2. Single listing directory (V1 — single-dir fast path, command parsing only)
3. Block pwd (existing behavior — all other commands)
```

## Related

- Issue: #9908
- Current code PR: #9974 (will be superseded by implementation based on this spec)