### PR TITLE
Adjust orchestration launch modal overlay background

### DIFF
--- a/app/src/workspace/view/orchestration_launch_modal/view.rs
+++ b/app/src/workspace/view/orchestration_launch_modal/view.rs
@@ -73,7 +73,7 @@ const FEATURE_ITEMS: &[FeatureItem] = &[
     FeatureItem {
         icon: Icon::Atom02,
         title: "Multi-agent orchestration",
-        description: "Warp Agents will now orchestrate subagents automatically, deploying and tracking parallel agents.",
+        description: "Warp Agents will now orchestrate swarms of subagents, allowing you to parallelize tasks.",
         badge: None,
     },
     FeatureItem {
@@ -193,7 +193,7 @@ impl OrchestrationLaunchModal {
         });
 
         let go_to_warp_button = ctx.add_view(|_ctx| {
-            ActionButton::new("Go to Warp", CtaButtonTheme)
+            ActionButton::new("Close", CtaButtonTheme)
                 .with_full_width(true)
                 .on_click(|ctx| ctx.dispatch_typed_action(OrchestrationLaunchModalAction::Close))
         });
@@ -280,7 +280,7 @@ impl OrchestrationLaunchModal {
 
     fn render_description(appearance: &Appearance) -> Box<dyn Element> {
         Text::new(
-            "Major improvements to Warp's cloud agent orchestration platform, Oz.",
+            "We've made major improvements to Warp's cloud agent orchestration platform, Oz.",
             appearance.ui_font_family(),
             14.,
         )

--- a/app/src/workspace/view/orchestration_launch_modal/view.rs
+++ b/app/src/workspace/view/orchestration_launch_modal/view.rs
@@ -424,13 +424,7 @@ impl View for OrchestrationLaunchModal {
         .finish();
 
         Container::new(Align::new(card).finish())
-            .with_background_color(
-                appearance
-                    .theme()
-                    .foreground()
-                    .with_opacity(70)
-                    .into_solid(),
-            )
+            .with_background(Fill::Solid(ColorU::new(97, 97, 97, 255)).with_opacity(50))
             .finish()
     }
 }


### PR DESCRIPTION
## Description
Change the orchestration launch modal overlay from using the theme foreground color at 70% opacity to a neutral gray (97, 97, 97) at 50% opacity. This darkens the background behind the modal instead of lightening it, consistent with other launch modals.

<img width="1033" height="1198" alt="Screenshot 2026-05-12 at 11 56 39 AM" src="https://github.com/user-attachments/assets/4f53e5c6-7556-4f0e-99ac-7d3ca5f8563d" />
<img width="887" height="1026" alt="Screenshot 2026-05-12 at 11 58 40 AM" src="https://github.com/user-attachments/assets/2c5e793c-b866-4045-bb3b-cd7f1da2da72" />


[Warp conversation](https://staging.warp.dev/conversation/2a9ce020-f4ac-4c06-b89a-31dc9a8d199d)

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>