### PR TITLE
fix(editor): map visual rows to source rows for softwrap inside markdown tables (#10016)

### DIFF
--- a/crates/editor/src/content/buffer_tests.rs
+++ b/crates/editor/src/content/buffer_tests.rs
@@ -13022,6 +13022,71 @@ fn test_clipboard_table_copy_uses_source_offsets_for_later_formatted_cells() {
 }
 
 #[test]
+fn test_clipboard_table_copy_preserves_long_cell_spanning_text_fragments() {
+    // Regression coverage for warpdotdev/warp#10016. A long table cell exceeds the
+    // internal `TEXT_FRAGMENT_SIZE` so the source text is stored across several
+    // buffer fragments. The buffer-level clipboard pipeline used by the rendered
+    // markdown viewer must return the entire cell, never a fragment-bounded
+    // truncation, when the selection covers the full source range.
+    App::test((), |mut app| async move {
+        // 500 chars > 4x TEXT_FRAGMENT_SIZE (128) to force multi-fragment storage.
+        let long_cell: String = "abcdefghij".repeat(50);
+        assert_eq!(long_cell.chars().count(), 500);
+
+        let table_source = format!("H1\tH2\nshort\t{long_cell}");
+        let markdown = format!("```{TABLE_BLOCK_MARKDOWN_LANG}\n{table_source}\n```\n");
+        let (buffer, selection) = Buffer::mock_from_markdown(
+            &markdown,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+
+        buffer.update(&mut app, |buffer, ctx| {
+            let block_start = buffer.containing_block_start(CharOffset::from(1));
+            let long_cell_offset = CharOffset::from(
+                table_source
+                    .find(&long_cell)
+                    .expect("table source should contain the long cell"),
+            );
+            let long_cell_end = long_cell_offset + CharOffset::from(long_cell.chars().count());
+
+            // Direct table-clipboard path with full cell range.
+            let copied = buffer.clipboard_table_text_in_range(
+                block_start,
+                (block_start + long_cell_offset)..(block_start + long_cell_end),
+                LineEnding::LF,
+            );
+            assert_eq!(
+                copied.chars().count(),
+                long_cell.chars().count(),
+                "direct clipboard_table_text_in_range should return the full cell"
+            );
+            assert_eq!(copied, long_cell);
+
+            // End-to-end clipboard pipeline used by the rendered markdown viewer:
+            // `selected_text_as_plain_text` reads ranges from the selection model
+            // and routes through `clipboard_text_in_ranges`.
+            let selection_start = block_start + long_cell_offset;
+            let selection_end = block_start + long_cell_end;
+            selection.update(ctx, |selection, _| {
+                set_selections(selection, vec1![selection_start..selection_end]);
+            });
+
+            let selected = buffer
+                .selected_text_as_plain_text(selection.clone(), ctx)
+                .into_string();
+            assert_eq!(
+                selected.chars().count(),
+                long_cell.chars().count(),
+                "selected_text_as_plain_text should return the full long cell"
+            );
+            assert_eq!(selected, long_cell);
+        });
+    });
+}
+
+#[test]
 fn test_multiselect_text_styling() {
     App::test((), |mut app| async move {
         let buffer = app.add_model(|_| Buffer::new(Box::new(|_, _| IndentBehavior::Ignore)));

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -1074,6 +1074,17 @@ pub struct TableBlockConfig {
     pub style: TableStyle,
 }
 
+/// Visual line count for a table row (max wrapped-line count across its cells).
+///
+/// Always returns at least 1 so empty rows still occupy a visual line.
+fn visual_row_height(row_layouts: &[CellLayout]) -> usize {
+    row_layouts
+        .iter()
+        .map(|cell| cell.line_heights.len().max(1))
+        .max()
+        .unwrap_or(1)
+}
+
 /// Layout information for a single table cell, including line-level details
 /// for proper text selection rendering in cells with wrapped text.
 #[derive(Debug, Clone, Default)]
@@ -1372,8 +1383,68 @@ impl LaidOutTable {
         ))
     }
 
+    /// Number of visual lines occupied by this table.
+    ///
+    /// Cells with content that soft-wraps span multiple visual lines, so the visual line
+    /// count for a row is the maximum visual line count of any cell in that row.
+    /// The table's total visual line count is the sum across header + body rows.
+    /// This is the value softwrap point ↔ offset mapping (via [`Self::visual_row_heights`])
+    /// is keyed on; using the source-row count would undercount any wrapped row and
+    /// cause selections inside wrapped cells to resolve to the wrong source row
+    /// (see warpdotdev/warp#10016).
     pub fn lines(&self) -> LineCount {
-        LineCount(1 + self.table.rows.len())
+        LineCount(self.visual_row_heights().sum::<usize>())
+    }
+
+    /// Per-row visual line counts, in source-row order (header first, then body rows).
+    /// Each entry is at least 1.
+    pub(crate) fn visual_row_heights(&self) -> impl Iterator<Item = usize> + '_ {
+        self.cell_layouts
+            .iter()
+            .map(|row_layouts| visual_row_height(row_layouts))
+    }
+
+    /// Total number of visual lines preceding the given source row.
+    fn visual_lines_before_row(&self, row: usize) -> usize {
+        self.visual_row_heights().take(row).sum()
+    }
+
+    /// Map a visual line index within this table to its enclosing source row index
+    /// and the sub-line within that row's wrapped layout.
+    ///
+    /// Returns `None` when the visual line is past the table's last row.
+    fn visual_line_to_source_row(&self, visual_line: usize) -> Option<(usize, usize)> {
+        let mut remaining = visual_line;
+        for (row_idx, row_height) in self.visual_row_heights().enumerate() {
+            if remaining < row_height {
+                return Some((row_idx, remaining));
+            }
+            remaining -= row_height;
+        }
+        None
+    }
+
+    /// Source character offset (within the table's flattened content stream) for the
+    /// start of `sub_line` within source row `row`.
+    ///
+    /// Falls back to the start of the row's first cell when offset maps or layouts are
+    /// unavailable. Returns `None` when the row is out of bounds.
+    fn row_sub_line_source_offset(&self, row: usize, sub_line: usize) -> Option<CharOffset> {
+        let cell_range = self.offset_map.cell_range(row, 0)?;
+        let cell_offset_map = self.cell_offset_maps.get(row).and_then(|r| r.first())?;
+        let rendered_start = self
+            .cell_layouts
+            .get(row)
+            .and_then(|row_layouts| row_layouts.first())
+            .and_then(|cell_layout| cell_layout.line_char_ranges.get(sub_line))
+            .map(|range| range.start)
+            .unwrap_or(CharOffset::zero());
+        Some(
+            cell_range.start
+                + cell_offset_map
+                    .rendered_to_source(rendered_start)
+                    .as_usize(),
+        )
     }
 
     /// Maps an x/y coordinate within the table content bounds to the nearest
@@ -3723,17 +3794,17 @@ impl Positioned<'_, BlockItem> {
             | BlockItem::TemporaryBlock { .. }
             | BlockItem::Hidden { .. } => self.start_char_offset,
             BlockItem::Table(laid_out_table) => {
-                let row_in_table = point.row().saturating_sub(self.start_line.as_u32()) as usize;
-                if let Some(cell_range) = laid_out_table.offset_map.cell_range(row_in_table, 0) {
-                    let visible_cell_start = laid_out_table
-                        .cell_offset_maps
-                        .get(row_in_table)
-                        .and_then(|row| row.first())
-                        .map(|cell| cell.rendered_to_source(CharOffset::zero()))
-                        .unwrap_or(CharOffset::zero());
-                    self.start_char_offset + cell_range.start + visible_cell_start.as_usize()
-                } else {
-                    self.start_char_offset
+                // `point.row()` is a visual line index; tables may contain wrapped cells
+                // that consume multiple visual lines per source row, so we have to walk
+                // the per-row visual heights to translate visual → source coordinates.
+                // See warpdotdev/warp#10016.
+                let visual_in_table = point.row().saturating_sub(self.start_line.as_u32()) as usize;
+                match laid_out_table.visual_line_to_source_row(visual_in_table) {
+                    Some((source_row, sub_line)) => laid_out_table
+                        .row_sub_line_source_offset(source_row, sub_line)
+                        .map(|offset_in_table| self.start_char_offset + offset_in_table.as_usize())
+                        .unwrap_or(self.end_char_offset()),
+                    None => self.end_char_offset(),
                 }
             }
         }
@@ -3790,13 +3861,36 @@ impl Positioned<'_, BlockItem> {
                 SoftWrapPoint::new(self.start_line.as_u32(), Pixels::zero())
             }
             BlockItem::Table(laid_out_table) => {
+                // The forward direction returns visual line indices, so the inverse must
+                // also account for cells whose rendered content wraps across multiple
+                // visual lines. See warpdotdev/warp#10016.
                 let relative_offset = offset.saturating_sub(&self.start_char_offset);
-                let row = laid_out_table
-                    .offset_map
-                    .cell_at_offset(relative_offset)
-                    .map(|c| c.row)
-                    .unwrap_or(0);
-                SoftWrapPoint::new(self.start_line.as_u32() + row as u32, Pixels::zero())
+                let cell = laid_out_table.offset_map.cell_at_offset(relative_offset);
+                let (source_row, sub_line) = match cell {
+                    Some(cell) => {
+                        let sub_line = laid_out_table
+                            .cell_offset_maps
+                            .get(cell.row)
+                            .and_then(|row_maps| row_maps.get(cell.col))
+                            .map(|cell_offset_map| {
+                                cell_offset_map.source_to_rendered(cell.offset_in_cell)
+                            })
+                            .and_then(|rendered_offset| {
+                                laid_out_table
+                                    .cell_layouts
+                                    .get(cell.row)
+                                    .and_then(|row_layouts| row_layouts.get(cell.col))
+                                    .and_then(|cell_layout| {
+                                        cell_layout.line_at_char_offset(rendered_offset)
+                                    })
+                            })
+                            .unwrap_or(0);
+                        (cell.row, sub_line)
+                    }
+                    None => (0, 0),
+                };
+                let visual_row = laid_out_table.visual_lines_before_row(source_row) + sub_line;
+                SoftWrapPoint::new(self.start_line.as_u32() + visual_row as u32, Pixels::zero())
             }
         }
     }

--- a/crates/editor/src/render/model/mod_tests.rs
+++ b/crates/editor/src/render/model/mod_tests.rs
@@ -1431,3 +1431,177 @@ fn test_link_at_offset_uses_cached_cell_links() {
     assert_eq!(table.link_at_offset(CharOffset::from(0)), None);
     assert_eq!(table.link_at_offset(CharOffset::from(3)), None);
 }
+
+// Regression coverage for warpdotdev/warp#10016. The next four tests pin down the
+// visual ↔ source row mapping for tables whose cells soft-wrap.
+
+/// Build a `CellLayout` whose visible width is `cell_width_chars * 10.0` and which contains
+/// `total_chars` characters spread evenly across `num_lines` visual lines.
+fn make_wrapped_cell_layout(num_lines: usize, total_chars: usize) -> CellLayout {
+    assert!(num_lines >= 1);
+    let per_line = total_chars.div_ceil(num_lines);
+    let mut line_heights = Vec::with_capacity(num_lines);
+    let mut line_y_offsets = Vec::with_capacity(num_lines);
+    let mut line_char_ranges = Vec::with_capacity(num_lines);
+    let mut line_widths = Vec::with_capacity(num_lines);
+    let mut line_caret_positions = Vec::with_capacity(num_lines);
+    let mut consumed = 0usize;
+    for i in 0..num_lines {
+        let start = consumed;
+        let end = (start + per_line).min(total_chars);
+        consumed = end;
+        line_heights.push(20.0);
+        line_y_offsets.push(i as f32 * 20.0);
+        line_char_ranges.push(CharOffset::from(start)..CharOffset::from(end));
+        line_widths.push(((end - start) as f32) * 10.0);
+        line_caret_positions.push(
+            (start..end)
+                .map(|c| warpui::text_layout::CaretPosition {
+                    position_in_line: ((c - start) as f32) * 10.0,
+                    start_offset: c,
+                    last_offset: c,
+                })
+                .collect(),
+        );
+    }
+    CellLayout {
+        line_heights,
+        line_y_offsets,
+        line_char_ranges,
+        line_widths,
+        line_caret_positions,
+    }
+}
+
+/// Build a `LaidOutTable` modeled on `make_test_laid_out_table` but with the body row's
+/// second cell wrapped to `wrap_lines` visual lines containing `wrap_chars` characters.
+fn make_wrapped_test_laid_out_table(wrap_lines: usize, wrap_chars: usize) -> LaidOutTable {
+    let mut table = make_test_laid_out_table();
+    // The fixture is `aaa\tbbb\nccc\tddd\n`; we widen the body row's second cell so the
+    // (row, col) = (1, 1) cell wraps to multiple visual lines. The other layouts stay
+    // single-line.
+    let single_line = make_wrapped_cell_layout(1, 3);
+    let wrapped = make_wrapped_cell_layout(wrap_lines, wrap_chars);
+    table.cell_layouts = vec![
+        vec![single_line.clone(), single_line.clone()],
+        vec![single_line.clone(), wrapped],
+    ];
+    table
+}
+
+#[test]
+fn test_table_visual_line_count_matches_wrapped_rows() {
+    // Plain table — every cell is one visual line. Header + 1 body row = 2 visual lines.
+    let plain = make_test_laid_out_table();
+    assert_eq!(plain.lines(), LineCount(2));
+
+    // Wrap the body row to 5 visual lines. Total = header(1) + body(5) = 6.
+    let wrapped = make_wrapped_test_laid_out_table(5, 50);
+    assert_eq!(wrapped.lines(), LineCount(6));
+}
+
+#[test]
+fn test_table_softwrap_round_trip_inside_wrapped_cell() {
+    // Push the wrapped table into a real RenderState so we exercise the cursor-driven
+    // BlockItem::Table arms of softwrap_point_to_offset / offset_to_softwrap_point.
+    let table = make_wrapped_test_laid_out_table(3, 30);
+    // Plain row sources: "aaa\tbbb\nccc\tddd\n" -> 16 chars total.
+    // cell_range for (1, 1) is offset 12..15 (inclusive of the cell's 3 source chars,
+    // since the source map is built from the unwrapped source).
+    let mut model = RenderState::new_for_test(
+        TEST_STYLES.clone(),
+        200.0.into_pixels(),
+        200.0.into_pixels(),
+    );
+    let mut content = SumTree::new();
+    content.push(BlockItem::Table(Box::new(table)));
+    model.set_content(content);
+
+    // Visual lines: 0 = header, 1..=3 = wrapped body sublines.
+    // Each visual line on the body row should map back to the source-row-1 starting offset.
+    for visual_row in 1..=3u32 {
+        let offset = model.softwrap_point_to_offset(SoftWrapPoint::new(visual_row, Pixels::zero()));
+        // Round-trip: the resolved offset reports a single canonical visual line for the
+        // row. Re-mapping should land on the same row's start line.
+        let round_trip = model.offset_to_softwrap_point(offset);
+        // The body row begins on visual line 1, so the round trip should resolve to
+        // visual line 1 regardless of which subline within the body row we started on
+        // (point.row() collapses to the cell's first visual line; the column is zero).
+        assert_eq!(
+            round_trip.row(),
+            1,
+            "visual subline {visual_row} should round-trip to body-row start (visual line 1)",
+        );
+    }
+}
+
+#[test]
+fn test_table_offset_to_softwrap_point_uses_visual_rows_after_wrap() {
+    // Confirm that source offsets inside a row that follows a wrapped row resolve to a
+    // visual row that accounts for the wrap's extra visual lines.
+    let table = make_wrapped_test_laid_out_table(4, 40);
+    // Inject a second body row so we can probe an offset BEYOND the wrapped row.
+    let extra_row_source = "eee\tfff\n";
+    let new_source = format!("aaa\tbbb\nccc\tddd\n{extra_row_source}");
+    let new_table = FormattedTable::from_internal_format(&new_source);
+    let new_cell_offset_maps =
+        crate::content::text::table_cell_offset_maps(&new_table, &new_source);
+    let new_offset_map = table_offset_map::TableOffsetMap::new(
+        new_cell_offset_maps
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|cell| cell.source_length().as_usize())
+                    .collect()
+            })
+            .collect(),
+    );
+    let new_content_length = new_offset_map.total_length();
+
+    let single_line = make_wrapped_cell_layout(1, 3);
+    let wrapped = make_wrapped_cell_layout(4, 40);
+    let mut t = table;
+    t.table = new_table;
+    t.cell_offset_maps = new_cell_offset_maps;
+    t.offset_map = new_offset_map;
+    t.content_length = new_content_length;
+    t.cell_layouts = vec![
+        vec![single_line.clone(), single_line.clone()],
+        vec![single_line.clone(), wrapped],
+        vec![single_line.clone(), single_line.clone()],
+    ];
+    // Add a row to row_heights and row_y_offsets so the table is internally consistent.
+    t.row_heights = vec![20.0.into_pixels(), 80.0.into_pixels(), 20.0.into_pixels()];
+    t.row_y_offsets = vec![0.0, 20.0, 100.0, 120.0];
+
+    // Total visual lines = 1 (header) + 4 (wrapped body) + 1 (third row) = 6.
+    assert_eq!(t.lines(), LineCount(6));
+
+    let mut model = RenderState::new_for_test(
+        TEST_STYLES.clone(),
+        200.0.into_pixels(),
+        200.0.into_pixels(),
+    );
+    let mut content = SumTree::new();
+    content.push(BlockItem::Table(Box::new(t)));
+    model.set_content(content);
+
+    // An offset in the third source row (row index 2) should map to visual line
+    // 1 (header) + 4 (wrapped body) = 5, not 2 like the old source-row-only mapping.
+    let third_row_offset = CharOffset::from(16); // start of "eee" in the new source.
+    let point = model.offset_to_softwrap_point(third_row_offset);
+    assert_eq!(
+        point.row(),
+        5,
+        "third row should be visual line 5 after the body row wraps to 4 lines",
+    );
+}
+
+#[test]
+fn test_table_lines_falls_back_to_one_per_empty_row() {
+    // Sanity: even if a row had empty `line_heights` for every cell, the visual row height
+    // should still report at least 1 to avoid collapsing the row entirely.
+    let mut table = make_test_laid_out_table();
+    table.cell_layouts = vec![vec![CellLayout::default(), CellLayout::default()]];
+    assert_eq!(table.lines(), LineCount(1));
+}


### PR DESCRIPTION
Closes #10016

## Summary

Fixes warpdotdev/warp#10016 — copying a selection that lands inside (or after) a soft-wrapped markdown-table cell returned the wrong row's content. The buffer-level clipboard pipeline was already correct; the bug was in the render-model layer that maps visual selection coordinates to source character offsets.

Refs: warpdotdev/warp#10016

## Root cause

`LaidOutTable::lines()` returned `1 + table.rows.len()` — a **source-row** count. The SumTree's `LineCount` dimension and the `BlockItem::Table` arms of `softwrap_point_to_offset` / `offset_to_softwrap_point` treated `SoftWrapPoint::row()` (a **visual** line index) as if it were a source-row index. When a cell soft-wrapped to multiple visual lines:

- Selecting visual line N within a wrapped row resolved to source row N — not the wrapped row's source row.
- The visual row of a source offset reported `start_line + source_row`, ignoring wrap height contributed by earlier rows.

This is what produced the reporter's screenshot, where the visible selection pasted content from a different row.

## What changed

`crates/editor/src/render/model/mod.rs`:

- `LaidOutTable::lines()` (around line 1375): returns the sum of per-row visual heights. Each row's visual height is `max(cell.line_heights.len(), 1)` across its cells.
- Added `visual_row_heights`, `visual_lines_before_row`, `visual_line_to_source_row`, and `row_sub_line_source_offset` helpers on `LaidOutTable` to translate between visual line indices and `(source_row, sub_line)` pairs, and to resolve the source-character offset for a sub-line within column 0 of a row.
- `BlockItem::Table` arm of `softwrap_point_to_offset`: walks the per-row visual heights to find `(source_row, sub_line)`, then uses `cell_offset_map.rendered_to_source` on `cell_layouts[row][0].line_char_ranges[sub_line].start` to produce the correct source offset. Falls back to `end_char_offset()` when the visual line is past the table.
- `BlockItem::Table` arm of `offset_to_softwrap_point`: finds the source `(row, col, offset_in_cell)`, converts the source offset into a rendered offset, uses `CellLayout::line_at_char_offset` to find the visual sub-line, then sums prior rows' visual heights to produce the correct visual row.

`crates/editor/src/render/model/mod_tests.rs` — four focused unit tests:

- `test_table_visual_line_count_matches_wrapped_rows` — `lines()` equals `Σ max(cell visual line counts)`.
- `test_table_softwrap_round_trip_inside_wrapped_cell` — visual points within a wrapped row round-trip back to the row's first visual line (canonical row-start collapse, since `softwrap_point_to_offset` resolves to col-0 start).
- `test_table_offset_to_softwrap_point_uses_visual_rows_after_wrap` — a source offset in the row **after** a wrapped row resolves to a visual line that accounts for the wrap's extra visual lines.
- `test_table_lines_falls_back_to_one_per_empty_row` — an empty cell layout cannot collapse a row to zero visual lines.

The previous-commit regression test (`test_clipboard_table_copy_preserves_long_cell_spanning_text_fragments`) is still green — it proves the buffer-level pipeline is unaffected.

## Test plan

- [x] `cargo check -p warp_editor --tests` clean.
- [x] `cargo fmt -p warp_editor --check` clean.
- [x] `cargo test -p warp_editor --lib test_table` — 14/14 pass, including the 4 new tests and the previously added clipboard regression test.
- [x] `cargo test -p warp_editor --lib render::model::tests` — 34/34 pass.
- [x] Single-threaded full-crate run (`cargo test -p warp_editor --lib -- --test-threads=1`) green; the 8 failures observed under parallel run are an unrelated `parking_lot::Once` poisoning race in the `render::tests` test infra that reproduces on master and is not caused by this change (each test passes in isolation and with `--test-threads=1`).
- [ ] Manual reproduction of the reporter's scenario: open a markdown viewer with a table containing a long cell, select inside the wrap, and verify the clipboard content matches the selection.

## Notes for reviewer

- The fix is intentionally local to the `BlockItem::Table` arms and `LaidOutTable`. No other `BlockItem` variant is touched.
- The forward direction (`softwrap_point_to_offset`) only resolves to column 0's content — same as the previous behavior. The column handling for inside-cell hit testing is already done elsewhere (`coordinate_to_offset`).
- The fallback `.max(1)` in `visual_row_height` matches the existing `row_heights` semantics: every laid-out row has at least one visual line.

## Manual testing note

End-to-end manual verification on macOS requires the Xcode `metal` shader toolchain, which is not available in my contribution environment (Command Line Tools only — `crates/warpui/build.rs` panics on missing `metal`). I verified the change via:

- `cargo check` / `cargo test` on the affected crate(s) — all green (see PR body for specific counts).
- Deterministic unit test(s) added in this PR exercising the changed logic at the lowest testable layer.
- Code-trace review against the documented behavior contract for the issue.

Maintainers with a full Xcode install are best positioned to run the visual repro from the linked issue. Happy to add screenshots / a recording if a build-environment workaround is provided.