### PR TITLE
Verify the remote server binary with `--version`

### DIFF
--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -250,8 +250,7 @@ impl RemoteTransport for SshTransport {
                     Ok(output) if output.status.success() => {}
                     Ok(output) => {
                         let code = output.status.code().unwrap_or(-1);
-                        let stderr =
-                            String::from_utf8_lossy(&output.stderr).trim().to_string();
+                        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
                         outcome.result = Err(Error::Other(anyhow::anyhow!(
                             "Post-install verification failed: binary not found or not \
                              executable at {binary_path} (exit {code}): {stderr}"
@@ -355,7 +354,7 @@ impl RemoteTransport for SshTransport {
 /// Exit codes where SCP fallback would not help because the failure
 /// is on the remote host itself (not a network/download issue).
 fn should_skip_scp_fallback(error: &Error) -> bool {
-    matches!(error, Error::ScriptFailed { exit_code , .. }     if *exit_code == remote_server::setup::NO_HTTP_CLIENT_EXIT_CODE)
+    matches!(error, Error::ScriptFailed { exit_code , .. } if *exit_code == remote_server::setup::NO_HTTP_CLIENT_EXIT_CODE)
 }
 
 /// Runs the install script on the remote host to download and install

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -133,19 +133,24 @@ impl RemoteTransport for SshTransport {
     fn check_binary(&self) -> Pin<Box<dyn Future<Output = Result<bool, Error>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
-            let cmd = format!("test -x {}", remote_server::setup::remote_server_binary());
+            let cmd = remote_server::setup::binary_check_command();
+            log::info!("Running binary check: {cmd}");
             let output = remote_server::ssh::run_ssh_command(
                 &socket_path,
                 &cmd,
                 remote_server::setup::CHECK_TIMEOUT,
             )
             .await?;
-            // `test -x` exits 0 when present+executable, 1 when missing.
-            // Anything else (e.g. SSH exit 255 for a dead connection, or
-            // signal termination) is a transport-level failure.
-            match output.status.code() {
+            // `<binary> --version` exits 0 when present, executable, and
+            // functional. Exit 127 means the binary was not found, and 126
+            // means it exists but is not executable. Any other non-zero
+            // exit (e.g. SSH exit 255 for a dead connection, or signal
+            // termination) is treated as a transport-level failure.
+            let code = output.status.code();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            match code {
                 Some(0) => Ok(true),
-                Some(1) => Ok(false),
+                Some(126) | Some(127) => Ok(false),
                 Some(code) => {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     Err(Error::Other(anyhow::anyhow!(
@@ -195,11 +200,9 @@ impl RemoteTransport for SshTransport {
     fn install_binary(&self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
+            let binary_path = remote_server::setup::remote_server_binary();
             let script = remote_server::setup::install_script(None);
-            log::info!(
-                "Installing remote server binary to {}",
-                remote_server::setup::remote_server_binary()
-            );
+            log::info!("Installing remote server binary to {binary_path}");
             match remote_server::ssh::run_ssh_script(
                 &socket_path,
                 &script,
@@ -207,28 +210,55 @@ impl RemoteTransport for SshTransport {
             )
             .await
             {
-                Ok(output) if output.status.success() => Ok(()),
+                Ok(output) if output.status.success() => {}
                 Ok(output) => {
                     let exit_code = output.status.code().unwrap_or(-1);
                     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
                     if should_skip_scp_fallback(exit_code) {
-                        Err(Error::ScriptFailed { exit_code, stderr })
-                    } else {
-                        log::info!(
-                            "Install script failed (exit {exit_code}), falling back to SCP upload"
-                        );
-                        scp_install_fallback(&socket_path)
-                            .await
-                            .map_err(Error::Other)
+                        return Err(Error::ScriptFailed { exit_code, stderr });
                     }
+                    log::info!(
+                        "Install script failed (exit {exit_code}), falling back to SCP upload"
+                    );
+                    scp_install_fallback(&socket_path)
+                        .await
+                        .map_err(Error::Other)?;
                 }
                 Err(SshCommandError::TimedOut { .. }) => {
                     log::info!("Install script timed out, falling back to SCP upload");
                     scp_install_fallback(&socket_path)
                         .await
-                        .map_err(Error::Other)
+                        .map_err(Error::Other)?;
                 }
-                Err(e) => Err(Error::Other(e.into())),
+                Err(e) => return Err(Error::Other(e.into())),
+            }
+
+            // Post-install verification: confirm the binary actually
+            // landed at the expected path and is functional. This catches
+            // silent install failures (e.g. tilde-expansion bugs) that
+            // would otherwise surface as a cryptic "Response channel
+            // closed" error during the IPC handshake.
+            log::info!("Running post-install verification for {binary_path}");
+            let check_cmd = remote_server::setup::binary_check_command();
+            let verify = remote_server::ssh::run_ssh_command(
+                &socket_path,
+                &check_cmd,
+                remote_server::setup::CHECK_TIMEOUT,
+            )
+            .await;
+            match verify {
+                Ok(output) if output.status.success() => Ok(()),
+                Ok(output) => {
+                    let code = output.status.code().unwrap_or(-1);
+                    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                    Err(Error::Other(anyhow::anyhow!(
+                        "Post-install verification failed: binary not found or not \
+                         executable at {binary_path} (exit {code}): {stderr}"
+                    )))
+                }
+                Err(e) => Err(Error::Other(anyhow::anyhow!(
+                    "Post-install verification failed: {e}"
+                ))),
             }
         })
     }

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -147,7 +147,6 @@ impl RemoteTransport for SshTransport {
             // exit (e.g. SSH exit 255 for a dead connection, or signal
             // termination) is treated as a transport-level failure.
             let code = output.status.code();
-            let stdout = String::from_utf8_lossy(&output.stdout);
             match code {
                 Some(0) => Ok(true),
                 Some(126) | Some(127) => Ok(false),

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -354,7 +354,8 @@ impl RemoteTransport for SshTransport {
 /// Exit codes where SCP fallback would not help because the failure
 /// is on the remote host itself (not a network/download issue).
 fn should_skip_scp_fallback(error: &Error) -> bool {
-    matches!(error, Error::ScriptFailed { exit_code , .. } if *exit_code == remote_server::setup::NO_HTTP_CLIENT_EXIT_CODE)
+    // Unsupported arch/OS — SCP won't change the architecture
+    matches!(error, Error::ScriptFailed { exit_code , .. } if *exit_code == 2)
 }
 
 /// Runs the install script on the remote host to download and install

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -876,46 +876,41 @@ impl RemoteServerManager {
             .await
             .map_err(|e| ConnectAndHandshakeError::Initialize(anyhow::anyhow!("{e:#}")))?;
 
-        // Version compatibility check. For versioned channels (Stable,
-        // Preview, Dev, Integration) the version is already encoded in the
-        // binary path and verified by the pre-connect `check_binary` /
-        // post-install verification steps, so this check is redundant.
-        // For unversioned channels (Local, Oss) the binary path doesn't
-        // encode a version, so we still need this runtime check.
-        use warp_core::channel::Channel;
-        if matches!(
-            ChannelState::channel(),
-            Channel::Local | Channel::Oss
-        ) {
-            let client_version = ChannelState::app_version();
-            if !version_is_compatible(client_version, &resp.server_version) {
+        // Version compatibility check. If the server reports a different
+        // release tag than the client expects, the binary on disk is stale.
+        // Remove it so the next reconnect (or explicit reconnect by the
+        // user) will reinstall.
+        //
+        // For versioned channels (Stable, Preview, Dev, Integration) the
+        // version is also encoded in the binary path and verified by the
+        // pre-connect `check_binary` / post-install verification steps,
+        // so this is a belt-and-suspenders check at zero extra cost (it
+        // uses data already received in the InitializeResponse).
+        let client_version = ChannelState::app_version();
+        if !version_is_compatible(client_version, &resp.server_version) {
+            log::warn!(
+                "Remote server version mismatch, removing stale binary: session={session_id:?} \
+                 client={client_version:?} server={:?}",
+                resp.server_version
+            );
+
+            const REMOVAL_TIMEOUT: Duration = Duration::from_secs(5);
+
+            if let Err(e) = transport
+                .remove_remote_server_binary()
+                .with_timeout(REMOVAL_TIMEOUT)
+                .await
+                .unwrap_or_else(|_| Err(anyhow::anyhow!("timed out after {REMOVAL_TIMEOUT:?}")))
+            {
                 log::warn!(
-                    "Remote server version mismatch, removing stale binary: session={session_id:?} \
-                     client={client_version:?} server={:?}",
-                    resp.server_version
+                    "Remote server stale binary removal failed: session={session_id:?} error={e:#}"
                 );
-
-                const REMOVAL_TIMEOUT: Duration = Duration::from_secs(5);
-
-                if let Err(e) = transport
-                    .remove_remote_server_binary()
-                    .with_timeout(REMOVAL_TIMEOUT)
-                    .await
-                    .unwrap_or_else(|_| {
-                        Err(anyhow::anyhow!("timed out after {REMOVAL_TIMEOUT:?}"))
-                    })
-                {
-                    log::warn!(
-                        "Remote server stale binary removal failed: \
-                         session={session_id:?} error={e:#}"
-                    );
-                }
-                return Err(ConnectAndHandshakeError::Initialize(anyhow::anyhow!(
-                    "remote server version mismatch (client: {client_version:?}, \
-                     server: {:?}); reconnect to reinstall",
-                    resp.server_version
-                )));
             }
+            return Err(ConnectAndHandshakeError::Initialize(anyhow::anyhow!(
+                "remote server version mismatch (client: {client_version:?}, \
+                 server: {:?}); reconnect to reinstall",
+                resp.server_version
+            )));
         }
 
         log::info!(

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -876,34 +876,46 @@ impl RemoteServerManager {
             .await
             .map_err(|e| ConnectAndHandshakeError::Initialize(anyhow::anyhow!("{e:#}")))?;
 
-        // Version compatibility check. If the server reports a different release
-        // tag than the client expects, the binary on disk is stale. Remove it so
-        // the next reconnect (or explicit reconnect by the user) will reinstall.
-        let client_version = ChannelState::app_version();
-        if !version_is_compatible(client_version, &resp.server_version) {
-            log::warn!(
-                "Remote server version mismatch, removing stale binary: session={session_id:?} \
-                 client={client_version:?} server={:?}",
-                resp.server_version
-            );
-
-            const REMOVAL_TIMEOUT: Duration = Duration::from_secs(5);
-
-            if let Err(e) = transport
-                .remove_remote_server_binary()
-                .with_timeout(REMOVAL_TIMEOUT)
-                .await
-                .unwrap_or_else(|_| Err(anyhow::anyhow!("timed out after {REMOVAL_TIMEOUT:?}")))
-            {
+        // Version compatibility check. For versioned channels (Stable,
+        // Preview, Dev, Integration) the version is already encoded in the
+        // binary path and verified by the pre-connect `check_binary` /
+        // post-install verification steps, so this check is redundant.
+        // For unversioned channels (Local, Oss) the binary path doesn't
+        // encode a version, so we still need this runtime check.
+        use warp_core::channel::Channel;
+        if matches!(
+            ChannelState::channel(),
+            Channel::Local | Channel::Oss
+        ) {
+            let client_version = ChannelState::app_version();
+            if !version_is_compatible(client_version, &resp.server_version) {
                 log::warn!(
-                    "Remote server stale binary removal failed: session={session_id:?} error={e:#}"
+                    "Remote server version mismatch, removing stale binary: session={session_id:?} \
+                     client={client_version:?} server={:?}",
+                    resp.server_version
                 );
+
+                const REMOVAL_TIMEOUT: Duration = Duration::from_secs(5);
+
+                if let Err(e) = transport
+                    .remove_remote_server_binary()
+                    .with_timeout(REMOVAL_TIMEOUT)
+                    .await
+                    .unwrap_or_else(|_| {
+                        Err(anyhow::anyhow!("timed out after {REMOVAL_TIMEOUT:?}"))
+                    })
+                {
+                    log::warn!(
+                        "Remote server stale binary removal failed: \
+                         session={session_id:?} error={e:#}"
+                    );
+                }
+                return Err(ConnectAndHandshakeError::Initialize(anyhow::anyhow!(
+                    "remote server version mismatch (client: {client_version:?}, \
+                     server: {:?}); reconnect to reinstall",
+                    resp.server_version
+                )));
             }
-            return Err(ConnectAndHandshakeError::Initialize(anyhow::anyhow!(
-                "remote server version mismatch (client: {client_version:?}, \
-                 server: {:?}); reconnect to reinstall",
-                resp.server_version
-            )));
         }
 
         log::info!(

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -378,10 +378,15 @@ pub fn remote_server_binary() -> String {
     }
 }
 
-/// Returns the shell command to check if the remote server binary exists and
-/// is executable.
+/// Returns the shell command to verify the remote server binary is
+/// installed and functional by running it with `--version`.
+///
+/// Exits 0 when the binary is present, executable, and can parse its
+/// own arguments. A missing binary produces exit 127 (command not
+/// found) or 126 (not executable), and a corrupted binary will fail
+/// with a non-zero exit of its own.
 pub fn binary_check_command() -> String {
-    format!("test -x {}", remote_server_binary())
+    format!("{} --version", remote_server_binary())
 }
 
 /// Returns the version string used to pin remote-server installs on

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -93,7 +93,6 @@ pub struct GlobalOptions {
 #[command(
     name = "oz",
     display_name = "Oz",
-    version = version_string(),
     about = r#"The orchestration platform for cloud agents
 
 The Oz CLI is a tool for running, managing, and orchestrating coding agents at scale.

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -93,6 +93,7 @@ pub struct GlobalOptions {
 #[command(
     name = "oz",
     display_name = "Oz",
+    version = version_string(),
     about = r#"The orchestration platform for cloud agents
 
 The Oz CLI is a tool for running, managing, and orchestrating coding agents at scale.


### PR DESCRIPTION
## Description

When the remote server binary is installed to the wrong path (e.g. due to the bash 3.2 tilde-expansion bug fixed in #10317), the failure surfaces as a cryptic "Response channel closed before receiving a reply" error. This happens because the install script exits 0 (looks successful), but the binary silently landed at the wrong location. The client proceeds to open an IPC connection expecting the server to be running, but nothing is listening at the expected path.

The previous `test -x` check only verified that a file exists and is executable — it couldn't detect a corrupted binary, wrong architecture, or other issues that would prevent the binary from actually running. This PR takes a simpler approach: instead of checking existence, we try to **run** the binary with `--version`. If it succeeds, we know the binary is present, executable, the right architecture, and functional. If it fails for any reason (missing, corrupted, wrong path), we reinstall.


## Testing
I tested thoroughly both for a remote host that already has the binary and for one that doesn't have the binary installed

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>