### PR TITLE
Add left padding to orchestration breadcrumb row

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -2025,14 +2025,20 @@ pub fn render_orchestration_breadcrumbs(
     .finish();
 
     // Center breadcrumbs while they fit; when they overflow, use the full
-    // width so horizontal scrolling still works.
+    // width so horizontal scrolling still works. Wrap in a `Container`
+    // with a touch of left padding so the leading parent crumb doesn't
+    // sit flush against the pane edge.
     Some(
-        Flex::row()
-            .with_main_axis_size(MainAxisSize::Max)
-            .with_main_axis_alignment(MainAxisAlignment::Center)
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(scrollable)
-            .finish(),
+        Container::new(
+            Flex::row()
+                .with_main_axis_size(MainAxisSize::Max)
+                .with_main_axis_alignment(MainAxisAlignment::Center)
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_child(scrollable)
+                .finish(),
+        )
+        .with_padding_left(4.)
+        .finish(),
     )
 }
 


### PR DESCRIPTION
Context: https://warpdev.slack.com/archives/C09769R5GBT/p1778542331023809

Before:
<img width="634" height="140" alt="image" src="https://github.com/user-attachments/assets/f9b8798a-3797-400b-b71e-89d0c49913a3" />


After:

<img width="413" height="151" alt="image" src="https://github.com/user-attachments/assets/c3657fe2-af8d-4cb0-82de-a8b7f3562098" />



## Description
The parent crumb in the split-off child agent breadcrumb row (which replaces the orchestration pill bar in "Open in new pane" / "Open in new tab" child panes) was sitting flush against the left pane edge when the breadcrumb overflowed its available width.

Wrap the breadcrumb row in a `Container` with 4px of left padding inside `render_orchestration_breadcrumbs` so the leading parent crumb gets a touch of breathing room.

Before/after: the second-row breadcrumb (e.g. `[Oz] Orchestrator > [I] Implement Daemon Indexing and …`) no longer paints right up against the pane's left edge.
