### PR TITLE
Wait on child process to exit before showing error

### DIFF
--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -38,6 +38,11 @@ const MAX_RECONNECT_ATTEMPTS: u32 = 2;
 /// Delay between reconnection attempts.
 #[cfg(not(target_family = "wasm"))]
 const RECONNECT_DELAY: Duration = Duration::from_secs(2);
+/// Brief timeout for awaiting a child process's exit status after a
+/// connection failure. Gives the SSH subprocess time to report its exit
+/// code and signal status before we give up and report `None`.
+#[cfg(not(target_family = "wasm"))]
+const EXIT_STATUS_WAIT_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Parameters that travel together through the reconnection flow.
 #[cfg(not(target_family = "wasm"))]
@@ -825,21 +830,57 @@ impl RemoteServerManager {
                             );
                             let phase = e.phase();
                             let error = format!("{e}");
-                            let _ = spawner
-                                .spawn(move |me, ctx| {
-                                    // Capture exit status from the Initializing
-                                    // child (if present) for telemetry diagnostics.
-                                    let exit_status = match me.sessions.get_mut(&session_id) {
+
+                            // Extract the child process from the Initializing
+                            // session state so we can asynchronously await its
+                            // exit status on this background thread. Transition
+                            // to Disconnected while we wait so the session slot
+                            // is not empty (an empty slot would be misread as
+                            // "user deregistered" by the is_cancelled check).
+                            let maybe_child = spawner
+                                .spawn(move |me, _ctx| {
+                                    match me.sessions.remove(&session_id) {
                                         Some(RemoteSessionState::Initializing {
                                             _child, ..
-                                        }) => Self::capture_exit_status(_child, session_id),
-                                        _ => None,
-                                    };
+                                        }) => {
+                                            me.sessions.insert(
+                                                session_id,
+                                                RemoteSessionState::Disconnected,
+                                            );
+                                            Some(_child)
+                                        }
+                                        other => {
+                                            // Put back whatever was there
+                                            // (including None for deregistered).
+                                            if let Some(state) = other {
+                                                me.sessions.insert(session_id, state);
+                                            }
+                                            None
+                                        }
+                                    }
+                                })
+                                .await
+                                .ok()
+                                .flatten();
 
+                            // Await the subprocess exit status with a short
+                            // timeout. This gives the SSH process time to
+                            // terminate and report its exit code / signal,
+                            // which is critical for ResponseChannelClosed
+                            // errors where the non-blocking try_status()
+                            // previously returned None due to a timing race.
+                            let exit_status = match maybe_child {
+                                Some(child) => Self::await_exit_status(child, session_id).await,
+                                None => None,
+                            };
+
+                            let _ = spawner
+                                .spawn(move |me, ctx| {
                                     // Classify: user cancellation vs real failure.
                                     //
                                     // Signal A: session was already deregistered
-                                    // (user exited before the error handler ran).
+                                    // (user exited before the error handler ran,
+                                    // or deregistered during the exit status wait).
                                     //
                                     // Signal B: the transport reports the
                                     // connection is unrecoverable (e.g. SSH
@@ -1545,6 +1586,56 @@ impl RemoteServerManager {
             Err(e) => {
                 log::warn!(
                     "Remote server exit status read failed: session={session_id:?} error={e}"
+                );
+                None
+            }
+        }
+    }
+
+    /// Asynchronously awaits the exit status of a `Child` process with a
+    /// short timeout.
+    ///
+    /// Unlike [`capture_exit_status`] which uses the non-blocking
+    /// `try_status()`, this method waits for the process to exit, giving
+    /// the SSH subprocess a window to report its exit code and signal
+    /// status. This is important for connection failures like
+    /// `ResponseChannelClosed` where the pipe breaks before the
+    /// subprocess has fully exited, causing `try_status()` to return
+    /// `None` due to the timing race.
+    #[cfg(not(target_family = "wasm"))]
+    async fn await_exit_status(
+        mut child: async_process::Child,
+        session_id: SessionId,
+    ) -> Option<RemoteServerExitStatus> {
+        match child.status().with_timeout(EXIT_STATUS_WAIT_TIMEOUT).await {
+            Ok(Ok(status)) => {
+                let code = status.code();
+                #[cfg(unix)]
+                let signal_killed = {
+                    use std::os::unix::process::ExitStatusExt;
+                    status.signal().is_some()
+                };
+                #[cfg(not(unix))]
+                let signal_killed = false;
+                log::info!(
+                    "Remote server process exited (async): session={session_id:?} \
+                     code={code:?} signal_killed={signal_killed}"
+                );
+                Some(RemoteServerExitStatus {
+                    code,
+                    signal_killed,
+                })
+            }
+            Ok(Err(e)) => {
+                log::warn!(
+                    "Remote server exit status read failed: session={session_id:?} error={e}"
+                );
+                None
+            }
+            Err(_) => {
+                log::warn!(
+                    "Remote server process did not exit within \
+                     {EXIT_STATUS_WAIT_TIMEOUT:?}: session={session_id:?}"
                 );
                 None
             }

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -248,6 +248,12 @@ pub enum RemoteSessionState {
         host_id: HostId,
         control_path: Option<PathBuf>,
     },
+    /// The connection failed and the background task is briefly awaiting
+    /// the child process's exit status before emitting the failure event.
+    /// Preserves the `control_path` so `deregister_session` can still
+    /// call `stop_control_master` if the user exits during this window.
+    #[cfg(not(target_family = "wasm"))]
+    AwaitingExitStatus { control_path: Option<PathBuf> },
     /// Connection dropped (EOF/error from the reader task).
     Disconnected,
 }
@@ -841,11 +847,15 @@ impl RemoteServerManager {
                                 .spawn(move |me, _ctx| {
                                     match me.sessions.remove(&session_id) {
                                         Some(RemoteSessionState::Initializing {
-                                            _child, ..
+                                            _child,
+                                            control_path,
+                                            ..
                                         }) => {
                                             me.sessions.insert(
                                                 session_id,
-                                                RemoteSessionState::Disconnected,
+                                                RemoteSessionState::AwaitingExitStatus {
+                                                    control_path,
+                                                },
                                             );
                                             Some(_child)
                                         }
@@ -1091,7 +1101,10 @@ impl RemoteServerManager {
         #[cfg(not(target_family = "wasm"))]
         let control_path = match &prev {
             Some(RemoteSessionState::Connected { control_path, .. })
-            | Some(RemoteSessionState::Initializing { control_path, .. }) => control_path.clone(),
+            | Some(RemoteSessionState::Initializing { control_path, .. })
+            | Some(RemoteSessionState::AwaitingExitStatus { control_path, .. }) => {
+                control_path.clone()
+            }
             Some(RemoteSessionState::Reconnecting { control_path, .. }) => control_path.clone(),
             _ => None,
         };
@@ -1193,6 +1206,8 @@ impl RemoteServerManager {
     pub fn is_session_potentially_active(&self, session_id: SessionId) -> bool {
         match self.sessions.get(&session_id) {
             Some(RemoteSessionState::Disconnected) | None => false,
+            #[cfg(not(target_family = "wasm"))]
+            Some(RemoteSessionState::AwaitingExitStatus { .. }) => false,
             Some(
                 RemoteSessionState::Connecting
                 | RemoteSessionState::Initializing { .. }
@@ -1712,8 +1727,9 @@ impl RemoteServerManager {
                 ctx,
             );
         } else {
-            // Non-Connected states (Initializing, Connecting, etc.) —
-            // no reconnect, just mark disconnected.
+            // Non-Connected states (Initializing, Connecting,
+            // AwaitingExitStatus, etc.) — no reconnect, just mark
+            // disconnected.
             self.sessions
                 .insert(session_id, RemoteSessionState::Disconnected);
         }


### PR DESCRIPTION
## Description
In my previous fix #10668 , we were trying to capture exit status with `async_process::Child::try_status`. Note that this is a synchronous method that will return None if the Child has not dropped yet -- this is very likely to happen in a killed stream

Instead, we should try to call `async_process::Child::status` which returns an async future that only resolves when the child is definitely exited. We also added a small timeout in case the child takes a while to exit so we don't block on it forever.

## Testing
Confirmed now exit status is consistently captured
```
16:47:48.226 [WARN] [remote_server::manager] DEBUG: Sleep complete, proceeding with initialize handshake
16:47:48.227 [WARN] [remote_server::manager] Remote server connection failed: session=SessionId(17786188531007) error=Connection was dropped
16:47:48.227 [INFO] [remote_server::manager] Remote server process exited (async): session=SessionId(17786188531007) code=Some(255) signal_killed=false
16:47:48.227 [INFO] [remote_server::manager] Remote server connection failure exit status captured: session=SessionId(17786188531007) exit_code=Some(255) signal_killed=Some(false)
```