### PR TITLE
Stop old remote daemon when autoupdating

### DIFF
--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -337,6 +337,44 @@ impl RemoteTransport for SshTransport {
         })
     }
 
+    fn stop_remote_server_daemon(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> {
+        let ssh_socket_path = self.socket_path.clone();
+        let pid_path = self.remote_daemon_pid_path();
+        let daemon_socket_path = self.remote_daemon_socket_path();
+        Box::pin(async move {
+            // Read the PID, kill the daemon, and clean up its files in a
+            // single SSH round-trip. The tilde-safe expansion mirrors
+            // install_remote_server.sh: use `case` + `${var#~}` instead
+            // of `${var/~/...}` to avoid bash version quirks.
+            let cmd = format!(
+                "pid_path={pid_path}; \
+                 case \"$pid_path\" in \"~\"|\"~/\"*) pid_path=\"${{HOME}}${{pid_path#\\~}}\";; esac; \
+                 sock_path={daemon_socket_path}; \
+                 case \"$sock_path\" in \"~\"|\"~/\"*) sock_path=\"${{HOME}}${{sock_path#\\~}}\";; esac; \
+                 if [ -f \"$pid_path\" ]; then \
+                   pid=$(cat \"$pid_path\" 2>/dev/null) && \
+                   [ -n \"$pid\" ] && kill \"$pid\" 2>/dev/null; \
+                 fi; \
+                 rm -f \"$pid_path\" \"$sock_path\""
+            );
+            log::info!("Stopping stale remote server daemon: {cmd}");
+            let output = remote_server::ssh::run_ssh_command(
+                &ssh_socket_path,
+                &cmd,
+                remote_server::setup::CHECK_TIMEOUT,
+            )
+            .await?;
+            if output.status.success() {
+                Ok(())
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                Err(anyhow::anyhow!("Failed to stop daemon: {stderr}"))
+            }
+        })
+    }
+
     /// SSH exit code 255 indicates a connection-level error (broken pipe,
     /// connection reset, host unreachable) — the ControlMaster's TCP
     /// connection is dead. A signal kill also suggests the transport was

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -355,7 +355,7 @@ impl RemoteTransport for SshTransport {
                  case \"$sock_path\" in \"~\"|\"~/\"*) sock_path=\"${{HOME}}${{sock_path#\\~}}\";; esac; \
                  if [ -f \"$pid_path\" ]; then \
                    pid=$(cat \"$pid_path\" 2>/dev/null) && \
-                   [ -n \"$pid\" ] && kill \"$pid\" 2>/dev/null; \
+                   case \"$pid\" in ''|*[!0-9]*|0) ;; *) kill \"$pid\" 2>/dev/null;; esac; \
                  fi; \
                  rm -f \"$pid_path\" \"$sock_path\""
             );

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -975,6 +975,24 @@ impl RemoteServerManager {
                     "Remote server stale binary removal failed: session={session_id:?} error={e:#}"
                 );
             }
+
+            // Also stop the running daemon process. The daemon is
+            // long-lived and was likely started from the old binary,
+            // so it will keep reporting the old version. Without
+            // stopping it, the next proxy invocation finds the old
+            // daemon still alive (via PID file) and connects to it,
+            // producing the same version mismatch in a loop.
+            if let Err(e) = transport
+                .stop_remote_server_daemon()
+                .with_timeout(REMOVAL_TIMEOUT)
+                .await
+                .unwrap_or_else(|_| Err(anyhow::anyhow!("timed out after {REMOVAL_TIMEOUT:?}")))
+            {
+                log::warn!(
+                    "Remote server stale daemon stop failed: session={session_id:?} error={e:#}"
+                );
+            }
+
             return Err(ConnectAndHandshakeError::Initialize(anyhow::anyhow!(
                 "remote server version mismatch (client: {client_version:?}, \
                  server: {:?}); reconnect to reinstall",

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -266,6 +266,25 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
         &self,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
 
+    /// Stop the remote server daemon process and clean up its PID/socket
+    /// files.
+    ///
+    /// Called by the manager alongside [`remove_remote_server_binary`]
+    /// when the initialize handshake reveals a version mismatch. The
+    /// daemon is a long-lived process that outlives individual proxy
+    /// connections; if we only remove the binary without stopping the
+    /// daemon, the next proxy invocation will find the old daemon still
+    /// running (via its PID file) and connect to it, producing the same
+    /// version mismatch in a loop.
+    ///
+    /// Best-effort: failures are logged but do not prevent the caller
+    /// from proceeding.
+    ///
+    /// [`remove_remote_server_binary`]: RemoteTransport::remove_remote_server_binary
+    fn stop_remote_server_daemon(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
+
     /// Returns `true` if the transport considers a reconnect viable after
     /// a spontaneous disconnect with the given exit status.
     ///

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -281,9 +281,8 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     /// from proceeding.
     ///
     /// [`remove_remote_server_binary`]: RemoteTransport::remove_remote_server_binary
-    fn stop_remote_server_daemon(
-        &self,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
+    fn stop_remote_server_daemon(&self)
+        -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
 
     /// Returns `true` if the transport considers a reconnect viable after
     /// a spontaneous disconnect with the given exit status.


### PR DESCRIPTION
## Summary

Fix an infinite version-mismatch loop during remote server initialization after a client update (e.g. `stable_03` → `stable_04`).

## Root cause

The remote server uses a daemon architecture: the `remote-server-proxy` connects to a long-lived daemon via a Unix socket. When the client updates, the new binary is installed but the **old daemon process keeps running** from the previous binary. The proxy finds it alive (via PID check) and connects to it, so the daemon reports the old version → mismatch → client removes the new binary → reinstalls → same old daemon → loop.

The APP-3805 version-skew fix added binary removal on mismatch, but missed the daemon — removing the binary does not stop the running process.

## Fix

Added `stop_remote_server_daemon()` to the `RemoteTransport` trait and `SshTransport`. On version mismatch, after removing the stale binary, we now also kill the old daemon process and clean up its PID/socket files. The next connection attempt starts a fresh daemon from the correct binary.

### Files changed
- `crates/remote_server/src/transport.rs` — new trait method
- `app/src/remote_server/ssh_transport.rs` — SSH implementation (single round-trip: read PID, kill, rm files)
- `crates/remote_server/src/manager.rs` — call `stop_remote_server_daemon()` alongside `remove_remote_server_binary()` in the version mismatch handler

---

[Oz conversation](https://staging.warp.dev/conversation/ed895867-f6c2-418f-b8a9-bac814ddd93b) | [Plan](https://staging.warp.dev/drive/notebook/SfDfpJHCRtgWfnPANoVfL2)

## Testing
Tested locally by spawning a named version client and confirmed the mismatched version client is successfully killed 