### PR TITLE
fix: use GitHub App token in feature flag cleanup workflow to trigger CI

### DIFF
--- a/.github/workflows/feature_flag_cleanup.yml
+++ b/.github/workflows/feature_flag_cleanup.yml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
         with:
           app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
           private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}

--- a/.github/workflows/feature_flag_cleanup.yml
+++ b/.github/workflows/feature_flag_cleanup.yml
@@ -227,11 +227,18 @@ jobs:
         run: |
           git apply --binary --whitespace=nowarn "$RUNNER_TEMP/cleanup.patch"
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.OZ_MGMT_GHA_APP_ID }}
+          private-key: ${{ secrets.OZ_MGMT_GHA_PRIVATE_KEY }}
+
       - name: Create Pull Request
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
           base: ${{ github.event.repository.default_branch }}
           commit-message: "Clean up ${{ needs.analyze.outputs.flag_name }} feature flag"
           branch: "oz-agent/cleanup-feature-flag-${{ needs.analyze.outputs.flag_name }}"


### PR DESCRIPTION
## Description

The `feature_flag_cleanup.yml` workflow creates PRs using `peter-evans/create-pull-request` with `token: ${{ github.token }}`. GitHub does not trigger workflows from events generated by the default `GITHUB_TOKEN` — this is a built-in safeguard against recursive workflow runs. As a result, the Warp CI workflow never ran on feature flag cleanup PRs, making their checks appear stalled until a human manually pushed a commit to the branch.

This PR switches to a GitHub App token minted from the Oz for OSS identity (`OZ_MGMT_GHA_APP_ID` / `OZ_MGMT_GHA_PRIVATE_KEY`) using `actions/create-github-app-token@v3`, so the `pull_request.opened` event properly triggers downstream workflows including CI.

**Affected PRs (examples):**
- #10485 (BlockToolbeltSaveAsWorkflow) — CI never ran until a human merge commit
- #10374 (SharedWithMe) — currently open with no CI checks at all

## Linked Issue

N/A — discovered during investigation of stalled CI on #10485.

## Testing

- [x] Verified the `OZ_MGMT_GHA_APP_ID` and `OZ_MGMT_GHA_PRIVATE_KEY` secrets are already used by other workflows in this repo (`update-pr-review-local.yml`, `update-triage-local.yml`, `update-dedupe-local.yml`)
- [ ] I have manually tested my changes locally with `./script/run`

N/A — this is a CI workflow change, not a code change. It will be validated when the next feature flag cleanup run creates a PR and CI triggers.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode


_Conversation: https://staging.warp.dev/conversation/159eafa2-0c0f-483c-99a9-a461b5bdb3a8_
_Run: https://oz.staging.warp.dev/runs/019e16ef-48f7-789c-9294-e926e5bff1e0_
_This PR was generated with [Oz](https://warp.dev/oz)._
