### PR TITLE
Add (and correctly trigger) failure state for cloud mode setup

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -26175,7 +26175,17 @@ impl View for TerminalView {
                         column.add_child(ChildView::new(&self.use_agent_footer).finish());
                     }
 
-                    if self.is_input_box_visible(&model, app) {
+                    if let Some(error_message) = self
+                        .ambient_agent_view_model
+                        .as_ref()
+                        .and_then(|m| m.as_ref(app).setup_failure_error())
+                    {
+                        column.add_child(ambient_agent::render_error_footer(
+                            "Environment setup failed",
+                            error_message,
+                            appearance,
+                        ));
+                    } else if self.is_input_box_visible(&model, app) {
                         column.add_child(self.render_input());
                     } else if !model.is_read_only()
                         && ambient_agent::is_cloud_agent_pre_first_exchange(

--- a/app/src/terminal/view/ambient_agent/block/setup_command.rs
+++ b/app/src/terminal/view/ambient_agent/block/setup_command.rs
@@ -77,16 +77,21 @@ impl CloudModeSetupCommandBlock {
         ctx.subscribe_to_model(model_events, |me, model_events, event, ctx| {
             if let ModelEvent::BlockCompleted(BlockCompletedEvent { block_id, .. }) = event {
                 if *block_id == me.block_id {
-                    if me
+                    let is_success = me
                         .terminal_model
                         .lock()
                         .block_list()
                         .block_with_id(block_id)
-                        .is_some_and(|block| block.exit_code().was_successful())
-                    {
-                        me.status = Status::Completed { is_success: true };
-                    } else {
-                        me.status = Status::Completed { is_success: false };
+                        .is_some_and(|block| block.exit_code().was_successful());
+                    me.status = Status::Completed { is_success };
+                    if !is_success {
+                        me.is_expanded = true;
+                        ctx.emit(CloudModeSetupCommandBlockEvent::ToggleBlockVisibility(
+                            me.block_id.clone(),
+                        ));
+                        ctx.emit(CloudModeSetupCommandBlockEvent::SetupCommandFailed(
+                            me.block_id.clone(),
+                        ));
                     }
                     ctx.unsubscribe_to_model(&model_events);
                     ctx.notify();
@@ -116,6 +121,7 @@ impl CloudModeSetupCommandBlock {
 #[derive(Debug, Clone)]
 pub enum CloudModeSetupCommandBlockEvent {
     ToggleBlockVisibility(BlockId),
+    SetupCommandFailed(BlockId),
 }
 
 impl Entity for CloudModeSetupCommandBlock {

--- a/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
+++ b/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
@@ -35,6 +35,7 @@ pub struct SetupCommandState {
     next_group_id: u64,
     expanded_groups: HashMap<SetupCommandGroupId, bool>,
     running_group_id: Option<SetupCommandGroupId>,
+    failed_group_id: Option<SetupCommandGroupId>,
 }
 
 impl Default for SetupCommandState {
@@ -48,6 +49,7 @@ impl Default for SetupCommandState {
             next_group_id: 1,
             expanded_groups,
             running_group_id: Some(current_group_id),
+            failed_group_id: None,
         }
     }
 }
@@ -83,6 +85,7 @@ impl SetupCommandState {
         self.did_execute_a_setup_command = false;
         self.expanded_groups.insert(group_id, true);
         self.running_group_id = Some(group_id);
+        self.failed_group_id = None;
         group_id
     }
 
@@ -90,6 +93,16 @@ impl SetupCommandState {
         if self.running_group_id == Some(group_id) {
             self.running_group_id = None;
         }
+    }
+
+    pub fn mark_group_failed(&mut self, group_id: SetupCommandGroupId) {
+        self.failed_group_id = Some(group_id);
+        self.running_group_id = None;
+        self.expanded_groups.insert(group_id, true);
+    }
+
+    pub fn is_failed(&self, group_id: SetupCommandGroupId) -> bool {
+        self.failed_group_id == Some(group_id)
     }
 }
 
@@ -168,16 +181,27 @@ impl View for CloudModeSetupTextBlock {
 
         let appearance = Appearance::as_ref(app);
         let icon_size = inline_action_icons::icon_size(app);
-        let text_color = appearance
-            .theme()
-            .disabled_text_color(agent_view_bg_color(app).into())
-            .into_solid();
+        let setup_state = self
+            .ambient_agent_view_model
+            .as_ref(app)
+            .setup_command_state();
+        let is_failed = setup_state.is_failed(self.group_id);
+        let text_color = if is_failed {
+            appearance.theme().ui_error_color()
+        } else {
+            appearance
+                .theme()
+                .disabled_text_color(agent_view_bg_color(app).into())
+                .into_solid()
+        };
         let expandable = Hoverable::new(self.mouse_state.clone(), move |_is_hovered| {
             Flex::row()
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_child(
                     Text::new(
-                        if self
+                        if is_failed {
+                            "Setup failed"
+                        } else if self
                             .ambient_agent_view_model
                             .as_ref(app)
                             .setup_command_state()

--- a/app/src/terminal/view/ambient_agent/footer.rs
+++ b/app/src/terminal/view/ambient_agent/footer.rs
@@ -93,20 +93,23 @@ pub fn render_loading_footer(appearance: &Appearance) -> Box<dyn Element> {
     )
 }
 
-/// Render an error footer that shows when the ambient agent failed to spawn.
-pub fn render_error_footer(error_message: &str, appearance: &Appearance) -> Box<dyn Element> {
+/// Render an error footer with the same layout as the loading footer but with
+/// red header text. Uses the same subtle background/border as the loading
+/// footer so it feels like the same component in an error state.
+pub fn render_error_footer(
+    header: &str,
+    error_message: &str,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
     let theme = appearance.theme();
 
     let header_color = theme.ui_error_color();
-    let body_color = blended_colors::text_main(theme, theme.background());
-    let background: ColorU = {
-        let red: warp_core::ui::theme::Fill = theme.ui_error_color().into();
-        red.with_opacity(50).into()
-    };
-    let border_color = theme.ui_error_color();
+    let body_color = theme.ui_error_color();
+    let background = theme.surface_2().into();
+    let border_color = blended_colors::neutral_4(theme);
 
     build_centered_footer(
-        "Agent failed".to_string(),
+        header.to_string(),
         error_message.to_string(),
         header_color,
         body_color,

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -127,7 +127,8 @@ pub fn create_cloud_mode_view(
                 | AmbientAgentViewModelEvent::PendingHandoffChanged
                 | AmbientAgentViewModelEvent::HandoffSnapshotUploadFailed { .. }
                 | AmbientAgentViewModelEvent::UpdatedSetupCommandVisibility
-                | AmbientAgentViewModelEvent::AuthSecretSelected => {}
+                | AmbientAgentViewModelEvent::AuthSecretSelected
+                | AmbientAgentViewModelEvent::EnvironmentSetupFailed => {}
             }
         });
     });

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -11,6 +11,7 @@ use warpui::{AppContext, Entity, EntityId, ModelContext, SingletonEntity};
 
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::{conversation::AIConversationId, extract_user_query_mode};
+use crate::ai::agent_conversations_model::{AgentConversationsModel, AgentConversationsModelEvent};
 use crate::ai::ambient_agents::spawn::{spawn_task, submit_run_followup, AmbientAgentEvent};
 use crate::ai::ambient_agents::task::{HarnessAuthSecretsConfig, HarnessConfig};
 use crate::ai::ambient_agents::telemetry::CloudAgentTelemetryEvent;
@@ -197,6 +198,11 @@ pub struct AmbientAgentViewModel {
     /// The task ID for the current cloud agent task, if one has been spawned.
     task_id: Option<AmbientAgentTaskId>,
 
+    /// Error message from the server when environment setup failed during the V2
+    /// inline setup phase. Set after detecting a failed setup command and fetching
+    /// the task's `status_message` from `AgentConversationsModel`.
+    setup_failure_error: Option<String>,
+
     /// The local conversation associated with this cloud agent run, if any.
     /// Set for remote child agents spawned via `start_agent` so the `run_id`
     /// from the server response can be wired back to the conversation.
@@ -275,6 +281,7 @@ impl AmbientAgentViewModel {
             ui_state,
             setup_commands_state: Default::default(),
             task_id: None,
+            setup_failure_error: None,
             conversation_id: None,
             harness,
             worker_host: None,
@@ -727,6 +734,11 @@ impl AmbientAgentViewModel {
         self.task_id
     }
 
+    /// Returns the setup failure error message, if environment setup failed.
+    pub fn setup_failure_error(&self) -> Option<&str> {
+        self.setup_failure_error.as_deref()
+    }
+
     /// Whether or not this terminal session is in the setup state (first-time environment creation).
     pub fn is_in_setup(&self) -> bool {
         matches!(self.status, Status::Setup)
@@ -941,11 +953,70 @@ impl AmbientAgentViewModel {
             )
     }
 
+    /// Records that environment setup failed during the V2 inline setup phase.
+    /// Marks the current setup command group as failed, then tries to read the
+    /// server error from `AgentConversationsModel`. If the task data isn't cached
+    /// yet, subscribes to `TasksUpdated` to pick it up when it arrives.
+    pub(super) fn record_environment_setup_failure(&mut self, ctx: &mut ModelContext<Self>) {
+        let group_id = self.setup_commands_state.current_group_id();
+        self.setup_commands_state.mark_group_failed(group_id);
+        ctx.emit(AmbientAgentViewModelEvent::UpdatedSetupCommandVisibility);
+
+        self.try_resolve_setup_failure_error(ctx);
+    }
+
+    /// Attempts to read the task's `status_message` from `AgentConversationsModel`.
+    /// If the data is available, sets `setup_failure_error` and emits
+    /// `EnvironmentSetupFailed`. Otherwise, subscribes to `TasksUpdated` for
+    /// a deferred resolution.
+    fn try_resolve_setup_failure_error(&mut self, ctx: &mut ModelContext<Self>) {
+        let Some(task_id) = self.task_id else {
+            self.setup_failure_error = Some(Self::generic_setup_failure_message().to_string());
+            ctx.emit(AmbientAgentViewModelEvent::EnvironmentSetupFailed);
+            return;
+        };
+
+        let task = AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
+            model.get_or_async_fetch_task_data(&task_id, ctx)
+        });
+
+        if let Some(task) = task {
+            let error = task
+                .status_message
+                .as_ref()
+                .filter(|msg| !msg.message.is_empty())
+                .map(|msg| msg.message.clone())
+                .unwrap_or_else(|| Self::generic_setup_failure_message().to_string());
+            self.setup_failure_error = Some(error);
+            ctx.emit(AmbientAgentViewModelEvent::EnvironmentSetupFailed);
+        } else {
+            // Task data not cached yet — subscribe for when it arrives.
+            ctx.subscribe_to_model(
+                &AgentConversationsModel::handle(ctx),
+                move |me, event, ctx| {
+                    if !matches!(event, AgentConversationsModelEvent::TasksUpdated) {
+                        return;
+                    }
+                    // Already resolved.
+                    if me.setup_failure_error.is_some() {
+                        return;
+                    }
+                    me.try_resolve_setup_failure_error(ctx);
+                },
+            );
+        }
+    }
+
+    fn generic_setup_failure_message() -> &'static str {
+        "Environment setup failed. Check your environment's repository URLs and setup commands."
+    }
+
     /// Reset cloud-specific prompt state so a retained cloud view can compose a new task.
     pub fn reset_for_new_cloud_prompt(&mut self, ctx: &mut ModelContext<Self>) {
         self.status = Status::Composing;
         self.environment_id = None;
         self.task_id = None;
+        self.setup_failure_error = None;
         self.conversation_id = None;
         self.harness_model_id = None;
         self.harness_command_started = false;
@@ -1572,6 +1643,9 @@ pub enum AmbientAgentViewModelEvent {
     UpdatedSetupCommandVisibility,
     /// The selected harness auth secret changed.
     AuthSecretSelected,
+    /// Environment setup failed during the V2 inline setup phase.
+    /// The error message is available via `setup_failure_error()`.
+    EnvironmentSetupFailed,
 }
 
 impl Entity for AmbientAgentViewModel {

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -379,6 +379,10 @@ impl TerminalView {
                 // triggers a re-render of pane chrome.
                 ctx.notify();
             }
+            AmbientAgentViewModelEvent::EnvironmentSetupFailed => {
+                ctx.emit(TerminalViewEvent::TerminalViewStateChanged);
+                ctx.notify();
+            }
             AmbientAgentViewModelEvent::UpdatedSetupCommandVisibility
             | AmbientAgentViewModelEvent::AuthSecretSelected => (),
         }
@@ -468,12 +472,40 @@ impl TerminalView {
                 ctx,
             )
         });
-        ctx.subscribe_to_view(&setup_command_block, |me, _, event, _| {
-            let super::CloudModeSetupCommandBlockEvent::ToggleBlockVisibility(block_id) = event;
-            me.model
-                .lock()
-                .block_list_mut()
-                .toggle_visibility_of_block(block_id);
+        ctx.subscribe_to_view(&setup_command_block, |me, _, event, ctx| match event {
+            super::CloudModeSetupCommandBlockEvent::ToggleBlockVisibility(block_id) => {
+                me.model
+                    .lock()
+                    .block_list_mut()
+                    .toggle_visibility_of_block(block_id);
+            }
+            super::CloudModeSetupCommandBlockEvent::SetupCommandFailed(block_id) => {
+                let conversation_id = me
+                    .agent_view_controller
+                    .as_ref(ctx)
+                    .agent_view_state()
+                    .active_conversation_id();
+                {
+                    let mut model = me.model.lock();
+                    if model
+                        .block_list()
+                        .is_executing_oz_environment_startup_commands()
+                    {
+                        model
+                            .block_list_mut()
+                            .finish_oz_environment_startup_commands_at_block(
+                                block_id,
+                                conversation_id,
+                            );
+                    }
+                }
+                me.remove_pending_user_query_block(ctx);
+                if let Some(ambient_agent_view_model) = me.ambient_agent_view_model.clone() {
+                    ambient_agent_view_model.update(ctx, |model, ctx| {
+                        model.record_environment_setup_failure(ctx);
+                    });
+                }
+            }
         });
         self.insert_rich_content(
             None,

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -59,7 +59,7 @@
       "source": "warpdotdev/common-skills",
       "sourceType": "github",
       "skillPath": ".agents/skills/write-tech-spec/SKILL.md",
-      "computedHash": "702924ae98de5466f452eba2effbd004de5edd91617097372c4725a5b5035919"
+      "computedHash": "3b5eb4ef021112d473984eca28412d372e87d9337ad5d9754f3ad3e01f94d39b"
     }
   }
 }

--- a/specs/APP-4432/PRODUCT.md
+++ b/specs/APP-4432/PRODUCT.md
@@ -1,0 +1,48 @@
+# Environment Setup Failure UI for Cloud Mode (V2)
+
+## Summary
+When a cloud agent's environment setup fails (clone, setup command, or cd), the cloud mode V2 UI gets stuck showing "Setting up environment" indefinitely. The setup failure should surface clearly: the failed command is auto-expanded with error styling, and the error footer above the input shows the server-reported error message.
+
+Figma: none provided
+
+## Behavior
+
+### Detection and error display
+
+1. When any environment setup command (git clone, setup command, or cd) exits with a non-zero exit code during the cloud mode V2 setup phase, the UI must transition out of the "setting up environment" state within a bounded time.
+
+2. After detecting a setup command failure, the client reads the task's error message from `AgentConversationsModel` (the same data source the conversation details side panel uses). If the server-reported error is already available (e.g. via RTC push), it is used immediately. If not, a fetch is triggered and the error footer appears once the data arrives.
+
+3. Once the server error message is available, an error footer renders above the input area. The footer has a red-tinted background and border (matching the existing `render_error_footer` styling) with:
+   - Header text: "Environment setup failed"
+   - Body text: the server-reported error message from the task's `status_message`
+
+4. If the task data fetch fails or the `status_message` is absent, the footer falls back to a generic body: "Environment setup failed. Check your environment's repository URLs and setup commands."
+
+5. While waiting for the server error (between detecting the failure and the task data arriving), the "Setting up environment" loading footer remains visible. The user should not see a blank or flickering state during this window.
+
+### Setup command text and expansion
+
+6. When a setup command fails, the collapsible "Running setup commands…" text changes to "Setup failed" with error styling (red/error color treatment matching the theme's error color).
+
+7. When a setup command fails, the setup command group auto-expands so the failed command block (which already shows a red X icon) is visible to the user without manual interaction.
+
+8. If the group was manually collapsed by the user before the failure, the auto-expand on failure overrides that preference.
+
+### Input and recovery
+
+9. After the error footer is displayed, no interactive input is shown. The user cannot type a new prompt or retry from the same pane.
+
+10. The user dismisses the failed pane by closing it (same as any other terminal tab) and starts a new cloud mode session if they want to retry.
+
+### Invariants
+
+11. The "Setting up environment" loading footer must never persist indefinitely. Any terminal failure state during environment setup must eventually resolve to the error footer or a session disconnect.
+
+12. The error footer must show the same error message that the conversation details side panel shows for the same failure. Both derive from the task's server-reported `status_message`.
+
+13. The individual setup command block's red X icon behavior is unchanged — it continues to show success/failure per-command as it does today.
+
+14. Setup command failures that occur before the shared session connects (i.e., the model is still in `WaitingForSession`) continue to use the existing pre-V2 error handling path. This spec only covers failures that occur after the session has connected and the V2 inline setup UI is active.
+
+15. Follow-up runs (cloud-to-cloud follow-ups) that fail during environment setup exhibit the same behavior: the setup text changes to "Setup failed", the group auto-expands, and the error footer appears with the server message.

--- a/specs/APP-4432/TECH.md
+++ b/specs/APP-4432/TECH.md
@@ -1,0 +1,137 @@
+# Environment Setup Failure UI for Cloud Mode (V2) — Tech Spec
+
+## Context
+
+Cloud mode V2 (`CloudModeSetupV2` feature flag) shows environment setup commands inline in the terminal via `CloudModeSetupCommandBlock` views. A boolean flag `is_executing_oz_environment_startup_commands` on `BlockList` (`terminal/model/blocks.rs:648`) controls visibility: while true, new command blocks are classified as setup commands and a loading footer ("Setting up environment") replaces the input.
+
+The flag is cleared by two signals — neither fires when setup fails:
+- First `AppendedExchange` from the Oz agent (`terminal/view.rs:5299-5310`)
+- `HarnessCommandStarted` for non-Oz harnesses (`terminal/view/ambient_agent/view_impl.rs:301-322`)
+
+Meanwhile, `AmbientAgentEvent::StateChanged { state: Failed }` from the server is ignored because the handler at `terminal/view/ambient_agent/model.rs:1170` only processes state changes when the model is in `Status::WaitingForSession` — by the time setup fails, the session has connected and the status is `AgentRunning`.
+
+### Key files
+- `app/src/terminal/view/ambient_agent/model.rs` — `AmbientAgentViewModel`, `Status` enum, `AmbientAgentViewModelEvent`
+- `app/src/terminal/view/ambient_agent/block/setup_command.rs` — `CloudModeSetupCommandBlock`, detects per-command success/failure via `BlockCompleted`
+- `app/src/terminal/view/ambient_agent/block/setup_command_text.rs` — `SetupCommandState`, `SetupCommandGroupId`, collapsible "Running setup commands…" text
+- `app/src/terminal/view/ambient_agent/footer.rs` — `render_loading_footer`, `render_error_footer`
+- `app/src/terminal/model/blocks.rs:1325-1363` — `is_executing_oz_environment_startup_commands`, `set_is_executing_oz_environment_startup_commands`, `finish_oz_environment_startup_commands_at_block`
+- `app/src/terminal/view.rs:26180-26188` — footer rendering slot (loading footer vs input)
+- `app/src/ai/agent_conversations_model.rs:1409-1490` — `get_or_async_fetch_task_data`, used by the side panel for task data including `status_message`
+
+See `PRODUCT.md` for the full behavior spec.
+
+## Proposed changes
+
+### 1. Propagate setup command failure from `CloudModeSetupCommandBlock`
+
+`CloudModeSetupCommandBlock` (`setup_command.rs:78-94`) already detects non-zero exit via its `BlockCompleted` subscription. Add a new event variant:
+
+```rust
+pub enum CloudModeSetupCommandBlockEvent {
+    ToggleBlockVisibility(BlockId),
+    SetupCommandFailed(BlockId),  // new
+}
+```
+
+Emit `SetupCommandFailed` when `BlockCompleted` fires with a non-successful exit code. The `TerminalView` handler for this event (in `maybe_insert_setup_command_blocks`'s subscription at `view_impl.rs:471-477`) will drive the rest of the failure flow.
+
+### 2. New state on `AmbientAgentViewModel`: setup failure with error message
+
+Add a new field to `AmbientAgentViewModel`:
+
+```rust
+/// Error message from the server when environment setup failed.
+/// Set after detecting a setup command failure and fetching task data.
+setup_failure_error: Option<String>,
+```
+
+Add a new event variant:
+
+```rust
+pub enum AmbientAgentViewModelEvent {
+    // ... existing variants ...
+    EnvironmentSetupFailed,
+}
+```
+
+Add a method `record_environment_setup_failure` that:
+1. Clears `is_executing_oz_environment_startup_commands` on the blocklist (via the same `finish_oz_environment_startup_commands_at_block` path)
+2. Marks the current setup command group as failed (new state on `SetupCommandState`, see §3)
+3. Reads the task's `status_message` from `AgentConversationsModel::get_or_async_fetch_task_data`. If the task data is already cached (e.g. via RTC push), sets `setup_failure_error` immediately. If not, the fetch is triggered and a subscription to `AgentConversationsModelEvent::TasksUpdated` retries the read when data arrives.
+4. Once the error is available (or if the fetch fails), sets `setup_failure_error` to either the server message or the generic fallback, then emits `EnvironmentSetupFailed`.
+
+### 3. Setup command text: failed state
+
+Add a `failed` field to `SetupCommandState` (`setup_command_text.rs`):
+
+```rust
+pub struct SetupCommandState {
+    // ... existing fields ...
+    failed_group_id: Option<SetupCommandGroupId>,
+}
+```
+
+Add `mark_group_failed(group_id)` which sets `failed_group_id` and forces `should_expand` to true for that group.
+
+In `CloudModeSetupTextBlock::render` (`setup_command_text.rs:157-222`):
+- When the current group is failed, render "Setup failed" in the theme's error color instead of "Running setup commands…" / "Ran setup commands".
+- Force the group to be expanded (override any user collapse).
+
+### 4. Error footer rendering
+
+Update `render_error_footer` (`footer.rs:97-117`) to accept a custom header parameter instead of hardcoding "Agent failed":
+
+```rust
+pub fn render_error_footer(
+    header: &str,
+    error_message: &str,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+```
+
+Update the existing call site to pass `"Agent failed"` to preserve current behavior.
+
+In the footer rendering slot (`view.rs:26180-26188`), add a branch: when `AmbientAgentViewModel` has a `setup_failure_error`, render `render_error_footer("Environment setup failed", &error_message, appearance)` instead of `render_loading_footer`.
+
+The precedence in the footer slot becomes:
+1. If setup failure error is set → error footer
+2. If `is_cloud_agent_pre_first_exchange` → loading footer
+3. Otherwise → normal input
+
+### 5. Wire the `TerminalView` handler
+
+In `TerminalView`'s subscription to `CloudModeSetupCommandBlockEvent` (currently at `view_impl.rs:471-477`), handle the new `SetupCommandFailed` variant:
+
+1. Call `ambient_agent_view_model.record_environment_setup_failure(block_id, ctx)` which drives §2.
+
+In `handle_ambient_agent_event` (`view_impl.rs:95-384`), handle the new `EnvironmentSetupFailed` event:
+
+1. Re-render to show the error footer via `ctx.notify()`.
+2. Emit `TerminalViewStateChanged` so pane chrome updates.
+
+### 6. Subscription to `AgentConversationsModel` for deferred error message
+
+In `AmbientAgentViewModel`, when `get_or_async_fetch_task_data` returns `None` (fetch in flight), subscribe to `AgentConversationsModelEvent::TasksUpdated`. On that event, re-check the task data. If the `status_message` is now available, set `setup_failure_error` and emit `EnvironmentSetupFailed`. If the task data shows a terminal failure state but no `status_message`, use the generic fallback.
+
+To avoid leaking the subscription, unsubscribe after the error is resolved or if the task data never arrives (the existing `TaskFetchState` cooldown/retry logic in `AgentConversationsModel` handles the backoff).
+
+## Testing and validation
+
+**Unit tests:**
+- `SetupCommandState`: test `mark_group_failed` sets the failed group, forces expansion, and `is_failed` returns the correct state. (Behavior §6, §7, §8)
+- `render_error_footer` with custom header: verify the header text parameter flows through. (Behavior §3)
+
+**Integration / manual validation:**
+- Trigger a cloud mode run with a setup command that will fail (e.g. an environment with `exit 1` as a setup command). Verify:
+  - The "Running setup commands…" text changes to "Setup failed" in red. (Behavior §6)
+  - The failed command group auto-expands. (Behavior §7)
+  - The error footer appears with "Environment setup failed" and the server error message. (Behavior §3)
+  - The loading footer does not persist indefinitely. (Behavior §11)
+  - The side panel shows the same error message. (Behavior §12)
+- Trigger a clone failure (environment with a nonexistent repo). Verify the same error flow. (Behavior §1)
+- Trigger a follow-up run that fails during setup. Verify the same error flow applies to the follow-up group. (Behavior §15)
+
+## Parallelization
+
+Not beneficial — the changes are tightly coupled across a small number of files in the same module hierarchy. A single agent can implement this sequentially.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

If any command in environment setup failed, the new setup UI would just get stuck in the "setting up environment" state. Instead, we should indicate this error state by blocking the input and expanding the error block.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

![image.png](https://app.graphite.com/user-attachments/assets/a74c70f1-4adf-4586-9250-0fa01ba39155.png)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
