### PR TITLE
fix(workspace): widen unified new-session menu so "New worktree config" fits (#10269)

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -253,10 +253,7 @@ use crate::drive::{
     CloudObjectTypeAndId, DriveObjectType, DrivePanel, DrivePanelEvent, OpenWarpDriveObjectSettings,
 };
 use crate::experiments::{BlockOnboarding, Experiment};
-use crate::menu::{
-    Event as MenuEvent, Menu, MenuItem, MenuItemFields, MenuSelectionSource,
-    DEFAULT_WIDTH as MENU_DEFAULT_WIDTH,
-};
+use crate::menu::{Event as MenuEvent, Menu, MenuItem, MenuItemFields, MenuSelectionSource};
 use crate::modal::{Modal, ModalEvent, ModalViewState};
 use crate::network::{NetworkStatus, NetworkStatusEvent};
 use crate::notebooks::manager::{NotebookManager, NotebookSource};
@@ -6316,7 +6313,10 @@ impl Workspace {
                 // Match the Figma mock width (OptionMenuItem component is 268px).
                 context_menu.set_width(268.);
             } else {
-                context_menu.set_width(MENU_DEFAULT_WIDTH);
+                // Horizontal variant renders the same items, so it needs the
+                // same 268px to avoid clipping "New worktree config" — the
+                // global MENU_DEFAULT_WIDTH (186px) was too narrow. See #10269.
+                context_menu.set_width(268.);
             }
             context_menu.set_items(menu_items, view_ctx);
             match open_source {


### PR DESCRIPTION
## Description

The unified new-session/tab config menu opened from the tab bar `+` chevron rendered the same items in both horizontal and vertical tab modes, but only the vertical-tabs branch of `WorkspaceView::open_tab_configs_menu` set the menu width to 268px (the OptionMenuItem Figma spec). The horizontal branch fell back to `MENU_DEFAULT_WIDTH` (186px), which was too narrow for the `New worktree config` label and clipped it at the right edge of the menu.

This PR sets the horizontal branch to the same 268px width so the label fits in both tab orientations. The now-unused `MENU_DEFAULT_WIDTH` import is removed.

## Linked Issue

Fixes #10269.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Built `WarpOss.app` from this branch, opened the tab bar `+` chevron menu in horizontal-tabs mode (the variant in the issue's repro), and confirmed `New worktree config` is now displayed in full with the submenu chevron visible at the right edge — no clipping.

### Screenshots / Videos

After (this PR — horizontal tabs `+` chevron menu):

<!-- Will attach after-fix screenshot when editing on GitHub web -->

The "before" state is in the issue body (image link `84a133db-cd00-4e93-8a62-5e1ccb08a84f`).

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed `New worktree config` label being clipped in the horizontal tab bar `+` chevron menu because the menu width fell back to a narrower default than the vertical-tabs variant.
-->
