### PR TITLE
Cloud status badge for remote child pills in orchestration pill bar

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -44,6 +44,9 @@ use crate::features::FeatureFlag;
 use crate::menu::{Event as MenuEvent, Menu, MenuItem, MenuItemFields};
 use crate::pane_group::pane::view::PaneHeaderAction;
 use crate::terminal::view::TerminalAction;
+use crate::ui_components::icon_with_status::{
+    self, render_icon_with_status, IconWithStatusVariant,
+};
 use crate::ui_components::icons::Icon;
 use crate::workspace::{WorkspaceAction, WorkspaceRegistry};
 use warp_core::ui::theme::color::internal_colors;
@@ -52,10 +55,9 @@ use warpui::EntityId;
 const PILL_HEIGHT: f32 = 22.;
 const PILL_RADIUS: f32 = PILL_HEIGHT / 2.;
 const AVATAR_SIZE: f32 = 16.;
-const AVATAR_WITH_STATUS_WIDTH: f32 = 20.;
-const STATUS_BADGE_SIZE: f32 = 12.;
-const STATUS_BADGE_ICON_SIZE: f32 = 7.2;
-const STATUS_BADGE_PADDING: f32 = (STATUS_BADGE_SIZE - STATUS_BADGE_ICON_SIZE) / 4.;
+/// `total_size` for the shared icon-with-status helper, chosen so the helper's
+/// brand-circle slot lands at `AVATAR_SIZE`.
+const AVATAR_WITH_STATUS_TOTAL_SIZE: f32 = AVATAR_SIZE / icon_with_status::CIRCLE_RATIO;
 const PILL_LABEL_MAX_WIDTH: f32 = 110.;
 const PILL_GAP: f32 = 6.;
 const PILL_GAP_WITH_STATUS: f32 = 2.;
@@ -169,6 +171,8 @@ struct PillSpec {
     is_selected: bool,
     kind: PillKind,
     pin_state: PillPinState,
+    /// Child running on a remote worker; drives the cloud-shaped badge variant.
+    is_remote_child: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -547,6 +551,8 @@ impl OrchestrationPillBar {
             is_selected: orchestrator_id == active_id,
             kind: PillKind::Orchestrator,
             pin_state: PillPinState::Unpinned,
+            // Orchestrators always run locally.
+            is_remote_child: false,
         });
 
         // Then a pill per descendant child. Pin detection is currently
@@ -567,6 +573,7 @@ impl OrchestrationPillBar {
                 is_selected: child.id() == active_id,
                 kind: PillKind::Child,
                 pin_state: PillPinState::Unpinned,
+                is_remote_child: child.is_remote_child(),
             });
         }
 
@@ -1351,6 +1358,7 @@ fn render_pill(
     let avatar_color = spec.avatar_color;
     let avatar_glyph = spec.avatar_glyph;
     let status = spec.status;
+    let is_remote_child = spec.is_remote_child;
 
     // `Hoverable::new`'s build closure is `FnOnce` (see
     // `crates/warpui_core/src/elements/hoverable.rs`). We can therefore move
@@ -1429,19 +1437,19 @@ fn render_pill(
                 .finish()
         };
 
-        // Pinned pills swap the avatar disc for a pin glyph (per Figma) so
-        // the user can spot at a glance that this child is currently living
-        // in a separate pane/tab. Unpinned child pills render the avatar with
-        // the compact status badge from the orchestration pill design.
+        // Pinned pills swap the avatar for a pin glyph (per Figma); unpinned
+        // child pills delegate to the shared icon-with-status helper so cloud
+        // and local children get the same badge treatment as other surfaces.
         let leading: Box<dyn Element> = match (is_pinned, status.as_ref()) {
             (true, _) => ConstrainedBox::new(Icon::Pin.to_warpui_icon(text_color.into()).finish())
                 .with_width(AVATAR_SIZE)
                 .with_height(AVATAR_SIZE)
                 .finish(),
-            (false, Some(status)) => render_avatar_with_status_badge(
+            (false, Some(status)) => render_avatar_with_status_overlay(
                 avatar_color,
                 avatar_glyph,
-                status,
+                status.clone(),
+                is_remote_child,
                 background,
                 theme,
                 appearance,
@@ -1642,64 +1650,37 @@ fn render_overflow_button(
     SavePosition::new(button, &overflow_button_position_id(conversation_id)).finish()
 }
 
-/// Renders a child-agent avatar with the compact status badge from the
-/// orchestration pill designs. The 20px-wide footprint keeps the label aligned
-/// with the old 16px avatar + 6px gap while making room for the badge overhang.
-fn render_avatar_with_status_badge(
+/// Pill avatar with a status badge (cloud-shaped when remote), delegated to
+/// the shared icon-with-status helper.
+fn render_avatar_with_status_overlay(
     avatar_color: ColorU,
     glyph: AvatarGlyph,
-    status: &ConversationStatus,
+    status: ConversationStatus,
+    is_remote_child: bool,
     pill_background: ColorU,
     theme: &WarpTheme,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
-    let avatar = render_avatar_disc(avatar_color, glyph, AVATAR_SIZE, theme, appearance);
-    let (status_icon, status_color) =
-        status.status_icon_and_color(theme, StatusColorStyle::Standard);
-    let icon = ConstrainedBox::new(status_icon.to_warpui_icon(status_color.into()).finish())
-        .with_width(STATUS_BADGE_ICON_SIZE)
-        .with_height(STATUS_BADGE_ICON_SIZE)
-        .finish();
-    let badge = Container::new(
-        Container::new(icon)
-            .with_uniform_padding(STATUS_BADGE_PADDING)
-            .finish(),
+    // Disc sized to match the helper's brand-circle slot.
+    let avatar = render_avatar_disc(
+        avatar_color,
+        glyph,
+        icon_with_status::circle_size(AVATAR_WITH_STATUS_TOTAL_SIZE),
+        theme,
+        appearance,
+    );
+    render_icon_with_status(
+        IconWithStatusVariant::CustomAvatar {
+            avatar,
+            status: Some(status),
+            is_ambient: is_remote_child,
+        },
+        AVATAR_WITH_STATUS_TOTAL_SIZE,
+        0.0,
+        theme,
+        // Cutout ring color for the local badge; ignored by the cloud path.
+        pill_background.into(),
     )
-    .with_uniform_padding(STATUS_BADGE_PADDING)
-    .with_background_color(pill_background)
-    .with_corner_radius(CornerRadius::with_all(Radius::Percentage(50.)))
-    .finish();
-
-    let mut stack = Stack::new();
-    stack.add_child(
-        ConstrainedBox::new(Empty::new().finish())
-            .with_width(AVATAR_WITH_STATUS_WIDTH)
-            .with_height(PILL_HEIGHT)
-            .finish(),
-    );
-    stack.add_positioned_child(
-        avatar,
-        OffsetPositioning::offset_from_parent(
-            vec2f(0., (PILL_HEIGHT - AVATAR_SIZE) / 2.),
-            ParentOffsetBounds::Unbounded,
-            ParentAnchor::TopLeft,
-            ChildAnchor::TopLeft,
-        ),
-    );
-    stack.add_positioned_child(
-        badge,
-        OffsetPositioning::offset_from_parent(
-            vec2f(0., 0.),
-            ParentOffsetBounds::Unbounded,
-            ParentAnchor::BottomRight,
-            ChildAnchor::BottomRight,
-        ),
-    );
-
-    ConstrainedBox::new(stack.finish())
-        .with_width(AVATAR_WITH_STATUS_WIDTH)
-        .with_height(PILL_HEIGHT)
-        .finish()
 }
 
 /// Renders the avatar circle as a colored disc with a centered glyph (letter

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -551,7 +551,7 @@ impl OrchestrationPillBar {
             is_selected: orchestrator_id == active_id,
             kind: PillKind::Orchestrator,
             pin_state: PillPinState::Unpinned,
-            // Orchestrators always run locally.
+            // Unused: orchestrator pills don't render a status overlay.
             is_remote_child: false,
         });
 

--- a/app/src/ui_components/agent_icon_tests.rs
+++ b/app/src/ui_components/agent_icon_tests.rs
@@ -60,7 +60,8 @@ impl AgentIconFields {
                 is_ambient: *is_ambient,
             }),
             IconWithStatusVariant::Neutral { .. }
-            | IconWithStatusVariant::NeutralElement { .. } => None,
+            | IconWithStatusVariant::NeutralElement { .. }
+            | IconWithStatusVariant::CustomAvatar { .. } => None,
         }
     }
 }

--- a/app/src/ui_components/icon_with_status.rs
+++ b/app/src/ui_components/icon_with_status.rs
@@ -24,8 +24,8 @@ const OZ_AMBIENT_BACKGROUND_COLOR: ColorU = ColorU {
 // Sub-component size ratios, expressed as fractions of `total_size`. The brand circle is
 // ~76% wide and the status badge is ~57% wide, with the badge's bottom-right anchored at
 // the box's bottom-right corner. With these ratios the badge center sits *inside* the
-// brand circle (not on its edge).
-/// Fraction of `total_size` taken up by the brand circle.
+// brand circle (not on its edge). `CIRCLE_RATIO` is `pub(crate)` so callers that
+// pre-render their own avatar can size it consistently with the other variants.
 pub(crate) const CIRCLE_RATIO: f32 = 0.76;
 const ICON_RATIO: f32 = 0.43;
 const BADGE_RATIO: f32 = 0.57;

--- a/app/src/ui_components/icon_with_status.rs
+++ b/app/src/ui_components/icon_with_status.rs
@@ -25,7 +25,8 @@ const OZ_AMBIENT_BACKGROUND_COLOR: ColorU = ColorU {
 // ~76% wide and the status badge is ~57% wide, with the badge's bottom-right anchored at
 // the box's bottom-right corner. With these ratios the badge center sits *inside* the
 // brand circle (not on its edge).
-const CIRCLE_RATIO: f32 = 0.76;
+/// Fraction of `total_size` taken up by the brand circle.
+pub(crate) const CIRCLE_RATIO: f32 = 0.76;
 const ICON_RATIO: f32 = 0.43;
 const BADGE_RATIO: f32 = 0.57;
 const BADGE_ICON_RATIO: f32 = 0.34;
@@ -37,7 +38,8 @@ const STATUS_IN_CLOUD_RATIO: f32 = 0.285;
 // a 24px container held a 16px glyph (16/24 ≈ 0.667).
 const NEUTRAL_GLYPH_RATIO: f32 = 16.0 / 24.0;
 
-fn circle_size(total: f32) -> f32 {
+/// Returns the brand-circle diameter for a given `total_size`.
+pub(crate) fn circle_size(total: f32) -> f32 {
     total * CIRCLE_RATIO
 }
 
@@ -110,6 +112,14 @@ pub(crate) enum IconWithStatusVariant {
     /// A CLI agent icon on the agent's brand color background.
     CLIAgent {
         agent: CLIAgent,
+        status: Option<ConversationStatus>,
+        is_ambient: bool,
+    },
+    /// A pre-rendered avatar with an optional status overlay (cloud lobe when
+    /// ambient). Caller must size `avatar` to `circle_size(total_size)` so the
+    /// overlay's overhang matches the other variants.
+    CustomAvatar {
+        avatar: Box<dyn Element>,
         status: Option<ConversationStatus>,
         is_ambient: bool,
     },
@@ -209,6 +219,19 @@ pub(crate) fn render_icon_with_status(
                 status_container_background,
             )
         }
+        IconWithStatusVariant::CustomAvatar {
+            avatar,
+            status,
+            is_ambient,
+        } => attach_status_overlay(
+            avatar,
+            status.as_ref(),
+            is_ambient,
+            total_size,
+            overlay_extra_overhang_ratio,
+            theme,
+            status_container_background,
+        ),
     }
 }
 


### PR DESCRIPTION
See https://warpdev.slack.com/archives/C09769R5GBT/p1778454446358659?thread_ts=1778358236.922579&cid=C09769R5GBT for context 
Fixes https://linear.app/warpdotdev/issue/QUALITY-679/add-cloud-indicator-to-pill-status-badge

<img width="944" height="126" alt="image" src="https://github.com/user-attachments/assets/041af75c-6b16-4fe4-9e4f-bf9d898d3f9c" />


zoomed out:
<img width="1265" height="742" alt="image" src="https://github.com/user-attachments/assets/05a5e286-db18-44b0-9f1e-f7f15cfae11c" />


## Description
Differentiates remote (cloud) child agents from local ones in the orchestration pill bar by rendering their status badge as a cloud silhouette (with the status icon inside) instead of the circular badge used for local children.

Routes the pill avatar through the shared icon-with-status helper that's already used by vertical tabs, the conversation list, agent management, etc. — adds a small `CustomAvatar` variant to the helper so callers with bespoke avatars (the pill bar uses a deterministic-color disc + initial letter) can reuse the existing circle/cloud overlay treatment. Local children keep the existing circle-badge look unchanged; only the cloud variant is new.

Picks up Harry's `StatusColorStyle::Cloud` work for free (status icons inside the cloud use `ansi_bg_*` tints so they stay readable on the white cloud fill).
