### PR TITLE
fix: handle InvalidTakeOver gracefully in shared session viewer

### DIFF
--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -318,7 +318,13 @@ impl CLISubagentController {
         let active_block = terminal_model.block_list_mut().active_block_mut();
         let block_id = active_block.id().clone();
         if let Err(e) = active_block.take_over_control_for_user(reason) {
-            log::error!("Failed to take control for user: {e:?}");
+            // The block is not in an agent-controlled state that can be taken
+            // over. This is expected when a shared-session viewer joins while
+            // the block is between agent-monitored commands (e.g. during the
+            // setup → agent-view transition). Log at warn level and bail out
+            // without cancelling the conversation so the agent continues
+            // running and the session viewer can still observe output.
+            log::warn!("Failed to take control for user: {e:?}");
             return;
         }
 


### PR DESCRIPTION
## Description

Stacked on #10648.

When a shared-session viewer joins while the terminal block is not in an agent-controlled state (e.g. during the environment setup → agent-view transition after `unset CI`), `take_over_control_for_user` returns `InvalidTakeOver`. This was previously logged at `error` level, which was misleading since the condition is expected for session viewers observing a running agent.

A customer reported they could see setup commands (cloning repos, running setup scripts) but the screen went blank right after `unset CI` / "environment started" — the exact transition from `prepare_environment` completion to agent view mode.

**Fix:** Change the log level from `error` to `warn` and add a detailed comment explaining why this happens. The early return is intentionally kept — the viewer doesn't need block control to observe the agent's conversation output, which flows through the separate `handle_shared_session_response_event` code path.

**Note:** The blank screen itself may have a deeper root cause in how the session-sharing viewer handles the setup → agent-view transition. This PR addresses the misleading error log; the rendering issue needs further investigation.

## Linked Issue

Reported by the same customer as #10648 (self-hosted K8s oz-agent-worker).

## Testing

- [x] I have manually tested my changes locally with `./script/run`
- `cargo check -p warp` passes cleanly

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/08d41ae5-dd93-416d-9be5-816df8998e0a_
_Run: https://oz.staging.warp.dev/runs/019e1794-1567-7928-9af5-543721598712_
_Plans:_
  - _[K8s Self-Hosted oz-agent-worker: Debugging Cancelled/Reconnect Cycling and Invisible Session](https://staging.warp.dev/drive/notebook/aSR5t3cAIuRnMXl9XGteCp)_

_This PR was generated with [Oz](https://warp.dev/oz)._
