### PR TITLE
[APP-4423] Local-to-cloud handoff for 3P harnesses

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -103,7 +103,7 @@ mod snapshot;
 pub(crate) mod terminal;
 
 use environment::PrepareEnvironmentError;
-pub(crate) use snapshot::upload_snapshot_for_handoff;
+pub(crate) use snapshot::{upload_snapshot_for_handoff, HandoffTranscript};
 use terminal::TerminalDriverEvent;
 
 const MCP_SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -103,7 +103,9 @@ mod snapshot;
 pub(crate) mod terminal;
 
 use environment::PrepareEnvironmentError;
-pub(crate) use snapshot::{upload_snapshot_for_handoff, HandoffTranscript};
+pub(crate) use snapshot::{
+    upload_snapshot_for_handoff, HandoffTranscript, TranscriptManifestEntry,
+};
 use terminal::TerminalDriverEvent;
 
 const MCP_SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);

--- a/app/src/ai/agent_sdk/driver/snapshot.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot.rs
@@ -47,6 +47,9 @@ use crate::server::server_api::ai::{
     AIClient, InitialSnapshotToken, SnapshotUploadFileInfo as AiSnapshotUploadFileInfo,
     UploadLocalHandoffSnapshotRequest,
 };
+
+use super::harness::claude_transcript::ClaudeTranscriptEnvelope;
+use super::harness::codex_transcript::CodexTranscriptEnvelope;
 use crate::server::server_api::harness_support::{
     upload_to_target, HarnessSupportClient, SnapshotFileInfo, SnapshotUploadRequest, UploadTarget,
 };
@@ -670,11 +673,19 @@ struct FileManifestEntry {
     error: Option<String>,
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct TranscriptManifestEntry {
+    pub(crate) file: String,
+    pub(crate) format: String,
+}
+
 #[derive(serde::Serialize)]
 struct SnapshotManifest {
     version: u32,
     repos: Vec<RepoManifestEntry>,
     files: Vec<FileManifestEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transcript: Option<TranscriptManifestEntry>,
 }
 
 // --- Upload helpers ---
@@ -741,13 +752,40 @@ async fn upload_snapshot_from_declarations_file(
 ///   it at an incomplete prefix. Manifest-upload failures are also routed through
 ///   `report_error!` so on-call alerting catches the silent regression.
 /// - `Err(_)` only for hard failures of `upload_local_handoff_snapshot` itself (auth, etc.).
+/// Transcript payload for local-to-cloud handoff of 3P harness sessions.
+pub(crate) enum HandoffTranscript {
+    Claude(ClaudeTranscriptEnvelope),
+    Codex(CodexTranscriptEnvelope),
+}
+
+impl HandoffTranscript {
+    fn format_string(&self) -> &'static str {
+        match self {
+            Self::Claude(_) => "claude_code_cli",
+            Self::Codex(_) => "codex_cli",
+        }
+    }
+
+    fn to_json_bytes(&self) -> Result<Vec<u8>> {
+        match self {
+            Self::Claude(envelope) => {
+                serde_json::to_vec(envelope).context("serialize claude transcript")
+            }
+            Self::Codex(envelope) => {
+                serde_json::to_vec(envelope).context("serialize codex transcript")
+            }
+        }
+    }
+}
+
 pub(crate) async fn upload_snapshot_for_handoff(
     repo_paths: Vec<PathBuf>,
     orphan_file_paths: Vec<PathBuf>,
+    transcript: Option<HandoffTranscript>,
     client: Arc<dyn AIClient>,
     http: &http_client::Client,
 ) -> Result<Option<InitialSnapshotToken>> {
-    if repo_paths.is_empty() && orphan_file_paths.is_empty() {
+    if repo_paths.is_empty() && orphan_file_paths.is_empty() && transcript.is_none() {
         log::info!("Handoff snapshot has no declarations; skipping upload");
         return Ok(None);
     }
@@ -770,7 +808,25 @@ pub(crate) async fn upload_snapshot_for_handoff(
         mut repos,
         mut files,
         mut pre_upload_entries,
+        mut used_filenames,
     } = gather_snapshot_entries(declarations).await;
+
+    // Serialize and include transcript if present.
+    let transcript_manifest = if let Some(ref transcript) = transcript {
+        let transcript_bytes = transcript.to_json_bytes()?;
+        let transcript_filename = unique_filename("transcript.json", &mut used_filenames);
+        upload_files.push(SnapshotUploadFile {
+            filename: transcript_filename.clone(),
+            content: transcript_bytes,
+            mime_type: "application/json".to_string(),
+        });
+        Some(TranscriptManifestEntry {
+            file: transcript_filename,
+            format: transcript.format_string().to_string(),
+        })
+    } else {
+        None
+    };
 
     apply_per_run_cap(
         &mut upload_files,
@@ -836,6 +892,7 @@ pub(crate) async fn upload_snapshot_for_handoff(
         files,
         pre_upload_entries,
         target_map,
+        transcript_manifest,
     )
     .await
     else {
@@ -876,6 +933,7 @@ async fn run_pipeline(
         repos,
         files,
         pre_upload_entries,
+        used_filenames: _,
     } = gather_snapshot_entries(declarations).await;
 
     upload_gathered_snapshot(
@@ -895,6 +953,7 @@ struct GatheredSnapshot {
     repos: Vec<RepoManifestEntry>,
     files: Vec<FileManifestEntry>,
     pre_upload_entries: Vec<EntryResult>,
+    used_filenames: HashSet<String>,
 }
 
 async fn gather_snapshot_entries(declarations: Vec<DeclarationEntry>) -> GatheredSnapshot {
@@ -942,6 +1001,7 @@ async fn gather_snapshot_entries(declarations: Vec<DeclarationEntry>) -> Gathere
         repos,
         files,
         pre_upload_entries,
+        used_filenames,
     }
 }
 
@@ -1017,6 +1077,7 @@ async fn upload_gathered_snapshot(
         files,
         pre_upload_entries,
         target_map,
+        None,
     )
     .await
 }
@@ -1029,6 +1090,7 @@ async fn upload_prepared_snapshot_files(
     mut files: Vec<FileManifestEntry>,
     pre_upload_entries: Vec<EntryResult>,
     target_map: HashMap<String, UploadTarget>,
+    transcript: Option<TranscriptManifestEntry>,
 ) -> Option<SnapshotOutcome> {
     // Upload non-manifest blobs concurrently, each with bounded retries on transient errors.
     let upload_futures = upload_files
@@ -1042,6 +1104,7 @@ async fn upload_prepared_snapshot_files(
         version: 1,
         repos,
         files,
+        transcript,
     };
     let manifest_bytes = match serde_json::to_vec_pretty(&manifest) {
         Ok(b) => b,

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1075,6 +1075,10 @@ impl AgentDriverRunner {
             }
         };
 
+        // Track whether the handoff snapshot carries a 3P transcript that needs
+        // to be materialized into a server-side conversation.
+        let mut handoff_transcript_conversation_id: Option<String> = None;
+
         match handoff_snapshot_result {
             Ok(Some(dir)) => {
                 // Ensure attachments_dir is set so it's passed to the server even when
@@ -1084,6 +1088,92 @@ impl AgentDriverRunner {
             Ok(None) => {}
             Err(e) => {
                 log::warn!("Failed to fetch handoff snapshot attachments: {e:#}");
+            }
+        }
+
+        // 3P handoff transcript materialization (spec §7).
+        // If the downloaded handoff snapshot contains a transcript entry, create
+        // an external conversation on the server, upload the transcript, and
+        // update the task so the resume flow picks it up.
+        if let Some(ref att_dir) = attachments_dir {
+            let manifest_path = std::path::PathBuf::from(att_dir)
+                .join("handoff")
+                .join("snapshot_state.json");
+            if let Ok(manifest_bytes) = tokio::fs::read(&manifest_path).await {
+                #[derive(serde::Deserialize)]
+                struct ManifestStub {
+                    transcript: Option<driver::TranscriptManifestEntry>,
+                }
+                if let Ok(manifest) = serde_json::from_slice::<ManifestStub>(&manifest_bytes) {
+                    if let Some(transcript_entry) = manifest.transcript {
+                        let transcript_file_path = std::path::PathBuf::from(att_dir)
+                            .join("handoff")
+                            .join(&transcript_entry.file);
+                        match tokio::fs::read(&transcript_file_path).await {
+                            Ok(transcript_bytes) => {
+                                use crate::server::server_api::harness_support::{
+                                    upload_to_target, HarnessSupportClient as _,
+                                };
+                                let harness_client: &dyn crate::server::server_api::harness_support::HarnessSupportClient = server_api.as_ref();
+                                let format = transcript_entry.format.clone();
+                                match harness_client.create_external_conversation(&format).await {
+                                    Ok(conv_id) => {
+                                        log::info!(
+                                            "Created external conversation {conv_id} for 3P handoff transcript"
+                                        );
+                                        // Upload transcript to conversation.
+                                        match harness_client
+                                            .get_transcript_upload_target(&conv_id)
+                                            .await
+                                        {
+                                            Ok(target) => {
+                                                if let Err(e) = upload_to_target(
+                                                    harness_client.http_client(),
+                                                    &target,
+                                                    transcript_bytes,
+                                                )
+                                                .await
+                                                {
+                                                    log::warn!("Failed to upload 3P handoff transcript: {e:#}");
+                                                }
+                                            }
+                                            Err(e) => {
+                                                log::warn!(
+                                                    "Failed to get transcript upload target: {e:#}"
+                                                );
+                                            }
+                                        }
+                                        if let Some(task_id) = parsed_task_id {
+                                            if let Err(e) = ai_client
+                                                .update_agent_task(
+                                                    task_id,
+                                                    None,
+                                                    None,
+                                                    Some(conv_id.to_string()),
+                                                    None,
+                                                )
+                                                .await
+                                            {
+                                                log::warn!("Failed to update task with 3P handoff conversation_id: {e:#}");
+                                            }
+                                        }
+                                        handoff_transcript_conversation_id =
+                                            Some(conv_id.to_string());
+                                    }
+                                    Err(e) => {
+                                        log::warn!("Failed to create external conversation for 3P handoff: {e:#}");
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                log::warn!(
+                                    "Failed to read 3P handoff transcript file '{}': {e}",
+                                    transcript_entry.file
+                                );
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -1191,7 +1281,10 @@ impl AgentDriverRunner {
             *dir = attachments_dir;
         }
 
-        Ok(task_conversation_id)
+        // If we materialized a conversation from a 3P handoff transcript, use
+        // that as the conversation to resume (overrides the task metadata's
+        // conversation_id which is None for 3P handoffs).
+        Ok(handoff_transcript_conversation_id.or(task_conversation_id))
     }
 
     /// If we are starting this agent run from an existing conversation, load the conversation

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -1441,12 +1441,17 @@ impl AgentInputFooter {
                 Some(ChildView::new(button).finish())
             }
             AgentToolbarItemKind::Settings => Some(ChildView::new(&self.settings_button).finish()),
+            AgentToolbarItemKind::HandoffToCloud => {
+                if !is_local_to_cloud_handoff_available() {
+                    return None;
+                }
+                Some(ChildView::new(&self.handoff_to_cloud_button).finish())
+            }
             // Handled by the available_in() guard above; included for exhaustiveness.
             AgentToolbarItemKind::ModelSelector
             | AgentToolbarItemKind::NLDToggle
             | AgentToolbarItemKind::ContextWindowUsage
-            | AgentToolbarItemKind::FastForwardToggle
-            | AgentToolbarItemKind::HandoffToCloud => None,
+            | AgentToolbarItemKind::FastForwardToggle => None,
         }
     }
 

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
@@ -83,8 +83,8 @@ impl AgentToolbarItemKind {
             Self::ModelSelector
             | Self::NLDToggle
             | Self::ContextWindowUsage
-            | Self::FastForwardToggle
-            | Self::HandoffToCloud => ToolbarAvailability::AgentViewOnly,
+            | Self::FastForwardToggle => ToolbarAvailability::AgentViewOnly,
+            Self::HandoffToCloud => ToolbarAvailability::Both,
             Self::FileExplorer | Self::RichInput | Self::Settings => {
                 ToolbarAvailability::CLIAgentOnly
             }
@@ -261,11 +261,15 @@ impl AgentToolbarItemKind {
 
     /// Default right-side items for the CLI agent footer.
     pub fn cli_default_right() -> Vec<Self> {
-        vec![
+        let mut items = vec![
             Self::ContextChip(ContextChipKind::WorkingDirectory),
             Self::ContextChip(ContextChipKind::ShellGitBranch),
             Self::Settings,
-        ]
+        ];
+        if is_local_to_cloud_handoff_available() {
+            items.push(Self::HandoffToCloud);
+        }
+        items
     }
 
     /// All items available for the CLI agent footer configurator.
@@ -285,6 +289,9 @@ impl AgentToolbarItemKind {
             && FeatureFlag::HOARemoteControl.is_enabled()
         {
             items.push(Self::ShareSession);
+        }
+        if is_local_to_cloud_handoff_available() {
+            items.push(Self::HandoffToCloud);
         }
         items
     }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -2528,6 +2528,23 @@ impl Input {
                     ctx.emit(Event::OpenPluginInstructionsPane(*agent, *kind));
                 }
                 AgentInputFooterEvent::OpenHandoffPane => {
+                    // In CLI agent mode the editor is hidden (input goes to the PTY),
+                    // so skip the `&` compose step and dispatch the handoff directly.
+                    #[cfg(not(target_family = "wasm"))]
+                    if CLIAgentSessionsModel::as_ref(ctx)
+                        .session(me.terminal_view_id)
+                        .is_some()
+                    {
+                        ctx.dispatch_typed_action_deferred(
+                            WorkspaceAction::OpenLocalToCloudHandoffPane {
+                                launch: None,
+                                explicit_environment_id: None,
+                            },
+                        );
+                    } else {
+                        me.activate_cloud_handoff_compose(ctx);
+                    }
+                    #[cfg(target_family = "wasm")]
                     me.activate_cloud_handoff_compose(ctx);
                 }
             }

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -129,7 +129,10 @@ impl SnapshotUploadStatus {
 pub(crate) struct PendingHandoff {
     /// Forked conversation id minted by `POST /agent/conversations/{conversation_id}/fork`.
     /// Sent under `conversation_id` on the subsequent `POST /agent/runs` request.
-    pub(crate) forked_conversation_id: String,
+    /// `None` for 3P handoffs where no server-side conversation exists pre-handoff.
+    pub(crate) forked_conversation_id: Option<String>,
+    /// Source harness for the handoff. The handoff pane locks to this harness.
+    pub(crate) handoff_harness: Harness,
     /// `None` until `derive_touched_workspace` completes.
     pub(crate) touched_workspace: Option<TouchedWorkspace>,
     /// Outcome of the async snapshot upload.
@@ -403,19 +406,17 @@ impl AmbientAgentViewModel {
     }
 
     pub fn selected_harness(&self) -> Harness {
-        if self.is_local_to_cloud_handoff() {
-            Harness::Oz
-        } else {
-            self.harness
+        #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+        if let Some(handoff) = &self.pending_handoff {
+            return handoff.handoff_harness;
         }
+        self.harness
     }
 
     pub fn set_harness(&mut self, harness: Harness, ctx: &mut ModelContext<Self>) {
-        // for local to cloud handoff, oz is the only option
-        // (we'll need to update this to lock to the correct 3p harness if/when
-        // we implement local -> cloud handoff for non-oz conversations).
+        // For handoff, lock to the source harness.
         let harness = if self.is_local_to_cloud_handoff() {
-            Harness::Oz
+            return;
         } else {
             harness
         };
@@ -590,7 +591,7 @@ impl AmbientAgentViewModel {
         &self,
         prompt: String,
         attachments: Vec<AttachmentInput>,
-        forked_conversation_id: String,
+        forked_conversation_id: Option<String>,
         initial_snapshot_token: Option<InitialSnapshotToken>,
         ctx: &AppContext,
     ) -> SpawnAgentRequest {
@@ -608,7 +609,7 @@ impl AmbientAgentViewModel {
             parent_run_id: None,
             runtime_skills: vec![],
             referenced_attachments: vec![],
-            conversation_id: Some(forked_conversation_id),
+            conversation_id: forked_conversation_id,
             initial_snapshot_token,
             agent_identity_uid: None,
         }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -341,6 +341,8 @@ use crate::workspace::cli_install;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::{report_if_error, AgentNotificationsModel};
 use ::settings::{Setting, ToggleableSetting};
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use warp_cli::agent::Harness;
 use warp_core::features::FeatureFlag;
 
 use crate::search::{self, QueryFilter};
@@ -13313,7 +13315,8 @@ impl Workspace {
 
         // Keep handoff state on the cloud model until snapshot prep and submit finish.
         let pending = PendingHandoff {
-            forked_conversation_id: forked_conversation_id.clone(),
+            forked_conversation_id: Some(forked_conversation_id.clone()),
+            handoff_harness: Harness::Oz,
             touched_workspace: None,
             snapshot_upload: SnapshotUploadStatus::Pending,
             submission_state: HandoffSubmissionState::Idle,
@@ -13344,6 +13347,7 @@ impl Workspace {
                 let upload_result = upload_snapshot_for_handoff(
                     repo_paths,
                     workspace.orphan_files.clone(),
+                    None,
                     ai_client,
                     http.as_ref(),
                 )

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13155,6 +13155,131 @@ impl Workspace {
         }
     }
 
+    /// 3P handoff: opens a cloud pane for a third-party CLI agent session.
+    /// Skips conversation fork (no server conversation), reads transcript from
+    /// disk, derives workspace from CLI session cwd, uploads snapshot with
+    /// transcript included.
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+    fn start_third_party_handoff(
+        &mut self,
+        source_view: ViewHandle<TerminalView>,
+        cli_session: crate::terminal::cli_agent_sessions::CLIAgentSession,
+        handoff_harness: Harness,
+        launch: Option<PendingCloudLaunch>,
+        explicit_environment_id: Option<SyncId>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        use crate::ai::agent_sdk::driver::harness::claude_transcript;
+        use crate::ai::agent_sdk::driver::HandoffTranscript;
+
+        let Some((_new_pane_view, model_handle)) = source_view.update(ctx, |view, view_ctx| {
+            view.start_local_to_cloud_handoff_pane(view_ctx)
+        }) else {
+            log::warn!("start_third_party_handoff: failed to push cloud-mode pane");
+            Self::restore_source_handoff_draft(&source_view, launch, explicit_environment_id, ctx);
+            Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
+            return;
+        };
+
+        if let Some(env_id) = explicit_environment_id {
+            model_handle.update(ctx, |model, ctx| {
+                model.set_environment_id(Some(env_id), ctx);
+            });
+        }
+
+        let pending = PendingHandoff {
+            forked_conversation_id: None,
+            handoff_harness,
+            touched_workspace: None,
+            snapshot_upload: SnapshotUploadStatus::Pending,
+            submission_state: HandoffSubmissionState::Idle,
+            auto_submit: launch,
+            explicit_environment_id: None,
+        };
+        model_handle.update(ctx, |model, model_ctx| {
+            model.set_pending_handoff(Some(pending), model_ctx);
+        });
+
+        Self::show_handoff_success_toast(ctx);
+        model_handle.update(ctx, |model, ctx| {
+            model.queue_handoff_auto_submit(ctx);
+        });
+
+        // Derive cwd from session context.
+        let cwd = cli_session
+            .session_context
+            .cwd
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+
+        // Read transcript from disk (Claude only for now).
+        let session_uuid = cli_session
+            .session_context
+            .session_id
+            .as_deref()
+            .and_then(|s| uuid::Uuid::parse_str(s).ok());
+        let transcript = match (handoff_harness, session_uuid) {
+            (Harness::Claude, Some(uuid)) => {
+                let config_root = claude_transcript::claude_config_dir();
+                config_root
+                    .and_then(|root| claude_transcript::read_envelope(uuid, &cwd, &root))
+                    .map(HandoffTranscript::Claude)
+                    .ok()
+            }
+            _ => None,
+        };
+
+        let server_api_provider = ServerApiProvider::as_ref(ctx);
+        let ai_client = server_api_provider.get_ai_client();
+        let http = server_api_provider.get_http_client();
+        let async_model_handle = model_handle.clone();
+
+        ctx.spawn(
+            async move {
+                let workspace = derive_touched_workspace(vec![cwd]).await;
+                let repo_paths: Vec<_> =
+                    workspace.repos.iter().map(|r| r.git_root.clone()).collect();
+                let upload_result = upload_snapshot_for_handoff(
+                    repo_paths,
+                    workspace.orphan_files.clone(),
+                    transcript,
+                    ai_client,
+                    http.as_ref(),
+                )
+                .await;
+                (workspace, upload_result)
+            },
+            move |_workspace, (derived_workspace, upload_result), ctx| {
+                async_model_handle.update(ctx, |model, model_ctx| {
+                    if !model.is_local_to_cloud_handoff() {
+                        return;
+                    }
+                    model.set_pending_handoff_workspace(derived_workspace, model_ctx);
+                    match upload_result {
+                        Ok(Some(token)) => {
+                            model.set_pending_handoff_snapshot_upload(
+                                SnapshotUploadStatus::Uploaded(token),
+                                model_ctx,
+                            );
+                        }
+                        Ok(None) => {
+                            model.set_pending_handoff_snapshot_upload(
+                                SnapshotUploadStatus::SkippedEmptyWorkspace,
+                                model_ctx,
+                            );
+                        }
+                        Err(err) => {
+                            log::warn!("3P handoff snapshot upload failed: {err:#}");
+                            model
+                                .record_handoff_snapshot_upload_failed(format!("{err}"), model_ctx);
+                        }
+                    }
+                });
+                Self::maybe_auto_submit_handoff(&source_view, &async_model_handle, ctx);
+            },
+        );
+    }
+
     /// Opens a local-to-cloud handoff pane in place over the active local pane.
     /// Triggered by `/move-to-cloud`, `&` compose mode, and the handoff footer chip.
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -13178,6 +13303,34 @@ impl Workspace {
         };
 
         let terminal_view_id = source_view.id();
+
+        // 3P handoff: when a CLI agent session is active, skip the Oz
+        // conversation-fork path and hand off the transcript + cwd instead.
+        let cli_session = CLIAgentSessionsModel::as_ref(ctx)
+            .session(terminal_view_id)
+            .cloned();
+        if let Some(cli_session) = cli_session {
+            let handoff_harness = match cli_session.agent {
+                crate::terminal::CLIAgent::Claude => Harness::Claude,
+                crate::terminal::CLIAgent::Codex => Harness::Codex,
+                crate::terminal::CLIAgent::Gemini => Harness::Gemini,
+                _ => {
+                    log::warn!("Handoff not supported for {:?}", cli_session.agent);
+                    Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
+                    return;
+                }
+            };
+            self.start_third_party_handoff(
+                source_view,
+                cli_session,
+                handoff_harness,
+                launch,
+                explicit_environment_id,
+                ctx,
+            );
+            return;
+        }
+
         let source_conversation = BlocklistAIHistoryModel::handle(ctx)
             .as_ref(ctx)
             .active_conversation(terminal_view_id)

--- a/specs/APP-4423/TECH.md
+++ b/specs/APP-4423/TECH.md
@@ -1,0 +1,167 @@
+# Local-to-Cloud Handoff for 3rd-Party Harnesses — Tech Spec
+Linear: [APP-4423](https://linear.app/warpdotdev/issue/APP-4423)
+
+## Context
+REMOTE-1486 shipped local→cloud handoff for Oz conversations. This spec extends it to third-party harness conversations (Claude Code first, then Codex).
+
+The Oz handoff flow forks a server-side `AIConversation` at chip-click time, uploads a workspace snapshot (git patches + orphan files), and spawns a cloud run with `conversation_id` + `initial_snapshot_token`. The cloud agent resumes the forked conversation and applies patches via a system-prompt checklist.
+
+For 3P harnesses, the situation differs in three ways:
+1. **No server-side conversation exists.** Local 3P runs don't call `create_external_conversation` — there's a `TODO(REMOTE-1149)` noting this. The transcript lives on disk (e.g. `~/.claude/projects/<encoded_cwd>/<uuid>.jsonl`).
+2. **Resume is driver-level, not prompt-level.** The cloud worker rehydrates the transcript onto disk and launches `claude --resume <uuid>`, handled by `ClaudeHarnessRunner` via `ResumePayload::Claude(ClaudeResumeInfo)`. This is code-level, not LLM-prompt-level.
+3. **The entry point is the CLI agent toolbar**, not the agent-view footer. The handoff chip is currently `AgentViewOnly`; 3P harnesses run in the terminal with the CLI agent toolbar.
+
+Key files:
+- `app/src/ai/agent_sdk/driver/snapshot.rs` — `SnapshotManifest`, `upload_snapshot_for_handoff`
+- `app/src/ai/agent_sdk/driver/harness/claude_transcript.rs` — `ClaudeTranscriptEnvelope`, `read_envelope`, `write_envelope`
+- `app/src/ai/agent_sdk/driver/harness/claude_code.rs:381-438` — `HarnessRunner::start`, `create_external_conversation` call, `save_conversation`
+- `app/src/ai/agent_sdk/driver/harness/mod.rs:48-87` — `ResumePayload`, `ClaudeResumeInfo`, `ThirdPartyHarness` trait
+- `app/src/ai/agent_sdk/mod.rs:929-1106` — `fetch_secrets_and_attachments`, `load_conversation_information`
+- `app/src/ai/agent_sdk/driver/attachments.rs:68-133` — `fetch_and_download_handoff_snapshot_attachments`
+- `app/src/terminal/view/ambient_agent/model.rs:387-441` — `selected_harness` hardcoded to Oz for handoff, `PendingHandoff`
+- `app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs` — `HandoffToCloud` item, `AgentViewOnly`
+- `app/src/workspace/view.rs:13010-13271` — `start_local_to_cloud_handoff`, `complete_local_to_cloud_handoff_open`
+- `warp-server-5/logic/ai/conversation_transcript/external_conversation.go` — `CreateThirdPartyConversation` (creates DB row + GCS manifest, no blobs)
+- `warp-server-5/logic/ai/ambient_agents/handoff_rehydration.go` — `ResolveHandoffRehydrationMetadata`, reads `InitialSnapshotToken`
+- `warp-server-5/router/handlers/public_api/harness_support.go:185-233` — `CreateExternalConversationHandler`
+
+## Proposed changes
+### 1. Snapshot manifest: add transcript section
+Extend `SnapshotManifest` (`snapshot.rs:673`) with an optional `transcript` field so the manifest is the single source of truth for "this snapshot carries a 3P transcript."
+
+```rust path=null start=null
+#[derive(serde::Serialize)]
+struct SnapshotManifest {
+    version: u32,
+    repos: Vec<RepoManifestEntry>,
+    files: Vec<FileManifestEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transcript: Option<TranscriptManifestEntry>,
+}
+
+#[derive(serde::Serialize)]
+struct TranscriptManifestEntry {
+    file: String,   // e.g. "transcript.json"
+    format: String, // e.g. "claude_code_cli"
+}
+```
+
+The `transcript` field is additive and optional — no version bump needed. Version `1` manifests without the field continue to work unchanged. The worker-side Go struct gets the same optional field.
+
+### 2. Client: read and upload transcript in handoff snapshot
+Extend `upload_snapshot_for_handoff` (or add a sibling) to accept an optional transcript payload. The client reads the local transcript (e.g. `read_envelope` for Claude) and includes it as another `SnapshotUploadFile` alongside patches. The transcript is uploaded to `handoff/{token}/transcript.json` via the same presigned-URL path as patches.
+
+```rust path=null start=null
+pub(crate) async fn upload_snapshot_for_handoff(
+    repo_paths: Vec<PathBuf>,
+    orphan_file_paths: Vec<PathBuf>,
+    transcript: Option<HandoffTranscript>, // new
+    client: Arc<dyn AIClient>,
+    http: &http_client::Client,
+) -> Result<Option<InitialSnapshotToken>>
+```
+
+The transcript parameter is a thin enum over existing envelope types:
+
+```rust path=null start=null
+enum HandoffTranscript {
+    Claude(ClaudeTranscriptEnvelope),
+    Codex(CodexTranscriptEnvelope),
+}
+```
+
+The function serializes the envelope to JSON bytes and includes it as a `SnapshotUploadFile`. The format string for the manifest entry is derived from the variant. The transcript counts against `MAX_SNAPSHOT_FILES_PER_RUN` like any other file.
+
+### 3. Client: entry point in CLI agent toolbar
+Add `HandoffToCloud` to the CLI agent footer for supported harnesses:
+- Keep `HandoffToCloud` as `AgentViewOnly` for the agent-view footer (unchanged).
+- In the CLI agent footer, conditionally show it when the active CLI agent session's harness supports cloud mode (Claude and Codex today — check `HarnessAvailabilityModel`).
+- Hide the chip entirely when the CLI agent plugin is not installed (no `session_id` means we can't locate the transcript).
+- Add it to `cli_default_right()` gated on `handoff_to_cloud_available()` + the active harness check.
+- The click handler dispatches `WorkspaceAction::OpenLocalToCloudHandoffPane` same as the agent-view chip.
+
+### 4. Client: derive snapshot from terminal cwd (not conversation walks)
+For 3P, we can't walk `AIConversation` exchanges (there is no `AIConversation`). Instead, use `CLIAgentSessionContext.cwd` from the active CLI agent session as the single repo to snapshot. This covers the primary case (one repo the agent was working in).
+
+`start_local_to_cloud_handoff` needs a 3P path that:
+- Skips the Oz-specific `fork_conversation` call (no server conversation to fork).
+- Reads the CLI agent session context to get `cwd` and `session_id`.
+- Reads the transcript from disk using harness-specific logic (`read_envelope` for Claude).
+- Uploads the snapshot with transcript included.
+
+### 5. Client: harness passthrough on handoff pane
+Remove the hardcoded `Harness::Oz` override in `selected_harness()` and `set_harness()` (`model.rs:387-410`). For 3P handoff, `PendingHandoff` should carry the source harness, and the handoff pane should lock to it (not allow switching).
+
+`SpawnAgentRequest` already carries `config.harness` — set it to the source conversation's harness.
+
+### 6. Client: skip conversation fork for 3P
+The Oz flow calls `AIClient::fork_conversation` at chip-click time. For 3P, skip this — there's no server conversation to fork. `PendingHandoff.forked_conversation_id` becomes `Option<String>` (None for 3P). The submit path sends `conversation_id: None` on the `SpawnAgentRequest`.
+
+### 7. Worker: materialize conversation and resume from snapshot transcript
+In `fetch_secrets_and_attachments` (`agent_sdk/mod.rs:929`), after handoff snapshot files are downloaded to `{attachments_dir}/handoff/`:
+1. Read `snapshot_state.json` from the handoff directory.
+2. If `manifest.transcript` is present:
+   a. Read the transcript file once from `{attachments_dir}/handoff/{manifest.transcript.file}`. Reuse the bytes for both the GCS upload and deserialization.
+   b. Call `create_external_conversation(manifest.transcript.format)` — the worker has a workload token, so this is allowed.
+   c. Upload the transcript to the new conversation via `get_transcript_upload_target` + `upload_to_target`.
+   d. Call `update_agent_task` with the new `conversation_id`.
+   e. Deserialize the transcript bytes (e.g. `serde_json::from_slice::<ClaudeTranscriptEnvelope>`) and build `ClaudeResumeInfo { conversation_id, session_id: envelope.uuid, envelope }`. Pass to `ClaudeHarnessRunner::new` → `write_envelope` → `claude --resume <uuid>`.
+
+This keeps `create_external_conversation` behind the workload-token gate. The client only writes to TTL-bounded `handoff/{token}/` staging. The worker skips the `fetch_resume_payload` round-trip since it already has the transcript. No changes needed to the harness runner itself.
+
+### 8. Feature flags
+No new flags. Gate on `FeatureFlag::OzHandoff && FeatureFlag::HandoffLocalCloud` (same as Oz handoff). The 3P path is differentiated by the presence of an active CLI agent session, not a separate flag.
+
+## Diagram
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as Local Warp Client
+    participant GCS as GCS (handoff/{token}/)
+    participant API as warp-server
+    participant W as Cloud Worker
+
+    U->>C: Click "Hand off to cloud" in CLI agent toolbar
+    C->>C: Read transcript from ~/.claude/... (read_envelope)
+    C->>C: Derive repo from CLIAgentSessionContext.cwd
+    C->>API: POST /agent/handoff/upload-snapshot {files + transcript}
+    API-->>C: {initial_snapshot_token, uploads[]}
+    C->>GCS: PUT patches + transcript.json + snapshot_state.json
+    C->>C: Open cloud-mode handoff pane (no hydration)
+    U->>C: Type prompt, submit
+    C->>API: POST /agent/runs {initial_snapshot_token, harness: claude, conversation_id: null}
+    API-->>C: {task_id, run_id}
+
+    W->>GCS: Download handoff/{token}/* to attachments/handoff/
+    W->>W: Read snapshot_state.json, find transcript entry
+    W->>API: POST /harness-support/external-conversation {format: claude_code_cli}
+    API-->>W: {conversation_id}
+    W->>API: POST /harness-support/transcript {conversation_id} → upload target
+    W->>GCS: PUT transcript to conversation GCS path
+    W->>API: update_agent_task {conversation_id}
+    W->>W: Deserialize transcript → build ClaudeResumeInfo directly
+    W->>W: write_envelope to ~/.claude/... , launch claude --resume <uuid>
+```
+
+## Risks and mitigations
+- **Arbitrary blob storage.** The client never calls `create_external_conversation` or the transcript/block-snapshot upload-target endpoints — those remain gated on the workload token, which only cloud workers have. The client only writes to `handoff/{token}/` via presigned URLs with a 15-minute TTL, subject to the same size caps as workspace patches. The worker is the one that creates the external conversation and uploads the transcript to persistent GCS, so a malicious authenticated user can't abuse the handoff flow for free blob storage.
+- **Transcript size.** Claude transcripts can be large (subagents, todos).
+- **No transcript on disk.** `read_envelope` can fail if the session is very early (no JSONL written yet). Fall back to snapshot-only (no resume) rather than blocking handoff.
+- **Concurrent transcript writes.** User may click handoff while Claude is actively appending to the JSONL. `read_envelope` reads synchronously — fine in practice since the JSONL is append-only and we tolerate a partial final line.
+- **`create_external_conversation` requires a task.** Today `CreateThirdPartyConversation` checks `info.Task.Owner` and `info.Task.AgentConversationID`. The worker calls it after the task exists, so this works. If we later start tracking local 3P runs as conversations pre-handoff, the conversation would already exist and the worker would skip this step (detected by `manifest.transcript` being absent or `task_conversation_id` being set).
+- **No conversation on spawn request.** The `SpawnAgentRequest.conversation_id` is null for 3P handoff. The server creates the task without a conversation; the worker materializes and attaches it post-claim. The task is briefly in a conversation-less state, which is fine — it's identical to fresh cloud runs before `create_external_conversation` is called.
+
+## Testing and validation
+- **Unit tests (client):** test `SnapshotManifest` serialization with and without `transcript` field; test that `upload_snapshot_for_handoff` includes the transcript file in the upload request.
+- **Unit tests (worker):** test the manifest-reading logic that detects transcript presence; test that `create_external_conversation` is called with the correct format and the `ResumePayload` is constructed directly from the downloaded transcript bytes.
+- **Integration / manual:**
+  - Run Claude Code locally, make edits, click "Hand off to cloud" → verify transcript + patches upload to `handoff/{token}/`, cloud agent resumes with full conversation history and dirty workspace.
+  - Run Claude Code locally with no edits → verify handoff still works (empty patches, transcript only).
+  - Verify the cloud agent's `claude --resume` picks up where the local session left off.
+  - Verify existing Oz handoff is unaffected (manifest version 1 → no transcript field → existing path).
+
+## Follow-ups
+- Codex handoff support (same pattern, different `read_envelope` + format string).
+- Gemini handoff support.
+- Pre-handoff local 3P conversation tracking (REMOTE-1149) — when local runs get server-side conversations from the start, the handoff flow skips transcript staging and uses fork semantics instead.
+- Transcript size limits / compression for large Claude sessions with many subagents.


### PR DESCRIPTION
## Summary
Implements the client-side E2E flow for local-to-cloud handoff of 3rd-party harness conversations (Claude Code first, Codex data types wired but not entry-pointed yet).

## Changes by commit
1. **Tech spec** — `specs/APP-4423/TECH.md`
2. **Snapshot manifest** — `TranscriptManifestEntry`, `HandoffTranscript` enum (Claude/Codex), extended `upload_snapshot_for_handoff` to accept + serialize transcript
3. **CLI toolbar** — `HandoffToCloud` chip now shows in CLI agent footer (was AgentViewOnly)
4. **PendingHandoff model** — `handoff_harness` field added, `forked_conversation_id` made `Option<String>`, harness passthrough (no more hardcoded `Harness::Oz`)
5. **3P handoff entry** — `start_third_party_handoff` + 3P branch in `start_local_to_cloud_handoff`: detects CLI agent session, skips fork, reads Claude transcript, derives workspace from cwd, uploads snapshot with transcript

## Follow-ups
- Worker-side transcript materialization (spec section 7)
- Codex transcript reading
- Gemini handoff

## Testing
- `cargo check` passes (1 expected dead_code warning for unused `Codex` variant)

_Conversation: https://staging.warp.dev/conversation/ca803033-7704-47cf-b465-2a1fe1d89bd1_
_Run: https://oz.staging.warp.dev/runs/019e104b-dac8-7a59-9ad7-f121d09cff4d_
_Plans:_
- _[APP-4423: Local-to-Cloud Handoff for 3P Harnesses](https://staging.warp.dev/drive/notebook/FBCcXdcqYdQxVJ2J4nUlDa)_

_This PR was generated with [Oz](https://warp.dev/oz)._
