### PR TITLE
Add "Clear" action to terminal right-click context menu (#10472)

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -15901,10 +15901,11 @@ impl TerminalView {
                 | BlockListMenuSource::RichContentTextRightClick { .. }
                 | BlockListMenuSource::OutsideBlockRightClick { .. }
         ) {
-            // Surface "Clear" in the right-click menu so it's discoverable
-            // without the keyboard shortcut. We skip text-selection contexts
-            // (`Regular*TextRightClick` / `RichContentTextRightClick`) because
-            // those menus are scoped to actions on the selected text.
+            // Surface "Clear Blocks" in the right-click menu so it's
+            // discoverable without the keyboard shortcut. We skip
+            // text-selection contexts (`Regular*TextRightClick` /
+            // `RichContentTextRightClick`) because those menus are scoped to
+            // actions on the selected text.
             let include_clear = matches!(
                 menu_source,
                 BlockListMenuSource::RegularBlockRightClick { .. }
@@ -15935,8 +15936,8 @@ impl TerminalView {
         items
     }
 
-    /// Builds the "Clear" entry for the terminal right-click context menu.
-    /// Returns `None` when there are no blocks to clear, mirroring the
+    /// Builds the "Clear Blocks" entry for the terminal right-click context
+    /// menu. Returns `None` when there are no blocks to clear, mirroring the
     /// `TerminalView_NonEmptyBlockList` predicate that gates the
     /// `terminal:clear_blocks` keybinding.
     fn clear_buffer_menu_item(
@@ -15948,7 +15949,7 @@ impl TerminalView {
             return None;
         }
         Some(
-            MenuItemFields::new("Clear")
+            MenuItemFields::new("Clear Blocks")
                 .with_on_select_action(TerminalAction::ClearBuffer)
                 .with_key_shortcut_label(keybinding_name_to_display_string(
                     "terminal:clear_blocks",

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -15901,6 +15901,26 @@ impl TerminalView {
                 | BlockListMenuSource::RichContentTextRightClick { .. }
                 | BlockListMenuSource::OutsideBlockRightClick { .. }
         ) {
+            // Surface "Clear" in the right-click menu so it's discoverable
+            // without the keyboard shortcut. We skip text-selection contexts
+            // (`Regular*TextRightClick` / `RichContentTextRightClick`) because
+            // those menus are scoped to actions on the selected text.
+            let include_clear = matches!(
+                menu_source,
+                BlockListMenuSource::RegularBlockRightClick { .. }
+                    | BlockListMenuSource::RichContentBlockRightClick { .. }
+                    | BlockListMenuSource::OutsideBlockRightClick { .. }
+            );
+            let clear_menu_item = include_clear
+                .then(|| self.clear_buffer_menu_item(&model, ctx))
+                .flatten();
+            if let Some(clear_menu_item) = clear_menu_item {
+                if !items.is_empty() {
+                    items.push(MenuItem::Separator);
+                }
+                items.push(clear_menu_item);
+            }
+
             let current_shell = model.shell_launch_state().available_shell();
             let pane_context_menu_items = self.pane_context_menu_items(current_shell, ctx);
             // Only add the separator if there's something before and after it.
@@ -15913,6 +15933,29 @@ impl TerminalView {
         }
 
         items
+    }
+
+    /// Builds the "Clear" entry for the terminal right-click context menu.
+    /// Returns `None` when there are no blocks to clear, mirroring the
+    /// `TerminalView_NonEmptyBlockList` predicate that gates the
+    /// `terminal:clear_blocks` keybinding.
+    fn clear_buffer_menu_item(
+        &self,
+        model: &TerminalModel,
+        ctx: &AppContext,
+    ) -> Option<MenuItem<TerminalAction>> {
+        if model.is_block_list_empty() {
+            return None;
+        }
+        Some(
+            MenuItemFields::new("Clear")
+                .with_on_select_action(TerminalAction::ClearBuffer)
+                .with_key_shortcut_label(keybinding_name_to_display_string(
+                    "terminal:clear_blocks",
+                    ctx,
+                ))
+                .into_item(),
+        )
     }
 
     fn copy_prompt_menu_items(

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -2063,8 +2063,8 @@ fn test_context_menu_includes_clear_when_block_list_non_empty() {
                 .filter_map(|item| item.fields().map(|fields| fields.label()))
                 .collect();
             assert!(
-                labels.contains(&"Clear"),
-                "Expected `Clear` menu item, got {labels:?}"
+                labels.contains(&"Clear Blocks"),
+                "Expected `Clear Blocks` menu item, got {labels:?}"
             );
         });
     })
@@ -2091,8 +2091,8 @@ fn test_context_menu_omits_clear_when_block_list_empty() {
                 .filter_map(|item| item.fields().map(|fields| fields.label()))
                 .collect();
             assert!(
-                !labels.contains(&"Clear"),
-                "Did not expect `Clear` menu item when block list is empty, got {labels:?}"
+                !labels.contains(&"Clear Blocks"),
+                "Did not expect `Clear Blocks` menu item when block list is empty, got {labels:?}"
             );
         });
     })
@@ -2120,8 +2120,8 @@ fn test_context_menu_omits_clear_for_text_right_click() {
                 .filter_map(|item| item.fields().map(|fields| fields.label()))
                 .collect();
             assert!(
-                !labels.contains(&"Clear"),
-                "Did not expect `Clear` in text-selection right-click menu, got {labels:?}"
+                !labels.contains(&"Clear Blocks"),
+                "Did not expect `Clear Blocks` in text-selection right-click menu, got {labels:?}"
             );
         });
     })

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -2042,6 +2042,92 @@ fn test_clear_buffer() {
 }
 
 #[test]
+fn test_context_menu_includes_clear_when_block_list_non_empty() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                model.simulate_block("ls", "foo");
+                assert!(!model.is_block_list_empty());
+            }
+
+            let menu_source = BlockListMenuSource::OutsideBlockRightClick {
+                position_in_terminal_view: Vector2F::zero(),
+            };
+            let items = view.context_menu_items(&menu_source, ctx);
+            let labels: Vec<&str> = items
+                .iter()
+                .filter_map(|item| item.fields().map(|fields| fields.label()))
+                .collect();
+            assert!(
+                labels.contains(&"Clear"),
+                "Expected `Clear` menu item, got {labels:?}"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_context_menu_omits_clear_when_block_list_empty() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let model = view.model.lock();
+                assert!(model.is_block_list_empty());
+            }
+
+            let menu_source = BlockListMenuSource::OutsideBlockRightClick {
+                position_in_terminal_view: Vector2F::zero(),
+            };
+            let items = view.context_menu_items(&menu_source, ctx);
+            let labels: Vec<&str> = items
+                .iter()
+                .filter_map(|item| item.fields().map(|fields| fields.label()))
+                .collect();
+            assert!(
+                !labels.contains(&"Clear"),
+                "Did not expect `Clear` menu item when block list is empty, got {labels:?}"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_context_menu_omits_clear_for_text_right_click() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                model.simulate_block("ls", "foo");
+                assert!(!model.is_block_list_empty());
+            }
+
+            let menu_source = BlockListMenuSource::RegularTextRightClick {
+                position_in_terminal_view: Vector2F::zero(),
+            };
+            let items = view.context_menu_items(&menu_source, ctx);
+            let labels: Vec<&str> = items
+                .iter()
+                .filter_map(|item| item.fields().map(|fields| fields.label()))
+                .collect();
+            assert!(
+                !labels.contains(&"Clear"),
+                "Did not expect `Clear` in text-selection right-click menu, got {labels:?}"
+            );
+        });
+    })
+}
+
+#[test]
 fn test_clear_buffer_clears_autosuggestion() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);


### PR DESCRIPTION
## Description

Closes #10472.

Clearing the terminal previously required the `⇧⌘K` (mac) / `Ctrl+Shift+K` (linux/windows) keyboard shortcut and was not surfaced anywhere in the right-click menu, so the action was hard to discover.

This PR adds a **Clear** menu item to the terminal right-click context menu, with the existing keybinding shown alongside it.

**What:**

- Add a `Clear` entry to the terminal right-click context menu in the non-text right-click variants:
  - `OutsideBlockRightClick` (right-click on empty terminal area — the case described in the issue)
  - `RegularBlockRightClick` (right-click on a regular block)
  - `RichContentBlockRightClick` (right-click on an AI / rich-content block)
- The new entry reuses the existing `TerminalAction::ClearBuffer` handler, so all the established semantics (full-screen agent view, agent monitoring guard, autosuggestion clearing, bookmark cleanup, etc.) carry over unchanged.
- The entry shows the `terminal:clear_blocks` keybinding label (`⇧⌘K` / `Ctrl+Shift+K`) on the right.

**Why these scopes / not others:**

- Text-selection right-click variants (`Regular*TextRightClick` / `RichContentTextRightClick`) are intentionally excluded — those menus are scoped to actions on the selected text (Copy / Insert into input / Ask AI), and a destructive terminal-wide "Clear" doesn't fit that grouping.
- The item is hidden when the block list is empty, mirroring the `TerminalView_NonEmptyBlockList` predicate that already gates the `terminal:clear_blocks` keybinding. This avoids showing a no-op entry on a fresh tab.

**How:**

- New helper `TerminalView::clear_buffer_menu_item` in `app/src/terminal/view.rs` builds the menu item (or returns `None` if the block list is empty).
- `context_menu_items` invokes it in the existing common bottom section, with the same separator handling pattern used for `pane_context_menu_items`.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

> Note: #10472 is currently labeled `triaged` + `enhancement` (no `ready-to-implement` yet). Flagging **@oss-maintainers** to confirm readiness — this is a small, self-contained UX improvement that reuses an existing action, so I went ahead with a code PR rather than a spec PR. Happy to convert this into a spec PR first if you'd prefer.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

**Manual testing performed:**

- Right-click on a block with several previous commands → "Clear" appears with the `⇧⌘K` label, clicking it clears the blocks (same result as the keyboard shortcut).
- Right-click in the empty terminal area below blocks → "Clear" appears.
- Right-click in a fresh terminal tab with no blocks → "Clear" is **not** shown (mirrors keybinding gating).
- Right-click after selecting text → menu still shows Copy / Insert into input / Ask AI without "Clear" (no regression to the text menu).

**Automated tests added** in `app/src/terminal/view_tests.rs`:

- `test_context_menu_includes_clear_when_block_list_non_empty`
- `test_context_menu_omits_clear_when_block_list_empty`
- `test_context_menu_omits_clear_for_text_right_click`

`cargo nextest run -p warp -E 'test(/context_menu/) + test(/clear_buffer/)'` passes 89/89 locally (3 new tests + all surrounding context-menu/clear-buffer regression coverage).

`cargo fmt -- --check` and `cargo clippy -p warp --tests --all-targets -- -D warnings` both pass.

### Screenshots / Videos

Agent Session:

<img width="1280" height="800" alt="Snipaste_agent_clear_1" src="https://github.com/user-attachments/assets/d7ba1061-f696-42d9-af57-fc4cfac22181" />
<img width="1280" height="499" alt="Snipaste_agent_clear_2" src="https://github.com/user-attachments/assets/aebf5edf-8ffb-402a-b598-337eded09eb1" />

Terminal Session:

<img width="1280" height="800" alt="Snipaste_terminal_clear_1" src="https://github.com/user-attachments/assets/3a75c786-4e29-44e0-861a-b904d2f54ec5" />
<img width="1280" height="800" alt="Snipaste_terminal_clear_2" src="https://github.com/user-attachments/assets/78e816a9-01dc-4b3d-b414-224cbdc6a626" />


## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added a "Clear" action to the terminal right-click context menu so clearing terminal output is discoverable without using the keyboard shortcut.

Made with [Cursor](https://cursor.com)