### PR TITLE
Enable heap usage tracking on stable macOS builds

### DIFF
--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -304,6 +304,8 @@ elif [[ $RELEASE_CHANNEL = "stable" ]]; then
     BUNDLE_ID="dev.warp.Warp-Stable"
     WARP_APP_NAME="Warp"
     WARP_SCHEME_NAME="warp"
+    # Enable heap usage tracking & profiling using jemalloc through pprof.
+    FEATURES="$FEATURES,jemalloc_pprof,heap_usage_tracking"
 elif [[ $RELEASE_CHANNEL = "oss" ]]; then
     WARP_BIN="warp-oss"
     BUNDLE_ID="dev.warp.WarpOss"


### PR DESCRIPTION
## Description
Enable `jemalloc_pprof` and `heap_usage_tracking` Cargo features for the stable release channel in the macOS bundle script. These features were already enabled for dev and preview channels; this extends the same automatic heap profile alerting via Sentry to stable builds on macOS.

When excessive memory usage is detected in a stable build, a heap profile will be captured via jemalloc/pprof and sent to Sentry with a memory breakdown, giving us visibility into memory issues affecting production users.

No Linux or other platform changes — this is macOS-only since the bundle script is platform-specific.

Mirrors warpdotdev/warp-internal#25632.

## Linked Issue
- N/A

## Testing
- [x] Verified the bundle script parses correctly (`bash -n script/macos/bundle`)
- [ ] I have manually tested my changes locally with `./script/run`

This is a build configuration change that will be validated by CI when it builds the stable channel.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

<!--
## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Enabled automatic memory profiling on macOS stable builds for better diagnostics of excessive memory usage.
-->
