### PR TITLE
Skip upgrade prompt for codex in cloud agent sessions

### DIFF
--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -447,6 +447,7 @@ const CODEX_TRUST_LEVEL_TRUSTED: &str = "trusted";
 /// Top-level config key codex reads to override the built-in `openai` provider's base URL
 /// (codex `core/src/config/mod.rs`).
 const CODEX_OPENAI_BASE_URL_KEY: &str = "openai_base_url";
+const CODEX_CHECK_FOR_UPDATE_ON_STARTUP_KEY: &str = "check_for_update_on_startup";
 const CODEX_MODEL_KEY: &str = "model";
 /// Target model for the `[notice.model_migrations]` table that suppresses Codex's
 /// "choose a newer model" upgrade prompt at session launch. We stamp this for any
@@ -594,6 +595,7 @@ fn resolve_openai_api_key(resolved_env_vars: &HashMap<OsString, OsString>) -> Op
 ///   set the projects to `trusted`.
 /// - base URL: set `openai_base_url = "<US data-residency endpoint>"` so we
 ///   hit the regional host our API keys require.
+/// - update checks: disable Codex's startup update prompt for unattended runs.
 /// - model override: when a non-default `third_party_harness_model_id` is
 ///   supplied, write the top-level `model` key so Codex pins the chosen model
 ///   for new sessions.
@@ -621,6 +623,7 @@ fn prepare_codex_config_toml(
     })?;
 
     set_codex_openai_base_url(&mut doc, CODEX_OPENAI_BASE_URL);
+    set_codex_check_for_update_on_startup(&mut doc, false);
     set_codex_model(&mut doc, third_party_harness_model_id);
 
     let canonical = working_dir.canonicalize().with_context(|| {
@@ -658,6 +661,10 @@ fn prepare_codex_config_toml(
 /// Set the top-level `openai_base_url` key, overwriting any existing value.
 fn set_codex_openai_base_url(doc: &mut toml_edit::DocumentMut, base_url: &str) {
     doc[CODEX_OPENAI_BASE_URL_KEY] = toml_edit::value(base_url);
+}
+
+fn set_codex_check_for_update_on_startup(doc: &mut toml_edit::DocumentMut, enabled: bool) {
+    doc[CODEX_CHECK_FOR_UPDATE_ON_STARTUP_KEY] = toml_edit::value(enabled);
 }
 
 fn set_codex_model(doc: &mut toml_edit::DocumentMut, third_party_harness_model_id: Option<&str>) {

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -183,6 +183,7 @@ fn prepare_codex_config_toml_writes_fresh_config() {
     let canonical = working_dir.canonicalize().unwrap();
     let key = canonical.to_string_lossy().into_owned();
     let cfg = read_codex_config(&config_path);
+    assert_eq!(cfg["check_for_update_on_startup"].as_bool(), Some(false));
     assert_eq!(
         cfg["projects"][&key]["trust_level"].as_str(),
         Some("trusted")


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
Skips the interactive upgrade prompt for codex:
<img width="549" height="186" alt="image" src="https://github.com/user-attachments/assets/3af6c292-fbda-4c78-8200-95d6be1dad1f" />

This allows us to pin to an older version of the codex CLI server-side without breaking cloud agents.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->
Tested locally and confirmed that writing to this line in `config.toml` suppresses the dialog.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

