### PR TITLE
fix(warpify): use target-OS path separator for rc file paths (#10474)

### DIFF
--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -333,31 +333,39 @@ impl ShellType {
     }
 
     /// Returns the potential paths to the RC file relative to the `home` directory.
+    ///
+    /// The path separator is chosen based on the target OS rather than the host OS,
+    /// because the resulting path is rendered into a shell command executed on the
+    /// target (e.g. via SSH or Auto-Warpify). Using `PathBuf::join` here would pick
+    /// the host's separator and produce strings like `~\.zshrc` on a Windows host
+    /// when targeting a Unix shell, which the remote shell cannot resolve.
     pub fn rc_file_paths(&self, os: TargetOS) -> Vec<PathBuf> {
-        let home_dir = Path::new(match os {
+        let home_dir = match os {
             TargetOS::Windows => "$HOME",
             _ => "~",
-        });
-        let relative_paths = match (self, os) {
+        };
+        let separator = match os {
+            TargetOS::Windows => '\\',
+            _ => '/',
+        };
+        let relative_paths: Vec<&str> = match (self, os) {
             (ShellType::PowerShell, TargetOS::Windows) => {
-                vec![Path::new(
-                    ".config/powershell/Microsoft.PowerShell_profile.ps1",
-                )]
+                vec![".config/powershell/Microsoft.PowerShell_profile.ps1"]
             }
             // We need to make sure this works for either editor of PowerShell (PowerShell Core or
             // Windows PowerShell) so just write the file to both.
             (ShellType::PowerShell, _) => vec![
-                Path::new("Documents/PowerShell/Microsoft.PowerShell_profile.ps1"),
-                Path::new("Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"),
+                "Documents/PowerShell/Microsoft.PowerShell_profile.ps1",
+                "Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1",
             ],
             (_, TargetOS::Windows) => vec![],
-            (ShellType::Bash, _) => vec![Path::new(".bashrc")],
-            (ShellType::Zsh, _) => vec![Path::new(".zshrc")],
-            (ShellType::Fish, _) => vec![Path::new(".config/fish/config.fish")],
+            (ShellType::Bash, _) => vec![".bashrc"],
+            (ShellType::Zsh, _) => vec![".zshrc"],
+            (ShellType::Fish, _) => vec![".config/fish/config.fish"],
         };
         relative_paths
             .iter()
-            .map(|relative_path| home_dir.join(relative_path))
+            .map(|relative_path| PathBuf::from(format!("{home_dir}{separator}{relative_path}")))
             .collect()
     }
 

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -334,20 +334,15 @@ impl ShellType {
 
     /// Returns the potential paths to the RC file relative to the `home` directory.
     ///
-    /// The path separator is chosen based on the target OS rather than the host OS,
-    /// because the resulting path is rendered into a shell command executed on the
-    /// target (e.g. via SSH or Auto-Warpify). Using `PathBuf::join` here would pick
-    /// the host's separator and produce strings like `~\.zshrc` on a Windows host
-    /// when targeting a Unix shell, which the remote shell cannot resolve.
-    pub fn rc_file_paths(&self, os: TargetOS) -> Vec<PathBuf> {
-        let home_dir = match os {
-            TargetOS::Windows => "$HOME",
-            _ => "~",
-        };
-        let separator = match os {
-            TargetOS::Windows => '\\',
-            _ => '/',
-        };
+    /// The returned [`TypedPathBuf`]s are encoded for the target OS rather than the
+    /// host OS, because the resulting path is rendered into a shell command executed
+    /// on the target (e.g. via SSH or Auto-Warpify). A plain `PathBuf` would pick the
+    /// host's separator and produce strings like `~\.zshrc` on a Windows host when
+    /// targeting a Unix shell, which the remote shell cannot resolve. Encoding for
+    /// the target OS lets `TypedPathBuf` enforce the correct separator.
+    pub fn rc_file_paths(&self, os: TargetOS) -> Vec<TypedPathBuf> {
+        let is_windows = matches!(os, TargetOS::Windows);
+        let home_dir = if is_windows { "$HOME" } else { "~" };
         let relative_paths: Vec<&str> = match (self, os) {
             (ShellType::PowerShell, TargetOS::Windows) => {
                 vec![".config/powershell/Microsoft.PowerShell_profile.ps1"]
@@ -365,7 +360,17 @@ impl ShellType {
         };
         relative_paths
             .iter()
-            .map(|relative_path| PathBuf::from(format!("{home_dir}{separator}{relative_path}")))
+            .map(|relative_path| {
+                let mut path = if is_windows {
+                    TypedPathBuf::from_windows(home_dir)
+                } else {
+                    TypedPathBuf::from_unix(home_dir)
+                };
+                // `push` uses the separator of the encoding picked above, so the
+                // result follows the target OS regardless of the host.
+                path.push(relative_path);
+                path
+            })
             .collect()
     }
 

--- a/crates/warp_terminal/src/shell/mod_tests.rs
+++ b/crates/warp_terminal/src/shell/mod_tests.rs
@@ -270,3 +270,51 @@ fn test_should_add_command_to_history() {
         assert!(fish_shell.should_add_command_to_history(" asdf"));
     }
 }
+
+/// Regression test for https://github.com/warpdotdev/warp/issues/10474.
+///
+/// `rc_file_paths` is rendered into a shell command that runs on the *target*
+/// (e.g. an SSH remote, or a subshell during Auto-Warpify). The path separator
+/// must therefore depend on the target OS, not the host that built Warp.
+/// Previously this used `PathBuf::join`, which uses the host's separator and
+/// produced strings like `~\.zshrc` on a Windows host targeting a Unix shell —
+/// the remote zsh then errored with "no such user or named directory".
+#[test]
+fn test_rc_file_paths_use_target_os_separator() {
+    for os in [TargetOS::Linux, TargetOS::MacOS] {
+        assert_eq!(
+            ShellType::Zsh.rc_file_paths(os.clone()),
+            vec![PathBuf::from("~/.zshrc")],
+            "Zsh rc path on {os:?} should use forward slash regardless of host",
+        );
+        assert_eq!(
+            ShellType::Bash.rc_file_paths(os.clone()),
+            vec![PathBuf::from("~/.bashrc")],
+        );
+        assert_eq!(
+            ShellType::Fish.rc_file_paths(os.clone()),
+            vec![PathBuf::from("~/.config/fish/config.fish")],
+        );
+        assert_eq!(
+            ShellType::PowerShell.rc_file_paths(os),
+            vec![
+                PathBuf::from("~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"),
+                PathBuf::from("~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"),
+            ],
+        );
+    }
+
+    // On Windows the only Auto-Warpify-supported shell is PowerShell; Unix
+    // shells deliberately return no rc paths.
+    // The leading separator follows target OS; the literal interior slashes
+    // are left as-is (PowerShell accepts forward slashes on Windows).
+    assert_eq!(
+        ShellType::PowerShell.rc_file_paths(TargetOS::Windows),
+        vec![PathBuf::from(
+            "$HOME\\.config/powershell/Microsoft.PowerShell_profile.ps1"
+        )],
+    );
+    assert!(ShellType::Zsh.rc_file_paths(TargetOS::Windows).is_empty());
+    assert!(ShellType::Bash.rc_file_paths(TargetOS::Windows).is_empty());
+    assert!(ShellType::Fish.rc_file_paths(TargetOS::Windows).is_empty());
+}

--- a/crates/warp_terminal/src/shell/mod_tests.rs
+++ b/crates/warp_terminal/src/shell/mod_tests.rs
@@ -279,27 +279,31 @@ fn test_should_add_command_to_history() {
 /// Previously this used `PathBuf::join`, which uses the host's separator and
 /// produced strings like `~\.zshrc` on a Windows host targeting a Unix shell —
 /// the remote zsh then errored with "no such user or named directory".
+/// `rc_file_paths` now returns `TypedPathBuf`s encoded for the target OS, so the
+/// separator is enforced by the encoding rather than the host.
 #[test]
 fn test_rc_file_paths_use_target_os_separator() {
     for os in [TargetOS::Linux, TargetOS::MacOS] {
         assert_eq!(
             ShellType::Zsh.rc_file_paths(os.clone()),
-            vec![PathBuf::from("~/.zshrc")],
+            vec![TypedPathBuf::from_unix("~/.zshrc")],
             "Zsh rc path on {os:?} should use forward slash regardless of host",
         );
         assert_eq!(
             ShellType::Bash.rc_file_paths(os.clone()),
-            vec![PathBuf::from("~/.bashrc")],
+            vec![TypedPathBuf::from_unix("~/.bashrc")],
         );
         assert_eq!(
             ShellType::Fish.rc_file_paths(os.clone()),
-            vec![PathBuf::from("~/.config/fish/config.fish")],
+            vec![TypedPathBuf::from_unix("~/.config/fish/config.fish")],
         );
         assert_eq!(
             ShellType::PowerShell.rc_file_paths(os),
             vec![
-                PathBuf::from("~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"),
-                PathBuf::from("~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"),
+                TypedPathBuf::from_unix("~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1"),
+                TypedPathBuf::from_unix(
+                    "~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"
+                ),
             ],
         );
     }
@@ -310,7 +314,7 @@ fn test_rc_file_paths_use_target_os_separator() {
     // are left as-is (PowerShell accepts forward slashes on Windows).
     assert_eq!(
         ShellType::PowerShell.rc_file_paths(TargetOS::Windows),
-        vec![PathBuf::from(
+        vec![TypedPathBuf::from_windows(
             "$HOME\\.config/powershell/Microsoft.PowerShell_profile.ps1"
         )],
     );


### PR DESCRIPTION
## Description

`ShellType::rc_file_paths` (`crates/warp_terminal/src/shell/mod.rs`) is rendered into the Auto-Warpify shell snippet that runs on the **target** (e.g. an SSH remote, or a subshell during local Auto-Warpify). It used `PathBuf::join`, whose separator follows the **host** OS that built Warp. On a Windows host targeting a Unix shell this produced `~\.zshrc`, which the remote zsh rejected with `no such user or named directory`.

This change builds the path string explicitly with a separator chosen from the `TargetOS` argument rather than relying on `PathBuf::join`'s host-dependent behavior. The internal forward slashes inside the literal relative paths (e.g. `.config/fish/config.fish`) are preserved as-is — only the leading separator that joins `~` / `$HOME` to the relative path now follows the target OS.

## Linked Issue

Fixes #10474.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Screenshots / Videos

n/a — the rendered string is covered by a new unit test.

## Testing

- New `test_rc_file_paths_use_target_os_separator` in `crates/warp_terminal/src/shell/mod_tests.rs` locks in the expected output for every (shell, target OS) combination — `~/.zshrc`, `~/.bashrc`, `~/.config/fish/config.fish` and the two PowerShell paths on `TargetOS::Linux`/`MacOS`; `\$HOME\.config/powershell/...` on `TargetOS::Windows`; and the deliberately-empty Unix-shell vectors on `TargetOS::Windows`.
- Full `cargo test -p warp_terminal --lib shell::` passes (16/16).

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed Auto-Warpify zsh setup snippet using a backslash path (`~\.zshrc`) when run from a Windows host targeting a Unix shell, causing the remote shell to fail with "no such user or named directory".
-->