### PR TITLE
Change remote daemon execution mode

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -431,11 +431,10 @@ impl LaunchMode {
             LaunchMode::App { .. } => ExecutionMode::App,
             LaunchMode::CommandLine { .. } => ExecutionMode::Sdk,
             LaunchMode::Test { .. } => ExecutionMode::App,
-            // RemoteServerProxy and RemoteServerDaemon don't use execution
-            // mode, but Sdk is the closest match (headless, no GUI).
-            LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon { .. } => {
-                ExecutionMode::Sdk
-            }
+            // RemoteServerProxy is a thin byte bridge; Sdk is the closest match.
+            LaunchMode::RemoteServerProxy => ExecutionMode::Sdk,
+            // RemoteServerDaemon gets its own mode for distinct Sentry tagging.
+            LaunchMode::RemoteServerDaemon { .. } => ExecutionMode::Daemon,
         }
     }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -434,7 +434,7 @@ impl LaunchMode {
             // RemoteServerProxy is a thin byte bridge; Sdk is the closest match.
             LaunchMode::RemoteServerProxy => ExecutionMode::Sdk,
             // RemoteServerDaemon gets its own mode for distinct Sentry tagging.
-            LaunchMode::RemoteServerDaemon { .. } => ExecutionMode::Daemon,
+            LaunchMode::RemoteServerDaemon { .. } => ExecutionMode::RemoteServerDaemon,
         }
     }
 

--- a/crates/warp_core/src/execution_mode.rs
+++ b/crates/warp_core/src/execution_mode.rs
@@ -91,10 +91,10 @@ impl AppExecutionMode {
     }
 
     /// Whether telemetry should be sent synchronously at shutdown.
-    /// In CLI mode, we synchronously send events at shutdown because there's a higher likelihood
-    /// that they will be lost otherwise.
+    /// In CLI and daemon modes, we synchronously send events at shutdown because there's a
+    /// higher likelihood that they will be lost otherwise.
     pub fn send_telemetry_at_shutdown(&self) -> bool {
-        matches!(self.mode, ExecutionMode::Sdk)
+        matches!(self.mode, ExecutionMode::Sdk | ExecutionMode::Daemon)
     }
 
     /// If true, the app is running autonomously, without a user present.

--- a/crates/warp_core/src/execution_mode.rs
+++ b/crates/warp_core/src/execution_mode.rs
@@ -11,6 +11,8 @@ pub enum ExecutionMode {
     App,
     /// Warp is running as a CLI.
     Sdk,
+    /// Warp is running as the remote server daemon.
+    Daemon,
 }
 
 impl ExecutionMode {
@@ -20,6 +22,7 @@ impl ExecutionMode {
         match self {
             ExecutionMode::App => "warp-app",
             ExecutionMode::Sdk => "warp-cli",
+            ExecutionMode::Daemon => "warp-daemon",
         }
     }
 }
@@ -98,7 +101,7 @@ impl AppExecutionMode {
     /// Wherever possible, prefer more targeted capability checks like
     /// [`Self::can_autostart_mcp_servers`].
     pub fn is_autonomous(&self) -> bool {
-        matches!(self.mode, ExecutionMode::Sdk)
+        matches!(self.mode, ExecutionMode::Sdk | ExecutionMode::Daemon)
     }
 
     /// Returns the client ID to report to the server.
@@ -119,7 +122,7 @@ impl Entity for AppExecutionMode {
 
 impl SingletonEntity for AppExecutionMode {}
 
-/// Returns the current global client ID string ("warp-app" or "warp-cli").
+/// Returns the current global client ID string ("warp-app", "warp-cli", or "warp-daemon").
 /// This is set when AppExecutionMode is constructed during application start.
 /// Returns None if the execution mode has not been set yet.
 pub fn current_client_id() -> Option<&'static str> {

--- a/crates/warp_core/src/execution_mode.rs
+++ b/crates/warp_core/src/execution_mode.rs
@@ -12,7 +12,7 @@ pub enum ExecutionMode {
     /// Warp is running as a CLI.
     Sdk,
     /// Warp is running as the remote server daemon.
-    Daemon,
+    RemoteServerDaemon,
 }
 
 impl ExecutionMode {
@@ -22,7 +22,7 @@ impl ExecutionMode {
         match self {
             ExecutionMode::App => "warp-app",
             ExecutionMode::Sdk => "warp-cli",
-            ExecutionMode::Daemon => "warp-daemon",
+            ExecutionMode::RemoteServerDaemon => "warp-remote-server-daemon",
         }
     }
 }
@@ -94,14 +94,20 @@ impl AppExecutionMode {
     /// In CLI and daemon modes, we synchronously send events at shutdown because there's a
     /// higher likelihood that they will be lost otherwise.
     pub fn send_telemetry_at_shutdown(&self) -> bool {
-        matches!(self.mode, ExecutionMode::Sdk | ExecutionMode::Daemon)
+        matches!(
+            self.mode,
+            ExecutionMode::Sdk | ExecutionMode::RemoteServerDaemon
+        )
     }
 
     /// If true, the app is running autonomously, without a user present.
     /// Wherever possible, prefer more targeted capability checks like
     /// [`Self::can_autostart_mcp_servers`].
     pub fn is_autonomous(&self) -> bool {
-        matches!(self.mode, ExecutionMode::Sdk | ExecutionMode::Daemon)
+        matches!(
+            self.mode,
+            ExecutionMode::Sdk | ExecutionMode::RemoteServerDaemon
+        )
     }
 
     /// Returns the client ID to report to the server.
@@ -122,7 +128,7 @@ impl Entity for AppExecutionMode {
 
 impl SingletonEntity for AppExecutionMode {}
 
-/// Returns the current global client ID string ("warp-app", "warp-cli", or "warp-daemon").
+/// Returns the current global client ID string ("warp-app", "warp-cli", or "warp-remote-server-daemon").
 /// This is set when AppExecutionMode is constructed during application start.
 /// Returns None if the execution mode has not been set yet.
 pub fn current_client_id() -> Option<&'static str> {


### PR DESCRIPTION
## Description
Fixes APP-4440

Add an unique `warp-remote-server-daemon` client ID for telemetry, sentry, and server requests.

Corresponding server PR: https://github.com/warpdotdev/warp-server/pull/11066 (currently we have no server dependency rn, but this adds it in preparation for adding them for codebase indexing)