### PR TITLE
Fix WASM tombstone for third-party cloud conversations

### DIFF
--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -135,6 +135,7 @@ impl TombstoneDisplayData {
             self.skill_name = config.name.clone();
             #[cfg(not(target_family = "wasm"))]
             {
+                // Only desktop uses harness to decide whether "Continue locally" is allowed.
                 self.harness = Some(
                     config
                         .harness
@@ -152,6 +153,9 @@ impl TombstoneDisplayData {
             }
         }
 
+        // We update to use the task values when we have them, which includes
+        // the full credit cost (inference + compute). This matches what we show in
+        // the details panel.
         if let Some(run_time) = task.run_time() {
             self.run_time = Some(human_readable_precise_duration(run_time));
         }
@@ -159,6 +163,8 @@ impl TombstoneDisplayData {
             self.credits = Some(format_credits(credits));
         }
 
+        // Surface task artifacts (plans, PRs, files, screenshots) for third-party
+        // harness runs.
         if !task.artifacts.is_empty() {
             self.artifacts = task.artifacts;
         }

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -1,10 +1,11 @@
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent_management::telemetry::{AgentManagementTelemetryEvent, ArtifactType};
+use crate::ai::ambient_agents::AmbientAgentTask;
 use crate::ai::ambient_agents::{
-    conversation_output_status_from_conversation, AmbientAgentTaskId, AmbientConversationStatus,
+    AmbientAgentTaskId, AmbientConversationStatus, conversation_output_status_from_conversation,
 };
 use crate::ai::artifacts::{Artifact, ArtifactButtonsRow, ArtifactButtonsRowEvent};
-use crate::ai::blocklist::{format_credits, BlocklistAIHistoryModel};
+use crate::ai::blocklist::{BlocklistAIHistoryModel, format_credits};
 use crate::appearance::Appearance;
 use crate::server::ids::SyncId;
 use crate::settings::ai::{AISettings, AISettingsChangedEvent};
@@ -18,9 +19,6 @@ use warp_cli::agent::Harness;
 #[cfg(not(target_family = "wasm"))]
 use warp_core::features::FeatureFlag;
 use warp_core::paths::home_relative_path;
-
-#[cfg(not(target_family = "wasm"))]
-use crate::ai::ambient_agents::AmbientAgentTask;
 use warp_core::send_telemetry_from_ctx;
 use warp_core::ui::icons::Icon;
 use warp_core::ui::theme::{AnsiColorIdentifier, Fill};
@@ -34,7 +32,6 @@ use warpui::{
     ViewHandle,
 };
 
-#[cfg(not(target_family = "wasm"))]
 use crate::server::server_api::ServerApiProvider;
 
 /// Metadata collected for display in the tombstone.
@@ -125,8 +122,6 @@ impl TombstoneDisplayData {
         }
     }
 
-    /// Update with data from an AmbientAgentTask fetch
-    #[cfg(not(target_family = "wasm"))]
     fn enrich_from_task(&mut self, task: AmbientAgentTask) {
         // Use task title if we don't have a conversation title.
         if self.title.is_none() {
@@ -138,14 +133,16 @@ impl TombstoneDisplayData {
         }
         if let Some(config) = &task.agent_config_snapshot {
             self.skill_name = config.name.clone();
-            // Default to Oz when the snapshot exists but has no explicit harness.
-            self.harness = Some(
-                config
-                    .harness
-                    .as_ref()
-                    .map(|h| h.harness_type)
-                    .unwrap_or(Harness::Oz),
-            );
+            #[cfg(not(target_family = "wasm"))]
+            {
+                self.harness = Some(
+                    config
+                        .harness
+                        .as_ref()
+                        .map(|h| h.harness_type)
+                        .unwrap_or(Harness::Oz),
+                );
+            }
         }
 
         if task.state.is_failure_like() {
@@ -155,9 +152,6 @@ impl TombstoneDisplayData {
             }
         }
 
-        // We update to use the task values when we have them, which includes
-        // the full credit cost (inference + compute). This matches what we show in
-        // the details panel.
         if let Some(run_time) = task.run_time() {
             self.run_time = Some(human_readable_precise_duration(run_time));
         }
@@ -165,8 +159,6 @@ impl TombstoneDisplayData {
             self.credits = Some(format_credits(credits));
         }
 
-        // Surface task artifacts (plans, PRs, files, screenshots) for third-party
-        // harness runs.
         if !task.artifacts.is_empty() {
             self.artifacts = task.artifacts;
         }
@@ -190,9 +182,7 @@ impl ConversationEndedTombstoneView {
     pub fn new(
         ctx: &mut ViewContext<Self>,
         terminal_view_id: EntityId,
-        #[cfg_attr(target_family = "wasm", allow(unused_variables))] task_id: Option<
-            AmbientAgentTaskId,
-        >,
+        task_id: Option<AmbientAgentTaskId>,
     ) -> Self {
         let conversation_id = BlocklistAIHistoryModel::handle(ctx)
             .as_ref(ctx)
@@ -325,7 +315,6 @@ impl ConversationEndedTombstoneView {
         });
 
         // Fetch AmbientAgentTask for additional metadata (source, skill, artifacts, etc.)
-        #[cfg(not(target_family = "wasm"))]
         if let Some(task_id) = task_id {
             let ai_client = ServerApiProvider::handle(ctx).as_ref(ctx).get_ai_client();
             ctx.spawn(

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -2,10 +2,10 @@ use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent_management::telemetry::{AgentManagementTelemetryEvent, ArtifactType};
 use crate::ai::ambient_agents::AmbientAgentTask;
 use crate::ai::ambient_agents::{
-    AmbientAgentTaskId, AmbientConversationStatus, conversation_output_status_from_conversation,
+    conversation_output_status_from_conversation, AmbientAgentTaskId, AmbientConversationStatus,
 };
 use crate::ai::artifacts::{Artifact, ArtifactButtonsRow, ArtifactButtonsRowEvent};
-use crate::ai::blocklist::{BlocklistAIHistoryModel, format_credits};
+use crate::ai::blocklist::{format_credits, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
 use crate::server::ids::SyncId;
 use crate::settings::ai::{AISettings, AISettingsChangedEvent};


### PR DESCRIPTION
## Description
Fix WASM tombstone showing "Agent task" and 0 credits for third-party cloud conversations.

The `enrich_from_task` method and the `AmbientAgentTask` fetch were gated behind `#[cfg(not(target_family = "wasm"))]`, so the WASM build never fetched task metadata. For non-Oz cloud runs (e.g. Claude Code) there's no `AIConversation`, so the tombstone fell back to defaults: "Agent task" title and 0 credits.

All the underlying types were already on WASM, so AFAICT this gate is old and no longer needed.

## Testing
Tested locally.

Before: 
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/d9066081-1037-4843-a8ef-f60e46239d1a" />


After:
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/65c81f2f-c395-4683-9b86-ec75c541e50d" />



## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode


_Conversation: https://staging.warp.dev/conversation/c24d6652-fcee-44b0-8afd-b74908cac971_
_Run: https://oz.staging.warp.dev/runs/019e1e55-e998-737d-aaec-39ef0ba131bd_
_This PR was generated with [Oz](https://warp.dev/oz)._
