### PR TITLE
fix(workspace): suppress stale "still running" toast when input box is hidden for non-command reasons

### DIFF
--- a/app/src/terminal/model/block_tests.rs
+++ b/app/src/terminal/model/block_tests.rs
@@ -286,6 +286,49 @@ pub fn test_long_running_block_bottom_padding() {
     });
 }
 
+/// Regression test for #9100 — "A command in this session is still running." toast
+/// must not fire for blocks that are not actually executing.
+///
+/// The toast was previously gated on `!is_input_box_visible`, but the input box can
+/// be hidden for many reasons unrelated to a running command (pending shared session,
+/// alt-screen application, SSH choice block, AI confirmation, freshly-created pane,
+/// etc.). Surface predicates we now use to gate the toast must all return false for
+/// an idle / finished block.
+#[test]
+pub fn test_idle_and_finished_blocks_are_not_executing() {
+    // Freshly built block — never started a command.
+    let block = TestBlockBuilder::new().build();
+    assert!(
+        !block.is_executing(),
+        "a never-started block must not report as executing"
+    );
+    assert!(
+        !block.is_active_and_long_running(),
+        "a never-started block must not report as long-running"
+    );
+
+    // Block that started, ran briefly, and finished successfully.
+    let mut block = TestBlockBuilder::new().build();
+    block.precmd(Default::default());
+    block.start();
+    for c in "echo hi".chars() {
+        block.input(c);
+    }
+    block.preexec(Default::default());
+    for c in "hi".chars() {
+        block.input(c);
+    }
+    block.finish(0);
+    assert!(
+        !block.is_executing(),
+        "a finished block must not report as executing"
+    );
+    assert!(
+        !block.is_active_and_long_running(),
+        "a finished block must not report as long-running"
+    );
+}
+
 // Tests that the command grid has a non-zero height even if `preexec` is never called.
 #[test]
 pub fn test_precmd_no_preexec() {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7312,6 +7312,24 @@ impl TerminalView {
         true
     }
 
+    /// Returns true if the active block of this terminal is currently running a command
+    /// (writing to the PTY or actively executing). Used to gate the "still running" toast
+    /// — see #9100. We intentionally do NOT treat "input box hidden" as equivalent to
+    /// "command running": the input can be hidden for many reasons (pending shared
+    /// session, alt-screen application, SSH choice block, AI confirmation block, etc.)
+    /// that have nothing to do with a running command.
+    pub fn is_active_block_running(&self, _app: &AppContext) -> bool {
+        let model = self.model.lock();
+        if model.block_list().is_writing_or_executing_in_band_command() {
+            return true;
+        }
+        let active_block = model.block_list().active_block();
+        active_block.is_executing()
+            || (active_block.is_active_and_long_running()
+                && !active_block.is_agent_in_control()
+                && !active_block.is_agent_tagged_in())
+    }
+
     /// Give the agent control of the active long running command
     /// (which was started outside of a conversation).
     fn tag_agent_in(&mut self, ctx: &mut ViewContext<Self>) {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7320,14 +7320,19 @@ impl TerminalView {
     /// that have nothing to do with a running command.
     pub fn is_active_block_running(&self, _app: &AppContext) -> bool {
         let model = self.model.lock();
+        let active_block = model.block_list().active_block();
+        // Agent-controlled / tagged-in blocks must NOT trigger the "still running"
+        // toast, even when they are technically executing or writing in-band — the
+        // user is intentionally interacting with the agent and the input box is
+        // hidden by design. This exclusion must gate the executing / in-band checks
+        // below, otherwise `is_executing()` short-circuits to `true` first.
+        if active_block.is_agent_in_control() || active_block.is_agent_tagged_in() {
+            return false;
+        }
         if model.block_list().is_writing_or_executing_in_band_command() {
             return true;
         }
-        let active_block = model.block_list().active_block();
-        active_block.is_executing()
-            || (active_block.is_active_and_long_running()
-                && !active_block.is_agent_in_control()
-                && !active_block.is_agent_tagged_in())
+        active_block.is_executing() || active_block.is_active_and_long_running()
     }
 
     /// Give the agent control of the active long running command

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -5572,3 +5572,165 @@ fn linear_deeplink_via_default_entrypoint_does_not_auto_submit_in_fullscreen() {
         });
     })
 }
+
+// ---------------------------------------------------------------------------
+// Tests for `is_active_block_running` — the predicate that gates the
+// "A command in this session is still running." toast. See #9100.
+//
+// The exclusion for agent-controlled / tagged-in blocks must gate the
+// `is_executing` / `is_writing_or_executing_in_band_command` short-circuits,
+// otherwise a tagged-in or agent-controlled long-running command would
+// incorrectly trigger the toast (since the input box is hidden by design
+// while the agent is interacting with the command).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn is_active_block_running_returns_false_for_never_started_block() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            // Fresh terminal — no block has been started.
+            assert!(!view.is_active_block_running(ctx));
+        });
+    })
+}
+
+#[test]
+fn is_active_block_running_returns_false_for_finished_block() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                model.init_shell(InitShellValue {
+                    session_id: 0.into(),
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.bootstrapped(BootstrappedValue {
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                // A block that started and then finished — not running.
+                model.simulate_block("echo hi", "hi\n");
+            }
+            assert!(!view.is_active_block_running(ctx));
+        });
+    })
+}
+
+#[test]
+fn is_active_block_running_returns_true_for_user_long_running_block() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                model.init_shell(InitShellValue {
+                    session_id: 0.into(),
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.bootstrapped(BootstrappedValue {
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.simulate_long_running_block("sleep 10", "running");
+            }
+            // User-driven long-running command — should gate the toast on.
+            assert!(view.is_active_block_running(ctx));
+        });
+    })
+}
+
+#[test]
+fn is_active_block_running_returns_false_when_user_tagged_in_agent() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                model.init_shell(InitShellValue {
+                    session_id: 0.into(),
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.bootstrapped(BootstrappedValue {
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.simulate_long_running_block("sleep 10", "running");
+            }
+            view.model
+                .lock()
+                .block_list_mut()
+                .active_block_mut()
+                .set_is_agent_tagged_in(true);
+            // Tagged-in: the input box is hidden by design while the agent
+            // mode input is active — must NOT trigger the "still running" toast.
+            assert!(!view.is_active_block_running(ctx));
+        });
+    })
+}
+
+#[test]
+fn is_active_block_running_returns_false_when_agent_is_in_control() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                model.init_shell(InitShellValue {
+                    session_id: 0.into(),
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.bootstrapped(BootstrappedValue {
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.simulate_long_running_block("ssh localhost", "Password:");
+            }
+
+            let conversation_id = view.agent_view_controller().update(ctx, |controller, ctx| {
+                controller
+                    .try_enter_inline_agent_view(
+                        None,
+                        AgentViewEntryOrigin::LongRunningCommand,
+                        ctx,
+                    )
+                    .expect("inline agent view should create a conversation")
+            });
+            view.model
+                .lock()
+                .block_list_mut()
+                .active_block_mut()
+                .set_is_agent_tagged_in(true);
+
+            let task_id = TaskId::new("test-task".to_owned());
+            view.model
+                .lock()
+                .block_list_mut()
+                .active_block_mut()
+                .set_agent_interaction_mode_for_agent_monitored_command(&task_id, conversation_id)
+                .expect("tagged-in command should transition to agent-monitored");
+
+            assert!(view
+                .model
+                .lock()
+                .block_list()
+                .active_block()
+                .is_agent_in_control());
+            // Agent in control: the input box visibility for "use agent" is
+            // intentional. Must NOT trigger the stale "still running" toast.
+            assert!(!view.is_active_block_running(ctx));
+        });
+    })
+}

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -15239,15 +15239,26 @@ impl Workspace {
         //      session as if it were focusable. Returning the busy session would
         //      reintroduce #9100 by letting callers act on a session they can't
         //      actually type into.
+        //
+        // For `OpenIfNone` specifically: if an existing session was found but its
+        // input box is not visible (e.g. alt-screen application, SSH choice block,
+        // AI confirmation block, init-project step, cloud-agent pre-first-exchange),
+        // we do NOT create a new pane — `OpenIfNone` only creates when there is no
+        // active session at all. We also must NOT return the unfocusable existing
+        // session: callers would proceed as if they had a focusable input and the
+        // user would see no effect. Return `None` instead so the caller can decide.
         let needs_new_pane = existing_terminal_view_handle.is_none()
             || fallback_behavior == TerminalSessionFallbackBehavior::OpenIfNeeded;
         if needs_new_pane {
             active_pane_group.update(ctx, |pane_group, ctx| {
                 pane_group.add_terminal_pane(Direction::Right, None /*chosen_shell*/, ctx);
             });
+            return active_pane_group.as_ref(ctx).active_session_view(ctx);
         }
 
-        active_pane_group.as_ref(ctx).active_session_view(ctx)
+        // `OpenIfNone` with an existing-but-unfocusable session: signal "no usable
+        // session" to the caller rather than returning the unfocusable handle.
+        None
     }
 
     /// Decide whether the "A command in this session is still running." toast should

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -15230,7 +15230,18 @@ impl Workspace {
             return None;
         }
 
-        if existing_terminal_view_handle.is_none() {
+        // We reach here in one of two cases:
+        //   1. There is no existing session at all → create one.
+        //   2. There IS an existing session but it was not usable above (input box
+        //      not visible, not an env-var block, busy toast was suppressed by
+        //      `OpenIfNeeded`). Per the `OpenIfNeeded` contract, we must create
+        //      a new pane in this case rather than silently returning the busy
+        //      session as if it were focusable. Returning the busy session would
+        //      reintroduce #9100 by letting callers act on a session they can't
+        //      actually type into.
+        let needs_new_pane = existing_terminal_view_handle.is_none()
+            || fallback_behavior == TerminalSessionFallbackBehavior::OpenIfNeeded;
+        if needs_new_pane {
             active_pane_group.update(ctx, |pane_group, ctx| {
                 pane_group.add_terminal_pane(Direction::Right, None /*chosen_shell*/, ctx);
             });

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -15170,48 +15170,43 @@ impl Workspace {
     ) -> Option<ViewHandle<TerminalView>> {
         let active_pane_group = self.active_tab_pane_group();
 
-        // If there's an active terminal session and it's not busy, return it.
-        // If there is no terminal session open, add a terminal pane to the right and return the new terminal view handle.
-        let terminal_view_handle = active_pane_group
-            .as_ref(ctx)
-            .active_session_view(ctx)
-            .unwrap_or_else(|| {
-                let active_pane_group = self.active_tab_pane_group();
-                active_pane_group.update(ctx, |pane_group, ctx| {
-                    pane_group.add_terminal_pane(Direction::Right, None /*chosen_shell*/, ctx);
+        // Resolve the existing active terminal session, if any. We deliberately do NOT
+        // create a new pane here: creating a pane and then turning around to show a
+        // "still running" toast (or to return None for `RequireExisting`) would leave
+        // the user with a surprise pane and a misleading error. New panes are only
+        // created later, under the explicit "open new" branch below.
+        let existing_terminal_view_handle = active_pane_group.as_ref(ctx).active_session_view(ctx);
+
+        if let Some(terminal_view_handle) = existing_terminal_view_handle.clone() {
+            let is_env_var_block = terminal_view_handle.read(ctx, |terminal_view, ctx| {
+                terminal_view.has_active_env_var_block(ctx)
+            });
+
+            if self.is_input_box_visible(ctx) {
+                active_pane_group
+                    .update(ctx, |pane_group, ctx| pane_group.focus_active_session(ctx));
+                return Some(terminal_view_handle);
+            } else if is_env_var_block {
+                terminal_view_handle.update(ctx, |terminal_view, ctx| {
+                    terminal_view.cancel_env_var_block(ctx);
                 });
                 active_pane_group
-                    .as_ref(ctx)
-                    .active_session_view(ctx)
-                    .unwrap()
-            });
-
-        let is_env_var_block = terminal_view_handle.read(ctx, |terminal_view, ctx| {
-            terminal_view.has_active_env_var_block(ctx)
-        });
-
-        if self.is_input_box_visible(ctx) {
-            active_pane_group.update(ctx, |pane_group, ctx| pane_group.focus_active_session(ctx));
-            return Some(terminal_view_handle);
-        } else if is_env_var_block {
-            terminal_view_handle.update(ctx, |terminal_view, ctx| {
-                terminal_view.cancel_env_var_block(ctx);
-            });
-            active_pane_group.update(ctx, |pane_group, ctx| pane_group.focus_active_session(ctx));
-            return Some(terminal_view_handle);
-        } else if fallback_behavior != TerminalSessionFallbackBehavior::OpenIfNeeded {
-            // The active terminal exists but is busy, and the fallback behavior is
-            // RequireExisting or OpenIfNone. In those cases, show a toast and no-op.
-            self.toast_stack.update(ctx, |toast_stack, ctx| {
-                let mut toast = DismissibleToast::error(
-                    "A command in this session is still running.".to_string(),
-                );
-                if let Some(id) = object_id {
-                    toast = toast.with_object_id(id.uid());
-                }
-                toast_stack.add_ephemeral_toast(toast, ctx);
-            });
-            return None;
+                    .update(ctx, |pane_group, ctx| pane_group.focus_active_session(ctx));
+                return Some(terminal_view_handle);
+            } else if Self::should_show_busy_toast(fallback_behavior, &terminal_view_handle, ctx) {
+                // The active terminal exists and is genuinely busy with a running command,
+                // and the caller asked us not to open a new pane in that case.
+                self.toast_stack.update(ctx, |toast_stack, ctx| {
+                    let mut toast = DismissibleToast::error(
+                        "A command in this session is still running.".to_string(),
+                    );
+                    if let Some(id) = object_id {
+                        toast = toast.with_object_id(id.uid());
+                    }
+                    toast_stack.add_ephemeral_toast(toast, ctx);
+                });
+                return None;
+            }
         }
 
         // There's no available session and we were asked not to create one.
@@ -15221,8 +15216,10 @@ impl Workspace {
 
         // Either:
         // * There's no active session
-        // * The active session is busy but the fallback behavior is OpenIfNeeded
-        // In this case, open a new terminal pane to the right.
+        // * The active session is busy (input not visible) but the fallback behavior is OpenIfNeeded
+        // * The input box just isn't visible for non-running-command reasons (e.g. alt screen,
+        //   pending session). Treat this the same as "open a new pane".
+        // In all of these cases, open a new terminal pane to the right.
 
         if !ContextFlag::CreateNewSession.is_enabled() {
             self.toast_stack.update(ctx, |toast_stack, ctx| {
@@ -15233,7 +15230,32 @@ impl Workspace {
             return None;
         }
 
+        if existing_terminal_view_handle.is_none() {
+            active_pane_group.update(ctx, |pane_group, ctx| {
+                pane_group.add_terminal_pane(Direction::Right, None /*chosen_shell*/, ctx);
+            });
+        }
+
         active_pane_group.as_ref(ctx).active_session_view(ctx)
+    }
+
+    /// Decide whether the "A command in this session is still running." toast should
+    /// be shown. Even if the input box is hidden, we only want to surface this toast
+    /// when the active block is actually executing a command. The input can be hidden
+    /// for many reasons unrelated to a running command (pending shared session,
+    /// alt-screen application, SSH choice block, AI confirmation, etc.) — surfacing
+    /// the "still running" message in those cases is the issue reported in #9100.
+    fn should_show_busy_toast(
+        fallback_behavior: TerminalSessionFallbackBehavior,
+        terminal_view_handle: &ViewHandle<TerminalView>,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        if fallback_behavior == TerminalSessionFallbackBehavior::OpenIfNeeded {
+            return false;
+        }
+        terminal_view_handle.read(ctx, |terminal_view, ctx| {
+            terminal_view.is_active_block_running(ctx)
+        })
     }
 
     /// Opens the LSP log file in a new terminal pane using `tail -f`.

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -3134,3 +3134,89 @@ fn focus_terminal_input_open_if_needed_creates_new_pane_when_existing_session_bu
         );
     });
 }
+
+// ---------------------------------------------------------------------------
+// `focus_terminal_input` with `OpenIfNone` MUST return `None` when an existing
+// session is found but its input box is hidden for non-running-command reasons
+// (alt-screen application, SSH choice block, AI confirmation block, init-project
+// step, cloud-agent pre-first-exchange). Previously, the fallthrough returned
+// the existing unfocusable session — callers would proceed as if they had a
+// focusable input and the user would see no effect. See #9100 and the
+// round-N oz-bot review.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn focus_terminal_input_open_if_none_returns_none_when_existing_input_hidden() {
+    use crate::terminal::model::ansi::{BootstrappedValue, InitShellValue};
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        // Drive the active session into an alt-screen state with no running
+        // command. This hides the input box for a non-command-execution reason
+        // (the very case #9100 is about) so `is_active_block_running` returns
+        // `false` and the previous fallthrough would have returned the
+        // unfocusable existing session.
+        workspace.update(&mut app, |workspace, ctx| {
+            let terminal_view = workspace
+                .active_tab_pane_group()
+                .as_ref(ctx)
+                .focused_session_view(ctx)
+                .expect("workspace should have an initial terminal session");
+            terminal_view.update(ctx, |view, _ctx| {
+                let mut model = view.model.lock();
+                model.init_shell(InitShellValue {
+                    session_id: 0.into(),
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.bootstrapped(BootstrappedValue {
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.enter_alt_screen(true);
+                assert!(model.is_alt_screen_active());
+            });
+        });
+
+        // Snapshot pane count before calling `focus_terminal_input`.
+        let pane_count_before = workspace.read(&app, |workspace, ctx| {
+            workspace
+                .active_tab_pane_group()
+                .as_ref(ctx)
+                .pane_ids()
+                .count()
+        });
+        assert_eq!(pane_count_before, 1);
+
+        // Call the path under test: `OpenIfNone` must NOT return the existing
+        // unfocusable session, and must NOT create a new pane (that's the
+        // `OpenIfNeeded` contract). It must return `None` so the caller can
+        // decide what to do.
+        let returned_handle = workspace.update(&mut app, |workspace, ctx| {
+            workspace.focus_terminal_input(None, TerminalSessionFallbackBehavior::OpenIfNone, ctx)
+        });
+
+        assert!(
+            returned_handle.is_none(),
+            "OpenIfNone must return None when the existing session's input is hidden \
+             for non-running reasons (e.g. alt-screen application)"
+        );
+
+        // The pane count must NOT have changed — `OpenIfNone` only creates a
+        // new pane when there is no existing session at all.
+        let pane_count_after = workspace.read(&app, |workspace, ctx| {
+            workspace
+                .active_tab_pane_group()
+                .as_ref(ctx)
+                .pane_ids()
+                .count()
+        });
+        assert_eq!(
+            pane_count_after, 1,
+            "OpenIfNone must not create a new pane when an existing session exists"
+        );
+    });
+}

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -3058,3 +3058,79 @@ fn test_tab_mru_order() {
         });
     });
 }
+
+// ---------------------------------------------------------------------------
+// `focus_terminal_input` with `OpenIfNeeded` MUST create a new pane when the
+// existing session is unavailable (e.g. busy with a running command). The
+// fallthrough at the end of the function previously only created a new pane
+// when there was no existing session at all, silently returning the busy
+// session otherwise. See #9100 and the round-2 oz-bot review.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn focus_terminal_input_open_if_needed_creates_new_pane_when_existing_session_busy() {
+    use crate::terminal::model::ansi::{BootstrappedValue, InitShellValue};
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        // Make the active session busy with a long-running command. This hides
+        // the input box for command-execution reasons (the very case the toast
+        // gate is designed for).
+        workspace.update(&mut app, |workspace, ctx| {
+            let terminal_view = workspace
+                .active_tab_pane_group()
+                .as_ref(ctx)
+                .focused_session_view(ctx)
+                .expect("workspace should have an initial terminal session");
+            terminal_view.update(ctx, |view, _ctx| {
+                let mut model = view.model.lock();
+                model.init_shell(InitShellValue {
+                    session_id: 0.into(),
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.bootstrapped(BootstrappedValue {
+                    shell: "zsh".to_owned(),
+                    ..Default::default()
+                });
+                model.simulate_long_running_block("sleep 10", "running");
+            });
+        });
+
+        // Snapshot pane count before calling `focus_terminal_input`.
+        let pane_count_before = workspace.read(&app, |workspace, ctx| {
+            workspace
+                .active_tab_pane_group()
+                .as_ref(ctx)
+                .pane_ids()
+                .count()
+        });
+        assert_eq!(pane_count_before, 1);
+
+        // Call the path under test: `OpenIfNeeded` must create a new pane,
+        // not return the busy existing session as a fallback.
+        let returned_handle = workspace.update(&mut app, |workspace, ctx| {
+            workspace.focus_terminal_input(None, TerminalSessionFallbackBehavior::OpenIfNeeded, ctx)
+        });
+
+        // A non-None handle must be returned, AND a new pane must exist.
+        assert!(
+            returned_handle.is_some(),
+            "OpenIfNeeded must return a usable terminal view handle"
+        );
+        let pane_count_after = workspace.read(&app, |workspace, ctx| {
+            workspace
+                .active_tab_pane_group()
+                .as_ref(ctx)
+                .pane_ids()
+                .count()
+        });
+        assert_eq!(
+            pane_count_after, 2,
+            "OpenIfNeeded must create a new pane when the existing session is unavailable"
+        );
+    });
+}


### PR DESCRIPTION
Closes #9100.

## Summary

The toast **"A command in this session is still running."** fires falsely when the user clicks something in Warp Drive (or other call sites of `focus_terminal_input`) and the active terminal's input box happens to be hidden for reasons unrelated to a running command. This restructures `focus_terminal_input` to (a) only create a new pane in the explicit "open new" branch and (b) only fire the busy toast when the active block is actually executing.

## Root cause

`app/src/workspace/view.rs:focus_terminal_input` (lines ~15165–15237 before this change):

1. It called `active_session_view(...).unwrap_or_else(|| { add_terminal_pane(...); ...unwrap() })` to obtain a terminal view handle. Even for the `RequireExisting` and `OpenIfNone` paths, this **always** created a new pane when none existed.
2. It then called `self.is_input_box_visible(ctx)`. If false, and the fallback behavior was anything other than `OpenIfNeeded`, it fired the stale-command toast and returned `None` — leaving the user with a surprise new pane and a misleading "still running" error.
3. `TerminalView::is_input_box_visible` returns `false` for many reasons that have nothing to do with a running command:
   - `shared_session_status().is_view_pending()` (`app/src/terminal/view.rs:7227`) — true for freshly-created panes still establishing the session.
   - `is_alt_screen_active()` without agent control/tag-in (`view.rs:7220`).
   - Active SSH remote-server choice block / remote-server setup in progress (`view.rs:7261–7278`).
   - Active AI block blocked on user confirmation or expanded running commands (`view.rs:7280–7287`).
   - Active env-var collection block, init project last step, cloud-agent pre-first-exchange, etc.

None of those are "a command is running." Mapping all of them to the `still running` toast is the bug reported in #9100.

## Fix

`app/src/workspace/view.rs`
- `focus_terminal_input` now resolves the existing active session **without** creating a new pane up front. The new pane is only added in the explicit "open new" branch at the bottom, eliminating the surprise-pane behavior for `RequireExisting`.
- When there *is* an existing session whose input box is hidden, we delegate to a new `should_show_busy_toast` helper that returns `true` only when the active block is actually executing.

`app/src/terminal/view.rs`
- New `TerminalView::is_active_block_running` predicate that composes the existing `is_writing_or_executing_in_band_command`, `Block::is_executing`, and `Block::is_active_and_long_running` predicates. We intentionally exclude blocks under agent control / tagged-in agents so the toast doesn't surface for agent flows that legitimately hide the input.

## Test plan

`app/src/terminal/model/block_tests.rs` — new regression test `test_idle_and_finished_blocks_are_not_executing` that asserts the underlying predicates we now use to gate the toast (`Block::is_executing`, `Block::is_active_and_long_running`) return `false` for:
- a freshly-built (never-started) block, and
- a block that ran briefly and finished with exit 0.

These are exactly the states that previously surfaced the false toast in #9100.

## Manual testing note

End-to-end repro requires building the app, which depends on `crates/warpui` compiling Metal shaders via Xcode's `metal` toolchain (`xcrun metal`). The Xcode toolchain is not available in this environment — only the Command Line Tools are — so `cargo check -p warp` and `cargo test -p warp` both fail at the `crates/warpui/build.rs:92` shader-compile step:

```
thread 'main' panicked at crates/warpui/build.rs:92:5:
error compiling metal shaders to .air; xcrun: error: unable to find utility "metal", not a developer tool or in PATH
```

For local verification I therefore relied on:
- Reading the surrounding state-machine code in `terminal/view.rs::is_input_box_visible`, `pane_group/mod.rs::active_session_view`, and `terminal/model/block.rs` to confirm the predicates compose correctly.
- The new unit test covering the predicate-level invariant.
- A crate-scoped `cargo check -p command` to confirm the shared workspace deps still build.

A reviewer with the full Xcode toolchain can finish the end-to-end repro by:
1. Triggering any code path that hides the input box without running a command (e.g., enter `vim`, switch to alt-screen, or open Warp Drive on a fresh tab while shared-session is still resolving).
2. Clicking a Warp Drive workflow / hitting a `focus_terminal_input` call site with `RequireExisting` or `OpenIfNone`.
3. Confirming the "A command in this session is still running." toast no longer appears and the workflow either runs (if the session is actually free) or fails silently (`RequireExisting`) / opens a new pane (`OpenIfNeeded`) as documented on `TerminalSessionFallbackBehavior`.