### PR TITLE
fix(terminal-input): suppress error underline until external commands load (#9182)

### DIFF
--- a/app/src/terminal/input/decorations.rs
+++ b/app/src/terminal/input/decorations.rs
@@ -77,6 +77,36 @@ fn valid_command_for_error_underline(command: &str) -> bool {
         .all(|x| !INVALID_SYMBOLS_COMMAND_ERROR_UNDERLINING.contains(&x))
 }
 
+/// Pure decision function for whether the first token of a command should
+/// be underlined as an unknown command.
+///
+/// Inputs:
+/// - `has_loaded_external_commands`: whether the session has finished loading
+///   external commands (i.e. executables on `$PATH`). Until this is `true`, we
+///   cannot reliably classify a command as unknown — `git` and other valid
+///   commands would otherwise be incorrectly underlined while the async
+///   command load is still in flight. See issue #9182.
+/// - `has_no_description`: whether the completer returned no description for
+///   the token (meaning it could not match any known command/alias/function).
+/// - `is_first_token`: whether this is the first token of the command (only
+///   the command name itself can be underlined as unknown — not its args).
+/// - `valid_symbols`: whether the token only contains characters we currently
+///   trust for the unknown-command heuristic.
+pub(crate) fn should_underline_unknown_command(
+    has_loaded_external_commands: bool,
+    has_no_description: bool,
+    is_first_token: bool,
+    valid_symbols: bool,
+) -> bool {
+    // If we haven't loaded the set of available external commands yet, we
+    // can't classify anything as unknown without producing false positives,
+    // so suppress the underline entirely until the load completes.
+    if !has_loaded_external_commands {
+        return false;
+    }
+    has_no_description && is_first_token && valid_symbols
+}
+
 impl Input {
     fn completion_session_context_or_empty_context(
         &self,
@@ -315,12 +345,24 @@ impl Input {
             return;
         };
 
+        // The error-underline heuristic relies on the session having a
+        // complete view of available external commands (executables on
+        // `$PATH`). If the async load hasn't completed yet, suppress
+        // underlining entirely to avoid false positives like underlining
+        // `git` before its entry has been loaded. See issue #9182.
+        let has_loaded_external_commands = self
+            .active_session(ctx)
+            .map(|session| session.has_loaded_external_commands())
+            .unwrap_or(false);
+
         let mut ranges = vec![];
         for token_data in &parsed_tokens_snapshot.parsed_tokens {
-            if token_data.token_description.is_none()
-                && token_data.token_index == 0
-                && valid_command_for_error_underline(&token_data.token.item)
-            {
+            if should_underline_unknown_command(
+                has_loaded_external_commands,
+                token_data.token_description.is_none(),
+                token_data.token_index == 0,
+                valid_command_for_error_underline(&token_data.token.item),
+            ) {
                 ranges.push(
                     ByteOffset::from(token_data.token.span.start())
                         ..ByteOffset::from(token_data.token.span.end()),

--- a/app/src/terminal/input/decorations_tests.rs
+++ b/app/src/terminal/input/decorations_tests.rs
@@ -4,7 +4,7 @@ use crate::{
     appearance::Appearance,
     terminal::{
         input::{
-            decorations::InputBackgroundJobOptions,
+            decorations::{should_underline_unknown_command, InputBackgroundJobOptions},
             tests::{
                 add_window_with_bootstrapped_terminal, initialize_app,
                 simulate_directory_for_completion,
@@ -15,6 +15,83 @@ use crate::{
     themes::theme::AnsiColorIdentifier,
 };
 use warp_completer::completer::SuggestionTypeName;
+
+/// Regression test for issue #9182: when the session has not yet finished
+/// loading its set of external commands (executables on PATH), valid commands
+/// like `git` would otherwise be incorrectly underlined as unknown. The
+/// decision function must suppress underlining entirely until the load
+/// completes.
+#[test]
+fn should_underline_unknown_command_suppresses_when_external_commands_not_loaded() {
+    // The completer returned no description (would otherwise indicate an
+    // unknown command), the token is the command position, and the symbols
+    // are valid for our heuristic — but external commands haven't loaded
+    // yet, so we must not underline.
+    let has_loaded_external_commands = false;
+    let has_no_description = true;
+    let is_first_token = true;
+    let valid_symbols = true;
+
+    let result = should_underline_unknown_command(
+        has_loaded_external_commands,
+        has_no_description,
+        is_first_token,
+        valid_symbols,
+    );
+
+    assert!(
+        !result,
+        "must not underline command before external commands have loaded (issue #9182)"
+    );
+}
+
+#[test]
+fn should_underline_unknown_command_underlines_unknown_after_load_completes() {
+    // After commands have loaded, an undescribed first-position token with
+    // valid symbols is an unknown command and should be underlined.
+    assert!(should_underline_unknown_command(
+        true, /* has_loaded_external_commands */
+        true, /* has_no_description */
+        true, /* is_first_token */
+        true, /* valid_symbols */
+    ));
+}
+
+#[test]
+fn should_underline_unknown_command_skips_known_commands() {
+    // After load, a token with a description (i.e. a known command) must
+    // not be underlined.
+    assert!(!should_underline_unknown_command(
+        true,  /* has_loaded_external_commands */
+        false, /* has_no_description -- known */
+        true,  /* is_first_token */
+        true,  /* valid_symbols */
+    ));
+}
+
+#[test]
+fn should_underline_unknown_command_skips_non_first_tokens() {
+    // Only the command position (token_index == 0) is subject to the
+    // unknown-command underline. Arguments are not.
+    assert!(!should_underline_unknown_command(
+        true,  /* has_loaded_external_commands */
+        true,  /* has_no_description */
+        false, /* is_first_token -- this is an argument */
+        true,  /* valid_symbols */
+    ));
+}
+
+#[test]
+fn should_underline_unknown_command_skips_invalid_symbols() {
+    // Tokens containing characters we don't trust for the heuristic
+    // (e.g. `!!`, `$foo`) should be left alone to avoid false positives.
+    assert!(!should_underline_unknown_command(
+        true,  /* has_loaded_external_commands */
+        true,  /* has_no_description */
+        true,  /* is_first_token */
+        false, /* valid_symbols -- contains e.g. `!` */
+    ));
+}
 
 #[test]
 fn test_decorations_with_multibyte_chars() {


### PR DESCRIPTION
## Summary

Fixes #9182. Valid commands like `git --version` were being red-underlined when typed before the session's external-commands list (executables on `\$PATH`) had finished loading asynchronously. The completer returns no description for `git` until that load completes, and the existing heuristic treats no-description first-position tokens as unknown commands.

The bootstrap path already deferred the *initial* decoration pass until the load resolved (with a comment in `terminal/view.rs` flagging this exact pitfall), but any decoration triggered before that — or via code paths that bypass the bootstrap re-decoration — still produced the false positive. This is most visible on Windows / PowerShell where the load latency is highest relative to first keystroke (matches the reporter's environment).

## Approach

Defense-in-depth: gate the underline decision on `session.has_loaded_external_commands()` inside the decoration logic itself.

- Extract the underline decision into a pure function `should_underline_unknown_command(has_loaded_external_commands, has_no_description, is_first_token, valid_symbols) -> bool`.
- When `has_loaded_external_commands` is `false`, suppress the underline regardless of other inputs.
- `apply_colors_error_underlining_all_tokens` now reads the loaded-state from the active session and feeds it into the decision function.

Backwards compatible: once external commands have loaded (the steady state for any normal session), behavior is identical to before.

## Files changed

- `app/src/terminal/input/decorations.rs` — pure decision function + plumb session loaded-state through.
- `app/src/terminal/input/decorations_tests.rs` — unit tests for the decision function.

## Test plan

- [x] New unit tests cover all four decision-function branches
  - Suppression when external commands are not loaded (the regression)
  - Underlines unknown command after load
  - Skips known (described) commands
  - Skips non-first tokens (arguments)
  - Skips tokens with invalid symbols
- [x] Existing integration test `test_decorations_with_multibyte_chars` continues to pass — it calls `session.load_external_commands()` before triggering decoration, so `has_loaded_external_commands()` is `true` at decoration time and the assertion that `echoo` gets underlined still holds.
- [ ] Manual repro on Windows + PowerShell: type `git --version` immediately after opening a tab — verify no red underline.
- [ ] Manual repro on macOS / Linux: type `echoo hello` — verify it still gets underlined as unknown after the brief load completes.