### PR TITLE
add cloud mode gate for handoff chip

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -2044,11 +2044,11 @@ impl AgentInputFooter {
                 if !is_local_to_cloud_handoff_available() {
                     return None;
                 }
-                // Render the chip when the native/local handoff surface is available.
-                // Per-conversation eligibility (synced server token, non-empty
-                // history) is enforced by `Workspace::start_local_to_cloud_handoff`,
-                // which surfaces an error toast and does not open a pane when
-                // the active conversation isn't handoff-able.
+
+                if is_cloud_mode {
+                    return None;
+                }
+
                 Some(ChildView::new(&self.handoff_to_cloud_button).finish())
             }
             // Handled by the available_in() guard above; included for exhaustiveness.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

The local -> cloud handoff chip shouldn't show up in cloud mode. I went back and forth on whether to disable it w/ a tooltip or just hide it, but hiding it is a little simpler and I didn't really think one was better than the other.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/20249e5362d844c8ac9f70ea6c718eb1

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode