### PR TITLE
Fix nested MCP integer coercion

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
@@ -203,9 +203,17 @@ fn coerce_integer_value(
         }
     }
 
-    for keyword in ["allOf", "anyOf", "oneOf"] {
+    if let Some(schemas) = schema.get("allOf").and_then(|schemas| schemas.as_array()) {
+        for nested_schema in schemas {
+            coerce_integer_value(value, nested_schema, root_schema, ref_stack);
+        }
+    }
+
+    for keyword in ["anyOf", "oneOf"] {
         if let Some(schemas) = schema.get(keyword).and_then(|schemas| schemas.as_array()) {
-            for nested_schema in schemas {
+            if let Some(nested_schema) = schemas.iter().find(|nested_schema| {
+                schema_matches_value(value, nested_schema, root_schema, ref_stack)
+            }) {
                 coerce_integer_value(value, nested_schema, root_schema, ref_stack);
             }
         }
@@ -217,7 +225,8 @@ fn coerce_integer_value(
 
     match value {
         serde_json::Value::Object(object) => {
-            if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
+            let declared_properties = schema.get("properties").and_then(|p| p.as_object());
+            if let Some(properties) = declared_properties {
                 for (key, property_schema) in properties {
                     if let Some(property_value) = object.get_mut(key) {
                         coerce_integer_value(
@@ -232,7 +241,12 @@ fn coerce_integer_value(
 
             if let Some(additional_properties) = schema.get("additionalProperties") {
                 if additional_properties.is_object() {
-                    for property_value in object.values_mut() {
+                    for (key, property_value) in object.iter_mut() {
+                        if declared_properties
+                            .is_some_and(|properties| properties.contains_key(key))
+                        {
+                            continue;
+                        }
                         coerce_integer_value(
                             property_value,
                             additional_properties,
@@ -251,6 +265,135 @@ fn coerce_integer_value(
             }
         }
         _ => {}
+    }
+}
+
+fn schema_matches_value(
+    value: &serde_json::Value,
+    schema: &serde_json::Value,
+    root_schema: &serde_json::Value,
+    ref_stack: &[String],
+) -> bool {
+    if let Some(ref_path) = schema.get("$ref").and_then(|ref_path| ref_path.as_str()) {
+        if !ref_path.starts_with('#') || ref_stack.iter().any(|seen| seen == ref_path) {
+            return true;
+        }
+
+        let mut next_ref_stack = ref_stack.to_owned();
+        next_ref_stack.push(ref_path.to_string());
+        if let Some(resolved_schema) =
+            root_schema.pointer(ref_path.strip_prefix('#').unwrap_or_default())
+        {
+            return schema_matches_value(value, resolved_schema, root_schema, &next_ref_stack);
+        }
+    }
+
+    if let Some(schemas) = schema.get("allOf").and_then(|schemas| schemas.as_array()) {
+        if !schemas
+            .iter()
+            .all(|schema| schema_matches_value(value, schema, root_schema, ref_stack))
+        {
+            return false;
+        }
+    }
+
+    if let Some(schemas) = schema.get("anyOf").and_then(|schemas| schemas.as_array()) {
+        if !schemas
+            .iter()
+            .any(|schema| schema_matches_value(value, schema, root_schema, ref_stack))
+        {
+            return false;
+        }
+    }
+
+    if let Some(schemas) = schema.get("oneOf").and_then(|schemas| schemas.as_array()) {
+        if !schemas
+            .iter()
+            .any(|schema| schema_matches_value(value, schema, root_schema, ref_stack))
+        {
+            return false;
+        }
+    }
+
+    if let Some(schema_type) = schema.get("type") {
+        let type_matches = match schema_type {
+            serde_json::Value::String(schema_type) => value_matches_schema_type(value, schema_type),
+            serde_json::Value::Array(schema_types) => schema_types.iter().any(|schema_type| {
+                schema_type
+                    .as_str()
+                    .is_some_and(|schema_type| value_matches_schema_type(value, schema_type))
+            }),
+            _ => true,
+        };
+        if !type_matches {
+            return false;
+        }
+    }
+
+    match value {
+        serde_json::Value::Object(object) => {
+            if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
+                for (key, property_schema) in properties {
+                    if let Some(property_value) = object.get(key) {
+                        if !schema_matches_value(
+                            property_value,
+                            property_schema,
+                            root_schema,
+                            ref_stack,
+                        ) {
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            if let Some(additional_properties) = schema.get("additionalProperties") {
+                if additional_properties.is_object() {
+                    let declared_properties = schema.get("properties").and_then(|p| p.as_object());
+                    for (key, property_value) in object {
+                        if declared_properties
+                            .is_some_and(|properties| properties.contains_key(key))
+                        {
+                            continue;
+                        }
+                        if !schema_matches_value(
+                            property_value,
+                            additional_properties,
+                            root_schema,
+                            ref_stack,
+                        ) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            if let Some(items_schema) = schema.get("items") {
+                if !items
+                    .iter()
+                    .all(|item| schema_matches_value(item, items_schema, root_schema, ref_stack))
+                {
+                    return false;
+                }
+            }
+        }
+        _ => {}
+    }
+
+    true
+}
+
+fn value_matches_schema_type(value: &serde_json::Value, schema_type: &str) -> bool {
+    match schema_type {
+        "array" => value.is_array(),
+        "boolean" => value.is_boolean(),
+        "integer" => value.as_f64().is_some_and(|number| number.fract() == 0.0),
+        "null" => value.is_null(),
+        "number" => value.is_number(),
+        "object" => value.is_object(),
+        "string" => value.is_string(),
+        _ => true,
     }
 }
 
@@ -274,7 +417,9 @@ fn coerce_number_to_integer(value: &mut serde_json::Value) {
     if !float.is_finite() || float.fract() != 0.0 {
         return;
     }
-    if float < i64::MIN as f64 || float > i64::MAX as f64 {
+    const I64_MIN_F64: f64 = -9_223_372_036_854_775_808.0;
+    const I64_MAX_PLUS_ONE_F64: f64 = 9_223_372_036_854_775_808.0;
+    if !(I64_MIN_F64..I64_MAX_PLUS_ONE_F64).contains(&float) {
         return;
     }
 

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
@@ -173,116 +173,312 @@ impl Entity for CallMCPToolExecutor {
 /// MCP tool args round-trip through `google.protobuf.Struct` on the wire, whose
 /// `NumberValue` stores everything as `f64`. Without this fix, serde_json emits
 /// whole-number floats as `"5.0"`, which strict MCP servers reject for integer fields.
-///
-/// Walks the schema recursively so integer fields nested inside objects, arrays,
-/// or `oneOf`/`anyOf`/`allOf` branches are all coerced. `$ref` is not resolved
-/// (the root schema would be required) and is skipped.
 pub(crate) fn coerce_integer_args(
     args: &mut serde_json::Map<String, serde_json::Value>,
     input_schema: &serde_json::Map<String, serde_json::Value>,
 ) {
-    // Delegate to the recursive walker by wrapping `args` in a borrowed `Value`.
-    // This keeps the root-level traversal consistent with nested levels, so
-    // top-level `oneOf`/`anyOf`/`allOf` and `additionalProperties` are honored
-    // the same way they are deeper in the schema.
-    let mut wrapped = serde_json::Value::Object(std::mem::take(args));
-    let schema_value = serde_json::Value::Object(input_schema.clone());
-    coerce_value_against_schema(&mut wrapped, &schema_value);
-    if let serde_json::Value::Object(restored) = wrapped {
-        *args = restored;
+    let schema = serde_json::Value::Object(input_schema.clone());
+    let mut value = serde_json::Value::Object(std::mem::take(args));
+    coerce_integer_value(&mut value, &schema, &schema, &mut Vec::new());
+
+    if let serde_json::Value::Object(coerced_args) = value {
+        *args = coerced_args;
     }
 }
 
-/// Returns true if the schema's `type` declares `"integer"`, including the
-/// nullable form `"type": ["integer", "null"]`.
-fn schema_declares_integer(schema: &serde_json::Value) -> bool {
-    match schema.get("type") {
-        Some(serde_json::Value::String(s)) => s == "integer",
-        Some(serde_json::Value::Array(types)) => {
-            types.iter().any(|t| t.as_str() == Some("integer"))
-        }
-        _ => false,
-    }
-}
-
-/// In-place coerces a whole-number `f64` `Number` to `i64`.
-fn coerce_number_to_int(n: &mut serde_json::Number) {
-    let Some(f) = n.as_f64() else { return };
-    if n.is_i64() || n.is_u64() {
-        return;
-    }
-    if f.fract() != 0.0 {
-        return;
-    }
-    if let Ok(i) = i64::try_from(f as i128) {
-        *n = serde_json::Number::from(i);
-    }
-}
-
-/// Recursively walks `value` against `schema`, coercing whole-number f64s to
-/// i64 wherever the schema declares `"type": "integer"`. Safe to call against
-/// multiple `oneOf`/`anyOf`/`allOf` branches: coercion is a no-op on values
-/// the schema does not match.
-fn coerce_value_against_schema(value: &mut serde_json::Value, schema: &serde_json::Value) {
-    if schema_declares_integer(schema) {
-        if let serde_json::Value::Number(n) = value {
-            coerce_number_to_int(n);
+fn coerce_integer_value(
+    value: &mut serde_json::Value,
+    schema: &serde_json::Value,
+    root_schema: &serde_json::Value,
+    ref_stack: &mut Vec<String>,
+) {
+    if let Some(ref_path) = schema.get("$ref").and_then(|ref_path| ref_path.as_str()) {
+        if ref_path.starts_with('#') && !ref_stack.iter().any(|seen| seen == ref_path) {
+            ref_stack.push(ref_path.to_string());
+            if let Some(resolved_schema) =
+                root_schema.pointer(ref_path.strip_prefix('#').unwrap_or_default())
+            {
+                coerce_integer_value(value, resolved_schema, root_schema, ref_stack);
+            }
+            ref_stack.pop();
         }
     }
 
-    // Visit every combinator key independently — a schema may declare more than
-    // one of {oneOf, anyOf, allOf} at the same level, and we need to walk every
-    // branch in every present combinator. Coercion is monotonic, so visiting
-    // branches whose constraints don't match `value` is a safe no-op.
-    for combinator in ["oneOf", "anyOf", "allOf"] {
-        if let Some(branches) = schema.get(combinator).and_then(|b| b.as_array()) {
-            for branch in branches {
-                coerce_value_against_schema(value, branch);
+    if let Some(schemas) = schema.get("allOf").and_then(|schemas| schemas.as_array()) {
+        for nested_schema in schemas {
+            coerce_integer_value(value, nested_schema, root_schema, ref_stack);
+        }
+    }
+
+    if let Some(schemas) = schema.get("anyOf").and_then(|schemas| schemas.as_array()) {
+        if let Some(nested_schema) = schemas.iter().find(|nested_schema| {
+            schema_matches_value(value, nested_schema, root_schema, ref_stack)
+        }) {
+            coerce_integer_value(value, nested_schema, root_schema, ref_stack);
+        }
+    }
+
+    if let Some(schemas) = schema.get("oneOf").and_then(|schemas| schemas.as_array()) {
+        // `oneOf` is satisfied by exactly one branch. When matching is ambiguous (zero or more
+        // than one branch matches) we cannot tell which schema the value was meant for, so we
+        // skip coercion rather than risk applying the wrong branch's `integer` declaration.
+        let mut matching = schemas.iter().filter(|nested_schema| {
+            schema_matches_value(value, nested_schema, root_schema, ref_stack)
+        });
+        if let Some(nested_schema) = matching.next() {
+            if matching.next().is_none() {
+                coerce_integer_value(value, nested_schema, root_schema, ref_stack);
             }
         }
     }
 
+    if schema_declares_integer(schema) {
+        coerce_number_to_integer(value);
+    }
+
     match value {
-        serde_json::Value::Object(map) => {
-            let properties = schema.get("properties").and_then(|p| p.as_object());
-            let additional = schema.get("additionalProperties");
-            // Per-key handling for the outer schema only. Per-branch handling
-            // for keys covered by `oneOf`/`anyOf`/`allOf` is reached through
-            // the top-level combinator recursion above: each branch is invoked
-            // with the full `value`, so the branch's own object handling runs
-            // and walks its `properties[k]`. Coercion is monotonic so the two
-            // passes stack safely.
-            for (k, v) in map.iter_mut() {
-                if let Some(prop_schema) = properties.and_then(|p| p.get(k)) {
-                    coerce_value_against_schema(v, prop_schema);
-                } else if let Some(extra_schema) = additional {
-                    if extra_schema.is_object() {
-                        coerce_value_against_schema(v, extra_schema);
+        serde_json::Value::Object(object) => {
+            let declared_properties = schema.get("properties").and_then(|p| p.as_object());
+            if let Some(properties) = declared_properties {
+                for (key, property_schema) in properties {
+                    if let Some(property_value) = object.get_mut(key) {
+                        coerce_integer_value(
+                            property_value,
+                            property_schema,
+                            root_schema,
+                            ref_stack,
+                        );
+                    }
+                }
+            }
+
+            if let Some(additional_properties) = schema.get("additionalProperties") {
+                if additional_properties.is_object() {
+                    for (key, property_value) in object.iter_mut() {
+                        if declared_properties
+                            .is_some_and(|properties| properties.contains_key(key))
+                        {
+                            continue;
+                        }
+                        coerce_integer_value(
+                            property_value,
+                            additional_properties,
+                            root_schema,
+                            ref_stack,
+                        );
                     }
                 }
             }
         }
         serde_json::Value::Array(items) => {
-            if let Some(item_schema) = schema.get("items") {
-                match item_schema {
-                    // `items` as an object schema: applies to every element.
-                    serde_json::Value::Object(_) => {
-                        for elem in items.iter_mut() {
-                            coerce_value_against_schema(elem, item_schema);
-                        }
-                    }
-                    // `items` as an array (tuple validation): positional schemas.
-                    serde_json::Value::Array(schemas) => {
-                        for (elem, elem_schema) in items.iter_mut().zip(schemas.iter()) {
-                            coerce_value_against_schema(elem, elem_schema);
-                        }
-                    }
-                    _ => {}
+            if let Some(items_schema) = schema.get("items") {
+                for item in items {
+                    coerce_integer_value(item, items_schema, root_schema, ref_stack);
                 }
             }
         }
         _ => {}
     }
+}
+
+fn schema_matches_value(
+    value: &serde_json::Value,
+    schema: &serde_json::Value,
+    root_schema: &serde_json::Value,
+    ref_stack: &[String],
+) -> bool {
+    if let Some(ref_path) = schema.get("$ref").and_then(|ref_path| ref_path.as_str()) {
+        if !ref_path.starts_with('#') || ref_stack.iter().any(|seen| seen == ref_path) {
+            return true;
+        }
+
+        let mut next_ref_stack = ref_stack.to_owned();
+        next_ref_stack.push(ref_path.to_string());
+        if let Some(resolved_schema) =
+            root_schema.pointer(ref_path.strip_prefix('#').unwrap_or_default())
+        {
+            return schema_matches_value(value, resolved_schema, root_schema, &next_ref_stack);
+        }
+    }
+
+    if let Some(schemas) = schema.get("allOf").and_then(|schemas| schemas.as_array()) {
+        if !schemas
+            .iter()
+            .all(|schema| schema_matches_value(value, schema, root_schema, ref_stack))
+        {
+            return false;
+        }
+    }
+
+    if let Some(schemas) = schema.get("anyOf").and_then(|schemas| schemas.as_array()) {
+        if !schemas
+            .iter()
+            .any(|schema| schema_matches_value(value, schema, root_schema, ref_stack))
+        {
+            return false;
+        }
+    }
+
+    if let Some(schemas) = schema.get("oneOf").and_then(|schemas| schemas.as_array()) {
+        if !schemas
+            .iter()
+            .any(|schema| schema_matches_value(value, schema, root_schema, ref_stack))
+        {
+            return false;
+        }
+    }
+
+    if let Some(schema_type) = schema.get("type") {
+        let type_matches = match schema_type {
+            serde_json::Value::String(schema_type) => value_matches_schema_type(value, schema_type),
+            serde_json::Value::Array(schema_types) => schema_types.iter().any(|schema_type| {
+                schema_type
+                    .as_str()
+                    .is_some_and(|schema_type| value_matches_schema_type(value, schema_type))
+            }),
+            _ => true,
+        };
+        if !type_matches {
+            return false;
+        }
+    }
+
+    // `const` and `enum` pin the value to specific literals. A branch only matches when the
+    // value is one of them, so honoring these keeps `find` from selecting a branch whose
+    // optional properties merely type-check.
+    if let Some(const_value) = schema.get("const") {
+        if value != const_value {
+            return false;
+        }
+    }
+
+    if let Some(enum_values) = schema.get("enum").and_then(|values| values.as_array()) {
+        if !enum_values.iter().any(|enum_value| enum_value == value) {
+            return false;
+        }
+    }
+
+    match value {
+        serde_json::Value::Object(object) => {
+            // `required` lists keys that must be present for the value to satisfy the branch.
+            if let Some(required) = schema
+                .get("required")
+                .and_then(|required| required.as_array())
+            {
+                for required_key in required {
+                    if let Some(required_key) = required_key.as_str() {
+                        if !object.contains_key(required_key) {
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            let declared_properties = schema.get("properties").and_then(|p| p.as_object());
+
+            // `additionalProperties: false` forbids keys not declared in `properties`; a value
+            // carrying an undeclared key does not match such a branch.
+            if schema.get("additionalProperties") == Some(&serde_json::Value::Bool(false)) {
+                for key in object.keys() {
+                    let declared =
+                        declared_properties.is_some_and(|properties| properties.contains_key(key));
+                    if !declared {
+                        return false;
+                    }
+                }
+            }
+
+            if let Some(properties) = declared_properties {
+                for (key, property_schema) in properties {
+                    if let Some(property_value) = object.get(key) {
+                        if !schema_matches_value(
+                            property_value,
+                            property_schema,
+                            root_schema,
+                            ref_stack,
+                        ) {
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            if let Some(additional_properties) = schema.get("additionalProperties") {
+                if additional_properties.is_object() {
+                    for (key, property_value) in object {
+                        if declared_properties
+                            .is_some_and(|properties| properties.contains_key(key))
+                        {
+                            continue;
+                        }
+                        if !schema_matches_value(
+                            property_value,
+                            additional_properties,
+                            root_schema,
+                            ref_stack,
+                        ) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            if let Some(items_schema) = schema.get("items") {
+                if !items
+                    .iter()
+                    .all(|item| schema_matches_value(item, items_schema, root_schema, ref_stack))
+                {
+                    return false;
+                }
+            }
+        }
+        _ => {}
+    }
+
+    true
+}
+
+fn value_matches_schema_type(value: &serde_json::Value, schema_type: &str) -> bool {
+    match schema_type {
+        "array" => value.is_array(),
+        "boolean" => value.is_boolean(),
+        "integer" => value.as_f64().is_some_and(|number| number.fract() == 0.0),
+        "null" => value.is_null(),
+        "number" => value.is_number(),
+        "object" => value.is_object(),
+        "string" => value.is_string(),
+        _ => true,
+    }
+}
+
+fn schema_declares_integer(schema: &serde_json::Value) -> bool {
+    match schema.get("type") {
+        Some(serde_json::Value::String(schema_type)) => schema_type == "integer",
+        Some(serde_json::Value::Array(schema_types)) => schema_types
+            .iter()
+            .any(|schema_type| schema_type.as_str() == Some("integer")),
+        _ => false,
+    }
+}
+
+fn coerce_number_to_integer(value: &mut serde_json::Value) {
+    let serde_json::Value::Number(number) = value else {
+        return;
+    };
+    let Some(float) = number.as_f64() else {
+        return;
+    };
+    if !float.is_finite() || float.fract() != 0.0 {
+        return;
+    }
+    const I64_MIN_F64: f64 = -9_223_372_036_854_775_808.0;
+    const I64_MAX_PLUS_ONE_F64: f64 = 9_223_372_036_854_775_808.0;
+    if !(I64_MIN_F64..I64_MAX_PLUS_ONE_F64).contains(&float) {
+        return;
+    }
+
+    *number = serde_json::Number::from(float as i64);
 }
 
 #[cfg(test)]

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
@@ -176,26 +176,109 @@ pub(crate) fn coerce_integer_args(
     args: &mut serde_json::Map<String, serde_json::Value>,
     input_schema: &serde_json::Map<String, serde_json::Value>,
 ) {
-    let Some(properties) = input_schema.get("properties").and_then(|p| p.as_object()) else {
-        return;
-    };
+    let schema = serde_json::Value::Object(input_schema.clone());
+    let mut value = serde_json::Value::Object(std::mem::take(args));
+    coerce_integer_value(&mut value, &schema, &schema, &mut Vec::new());
 
-    for (key, prop_def) in properties {
-        let is_integer = prop_def.get("type").and_then(|t| t.as_str()) == Some("integer");
-        if !is_integer {
-            continue;
-        }
-        let Some(serde_json::Value::Number(n)) = args.get_mut(key) else {
-            continue;
-        };
-        let Some(f) = n.as_f64() else { continue };
-        if f.fract() != 0.0 {
-            continue;
-        }
-        if let Ok(i) = i64::try_from(f as i128) {
-            *n = serde_json::Number::from(i);
+    if let serde_json::Value::Object(coerced_args) = value {
+        *args = coerced_args;
+    }
+}
+
+fn coerce_integer_value(
+    value: &mut serde_json::Value,
+    schema: &serde_json::Value,
+    root_schema: &serde_json::Value,
+    ref_stack: &mut Vec<String>,
+) {
+    if let Some(ref_path) = schema.get("$ref").and_then(|ref_path| ref_path.as_str()) {
+        if ref_path.starts_with('#') && !ref_stack.iter().any(|seen| seen == ref_path) {
+            ref_stack.push(ref_path.to_string());
+            if let Some(resolved_schema) =
+                root_schema.pointer(ref_path.strip_prefix('#').unwrap_or_default())
+            {
+                coerce_integer_value(value, resolved_schema, root_schema, ref_stack);
+            }
+            ref_stack.pop();
         }
     }
+
+    for keyword in ["allOf", "anyOf", "oneOf"] {
+        if let Some(schemas) = schema.get(keyword).and_then(|schemas| schemas.as_array()) {
+            for nested_schema in schemas {
+                coerce_integer_value(value, nested_schema, root_schema, ref_stack);
+            }
+        }
+    }
+
+    if schema_declares_integer(schema) {
+        coerce_number_to_integer(value);
+    }
+
+    match value {
+        serde_json::Value::Object(object) => {
+            if let Some(properties) = schema.get("properties").and_then(|p| p.as_object()) {
+                for (key, property_schema) in properties {
+                    if let Some(property_value) = object.get_mut(key) {
+                        coerce_integer_value(
+                            property_value,
+                            property_schema,
+                            root_schema,
+                            ref_stack,
+                        );
+                    }
+                }
+            }
+
+            if let Some(additional_properties) = schema.get("additionalProperties") {
+                if additional_properties.is_object() {
+                    for property_value in object.values_mut() {
+                        coerce_integer_value(
+                            property_value,
+                            additional_properties,
+                            root_schema,
+                            ref_stack,
+                        );
+                    }
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            if let Some(items_schema) = schema.get("items") {
+                for item in items {
+                    coerce_integer_value(item, items_schema, root_schema, ref_stack);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn schema_declares_integer(schema: &serde_json::Value) -> bool {
+    match schema.get("type") {
+        Some(serde_json::Value::String(schema_type)) => schema_type == "integer",
+        Some(serde_json::Value::Array(schema_types)) => schema_types
+            .iter()
+            .any(|schema_type| schema_type.as_str() == Some("integer")),
+        _ => false,
+    }
+}
+
+fn coerce_number_to_integer(value: &mut serde_json::Value) {
+    let serde_json::Value::Number(number) = value else {
+        return;
+    };
+    let Some(float) = number.as_f64() else {
+        return;
+    };
+    if !float.is_finite() || float.fract() != 0.0 {
+        return;
+    }
+    if float < i64::MIN as f64 || float > i64::MAX as f64 {
+        return;
+    }
+
+    *number = serde_json::Number::from(float as i64);
 }
 
 #[cfg(test)]

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs
@@ -127,6 +127,56 @@ fn array_items_and_one_of_branches_are_coerced() {
 }
 
 #[test]
+fn one_of_uses_first_matching_branch_before_coercing() {
+    let mut args = obj(json!({ "value": 1.0 }));
+    let schema = obj(json!({
+        "properties": {
+            "value": {
+                "oneOf": [
+                    { "type": "number" },
+                    { "type": "integer" }
+                ]
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(serde_json::to_string(&args["value"]).unwrap(), "1.0");
+}
+
+#[test]
+fn additional_properties_skip_declared_properties() {
+    let mut args = obj(json!({
+        "price": 1.0,
+        "quantity": 2.0
+    }));
+    let schema = obj(json!({
+        "properties": {
+            "price": { "type": "number" }
+        },
+        "additionalProperties": { "type": "integer" }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(serde_json::to_string(&args["price"]).unwrap(), "1.0");
+    assert_eq!(serde_json::to_string(&args["quantity"]).unwrap(), "2");
+}
+
+#[test]
+fn integer_coercion_rejects_f64_i64_upper_rounding_boundary() {
+    let mut args = obj(json!({ "id": 9_223_372_036_854_775_808.0 }));
+    let schema = obj(json!({
+        "properties": { "id": { "type": "integer" } }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["id"].as_f64(), Some(9_223_372_036_854_775_808.0));
+}
+
+#[test]
 fn refs_and_nullable_integer_types_are_coerced() {
     let mut args = obj(json!({
         "limit": 5.0,

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs
@@ -1,8 +1,7 @@
 //! Unit tests for the `coerce_integer_args` helper.
 
-use serde_json::json;
-
 use super::*;
+use serde_json::json;
 
 fn obj(value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
     match value {
@@ -49,64 +48,49 @@ fn no_coercion_when_not_typed_as_integer() {
 }
 
 #[test]
-fn nested_object_integer_is_coerced() {
-    let mut args = obj(json!({ "outer": { "inner": 5.0 } }));
+fn nested_integer_fields_are_coerced() {
+    let mut args = obj(json!({
+        "request_data": {
+            "search_from": 0.0,
+            "search_to": 100.0,
+            "ratio": 1.5
+        }
+    }));
     let schema = obj(json!({
         "properties": {
-            "outer": {
+            "request_data": {
                 "type": "object",
-                "properties": { "inner": { "type": "integer" } }
+                "properties": {
+                    "search_from": { "type": "integer" },
+                    "search_to": { "type": "integer" },
+                    "ratio": { "type": "number" }
+                }
             }
         }
     }));
 
     coerce_integer_args(&mut args, &schema);
 
-    assert_eq!(args["outer"]["inner"].as_i64(), Some(5));
-    assert_eq!(serde_json::to_string(&args["outer"]["inner"]).unwrap(), "5");
+    assert_eq!(
+        serde_json::to_string(&args["request_data"]["search_from"]).unwrap(),
+        "0"
+    );
+    assert_eq!(
+        serde_json::to_string(&args["request_data"]["search_to"]).unwrap(),
+        "100"
+    );
+    assert_eq!(
+        serde_json::to_string(&args["request_data"]["ratio"]).unwrap(),
+        "1.5"
+    );
 }
 
 #[test]
-fn array_items_integer_is_coerced() {
-    let mut args = obj(json!({ "ids": [1.0, 2.0, 3.5] }));
-    let schema = obj(json!({
-        "properties": {
-            "ids": { "type": "array", "items": { "type": "integer" } }
-        }
-    }));
-
-    coerce_integer_args(&mut args, &schema);
-
-    // Whole-number floats become i64; fractional values are left alone.
-    assert_eq!(args["ids"][0].as_i64(), Some(1));
-    assert_eq!(args["ids"][1].as_i64(), Some(2));
-    assert_eq!(args["ids"][2].as_f64(), Some(3.5));
-}
-
-#[test]
-fn nullable_integer_type_array_is_coerced() {
-    let mut args = obj(json!({ "n": 7.0, "m": null }));
-    let schema = obj(json!({
-        "properties": {
-            "n": { "type": ["integer", "null"] },
-            "m": { "type": ["integer", "null"] }
-        }
-    }));
-
-    coerce_integer_args(&mut args, &schema);
-
-    assert_eq!(args["n"].as_i64(), Some(7));
-    assert!(args["m"].is_null());
-}
-
-#[test]
-fn one_of_branch_with_integer_is_coerced() {
-    // Mirrors the schema shape from issue #10596: a `filters` array whose items
-    // are a oneOf where one branch has `value: integer` (a millisecond timestamp).
+fn array_items_and_one_of_branches_are_coerced() {
     let mut args = obj(json!({
         "filters": [
-            { "value": ["a", "b"] },
-            { "value": 1730419200000.0 }
+            { "field": "timestamp", "value": 1730419200000.0 },
+            { "field": "names", "value": ["a", "b"] }
         ]
     }));
     let schema = obj(json!({
@@ -115,8 +99,18 @@ fn one_of_branch_with_integer_is_coerced() {
                 "type": "array",
                 "items": {
                     "oneOf": [
-                        { "properties": { "value": { "type": "array", "items": { "type": "string" } } } },
-                        { "properties": { "value": { "type": "integer" } } }
+                        {
+                            "type": "object",
+                            "properties": {
+                                "value": { "type": "array", "items": { "type": "string" } }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "value": { "type": "integer" }
+                            }
+                        }
                     ]
                 }
             }
@@ -125,21 +119,59 @@ fn one_of_branch_with_integer_is_coerced() {
 
     coerce_integer_args(&mut args, &schema);
 
-    assert_eq!(args["filters"][1]["value"].as_i64(), Some(1730419200000));
     assert_eq!(
-        serde_json::to_string(&args["filters"][1]["value"]).unwrap(),
+        serde_json::to_string(&args["filters"][0]["value"]).unwrap(),
         "1730419200000"
     );
-    // The string-array branch value is untouched.
-    assert_eq!(args["filters"][0]["value"][0].as_str(), Some("a"));
+    assert_eq!(args["filters"][1]["value"], json!(["a", "b"]));
 }
 
 #[test]
-fn any_of_at_property_level_is_coerced() {
-    let mut args = obj(json!({ "x": 9.0 }));
+fn one_of_skips_coercion_when_branch_matching_is_ambiguous() {
+    // `1.0` matches both the `number` and `integer` branches, so the matching branch is
+    // ambiguous. We skip coercion rather than risk applying the `integer` branch.
+    let mut args = obj(json!({ "value": 1.0 }));
     let schema = obj(json!({
         "properties": {
-            "x": {
+            "value": {
+                "oneOf": [
+                    { "type": "number" },
+                    { "type": "integer" }
+                ]
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(serde_json::to_string(&args["value"]).unwrap(), "1.0");
+}
+
+#[test]
+fn any_of_uses_matching_branch_before_coercing() {
+    // The selected `number` branch must not be coerced even though a later `integer` branch
+    // would type-check the same value.
+    let mut number_args = obj(json!({ "value": 1.0 }));
+    let number_schema = obj(json!({
+        "properties": {
+            "value": {
+                "anyOf": [
+                    { "type": "number" },
+                    { "type": "integer" }
+                ]
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut number_args, &number_schema);
+
+    assert_eq!(serde_json::to_string(&number_args["value"]).unwrap(), "1.0");
+
+    // When only the `integer` branch matches, coercion still applies.
+    let mut integer_args = obj(json!({ "value": 2.0 }));
+    let integer_schema = obj(json!({
+        "properties": {
+            "value": {
                 "anyOf": [
                     { "type": "string" },
                     { "type": "integer" }
@@ -148,173 +180,172 @@ fn any_of_at_property_level_is_coerced() {
         }
     }));
 
-    coerce_integer_args(&mut args, &schema);
+    coerce_integer_args(&mut integer_args, &integer_schema);
 
-    assert_eq!(args["x"].as_i64(), Some(9));
+    assert_eq!(serde_json::to_string(&integer_args["value"]).unwrap(), "2");
 }
 
 #[test]
-fn all_of_with_integer_branch_is_coerced() {
-    let mut args = obj(json!({ "x": 4.0 }));
+fn one_of_branch_selection_honors_required() {
+    // Both branches declare an optional `id: integer`, but only the branch whose `required`
+    // key (`amount`) is present should match. Selecting the wrong branch would still coerce
+    // `id`, so this exercises that `required` actually narrows the selection.
+    let mut args = obj(json!({ "amount": 3.0, "id": 4.0 }));
     let schema = obj(json!({
         "properties": {
-            "x": {
-                "allOf": [
-                    { "type": "integer" },
-                    { "minimum": 0 }
-                ]
-            }
-        }
-    }));
-
-    coerce_integer_args(&mut args, &schema);
-
-    assert_eq!(args["x"].as_i64(), Some(4));
-}
-
-#[test]
-fn additional_properties_schema_is_applied() {
-    let mut args = obj(json!({ "meta": { "a": 1.0, "b": 2.0 } }));
-    let schema = obj(json!({
-        "properties": {
-            "meta": {
+            "payload": { "type": "object" }
+        },
+        "oneOf": [
+            {
                 "type": "object",
-                "additionalProperties": { "type": "integer" }
+                "required": ["label"],
+                "properties": {
+                    "label": { "type": "string" },
+                    "id": { "type": "integer" }
+                }
+            },
+            {
+                "type": "object",
+                "required": ["amount"],
+                "properties": {
+                    "amount": { "type": "number" },
+                    "id": { "type": "integer" }
+                }
             }
-        }
-    }));
-
-    coerce_integer_args(&mut args, &schema);
-
-    assert_eq!(args["meta"]["a"].as_i64(), Some(1));
-    assert_eq!(args["meta"]["b"].as_i64(), Some(2));
-}
-
-#[test]
-fn fractional_value_is_not_coerced_to_int() {
-    let mut args = obj(json!({ "x": 2.5 }));
-    let schema = obj(json!({
-        "properties": { "x": { "type": "integer" } }
-    }));
-
-    coerce_integer_args(&mut args, &schema);
-
-    // Schema mismatch (server will reject) but we must not silently truncate.
-    assert_eq!(args["x"].as_f64(), Some(2.5));
-}
-
-#[test]
-fn root_level_one_of_branch_with_integer_is_coerced() {
-    // When the root schema uses a combinator instead of (or alongside)
-    // `properties`, the entrypoint must walk every branch, not stop at the
-    // first one.
-    let mut args = obj(json!({ "x": 6.0 }));
-    let schema = obj(json!({
-        "oneOf": [
-            { "properties": { "x": { "type": "string" } } },
-            { "properties": { "x": { "type": "integer" } } }
         ]
     }));
 
     coerce_integer_args(&mut args, &schema);
 
-    assert_eq!(args["x"].as_i64(), Some(6));
+    // Second branch is selected: `amount` stays a float, `id` is coerced.
+    assert_eq!(serde_json::to_string(&args["amount"]).unwrap(), "3.0");
+    assert_eq!(serde_json::to_string(&args["id"]).unwrap(), "4");
 }
 
 #[test]
-fn root_level_additional_properties_is_applied() {
-    let mut args = obj(json!({ "anything": 8.0, "more": 9.0 }));
-    let schema = obj(json!({ "additionalProperties": { "type": "integer" } }));
-
-    coerce_integer_args(&mut args, &schema);
-
-    assert_eq!(args["anything"].as_i64(), Some(8));
-    assert_eq!(args["more"].as_i64(), Some(9));
-}
-
-#[test]
-fn negative_whole_float_is_coerced() {
-    let mut args = obj(json!({ "x": -42.0 }));
+fn one_of_branch_selection_honors_const_and_enum() {
+    // The discriminant `kind` pins each branch via `const`/`enum`. Only the matching branch's
+    // `integer` declaration should be applied.
     let schema = obj(json!({
-        "properties": { "x": { "type": "integer" } }
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "kind": { "const": "ratio" },
+                    "value": { "type": "number" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "kind": { "enum": ["count"] },
+                    "value": { "type": "integer" }
+                }
+            }
+        ]
+    }));
+
+    let mut ratio_args = obj(json!({ "kind": "ratio", "value": 5.0 }));
+    coerce_integer_args(&mut ratio_args, &schema);
+    assert_eq!(serde_json::to_string(&ratio_args["value"]).unwrap(), "5.0");
+
+    let mut count_args = obj(json!({ "kind": "count", "value": 5.0 }));
+    coerce_integer_args(&mut count_args, &schema);
+    assert_eq!(serde_json::to_string(&count_args["value"]).unwrap(), "5");
+}
+
+#[test]
+fn one_of_branch_selection_honors_additional_properties_false() {
+    // The first (closed) branch forbids the extra `id` key, so the open second branch must be
+    // selected and its `integer` declaration applied to `id`.
+    let mut args = obj(json!({ "name": "abc", "id": 7.0 }));
+    let schema = obj(json!({
+        "oneOf": [
+            {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": { "type": "string" }
+                }
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "id": { "type": "integer" }
+                }
+            }
+        ]
     }));
 
     coerce_integer_args(&mut args, &schema);
 
-    assert_eq!(args["x"].as_i64(), Some(-42));
-    assert_eq!(serde_json::to_string(&args["x"]).unwrap(), "-42");
+    assert_eq!(serde_json::to_string(&args["id"]).unwrap(), "7");
 }
 
 #[test]
-fn tuple_style_items_coerces_positional_schemas() {
-    let mut args = obj(json!({ "pair": [1.0, "hi", 2.0] }));
+fn additional_properties_skip_declared_properties() {
+    let mut args = obj(json!({
+        "price": 1.0,
+        "quantity": 2.0
+    }));
     let schema = obj(json!({
         "properties": {
-            "pair": {
-                "type": "array",
-                "items": [
-                    { "type": "integer" },
-                    { "type": "string" },
-                    { "type": "integer" }
-                ]
+            "price": { "type": "number" }
+        },
+        "additionalProperties": { "type": "integer" }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(serde_json::to_string(&args["price"]).unwrap(), "1.0");
+    assert_eq!(serde_json::to_string(&args["quantity"]).unwrap(), "2");
+}
+
+#[test]
+fn integer_coercion_rejects_f64_i64_upper_rounding_boundary() {
+    let mut args = obj(json!({ "id": 9_223_372_036_854_775_808.0 }));
+    let schema = obj(json!({
+        "properties": { "id": { "type": "integer" } }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["id"].as_f64(), Some(9_223_372_036_854_775_808.0));
+}
+
+#[test]
+fn refs_and_nullable_integer_types_are_coerced() {
+    let mut args = obj(json!({
+        "limit": 5.0,
+        "cursor": null,
+        "range": { "start": 10.0, "end": 12.0 }
+    }));
+    let schema = obj(json!({
+        "$defs": {
+            "nullable_integer": { "type": ["integer", "null"] },
+            "range": {
+                "type": "object",
+                "properties": {
+                    "start": { "$ref": "#/$defs/nullable_integer" },
+                    "end": { "type": "integer" }
+                }
             }
+        },
+        "properties": {
+            "limit": { "$ref": "#/$defs/nullable_integer" },
+            "cursor": { "$ref": "#/$defs/nullable_integer" },
+            "range": { "$ref": "#/$defs/range" }
         }
     }));
 
     coerce_integer_args(&mut args, &schema);
 
-    assert_eq!(args["pair"][0].as_i64(), Some(1));
-    assert_eq!(args["pair"][1].as_str(), Some("hi"));
-    assert_eq!(args["pair"][2].as_i64(), Some(2));
-}
-
-#[test]
-fn multiple_combinators_at_same_level_are_all_traversed() {
-    // A schema may declare more than one of {oneOf, anyOf, allOf} at the
-    // same level, and every combinator must be walked — not just the first
-    // present key.
-    let mut args = obj(json!({ "a": 1.0, "b": 2.0, "c": 3.0 }));
-    let schema = obj(json!({
-        "oneOf": [{ "properties": { "a": { "type": "integer" } } }],
-        "anyOf": [{ "properties": { "b": { "type": "integer" } } }],
-        "allOf": [{ "properties": { "c": { "type": "integer" } } }]
-    }));
-
-    coerce_integer_args(&mut args, &schema);
-
-    assert_eq!(args["a"].as_i64(), Some(1));
-    assert_eq!(args["b"].as_i64(), Some(2));
-    assert_eq!(args["c"].as_i64(), Some(3));
-}
-
-#[test]
-fn one_of_with_multiple_branches_all_visited() {
-    // Every branch under a combinator must be visited, not just the first
-    // match. The same property name across branches with different types
-    // should still get the integer branch's coercion when applicable.
-    let mut args = obj(json!({ "v": 11.0 }));
-    let schema = obj(json!({
-        "oneOf": [
-            { "properties": { "v": { "type": "string" } } },
-            { "properties": { "v": { "type": "number" } } },
-            { "properties": { "v": { "type": "integer" } } }
-        ]
-    }));
-
-    coerce_integer_args(&mut args, &schema);
-
-    assert_eq!(args["v"].as_i64(), Some(11));
-}
-
-#[test]
-fn already_integer_value_is_unchanged() {
-    let mut args = obj(json!({ "x": 5 }));
-    let schema = obj(json!({
-        "properties": { "x": { "type": "integer" } }
-    }));
-
-    coerce_integer_args(&mut args, &schema);
-
-    assert_eq!(args["x"].as_i64(), Some(5));
-    assert_eq!(serde_json::to_string(&args["x"]).unwrap(), "5");
+    assert_eq!(serde_json::to_string(&args["limit"]).unwrap(), "5");
+    assert_eq!(args["cursor"], serde_json::Value::Null);
+    assert_eq!(
+        serde_json::to_string(&args["range"]["start"]).unwrap(),
+        "10"
+    );
+    assert_eq!(serde_json::to_string(&args["range"]["end"]).unwrap(), "12");
 }

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs
@@ -46,3 +46,118 @@ fn no_coercion_when_not_typed_as_integer() {
         assert_eq!(serde_json::to_string(&args["x"]).unwrap(), "1.0");
     }
 }
+
+#[test]
+fn nested_integer_fields_are_coerced() {
+    let mut args = obj(json!({
+        "request_data": {
+            "search_from": 0.0,
+            "search_to": 100.0,
+            "ratio": 1.5
+        }
+    }));
+    let schema = obj(json!({
+        "properties": {
+            "request_data": {
+                "type": "object",
+                "properties": {
+                    "search_from": { "type": "integer" },
+                    "search_to": { "type": "integer" },
+                    "ratio": { "type": "number" }
+                }
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(
+        serde_json::to_string(&args["request_data"]["search_from"]).unwrap(),
+        "0"
+    );
+    assert_eq!(
+        serde_json::to_string(&args["request_data"]["search_to"]).unwrap(),
+        "100"
+    );
+    assert_eq!(
+        serde_json::to_string(&args["request_data"]["ratio"]).unwrap(),
+        "1.5"
+    );
+}
+
+#[test]
+fn array_items_and_one_of_branches_are_coerced() {
+    let mut args = obj(json!({
+        "filters": [
+            { "field": "timestamp", "value": 1730419200000.0 },
+            { "field": "names", "value": ["a", "b"] }
+        ]
+    }));
+    let schema = obj(json!({
+        "properties": {
+            "filters": {
+                "type": "array",
+                "items": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "value": { "type": "array", "items": { "type": "string" } }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "value": { "type": "integer" }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(
+        serde_json::to_string(&args["filters"][0]["value"]).unwrap(),
+        "1730419200000"
+    );
+    assert_eq!(args["filters"][1]["value"], json!(["a", "b"]));
+}
+
+#[test]
+fn refs_and_nullable_integer_types_are_coerced() {
+    let mut args = obj(json!({
+        "limit": 5.0,
+        "cursor": null,
+        "range": { "start": 10.0, "end": 12.0 }
+    }));
+    let schema = obj(json!({
+        "$defs": {
+            "nullable_integer": { "type": ["integer", "null"] },
+            "range": {
+                "type": "object",
+                "properties": {
+                    "start": { "$ref": "#/$defs/nullable_integer" },
+                    "end": { "type": "integer" }
+                }
+            }
+        },
+        "properties": {
+            "limit": { "$ref": "#/$defs/nullable_integer" },
+            "cursor": { "$ref": "#/$defs/nullable_integer" },
+            "range": { "$ref": "#/$defs/range" }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(serde_json::to_string(&args["limit"]).unwrap(), "5");
+    assert_eq!(args["cursor"], serde_json::Value::Null);
+    assert_eq!(
+        serde_json::to_string(&args["range"]["start"]).unwrap(),
+        "10"
+    );
+    assert_eq!(serde_json::to_string(&args["range"]["end"]).unwrap(), "12");
+}


### PR DESCRIPTION
Summary
- Walk MCP tool arguments recursively against their input schema before dispatch.
- Coerce whole-number values for nested integer properties, array items, composition branches, nullable integer types, and local `$ref`s.
- Select a matching `anyOf`/`oneOf` branch before coercing, apply `additionalProperties` only to undeclared keys, and reject the f64 upper i64 boundary.
- Add coverage for nested request data, timestamp filter shapes, branch selection, additionalProperties semantics, and the i64 upper rounding boundary.

Why
Strict MCP servers reject `5.0` for fields declared as integers. The previous helper only handled top-level `type: integer` properties, so common OpenAPI-derived schemas still leaked float JSON.

Tests
- `git diff --check`
- `rustfmt app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs`
- Attempted `cargo test -p warp call_mcp_tool`, but this machine ran out of disk while compiling dependencies.

Fixes #10596
