### PR TITLE
Third-party harness session sharing fixes.

### DIFF
--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -17,6 +17,7 @@ use async_broadcast::InactiveReceiver;
 use std::any::Any;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::collections::HashSet;
 use std::sync::mpsc::{SendError, SyncSender};
 use std::{collections::HashMap, ffi::OsString, path::PathBuf, sync::Arc, thread::JoinHandle};
 
@@ -1671,23 +1672,25 @@ impl TerminalManager {
                 // Check eligibility from the incoming participant list directly,
                 // since the presence manager processes new viewers asynchronously.
                 if was_viewer_driven_sizing_eligible {
-                    let sharer_uid = &participant_list.sharer.info.profile_data.firebase_uid;
                     let is_ambient_agent = terminal_view
                         .as_ref(ctx)
                         .is_shared_session_for_ambient_agent();
-                    let present_viewers: Vec<_> = participant_list
-                        .viewers
-                        .iter()
-                        .filter(|v| v.is_present)
-                        .collect();
-                    let still_eligible = present_viewers.len() == 1
-                        && (is_ambient_agent
-                            || present_viewers[0].info.profile_data.firebase_uid
-                                == *sharer_uid);
-                    if !still_eligible {
-                        terminal_view.update(ctx, |view, ctx| {
-                            view.restore_pty_to_sharer_size(ctx);
-                        });
+                    // We never want to reset back to the sharer size if we are a cloud agent, since that was a default.
+                    if !is_ambient_agent {
+                        let sharer_uid = &participant_list.sharer.info.profile_data.firebase_uid;
+                        let distinct_viewer_uids: HashSet<_> = participant_list
+                            .viewers
+                            .iter()
+                            .filter(|v| v.is_present)
+                            .map(|v| &v.info.profile_data.firebase_uid)
+                            .collect();
+                        let still_eligible = distinct_viewer_uids.len() == 1
+                            && distinct_viewer_uids.contains(sharer_uid);
+                        if !still_eligible {
+                            terminal_view.update(ctx, |view, ctx| {
+                                view.restore_pty_to_sharer_size(ctx);
+                            });
+                        }
                     }
                 }
 

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -17,7 +17,6 @@ use async_broadcast::InactiveReceiver;
 use std::any::Any;
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::collections::HashSet;
 use std::sync::mpsc::{SendError, SyncSender};
 use std::{collections::HashMap, ffi::OsString, path::PathBuf, sync::Arc, thread::JoinHandle};
 
@@ -31,6 +30,7 @@ use crate::editor::CrdtOperation;
 use crate::network::{NetworkStatusEvent, NetworkStatusKind};
 use crate::terminal::available_shells::{AvailableShell, AvailableShells};
 use crate::terminal::shared_session::permissions_manager::SessionPermissionsManager;
+use crate::terminal::shared_session::presence_manager::PresenceManager;
 use crate::terminal::ShellLaunchData;
 use crate::terminal::ShellLaunchState;
 use crate::view_components::ToastFlavor;
@@ -1675,17 +1675,17 @@ impl TerminalManager {
                     let is_ambient_agent = terminal_view
                         .as_ref(ctx)
                         .is_shared_session_for_ambient_agent();
-                    // We never want to reset back to the sharer size if we are a cloud agent, since that was a default.
+                    // We never want to reset back to the sharer size if we are a cloud agent,
+                    // since it was a default. Prefer to keep the viewer-set size for transcript
+                    // persistence.
                     if !is_ambient_agent {
-                        let sharer_uid = &participant_list.sharer.info.profile_data.firebase_uid;
-                        let distinct_viewer_uids: HashSet<_> = participant_list
-                            .viewers
-                            .iter()
-                            .filter(|v| v.is_present)
-                            .map(|v| &v.info.profile_data.firebase_uid)
-                            .collect();
-                        let still_eligible = distinct_viewer_uids.len() == 1
-                            && distinct_viewer_uids.contains(sharer_uid);
+                        let sharer_uid =
+                            participant_list.sharer.info.profile_data.firebase_uid.as_str();
+                        let still_eligible =
+                            PresenceManager::single_distinct_present_viewer_uid_from_viewers(
+                                participant_list.viewers.iter(),
+                            )
+                            .is_some_and(|viewer_uid| viewer_uid == sharer_uid);
                         if !still_eligible {
                             terminal_view.update(ctx, |view, ctx| {
                                 view.restore_pty_to_sharer_size(ctx);

--- a/app/src/terminal/shared_session/presence_manager.rs
+++ b/app/src/terminal/shared_session/presence_manager.rs
@@ -8,9 +8,11 @@ use futures_util::future::join_all;
 use itertools::{Either, Itertools};
 use pathfinder_color::ColorU;
 use rand::Rng;
+#[cfg(not(target_arch = "wasm32"))]
+use session_sharing_protocol::common::Viewer;
 use session_sharing_protocol::common::{
     InputReplicaId, ParticipantInfo, ParticipantList, ParticipantPresenceUpdate, PresenceUpdate,
-    Role, RoleRequestId, Selection, Viewer,
+    Role, RoleRequestId, Selection,
 };
 
 use asset_cache::AssetCacheExt as _;
@@ -777,6 +779,7 @@ impl PresenceManager {
 
     /// Like `single_distinct_present_viewer_uid`, but reads directly from a
     /// participant list before the presence manager finishes processing it.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn single_distinct_present_viewer_uid_from_viewers<'a>(
         viewers: impl Iterator<Item = &'a Viewer>,
     ) -> Option<&'a str> {

--- a/app/src/terminal/shared_session/presence_manager.rs
+++ b/app/src/terminal/shared_session/presence_manager.rs
@@ -10,7 +10,7 @@ use pathfinder_color::ColorU;
 use rand::Rng;
 use session_sharing_protocol::common::{
     InputReplicaId, ParticipantInfo, ParticipantList, ParticipantPresenceUpdate, PresenceUpdate,
-    Role, RoleRequestId, Selection,
+    Role, RoleRequestId, Selection, Viewer,
 };
 
 use asset_cache::AssetCacheExt as _;
@@ -97,7 +97,7 @@ const PRESET_COLORS: &[ColorU] = &[
 ];
 
 /// Helper struct containing participant info and anything else necessary for rendering
-/// for an present participant.
+/// for a present participant.
 #[derive(Clone)]
 pub struct Participant {
     pub info: ParticipantInfo,
@@ -333,11 +333,6 @@ impl PresenceManager {
     /// `None` if the viewer does not have a pending request.
     pub fn get_role_request(&self, participant_id: &ParticipantId) -> Option<&RoleRequestId> {
         self.role_requests.get(participant_id)
-    }
-
-    /// Returns the number of present viewers (not including ourselves).
-    pub(crate) fn present_viewer_count(&self) -> usize {
-        self.present_viewers.len()
     }
 
     /// Returns the present viewers of this shared session, not including ourselves.
@@ -769,6 +764,32 @@ impl PresenceManager {
     /// Firebase UID.
     pub fn present_viewer_id_for_uid(&self, viewer_uid: UserUid) -> Option<&ParticipantId> {
         self.present_viewer_ids_for_uid(viewer_uid).next()
+    }
+
+    /// Returns the only distinct present viewer UID. Multiple present viewers
+    /// with the same UID count as one user.
+    pub fn single_distinct_present_viewer_uid(&self) -> Option<&str> {
+        Self::single_distinct_uid(
+            self.get_present_viewers()
+                .map(|v| v.info.profile_data.firebase_uid.as_str()),
+        )
+    }
+
+    /// Like `single_distinct_present_viewer_uid`, but reads directly from a
+    /// participant list before the presence manager finishes processing it.
+    pub(crate) fn single_distinct_present_viewer_uid_from_viewers<'a>(
+        viewers: impl Iterator<Item = &'a Viewer>,
+    ) -> Option<&'a str> {
+        Self::single_distinct_uid(
+            viewers
+                .filter(|v| v.is_present)
+                .map(|v| v.info.profile_data.firebase_uid.as_str()),
+        )
+    }
+
+    fn single_distinct_uid<'a>(mut uids: impl Iterator<Item = &'a str>) -> Option<&'a str> {
+        let uid = uids.next()?;
+        uids.all(|other_uid| other_uid == uid).then_some(uid)
     }
 }
 

--- a/app/src/terminal/shared_session/presence_manager_tests.rs
+++ b/app/src/terminal/shared_session/presence_manager_tests.rs
@@ -14,6 +14,48 @@ use session_sharing_protocol::common::{
 use warp_core::command::ExitCode;
 use warpui::App;
 
+fn viewer_with_uid(uid: &str, is_present: bool) -> Viewer {
+    Viewer {
+        info: ParticipantInfo {
+            profile_data: ProfileData {
+                firebase_uid: uid.to_owned(),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        role: Role::Reader,
+        is_present,
+    }
+}
+
+#[test]
+fn single_distinct_present_viewer_uid_filters_absent_duplicates() {
+    let viewers = [
+        viewer_with_uid("same", true),
+        viewer_with_uid("same", true),
+        viewer_with_uid("other", false),
+    ];
+
+    assert_eq!(
+        PresenceManager::single_distinct_present_viewer_uid_from_viewers(viewers.iter()),
+        Some("same")
+    );
+}
+
+#[test]
+fn single_distinct_present_viewer_uid_returns_none_for_zero_or_multiple_uids() {
+    assert_eq!(
+        PresenceManager::single_distinct_present_viewer_uid_from_viewers([].iter()),
+        None
+    );
+
+    let viewers = [viewer_with_uid("one", true), viewer_with_uid("two", true)];
+    assert_eq!(
+        PresenceManager::single_distinct_present_viewer_uid_from_viewers(viewers.iter()),
+        None
+    );
+}
+
 #[test]
 fn test_choosing_preset_colors() {
     App::test((), |mut app| async move {

--- a/app/src/terminal/terminal_manager.rs
+++ b/app/src/terminal/terminal_manager.rs
@@ -54,9 +54,9 @@ pub(super) fn compute_block_size(initial_size: Vector2F, ctx: &mut AppContext) -
         TerminalSettings::as_ref(ctx).terminal_spacing(appearance.line_height_ratio(), ctx);
     let size_info = if ctx.is_headless() {
         // In headless mode, we don't actually have a font since we aren't rendering anything.
-        // We skip the font-based size computation and hardcode a standard 80x24 terminal, so that
+        // We skip the font-based size computation and hardcode a terminal size, so that
         // viewers of the shared session see a reasonable terminal width.
-        SizeInfo::new_without_font_metrics(24, 80)
+        SizeInfo::new_without_font_metrics(24, 120)
     } else {
         let font_cache = ctx.font_cache();
         create_size_info_for_blocklist(

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -747,7 +747,7 @@ impl TerminalView {
             }
         }
         #[cfg(not(target_arch = "wasm32"))]
-        if self.active_viewer_driven_size.is_some() {
+        if self.active_viewer_driven_size.is_some() && !self.is_shared_session_for_ambient_agent() {
             self.restore_pty_to_sharer_size(ctx);
         }
 

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -1821,18 +1821,18 @@ impl TerminalView {
             .map(|manager| {
                 let manager = manager.as_ref(ctx);
                 if is_sharer {
-                    let one_viewer = manager.present_viewer_count() == 1;
-                    one_viewer
-                        && (skip_uid_check
-                            || manager.get_present_viewers().all(|v| {
-                                v.info.profile_data.firebase_uid
-                                    == manager.firebase_uid().as_string()
-                            }))
+                    manager
+                        .single_distinct_present_viewer_uid()
+                        .is_some_and(|viewer_uid| {
+                            skip_uid_check || viewer_uid == manager.firebase_uid().as_str()
+                        })
                 } else {
-                    // We are a viewer — we must be the only viewer and the sharer must be us.
-                    // (present_viewer_count() excludes ourselves)
-                    let only_viewer = manager.present_viewer_count() == 0;
-                    only_viewer
+                    // No other distinct user should be viewing.
+                    // Stale copies of our own connection share our UID.
+                    let no_other_user = manager.get_present_viewers().all(|v| {
+                        v.info.profile_data.firebase_uid == manager.firebase_uid().as_string()
+                    });
+                    no_other_user
                         && (skip_uid_check
                             || manager.get_sharer().is_some_and(|s| {
                                 s.info.profile_data.firebase_uid


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
This PR addresses three session sharing issues for third-party harnesses (each landed in its own commit):
1. We increase the width of the default PTY size for a headless Warp instance so that for a terminal session that never has a viewer, the saved block transcript is a reasonable width and not super skinny. Tested by running locally and never opening the session before it closes; the width is much more reasonable now.

2. We don't ever reset to the sharer size when a viewer joins and exits an ambient session. It doesn't make sense to revert to the default headless value once we've gotten a real value from a viewer.


3. We dedupe the viewer checks by firebase ID. There was a bug where, if you join a session, leave it, and rejoin it, your resize events don't get respected on the second rejoin. This happened because the presence manager holds onto stale visitors for some time before dropping them, and it incorrectly decided we were ineligible for resizing because it saw "another person" in the session, even though it was a phantom you.
    - This does mean that if you are viewing an ambient agent session from two different locations simultaneously, we'll allow resizing from both. I think this is actually correct given that you can't really be resizing both at the same time if you are one person.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

Behavior before: https://www.loom.com/share/0443fc35324d4b0a9e207bbb8f0a9fa9
Behavior after: https://www.loom.com/share/6ff55284504e4d37b6c0b6d98198fe0f

New default width example (ran without ever opening from a viewer):
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/c90e0d07-bc33-4ac3-8d4e-0ec4d8ce8123" />
 

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

