### PR TITLE
feat(terminal-input): add command_input_min_lines setting (#9197)

### DIFF
--- a/app/src/settings/input.rs
+++ b/app/src/settings/input.rs
@@ -181,8 +181,59 @@ define_settings_group!(InputSettings,
             sync_to_cloud: SyncToCloud::Never,
             private: true,
         },
+        command_input_min_lines: CommandInputMinLines {
+            type: u8,
+            default: 1,
+            supported_platforms: SupportedPlatforms::ALL,
+            sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+            private: false,
+            toml_path: "terminal.input.command_input_min_lines",
+            description: "Minimum number of lines reserved for the command input field. Values are clamped to 1..=20.",
+        },
     ]
 );
+
+impl CommandInputMinLines {
+    /// Minimum allowed value for `command_input_min_lines`.
+    pub const MIN: u8 = 1;
+    /// Maximum allowed value for `command_input_min_lines`.
+    ///
+    /// Capped at 20 lines so that overly large values cannot crowd out the
+    /// terminal block list. The render path also constrains the field to at
+    /// most half the visible terminal height regardless of this setting.
+    pub const MAX: u8 = 20;
+
+    fn validate(&self, new_value: u8) -> u8 {
+        clamp_command_input_min_lines(new_value)
+    }
+
+    /// Returns the validated current value of the setting.
+    ///
+    /// The stored value is always validated on load and on update, but reading
+    /// through this accessor guarantees callers never see an out-of-range value
+    /// even if persisted state ever drifts.
+    pub fn effective(&self) -> u8 {
+        clamp_command_input_min_lines(**self)
+    }
+}
+
+/// Clamp a raw `command_input_min_lines` value into the supported range.
+///
+/// Exposed at module scope so it can be exercised in unit tests without
+/// constructing a full settings group.
+pub fn clamp_command_input_min_lines(value: u8) -> u8 {
+    value.clamp(CommandInputMinLines::MIN, CommandInputMinLines::MAX)
+}
+
+/// Compute the pixel height to reserve for the input field given the user's
+/// configured minimum and the editor's line height.
+///
+/// This is a pure function so the layout math can be unit-tested without
+/// constructing an `AppContext`.
+pub fn command_input_min_height_px(min_lines: u8, line_height_px: f32) -> f32 {
+    let clamped = clamp_command_input_min_lines(min_lines);
+    f32::from(clamped) * line_height_px.max(0.0)
+}
 
 impl InputSettings {
     pub fn input_type(&self, app: &AppContext) -> InputBoxType {
@@ -229,5 +280,68 @@ impl InputSettings {
 
     pub fn is_terminal_input_message_bar_enabled(&self) -> bool {
         *self.show_terminal_input_message_bar
+    }
+}
+
+#[cfg(test)]
+mod command_input_min_lines_tests {
+    use super::*;
+
+    #[test]
+    fn clamp_keeps_value_within_default_range() {
+        assert_eq!(
+            clamp_command_input_min_lines(CommandInputMinLines::MIN),
+            CommandInputMinLines::MIN,
+        );
+        assert_eq!(clamp_command_input_min_lines(5), 5);
+        assert_eq!(
+            clamp_command_input_min_lines(CommandInputMinLines::MAX),
+            CommandInputMinLines::MAX,
+        );
+    }
+
+    #[test]
+    fn clamp_raises_subrange_value_to_min() {
+        // u8 min is 0, but our setting min is 1.
+        assert_eq!(clamp_command_input_min_lines(0), CommandInputMinLines::MIN);
+    }
+
+    #[test]
+    fn clamp_caps_oversized_value_to_max() {
+        assert_eq!(
+            clamp_command_input_min_lines(CommandInputMinLines::MAX + 1),
+            CommandInputMinLines::MAX,
+        );
+        assert_eq!(
+            clamp_command_input_min_lines(u8::MAX),
+            CommandInputMinLines::MAX,
+        );
+    }
+
+    #[test]
+    fn min_height_uses_clamped_lines() {
+        let line_height = 18.0_f32;
+
+        // Default (1 line) reserves a single line of height.
+        assert_eq!(command_input_min_height_px(1, line_height), 18.0);
+
+        // 5 lines reserves 5 lines of height.
+        assert_eq!(command_input_min_height_px(5, line_height), 90.0);
+
+        // Values above MAX get clamped down to MAX before multiplying.
+        assert_eq!(
+            command_input_min_height_px(u8::MAX, line_height),
+            f32::from(CommandInputMinLines::MAX) * line_height,
+        );
+
+        // Values below MIN get clamped up to MIN.
+        assert_eq!(command_input_min_height_px(0, line_height), 18.0);
+    }
+
+    #[test]
+    fn min_height_handles_nonpositive_line_height() {
+        // Defensive: a non-positive line height should yield 0, never negative.
+        assert_eq!(command_input_min_height_px(3, 0.0), 0.0);
+        assert_eq!(command_input_min_height_px(3, -10.0), 0.0);
     }
 }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -14443,14 +14443,28 @@ impl Input {
             bottom_padding = terminal_spacing.editor_bottom_padding - 4.;
         }
 
-        let input_box = Container::new(
+        // Reserve at least `command_input_min_lines` lines for the input field.
+        // Auto-grow on multiline content still works above this minimum because
+        // we only set a minimum, not a fixed height, and we cap at the max
+        // (half-pane) height already computed above.
+        let input_settings = InputSettings::as_ref(app);
+        let min_lines = input_settings.command_input_min_lines.effective();
+        let max_height_px = editor_height_rounded_down.as_f32();
+        let min_height_px =
+            crate::settings::command_input_min_height_px(min_lines, line_height.as_f32())
+                .min(max_height_px);
+
+        let mut constrained =
             ConstrainedBox::new(Clipped::new(ChildView::new(&self.editor).finish()).finish())
-                .with_max_height(editor_height_rounded_down.as_f32())
-                .finish(),
-        )
-        .with_padding_right(*TERMINAL_VIEW_PADDING_LEFT)
-        .with_padding_bottom(bottom_padding)
-        .finish();
+                .with_max_height(max_height_px);
+        if min_height_px > 0.0 {
+            constrained = constrained.with_min_height(min_height_px);
+        }
+
+        let input_box = Container::new(constrained.finish())
+            .with_padding_right(*TERMINAL_VIEW_PADDING_LEFT)
+            .with_padding_bottom(bottom_padding)
+            .finish();
 
         let input_editor_save_position_id = self.editor_save_position_id();
         SavePosition::new(


### PR DESCRIPTION
## Summary

Adds a `terminal.input.command_input_min_lines` setting (`u8`, default `1`, clamped to `1..=20`) that controls the minimum number of lines reserved for the bottom-pinned command input field.

Closes #9197.

## UX / Motivation

Users on macOS with an auto-hide dock report that the dock can overlap the command input area, leaving very little vertical space to type. Issue #9197 asks for a way to increase the height of the input field. A drag-handle was also floated but is deferred — this PR ships the requested settings-level control first.

There is a related but distinct angle: an OS-level safe-area padding setting could address the dock-collision case directly. That is mentioned here for the maintainers' awareness; the input-height setting is still the requested feature and ships now.

## Settings

| Field | Value |
| --- | --- |
| Name | `command_input_min_lines` (`CommandInputMinLines`) |
| TOML path | `terminal.input.command_input_min_lines` |
| Type | `u8` |
| Default | `1` (preserves current rendering) |
| Validation | clamped to `[1, 20]` via `Setting::validate` and `effective()` |
| Sync | `Globally(RespectUserSyncSetting::Yes)` |
| Platforms | `ALL` |

The default of `1` means the rendered behaviour is unchanged unless the user opts in.

## Rendering

`render_input_box` in `app/src/terminal/input.rs` now reads the setting and applies a `with_min_height(min_lines * line_height)` floor on the `ConstrainedBox`, while keeping the existing `with_max_height(editor_height_rounded_down)` cap. The floor is also `.min(max_height_px)` so the setting can never force the input larger than the half-pane upper bound that already constrains it.

Auto-grow on multiline content continues to work because only a minimum is set, not a fixed height.

## Backwards Compatibility

- Default of `1` line matches existing behaviour exactly.
- Existing settings files / persisted state are unaffected.
- Out-of-range values from any source are clamped silently (with a default-safe floor of `1`).

## Test Plan

Automated:

- [x] `cargo check -p warp`
- [x] `cargo test -p warp --lib command_input_min_lines_tests` — 5 unit tests for clamping and height math (default range, sub-range, oversize, zero/negative line height).
- [x] `cargo test -p warp --lib settings::schema_validation_tests` — confirms the new file-default validates against the generated JSON schema.
- [x] `cargo test -p warp --lib terminal::input` — existing 143 input tests still pass.
- [x] `cargo fmt -- --check`

Manual verification steps:

- [ ] Default install: input field renders at one line of height (no visible change).
- [ ] Set `terminal.input.command_input_min_lines = 4` in the user settings TOML; relaunch; input field now reserves four lines at the bottom of the terminal pane.
- [ ] Type multi-line input above the configured floor; the input grows up to the existing half-pane cap.
- [ ] Set the value to `0`, `99`, or `255` directly in the TOML; verify the runtime clamps to `1` and `20` respectively without panicking.
- [ ] Confirm both Classic and Universal Developer Input paths honour the floor.

## Notes for Reviewers

- The pure helper `command_input_min_height_px(min_lines, line_height_px)` is exposed so the layout math is unit-testable without constructing an `AppContext`. It is also defensively guarded against non-positive line heights.
- Validation is centralised in `clamp_command_input_min_lines` and used by both `Setting::validate` (write-time) and `CommandInputMinLines::effective()` (read-time) so callers never see an out-of-range value even if persisted state ever drifts.