### PR TITLE
fix(settings-keybindings): honor user-defined keybindings over default conflicts (#9128)

### DIFF
--- a/crates/warpui_core/src/keymap.rs
+++ b/crates/warpui_core/src/keymap.rs
@@ -439,9 +439,23 @@ impl Keymap {
     /// Items will be returned in the reverse order they were registered, the most recently
     /// registered editable binding will have the highest precedence
     fn editable_bindings(&self) -> impl Iterator<Item = EditableBindingLens<'_>> {
-        self.editable_bindings
+        // Iterate user-customized bindings before defaults, so an explicit user
+        // override always wins precedence over a default binding that happens to
+        // use the same keystroke. Within each partition, retain reverse-registration
+        // order (most recently registered first), matching the prior behavior.
+        // See https://github.com/warpdotdev/warp/issues/9128.
+        let user_overridden = self
+            .editable_bindings
             .iter()
             .rev()
+            .filter(|binding| binding.custom_trigger.is_some());
+        let defaults = self
+            .editable_bindings
+            .iter()
+            .rev()
+            .filter(|binding| binding.custom_trigger.is_none());
+        user_overridden
+            .chain(defaults)
             .map(|binding| binding.as_lens())
             .filter(|binding| binding.is_enabled())
     }
@@ -450,7 +464,9 @@ impl Keymap {
     /// modified by the custom bindings, where appropriate.
     ///
     /// Editable bindings will be returned first, followed by any fixed bindings in the reverse
-    /// order they were added.
+    /// order they were added. Among editable bindings, user-customized ones take precedence
+    /// over defaults so an explicit user override is not shadowed by a default binding that
+    /// shares the same keystroke (#9128).
     fn bindings(&self) -> impl Iterator<Item = BindingLens<'_>> {
         self.editable_bindings()
             .map(|lens| lens.as_binding())
@@ -464,9 +480,19 @@ impl Keymap {
     }
 
     fn editable_custom_action_bindings(&self) -> impl Iterator<Item = EditableBindingLens<'_>> {
-        self.editable_custom_action_bindings
+        // Mirror the precedence rule used by `editable_bindings` (#9128).
+        let user_overridden = self
+            .editable_custom_action_bindings
             .iter()
             .rev()
+            .filter(|binding| binding.custom_trigger.is_some());
+        let defaults = self
+            .editable_custom_action_bindings
+            .iter()
+            .rev()
+            .filter(|binding| binding.custom_trigger.is_none());
+        user_overridden
+            .chain(defaults)
             .map(|binding| binding.as_lens())
             .filter(|binding| binding.is_enabled())
     }

--- a/crates/warpui_core/src/keymap/matcher_tests.rs
+++ b/crates/warpui_core/src/keymap/matcher_tests.rs
@@ -176,6 +176,67 @@ fn test_editable_binding_matching() {
     );
 }
 
+/// Regression test for https://github.com/warpdotdev/warp/issues/9128.
+///
+/// When the user explicitly rebinds an editable action to a keystroke that another editable
+/// action already uses by default, the user's binding must win precedence regardless of
+/// registration order. Previously, the iteration order followed only registration order
+/// (most-recently-registered wins), so default bindings registered *after* the user's
+/// rebound action would silently shadow the user override.
+#[test]
+fn test_user_override_wins_over_default_with_same_keystroke() {
+    #[derive(Debug, PartialEq)]
+    enum Action {
+        Copy,
+        SplitPaneDown,
+    }
+
+    let mut keymap = Keymap::default();
+    use crate::keymap::macros::*;
+
+    // Simulate the real-world ordering from #9128: an action that the user wants to bind
+    // (`split_pane_down`) is registered BEFORE the action whose default keystroke conflicts
+    // with the user override (`copy`). In the buggy precedence model, `copy` is iterated
+    // first because it was registered later, so the user's override never fires.
+    keymap.register_editable_bindings([EditableBinding::new(
+        "split_pane_down",
+        "Split pane down",
+        Action::SplitPaneDown,
+    )
+    .with_key_binding("ctrl-shift-E")
+    .with_context_predicate(id!("PaneGroup"))]);
+    keymap.register_editable_bindings([EditableBinding::new("copy", "Copy", Action::Copy)
+        .with_key_binding("ctrl-shift-C")
+        .with_context_predicate(id!("Terminal"))]);
+
+    // The user rebinds Split Pane Down to ctrl-shift-C, which collides with the default
+    // Copy binding above.
+    keymap.update_custom_trigger(
+        "split_pane_down",
+        Some(Trigger::Keystrokes(vec![
+            Keystroke::parse("ctrl-shift-C").unwrap()
+        ])),
+    );
+
+    // Build a context that satisfies BOTH bindings' predicates — this is the real-world
+    // case: the terminal lives inside the pane group, so the active context contains
+    // both `Terminal` and `PaneGroup` tags.
+    let mut ctx = Context::default();
+    ctx.set.insert("Terminal");
+    ctx.set.insert("PaneGroup");
+
+    let mut matcher = Matcher::new(keymap);
+    let view_id = EntityId::new();
+    let action = matcher
+        .test_keystroke("ctrl-shift-C", view_id, &ctx)
+        .expect("user-overridden binding should fire");
+    assert_eq!(
+        action.as_action::<Action>(),
+        &Action::SplitPaneDown,
+        "user-customized binding should take precedence over a default that uses the same keystroke"
+    );
+}
+
 #[test]
 fn test_bindings_for_context() {
     #[derive(Debug)]

--- a/crates/warpui_core/src/keymap_tests.rs
+++ b/crates/warpui_core/src/keymap_tests.rs
@@ -274,10 +274,13 @@ fn test_custom_triggers() {
         Some(Trigger::Keystrokes(vec![first_custom_trigger.clone()])),
     );
 
+    // User-customized bindings take precedence in iteration order over defaults, so an
+    // explicit override is not shadowed by a default binding that happens to share the same
+    // keystroke. See https://github.com/warpdotdev/warp/issues/9128.
     {
         let mut bindings = map.bindings();
-        let second = bindings.next().unwrap();
         let first = bindings.next().unwrap();
+        let second = bindings.next().unwrap();
         assert!(bindings.next().is_none());
 
         match first.trigger {
@@ -297,8 +300,8 @@ fn test_custom_triggers() {
 
     {
         let mut editable_bindings = map.editable_bindings();
-        let second = editable_bindings.next().unwrap();
         let first = editable_bindings.next().unwrap();
+        let second = editable_bindings.next().unwrap();
         assert!(editable_bindings.next().is_none());
 
         match first.trigger {


### PR DESCRIPTION
Closes #9128

## Summary

Fixes #9128 — user keybindings (e.g. `Split Pane Down` → `Ctrl+Shift+C`) were silently shadowed by a default binding that used the same keystroke (`Copy` on Linux/Windows), so the user override only fired in narrow contexts (the bash-subshell case from the bug report).

### Root cause

`Keymap::bindings()` iterates editable bindings in reverse-registration order, then fixed bindings. The matcher takes the first binding whose keystroke + context predicate both match.

`pane_group::init` (registers `pane_group:add_down` / SplitPaneDown) runs **before** `terminal::init` (registers `terminal:copy`). In reverse-registration order, `terminal:copy` is iterated first. Its trigger resolves to `ctrl-shift-C` on Linux/Windows (via `cmd_or_ctrl_shift("c")`), and its context predicate `Terminal & !IMEOpen` matches the main terminal — so `Copy` wins, and the user's explicit Ctrl+Shift+C → SplitPaneDown override never fires.

Inside a bash subshell, the user happens to have block-selection state and altscreen flags that change which `Copy`-flavored binding matches, which is why the override appears to work there — pure coincidence, not by design.

### Fix

Partition editable bindings in `Keymap::editable_bindings()` / `editable_custom_action_bindings()` so user-customized ones (`custom_trigger.is_some()`) iterate **before** defaults. Within each partition, reverse-registration order is preserved, so default-vs-default precedence is unchanged. This makes an explicit user override always beat a default binding that happens to share the same keystroke, regardless of which crate registered first.

### Files

- `crates/warpui_core/src/keymap.rs` — partition the editable-binding iterators
- `crates/warpui_core/src/keymap/matcher_tests.rs` — new regression test exercising the #9128 scenario (SplitPaneDown rebound to ctrl-shift-C while Copy default also uses ctrl-shift-C)
- `crates/warpui_core/src/keymap_tests.rs` — update the existing custom-trigger ordering test to reflect the new precedence semantics

## Test plan

- [x] cargo test -p warpui_core --lib keymap (19/19 passing including new regression test)
- [x] cargo test -p warpui_core --lib (275/275 passing)
- [x] cargo clippy -p warpui_core --tests --no-deps -- -D warnings (clean)
- [x] cargo fmt --check -p warpui_core (clean)
- [ ] Manual: on Linux/WSL, bind Split Pane Down to Ctrl+Shift+C in Settings, press in main terminal, confirm split fires
- [ ] Manual: confirm default Ctrl+Shift+C still copies when no override set
- [ ] Manual: confirm other defaults (Ctrl+Shift+D, etc.) unchanged

## Manual testing note

End-to-end manual verification on macOS requires the Xcode `metal` shader toolchain, which is not available in my contribution environment (Command Line Tools only — `crates/warpui/build.rs` panics on missing `metal`). I verified the change via:

- `cargo check` / `cargo test` on the affected crate(s) — all green (see PR body for specific counts).
- Deterministic unit test(s) added in this PR exercising the changed logic at the lowest testable layer.
- Code-trace review against the documented behavior contract for the issue.

Maintainers with a full Xcode install are best positioned to run the visual repro from the linked issue. Happy to add screenshots / a recording if a build-environment workaround is provided.