### PR TITLE
Reduce shared session scrollback payload size

### DIFF
--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -1538,6 +1538,7 @@ impl TerminalManager {
                 {
                     let mut model = model.lock();
                     model.set_shared_session_status(SharedSessionStatus::NotShared);
+                    model.set_obfuscate_secrets(get_secret_obfuscation_mode(ctx));
                     model.clear_ordered_terminal_events_for_shared_session_tx();
                 }
 

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -1535,9 +1535,11 @@ impl TerminalManager {
             } => {
                 log::warn!("Failed to create shared session: reason={reason:?}, cause={cause:?}");
 
-                model
-                    .lock()
-                    .set_shared_session_status(SharedSessionStatus::NotShared);
+                {
+                    let mut model = model.lock();
+                    model.set_shared_session_status(SharedSessionStatus::NotShared);
+                    model.clear_ordered_terminal_events_for_shared_session_tx();
+                }
 
                 Manager::handle(ctx).update(ctx, |manager, ctx| {
                     manager.share_failed(window_id, ctx);

--- a/app/src/terminal/shared_session/mod.rs
+++ b/app/src/terminal/shared_session/mod.rs
@@ -208,7 +208,7 @@ impl SharedSessionScrollbackType {
             })
             .filter_map(|block| {
                 let serialized_block: SerializedBlock = block.into();
-                let bytes = serde_json::to_vec(&serialized_block);
+                let bytes = serialized_block.to_json();
                 bytes.ok().map(|raw| ScrollbackBlock { raw })
             })
             .collect();
@@ -413,7 +413,7 @@ pub(crate) fn decode_scrollback(scrollback: &Scrollback) -> Vec<SerializedBlock>
     scrollback
         .blocks
         .iter()
-        .filter_map(|block| serde_json::from_slice(&block.raw).ok())
+        .filter_map(|block| SerializedBlock::from_json(&block.raw).ok())
         .collect()
 }
 

--- a/app/src/terminal/shared_session/mod_tests.rs
+++ b/app/src/terminal/shared_session/mod_tests.rs
@@ -166,29 +166,30 @@ fn test_scrollback_serialization() {
         .expect("expected first scrollback block");
     let json: Value = serde_json::from_slice(&first_block.raw).expect("valid scrollback json");
 
-    // Capture the expected bytes from the model so we can assert exact JSON array contents.
+    // Capture the expected bytes from the model so we can assert exact base64 JSON contents.
     let completed_block = model.block_list().block_at(1.into()).unwrap();
     let expected: SerializedBlock = completed_block.into();
-
-    let expected_command: Vec<Value> = expected
-        .stylized_command
-        .iter()
-        .map(|&b| Value::from(b))
-        .collect();
-    let expected_output: Vec<Value> = expected
-        .stylized_output
-        .iter()
-        .map(|&b| Value::from(b))
-        .collect();
+    let expected_json: Value =
+        serde_json::from_slice(&expected.to_json().expect("serialize block to base64 json"))
+            .expect("valid expected block json");
 
     assert_eq!(
         json.get("stylized_command"),
-        Some(&Value::Array(expected_command)),
+        expected_json.get("stylized_command"),
     );
     assert_eq!(
         json.get("stylized_output"),
-        Some(&Value::Array(expected_output)),
+        expected_json.get("stylized_output"),
     );
+
+    assert!(matches!(
+        json.get("stylized_command"),
+        Some(Value::String(_))
+    ));
+    assert!(matches!(
+        json.get("stylized_output"),
+        Some(Value::String(_))
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Reduce shared-session scrollback payload size by serializing blocks through `SerializedBlock::to_json`, which base64-encodes byte fields instead of emitting large JSON integer arrays. Decode through `SerializedBlock::from_json` so existing integer-array scrollback still loads.

Also clear the ordered-terminal-event sender when session creation fails, matching the successful stop path and avoiding closed-channel reuse after failed share attempts.

## Linked Issue

Fixes #9198

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots or video are not applicable; this is a serialization and failure-cleanup change covered by unit tests.

## Testing

- `cargo fmt --check`
- `cargo test -p warp terminal::shared_session::tests:: -- --nocapture`
- `cargo test -p warp from_json_accepts -- --nocapture`
- `cargo clippy -p warp --all-targets --tests -- -D warnings`

Manual app testing with `./script/run` was not run because this change does not alter a visual flow; the behavior is covered at the shared-session serialization boundary.

CHANGELOG-BUG-FIX: Reduce shared-session scrollback payload size for large remote-control sessions.