### PR TITLE
Fix restored command history after SSH close

### DIFF
--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -29,8 +29,8 @@ use super::ansi::{
     WarpificationUnavailableReason,
 };
 use super::block::{
-    AgentInteractionMetadata, Block, BlockId, BlockMetadata, BlockSize, BlocklistEnvVarMetadata,
-    BlockState, SerializedBlock,
+    AgentInteractionMetadata, Block, BlockId, BlockMetadata, BlockSize, BlockState,
+    BlocklistEnvVarMetadata, SerializedBlock,
 };
 use super::blockgrid::BlockGrid;
 use super::grid::grid_handler::{

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -29,8 +29,8 @@ use super::ansi::{
     WarpificationUnavailableReason,
 };
 use super::block::{
-    AgentInteractionMetadata, Block, BlockId, BlockMetadata, BlockSize, BlockState,
-    BlocklistEnvVarMetadata, SerializedBlock,
+    AgentInteractionMetadata, Block, BlockId, BlockMetadata, BlockSize, BlocklistEnvVarMetadata,
+    BlockState, SerializedBlock,
 };
 use super::blockgrid::BlockGrid;
 use super::grid::grid_handler::{

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -29,8 +29,8 @@ use super::ansi::{
     WarpificationUnavailableReason,
 };
 use super::block::{
-    AgentInteractionMetadata, Block, BlockId, BlockMetadata, BlockSize, BlocklistEnvVarMetadata,
-    SerializedBlock,
+    AgentInteractionMetadata, Block, BlockId, BlockMetadata, BlockSize, BlockState,
+    BlocklistEnvVarMetadata, SerializedBlock,
 };
 use super::blockgrid::BlockGrid;
 use super::grid::grid_handler::{
@@ -2153,7 +2153,10 @@ impl TerminalModel {
     fn restored_block_commands(&self) -> Vec<HistoryEntry> {
         let mut commands = Vec::new();
         for block in self.block_list.blocks() {
-            if block.is_restored() && !block.is_background() {
+            if block.is_restored()
+                && !block.is_background()
+                && block.state() != BlockState::DoneWithNoExecution
+            {
                 let entry = HistoryEntry::for_restored_block(block.command_to_string(), block);
                 commands.push(entry);
             }


### PR DESCRIPTION
## Description
Fixes restored command history after closing an SSH session.

When Warp restores blocks after relaunch, some blocks can exist in a `DoneWithNoExecution` state. Those blocks are bootstrap / shell output, not user commands, so they should not be appended back into session history. This change skips those restored blocks when building the restored command history.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

Closes #3523

## Testing
- [x] I have manually tested my changes locally with `./script/run`

Manual verification:
- Opened an SSH session.
- Closed Warp during the session.
- Reopened Warp and confirmed the SSH MOTD / login banner no longer reappears in command history suggestions.

### Result
Login banner message is not shown in the restored command history

### Screenshots / Videos
<img width="1281" height="804" alt="image" src="https://github.com/user-attachments/assets/70d662fb-36ec-48c7-9ace-d5f3e36cc4fb" />

