### PR TITLE
Add foundation for richer PR badge metadata (#10566, #10568)

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -601,6 +601,7 @@ default = [
     "kitty_keyboard_protocol",
     "inline_menu_headers",
     "github_pr_prompt_chip",
+    "github_pr_rich_metadata",
     "conversations_as_context",
     "markdown_tables",
     "markdown_mermaid",
@@ -665,6 +666,7 @@ welcome_tab = []
 get_started_tab = []
 code_mode_chip = []
 github_pr_prompt_chip = []
+github_pr_rich_metadata = []
 create_project_flow = []
 agent_mode_evals = [
     "integration_tests",

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2690,6 +2690,8 @@ pub fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::CodeModeChip,
         #[cfg(feature = "github_pr_prompt_chip")]
         FeatureFlag::GithubPrPromptChip,
+        #[cfg(feature = "github_pr_rich_metadata")]
+        FeatureFlag::GithubPrRichMetadata,
         #[cfg(feature = "create_project_flow")]
         FeatureFlag::CreateProjectFlow,
         #[cfg(feature = "vim_code_editor")]

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -224,6 +224,17 @@ impl WorkingDirectoriesModel {
             .and_then(|roots| roots.get(root_path).copied())
     }
 
+    /// Read-only lookup of an existing `DiffStateModel` for a repository, if
+    /// one has been created. Unlike [`get_or_create_diff_state_model`] this
+    /// never instantiates a new model — useful from render paths that have
+    /// only `&AppContext`.
+    pub fn diff_state_model_for(
+        &self,
+        key: &BufferLocation,
+    ) -> Option<ModelHandle<DiffStateModel>> {
+        self.diff_state_models.get(key).cloned()
+    }
+
     /// Get or create a DiffStateModel for a specific repository.
     /// If the model doesn't exist, it will be created.
     pub fn get_or_create_diff_state_model(

--- a/app/src/terminal/view/tab_metadata.rs
+++ b/app/src/terminal/view/tab_metadata.rs
@@ -1,7 +1,15 @@
 use crate::context_chips::display_chip::GitLineChanges;
-use crate::context_chips::{git_line_changes_from_chips, ContextChipKind};
+use crate::context_chips::{
+    git_line_changes_from_chips, github_pr_number_from_url, ContextChipKind,
+};
 use crate::terminal::TerminalView;
+use crate::util::git::PrInfo;
 use warpui::AppContext;
+
+#[cfg(feature = "local_fs")]
+use crate::code::buffer_location::BufferLocation;
+#[cfg(feature = "local_fs")]
+use crate::pane_group::WorkingDirectoriesModel;
 
 impl TerminalView {
     fn prompt_chip_value(&self, chip_kind: &ContextChipKind, ctx: &AppContext) -> Option<String> {
@@ -82,6 +90,55 @@ impl TerminalView {
             .latest_chip_value(&ContextChipKind::GithubPullRequest, ctx)
             .map(|v| v.to_string())
             .filter(|value| !value.trim().is_empty())
+    }
+
+    /// PR info for this terminal's current branch.
+    ///
+    /// Under `local_fs`, the canonical substrate is the `DiffStateModel` for
+    /// the terminal's repo — when one has been created (i.e. code review has
+    /// been opened for that repo at some point in the session), its cached
+    /// `pr_info` provides title/state/reviewers.
+    ///
+    /// The PR-chip URL from the prompt is used as the identity check: the
+    /// cached info is only trusted when its URL matches the chip's URL. If
+    /// they disagree (e.g. the active code-review repo differs from this
+    /// terminal's repo), or no cached info exists, the result degrades to a
+    /// number+URL-only `PrInfo`.
+    ///
+    /// Under `cfg(not(feature = "local_fs"))` (wasm builds) the chip URL is
+    /// the only substrate.
+    #[cfg(feature = "local_fs")]
+    pub fn current_pull_request_info(
+        &self,
+        working_directories: &WorkingDirectoriesModel,
+        ctx: &AppContext,
+    ) -> Option<PrInfo> {
+        let url = self.current_pull_request_url(ctx)?;
+        let number = github_pr_number_from_url(&url)
+            .and_then(|n| n.parse::<u64>().ok())?;
+
+        let cached = self.current_repo_path().and_then(|repo_path| {
+            let key = BufferLocation::Local(repo_path.clone());
+            working_directories
+                .diff_state_model_for(&key)
+                .and_then(|handle| handle.as_ref(ctx).pr_info(ctx).cloned())
+        });
+
+        if let Some(info) = cached {
+            if info.url == url {
+                return Some(info);
+            }
+        }
+
+        Some(PrInfo::minimal(number, url))
+    }
+
+    #[cfg(not(feature = "local_fs"))]
+    pub fn current_pull_request_info(&self, ctx: &AppContext) -> Option<PrInfo> {
+        let url = self.current_pull_request_url(ctx)?;
+        let number = github_pr_number_from_url(&url)
+            .and_then(|n| n.parse::<u64>().ok())?;
+        Some(PrInfo::minimal(number, url))
     }
 
     #[cfg_attr(not(feature = "local_fs"), allow(clippy::unnecessary_lazy_evaluations))]

--- a/app/src/util/git.rs
+++ b/app/src/util/git.rs
@@ -742,11 +742,95 @@ pub async fn run_push(_repo_path: &Path, _branch: &str, _path_env: Option<&str>)
 
 // ── gh CLI helpers ───────────────────────────────────────────────────────────
 
-/// PR information returned by `gh pr view`.
+/// PR information returned by `gh pr view`. Optional fields are populated when
+/// `gh pr view --json …` returns the corresponding key; older callers and
+/// degraded paths (e.g. `create_pr` parsing only a URL) leave them `None`.
 #[derive(Debug, Clone)]
 pub struct PrInfo {
     pub number: u64,
     pub url: String,
+    pub title: Option<String>,
+    pub state: Option<PrState>,
+    pub review_decision: Option<PrReviewDecision>,
+    /// Full reviewer list; rendering code is responsible for any visible cap.
+    pub reviewers: Vec<PrReviewer>,
+    pub merge_state: Option<PrMergeState>,
+    pub checks: Option<PrCheckSummary>,
+}
+
+impl PrInfo {
+    /// Minimal `PrInfo` carrying only the number+URL. Used by code paths that
+    /// don't have the richer `gh pr view --json` payload (e.g. `create_pr`,
+    /// which only parses the printed URL).
+    pub fn minimal(number: u64, url: String) -> Self {
+        Self {
+            number,
+            url,
+            title: None,
+            state: None,
+            review_decision: None,
+            reviewers: Vec::new(),
+            merge_state: None,
+            checks: None,
+        }
+    }
+}
+
+/// Overall lifecycle state of a pull request. `Draft` is folded in from the
+/// `isDraft` boolean alongside the `state` string returned by `gh`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrState {
+    Open,
+    Draft,
+    Merged,
+    Closed,
+}
+
+/// Aggregate review decision reported by GitHub.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrReviewDecision {
+    Approved,
+    ChangesRequested,
+    ReviewRequired,
+}
+
+/// State of an individual reviewer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrReviewState {
+    Approved,
+    ChangesRequested,
+    Commented,
+    Requested,
+    Pending,
+    Dismissed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrReviewer {
+    pub login: String,
+    pub state: PrReviewState,
+}
+
+/// Mergeability state from `mergeStateStatus`. Captured now so a later
+/// CI/merge-status surface can read it without a cache-shape migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrMergeState {
+    Clean,
+    Dirty,
+    Blocked,
+    Behind,
+    HasHooks,
+    Unstable,
+    Unknown,
+}
+
+/// Roll-up of CI checks from `statusCheckRollup`. Captured for future use; PR 1
+/// and PR 2 do not render this.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PrCheckSummary {
+    pub passing: u32,
+    pub failing: u32,
+    pub pending: u32,
 }
 
 /// Runs a `gh` CLI command and returns stdout on success. `path_env`, when
@@ -788,23 +872,32 @@ async fn run_gh_command(repo_path: &Path, args: &[&str], path_env: Option<&str>)
     }
 }
 
+/// JSON fields requested from `gh pr view` for the rich-metadata PR info
+/// (title, state, review decision, reviewers, mergeability, CI checks).
+/// `mergeStateStatus` and `statusCheckRollup` are captured even though PR 1 /
+/// PR 2 don't render them, so a follow-up CI/merge-status surface doesn't need
+/// a second cache-shape migration.
+#[cfg(feature = "local_fs")]
+const GH_PR_VIEW_JSON_FIELDS: &str =
+    "number,url,title,state,isDraft,reviewDecision,reviewRequests,latestReviews,\
+     mergeStateStatus,statusCheckRollup";
+
 /// Looks up the PR for the current branch via `gh pr view`.
 /// Returns `Ok(None)` if there is simply no PR for this branch.
 /// Returns `Err` for real failures (auth, network, gh not installed).
 #[cfg(feature = "local_fs")]
 pub async fn get_pr_for_branch(repo_path: &Path, path_env: Option<&str>) -> Result<Option<PrInfo>> {
-    match run_gh_command(repo_path, &["pr", "view", "--json", "number,url"], path_env).await {
+    match run_gh_command(
+        repo_path,
+        &["pr", "view", "--json", GH_PR_VIEW_JSON_FIELDS],
+        path_env,
+    )
+    .await
+    {
         Ok(stdout) => {
             let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
                 .map_err(|e| anyhow!("Failed to parse gh output: {e}"))?;
-            let number = parsed["number"]
-                .as_u64()
-                .ok_or_else(|| anyhow!("Missing 'number' in gh output"))?;
-            let url = parsed["url"]
-                .as_str()
-                .ok_or_else(|| anyhow!("Missing 'url' in gh output"))?
-                .to_string();
-            Ok(Some(PrInfo { number, url }))
+            Ok(Some(parse_pr_info(&parsed)?))
         }
         Err(e) => {
             let msg = e.to_string();
@@ -815,6 +908,165 @@ pub async fn get_pr_for_branch(repo_path: &Path, path_env: Option<&str>) -> Resu
             }
         }
     }
+}
+
+/// Pure parser for the `gh pr view --json …` payload. Pulled out of the
+/// network path so tests can exercise field handling without spawning `gh`.
+/// `number` and `url` are required; everything else is optional and degrades
+/// to `None` / empty when missing or malformed.
+pub fn parse_pr_info(json: &serde_json::Value) -> Result<PrInfo> {
+    let number = json["number"]
+        .as_u64()
+        .ok_or_else(|| anyhow!("Missing 'number' in gh output"))?;
+    let url = json["url"]
+        .as_str()
+        .ok_or_else(|| anyhow!("Missing 'url' in gh output"))?
+        .to_string();
+
+    let title = json["title"]
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let is_draft = json["isDraft"].as_bool().unwrap_or(false);
+    let state = parse_pr_state(json["state"].as_str(), is_draft);
+    let review_decision = parse_review_decision(json["reviewDecision"].as_str());
+    let reviewers = parse_reviewers(&json["reviewRequests"], &json["latestReviews"]);
+    let merge_state = parse_merge_state(json["mergeStateStatus"].as_str());
+    let checks = parse_check_rollup(&json["statusCheckRollup"]);
+
+    Ok(PrInfo {
+        number,
+        url,
+        title,
+        state,
+        review_decision,
+        reviewers,
+        merge_state,
+        checks,
+    })
+}
+
+fn parse_pr_state(raw: Option<&str>, is_draft: bool) -> Option<PrState> {
+    let s = raw?.trim();
+    if s.is_empty() {
+        return None;
+    }
+    Some(match s.to_ascii_uppercase().as_str() {
+        "OPEN" if is_draft => PrState::Draft,
+        "OPEN" => PrState::Open,
+        "MERGED" => PrState::Merged,
+        "CLOSED" => PrState::Closed,
+        _ => return None,
+    })
+}
+
+fn parse_review_decision(raw: Option<&str>) -> Option<PrReviewDecision> {
+    match raw?.to_ascii_uppercase().as_str() {
+        "APPROVED" => Some(PrReviewDecision::Approved),
+        "CHANGES_REQUESTED" => Some(PrReviewDecision::ChangesRequested),
+        "REVIEW_REQUIRED" => Some(PrReviewDecision::ReviewRequired),
+        _ => None,
+    }
+}
+
+/// Build the unified reviewer list from `reviewRequests` (still-pending
+/// invitations) and `latestReviews` (most recent review per reviewer). When a
+/// login appears in both, the actual review state wins over the pending
+/// request.
+fn parse_reviewers(
+    review_requests: &serde_json::Value,
+    latest_reviews: &serde_json::Value,
+) -> Vec<PrReviewer> {
+    let mut out: Vec<PrReviewer> = Vec::new();
+
+    if let Some(arr) = review_requests.as_array() {
+        for entry in arr {
+            let Some(login) = reviewer_login(entry) else {
+                continue;
+            };
+            if out.iter().any(|r| r.login == login) {
+                continue;
+            }
+            out.push(PrReviewer {
+                login,
+                state: PrReviewState::Requested,
+            });
+        }
+    }
+
+    if let Some(arr) = latest_reviews.as_array() {
+        for entry in arr {
+            let Some(login) = reviewer_login(&entry["author"]).or_else(|| reviewer_login(entry))
+            else {
+                continue;
+            };
+            let state = match entry["state"].as_str().unwrap_or("").to_ascii_uppercase().as_str() {
+                "APPROVED" => PrReviewState::Approved,
+                "CHANGES_REQUESTED" => PrReviewState::ChangesRequested,
+                "COMMENTED" => PrReviewState::Commented,
+                "DISMISSED" => PrReviewState::Dismissed,
+                "PENDING" => PrReviewState::Pending,
+                _ => continue,
+            };
+            if let Some(existing) = out.iter_mut().find(|r| r.login == login) {
+                existing.state = state;
+            } else {
+                out.push(PrReviewer { login, state });
+            }
+        }
+    }
+
+    out
+}
+
+fn reviewer_login(value: &serde_json::Value) -> Option<String> {
+    let s = value["login"].as_str().or_else(|| value.as_str())?.trim();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+fn parse_merge_state(raw: Option<&str>) -> Option<PrMergeState> {
+    match raw?.to_ascii_uppercase().as_str() {
+        "CLEAN" => Some(PrMergeState::Clean),
+        "DIRTY" => Some(PrMergeState::Dirty),
+        "BLOCKED" => Some(PrMergeState::Blocked),
+        "BEHIND" => Some(PrMergeState::Behind),
+        "HAS_HOOKS" => Some(PrMergeState::HasHooks),
+        "UNSTABLE" => Some(PrMergeState::Unstable),
+        "UNKNOWN" => Some(PrMergeState::Unknown),
+        _ => None,
+    }
+}
+
+fn parse_check_rollup(value: &serde_json::Value) -> Option<PrCheckSummary> {
+    let arr = value.as_array()?;
+    if arr.is_empty() {
+        return None;
+    }
+    let mut summary = PrCheckSummary::default();
+    for entry in arr {
+        let conclusion = entry["conclusion"]
+            .as_str()
+            .or_else(|| entry["state"].as_str())
+            .unwrap_or("")
+            .to_ascii_uppercase();
+        match conclusion.as_str() {
+            "SUCCESS" | "NEUTRAL" | "SKIPPED" => summary.passing += 1,
+            "FAILURE" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE" | "CANCELLED" => {
+                summary.failing += 1
+            }
+            "" | "PENDING" | "QUEUED" | "IN_PROGRESS" | "WAITING" | "EXPECTED" => {
+                summary.pending += 1
+            }
+            _ => summary.pending += 1,
+        }
+    }
+    Some(summary)
 }
 
 #[cfg(not(feature = "local_fs"))]
@@ -917,7 +1169,7 @@ pub async fn create_pr(
         .next()
         .and_then(|s| s.parse::<u64>().ok())
         .ok_or_else(|| anyhow!("Could not parse PR number from URL: {url}"))?;
-    Ok(PrInfo { number, url })
+    Ok(PrInfo::minimal(number, url))
 }
 
 /// Trims an AI-generated PR title to a single line and caps its length.

--- a/app/src/util/git_tests.rs
+++ b/app/src/util/git_tests.rs
@@ -85,3 +85,167 @@ async fn detached_tag_display_returns_short_sha() {
         "expected {full_sha} to start with {result}"
     );
 }
+
+// ── PrInfo parser tests ──────────────────────────────────────────────────────
+//
+// These exercise the pure `parse_pr_info` helper against representative
+// `gh pr view --json …` payloads so we don't have to spawn `gh` to verify
+// schema handling.
+
+#[cfg(feature = "local_fs")]
+mod pr_info_parser {
+    use super::super::{
+        parse_pr_info, PrMergeState, PrReviewDecision, PrReviewState, PrState,
+    };
+    use serde_json::json;
+
+    fn full_payload() -> serde_json::Value {
+        json!({
+            "number": 10432,
+            "url": "https://github.com/warp/warp/pull/10432",
+            "title": "Refactor foo crate",
+            "state": "OPEN",
+            "isDraft": false,
+            "reviewDecision": "APPROVED",
+            "reviewRequests": [{"login": "carol"}],
+            "latestReviews": [
+                {"author": {"login": "alice"}, "state": "APPROVED"},
+                {"author": {"login": "bob"}, "state": "CHANGES_REQUESTED"}
+            ],
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": [
+                {"conclusion": "SUCCESS"},
+                {"conclusion": "FAILURE"},
+                {"conclusion": "PENDING"}
+            ]
+        })
+    }
+
+    #[test]
+    fn parses_full_payload() {
+        let info = parse_pr_info(&full_payload()).expect("parse");
+        assert_eq!(info.number, 10432);
+        assert_eq!(info.url, "https://github.com/warp/warp/pull/10432");
+        assert_eq!(info.title.as_deref(), Some("Refactor foo crate"));
+        assert_eq!(info.state, Some(PrState::Open));
+        assert_eq!(info.review_decision, Some(PrReviewDecision::Approved));
+        assert_eq!(info.merge_state, Some(PrMergeState::Clean));
+
+        let checks = info.checks.expect("checks");
+        assert_eq!(checks.passing, 1);
+        assert_eq!(checks.failing, 1);
+        assert_eq!(checks.pending, 1);
+
+        let logins: Vec<_> = info.reviewers.iter().map(|r| r.login.as_str()).collect();
+        assert!(logins.contains(&"alice"));
+        assert!(logins.contains(&"bob"));
+        assert!(logins.contains(&"carol"));
+        let alice = info.reviewers.iter().find(|r| r.login == "alice").unwrap();
+        assert_eq!(alice.state, PrReviewState::Approved);
+        let bob = info.reviewers.iter().find(|r| r.login == "bob").unwrap();
+        assert_eq!(bob.state, PrReviewState::ChangesRequested);
+        let carol = info.reviewers.iter().find(|r| r.login == "carol").unwrap();
+        assert_eq!(carol.state, PrReviewState::Requested);
+    }
+
+    #[test]
+    fn folds_is_draft_into_pr_state() {
+        let mut payload = full_payload();
+        payload["isDraft"] = json!(true);
+        let info = parse_pr_info(&payload).expect("parse");
+        assert_eq!(info.state, Some(PrState::Draft));
+    }
+
+    #[test]
+    fn parses_merged_state() {
+        let mut payload = full_payload();
+        payload["state"] = json!("MERGED");
+        payload["isDraft"] = json!(false);
+        let info = parse_pr_info(&payload).expect("parse");
+        assert_eq!(info.state, Some(PrState::Merged));
+    }
+
+    #[test]
+    fn parses_closed_state() {
+        let mut payload = full_payload();
+        payload["state"] = json!("CLOSED");
+        let info = parse_pr_info(&payload).expect("parse");
+        assert_eq!(info.state, Some(PrState::Closed));
+    }
+
+    #[test]
+    fn missing_optional_fields_degrade_to_none() {
+        let payload = json!({
+            "number": 1,
+            "url": "https://example.com/pull/1"
+        });
+        let info = parse_pr_info(&payload).expect("parse");
+        assert_eq!(info.number, 1);
+        assert!(info.title.is_none());
+        assert!(info.state.is_none());
+        assert!(info.review_decision.is_none());
+        assert!(info.reviewers.is_empty());
+        assert!(info.merge_state.is_none());
+        assert!(info.checks.is_none());
+    }
+
+    #[test]
+    fn blank_title_degrades_to_none() {
+        let mut payload = full_payload();
+        payload["title"] = json!("   ");
+        let info = parse_pr_info(&payload).expect("parse");
+        assert!(info.title.is_none());
+    }
+
+    #[test]
+    fn missing_number_is_an_error() {
+        let payload = json!({"url": "https://example.com/pull/1"});
+        assert!(parse_pr_info(&payload).is_err());
+    }
+
+    #[test]
+    fn missing_url_is_an_error() {
+        let payload = json!({"number": 1});
+        assert!(parse_pr_info(&payload).is_err());
+    }
+
+    #[test]
+    fn unknown_merge_state_degrades_to_none() {
+        let mut payload = full_payload();
+        payload["mergeStateStatus"] = json!("SOMETHING_NEW");
+        let info = parse_pr_info(&payload).expect("parse");
+        assert!(info.merge_state.is_none());
+    }
+
+    #[test]
+    fn unknown_review_decision_degrades_to_none() {
+        let mut payload = full_payload();
+        payload["reviewDecision"] = json!("MAYBE");
+        let info = parse_pr_info(&payload).expect("parse");
+        assert!(info.review_decision.is_none());
+    }
+
+    #[test]
+    fn empty_check_rollup_degrades_to_none() {
+        let mut payload = full_payload();
+        payload["statusCheckRollup"] = json!([]);
+        let info = parse_pr_info(&payload).expect("parse");
+        assert!(info.checks.is_none());
+    }
+
+    #[test]
+    fn reviewer_dedupe_prefers_actual_review_over_pending_request() {
+        let payload = json!({
+            "number": 1,
+            "url": "https://example.com/pull/1",
+            "reviewRequests": [{"login": "alice"}],
+            "latestReviews": [
+                {"author": {"login": "alice"}, "state": "APPROVED"}
+            ]
+        });
+        let info = parse_pr_info(&payload).expect("parse");
+        assert_eq!(info.reviewers.len(), 1);
+        assert_eq!(info.reviewers[0].login, "alice");
+        assert_eq!(info.reviewers[0].state, PrReviewState::Approved);
+    }
+}

--- a/app/src/workspace/tab_settings.rs
+++ b/app/src/workspace/tab_settings.rs
@@ -520,6 +520,17 @@ define_settings_group!(TabSettings, settings: [
         toml_path: "appearance.vertical_tabs.show_pr_link",
         description: "Whether to show PR links on vertical tabs.",
     },
+    // Title is gated on the PR link badge being shown — there is no useful
+    // place to render it otherwise. The badge call site checks both settings.
+    vertical_tabs_show_pr_title: VerticalTabsShowPrTitle {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "appearance.vertical_tabs.show_pr_title",
+        description: "Whether to show the PR title alongside the PR number on vertical tabs.",
+    },
     vertical_tabs_show_diff_stats: VerticalTabsShowDiffStats {
         type: bool,
         default: true,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3531,6 +3531,7 @@ impl Workspace {
                 ..
             }
             | TabSettingsChangedEvent::VerticalTabsShowPrLink { .. }
+            | TabSettingsChangedEvent::VerticalTabsShowPrTitle { .. }
             | TabSettingsChangedEvent::VerticalTabsShowDiffStats { .. } => {
                 ctx.notify();
             }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -396,6 +396,10 @@ pub enum FeatureFlag {
     /// Enables the prompt chip that displays the GitHub PR for the current branch.
     GithubPrPromptChip,
 
+    /// Enables richer PR metadata (title, state, reviewers) on the vertical-tab
+    /// PR badge. Tracks [warpdotdev/warp#10566].
+    GithubPrRichMetadata,
+
     /// A button on the homepage for easily creating new projects.
     CreateProjectFlow,
 


### PR DESCRIPTION
## Summary

Foundation PR for issues #10566 (show PR titles in vertical tab metadata) and #10568 (show PR metadata when hovering over PR chips). This PR is data-plumb only — **no user-visible UI change**. A follow-up will thread the new info into the badge rendering chain and produce the title-after-number display.

- Extends `PrInfo` with `title`, `state` (`Open`/`Draft`/`Merged`/`Closed`), `review_decision`, full `reviewers` list, `merge_state`, and `checks` — broadens the `gh pr view --json …` argument to fetch all of them in the same single CLI call.
- Adds a pure `parse_pr_info` helper so JSON-handling is unit-testable without spawning `gh`. 12 new tests cover the full payload, draft/merged/closed states, missing fields, blank title, unknown enum values, an empty `statusCheckRollup`, and the reviewer-dedupe rule that prefers an actual review state over a still-pending request.
- Captures `mergeStateStatus` and `statusCheckRollup` now (zero CLI-call cost) so a future CI/merge-status surface doesn't require a second cache-shape migration.
- Stores the full reviewer list in `PrInfo`; any visible cap is the renderer's call, not baked into the data layer.

### New plumbing

- `FeatureFlag::GithubPrRichMetadata` + `github_pr_rich_metadata` Cargo feature.
- `vertical_tabs_show_pr_title` tab setting (off by default, mocks pending). The call site is expected to AND this with the existing `vertical_tabs_show_pr_link` so the title is hidden when the badge is hidden.
- `WorkingDirectoriesModel::diff_state_model_for()` — read-only lookup of an existing per-repo `DiffStateModel`, usable from render paths that only have `&AppContext`.
- `TerminalView::current_pull_request_info()` — cfg-split. Under `local_fs` it reads `pr_info` from the per-repo `DiffStateModel` and validates the URL matches the prompt chip (cross-repo defense). Under wasm it falls back to the URL-only chip read.

### Why split into two PRs

The follow-up has to thread `WorkingDirectoriesModel` through `PaneProps` and the `render_pane_row → render_terminal_metadata_line → render_terminal_right_badges` chain, plus update `terminal_pull_request_badge_label`, `render_terminal_pull_request_badge`, and `render_pull_request_badge_content` to render title-after-number with sub-text color on the title. Keeping that UI change separate from the data layer makes both diffs easier to review and lets each land behind its own flag.

Closes neither issue yet — completed when the follow-up lands.

## Test plan

- [x] `cargo check -p warp` — clean.
- [x] `cargo check -p warp_features` — clean.
- [x] `cargo build -p warp --features github_pr_rich_metadata` — clean.
- [x] `cargo test -p warp --lib pr_info_parser` — 12/12 pass.
- [ ] (Follow-up PR) Manual UI verification with a branch that has an open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)