### PR TITLE
Promote GitCredentialRefresh to Preview

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -940,7 +940,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::DragTabsToWindows,
     FeatureFlag::OrchestrationLaunchModal,
     FeatureFlag::NamedAgents,
-    FeatureFlag::GitCredentialRefresh,
     FeatureFlag::HandoffCloudCloud,
     FeatureFlag::HarnessSessionHeader,
     FeatureFlag::SoloUserByok,
@@ -953,6 +952,7 @@ pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::BlocklistMarkdownTableRendering,
     FeatureFlag::MarkdownTables,
     FeatureFlag::GitOperationsInCodeReview,
+    FeatureFlag::GitCredentialRefresh,
 ];
 
 /// Features enabled for all release builds (i.e.: everything but WarpLocal).


### PR DESCRIPTION
## Description
Move `FeatureFlag::GitCredentialRefresh` from `DOGFOOD_FLAGS` to `PREVIEW_FLAGS`, enabling the git credential refresh feature for Preview build users.

This flag gates the driver behavior that writes GitHub credentials to disk and runs the background refresh loop that keeps them fresh during a task run.

[Warp Agent conversation](https://staging.warp.dev/conversation/21127773-2543-4004-8484-7f6b52b94c9c)

## Linked Issue
N/A — feature promotion only.

## Testing
- [x] I have manually tested my changes locally with `./script/run`
- Verified `cargo fmt` and `cargo clippy` pass on the `warp_features` crate.
- This is a one-line flag move with no logic changes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>