### PR TITLE
Fix orchestration picker theming in light themes

### DIFF
--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -28,7 +28,6 @@ use warpui::{
 
 use warp_cli::agent::Harness;
 use warp_core::channel::{Channel, ChannelState};
-use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill;
 
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
@@ -243,22 +242,22 @@ pub fn picker_styles(appearance: &Appearance) -> (UiComponentStyles, PickerColor
     };
     let corner_radius = CornerRadius::with_all(Radius::Pixels(ORCHESTRATION_PICKER_RADIUS));
     // The picker bg is a translucent overlay (surface_overlay_1 =
-    // fg at 5%). Composite it against the card background to derive
-    // opaque text color that works on any theme.
+    // fg at 5%). It must stay translucent so that the accent-tinted
+    // card background in the config block shows through, and so that
+    // gradient-background themes render correctly.
     let background_fill: Fill = theme.surface_overlay_1();
-    let composited_bg = theme.background().blend(&background_fill).into_solid();
-    let border_color: warpui::elements::Fill = theme.surface_2().into();
-    let font_color = blended_colors::text_main(theme, composited_bg);
     let background: warpui::elements::Fill = background_fill.into();
+    // Border and font colors are intentionally left to the dropdown's
+    // default ButtonVariant::Secondary styling, which uses
+    // theme.outline() and theme.main_text_color() — both are
+    // contrast-aware and adapt correctly to all themes.
 
     let styles = UiComponentStyles {
         height: Some(ORCHESTRATION_PICKER_HEIGHT),
         background: Some(background),
-        border_color: Some(border_color),
         border_width: Some(ORCHESTRATION_PICKER_BORDER_WIDTH),
         border_radius: Some(corner_radius),
         font_size: Some(ORCHESTRATION_PICKER_FONT_SIZE),
-        font_color: Some(font_color),
         padding: Some(padding),
         ..Default::default()
     };
@@ -266,8 +265,6 @@ pub fn picker_styles(appearance: &Appearance) -> (UiComponentStyles, PickerColor
         padding,
         corner_radius,
         background,
-        border_color,
-        font_color,
     };
     (styles, colors)
 }
@@ -277,8 +274,6 @@ pub struct PickerColors {
     pub padding: Coords,
     pub corner_radius: CornerRadius,
     pub background: warpui::elements::Fill,
-    pub border_color: warpui::elements::Fill,
-    pub font_color: ColorU,
 }
 
 // ── Picker creation (generic over action type) ──────────────────────
@@ -292,8 +287,6 @@ pub fn new_standard_picker_dropdown<A: OrchestrationControlAction, V: View>(
     let padding = colors.padding;
     let corner_radius = colors.corner_radius;
     let background = colors.background;
-    let border_color = colors.border_color;
-    let font_color = colors.font_color;
     ctx.add_typed_action_view(move |ctx_dropdown| {
         let mut dropdown = Dropdown::<A>::new(ctx_dropdown);
         dropdown.set_use_overlay_layer(false, ctx_dropdown);
@@ -304,10 +297,8 @@ pub fn new_standard_picker_dropdown<A: OrchestrationControlAction, V: View>(
         dropdown.set_padding(padding, ctx_dropdown);
         dropdown.set_border_radius(corner_radius, ctx_dropdown);
         dropdown.set_background(background, ctx_dropdown);
-        dropdown.set_border_color(border_color, ctx_dropdown);
         dropdown.set_border_width(ORCHESTRATION_PICKER_BORDER_WIDTH, ctx_dropdown);
         dropdown.set_font_size(ORCHESTRATION_PICKER_FONT_SIZE, ctx_dropdown);
-        dropdown.set_font_color(font_color, ctx_dropdown);
         dropdown
     })
 }

--- a/app/src/view_components/dropdown.rs
+++ b/app/src/view_components/dropdown.rs
@@ -272,11 +272,6 @@ where
         ctx.notify();
     }
 
-    pub fn set_border_color(&mut self, border_color: Fill, ctx: &mut ViewContext<Self>) {
-        self.border_color = Some(border_color);
-        ctx.notify();
-    }
-
     pub fn set_border_width(&mut self, border_width: f32, ctx: &mut ViewContext<Self>) {
         self.border_width = Some(border_width);
         ctx.notify();


### PR DESCRIPTION
## What
Remove custom font_color and border_color overrides from picker_styles(), letting ButtonVariant::Secondary theme-aware defaults handle contrast in all themes.

<img width="1100" height="478" alt="Screenshot 2026-05-11 at 8 32 05 PM" src="https://github.com/user-attachments/assets/00ec0b88-a161-40e5-8cb3-978dc90c1d6b" />

<img width="951" height="484" alt="Screenshot 2026-05-11 at 8 32 26 PM" src="https://github.com/user-attachments/assets/eab471a4-fd2b-4cc7-ac9e-adac2c5d197b" />

## Why
The previous custom colors used blended_colors::text_main with a composited background, which produced washed-out text and borders in light themes. The dropdown's built-in Secondary styling uses theme.outline() and theme.main_text_color() which are contrast-aware and adapt correctly.

Affects both the plan config block and the run_agents confirmation card (shared picker_styles function).

## Agent Mode
- [x] This PR was created by Warp Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>