### PR TITLE
Add "Create new branch" option to branch switcher

### DIFF
--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -11,7 +11,7 @@ use crate::code::editor::{add_color, remove_color};
 use crate::code_review::code_review_view::CODE_REVIEW_TOOLTIP_TEXT;
 use crate::code_review::diff_state::DiffStats;
 use crate::context_chips::git_branch_on_click::{
-    GitBranchOnClickValue, is_plausible_new_branch_name,
+    is_plausible_new_branch_name, GitBranchOnClickValue,
 };
 use crate::context_chips::node_version_popup::{NodeVersionPopupEvent, NodeVersionPopupView};
 use crate::context_chips::spacing;
@@ -28,7 +28,7 @@ use crate::util::truncation::truncate_from_beginning;
 use crate::view_components::action_button::{ActionButtonTheme, NakedTheme};
 use crate::view_components::{FeaturePopup, NewFeaturePopupEvent, NewFeaturePopupLabel};
 use pathfinder_color::ColorU;
-use pathfinder_geometry::vector::{Vector2F, vec2f};
+use pathfinder_geometry::vector::{vec2f, Vector2F};
 use std::path::PathBuf;
 use warp_core::ui::theme::Fill;
 use warp_core::{features::FeatureFlag, ui::theme::color::internal_colors};
@@ -38,27 +38,27 @@ use warpui::platform::Cursor;
 use warpui::ui_components::components::UiComponentStyles;
 use warpui::ui_components::components::{Coords, UiComponent};
 use warpui::{
-    AppContext, Element, Entity, EntityId, Gradient, ModelHandle, SingletonEntity, TypedActionView,
-    View, ViewContext, ViewHandle,
     elements::{
         Border, ChildAnchor, ChildView, ConstrainedBox, Container, CornerRadius,
-        CrossAxisAlignment, DEFAULT_UI_LINE_HEIGHT_RATIO, Flex, Hoverable, MouseStateHandle,
-        OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds, Radius, Stack, Text,
+        CrossAxisAlignment, Flex, Hoverable, MouseStateHandle, OffsetPositioning, ParentAnchor,
+        ParentElement, ParentOffsetBounds, Radius, Stack, Text, DEFAULT_UI_LINE_HEIGHT_RATIO,
     },
     fonts::{Cache, FamilyId, Properties, Weight},
+    AppContext, Element, Entity, EntityId, Gradient, ModelHandle, SingletonEntity, TypedActionView,
+    View, ViewContext, ViewHandle,
 };
 
 use crate::appearance::Appearance;
 use crate::completer::SessionContext;
-use crate::{TelemetryEvent, send_telemetry_from_ctx};
+use crate::{send_telemetry_from_ctx, TelemetryEvent};
 
 use super::{
-    ChipResult, ContextChipKind, agent_view_chip_color,
+    agent_view_chip_color,
     directory_fetcher::{DirectoryFetcher, DirectoryFetcherEvent, DirectoryItem, DirectoryType},
     display_menu::{
         ChipMenuType, DisplayChipMenu, FixedFooter, GenericMenuItem, PromptDisplayMenuEvent,
     },
-    github_pr_display_text_from_url, render_text_from_kind,
+    github_pr_display_text_from_url, render_text_from_kind, ChipResult, ContextChipKind,
 };
 use crate::workspace::view::TOGGLE_RIGHT_PANEL_BINDING_NAME;
 
@@ -613,21 +613,20 @@ impl DisplayChip {
                 ctx.subscribe_to_view(&menu_view, |me, _, event, ctx| match event {
                     PromptDisplayMenuEvent::MenuAction(generic_event) => {
                         let action_item = generic_event.action_item.as_any();
-                        let command = if let Some(git_branch) =
-                            action_item.downcast_ref::<GitBranch>()
-                        {
-                            git_branch.command()
-                        } else if let Some(create_branch) =
-                            action_item.downcast_ref::<CreateGitBranch>()
-                        {
-                            create_branch.command()
-                        } else {
-                            log::warn!(
+                        let command =
+                            if let Some(git_branch) = action_item.downcast_ref::<GitBranch>() {
+                                git_branch.command()
+                            } else if let Some(create_branch) =
+                                action_item.downcast_ref::<CreateGitBranch>()
+                            {
+                                create_branch.command()
+                            } else {
+                                log::warn!(
                                 "MenuAction event should contain a GitBranch or CreateGitBranch \
                                  action item"
                             );
-                            return;
-                        };
+                                return;
+                            };
 
                         ctx.emit(PromptDisplayChipEvent::TryExecuteCommand(command));
                         me.close_git_branch_menu(ctx);

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -10,7 +10,9 @@ use crate::ai::{
 use crate::code::editor::{add_color, remove_color};
 use crate::code_review::code_review_view::CODE_REVIEW_TOOLTIP_TEXT;
 use crate::code_review::diff_state::DiffStats;
-use crate::context_chips::git_branch_on_click::GitBranchOnClickValue;
+use crate::context_chips::git_branch_on_click::{
+    GitBranchOnClickValue, is_plausible_new_branch_name,
+};
 use crate::context_chips::node_version_popup::{NodeVersionPopupEvent, NodeVersionPopupView};
 use crate::context_chips::spacing;
 use crate::settings::{AISettings, AISettingsChangedEvent, InputSettings};
@@ -26,7 +28,7 @@ use crate::util::truncation::truncate_from_beginning;
 use crate::view_components::action_button::{ActionButtonTheme, NakedTheme};
 use crate::view_components::{FeaturePopup, NewFeaturePopupEvent, NewFeaturePopupLabel};
 use pathfinder_color::ColorU;
-use pathfinder_geometry::vector::{vec2f, Vector2F};
+use pathfinder_geometry::vector::{Vector2F, vec2f};
 use std::path::PathBuf;
 use warp_core::ui::theme::Fill;
 use warp_core::{features::FeatureFlag, ui::theme::color::internal_colors};
@@ -36,27 +38,27 @@ use warpui::platform::Cursor;
 use warpui::ui_components::components::UiComponentStyles;
 use warpui::ui_components::components::{Coords, UiComponent};
 use warpui::{
-    elements::{
-        Border, ChildAnchor, ChildView, ConstrainedBox, Container, CornerRadius,
-        CrossAxisAlignment, Flex, Hoverable, MouseStateHandle, OffsetPositioning, ParentAnchor,
-        ParentElement, ParentOffsetBounds, Radius, Stack, Text, DEFAULT_UI_LINE_HEIGHT_RATIO,
-    },
-    fonts::{Cache, FamilyId, Properties, Weight},
     AppContext, Element, Entity, EntityId, Gradient, ModelHandle, SingletonEntity, TypedActionView,
     View, ViewContext, ViewHandle,
+    elements::{
+        Border, ChildAnchor, ChildView, ConstrainedBox, Container, CornerRadius,
+        CrossAxisAlignment, DEFAULT_UI_LINE_HEIGHT_RATIO, Flex, Hoverable, MouseStateHandle,
+        OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds, Radius, Stack, Text,
+    },
+    fonts::{Cache, FamilyId, Properties, Weight},
 };
 
 use crate::appearance::Appearance;
 use crate::completer::SessionContext;
-use crate::{send_telemetry_from_ctx, TelemetryEvent};
+use crate::{TelemetryEvent, send_telemetry_from_ctx};
 
 use super::{
-    agent_view_chip_color,
+    ChipResult, ContextChipKind, agent_view_chip_color,
     directory_fetcher::{DirectoryFetcher, DirectoryFetcherEvent, DirectoryItem, DirectoryType},
     display_menu::{
         ChipMenuType, DisplayChipMenu, FixedFooter, GenericMenuItem, PromptDisplayMenuEvent,
     },
-    github_pr_display_text_from_url, render_text_from_kind, ChipResult, ContextChipKind,
+    github_pr_display_text_from_url, render_text_from_kind,
 };
 use crate::workspace::view::TOGGLE_RIGHT_PANEL_BINDING_NAME;
 
@@ -477,6 +479,45 @@ impl GenericMenuItem for GitBranch {
     }
 }
 
+/// Synthetic menu entry shown in the branch switcher when the user types a
+/// query that does not match any existing branch. Selecting it runs
+/// `git checkout -b <branch>` so the user can create the branch they were
+/// about to switch to without leaving the picker.
+#[derive(Debug, Clone)]
+pub(crate) struct CreateGitBranch(String);
+
+impl CreateGitBranch {
+    pub(crate) fn new(branch_name: String) -> Self {
+        Self(branch_name.trim().to_string())
+    }
+
+    pub(crate) fn branch_name(&self) -> &str {
+        &self.0
+    }
+
+    fn command(&self) -> String {
+        format_create_git_branch_command(&self.0)
+    }
+}
+
+impl GenericMenuItem for CreateGitBranch {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> String {
+        format!("Create new branch \"{}\"", self.0)
+    }
+
+    fn icon(&self, _app: &AppContext) -> Option<Icon> {
+        Some(Icon::Plus)
+    }
+
+    fn action_data(&self) -> String {
+        self.0.clone()
+    }
+}
+
 impl DisplayChip {
     /// Convert MenuPositioning to appropriate anchor pair for overlay positioning
     fn positioning_to_anchors(positioning: MenuPositioning) -> (ParentAnchor, ChildAnchor) {
@@ -560,21 +601,35 @@ impl DisplayChip {
                         ChipMenuType::Branches,
                         ctx,
                     )
+                    .with_create_item_from_query(Arc::new(|query: &str| {
+                        if !is_plausible_new_branch_name(query) {
+                            return None;
+                        }
+                        let create_branch = CreateGitBranch::new(query.to_string());
+                        let arc: Arc<dyn GenericMenuItem> = Arc::new(create_branch);
+                        Some(arc)
+                    }))
                 });
                 ctx.subscribe_to_view(&menu_view, |me, _, event, ctx| match event {
                     PromptDisplayMenuEvent::MenuAction(generic_event) => {
-                        let Some(git_branch) = generic_event
-                            .action_item
-                            .as_any()
-                            .downcast_ref::<GitBranch>()
-                        else {
-                            log::warn!("MenuAction event should contain ActionItem action item");
+                        let action_item = generic_event.action_item.as_any();
+                        let command = if let Some(git_branch) =
+                            action_item.downcast_ref::<GitBranch>()
+                        {
+                            git_branch.command()
+                        } else if let Some(create_branch) =
+                            action_item.downcast_ref::<CreateGitBranch>()
+                        {
+                            create_branch.command()
+                        } else {
+                            log::warn!(
+                                "MenuAction event should contain a GitBranch or CreateGitBranch \
+                                 action item"
+                            );
                             return;
                         };
 
-                        ctx.emit(PromptDisplayChipEvent::TryExecuteCommand(
-                            git_branch.command(),
-                        ));
+                        ctx.emit(PromptDisplayChipEvent::TryExecuteCommand(command));
                         me.close_git_branch_menu(ctx);
                         ctx.notify();
                     }
@@ -1815,6 +1870,14 @@ pub fn format_git_branch_command(encoded_git_branch_on_click_value: &str) -> Str
     }
 
     format!("git checkout {}", shell_single_quote(&branch.branch_name))
+}
+
+/// Format a `git checkout -b <branch>` command for the given (already-trimmed)
+/// branch name. The trailing `--` ensures the branch name is treated as a
+/// positional argument rather than a flag if it happens to contain unusual
+/// characters that survived our front-end validation.
+pub fn format_create_git_branch_command(branch_name: &str) -> String {
+    format!("git checkout -b {} --", shell_single_quote(branch_name))
 }
 
 pub(crate) fn chip_container(

--- a/app/src/context_chips/display_chip_tests.rs
+++ b/app/src/context_chips/display_chip_tests.rs
@@ -1,10 +1,10 @@
 use super::{
-    CreateGitBranch, GitBranch, GitLineChanges, format_create_git_branch_command,
-    format_git_branch_command, truncate_from_beginning,
+    format_create_git_branch_command, format_git_branch_command, truncate_from_beginning,
+    CreateGitBranch, GitBranch, GitLineChanges,
 };
 use crate::context_chips::display_menu::GenericMenuItem;
 use crate::context_chips::{
-    ContextChipKind, git_branch_on_click::GitBranchOnClickValue, github_pr_display_text_from_url,
+    git_branch_on_click::GitBranchOnClickValue, github_pr_display_text_from_url, ContextChipKind,
 };
 use crate::ui_components::icons::Icon;
 

--- a/app/src/context_chips/display_chip_tests.rs
+++ b/app/src/context_chips/display_chip_tests.rs
@@ -1,6 +1,10 @@
-use super::{format_git_branch_command, truncate_from_beginning, GitBranch, GitLineChanges};
+use super::{
+    CreateGitBranch, GitBranch, GitLineChanges, format_create_git_branch_command,
+    format_git_branch_command, truncate_from_beginning,
+};
+use crate::context_chips::display_menu::GenericMenuItem;
 use crate::context_chips::{
-    git_branch_on_click::GitBranchOnClickValue, github_pr_display_text_from_url, ContextChipKind,
+    ContextChipKind, git_branch_on_click::GitBranchOnClickValue, github_pr_display_text_from_url,
 };
 use crate::ui_components::icons::Icon;
 
@@ -100,6 +104,42 @@ fn test_git_branch_menu_icon_uses_worktree_icon_for_linked_worktree() {
     .encode();
 
     assert_eq!(GitBranch(value).icon_for_menu(), Icon::Dataflow02);
+}
+
+#[test]
+fn test_format_create_git_branch_command_quotes_branch_and_appends_double_dash() {
+    assert_eq!(
+        format_create_git_branch_command("feature/xyz"),
+        "git checkout -b 'feature/xyz' --"
+    );
+}
+
+#[test]
+fn test_format_create_git_branch_command_escapes_single_quotes() {
+    assert_eq!(
+        format_create_git_branch_command("alice's-branch"),
+        "git checkout -b 'alice'\\''s-branch' --"
+    );
+}
+
+#[test]
+fn test_create_git_branch_menu_name_quotes_query() {
+    let item = CreateGitBranch::new("feature/xyz".to_string());
+    assert_eq!(item.name(), "Create new branch \"feature/xyz\"");
+}
+
+#[test]
+fn test_create_git_branch_action_data_returns_branch_name() {
+    let item = CreateGitBranch::new("feature/xyz".to_string());
+    assert_eq!(item.action_data(), "feature/xyz");
+    assert_eq!(item.branch_name(), "feature/xyz");
+}
+
+#[test]
+fn test_create_git_branch_trims_whitespace_in_constructor() {
+    let item = CreateGitBranch::new("  feature/xyz  ".to_string());
+    assert_eq!(item.branch_name(), "feature/xyz");
+    assert_eq!(item.name(), "Create new branch \"feature/xyz\"");
 }
 
 #[test]

--- a/app/src/context_chips/display_menu.rs
+++ b/app/src/context_chips/display_menu.rs
@@ -16,18 +16,22 @@ use crate::{
     server::ids::{ClientId, HashableId, ServerId, SyncId},
     ui_components::icons::Icon,
     view_components::copyable_text_field::{
-        COPY_FEEDBACK_DURATION, CopyButtonPlacement, CopyableTextFieldConfig,
-        render_copyable_text_field,
+        render_copyable_text_field, CopyButtonPlacement, CopyableTextFieldConfig,
+        COPY_FEEDBACK_DURATION,
     },
 };
-use fuzzy_match::{FuzzyMatchResult, match_indices_case_insensitive};
+use fuzzy_match::{match_indices_case_insensitive, FuzzyMatchResult};
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::{appearance::Appearance, builder::MIN_FONT_SIZE, theme::Fill};
 use warp_editor::editor::NavigationKey;
 use warpui::units::Pixels;
 use warpui::{
-    AppContext, Element, Entity, FocusContext, SingletonEntity as _, TypedActionView, View,
-    ViewContext, ViewHandle, WindowId,
+    color::ColorU,
+    elements::Highlight,
+    fonts::{Properties, Weight},
+    ui_components::components::{Coords, UiComponentStyles},
+};
+use warpui::{
     elements::{
         Border, ChildAnchor, ChildView, ClippedScrollStateHandle, ClippedScrollable,
         ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Dismiss, DispatchEventResult,
@@ -39,16 +43,12 @@ use warpui::{
     },
     keymap::FixedBinding,
     ui_components::components::UiComponent,
-};
-use warpui::{
-    color::ColorU,
-    elements::Highlight,
-    fonts::{Properties, Weight},
-    ui_components::components::{Coords, UiComponentStyles},
+    AppContext, Element, Entity, FocusContext, SingletonEntity as _, TypedActionView, View,
+    ViewContext, ViewHandle, WindowId,
 };
 
-use warpui::r#async::Timer;
 use warpui::clipboard::ClipboardContent;
+use warpui::r#async::Timer;
 
 /// Trait for items that can be displayed in a generic menu
 pub trait GenericMenuItem: Debug + 'static {
@@ -1533,7 +1533,7 @@ mod tests {
 
     #[test]
     fn query_matches_existing_name_works_with_owned_strings() {
-        let names = vec![String::from("main"), String::from("Develop")];
+        let names = [String::from("main"), String::from("Develop")];
         assert!(query_matches_existing_name(names.iter(), "Main"));
         assert!(query_matches_existing_name(names.iter(), "develop"));
     }

--- a/app/src/context_chips/display_menu.rs
+++ b/app/src/context_chips/display_menu.rs
@@ -180,13 +180,33 @@ enum EnvironmentSidecarSide {
 ///
 /// When set, [`DisplayChipMenu`] calls the builder on every search-query
 /// change. If the builder returns `Some(item)` and no existing menu item
-/// already has the same trimmed name, the returned item is prepended to the
-/// filtered results so the user can act on the unmatched query (for example,
-/// "Create new branch <name>"). The builder itself is responsible for
-/// validating the query (e.g. rejecting empty / invalid inputs) and returning
-/// `None` when no synthetic item should be offered.
+/// already has the same name (compared ASCII case-insensitively), the
+/// returned item is prepended to the filtered results so the user can act on
+/// the unmatched query (for example, "Create new branch <name>"). The
+/// builder itself is responsible for validating the query (e.g. rejecting
+/// empty / invalid inputs) and returning `None` when no synthetic item
+/// should be offered.
 pub type CreateItemFromQueryFn =
     dyn Fn(&str) -> Option<Arc<dyn GenericMenuItem>> + Send + Sync + 'static;
+
+/// Returns whether `query` matches any of `item_names`, ignoring ASCII case.
+///
+/// Used by [`DisplayChipMenu::update_filtered_items`] to suppress the
+/// "create from query" affordance when an existing item already covers the
+/// query. The comparison is case-insensitive on purpose: case-insensitive
+/// filesystems (the default on macOS and Windows) treat refs like `main` and
+/// `Main` as the same branch, so offering "Create new branch \"Main\"" while
+/// `main` already exists would just hand the user a `branch already exists`
+/// failure from git.
+fn query_matches_existing_name<I, S>(item_names: I, query: &str) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    item_names
+        .into_iter()
+        .any(|name| name.as_ref().eq_ignore_ascii_case(query))
+}
 
 pub struct DisplayChipMenu {
     list_state: UniformListState,
@@ -469,8 +489,10 @@ impl DisplayChipMenu {
         // switcher.
         if let Some(builder) = self.create_item_from_query.as_ref() {
             let trimmed = self.search_query.trim();
-            let already_matches_existing =
-                self.menu_items.iter().any(|item| item.name() == trimmed);
+            let already_matches_existing = query_matches_existing_name(
+                self.menu_items.iter().map(|item| item.name()),
+                trimmed,
+            );
             if !already_matches_existing {
                 if let Some(synthetic) = builder(trimmed) {
                     self.filtered_items.insert(
@@ -1479,5 +1501,40 @@ impl TypedActionView for DisplayChipMenu {
             }
             DisplayChipMenuAction::Close => self.close(ctx),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::query_matches_existing_name;
+
+    #[test]
+    fn query_matches_existing_name_is_ascii_case_insensitive() {
+        let names = ["main", "feature/Foo"];
+        assert!(query_matches_existing_name(names, "main"));
+        assert!(query_matches_existing_name(names, "Main"));
+        assert!(query_matches_existing_name(names, "MAIN"));
+        assert!(query_matches_existing_name(names, "feature/foo"));
+        assert!(query_matches_existing_name(names, "FEATURE/FOO"));
+    }
+
+    #[test]
+    fn query_matches_existing_name_returns_false_when_no_overlap() {
+        let names = ["main", "feature/foo"];
+        assert!(!query_matches_existing_name(names, "develop"));
+        assert!(!query_matches_existing_name(names, "feature/bar"));
+    }
+
+    #[test]
+    fn query_matches_existing_name_returns_false_for_empty_input() {
+        let names: [&str; 0] = [];
+        assert!(!query_matches_existing_name(names, "main"));
+    }
+
+    #[test]
+    fn query_matches_existing_name_works_with_owned_strings() {
+        let names = vec![String::from("main"), String::from("Develop")];
+        assert!(query_matches_existing_name(names.iter(), "Main"));
+        assert!(query_matches_existing_name(names.iter(), "develop"));
     }
 }

--- a/app/src/context_chips/display_menu.rs
+++ b/app/src/context_chips/display_menu.rs
@@ -16,22 +16,18 @@ use crate::{
     server::ids::{ClientId, HashableId, ServerId, SyncId},
     ui_components::icons::Icon,
     view_components::copyable_text_field::{
-        render_copyable_text_field, CopyButtonPlacement, CopyableTextFieldConfig,
-        COPY_FEEDBACK_DURATION,
+        COPY_FEEDBACK_DURATION, CopyButtonPlacement, CopyableTextFieldConfig,
+        render_copyable_text_field,
     },
 };
-use fuzzy_match::{match_indices_case_insensitive, FuzzyMatchResult};
+use fuzzy_match::{FuzzyMatchResult, match_indices_case_insensitive};
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::{appearance::Appearance, builder::MIN_FONT_SIZE, theme::Fill};
 use warp_editor::editor::NavigationKey;
 use warpui::units::Pixels;
 use warpui::{
-    color::ColorU,
-    elements::Highlight,
-    fonts::{Properties, Weight},
-    ui_components::components::{Coords, UiComponentStyles},
-};
-use warpui::{
+    AppContext, Element, Entity, FocusContext, SingletonEntity as _, TypedActionView, View,
+    ViewContext, ViewHandle, WindowId,
     elements::{
         Border, ChildAnchor, ChildView, ClippedScrollStateHandle, ClippedScrollable,
         ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Dismiss, DispatchEventResult,
@@ -43,12 +39,16 @@ use warpui::{
     },
     keymap::FixedBinding,
     ui_components::components::UiComponent,
-    AppContext, Element, Entity, FocusContext, SingletonEntity as _, TypedActionView, View,
-    ViewContext, ViewHandle, WindowId,
+};
+use warpui::{
+    color::ColorU,
+    elements::Highlight,
+    fonts::{Properties, Weight},
+    ui_components::components::{Coords, UiComponentStyles},
 };
 
-use warpui::clipboard::ClipboardContent;
 use warpui::r#async::Timer;
+use warpui::clipboard::ClipboardContent;
 
 /// Trait for items that can be displayed in a generic menu
 pub trait GenericMenuItem: Debug + 'static {
@@ -176,6 +176,18 @@ enum EnvironmentSidecarSide {
     Right,
 }
 
+/// Builds an optional synthetic menu item from the current search query.
+///
+/// When set, [`DisplayChipMenu`] calls the builder on every search-query
+/// change. If the builder returns `Some(item)` and no existing menu item
+/// already has the same trimmed name, the returned item is prepended to the
+/// filtered results so the user can act on the unmatched query (for example,
+/// "Create new branch <name>"). The builder itself is responsible for
+/// validating the query (e.g. rejecting empty / invalid inputs) and returning
+/// `None` when no synthetic item should be offered.
+pub type CreateItemFromQueryFn =
+    dyn Fn(&str) -> Option<Arc<dyn GenericMenuItem>> + Send + Sync + 'static;
+
 pub struct DisplayChipMenu {
     list_state: UniformListState,
     scroll_state: ScrollStateHandle,
@@ -187,6 +199,10 @@ pub struct DisplayChipMenu {
     search_input: Option<ViewHandle<EditorView>>,
     search_query: String,
     chip_menu_type: ChipMenuType,
+    /// When set, the menu offers a synthetic "create from query" item whenever
+    /// the user's query doesn't exactly match an existing item. See
+    /// [`CreateItemFromQueryFn`].
+    create_item_from_query: Option<Arc<CreateItemFromQueryFn>>,
 
     // Environment sidecar state
     window_id: WindowId,
@@ -360,6 +376,7 @@ impl DisplayChipMenu {
             search_input,
             search_query: String::new(),
             chip_menu_type,
+            create_item_from_query: None,
 
             window_id: ctx.window_id(),
             env_sidecar_copy_id_mouse_state: Default::default(),
@@ -367,6 +384,13 @@ impl DisplayChipMenu {
             env_sidecar_copy_feedback_times: HashMap::new(),
             env_sidecar_scroll_state: Default::default(),
         }
+    }
+
+    /// Register a builder that produces a synthetic top-of-list item for
+    /// otherwise-unmatched search queries. See [`CreateItemFromQueryFn`].
+    pub fn with_create_item_from_query(mut self, builder: Arc<CreateItemFromQueryFn>) -> Self {
+        self.create_item_from_query = Some(builder);
+        self
     }
 
     pub fn reset_selected_index(&mut self) {
@@ -414,28 +438,50 @@ impl DisplayChipMenu {
                     match_result: None,
                 })
                 .collect();
-        } else {
-            // Filter items based on search query
-            self.filtered_items = self
-                .menu_items
-                .iter()
-                .filter_map(|item| {
-                    let item_name = item.name();
-                    match_indices_case_insensitive(&item_name, &self.search_query).map(
-                        |match_result| FilteredMenuItem {
-                            item: item.clone(),
-                            match_result: Some(match_result),
-                        },
-                    )
-                })
-                .collect();
+            return;
+        }
 
-            // Sort by match score (higher scores first)
-            self.filtered_items.sort_by(|a, b| {
-                let score_a = a.match_result.as_ref().map(|r| r.score).unwrap_or(0);
-                let score_b = b.match_result.as_ref().map(|r| r.score).unwrap_or(0);
-                score_b.cmp(&score_a)
-            });
+        // Filter items based on search query
+        self.filtered_items = self
+            .menu_items
+            .iter()
+            .filter_map(|item| {
+                let item_name = item.name();
+                match_indices_case_insensitive(&item_name, &self.search_query).map(|match_result| {
+                    FilteredMenuItem {
+                        item: item.clone(),
+                        match_result: Some(match_result),
+                    }
+                })
+            })
+            .collect();
+
+        // Sort by match score (higher scores first)
+        self.filtered_items.sort_by(|a, b| {
+            let score_a = a.match_result.as_ref().map(|r| r.score).unwrap_or(0);
+            let score_b = b.match_result.as_ref().map(|r| r.score).unwrap_or(0);
+            score_b.cmp(&score_a)
+        });
+
+        // Offer a synthetic top-of-list "create from query" item when the
+        // current query has no exact match against an existing item. This is
+        // what powers the "Create new branch …" affordance in the branch
+        // switcher.
+        if let Some(builder) = self.create_item_from_query.as_ref() {
+            let trimmed = self.search_query.trim();
+            let already_matches_existing =
+                self.menu_items.iter().any(|item| item.name() == trimmed);
+            if !already_matches_existing {
+                if let Some(synthetic) = builder(trimmed) {
+                    self.filtered_items.insert(
+                        0,
+                        FilteredMenuItem {
+                            item: synthetic,
+                            match_result: None,
+                        },
+                    );
+                }
+            }
         }
     }
 

--- a/app/src/context_chips/git_branch_on_click.rs
+++ b/app/src/context_chips/git_branch_on_click.rs
@@ -179,6 +179,32 @@ fn parse_git_worktree_paths(lines: &[String]) -> HashMap<String, String> {
     branch_to_worktree_path
 }
 
+/// Returns `true` when `name` looks like a plausible git branch name that can
+/// be created via `git checkout -b`.
+///
+/// We err on the side of letting git itself reject borderline cases: this
+/// helper only filters out the most obviously broken inputs so that the
+/// "Create new branch …" affordance does not appear for clearly invalid
+/// queries (e.g. an empty string after the user backspaces, or whitespace).
+/// Anything we accept here may still be rejected by `git check-ref-format`,
+/// in which case the user sees the failure in the terminal.
+pub(crate) fn is_plausible_new_branch_name(name: &str) -> bool {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // git rejects names beginning with `-` outright, and they would also be
+    // ambiguous with `git checkout -b` flags, so don't offer the affordance.
+    if trimmed.starts_with('-') {
+        return false;
+    }
+    // git refuses whitespace (other than as a separator) inside refs.
+    if trimmed.chars().any(char::is_whitespace) {
+        return false;
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,5 +270,43 @@ mod tests {
         assert_eq!(value.branch_name, "feature");
         assert_eq!(value.worktree_path, None);
         assert!(value.is_linked_worktree);
+    }
+
+    #[test]
+    fn test_is_plausible_new_branch_name_accepts_typical_names() {
+        for name in [
+            "feature/xyz",
+            "fix-123",
+            "release/v1.2.3",
+            "user/alice/work",
+            "main",
+        ] {
+            assert!(
+                is_plausible_new_branch_name(name),
+                "expected {name:?} to be accepted",
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_plausible_new_branch_name_rejects_empty_or_whitespace() {
+        for name in ["", "   ", "\t\n"] {
+            assert!(
+                !is_plausible_new_branch_name(name),
+                "expected {name:?} to be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_plausible_new_branch_name_rejects_leading_dash() {
+        assert!(!is_plausible_new_branch_name("-foo"));
+        assert!(!is_plausible_new_branch_name("--all"));
+    }
+
+    #[test]
+    fn test_is_plausible_new_branch_name_rejects_internal_whitespace() {
+        assert!(!is_plausible_new_branch_name("my branch"));
+        assert!(!is_plausible_new_branch_name("foo\tbar"));
     }
 }


### PR DESCRIPTION
## Description

Implements the enhancement requested in #10605.

When the user types a branch name that doesn't exist in the repository, the branch switcher now shows a `Create new branch "<name>"` entry at the top of the results list. Selecting it runs `git checkout -b <name> --` from the current HEAD, eliminating the need to leave the picker to create a new branch via the terminal — matching the experience of VS Code, GitHub Desktop, and JetBrains branch pickers.

**How it works:**
- `DisplayChipMenu` gains an optional `with_create_item_from_query` hook that, when set, prepends a synthetic menu item built from the current search query whenever no existing item matches it exactly. This keeps the branch-specific logic out of the generic menu while reusing all of its selection / keyboard / click plumbing.
- A new `CreateGitBranch` `GenericMenuItem` renders with the Plus icon and emits `git checkout -b '<branch>' --` (the trailing `--` guards against any flag-like input that survives front-end validation).
- `is_plausible_new_branch_name` rejects empty / whitespace-only / leading-dash / whitespace-containing inputs so the affordance does not appear for clearly invalid queries; everything else is left to git itself to validate at execution time.
- Existing branches still take precedence: if the trimmed query exactly matches an existing branch's name, only the existing branch is shown (avoiding a confusing \`branch already exists\` failure).

## Linked Issue

Closes #10605

- [x] The linked issue is labeled \`ready-to-spec\` or \`ready-to-implement\`.

> Note for maintainers: the issue is currently labeled \`enhancement\` + \`triaged\` but does not yet carry a \`ready-to-implement\` label. Happy to first land a \`specs/GH10605/{product,tech}.md\` PR if you'd prefer this go through the spec flow — let me know.

- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

- Added unit tests in \`display_chip_tests.rs\` covering \`format_create_git_branch_command\` (with single-quote escaping) and \`CreateGitBranch\` (name formatting, action data, whitespace trimming).
- Added unit tests in \`git_branch_on_click.rs\` covering \`is_plausible_new_branch_name\` (accepted typical names, rejected empty / whitespace-only / leading-dash / whitespace-containing inputs).
- Ran \`cargo fmt\`, \`cargo clippy -p warp --tests -- -D warnings\`, and \`cargo nextest run -p warp -E 'test(context_chips::)'\` (78/78 passing, including the 9 new tests).
- Manually tested via \`./script/run\`:
  1. Open branch switcher in a git repo, type a non-existent name → "Create new branch …" appears at top, default-selected.
  2. Press Enter → terminal executes \`git checkout -b <name> --\`, branch chip refreshes to the new branch.
  3. Type a partial fuzzy match → create option still on top, fuzzy matches below.
  4. Type the name of an existing branch → create option disappears (no duplicate).
  5. Type \`-foo\` / \`my branch\` / whitespace → no create option (falls back to "No results found").

- [x] I have manually tested my changes locally with \`./script/run\`

### Screenshots / Videos

<img width="1280" height="800" alt="Snipaste_create_branch_1" src="https://github.com/user-attachments/assets/ddc8eff3-accb-4c2c-a48d-aad4a7aded93" />

<img width="1280" height="800" alt="Snipaste_create_branch_2" src="https://github.com/user-attachments/assets/57a112e8-1699-49f3-a704-4ef44d435b54" />


## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Branch switcher now offers a "Create new branch" option when the typed name doesn't match an existing branch, running git checkout -b from the current HEAD.
-->

Made with [Cursor](https://cursor.com)