### PR TITLE
Add copy Markdown action for plans

### DIFF
--- a/app/src/ai/ai_document_view.rs
+++ b/app/src/ai/ai_document_view.rs
@@ -114,6 +114,7 @@ pub enum AIDocumentAction {
     RevertToDocumentVersion,
     SendUpdatedPlan,
     CopyLink(String),
+    CopyMarkdown,
     CopyPlanId,
     ShowInWarpDrive,
     AttachToActiveSession,
@@ -1143,6 +1144,19 @@ impl TypedActionView for AIDocumentView {
                     );
                 });
             }
+            AIDocumentAction::CopyMarkdown => {
+                let markdown = self.editor.as_ref(ctx).markdown_unescaped(ctx);
+                ctx.clipboard().write(ClipboardContent::plain_text(markdown));
+
+                let window_id = ctx.window_id();
+                ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::success("Markdown copied to clipboard".to_string()),
+                        window_id,
+                        ctx,
+                    );
+                });
+            }
             AIDocumentAction::CopyPlanId => {
                 ctx.clipboard()
                     .write(ClipboardContent::plain_text(self.document_id.to_string()));
@@ -1322,6 +1336,13 @@ impl BackingView for AIDocumentView {
                     .into_item(),
             );
         }
+
+        menu_items.push(
+            MenuItemFields::new("Copy Markdown")
+                .with_on_select_action(AIDocumentAction::CopyMarkdown)
+                .with_icon(Icon::Copy)
+                .into_item(),
+        );
 
         // Add "Attach to active session" menu item
         menu_items.push(


### PR DESCRIPTION
Summary
- Add a `Copy Markdown` action to the plan overflow menu.
- Copy the current plan's raw Markdown to the clipboard using the same editor serialization path as export.
- Show a confirmation toast after copying.

Why
Saving a plan as a Markdown file just to copy the contents is unnecessary friction. The plan menu can expose the markdown directly.

Testing
- `git diff --check`

Manual verification
- Not captured in this environment. This runner is a headless Linux shell without a running Warp desktop session, so I cannot open the plan overflow menu or record the clipboard toast end to end here.
- The action is wired through the existing overflow menu action path, writes `markdown_unescaped(ctx)` to the clipboard, and shows the existing success toast component.

Fixes #9214
