### PR TITLE
Fix unreadable repo switcher text in Code Review pane after theme switch (#10600)

### DIFF
--- a/app/src/workspace/view/right_panel.rs
+++ b/app/src/workspace/view/right_panel.rs
@@ -25,7 +25,7 @@ use crate::view_components::{Dropdown, DropdownItem};
 use crate::workspace::view::TOGGLE_RIGHT_PANEL_BINDING_NAME;
 use crate::workspace::WorkspaceAction;
 use crate::{
-    appearance::Appearance,
+    appearance::{Appearance, AppearanceEvent},
     drive::panel::{MAX_SIDEBAR_WIDTH_RATIO, MIN_SIDEBAR_WIDTH},
     terminal::resizable_data::{ModalType, ResizableData},
 };
@@ -35,6 +35,7 @@ use crate::{
 };
 use dunce::canonicalize;
 use itertools::Itertools;
+use pathfinder_color::ColorU;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -139,16 +140,27 @@ struct CodeReviewSessionEnv {
     is_wsl: bool,
 }
 
+/// Resolve the repo-switcher dropdown's text color from the current theme.
+/// Kept as a free function so the construction site and the
+/// `AppearanceEvent::ThemeChanged` subscription compute the exact same color.
+fn repo_dropdown_font_color(appearance: &Appearance) -> ColorU {
+    appearance
+        .theme()
+        .sub_text_color(appearance.theme().background())
+        .into_solid()
+}
+
 impl CodeReviewState {
     pub fn new(ctx: &mut ViewContext<RightPanelView>) -> Self {
         CodeReviewState {
             dropdown: ctx.add_typed_action_view(|ctx| {
-                let appearance = Appearance::as_ref(ctx);
-                let font_color = appearance
-                    .theme()
-                    .sub_text_color(appearance.theme().background())
-                    .into_solid();
-                let ui_font_size = appearance.ui_font_size();
+                let (font_color, ui_font_size) = {
+                    let appearance = Appearance::as_ref(ctx);
+                    (
+                        repo_dropdown_font_color(appearance),
+                        appearance.ui_font_size(),
+                    )
+                };
                 let mut dropdown = Dropdown::new(ctx);
                 dropdown.set_menu_position(
                     PositionedElementAnchor::BottomRight,
@@ -161,6 +173,19 @@ impl CodeReviewState {
                 dropdown.set_vertical_margin(0., ctx);
                 dropdown.set_top_bar_height(warp_core::ui::icons::ICON_DIMENSIONS, ctx);
                 dropdown.set_padding(HEADER_BUTTON_PADDING, ctx);
+
+                // The font color above is derived from the active theme and
+                // cached inside the dropdown. Without this subscription, the
+                // cached value goes stale across light/dark switches and the
+                // header label becomes unreadable on the new background
+                // (e.g. white-on-white in light mode after starting in dark).
+                ctx.subscribe_to_model(&Appearance::handle(ctx), |dropdown, _, event, ctx| {
+                    if matches!(event, AppearanceEvent::ThemeChanged) {
+                        let font_color = repo_dropdown_font_color(Appearance::as_ref(ctx));
+                        dropdown.set_font_color(font_color, ctx);
+                    }
+                });
+
                 dropdown
             }),
             available_repos: vec![],


### PR DESCRIPTION
## Description

Fixes #10600.

The repository / branch switcher dropdown at the top of the Code Review pane caches its text color via `Dropdown::set_font_color` from `theme.sub_text_color(theme.background())` once at construction time in `CodeReviewState::new` (`app/src/workspace/view/right_panel.rs`). The dropdown view re-renders on `Appearance` changes, but `Dropdown::render_top_bar` reads back the cached `ColorU` instead of re-deriving it from the live theme, so the color goes stale across light ↔ dark switches:

- Open the Code Review pane in dark mode (default) → text color is cached as a near-white (correct against a dark background).
- Switch to a light theme → the dropdown re-renders, but the cached near-white label is now painted on a near-white background → unreadable, exactly the symptom reported in #10600.
- The reverse direction (light → dark) is the same bug: dark text remains on a now-dark background.

The chevron icon already reacts correctly because its `Icon::new(...)` color uses `unwrap_or_else(|| appearance.theme().active_ui_text_color().into())`, which re-derives from the current theme each render. Only the cached `font_color` path is stale.

This PR subscribes the dropdown to `AppearanceEvent::ThemeChanged` from its own `ViewContext` and reapplies the freshly derived color via `set_font_color`. The derivation is extracted into a `repo_dropdown_font_color` helper so the construction site and the subscription stay in lock-step. The pattern matches the existing convention used by other selectors in the codebase (e.g. `harness_selector.rs`, `auth_secret_selector.rs`, `update_environment_form.rs`).

The subscription is scoped to the dropdown view, so it is dropped automatically when the Code Review state is torn down (e.g. when the panel is closed) — no leak, no impact on pane-group switching where the dropdown is reused.

## Linked Issue

Fixes #10600.
- [x] The linked issue is labeled \`ready-to-spec\` or \`ready-to-implement\` (triaged bug, implicitly \`ready-to-implement\` per CONTRIBUTING.md).
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

Verified locally with \`./script/run\` against the exact reproduction steps from the issue:

1. Launch Warp (defaults to dark theme).
2. Open two tabs in two different git repositories so the repo switcher is visible (it only renders when \`available_repos.len() > 1\`).
3. Open the Code Review pane and confirm the repository name in the top-left dropdown is readable.
4. Switch \`Settings → Appearance\` to a Light theme **without closing the panel**.
   - Before this fix: the label is near-white on near-white and effectively invisible.
   - After this fix: the label re-derives a dark text color and stays readable.
5. Switch back to the dark theme — label updates to a light color, still readable.
6. Close and reopen the panel in light mode — label is correct from the start (sanity check that the construction path also still works).

Automated coverage:

- \`cargo fmt -- --check\` ✓
- \`cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings\` ✓
- \`cargo nextest run -p warp\` — 4011 / 4012 passing. The single failure (\`settings::init::tests::test_migration_does_not_rerun_when_marker_present\`) reproduces identically on a clean \`master\` checkout in the same workspace and is unrelated to this change (it's a settings-migration test sensitive to local marker state).

No new automated test added — the regression is a stale cache in a generic \`Dropdown<A>\` view; asserting it would require either exposing a \`font_color\` getter on the shared component or building a theme-switch UI test harness, both of which feel disproportionate for a 12-line view-construction fix. Happy to wire up coverage in either direction if reviewers prefer.

- [x] I have manually tested my changes locally with \`./script/run\`.

### Screenshots / Videos

Before:

<img width="790" height="670" alt="image" src="https://github.com/user-attachments/assets/e27895fa-7afd-4058-966a-7072b52b26af" />

Fixed:

<img width="383" height="173" alt="image" src="https://github.com/user-attachments/assets/bf1de60e-9f5b-458c-90cf-7d718dec6cd0" />


## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fix unreadable repository switcher text in the Code Review pane after toggling between light and dark themes.
-->

CHANGELOG-BUG-FIX: Fix unreadable repository switcher text in the Code Review pane after toggling between light and dark themes.

Co-Authored-By: Warp <agent@warp.dev>
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)