### PR TITLE
[QUALITY-644] Fix environment picker empty state expanding to full window width

### DIFF
--- a/app/src/view_components/filterable_dropdown.rs
+++ b/app/src/view_components/filterable_dropdown.rs
@@ -554,7 +554,7 @@ where
                 .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
                 .finish(),
         )
-        .with_max_width(self.top_bar_max_width)
+        .with_max_width(self.menu_width.unwrap_or(self.top_bar_max_width))
         .with_height(EMPTY_DROPDOWN_HEIGHT)
         .finish();
 


### PR DESCRIPTION
## Description
The `FilterableDropdown::render_empty_menu()` "No matches found" placeholder expanded to
full window width when used in the orchestration config environment picker. The empty state
used `top_bar_max_width` for its width constraint, but the environment picker sets that to
`f32::INFINITY`. The normal (has-results) menu correctly uses the 280px `menu_width` set
via `set_menu_width()`, but the empty state ignored it.

Fixed by using `menu_width` (when set) as the max width for the empty menu, falling back to
`top_bar_max_width` for callers that do not set an explicit menu width.

Screenshot:
<img width="1012" height="978" alt="Screenshot 2026-05-11 at 1 24 09 PM" src="https://github.com/user-attachments/assets/c47a91e7-1f49-4975-82ec-5685353cc0db" />

## Linked Issue
https://linear.app/warpdotdev/issue/QUALITY-644

## Testing
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed the environment search dropdown in orchestration config expanding to full window width when no matches are found.
-->

Co-Authored-By: Oz <oz-agent@warp.dev>