### PR TITLE
docs: attribute Alacritty VTE parser integration

### DIFF
--- a/app/src/terminal/model/ansi/mod.rs
+++ b/app/src/terminal/model/ansi/mod.rs
@@ -1,3 +1,6 @@
+// This module integrates with the vte crate (an Alacritty project) under the
+// Apache license; see: crates/warp_terminal/src/model/LICENSE-ALACRITTY.
+
 //! This module implements processing logic for pty output.
 //!
 //! The top-level export is [`Processor`], which is a lightweight wrapper


### PR DESCRIPTION
## Summary
- add an explicit Alacritty/vte attribution notice to the ANSI terminal processing module
- point the module at the existing bundled Alacritty Apache license file

## Validation
- git diff --check
- cargo test -p warp_editor table --lib

Refs #9522