### PR TITLE
Trim orchestration config block UI

### DIFF
--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -69,10 +69,7 @@ fn render_pill_toggle(is_on: bool, theme: &WarpTheme) -> Box<dyn Element> {
 
 const CONFIG_BLOCK_HEADER: &str = "Use orchestration";
 const CONFIG_BLOCK_DESCRIPTION: &str =
-    "Break this work into coordinated streams handled by specialized agents. \
-     Each agent focuses on a specific part of the plan\u{2014}design, instrumentation, \
-     backend, testing, and rollout\u{2014}while sharing context to stay aligned. \
-     This approach speeds up execution and reduces gaps between steps.";
+    "Break this work into coordinated streams with multiple agents.";
 const BASE_MODEL_HELPER: &str = "The primary model all agents will use.";
 
 // ── Action type ─────────────────────────────────────────────────────
@@ -395,19 +392,18 @@ impl View for OrchestrationConfigBlockView {
                 .with_child(details_text)
                 .with_child(chevron)
                 .finish();
+            let details_link_hoverable =
+                Hoverable::new(self.details_mouse_state.clone(), move |_| details_link)
+                    .on_click(|ctx, _, _| {
+                        ctx.dispatch_typed_action(
+                            OrchestrationConfigBlockAction::ToggleDetails,
+                        );
+                    })
+                    .with_cursor(Cursor::PointingHand)
+                    .finish();
             let details_row = Flex::row()
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_child(warpui::elements::Expanded::new(1.0, Empty::new().finish()).finish())
-                .with_child(
-                    Hoverable::new(self.details_mouse_state.clone(), move |_| details_link)
-                        .on_click(|ctx, _, _| {
-                            ctx.dispatch_typed_action(
-                                OrchestrationConfigBlockAction::ToggleDetails,
-                            );
-                        })
-                        .with_cursor(Cursor::PointingHand)
-                        .finish(),
-                )
+                .with_child(details_link_hoverable)
                 .finish();
             column.add_child(Container::new(details_row).with_margin_top(8.).finish());
 

--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -395,9 +395,7 @@ impl View for OrchestrationConfigBlockView {
             let details_link_hoverable =
                 Hoverable::new(self.details_mouse_state.clone(), move |_| details_link)
                     .on_click(|ctx, _, _| {
-                        ctx.dispatch_typed_action(
-                            OrchestrationConfigBlockAction::ToggleDetails,
-                        );
+                        ctx.dispatch_typed_action(OrchestrationConfigBlockAction::ToggleDetails);
                     })
                     .with_cursor(Cursor::PointingHand)
                     .finish();


### PR DESCRIPTION
## What
- Shorten the orchestration config block description to a single sentence
- Left-align the View details control (was right-aligned)

<img width="948" height="149" alt="Screenshot 2026-05-11 at 8 28 32 PM" src="https://github.com/user-attachments/assets/9b67944d-ea4b-4262-9c27-44d42b23d039" />



## Why
Feedback from Peter: the config block takes up too much space and the View details control is better positioned on the left.

## Agent Mode
- [x] This PR was created by Warp Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>