### PR TITLE
fix bug where the agent view was empty when joining shared sessions

### DIFF
--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -27,6 +27,11 @@ pub struct TaskStore {
     root_task_id: TaskId,
     tasks: HashMap<TaskId, Task>,
     linearized_refs: Vec<ExchangeRef>,
+    /// If the root task was upgraded from an optimistic (client-generated) ID
+    /// to a server-assigned ID, stores `(old_id, new_id)` so that deferred
+    /// event handlers referencing the stale optimistic ID can still resolve
+    /// the task.
+    upgraded_task_id: Option<(TaskId, TaskId)>,
 }
 
 impl TaskStore {
@@ -36,6 +41,7 @@ impl TaskStore {
             tasks: HashMap::new(),
             linearized_refs: Vec::new(),
             root_task_id: root_task_id.clone(),
+            upgraded_task_id: None,
         };
         store.tasks.insert(root_task_id, root_task);
         store.rebuild_linearized_refs_index();
@@ -49,6 +55,7 @@ impl TaskStore {
             tasks,
             linearized_refs: Vec::new(),
             root_task_id,
+            upgraded_task_id: None,
         };
         store.rebuild_linearized_refs_index();
         store
@@ -59,7 +66,10 @@ impl TaskStore {
     }
 
     pub fn get(&self, task_id: &TaskId) -> Option<&Task> {
-        self.tasks.get(task_id)
+        self.tasks.get(task_id).or_else(|| {
+            let (old_id, new_id) = self.upgraded_task_id.as_ref()?;
+            (old_id == task_id).then(|| self.tasks.get(new_id))?
+        })
     }
 
     pub fn tasks(&self) -> impl Iterator<Item = &Task> {
@@ -142,6 +152,9 @@ impl TaskStore {
         self.remove(&old_root_id);
 
         let new_root_id = root_task.id().clone();
+        if old_root_id != new_root_id {
+            self.upgraded_task_id = Some((old_root_id, new_root_id.clone()));
+        }
         self.root_task_id = new_root_id;
         self.insert(root_task);
     }

--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -28,10 +28,10 @@ pub struct TaskStore {
     tasks: HashMap<TaskId, Task>,
     linearized_refs: Vec<ExchangeRef>,
     /// If the root task was upgraded from an optimistic (client-generated) ID
-    /// to a server-assigned ID, stores `(old_id, new_id)` so that deferred
-    /// event handlers referencing the stale optimistic ID can still resolve
-    /// the task.
-    upgraded_task_id: Option<(TaskId, TaskId)>,
+    /// to a server-assigned ID, stores the original optimistic ID so that
+    /// deferred event handlers referencing the stale ID can still resolve
+    /// the task via `root_task_id`.
+    optimistic_root_task_id: Option<TaskId>,
 }
 
 impl TaskStore {
@@ -41,7 +41,7 @@ impl TaskStore {
             tasks: HashMap::new(),
             linearized_refs: Vec::new(),
             root_task_id: root_task_id.clone(),
-            upgraded_task_id: None,
+            optimistic_root_task_id: None,
         };
         store.tasks.insert(root_task_id, root_task);
         store.rebuild_linearized_refs_index();
@@ -55,7 +55,7 @@ impl TaskStore {
             tasks,
             linearized_refs: Vec::new(),
             root_task_id,
-            upgraded_task_id: None,
+            optimistic_root_task_id: None,
         };
         store.rebuild_linearized_refs_index();
         store
@@ -67,8 +67,8 @@ impl TaskStore {
 
     pub fn get(&self, task_id: &TaskId) -> Option<&Task> {
         self.tasks.get(task_id).or_else(|| {
-            let (old_id, new_id) = self.upgraded_task_id.as_ref()?;
-            (old_id == task_id).then(|| self.tasks.get(new_id))?
+            let old_id = self.optimistic_root_task_id.as_ref()?;
+            (old_id == task_id).then(|| self.tasks.get(&self.root_task_id))?
         })
     }
 
@@ -153,7 +153,7 @@ impl TaskStore {
 
         let new_root_id = root_task.id().clone();
         if old_root_id != new_root_id {
-            self.upgraded_task_id = Some((old_root_id, new_root_id.clone()));
+            self.optimistic_root_task_id = Some(old_root_id);
         }
         self.root_task_id = new_root_id;
         self.insert(root_task);

--- a/app/src/ai/agent/task_store_tests.rs
+++ b/app/src/ai/agent/task_store_tests.rs
@@ -216,7 +216,8 @@ fn test_set_root_task_replaces_old() {
 
     assert_eq!(store.task_count(), 1);
     assert_eq!(store.exchange_count(), 3);
-    assert!(store.get(&task1_id).is_none());
+    // task1_id is now aliased to the new root task via optimistic_root_task_id
+    assert!(store.get(&task1_id).is_some());
     assert!(store.get(&task2_id).is_some());
     assert_eq!(store.root_task_id(), &task2_id);
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5319,17 +5319,11 @@ impl TerminalView {
                 let should_add_ai_block = history_model
                     .as_ref(ctx)
                     .conversation(conversation_id)
-                    .and_then(|conversation| {
-                        // First try the exact task_id from the event. If not found
-                        // (e.g. because the optimistic root was upgraded to a
-                        // server-created task between emit and dispatch), fall back
-                        // to the conversation's current root task.
-                        conversation
-                            .get_task(task_id)
-                            .or_else(|| conversation.get_root_task())
-                    })
+                    .and_then(|conversation| conversation.get_task(task_id))
                     .is_some_and(blocklist_filter::should_show_task_in_blocklist);
                 if !should_add_ai_block {
+                    // Only add AI blocks to the blocklist for root task exchanges (normal Agent Mode)
+                    // and advice subagent exchanges (so advice tool calls/results are visible).
                     return;
                 }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5319,11 +5319,17 @@ impl TerminalView {
                 let should_add_ai_block = history_model
                     .as_ref(ctx)
                     .conversation(conversation_id)
-                    .and_then(|conversation| conversation.get_task(task_id))
+                    .and_then(|conversation| {
+                        // First try the exact task_id from the event. If not found
+                        // (e.g. because the optimistic root was upgraded to a
+                        // server-created task between emit and dispatch), fall back
+                        // to the conversation's current root task.
+                        conversation
+                            .get_task(task_id)
+                            .or_else(|| conversation.get_root_task())
+                    })
                     .is_some_and(blocklist_filter::should_show_task_in_blocklist);
                 if !should_add_ai_block {
-                    // Only add AI blocks to the blocklist for root task exchanges (normal Agent Mode)
-                    // and advice subagent exchanges (so advice tool calls/results are visible).
                     return;
                 }
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

There was a bug where, when opening an in-progress cloud conversation from the shared session link, the conversation would sometimes be completely empty.

The root cause here is was a race condition in the event loop, triggered by a change from last week to optimistically create the shared conversation's task Id in `on_shared_init`. The race is as follows:
1. `AgentResponseEvent::Init` → `on_shared_init` creates an exchange with the optimistic root task ID → `AppendedExchange` event emitted (deferred)
2. `AgentResponseEvent::ClientActions` → `apply_client_actions` processes `CreateTask` → replaces the optimistic root task with a server-assigned task that has a different ID (`conversation.rs:2253-2280`)
3. Deferred events dispatch → `AppendedExchange` handler runs → `conversation.get_task(optimistic_id)` returns None → AI block is never inserted → pane is blank

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/5ae0c49e08ef4d79989a58409e1ecae9

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->
CHANGELOG-BUG-FIX: Fixed a bug where cloud conversations were sometimes empty on-join.