### PR TITLE
Fix daemon message too big error

### DIFF
--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -1022,16 +1022,35 @@ impl ServerModel {
             move |me, result, _ctx| {
                 let result_oneof = match result {
                     Ok(output) => {
+                        let mut stdout = output.stdout.clone();
+                        let mut stderr = output.stderr.clone();
+
+                        // Truncate to stay under the wire-level message size
+                        // limit. Leave headroom for protobuf framing overhead.
+                        const MAX_OUTPUT_BYTES: usize =
+                            remote_server::protocol::MAX_MESSAGE_SIZE - 1024;
+                        let total = stdout.len() + stderr.len();
+                        if total > MAX_OUTPUT_BYTES {
+                            log::warn!(
+                                "RunCommand output too large \
+                                 (request_id={request_id_for_response}): \
+                                 {total} bytes, truncating to {MAX_OUTPUT_BYTES}"
+                            );
+                            let ratio = MAX_OUTPUT_BYTES as f64 / total as f64;
+                            stdout.truncate((stdout.len() as f64 * ratio) as usize);
+                            stderr.truncate((stderr.len() as f64 * ratio) as usize);
+                        }
+
                         log::info!(
                             "RunCommand completed (request_id={request_id_for_response}): \
                              exit_code={:?}, stdout_len={}, stderr_len={}",
                             output.exit_code,
-                            output.stdout.len(),
-                            output.stderr.len(),
+                            stdout.len(),
+                            stderr.len(),
                         );
                         run_command_response::Result::Success(RunCommandSuccess {
-                            stdout: output.stdout.clone(),
-                            stderr: output.stderr.clone(),
+                            stdout,
+                            stderr,
                             exit_code: output.exit_code.map(|c| c.value()),
                         })
                     }

--- a/app/src/remote_server/unix/mod.rs
+++ b/app/src/remote_server/unix/mod.rs
@@ -193,8 +193,36 @@ pub(super) async fn handle_daemon_connection(
     // deregister_connection) or a fatal write error occurs.
     while let Ok(msg) = conn_rx.recv().await {
         if let Err(e) = remote_server::protocol::write_server_message(&mut writer, &msg).await {
-            log::error!("Daemon: write error on conn {conn_id}: {e}");
-            break;
+            if !e.is_write_recoverable() {
+                log::error!("Daemon: write error on conn {conn_id}: {e}");
+                break;
+            }
+            // Recoverable write error (e.g. MessageTooLarge): nothing was
+            // written to the stream, so it remains aligned. Log and skip
+            // rather than tearing down the entire connection.
+            log::warn!("Daemon: skipping undeliverable message on conn {conn_id}: {e}");
+
+            // Send an ErrorResponse so the client doesn't hang waiting
+            // for a response that will never arrive.
+            if msg.request_id.is_empty() {
+                continue;
+            }
+            let error_msg = remote_server::proto::ServerMessage {
+                request_id: msg.request_id.clone(),
+                message: Some(remote_server::proto::server_message::Message::Error(
+                    remote_server::proto::ErrorResponse {
+                        code: remote_server::proto::ErrorCode::Internal.into(),
+                        message: format!("Response could not be delivered: {e}"),
+                    },
+                )),
+            };
+            if let Err(e2) =
+                remote_server::protocol::write_server_message(&mut writer, &error_msg).await
+            {
+                log::warn!("Daemon: failed to send error response on conn {conn_id}: {e2}");
+                continue;
+            }
+            // Fall through to flush the error response.
         }
         // Flush after every message so responses reach the proxy without
         // waiting for the BufWriter's internal buffer to fill up.

--- a/app/src/remote_server/unix/mod.rs
+++ b/app/src/remote_server/unix/mod.rs
@@ -219,6 +219,10 @@ pub(super) async fn handle_daemon_connection(
             if let Err(e2) =
                 remote_server::protocol::write_server_message(&mut writer, &error_msg).await
             {
+                if !e2.is_write_recoverable() {
+                    log::error!("Daemon: failed to send error response on conn {conn_id}: {e2}");
+                    break;
+                }
                 log::warn!("Daemon: failed to send error response on conn {conn_id}: {e2}");
                 continue;
             }


### PR DESCRIPTION
## Description
This PR includes two parts:
1. In our run command executor, we do not put a cap on the response sizing. This could cause us to return an output that exceeds the max allowed size for the proto stream
2. On the remote server, we were dropping the stream when we encounter a write error, even when the error is recoverable (e.g. message too big). Instead we should send an error response and allow the stream to continue.
