### PR TITLE
Use restored CLI agent harness title for pane/tab

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -4065,17 +4065,9 @@ impl PaneGroup {
                     // 3p runs have no materialized AIConversation, so enter agent view with a
                     // fresh vehicle conversation and retag the restored snapshot block onto it so
                     // it passes `should_hide_block`'s agent view filter.
-                    view.enter_agent_view_for_new_conversation(
-                        None,
-                        AgentViewEntryOrigin::ThirdPartyCloudAgent,
-                        ctx,
-                    );
-                    if let Some(vehicle_conversation_id) = view.active_conversation_id(ctx) {
-                        TerminalView::apply_restored_cli_agent_title_to_vehicle_conversation(
-                            fallback_title,
-                            vehicle_conversation_id,
-                            ctx,
-                        );
+                    if let Some(vehicle_conversation_id) =
+                        view.enter_agent_view_for_restored_cli_agent(fallback_title, ctx)
+                    {
                         view.model
                             .lock()
                             .block_list_mut()
@@ -5497,17 +5489,9 @@ impl PaneGroup {
                             });
                         }
                     }
-                    view.enter_agent_view_for_new_conversation(
-                        None,
-                        AgentViewEntryOrigin::ThirdPartyCloudAgent,
-                        ctx,
-                    );
-                    if let Some(vehicle_conversation_id) = view.active_conversation_id(ctx) {
-                        TerminalView::apply_restored_cli_agent_title_to_vehicle_conversation(
-                            fallback_title,
-                            vehicle_conversation_id,
-                            ctx,
-                        );
+                    if let Some(vehicle_conversation_id) =
+                        view.enter_agent_view_for_restored_cli_agent(fallback_title, ctx)
+                    {
                         view.model
                             .lock()
                             .block_list_mut()

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -4044,6 +4044,7 @@ impl PaneGroup {
                     AIAgentHarness::Oz => None,
                     AIAgentHarness::Unknown => Some(Harness::Unknown),
                 };
+                let fallback_title = cli_conversation.metadata.title.clone();
                 terminal_view.update(ctx, |view, ctx| {
                     view.restore_conversation_and_directory_context(
                         CloudConversationData::CLIAgent(cli_conversation),
@@ -4070,6 +4071,11 @@ impl PaneGroup {
                         ctx,
                     );
                     if let Some(vehicle_conversation_id) = view.active_conversation_id(ctx) {
+                        TerminalView::apply_restored_cli_agent_title_to_vehicle_conversation(
+                            fallback_title,
+                            vehicle_conversation_id,
+                            ctx,
+                        );
                         view.model
                             .lock()
                             .block_list_mut()
@@ -5475,6 +5481,7 @@ impl PaneGroup {
                         AIAgentHarness::Oz => None,
                         AIAgentHarness::Unknown => Some(Harness::Unknown),
                     };
+                    let fallback_title = cli_conversation.metadata.title.clone();
                     view.restore_conversation_and_directory_context(
                         CloudConversationData::CLIAgent(cli_conversation),
                         true,
@@ -5496,6 +5503,11 @@ impl PaneGroup {
                         ctx,
                     );
                     if let Some(vehicle_conversation_id) = view.active_conversation_id(ctx) {
+                        TerminalView::apply_restored_cli_agent_title_to_vehicle_conversation(
+                            fallback_title,
+                            vehicle_conversation_id,
+                            ctx,
+                        );
                         view.model
                             .lock()
                             .block_list_mut()

--- a/app/src/terminal/view/agent_view.rs
+++ b/app/src/terminal/view/agent_view.rs
@@ -86,7 +86,7 @@ impl TerminalView {
     }
 
     // Enters the agent view for a restored CLI agent transcript, setting the title using the
-	// restored CLI conversation metadata if we have it.
+    // restored CLI conversation metadata if we have it.
     pub(crate) fn enter_agent_view_for_restored_cli_agent(
         &mut self,
         fallback_title: String,

--- a/app/src/terminal/view/agent_view.rs
+++ b/app/src/terminal/view/agent_view.rs
@@ -85,6 +85,43 @@ impl TerminalView {
         self.redetermine_global_focus(ctx);
     }
 
+    // Enters the agent view for a restored CLI agent transcript, setting the title using the
+	// restored CLI conversation metadata if we have it.
+    pub(crate) fn enter_agent_view_for_restored_cli_agent(
+        &mut self,
+        fallback_title: String,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<AIConversationId> {
+        let origin = AgentViewEntryOrigin::ThirdPartyCloudAgent;
+        let conversation_id = BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+            let conversation_id = history.start_new_conversation(self.view_id, false, false, ctx);
+            let title = fallback_title.trim();
+            if !title.is_empty() {
+                if let Some(conversation) = history.conversation_mut(&conversation_id) {
+                    conversation.set_fallback_display_title(title.to_owned());
+                }
+            }
+            conversation_id
+        });
+
+        match self.try_enter_agent_view(None, origin, Some(conversation_id), ctx) {
+            Ok(conversation_id) => {
+                self.redetermine_global_focus(ctx);
+                Some(conversation_id)
+            }
+            Err(e) => {
+                log::error!(
+                    "Failed to enter agent view for restored CLI agent from origin {:?}: {:?}",
+                    origin,
+                    e
+                );
+                self.show_error_toast(e.to_string(), ctx);
+                self.redetermine_global_focus(ctx);
+                None
+            }
+        }
+    }
+
     pub fn enter_agent_view_for_conversation(
         &mut self,
         initial_prompt: Option<String>,

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -328,28 +328,6 @@ impl TerminalView {
             .insert_restored_block(&block);
     }
 
-    /// Stamps the restored CLI agent harness conversation's title onto the freshly
-    /// created vehicle agent-view conversation as a fallback display title. Without
-    /// this, pane/tab chrome and the ambient agent entry block fall back to the
-    /// generic "New cloud agent" placeholder for 3p cloud agent transcripts (which
-    /// have no materialized [`AIConversation`] of their own to derive a title from).
-    pub(crate) fn apply_restored_cli_agent_title_to_vehicle_conversation(
-        fallback_title: String,
-        vehicle_conversation_id: AIConversationId,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        let trimmed = fallback_title.trim();
-        if trimmed.is_empty() {
-            return;
-        }
-        let title = trimmed.to_owned();
-        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _| {
-            if let Some(conversation) = history.conversation_mut(&vehicle_conversation_id) {
-                conversation.set_fallback_display_title(title);
-            }
-        });
-    }
-
     /// Get AIConversations to restore given conversation IDs.
     pub(super) fn get_conversations_to_restore(
         conversation_ids: &[AIConversationId],

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -328,6 +328,28 @@ impl TerminalView {
             .insert_restored_block(&block);
     }
 
+    /// Stamps the restored CLI agent harness conversation's title onto the freshly
+    /// created vehicle agent-view conversation as a fallback display title. Without
+    /// this, pane/tab chrome and the ambient agent entry block fall back to the
+    /// generic "New cloud agent" placeholder for 3p cloud agent transcripts (which
+    /// have no materialized [`AIConversation`] of their own to derive a title from).
+    pub(crate) fn apply_restored_cli_agent_title_to_vehicle_conversation(
+        fallback_title: String,
+        vehicle_conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let trimmed = fallback_title.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        let title = trimmed.to_owned();
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _| {
+            if let Some(conversation) = history.conversation_mut(&vehicle_conversation_id) {
+                conversation.set_fallback_display_title(title);
+            }
+        });
+    }
+
     /// Get AIConversations to restore given conversation IDs.
     pub(super) fn get_conversations_to_restore(
         conversation_ids: &[AIConversationId],


### PR DESCRIPTION
## Summary

Restored cloud agent transcripts for harness conversations currently show a generic "New cloud agent" tab and pane title. This PR updates it to use the title associated with the CLI conversation metadata by setting the title of the agent view when we create it.

## Testing

Before:
<img width="1099" height="611" alt="image" src="https://github.com/user-attachments/assets/e7649f98-07ea-4fef-8985-e173e0e28677" />

After (see pane header and sidebar):
<img width="1243" height="912" alt="image" src="https://github.com/user-attachments/assets/32c96c44-891a-48cb-8438-acaf56e6d053" />



_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._