### PR TITLE
Expose stable artifact download URLs in CLI

### DIFF
--- a/app/src/ai/agent_sdk/artifact.rs
+++ b/app/src/ai/agent_sdk/artifact.rs
@@ -2,12 +2,12 @@ use std::{path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Result};
 use serde::Serialize;
+use warp_cli::GlobalOptions;
 use warp_cli::agent::OutputFormat;
 use warp_cli::artifact::{
     ArtifactCommand, DownloadArtifactArgs, GetArtifactArgs, UploadArtifactArgs,
 };
-use warp_cli::GlobalOptions;
-use warpui::{platform::TerminationMode, AppContext, ModelContext, SingletonEntity};
+use warpui::{AppContext, ModelContext, SingletonEntity, platform::TerminationMode};
 
 use crate::ai::artifact_download::{download_artifact_bytes, download_destination};
 #[cfg(test)]
@@ -163,6 +163,7 @@ struct ArtifactMetadataOutput {
     artifact_type: String,
     created_at: String,
     download_url: String,
+    stable_download_url: String,
     expires_at: String,
     content_type: String,
     filepath: Option<String>,
@@ -178,6 +179,7 @@ impl ArtifactMetadataOutput {
             artifact_type: artifact.artifact_type().to_string(),
             created_at: artifact.created_at().to_rfc3339(),
             download_url: artifact.download_url().to_string(),
+            stable_download_url: artifact.stable_download_url().to_string(),
             expires_at: artifact.expires_at().to_rfc3339(),
             content_type: artifact.content_type().to_string(),
             filepath: artifact.filepath().map(ToString::to_string),
@@ -208,6 +210,7 @@ impl DownloadArtifactOutput {
 #[derive(Debug, Serialize)]
 struct UploadArtifactOutput {
     artifact_uid: String,
+    stable_download_url: String,
     filepath: String,
     description: Option<String>,
     mime_type: String,
@@ -244,6 +247,11 @@ fn write_get_output_to<W: std::io::Write>(
             )?;
             writeln!(&mut *output, "Created at: {}", output_record.created_at)?;
             writeln!(&mut *output, "Download URL: {}", output_record.download_url)?;
+            writeln!(
+                &mut *output,
+                "Stable download URL: {}",
+                output_record.stable_download_url
+            )?;
             writeln!(&mut *output, "Expires at: {}", output_record.expires_at)?;
             writeln!(&mut *output, "Content type: {}", output_record.content_type)?;
             if let Some(filepath) = output_record.filepath {
@@ -262,15 +270,16 @@ fn write_get_output_to<W: std::io::Write>(
         OutputFormat::Text => {
             writeln!(
                 &mut *output,
-                "Artifact UID\tArtifact type\tCreated at\tDownload URL\tExpires at\tContent type\tFilepath\tFilename\tDescription\tSize bytes"
+                "Artifact UID\tArtifact type\tCreated at\tDownload URL\tStable download URL\tExpires at\tContent type\tFilepath\tFilename\tDescription\tSize bytes"
             )?;
             writeln!(
                 &mut *output,
-                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
                 output_record.artifact_uid,
                 output_record.artifact_type,
                 output_record.created_at,
                 output_record.download_url,
+                output_record.stable_download_url,
                 output_record.expires_at,
                 output_record.content_type,
                 output_record.filepath.unwrap_or_default(),
@@ -346,6 +355,7 @@ fn write_upload_output_to<W: std::io::Write>(
 ) -> Result<()> {
     let output_record = UploadArtifactOutput {
         artifact_uid: artifact.artifact.artifact_uid.clone(),
+        stable_download_url: artifact.artifact.stable_download_url.clone(),
         filepath: artifact.artifact.filepath.clone(),
         description: artifact.artifact.description.clone(),
         mime_type: artifact.artifact.mime_type.clone(),
@@ -361,6 +371,11 @@ fn write_upload_output_to<W: std::io::Write>(
         OutputFormat::Pretty => {
             writeln!(&mut *output, "Artifact uploaded")?;
             writeln!(&mut *output, "Artifact UID: {}", output_record.artifact_uid)?;
+            writeln!(
+                &mut *output,
+                "Stable download URL: {}",
+                output_record.stable_download_url
+            )?;
             writeln!(&mut *output, "Filepath: {}", output_record.filepath)?;
             writeln!(
                 &mut *output,
@@ -380,12 +395,13 @@ fn write_upload_output_to<W: std::io::Write>(
         OutputFormat::Text => {
             writeln!(
                 &mut *output,
-                "Artifact UID\tFilepath\tDescription\tMIME type\tSize bytes"
+                "Artifact UID\tStable download URL\tFilepath\tDescription\tMIME type\tSize bytes"
             )?;
             writeln!(
                 &mut *output,
-                "{}\t{}\t{}\t{}\t{}",
+                "{}\t{}\t{}\t{}\t{}\t{}",
                 output_record.artifact_uid,
+                output_record.stable_download_url,
                 output_record.filepath,
                 output_record.description.unwrap_or_default(),
                 output_record.mime_type,

--- a/app/src/ai/agent_sdk/artifact_tests.rs
+++ b/app/src/ai/agent_sdk/artifact_tests.rs
@@ -13,6 +13,8 @@ fn sample_completed_upload() -> CompletedFileArtifactUpload {
 fn sample_artifact_record() -> FileArtifactRecord {
     FileArtifactRecord {
         artifact_uid: "artifact-123".to_string(),
+        stable_download_url: "https://api.example.com/api/v1/agent/artifacts/artifact-123/download"
+            .to_string(),
         filepath: "outputs/report.txt".to_string(),
         description: Some("daily summary".to_string()),
         mime_type: "text/plain".to_string(),
@@ -28,6 +30,7 @@ fn sample_file_download_response() -> ArtifactDownloadResponse {
             "created_at": "2024-01-15T10:30:00Z",
             "data": {
                 "download_url": "https://storage.example.com/report.txt",
+                "stable_download_url": "https://api.example.com/api/v1/agent/artifacts/artifact-123/download",
                 "expires_at": "2024-01-15T11:30:00Z",
                 "content_type": "text/plain",
                 "filepath": "outputs/report.txt",
@@ -48,6 +51,7 @@ fn sample_screenshot_download_response() -> ArtifactDownloadResponse {
             "created_at": "2024-01-15T10:30:00Z",
             "data": {
                 "download_url": "https://storage.example.com/screenshot.png",
+                "stable_download_url": "https://api.example.com/api/v1/agent/artifacts/screenshot-123/download",
                 "expires_at": "2024-01-15T11:30:00Z",
                 "content_type": "image/png",
                 "description": "dashboard screenshot"
@@ -70,7 +74,7 @@ fn write_get_output_to_writes_json_output() {
 
     assert_eq!(
         String::from_utf8(output).unwrap(),
-        "{\"artifact_uid\":\"artifact-123\",\"artifact_type\":\"FILE\",\"created_at\":\"2024-01-15T10:30:00+00:00\",\"download_url\":\"https://storage.example.com/report.txt\",\"expires_at\":\"2024-01-15T11:30:00+00:00\",\"content_type\":\"text/plain\",\"filepath\":\"outputs/report.txt\",\"filename\":\"report.txt\",\"description\":\"daily summary\",\"size_bytes\":42}\n"
+        "{\"artifact_uid\":\"artifact-123\",\"artifact_type\":\"FILE\",\"created_at\":\"2024-01-15T10:30:00+00:00\",\"download_url\":\"https://storage.example.com/report.txt\",\"stable_download_url\":\"https://api.example.com/api/v1/agent/artifacts/artifact-123/download\",\"expires_at\":\"2024-01-15T11:30:00+00:00\",\"content_type\":\"text/plain\",\"filepath\":\"outputs/report.txt\",\"filename\":\"report.txt\",\"description\":\"daily summary\",\"size_bytes\":42}\n"
     );
 }
 
@@ -87,7 +91,7 @@ fn write_get_output_to_writes_ndjson_output() {
 
     assert_eq!(
         String::from_utf8(output).unwrap(),
-        "{\"artifact_uid\":\"artifact-123\",\"artifact_type\":\"FILE\",\"created_at\":\"2024-01-15T10:30:00+00:00\",\"download_url\":\"https://storage.example.com/report.txt\",\"expires_at\":\"2024-01-15T11:30:00+00:00\",\"content_type\":\"text/plain\",\"filepath\":\"outputs/report.txt\",\"filename\":\"report.txt\",\"description\":\"daily summary\",\"size_bytes\":42}\n"
+        "{\"artifact_uid\":\"artifact-123\",\"artifact_type\":\"FILE\",\"created_at\":\"2024-01-15T10:30:00+00:00\",\"download_url\":\"https://storage.example.com/report.txt\",\"stable_download_url\":\"https://api.example.com/api/v1/agent/artifacts/artifact-123/download\",\"expires_at\":\"2024-01-15T11:30:00+00:00\",\"content_type\":\"text/plain\",\"filepath\":\"outputs/report.txt\",\"filename\":\"report.txt\",\"description\":\"daily summary\",\"size_bytes\":42}\n"
     );
 }
 
@@ -104,7 +108,7 @@ fn write_get_output_to_writes_pretty_output() {
 
     assert_eq!(
         String::from_utf8(output).unwrap(),
-        "Artifact UID: artifact-123\nArtifact type: FILE\nCreated at: 2024-01-15T10:30:00+00:00\nDownload URL: https://storage.example.com/report.txt\nExpires at: 2024-01-15T11:30:00+00:00\nContent type: text/plain\nFilepath: outputs/report.txt\nFilename: report.txt\nDescription: daily summary\nSize bytes: 42\n"
+        "Artifact UID: artifact-123\nArtifact type: FILE\nCreated at: 2024-01-15T10:30:00+00:00\nDownload URL: https://storage.example.com/report.txt\nStable download URL: https://api.example.com/api/v1/agent/artifacts/artifact-123/download\nExpires at: 2024-01-15T11:30:00+00:00\nContent type: text/plain\nFilepath: outputs/report.txt\nFilename: report.txt\nDescription: daily summary\nSize bytes: 42\n"
     );
 }
 
@@ -121,7 +125,7 @@ fn write_get_output_to_writes_text_output() {
 
     assert_eq!(
         String::from_utf8(output).unwrap(),
-        "Artifact UID\tArtifact type\tCreated at\tDownload URL\tExpires at\tContent type\tFilepath\tFilename\tDescription\tSize bytes\nartifact-123\tFILE\t2024-01-15T10:30:00+00:00\thttps://storage.example.com/report.txt\t2024-01-15T11:30:00+00:00\ttext/plain\toutputs/report.txt\treport.txt\tdaily summary\t42\n"
+        "Artifact UID\tArtifact type\tCreated at\tDownload URL\tStable download URL\tExpires at\tContent type\tFilepath\tFilename\tDescription\tSize bytes\nartifact-123\tFILE\t2024-01-15T10:30:00+00:00\thttps://storage.example.com/report.txt\thttps://api.example.com/api/v1/agent/artifacts/artifact-123/download\t2024-01-15T11:30:00+00:00\ttext/plain\toutputs/report.txt\treport.txt\tdaily summary\t42\n"
     );
 }
 
@@ -204,7 +208,7 @@ fn write_upload_output_to_writes_json_output() {
 
     assert_eq!(
         String::from_utf8(output).unwrap(),
-        "{\"artifact_uid\":\"artifact-123\",\"filepath\":\"outputs/report.txt\",\"description\":\"daily summary\",\"mime_type\":\"text/plain\",\"size_bytes\":42}\n"
+        "{\"artifact_uid\":\"artifact-123\",\"stable_download_url\":\"https://api.example.com/api/v1/agent/artifacts/artifact-123/download\",\"filepath\":\"outputs/report.txt\",\"description\":\"daily summary\",\"mime_type\":\"text/plain\",\"size_bytes\":42}\n"
     );
 }
 
@@ -221,7 +225,7 @@ fn write_upload_output_to_writes_ndjson_output() {
 
     assert_eq!(
         String::from_utf8(output).unwrap(),
-        "{\"artifact_uid\":\"artifact-123\",\"filepath\":\"outputs/report.txt\",\"description\":\"daily summary\",\"mime_type\":\"text/plain\",\"size_bytes\":42}\n"
+        "{\"artifact_uid\":\"artifact-123\",\"stable_download_url\":\"https://api.example.com/api/v1/agent/artifacts/artifact-123/download\",\"filepath\":\"outputs/report.txt\",\"description\":\"daily summary\",\"mime_type\":\"text/plain\",\"size_bytes\":42}\n"
     );
 }
 
@@ -238,7 +242,7 @@ fn write_upload_output_to_writes_pretty_output() {
 
     assert_eq!(
         String::from_utf8(output).unwrap(),
-        "Artifact uploaded\nArtifact UID: artifact-123\nFilepath: outputs/report.txt\nDescription: daily summary\nMIME type: text/plain\nSize bytes: 42\n"
+        "Artifact uploaded\nArtifact UID: artifact-123\nStable download URL: https://api.example.com/api/v1/agent/artifacts/artifact-123/download\nFilepath: outputs/report.txt\nDescription: daily summary\nMIME type: text/plain\nSize bytes: 42\n"
     );
 }
 
@@ -250,6 +254,6 @@ fn write_upload_output_to_writes_text_output() {
 
     assert_eq!(
         String::from_utf8(output).unwrap(),
-        "Artifact UID\tFilepath\tDescription\tMIME type\tSize bytes\nartifact-123\toutputs/report.txt\tdaily summary\ttext/plain\t42\n"
+        "Artifact UID\tStable download URL\tFilepath\tDescription\tMIME type\tSize bytes\nartifact-123\thttps://api.example.com/api/v1/agent/artifacts/artifact-123/download\toutputs/report.txt\tdaily summary\ttext/plain\t42\n"
     );
 }

--- a/app/src/ai/artifact_download.rs
+++ b/app/src/ai/artifact_download.rs
@@ -63,7 +63,7 @@ pub(crate) async fn download_artifact_bytes(
 ) -> anyhow::Result<()> {
     use std::time::Duration;
 
-    use anyhow::{anyhow, Context as _};
+    use anyhow::{Context as _, anyhow};
     use futures::TryStreamExt as _;
     use tokio_util::io::StreamReader;
 
@@ -125,6 +125,7 @@ mod tests {
             },
             data: FileArtifactResponseData {
                 download_url: "https://storage.example.com/report.txt".to_string(),
+                stable_download_url: None,
                 expires_at: Utc.with_ymd_and_hms(2024, 1, 15, 11, 30, 0).unwrap(),
                 content_type: "text/plain".to_string(),
                 filepath: filepath.to_string(),
@@ -189,6 +190,7 @@ mod tests {
             },
             data: ScreenshotArtifactResponseData {
                 download_url: "https://storage.example.com/screenshot".to_string(),
+                stable_download_url: None,
                 expires_at: Utc.with_ymd_and_hms(2024, 1, 15, 11, 30, 0).unwrap(),
                 content_type: "application/octet-stream".to_string(),
                 description: Some("dashboard screenshot".to_string()),

--- a/app/src/ai/artifacts/mod_tests.rs
+++ b/app/src/ai/artifacts/mod_tests.rs
@@ -35,6 +35,7 @@ fn skips_lightbox_update_for_non_screenshot_artifact() {
             },
             data: FileArtifactResponseData {
                 download_url: "https://storage.example.com/report.txt".to_string(),
+                stable_download_url: None,
                 expires_at: Utc.with_ymd_and_hms(2024, 1, 15, 11, 30, 0).unwrap(),
                 content_type: "text/plain".to_string(),
                 filepath: "outputs/report.txt".to_string(),
@@ -73,6 +74,7 @@ fn resolves_lightbox_image_for_screenshot_artifact() {
             },
             data: ScreenshotArtifactResponseData {
                 download_url: "https://storage.example.com/screenshot.png".to_string(),
+                stable_download_url: None,
                 expires_at: Utc.with_ymd_and_hms(2024, 1, 15, 11, 30, 0).unwrap(),
                 content_type: "image/png".to_string(),
                 description: Some("dashboard screenshot".to_string()),
@@ -116,6 +118,7 @@ fn default_download_filename_prefers_server_filename() {
             },
             data: FileArtifactResponseData {
                 download_url: "https://storage.example.com/report.txt".to_string(),
+                stable_download_url: None,
                 expires_at: Utc.with_ymd_and_hms(2024, 1, 15, 11, 30, 0).unwrap(),
                 content_type: "text/plain".to_string(),
                 filepath: "outputs/report.txt".to_string(),
@@ -139,6 +142,7 @@ fn default_download_filename_falls_back_to_artifact_uid_with_extension() {
             },
             data: FileArtifactResponseData {
                 download_url: "https://storage.example.com/report.txt".to_string(),
+                stable_download_url: None,
                 expires_at: Utc.with_ymd_and_hms(2024, 1, 15, 11, 30, 0).unwrap(),
                 content_type: "text/plain".to_string(),
                 filepath: "outputs/report.txt".to_string(),
@@ -156,6 +160,9 @@ fn converts_graphql_file_artifact() {
     let artifact = Artifact::try_from(warp_graphql::ai::AIConversationArtifact::FileArtifact(
         warp_graphql::ai::FileArtifact {
             artifact_uid: "artifact-file-1".into(),
+            stable_download_url:
+                "https://api.example.com/api/v1/agent/artifacts/artifact-file-1/download"
+                    .to_string(),
             filepath: "outputs/report.txt".to_string(),
             mime_type: "text/plain".to_string(),
             description: Some("Daily summary".to_string()),

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -15,9 +15,11 @@ use warp_core::channel::ChannelState;
 use warp_core::{features::FeatureFlag, report_error};
 use warp_multi_agent_api::ConversationData;
 
+use super::ServerApi;
 use super::auth::AuthClient;
 use super::harness_support::UploadTarget;
-use super::ServerApi;
+#[cfg(not(feature = "agent_mode_evals"))]
+use crate::ai::BonusGrant;
 use crate::ai::agent::conversation::{
     AIAgentConversationFormat, AIAgentHarness, AIAgentSerializedBlockFormat,
     ServerAIConversationMetadata,
@@ -29,8 +31,6 @@ use crate::ai::generate_code_review_content::api::{
 };
 #[cfg(feature = "agent_mode_evals")]
 use crate::ai::request_usage_model::RequestLimitInfo;
-#[cfg(not(feature = "agent_mode_evals"))]
-use crate::ai::BonusGrant;
 use crate::ai::{agent::api::ServerConversationToken, harness_availability::HarnessAvailability};
 use crate::persistence::model::ConversationUsageMetadata;
 use crate::terminal::model::block::SerializedBlock;
@@ -42,15 +42,16 @@ use crate::{
 };
 use crate::{
     ai::{
+        RequestUsageInfo,
         llms::{
             AvailableLLMs, DisableReason, LLMContextWindow, LLMInfo, LLMModelHost, LLMProvider,
             LLMSpec, LLMUsageMetadata, ModelsByFeature, RoutingHostConfig,
         },
-        RequestUsageInfo,
     },
     ai_assistant::{
+        AIGeneratedCommand, GenerateCommandsFromNaturalLanguageError,
         execution_context::WarpAiExecutionContext, requests::GenerateDialogueResult,
-        utils::TranscriptPart, AIGeneratedCommand, GenerateCommandsFromNaturalLanguageError,
+        utils::TranscriptPart,
     },
     drive::workflows::ai_assist::{GeneratedCommandMetadata, GeneratedCommandMetadataError},
     server::graphql::{
@@ -58,9 +59,8 @@ use crate::{
     },
 };
 use ai::index::full_source_code_embedding::{
-    self,
+    self, CodebaseContextConfig, ContentHash, EmbeddingConfig, NodeHash, RepoMetadata,
     store_client::{IntermediateNode, StoreClient},
-    CodebaseContextConfig, ContentHash, EmbeddingConfig, NodeHash, RepoMetadata,
 };
 use warp_graphql::client::Operation;
 #[cfg(not(feature = "agent_mode_evals"))]
@@ -153,8 +153,8 @@ use warp_graphql::{
 pub use crate::ai::agent::UserQueryMode;
 // Re-export ambient agent types for backwards compatibility
 pub use crate::ai::ambient_agents::{
-    task::{AttachmentInput, TaskAttachment},
     AgentConfigSnapshot, AgentSource, AmbientAgentTask, AmbientAgentTaskState, TaskStatusMessage,
+    task::{AttachmentInput, TaskAttachment},
 };
 
 const AI_ASSISTANT_REQUEST_TIMEOUT_SECONDS: u64 = 30;
@@ -429,6 +429,19 @@ impl ArtifactDownloadResponse {
         }
     }
 
+    pub fn stable_download_url(&self) -> &str {
+        match self {
+            ArtifactDownloadResponse::Screenshot { data, .. } => data
+                .stable_download_url
+                .as_deref()
+                .unwrap_or(&data.download_url),
+            ArtifactDownloadResponse::File { data, .. } => data
+                .stable_download_url
+                .as_deref()
+                .unwrap_or(&data.download_url),
+        }
+    }
+
     pub fn expires_at(&self) -> DateTime<Utc> {
         match self {
             ArtifactDownloadResponse::Screenshot { data, .. } => data.expires_at,
@@ -482,6 +495,7 @@ pub struct ArtifactDownloadCommonFields {
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct ScreenshotArtifactResponseData {
     pub download_url: String,
+    pub stable_download_url: Option<String>,
     pub expires_at: DateTime<Utc>,
     pub content_type: String,
     pub description: Option<String>,
@@ -491,6 +505,7 @@ pub struct ScreenshotArtifactResponseData {
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct FileArtifactResponseData {
     pub download_url: String,
+    pub stable_download_url: Option<String>,
     pub expires_at: DateTime<Utc>,
     pub content_type: String,
     pub filepath: String,
@@ -563,6 +578,7 @@ pub struct CreateFileArtifactUploadRequest {
 #[derive(Debug, Clone)]
 pub struct FileArtifactRecord {
     pub artifact_uid: String,
+    pub stable_download_url: String,
     pub filepath: String,
     pub description: Option<String>,
     pub mime_type: String,
@@ -1115,6 +1131,7 @@ fn into_file_artifact_record(
 ) -> FileArtifactRecord {
     FileArtifactRecord {
         artifact_uid: artifact.artifact_uid.into_inner(),
+        stable_download_url: artifact.stable_download_url,
         filepath: artifact.filepath,
         description: artifact.description,
         mime_type: artifact.mime_type,

--- a/app/src/server/server_api/ai_tests.rs
+++ b/app/src/server/server_api/ai_tests.rs
@@ -2,14 +2,14 @@ use chrono::TimeZone;
 use chrono::Utc;
 use futures::executor::block_on;
 
-use super::super::auth::CLOUD_AGENT_ID_HEADER;
 use super::super::ServerApi;
+use super::super::auth::CLOUD_AGENT_ID_HEADER;
 use super::{
-    build_fork_conversation_url, build_list_agent_runs_url, build_run_followup_url,
     AgentMessageHeader, AgentRunEvent, AgentSource, AmbientAgentTaskState, Artifact,
     ArtifactDownloadResponse, ArtifactType, ExecutionLocation, ForkConversationResponse,
     ListRunsResponse, ReadAgentMessageResponse, RunFollowupRequest, RunSortBy, RunSortOrder,
-    SpawnAgentRequest, TaskListFilter, UserQueryMode,
+    SpawnAgentRequest, TaskListFilter, UserQueryMode, build_fork_conversation_url,
+    build_list_agent_runs_url, build_run_followup_url,
 };
 use crate::notebooks::NotebookId;
 

--- a/crates/graphql/src/api/ai.rs
+++ b/crates/graphql/src/api/ai.rs
@@ -102,6 +102,7 @@ pub struct ScreenshotArtifact {
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct FileArtifact {
     pub artifact_uid: cynic::Id,
+    pub stable_download_url: String,
     pub filepath: String,
     pub mime_type: String,
     pub description: Option<String>,

--- a/crates/graphql/src/api/mutations/create_file_artifact_upload_target.rs
+++ b/crates/graphql/src/api/mutations/create_file_artifact_upload_target.rs
@@ -41,6 +41,7 @@ pub struct CreateFileArtifactUploadTargetOutput {
 #[derive(cynic::QueryFragment, Debug)]
 pub struct FileArtifact {
     pub artifact_uid: cynic::Id,
+    pub stable_download_url: String,
     pub filepath: String,
     pub description: Option<String>,
     pub mime_type: String,

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -1258,6 +1258,7 @@ type FeatureModelChoice {
 
 type FileArtifact {
   artifactUid: ID!
+  stableDownloadUrl: String!
   description: String
   filepath: String!
   mimeType: String!


### PR DESCRIPTION
## Summary
- add stable_download_url to FileArtifact GraphQL fragments and client schema
- surface stable download URLs in artifact get and hidden artifact upload CLI outputs
- preserve compatibility with older REST responses by falling back to temporary download_url when stable_download_url is absent

## Verification
- cargo test -p warp --lib write_get_output_to --features local_fs
- cargo test -p warp --lib write_upload_output_to --features local_fs
- cargo test -p warp --lib file_artifact --features local_fs
- cargo test -p warp --lib screenshot_artifact --features local_fs

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._