### PR TITLE
Fix bash HISTSIZE startup sentinel

### DIFF
--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -1133,17 +1133,22 @@ esac
         rcfiles_end_time="$(LC_ALL="C"; echo $EPOCHREALTIME)"
     fi
 
-    # Unset HISTFILESIZE if the user rcfiles didn't change it away from our
-    # very large sentinel value.  We need to set the initial value of HISTSIZE
-    # to ensure that the user's history file doesn't get truncated when we spawn
-    # the shell, but once bootstrap has completes, we want the value to be what
-    # it would have been if we hadn't set an initial value.
+    # Unset HISTFILESIZE and HISTSIZE if the user rcfiles didn't change them
+    # away from our very large sentinel values.  We need to set the initial
+    # values to ensure that the user's history file and in-memory history list
+    # don't get truncated when we spawn the shell, but once bootstrap has
+    # completed, we want the values to be what they would have been if we hadn't
+    # set initial values.
     #
     # For more context, see: https://github.com/warpdotdev/Warp/issues/1262
     if [[ $HISTFILESIZE == $WARP_INITIAL_HISTFILESIZE ]]; then
         unset HISTFILESIZE
     fi
     unset WARP_INITIAL_HISTFILESIZE
+    if [[ $HISTSIZE == $WARP_INITIAL_HISTSIZE ]]; then
+        unset HISTSIZE
+    fi
+    unset WARP_INITIAL_HISTSIZE
 
     # Save the value of HISTCONTROL as it existed just after reading the user's
     # rcfiles.

--- a/app/src/terminal/local_tty/shell.rs
+++ b/app/src/terminal/local_tty/shell.rs
@@ -418,6 +418,15 @@ impl From<ShellStarterSource> for ShellStarterSourceOrWslName {
 }
 
 impl DirectShellStarter {
+    #[cfg(test)]
+    pub fn new_for_test(shell_type: ShellType, shell_path: PathBuf, args: Vec<OsString>) -> Self {
+        Self {
+            shell_type,
+            shell_path,
+            args,
+        }
+    }
+
     pub fn shell_path(&self) -> &Path {
         &self.shell_path
     }

--- a/app/src/terminal/local_tty/unix.rs
+++ b/app/src/terminal/local_tty/unix.rs
@@ -50,6 +50,8 @@ use std::{
 use warp_core::channel::ChannelState;
 use warpui::{AppContext, SingletonEntity};
 
+const BASH_HISTORY_SIZE_SENTINEL: &str = "57265949261";
+
 /// Get raw fds for leader/follower ends of a new PTY.
 fn make_pty(size: winsize) -> Result<(RawFd, RawFd)> {
     let mut win_size = size;
@@ -340,13 +342,14 @@ fn build_host_shell_command(
     builder.env("WARP_PATH_APPEND", path_append);
 
     if matches!(shell_starter.shell_type(), ShellType::Bash) {
-        // Set an initial very large value for HISTFILESIZE so that it
-        // doesn't get truncated on startup.
-        let sentinel_value = "57265949261";
-        builder.env("HISTFILESIZE", sentinel_value);
-        // Set a second environment variable that we can use to know whether
-        // the user rcfiles set HISTFILESIZE or not.
-        builder.env("WARP_INITIAL_HISTFILESIZE", sentinel_value);
+        // Set initial very large values so bash imports the user's existing
+        // history without truncating the file or in-memory list on startup.
+        builder.env("HISTFILESIZE", BASH_HISTORY_SIZE_SENTINEL);
+        builder.env("HISTSIZE", BASH_HISTORY_SIZE_SENTINEL);
+        // Set second environment variables that we can use to know whether
+        // the user rcfiles set these variables or not.
+        builder.env("WARP_INITIAL_HISTFILESIZE", BASH_HISTORY_SIZE_SENTINEL);
+        builder.env("WARP_INITIAL_HISTSIZE", BASH_HISTORY_SIZE_SENTINEL);
     }
 
     // Pass the desired initial working directory as an environment variable
@@ -808,9 +811,10 @@ fn build_docker_sandbox_command(
     builder.env("WARP_PATH_APPEND", path_append);
     // Sandbox shell is always bash (per the container image convention),
     // matching the host-shell path's behavior for bash shells.
-    let sentinel_value = "57265949261";
-    builder.env("HISTFILESIZE", sentinel_value);
-    builder.env("WARP_INITIAL_HISTFILESIZE", sentinel_value);
+    builder.env("HISTFILESIZE", BASH_HISTORY_SIZE_SENTINEL);
+    builder.env("HISTSIZE", BASH_HISTORY_SIZE_SENTINEL);
+    builder.env("WARP_INITIAL_HISTFILESIZE", BASH_HISTORY_SIZE_SENTINEL);
+    builder.env("WARP_INITIAL_HISTSIZE", BASH_HISTORY_SIZE_SENTINEL);
     // Intentionally do NOT set `WARP_INITIAL_WORKING_DIR` for sandboxes:
     // the container's init script cds into the sandbox home dir, not
     // the host's startup dir.
@@ -875,6 +879,101 @@ fn prepare_docker_sandbox(starter: &DockerSandboxShellStarter) -> Result<()> {
     mk_owner_only_dir(&starter.workspace_dir())?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shell_starter(shell_type: ShellType, shell_path: &str) -> DirectShellStarter {
+        DirectShellStarter::new_for_test(shell_type, PathBuf::from(shell_path), Vec::new())
+    }
+
+    fn env_value(command: &Command, key: &str) -> Option<Option<String>> {
+        command
+            .get_envs()
+            .find(|(env_key, _)| *env_key == std::ffi::OsStr::new(key))
+            .map(|(_, value)| value.map(|value| value.to_string_lossy().into_owned()))
+    }
+
+    #[test]
+    fn host_bash_command_sets_history_size_sentinels() {
+        let command = build_host_shell_command(
+            shell_starter(ShellType::Bash, "/bin/bash"),
+            None,
+            HashMap::new(),
+            None,
+            false,
+            false,
+            false,
+        );
+
+        assert_eq!(
+            env_value(&command, "HISTFILESIZE"),
+            Some(Some(BASH_HISTORY_SIZE_SENTINEL.to_owned()))
+        );
+        assert_eq!(
+            env_value(&command, "HISTSIZE"),
+            Some(Some(BASH_HISTORY_SIZE_SENTINEL.to_owned()))
+        );
+        assert_eq!(
+            env_value(&command, "WARP_INITIAL_HISTFILESIZE"),
+            Some(Some(BASH_HISTORY_SIZE_SENTINEL.to_owned()))
+        );
+        assert_eq!(
+            env_value(&command, "WARP_INITIAL_HISTSIZE"),
+            Some(Some(BASH_HISTORY_SIZE_SENTINEL.to_owned()))
+        );
+    }
+
+    #[test]
+    fn host_non_bash_command_does_not_set_history_size_sentinels() {
+        let command = build_host_shell_command(
+            shell_starter(ShellType::Zsh, "/bin/zsh"),
+            None,
+            HashMap::new(),
+            None,
+            false,
+            false,
+            false,
+        );
+
+        assert_eq!(env_value(&command, "HISTFILESIZE"), None);
+        assert_eq!(env_value(&command, "HISTSIZE"), None);
+        assert_eq!(env_value(&command, "WARP_INITIAL_HISTFILESIZE"), None);
+        assert_eq!(env_value(&command, "WARP_INITIAL_HISTSIZE"), None);
+    }
+
+    #[test]
+    fn docker_sandbox_command_sets_history_size_sentinels() {
+        let docker_starter =
+            DockerSandboxShellStarter::new(shell_starter(ShellType::Bash, "sbx"), None);
+        let command = build_docker_sandbox_command(
+            &docker_starter,
+            None,
+            HashMap::new(),
+            false,
+            false,
+            false,
+        );
+
+        assert_eq!(
+            env_value(&command, "HISTFILESIZE"),
+            Some(Some(BASH_HISTORY_SIZE_SENTINEL.to_owned()))
+        );
+        assert_eq!(
+            env_value(&command, "HISTSIZE"),
+            Some(Some(BASH_HISTORY_SIZE_SENTINEL.to_owned()))
+        );
+        assert_eq!(
+            env_value(&command, "WARP_INITIAL_HISTFILESIZE"),
+            Some(Some(BASH_HISTORY_SIZE_SENTINEL.to_owned()))
+        );
+        assert_eq!(
+            env_value(&command, "WARP_INITIAL_HISTSIZE"),
+            Some(Some(BASH_HISTORY_SIZE_SENTINEL.to_owned()))
+        );
+    }
 }
 
 /// A set of platform helper utilities copied directly from std::sys.


### PR DESCRIPTION
## Summary
- set a large initial HISTSIZE sentinel alongside HISTFILESIZE for bash startup
- unset HISTSIZE after rcfile loading when the user did not override it
- cover host bash, non-bash, and docker sandbox command environments with regression tests

Fixes #10565

## Tests
- cargo fmt --check
- git diff --check
- cargo test -p warp history_size_sentinels