### PR TITLE
Show error state in conversation details panel when run API fetch fails

### DIFF
--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -77,10 +77,12 @@ enum TaskFetchState {
     /// The fetch returned a permanent (non-transient) HTTP error such as 401/403/404; remember
     /// when it failed so we can back off for [`PERMANENT_FETCH_FAILURE_COOLDOWN`] before
     /// retrying. We don't refuse forever in case permissions change mid-session.
-    PermanentlyFailedAt(Instant),
+    /// The `String` carries a human-readable description of the failure for display in the UI.
+    PermanentlyFailed { at: Instant, message: String },
     /// The retry chain just exhausted on a transient error; remember when it failed so we
     /// can back off for [`TRANSIENT_FETCH_FAILURE_COOLDOWN`] before retrying.
-    TransientlyFailedAt(Instant),
+    /// The `String` carries a human-readable description of the failure for display in the UI.
+    TransientlyFailed { at: Instant, message: String },
 }
 
 /// Protected eviction: we'll always keep at least 200 personal tasks in the model.
@@ -1392,14 +1394,17 @@ impl AgentConversationsModel {
         self.tasks.get(task_id).cloned()
     }
 
-    /// Returns `true` when the most recent fetch for `task_id` ended in a permanent
-    /// or transient failure and the cooldown has not yet elapsed. The caller can use
-    /// this to display an error state in the details panel.
-    pub fn is_task_fetch_failed(&self, task_id: &AmbientAgentTaskId) -> bool {
-        matches!(
-            self.task_fetch_state.get(task_id),
-            Some(TaskFetchState::PermanentlyFailedAt(_) | TaskFetchState::TransientlyFailedAt(_))
-        )
+    /// Returns the error message when the most recent fetch for `task_id` ended in a
+    /// permanent or transient failure and the cooldown has not yet elapsed. The caller
+    /// can use this to display an error state in the details panel.
+    pub fn task_fetch_error(&self, task_id: &AmbientAgentTaskId) -> Option<&str> {
+        match self.task_fetch_state.get(task_id) {
+            Some(
+                TaskFetchState::PermanentlyFailed { message, .. }
+                | TaskFetchState::TransientlyFailed { message, .. },
+            ) => Some(message),
+            _ => None,
+        }
     }
 
     /// Get raw task data by task ID, fetching from server if not in memory.
@@ -1430,15 +1435,15 @@ impl AgentConversationsModel {
         // one applies to a given id.
         match self.task_fetch_state.get(task_id) {
             Some(TaskFetchState::InFlight) => return None,
-            Some(TaskFetchState::PermanentlyFailedAt(failed_at)) => {
-                if failed_at.elapsed() < PERMANENT_FETCH_FAILURE_COOLDOWN {
+            Some(TaskFetchState::PermanentlyFailed { at, .. }) => {
+                if at.elapsed() < PERMANENT_FETCH_FAILURE_COOLDOWN {
                     return None;
                 }
                 // Cooldown has elapsed; clear the entry and fall through to fetch again.
                 self.task_fetch_state.remove(task_id);
             }
-            Some(TaskFetchState::TransientlyFailedAt(failed_at)) => {
-                if failed_at.elapsed() < TRANSIENT_FETCH_FAILURE_COOLDOWN {
+            Some(TaskFetchState::TransientlyFailed { at, .. }) => {
+                if at.elapsed() < TRANSIENT_FETCH_FAILURE_COOLDOWN {
                     return None;
                 }
                 self.task_fetch_state.remove(task_id);
@@ -1448,11 +1453,11 @@ impl AgentConversationsModel {
 
         // Opportunistically purge other expired entries so the map doesn't grow unbounded.
         self.task_fetch_state.retain(|_, state| match state {
-            TaskFetchState::TransientlyFailedAt(failed_at) => {
-                failed_at.elapsed() < TRANSIENT_FETCH_FAILURE_COOLDOWN
+            TaskFetchState::TransientlyFailed { at, .. } => {
+                at.elapsed() < TRANSIENT_FETCH_FAILURE_COOLDOWN
             }
-            TaskFetchState::PermanentlyFailedAt(failed_at) => {
-                failed_at.elapsed() < PERMANENT_FETCH_FAILURE_COOLDOWN
+            TaskFetchState::PermanentlyFailed { at, .. } => {
+                at.elapsed() < PERMANENT_FETCH_FAILURE_COOLDOWN
             }
             TaskFetchState::InFlight => true,
         });
@@ -1482,13 +1487,17 @@ impl AgentConversationsModel {
                 }
                 RequestState::RequestFailed(e) => {
                     let now = Instant::now();
+                    let message = format!("{e}");
                     let new_state = if is_transient_http_error(&e) {
-                        TaskFetchState::TransientlyFailedAt(now)
+                        TaskFetchState::TransientlyFailed { at: now, message }
                     } else {
-                        TaskFetchState::PermanentlyFailedAt(now)
+                        TaskFetchState::PermanentlyFailed { at: now, message }
                     };
                     model.task_fetch_state.insert(task_id_clone, new_state);
                     report_error!(e);
+
+                    // On failure, this still emits an update event so that the details panel can re-render with the error message.
+                    ctx.emit(AgentConversationsModelEvent::TasksUpdated);
                 }
                 RequestState::RequestFailedRetryPending(_) => {
                     // Wait for a terminal outcome before updating dedup/backoff state.

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -77,10 +77,12 @@ enum TaskFetchState {
     /// The fetch returned a permanent (non-transient) HTTP error such as 401/403/404; remember
     /// when it failed so we can back off for [`PERMANENT_FETCH_FAILURE_COOLDOWN`] before
     /// retrying. We don't refuse forever in case permissions change mid-session.
-    PermanentlyFailedAt(Instant),
+    /// The `String` carries a human-readable description of the failure for display in the UI.
+    PermanentlyFailed { at: Instant, message: String },
     /// The retry chain just exhausted on a transient error; remember when it failed so we
     /// can back off for [`TRANSIENT_FETCH_FAILURE_COOLDOWN`] before retrying.
-    TransientlyFailedAt(Instant),
+    /// The `String` carries a human-readable description of the failure for display in the UI.
+    TransientlyFailed { at: Instant, message: String },
 }
 
 /// Protected eviction: we'll always keep at least 200 personal tasks in the model.
@@ -1392,14 +1394,17 @@ impl AgentConversationsModel {
         self.tasks.get(task_id).cloned()
     }
 
-    /// Returns `true` when the most recent fetch for `task_id` ended in a permanent
-    /// or transient failure and the cooldown has not yet elapsed. The caller can use
-    /// this to display an error state in the details panel.
-    pub fn is_task_fetch_failed(&self, task_id: &AmbientAgentTaskId) -> bool {
-        matches!(
-            self.task_fetch_state.get(task_id),
-            Some(TaskFetchState::PermanentlyFailedAt(_) | TaskFetchState::TransientlyFailedAt(_))
-        )
+    /// Returns the error message when the most recent fetch for `task_id` ended in a
+    /// permanent or transient failure and the cooldown has not yet elapsed. The caller
+    /// can use this to display an error state in the details panel.
+    pub fn task_fetch_error(&self, task_id: &AmbientAgentTaskId) -> Option<&str> {
+        match self.task_fetch_state.get(task_id) {
+            Some(
+                TaskFetchState::PermanentlyFailed { message, .. }
+                | TaskFetchState::TransientlyFailed { message, .. },
+            ) => Some(message),
+            _ => None,
+        }
     }
 
     /// Get raw task data by task ID, fetching from server if not in memory.
@@ -1430,15 +1435,15 @@ impl AgentConversationsModel {
         // one applies to a given id.
         match self.task_fetch_state.get(task_id) {
             Some(TaskFetchState::InFlight) => return None,
-            Some(TaskFetchState::PermanentlyFailedAt(failed_at)) => {
-                if failed_at.elapsed() < PERMANENT_FETCH_FAILURE_COOLDOWN {
+            Some(TaskFetchState::PermanentlyFailed { at, .. }) => {
+                if at.elapsed() < PERMANENT_FETCH_FAILURE_COOLDOWN {
                     return None;
                 }
                 // Cooldown has elapsed; clear the entry and fall through to fetch again.
                 self.task_fetch_state.remove(task_id);
             }
-            Some(TaskFetchState::TransientlyFailedAt(failed_at)) => {
-                if failed_at.elapsed() < TRANSIENT_FETCH_FAILURE_COOLDOWN {
+            Some(TaskFetchState::TransientlyFailed { at, .. }) => {
+                if at.elapsed() < TRANSIENT_FETCH_FAILURE_COOLDOWN {
                     return None;
                 }
                 self.task_fetch_state.remove(task_id);
@@ -1448,11 +1453,11 @@ impl AgentConversationsModel {
 
         // Opportunistically purge other expired entries so the map doesn't grow unbounded.
         self.task_fetch_state.retain(|_, state| match state {
-            TaskFetchState::TransientlyFailedAt(failed_at) => {
-                failed_at.elapsed() < TRANSIENT_FETCH_FAILURE_COOLDOWN
+            TaskFetchState::TransientlyFailed { at, .. } => {
+                at.elapsed() < TRANSIENT_FETCH_FAILURE_COOLDOWN
             }
-            TaskFetchState::PermanentlyFailedAt(failed_at) => {
-                failed_at.elapsed() < PERMANENT_FETCH_FAILURE_COOLDOWN
+            TaskFetchState::PermanentlyFailed { at, .. } => {
+                at.elapsed() < PERMANENT_FETCH_FAILURE_COOLDOWN
             }
             TaskFetchState::InFlight => true,
         });
@@ -1482,10 +1487,11 @@ impl AgentConversationsModel {
                 }
                 RequestState::RequestFailed(e) => {
                     let now = Instant::now();
+                    let message = format!("{e}");
                     let new_state = if is_transient_http_error(&e) {
-                        TaskFetchState::TransientlyFailedAt(now)
+                        TaskFetchState::TransientlyFailed { at: now, message }
                     } else {
-                        TaskFetchState::PermanentlyFailedAt(now)
+                        TaskFetchState::PermanentlyFailed { at: now, message }
                     };
                     model.task_fetch_state.insert(task_id_clone, new_state);
                     report_error!(e);

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -1392,6 +1392,16 @@ impl AgentConversationsModel {
         self.tasks.get(task_id).cloned()
     }
 
+    /// Returns `true` when the most recent fetch for `task_id` ended in a permanent
+    /// or transient failure and the cooldown has not yet elapsed. The caller can use
+    /// this to display an error state in the details panel.
+    pub fn is_task_fetch_failed(&self, task_id: &AmbientAgentTaskId) -> bool {
+        matches!(
+            self.task_fetch_state.get(task_id),
+            Some(TaskFetchState::PermanentlyFailedAt(_) | TaskFetchState::TransientlyFailedAt(_))
+        )
+    }
+
     /// Get raw task data by task ID, fetching from server if not in memory.
     /// If the task is already in memory, returns it immediately.
     /// If not, spawns an async task to fetch it from the server, stores it in memory,

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -2033,9 +2033,13 @@ fn test_get_or_async_fetch_task_data_returns_cached_task_without_fetching() {
             let mut model = create_test_model();
             model.tasks.insert(task_id, task.clone());
             // Sentinel: even if a permanent-failure entry is present, the cached task wins.
-            model
-                .task_fetch_state
-                .insert(task_id, TaskFetchState::PermanentlyFailedAt(Instant::now()));
+            model.task_fetch_state.insert(
+                task_id,
+                TaskFetchState::PermanentlyFailed {
+                    at: Instant::now(),
+                    message: "test".to_string(),
+                },
+            );
             model
         });
 
@@ -2049,7 +2053,7 @@ fn test_get_or_async_fetch_task_data_returns_cached_task_without_fetching() {
             // entry is left as-is and (importantly) no `InFlight` entry was added.
             assert!(matches!(
                 model.task_fetch_state.get(&task_id),
-                Some(TaskFetchState::PermanentlyFailedAt(_))
+                Some(TaskFetchState::PermanentlyFailed { .. })
             ));
         });
     });
@@ -2057,16 +2061,20 @@ fn test_get_or_async_fetch_task_data_returns_cached_task_without_fetching() {
 
 #[test]
 fn test_get_or_async_fetch_task_data_skips_when_permanently_failed() {
-    // A task id marked as `PermanentlyFailedAt` within its cooldown (e.g. very recent 403) must
+    // A task id marked as `PermanentlyFailed` within its cooldown (e.g. very recent 403) must
     // not spawn a new fetch.
     App::test((), |mut app| async move {
         let task_id: AmbientAgentTaskId = make_uuid(7001).parse().unwrap();
 
         let model_handle = app.add_singleton_model(|_| {
             let mut model = create_test_model();
-            model
-                .task_fetch_state
-                .insert(task_id, TaskFetchState::PermanentlyFailedAt(Instant::now()));
+            model.task_fetch_state.insert(
+                task_id,
+                TaskFetchState::PermanentlyFailed {
+                    at: Instant::now(),
+                    message: "403 Forbidden".to_string(),
+                },
+            );
             model
         });
 
@@ -2076,10 +2084,10 @@ fn test_get_or_async_fetch_task_data_skips_when_permanently_failed() {
 
         assert!(result.is_none());
         model_handle.update(&mut app, |model, _| {
-            // The state is unchanged — still permanently failed, no in-flight upgrade.
+            // The state is unchanged -- still permanently failed, no in-flight upgrade.
             assert!(matches!(
                 model.task_fetch_state.get(&task_id),
-                Some(TaskFetchState::PermanentlyFailedAt(_))
+                Some(TaskFetchState::PermanentlyFailed { .. })
             ));
         });
     });
@@ -2123,9 +2131,13 @@ fn test_get_or_async_fetch_task_data_skips_within_transient_cooldown() {
 
         let model_handle = app.add_singleton_model(|_| {
             let mut model = create_test_model();
-            model
-                .task_fetch_state
-                .insert(task_id, TaskFetchState::TransientlyFailedAt(Instant::now()));
+            model.task_fetch_state.insert(
+                task_id,
+                TaskFetchState::TransientlyFailed {
+                    at: Instant::now(),
+                    message: "500 Internal Server Error".to_string(),
+                },
+            );
             model
         });
 
@@ -2138,7 +2150,7 @@ fn test_get_or_async_fetch_task_data_skips_within_transient_cooldown() {
             // The transient entry is preserved (no upgrade to in-flight).
             assert!(matches!(
                 model.task_fetch_state.get(&task_id),
-                Some(TaskFetchState::TransientlyFailedAt(_))
+                Some(TaskFetchState::TransientlyFailed { .. })
             ));
         });
     });

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -124,6 +124,7 @@ struct PanelMouseStates {
     copy_run_id: MouseStateHandle,
     copy_environment_id: MouseStateHandle,
     copy_docker_image: MouseStateHandle,
+    copy_fetch_error: MouseStateHandle,
     copy_error: MouseStateHandle,
     copy_setup_commands: MouseStateHandle,
     skill_link: MouseStateHandle,
@@ -139,6 +140,7 @@ enum CopyButtonKind {
     RunId,
     EnvironmentId,
     DockerImage,
+    FetchError,
     Error,
     SetupCommands,
 }
@@ -492,7 +494,7 @@ impl ConversationDetailsData {
 
     /// Minimal details data for when we only know the task id (e.g. shared sessions)
     /// but have not loaded the full `AmbientAgentTask` yet.
-    pub fn from_task_id(task_id: AmbientAgentTaskId, fetch_failed: bool) -> Self {
+    pub fn from_task_id(task_id: AmbientAgentTaskId, fetch_error: Option<String>) -> Self {
         ConversationDetailsData {
             mode: PanelMode::Task {
                 task_id: Some(task_id),
@@ -514,7 +516,7 @@ impl ConversationDetailsData {
             copy_link_url: None,
             skill_spec: None,
             harness: None,
-            fetch_error: fetch_failed.then(|| "Failed to load run details".to_string()),
+            fetch_error,
         }
     }
 
@@ -577,6 +579,7 @@ pub enum ConversationDetailsPanelAction {
     CopyRunId,
     CopyEnvironmentId,
     CopyDockerImage,
+    CopyFetchError,
     CopyError,
     CopySetupCommands(String),
     Focus,
@@ -1595,6 +1598,7 @@ impl ConversationDetailsPanel {
             CopyButtonKind::RunId => self.mouse_states.copy_run_id.clone(),
             CopyButtonKind::EnvironmentId => self.mouse_states.copy_environment_id.clone(),
             CopyButtonKind::DockerImage => self.mouse_states.copy_docker_image.clone(),
+            CopyButtonKind::FetchError => self.mouse_states.copy_fetch_error.clone(),
             CopyButtonKind::Error => self.mouse_states.copy_error.clone(),
             CopyButtonKind::SetupCommands => self.mouse_states.copy_setup_commands.clone(),
         }
@@ -1768,17 +1772,24 @@ impl View for ConversationDetailsPanel {
             .with_width(STATUS_ICON_SIZE)
             .with_height(STATUS_ICON_SIZE)
             .finish();
-            let error_text = Text::new(
-                fetch_error.clone(),
-                appearance.ui_font_family(),
-                ui_font_size,
-            )
-            .with_color(theme.ansi_fg_red())
-            .finish();
+            let error_text = render_copyable_text_field(
+                CopyableTextFieldConfig::new(fetch_error.clone())
+                    .with_font_size(ui_font_size)
+                    .with_text_color(theme.ansi_fg_red())
+                    .with_wrap_text(true)
+                    .with_icon_size(16.)
+                    .with_mouse_state(self.mouse_state_for_copy_button(CopyButtonKind::FetchError))
+                    .with_last_copied_at(self.copy_feedback_times.get(&CopyButtonKind::FetchError))
+                    .with_cross_axis_alignment(CrossAxisAlignment::Start),
+                |ctx| {
+                    ctx.dispatch_typed_action(ConversationDetailsPanelAction::CopyFetchError);
+                },
+                app,
+            );
             let error_row = Flex::row()
-                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_cross_axis_alignment(CrossAxisAlignment::Start)
                 .with_child(Container::new(error_icon).with_margin_right(4.).finish())
-                .with_child(error_text)
+                .with_child(Expanded::new(1., error_text).finish())
                 .finish();
             let error_banner = Container::new(error_row)
                 .with_uniform_padding(8.)
@@ -2092,6 +2103,13 @@ impl TypedActionView for ConversationDetailsPanel {
                             self.record_copy(CopyButtonKind::DockerImage, ctx);
                         }
                     }
+                }
+            }
+            ConversationDetailsPanelAction::CopyFetchError => {
+                if let Some(error) = &self.data.fetch_error {
+                    ctx.clipboard()
+                        .write(ClipboardContent::plain_text(error.clone()));
+                    self.record_copy(CopyButtonKind::FetchError, ctx);
                 }
             }
             ConversationDetailsPanelAction::CopyError => {

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -492,7 +492,7 @@ impl ConversationDetailsData {
 
     /// Minimal details data for when we only know the task id (e.g. shared sessions)
     /// but have not loaded the full `AmbientAgentTask` yet.
-    pub fn from_task_id(task_id: AmbientAgentTaskId, fetch_failed: bool) -> Self {
+    pub fn from_task_id(task_id: AmbientAgentTaskId, fetch_error: Option<String>) -> Self {
         ConversationDetailsData {
             mode: PanelMode::Task {
                 task_id: Some(task_id),
@@ -514,7 +514,7 @@ impl ConversationDetailsData {
             copy_link_url: None,
             skill_spec: None,
             harness: None,
-            fetch_error: fetch_failed.then(|| "Failed to load run details".to_string()),
+            fetch_error,
         }
     }
 

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -214,6 +214,8 @@ pub struct ConversationDetailsData {
     skill_spec: Option<SkillSpec>,
     /// Execution harness for this conversation/task.
     harness: Option<Harness>,
+    /// Error message displayed when the API call to fetch run data failed.
+    fetch_error: Option<String>,
 }
 
 impl ConversationDetailsData {
@@ -323,6 +325,7 @@ impl ConversationDetailsData {
             copy_link_url,
             skill_spec: None,
             harness,
+            fetch_error: None,
         }
     }
 
@@ -384,6 +387,7 @@ impl ConversationDetailsData {
             copy_link_url,
             skill_spec,
             harness,
+            fetch_error: None,
         }
     }
 
@@ -455,6 +459,7 @@ impl ConversationDetailsData {
                 copy_link_url,
                 skill_spec,
                 harness,
+                fetch_error: None,
             };
         }
 
@@ -481,12 +486,13 @@ impl ConversationDetailsData {
             copy_link_url,
             skill_spec: None,
             harness,
+            fetch_error: None,
         }
     }
 
     /// Minimal details data for when we only know the task id (e.g. shared sessions)
     /// but have not loaded the full `AmbientAgentTask` yet.
-    pub fn from_task_id(task_id: AmbientAgentTaskId) -> Self {
+    pub fn from_task_id(task_id: AmbientAgentTaskId, fetch_failed: bool) -> Self {
         ConversationDetailsData {
             mode: PanelMode::Task {
                 task_id: Some(task_id),
@@ -508,6 +514,7 @@ impl ConversationDetailsData {
             copy_link_url: None,
             skill_spec: None,
             harness: None,
+            fetch_error: fetch_failed.then(|| "Failed to load run details".to_string()),
         }
     }
 
@@ -549,6 +556,7 @@ impl ConversationDetailsData {
             copy_link_url,
             skill_spec: None,
             harness,
+            fetch_error: None,
         }
     }
 }
@@ -1749,6 +1757,40 @@ impl View for ConversationDetailsPanel {
             .with_margin_bottom(FIELD_SPACING)
             .finish(),
         );
+
+        // Fetch error banner (shown when the API call to load run data failed)
+        if let Some(fetch_error) = &self.data.fetch_error {
+            let error_icon = ConstrainedBox::new(
+                Icon::Triangle
+                    .to_warpui_icon(theme.ansi_fg_red().into())
+                    .finish(),
+            )
+            .with_width(STATUS_ICON_SIZE)
+            .with_height(STATUS_ICON_SIZE)
+            .finish();
+            let error_text = Text::new(
+                fetch_error.clone(),
+                appearance.ui_font_family(),
+                ui_font_size,
+            )
+            .with_color(theme.ansi_fg_red())
+            .finish();
+            let error_row = Flex::row()
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_child(Container::new(error_icon).with_margin_right(4.).finish())
+                .with_child(error_text)
+                .finish();
+            let error_banner = Container::new(error_row)
+                .with_uniform_padding(8.)
+                .with_background(coloru_with_opacity(theme.ansi_fg_red(), 10))
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+                .finish();
+            content.add_child(
+                Container::new(error_banner)
+                    .with_margin_bottom(FIELD_SPACING)
+                    .finish(),
+            );
+        }
 
         // Status section
         if let Some(status_section) = self.render_status_section(appearance) {

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -922,10 +922,11 @@ impl TerminalView {
                 .as_ref()
                 .map(|task| ConversationDetailsData::from_task(task, None, None, ctx))
                 .unwrap_or_else(|| {
-                    let fetch_failed = conversations_handle
+                    let fetch_error = conversations_handle
                         .as_ref(ctx)
-                        .is_task_fetch_failed(&task_id);
-                    ConversationDetailsData::from_task_id(task_id, fetch_failed)
+                        .task_fetch_error(&task_id)
+                        .map(str::to_owned);
+                    ConversationDetailsData::from_task_id(task_id, fetch_error)
                 });
             self.conversation_details_panel.update(ctx, |panel, ctx| {
                 panel.set_conversation_details(data, ctx);

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -912,15 +912,21 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         if let Some(task_id) = self.ambient_agent_task_id_for_details_panel(ctx) {
-            let task = crate::ai::agent_conversations_model::AgentConversationsModel::handle(ctx)
-                .update(ctx, |model, ctx| {
-                    model.get_or_async_fetch_task_data(&task_id, ctx)
-                });
+            let conversations_handle =
+                crate::ai::agent_conversations_model::AgentConversationsModel::handle(ctx);
+            let task = conversations_handle.update(ctx, |model, ctx| {
+                model.get_or_async_fetch_task_data(&task_id, ctx)
+            });
 
             let data = task
                 .as_ref()
                 .map(|task| ConversationDetailsData::from_task(task, None, None, ctx))
-                .unwrap_or_else(|| ConversationDetailsData::from_task_id(task_id));
+                .unwrap_or_else(|| {
+                    let fetch_failed = conversations_handle
+                        .as_ref(ctx)
+                        .is_task_fetch_failed(&task_id);
+                    ConversationDetailsData::from_task_id(task_id, fetch_failed)
+                });
             self.conversation_details_panel.update(ctx, |panel, ctx| {
                 panel.set_conversation_details(data, ctx);
             });

--- a/app/src/workspace/view/wasm_view.rs
+++ b/app/src/workspace/view/wasm_view.rs
@@ -196,11 +196,13 @@ impl Workspace {
                 }
 
                 // Task not yet available - check if the fetch failed and show error state
-                let fetch_failed = conversations_model_handle
+                if let Some(error_message) = conversations_model_handle
                     .as_ref(ctx)
-                    .is_task_fetch_failed(&task_id);
-                if fetch_failed {
-                    let details = ConversationDetailsData::from_task_id(task_id, true);
+                    .task_fetch_error(&task_id)
+                    .map(str::to_owned)
+                {
+                    let details =
+                        ConversationDetailsData::from_task_id(task_id, Some(error_message));
                     panel.set_conversation_details(details, ctx);
                     ctx.notify();
                     return;

--- a/app/src/workspace/view/wasm_view.rs
+++ b/app/src/workspace/view/wasm_view.rs
@@ -194,6 +194,17 @@ impl Workspace {
                     ctx.notify();
                     return;
                 }
+
+                // Task not yet available - check if the fetch failed and show error state
+                let fetch_failed = conversations_model_handle
+                    .as_ref(ctx)
+                    .is_task_fetch_failed(&task_id);
+                if fetch_failed {
+                    let details = ConversationDetailsData::from_task_id(task_id, true);
+                    panel.set_conversation_details(details, ctx);
+                    ctx.notify();
+                    return;
+                }
             }
 
             // Otherwise, populate from conversation


### PR DESCRIPTION
## Description
When the `/api/v1/agent/runs/` API call fails while fetching run info for the conversation details panel, the panel now shows an error state instead of silently displaying a bare "Cloud agent run" title with no details.

Instead, we should show the error message so that the user knows something went wrong and can troubleshoot or report the error.

## Testing
- [x] Verified compilation with `cargo check --package warp`
- [x] Verified formatting with `cargo fmt`

### Screenshots / Videos

https://www.loom.com/share/e7816b6081e1445c9a694736bc33ea77

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: The details panel for cloud agent runs now displays any failures fetching the agent metadata

_Conversation: https://staging.warp.dev/conversation/b6e0e0e7-f9c7-45de-b750-20cdc029ad8e_
_Run: https://oz.staging.warp.dev/runs/019e1dc6-cd84-74b9-a544-8e704c214bd9_
_This PR was generated with [Oz](https://warp.dev/oz)._
