### PR TITLE
feat: default environment/host selection and deferred auto-launch for orchestration config UI

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -10,8 +10,10 @@ use ai::agent::action_result::{
     RunAgentsAgentOutcome, RunAgentsAgentOutcomeKind, RunAgentsLaunchedExecutionMode,
     RunAgentsResult,
 };
-use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationExecutionMode};
+use ai::agent::orchestration_config::OrchestrationConfig;
 use ai::skills::SkillReference;
+
+use crate::ai::blocklist::inline_action::orchestration_controls::OrchestrationEditState;
 use futures::{future::BoxFuture, FutureExt};
 use warp_core::execution_mode::AppExecutionMode;
 use warpui::{Entity, ModelContext, ModelHandle};
@@ -262,7 +264,7 @@ impl RunAgentsExecutor {
         // When auto-executing (autonomous/CLI-driver mode), the confirmation
         // card is bypassed. Replicate its policy/normalization here:
         // 1. Deny if the orchestration config is explicitly disapproved.
-        // 2. Resolve empty model/harness/execution_mode from the approved config.
+        // 2. Override model/harness/execution_mode from the approved config.
         if AppExecutionMode::as_ref(ctx).is_autonomous() {
             if let Some(conversation) =
                 BlocklistAIHistoryModel::as_ref(ctx).conversation(&parent_conversation_id)
@@ -319,29 +321,19 @@ enum ChildSlot {
     Pending(async_channel::Receiver<StartAgentOutcome>),
 }
 
-/// Resolves empty fields on a `RunAgentsRequest` from an approved
-/// orchestration config — the same normalization the confirmation card
-/// applies via `OrchestrationEditState::resolve_from_config`.
+/// Unconditionally overrides run-wide fields on a `RunAgentsRequest`
+/// from the approved orchestration config, delegating to
+/// `OrchestrationEditState::override_from_approved_config`.
 fn resolve_request_from_config(request: &mut RunAgentsRequest, config: &OrchestrationConfig) {
-    if request.harness_type.is_empty() && !config.harness_type.is_empty() {
-        request.harness_type = config.harness_type.clone();
-    }
-    if request.model_id.is_empty() && !config.model_id.is_empty() {
-        request.model_id = config.model_id.clone();
-    }
-    if !request.execution_mode.is_remote() && config.execution_mode.is_remote() {
-        if let OrchestrationExecutionMode::Remote {
-            environment_id,
-            worker_host,
-        } = &config.execution_mode
-        {
-            request.execution_mode = RunAgentsExecutionMode::Remote {
-                environment_id: environment_id.clone(),
-                worker_host: worker_host.clone(),
-                computer_use_enabled: false,
-            };
-        }
-    }
+    let mut edit_state = OrchestrationEditState::from_run_agents_fields(
+        &request.model_id,
+        &request.harness_type,
+        &request.execution_mode,
+    );
+    edit_state.override_from_approved_config(config);
+    request.model_id = edit_state.model_id;
+    request.harness_type = edit_state.harness_type;
+    request.execution_mode = edit_state.execution_mode;
 }
 
 /// Defence-in-depth validation; mirrors the card view's

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -10,8 +10,10 @@ use ai::agent::action_result::{
     RunAgentsAgentOutcome, RunAgentsAgentOutcomeKind, RunAgentsLaunchedExecutionMode,
     RunAgentsResult,
 };
+use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationExecutionMode};
 use ai::skills::SkillReference;
 use futures::{future::BoxFuture, FutureExt};
+use warp_core::execution_mode::AppExecutionMode;
 use warpui::{Entity, ModelContext, ModelHandle};
 
 use super::start_agent::{StartAgentExecutor, StartAgentOutcome};
@@ -253,9 +255,35 @@ impl RunAgentsExecutor {
         let AIAgentActionType::RunAgents(request) = action else {
             return ActionExecution::InvalidAction;
         };
-        let request = request.clone();
+        let mut request = request.clone();
         let action_id = id.clone();
         let parent_conversation_id = input.conversation_id;
+
+        // When auto-executing (autonomous/CLI-driver mode), the confirmation
+        // card is bypassed. Replicate its policy/normalization here:
+        // 1. Deny if the orchestration config is explicitly disapproved.
+        // 2. Resolve empty model/harness/execution_mode from the approved config.
+        if AppExecutionMode::as_ref(ctx).is_autonomous() {
+            if let Some(conversation) =
+                BlocklistAIHistoryModel::as_ref(ctx).conversation(&parent_conversation_id)
+            {
+                if let Some((config, status)) =
+                    conversation.orchestration_config_for_plan(&request.plan_id)
+                {
+                    if status.is_disapproved() {
+                        return ActionExecution::Sync(AIAgentActionResultType::RunAgents(
+                            RunAgentsResult::Denied {
+                                reason: "Orchestration config was disapproved".to_string(),
+                            },
+                        ));
+                    }
+                    if status.is_approved() {
+                        resolve_request_from_config(&mut request, config);
+                    }
+                }
+            }
+        }
+
         let receiver = self.dispatch_run_agents(action_id, request, parent_conversation_id, ctx);
 
         ActionExecution::new_async(
@@ -270,10 +298,11 @@ impl RunAgentsExecutor {
     pub(super) fn should_autoexecute(
         &self,
         _input: ExecuteActionInput,
-        _ctx: &mut ModelContext<Self>,
+        ctx: &mut ModelContext<Self>,
     ) -> bool {
-        // Confirmation card always required.
-        false
+        // Non-interactive (CLI driver) agents cannot present a
+        // confirmation card, so they must auto-execute.
+        AppExecutionMode::as_ref(ctx).is_autonomous()
     }
 
     pub(super) fn preprocess_action(
@@ -288,6 +317,31 @@ impl RunAgentsExecutor {
 enum ChildSlot {
     Failed(String),
     Pending(async_channel::Receiver<StartAgentOutcome>),
+}
+
+/// Resolves empty fields on a `RunAgentsRequest` from an approved
+/// orchestration config — the same normalization the confirmation card
+/// applies via `OrchestrationEditState::resolve_from_config`.
+fn resolve_request_from_config(request: &mut RunAgentsRequest, config: &OrchestrationConfig) {
+    if request.harness_type.is_empty() && !config.harness_type.is_empty() {
+        request.harness_type = config.harness_type.clone();
+    }
+    if request.model_id.is_empty() && !config.model_id.is_empty() {
+        request.model_id = config.model_id.clone();
+    }
+    if !request.execution_mode.is_remote() && config.execution_mode.is_remote() {
+        if let OrchestrationExecutionMode::Remote {
+            environment_id,
+            worker_host,
+        } = &config.execution_mode
+        {
+            request.execution_mode = RunAgentsExecutionMode::Remote {
+                environment_id: environment_id.clone(),
+                worker_host: worker_host.clone(),
+                computer_use_enabled: false,
+            };
+        }
+    }
 }
 
 /// Defence-in-depth validation; mirrors the card view's

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -26,10 +26,12 @@ use warpui::{
     SingletonEntity, SizeConstraint, View, ViewContext, ViewHandle,
 };
 
+use settings::Setting;
 use warp_cli::agent::Harness;
 use warp_core::channel::{Channel, ChannelState};
 use warp_core::ui::theme::Fill;
 
+use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::execution_profiles::model_menu_items::available_model_menu_items;
 use crate::ai::harness_availability::HarnessAvailabilityModel;
@@ -149,33 +151,6 @@ impl OrchestrationEditState {
         }
     }
 
-    /// Fills empty execution-mode fields from the given config.
-    /// If both sides are `Remote`, inherits empty `environment_id` and
-    /// `worker_host` from the config. If the state is `Local` while the
-    /// config is `Remote` (or vice-versa), does nothing — variant
-    /// mismatches are intentional.
-    pub fn resolve_execution_mode_from_config(&mut self, config_mode: &OrchestrationExecutionMode) {
-        if let (
-            RunAgentsExecutionMode::Remote {
-                environment_id,
-                worker_host,
-                ..
-            },
-            OrchestrationExecutionMode::Remote {
-                environment_id: cfg_env,
-                worker_host: cfg_host,
-            },
-        ) = (&mut self.execution_mode, config_mode)
-        {
-            if environment_id.is_empty() {
-                *environment_id = cfg_env.clone();
-            }
-            if worker_host.is_empty() {
-                *worker_host = cfg_host.clone();
-            }
-        }
-    }
-
     /// Returns `Some(reason)` if Accept / Apply must be disabled.
     /// Only hard block: OpenCode + Cloud.
     pub fn accept_disabled_reason(&self) -> Option<&'static str> {
@@ -205,6 +180,42 @@ impl OrchestrationEditState {
         }
         if !self.execution_mode.is_remote() && config.execution_mode.is_remote() {
             self.execution_mode = Self::from_orchestration_config(config).execution_mode;
+        }
+    }
+
+    /// Unconditionally overrides model, harness, and execution mode
+    /// from the approved orchestration config. The plan config is the
+    /// user-approved source of truth — the LLM's run_agents call may
+    /// omit or set these differently, but the config always wins.
+    ///
+    /// `computer_use_enabled` is preserved from the current state when
+    /// both sides are Remote, since it is a per-call flag set by the LLM.
+    pub fn override_from_approved_config(&mut self, config: &OrchestrationConfig) {
+        self.model_id = config.model_id.clone();
+        self.harness_type = config.harness_type.clone();
+
+        let preserve_computer_use = match (&self.execution_mode, &config.execution_mode) {
+            (
+                RunAgentsExecutionMode::Remote {
+                    computer_use_enabled,
+                    ..
+                },
+                OrchestrationExecutionMode::Remote { .. },
+            ) => Some(*computer_use_enabled),
+            _ => None,
+        };
+
+        self.execution_mode = Self::from_orchestration_config(config).execution_mode;
+
+        if let (
+            Some(cue),
+            RunAgentsExecutionMode::Remote {
+                computer_use_enabled,
+                ..
+            },
+        ) = (preserve_computer_use, &mut self.execution_mode)
+        {
+            *computer_use_enabled = cue;
         }
     }
 
@@ -648,6 +659,57 @@ pub fn harness_save_key(harness_type: &str) -> &str {
     }
 }
 
+// ── Default environment resolution ──────────────────────────────────
+
+/// Resolves a default environment ID using the same logic as the
+/// `/cloud-agent` environment selector: first tries the user's
+/// last-selected environment from settings, then falls back to the
+/// most recently used environment.
+pub fn resolve_default_environment_id(ctx: &AppContext) -> Option<String> {
+    if let Some(env_id) = *CloudAgentSettings::as_ref(ctx)
+        .last_selected_environment_id
+        .value()
+    {
+        if CloudAmbientAgentEnvironment::get_by_id(&env_id, ctx).is_some() {
+            return Some(env_id.uid());
+        }
+    }
+    let mut envs = CloudAmbientAgentEnvironment::get_all(ctx);
+    envs.sort_by(|a, b| {
+        b.metadata
+            .last_task_run_ts
+            .cmp(&a.metadata.last_task_run_ts)
+            .then_with(|| {
+                a.model()
+                    .string_model
+                    .name
+                    .cmp(&b.model().string_model.name)
+            })
+    });
+    envs.first().map(|e| e.id.uid())
+}
+
+/// Persists the user's environment selection to settings so it can
+/// be restored as the default next time. Shared by both the plan
+/// card and confirmation card `EnvironmentChanged` handlers.
+pub fn persist_environment_selection<V: View>(environment_id: &str, ctx: &mut ViewContext<V>) {
+    if environment_id.is_empty() {
+        return;
+    }
+    let all_envs = CloudAmbientAgentEnvironment::get_all(ctx);
+    if let Some(env) = all_envs.iter().find(|e| e.id.uid() == environment_id) {
+        let sync_id = env.id;
+        CloudAgentSettings::handle(ctx).update(ctx, |settings, ctx| {
+            if let Err(e) = settings
+                .last_selected_environment_id
+                .set_value(Some(sync_id), ctx)
+            {
+                log::warn!("Failed to persist environment selection: {e:?}");
+            }
+        });
+    }
+}
+
 // ── Shared action helpers ───────────────────────────────────────────
 
 /// Handles a harness change for both card views: saves the current
@@ -705,6 +767,17 @@ pub fn apply_execution_mode_change<A: OrchestrationControlAction, V: View>(
     ctx: &mut ViewContext<V>,
 ) {
     state.toggle_execution_mode_to_remote(is_remote);
+    // When switching to Cloud with no environment set, pre-fill with
+    // the user's last-selected or most recently used environment.
+    if is_remote {
+        if let RunAgentsExecutionMode::Remote { environment_id, .. } = &state.execution_mode {
+            if environment_id.is_empty() {
+                if let Some(default_env) = resolve_default_environment_id(ctx) {
+                    state.set_environment_id(default_env);
+                }
+            }
+        }
+    }
     let is_local = !state.execution_mode.is_remote();
     if !is_model_in_filtered_choices(&state.model_id, &state.harness_type, is_local, ctx) {
         let reset_id = fallback_base_model_id(ctx)

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -7,9 +7,7 @@ use std::collections::HashMap;
 
 use ai::agent::action::{RunAgentsAgentRunConfig, RunAgentsExecutionMode, RunAgentsRequest};
 use ai::agent::action_result::{RunAgentsAgentOutcomeKind, RunAgentsResult};
-use ai::agent::orchestration_config::{
-    matches_active_config, OrchestrationConfig, OrchestrationConfigStatus,
-};
+use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationConfigStatus};
 
 use crate::ai::agent::conversation::AIConversationId;
 use crate::BlocklistAIHistoryModel;
@@ -176,8 +174,8 @@ pub struct RunAgentsCardView {
     state: RunAgentsEditState,
     handles: RunAgentsCardHandles,
     spawning: Option<RunAgentsSpawningSnapshot>,
-    /// Set when the active config was approved and matched the request,
-    /// causing immediate dispatch without user confirmation.
+    /// Set when an approved plan config triggered immediate dispatch
+    /// without user confirmation.
     auto_launched: bool,
     /// Set when the action has a `RunAgentsResult::Denied` result in
     /// history (e.g. orchestration was disabled at dispatch time).
@@ -197,30 +195,6 @@ pub struct RunAgentsCardView {
     /// UI-only per-harness model memory so switching harnesses preserves
     /// the user's previous model selection for each harness.
     saved_model_per_harness: HashMap<String, String>,
-}
-
-/// Returns `true` when the conditions for auto-launching are met.
-///
-/// Extracted from `try_auto_launch_on_stream_complete` so the
-/// decision logic can be unit-tested without constructing a full
-/// `RunAgentsCardView`.
-pub(crate) fn should_auto_launch(
-    auto_launched: bool,
-    is_denied: bool,
-    is_spawning: bool,
-    state: &RunAgentsEditState,
-    active_config: &Option<(OrchestrationConfig, OrchestrationConfigStatus)>,
-) -> bool {
-    if auto_launched || is_denied || is_spawning || state.agent_run_configs.is_empty() {
-        return false;
-    }
-    match active_config {
-        Some((config, status)) => {
-            let request = state.to_request();
-            status.is_approved() && matches_active_config(&request, config)
-        }
-        None => false,
-    }
 }
 
 /// Computes the `is_denied` flag at construction time.
@@ -243,6 +217,49 @@ fn is_opencode_on_remote(request: &RunAgentsRequest) -> bool {
         request.execution_mode,
         RunAgentsExecutionMode::Remote { .. }
     ) && request.harness_type.eq_ignore_ascii_case("opencode")
+}
+
+/// Resolves UI-only interactive defaults on edit state that has
+/// already had config-inherited fields resolved. These defaults are
+/// for the picker display and should NOT run before auto-launch
+/// matching.
+///
+/// 1. Defaults the Oz model to the conversation's base model.
+/// 2. Defaults Remote worker_host to "warp".
+/// 3. Defaults a Remote environment from settings / recency.
+fn resolve_interactive_defaults(
+    state: &mut RunAgentsEditState,
+    block_model: &dyn AIBlockModel<View = AIBlock>,
+    ctx: &AppContext,
+) {
+    if state.orch.model_id.is_empty() {
+        let harness =
+            warp_cli::agent::Harness::parse_orchestration_harness(&state.orch.harness_type);
+        if matches!(harness, Some(warp_cli::agent::Harness::Oz) | None) {
+            if let Some(base) = block_model.base_model(ctx).map(|id| id.to_string()) {
+                state.orch.model_id = base;
+            }
+        }
+    }
+    if let RunAgentsExecutionMode::Remote {
+        environment_id,
+        worker_host,
+        ..
+    } = &state.orch.execution_mode
+    {
+        let needs_host = worker_host.is_empty();
+        let needs_env = environment_id.is_empty();
+        if needs_host {
+            state
+                .orch
+                .set_worker_host(oc::ORCHESTRATION_WARP_WORKER_HOST.to_string());
+        }
+        if needs_env {
+            if let Some(default_env) = oc::resolve_default_environment_id(ctx) {
+                state.orch.set_environment_id(default_env);
+            }
+        }
+    }
 }
 
 impl RunAgentsCardView {
@@ -268,37 +285,15 @@ impl RunAgentsCardView {
             false
         };
 
-        // Auto-launch when the active config is approved and matches
-        // the request — skip the confirmation card entirely.
-        // The active_config is now conversation-scoped so cross-conversation
-        // leakage is no longer possible.
-        // Also treat the action as denied when the config is explicitly
+        // Treat the action as denied when the config is explicitly
         // disapproved — the card will auto-deny via the subscription
         // once the action becomes blocked.
         let is_denied = compute_is_denied(is_denied, &active_config);
 
-        let mut state = RunAgentsEditState::from_request(request);
-        // When the LLM omits harness/model to inherit from the active
-        // config, resolve empty fields so the card shows the intended
-        // settings rather than defaults.
-        if let Some((config, status)) = &active_config {
-            if status.is_approved() {
-                state.orch.resolve_from_config(config);
-            }
-        }
-        // For Oz (or empty harness), default to the conversation's base
-        // model so the picker shows e.g. "auto (genius)" instead of the
-        // system default.
-        if state.orch.model_id.is_empty() {
-            let harness =
-                warp_cli::agent::Harness::parse_orchestration_harness(&state.orch.harness_type);
-            if matches!(harness, Some(warp_cli::agent::Harness::Oz) | None) {
-                if let Some(base) = block_model.base_model(ctx).map(|id| id.to_string()) {
-                    state.orch.model_id = base;
-                }
-            }
-        }
-        let auto_launched = should_auto_launch(false, is_denied, false, &state, &active_config);
+        // Auto-launch is deferred to try_auto_launch_on_stream_complete
+        // (called after streaming finishes and agent_run_configs is populated).
+        let state = RunAgentsEditState::from_request(request);
+        let auto_launched = false;
 
         let reject_keystroke = CTRL_C_KEYSTROKE.clone();
         let accept_keystroke = ENTER_KEYSTROKE.clone();
@@ -521,38 +516,37 @@ impl RunAgentsCardView {
                     conv.orchestration_config_for_plan(&self.state.plan_id)
                         .map(|(c, s)| (c.clone(), s))
                 });
-            // Resolve empty/default state fields from the config so the
-            // dispatched request carries concrete values rather than
-            // relying on server-side inheritance.
-            if let Some((config, _)) = &self.active_config {
-                if self.state.orch.model_id.is_empty() {
-                    self.state.orch.model_id = config.model_id.clone();
-                }
-                if self.state.orch.harness_type.is_empty() {
-                    self.state.orch.harness_type = config.harness_type.clone();
-                }
-                self.state
-                    .orch
-                    .resolve_execution_mode_from_config(&config.execution_mode);
-            }
             // Re-evaluate denied status with the refreshed config.
             self.is_denied = compute_is_denied(self.is_denied, &self.active_config);
         }
+        // If there's an approved config for this plan, the user has
+        // already approved these settings — auto-launch without
+        // needing to match individual fields.
+        if let Some((config, status)) = &self.active_config {
+            if status.is_approved()
+                && !self.auto_launched
+                && !self.is_denied
+                && self.spawning.is_none()
+                && !self.state.agent_run_configs.is_empty()
+            {
+                self.state.orch.override_from_approved_config(config);
 
-        if should_auto_launch(
-            self.auto_launched,
-            self.is_denied,
-            self.spawning.is_some(),
-            &self.state,
-            &self.active_config,
-        ) {
-            self.auto_launched = true;
-            // Don't call execute_run_agents here — the action
-            // hasn't been queued as Blocked yet. The subscription
-            // on ActionBlockedOnUserConfirmation will dispatch it
-            // once the action model is ready.
-            ctx.notify();
+                self.auto_launched = true;
+                ctx.notify();
+                return;
+            }
         }
+
+        // No approved config — the confirmation card will be shown.
+        // Resolve from config (if any) then apply interactive defaults
+        // so the pickers display sensible values.
+        if let Some((config, status)) = &self.active_config {
+            if status.is_approved() {
+                self.state.orch.resolve_from_config(config);
+            }
+        }
+        resolve_interactive_defaults(&mut self.state, &*self.block_model, ctx);
+        oc::repopulate_all_pickers(&mut self.state.orch, &self.handles.pickers, ctx);
     }
 
     /// Validates and dispatches the resolved request.
@@ -864,6 +858,7 @@ impl TypedActionView for RunAgentsCardView {
             }
             RunAgentsCardViewAction::EnvironmentChanged { environment_id } => {
                 self.state.orch.set_environment_id(environment_id.clone());
+                oc::persist_environment_selection(environment_id, ctx);
                 ctx.notify();
             }
             RunAgentsCardViewAction::WorkerHostChanged { worker_host } => {

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
@@ -306,176 +306,140 @@ mod format_terminal_state_tests {
     }
 }
 
-mod should_auto_launch_tests {
-    use super::super::{should_auto_launch, RunAgentsEditState};
+mod override_from_approved_config_tests {
+    use super::super::RunAgentsEditState;
     use super::*;
-    use ai::agent::orchestration_config::{
-        OrchestrationConfig, OrchestrationConfigStatus, OrchestrationExecutionMode,
-    };
+    use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationExecutionMode};
 
-    fn matching_config() -> (OrchestrationConfig, OrchestrationConfigStatus) {
-        (
-            OrchestrationConfig {
-                model_id: "auto".to_string(),
-                harness_type: "oz".to_string(),
-                execution_mode: OrchestrationExecutionMode::Local,
+    fn local_config(model: &str, harness: &str) -> OrchestrationConfig {
+        OrchestrationConfig {
+            model_id: model.to_string(),
+            harness_type: harness.to_string(),
+            execution_mode: OrchestrationExecutionMode::Local,
+        }
+    }
+
+    fn remote_config(model: &str, harness: &str, env: &str) -> OrchestrationConfig {
+        OrchestrationConfig {
+            model_id: model.to_string(),
+            harness_type: harness.to_string(),
+            execution_mode: OrchestrationExecutionMode::Remote {
+                environment_id: env.to_string(),
+                worker_host: "warp".to_string(),
             },
-            OrchestrationConfigStatus::Approved,
-        )
-    }
-
-    fn default_state() -> RunAgentsEditState {
-        RunAgentsEditState::from_request(&make_request("oz", RunAgentsExecutionMode::Local))
+        }
     }
 
     #[test]
-    fn returns_true_when_all_conditions_met() {
-        let state = default_state();
-        let config = Some(matching_config());
-        assert!(should_auto_launch(false, false, false, &state, &config));
+    fn overrides_model_and_harness_unconditionally() {
+        let mut state =
+            RunAgentsEditState::from_request(&make_request("oz", RunAgentsExecutionMode::Local));
+        assert_eq!(state.orch.model_id, "auto");
+        assert_eq!(state.orch.harness_type, "oz");
+
+        state
+            .orch
+            .override_from_approved_config(&local_config("claude-4-opus", "claude"));
+        assert_eq!(state.orch.model_id, "claude-4-opus");
+        assert_eq!(state.orch.harness_type, "claude");
     }
 
     #[test]
-    fn returns_false_when_already_auto_launched() {
-        let state = default_state();
-        let config = Some(matching_config());
-        assert!(!should_auto_launch(true, false, false, &state, &config));
-    }
-
-    #[test]
-    fn returns_false_when_denied() {
-        let state = default_state();
-        let config = Some(matching_config());
-        assert!(!should_auto_launch(false, true, false, &state, &config));
-    }
-
-    #[test]
-    fn returns_false_when_spawning() {
-        let state = default_state();
-        let config = Some(matching_config());
-        assert!(!should_auto_launch(false, false, true, &state, &config));
-    }
-
-    #[test]
-    fn returns_false_when_agent_run_configs_empty() {
-        let mut state = default_state();
-        state.agent_run_configs.clear();
-        let config = Some(matching_config());
-        assert!(!should_auto_launch(false, false, false, &state, &config));
-    }
-
-    #[test]
-    fn returns_false_when_no_active_config() {
-        let state = default_state();
-        assert!(!should_auto_launch(false, false, false, &state, &None));
-    }
-
-    #[test]
-    fn returns_false_when_config_not_approved() {
-        let state = default_state();
-        let config = Some((
-            OrchestrationConfig {
-                model_id: "auto".to_string(),
-                harness_type: "oz".to_string(),
-                execution_mode: OrchestrationExecutionMode::Local,
-            },
-            OrchestrationConfigStatus::None,
+    fn overrides_even_when_request_has_values() {
+        let mut state = RunAgentsEditState::from_request(&make_request(
+            "claude",
+            RunAgentsExecutionMode::Local,
         ));
-        assert!(!should_auto_launch(false, false, false, &state, &config));
+        state
+            .orch
+            .override_from_approved_config(&local_config("gpt-5", "codex"));
+        assert_eq!(state.orch.model_id, "gpt-5");
+        assert_eq!(state.orch.harness_type, "codex");
     }
 
     #[test]
-    fn returns_false_when_config_disapproved() {
-        let state = default_state();
-        let config = Some((
-            OrchestrationConfig {
-                model_id: "auto".to_string(),
-                harness_type: "oz".to_string(),
-                execution_mode: OrchestrationExecutionMode::Local,
-            },
-            OrchestrationConfigStatus::Disapproved,
-        ));
-        assert!(!should_auto_launch(false, false, false, &state, &config));
+    fn overrides_local_to_remote() {
+        let mut state =
+            RunAgentsEditState::from_request(&make_request("oz", RunAgentsExecutionMode::Local));
+        state
+            .orch
+            .override_from_approved_config(&remote_config("auto", "oz", "env-1"));
+        let RunAgentsExecutionMode::Remote {
+            environment_id,
+            worker_host,
+            ..
+        } = &state.orch.execution_mode
+        else {
+            panic!("expected Remote after override");
+        };
+        assert_eq!(environment_id, "env-1");
+        assert_eq!(worker_host, "warp");
     }
 
     #[test]
-    fn returns_false_when_model_id_mismatches() {
-        let state = default_state();
-        let config = Some((
-            OrchestrationConfig {
-                model_id: "claude-4".to_string(),
-                harness_type: "oz".to_string(),
-                execution_mode: OrchestrationExecutionMode::Local,
-            },
-            OrchestrationConfigStatus::Approved,
-        ));
-        assert!(!should_auto_launch(false, false, false, &state, &config));
-    }
-
-    #[test]
-    fn returns_false_when_harness_type_mismatches() {
-        let state = default_state();
-        let config = Some((
-            OrchestrationConfig {
-                model_id: "auto".to_string(),
-                harness_type: "claude".to_string(),
-                execution_mode: OrchestrationExecutionMode::Local,
-            },
-            OrchestrationConfigStatus::Approved,
-        ));
-        assert!(!should_auto_launch(false, false, false, &state, &config));
-    }
-
-    #[test]
-    fn returns_false_when_execution_mode_mismatches() {
-        let state = default_state();
-        let config = Some((
-            OrchestrationConfig {
-                model_id: "auto".to_string(),
-                harness_type: "oz".to_string(),
-                execution_mode: OrchestrationExecutionMode::Remote {
-                    environment_id: "env-1".to_string(),
-                    worker_host: "warp".to_string(),
-                },
-            },
-            OrchestrationConfigStatus::Approved,
-        ));
-        assert!(!should_auto_launch(false, false, false, &state, &config));
-    }
-
-    #[test]
-    fn matches_remote_config_when_fields_agree() {
-        let state = RunAgentsEditState::from_request(&make_request(
+    fn overrides_remote_to_local() {
+        let mut state = RunAgentsEditState::from_request(&make_request(
             "oz",
             RunAgentsExecutionMode::Remote {
                 environment_id: "env-1".to_string(),
                 worker_host: "warp".to_string(),
-                computer_use_enabled: false,
+                computer_use_enabled: true,
             },
         ));
-        let config = Some((
-            OrchestrationConfig {
-                model_id: "auto".to_string(),
-                harness_type: "oz".to_string(),
-                execution_mode: OrchestrationExecutionMode::Remote {
-                    environment_id: "env-1".to_string(),
-                    worker_host: "warp".to_string(),
-                },
-            },
-            OrchestrationConfigStatus::Approved,
-        ));
-        assert!(should_auto_launch(false, false, false, &state, &config));
+        state
+            .orch
+            .override_from_approved_config(&local_config("auto", "oz"));
+        assert!(
+            matches!(state.orch.execution_mode, RunAgentsExecutionMode::Local),
+            "should be Local after override"
+        );
     }
 
     #[test]
-    fn empty_model_id_inherits_from_config() {
-        let mut req = make_request("oz", RunAgentsExecutionMode::Local);
-        req.model_id = String::new();
-        let state = RunAgentsEditState::from_request(&req);
-        let config = Some(matching_config());
+    fn preserves_computer_use_when_both_remote() {
+        let mut state = RunAgentsEditState::from_request(&make_request(
+            "oz",
+            RunAgentsExecutionMode::Remote {
+                environment_id: "old-env".to_string(),
+                worker_host: "warp".to_string(),
+                computer_use_enabled: true,
+            },
+        ));
+        state
+            .orch
+            .override_from_approved_config(&remote_config("auto", "oz", "new-env"));
+        let RunAgentsExecutionMode::Remote {
+            environment_id,
+            computer_use_enabled,
+            ..
+        } = &state.orch.execution_mode
+        else {
+            panic!("expected Remote");
+        };
+        assert_eq!(environment_id, "new-env", "env should come from config");
         assert!(
-            should_auto_launch(false, false, false, &state, &config),
-            "Empty model_id on request should inherit from config and match"
+            *computer_use_enabled,
+            "computer_use_enabled should be preserved from original request"
+        );
+    }
+
+    #[test]
+    fn does_not_carry_computer_use_from_local_to_remote() {
+        let mut state =
+            RunAgentsEditState::from_request(&make_request("oz", RunAgentsExecutionMode::Local));
+        state
+            .orch
+            .override_from_approved_config(&remote_config("auto", "oz", "env-1"));
+        let RunAgentsExecutionMode::Remote {
+            computer_use_enabled,
+            ..
+        } = &state.orch.execution_mode
+        else {
+            panic!("expected Remote");
+        };
+        assert!(
+            !*computer_use_enabled,
+            "computer_use_enabled should default to false when original was Local"
         );
     }
 }

--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -118,6 +118,10 @@ pub struct OrchestrationConfigBlockView {
     /// UI-only per-harness model memory so switching harnesses preserves
     /// the user's previous model selection for each harness.
     saved_model_per_harness: HashMap<String, String>,
+    /// Suppresses self-triggered refresh when `apply_field_change`
+    /// saves the config and the resulting event re-enters
+    /// `refresh_from_model`.
+    suppress_refresh: bool,
 }
 
 impl OrchestrationConfigBlockView {
@@ -206,6 +210,7 @@ impl OrchestrationConfigBlockView {
             toggle_mouse_state: MouseStateHandle::default(),
             details_mouse_state: MouseStateHandle::default(),
             saved_model_per_harness: HashMap::new(),
+            suppress_refresh: false,
         };
         if view.is_approved {
             view.ensure_pickers(ctx);
@@ -214,6 +219,10 @@ impl OrchestrationConfigBlockView {
     }
 
     fn refresh_from_model(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.suppress_refresh {
+            self.suppress_refresh = false;
+            return;
+        }
         let history = BlocklistAIHistoryModel::as_ref(ctx);
         if let Some(conv) = history.conversation(&self.conversation_id) {
             if let Some((config, status)) = conv.orchestration_config_for_plan(&self.plan_id) {
@@ -263,6 +272,33 @@ impl OrchestrationConfigBlockView {
         oc::populate_harness_picker(&harness_handle, &self.edit_state.harness_type, ctx);
         self.pickers.harness_picker = Some(harness_handle);
 
+        // When restoring a Remote config with empty host or
+        // environment, fill defaults so the pickers aren't blank.
+        // If the config is approved, persist the defaults so the
+        // stored config used by auto-launch has concrete values.
+        let (needs_host, needs_env) = match &self.edit_state.execution_mode {
+            RunAgentsExecutionMode::Remote {
+                worker_host,
+                environment_id,
+                ..
+            } => (worker_host.is_empty(), environment_id.is_empty()),
+            RunAgentsExecutionMode::Local => (false, false),
+        };
+        let mut filled_defaults = false;
+        if needs_host {
+            self.edit_state
+                .set_worker_host(oc::ORCHESTRATION_WARP_WORKER_HOST.to_string());
+            filled_defaults = true;
+        }
+        if needs_env {
+            if let Some(default_env) = oc::resolve_default_environment_id(ctx) {
+                self.edit_state.set_environment_id(default_env);
+                filled_defaults = true;
+            }
+        }
+        if filled_defaults && self.is_approved {
+            self.apply_field_change(ctx);
+        }
         let initial_env = match &self.edit_state.execution_mode {
             RunAgentsExecutionMode::Remote { environment_id, .. } => environment_id.as_str(),
             RunAgentsExecutionMode::Local => "",
@@ -285,6 +321,7 @@ impl OrchestrationConfigBlockView {
     }
 
     fn apply_field_change(&mut self, ctx: &mut ViewContext<Self>) {
+        self.suppress_refresh = true;
         let config = self.edit_state.to_orchestration_config();
         let status = if self.is_approved {
             OrchestrationConfigStatus::Approved
@@ -531,6 +568,7 @@ impl TypedActionView for OrchestrationConfigBlockView {
             }
             OrchestrationConfigBlockAction::EnvironmentChanged { environment_id } => {
                 self.edit_state.set_environment_id(environment_id.clone());
+                oc::persist_environment_selection(environment_id, ctx);
                 self.apply_field_change(ctx);
                 ctx.notify();
             }


### PR DESCRIPTION
## Description

Two changes to orchestration config handling:

**1. Default environment and host selection** — When the orchestration config UI opens in Remote mode with no environment selected, auto-fill from the user's last-selected or most recently used environment (matching `/cloud-agent` behavior). Worker host defaults to "warp". Selections are persisted to settings for cross-flow consistency.

**2. Deferred auto-launch with unconditional config override** — Auto-launch evaluation is deferred to stream completion so the full request (including plan_id and agent_run_configs) is available. When an approved plan config exists, its model/harness/execution_mode unconditionally override the LLM's run_agents call (preserving only computer_use_enabled). This also applies to the autonomous executor path for CLI-driver agents.

[Agent conversation](https://staging.warp.dev/conversation/ba65e2ae-16d1-458e-8de7-c599e0b83c24) | [Plan](https://staging.warp.dev/drive/notebook/qS8CS7tIdHkdE5EKkHFeqi)

## Testing

- [x] I have manually tested my changes locally with `./script/run`
- [x] New unit tests for `override_from_approved_config` (6 tests covering all override/preserve scenarios)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>