### PR TITLE
Fix issue with rendering duplicate commands when restoring cloud mode conversations.

### DIFF
--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -1222,7 +1222,7 @@ impl TerminalModel {
         is_inverted: bool,
         obfuscate_secrets: ObfuscateSecrets,
     ) -> Self {
-        let mut me = Self::new_internal(
+        Self::new_internal(
             None,
             sizes,
             colors,
@@ -1244,12 +1244,7 @@ impl TerminalModel {
             },
             SharedSessionStatus::ViewPending,
             true,
-        );
-        if FeatureFlag::CloudModeSetupV2.is_enabled() {
-            me.block_list_mut()
-                .set_is_executing_oz_environment_startup_commands(true);
-        }
-        me
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -50,7 +50,7 @@ fn create_default_serialized_block() -> SerializedBlock {
 
 #[test]
 fn cloud_mode_deferred_terminal_model_starts_view_pending() {
-    let model = TerminalModel::new_for_cloud_mode_shared_session_viewer(
+    let mut model = TerminalModel::new_for_cloud_mode_shared_session_viewer(
         block_size(),
         color::List::from(&color::Colors::default()),
         ChannelEventListener::new_for_test(),
@@ -67,6 +67,27 @@ fn cloud_mode_deferred_terminal_model_starts_view_pending() {
     ));
     assert!(model.shared_session_status().is_viewer());
     assert!(model.is_dummy_cloud_mode_session());
+    assert!(!model
+        .block_list()
+        .is_executing_oz_environment_startup_commands());
+
+    model.block_list_mut().create_restored_command_block(
+        "setup-looking-command",
+        "output",
+        None,
+        0,
+        None,
+        None,
+    );
+
+    let restored_command_block = model
+        .block_list()
+        .blocks()
+        .iter()
+        .find(|block| block.command_to_string() == "setup-looking-command")
+        .expect("restored command block should exist");
+    assert!(!restored_command_block.is_hidden());
+    assert!(!restored_command_block.is_oz_environment_startup_command());
 }
 
 #[test]

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -372,19 +372,22 @@ impl TerminalManager {
                 return false;
             }
         }
+        self.connect_session(
+            session_id,
+            SharedSessionInitialLoadMode::AppendFollowupScrollback,
+            ctx,
+        );
+        self.start_cloud_mode_setup_command_tracking();
+        true
+    }
 
+    pub fn start_cloud_mode_setup_command_tracking(&mut self) {
         if FeatureFlag::CloudModeSetupV2.is_enabled() {
             self.model
                 .lock()
                 .block_list_mut()
                 .set_is_executing_oz_environment_startup_commands(true);
         }
-        self.connect_session(
-            session_id,
-            SharedSessionInitialLoadMode::AppendFollowupScrollback,
-            ctx,
-        );
-        true
     }
 
     /// Connects this terminal manager to a shared session.

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -104,7 +104,9 @@ pub fn create_cloud_mode_view(
                     let append_followup_scrollback = view_model_for_subscription
                         .as_ref(ctx)
                         .is_local_to_cloud_handoff();
-                    manager.connect_to_session(*session_id, append_followup_scrollback, ctx);
+                    if manager.connect_to_session(*session_id, append_followup_scrollback, ctx) {
+                        manager.start_cloud_mode_setup_command_tracking();
+                    }
                 }
                 AmbientAgentViewModelEvent::FollowupSessionReady { session_id } => {
                     manager.attach_followup_session(*session_id, ctx);


### PR DESCRIPTION
## Description

Fixes issue where upon restoring cloud agent conversations, duplicate requested command UI is rendered due to incorrect set-up command 'tracking'  
  
Fixes [APP-4456](https://linear.app/warpdotdev/issue/APP-4456)



<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->