### PR TITLE
Bypass RunAgents confirmation for autonomous (CLI driver) agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14831,7 +14831,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=3dd0cd81eae83b4ce09c7805c8ef12599798aa26#3dd0cd81eae83b4ce09c7805c8ef12599798aa26"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=72b3864#72b386424457094b7d06704298d3245fb08fea90"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14831,7 +14831,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=72b3864#72b386424457094b7d06704298d3245fb08fea90"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=72b386424457094b7d06704298d3245fb08fea90#72b386424457094b7d06704298d3245fb08fea90"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "72b3864" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "72b386424457094b7d06704298d3245fb08fea90" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "3dd0cd81eae83b4ce09c7805c8ef12599798aa26" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "72b3864" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_from.rs
+++ b/app/src/ai/agent/api/convert_from.rs
@@ -133,6 +133,7 @@ fn convert_run_agents(run_agents: api::RunAgents) -> AIAgentActionType {
         harness,
         agent_run_configs,
         execution_mode,
+        plan_id,
     } = run_agents;
     AIAgentActionType::RunAgents(RunAgentsRequest {
         summary,
@@ -152,6 +153,7 @@ fn convert_run_agents(run_agents: api::RunAgents) -> AIAgentActionType {
                 title: config.title,
             })
             .collect(),
+        plan_id,
     })
 }
 

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -233,11 +233,10 @@ pub struct AIConversation {
     /// re-delivering already-processed events.
     last_event_sequence: Option<i64>,
 
-    /// Per-conversation orchestration config hydrated from
+    /// Per-plan orchestration configs hydrated from
     /// `OrchestrationConfigSnapshot` messages in the conversation's task list.
-    orchestration_config: Option<OrchestrationConfig>,
-    orchestration_status: OrchestrationConfigStatus,
-    orchestration_plan_id: Option<String>,
+    /// Keyed by `plan_id`; snapshots with empty `plan_id` are ignored.
+    orchestration_configs: HashMap<String, (OrchestrationConfig, OrchestrationConfigStatus)>,
 }
 
 pub(crate) fn artifact_from_fork_proto(
@@ -289,9 +288,7 @@ impl AIConversation {
             parent_conversation_id: None,
             is_remote_child: false,
             last_event_sequence: None,
-            orchestration_config: None,
-            orchestration_status: OrchestrationConfigStatus::default(),
-            orchestration_plan_id: None,
+            orchestration_configs: HashMap::new(),
         }
     }
 
@@ -482,9 +479,7 @@ impl AIConversation {
             parent_conversation_id,
             is_remote_child,
             last_event_sequence,
-            orchestration_config: None,
-            orchestration_status: OrchestrationConfigStatus::default(),
-            orchestration_plan_id: None,
+            orchestration_configs: HashMap::new(),
         })
     }
 
@@ -879,33 +874,67 @@ impl AIConversation {
         self.is_remote_child = true;
     }
 
-    pub fn orchestration_config(&self) -> Option<&OrchestrationConfig> {
-        self.orchestration_config.as_ref()
+    /// Returns the orchestration config and status for a specific plan,
+    /// or `None` if no config has been hydrated for that plan.
+    pub fn orchestration_config_for_plan(
+        &self,
+        plan_id: &str,
+    ) -> Option<(&OrchestrationConfig, OrchestrationConfigStatus)> {
+        self.orchestration_configs
+            .get(plan_id)
+            .map(|(config, status)| (config, *status))
     }
 
-    pub fn orchestration_status(&self) -> OrchestrationConfigStatus {
-        self.orchestration_status
+    /// Returns `true` if at least one plan has an orchestration config.
+    pub fn has_any_orchestration_config(&self) -> bool {
+        !self.orchestration_configs.is_empty()
     }
 
-    pub fn orchestration_plan_id(&self) -> Option<&str> {
-        self.orchestration_plan_id.as_deref()
-    }
-
-    /// Replaces the orchestration config, status, and plan_id for this
-    /// conversation. Returns `true` if any value actually changed.
-    pub fn set_orchestration_config(
+    /// Inserts or replaces the orchestration config for a specific plan.
+    /// Returns `true` if the value actually changed.
+    pub fn set_orchestration_config_for_plan(
         &mut self,
-        config: Option<OrchestrationConfig>,
+        plan_id: String,
+        config: OrchestrationConfig,
         status: OrchestrationConfigStatus,
-        plan_id: Option<String>,
     ) -> bool {
-        let changed = self.orchestration_config != config
-            || self.orchestration_status != status
-            || self.orchestration_plan_id != plan_id;
-        self.orchestration_config = config;
-        self.orchestration_status = status;
-        self.orchestration_plan_id = plan_id;
-        changed
+        use std::collections::hash_map::Entry;
+        match self.orchestration_configs.entry(plan_id) {
+            Entry::Occupied(mut entry) => {
+                let existing = entry.get();
+                if existing.0 != config || existing.1 != status {
+                    entry.insert((config, status));
+                    true
+                } else {
+                    false
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((config, status));
+                true
+            }
+        }
+    }
+
+    /// Returns a reference to the full per-plan config map.
+    pub fn orchestration_configs(
+        &self,
+    ) -> &HashMap<String, (OrchestrationConfig, OrchestrationConfigStatus)> {
+        &self.orchestration_configs
+    }
+
+    /// Bulk-replaces all orchestration configs (used during hydration).
+    /// Returns `true` if the map actually changed.
+    pub fn set_orchestration_configs(
+        &mut self,
+        configs: HashMap<String, (OrchestrationConfig, OrchestrationConfigStatus)>,
+    ) -> bool {
+        if self.orchestration_configs != configs {
+            self.orchestration_configs = configs;
+            true
+        } else {
+            false
+        }
     }
 
     /// Returns a flat list of linearized messages across all tasks, interpolating subtask messages
@@ -2380,24 +2409,27 @@ impl AIConversation {
                         Some(api::message::Message::OrchestrationConfigSnapshot(
                             snapshot,
                         )) => {
-                            let config = snapshot
-                                .config
-                                .as_ref()
-                                .map(OrchestrationConfig::from_proto);
-                            let status = OrchestrationConfigStatus::from_proto(
-                                snapshot.status.as_ref(),
-                            );
-                            let plan_id = if snapshot.plan_id.is_empty() {
-                                None
-                            } else {
-                                Some(snapshot.plan_id.clone())
-                            };
-                            if self.set_orchestration_config(config, status, plan_id) {
-                                ctx.emit(
-                                    BlocklistAIHistoryEvent::OrchestrationConfigUpdated {
-                                        conversation_id: self.id,
-                                    },
-                                );
+                            if !snapshot.plan_id.is_empty() {
+                                if let Some(config) = snapshot
+                                    .config
+                                    .as_ref()
+                                    .map(OrchestrationConfig::from_proto)
+                                {
+                                    let status = OrchestrationConfigStatus::from_proto(
+                                        snapshot.status.as_ref(),
+                                    );
+                                    if self.set_orchestration_config_for_plan(
+                                        snapshot.plan_id.clone(),
+                                        config,
+                                        status,
+                                    ) {
+                                        ctx.emit(
+                                            BlocklistAIHistoryEvent::OrchestrationConfigUpdated {
+                                                conversation_id: self.id,
+                                            },
+                                        );
+                                    }
+                                }
                             }
                         }
                         Some(api::message::Message::ToolCallResult(tcr)) => {

--- a/app/src/ai/ai_document_view.rs
+++ b/app/src/ai/ai_document_view.rs
@@ -306,9 +306,7 @@ impl AIDocumentView {
                                 let plan_id = document_id.to_string();
                                 me.orchestration_config_block =
                                     Some(ctx.add_typed_action_view(move |ctx| {
-                                        OrchestrationConfigBlockView::new(
-                                            conv_id, plan_id, ctx,
-                                        )
+                                        OrchestrationConfigBlockView::new(conv_id, plan_id, ctx)
                                     }));
                             }
                             ctx.notify();
@@ -1071,10 +1069,7 @@ impl View for AIDocumentView {
                 let plan_id_str = self.document_id.to_string();
                 BlocklistAIHistoryModel::as_ref(app)
                     .conversation(&cid)
-                    .and_then(|conv| {
-                        conv.orchestration_config_for_plan(&plan_id_str)
-                            .map(|_| ())
-                    })
+                    .and_then(|conv| conv.orchestration_config_for_plan(&plan_id_str).map(|_| ()))
             })
             .is_some();
 

--- a/app/src/ai/ai_document_view.rs
+++ b/app/src/ai/ai_document_view.rs
@@ -303,10 +303,11 @@ impl AIDocumentView {
                             // sends the orchestration config).
                             if me.orchestration_config_block.is_none() {
                                 let conv_id = *cid;
+                                let plan_id = document_id.to_string();
                                 me.orchestration_config_block =
                                     Some(ctx.add_typed_action_view(move |ctx| {
-                                        OrchestrationConfigBlockView::new_with_conversation_id(
-                                            conv_id, ctx,
+                                        OrchestrationConfigBlockView::new(
+                                            conv_id, plan_id, ctx,
                                         )
                                     }));
                             }
@@ -436,11 +437,17 @@ impl AIDocumentView {
         let has_orchestration_config = doc_conversation_id.and_then(|cid| {
             BlocklistAIHistoryModel::as_ref(ctx)
                 .conversation(&cid)
-                .and_then(|conv| conv.orchestration_config().map(|_| cid))
+                .and_then(|conv| {
+                    let plan_id_str = document_id.to_string();
+                    conv.orchestration_config_for_plan(&plan_id_str)
+                        .map(|_| cid)
+                })
         });
+        let doc_id_for_block = document_id;
         let orchestration_config_block = has_orchestration_config.map(|conv_id| {
+            let plan_id = doc_id_for_block.to_string();
             ctx.add_typed_action_view(move |ctx| {
-                OrchestrationConfigBlockView::new_with_conversation_id(conv_id, ctx)
+                OrchestrationConfigBlockView::new(conv_id, plan_id, ctx)
             })
         });
 
@@ -1061,9 +1068,13 @@ impl View for AIDocumentView {
         let has_orchestration_config = AIDocumentModel::as_ref(app)
             .get_conversation_id_for_document_id(&self.document_id)
             .and_then(|cid| {
+                let plan_id_str = self.document_id.to_string();
                 BlocklistAIHistoryModel::as_ref(app)
                     .conversation(&cid)
-                    .and_then(|conv| conv.orchestration_config().map(|_| ()))
+                    .and_then(|conv| {
+                        conv.orchestration_config_for_plan(&plan_id_str)
+                            .map(|_| ())
+                    })
             })
             .is_some();
 

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -10,8 +10,10 @@ use ai::agent::action_result::{
     RunAgentsAgentOutcome, RunAgentsAgentOutcomeKind, RunAgentsLaunchedExecutionMode,
     RunAgentsResult,
 };
+use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationExecutionMode};
 use ai::skills::SkillReference;
 use futures::{future::BoxFuture, FutureExt};
+use warp_core::execution_mode::AppExecutionMode;
 use warpui::{Entity, ModelContext, ModelHandle};
 
 use super::start_agent::{StartAgentExecutor, StartAgentOutcome};
@@ -253,9 +255,35 @@ impl RunAgentsExecutor {
         let AIAgentActionType::RunAgents(request) = action else {
             return ActionExecution::InvalidAction;
         };
-        let request = request.clone();
+        let mut request = request.clone();
         let action_id = id.clone();
         let parent_conversation_id = input.conversation_id;
+
+        // When auto-executing (autonomous/CLI-driver mode), the confirmation
+        // card is bypassed. Replicate its policy/normalization here:
+        // 1. Deny if the orchestration config is explicitly disapproved.
+        // 2. Resolve empty model/harness/execution_mode from the approved config.
+        if AppExecutionMode::as_ref(ctx).is_autonomous() {
+            if let Some(conversation) =
+                BlocklistAIHistoryModel::as_ref(ctx).conversation(&parent_conversation_id)
+            {
+                if let Some((config, status)) =
+                    conversation.orchestration_config_for_plan(&request.plan_id)
+                {
+                    if status.is_disapproved() {
+                        return ActionExecution::Sync(AIAgentActionResultType::RunAgents(
+                            RunAgentsResult::Denied {
+                                reason: "Orchestration config was disapproved".to_string(),
+                            },
+                        ));
+                    }
+                    if status.is_approved() {
+                        resolve_request_from_config(&mut request, config);
+                    }
+                }
+            }
+        }
+
         let receiver = self.dispatch_run_agents(action_id, request, parent_conversation_id, ctx);
 
         ActionExecution::new_async(
@@ -270,10 +298,11 @@ impl RunAgentsExecutor {
     pub(super) fn should_autoexecute(
         &self,
         _input: ExecuteActionInput,
-        _ctx: &mut ModelContext<Self>,
+        ctx: &mut ModelContext<Self>,
     ) -> bool {
-        // Confirmation card always required.
-        false
+        // Non-interactive (CLI driver) agents cannot present a
+        // confirmation card, so they must auto-execute.
+        AppExecutionMode::as_ref(ctx).is_autonomous()
     }
 
     pub(super) fn preprocess_action(
@@ -288,6 +317,31 @@ impl RunAgentsExecutor {
 enum ChildSlot {
     Failed(String),
     Pending(async_channel::Receiver<StartAgentOutcome>),
+}
+
+/// Resolves empty fields on a `RunAgentsRequest` from an approved
+/// orchestration config — the same normalization the confirmation card
+/// applies via `OrchestrationEditState::resolve_from_config`.
+fn resolve_request_from_config(request: &mut RunAgentsRequest, config: &OrchestrationConfig) {
+    if request.harness_type.is_empty() && !config.harness_type.is_empty() {
+        request.harness_type = config.harness_type.clone();
+    }
+    if request.model_id.is_empty() && !config.model_id.is_empty() {
+        request.model_id = config.model_id.clone();
+    }
+    if !request.execution_mode.is_remote() && config.execution_mode.is_remote() {
+        if let OrchestrationExecutionMode::Remote {
+            environment_id,
+            worker_host,
+        } = &config.execution_mode
+        {
+            request.execution_mode = RunAgentsExecutionMode::Remote {
+                environment_id: environment_id.clone(),
+                worker_host: worker_host.clone(),
+                computer_use_enabled: false,
+            };
+        }
+    }
 }
 
 /// Defence-in-depth validation; mirrors the card view's

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -6497,11 +6497,14 @@ impl AIBlock {
         let active_config = {
             let history = crate::BlocklistAIHistoryModel::as_ref(ctx);
             let conv = history.conversation(&self.client_ids.conversation_id);
-            let result = conv.and_then(|conv| {
-                conv.orchestration_config()
-                    .cloned()
-                    .map(|config| (config, conv.orchestration_status()))
-            });
+            let result = if !request.plan_id.is_empty() {
+                conv.and_then(|conv| {
+                    conv.orchestration_config_for_plan(&request.plan_id)
+                        .map(|(config, status)| (config.clone(), status))
+                })
+            } else {
+                None
+            };
             result
         };
 

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -2356,9 +2356,10 @@ impl AIBlock {
         // Now that streaming is complete and all RunAgents requests are
         // fully populated, re-evaluate auto-launch for any card that
         // was created during streaming with an empty agent_run_configs.
+        let conversation_id_for_auto_launch = self.client_ids.conversation_id;
         for view in self.run_agents_card_views.values() {
             view.update(ctx, |card, ctx| {
-                card.try_auto_launch_on_stream_complete(ctx);
+                card.try_auto_launch_on_stream_complete(conversation_id_for_auto_launch, ctx);
             });
         }
 

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -743,11 +743,11 @@ impl BlocklistAIController {
         };
         inputs.push(ai_input);
 
-        // Piggyback any pending orchestration config update for this conversation.
-        let taken_dirty_event = AIDocumentModel::handle(ctx).update(ctx, |model, _| {
-            model.take_dirty_orchestration_event(&conversation_id)
+        // Piggyback any pending orchestration config updates for this conversation.
+        let taken_dirty_events = AIDocumentModel::handle(ctx).update(ctx, |model, _| {
+            model.take_dirty_orchestration_events(&conversation_id)
         });
-        if let Some(ref dirty_event) = taken_dirty_event {
+        for dirty_event in &taken_dirty_events {
             inputs.push(AIAgentInput::OrchestrationConfigUpdate {
                 plan_id: dirty_event.plan_id.clone(),
                 config: dirty_event.config.clone(),
@@ -776,13 +776,13 @@ impl BlocklistAIController {
             ctx,
         );
 
-        // If the request failed, re-insert the dirty event so it isn't
+        // If the request failed, re-insert the dirty events so they aren't
         // silently lost.
         if let Err(e) = &send_result {
             log::error!("Failed to send agent request: {e:?}");
-            if let Some(dirty_event) = taken_dirty_event {
+            if !taken_dirty_events.is_empty() {
                 AIDocumentModel::handle(ctx).update(ctx, |model, _| {
-                    model.set_dirty_orchestration_event(conversation_id, dirty_event);
+                    model.set_dirty_orchestration_events(conversation_id, taken_dirty_events);
                 });
             }
         }

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -152,10 +152,7 @@ impl OrchestrationEditState {
     /// `worker_host` from the config. If the state is `Local` while the
     /// config is `Remote` (or vice-versa), does nothing — variant
     /// mismatches are intentional.
-    pub fn resolve_execution_mode_from_config(
-        &mut self,
-        config_mode: &OrchestrationExecutionMode,
-    ) {
+    pub fn resolve_execution_mode_from_config(&mut self, config_mode: &OrchestrationExecutionMode) {
         if let (
             RunAgentsExecutionMode::Remote {
                 environment_id,

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -147,6 +147,36 @@ impl OrchestrationEditState {
         }
     }
 
+    /// Fills empty execution-mode fields from the given config.
+    /// If both sides are `Remote`, inherits empty `environment_id` and
+    /// `worker_host` from the config. If the state is `Local` while the
+    /// config is `Remote` (or vice-versa), does nothing — variant
+    /// mismatches are intentional.
+    pub fn resolve_execution_mode_from_config(
+        &mut self,
+        config_mode: &OrchestrationExecutionMode,
+    ) {
+        if let (
+            RunAgentsExecutionMode::Remote {
+                environment_id,
+                worker_host,
+                ..
+            },
+            OrchestrationExecutionMode::Remote {
+                environment_id: cfg_env,
+                worker_host: cfg_host,
+            },
+        ) = (&mut self.execution_mode, config_mode)
+        {
+            if environment_id.is_empty() {
+                *environment_id = cfg_env.clone();
+            }
+            if worker_host.is_empty() {
+                *worker_host = cfg_host.clone();
+            }
+        }
+    }
+
     /// Returns `Some(reason)` if Accept / Apply must be disabled.
     /// Only hard block: OpenCode + Cloud.
     pub fn accept_disabled_reason(&self) -> Option<&'static str> {

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -87,6 +87,8 @@ pub struct RunAgentsEditState {
     pub summary: String,
     /// Run-wide skills propagated to each child at dispatch.
     pub skills: Vec<SkillReference>,
+    /// The plan that this RunAgents call is executing for.
+    pub plan_id: String,
 }
 
 impl RunAgentsEditState {
@@ -101,6 +103,7 @@ impl RunAgentsEditState {
             base_prompt: req.base_prompt.clone(),
             summary: req.summary.clone(),
             skills: req.skills.clone(),
+            plan_id: req.plan_id.clone(),
         }
     }
 
@@ -113,6 +116,7 @@ impl RunAgentsEditState {
             harness_type: self.orch.harness_type.clone(),
             execution_mode: self.orch.execution_mode.clone(),
             agent_run_configs: self.agent_run_configs.clone(),
+            plan_id: self.plan_id.clone(),
         }
     }
 }

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -477,9 +477,9 @@ impl RunAgentsCardView {
                 if self.state.orch.harness_type.is_empty() {
                     self.state.orch.harness_type = config.harness_type.clone();
                 }
-                self.state.orch.resolve_execution_mode_from_config(
-                    &config.execution_mode,
-                );
+                self.state
+                    .orch
+                    .resolve_execution_mode_from_config(&config.execution_mode);
             }
             // Re-evaluate denied status with the refreshed config.
             self.is_denied = compute_is_denied(self.is_denied, &self.active_config);

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -8,6 +8,8 @@ use ai::agent::action_result::{RunAgentsAgentOutcomeKind, RunAgentsResult};
 use ai::agent::orchestration_config::{
     matches_active_config, OrchestrationConfig, OrchestrationConfigStatus,
 };
+
+use crate::ai::agent::conversation::AIConversationId;
 use ai::skills::SkillReference;
 use pathfinder_geometry::vector::vec2f;
 use std::rc::Rc;
@@ -449,7 +451,26 @@ impl RunAgentsCardView {
     /// the request is fully populated.  Called from
     /// `AIBlock::handle_complete_output` so we don't act on partial
     /// streaming chunks that arrive with an empty `agent_run_configs`.
-    pub fn try_auto_launch_on_stream_complete(&mut self, ctx: &mut ViewContext<Self>) {
+    pub fn try_auto_launch_on_stream_complete(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        // Refresh active_config: at card construction time plan_id may
+        // have been empty (not yet streamed) so active_config was None.
+        // Now that streaming is complete the full plan_id is available
+        // and the OrchestrationConfigSnapshot should already be hydrated.
+        if self.active_config.is_none() && !self.state.plan_id.is_empty() {
+            self.active_config = crate::BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .and_then(|conv| {
+                    conv.orchestration_config_for_plan(&self.state.plan_id)
+                        .map(|(c, s)| (c.clone(), s))
+                });
+            // Re-evaluate denied status with the refreshed config.
+            self.is_denied = compute_is_denied(self.is_denied, &self.active_config);
+        }
+
         if should_auto_launch(
             self.auto_launched,
             self.is_denied,

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -467,6 +467,20 @@ impl RunAgentsCardView {
                     conv.orchestration_config_for_plan(&self.state.plan_id)
                         .map(|(c, s)| (c.clone(), s))
                 });
+            // Resolve empty/default state fields from the config so the
+            // dispatched request carries concrete values rather than
+            // relying on server-side inheritance.
+            if let Some((config, _)) = &self.active_config {
+                if self.state.orch.model_id.is_empty() {
+                    self.state.orch.model_id = config.model_id.clone();
+                }
+                if self.state.orch.harness_type.is_empty() {
+                    self.state.orch.harness_type = config.harness_type.clone();
+                }
+                self.state.orch.resolve_execution_mode_from_config(
+                    &config.execution_mode,
+                );
+            }
             // Re-evaluate denied status with the refreshed config.
             self.is_denied = compute_is_denied(self.is_denied, &self.active_config);
         }

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
@@ -29,6 +29,7 @@ fn make_request_with_skills(
             prompt: "do work".to_string(),
             title: "Child agent".to_string(),
         }],
+        plan_id: String::new(),
     }
 }
 

--- a/app/src/ai/document/ai_document_model.rs
+++ b/app/src/ai/document/ai_document_model.rs
@@ -1232,8 +1232,10 @@ impl AIDocumentModel {
                     &message.message
                 {
                     if !snapshot.plan_id.is_empty() && !configs.contains_key(&snapshot.plan_id) {
-                        if let Some(config) =
-                            snapshot.config.as_ref().map(OrchestrationConfig::from_proto)
+                        if let Some(config) = snapshot
+                            .config
+                            .as_ref()
+                            .map(OrchestrationConfig::from_proto)
                         {
                             let status =
                                 OrchestrationConfigStatus::from_proto(snapshot.status.as_ref());

--- a/app/src/ai/document/ai_document_model.rs
+++ b/app/src/ai/document/ai_document_model.rs
@@ -196,7 +196,7 @@ pub struct AIDocumentModel {
     /// Set when the user edits the config or toggles approval on the
     /// plan card; cleared by the controller after piggybacking onto
     /// the outbound `UserInputs`.
-    dirty_orchestration_events: HashMap<AIConversationId, DirtyOrchestrationEvent>,
+    dirty_orchestration_events: HashMap<(AIConversationId, String), DirtyOrchestrationEvent>,
 }
 
 impl AIDocumentModel {
@@ -1208,113 +1208,112 @@ impl AIDocumentModel {
     }
 
     /// Scans all messages across all tasks in a restored conversation to find
-    /// the last `OrchestrationConfigSnapshot` and hydrate the config from it.
+    /// per-plan `OrchestrationConfigSnapshot` messages and hydrate the config map.
+    /// Backward scan: for each `plan_id`, the first snapshot found (most recent) wins.
     fn scan_conversation_for_orchestration_config(
         &mut self,
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
     ) {
-        // Clone the snapshot out of the history borrow so we can pass
-        // &mut ctx to hydrate below.
-        let snapshot = {
+        use std::collections::HashMap;
+        let configs = {
             let history = BlocklistAIHistoryModel::as_ref(ctx);
             let Some(conversation) = history.conversation(&conversation_id) else {
                 return;
             };
-            // Find the *last* snapshot so we hydrate the most recent config.
-            conversation
+            let mut configs: HashMap<String, (OrchestrationConfig, OrchestrationConfigStatus)> =
+                HashMap::new();
+            let messages: Vec<_> = conversation
                 .all_tasks()
                 .flat_map(|task| task.messages())
-                .filter_map(|message| {
-                    if let Some(maa_api::message::Message::OrchestrationConfigSnapshot(snapshot)) =
-                        &message.message
-                    {
-                        Some(snapshot.clone())
-                    } else {
-                        None
+                .collect();
+            for message in messages.iter().rev() {
+                if let Some(maa_api::message::Message::OrchestrationConfigSnapshot(snapshot)) =
+                    &message.message
+                {
+                    if !snapshot.plan_id.is_empty() && !configs.contains_key(&snapshot.plan_id) {
+                        if let Some(config) =
+                            snapshot.config.as_ref().map(OrchestrationConfig::from_proto)
+                        {
+                            let status =
+                                OrchestrationConfigStatus::from_proto(snapshot.status.as_ref());
+                            configs.insert(snapshot.plan_id.clone(), (config, status));
+                        }
                     }
-                })
-                .last()
+                }
+            }
+            configs
         };
-        if let Some(snapshot) = snapshot {
-            Self::hydrate_orchestration_config_from_snapshot(conversation_id, &snapshot, ctx);
+        if !configs.is_empty() {
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, hctx| {
+                if let Some(conversation) = history.conversation_mut(&conversation_id) {
+                    if conversation.set_orchestration_configs(configs) {
+                        hctx.emit(BlocklistAIHistoryEvent::OrchestrationConfigUpdated {
+                            conversation_id,
+                        });
+                    }
+                }
+            });
         }
     }
 
     // ── Orchestration config accessors ────────────────────────────
 
-    pub fn take_dirty_orchestration_event(
+    /// Takes all dirty orchestration events for the given conversation,
+    /// returning one event per plan that was edited.
+    pub fn take_dirty_orchestration_events(
         &mut self,
         conversation_id: &AIConversationId,
-    ) -> Option<DirtyOrchestrationEvent> {
-        self.dirty_orchestration_events.remove(conversation_id)
+    ) -> Vec<DirtyOrchestrationEvent> {
+        let keys_to_remove: Vec<_> = self
+            .dirty_orchestration_events
+            .keys()
+            .filter(|(cid, _)| cid == conversation_id)
+            .cloned()
+            .collect();
+        keys_to_remove
+            .into_iter()
+            .filter_map(|key| self.dirty_orchestration_events.remove(&key))
+            .collect()
     }
 
-    /// Re-insert a dirty event that was taken but not successfully sent.
-    pub fn set_dirty_orchestration_event(
+    /// Re-insert dirty events that were taken but not successfully sent.
+    pub fn set_dirty_orchestration_events(
         &mut self,
         conversation_id: AIConversationId,
-        event: DirtyOrchestrationEvent,
+        events: Vec<DirtyOrchestrationEvent>,
     ) {
-        self.dirty_orchestration_events
-            .insert(conversation_id, event);
+        for event in events {
+            let plan_id = event.plan_id.clone();
+            self.dirty_orchestration_events
+                .insert((conversation_id, plan_id), event);
+        }
     }
 
-    /// Updates the conversation-level orchestration config and status.
+    /// Updates the per-plan orchestration config and status.
     /// Called from the plan card config block when the user edits a field
     /// or toggles the approval switch.
-    pub fn set_orchestration_config(
+    pub fn set_orchestration_config_for_plan(
         &mut self,
         conversation_id: AIConversationId,
+        plan_id: String,
         config: OrchestrationConfig,
         status: OrchestrationConfigStatus,
-        plan_id: Option<String>,
         ctx: &mut ModelContext<Self>,
     ) {
         self.dirty_orchestration_events.insert(
-            conversation_id,
+            (conversation_id, plan_id.clone()),
             DirtyOrchestrationEvent {
-                plan_id: plan_id.clone().unwrap_or_default(),
+                plan_id: plan_id.clone(),
                 config: config.clone(),
                 status,
             },
         );
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, hctx| {
             if let Some(conversation) = history.conversation_mut(&conversation_id) {
-                conversation.set_orchestration_config(Some(config), status, plan_id);
+                conversation.set_orchestration_config_for_plan(plan_id, config, status);
             }
             hctx.emit(BlocklistAIHistoryEvent::OrchestrationConfigUpdated { conversation_id });
-        });
-    }
-
-    /// Hydrates the orchestration config from an in-history
-    /// `Message.OrchestrationConfigSnapshot`. Called during conversation
-    /// restore and on incoming `UpdateTaskMessage` / `AddMessagesToTask`
-    /// events that carry the snapshot.
-    fn hydrate_orchestration_config_from_snapshot(
-        conversation_id: AIConversationId,
-        snapshot: &maa_api::OrchestrationConfigSnapshot,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let config = snapshot
-            .config
-            .as_ref()
-            .map(OrchestrationConfig::from_proto);
-        let status = OrchestrationConfigStatus::from_proto(snapshot.status.as_ref());
-        let plan_id = if snapshot.plan_id.is_empty() {
-            None
-        } else {
-            Some(snapshot.plan_id.clone())
-        };
-
-        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, hctx| {
-            if let Some(conversation) = history.conversation_mut(&conversation_id) {
-                if conversation.set_orchestration_config(config, status, plan_id) {
-                    hctx.emit(BlocklistAIHistoryEvent::OrchestrationConfigUpdated {
-                        conversation_id,
-                    });
-                }
-            }
         });
     }
 

--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -108,6 +108,7 @@ impl OrchestrationControlAction for OrchestrationConfigBlockAction {
 
 pub struct OrchestrationConfigBlockView {
     conversation_id: AIConversationId,
+    plan_id: String,
     edit_state: OrchestrationEditState,
     pickers: OrchestrationPickerHandles<OrchestrationConfigBlockAction>,
     is_approved: bool,
@@ -118,20 +119,22 @@ pub struct OrchestrationConfigBlockView {
 }
 
 impl OrchestrationConfigBlockView {
-    pub fn new_with_conversation_id(
+    pub fn new(
         conversation_id: AIConversationId,
+        plan_id: String,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         let history = BlocklistAIHistoryModel::as_ref(ctx);
         let (edit_state, is_approved) = history
             .conversation(&conversation_id)
             .and_then(|conv| {
-                conv.orchestration_config().map(|config| {
-                    (
-                        OrchestrationEditState::from_orchestration_config(config),
-                        conv.orchestration_status().is_approved(),
-                    )
-                })
+                conv.orchestration_config_for_plan(&plan_id)
+                    .map(|(config, status)| {
+                        (
+                            OrchestrationEditState::from_orchestration_config(config),
+                            status.is_approved(),
+                        )
+                    })
             })
             .unwrap_or_else(|| {
                 (
@@ -171,6 +174,7 @@ impl OrchestrationConfigBlockView {
 
         let mut view = Self {
             conversation_id,
+            plan_id,
             edit_state,
             pickers: OrchestrationPickerHandles::default(),
             is_approved,
@@ -188,9 +192,9 @@ impl OrchestrationConfigBlockView {
     fn refresh_from_model(&mut self, ctx: &mut ViewContext<Self>) {
         let history = BlocklistAIHistoryModel::as_ref(ctx);
         if let Some(conv) = history.conversation(&self.conversation_id) {
-            if let Some(config) = conv.orchestration_config() {
+            if let Some((config, status)) = conv.orchestration_config_for_plan(&self.plan_id) {
                 self.edit_state = OrchestrationEditState::from_orchestration_config(config);
-                self.is_approved = conv.orchestration_status().is_approved();
+                self.is_approved = status.is_approved();
                 if self.pickers_initialized {
                     oc::sync_picker_selections(&self.edit_state, &self.pickers, ctx);
                 }
@@ -257,13 +261,9 @@ impl OrchestrationConfigBlockView {
             OrchestrationConfigStatus::Disapproved
         };
         let conversation_id = self.conversation_id;
-        // Preserve the existing plan_id from the conversation so we don't
-        // clobber it when the user only edits config fields.
-        let plan_id = BlocklistAIHistoryModel::as_ref(ctx)
-            .conversation(&conversation_id)
-            .and_then(|conv| conv.orchestration_plan_id().map(str::to_string));
+        let plan_id = self.plan_id.clone();
         AIDocumentModel::handle(ctx).update(ctx, |model, ctx| {
-            model.set_orchestration_config(conversation_id, config, status, plan_id, ctx);
+            model.set_orchestration_config_for_plan(conversation_id, plan_id, config, status, ctx);
         });
     }
 }

--- a/crates/ai/src/agent/action/mod.rs
+++ b/crates/ai/src/agent/action/mod.rs
@@ -192,6 +192,7 @@ pub struct RunAgentsRequest {
     pub harness_type: String,
     pub execution_mode: RunAgentsExecutionMode,
     pub agent_run_configs: Vec<RunAgentsAgentRunConfig>,
+    pub plan_id: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/ai/src/agent/orchestration_config_tests.rs
+++ b/crates/ai/src/agent/orchestration_config_tests.rs
@@ -37,6 +37,7 @@ fn make_request(model: &str, harness: &str, remote: bool) -> RunAgentsRequest {
             prompt: String::new(),
             title: String::new(),
         }],
+        plan_id: String::new(),
     }
 }
 

--- a/specs/QUALITY-657/TECH.md
+++ b/specs/QUALITY-657/TECH.md
@@ -1,0 +1,277 @@
+# Associate Orchestration Config with Plan ID — Client Tech Spec
+
+## Problem
+The Warp desktop client stores orchestration config as a **single value per conversation**. When the server switches to per-plan snapshots (append-only, one per plan — see `warp-server/specs/QUALITY-657/TECH.md`), the client needs to:
+1. Hydrate multiple orchestration configs from conversation history, indexed by `plan_id`.
+2. Render a config block on each plan card showing that plan's config.
+3. Thread `plan_id` through the `RunAgents` request so the auto-launch match check is plan-scoped.
+4. Send per-plan dirty events back to the server.
+
+## Companion spec
+Server-side changes are documented in `warp-server/specs/QUALITY-657/TECH.md`. The proto changes (`plan_id` on `RunAgents` field 9, append-only `OrchestrationConfigSnapshot` messages) land in `warp-proto-apis` before this work begins. This spec covers only the Warp desktop client (Rust).
+
+## Relevant code
+
+### Hydration and model
+- `app/src/ai/document/ai_document_model.rs (1192-1319)` — `handle_history_event_for_orchestration_config()` and `scan_conversation_for_orchestration_config()`. Currently calls `.last()` on all snapshot messages to find the single config.
+- `app/src/ai/document/ai_document_model.rs (195-199)` — `dirty_orchestration_events: HashMap<AIConversationId, DirtyOrchestrationEvent>`. One dirty event per conversation.
+
+### Conversation state
+- `app/src/ai/agent/conversation.rs (882-909)` — `orchestration_config()`, `orchestration_status()`, `orchestration_plan_id()`, `set_orchestration_config()`. Single config/status/plan_id stored per conversation.
+
+### Plan card config block
+- `app/src/ai/document/orchestration_config_block.rs (109-186)` — `OrchestrationConfigBlockView`. Keyed by conversation, not by plan.
+- `app/src/ai/ai_document_view.rs (1061-1085)` — Renders a single config block if the conversation has an orchestration config.
+
+### Auto-launch / match check
+- `crates/ai/src/agent/orchestration_config.rs (52-96)` — `matches_active_config()`. Compares a `RunAgentsRequest` against a single `OrchestrationConfig`.
+- `app/src/ai/blocklist/inline_action/run_agents_card_view.rs (189-268)` — `should_auto_launch()`. Receives `active_config: Option<(OrchestrationConfig, OrchestrationConfigStatus)>` — no `plan_id` context.
+
+### RunAgents request
+- `crates/ai/src/agent/action/mod.rs (187-195)` — `RunAgentsRequest` struct. No `plan_id` field.
+
+### Dirty sync
+- `app/src/ai/blocklist/controller.rs (746-788)` — Takes one dirty event per conversation from `AIDocumentModel`, appends to `inputs`.
+- `app/src/ai/agent/api/convert_to.rs (438-450)` — Converts `AIAgentInput::OrchestrationConfigUpdate` to proto, already includes `plan_id`.
+
+### Dispatch
+- `app/src/ai/blocklist/action_model/execute/run_agents.rs (77-245)` — `dispatch_run_agents()`. No `plan_id` handling. Needs to thread `plan_id` from `RunAgentsRequest` into per-child dispatch calls (for logging/telemetry context, not for child execution).
+
+## Current state
+The client treats orchestration config as a conversation-level singleton:
+- **Hydration**: Scans all messages, takes the `.last()` snapshot, stores one config on the conversation.
+- **Plan card**: One config block per conversation. All plan cards share it.
+- **Auto-launch**: `should_auto_launch()` receives the single active config. No plan_id filtering.
+- **RunAgentsRequest**: No `plan_id` field. The request can't express which plan it's executing.
+- **Dirty sync**: One dirty event per conversation. Editing the config block queues one event.
+
+## Proposed changes
+
+### 1. `RunAgentsRequest`: add `plan_id`
+Add `plan_id` to the request struct in `crates/ai/src/agent/action/mod.rs`:
+```rust
+pub struct RunAgentsRequest {
+    pub summary: String,
+    pub base_prompt: String,
+    pub skills: Vec<SkillReference>,
+    pub model_id: String,
+    pub harness_type: String,
+    pub execution_mode: RunAgentsExecutionMode,
+    pub agent_run_configs: Vec<RunAgentsAgentRunConfig>,
+    pub plan_id: String,  // NEW
+}
+```
+Update the proto-to-struct conversion (wherever `RunAgentsRequest` is built from the `RunAgents` proto) to read `plan_id` from the proto field 9.
+
+Note: `RunAgentsResult::Launched` does not need a `plan_id` field — the client already has `plan_id` from the `RunAgentsRequest` and does not need it repeated on the result.
+
+### 2. Conversation state: per-plan config map
+Replace the single config on `AIAgentConversation` with a map:
+```rust
+// Before (conversation.rs):
+orchestration_config: Option<OrchestrationConfig>,
+orchestration_status: OrchestrationConfigStatus,
+orchestration_plan_id: Option<String>,
+
+// After:
+orchestration_configs: HashMap<String, (OrchestrationConfig, OrchestrationConfigStatus)>,
+```
+Keyed by `plan_id`. Snapshots with empty `plan_id` are ignored (legacy conversations).
+
+New accessors:
+```rust
+pub fn orchestration_config_for_plan(&self, plan_id: &str)
+    -> Option<(&OrchestrationConfig, OrchestrationConfigStatus)>
+
+pub fn set_orchestration_config_for_plan(
+    &mut self,
+    plan_id: String,
+    config: OrchestrationConfig,
+    status: OrchestrationConfigStatus,
+) -> bool
+```
+
+Remove the old `orchestration_config()`, `orchestration_status()`, `orchestration_plan_id()`, `set_orchestration_config()` accessors.
+
+### 3. Hydration: scan and index by `plan_id`
+Change `scan_conversation_for_orchestration_config()` in `ai_document_model.rs`:
+
+**Before**: Finds the `.last()` `OrchestrationConfigSnapshot` message, stores a single config.
+
+**After**: Scans backward through all messages. For each `OrchestrationConfigSnapshot` with a non-empty `plan_id`, stores the first one found during the backward scan (i.e. the most recent) per `plan_id`. Result is a map of `plan_id → (config, status)` set on the conversation.
+
+```rust
+fn scan_conversation_for_orchestration_config(messages: &[Message]) -> HashMap<String, (OrchestrationConfig, OrchestrationConfigStatus)> {
+    let mut configs = HashMap::new();
+    for msg in messages.iter().rev() {
+        if let Some(snapshot) = msg.orchestration_config_snapshot() {
+            let plan_id = snapshot.plan_id();
+            if !plan_id.is_empty() && !configs.contains_key(plan_id) {
+                configs.insert(plan_id.to_string(), (
+                    OrchestrationConfig::from_proto(snapshot.config()),
+                    OrchestrationConfigStatus::from_proto(snapshot.status()),
+                ));
+            }
+        }
+    }
+    configs
+}
+```
+
+Also update `handle_history_event_for_orchestration_config()` to process incremental snapshot messages the same way — when a new snapshot arrives (via `UpdatedConversationStatus` or `AppendedExchange`), insert/overwrite the entry for that `plan_id` in the map.
+
+### 4. Plan card config block: per-plan rendering
+Change `OrchestrationConfigBlockView` to be keyed by `(conversation_id, plan_id)` instead of just `conversation_id`.
+
+In `ai_document_view.rs`, each `AIDocumentView` knows its plan's `document_id` (which is the `plan_id`). Pass it to the config block constructor:
+```rust
+// Before:
+OrchestrationConfigBlockView::new_with_conversation_id(conversation_id, ctx)
+
+// After:
+OrchestrationConfigBlockView::new(conversation_id, plan_id, ctx)
+```
+
+The config block reads its config from `conversation.orchestration_config_for_plan(plan_id)` instead of `conversation.orchestration_config()`.
+
+A plan card only shows a config block if a config exists for its `plan_id`. Plans without configs show no block (rather than sharing a global config).
+
+### 5. Auto-launch: plan-scoped match check
+Change `RunAgentsCardView` construction to look up the config by `plan_id` from the request:
+
+**Before** (line 250-254 of `run_agents_card_view.rs`):
+```rust
+let active_config = conversation.orchestration_config()
+    .map(|c| (c.clone(), conversation.orchestration_status()));
+```
+
+**After**:
+```rust
+let active_config = if !state.plan_id.is_empty() {
+    conversation.orchestration_config_for_plan(&state.plan_id)
+        .map(|(c, s)| (c.clone(), s))
+} else {
+    None
+};
+```
+
+`should_auto_launch()` signature stays the same — it already receives `active_config: &Option<(OrchestrationConfig, OrchestrationConfigStatus)>`. The plan-scoping happens at the call site.
+
+`matches_active_config()` in `orchestration_config.rs` is unchanged — it compares request fields against a config. The plan_id filtering is done before calling it.
+
+### 6. Dirty sync: per-plan dirty events
+Change the dirty event queue from `HashMap<AIConversationId, DirtyOrchestrationEvent>` to `HashMap<(AIConversationId, String), DirtyOrchestrationEvent>` where the second key element is `plan_id`.
+
+In `controller.rs`, the current `take_dirty_orchestration_event(&conversation_id)` becomes `take_dirty_orchestration_events(&conversation_id)` which returns all dirty events for the conversation (one per plan that was edited). Each is appended as a separate `AIAgentInput::OrchestrationConfigUpdate`.
+
+The proto conversion in `convert_to.rs` is unchanged — each `OrchestrationConfigUpdate` already carries its own `plan_id`.
+
+### 7. Config block editing: plan-scoped dirty events
+When the user edits a field in `OrchestrationConfigBlockView`, the `apply_field_change()` method currently calls:
+```rust
+model.set_orchestration_config(config, status, plan_id);
+model.set_dirty_orchestration_event(conversation_id, dirty_event);
+```
+
+After the change, this becomes:
+```rust
+model.set_orchestration_config_for_plan(plan_id, config, status);
+model.set_dirty_orchestration_event(conversation_id, plan_id, dirty_event);
+```
+
+Each config block edit only affects its own plan's config and queues a dirty event for that plan.
+
+## End-to-end flow
+
+### Hydration (restore)
+1. Client opens a conversation with history.
+2. `scan_conversation_for_orchestration_config()` scans backward, builds `HashMap<plan_id, (config, status)>`.
+3. Each plan card's `AIDocumentView` checks if its `plan_id` has an entry → renders config block if so.
+
+### Agent calls `run_agents` with `plan_id`
+1. Server emits `SetRunAgentsToolCall` with `plan_id` and resolved defaults.
+2. Client parses `RunAgentsRequest` including `plan_id`.
+3. `RunAgentsCardView` construction looks up `conversation.orchestration_config_for_plan(plan_id)`.
+4. If config found + approved + fields match → auto-launch (no card shown).
+5. If no config or mismatch → show confirmation card.
+
+### User edits config on plan B's card
+1. User toggles a field on plan B's config block.
+2. `apply_field_change()` updates `orchestration_configs["plan-B"]` on the conversation.
+3. Dirty event queued for `(conversation_id, "plan-B")`.
+4. On next outbound request, dirty event piggybacked as `OrchestrationConfigUpdate { plan_id: "plan-B", ... }`.
+5. Server appends a new `OrchestrationConfigSnapshot` message with `plan_id = "plan-B"`.
+
+### Two plans, independent configs
+- Plan A has `local` config. Plan B has `remote` config.
+- `run_agents(plan_id="A")` → inherits local. `run_agents(plan_id="B")` → inherits remote.
+- Editing plan A's config does not affect plan B's.
+
+## Coordination with server changes
+
+### Proto dependency
+The `plan_id` field on `RunAgents` (field 9) must land in `warp-proto-apis` before the client work begins. The `OrchestrationConfigSnapshot` proto already has `plan_id` (field 1) — no proto change needed for that.
+
+### Backward compatibility
+- **New client + old server**: Server sends `OrchestrationConfigSnapshot` with empty `plan_id` (singleton model). Client ignores empty `plan_id` snapshots → no config hydrated → every `run_agents` call shows a confirmation card. Functionally correct, just no auto-launch.
+- **Old client + new server**: Server appends per-plan snapshots. Old client's `.last()` scan picks up whichever snapshot was appended most recently → may show the wrong plan's config. Acceptable during rollout since the old client doesn't use `plan_id` for match-checking anyway.
+- **New client + new server**: Full per-plan behavior.
+
+### Rollout order
+1. Proto PR (`warp-proto-apis`): adds `plan_id` field 9 to `RunAgents`.
+2. Server PR (`warp-server`): implements per-plan append-only snapshots, `plan_id` on `create_orchestration_config` and `run_agents`.
+3. Client PR (`warp`): implements per-plan hydration, config blocks, auto-launch, dirty sync.
+
+Server and client PRs can land in either order after the proto — backward compatibility is maintained in both directions.
+
+## Risks and mitigations
+
+**Risk: Conversations with many plans accumulate snapshot messages.** Client scans backward through all messages on hydration.
+*Mitigation:* The backward scan is O(n) over messages but short-circuits per plan_id (first match wins). For typical conversations this is negligible.
+
+**Risk: Old singleton snapshots (empty `plan_id`) are orphaned.** After the client upgrade, they're never hydrated.
+*Mitigation:* Desired behavior. The agent will call `create_orchestration_config` with a `plan_id` on its next interaction, creating a proper per-plan snapshot.
+
+**Risk: Behavioral change — `run_agents` without `plan_id` no longer auto-launches.** Today, any `run_agents` call can auto-launch against the singleton config. After this change, `run_agents` without `plan_id` always shows a confirmation card because `active_config` is `None` when `plan_id` is empty. This is intentional — inheritance now requires the agent to specify which plan it's executing — but it changes the default experience for agents that orchestrate without plans.
+
+**Risk: Config block flicker during hydration.** Plan cards may briefly render without config blocks until hydration completes.
+*Mitigation:* Hydration runs synchronously in `scan_conversation_for_orchestration_config()` before the plan card view is built. No async gap.
+
+## Testing and validation
+
+### Unit tests
+
+**`orchestration_config.rs` (crate-level):**
+- `matches_active_config()` — unchanged; existing tests still pass.
+
+**`ai_document_model.rs`:**
+- Hydration with multiple snapshots for different `plan_id`s → map contains one entry per plan.
+- Hydration with multiple snapshots for the same `plan_id` → most recent wins.
+- Hydration with empty `plan_id` snapshots → ignored.
+- Incremental snapshot arrival → updates the correct plan's entry.
+
+**`run_agents_card_view.rs`:**
+- `should_auto_launch()` with matching plan config → true.
+- `should_auto_launch()` with no config for plan → false.
+- `should_auto_launch()` with config for a different plan → false.
+
+**`conversation.rs`:**
+- `orchestration_config_for_plan()` returns correct config per plan.
+- `set_orchestration_config_for_plan()` doesn't affect other plans.
+
+**`controller.rs` (dirty sync):**
+- Editing plan A queues one dirty event; editing plan B queues another.
+- Both are sent on the next outbound request.
+- Events are cleared after send.
+
+### Manual validation
+- Create two plans in the same conversation with different orchestration configs.
+- Verify each plan card shows its own config block.
+- Verify `run_agents` for each plan inherits from its own config.
+- Verify editing one plan's config doesn't affect the other.
+- Verify auto-launch works per-plan.
+- Verify disapproving one plan's config doesn't block the other.
+
+## Follow-ups
+- **Config block visibility without explicit create.** If the user wants to add a config to a plan that doesn't have one, the plan card currently shows nothing. A future enhancement could add an "Add orchestration config" affordance.
+- **Garbage collection of stale snapshots.** If a plan is deleted, its snapshot messages remain. Not harmful (they're never matched), but could be cleaned up in a future pass.


### PR DESCRIPTION
## Description

Bypass the `RunAgents` confirmation card for autonomous (CLI driver) agents.

`RunAgentsExecutor::should_autoexecute` previously always returned `false`, which meant the action required user confirmation via the orchestration card. Non-interactive agents running via the CLI driver (SDK mode) cannot present or interact with this card, causing them to get stuck indefinitely with: "The agent got stuck waiting for user confirmation."

Now `should_autoexecute` checks `AppExecutionMode::is_autonomous()` and returns `true` for SDK/driver mode, letting `RunAgents` proceed directly through the standard executor path.

## Linked Issue

- [QUALITY-667](https://linear.app/warpdotdev/issue/QUALITY-667/remote-agents-cannot-invoke-run-agents-because-they-get-blocked)

## Testing

- [x] Verified cargo check, cargo fmt, and cargo clippy pass cleanly

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-OZ: Cloud agents can now orchestrate sub-agents without getting stuck on confirmation
-->

_Conversation: https://staging.warp.dev/conversation/9065c77e-f3cc-4b6d-838c-d1a412d2b60a_
_Run: https://oz.staging.warp.dev/runs/019e18fa-e9a2-7774-8875-4169ec7c74f6_
_This PR was generated with [Oz](https://warp.dev/oz)._
