### PR TITLE
Switch to upstream `rmcp`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aha-reqwest-eventsource"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740300e9f9146e918e72e9b50815bd4df35fe80659d1f16b702164cdbd152dc6"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom 7.1.3",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror 1.0.63",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6168,6 +6184,7 @@ checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
 name = "http_client"
 version = "0.0.0"
 dependencies = [
+ "aha-reqwest-eventsource",
  "anyhow",
  "async-compat",
  "async-stream",
@@ -6181,7 +6198,6 @@ dependencies = [
  "prevent_sleep",
  "prost 0.14.3",
  "reqwest",
- "reqwest-eventsource",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6266,7 +6282,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -8580,7 +8595,6 @@ dependencies = [
  "getrandom 0.2.16",
  "http 1.4.0",
  "rand 0.8.6",
- "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -10221,6 +10235,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -10754,9 +10769,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -10778,8 +10793,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -10795,23 +10810,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.1",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom 7.1.3",
- "pin-project-lite",
- "reqwest",
- "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -10895,9 +10893,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.15.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10924,9 +10922,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.15.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -11510,10 +11508,11 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "sentry"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507ac2be9bf2da56c831da57faf1dadd81f434bd282935cdb06193d0c94e8811"
+checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
 dependencies = [
+ "cfg_aliases 0.2.1",
  "httpdate",
  "reqwest",
  "rustls",
@@ -11531,9 +11530,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8402c142005ee560ae361c73ebece13a299ec3e9cce5b8654479ea9aac8dc8df"
+checksum = "9453d18fc9a45d841636004aad50288d80cc07c34a9e88cd4397cb66e6356f67"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -11544,9 +11543,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fce8e095bb4e66cbf92f7eb3fb0ff7014f7943de3e4f55b3ef69261cf32d913"
+checksum = "e15257eeba11d42eb0d6893fed26033504b031abaef3b3809343e4967f476502"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -11555,9 +11554,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4416302fa5325181a120e0fe7d4afd83cd95e52a9b86afa34a8161383fe0dc"
+checksum = "46a8c2c1bd5c1f735e84f28b48e7d72efcaafc362b7541bc8253e60e8fcdffc6"
 dependencies = [
  "backtrace",
  "regex",
@@ -11566,9 +11565,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936752f42b6f651dcb257da0bfa235ecc79e82011c49ed3383c212cc582263ff"
+checksum = "9b88a90baa654d7f0e1f4b667f6b434293d9f72c71bef16b197c76af5b7d5803"
 dependencies = [
  "hostname",
  "libc",
@@ -11580,21 +11579,22 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e9bd2cadaeda3af41e9fa5d14645127d6f6a4aec73da3ae38e477ecafd3682"
+checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
 dependencies = [
  "rand 0.9.4",
  "sentry-types",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e074fe9a0970c91999b23ed3195e6e30990d589fba3a68f20a1686af0f5cda"
+checksum = "dd9646a972b57896d4a92ed200cf76139f8e30b3cfd03b6662ae59926d26633c"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -11602,19 +11602,20 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a693f27e3f63ae085cf7c176b5c44038af27c8a0170d01db30ccf776c2d40ce3"
+checksum = "235865e639f1d72414fa5d35374e105c292e2ee3a2f90919d961bbb486626ee6"
 dependencies = [
+ "bitflags 2.9.4",
  "log",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-panic"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4651d34f3ba649d9e6dc1268443cae6728b8f741c2f0264004f8ecf5b247330d"
+checksum = "6127d3d304ba5ce0409401e85aae538e303a569f8dbb031bf64f9ba0f7174346"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -11622,9 +11623,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25c47d36bc80c74d26d568ffe970c37b337c061b7234ad6f2d159439c16f000"
+checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
 dependencies = [
  "bitflags 2.9.4",
  "sentry-backtrace",
@@ -11635,9 +11636,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.41.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08e7154abe2cd557f26fd70038452810748aefdf39bc973f674421224b147c1"
+checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
 dependencies = [
  "debugid",
  "hex",
@@ -14265,6 +14266,7 @@ name = "warp"
 version = "0.1.0"
 dependencies = [
  "addr",
+ "aha-reqwest-eventsource",
  "aho-corasick",
  "ai",
  "anyhow",
@@ -14431,7 +14433,6 @@ dependencies = [
  "remote_server",
  "repo_metadata",
  "reqwest",
- "reqwest-eventsource",
  "rmcp",
  "rquickjs",
  "rust-embed 8.7.2",
@@ -15330,9 +15331,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3748,6 +3748,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3776,6 +3786,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3793,6 +3816,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -7228,9 +7262,9 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -7731,6 +7765,22 @@ checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
  "rayon",
+]
+
+[[package]]
+name = "mcp"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "http 1.4.0",
+ "pin-project-lite",
+ "reqwest",
+ "rmcp",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -8246,6 +8296,18 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "memoffset 0.9.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
 ]
 
 [[package]]
@@ -9847,16 +9909,16 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "8.2.1"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap 2.12.0",
- "nix 0.30.1",
+ "nix 0.31.2",
  "tokio",
  "tracing",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -10833,8 +10895,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.10.0"
-source = "git+https://github.com/warpdotdev/rmcp.git?rev=c0f65dc441af7d714b9c453ac5e7ef641451abe3#c0f65dc441af7d714b9c453ac5e7ef641451abe3"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10861,10 +10924,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.10.0"
-source = "git+https://github.com/warpdotdev/rmcp.git?rev=c0f65dc441af7d714b9c453ac5e7ef641451abe3#c0f65dc441af7d714b9c453ac5e7ef641451abe3"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -14325,6 +14389,7 @@ dependencies = [
  "lz4_flex 0.11.6",
  "mach2 0.5.0",
  "markdown_parser",
+ "mcp",
  "memchr",
  "memo-map",
  "mermaid_to_svg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -378,7 +378,8 @@ typed-path = "0.10.0"
 streaming-iterator = "0.1.0"
 derivative = "2.2.0"
 parquet = { version = "55.0.0", features = ["arrow"] }
-rmcp = { git = "https://github.com/warpdotdev/rmcp.git", rev = "c0f65dc441af7d714b9c453ac5e7ef641451abe3" }
+mcp = { path = "crates/mcp" }
+rmcp = { version = "0.15" }
 
 [profile.release]
 # Use line-tables-only (debug = 1) rather than full debuginfo (debug = 2 /

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ jsonrpc = { path = "crates/jsonrpc" }
 languages = { path = "crates/languages" }
 lsp = { path = "crates/lsp" }
 markdown_parser = { path = "crates/markdown_parser" }
+mcp = { path = "crates/mcp" }
 natural_language_detection = { path = "crates/natural_language_detection" }
 node_runtime = { path = "crates/node_runtime" }
 onboarding = { path = "crates/onboarding" }
@@ -378,7 +379,6 @@ typed-path = "0.10.0"
 streaming-iterator = "0.1.0"
 derivative = "2.2.0"
 parquet = { version = "55.0.0", features = ["arrow"] }
-mcp = { path = "crates/mcp" }
 rmcp = { version = "0.15" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,10 +187,7 @@ nix = { version = "0.26.4", default-features = false, features = ["signal"] }
 notify-debouncer-full = { git = "https://github.com/warpdotdev/notify", rev = "f3afcda3058941e17e09689afea40e2a2db057e0" }
 nom = "7.1.1"
 num-traits = "0.2"
-# We disable default features as the "rustls-tls" feature enables the reqwest
-# feature of the same name, which itself enables the "rustls-tls-webpki-roots"
-# feature, whereas we want to use native roots instead.
-oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest"] }
+oauth2 = { version = "5.0.0", default-features = false }
 openh264 = "0.8"
 static_assertions = "1.1.0"
 url = "2.5.4"
@@ -214,25 +211,22 @@ prost-reflect = "0.16.3"
 prost-types = "0.14.3"
 rand = "0.8.6"
 rangemap = "1.3.0"
-reqwest = { version = "0.12.28", default-features = false, features = [
+reqwest = { version = "0.13", features = [
   "blocking",
   "brotli",
-  "charset",
   "gzip",
-  "http2",
+  "form",
   "json",
-  "macos-system-configuration",
-  "rustls-tls-native-roots-no-provider",
+  "query",
   "stream",
-  "system-proxy",
 ] }
-reqwest-eventsource = "0.6.0"
+reqwest-eventsource = { package = "aha-reqwest-eventsource", version = "0.1" }
 resvg = "0.47.0"
 rust-embed = { version = "8.7.0", features = ["include-exclude"] }
 rustc-hash = "2.1.1"
 rustls = "0.23.39"
 schemars = { version = "1", features = ["chrono04"] }
-sentry = { version = "0.41.0", default-features = false, features = [
+sentry = { version = "0.47.0", default-features = false, features = [
   "anyhow",
   "backtrace",
   "contexts",
@@ -242,7 +236,7 @@ sentry = { version = "0.41.0", default-features = false, features = [
   "reqwest",
   "rustls",
 ] }
-sentry-log = "0.41.0"
+sentry-log = "0.47.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde-bytes-repr = "0.3"
@@ -379,7 +373,7 @@ typed-path = "0.10.0"
 streaming-iterator = "0.1.0"
 derivative = "2.2.0"
 parquet = { version = "55.0.0", features = ["arrow"] }
-rmcp = { version = "0.15" }
+rmcp = { version = "1.6" }
 
 [profile.release]
 # Use line-tables-only (debug = 1) rather than full debuginfo (debug = 2 /

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -297,10 +297,10 @@ aws-credential-types = "1"
 aws-sdk-sts = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-types = "1"
 
+mcp.workspace = true
 rmcp = { workspace = true, features = [
     "auth",
     "transport-streamable-http-client-reqwest",
-    "transport-sse-client-reqwest",
     "transport-child-process",
 ] }
 notify-debouncer-full.workspace = true

--- a/app/src/ai/agent_sdk/test_support.rs
+++ b/app/src/ai/agent_sdk/test_support.rs
@@ -8,9 +8,7 @@
 /// that spin up multiple connections.
 pub(super) fn build_test_http_client() -> http_client::Client {
     let builder = reqwest::ClientBuilder::new()
-        .tls_built_in_native_certs(false)
-        .tls_built_in_root_certs(false)
-        .tls_built_in_webpki_certs(false)
+        .tls_certs_only([])
         .no_proxy()
         .pool_max_idle_per_host(0);
     http_client::Client::from_client_builder(builder)

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
@@ -141,10 +141,10 @@ impl CallMCPToolExecutor {
             ActionExecution::new_async(
                 async move {
                     reconnecting_peer
-                    .call_tool(
-                        rmcp::model::CallToolRequestParams::new(name_owned_inner)
-                            .with_arguments(arguments),
-                    )
+                        .call_tool(
+                            rmcp::model::CallToolRequestParams::new(name_owned_inner)
+                                .with_arguments(arguments),
+                        )
                         .await
                 },
                 move |res, ctx| handle_call_tool_result(res, server_output_id, name_clone, ctx),

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
@@ -141,12 +141,12 @@ impl CallMCPToolExecutor {
             ActionExecution::new_async(
                 async move {
                     reconnecting_peer
-                    .call_tool(rmcp::model::CallToolRequestParams {
-                        name: name_owned_inner.into(),
-                        arguments: Some(arguments),
-                        meta: None,
-                        task: None,
-                    })
+                        .call_tool(rmcp::model::CallToolRequestParams {
+                            name: name_owned_inner.into(),
+                            arguments: Some(arguments),
+                            meta: None,
+                            task: None,
+                        })
                         .await
                 },
                 move |res, ctx| handle_call_tool_result(res, server_output_id, name_clone, ctx),

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
@@ -141,12 +141,10 @@ impl CallMCPToolExecutor {
             ActionExecution::new_async(
                 async move {
                     reconnecting_peer
-                        .call_tool(rmcp::model::CallToolRequestParams {
-                            name: name_owned_inner.into(),
-                            arguments: Some(arguments),
-                            meta: None,
-                            task: None,
-                        })
+                    .call_tool(
+                        rmcp::model::CallToolRequestParams::new(name_owned_inner)
+                            .with_arguments(arguments),
+                    )
                         .await
                 },
                 move |res, ctx| handle_call_tool_result(res, server_output_id, name_clone, ctx),

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
@@ -141,10 +141,12 @@ impl CallMCPToolExecutor {
             ActionExecution::new_async(
                 async move {
                     reconnecting_peer
-                        .call_tool(rmcp::model::CallToolRequestParam {
-                            name: name_owned_inner.into(),
-                            arguments: Some(arguments),
-                        })
+                    .call_tool(rmcp::model::CallToolRequestParams {
+                        name: name_owned_inner.into(),
+                        arguments: Some(arguments),
+                        meta: None,
+                        task: None,
+                    })
                         .await
                 },
                 move |res, ctx| handle_call_tool_result(res, server_output_id, name_clone, ctx),

--- a/app/src/ai/blocklist/action_model/execute/read_mcp_resource.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_mcp_resource.rs
@@ -128,7 +128,7 @@ impl ReadMCPResourceExecutor {
             ActionExecution::new_async(
                 async move {
                     reconnecting_peer
-                    .read_resource(rmcp::model::ReadResourceRequestParams { uri, meta: None })
+                        .read_resource(rmcp::model::ReadResourceRequestParams { uri, meta: None })
                         .await
                 },
                 |res, _ctx| handle_read_resource_result(res),

--- a/app/src/ai/blocklist/action_model/execute/read_mcp_resource.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_mcp_resource.rs
@@ -128,7 +128,7 @@ impl ReadMCPResourceExecutor {
             ActionExecution::new_async(
                 async move {
                     reconnecting_peer
-                    .read_resource(rmcp::model::ReadResourceRequestParams::new(uri))
+                        .read_resource(rmcp::model::ReadResourceRequestParams::new(uri))
                         .await
                 },
                 |res, _ctx| handle_read_resource_result(res),

--- a/app/src/ai/blocklist/action_model/execute/read_mcp_resource.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_mcp_resource.rs
@@ -128,7 +128,7 @@ impl ReadMCPResourceExecutor {
             ActionExecution::new_async(
                 async move {
                     reconnecting_peer
-                        .read_resource(rmcp::model::ReadResourceRequestParams { uri, meta: None })
+                    .read_resource(rmcp::model::ReadResourceRequestParams::new(uri))
                         .await
                 },
                 |res, _ctx| handle_read_resource_result(res),

--- a/app/src/ai/blocklist/action_model/execute/read_mcp_resource.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_mcp_resource.rs
@@ -128,7 +128,7 @@ impl ReadMCPResourceExecutor {
             ActionExecution::new_async(
                 async move {
                     reconnecting_peer
-                        .read_resource(rmcp::model::ReadResourceRequestParam { uri })
+                    .read_resource(rmcp::model::ReadResourceRequestParams { uri, meta: None })
                         .await
                 },
                 |res, _ctx| handle_read_resource_result(res),

--- a/app/src/ai/mcp/reconnecting_peer.rs
+++ b/app/src/ai/mcp/reconnecting_peer.rs
@@ -120,7 +120,7 @@ impl ReconnectingPeer {
     /// Calls a tool on the MCP server.
     pub async fn call_tool(
         &self,
-        params: rmcp::model::CallToolRequestParam,
+        params: rmcp::model::CallToolRequestParams,
     ) -> Result<rmcp::model::CallToolResult, rmcp::ServiceError> {
         self.with_reconnect_retry(params, |peer, p| async move { peer.call_tool(p).await })
             .await
@@ -129,7 +129,7 @@ impl ReconnectingPeer {
     /// Reads a resource from the MCP server.
     pub async fn read_resource(
         &self,
-        params: rmcp::model::ReadResourceRequestParam,
+        params: rmcp::model::ReadResourceRequestParams,
     ) -> Result<rmcp::model::ReadResourceResult, rmcp::ServiceError> {
         self.with_reconnect_retry(params, |peer, p| async move { peer.read_resource(p).await })
             .await

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -160,6 +160,10 @@ fn error_to_user_message(error: &rmcp::RmcpError) -> String {
             }
             _ => format!("Service error: {}", err),
         },
+        // The enum is marked as non-exhaustive, so we need a catch-all.
+        _ => {
+            format!("Error: {error}")
+        }
     }
 }
 
@@ -1723,7 +1727,7 @@ impl TemplatableMCPServerManager {
 }
 
 type ReqwestHttpTransport = rmcp::transport::StreamableHttpClientTransport<reqwest::Client>;
-type ReqwestSseTransport = rmcp::transport::SseClientTransport<reqwest::Client>;
+type ReqwestSseTransport = mcp::sse_transport::SseClientTransport<reqwest::Client>;
 
 /// Spawns a new MCP server from a given [`TransportType`].
 async fn spawn_server(
@@ -1891,9 +1895,9 @@ async fn spawn_server(
                     is_authenticated_transport = true;
 
                     logger.log("[info] MCP: Using (legacy) SSE transport (due to preflight failing with a 404)".to_string());
-                    let transport = rmcp::transport::SseClientTransport::start_with_client(
+                    let transport = mcp::sse_transport::SseClientTransport::start_with_client(
                         client,
-                        rmcp::transport::sse_client::SseClientConfig {
+                        mcp::sse_transport::SseClientConfig {
                             sse_endpoint: sse_server.url.into(),
                             ..Default::default()
                         },
@@ -1909,16 +1913,16 @@ async fn spawn_server(
                 Ok(Transport::Sse(None)) => {
                     logger.log("[info] MCP: Using (legacy) SSE transport (due to preflight failing with a 404)".to_string());
                     let transport = if headers.is_empty() {
-                        rmcp::transport::SseClientTransport::start(sse_server.url.clone())
+                        mcp::sse_transport::SseClientTransport::start(sse_server.url.clone())
                             .await
                             .map_err(|e| {
                                 rmcp::RmcpError::transport_creation::<ReqwestSseTransport>(e)
                             })?
                     } else {
                         let client = build_client_with_headers(&headers)?;
-                        rmcp::transport::SseClientTransport::start_with_client(
+                        mcp::sse_transport::SseClientTransport::start_with_client(
                             client,
-                            rmcp::transport::sse_client::SseClientConfig {
+                            mcp::sse_transport::SseClientConfig {
                                 sse_endpoint: sse_server.url.clone().into(),
                                 ..Default::default()
                             },
@@ -2087,9 +2091,11 @@ fn make_client_info() -> rmcp::model::ClientInfo {
                 .map(|v| v.to_string())
                 .unwrap_or_default(),
             title: None,
+            description: None,
             icons: None,
             website_url: None,
         },
+        meta: None,
     }
 }
 

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -2082,21 +2082,15 @@ async fn send_initialize_request(
 ///
 /// This tells the MCP server who we are and what capabilities we have.
 fn make_client_info() -> rmcp::model::ClientInfo {
-    rmcp::model::ClientInfo {
-        protocol_version: Default::default(),
-        capabilities: Default::default(),
-        client_info: rmcp::model::Implementation {
-            name: warp_core::channel::ChannelState::app_id().to_string(),
-            version: warp_core::channel::ChannelState::app_version()
+    rmcp::model::ClientInfo::new(
+        Default::default(),
+        rmcp::model::Implementation::new(
+            warp_core::channel::ChannelState::app_id().to_string(),
+            warp_core::channel::ChannelState::app_version()
                 .map(|v| v.to_string())
                 .unwrap_or_default(),
-            title: None,
-            description: None,
-            icons: None,
-            website_url: None,
-        },
-        meta: None,
-    }
+        ),
+    )
 }
 
 /// A wrapper around a [`rmcp::transport::Transport`] that logs all requests and responses.

--- a/app/src/ai/mcp/templatable_manager/oauth.rs
+++ b/app/src/ai/mcp/templatable_manager/oauth.rs
@@ -3,11 +3,9 @@ use std::collections::HashMap;
 use anyhow::{anyhow, bail};
 use oauth2::{RefreshToken, TokenResponse as _};
 use rmcp::transport::{
-    auth::{
-        AuthClient, AuthorizationManager, CredentialStore, InMemoryCredentialStore,
-        OAuthClientConfig, OAuthState, StoredCredentials,
-    },
-    AuthError, AuthorizationSession, ClientCredentialsConfig,
+    AuthError, AuthorizationSession, auth::{
+        AuthClient, AuthorizationManager, CredentialStore, InMemoryCredentialStore, OAuthClientConfig, OAuthState, OAuthTokenResponse, StoredCredentials
+    }
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -46,6 +44,25 @@ pub struct PersistedCredentials {
     /// This is needed to properly refresh tokens when using DCR (Dynamic Client Registration),
     /// as the server expects the client to provide the secret when refreshing.
     client_secret: Option<String>,
+}
+
+impl PersistedCredentials {
+    fn new(
+        client_id: String,
+        client_secret: Option<String>,
+        token_response: Option<OAuthTokenResponse>,
+        token_received_at: Option<u64>,
+    ) -> Self {
+        Self {
+            credentials: StoredCredentials::new(
+                client_id,
+                token_response,
+                Vec::new(),
+                token_received_at,
+            ),
+            client_secret,
+        }
+    }
 }
 
 /// Maps cloud MCP installation UUID to its OAuth credentials in secure storage.
@@ -268,71 +285,50 @@ pub async fn make_authenticated_client(
         ));
     }
 
-    // With DCR (Dynamic Client Registration), we don't pass in explicit scopes; they are specified
-    // during dynamic registration.
-    //
-    // For apps for which we have static client IDs (e.g. GitHub), we manually override scopes.
-    let mut scopes: &[&str] = &[];
+    let metadata = auth_manager.discover_metadata().await?;
 
-    // Create the OAuth state machine.
-    let mut oauth_state = OAuthState::Unauthorized(auth_manager);
-
-    // Determine whether we can use DCR or need to use static registration.
-    let can_use_dcr = match oauth_state
-        .start_authorization(&[], &redirect_uri, Some("Warp"))
-        .await
+    // Configure the auth manager's OAuth client using dynamic or static client registration.
+    let mut oauth_state = if let Some(provider) = metadata
+        .issuer
+        .as_deref()
+        .and_then(ChannelState::mcp_oauth_provider_by_issuer)
     {
-        Ok(_) => true,
-        Err(AuthError::RegistrationFailed(_)) => false,
-        Err(e) => return Err(e),
-    };
+        // Configure the auth manager based on the static MCP configuration for this
+        // issuer.
+        auth_manager.set_metadata(metadata);
 
-    let OAuthState::Session(AuthorizationSession {
-        mut auth_manager, ..
-    }) = oauth_state
-    else {
-        return Err(AuthError::InternalError(
-            "OAuth state is not in the expected state".to_string(),
-        ));
-    };
+        let scopes = if provider.issuer == GITHUB_ISSUER {
+            GITHUB_OAUTH_SCOPES
+                .into_iter()
+                .map(ToString::to_string)
+                .collect()
+        } else {
+            vec![]
+        };
+        auth_manager.configure_client(
+            OAuthClientConfig::new(provider.client_id, redirect_uri.clone())
+                .with_client_secret(provider.client_secret)
+                .with_scopes(scopes),
+        )?;
 
-    // Start the authorization process with our custom redirect URI
-    let config = if can_use_dcr {
-        auth_manager
-            .register_client("Warp", &redirect_uri, scopes)
-            .await?
+        // We do a scope "upgrade" with no additional scopes here as it's the easiest way
+        // to construct an auth URL.
+        let auth_url = auth_manager.request_scope_upgrade("").await?;
+        OAuthState::Session(AuthorizationSession::for_scope_upgrade(
+            auth_manager,
+            auth_url,
+            &redirect_uri,
+        ))
     } else {
-        // If we failed dynamic registration, check to see if this is an auth
-        // server we have a static client ID for.
-
-        // TODO(vorporeal): adjust APIs in rmcp so that we don't need to make this redundant
-        // discover_metadata() call (as it gets made within start_authorization() but we can't
-        // look at the results).
-        let metadata = auth_manager.discover_metadata().await?;
-        let provider = metadata
-            .issuer
-            .as_deref()
-            .and_then(ChannelState::mcp_oauth_provider_by_issuer)
-            .ok_or(AuthError::RegistrationFailed("DCR is not supported and provider is not known".to_string()))?;
-
-        if provider.issuer == GITHUB_ISSUER {
-            scopes = &GITHUB_OAUTH_SCOPES;
-        }
-
-        OAuthClientConfig::new(provider.client_id.into_owned(), redirect_uri.clone())
-            .with_client_secret(provider.client_secret.into_owned())
+        // Try dynamic client registration.
+        let mut oauth_state = OAuthState::Unauthorized(auth_manager);
+        oauth_state
+            .start_authorization(&[], &redirect_uri, Some("Warp"))
+            .await?;
+        oauth_state
     };
 
-    let client_secret = config.client_secret.clone();
-
-    auth_manager.configure_client(config)?;
-
-    let auth_url = auth_manager.get_authorization_url(scopes).await?;
-    oauth_state = OAuthState::Session(AuthorizationSession::for_scope_upgrade(
-        auth_manager,
-        auth_url.clone(),
-        &redirect_uri,
-    ));
+    let auth_url = oauth_state.get_authorization_url().await?;
 
     // Extract the CSRF token that rmcp embedded as the `state` query parameter in the
     // authorization URL. We register a csrf→uuid mapping on the manager so that
@@ -526,7 +522,6 @@ pub(crate) fn write_to_secure_storage<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rmcp::transport::auth::OAuthTokenResponse;
 
     /// Builds a minimal `OAuthTokenResponse` for tests, optionally with a refresh token.
     fn make_test_token_response(refresh_token: Option<&str>) -> OAuthTokenResponse {
@@ -563,16 +558,16 @@ mod tests {
         let original = PersistedCredentials::new(
             "client-abc".to_string(),
             Some("shh".to_string()),
-            make_test_token_response(Some("refresh-1")),
+            Some(make_test_token_response(Some("refresh-1"))),
             Some(1_700_000_000),
         );
 
         let json = serde_json::to_string(&original).expect("serialize");
         let parsed: PersistedCredentials = serde_json::from_str(&json).expect("deserialize");
 
-        assert_eq!(parsed.client_id, original.client_id);
+        assert_eq!(parsed.credentials.client_id, original.credentials.client_id);
         assert_eq!(parsed.client_secret, original.client_secret);
-        assert_eq!(parsed.token_received_at, Some(1_700_000_000));
+        assert_eq!(parsed.credentials.token_received_at, Some(1_700_000_000));
     }
 
     /// Backward compatibility: credentials persisted by older Warp versions do not
@@ -596,8 +591,8 @@ mod tests {
         let parsed: PersistedCredentials =
             serde_json::from_str(legacy_json).expect("legacy format must deserialize");
 
-        assert_eq!(parsed.client_id, "client-abc");
-        assert_eq!(parsed.token_received_at, None);
+        assert_eq!(parsed.credentials.client_id, "client-abc");
+        assert_eq!(parsed.credentials.token_received_at, None);
     }
 
     /// Regression test for #8863. When rmcp persists refreshed credentials via
@@ -620,8 +615,8 @@ mod tests {
         store.save(credentials).await.expect("save succeeds");
 
         let persisted = rx.try_recv().expect("persist channel received credentials");
-        assert_eq!(persisted.token_received_at, Some(1_700_000_500));
-        assert_eq!(persisted.client_id, "client-id");
+        assert_eq!(persisted.credentials.token_received_at, Some(1_700_000_500));
+        assert_eq!(persisted.credentials.client_id, "client-id");
         assert_eq!(
             persisted.client_secret.as_deref(),
             Some("client_secret_xyz")
@@ -645,7 +640,7 @@ mod tests {
         store.save(credentials).await.expect("save succeeds");
 
         let persisted = rx.try_recv().expect("persist channel received credentials");
-        assert_eq!(persisted.token_received_at, None);
+        assert_eq!(persisted.credentials.token_received_at, None);
     }
 
     /// `save` only forwards a credentials snapshot to the persist channel when
@@ -698,15 +693,17 @@ mod tests {
 
         let persisted = rx.try_recv().expect("persist channel received credentials");
         assert_eq!(
-            persisted.token_received_at,
+            persisted.credentials.token_received_at,
             Some(1_700_000_500),
             "newer received_at preserved"
         );
+
+        let refresh_token = persisted
+            .credentials
+            .token_response
+            .and_then(|tr| tr.refresh_token().cloned());
         assert_eq!(
-            persisted
-                .token_response
-                .refresh_token()
-                .map(|rt| rt.secret().to_string()),
+            refresh_token.map(|rt| rt.secret().to_string()),
             Some("prior-refresh-token".to_string()),
             "prior refresh token carried forward"
         );

--- a/app/src/ai/mcp/templatable_manager/oauth.rs
+++ b/app/src/ai/mcp/templatable_manager/oauth.rs
@@ -5,7 +5,7 @@ use oauth2::{RefreshToken, TokenResponse as _};
 use rmcp::transport::{
     auth::{
         AuthClient, AuthorizationManager, CredentialStore, InMemoryCredentialStore,
-        OAuthClientConfig, OAuthState, OAuthTokenResponse, StoredCredentials,
+        OAuthClientConfig, OAuthState, StoredCredentials,
     },
     AuthError, AuthorizationSession,
 };
@@ -244,7 +244,7 @@ pub async fn make_authenticated_client(
 
     // If we have a valid access token (or successfully refreshed a valid refresh token),
     // we're already authorized and good to go.
-    if let Ok(_) = auth_manager.get_access_token().await {
+    if auth_manager.get_access_token().await.is_ok() {
         if let (Some(client_id), Some(client_secret)) = (client_id, client_secret) {
             auth_manager.configure_client(
                 OAuthClientConfig::new(client_id, redirect_uri.clone())
@@ -507,6 +507,8 @@ pub(crate) fn write_to_secure_storage<T: Serialize>(
 
 #[cfg(test)]
 mod tests {
+    use rmcp::transport::auth::OAuthTokenResponse;
+
     use super::*;
 
     /// Builds a minimal `OAuthTokenResponse` for tests, optionally with a refresh token.

--- a/app/src/ai/mcp/templatable_manager/oauth.rs
+++ b/app/src/ai/mcp/templatable_manager/oauth.rs
@@ -46,25 +46,6 @@ pub struct PersistedCredentials {
     client_secret: Option<String>,
 }
 
-impl PersistedCredentials {
-    fn new(
-        client_id: String,
-        client_secret: Option<String>,
-        token_response: Option<OAuthTokenResponse>,
-        token_received_at: Option<u64>,
-    ) -> Self {
-        Self {
-            credentials: StoredCredentials::new(
-                client_id,
-                token_response,
-                Vec::new(),
-                token_received_at,
-            ),
-            client_secret,
-        }
-    }
-}
-
 /// Maps cloud MCP installation UUID to its OAuth credentials in secure storage.
 pub type PersistedCredentialsMap = HashMap<Uuid, PersistedCredentials>;
 
@@ -132,10 +113,13 @@ impl CredentialStore for PersistingCredentialStore {
 
         self.inner.save(credentials.clone()).await?;
 
-        let _ = self.persist_tx.try_send(PersistedCredentials {
-            credentials,
-            client_secret: self.client_secret.clone(),
-        });
+        // Only persist credentials if we actually have any.
+        if credentials.token_response.is_some() {
+            let _ = self.persist_tx.try_send(PersistedCredentials {
+                credentials,
+                client_secret: self.client_secret.clone(),
+            });
+        }
         Ok(())
     }
 
@@ -551,23 +535,6 @@ mod tests {
             persist_tx: tx,
         };
         (store, rx)
-    }
-
-    #[test]
-    fn persisted_credentials_round_trip_through_serde_preserves_received_at() {
-        let original = PersistedCredentials::new(
-            "client-abc".to_string(),
-            Some("shh".to_string()),
-            Some(make_test_token_response(Some("refresh-1"))),
-            Some(1_700_000_000),
-        );
-
-        let json = serde_json::to_string(&original).expect("serialize");
-        let parsed: PersistedCredentials = serde_json::from_str(&json).expect("deserialize");
-
-        assert_eq!(parsed.credentials.client_id, original.credentials.client_id);
-        assert_eq!(parsed.client_secret, original.client_secret);
-        assert_eq!(parsed.credentials.token_received_at, Some(1_700_000_000));
     }
 
     /// Backward compatibility: credentials persisted by older Warp versions do not

--- a/app/src/ai/mcp/templatable_manager/oauth.rs
+++ b/app/src/ai/mcp/templatable_manager/oauth.rs
@@ -187,10 +187,12 @@ async fn install_persisting_credential_store(
     if let Ok((client_id, Some(token_response))) = auth_manager.get_credentials().await {
         let _ = store
             .inner
-            .save(StoredCredentials {
+            .save(StoredCredentials::new(
                 client_id,
-                token_response: Some(token_response),
-            })
+                Some(token_response),
+                Vec::new(),
+                None,
+            ))
             .await;
     }
 
@@ -272,12 +274,13 @@ pub async fn make_authenticated_client(
             // If this is a client for which we have a known client secret,
             // update our client config accordingly.
             if let Some(client_secret) = &client_secret {
-                auth_manager.configure_client(OAuthClientConfig {
-                    client_id: credentials.client_id.clone(),
-                    client_secret: Some(client_secret.clone()),
-                    scopes: vec![],
-                    redirect_uri: redirect_uri.clone(),
-                })?;
+                auth_manager.configure_client(
+                    OAuthClientConfig::new(
+                        credentials.client_id.clone(),
+                        redirect_uri.clone(),
+                    )
+                    .with_client_secret(client_secret.clone()),
+                )?;
             }
 
             // GitHub does not issue refresh tokens for OAuth apps; their access tokens are valid
@@ -357,7 +360,7 @@ pub async fn make_authenticated_client(
     // For apps for which we have static client IDs (e.g. GitHub), we manually override scopes.
     let mut scopes: &[&str] = &[];
 
-    let config = match auth_manager.register_client("Warp", &redirect_uri).await {
+    let config = match auth_manager.register_client("Warp", &redirect_uri, scopes).await {
         Ok(config) => config,
         Err(err @ AuthError::RegistrationFailed(_)) => {
             // If we failed dynamic registration, check to see if this is an auth
@@ -377,14 +380,11 @@ pub async fn make_authenticated_client(
                 scopes = &GITHUB_OAUTH_SCOPES;
             }
 
-            OAuthClientConfig {
-                client_id: provider.client_id.into_owned(),
-                client_secret: Some(provider.client_secret.into_owned()),
-                redirect_uri: redirect_uri.clone(),
-                // This `scopes` field appears to be unused by rmcp as of 9/17/25 - we pass scopes
-                // in construction of the authorization url below.
-                scopes: vec![],
-            }
+            OAuthClientConfig::new(
+                provider.client_id.into_owned(),
+                redirect_uri.clone(),
+            )
+            .with_client_secret(provider.client_secret.into_owned())
         }
         Err(e) => return Err(e),
     };
@@ -393,11 +393,9 @@ pub async fn make_authenticated_client(
     auth_manager.configure_client(config)?;
 
     let auth_url = auth_manager.get_authorization_url(scopes).await?;
-    oauth_state = OAuthState::Session(AuthorizationSession {
-        auth_manager,
-        auth_url: auth_url.clone(),
-        redirect_uri,
-    });
+    oauth_state = OAuthState::Session(
+        AuthorizationSession::for_scope_upgrade(auth_manager, auth_url.clone(), &redirect_uri),
+    );
 
     // Extract the CSRF token that rmcp embedded as the `state` query parameter in the
     // authorization URL. We register a csrf→uuid mapping on the manager so that

--- a/app/src/ai/mcp/templatable_manager/oauth.rs
+++ b/app/src/ai/mcp/templatable_manager/oauth.rs
@@ -190,8 +190,6 @@ async fn install_persisting_credential_store(
             .save(StoredCredentials {
                 client_id,
                 token_response: Some(token_response),
-                granted_scopes: Vec::new(),
-                token_received_at,
             })
             .await;
     }

--- a/app/src/ai/mcp/templatable_manager/oauth.rs
+++ b/app/src/ai/mcp/templatable_manager/oauth.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail};
 use oauth2::{RefreshToken, TokenResponse as _};
@@ -8,7 +7,7 @@ use rmcp::transport::{
         AuthClient, AuthorizationManager, CredentialStore, InMemoryCredentialStore,
         OAuthClientConfig, OAuthState, StoredCredentials,
     },
-    AuthError, AuthorizationSession,
+    AuthError, AuthorizationSession, ClientCredentialsConfig,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -141,35 +140,26 @@ impl CredentialStore for PersistingCredentialStore {
 /// sole role is to write token updates back to secure storage as they occur.
 async fn install_persisting_credential_store(
     auth_manager: &mut AuthorizationManager,
-    client_secret: Option<String>,
+    persisted_credentials: Option<PersistedCredentials>,
     spawner: ModelSpawner<TemplatableMCPServerManager>,
     installation_uuid: Uuid,
 ) {
+    let client_secret = persisted_credentials
+        .as_ref()
+        .and_then(|c| c.client_secret.clone());
+    let in_memory_store = InMemoryCredentialStore::new();
+
+    // If we have persisted credentials, populate the backing in-memory store with them.
+    if let Some(credentials) = persisted_credentials {
+        let _ = in_memory_store.save(credentials.credentials).await;
+    }
+
     let (persist_tx, persist_rx) = async_channel::unbounded();
     let store = PersistingCredentialStore {
-        inner: InMemoryCredentialStore::new(),
+        inner: in_memory_store,
         client_secret,
         persist_tx,
     };
-
-    // Seed the new store with the current credentials so that subsequent
-    // get_access_token() calls can find them. `token_received_at` must be
-    // preserved across the seed; otherwise rmcp's pre-emptive refresh check
-    // (which requires both `expires_in` and `token_received_at`) is skipped
-    // for the lifetime of this store, and the cached token will be used past
-    // its TTL until a request fails with 401 (#8863).
-    if let Ok((client_id, Some(token_response))) = auth_manager.get_credentials().await {
-        let _ = store
-            .inner
-            .save(StoredCredentials::new(
-                client_id,
-                Some(token_response),
-                Vec::new(),
-                // TODO(vorporeal): gotta initialize this better
-                None,
-            ))
-            .await;
-    }
 
     auth_manager.set_credential_store(store);
 
@@ -232,71 +222,33 @@ pub async fn make_authenticated_client(
     // Dynamic Client Registration, satisfying RFC 6749 §3.1.2.2 exact-match validation.
     let redirect_uri = format!("{}://mcp/oauth2callback", ChannelState::url_scheme());
 
-    // Create the OAuth state machine.
-    let mut oauth_state = OAuthState::new(resource_url, None).await?;
+    // Create the auth manager and initialize it with a backing credential store that persists
+    // new credentials to secure storage.
+    let client_id = persisted_credentials
+        .as_ref()
+        .map(|c| c.credentials.client_id.clone());
+    let client_secret = persisted_credentials
+        .as_ref()
+        .and_then(|c| c.client_secret.clone());
+    let mut auth_manager = AuthorizationManager::new(resource_url).await?;
+    install_persisting_credential_store(
+        &mut auth_manager,
+        persisted_credentials,
+        spawner.clone(),
+        uuid,
+    )
+    .await;
 
-    // If we have cached credentials, use them.
-    if let Some(credentials) = persisted_credentials {
-        let provider =
-            ChannelState::mcp_oauth_provider_by_client_id(&credentials.credentials.client_id);
-        let client_secret = credentials
-            .client_secret
-            .or_else(|| provider.as_ref().map(|p| p.client_secret.to_string()));
-        if let Some(token_response) = credentials.credentials.token_response {
-            oauth_state
-                .set_credentials(&credentials.credentials.client_id, token_response)
-                .await?;
+    // If we have a valid access token (or successfully refreshed a valid refresh token),
+    // we're already authorized and good to go.
+    if let Ok(_) = auth_manager.get_access_token().await {
+        if let (Some(client_id), Some(client_secret)) = (client_id, client_secret) {
+            auth_manager.configure_client(
+                OAuthClientConfig::new(client_id, redirect_uri.clone())
+                    .with_client_secret(client_secret),
+            )?;
         }
-        if let OAuthState::Authorized(mut auth_manager) = oauth_state {
-            // If this is a client for which we have a known client secret,
-            // update our client config accordingly.
-            if let Some(client_secret) = &client_secret {
-                auth_manager.configure_client(
-                    OAuthClientConfig::new(
-                        credentials.credentials.client_id.clone(),
-                        redirect_uri.clone(),
-                    )
-                    .with_client_secret(client_secret.clone()),
-                )?;
-            }
-
-            // GitHub does not issue refresh tokens for OAuth apps; their access tokens are valid
-            // until the user explicitly revokes them.
-            //
-            // As such, if we have an access token for a GitHub server, we must assume it's valid.
-            if provider.as_ref().is_some_and(|p| p.issuer == GITHUB_ISSUER) {
-                return Ok((AuthClient::new(reqwest::Client::new(), auth_manager), false));
-            }
-
-            // Else, make sure we have an up-to-date access token.
-            // We need to do this because our fork of rmcp does not properly detect expired tokens.
-            // This is fixed in https://github.com/modelcontextprotocol/rust-sdk/pull/680
-            //
-            // Install the persisting credential store before refreshing so that
-            // the refresh result is automatically written back to secure storage.
-            // Pass the cached `token_received_at` so rmcp's pre-emptive refresh
-            // check has the data it needs after this connect-time refresh — see
-            // #8863 for what happens when this is `None`.
-            install_persisting_credential_store(
-                &mut auth_manager,
-                client_secret,
-                spawner.clone(),
-                uuid,
-            )
-            .await;
-            match auth_manager.refresh_token().await {
-                Ok(_) => {
-                    return Ok((AuthClient::new(reqwest::Client::new(), auth_manager), false));
-                }
-                Err(e) => {
-                    log::warn!("Failed to refresh token: {e:#}");
-
-                    // We didn't have a valid auth token _and_ we could not refresh it, so
-                    // we need to go through the OAuth flow again.
-                    oauth_state = OAuthState::new(resource_url, None).await?;
-                }
-            }
-        }
+        return Ok((AuthClient::new(reqwest::Client::new(), auth_manager), false));
     }
 
     // If we're in headless mode and we reach here, it means we either have no credentials
@@ -316,10 +268,24 @@ pub async fn make_authenticated_client(
         ));
     }
 
-    // Start the authorization process with our custom redirect URI
-    oauth_state
+    // With DCR (Dynamic Client Registration), we don't pass in explicit scopes; they are specified
+    // during dynamic registration.
+    //
+    // For apps for which we have static client IDs (e.g. GitHub), we manually override scopes.
+    let mut scopes: &[&str] = &[];
+
+    // Create the OAuth state machine.
+    let mut oauth_state = OAuthState::Unauthorized(auth_manager);
+
+    // Determine whether we can use DCR or need to use static registration.
+    let can_use_dcr = match oauth_state
         .start_authorization(&[], &redirect_uri, Some("Warp"))
-        .await?;
+        .await
+    {
+        Ok(_) => true,
+        Err(AuthError::RegistrationFailed(_)) => false,
+        Err(e) => return Err(e),
+    };
 
     let OAuthState::Session(AuthorizationSession {
         mut auth_manager, ..
@@ -330,42 +296,35 @@ pub async fn make_authenticated_client(
         ));
     };
 
-    // With DCR (Dynamic Client Registration), we don't pass in explicit scopes; they are specified
-    // during dynamic registration.
-    //
-    // For apps for which we have static client IDs (e.g. GitHub), we manually override scopes.
-    let mut scopes: &[&str] = &[];
+    // Start the authorization process with our custom redirect URI
+    let config = if can_use_dcr {
+        auth_manager
+            .register_client("Warp", &redirect_uri, scopes)
+            .await?
+    } else {
+        // If we failed dynamic registration, check to see if this is an auth
+        // server we have a static client ID for.
 
-    let config = match auth_manager
-        .register_client("Warp", &redirect_uri, scopes)
-        .await
-    {
-        Ok(config) => config,
-        Err(err @ AuthError::RegistrationFailed(_)) => {
-            // If we failed dynamic registration, check to see if this is an auth
-            // server we have a static client ID for.
+        // TODO(vorporeal): adjust APIs in rmcp so that we don't need to make this redundant
+        // discover_metadata() call (as it gets made within start_authorization() but we can't
+        // look at the results).
+        let metadata = auth_manager.discover_metadata().await?;
+        let provider = metadata
+            .issuer
+            .as_deref()
+            .and_then(ChannelState::mcp_oauth_provider_by_issuer)
+            .ok_or(AuthError::RegistrationFailed("DCR is not supported and provider is not known".to_string()))?;
 
-            // TODO(vorporeal): adjust APIs in rmcp so that we don't need to make this redundant
-            // discover_metadata() call (as it gets made within start_authorization() but we can't
-            // look at the results).
-            let metadata = auth_manager.discover_metadata().await?;
-            let provider = metadata
-                .issuer
-                .as_deref()
-                .and_then(ChannelState::mcp_oauth_provider_by_issuer)
-                .ok_or(err)?;
-
-            if provider.issuer == GITHUB_ISSUER {
-                scopes = &GITHUB_OAUTH_SCOPES;
-            }
-
-            OAuthClientConfig::new(provider.client_id.into_owned(), redirect_uri.clone())
-                .with_client_secret(provider.client_secret.into_owned())
+        if provider.issuer == GITHUB_ISSUER {
+            scopes = &GITHUB_OAUTH_SCOPES;
         }
-        Err(e) => return Err(e),
+
+        OAuthClientConfig::new(provider.client_id.into_owned(), redirect_uri.clone())
+            .with_client_secret(provider.client_secret.into_owned())
     };
 
     let client_secret = config.client_secret.clone();
+
     auth_manager.configure_client(config)?;
 
     let auth_url = auth_manager.get_authorization_url(scopes).await?;
@@ -419,37 +378,11 @@ pub async fn make_authenticated_client(
     // Handle the callback with the received authorization code and CSRF token.
     oauth_state.handle_callback(code, csrf_token).await?;
 
-    // Save the credentials to secure storage. Stamp `token_received_at` so the
-    // pre-emptive refresh check in rmcp has a timestamp to compute remaining
-    // lifetime against on subsequent connects (without it, the cached token
-    // would be used past its TTL — see #8863).
-    let (client_id, token_response) = oauth_state.get_credentials().await?;
-    if let Some(token_response) = token_response {
-        let credentials = PersistedCredentials {
-            credentials: StoredCredentials::new(client_id, Some(token_response), Vec::new(), None),
-            client_secret: client_secret.clone(),
-        };
-        spawner
-            .spawn(move |manager, ctx| {
-                manager.save_credentials_to_secure_storage(ctx, uuid, credentials);
-            })
-            .await
-            .map_err(|e| AuthError::InternalError(e.to_string()))?;
-    }
-
-    let mut am = oauth_state.into_authorization_manager().ok_or_else(|| {
+    let auth_manager = oauth_state.into_authorization_manager().ok_or_else(|| {
         AuthError::InternalError("Failed to create authorization manager".to_string())
     })?;
 
-    install_persisting_credential_store(
-        &mut am,
-        client_secret,
-        spawner,
-        uuid,
-    )
-    .await;
-
-    Ok((AuthClient::new(reqwest::Client::new(), am), true))
+    Ok((AuthClient::new(reqwest::Client::new(), auth_manager), true))
 }
 
 impl TemplatableMCPServerManager {
@@ -721,12 +654,8 @@ mod tests {
     async fn save_skips_persist_when_token_response_absent() {
         let (store, rx) = make_test_store(None);
 
-        let credentials = StoredCredentials::new(
-            "c".to_string(),
-            None,
-            Vec::new(),
-            Some(1_700_000_500),
-        );
+        let credentials =
+            StoredCredentials::new("c".to_string(), None, Vec::new(), Some(1_700_000_500));
 
         store.save(credentials).await.expect("save succeeds");
 

--- a/app/src/ai/mcp/templatable_manager/oauth.rs
+++ b/app/src/ai/mcp/templatable_manager/oauth.rs
@@ -6,7 +6,7 @@ use oauth2::{RefreshToken, TokenResponse as _};
 use rmcp::transport::{
     auth::{
         AuthClient, AuthorizationManager, CredentialStore, InMemoryCredentialStore,
-        OAuthClientConfig, OAuthState, OAuthTokenResponse, StoredCredentials,
+        OAuthClientConfig, OAuthState, StoredCredentials,
     },
     AuthError, AuthorizationSession,
 };
@@ -39,32 +39,14 @@ static GITHUB_OAUTH_SCOPES: [&str; 7] = [
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PersistedCredentials {
-    client_id: String,
+    /// The credential information that `rmcp` wants us to store and retrieve.
+    #[serde(flatten)]
+    credentials: StoredCredentials,
+    /// The client secret for the OAuth application.
+    ///
+    /// This is needed to properly refresh tokens when using DCR (Dynamic Client Registration),
+    /// as the server expects the client to provide the secret when refreshing.
     client_secret: Option<String>,
-    token_response: OAuthTokenResponse,
-    /// Unix timestamp (seconds) when this token was received from the OAuth server.
-    ///
-    /// Required for rmcp's pre-emptive refresh: it computes remaining lifetime as
-    /// `expires_in - (now - token_received_at)` and refreshes when below the buffer.
-    /// Without this value the check is skipped, the cached token stays in use past
-    /// its TTL, and the next request fails with 401 (see #8863).
-    ///
-    /// `None` for credentials persisted by older Warp versions; the next refresh
-    /// will populate it via the credential-store save path.
-    #[serde(default)]
-    token_received_at: Option<u64>,
-}
-
-/// Returns the current Unix timestamp in seconds.
-///
-/// Mirrors rmcp's internal `now_epoch_secs` (which is private) so we can stamp
-/// `token_received_at` consistently with the timestamps rmcp itself emits during
-/// refresh.
-fn now_epoch_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
 }
 
 /// Maps cloud MCP installation UUID to its OAuth credentials in secure storage.
@@ -132,19 +114,12 @@ impl CredentialStore for PersistingCredentialStore {
         self.apply_refresh_token_carry_forward(&mut credentials)
             .await;
 
-        // Capture before `credentials` is consumed below.
-        let token_received_at = credentials.token_received_at;
-
         self.inner.save(credentials.clone()).await?;
 
-        if let Some(token_response) = credentials.token_response {
-            let _ = self.persist_tx.try_send(PersistedCredentials {
-                client_id: credentials.client_id,
-                client_secret: self.client_secret.clone(),
-                token_response,
-                token_received_at,
-            });
-        }
+        let _ = self.persist_tx.try_send(PersistedCredentials {
+            credentials,
+            client_secret: self.client_secret.clone(),
+        });
         Ok(())
     }
 
@@ -169,7 +144,6 @@ async fn install_persisting_credential_store(
     client_secret: Option<String>,
     spawner: ModelSpawner<TemplatableMCPServerManager>,
     installation_uuid: Uuid,
-    token_received_at: Option<u64>,
 ) {
     let (persist_tx, persist_rx) = async_channel::unbounded();
     let store = PersistingCredentialStore {
@@ -191,6 +165,7 @@ async fn install_persisting_credential_store(
                 client_id,
                 Some(token_response),
                 Vec::new(),
+                // TODO(vorporeal): gotta initialize this better
                 None,
             ))
             .await;
@@ -262,21 +237,26 @@ pub async fn make_authenticated_client(
 
     // If we have cached credentials, use them.
     if let Some(credentials) = persisted_credentials {
-        let provider = ChannelState::mcp_oauth_provider_by_client_id(&credentials.client_id);
+        let provider =
+            ChannelState::mcp_oauth_provider_by_client_id(&credentials.credentials.client_id);
         let client_secret = credentials
             .client_secret
             .or_else(|| provider.as_ref().map(|p| p.client_secret.to_string()));
-        let cached_token_received_at = credentials.token_received_at;
-        oauth_state
-            .set_credentials(&credentials.client_id, credentials.token_response)
-            .await?;
+        if let Some(token_response) = credentials.credentials.token_response {
+            oauth_state
+                .set_credentials(&credentials.credentials.client_id, token_response)
+                .await?;
+        }
         if let OAuthState::Authorized(mut auth_manager) = oauth_state {
             // If this is a client for which we have a known client secret,
             // update our client config accordingly.
             if let Some(client_secret) = &client_secret {
                 auth_manager.configure_client(
-                    OAuthClientConfig::new(credentials.client_id.clone(), redirect_uri.clone())
-                        .with_client_secret(client_secret.clone()),
+                    OAuthClientConfig::new(
+                        credentials.credentials.client_id.clone(),
+                        redirect_uri.clone(),
+                    )
+                    .with_client_secret(client_secret.clone()),
                 )?;
             }
 
@@ -302,7 +282,6 @@ pub async fn make_authenticated_client(
                 client_secret,
                 spawner.clone(),
                 uuid,
-                cached_token_received_at,
             )
             .await;
             match auth_manager.refresh_token().await {
@@ -444,14 +423,11 @@ pub async fn make_authenticated_client(
     // pre-emptive refresh check in rmcp has a timestamp to compute remaining
     // lifetime against on subsequent connects (without it, the cached token
     // would be used past its TTL — see #8863).
-    let token_received_at = now_epoch_secs();
     let (client_id, token_response) = oauth_state.get_credentials().await?;
     if let Some(token_response) = token_response {
         let credentials = PersistedCredentials {
-            client_id,
+            credentials: StoredCredentials::new(client_id, Some(token_response), Vec::new(), None),
             client_secret: client_secret.clone(),
-            token_response,
-            token_received_at: Some(token_received_at),
         };
         spawner
             .spawn(move |manager, ctx| {
@@ -470,7 +446,6 @@ pub async fn make_authenticated_client(
         client_secret,
         spawner,
         uuid,
-        Some(token_received_at),
     )
     .await;
 
@@ -652,12 +627,12 @@ mod tests {
 
     #[test]
     fn persisted_credentials_round_trip_through_serde_preserves_received_at() {
-        let original = PersistedCredentials {
-            client_id: "client-abc".to_string(),
-            client_secret: Some("shh".to_string()),
-            token_response: make_test_token_response(Some("refresh-1")),
-            token_received_at: Some(1_700_000_000),
-        };
+        let original = PersistedCredentials::new(
+            "client-abc".to_string(),
+            Some("shh".to_string()),
+            make_test_token_response(Some("refresh-1")),
+            Some(1_700_000_000),
+        );
 
         let json = serde_json::to_string(&original).expect("serialize");
         let parsed: PersistedCredentials = serde_json::from_str(&json).expect("deserialize");
@@ -702,12 +677,12 @@ mod tests {
     async fn save_forwards_token_received_at_to_persist_channel() {
         let (store, rx) = make_test_store(Some("client_secret_xyz".to_string()));
 
-        let credentials = StoredCredentials {
-            client_id: "client-id".to_string(),
-            token_response: Some(make_test_token_response(Some("refresh-1"))),
-            granted_scopes: Vec::new(),
-            token_received_at: Some(1_700_000_500),
-        };
+        let credentials = StoredCredentials::new(
+            "client-id".to_string(),
+            Some(make_test_token_response(Some("refresh-1"))),
+            Vec::new(),
+            Some(1_700_000_500),
+        );
 
         store.save(credentials).await.expect("save succeeds");
 
@@ -727,12 +702,12 @@ mod tests {
     async fn save_forwards_none_when_received_at_is_none() {
         let (store, rx) = make_test_store(None);
 
-        let credentials = StoredCredentials {
-            client_id: "c".to_string(),
-            token_response: Some(make_test_token_response(None)),
-            granted_scopes: Vec::new(),
-            token_received_at: None,
-        };
+        let credentials = StoredCredentials::new(
+            "c".to_string(),
+            Some(make_test_token_response(None)),
+            Vec::new(),
+            None,
+        );
 
         store.save(credentials).await.expect("save succeeds");
 
@@ -746,12 +721,12 @@ mod tests {
     async fn save_skips_persist_when_token_response_absent() {
         let (store, rx) = make_test_store(None);
 
-        let credentials = StoredCredentials {
-            client_id: "c".to_string(),
-            token_response: None,
-            granted_scopes: Vec::new(),
-            token_received_at: Some(1_700_000_500),
-        };
+        let credentials = StoredCredentials::new(
+            "c".to_string(),
+            None,
+            Vec::new(),
+            Some(1_700_000_500),
+        );
 
         store.save(credentials).await.expect("save succeeds");
 
@@ -772,23 +747,23 @@ mod tests {
         // Seed the inner store with prior credentials that have a refresh token.
         store
             .inner
-            .save(StoredCredentials {
-                client_id: "c".to_string(),
-                token_response: Some(make_test_token_response(Some("prior-refresh-token"))),
-                granted_scopes: Vec::new(),
-                token_received_at: Some(1_699_000_000),
-            })
+            .save(StoredCredentials::new(
+                "c".to_string(),
+                Some(make_test_token_response(Some("prior-refresh-token"))),
+                Vec::new(),
+                Some(1_699_000_000),
+            ))
             .await
             .expect("seed succeeds");
 
         // Now save NEW credentials that omit a refresh token, simulating a
         // refresh response from a server that does not rotate refresh tokens.
-        let new_credentials = StoredCredentials {
-            client_id: "c".to_string(),
-            token_response: Some(make_test_token_response(None)),
-            granted_scopes: Vec::new(),
-            token_received_at: Some(1_700_000_500),
-        };
+        let new_credentials = StoredCredentials::new(
+            "c".to_string(),
+            Some(make_test_token_response(None)),
+            Vec::new(),
+            Some(1_700_000_500),
+        );
 
         store.save(new_credentials).await.expect("save succeeds");
 
@@ -805,20 +780,6 @@ mod tests {
                 .map(|rt| rt.secret().to_string()),
             Some("prior-refresh-token".to_string()),
             "prior refresh token carried forward"
-        );
-    }
-
-    /// `now_epoch_secs` returns a non-zero monotonic-ish value. Sanity check
-    /// that the helper does what it claims and matches rmcp's own clock domain.
-    #[test]
-    fn now_epoch_secs_returns_recent_unix_time() {
-        let now = now_epoch_secs();
-        // Sanity: any timestamp produced by the running test process must be
-        // after the OSS-release date (2026-04-28) and before the year 2200.
-        assert!(now > 1_745_000_000, "epoch seconds must be a real time");
-        assert!(
-            now < 7_258_118_400,
-            "epoch seconds must be before year 2200"
         );
     }
 }

--- a/app/src/ai/mcp/templatable_manager/oauth.rs
+++ b/app/src/ai/mcp/templatable_manager/oauth.rs
@@ -3,9 +3,11 @@ use std::collections::HashMap;
 use anyhow::{anyhow, bail};
 use oauth2::{RefreshToken, TokenResponse as _};
 use rmcp::transport::{
-    AuthError, AuthorizationSession, auth::{
-        AuthClient, AuthorizationManager, CredentialStore, InMemoryCredentialStore, OAuthClientConfig, OAuthState, OAuthTokenResponse, StoredCredentials
-    }
+    auth::{
+        AuthClient, AuthorizationManager, CredentialStore, InMemoryCredentialStore,
+        OAuthClientConfig, OAuthState, OAuthTokenResponse, StoredCredentials,
+    },
+    AuthError, AuthorizationSession,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};

--- a/app/src/ai/mcp/templatable_manager/oauth.rs
+++ b/app/src/ai/mcp/templatable_manager/oauth.rs
@@ -275,11 +275,8 @@ pub async fn make_authenticated_client(
             // update our client config accordingly.
             if let Some(client_secret) = &client_secret {
                 auth_manager.configure_client(
-                    OAuthClientConfig::new(
-                        credentials.client_id.clone(),
-                        redirect_uri.clone(),
-                    )
-                    .with_client_secret(client_secret.clone()),
+                    OAuthClientConfig::new(credentials.client_id.clone(), redirect_uri.clone())
+                        .with_client_secret(client_secret.clone()),
                 )?;
             }
 
@@ -360,7 +357,10 @@ pub async fn make_authenticated_client(
     // For apps for which we have static client IDs (e.g. GitHub), we manually override scopes.
     let mut scopes: &[&str] = &[];
 
-    let config = match auth_manager.register_client("Warp", &redirect_uri, scopes).await {
+    let config = match auth_manager
+        .register_client("Warp", &redirect_uri, scopes)
+        .await
+    {
         Ok(config) => config,
         Err(err @ AuthError::RegistrationFailed(_)) => {
             // If we failed dynamic registration, check to see if this is an auth
@@ -380,11 +380,8 @@ pub async fn make_authenticated_client(
                 scopes = &GITHUB_OAUTH_SCOPES;
             }
 
-            OAuthClientConfig::new(
-                provider.client_id.into_owned(),
-                redirect_uri.clone(),
-            )
-            .with_client_secret(provider.client_secret.into_owned())
+            OAuthClientConfig::new(provider.client_id.into_owned(), redirect_uri.clone())
+                .with_client_secret(provider.client_secret.into_owned())
         }
         Err(e) => return Err(e),
     };
@@ -393,9 +390,11 @@ pub async fn make_authenticated_client(
     auth_manager.configure_client(config)?;
 
     let auth_url = auth_manager.get_authorization_url(scopes).await?;
-    oauth_state = OAuthState::Session(
-        AuthorizationSession::for_scope_upgrade(auth_manager, auth_url.clone(), &redirect_uri),
-    );
+    oauth_state = OAuthState::Session(AuthorizationSession::for_scope_upgrade(
+        auth_manager,
+        auth_url.clone(),
+        &redirect_uri,
+    ));
 
     // Extract the CSRF token that rmcp embedded as the `state` query parameter in the
     // authorization URL. We register a csrf→uuid mapping on the manager so that

--- a/app/src/ai/mcp/templatable_manager/utils_tests.rs
+++ b/app/src/ai/mcp/templatable_manager/utils_tests.rs
@@ -11,10 +11,14 @@ mod tests {
     /// Each `Some(default)` mirrors how rmcp deserializes a capability the
     /// server advertised with no inner flags set.
     fn caps(tools: bool, resources: bool) -> ServerCapabilities {
-        ServerCapabilities {
-            tools: tools.then(Default::default),
-            resources: resources.then(Default::default),
-            ..Default::default()
+        match (tools, resources) {
+            (true, true) => ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
+            (true, false) => ServerCapabilities::builder().enable_tools().build(),
+            (false, true) => ServerCapabilities::builder().enable_resources().build(),
+            (false, false) => ServerCapabilities::builder().build(),
         }
     }
 

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -374,6 +374,8 @@ impl From<rmcp::RmcpError> for MCPServerTelemetryError {
                 // The enum is marked as non-exhaustive, so we need a catch-all.
                 _ => Self::InternalError(err.to_string()),
             },
+            // The enum is marked as non-exhaustive, so we need a catch-all.
+            _ => Self::InternalError(err.to_string()),
         }
     }
 }

--- a/crates/http_client/src/lib.rs
+++ b/crates/http_client/src/lib.rs
@@ -145,9 +145,7 @@ impl Client {
         let client_builder = reqwest::ClientBuilder::new()
             // Don't load any SSL/TLS certificates, as doing so can be slow and we should
             // never be making real requests in tests.
-            .tls_built_in_native_certs(false)
-            .tls_built_in_root_certs(false)
-            .tls_built_in_webpki_certs(false)
+            .tls_certs_only([])
             // Disable proxy usage in tests, as loading system proxy configuration can be
             // slow.
             .no_proxy();

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mcp"
+version = "0.1.0"
+edition = "2021"
+publish.workspace = true
+license.workspace = true
+
+[dependencies]
+futures.workspace = true
+http = "1"
+pin-project-lite = "0.2"
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream"] }
+rmcp = { workspace = true, features = ["client", "client-side-sse", "auth"] }
+serde_json.workspace = true
+sse-stream = "0.2"
+thiserror.workspace = true
+tokio = { workspace = true, features = ["sync", "macros", "rt", "time"] }
+tracing.workspace = true

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 futures.workspace = true
 http = "1"
 pin-project-lite = "0.2"
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream"] }
+reqwest = { workspace = true, features = ["json", "stream"] }
 rmcp = { workspace = true, features = ["client", "client-side-sse", "auth"] }
 serde_json.workspace = true
 sse-stream = "0.2"

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod sse_transport;

--- a/crates/mcp/src/sse_transport/auth_impl.rs
+++ b/crates/mcp/src/sse_transport/auth_impl.rs
@@ -1,5 +1,7 @@
-// Adapted from the rmcp fork's `transport::common::auth::sse_client` module.
-// Original source: https://github.com/modelcontextprotocol/rust-sdk
+// This file contains code copied from the rmcp crate (https://github.com/modelcontextprotocol/rust-sdk),
+// originally located at `crates/rmcp/src/transport/common/auth/sse_client.rs`.
+// Used under the terms of the Apache License, Version 2.0.
+// See https://github.com/modelcontextprotocol/rust-sdk/blob/main/LICENSE for the full license text.
 
 use http::Uri;
 use rmcp::transport::auth::AuthClient;

--- a/crates/mcp/src/sse_transport/auth_impl.rs
+++ b/crates/mcp/src/sse_transport/auth_impl.rs
@@ -34,10 +34,7 @@ where
         uri: Uri,
         last_event_id: Option<String>,
         mut auth_token: Option<String>,
-    ) -> Result<
-        super::client_side_sse::BoxedSseResponse,
-        SseTransportError<Self::Error>,
-    > {
+    ) -> Result<super::client_side_sse::BoxedSseResponse, SseTransportError<Self::Error>> {
         if auth_token.is_none() {
             auth_token = Some(self.get_access_token().await?);
         }

--- a/crates/mcp/src/sse_transport/auth_impl.rs
+++ b/crates/mcp/src/sse_transport/auth_impl.rs
@@ -1,0 +1,47 @@
+// Adapted from the rmcp fork's `transport::common::auth::sse_client` module.
+// Original source: https://github.com/modelcontextprotocol/rust-sdk
+
+use http::Uri;
+use rmcp::transport::auth::AuthClient;
+
+use super::sse_client::{SseClient, SseTransportError};
+
+impl<C> SseClient for AuthClient<C>
+where
+    C: SseClient,
+{
+    type Error = SseTransportError<C::Error>;
+
+    async fn post_message(
+        &self,
+        uri: Uri,
+        message: rmcp::model::ClientJsonRpcMessage,
+        mut auth_token: Option<String>,
+    ) -> Result<(), SseTransportError<Self::Error>> {
+        if auth_token.is_none() {
+            auth_token = Some(self.get_access_token().await?);
+        }
+        self.http_client
+            .post_message(uri, message, auth_token)
+            .await
+            .map_err(SseTransportError::Client)
+    }
+
+    async fn get_stream(
+        &self,
+        uri: Uri,
+        last_event_id: Option<String>,
+        mut auth_token: Option<String>,
+    ) -> Result<
+        super::client_side_sse::BoxedSseResponse,
+        SseTransportError<Self::Error>,
+    > {
+        if auth_token.is_none() {
+            auth_token = Some(self.get_access_token().await?);
+        }
+        self.http_client
+            .get_stream(uri, last_event_id, auth_token)
+            .await
+            .map_err(SseTransportError::Client)
+    }
+}

--- a/crates/mcp/src/sse_transport/client_side_sse.rs
+++ b/crates/mcp/src/sse_transport/client_side_sse.rs
@@ -1,5 +1,7 @@
-// Adapted from the rmcp fork's `transport::common::client_side_sse` module.
-// Original source: https://github.com/modelcontextprotocol/rust-sdk
+// This file contains code copied from the rmcp crate (https://github.com/modelcontextprotocol/rust-sdk),
+// originally located at `crates/rmcp/src/transport/common/client_side_sse.rs`.
+// Used under the terms of the Apache License, Version 2.0.
+// See https://github.com/modelcontextprotocol/rust-sdk/blob/main/LICENSE for the full license text.
 
 use std::{
     future::Future,

--- a/crates/mcp/src/sse_transport/client_side_sse.rs
+++ b/crates/mcp/src/sse_transport/client_side_sse.rs
@@ -1,0 +1,281 @@
+// Adapted from the rmcp fork's `transport::common::client_side_sse` module.
+// Original source: https://github.com/modelcontextprotocol/rust-sdk
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Poll, ready},
+    time::Duration,
+};
+
+use futures::{Stream, stream::BoxStream};
+use rmcp::model::ServerJsonRpcMessage;
+use sse_stream::{Error as SseError, Sse};
+
+pub type BoxedSseResponse = BoxStream<'static, Result<Sse, SseError>>;
+
+pub trait SseRetryPolicy: std::fmt::Debug + Send + Sync {
+    fn retry(&self, current_times: usize) -> Option<Duration>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FixedInterval {
+    pub max_times: Option<usize>,
+    pub duration: Duration,
+}
+
+impl SseRetryPolicy for FixedInterval {
+    fn retry(&self, current_times: usize) -> Option<Duration> {
+        if let Some(max_times) = self.max_times {
+            if current_times >= max_times {
+                return None;
+            }
+        }
+        Some(self.duration)
+    }
+}
+
+impl FixedInterval {
+    pub const DEFAULT_MIN_DURATION: Duration = Duration::from_millis(1000);
+}
+
+impl Default for FixedInterval {
+    fn default() -> Self {
+        Self {
+            max_times: None,
+            duration: Self::DEFAULT_MIN_DURATION,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExponentialBackoff {
+    pub max_times: Option<usize>,
+    pub base_duration: Duration,
+}
+
+impl ExponentialBackoff {
+    pub const DEFAULT_DURATION: Duration = Duration::from_millis(1000);
+}
+
+impl Default for ExponentialBackoff {
+    fn default() -> Self {
+        Self {
+            max_times: None,
+            base_duration: Self::DEFAULT_DURATION,
+        }
+    }
+}
+
+impl SseRetryPolicy for ExponentialBackoff {
+    fn retry(&self, current_times: usize) -> Option<Duration> {
+        if let Some(max_times) = self.max_times {
+            if current_times >= max_times {
+                return None;
+            }
+        }
+        Some(self.base_duration * (2u32.pow(current_times as u32)))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NeverRetry;
+
+impl SseRetryPolicy for NeverRetry {
+    fn retry(&self, _current_times: usize) -> Option<Duration> {
+        None
+    }
+}
+
+/// Abstraction for SSE reconnection logic. Implementors can hook into
+/// [`handle_control_event`](Self::handle_control_event) to consume control
+/// frames (e.g. `event: endpoint`) that arrive when a server restarts an SSE
+/// stream. The default implementation is a no-op, keeping existing behaviour
+/// intact.
+pub(crate) trait SseStreamReconnect {
+    type Error: std::error::Error;
+    type Future: std::future::Future<Output = Result<BoxedSseResponse, Self::Error>> + Send;
+    fn retry_connection(&mut self, last_event_id: Option<&str>) -> Self::Future;
+    fn handle_control_event(&mut self, _event: &Sse) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn handle_stream_error(
+        &mut self,
+        error: &(dyn std::error::Error + 'static),
+        last_event_id: Option<&str>,
+    ) {
+        if let Some(id) = last_event_id {
+            tracing::warn!(%id, "sse stream error: {error}");
+        } else {
+            tracing::warn!("sse stream error: {error}");
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    pub(crate) struct SseAutoReconnectStream<R>
+    where R: SseStreamReconnect
+     {
+        retry_policy: Arc<dyn SseRetryPolicy>,
+        last_event_id: Option<String>,
+        server_retry_interval: Option<Duration>,
+        connector: R,
+        #[pin]
+        state: SseAutoReconnectStreamState<R::Future>,
+    }
+}
+
+impl<R: SseStreamReconnect> SseAutoReconnectStream<R> {
+    pub fn new(
+        stream: BoxedSseResponse,
+        connector: R,
+        retry_policy: Arc<dyn SseRetryPolicy>,
+    ) -> Self {
+        Self {
+            retry_policy,
+            last_event_id: None,
+            server_retry_interval: None,
+            connector,
+            state: SseAutoReconnectStreamState::Connected { stream },
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    #[project = SseAutoReconnectStreamStateProj]
+    pub enum SseAutoReconnectStreamState<F> {
+        Connected {
+            #[pin]
+            stream: BoxedSseResponse,
+        },
+        Retrying {
+            retry_times: usize,
+            #[pin]
+            retrying: F,
+        },
+        WaitingNextRetry {
+            #[pin]
+            sleep: tokio::time::Sleep,
+            retry_times: usize,
+        },
+        Terminated,
+    }
+}
+
+impl<R> Stream for SseAutoReconnectStream<R>
+where
+    R: SseStreamReconnect,
+{
+    type Item = Result<ServerJsonRpcMessage, R::Error>;
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let mut this = self.as_mut().project();
+        let state = this.state.as_mut().project();
+        let next_state = match state {
+            SseAutoReconnectStreamStateProj::Connected { stream } => {
+                match ready!(stream.poll_next(cx)) {
+                    Some(Ok(sse)) => {
+                        if let Some(new_server_retry) = sse.retry {
+                            *this.server_retry_interval =
+                                Some(Duration::from_millis(new_server_retry));
+                        }
+                        if let Some(ref event_id) = sse.id {
+                            *this.last_event_id = Some(event_id.clone());
+                        }
+                        // Only treat blank/`message` events as JSON-RPC payloads.
+                        // Other control frames (endpoint, ping, etc.) are passed to
+                        // the reconnection handler.
+                        let is_message_event =
+                            matches!(sse.event.as_deref(), None | Some("") | Some("message"));
+                        if !is_message_event {
+                            match this.connector.handle_control_event(&sse) {
+                                Ok(()) => return self.poll_next(cx),
+                                Err(e) => {
+                                    this.state.set(SseAutoReconnectStreamState::Terminated);
+                                    return Poll::Ready(Some(Err(e)));
+                                }
+                            }
+                        }
+                        if let Some(data) = sse.data {
+                            match serde_json::from_str::<ServerJsonRpcMessage>(&data) {
+                                Err(e) => {
+                                    let last_id = this.last_event_id.as_deref().unwrap_or("");
+                                    tracing::debug!(last_event_id=%last_id, "failed to deserialize server message: {e}");
+                                    return self.poll_next(cx);
+                                }
+                                Ok(message) => {
+                                    return Poll::Ready(Some(Ok(message)));
+                                }
+                            };
+                        } else {
+                            return self.poll_next(cx);
+                        }
+                    }
+                    Some(Err(e)) => {
+                        this.connector
+                            .handle_stream_error(&e, this.last_event_id.as_deref());
+                        let retrying = this
+                            .connector
+                            .retry_connection(this.last_event_id.as_deref());
+                        SseAutoReconnectStreamState::Retrying {
+                            retry_times: 0,
+                            retrying,
+                        }
+                    }
+                    None => {
+                        tracing::debug!("sse stream terminated");
+                        return Poll::Ready(None);
+                    }
+                }
+            }
+            SseAutoReconnectStreamStateProj::Retrying {
+                retry_times,
+                retrying,
+            } => {
+                let retry_result = ready!(retrying.poll(cx));
+                match retry_result {
+                    Ok(new_stream) => SseAutoReconnectStreamState::Connected { stream: new_stream },
+                    Err(e) => {
+                        tracing::debug!("retry sse stream error: {e}");
+                        *retry_times += 1;
+                        if let Some(interval) = this.retry_policy.retry(*retry_times) {
+                            let interval = this
+                                .server_retry_interval
+                                .map(|server_retry_interval| server_retry_interval.max(interval))
+                                .unwrap_or(interval);
+                            let sleep = tokio::time::sleep(interval);
+                            SseAutoReconnectStreamState::WaitingNextRetry {
+                                sleep,
+                                retry_times: *retry_times,
+                            }
+                        } else {
+                            tracing::error!("sse stream error: {e}, max retry times reached");
+                            this.state.set(SseAutoReconnectStreamState::Terminated);
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    }
+                }
+            }
+            SseAutoReconnectStreamStateProj::WaitingNextRetry { sleep, retry_times } => {
+                ready!(sleep.poll(cx));
+                let retrying = this
+                    .connector
+                    .retry_connection(this.last_event_id.as_deref());
+                let retry_times = *retry_times;
+                SseAutoReconnectStreamState::Retrying {
+                    retry_times,
+                    retrying,
+                }
+            }
+            SseAutoReconnectStreamStateProj::Terminated => {
+                return Poll::Ready(None);
+            }
+        };
+        // Update the state.
+        this.state.set(next_state);
+        self.poll_next(cx)
+    }
+}

--- a/crates/mcp/src/sse_transport/client_side_sse.rs
+++ b/crates/mcp/src/sse_transport/client_side_sse.rs
@@ -7,11 +7,11 @@ use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
-    task::{Poll, ready},
+    task::{ready, Poll},
     time::Duration,
 };
 
-use futures::{Stream, stream::BoxStream};
+use futures::{stream::BoxStream, Stream};
 use rmcp::model::ServerJsonRpcMessage;
 use sse_stream::{Error as SseError, Sse};
 

--- a/crates/mcp/src/sse_transport/mod.rs
+++ b/crates/mcp/src/sse_transport/mod.rs
@@ -1,0 +1,10 @@
+/// Legacy SSE client transport for MCP, preserved from the rmcp fork after upstream
+/// removed SSE transport support in v0.11.0. This allows Warp to continue connecting
+/// to MCP servers that only support the older SSE protocol.
+mod auth_impl;
+mod client_side_sse;
+mod reqwest_impl;
+mod sse_client;
+
+pub use client_side_sse::{ExponentialBackoff, FixedInterval, NeverRetry, SseRetryPolicy};
+pub use sse_client::{SseClient, SseClientConfig, SseClientTransport, SseTransportError};

--- a/crates/mcp/src/sse_transport/reqwest_impl.rs
+++ b/crates/mcp/src/sse_transport/reqwest_impl.rs
@@ -47,10 +47,7 @@ impl SseClient for reqwest::Client {
         uri: Uri,
         last_event_id: Option<String>,
         auth_token: Option<String>,
-    ) -> Result<
-        super::client_side_sse::BoxedSseResponse,
-        SseTransportError<Self::Error>,
-    > {
+    ) -> Result<super::client_side_sse::BoxedSseResponse, SseTransportError<Self::Error>> {
         let mut request_builder = self
             .get(uri.to_string())
             .header(ACCEPT, EVENT_STREAM_MIME_TYPE);

--- a/crates/mcp/src/sse_transport/reqwest_impl.rs
+++ b/crates/mcp/src/sse_transport/reqwest_impl.rs
@@ -1,5 +1,7 @@
-// Adapted from the rmcp fork's `transport::common::reqwest::sse_client` module.
-// Original source: https://github.com/modelcontextprotocol/rust-sdk
+// This file contains code copied from the rmcp crate (https://github.com/modelcontextprotocol/rust-sdk),
+// originally located at `crates/rmcp/src/transport/common/reqwest/sse_client.rs`.
+// Used under the terms of the Apache License, Version 2.0.
+// See https://github.com/modelcontextprotocol/rust-sdk/blob/main/LICENSE for the full license text.
 
 use std::sync::Arc;
 

--- a/crates/mcp/src/sse_transport/reqwest_impl.rs
+++ b/crates/mcp/src/sse_transport/reqwest_impl.rs
@@ -1,0 +1,97 @@
+// Adapted from the rmcp fork's `transport::common::reqwest::sse_client` module.
+// Original source: https://github.com/modelcontextprotocol/rust-sdk
+
+use std::sync::Arc;
+
+use futures::StreamExt;
+use http::Uri;
+use reqwest::header::ACCEPT;
+use sse_stream::SseStream;
+
+use super::sse_client::{SseClient, SseClientConfig, SseClientTransport, SseTransportError};
+
+const HEADER_LAST_EVENT_ID: &str = "Last-Event-Id";
+const EVENT_STREAM_MIME_TYPE: &str = "text/event-stream";
+
+impl From<reqwest::Error> for SseTransportError<reqwest::Error> {
+    fn from(e: reqwest::Error) -> Self {
+        SseTransportError::Client(e)
+    }
+}
+
+impl SseClient for reqwest::Client {
+    type Error = reqwest::Error;
+
+    async fn post_message(
+        &self,
+        uri: Uri,
+        message: rmcp::model::ClientJsonRpcMessage,
+        auth_token: Option<String>,
+    ) -> Result<(), SseTransportError<Self::Error>> {
+        let mut request_builder = self.post(uri.to_string()).json(&message);
+        if let Some(auth_header) = auth_token {
+            request_builder = request_builder.bearer_auth(auth_header);
+        }
+        request_builder
+            .send()
+            .await
+            .and_then(|resp| resp.error_for_status())
+            .map_err(SseTransportError::from)
+            .map(drop)
+    }
+
+    async fn get_stream(
+        &self,
+        uri: Uri,
+        last_event_id: Option<String>,
+        auth_token: Option<String>,
+    ) -> Result<
+        super::client_side_sse::BoxedSseResponse,
+        SseTransportError<Self::Error>,
+    > {
+        let mut request_builder = self
+            .get(uri.to_string())
+            .header(ACCEPT, EVENT_STREAM_MIME_TYPE);
+        if let Some(auth_header) = auth_token {
+            request_builder = request_builder.bearer_auth(auth_header);
+        }
+        if let Some(last_event_id) = last_event_id {
+            request_builder = request_builder.header(HEADER_LAST_EVENT_ID, last_event_id);
+        }
+        let response = request_builder.send().await?;
+        let response = response.error_for_status()?;
+        match response.headers().get(reqwest::header::CONTENT_TYPE) {
+            Some(ct) => {
+                if !ct.as_bytes().starts_with(EVENT_STREAM_MIME_TYPE.as_bytes()) {
+                    return Err(SseTransportError::UnexpectedContentType(Some(
+                        String::from_utf8_lossy(ct.as_bytes()).to_string(),
+                    )));
+                }
+            }
+            None => {
+                return Err(SseTransportError::UnexpectedContentType(None));
+            }
+        }
+        let event_stream = SseStream::from_byte_stream(response.bytes_stream()).boxed();
+        Ok(event_stream)
+    }
+}
+
+impl SseClientTransport<reqwest::Client> {
+    /// Creates a new transport using reqwest with the specified SSE endpoint.
+    ///
+    /// This is a convenience method that creates a transport using the default
+    /// reqwest client.
+    pub async fn start(
+        uri: impl Into<Arc<str>>,
+    ) -> Result<Self, SseTransportError<reqwest::Error>> {
+        SseClientTransport::start_with_client(
+            reqwest::Client::default(),
+            SseClientConfig {
+                sse_endpoint: uri.into(),
+                ..Default::default()
+            },
+        )
+        .await
+    }
+}

--- a/crates/mcp/src/sse_transport/sse_client.rs
+++ b/crates/mcp/src/sse_transport/sse_client.rs
@@ -1,0 +1,259 @@
+// Adapted from the rmcp fork's `transport::sse_client` module.
+// Original source: https://github.com/modelcontextprotocol/rust-sdk
+//
+// Reference: <https://html.spec.whatwg.org/multipage/server-sent-events.html>
+
+use std::{
+    pin::Pin,
+    sync::{Arc, RwLock},
+};
+
+use futures::{StreamExt, future::BoxFuture};
+use http::Uri;
+use rmcp::{
+    RoleClient,
+    model::{ClientJsonRpcMessage, ServerJsonRpcMessage},
+    transport::Transport,
+};
+use sse_stream::{Error as SseError, Sse};
+use thiserror::Error;
+
+use super::client_side_sse::{
+    BoxedSseResponse, SseAutoReconnectStream, SseRetryPolicy, SseStreamReconnect,
+};
+
+#[derive(Error, Debug)]
+pub enum SseTransportError<E: std::error::Error + Send + Sync + 'static> {
+    #[error("SSE error: {0}")]
+    Sse(#[from] SseError),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Client error: {0}")]
+    Client(E),
+    #[error("unexpected end of stream")]
+    UnexpectedEndOfStream,
+    #[error("Unexpected content type: {0:?}")]
+    UnexpectedContentType(Option<String>),
+    #[error("Auth error: {0}")]
+    Auth(#[from] rmcp::transport::AuthError),
+    #[error("Invalid uri: {0}")]
+    InvalidUri(#[from] http::uri::InvalidUri),
+    #[error("Invalid uri parts: {0}")]
+    InvalidUriParts(#[from] http::uri::InvalidUriParts),
+}
+
+pub trait SseClient: Clone + Send + Sync + 'static {
+    type Error: std::error::Error + Send + Sync + 'static;
+    fn post_message(
+        &self,
+        uri: Uri,
+        message: ClientJsonRpcMessage,
+        auth_token: Option<String>,
+    ) -> impl std::future::Future<Output = Result<(), SseTransportError<Self::Error>>> + Send + '_;
+    fn get_stream(
+        &self,
+        uri: Uri,
+        last_event_id: Option<String>,
+        auth_token: Option<String>,
+    ) -> impl std::future::Future<Output = Result<BoxedSseResponse, SseTransportError<Self::Error>>> + Send + '_;
+}
+
+/// Helper that refreshes the POST endpoint whenever the server emits
+/// control frames during SSE reconnect; used together with
+/// [`SseAutoReconnectStream`].
+struct SseClientReconnect<C> {
+    pub client: C,
+    pub uri: Uri,
+    pub message_endpoint: Arc<RwLock<Uri>>,
+}
+
+impl<C: SseClient> SseStreamReconnect for SseClientReconnect<C> {
+    type Error = SseTransportError<C::Error>;
+    type Future = BoxFuture<'static, Result<BoxedSseResponse, Self::Error>>;
+    fn retry_connection(&mut self, last_event_id: Option<&str>) -> Self::Future {
+        let client = self.client.clone();
+        let uri = self.uri.clone();
+        let last_event_id = last_event_id.map(|s| s.to_owned());
+        Box::pin(async move { client.get_stream(uri, last_event_id, None).await })
+    }
+
+    fn handle_control_event(&mut self, event: &Sse) -> Result<(), Self::Error> {
+        if event.event.as_deref() != Some("endpoint") {
+            return Ok(());
+        }
+        let Some(data) = event.data.as_ref() else {
+            return Ok(());
+        };
+        // Servers typically resend the message POST endpoint (often with a new
+        // sessionId) when a stream reconnects. Reuse `message_endpoint` helper
+        // to resolve it and update the shared URI.
+        let new_endpoint = message_endpoint(self.uri.clone(), data.clone())
+            .map_err(SseTransportError::InvalidUri)?;
+        *self
+            .message_endpoint
+            .write()
+            .expect("message endpoint lock poisoned") = new_endpoint;
+        Ok(())
+    }
+
+    fn handle_stream_error(
+        &mut self,
+        error: &(dyn std::error::Error + 'static),
+        last_event_id: Option<&str>,
+    ) {
+        tracing::warn!(
+            uri = %self.uri,
+            last_event_id = last_event_id.unwrap_or(""),
+            "sse stream error: {error}"
+        );
+    }
+}
+type ServerMessageStream<C> = Pin<Box<SseAutoReconnectStream<SseClientReconnect<C>>>>;
+
+/// A client-agnostic SSE transport for MCP that supports Server-Sent Events.
+///
+/// This transport allows you to choose your preferred HTTP client implementation
+/// by implementing the [`SseClient`] trait. The transport handles SSE streaming
+/// and automatic reconnection.
+pub struct SseClientTransport<C: SseClient> {
+    client: C,
+    config: SseClientConfig,
+    /// Current POST endpoint; refreshed when the server sends new endpoint
+    /// control frames.
+    message_endpoint: Arc<RwLock<Uri>>,
+    stream: Option<ServerMessageStream<C>>,
+}
+
+impl<C: SseClient> Transport<RoleClient> for SseClientTransport<C> {
+    type Error = SseTransportError<C::Error>;
+    async fn receive(&mut self) -> Option<ServerJsonRpcMessage> {
+        self.stream.as_mut()?.next().await?.ok()
+    }
+    fn send(
+        &mut self,
+        item: rmcp::service::TxJsonRpcMessage<RoleClient>,
+    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
+        let client = self.client.clone();
+        let message_endpoint = self.message_endpoint.clone();
+        async move {
+            let uri = {
+                let guard = message_endpoint
+                    .read()
+                    .expect("message endpoint lock poisoned");
+                guard.clone()
+            };
+            client.post_message(uri, item, None).await
+        }
+    }
+    async fn close(&mut self) -> Result<(), Self::Error> {
+        self.stream.take();
+        Ok(())
+    }
+}
+
+impl<C: SseClient + std::fmt::Debug> std::fmt::Debug for SseClientTransport<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SseClientTransport")
+            .field("client", &self.client)
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+impl<C: SseClient> SseClientTransport<C> {
+    pub async fn start_with_client(
+        client: C,
+        config: SseClientConfig,
+    ) -> Result<Self, SseTransportError<C::Error>> {
+        let sse_endpoint = config.sse_endpoint.as_ref().parse::<http::Uri>()?;
+
+        let mut sse_stream = client.get_stream(sse_endpoint.clone(), None, None).await?;
+        let initial_message_endpoint = if let Some(endpoint) = config.use_message_endpoint.clone() {
+            let ep = endpoint.parse::<http::Uri>()?;
+            let mut sse_endpoint_parts = sse_endpoint.clone().into_parts();
+            sse_endpoint_parts.path_and_query = ep.into_parts().path_and_query;
+            Uri::from_parts(sse_endpoint_parts)?
+        } else {
+            // Wait for the endpoint event.
+            loop {
+                let sse = sse_stream
+                    .next()
+                    .await
+                    .ok_or(SseTransportError::UnexpectedEndOfStream)??;
+                let Some("endpoint") = sse.event.as_deref() else {
+                    continue;
+                };
+                let ep = sse.data.unwrap_or_default();
+
+                break message_endpoint(sse_endpoint.clone(), ep)?;
+            }
+        };
+        let message_endpoint = Arc::new(RwLock::new(initial_message_endpoint));
+
+        let stream = Box::pin(SseAutoReconnectStream::new(
+            sse_stream,
+            SseClientReconnect {
+                client: client.clone(),
+                uri: sse_endpoint.clone(),
+                message_endpoint: message_endpoint.clone(),
+            },
+            config.retry_policy.clone(),
+        ));
+        Ok(Self {
+            client,
+            config,
+            message_endpoint,
+            stream: Some(stream),
+        })
+    }
+}
+
+fn message_endpoint(base: http::Uri, endpoint: String) -> Result<http::Uri, http::uri::InvalidUri> {
+    // If endpoint is a full URL, parse and return it directly.
+    if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        return endpoint.parse::<http::Uri>();
+    }
+
+    let mut base_parts = base.into_parts();
+    let endpoint_clone = endpoint.clone();
+
+    if endpoint.starts_with("?") {
+        // Query only - keep base path and append query.
+        if let Some(base_path_and_query) = &base_parts.path_and_query {
+            let base_path = base_path_and_query.path();
+            base_parts.path_and_query = Some(format!("{base_path}{endpoint}").parse()?);
+        } else {
+            base_parts.path_and_query = Some(format!("/{endpoint}").parse()?);
+        }
+    } else {
+        // Path (with optional query) - replace entire path_and_query.
+        let path_to_use = if endpoint.starts_with("/") {
+            endpoint // Use absolute path as-is.
+        } else {
+            format!("/{endpoint}") // Make relative path absolute.
+        };
+        base_parts.path_and_query = Some(path_to_use.parse()?);
+    }
+
+    http::Uri::from_parts(base_parts).map_err(|_| endpoint_clone.parse::<http::Uri>().unwrap_err())
+}
+
+#[derive(Debug, Clone)]
+pub struct SseClientConfig {
+    /// The client SSE endpoint URL.
+    pub sse_endpoint: Arc<str>,
+    pub retry_policy: Arc<dyn SseRetryPolicy>,
+    /// If this is set, the client will use this endpoint to send messages and
+    /// skip waiting for the endpoint event.
+    pub use_message_endpoint: Option<String>,
+}
+
+impl Default for SseClientConfig {
+    fn default() -> Self {
+        Self {
+            sse_endpoint: "".into(),
+            retry_policy: Arc::new(super::client_side_sse::FixedInterval::default()),
+            use_message_endpoint: None,
+        }
+    }
+}

--- a/crates/mcp/src/sse_transport/sse_client.rs
+++ b/crates/mcp/src/sse_transport/sse_client.rs
@@ -1,5 +1,7 @@
-// Adapted from the rmcp fork's `transport::sse_client` module.
-// Original source: https://github.com/modelcontextprotocol/rust-sdk
+// This file contains code copied from the rmcp crate (https://github.com/modelcontextprotocol/rust-sdk),
+// originally located at `crates/rmcp/src/transport/sse_client.rs`.
+// Used under the terms of the Apache License, Version 2.0.
+// See https://github.com/modelcontextprotocol/rust-sdk/blob/main/LICENSE for the full license text.
 //
 // Reference: <https://html.spec.whatwg.org/multipage/server-sent-events.html>
 

--- a/crates/mcp/src/sse_transport/sse_client.rs
+++ b/crates/mcp/src/sse_transport/sse_client.rs
@@ -10,12 +10,12 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use futures::{StreamExt, future::BoxFuture};
+use futures::{future::BoxFuture, StreamExt};
 use http::Uri;
 use rmcp::{
-    RoleClient,
     model::{ClientJsonRpcMessage, ServerJsonRpcMessage},
     transport::Transport,
+    RoleClient,
 };
 use sse_stream::{Error as SseError, Sse};
 use thiserror::Error;
@@ -57,7 +57,9 @@ pub trait SseClient: Clone + Send + Sync + 'static {
         uri: Uri,
         last_event_id: Option<String>,
         auth_token: Option<String>,
-    ) -> impl std::future::Future<Output = Result<BoxedSseResponse, SseTransportError<Self::Error>>> + Send + '_;
+    ) -> impl std::future::Future<Output = Result<BoxedSseResponse, SseTransportError<Self::Error>>>
+           + Send
+           + '_;
 }
 
 /// Helper that refreshes the POST endpoint whenever the server emits


### PR DESCRIPTION
## Description

Switches Warp from our fork of `rmcp` back to the upstream crates.io release so we no longer have to carry and maintain a fork just for Warp-specific compatibility.

Our fork primarily existed because older upstream `rmcp` supported the legacy SSE client transport that some MCP servers still rely on, but current upstream releases no longer include that transport. To preserve compatibility while using upstream `rmcp`, this PR adds a small local `mcp` workspace crate that contains the old upstream SSE transport implementation (`SseClientTransport`, reconnect handling, reqwest integration, and auth integration), copied from an earlier version of upstream `rmcp` under its Apache-2.0 license with attribution in the copied files.

This also updates Warp's MCP integration for the newer upstream APIs and related dependency changes:

- Replace the forked `rmcp` git dependency with upstream `rmcp = "1.6"`.
- Add `crates/mcp` to host the legacy SSE transport shim used by Warp.
- Update MCP tool/resource call sites and capability builders for upstream `rmcp` API changes.
- Update the reqwest integration for the newer reqwest API.
- Persist the full upstream `StoredCredentials` shape for MCP OAuth so refreshed tokens, `token_received_at`, and DCR client secrets survive restarts.
- Preserve existing refresh tokens when an OAuth refresh response omits a replacement refresh token.

## Testing

- `cargo check -p warp` passes.
- Added/updated unit coverage for MCP OAuth credential deserialization, token timestamp persistence, skipped empty-token persistence, and refresh-token carry-forward behavior.
- Updated MCP capability helper tests for the upstream builder-style APIs.
- Manually tested MCP server connections using the legacy SSE transport with a local build.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
