### PR TITLE
Update orchestration launch modal copy

### DIFF
--- a/app/src/workspace/view/orchestration_launch_modal/view.rs
+++ b/app/src/workspace/view/orchestration_launch_modal/view.rs
@@ -73,7 +73,7 @@ const FEATURE_ITEMS: &[FeatureItem] = &[
     FeatureItem {
         icon: Icon::Atom02,
         title: "Multi-agent orchestration",
-        description: "Warp Agents will now orchestrate subagents automatically, deploying and tracking parallel agents.",
+        description: "Warp Agents will now orchestrate swarms of subagents, allowing you to parallelize tasks.",
         badge: None,
     },
     FeatureItem {
@@ -193,7 +193,7 @@ impl OrchestrationLaunchModal {
         });
 
         let go_to_warp_button = ctx.add_view(|_ctx| {
-            ActionButton::new("Go to Warp", CtaButtonTheme)
+            ActionButton::new("Close", CtaButtonTheme)
                 .with_full_width(true)
                 .on_click(|ctx| ctx.dispatch_typed_action(OrchestrationLaunchModalAction::Close))
         });
@@ -280,7 +280,7 @@ impl OrchestrationLaunchModal {
 
     fn render_description(appearance: &Appearance) -> Box<dyn Element> {
         Text::new(
-            "Major improvements to Warp's cloud agent orchestration platform, Oz.",
+            "We've made major improvements to Warp's cloud agent orchestration platform, Oz.",
             appearance.ui_font_family(),
             14.,
         )


### PR DESCRIPTION
## Description
Update copy in the orchestration launch modal:
- Description: "Major improvements to…" → "We've made major improvements to…"
- Feature 2: "orchestrate subagents automatically, deploying and tracking parallel agents" → "orchestrate swarms of subagents, allowing you to parallelize tasks"
- CTA button: "Go to Warp" → "Close"
- 
<img width="413" height="508" alt="Screenshot 2026-05-12 at 12 52 33 PM" src="https://github.com/user-attachments/assets/7d1da4df-974e-4700-a402-5222413882c3" />


## Linked Issue
N/A — copy polish

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Warp conversation](https://staging.warp.dev/conversation/1db8b6a2-86bb-480c-a7bd-e166c0f6b46f)

Co-Authored-By: Oz <oz-agent@warp.dev>