### PR TITLE
Change handoff conversations to use "<original conversation title> (Moved to cloud)" for the new conversation title

### DIFF
--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -2558,6 +2558,11 @@ fn update_forked_task_properties(
     preserve_task_ids: bool,
     title_override: Option<&str>,
 ) -> Vec<warp_multi_agent_api::Task> {
+    let root_description = |current: &str| match title_override {
+        Some(title) => title.to_owned(),
+        None => format!("{prefix}{current}"),
+    };
+
     if preserve_task_ids {
         return tasks
             .into_iter()
@@ -2568,10 +2573,7 @@ fn update_forked_task_properties(
                     .map(|deps| deps.parent_task_id.is_empty())
                     .unwrap_or(true);
                 if is_root {
-                    t.description = match title_override {
-                        Some(title) => title.to_owned(),
-                        None => format!("{prefix}{}", t.description),
-                    };
+                    t.description = root_description(&t.description);
                 }
                 t
             })
@@ -2608,10 +2610,7 @@ fn update_forked_task_properties(
                 deps.parent_task_id =
                     get_new_task_id(&mut old_to_new_task_ids, &deps.parent_task_id).clone();
             } else {
-                t.description = match title_override {
-                    Some(title) => title.to_owned(),
-                    None => format!("{prefix}{}", t.description),
-                };
+                t.description = root_description(&t.description);
             }
             t
         })

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1101,6 +1101,7 @@ impl BlocklistAIHistoryModel {
         source_conversation: &AIConversation,
         prefix: &str,
         preserve_task_ids: bool,
+        title_override: Option<&str>,
         app: &AppContext,
     ) -> Result<AIConversation, anyhow::Error> {
         let tasks: Vec<warp_multi_agent_api::Task> = source_conversation
@@ -1109,7 +1110,7 @@ impl BlocklistAIHistoryModel {
             .collect();
 
         let updated_tasks_with_new_ids =
-            update_forked_task_properties(tasks, prefix, preserve_task_ids);
+            update_forked_task_properties(tasks, prefix, preserve_task_ids, title_override);
         let Some(sqlite_sender) = GlobalResourceHandlesProvider::as_ref(app)
             .get()
             .model_event_sender
@@ -1197,6 +1198,7 @@ impl BlocklistAIHistoryModel {
         from_exchange_id: AIAgentExchangeId,
         fork_from_exact_exchange: bool,
         prefix: &str,
+        title_override: Option<&str>,
         app: &AppContext,
     ) -> Result<AIConversation, anyhow::Error> {
         let conversation = source_conversation;
@@ -1262,7 +1264,7 @@ impl BlocklistAIHistoryModel {
         }
 
         let updated_tasks_with_new_ids =
-            update_forked_task_properties(truncated_tasks, prefix, false);
+            update_forked_task_properties(truncated_tasks, prefix, false, title_override);
 
         let Some(sqlite_sender) = GlobalResourceHandlesProvider::as_ref(app)
             .get()
@@ -2554,6 +2556,7 @@ fn update_forked_task_properties(
     tasks: Vec<warp_multi_agent_api::Task>,
     prefix: &str,
     preserve_task_ids: bool,
+    title_override: Option<&str>,
 ) -> Vec<warp_multi_agent_api::Task> {
     if preserve_task_ids {
         return tasks
@@ -2565,7 +2568,10 @@ fn update_forked_task_properties(
                     .map(|deps| deps.parent_task_id.is_empty())
                     .unwrap_or(true);
                 if is_root {
-                    t.description = format!("{}{}", prefix, t.description);
+                    t.description = match title_override {
+                        Some(title) => title.to_owned(),
+                        None => format!("{prefix}{}", t.description),
+                    };
                 }
                 t
             })
@@ -2602,7 +2608,10 @@ fn update_forked_task_properties(
                 deps.parent_task_id =
                     get_new_task_id(&mut old_to_new_task_ids, &deps.parent_task_id).clone();
             } else {
-                t.description = format!("{}{}", prefix, t.description);
+                t.description = match title_override {
+                    Some(title) => title.to_owned(),
+                    None => format!("{prefix}{}", t.description),
+                };
             }
             t
         })

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -1640,13 +1640,7 @@ fn test_fork_conversation_title_override_replaces_prefix() {
                 .expect("source must be in memory")
                 .clone();
             let forked = model
-                .fork_conversation(
-                    &source,
-                    "[Fork] ",
-                    false,
-                    Some("Custom title"),
-                    ctx,
-                )
+                .fork_conversation(&source, "[Fork] ", false, Some("Custom title"), ctx)
                 .expect("fork must succeed");
 
             let forked_root = forked

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -1458,7 +1458,7 @@ fn test_fork_then_bind_handoff_token_resolves_to_forked_conversation() {
                 .expect("source conversation must be in memory after restore")
                 .clone();
             let forked = model
-                .fork_conversation(&source, "[Fork] ", false, ctx)
+                .fork_conversation(&source, "[Fork] ", false, None, ctx)
                 .expect("fork must succeed when sqlite sender is wired up");
             assert_eq!(
                 forked
@@ -1554,7 +1554,7 @@ fn test_fork_conversation_preserves_task_ids_when_requested() {
                 .expect("source conversation must be in memory after restore")
                 .clone();
             let forked = model
-                .fork_conversation(&source, "[Fork] ", true, ctx)
+                .fork_conversation(&source, "[Fork] ", true, None, ctx)
                 .expect("fork must succeed when sqlite sender is wired up");
 
             let forked_tasks: Vec<&warp_multi_agent_api::Task> =
@@ -1582,6 +1582,80 @@ fn test_fork_conversation_preserves_task_ids_when_requested() {
             assert_eq!(
                 forked_subtask.description, "Original subtask",
                 "subtask description must not be prefixed",
+            );
+        });
+    });
+}
+
+#[test]
+fn test_fork_conversation_title_override_replaces_prefix() {
+    use crate::ai::agent::conversation::AIConversation;
+    use crate::persistence::model::AgentConversationData;
+    use crate::test_util::ai_agent_tasks::{create_api_task, create_message};
+
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        let (sender, _receiver) = std::sync::mpsc::sync_channel(2);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let terminal_view_id = EntityId::new();
+
+        let source_id = AIConversationId::new();
+        let mut root_task = create_api_task(
+            "root-task-id",
+            vec![create_message("root-msg", "root-task-id")],
+        );
+        root_task.description = "Original root".to_string();
+        let source = AIConversation::new_restored(
+            source_id,
+            vec![root_task],
+            Some(AgentConversationData {
+                server_conversation_token: None,
+                conversation_usage_metadata: None,
+                reverted_action_ids: None,
+                forked_from_server_conversation_token: None,
+                artifacts_json: None,
+                parent_agent_id: None,
+                agent_name: None,
+                orchestration_harness_type: None,
+                parent_conversation_id: None,
+                is_remote_child: false,
+                run_id: None,
+                autoexecute_override: None,
+                last_event_sequence: None,
+            }),
+        )
+        .expect("restored source conversation should build");
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![source], ctx);
+        });
+
+        history_model.update(&mut app, |model, ctx| {
+            let source = model
+                .conversation(&source_id)
+                .expect("source must be in memory")
+                .clone();
+            let forked = model
+                .fork_conversation(
+                    &source,
+                    "[Fork] ",
+                    false,
+                    Some("Custom title"),
+                    ctx,
+                )
+                .expect("fork must succeed");
+
+            let forked_root = forked
+                .all_tasks()
+                .find_map(|t| t.source())
+                .expect("forked conversation must have a root task");
+            assert_eq!(
+                forked_root.description, "Custom title",
+                "title_override must replace the prefix+description",
             );
         });
     });

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -287,6 +287,13 @@ pub struct UploadLocalHandoffSnapshotResponse {
     pub uploads: Vec<UploadTarget>,
 }
 
+/// Request body for `POST /agent/conversations/{conversation_id}/fork`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ForkConversationRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+}
+
 /// Response body for `POST /agent/conversations/{conversation_id}/fork`. The returned id is sent
 /// on the subsequent `POST /agent/runs` request under `conversation_id` (resume semantics).
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -929,6 +936,7 @@ pub trait AIClient: 'static + Send + Sync {
     async fn fork_conversation(
         &self,
         conversation_id: String,
+        title: Option<String>,
     ) -> anyhow::Result<ForkConversationResponse, anyhow::Error>;
 
     async fn list_ambient_agent_tasks(
@@ -1671,9 +1679,11 @@ impl AIClient for ServerApi {
     async fn fork_conversation(
         &self,
         conversation_id: String,
+        title: Option<String>,
     ) -> anyhow::Result<ForkConversationResponse, anyhow::Error> {
+        let request = ForkConversationRequest { title };
         let response: ForkConversationResponse = self
-            .post_public_api(&build_fork_conversation_url(&conversation_id), &())
+            .post_public_api(&build_fork_conversation_url(&conversation_id), &request)
             .await?;
         Ok(response)
     }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -23534,6 +23534,7 @@ impl TerminalView {
                     &conversation,
                     PRE_REWIND_PREFIX,
                     false, /* preserve_task_ids */
+                    None,
                     ctx,
                 ) {
                     log::warn!("Failed to save pre-rewind backup of conversation {conversation_id}: {e}");

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -130,6 +130,8 @@ pub(crate) struct PendingHandoff {
     /// Forked conversation id minted by `POST /agent/conversations/{conversation_id}/fork`.
     /// Sent under `conversation_id` on the subsequent `POST /agent/runs` request.
     pub(crate) forked_conversation_id: String,
+    /// Title override for the cloud run (e.g. "<title> (Moved to cloud)").
+    pub(crate) title: Option<String>,
     /// `None` until `derive_touched_workspace` completes.
     pub(crate) touched_workspace: Option<TouchedWorkspace>,
     /// Outcome of the async snapshot upload.
@@ -600,7 +602,7 @@ impl AmbientAgentViewModel {
             prompt,
             mode,
             config,
-            title: None,
+            title: self.pending_handoff.as_ref().and_then(|h| h.title.clone()),
             team: None,
             skill: None,
             attachments,

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -25,6 +25,7 @@ fn pending_launch() -> PendingCloudLaunch {
 fn pending_handoff() -> PendingHandoff {
     PendingHandoff {
         forked_conversation_id: "forked-conversation".to_owned(),
+        title: None,
         touched_workspace: None,
         snapshot_upload: SnapshotUploadStatus::Pending,
         submission_state: HandoffSubmissionState::Idle,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13210,7 +13210,11 @@ impl Workspace {
             .title()
             .map(|t| format!("{t} (Moved to cloud)"));
         ctx.spawn(
-            async move { ai_client.fork_conversation(source_conversation_id, title_for_fork).await },
+            async move {
+                ai_client
+                    .fork_conversation(source_conversation_id, title_for_fork)
+                    .await
+            },
             move |me, result, ctx| match result {
                 Ok(response) => {
                     me.complete_local_to_cloud_handoff_open(
@@ -13328,6 +13332,7 @@ impl Workspace {
         // Keep handoff state on the cloud model until snapshot prep and submit finish.
         let pending = PendingHandoff {
             forked_conversation_id: forked_conversation_id.clone(),
+            title: title_override,
             touched_workspace: None,
             snapshot_upload: SnapshotUploadStatus::Pending,
             submission_state: HandoffSubmissionState::Idle,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11732,6 +11732,7 @@ impl Workspace {
                         fork_from.exchange_id,
                         fork_from.fork_from_exact_exchange,
                         FORK_PREFIX,
+                        None,
                         ctx,
                     )
                 } else {
@@ -11739,6 +11740,7 @@ impl Workspace {
                         &source_conversation,
                         FORK_PREFIX,
                         false, /* preserve_task_ids */
+                        None,
                         ctx,
                     )
                 }
@@ -13204,8 +13206,11 @@ impl Workspace {
 
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let source_conversation_id = source_token.as_str().to_string();
+        let title_for_fork = source_conversation
+            .title()
+            .map(|t| format!("{t} (Moved to cloud)"));
         ctx.spawn(
-            async move { ai_client.fork_conversation(source_conversation_id).await },
+            async move { ai_client.fork_conversation(source_conversation_id, title_for_fork).await },
             move |me, result, ctx| match result {
                 Ok(response) => {
                     me.complete_local_to_cloud_handoff_open(
@@ -13245,8 +13250,17 @@ impl Workspace {
     ) {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         // Materialize the fork locally so the new pane can restore it.
+        let title_override = source_conversation
+            .title()
+            .map(|t| format!("{t} (Moved to cloud)"));
         let local_fork = match history_model.update(ctx, |history_model, ctx| {
-            history_model.fork_conversation(&source_conversation, FORK_PREFIX, true, ctx)
+            history_model.fork_conversation(
+                &source_conversation,
+                FORK_PREFIX,
+                true,
+                title_override.as_deref(),
+                ctx,
+            )
         }) {
             Ok(forked) => forked,
             Err(err) => {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

WISOTT. The bulk of this change is on the server-side to allow the conversation forking endpoint to accept custom titles (because the conversation forking endpoint we use for handoff is generic, so we can't just change the title there by default to include "moved to cloud"). 

On the client, we just have to pass this new field in, and also pass in a custom title field for our new task.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

![image.png](https://app.graphite.com/user-attachments/assets/5f46177e-8887-4bd8-96f5-0613d3524b76.png)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode