### PR TITLE
Auto-select environment on `&` entry, not on handoff submit

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
@@ -79,13 +79,6 @@ impl EnvironmentSelectorTarget {
     ) {
         match self {
             Self::CloudPane(model) => {
-                // During local-to-cloud handoff with an explicit env, skip
-                // default selection so the user's `&` choice is preserved.
-                #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-                if model.as_ref(ctx).pending_handoff_has_explicit_environment() {
-                    return;
-                }
-
                 model.update(ctx, |model, ctx| {
                     model.set_environment_id(Some(environment_id), ctx);
                 });

--- a/app/src/ai/blocklist/handoff/touched_repos.rs
+++ b/app/src/ai/blocklist/handoff/touched_repos.rs
@@ -189,6 +189,18 @@ fn parse_github_repo(remote_url: &str) -> Option<GithubRepo> {
     Some(GithubRepo::new(owner, repo))
 }
 
+/// Resolve a single directory path to its enclosing git repo and parsed GitHub
+/// remote, if any. Used by `&` handoff compose to do pwd-based environment
+/// overlap at activation time.
+pub(crate) async fn resolve_pwd_repo(pwd: PathBuf) -> Option<TouchedRepo> {
+    let git_root = find_git_root(&pwd).await?;
+    let repo_id = git_origin_url(&git_root)
+        .await
+        .as_deref()
+        .and_then(parse_github_repo);
+    Some(TouchedRepo { git_root, repo_id })
+}
+
 /// Pick the env that has the most overlap with the touched repos, breaking ties by
 /// recency. Returns `None` when no env contains any of the touched repos (or when
 /// `envs` is empty / the workspace touched no GitHub-mapped repos).

--- a/app/src/ai/blocklist/handoff/touched_repos.rs
+++ b/app/src/ai/blocklist/handoff/touched_repos.rs
@@ -190,10 +190,9 @@ fn parse_github_repo(remote_url: &str) -> Option<GithubRepo> {
 }
 
 /// Resolve a single directory path to its enclosing git repo and parsed GitHub
-/// remote, if any. Used by `&` handoff compose to do pwd-based environment
-/// overlap at activation time.
-pub(crate) async fn resolve_pwd_repo(pwd: PathBuf) -> Option<TouchedRepo> {
-    let git_root = find_git_root(&pwd).await?;
+/// remote, if any.
+pub(crate) async fn resolve_repo_for_path(path: &Path) -> Option<TouchedRepo> {
+    let git_root = find_git_root(path).await?;
     let repo_id = git_origin_url(&git_root)
         .await
         .as_deref()

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -109,8 +109,14 @@ use crate::persistence::{database_file_path_for_scope, establish_ro_connection, 
 
 use crate::ai::attachment_utils::MAX_ATTACHMENT_SIZE_BYTES;
 use crate::ai::block_context::BlockContext;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::blocklist::agent_view::agent_input_footer::sort_environments_by_recency;
 use crate::ai::blocklist::agent_view::{
     AgentInputFooter, AgentInputFooterEvent, AgentViewController,
+};
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::blocklist::handoff::touched_repos::{
+    pick_handoff_overlap_env, resolve_repo_for_path, TouchedWorkspace,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::{HandoffLaunchAttachments, PendingCloudLaunch};
@@ -275,6 +281,8 @@ use string_offset::CharOffset;
 use vec1::Vec1;
 use vim::vim::{VimHandler, VimMode};
 use warp_completer::util::parse_current_commands_and_tokens;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use warpui::r#async::FutureExt as _;
 
 use warp_completer::{
     completer::{
@@ -3760,18 +3768,22 @@ impl Input {
     /// environment overlap, updating the handoff compose state when done.
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn start_pwd_environment_overlap(&mut self, ctx: &mut ViewContext<Self>) {
-        use crate::ai::blocklist::agent_view::agent_input_footer::sort_environments_by_recency;
-        use crate::ai::blocklist::handoff::touched_repos::{
-            pick_handoff_overlap_env, resolve_pwd_repo, TouchedWorkspace,
-        };
-
-        let Some(pwd) = self.active_session_path_if_local(ctx).map(Path::to_path_buf) else {
+        let Some(pwd) = self
+            .active_session_path_if_local(ctx)
+            .map(Path::to_path_buf)
+        else {
             return;
         };
 
         let handoff_compose_state = self.handoff_compose_state.clone();
         ctx.spawn(
-            async move { resolve_pwd_repo(pwd).await },
+            async move {
+                resolve_repo_for_path(&pwd)
+                    .with_timeout(Duration::from_secs(5))
+                    .await
+                    .ok()
+                    .flatten()
+            },
             move |_input, touched_repo, ctx| {
                 let Some(touched_repo) = touched_repo else {
                     return;

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3759,7 +3759,7 @@ impl Input {
         self.is_editor_empty_on_last_edit = is_input_buffer_empty;
 
         #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-        self.start_pwd_environment_overlap(ctx);
+        self.auto_select_environment_from_pwd(ctx);
 
         ctx.notify();
     }
@@ -3767,7 +3767,7 @@ impl Input {
     /// Spawns an async task to resolve the pwd's git repo and pick the best
     /// environment overlap, updating the handoff compose state when done.
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-    fn start_pwd_environment_overlap(&mut self, ctx: &mut ViewContext<Self>) {
+    fn auto_select_environment_from_pwd(&mut self, ctx: &mut ViewContext<Self>) {
         let Some(pwd) = self
             .active_session_path_if_local(ctx)
             .map(Path::to_path_buf)
@@ -3894,7 +3894,7 @@ impl Input {
         self.is_editor_empty_on_last_edit = is_input_buffer_empty;
 
         #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-        self.start_pwd_environment_overlap(ctx);
+        self.auto_select_environment_from_pwd(ctx);
 
         ctx.notify();
         true

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3749,7 +3749,46 @@ impl Input {
         self.handoff_compose_state
             .update(ctx, |state, ctx| state.activate(ctx));
         self.is_editor_empty_on_last_edit = is_input_buffer_empty;
+
+        #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+        self.start_pwd_environment_overlap(ctx);
+
         ctx.notify();
+    }
+
+    /// Spawns an async task to resolve the pwd's git repo and pick the best
+    /// environment overlap, updating the handoff compose state when done.
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+    fn start_pwd_environment_overlap(&mut self, ctx: &mut ViewContext<Self>) {
+        use crate::ai::blocklist::agent_view::agent_input_footer::sort_environments_by_recency;
+        use crate::ai::blocklist::handoff::touched_repos::{
+            pick_handoff_overlap_env, resolve_pwd_repo, TouchedWorkspace,
+        };
+
+        let Some(pwd) = self.active_session_path_if_local(ctx).map(Path::to_path_buf) else {
+            return;
+        };
+
+        let handoff_compose_state = self.handoff_compose_state.clone();
+        ctx.spawn(
+            async move { resolve_pwd_repo(pwd).await },
+            move |_input, touched_repo, ctx| {
+                let Some(touched_repo) = touched_repo else {
+                    return;
+                };
+                let workspace = TouchedWorkspace {
+                    repos: vec![touched_repo],
+                    orphan_files: vec![],
+                };
+                let mut envs = CloudAmbientAgentEnvironment::get_all(ctx);
+                sort_environments_by_recency(&mut envs);
+                if let Some(overlap_env) = pick_handoff_overlap_env(&workspace, envs) {
+                    handoff_compose_state.update(ctx, |state, ctx| {
+                        state.set_environment_id(Some(overlap_env), false, ctx);
+                    });
+                }
+            },
+        );
     }
 
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -3841,6 +3880,10 @@ impl Input {
         self.handoff_compose_state
             .update(ctx, |state, ctx| state.activate(ctx));
         self.is_editor_empty_on_last_edit = is_input_buffer_empty;
+
+        #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+        self.start_pwd_environment_overlap(ctx);
+
         ctx.notify();
         true
     }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3701,7 +3701,7 @@ impl Input {
     pub(crate) fn restore_cloud_handoff_draft(
         &mut self,
         launch: PendingCloudLaunch,
-        explicit_environment_id: Option<SyncId>,
+        environment_id: Option<SyncId>,
         ctx: &mut ViewContext<Self>,
     ) {
         self.activate_cloud_handoff_compose(ctx);
@@ -3713,7 +3713,7 @@ impl Input {
                 model.append_pending_attachments(vec![attachment], ctx);
             }
         });
-        if let Some(env_id) = explicit_environment_id {
+        if let Some(env_id) = environment_id {
             self.handoff_compose_state.update(ctx, |state, ctx| {
                 state.set_environment_id(Some(env_id), true, ctx);
             });
@@ -3990,10 +3990,11 @@ impl Input {
         }
 
         let attachments = self.collect_cloud_launch_attachments(ctx);
-        let explicit_environment_id = self
+        let environment_id = self
             .handoff_compose_state
             .as_ref(ctx)
-            .explicit_environment_id();
+            .selected_environment_id()
+            .cloned();
         let launch = PendingCloudLaunch {
             prompt,
             attachments,
@@ -4003,7 +4004,7 @@ impl Input {
 
         ctx.dispatch_typed_action_deferred(WorkspaceAction::OpenLocalToCloudHandoffPane {
             launch: Some(launch),
-            explicit_environment_id,
+            environment_id,
         });
         true
     }

--- a/app/src/terminal/input/handoff_compose.rs
+++ b/app/src/terminal/input/handoff_compose.rs
@@ -44,13 +44,6 @@ impl HandoffComposeState {
         self.selected_environment_id.as_ref()
     }
 
-    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-    pub(crate) fn explicit_environment_id(&self) -> Option<SyncId> {
-        self.has_explicit_environment_selection
-            .then_some(self.selected_environment_id)
-            .flatten()
-    }
-
     pub(crate) fn set_environment_id(
         &mut self,
         environment_id: Option<SyncId>,

--- a/app/src/terminal/input/handoff_compose.rs
+++ b/app/src/terminal/input/handoff_compose.rs
@@ -50,6 +50,14 @@ impl HandoffComposeState {
         is_explicit: bool,
         ctx: &mut ModelContext<Self>,
     ) {
+        // Async/implicit updates (e.g. pwd-based overlap resolution) must not
+        // overwrite an environment the user already picked explicitly.
+        if !is_explicit && self.has_explicit_environment_selection {
+            return;
+        }
+
+        // No-op when the value is unchanged, unless this is the first explicit
+        // selection (which needs to promote `has_explicit_environment_selection`).
         if self.selected_environment_id == environment_id
             && (!is_explicit || self.has_explicit_environment_selection)
         {

--- a/app/src/terminal/input/handoff_compose_tests.rs
+++ b/app/src/terminal/input/handoff_compose_tests.rs
@@ -18,9 +18,9 @@ fn preserves_explicit_environment_selection() {
                 state.selected_environment_id(),
                 Some(&default_environment_id)
             );
-            assert_eq!(state.explicit_environment_id(), None);
         });
 
+        // Explicit selection should stick even when ensure_default tries to overwrite.
         state.update(&mut app, |state, ctx| {
             state.set_environment_id(Some(explicit_environment_id), true, ctx);
             state.ensure_default_environment_id(default_environment_id, ctx);
@@ -29,10 +29,6 @@ fn preserves_explicit_environment_selection() {
             assert_eq!(
                 state.selected_environment_id(),
                 Some(&explicit_environment_id)
-            );
-            assert_eq!(
-                state.explicit_environment_id(),
-                Some(explicit_environment_id)
             );
         });
     });

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -915,7 +915,7 @@ impl Input {
                     ctx.dispatch_typed_action_deferred(
                         WorkspaceAction::OpenLocalToCloudHandoffPane {
                             launch: Some(launch),
-                            explicit_environment_id: None,
+                            environment_id: None,
                         },
                     );
                 } else {

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -143,8 +143,6 @@ pub(crate) struct PendingHandoff {
     /// stashed here so `maybe_auto_submit_handoff` can consume it once
     /// the touched workspace and snapshot upload have settled.
     pub(crate) auto_submit: Option<PendingCloudLaunch>,
-    /// Explicit source environment selection. When set, touched-repo overlap must not override it.
-    pub(crate) explicit_environment_id: Option<SyncId>,
 }
 
 /// Status of the ambient agent run.
@@ -548,14 +546,7 @@ impl AmbientAgentViewModel {
         ctx.emit(AmbientAgentViewModelEvent::PendingHandoffChanged);
     }
 
-    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-    pub(crate) fn pending_handoff_has_explicit_environment(&self) -> bool {
-        self.pending_handoff
-            .as_ref()
-            .is_some_and(|handoff| handoff.explicit_environment_id.is_some())
-    }
-
-    /// Records the outcome of the async snapshot upload. The standard success
+    /// Records the outcome of the async snapshot upload.
     /// case is `Uploaded(token)`; `SkippedEmptyWorkspace` when the workspace
     /// had nothing to upload; `Failed` is set by `record_handoff_snapshot_upload_failed`.
     /// No-op when no handoff context is set.

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -547,9 +547,6 @@ impl AmbientAgentViewModel {
     }
 
     /// Records the outcome of the async snapshot upload.
-    /// case is `Uploaded(token)`; `SkippedEmptyWorkspace` when the workspace
-    /// had nothing to upload; `Failed` is set by `record_handoff_snapshot_upload_failed`.
-    /// No-op when no handoff context is set.
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     pub(crate) fn set_pending_handoff_snapshot_upload(
         &mut self,

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -30,7 +30,6 @@ fn pending_handoff() -> PendingHandoff {
         snapshot_upload: SnapshotUploadStatus::Pending,
         submission_state: HandoffSubmissionState::Idle,
         auto_submit: Some(pending_launch()),
-        explicit_environment_id: None,
     }
 }
 
@@ -42,7 +41,6 @@ fn pending_handoff_fresh_launch() -> PendingHandoff {
         snapshot_upload: SnapshotUploadStatus::Pending,
         submission_state: HandoffSubmissionState::Idle,
         auto_submit: Some(pending_launch()),
-        explicit_environment_id: None,
     }
 }
 

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -495,7 +495,7 @@ pub enum WorkspaceAction {
         launch: Option<crate::ai::blocklist::handoff::PendingCloudLaunch>,
         #[cfg(not(all(feature = "local_fs", not(target_family = "wasm"))))]
         launch: Option<()>,
-        explicit_environment_id: Option<crate::server::ids::SyncId>,
+        environment_id: Option<crate::server::ids::SyncId>,
     },
     /// Show the environment creation modal during `&` handoff compose when no
     /// environments exist.

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -55,6 +55,7 @@ use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::touched_repos::{
     derive_touched_workspace, extract_paths_from_conversation, pick_handoff_overlap_env,
+    resolve_pwd_repo, TouchedWorkspace,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::PendingCloudLaunch;

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -49,13 +49,10 @@ use crate::ai::agent_sdk::driver::upload_snapshot_for_handoff;
 use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEntryPoint};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::agent_input_footer::editor::AgentToolbarEditorMode;
-#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::blocklist::agent_view::agent_input_footer::sort_environments_by_recency;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::touched_repos::{
-    derive_touched_workspace, extract_paths_from_conversation, pick_handoff_overlap_env,
-    resolve_repo_for_path, TouchedWorkspace,
+    derive_touched_workspace, extract_paths_from_conversation,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::PendingCloudLaunch;
@@ -65,8 +62,6 @@ use crate::ai::blocklist::suggested_rule_modal::{
     SuggestedRuleAndId, SuggestedRuleModal, SuggestedRuleModalEvent,
 };
 use crate::ai::blocklist::FORK_PREFIX;
-#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::conversation_utils;
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel};
 use crate::ai::llms::LLMPreferences;
@@ -162,8 +157,6 @@ use ai::index::full_source_code_embedding::manager::CodebaseIndexManager;
 use sentry::protocol::{Attachment, AttachmentType};
 use serde_json;
 use warpui::notification::NotificationSendError;
-#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use warpui::r#async::FutureExt as _;
 
 use super::hoa_onboarding::{
     mark_hoa_onboarding_completed, HoaOnboardingFlow, HoaOnboardingFlowEvent, HoaOnboardingStep,
@@ -13163,7 +13156,7 @@ impl Workspace {
                         ctx.dispatch_typed_action_deferred(
                             WorkspaceAction::OpenLocalToCloudHandoffPane {
                                 launch,
-                                explicit_environment_id: Some(env_id),
+                                environment_id: Some(env_id),
                             },
                         );
                     }
@@ -13209,7 +13202,7 @@ impl Workspace {
     fn restore_source_handoff_draft(
         source_view: &ViewHandle<TerminalView>,
         launch: Option<PendingCloudLaunch>,
-        explicit_environment_id: Option<SyncId>,
+        environment_id: Option<SyncId>,
         ctx: &mut ViewContext<Self>,
     ) {
         let Some(launch) = launch else {
@@ -13218,7 +13211,7 @@ impl Workspace {
         source_view.update(ctx, |view, ctx| {
             let input = view.input().clone();
             input.update(ctx, |input, ctx| {
-                input.restore_cloud_handoff_draft(launch, explicit_environment_id, ctx);
+                input.restore_cloud_handoff_draft(launch, environment_id, ctx);
             });
         });
     }
@@ -13271,15 +13264,6 @@ impl Workspace {
                     if !model.is_local_to_cloud_handoff() {
                         return;
                     }
-                    if !model.pending_handoff_has_explicit_environment() {
-                        let mut envs = CloudAmbientAgentEnvironment::get_all(model_ctx);
-                        sort_environments_by_recency(&mut envs);
-                        if let Some(overlap_env) =
-                            pick_handoff_overlap_env(&derived_workspace, envs)
-                        {
-                            model.set_environment_id(Some(overlap_env), model_ctx);
-                        }
-                    }
                     model.set_pending_handoff_workspace(derived_workspace, model_ctx);
                     match upload_result {
                         Ok(Some(initial_snapshot_token)) => {
@@ -13328,7 +13312,7 @@ impl Workspace {
         &mut self,
         source_view: ViewHandle<TerminalView>,
         launch: Option<PendingCloudLaunch>,
-        explicit_environment_id: Option<SyncId>,
+        environment_id: Option<SyncId>,
         ctx: &mut ViewContext<Self>,
     ) {
         // Push a cloud-mode pane for the fresh launch.
@@ -13336,14 +13320,14 @@ impl Workspace {
             view.start_local_to_cloud_handoff_pane(view_ctx)
         }) else {
             log::warn!("start_local_to_cloud_handoff: failed to push fresh cloud-mode pane");
-            Self::restore_source_handoff_draft(&source_view, launch, explicit_environment_id, ctx);
+            Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
             Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
             return;
         };
 
-        if let Some(env_id) = explicit_environment_id {
+        if let Some(environment_id) = environment_id {
             model_handle.update(ctx, |model, ctx| {
-                model.set_environment_id(Some(env_id), ctx);
+                model.set_environment_id(Some(environment_id), ctx);
             });
         }
         Self::show_handoff_success_toast(ctx);
@@ -13355,7 +13339,6 @@ impl Workspace {
             snapshot_upload: SnapshotUploadStatus::Pending,
             submission_state: HandoffSubmissionState::Idle,
             auto_submit: launch,
-            explicit_environment_id,
         };
         model_handle.update(ctx, |model, model_ctx| {
             model.set_pending_handoff(Some(pending), model_ctx);
@@ -13375,7 +13358,7 @@ impl Workspace {
     fn start_local_to_cloud_handoff(
         &mut self,
         launch: Option<PendingCloudLaunch>,
-        explicit_environment_id: Option<SyncId>,
+        environment_id: Option<SyncId>,
         ctx: &mut ViewContext<Self>,
     ) {
         if !FeatureFlag::OzHandoff.is_enabled() || !FeatureFlag::HandoffLocalCloud.is_enabled() {
@@ -13400,20 +13383,20 @@ impl Workspace {
         let Some(source_conversation) =
             source_conversation.filter(|conversation| !conversation.is_empty())
         else {
-            self.start_fresh_cloud_launch(source_view, launch, explicit_environment_id, ctx);
+            self.start_fresh_cloud_launch(source_view, launch, environment_id, ctx);
             return;
         };
 
         if source_conversation.status().is_in_progress()
             || source_conversation.status().is_blocked()
         {
-            Self::restore_source_handoff_draft(&source_view, launch, explicit_environment_id, ctx);
+            Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
             Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
             return;
-        }
+        };
 
         let Some(source_token) = source_conversation.server_conversation_token().cloned() else {
-            Self::restore_source_handoff_draft(&source_view, launch, explicit_environment_id, ctx);
+            Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
             Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
             return;
         };
@@ -13436,18 +13419,13 @@ impl Workspace {
                         source_conversation,
                         response.forked_conversation_id,
                         launch,
-                        explicit_environment_id,
+                        environment_id,
                         ctx,
                     );
                 }
                 Err(err) => {
                     log::warn!("fork_conversation failed: {err:#}");
-                    Self::restore_source_handoff_draft(
-                        &source_view,
-                        launch,
-                        explicit_environment_id,
-                        ctx,
-                    );
+                    Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
                     Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
                 }
             },
@@ -13463,7 +13441,7 @@ impl Workspace {
         source_conversation: AIConversation,
         forked_conversation_id: String,
         launch: Option<PendingCloudLaunch>,
-        explicit_environment_id: Option<SyncId>,
+        environment_id: Option<SyncId>,
         ctx: &mut ViewContext<Self>,
     ) {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
@@ -13537,7 +13515,7 @@ impl Workspace {
             });
         }
 
-        if let Some(env_id) = explicit_environment_id {
+        if let Some(env_id) = environment_id {
             model_handle.update(ctx, |model, ctx| {
                 model.set_environment_id(Some(env_id), ctx);
             });
@@ -13551,7 +13529,6 @@ impl Workspace {
             snapshot_upload: SnapshotUploadStatus::Pending,
             submission_state: HandoffSubmissionState::Idle,
             auto_submit: launch,
-            explicit_environment_id,
         };
         model_handle.update(ctx, |model, model_ctx| {
             model.set_pending_handoff(Some(pending), model_ctx);
@@ -20818,13 +20795,13 @@ impl TypedActionView for Workspace {
             }
             OpenLocalToCloudHandoffPane {
                 launch,
-                explicit_environment_id,
+                environment_id,
             } => {
                 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-                self.start_local_to_cloud_handoff(launch.clone(), *explicit_environment_id, ctx);
+                self.start_local_to_cloud_handoff(launch.clone(), *environment_id, ctx);
                 #[cfg(not(all(feature = "local_fs", not(target_family = "wasm"))))]
                 {
-                    let _ = (launch, explicit_environment_id);
+                    let _ = (launch, environment_id);
                 }
             }
             ShowHandoffEnvironmentCreationModal => {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -55,7 +55,7 @@ use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::touched_repos::{
     derive_touched_workspace, extract_paths_from_conversation, pick_handoff_overlap_env,
-    resolve_pwd_repo, TouchedWorkspace,
+    resolve_repo_for_path, TouchedWorkspace,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::PendingCloudLaunch;
@@ -162,6 +162,8 @@ use ai::index::full_source_code_embedding::manager::CodebaseIndexManager;
 use sentry::protocol::{Attachment, AttachmentType};
 use serde_json;
 use warpui::notification::NotificationSendError;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use warpui::r#async::FutureExt as _;
 
 use super::hoa_onboarding::{
     mark_hoa_onboarding_completed, HoaOnboardingFlow, HoaOnboardingFlowEvent, HoaOnboardingStep,

--- a/specs/APP-4427/PRODUCT.md
+++ b/specs/APP-4427/PRODUCT.md
@@ -10,18 +10,16 @@ Figma: none provided
 
 1. When the user types `&` or runs `/handoff` (no query), the system checks the terminal's current working directory for a git repo (walk up to `.git`, read `origin` remote URL, parse `<owner>/<repo>`).
 
-2. If a git repo is found and at least one cloud environment's `github_repos` contains that repo, select the environment with the most overlap (breaking ties by most-recently-used). This is a non-explicit selection — the user can still override it from the environment dropdown.
+2. If a git repo is found and at least one cloud environment's `github_repos` contains that repo, select the environment with the most overlap (breaking ties by most-recently-used). The user can still override this from the environment dropdown.
 
 3. If no git repo is found, or no environment matches the repo, fall back to the existing default: saved `last_selected_environment_id` setting, then most-recently-used environment.
 
-4. The environment chip in the footer reflects the selected environment immediately (or near-immediately after the async git check completes). There is no environment shift after pressing Enter.
+4. The environment chip in the footer reflects the selected environment immediately (or near-immediately after the async git check completes).
 
-5. For `/handoff query` (auto-submit path), the same pwd-based overlap check runs before dispatching. The result is passed as a non-explicit environment selection alongside the launch payload.
+5. When the user presses Enter, the compose state's current `selected_environment_id` is passed directly to the new cloud pane. The environment does not change during the transition from compose mode to the cloud pane.
 
-6. If the user explicitly selects an environment from the dropdown during `&` compose, that explicit selection takes priority over the pwd-based result and is preserved through the handoff.
+6. For `/handoff query` (auto-submit path), the environment is `None` (compose state isn't active), so the cloud pane falls back to its own default selection.
 
-7. The post-dispatch async overlap check (layer 2) that previously ran after pressing Enter is removed. The `pick_handoff_overlap_env` call in `complete_local_to_cloud_handoff_open` no longer overwrites the selected environment after the handoff pane opens.
+7. The pwd-based check uses the same `find_git_root` / `git_origin_url` / `parse_github_repo` / `pick_handoff_overlap_env` utilities as the existing touched-workspace pipeline — just scoped to a single directory instead of the full conversation history.
 
-8. The pwd-based check uses the same `find_git_root` / `git_origin_url` / `parse_github_repo` / `pick_handoff_overlap_env` utilities as the existing touched-workspace pipeline — just scoped to a single directory instead of the full conversation history.
-
-9. The async git check should complete quickly (single local git command with the existing 5-second timeout). If the check hasn't completed when the user presses Enter, the current selection (from the fallback defaults) is used.
+8. The async git check should complete quickly (single local git command with the existing 5-second timeout). If the check hasn't completed when the user presses Enter, the current selection (from the fallback defaults) is used.

--- a/specs/APP-4427/PRODUCT.md
+++ b/specs/APP-4427/PRODUCT.md
@@ -1,0 +1,27 @@
+# Handoff Environment Selection: PWD-Based Overlap at Activation
+Linear: [APP-4427](https://linear.app/warpdotdev/issue/APP-4427)
+
+## Summary
+When a user enters `&` handoff compose mode or uses `/handoff`, auto-select the cloud environment that matches the repo they're currently working in — at activation time, not after pressing Enter. This replaces the current two-layer system where the environment visibly shifts after the handoff is dispatched.
+
+Figma: none provided
+
+## Behavior
+
+1. When the user types `&` or runs `/handoff` (no query), the system checks the terminal's current working directory for a git repo (walk up to `.git`, read `origin` remote URL, parse `<owner>/<repo>`).
+
+2. If a git repo is found and at least one cloud environment's `github_repos` contains that repo, select the environment with the most overlap (breaking ties by most-recently-used). This is a non-explicit selection — the user can still override it from the environment dropdown.
+
+3. If no git repo is found, or no environment matches the repo, fall back to the existing default: saved `last_selected_environment_id` setting, then most-recently-used environment.
+
+4. The environment chip in the footer reflects the selected environment immediately (or near-immediately after the async git check completes). There is no environment shift after pressing Enter.
+
+5. For `/handoff query` (auto-submit path), the same pwd-based overlap check runs before dispatching. The result is passed as a non-explicit environment selection alongside the launch payload.
+
+6. If the user explicitly selects an environment from the dropdown during `&` compose, that explicit selection takes priority over the pwd-based result and is preserved through the handoff.
+
+7. The post-dispatch async overlap check (layer 2) that previously ran after pressing Enter is removed. The `pick_handoff_overlap_env` call in `complete_local_to_cloud_handoff_open` no longer overwrites the selected environment after the handoff pane opens.
+
+8. The pwd-based check uses the same `find_git_root` / `git_origin_url` / `parse_github_repo` / `pick_handoff_overlap_env` utilities as the existing touched-workspace pipeline — just scoped to a single directory instead of the full conversation history.
+
+9. The async git check should complete quickly (single local git command with the existing 5-second timeout). If the check hasn't completed when the user presses Enter, the current selection (from the fallback defaults) is used.

--- a/specs/APP-4427/TECH.md
+++ b/specs/APP-4427/TECH.md
@@ -3,51 +3,41 @@ Product spec: `specs/APP-4427/PRODUCT.md`
 Linear: [APP-4427](https://linear.app/warpdotdev/issue/APP-4427)
 
 ## Context
-Currently, environment auto-selection for `&` handoff has two layers:
-- **Layer 1** (activation time): `EnvironmentSelector::ensure_default_selection` in `environment_selector.rs:372` picks from saved setting or MRU when `HandoffComposeState` activates.
-- **Layer 2** (post-dispatch): After pressing Enter, an async task in `workspace/view.rs (13417-13469)` derives touched repos from the full conversation, then calls `pick_handoff_overlap_env` at `workspace/view.rs:13440` to overwrite the environment — unless the user made an explicit selection.
+Environment auto-selection for `&` handoff has two layers:
+- **Layer 1** (activation time): `start_pwd_environment_overlap` in `input.rs:3769` spawns an async task that resolves the pwd's git repo and calls `pick_handoff_overlap_env` to select the best environment. `EnvironmentSelector::ensure_default_selection` (`environment_selector.rs:372`) also runs synchronously to pick a saved/MRU fallback.
+- **Layer 2** (post-dispatch): After pressing Enter, an async task in `workspace/view.rs:13422-13488` re-resolves the pwd repo and overwrites the environment on the new cloud pane model.
 
-Layer 2 causes a visible environment shift after the handoff pane opens. We want to move the overlap logic into layer 1 (at `&` activation time, scoped to just the pwd's repo) and remove layer 2's environment overwrite entirely.
+Layer 2 causes a visible environment flicker after the handoff pane opens. The compose state already has the correct environment by the time Enter is pressed — layer 2 is redundant.
 
 Key files:
 - `app/src/terminal/input/handoff_compose.rs` — `HandoffComposeState` model
-- `app/src/terminal/input.rs:3731` — `activate_cloud_handoff_compose`
-- `app/src/terminal/input.rs:14258` — `active_session_path_if_local` (gives pwd)
+- `app/src/terminal/input.rs:3739` — `activate_cloud_handoff_compose`
+- `app/src/terminal/input.rs:3769` — `start_pwd_environment_overlap` (layer 1)
+- `app/src/terminal/input.rs:3973` — `maybe_launch_cloud_handoff_request` (Enter dispatch)
 - `app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs:372` — `ensure_default_selection`
-- `app/src/ai/blocklist/handoff/touched_repos.rs:200` — `pick_handoff_overlap_env`
-- `app/src/ai/blocklist/handoff/touched_repos.rs:121-164` — `find_git_root`, `git_origin_url`, `parse_github_repo`
-- `app/src/workspace/view.rs:13437-13444` — post-dispatch overlap overwrite (to remove)
-- `app/src/terminal/input/slash_commands/mod.rs:898-926` — `/handoff` slash command handler
+- `app/src/workspace/view.rs:13319` — `complete_local_to_cloud_handoff_open`
+- `app/src/workspace/view.rs:13450-13464` — post-dispatch overlap overwrite (to remove)
+- `app/src/workspace/action.rs:493` — `OpenLocalToCloudHandoffPane` action
 
 ## Proposed changes
-### 1. Add pwd-based overlap selection to `HandoffComposeState` activation
-In `activate_cloud_handoff_compose` (`input.rs:3731`), after activating the state, grab the pwd via `active_session_path_if_local` and spawn a lightweight async task that:
-1. Calls `find_git_root(pwd)` → `git_origin_url(root)` → `parse_github_repo(url)` to get the pwd's `GithubRepo`
-2. Gets all environments and calls `pick_handoff_overlap_env` with a single-repo `TouchedWorkspace`
-3. On completion, calls `handoff_compose_state.set_environment_id(overlap_env, false, ctx)` — non-explicit, so it doesn't prevent user override
+### 1. Rename action field and pass compose state's selection
+Rename `explicit_environment_id` → `environment_id` on `OpenLocalToCloudHandoffPane` (`workspace/action.rs:498`). In `maybe_launch_cloud_handoff_request` (`input.rs:3991`), pass `selected_environment_id().cloned()` from the compose state instead of `explicit_environment_id()`. This carries the pwd-overlap result (or MRU fallback) to the new cloud pane.
 
-This uses the same utility functions already in `touched_repos.rs`. We'll add a small helper (e.g. `resolve_pwd_repo`) that wraps the `find_git_root` → `git_origin_url` → `parse_github_repo` chain for a single path, returning `Option<(PathBuf, GithubRepo)>`.
+### 2. Remove async env overwrite in `complete_local_to_cloud_handoff_open`
+Remove the `resolve_repo_for_path` call inside the async task (`workspace/view.rs:13435-13442`), the `pwd_repo` plumbing through the tuple, and the env overwrite block in the completion handler (`view.rs:13450-13464`). The `source_pwd` capture (`view.rs:13420`) is also removed. The workspace derivation and snapshot upload continue unchanged.
 
-The `ensure_default_selection` in `EnvironmentSelector` still runs synchronously and picks the saved/MRU default. The async pwd overlap result then overwrites it (if found) once the git command returns. If the user has already explicitly selected an environment before the async result arrives, `set_environment_id` with `is_explicit: false` will not overwrite it because `HandoffComposeState::set_environment_id` respects `has_explicit_environment_selection`.
+### 3. Clean up `PendingHandoff.explicit_environment_id`
+Remove the `explicit_environment_id` field from `PendingHandoff`, the `pending_handoff_has_explicit_environment()` method on `AmbientAgentViewModel` (`model.rs:549`), and the guard in `EnvironmentSelectorTarget::ensure_default_environment_id` (`environment_selector.rs:84-87`). The guard is no longer needed: the env is set on the model before the `EnvironmentSelector` is created, so `ensure_default_selection` already short-circuits at line 374 (`if current_selection.is_some() { return; }`).
 
-### 2. Apply the same logic for `/handoff query`
-`/handoff query` dispatches `OpenLocalToCloudHandoffPane` synchronously, but `complete_local_to_cloud_handoff_open` already runs an async task for snapshot upload and touched-workspace derivation (`workspace/view.rs:13417-13469`). Replace the conversation-wide `pick_handoff_overlap_env` call in that async task's completion handler with a pwd-scoped overlap check using the same `resolve_pwd_repo` helper from §1. This piggybacks on the existing async work — no additional latency, no new async task, and the environment is set before auto-submit fires (since auto-submit already waits for touched-workspace derivation to complete).
-
-### 3. Remove conversation-wide overlap overwrite
-In `complete_local_to_cloud_handoff_open` (`workspace/view.rs:13432-13469`), replace the block at lines 13437-13444 that calls `pick_handoff_overlap_env` with the full conversation's `TouchedWorkspace`. Instead, call `resolve_pwd_repo` on the source terminal's pwd (captured before the async task is spawned) and use its result for the single-repo overlap check. The touched-workspace derivation and snapshot upload continue unchanged — only the environment selection source changes from conversation-wide repos to the pwd repo.
+### 4. Update all dispatch and handler sites
+Rename `explicit_environment_id` → `environment_id` at all sites that construct or destructure the action, and update intermediate function signatures (`start_local_to_cloud_handoff`, `complete_local_to_cloud_handoff_open`, `start_fresh_cloud_launch`, `restore_source_handoff_draft`, `restore_cloud_handoff_draft`).
 
 ## Testing and validation
-### Unit tests
-- `touched_repos_tests.rs`: Add a test for the new `resolve_pwd_repo` helper — given a path inside a git repo with a GitHub origin, returns the correct `GithubRepo`; given a path outside any repo, returns `None`.
-- `handoff_compose_tests.rs`: Verify that `set_environment_id(_, false, _)` does not overwrite when `has_explicit_environment_selection` is true.
-- `input_test.rs`: Verify that `activate_cloud_handoff_compose` triggers the async pwd overlap check (mock the git command to return a known repo, assert the environment is updated).
-
 ### Manual
-- In a terminal whose pwd is inside a repo that matches exactly one environment: type `&`, observe the matching environment selected in the chip.
+- In a terminal whose pwd is inside a repo that matches exactly one environment: type `&`, observe the matching environment in the chip. Press Enter — the cloud pane opens with the same environment, no shift.
 - Same setup but explicitly pick a different environment from the dropdown, press Enter — the explicit choice is preserved.
-- In a directory outside any git repo: type `&`, observe fallback to saved/MRU default.
-- `/handoff query` from a repo-matching directory: observe the correct environment is used.
-- Verify no environment shift after pressing Enter in any of the above cases.
+- In a directory outside any git repo: type `&`, observe fallback to saved/MRU default. Press Enter — same env, no shift.
+- `/handoff query` from a repo-matching directory: cloud pane opens with its own default selection (compose state isn't active in this path).
 
 ## Parallelization
-This is a small, tightly coupled change across input activation, environment selector, and workspace handoff paths. A single agent should implement it sequentially.
+This is a small, tightly coupled change across a few files in a single call chain. A single agent should implement it sequentially.

--- a/specs/APP-4427/TECH.md
+++ b/specs/APP-4427/TECH.md
@@ -1,0 +1,53 @@
+# Handoff Environment Selection: PWD-Based Overlap at Activation — Tech Spec
+Product spec: `specs/APP-4427/PRODUCT.md`
+Linear: [APP-4427](https://linear.app/warpdotdev/issue/APP-4427)
+
+## Context
+Currently, environment auto-selection for `&` handoff has two layers:
+- **Layer 1** (activation time): `EnvironmentSelector::ensure_default_selection` in `environment_selector.rs:372` picks from saved setting or MRU when `HandoffComposeState` activates.
+- **Layer 2** (post-dispatch): After pressing Enter, an async task in `workspace/view.rs (13417-13469)` derives touched repos from the full conversation, then calls `pick_handoff_overlap_env` at `workspace/view.rs:13440` to overwrite the environment — unless the user made an explicit selection.
+
+Layer 2 causes a visible environment shift after the handoff pane opens. We want to move the overlap logic into layer 1 (at `&` activation time, scoped to just the pwd's repo) and remove layer 2's environment overwrite entirely.
+
+Key files:
+- `app/src/terminal/input/handoff_compose.rs` — `HandoffComposeState` model
+- `app/src/terminal/input.rs:3731` — `activate_cloud_handoff_compose`
+- `app/src/terminal/input.rs:14258` — `active_session_path_if_local` (gives pwd)
+- `app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs:372` — `ensure_default_selection`
+- `app/src/ai/blocklist/handoff/touched_repos.rs:200` — `pick_handoff_overlap_env`
+- `app/src/ai/blocklist/handoff/touched_repos.rs:121-164` — `find_git_root`, `git_origin_url`, `parse_github_repo`
+- `app/src/workspace/view.rs:13437-13444` — post-dispatch overlap overwrite (to remove)
+- `app/src/terminal/input/slash_commands/mod.rs:898-926` — `/handoff` slash command handler
+
+## Proposed changes
+### 1. Add pwd-based overlap selection to `HandoffComposeState` activation
+In `activate_cloud_handoff_compose` (`input.rs:3731`), after activating the state, grab the pwd via `active_session_path_if_local` and spawn a lightweight async task that:
+1. Calls `find_git_root(pwd)` → `git_origin_url(root)` → `parse_github_repo(url)` to get the pwd's `GithubRepo`
+2. Gets all environments and calls `pick_handoff_overlap_env` with a single-repo `TouchedWorkspace`
+3. On completion, calls `handoff_compose_state.set_environment_id(overlap_env, false, ctx)` — non-explicit, so it doesn't prevent user override
+
+This uses the same utility functions already in `touched_repos.rs`. We'll add a small helper (e.g. `resolve_pwd_repo`) that wraps the `find_git_root` → `git_origin_url` → `parse_github_repo` chain for a single path, returning `Option<(PathBuf, GithubRepo)>`.
+
+The `ensure_default_selection` in `EnvironmentSelector` still runs synchronously and picks the saved/MRU default. The async pwd overlap result then overwrites it (if found) once the git command returns. If the user has already explicitly selected an environment before the async result arrives, `set_environment_id` with `is_explicit: false` will not overwrite it because `HandoffComposeState::set_environment_id` respects `has_explicit_environment_selection`.
+
+### 2. Apply the same logic for `/handoff query`
+`/handoff query` dispatches `OpenLocalToCloudHandoffPane` synchronously, but `complete_local_to_cloud_handoff_open` already runs an async task for snapshot upload and touched-workspace derivation (`workspace/view.rs:13417-13469`). Replace the conversation-wide `pick_handoff_overlap_env` call in that async task's completion handler with a pwd-scoped overlap check using the same `resolve_pwd_repo` helper from §1. This piggybacks on the existing async work — no additional latency, no new async task, and the environment is set before auto-submit fires (since auto-submit already waits for touched-workspace derivation to complete).
+
+### 3. Remove conversation-wide overlap overwrite
+In `complete_local_to_cloud_handoff_open` (`workspace/view.rs:13432-13469`), replace the block at lines 13437-13444 that calls `pick_handoff_overlap_env` with the full conversation's `TouchedWorkspace`. Instead, call `resolve_pwd_repo` on the source terminal's pwd (captured before the async task is spawned) and use its result for the single-repo overlap check. The touched-workspace derivation and snapshot upload continue unchanged — only the environment selection source changes from conversation-wide repos to the pwd repo.
+
+## Testing and validation
+### Unit tests
+- `touched_repos_tests.rs`: Add a test for the new `resolve_pwd_repo` helper — given a path inside a git repo with a GitHub origin, returns the correct `GithubRepo`; given a path outside any repo, returns `None`.
+- `handoff_compose_tests.rs`: Verify that `set_environment_id(_, false, _)` does not overwrite when `has_explicit_environment_selection` is true.
+- `input_test.rs`: Verify that `activate_cloud_handoff_compose` triggers the async pwd overlap check (mock the git command to return a known repo, assert the environment is updated).
+
+### Manual
+- In a terminal whose pwd is inside a repo that matches exactly one environment: type `&`, observe the matching environment selected in the chip.
+- Same setup but explicitly pick a different environment from the dropdown, press Enter — the explicit choice is preserved.
+- In a directory outside any git repo: type `&`, observe fallback to saved/MRU default.
+- `/handoff query` from a repo-matching directory: observe the correct environment is used.
+- Verify no environment shift after pressing Enter in any of the above cases.
+
+## Parallelization
+This is a small, tightly coupled change across input activation, environment selector, and workspace handoff paths. A single agent should implement it sequentially.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

There was a weird interaction/product pattern where, on handoff-submit (so after you typed in `&`, typed in the query, and hit enter), we were auto-selecting a good environment for handoff (assuming you hadn't manually selected an environment). This was a vestige of the pre-`&` handoff implementation where we had a dedicated cloud pane that we took you into _before_ you typed in your handoff query and hit enter, as we were doing all of our snapshotting and environment selection during that pane transition (but that transition now happens when you hit enter). TLDR, this was causing a weird interaction where, after hitting enter, the environment for the cloud run could suddenly/unexpectedly change.

The fix here is to do our smart-environment-selection when you first enter the handoff input mode (so when you type `&` or click the handoff chip), instead of doing it when you press enter.

To do this, we need to make our environment selection a little faster and make it independent of snapshotting (because I still think we want to avoid snapshotting until you actually submit the prompt, in case you decide not to handoff or do more work between entering the handoff input mode and actually handing off). 

I optimized for the one-repo-conversation case here and changed it so that, when you type `&`, we asynchronously figure out what (if any) git repo you're currently in, and then do our smart environment selection with that one repo (so find which environments contain that repo and select the most recently used one, falling back to your default environment otherwise).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/dc48cec94629458a89113cb0207fd63a

(note: I fixed the handoff environment flicker that you can see in this demo after recording)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode