### PR TITLE
fix(window-tabs-panes): preserve user-set tab name across AI auto-naming (#9102)

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1060,9 +1060,12 @@ impl VerticalTabsPanelState {
                         )
                         .into_iter()
                         .any(|pane_id| {
-                            let title_override = (!uses_outer_group_container(display_granularity))
-                                .then(|| pane_group.custom_title(app))
-                                .flatten();
+                            let title_override = tab_title_override_for_row(
+                                pane_group,
+                                &visible_pane_ids,
+                                display_granularity,
+                                app,
+                            );
                             let ms = MouseStateHandle::default();
                             PaneProps::new(
                                 pane_group,
@@ -1600,9 +1603,12 @@ fn render_groups(
                         .then_some((tab_index, None))
                     }
                     VerticalTabsResolvedMode::Panes | VerticalTabsResolvedMode::FocusedSession => {
-                        let title_override = (!uses_outer_group_container)
-                            .then(|| pane_group.custom_title(app))
-                            .flatten();
+                        let title_override = tab_title_override_for_row(
+                            pane_group,
+                            &visible_pane_ids,
+                            display_granularity,
+                            app,
+                        );
                         let matching_ids: Vec<PaneId> = pane_ids_for_display_granularity(
                             &visible_pane_ids,
                             pane_group.focused_pane_id(app),
@@ -1864,9 +1870,8 @@ fn render_tab_group_internal(
     let is_being_renamed = is_active && workspace.current_workspace_state.is_tab_being_renamed();
     let rename_editor = workspace.tab_rename_editor.clone();
     let has_custom_title = pane_group.custom_title(app).is_some();
-    let displayed_tab_title_override = (!uses_outer_group_container)
-        .then(|| pane_group.custom_title(app))
-        .flatten();
+    let displayed_tab_title_override =
+        tab_title_override_for_row(pane_group, &visible_pane_ids, display_granularity, app);
     let is_menu_open_for_tab = workspace
         .show_tab_right_click_menu
         .is_some_and(|(idx, _)| idx == tab_index);
@@ -2953,6 +2958,56 @@ fn pane_matches_query(props: &PaneProps<'_>, query_lower: &str, app: &AppContext
 
 fn uses_outer_group_container(display_granularity: VerticalTabsDisplayGranularity) -> bool {
     matches!(display_granularity, VerticalTabsDisplayGranularity::Panes)
+}
+
+/// Returns the tab-level custom title (set via `/rename-tab`) that should be
+/// surfaced on a pane row when rendering the vertical-tabs sidebar.
+///
+/// A user-set tab title is the source of truth and must take precedence over
+/// any AI-generated conversation title that the agent writes after each
+/// prompt. Without this override the row falls through to the
+/// agent/conversation title and the user-set name appears to be "clobbered"
+/// after the next AI prompt (#9102).
+///
+/// We only surface the override when the tab contains a single visible pane.
+/// For multi-pane groups in `Panes` granularity the group header already
+/// displays the custom title, and propagating it onto every individual row
+/// would visually overwrite each pane's own title, which is the wrong UX.
+///
+/// Pane-level renames via `set_custom_vertical_tabs_title` continue to take
+/// precedence at the row level — see [`PaneProps::displayed_title`].
+fn tab_title_override_for_row(
+    pane_group: &PaneGroup,
+    visible_pane_ids: &[PaneId],
+    display_granularity: VerticalTabsDisplayGranularity,
+    app: &AppContext,
+) -> Option<String> {
+    select_tab_title_override_for_row(
+        pane_group.custom_title(app),
+        visible_pane_ids.len(),
+        display_granularity,
+    )
+}
+
+/// Pure-decision counterpart of [`tab_title_override_for_row`] used for unit
+/// tests. Given the tab's custom title (if any), the number of visible panes,
+/// and the resolved display granularity, returns the title that should be
+/// shown on each row of the vertical-tabs sidebar.
+fn select_tab_title_override_for_row(
+    custom_title: Option<String>,
+    visible_pane_count: usize,
+    display_granularity: VerticalTabsDisplayGranularity,
+) -> Option<String> {
+    let custom_title = custom_title?;
+    // When the outer group container is suppressed, the row is the only place
+    // the user-set title can appear, so always surface it.
+    if !uses_outer_group_container(display_granularity) {
+        return Some(custom_title);
+    }
+    // In `Panes` mode the group header carries the custom title for
+    // multi-pane groups; only mirror it onto the row in the single-pane
+    // case — the common shape, and the one reported in #9102.
+    (visible_pane_count == 1).then_some(custom_title)
 }
 
 fn search_fragments_contain_query(fragments: &[String], query_lower: &str) -> bool {

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -17,7 +17,8 @@ use super::{
     detail_target_for_hovered_row, non_terminal_search_text_fragments,
     pane_ids_for_display_granularity, pane_search_text_fragments, preferred_agent_tab_titles,
     push_normalized_unique_summary_label, search_fragments_contain_query,
-    select_summary_pane_kind_icons, should_keep_detail_sidecar_visible_for_mouse_position,
+    select_summary_pane_kind_icons, select_tab_title_override_for_row,
+    should_keep_detail_sidecar_visible_for_mouse_position,
     sort_summary_primary_labels_status_first, summary_overflow_count,
     summary_search_text_fragments, terminal_kind_badge_label, terminal_primary_line_data,
     terminal_pull_request_badge_label, terminal_search_text_fragments,
@@ -1139,4 +1140,64 @@ fn summary_search_fragments_include_hidden_overflow_values() {
     assert!(search_fragments_contain_query(&fragments, "#789"));
     assert!(search_fragments_contain_query(&fragments, "+2"));
     assert!(search_fragments_contain_query(&fragments, "-3"));
+}
+
+// Regression tests for #9102: when a user invokes `/rename-tab`, the row in
+// the vertical-tabs sidebar must continue to show that custom title even
+// after subsequent AI prompts generate a new conversation title.
+#[test]
+fn rename_tab_title_overrides_row_in_panes_mode_single_pane() {
+    // Single-pane tab in `Panes` granularity (the regression case in #9102):
+    // the user-set title must reach the row so it wins over AI auto-naming.
+    let override_title = select_tab_title_override_for_row(
+        Some("MY SESSION".to_string()),
+        1,
+        VerticalTabsDisplayGranularity::Panes,
+    );
+    assert_eq!(override_title, Some("MY SESSION".to_string()));
+}
+
+#[test]
+fn rename_tab_title_does_not_clobber_per_pane_titles_in_multi_pane_group() {
+    // Multi-pane tab in `Panes` mode: the group header already shows the
+    // custom title; we must NOT mirror it onto every row, which would erase
+    // each pane's own title.
+    let override_title = select_tab_title_override_for_row(
+        Some("MY SESSION".to_string()),
+        3,
+        VerticalTabsDisplayGranularity::Panes,
+    );
+    assert_eq!(override_title, None);
+}
+
+#[test]
+fn rename_tab_title_overrides_row_in_tabs_granularity() {
+    // `Tabs` granularity has no outer group container, so the row is the
+    // only place the custom title can appear — always surface it.
+    let override_title_single = select_tab_title_override_for_row(
+        Some("MY SESSION".to_string()),
+        1,
+        VerticalTabsDisplayGranularity::Tabs,
+    );
+    assert_eq!(override_title_single, Some("MY SESSION".to_string()));
+
+    let override_title_multi = select_tab_title_override_for_row(
+        Some("MY SESSION".to_string()),
+        4,
+        VerticalTabsDisplayGranularity::Tabs,
+    );
+    assert_eq!(override_title_multi, Some("MY SESSION".to_string()));
+}
+
+#[test]
+fn tab_title_override_for_row_is_none_when_no_custom_title_is_set() {
+    // Without `/rename-tab` there is no override, so the row falls back to
+    // its native title (which includes AI conversation titles).
+    let override_title =
+        select_tab_title_override_for_row(None, 1, VerticalTabsDisplayGranularity::Panes);
+    assert_eq!(override_title, None);
+
+    let override_title_tabs =
+        select_tab_title_override_for_row(None, 1, VerticalTabsDisplayGranularity::Tabs);
+    assert_eq!(override_title_tabs, None);
 }


### PR DESCRIPTION
Closes #9102

## Summary

Fixes #9102 — a regression where `/rename-tab` no longer persists the tab name in the vertical-tabs sidebar: the AI session auto-naming would overwrite the user-set name after every subsequent agent prompt.

The macOS window menu kept showing the renamed value (because it reads `PaneGroup::display_title`, which honors `custom_title`), but the vertical-tabs sidebar row reverted to the AI conversation title — making `/rename-tab` feel broken in this layout.

## Root cause

In `app/src/workspace/view/vertical_tabs.rs`, the tab-level custom title was being suppressed at the row level in `Panes` granularity. Three call sites set `PaneProps::display_title_override` via:

```rust
let title_override = (!uses_outer_group_container(display_granularity))
    .then(|| pane_group.custom_title(app))
    .flatten();
```

Because `uses_outer_group_container == true` for `Panes`, the row override was always `None` and the row fell through to `props.title` / the agent conversation title. The group header above the row showed the user-set name (which is why the macOS menu was fine), but the prominent row title underneath continued to refresh from agent activity, so the user perceived their rename as having been clobbered.

Pre-fix behavior, single-pane tab in `Panes` mode:

| Surface                           | Title shown after AI prompt |
|-----------------------------------|------------------------------|
| `PaneGroup::display_title` (menu) | `MY SESSION` (user set)      |
| Vertical-tabs group header        | `MY SESSION` (user set)      |
| Vertical-tabs row (the visible one) | AI conversation title (regression) |

## Fix

Replaces the inlined predicate at all three call sites with a single helper, `tab_title_override_for_row`, plus a pure-decision counterpart `select_tab_title_override_for_row` that is unit-testable. The new helper:

- Always surfaces `custom_title` when there is no outer group container (`Tabs` granularity / `FocusedSession` mode) — the row is the only place the user-set title can appear.
- Surfaces `custom_title` for single-pane groups in `Panes` mode (the common shape and the one reported here), so the user-set name takes precedence over AI auto-naming in the row title.
- Leaves multi-pane groups in `Panes` mode unchanged: each pane keeps its own row title, and the group header continues to carry the custom name. (Mirroring the tab-level custom title onto every pane row would itself be a regression for multi-pane tabs.)

`PaneProps::displayed_title` continues to prefer pane-level renames (`set_custom_vertical_tabs_title`) over the tab-level override, so pane-level rename UX is unaffected.

## Files changed

- `app/src/workspace/view/vertical_tabs.rs` — new `tab_title_override_for_row` + `select_tab_title_override_for_row` helpers; 3 call sites updated.
- `app/src/workspace/view/vertical_tabs_tests.rs` — 4 new regression tests.

## Test plan

- [x] `cargo test -p warp --lib rename_tab_title` — 3 new tests pass.
- [x] `cargo test -p warp --lib tab_title_override_for_row_is_none` — 1 new test passes.
- [x] `cargo test -p warp --lib "vertical_tabs::tests"` — full module (existing + new) passes.
- [x] `cargo check -p warp --tests` — clean.
- [x] `cargo fmt -p warp -- --check` — clean.
- [ ] Manual repro from the issue:
  1. Switch the sidebar to vertical-tabs (`Panes` granularity).
  2. Start a Claude Code session (or any AI session).
  3. Run `/rename-tab MY SESSION`. Sidebar row should now read `MY SESSION`.
  4. Send any follow-up prompt to the agent.
  5. **Before the fix:** the row reverts to the AI-generated summary.
     **After the fix:** the row stays on `MY SESSION` regardless of how many prompts you send.
  6. Verify the macOS Window menu also continues to show `MY SESSION` (no regression).

## Manual testing note

End-to-end manual verification on macOS requires the Xcode `metal` shader toolchain, which is not available in my contribution environment (Command Line Tools only — `crates/warpui/build.rs` panics on missing `metal`). I verified the change via:

- `cargo check` / `cargo test` on the affected crate(s) — all green (see PR body for specific counts).
- Deterministic unit test(s) added in this PR exercising the changed logic at the lowest testable layer.
- Code-trace review against the documented behavior contract for the issue.

Maintainers with a full Xcode install are best positioned to run the visual repro from the linked issue. Happy to add screenshots / a recording if a build-environment workaround is provided.