### PR TITLE
fix: exempt SharedSessionSelection from long-running command guard in agent view entry

### DIFF
--- a/app/src/ai/blocklist/agent_view/controller.rs
+++ b/app/src/ai/blocklist/agent_view/controller.rs
@@ -691,8 +691,10 @@ impl AgentViewController {
         ctx: &mut ModelContext<Self>,
     ) -> Result<AIConversationId, EnterAgentViewError> {
         // Block entry to fullscreen mode if there's an active long-running command. Transcript
-        // viewers and 3p cloud viewers are exempt: in those contexts the long-running block is
-        // either a restored snapshot or the harness CLI we want to wrap in agent-view chrome.
+        // viewers, 3p cloud viewers, and shared-session viewers are exempt: in those contexts
+        // the long-running block is either a restored snapshot, the harness CLI we want to wrap
+        // in agent-view chrome, or replayed scrollback from a shared session whose setup
+        // commands left a long-running block active.
         let is_long_running = {
             let terminal_model = self.terminal_model.lock();
             terminal_model
@@ -700,7 +702,11 @@ impl AgentViewController {
                 .active_block()
                 .is_active_and_long_running()
                 && !terminal_model.is_conversation_transcript_viewer()
-                && !matches!(origin, AgentViewEntryOrigin::ThirdPartyCloudAgent)
+                && !matches!(
+                    origin,
+                    AgentViewEntryOrigin::ThirdPartyCloudAgent
+                        | AgentViewEntryOrigin::SharedSessionSelection
+                )
         };
 
         if is_long_running {

--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -730,7 +730,7 @@ impl BlocklistAIContextModel {
             if let Err(e) = self.agent_view_controller.update(ctx, |controller, ctx| {
                 controller.try_enter_agent_view(Some(conversation_id), origin, ctx)
             }) {
-                log::error!("Failed to enter agent view for existing conversation: {e}");
+                log::error!("Failed to enter agent view for existing conversation (origin={origin:?}): {e}");
             }
         }
     }


### PR DESCRIPTION
## Description

When a shared-session viewer receives the first agent response event after environment setup completes, `on_shared_init` calls `try_enter_agent_view` with origin `SharedSessionSelection`. If the viewer's terminal has an active block that `is_active_and_long_running()` considers long-running (from replayed scrollback), the guard at `controller.rs:696-708` blocks entry and the viewer never transitions from the terminal view to the agent conversation view — resulting in a blank screen.

A self-hosted K8s customer with long-running environment setup commands (`scripts/stack-up` running DB migrations, service startup, etc.) consistently reproduced this: they could see setup commands during session sharing but the screen went blank after `unset CI` / "environment started," never showing the agent's conversation content.

### The fix

Add `SharedSessionSelection` to the exemption list in `try_enter_agent_view`, alongside `ThirdPartyCloudAgent`. The long-running block in a shared-session viewer is replayed scrollback, not a live command the viewer owns — blocking agent view entry is incorrect.

### Caveat

We don't have 100% confirmation that `is_active_and_long_running()` is returning `true` on the viewer's active block in this specific scenario (the logs don't include this check). However, this is the only code path that can prevent `on_shared_init` from entering agent view, and the exemption is correct regardless — a shared-session viewer should never be blocked from viewing a conversation because of replayed terminal state.

### Related PRs

- warp#10648 — fixes the separate Stopped/Running cycling issue (CANCELLED state from `OptimisticCLISubagentCompletion`)
- warp-server#11044 — fixes `IsSandboxRunning` cross-instance check for self-hosted workers

## Testing

- [x] I have manually tested my changes locally with `./script/run`
- Single-line change, no new behavior paths introduced
- The exemption mirrors the existing `ThirdPartyCloudAgent` exemption pattern

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed blank screen when viewing a shared agent session with long-running environment setup commands.
-->

_Conversation: https://staging.warp.dev/conversation/08d41ae5-dd93-416d-9be5-816df8998e0a_
_Run: https://oz.staging.warp.dev/runs/019e1794-1567-7928-9af5-543721598712_
_Plans:_
  - _[K8s Self-Hosted oz-agent-worker: Debugging Cancelled/Reconnect Cycling and Invisible Session](https://staging.warp.dev/drive/notebook/aSR5t3cAIuRnMXl9XGteCp)_

_This PR was generated with [Oz](https://warp.dev/oz)._
