### PR TITLE
Gate outbound input updates on editor visibility.

### DIFF
--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -1375,14 +1375,13 @@ impl TerminalManager {
                 block_id,
                 operations,
             } => {
-                // If the block ID has become stale by the time we get here,
-                // we don't need to send this update to the server.
-                if model.lock().block_list().active_block_id() != block_id {
-                    return;
-                }
-
-                // Only send input updates if the viewer is an executor
-                if model.lock().shared_session_status().is_executor() {
+                let should_send_input_update = view.read(ctx, |view, ctx| {
+                    let model = model.lock();
+                    model.block_list().active_block_id() == block_id
+                        && model.shared_session_status().is_executor()
+                        && view.should_publish_shared_session_input_editor_update(&model, ctx)
+                });
+                if should_send_input_update {
                     Self::update_current_network(&current_network, ctx, |network, _| {
                         network.send_input_update(block_id, operations.iter());
                     });

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -3004,6 +3004,20 @@ impl TerminalView {
         }
     }
 
+    /// Returns whether local input-editor CRDT edits should be published to the shared-session
+    /// sharer. Viewer-local editor events can still fire from ended/setup-only cloud agent surfaces,
+    /// where sending them upstream would be rejected and surfaced back as edit failures.
+    pub(crate) fn should_publish_shared_session_input_editor_update(
+        &self,
+        model: &TerminalModel,
+        app: &AppContext,
+    ) -> bool {
+        let input_is_visible = self.is_input_box_visible(model, app);
+        // If there is a conversation tombstone and the input is hidden, should not broadcast input updates as
+        // the cloud agent session is over.
+        self.conversation_ended_tombstone_view_id.is_none() || input_is_visible
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         resources: TerminalViewResources,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -3004,6 +3004,20 @@ impl TerminalView {
         }
     }
 
+    /// Returns whether local input-editor CRDT edits should be published to the shared-session
+    /// sharer. Viewer-local editor events can still fire from ended/setup-only cloud agent surfaces,
+    /// where sending them upstream would be rejected and surfaced back as edit failures.
+    pub(crate) fn should_publish_shared_session_input_editor_update(
+        &self,
+        model: &TerminalModel,
+        app: &AppContext,
+    ) -> bool {
+        let input_is_visible = self.is_input_box_visible(model, app);
+        // If there is a conversation tombstone and the input is hidden, should not broadcast input updates as
+        // the cloud agent session is over.
+        !(self.conversation_ended_tombstone_view_id.is_some() && !input_is_visible)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         resources: TerminalViewResources,

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -555,6 +555,8 @@ fn test_on_session_share_ended_inserts_tombstone_for_owned_ambient_session_witho
                     .interaction_state(ctx),
                 InteractionState::Selectable
             );
+            let model = view.model.lock();
+            assert!(!view.should_publish_shared_session_input_editor_update(&model, ctx));
         });
     });
 }


### PR DESCRIPTION
## Description
Don't broadcast viewer-side input editor updates if there is a visible conversation tombstone and no visible input editor.

There are certain cases where you can get into a cloud agent session with some inconsistent state with both a visible tombstone and a hidden input, and typing on the keyboard triggers error toasts corresponding to inability to apply input updates from the viewer.