### PR TITLE
Add one-time migration to add handoff chip to custom toolbar layouts

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -6,7 +6,6 @@ pub mod toolbar_item;
 use crate::{
     ai::{
         blocklist::{
-            handoff::is_local_to_cloud_handoff_available,
             history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel},
             prompt::prompt_alert::{PromptAlertEvent, PromptAlertView},
             usage::icon_for_context_window_usage,
@@ -2538,7 +2537,10 @@ impl TypedActionView for AgentInputFooter {
                 });
             }
             AgentInputFooterAction::OpenHandoffPane => {
-                if is_local_to_cloud_handoff_available() {
+                if FeatureFlag::OzHandoff.is_enabled()
+                    && FeatureFlag::HandoffLocalCloud.is_enabled()
+                    && cfg!(all(feature = "local_fs", not(target_family = "wasm")))
+                {
                     ctx.emit(AgentInputFooterEvent::OpenHandoffPane);
                 }
             }

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -6,8 +6,8 @@ pub mod toolbar_item;
 use crate::{
     ai::{
         blocklist::{
+            handoff::is_local_to_cloud_handoff_available,
             history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel},
-            is_local_to_cloud_handoff_available,
             prompt::prompt_alert::{PromptAlertEvent, PromptAlertView},
             usage::icon_for_context_window_usage,
             BlocklistAIInputModel,

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use warpui::SingletonEntity;
-
-use crate::ai::blocklist::is_local_to_cloud_handoff_available;
+use crate::ai::blocklist::handoff::is_local_to_cloud_handoff_available;
 use crate::context_chips::{agent_footer_available_chips, available_chips, ContextChipKind};
 use crate::features::FeatureFlag;
 use crate::settings::AISettings;

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::ai::blocklist::is_local_to_cloud_handoff_available;
+use crate::ai::blocklist::handoff::is_local_to_cloud_handoff_available;
 use crate::context_chips::{agent_footer_available_chips, available_chips, ContextChipKind};
 use crate::features::FeatureFlag;
 use crate::terminal::shared_session::SharedSessionStatus;

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
+use warpui::SingletonEntity;
 
-use crate::ai::blocklist::handoff::is_local_to_cloud_handoff_available;
 use crate::context_chips::{agent_footer_available_chips, available_chips, ContextChipKind};
 use crate::features::FeatureFlag;
 use crate::settings::AISettings;
@@ -216,7 +216,10 @@ impl AgentToolbarItemKind {
         {
             items.push(Self::ShareSession);
         }
-        if is_local_to_cloud_handoff_available() {
+        if FeatureFlag::OzHandoff.is_enabled()
+            && FeatureFlag::HandoffLocalCloud.is_enabled()
+            && cfg!(all(feature = "local_fs", not(target_family = "wasm")))
+        {
             items.push(Self::HandoffToCloud);
         }
         items.push(Self::VoiceInput);
@@ -245,7 +248,10 @@ impl AgentToolbarItemKind {
         {
             items.push(Self::ShareSession);
         }
-        if is_local_to_cloud_handoff_available() {
+        if FeatureFlag::OzHandoff.is_enabled()
+            && FeatureFlag::HandoffLocalCloud.is_enabled()
+            && cfg!(all(feature = "local_fs", not(target_family = "wasm")))
+        {
             items.push(Self::HandoffToCloud);
         }
         items

--- a/app/src/ai/blocklist/handoff/mod.rs
+++ b/app/src/ai/blocklist/handoff/mod.rs
@@ -14,9 +14,15 @@
 //! `AmbientAgentViewModel::submit_handoff`, which reads the cached
 //! `forked_conversation_id` and `snapshot_upload` off `PendingHandoff`.
 
-use super::PendingAttachment;
+use crate::features::FeatureFlag;
 use crate::server::server_api::ai::AttachmentInput;
 
+use super::PendingAttachment;
+
+#[cfg(feature = "local_fs")]
+pub(crate) mod touched_repos;
+
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
 #[derive(Debug, Clone, Default)]
 pub struct HandoffLaunchAttachments {
     pub(crate) request_attachments: Vec<AttachmentInput>,
@@ -26,11 +32,15 @@ pub struct HandoffLaunchAttachments {
 /// Carries the auto-submit payload for `& query` and `/handoff query`.
 /// `request_attachments` feed the spawn request while `display_attachments`
 /// are restored into the source input on failure.
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
 #[derive(Debug, Clone)]
 pub struct PendingCloudLaunch {
     pub(crate) prompt: String,
     pub(crate) attachments: HandoffLaunchAttachments,
 }
 
-#[cfg(feature = "local_fs")]
-pub(crate) mod touched_repos;
+pub(crate) fn is_local_to_cloud_handoff_available() -> bool {
+    FeatureFlag::OzHandoff.is_enabled()
+        && FeatureFlag::HandoffLocalCloud.is_enabled()
+        && cfg!(all(feature = "local_fs", not(target_family = "wasm")))
+}

--- a/app/src/ai/blocklist/handoff/mod.rs
+++ b/app/src/ai/blocklist/handoff/mod.rs
@@ -14,7 +14,6 @@
 //! `AmbientAgentViewModel::submit_handoff`, which reads the cached
 //! `forked_conversation_id` and `snapshot_upload` off `PendingHandoff`.
 
-use crate::features::FeatureFlag;
 use crate::server::server_api::ai::AttachmentInput;
 
 use super::PendingAttachment;
@@ -37,10 +36,4 @@ pub struct HandoffLaunchAttachments {
 pub struct PendingCloudLaunch {
     pub(crate) prompt: String,
     pub(crate) attachments: HandoffLaunchAttachments,
-}
-
-pub(crate) fn is_local_to_cloud_handoff_available() -> bool {
-    FeatureFlag::OzHandoff.is_enabled()
-        && FeatureFlag::HandoffLocalCloud.is_enabled()
-        && cfg!(all(feature = "local_fs", not(target_family = "wasm")))
 }

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -5,15 +5,8 @@ pub mod block;
 pub mod code_block;
 mod context_model;
 mod controller;
-#[cfg(feature = "local_fs")]
 pub(crate) mod handoff;
 
-pub(crate) fn is_local_to_cloud_handoff_available() -> bool {
-    use crate::features::FeatureFlag;
-    FeatureFlag::OzHandoff.is_enabled()
-        && FeatureFlag::HandoffLocalCloud.is_enabled()
-        && cfg!(all(feature = "local_fs", not(target_family = "wasm")))
-}
 pub(crate) mod orchestration_event_streamer;
 pub(crate) mod orchestration_events;
 mod passive_suggestions;

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1696,7 +1696,10 @@ impl AISettings {
         if !self.is_any_ai_enabled(app) || *self.should_force_disable_cloud_handoff {
             return false;
         }
-        if !crate::ai::blocklist::is_local_to_cloud_handoff_available() {
+        if !FeatureFlag::OzHandoff.is_enabled()
+            || !FeatureFlag::HandoffLocalCloud.is_enabled()
+            || !cfg!(all(feature = "local_fs", not(target_family = "wasm")))
+        {
             return false;
         }
         let privacy = PrivacySettings::as_ref(app);

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -129,7 +129,7 @@ use crate::{
     ai::{
         agent::{AIAgentContext, EntrypointType},
         blocklist::{
-            is_local_to_cloud_handoff_available,
+            handoff::is_local_to_cloud_handoff_available,
             prompt::prompt_alert::{PromptAlertEvent, PromptAlertView},
             render_ai_agent_mode_icon, render_ai_follow_up_icon,
             telemetry_banner::should_collect_ai_ugc_telemetry,

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -120,8 +120,6 @@ use crate::ai::blocklist::handoff::touched_repos::{
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::{HandoffLaunchAttachments, PendingCloudLaunch};
-#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::blocklist::handoff::is_local_to_cloud_handoff_available;
 use crate::ai::blocklist::AttachmentType;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::PendingAttachment;
@@ -3984,7 +3982,9 @@ impl Input {
 
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn maybe_launch_cloud_handoff_request(&mut self, ctx: &mut ViewContext<Self>) -> bool {
-        if !is_local_to_cloud_handoff_available()
+        if !FeatureFlag::OzHandoff.is_enabled()
+            || !FeatureFlag::HandoffLocalCloud.is_enabled()
+            || !cfg!(all(feature = "local_fs", not(target_family = "wasm")))
             || self.prefix_mode(ctx) != InputPrefixMode::CloudHandoff
         {
             return false;

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -121,7 +121,7 @@ use crate::ai::blocklist::handoff::touched_repos::{
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::{HandoffLaunchAttachments, PendingCloudLaunch};
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::blocklist::is_local_to_cloud_handoff_available;
+use crate::ai::blocklist::handoff::is_local_to_cloud_handoff_available;
 use crate::ai::blocklist::AttachmentType;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::PendingAttachment;

--- a/app/src/terminal/session_settings.rs
+++ b/app/src/terminal/session_settings.rs
@@ -406,6 +406,17 @@ define_settings_group!(SessionSettings, settings: [
         sync_to_cloud: SyncToCloud::Never,
         private: true,
     },
+    // One-time flag: whether we've already migrated the handoff-to-cloud chip
+    // into a user's custom agent toolbar layout. When `Default`, the chip is
+    // already present via `AgentToolbarItemKind::default_right()`, so this
+    // only matters for `Custom` layouts that were saved before the chip existed.
+    did_add_handoff_chip_to_toolbar: DidAddHandoffChipToToolbar {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::No),
+        private: true,
+    },
 ]);
 
 settings::macros::implement_setting_for_enum!(

--- a/app/src/workspace/one_time_modal_model.rs
+++ b/app/src/workspace/one_time_modal_model.rs
@@ -1,4 +1,6 @@
 use super::hoa_onboarding;
+use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
+use crate::ai::blocklist::is_local_to_cloud_handoff_available;
 use crate::auth::auth_manager::AuthManagerEvent;
 use crate::auth::AuthManager;
 use crate::channel::{Channel, ChannelState};
@@ -7,6 +9,7 @@ use crate::settings::cloud_preferences_syncer::{
 };
 use crate::settings::{AISettings, CodeSettings};
 use crate::terminal::general_settings::GeneralSettings;
+use crate::terminal::session_settings::{AgentToolbarChipSelection, SessionSettings};
 use settings::Setting as _;
 use warp_core::features::FeatureFlag;
 use warpui::{Entity, ModelContext, SingletonEntity, WindowId};
@@ -62,6 +65,7 @@ impl OneTimeModalModel {
                         if let CloudPreferencesSyncerEvent::InitialLoadCompleted = event {
                             ctx.unsubscribe_from_model(&CloudPreferencesSyncer::handle(ctx));
                             me.check_and_trigger_all_modals(ctx);
+                            ensure_handoff_chip_in_toolbar(ctx);
                         }
                     },
                 );
@@ -438,6 +442,55 @@ impl OneTimeModalModel {
         // All conditions met, show the modal
         self.set_build_plan_migration_modal_open(true, ctx)
     }
+}
+
+/// One-time migration: if the user has a custom agent toolbar layout that
+/// predates the handoff-to-cloud chip, append the chip so they get the
+/// new feature without losing their customization.
+///
+/// Users on `Default` already see the chip via `AgentToolbarItemKind::default_right()`.
+fn ensure_handoff_chip_in_toolbar(ctx: &mut ModelContext<OneTimeModalModel>) {
+    if !is_local_to_cloud_handoff_available() {
+        return;
+    }
+
+    let session_settings = SessionSettings::as_ref(ctx);
+    if *session_settings.did_add_handoff_chip_to_toolbar {
+        return;
+    }
+
+    // Mark as done so future app starts skip this path.
+    SessionSettings::handle(ctx).update(ctx, |settings, ctx| {
+        if let Err(e) = settings
+            .did_add_handoff_chip_to_toolbar
+            .set_value(true, ctx)
+        {
+            log::warn!("Failed to mark handoff chip toolbar migration as done: {e}");
+        }
+    });
+
+    // `Default` already includes the chip — nothing to do.
+    let selection = SessionSettings::as_ref(ctx)
+        .agent_footer_chip_selection
+        .clone();
+    let AgentToolbarChipSelection::Custom { mut left, right } = selection else {
+        return;
+    };
+
+    let handoff = AgentToolbarItemKind::HandoffToCloud;
+    if left.contains(&handoff) || right.contains(&handoff) {
+        return;
+    }
+
+    left.push(handoff);
+    SessionSettings::handle(ctx).update(ctx, |settings, ctx| {
+        if let Err(e) = settings
+            .agent_footer_chip_selection
+            .set_value(AgentToolbarChipSelection::Custom { left, right }, ctx)
+        {
+            log::warn!("Failed to add handoff chip to toolbar: {e}");
+        }
+    });
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/app/src/workspace/one_time_modal_model.rs
+++ b/app/src/workspace/one_time_modal_model.rs
@@ -1,6 +1,6 @@
 use super::hoa_onboarding;
 use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
-use crate::ai::blocklist::is_local_to_cloud_handoff_available;
+use crate::ai::blocklist::handoff::is_local_to_cloud_handoff_available;
 use crate::auth::auth_manager::AuthManagerEvent;
 use crate::auth::AuthManager;
 use crate::channel::{Channel, ChannelState};
@@ -65,7 +65,7 @@ impl OneTimeModalModel {
                         if let CloudPreferencesSyncerEvent::InitialLoadCompleted = event {
                             ctx.unsubscribe_from_model(&CloudPreferencesSyncer::handle(ctx));
                             me.check_and_trigger_all_modals(ctx);
-                            ensure_handoff_chip_in_toolbar(ctx);
+                            maybe_ensure_handoff_chip_in_toolbar(ctx);
                         }
                     },
                 );
@@ -449,7 +449,7 @@ impl OneTimeModalModel {
 /// new feature without losing their customization.
 ///
 /// Users on `Default` already see the chip via `AgentToolbarItemKind::default_right()`.
-fn ensure_handoff_chip_in_toolbar(ctx: &mut ModelContext<OneTimeModalModel>) {
+fn maybe_ensure_handoff_chip_in_toolbar(ctx: &mut ModelContext<OneTimeModalModel>) {
     if !is_local_to_cloud_handoff_available() {
         return;
     }

--- a/app/src/workspace/one_time_modal_model.rs
+++ b/app/src/workspace/one_time_modal_model.rs
@@ -1,6 +1,6 @@
 use super::hoa_onboarding;
 use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
-use crate::ai::blocklist::is_local_to_cloud_handoff_available;
+use crate::ai::blocklist::handoff::is_local_to_cloud_handoff_available;
 use crate::auth::auth_manager::AuthManagerEvent;
 use crate::auth::AuthManager;
 use crate::channel::{Channel, ChannelState};
@@ -64,7 +64,7 @@ impl OneTimeModalModel {
                         if let CloudPreferencesSyncerEvent::InitialLoadCompleted = event {
                             ctx.unsubscribe_from_model(&CloudPreferencesSyncer::handle(ctx));
                             me.check_and_trigger_all_modals(ctx);
-                            ensure_handoff_chip_in_toolbar(ctx);
+                            maybe_ensure_handoff_chip_in_toolbar(ctx);
                         }
                     },
                 );
@@ -383,7 +383,7 @@ impl OneTimeModalModel {
 /// new feature without losing their customization.
 ///
 /// Users on `Default` already see the chip via `AgentToolbarItemKind::default_right()`.
-fn ensure_handoff_chip_in_toolbar(ctx: &mut ModelContext<OneTimeModalModel>) {
+fn maybe_ensure_handoff_chip_in_toolbar(ctx: &mut ModelContext<OneTimeModalModel>) {
     if !is_local_to_cloud_handoff_available() {
         return;
     }

--- a/app/src/workspace/one_time_modal_model.rs
+++ b/app/src/workspace/one_time_modal_model.rs
@@ -1,6 +1,5 @@
 use super::hoa_onboarding;
 use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
-use crate::ai::blocklist::handoff::is_local_to_cloud_handoff_available;
 use crate::auth::auth_manager::AuthManagerEvent;
 use crate::auth::AuthManager;
 use crate::channel::{Channel, ChannelState};
@@ -450,7 +449,10 @@ impl OneTimeModalModel {
 ///
 /// Users on `Default` already see the chip via `AgentToolbarItemKind::default_right()`.
 fn maybe_ensure_handoff_chip_in_toolbar(ctx: &mut ModelContext<OneTimeModalModel>) {
-    if !is_local_to_cloud_handoff_available() {
+    if !FeatureFlag::OzHandoff.is_enabled()
+        || !FeatureFlag::HandoffLocalCloud.is_enabled()
+        || !cfg!(all(feature = "local_fs", not(target_family = "wasm")))
+    {
         return;
     }
 

--- a/app/src/workspace/one_time_modal_model.rs
+++ b/app/src/workspace/one_time_modal_model.rs
@@ -1,4 +1,6 @@
 use super::hoa_onboarding;
+use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
+use crate::ai::blocklist::is_local_to_cloud_handoff_available;
 use crate::auth::auth_manager::AuthManagerEvent;
 use crate::auth::AuthManager;
 use crate::channel::{Channel, ChannelState};
@@ -7,6 +9,7 @@ use crate::settings::cloud_preferences_syncer::{
 };
 use crate::settings::{AISettings, CodeSettings};
 use crate::terminal::general_settings::GeneralSettings;
+use crate::terminal::session_settings::{AgentToolbarChipSelection, SessionSettings};
 use settings::Setting as _;
 use warp_core::features::FeatureFlag;
 use warpui::{Entity, ModelContext, SingletonEntity, WindowId};
@@ -61,6 +64,7 @@ impl OneTimeModalModel {
                         if let CloudPreferencesSyncerEvent::InitialLoadCompleted = event {
                             ctx.unsubscribe_from_model(&CloudPreferencesSyncer::handle(ctx));
                             me.check_and_trigger_all_modals(ctx);
+                            ensure_handoff_chip_in_toolbar(ctx);
                         }
                     },
                 );
@@ -372,6 +376,55 @@ impl OneTimeModalModel {
         // All conditions met, show the modal
         self.set_build_plan_migration_modal_open(true, ctx)
     }
+}
+
+/// One-time migration: if the user has a custom agent toolbar layout that
+/// predates the handoff-to-cloud chip, append the chip so they get the
+/// new feature without losing their customization.
+///
+/// Users on `Default` already see the chip via `AgentToolbarItemKind::default_right()`.
+fn ensure_handoff_chip_in_toolbar(ctx: &mut ModelContext<OneTimeModalModel>) {
+    if !is_local_to_cloud_handoff_available() {
+        return;
+    }
+
+    let session_settings = SessionSettings::as_ref(ctx);
+    if *session_settings.did_add_handoff_chip_to_toolbar {
+        return;
+    }
+
+    // Mark as done so future app starts skip this path.
+    SessionSettings::handle(ctx).update(ctx, |settings, ctx| {
+        if let Err(e) = settings
+            .did_add_handoff_chip_to_toolbar
+            .set_value(true, ctx)
+        {
+            log::warn!("Failed to mark handoff chip toolbar migration as done: {e}");
+        }
+    });
+
+    // `Default` already includes the chip — nothing to do.
+    let selection = SessionSettings::as_ref(ctx)
+        .agent_footer_chip_selection
+        .clone();
+    let AgentToolbarChipSelection::Custom { mut left, right } = selection else {
+        return;
+    };
+
+    let handoff = AgentToolbarItemKind::HandoffToCloud;
+    if left.contains(&handoff) || right.contains(&handoff) {
+        return;
+    }
+
+    left.push(handoff);
+    SessionSettings::handle(ctx).update(ctx, |settings, ctx| {
+        if let Err(e) = settings
+            .agent_footer_chip_selection
+            .set_value(AgentToolbarChipSelection::Custom { left, right }, ctx)
+        {
+            log::warn!("Failed to add handoff chip to toolbar: {e}");
+        }
+    });
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Description

When we release local -> cloud handoff, we'll want to make it so that the handoff chip is added to folks' toolbars for visibility into the new feature. For people who just use the default chip  set, this will happen automatically. However, for people with custom toolbar arrangements, the chip won't be added by default because it's not part of their custom set.

To fix this, we can add a one-time migration that functions similarly to the code we have around showing launch modals. On-app-start, we check if we have already tried to add the chip to the user's toolbar arrangement, and if we have we immediately return. If we haven't, we first update the persistent setting to record that we now have done the update (so in the future we early return), and we then add it to their toolbar arrangement (also returning early if they just have the default arrangement, because there's nothing to do in this case). We also gate this entire fn on the handoff feature flag being enabled so that this process doesn't run until the feature is released.

The end-result here is that, when we release the handoff feature, the cloud chip will be added to everyone's toolbelts _once_ (if they remove it it will stay removed).

Implements APP-4424

## Demo

https://www.loom.com/share/ca4b8a8289b8444e9d187bc0a307861a

## Testing

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/d0938e82-581e-45a9-a7ed-bc41bfdba1b0_
_Run: https://oz.staging.warp.dev/runs/019e1357-8372-772d-824d-35285a5466b6_
_This PR was generated with [Oz](https://warp.dev/oz)._
