### PR TITLE
fix(window-tabs-panes): preserve terminal scroll position across tab switches (#9171)

### DIFF
--- a/app/src/terminal/block_list_viewport.rs
+++ b/app/src/terminal/block_list_viewport.rs
@@ -38,11 +38,26 @@ use super::{
 /// Wraps a scroll position for the purposes of centralizing update logic.
 pub struct ScrollState {
     position: ScrollPosition,
+
+    /// The scroll position recorded at the moment of last tab deactivation.
+    ///
+    /// While a tab is inactive, the blocklist is not rendered and `after_terminal_view_layout`
+    /// doesn't fire — but streaming output, rich-block insertion, and other model updates
+    /// can still mutate `position` (e.g. switching `FixedAtPosition` to
+    /// `FollowsBottomOfMostRecentBlock`). On reactivation we restore the snapshot so the
+    /// user returns to exactly where they left off, instead of getting yanked to the top
+    /// or bottom of a buffer that grew while they were away.
+    ///
+    /// This is `None` whenever the owning tab is active or has never been deactivated.
+    saved_for_tab_deactivation: Option<ScrollPosition>,
 }
 
 impl ScrollState {
     pub fn new(position: ScrollPosition) -> Self {
-        Self { position }
+        Self {
+            position,
+            saved_for_tab_deactivation: None,
+        }
     }
 
     pub fn position(&self) -> ScrollPosition {
@@ -68,6 +83,64 @@ impl ScrollState {
             return true;
         }
         false
+    }
+
+    /// Snapshot the current scroll position so it can be restored when the owning tab
+    /// becomes active again.
+    ///
+    /// Idempotent: if a snapshot already exists, calling this again is a no-op. This
+    /// matters because tab deactivation paths can fire more than once (e.g. window
+    /// focus + tab switch) and we want to preserve the position at the FIRST
+    /// deactivation, before any inactive-tab mutations.
+    ///
+    /// Returns `true` if a new snapshot was taken.
+    pub fn save_for_tab_deactivation(&mut self) -> bool {
+        if self.saved_for_tab_deactivation.is_none() {
+            self.saved_for_tab_deactivation = Some(self.position);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Restore the scroll position recorded at the moment of last tab deactivation,
+    /// if any.
+    ///
+    /// Clears the snapshot so future deactivations capture a fresh value. Returns
+    /// `true` if the position was actually mutated (i.e. drift had occurred while the
+    /// tab was inactive).
+    ///
+    /// The restored value is the opaque `ScrollPosition` previously stored — clamping
+    /// against the current content range is handled at render time by
+    /// `ViewportState::scroll_top_in_lines`, so this method does not need to inspect
+    /// the block list.
+    pub fn restore_after_tab_activation(&mut self) -> bool {
+        let Some(saved) = self.saved_for_tab_deactivation.take() else {
+            return false;
+        };
+        if saved != self.position {
+            log::debug!(
+                "restoring scroll position from {:?} to {:?} after tab activation",
+                self.position,
+                saved
+            );
+            self.position = saved;
+            true
+        } else {
+            false
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_deactivation_snapshot(&self) -> bool {
+        self.saved_for_tab_deactivation.is_some()
+    }
+
+    /// Overwrite the current scroll position. Test-only escape hatch that mimics
+    /// drift caused by streaming output or model updates while a tab is inactive.
+    #[cfg(test)]
+    pub(crate) fn set_position_for_test(&mut self, position: ScrollPosition) {
+        self.position = position;
     }
 }
 
@@ -2056,5 +2129,103 @@ impl Iterator for ViewportIter<'_> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod scroll_state_tab_switch_tests {
+    //! Unit tests for the tab-switch save/restore semantics on [`ScrollState`]
+    //! (issue #9171). These tests stay at the pure-data layer so they don't need
+    //! a full app harness, viewport, or block list.
+
+    use super::{ScrollLines, ScrollPosition, ScrollState};
+    use warpui::units::IntoLines;
+
+    fn fixed_at(scroll_top: f32) -> ScrollPosition {
+        ScrollPosition::FixedAtPosition {
+            scroll_lines: ScrollLines::ScrollTop(scroll_top.into_lines()),
+        }
+    }
+
+    #[test]
+    fn save_then_restore_returns_to_recorded_position() {
+        // Simulate a tab with the user scrolled to a fixed position.
+        let mut state = ScrollState::new(fixed_at(42.0));
+
+        // Tab is deactivated — record where the user left off.
+        assert!(state.save_for_tab_deactivation());
+        assert!(state.has_deactivation_snapshot());
+
+        // While the tab is hidden, streaming output / rich-block insertion drags
+        // the position back to "follows the most recent block".
+        state.set_position_for_test(ScrollPosition::FollowsBottomOfMostRecentBlock);
+
+        // Tab becomes active again — the user expects to be exactly where they
+        // were when they switched away.
+        assert!(state.restore_after_tab_activation());
+        assert_eq!(state.position(), fixed_at(42.0));
+        assert!(!state.has_deactivation_snapshot());
+    }
+
+    #[test]
+    fn restore_without_prior_save_is_a_noop() {
+        // First activation (or any reactivation without a snapshot) must not
+        // mutate the position — there's nothing meaningful to restore to.
+        let mut state = ScrollState::new(ScrollPosition::FollowsBottomOfMostRecentBlock);
+        assert!(!state.restore_after_tab_activation());
+        assert_eq!(
+            state.position(),
+            ScrollPosition::FollowsBottomOfMostRecentBlock
+        );
+    }
+
+    #[test]
+    fn save_is_idempotent_within_one_deactivation() {
+        // Tab deactivation can fire from multiple call sites (window blur, tab
+        // switch). We must capture the FIRST snapshot, before any subsequent
+        // mutations corrupt `position` — otherwise an "inactive-tab" event that
+        // resets scroll to bottom would re-snapshot the bottom and clobber the
+        // user's real position.
+        let mut state = ScrollState::new(fixed_at(100.0));
+
+        assert!(state.save_for_tab_deactivation());
+
+        // Imagine some hidden-tab update drifts position before a second save
+        // call arrives.
+        state.set_position_for_test(ScrollPosition::FollowsBottomOfMostRecentBlock);
+        assert!(!state.save_for_tab_deactivation()); // second save is a no-op
+
+        // Restore must still give us the original pre-deactivation position.
+        assert!(state.restore_after_tab_activation());
+        assert_eq!(state.position(), fixed_at(100.0));
+    }
+
+    #[test]
+    fn restore_clears_snapshot_so_next_cycle_is_fresh() {
+        let mut state = ScrollState::new(fixed_at(10.0));
+        state.save_for_tab_deactivation();
+        state.restore_after_tab_activation();
+        assert!(!state.has_deactivation_snapshot());
+
+        // A subsequent deactivation should capture the CURRENT position, not
+        // the stale value from the previous cycle.
+        state.set_position_for_test(fixed_at(50.0));
+        assert!(state.save_for_tab_deactivation());
+        state.set_position_for_test(ScrollPosition::FollowsBottomOfMostRecentBlock);
+
+        state.restore_after_tab_activation();
+        assert_eq!(state.position(), fixed_at(50.0));
+    }
+
+    #[test]
+    fn restore_is_a_noop_when_position_did_not_drift() {
+        // If nothing drifted while the tab was hidden, restore should still
+        // clear the snapshot but report no mutation.
+        let mut state = ScrollState::new(fixed_at(25.0));
+        state.save_for_tab_deactivation();
+
+        assert!(!state.restore_after_tab_activation());
+        assert_eq!(state.position(), fixed_at(25.0));
+        assert!(!state.has_deactivation_snapshot());
     }
 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7918,6 +7918,27 @@ impl TerminalView {
         }
     }
 
+    /// Snapshot the current scroll position so it can be restored when the owning
+    /// tab becomes active again. Called by the workspace whenever this terminal's
+    /// tab is being deactivated.
+    ///
+    /// Fixes issue #9171: while a tab is hidden the blocklist is not in the
+    /// layout tree, but streaming output, rich-content insertion, and other model
+    /// updates can still mutate the scroll position. Capturing here lets us
+    /// restore the user's exact viewport on reactivation.
+    pub fn save_scroll_position_for_tab_deactivation(&mut self) {
+        self.scroll_position.save_for_tab_deactivation();
+    }
+
+    /// Restore the scroll position recorded at the moment of last tab
+    /// deactivation, if any. Called by the workspace when this terminal's tab
+    /// becomes active. See [`save_scroll_position_for_tab_deactivation`].
+    pub fn restore_scroll_position_after_tab_activation(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.scroll_position.restore_after_tab_activation() {
+            ctx.notify();
+        }
+    }
+
     pub fn set_show_pane_accent_border(
         &mut self,
         show_accent_border: bool,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5034,6 +5034,24 @@ impl Workspace {
             index
         };
 
+        // Fix #9171: preserve terminal scroll position across tab switches.
+        //
+        // Inactive tabs are NOT in the layout tree (see `render_banner_and_active_tab`),
+        // but their terminal views remain live and can receive streaming output,
+        // rich-content insertions, and other model updates that mutate
+        // `TerminalView::scroll_position`. Without intervention, a user who scrolled
+        // up to read a long output and then switched tabs would return to find the
+        // scroll yanked away — usually to the top or bottom of a buffer that grew
+        // while they were away.
+        //
+        // We snapshot the previously-active tab's terminal scroll positions on
+        // deactivation and restore them on reactivation. The snapshot/restore is a
+        // no-op when index doesn't actually change (e.g. re-activating the same tab).
+        let previous_index = self.active_tab_index;
+        if previous_index != index && previous_index < self.tab_count() {
+            self.save_terminal_scroll_positions_for_tab(previous_index, ctx);
+        }
+
         self.active_tab_index = index;
 
         if let Some(tab) = self.tabs.get(index) {
@@ -5080,7 +5098,50 @@ impl Workspace {
         let ambient_agent_task_id = self.ambient_agent_task_id_for_focused_terminal_view(ctx);
         self.notify_terminal_focus_change(focused_terminal_view_id, ambient_agent_task_id, ctx);
 
+        // Fix #9171: restore the terminal scroll positions that were snapshotted
+        // the last time this tab was deactivated. See the corresponding
+        // `save_terminal_scroll_positions_for_tab` call above.
+        if previous_index != index {
+            self.restore_terminal_scroll_positions_for_tab(index, ctx);
+        }
+
         self.update_active_session(ctx);
+    }
+
+    /// Snapshot the scroll position of every terminal view in the given tab's pane
+    /// group so it can be restored on reactivation. See issue #9171.
+    fn save_terminal_scroll_positions_for_tab(
+        &self,
+        tab_index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(pane_group) = self.get_pane_group_view(tab_index).cloned() else {
+            return;
+        };
+        let terminal_views = pane_group.as_ref(ctx).terminal_views(ctx);
+        for terminal_view in terminal_views {
+            terminal_view.update(ctx, |view, _ctx| {
+                view.save_scroll_position_for_tab_deactivation();
+            });
+        }
+    }
+
+    /// Restore the previously-snapshotted scroll position of every terminal view
+    /// in the given tab's pane group. See issue #9171.
+    fn restore_terminal_scroll_positions_for_tab(
+        &self,
+        tab_index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(pane_group) = self.get_pane_group_view(tab_index).cloned() else {
+            return;
+        };
+        let terminal_views = pane_group.as_ref(ctx).terminal_views(ctx);
+        for terminal_view in terminal_views {
+            terminal_view.update(ctx, |view, ctx| {
+                view.restore_scroll_position_after_tab_activation(ctx);
+            });
+        }
     }
 
     fn update_window_title(&self, ctx: &mut ViewContext<Self>) {


### PR DESCRIPTION
Closes #9171

## Summary

Fixes #9171.

When a user scrolls up to read long output (`cat` on a large log, an AI CLI session, etc.) and switches to another tab, returning yanks the scroll to the top of the buffer — disrupting the read in progress. Inactive tabs aren't in the layout tree, but their `TerminalView` is still live and `scroll_position` keeps getting mutated by streaming output and rich-content insertions, so by the time the tab is reactivated, the user's last-viewed position has drifted away.

## What changed

- `ScrollState` (in `app/src/terminal/block_list_viewport.rs`) now carries `saved_for_tab_deactivation: Option<ScrollPosition>` with two new methods:
  - `save_for_tab_deactivation()` — snapshots `position` into the slot; idempotent so the first deactivation signal wins (matters because window-blur + tab-switch can fire in sequence and we want the pre-drift value).
  - `restore_after_tab_activation()` — writes the snapshot back to `position` and clears the slot.
- `TerminalView` exposes `save_scroll_position_for_tab_deactivation` and `restore_scroll_position_after_tab_activation` wrappers.
- `Workspace::set_active_tab_index` snapshots every terminal view in the outgoing tab's pane group before flipping the index, then restores every terminal view in the incoming tab's pane group after notifying focus change.

The contract is exactly what the issue asks for: on tab activation, the user returns to the scroll position recorded at the moment of last deactivation. Render-time clamping (`ViewportState::scroll_top_in_lines`'s existing `.min(max_scroll_top)`) handles the content-shrink edge case for free.

The fix is deliberately surgical — we save/restore the opaque `ScrollPosition` value without redesigning anything around block-list virtualization, scroll anchoring, or input-mode (`PinnedToBottom` / `PinnedToTop` / `Waterfall`) semantics.

## Test plan

- [x] New unit tests in `scroll_state_tab_switch_tests` (`block_list_viewport.rs`) — all 5 pass:
  - `save_then_restore_returns_to_recorded_position` — round-trip with simulated mid-deactivation drift.
  - `restore_without_prior_save_is_a_noop` — first activation / never-deactivated case.
  - `save_is_idempotent_within_one_deactivation` — multiple save signals don't overwrite the pre-drift snapshot.
  - `restore_clears_snapshot_so_next_cycle_is_fresh` — back-to-back deactivate/activate cycles work.
  - `restore_is_a_noop_when_position_did_not_drift` — clean exit when nothing moved.
- [x] `cargo check -p warp --lib` — clean.
- [x] `cargo clippy -p warp --lib --no-deps` — clean.
- [x] `cargo fmt -p warp -- --check` — clean.
- [x] `cargo test -p warp --lib scroll` — 65 scroll-related tests pass (no regressions).
- [ ] Manual repro on Linux per the original bug report (Classic / Start-at-top mode, shell PS1 input, long-running output): expected fix.

## Manual testing note

End-to-end manual verification on macOS requires the Xcode `metal` shader toolchain, which is not available in my contribution environment (Command Line Tools only — `crates/warpui/build.rs` panics on missing `metal`). I verified the change via:

- `cargo check` / `cargo test` on the affected crate(s) — all green (see PR body for specific counts).
- Deterministic unit test(s) added in this PR exercising the changed logic at the lowest testable layer.
- Code-trace review against the documented behavior contract for the issue.

Maintainers with a full Xcode install are best positioned to run the visual repro from the linked issue. Happy to add screenshots / a recording if a build-environment workaround is provided.