### PR TITLE
[REMOTE-1470] Right-align Open in Warp button in snapshot footer

### DIFF
--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -25,8 +25,8 @@ use warp_core::send_telemetry_from_ctx;
 use warp_core::ui::icons::Icon;
 use warp_core::ui::theme::{AnsiColorIdentifier, Fill};
 use warpui::elements::{
-    Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty, Flex,
-    MainAxisSize, Padding, ParentElement, Radius, Shrinkable, Text,
+    Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty,
+    Expanded, Flex, MainAxisSize, Padding, ParentElement, Radius, Shrinkable, Text,
 };
 use warpui::fonts::{Properties, Weight};
 use warpui::{
@@ -592,7 +592,7 @@ impl View for ConversationEndedTombstoneView {
             .with_main_axis_size(MainAxisSize::Max)
             .with_cross_axis_alignment(CrossAxisAlignment::Start)
             .with_spacing(12.)
-            .with_child(Shrinkable::new(1., left_column.finish()).finish())
+            .with_child(Expanded::new(1., left_column.finish()).finish())
             .with_child(self.render_action_buttons(appearance, app))
             .finish();
 


### PR DESCRIPTION
## Description
In the shared session snapshot footer (`ConversationEndedTombstoneView`), the `Open in Warp` button was not right-aligned because the left content column used `Shrinkable`.

This switches the left column wrapper to `Expanded`, so the text column takes remaining row width and the action button is pinned to the right edge.

## Linked Issue
REMOTE-1470


## Testing
- `cargo fmt --all`
- `cargo check -p warp`
- `cargo clippy -p warp --lib -- -D warnings`
- `cargo clippy -p warp --all-targets --all-features -- -D warnings` *(fails in this environment due missing generated channel config JSON files in `OUT_DIR`, unrelated to this diff)*

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<img width="2243" height="241" alt="image" src="https://github.com/user-attachments/assets/ec4f2006-2fb1-4729-b85a-aa2c9bc93405" />


## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Right-aligned the `Open in Warp` button in the shared session snapshot footer.

Co-Authored-By: Oz <oz-agent@warp.dev>
