### PR TITLE
fix: reauth stale GitHub OAuth tokens

### DIFF
--- a/app/src/server/server_api/integrations.rs
+++ b/app/src/server/server_api/integrations.rs
@@ -171,9 +171,6 @@ impl ServerApi {
         let message = message.to_ascii_lowercase();
         let missing_user_github_info_data =
             message.contains("missing response data") && message.contains("usergithubinfo");
-        if missing_user_github_info_data {
-            return true;
-        }
 
         let mentions_github = message.contains("github") || message.contains("usergithubinfo");
         let mentions_auth_material = message.contains("oauth")
@@ -187,10 +184,16 @@ impl ServerApi {
             || message.contains("revoked")
             || message.contains("unauthorized")
             || message.contains("401");
+        let auth_specific_error = message.contains("bad credentials")
+            || message.contains("unauthorized")
+            || message.contains("401")
+            || (mentions_auth_material && looks_invalid);
 
-        (mentions_github || message.contains("bad credentials"))
-            && mentions_auth_material
-            && looks_invalid
+        if missing_user_github_info_data {
+            return auth_specific_error;
+        }
+
+        (mentions_github || message.contains("bad credentials")) && auth_specific_error
     }
 }
 
@@ -222,6 +225,14 @@ mod tests {
     #[test]
     fn unrelated_missing_data_does_not_require_auth_refresh() {
         let error = anyhow::anyhow!("missing response data for GetUserSettings");
+
+        assert!(!ServerApi::should_refresh_github_auth_for_user_github_info_error(&error));
+    }
+
+    #[test]
+    fn unrelated_user_github_info_missing_data_does_not_require_auth_refresh() {
+        let error =
+            anyhow::anyhow!("missing response data for UserGithubInfo: GitHub rate limit exceeded");
 
         assert!(!ServerApi::should_refresh_github_auth_for_user_github_info_error(&error));
     }

--- a/app/src/server/server_api/integrations.rs
+++ b/app/src/server/server_api/integrations.rs
@@ -39,6 +39,19 @@ use warp_graphql::queries::user_repo_auth_status::{
     UserRepoAuthStatusOutput, UserRepoAuthStatusResult, UserRepoAuthStatusVariables,
 };
 
+const GITHUB_PROVIDER_SLUG: &str = "github";
+
+#[derive(Debug, thiserror::Error)]
+#[error("GitHub authentication needs to be refreshed")]
+pub struct GithubAuthRefreshRequired {
+    #[source]
+    source: anyhow::Error,
+}
+
+pub fn is_github_auth_refresh_required_error(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<GithubAuthRefreshRequired>().is_some()
+}
+
 #[cfg(not(target_family = "wasm"))]
 pub trait IntegrationsClientBounds: Send + Sync {}
 
@@ -50,6 +63,185 @@ pub trait IntegrationsClientBounds {}
 
 #[cfg(target_family = "wasm")]
 impl<T: 'static> IntegrationsClientBounds for T {}
+
+impl ServerApi {
+    #[allow(clippy::too_many_arguments)]
+    async fn create_or_update_simple_integration_request(
+        &self,
+        integration_type: String,
+        is_update: bool,
+        environment_uid: Option<String>,
+        base_prompt: Option<String>,
+        model_id: Option<String>,
+        mcp_servers_json: Option<String>,
+        remove_mcp_server_names: Option<Vec<String>>,
+        worker_host: Option<String>,
+        enabled: bool,
+    ) -> Result<CreateSimpleIntegrationOutput> {
+        let variables = CreateSimpleIntegrationVariables {
+            config: SimpleIntegrationConfig {
+                base_prompt,
+                environment_uid,
+                model_id,
+                mcp_servers_json,
+                remove_mcp_server_names,
+                worker_host,
+            },
+            enabled,
+            integration_type,
+            is_update,
+            request_context: get_request_context(),
+        };
+
+        let operation = CreateSimpleIntegration::build(variables);
+        let response = self.send_graphql_request(operation, None).await?;
+        match response.create_simple_integration {
+            CreateSimpleIntegrationResult::CreateSimpleIntegrationOutput(output) => Ok(output),
+            CreateSimpleIntegrationResult::UserFacingError(error) => {
+                Err(anyhow!(get_user_facing_error_message(error)))
+            }
+            CreateSimpleIntegrationResult::Unknown => {
+                Err(anyhow!("Unknown error while creating integration"))
+            }
+        }
+    }
+
+    fn github_oauth_connect_url() -> String {
+        format!("{}/oauth/connect/github", ChannelState::server_root_url())
+    }
+
+    fn github_auth_required_output(
+        auth_url: String,
+        tx_id: Option<cynic::Id>,
+    ) -> GithubAuthRequiredOutput {
+        // appInstallLink is unused while the user is unauthenticated. A post-auth
+        // refetch replaces it with the actual GitHub App configuration URL.
+        GithubAuthRequiredOutput {
+            app_install_link: auth_url.clone(),
+            auth_url,
+            tx_id: tx_id.unwrap_or_else(|| cynic::Id::new("github-reauth")),
+        }
+    }
+
+    async fn refresh_github_auth_output(&self) -> GithubAuthRequiredOutput {
+        let fallback_auth_url = Self::github_oauth_connect_url();
+
+        // The simple-integration endpoint owns the server-side GitHub connection
+        // state. Asking it to update GitHub gives the server a chance to invalidate
+        // the stale OAuth record and return a fresh tx-bound auth URL.
+        let reauth_result = self
+            .create_or_update_simple_integration_request(
+                GITHUB_PROVIDER_SLUG.to_string(),
+                true,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                true,
+            )
+            .await;
+
+        match reauth_result {
+            Ok(output) => {
+                let auth_url = output.auth_url.unwrap_or(fallback_auth_url);
+                Self::github_auth_required_output(auth_url, output.tx_id)
+            }
+            Err(error) => {
+                log::warn!(
+                    "Failed to start GitHub OAuth reauth transaction after stale token: {error:#}"
+                );
+                Self::github_auth_required_output(fallback_auth_url, None)
+            }
+        }
+    }
+
+    fn should_refresh_github_auth_for_user_github_info_error(error: &anyhow::Error) -> bool {
+        let message = error
+            .chain()
+            .map(|cause| cause.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Self::should_refresh_github_auth_for_user_github_info_message(&message)
+    }
+
+    fn should_refresh_github_auth_for_user_github_info_message(message: &str) -> bool {
+        let message = message.to_ascii_lowercase();
+        let missing_user_github_info_data =
+            message.contains("missing response data") && message.contains("usergithubinfo");
+        if missing_user_github_info_data {
+            return true;
+        }
+
+        let mentions_github = message.contains("github") || message.contains("usergithubinfo");
+        let mentions_auth_material = message.contains("oauth")
+            || message.contains("token")
+            || message.contains("credential")
+            || message.contains("authorization")
+            || message.contains("authentication");
+        let looks_invalid = message.contains("bad credentials")
+            || message.contains("invalid")
+            || message.contains("expired")
+            || message.contains("revoked")
+            || message.contains("unauthorized")
+            || message.contains("401");
+
+        (mentions_github || message.contains("bad credentials"))
+            && mentions_auth_material
+            && looks_invalid
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GithubAuthRefreshRequired, ServerApi};
+
+    #[test]
+    fn user_github_info_missing_data_requires_auth_refresh() {
+        let error = anyhow::anyhow!("missing response data for UserGithubInfo: Bad credentials");
+
+        assert!(ServerApi::should_refresh_github_auth_for_user_github_info_error(&error));
+    }
+
+    #[test]
+    fn invalid_github_oauth_token_requires_auth_refresh() {
+        let error = anyhow::anyhow!("GitHub OAuth token is invalid or revoked");
+
+        assert!(ServerApi::should_refresh_github_auth_for_user_github_info_error(&error));
+    }
+
+    #[test]
+    fn user_github_info_bad_credentials_message_requires_auth_refresh() {
+        assert!(
+            ServerApi::should_refresh_github_auth_for_user_github_info_message("Bad credentials")
+        );
+    }
+
+    #[test]
+    fn unrelated_missing_data_does_not_require_auth_refresh() {
+        let error = anyhow::anyhow!("missing response data for GetUserSettings");
+
+        assert!(!ServerApi::should_refresh_github_auth_for_user_github_info_error(&error));
+    }
+
+    #[test]
+    fn unrelated_github_error_does_not_require_auth_refresh() {
+        let error = anyhow::anyhow!("GitHub rate limit exceeded");
+
+        assert!(!ServerApi::should_refresh_github_auth_for_user_github_info_error(&error));
+    }
+
+    #[test]
+    fn auth_refresh_required_errors_are_identifiable() {
+        let error = anyhow::anyhow!(GithubAuthRefreshRequired {
+            source: anyhow::anyhow!("missing response data for UserGithubInfo"),
+        });
+
+        assert!(super::is_github_auth_refresh_required_error(&error));
+    }
+}
 
 #[cfg_attr(test, automock)]
 #[cfg_attr(target_family = "wasm", allow(dead_code))]
@@ -109,6 +301,9 @@ pub trait IntegrationsClient: 'static + IntegrationsClientBounds {
     /// * `Ok(OauthConnectTxStatus)` - The current status of the transaction
     /// * `Err` - If the transaction is not found or polling fails
     async fn poll_oauth_connect_status(&self, tx_id: String) -> Result<OauthConnectTxStatus>;
+
+    /// Starts a fresh GitHub authorization flow, invalidating stale connection state when possible.
+    async fn refresh_github_auth(&self) -> Result<GithubAuthRequiredOutput>;
 
     /// Gets the list of integration provider names that are using the specified environment.
     ///
@@ -178,32 +373,18 @@ impl IntegrationsClient for ServerApi {
         worker_host: Option<String>,
         enabled: bool,
     ) -> Result<CreateSimpleIntegrationOutput> {
-        let variables = CreateSimpleIntegrationVariables {
-            config: SimpleIntegrationConfig {
-                base_prompt,
-                environment_uid,
-                model_id,
-                mcp_servers_json,
-                remove_mcp_server_names,
-                worker_host,
-            },
-            enabled,
+        self.create_or_update_simple_integration_request(
             integration_type,
             is_update,
-            request_context: get_request_context(),
-        };
-
-        let operation = CreateSimpleIntegration::build(variables);
-        let response = self.send_graphql_request(operation, None).await?;
-        match response.create_simple_integration {
-            CreateSimpleIntegrationResult::CreateSimpleIntegrationOutput(output) => Ok(output),
-            CreateSimpleIntegrationResult::UserFacingError(error) => {
-                Err(anyhow!(get_user_facing_error_message(error)))
-            }
-            CreateSimpleIntegrationResult::Unknown => {
-                Err(anyhow!("Unknown error while creating integration"))
-            }
-        }
+            environment_uid,
+            base_prompt,
+            model_id,
+            mcp_servers_json,
+            remove_mcp_server_names,
+            worker_host,
+            enabled,
+        )
+        .await
     }
 
     async fn get_integrations_using_environment(
@@ -278,13 +459,26 @@ impl IntegrationsClient for ServerApi {
         }
     }
 
+    async fn refresh_github_auth(&self) -> Result<GithubAuthRequiredOutput> {
+        Ok(self.refresh_github_auth_output().await)
+    }
+
     async fn get_user_github_info(&self) -> Result<UserGithubInfoResult> {
         let variables = UserGithubInfoVariables {
             request_context: get_request_context(),
         };
 
         let operation = UserGithubInfo::build(variables);
-        let response = self.send_graphql_request(operation, None).await?;
+        let response = match self.send_graphql_request(operation, None).await {
+            Ok(response) => response,
+            Err(error) if Self::should_refresh_github_auth_for_user_github_info_error(&error) => {
+                log::warn!(
+                    "GitHub info fetch failed with stale or invalid OAuth credentials; auth refresh required: {error:#}"
+                );
+                return Err(anyhow!(GithubAuthRefreshRequired { source: error }));
+            }
+            Err(error) => return Err(error),
+        };
 
         let result = response.user_github_info;
 
@@ -308,7 +502,22 @@ impl IntegrationsClient for ServerApi {
             }
         }
 
-        Ok(result)
+        match result {
+            UserGithubInfoResult::UserFacingError(error) => {
+                let message = get_user_facing_error_message(error);
+                if Self::should_refresh_github_auth_for_user_github_info_message(&message) {
+                    log::warn!(
+                        "GitHub info fetch returned stale or invalid OAuth credentials; auth refresh required: {message}"
+                    );
+                    return Err(anyhow!(GithubAuthRefreshRequired {
+                        source: anyhow!(message),
+                    }));
+                }
+
+                Err(anyhow!(message))
+            }
+            result => Ok(result),
+        }
     }
 
     async fn suggest_cloud_environment_image(

--- a/app/src/settings_view/update_environment_form.rs
+++ b/app/src/settings_view/update_environment_form.rs
@@ -2,7 +2,10 @@ use super::{
     editor_text_colors,
     settings_page::{render_input_list, InputListItem},
 };
-use crate::server::server_api::ServerApiProvider;
+use crate::server::{
+    graphql::get_user_facing_error_message,
+    server_api::{integrations, ServerApiProvider},
+};
 use crate::{
     ai::ambient_agents::telemetry::CloudAgentTelemetryEvent,
     ai::{
@@ -355,6 +358,7 @@ const FORM_DESCRIPTION_VERTICAL_PADDING: f32 = 6.;
 const CARD_BORDER_WIDTH: f32 = 1.;
 const REPO_CHIP_MAX_WIDTH: f32 = 200.;
 const DROPDOWN_MAX_WIDTH: f32 = 800.;
+const FORM_SIDE_BUTTON_WIDTH: f32 = 160.;
 const DROPDOWN_MAX_HEIGHT: f32 = 300.;
 const REPOS_DROPDOWN_ANCHOR: &str = "repos_dropdown_anchor";
 const HEADER_VERTICAL_LAYOUT_THRESHOLD: f32 = 520.;
@@ -1198,7 +1202,17 @@ impl UpdateEnvironmentForm {
             .get_integrations_client();
 
         ctx.spawn(
-            async move { integrations_client.get_user_github_info().await },
+            async move {
+                match integrations_client.get_user_github_info().await {
+                    Err(error) if integrations::is_github_auth_refresh_required_error(&error) => {
+                        integrations_client
+                            .refresh_github_auth()
+                            .await
+                            .map(UserGithubInfoResult::GithubAuthRequiredOutput)
+                    }
+                    result => result,
+                }
+            },
             move |me, result, ctx| {
                 me.github_dropdown_state.is_loading = false;
                 let mut should_open_auth = open_auth_after_fetch;
@@ -1246,6 +1260,12 @@ impl UpdateEnvironmentForm {
                     Ok(UserGithubInfoResult::Unknown) => {
                         me.github_dropdown_state.load_error_message =
                             Some("Failed to load GitHub repos".to_string());
+                    }
+                    Ok(UserGithubInfoResult::UserFacingError(error)) => {
+                        me.github_dropdown_state.load_error_message = Some(format!(
+                            "Failed to load GitHub repos: {}",
+                            get_user_facing_error_message(error)
+                        ));
                     }
                     Err(e) => {
                         me.github_dropdown_state.load_error_message =
@@ -1998,7 +2018,7 @@ impl UpdateEnvironmentForm {
                         )
                         .with_child(
                             Text::new(
-                                "Auth with GitHub",
+                                "GitHub Auth",
                                 appearance.ui_font_family(),
                                 appearance.ui_font_size(),
                             )
@@ -2014,6 +2034,7 @@ impl UpdateEnvironmentForm {
                 .with_background(bg)
                 .finish(),
             )
+            .with_width(FORM_SIDE_BUTTON_WIDTH)
             .with_height(FORM_INPUT_HEIGHT)
             .finish()
         })
@@ -2031,7 +2052,7 @@ impl UpdateEnvironmentForm {
             .finish();
         field.add_child(
             ConstrainedBox::new(row)
-                .with_max_width(DROPDOWN_MAX_WIDTH)
+                .with_width(DROPDOWN_MAX_WIDTH)
                 .finish(),
         );
         field.finish()
@@ -3118,6 +3139,7 @@ impl UpdateEnvironmentForm {
                 .finish();
 
                 let button = ConstrainedBox::new(button_content)
+                    .with_width(FORM_SIDE_BUTTON_WIDTH)
                     .with_height(FORM_INPUT_HEIGHT)
                     .finish();
 

--- a/app/src/settings_view/update_environment_form.rs
+++ b/app/src/settings_view/update_environment_form.rs
@@ -2052,7 +2052,7 @@ impl UpdateEnvironmentForm {
             .finish();
         field.add_child(
             ConstrainedBox::new(row)
-                .with_width(DROPDOWN_MAX_WIDTH)
+                .with_max_width(DROPDOWN_MAX_WIDTH)
                 .finish(),
         );
         field.finish()

--- a/app/src/settings_view/update_environment_form_tests.rs
+++ b/app/src/settings_view/update_environment_form_tests.rs
@@ -459,8 +459,8 @@ fn test_render_repos_field_auth_required() {
                 "Expected 'Repo(s)' label in rendered content: {text_content}"
             );
             assert!(
-                text_content.contains("Auth with GitHub"),
-                "Expected 'Auth with GitHub' in rendered content: {text_content}"
+                text_content.contains("GitHub Auth"),
+                "Expected 'GitHub Auth' in rendered content: {text_content}"
             );
         });
     })

--- a/crates/graphql/src/api/queries/user_github_info.rs
+++ b/crates/graphql/src/api/queries/user_github_info.rs
@@ -1,4 +1,4 @@
-use crate::{request_context::RequestContext, schema};
+use crate::{error::UserFacingError, request_context::RequestContext, schema};
 
 #[derive(cynic::QueryVariables, Debug)]
 pub struct UserGithubInfoVariables {
@@ -27,11 +27,12 @@ pub struct RepoResult {
     pub is_public: bool,
 }
 
-#[derive(cynic::InlineFragments, Debug, Clone)]
+#[derive(cynic::InlineFragments, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum UserGithubInfoResult {
     GithubConnectedOutput(GithubConnectedOutput),
     GithubAuthRequiredOutput(GithubAuthRequiredOutput),
+    UserFacingError(UserFacingError),
     #[cynic(fallback)]
     Unknown,
 }


### PR DESCRIPTION
## Description
Handles stale or invalid GitHub OAuth tokens when loading GitHub repo info. If `userGithubInfo` fails in the stale-token path, Warp now routes the user back through GitHub auth by requesting a fresh GitHub integration auth transaction, with a fallback to the generic GitHub connect URL.

## Linked Issue
Closes https://github.com/warpdotdev/warp/issues/10053

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).
<img width="1392" height="912" alt="スクリーンショット 2026-05-10 22 32 51" src="https://github.com/user-attachments/assets/7854c467-5a74-4b7f-be80-f944621242ea" />

## Testing
- `cargo fmt`
- `cargo test -p warp server::server_api::integrations::tests --lib`
- `cargo test -p warp settings_view::update_environment_form::tests::test_render_repos_field_auth_required --lib`
- `cargo test -p warp settings_view::update_environment_form::tests::test_render_repos_field_error_state --lib`
- `cargo clippy -p warp --lib --tests -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed GitHub reauthorization when a stored OAuth token is stale or revoked.