### PR TITLE
tell Inno Setup to kill the minidump server process if it failed to exit

### DIFF
--- a/app/src/autoupdate/windows.rs
+++ b/app/src/autoupdate/windows.rs
@@ -77,25 +77,37 @@ fn autoupdate_log_file() -> Result<PathBuf> {
     warp_logging::log_directory().map(|dir| dir.join(UPDATE_LOG_FILENAME))
 }
 
+fn parse_exit_code_after_marker(contents_lowercase: &[u8], failed_marker: &[u8]) -> Option<i32> {
+    const EXIT_CODE_MARKER: &[u8] = b"exit code: ";
+
+    let failed_pos = memchr::memmem::find(contents_lowercase, failed_marker)?;
+    let after_failed = &contents_lowercase[failed_pos..];
+    let marker_pos = memchr::memmem::find(after_failed, EXIT_CODE_MARKER)?;
+    let after_marker = &after_failed[marker_pos + EXIT_CODE_MARKER.len()..];
+    let sign_len = if after_marker.first() == Some(&b'-') {
+        1
+    } else {
+        0
+    };
+    let digit_len = after_marker[sign_len..]
+        .iter()
+        .take_while(|b| b.is_ascii_digit())
+        .count();
+    if digit_len == 0 {
+        return None;
+    }
+    std::str::from_utf8(&after_marker[..sign_len + digit_len])
+        .ok()?
+        .parse()
+        .ok()
+}
+
 /// Parses the taskkill exit code from an Inno Setup log containing a
 /// "force-kill failed for" line. Returns `None` if no such line is found or
 /// the exit code cannot be parsed.
 fn parse_forcekill_exit_code(contents_lowercase: &[u8]) -> Option<i32> {
     const FAILED_MARKER: &[u8] = b"force-kill failed for";
-    const EXIT_CODE_MARKER: &[u8] = b"exit code: ";
-
-    let failed_pos = memchr::memmem::find(contents_lowercase, FAILED_MARKER)?;
-    let after_failed = &contents_lowercase[failed_pos..];
-    let marker_pos = memchr::memmem::find(after_failed, EXIT_CODE_MARKER)?;
-    let after_marker = &after_failed[marker_pos + EXIT_CODE_MARKER.len()..];
-    let digit_len = after_marker
-        .iter()
-        .take_while(|b| b.is_ascii_digit())
-        .count();
-    std::str::from_utf8(&after_marker[..digit_len])
-        .ok()?
-        .parse()
-        .ok()
+    parse_exit_code_after_marker(contents_lowercase, FAILED_MARKER)
 }
 
 /// Parses the PowerShell exit code from an Inno Setup log containing a
@@ -103,20 +115,7 @@ fn parse_forcekill_exit_code(contents_lowercase: &[u8]) -> Option<i32> {
 /// found or the exit code cannot be parsed.
 fn parse_minidump_cleanup_exit_code(contents_lowercase: &[u8]) -> Option<i32> {
     const FAILED_MARKER: &[u8] = b"minidump-server cleanup failed";
-    const EXIT_CODE_MARKER: &[u8] = b"exit code: ";
-
-    let failed_pos = memchr::memmem::find(contents_lowercase, FAILED_MARKER)?;
-    let after_failed = &contents_lowercase[failed_pos..];
-    let marker_pos = memchr::memmem::find(after_failed, EXIT_CODE_MARKER)?;
-    let after_marker = &after_failed[marker_pos + EXIT_CODE_MARKER.len()..];
-    let digit_len = after_marker
-        .iter()
-        .take_while(|b| b.is_ascii_digit())
-        .count();
-    std::str::from_utf8(&after_marker[..digit_len])
-        .ok()?
-        .parse()
-        .ok()
+    parse_exit_code_after_marker(contents_lowercase, FAILED_MARKER)
 }
 
 /// Checks the autoupdate log file from a previous update attempt.
@@ -325,7 +324,7 @@ fn app_name_prefix(channel: Channel) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_forcekill_exit_code;
+    use super::{parse_forcekill_exit_code, parse_minidump_cleanup_exit_code};
 
     fn log(line: &str) -> Vec<u8> {
         line.to_ascii_lowercase().into_bytes()
@@ -369,9 +368,32 @@ mod tests {
         let contents = log("force-kill failed for dev.exe");
         assert_eq!(parse_forcekill_exit_code(&contents), None);
     }
+    #[test]
+    fn returns_none_when_exit_code_has_no_digits() {
+        // Malformed log line — marker present but no parseable integer.
+        let contents = log("force-kill failed for dev.exe (exit code: -)");
+        assert_eq!(parse_forcekill_exit_code(&contents), None);
+    }
+
+    #[test]
+    fn parses_signed_minidump_cleanup_exit_code() {
+        // PowerShell can report signed HRESULT values for cleanup failures.
+        let contents = log("minidump-server cleanup failed (exit code: -2147024891)");
+        assert_eq!(
+            parse_minidump_cleanup_exit_code(&contents),
+            Some(-2147024891)
+        );
+    }
+
+    #[test]
+    fn parses_unsigned_minidump_cleanup_exit_code() {
+        let contents = log("minidump-server cleanup failed (exit code: 5)");
+        assert_eq!(parse_minidump_cleanup_exit_code(&contents), Some(5));
+    }
 
     #[test]
     fn returns_none_for_empty_log() {
         assert_eq!(parse_forcekill_exit_code(b""), None);
+        assert_eq!(parse_minidump_cleanup_exit_code(b""), None);
     }
 }

--- a/app/src/autoupdate/windows.rs
+++ b/app/src/autoupdate/windows.rs
@@ -98,6 +98,27 @@ fn parse_forcekill_exit_code(contents_lowercase: &[u8]) -> Option<i32> {
         .ok()
 }
 
+/// Parses the PowerShell exit code from an Inno Setup log containing a
+/// "minidump-server cleanup failed" line. Returns `None` if no such line is
+/// found or the exit code cannot be parsed.
+fn parse_minidump_cleanup_exit_code(contents_lowercase: &[u8]) -> Option<i32> {
+    const FAILED_MARKER: &[u8] = b"minidump-server cleanup failed";
+    const EXIT_CODE_MARKER: &[u8] = b"exit code: ";
+
+    let failed_pos = memchr::memmem::find(contents_lowercase, FAILED_MARKER)?;
+    let after_failed = &contents_lowercase[failed_pos..];
+    let marker_pos = memchr::memmem::find(after_failed, EXIT_CODE_MARKER)?;
+    let after_marker = &after_failed[marker_pos + EXIT_CODE_MARKER.len()..];
+    let digit_len = after_marker
+        .iter()
+        .take_while(|b| b.is_ascii_digit())
+        .count();
+    std::str::from_utf8(&after_marker[..digit_len])
+        .ok()?
+        .parse()
+        .ok()
+}
+
 /// Checks the autoupdate log file from a previous update attempt.
 /// Sends telemetry for specific known issues, and sends a Sentry event if errors are found.
 /// The log file is renamed after processing to avoid duplicate reports on subsequent launches.
@@ -164,6 +185,15 @@ pub(super) fn check_and_report_update_errors(ctx: &mut AppContext) {
                 ctx
             );
         }
+    }
+
+    // Fired when the PowerShell cleanup of the orphaned minidump server process
+    // returned a non-zero exit code.
+    if let Some(exit_code) = parse_minidump_cleanup_exit_code(&contents_lowercase) {
+        crate::send_telemetry_sync_from_app_ctx!(
+            TelemetryEvent::AutoupdateMinidumpCleanupFailed { exit_code },
+            ctx
+        );
     }
 
     #[cfg(feature = "crash_reporting")]

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -6056,7 +6056,9 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             #[cfg(windows)]
             Self::AutoupdateForcekillFailed { .. } => "Windows Autoupdate: Forcekill Failed",
             #[cfg(windows)]
-            Self::AutoupdateMinidumpCleanupFailed { .. } => "Windows Autoupdate: Minidump Cleanup Failed",
+            Self::AutoupdateMinidumpCleanupFailed { .. } => {
+                "Windows Autoupdate: Minidump Cleanup Failed"
+            }
             Self::ToggleCodebaseContext => "Toggle Agent Mode Codebase Context",
             Self::ToggleAutoIndexing => "Toggle Codebase Context Autoindexing",
             Self::ActiveIndexedReposChanged => "Active Indexed Repos Changed",

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -2349,6 +2349,10 @@ pub enum TelemetryEvent {
     AutoupdateForcekillFailed {
         exit_code: i32,
     },
+    #[cfg(windows)]
+    AutoupdateMinidumpCleanupFailed {
+        exit_code: i32,
+    },
     ExecutedWarpDrivePrompt {
         id: Option<WorkflowId>,
         selection_source: WorkflowSelectionSource,
@@ -4334,6 +4338,10 @@ impl TelemetryEvent {
             TelemetryEvent::AutoupdateForcekillFailed { exit_code } => Some(json!({
                 "exit_code": exit_code,
             })),
+            #[cfg(windows)]
+            TelemetryEvent::AutoupdateMinidumpCleanupFailed { exit_code } => Some(json!({
+                "exit_code": exit_code,
+            })),
             TelemetryEvent::InputBufferSubmitted {
                 input_type,
                 is_locked,
@@ -5070,7 +5078,8 @@ impl TelemetryEvent {
             | TelemetryEvent::AutoupdateUnableToCloseApplications
             | TelemetryEvent::AutoupdateFileInUse
             | TelemetryEvent::AutoupdateMutexTimeout
-            | TelemetryEvent::AutoupdateForcekillFailed { .. } => false,
+            | TelemetryEvent::AutoupdateForcekillFailed { .. }
+            | TelemetryEvent::AutoupdateMinidumpCleanupFailed { .. } => false,
         }
     }
 
@@ -5514,7 +5523,8 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             | Self::AutoupdateUnableToCloseApplications
             | Self::AutoupdateFileInUse
             | Self::AutoupdateMutexTimeout
-            | Self::AutoupdateForcekillFailed { .. } => EnablementState::Always,
+            | Self::AutoupdateForcekillFailed { .. }
+            | Self::AutoupdateMinidumpCleanupFailed { .. } => EnablementState::Always,
             Self::ToggleCodebaseContext => EnablementState::Always,
             Self::ToggleAutoIndexing => EnablementState::Always,
             Self::AgentModeRatedResponse => {
@@ -6045,6 +6055,8 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             Self::AutoupdateMutexTimeout => "Windows Autoupdate: Mutex Timeout",
             #[cfg(windows)]
             Self::AutoupdateForcekillFailed { .. } => "Windows Autoupdate: Forcekill Failed",
+            #[cfg(windows)]
+            Self::AutoupdateMinidumpCleanupFailed { .. } => "Windows Autoupdate: Minidump Cleanup Failed",
             Self::ToggleCodebaseContext => "Toggle Agent Mode Codebase Context",
             Self::ToggleAutoIndexing => "Toggle Codebase Context Autoindexing",
             Self::ActiveIndexedReposChanged => "Active Indexed Repos Changed",
@@ -6864,6 +6876,10 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             #[cfg(windows)]
             Self::AutoupdateForcekillFailed { .. } => {
                 "The Windows auto-update installer failed to force-kill Warp after the mutex timeout"
+            }
+            #[cfg(windows)]
+            Self::AutoupdateMinidumpCleanupFailed { .. } => {
+                "The Windows auto-update installer failed to clean up the orphaned minidump server process"
             }
             Self::ToggleCodebaseContext => {
                 "Toggled on/off the enablement of codebase context usage for Agent Mode."

--- a/script/windows/windows-installer.iss
+++ b/script/windows/windows-installer.iss
@@ -219,7 +219,7 @@ begin
           which causes the file-copy step to fail with "Access is denied".
           We identify it by the "minidump-server" argument in its command line. }
         Exec('powershell.exe',
-          '-NoProfile -NoLogo -Command "$stopError = 0; Get-CimInstance Win32_Process -Filter \"Name=''''{#MyAppExeName}'''' and CommandLine like ''''%minidump-server%''''\" | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorVariable e -ErrorAction SilentlyContinue; if ($e) { $stopError = $e[0].Exception.HResult } }; exit $stopError"',
+          '-NoProfile -NoLogo -Command "$stopError = 0; Get-CimInstance Win32_Process -Filter \"Name=''{#MyAppExeName}'' and CommandLine like ''%minidump-server%''\" | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorVariable e -ErrorAction SilentlyContinue; if ($e) { $stopError = $e[0].Exception.HResult } }; exit $stopError"',
           '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
         if ResultCode <> 0 then
           Log('minidump-server cleanup failed (exit code: ' + IntToStr(ResultCode) + ')');

--- a/script/windows/windows-installer.iss
+++ b/script/windows/windows-installer.iss
@@ -219,7 +219,7 @@ begin
           which causes the file-copy step to fail with "Access is denied".
           We identify it by the "minidump-server" argument in its command line. }
         Exec('powershell.exe',
-          '-NoProfile -NoLogo -Command "Get-CimInstance Win32_Process -Filter \"Name=''''{#MyAppExeName}'''' and CommandLine like ''''%minidump-server%''''\" | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"',
+          '-NoProfile -NoLogo -Command "$stopError = 0; Get-CimInstance Win32_Process -Filter \"Name=''''{#MyAppExeName}'''' and CommandLine like ''''%minidump-server%''''\" | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorVariable e -ErrorAction SilentlyContinue; if ($e) { $stopError = $e[0].Exception.HResult } }; exit $stopError"',
           '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
         if ResultCode <> 0 then
           Log('minidump-server cleanup failed (exit code: ' + IntToStr(ResultCode) + ')');

--- a/script/windows/windows-installer.iss
+++ b/script/windows/windows-installer.iss
@@ -212,7 +212,19 @@ begin
         Sleep(1000);
       end
       else
+      begin
         Log('Warp has exited; proceeding with file installation.');
+        { The minidump crash-reporter is a child process (same exe name) that
+          may outlive the main Warp process. It holds the executable file open,
+          which causes the file-copy step to fail with "Access is denied".
+          We identify it by the "minidump-server" argument in its command line. }
+        Exec('powershell.exe',
+          '-NoProfile -NoLogo -Command "Get-CimInstance Win32_Process -Filter \"Name=''''{#MyAppExeName}'''' and CommandLine like ''''%minidump-server%''''\" | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"',
+          '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+        if ResultCode <> 0 then
+          Log('minidump-server cleanup failed (exit code: ' + IntToStr(ResultCode) + ')');
+        Sleep(500);
+      end;
     end;
   end;
 


### PR DESCRIPTION
## Description

This PR is to help with Windows auto-update failures. Specifically, we are getting blocked updates due to the minidump server not exiting.

This is a follow-up to #10528.

As of that PR, the minidump server should exit on its own. However, if for some that fails, we add a fail-safe into inno setup to close this process by force.

I've also added the appropriate telemetry for when this fail-safe fails.

## Linked Issue

This PR also helps with #10202. Master issue is #10044

## Testing

I ran the powershell command manually in a terminal session to verify that it kills the minidump server as intended.

