### PR TITLE
Improve error message for team API key schedule operations

### DIFF
--- a/app/src/ai/agent_sdk/schedule.rs
+++ b/app/src/ai/agent_sdk/schedule.rs
@@ -6,21 +6,39 @@ use warp_cli::schedule::{
     CreateScheduleArgs, DeleteScheduleArgs, GetScheduleArgs, PauseScheduleArgs, ScheduleCommand,
     ScheduleSubcommand, UnpauseScheduleArgs, UpdateScheduleArgs,
 };
-use warp_cli::{agent::OutputFormat, GlobalOptions};
+use warp_cli::{GlobalOptions, agent::OutputFormat};
 use warp_graphql::queries::get_scheduled_agent_history::ScheduledAgentHistory;
 use warpui::platform::TerminationMode;
 use warpui::{AppContext, SingletonEntity};
 
+use crate::ai::ambient_agents::AgentConfigSnapshot;
 use crate::ai::ambient_agents::scheduled::{
     CloudScheduledAmbientAgent, ScheduledAgentManager, ScheduledAmbientAgent, UpdateScheduleParams,
 };
-use crate::ai::ambient_agents::AgentConfigSnapshot;
 use crate::cloud_object::CloudObject;
 use crate::server::ids::{ServerId, SyncId};
 use crate::util::time_format::format_approx_duration_from_now_utc;
 
 use super::common::{EnvironmentChoice, ResolveConfigurationError};
 use super::output::{self, TableFormat};
+
+/// Checks if an error is caused by a service account (team API key) attempting a schedule
+/// operation that requires a user principal, and returns a user-friendly error message.
+fn report_schedule_error(err: anyhow::Error, ctx: &mut AppContext) {
+    let err_str = format!("{err:#}");
+    if err_str.contains("Expected a user account") {
+        super::report_fatal_error(
+            anyhow::anyhow!(
+                "Creating schedules with team-scoped API keys is not currently supported. \
+                To have a schedule run as a service account, please create one in the Oz \
+                web UI and then assign it to a team-owned agent."
+            ),
+            ctx,
+        );
+    } else {
+        super::report_fatal_error(err, ctx);
+    }
+}
 
 /// Run a scheduled agent command.
 pub fn run(
@@ -157,7 +175,7 @@ fn create(ctx: &mut AppContext, args: CreateScheduleArgs) -> anyhow::Result<()> 
                     ctx.terminate_app(TerminationMode::ForceTerminate, None);
                 }
                 Err(err) => {
-                    super::report_fatal_error(err, ctx);
+                    report_schedule_error(err, ctx);
                 }
             });
         });
@@ -354,7 +372,7 @@ fn pause(ctx: &mut AppContext, args: PauseScheduleArgs) -> anyhow::Result<()> {
                     ctx.terminate_app(TerminationMode::ForceTerminate, None);
                 }
                 Err(err) => {
-                    super::report_fatal_error(err, ctx);
+                    report_schedule_error(err, ctx);
                 }
             });
         });
@@ -382,7 +400,7 @@ fn unpause(ctx: &mut AppContext, args: UnpauseScheduleArgs) -> anyhow::Result<()
                     ctx.terminate_app(TerminationMode::ForceTerminate, None);
                 }
                 Err(err) => {
-                    super::report_fatal_error(err, ctx);
+                    report_schedule_error(err, ctx);
                 }
             });
         });
@@ -522,7 +540,7 @@ fn update(ctx: &mut AppContext, args: UpdateScheduleArgs) -> anyhow::Result<()> 
                     ctx.terminate_app(TerminationMode::ForceTerminate, None);
                 }
                 Err(err) => {
-                    super::report_fatal_error(err, ctx);
+                    report_schedule_error(err, ctx);
                 }
             });
         });
@@ -658,7 +676,7 @@ fn delete(ctx: &mut AppContext, args: DeleteScheduleArgs) -> anyhow::Result<()> 
                     ctx.terminate_app(TerminationMode::ForceTerminate, None);
                 }
                 Err(err) => {
-                    super::report_fatal_error(err, ctx);
+                    report_schedule_error(err, ctx);
                 }
             });
         });


### PR DESCRIPTION
## Description

Improves the error message when a team API key (service account) is used to manage schedules via the CLI. Instead of the cryptic `"Error: missing response data for CreateGenericStringObject: Unauthorized: Expected a user account"`, the user now sees:

> Creating schedules with team-scoped API keys is not currently supported. To have a schedule run as a service account, please create one in the Oz web UI and then assign it to a team-owned agent.

Adds a `report_schedule_error` helper that intercepts the "Expected a user account" error pattern in all 5 schedule mutation handlers (create, pause, unpause, update, delete) and replaces it with the actionable message.

## Linked Issue

- [REMOTE-1652](https://linear.app/warpdotdev/issue/REMOTE-1652) - Error scheduling with team API key due to unauthorized access
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] `cargo check -p warp --lib` passes
- [x] `cargo fmt` passes
- [ ] I have manually tested my changes locally with `./script/run`

Companion PR: https://github.com/warpdotdev/warp-server/pull/11087 (server-side REST API error message improvement)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Improved error message when attempting to create schedules with team-scoped API keys

_Conversation: https://staging.warp.dev/conversation/30ead947-a108-4719-b54f-03869833b6cb_
_Run: https://oz.staging.warp.dev/runs/019e1c75-18ff-7066-91c9-f93ded1c3ffb_
_This PR was generated with [Oz](https://warp.dev/oz)._
