### PR TITLE
avoid dropping installer file handle to prevent race

### DIFF
--- a/app/src/autoupdate/windows.rs
+++ b/app/src/autoupdate/windows.rs
@@ -259,14 +259,6 @@ pub(super) fn relaunch() -> Result<()> {
         ])
         .spawn()?;
 
-    // DEV ONLY: Sleep after spawning the installer so this process is still alive
-    // when Inno Setup tries to overwrite files. This reliably reproduces the
-    // auto-update race condition (APP-3702) for testing.
-    if matches!(ChannelState::channel(), Channel::Dev) {
-        log::info!("DEV: Sleeping 10s after spawning installer to reproduce update race");
-        std::thread::sleep(Duration::from_secs(10));
-    }
-
     Ok(())
 }
 

--- a/app/src/autoupdate/windows.rs
+++ b/app/src/autoupdate/windows.rs
@@ -219,7 +219,11 @@ pub(super) fn check_and_report_update_errors(ctx: &mut AppContext) {
 
 pub(super) fn relaunch() -> Result<()> {
     let install_dir = install_dir()?;
-    let Some(installer_path) = INSTALLER_PATH.lock().take() else {
+    let Some(installer_path) = INSTALLER_PATH
+        .lock()
+        .as_ref()
+        .map(|path| path.to_path_buf())
+    else {
         bail!("No installer path");
     };
 


### PR DESCRIPTION
## Description

This PR avoids deletion of the inno setup installer during auto-update.

The linked issue shows that in some cases, auto-update fails with a "file not found" error dialog. This is because of a race condition between dropping the `TempPath`, an RAII wrapper around the installer exe, and the installer itself actually starting up. It may have seemed like the installer should have started up sequentially first by calling a blocking call to `spawn`. This is not so b/c the exe actually spawns another process and exits immediately. To resolve this race, we simply do not delete the installer. There is no need, as the installer lives in `%TEMP%` anyways. 

## Linked Issue

This PR addresses #10767. Master issue is #10044.

## Testing

Untested due to the lack of a robust reproduction case.
