### PR TITLE
Hide third-party transcript vehicle conversations from the management view.

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -259,7 +259,7 @@ pub(crate) fn artifact_from_fork_proto(
 }
 
 impl AIConversation {
-    pub fn new(is_viewing_shared_session: bool) -> Self {
+    pub fn new(is_viewing_shared_session: bool, is_cli_agent_transcript: bool) -> Self {
         let root_task = Task::new_optimistic_root();
         Self {
             id: AIConversationId::new(),
@@ -267,7 +267,7 @@ impl AIConversation {
             optimistic_cli_subagent_subtask_id: None,
             code_review: None,
             is_viewing_shared_session,
-            is_cli_agent_transcript: false,
+            is_cli_agent_transcript,
             todo_lists: vec![],
             status: ConversationStatus::InProgress,
             status_error_message: None,
@@ -515,10 +515,6 @@ impl AIConversation {
 
     pub fn is_cli_agent_transcript(&self) -> bool {
         self.is_cli_agent_transcript
-    }
-
-    pub fn mark_as_cli_agent_transcript(&mut self) {
-        self.is_cli_agent_transcript = true;
     }
 
     pub fn was_summarized(&self) -> bool {

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -212,6 +212,11 @@ pub struct AIConversation {
     /// Artifacts created during this conversation (plans, PRs, etc.).
     artifacts: Vec<Artifact>,
 
+    /// Whether the AIConversation is being used as a vehicle for a CLI conversation, that
+    /// doesn't have a full internal representation but uses an AIConversationId to render
+    /// in the agent view.
+    is_cli_agent_transcript: bool,
+
     /// Server-side identifier of the parent agent that spawned this child, if any.
     /// In v1 this holds the parent's `server_conversation_token`; in v2 (OrchestrationV2)
     /// it holds the parent's `run_id`. Persisted as `parent_agent_id` for serde compat.
@@ -262,6 +267,7 @@ impl AIConversation {
             optimistic_cli_subagent_subtask_id: None,
             code_review: None,
             is_viewing_shared_session,
+            is_cli_agent_transcript: false,
             todo_lists: vec![],
             status: ConversationStatus::InProgress,
             status_error_message: None,
@@ -449,6 +455,7 @@ impl AIConversation {
         Ok(Self {
             id,
             is_viewing_shared_session: false,
+            is_cli_agent_transcript: false,
             task_store,
             status,
             status_error_message: None,
@@ -504,6 +511,14 @@ impl AIConversation {
 
     pub fn set_is_viewing_shared_session(&mut self, is_viewing_shared_session: bool) {
         self.is_viewing_shared_session = is_viewing_shared_session;
+    }
+
+    pub fn is_cli_agent_transcript(&self) -> bool {
+        self.is_cli_agent_transcript
+    }
+
+    pub fn mark_as_cli_agent_transcript(&mut self) {
+        self.is_cli_agent_transcript = true;
     }
 
     pub fn was_summarized(&self) -> bool {
@@ -1104,6 +1119,9 @@ impl AIConversation {
             // Shared session viewer conversations are excluded because the shared session itself
             // is visible/represented elsewhere.
             || self.is_viewing_shared_session()
+            // 3p transcript viewers create an internal conversation only so agent-view
+            // filtering can associate the restored block snapshot with an active conversation.
+            || self.is_cli_agent_transcript()
             // Child agent conversations spawned by an orchestrator are managed via the parent's
             // status card and shouldn't clutter the navigation list.
             || self.is_child_agent_conversation()

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -157,6 +157,15 @@ fn child_conversation_detection_uses_parent_agent_id() {
 }
 
 #[test]
+fn cli_agent_transcript_vehicle_is_excluded_from_navigation() {
+    let mut conversation = AIConversation::new(false);
+
+    conversation.mark_as_cli_agent_transcript();
+
+    assert!(conversation.should_exclude_from_navigation());
+}
+
+#[test]
 fn restored_conversation_defaults_unknown_persisted_autoexecute_override() {
     let _flag = FeatureFlag::RememberFastForwardState.override_enabled(true);
     let conversation_data: AgentConversationData = serde_json::from_str(

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -158,9 +158,7 @@ fn child_conversation_detection_uses_parent_agent_id() {
 
 #[test]
 fn cli_agent_transcript_vehicle_is_excluded_from_navigation() {
-    let mut conversation = AIConversation::new(false);
-
-    conversation.mark_as_cli_agent_transcript();
+    let conversation = AIConversation::new(false, true);
 
     assert!(conversation.should_exclude_from_navigation());
 }

--- a/app/src/ai/blocklist/action_model/execute/ask_user_question_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/ask_user_question_tests.rs
@@ -45,7 +45,7 @@ fn should_autoexecute_returns_false_when_autoapprove_is_enabled_and_profile_alwa
         let executor = app.add_model(|_| AskUserQuestionExecutor::new(terminal_view_id));
         let action = build_action("ask-user-question");
         let conversation_id = history.update(&mut app, |history, ctx| {
-            history.start_new_conversation(terminal_view_id, true, false, ctx)
+            history.start_new_conversation(terminal_view_id, true, false, false, ctx)
         });
 
         profiles.update(&mut app, |profiles, ctx| {
@@ -128,7 +128,7 @@ fn should_autoexecute_returns_true_when_autoapprove_is_enabled_and_profile_allow
         let executor = app.add_model(|_| AskUserQuestionExecutor::new(terminal_view_id));
         let action = build_action("ask-user-question");
         let conversation_id = history.update(&mut app, |history, ctx| {
-            history.start_new_conversation(terminal_view_id, true, false, ctx)
+            history.start_new_conversation(terminal_view_id, true, false, false, ctx)
         });
         let result = executor.update(&mut app, |executor, ctx| {
             let input = ExecuteActionInput {
@@ -150,7 +150,7 @@ fn execute_returns_sync_skipped_question_ids_when_autoapprove_is_enabled() {
         let executor = app.add_model(|_| AskUserQuestionExecutor::new(terminal_view_id));
         let action = build_action("ask-user-question");
         let conversation_id = history.update(&mut app, |history, ctx| {
-            history.start_new_conversation(terminal_view_id, true, false, ctx)
+            history.start_new_conversation(terminal_view_id, true, false, false, ctx)
         });
 
         let execution = executor.update(&mut app, |executor, ctx| {
@@ -261,7 +261,7 @@ fn should_autoexecute_uses_active_terminal_profile_permission() {
         let executor = app.add_model(|_| AskUserQuestionExecutor::new(terminal_view_id));
         let action = build_action("ask-user-question");
         let conversation_id = history.update(&mut app, |history, ctx| {
-            history.start_new_conversation(terminal_view_id, false, false, ctx)
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         profiles.update(&mut app, |profiles, ctx| {

--- a/app/src/ai/blocklist/action_model/execute/send_message_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/send_message_tests.rs
@@ -8,7 +8,7 @@ fn sender_run_id_and_task_id_for_send_falls_back_to_ambient_task_id() {
         let terminal_view_id = EntityId::new();
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let ambient_task_id = "11111111-1111-1111-1111-111111111111"
             .parse()
@@ -33,7 +33,7 @@ fn sender_run_id_and_task_id_for_send_prefers_conversation_task_id() {
         let terminal_view_id = EntityId::new();
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let conversation_task_id = "22222222-2222-2222-2222-222222222222"
             .parse()

--- a/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
@@ -39,7 +39,7 @@ fn execute_returns_error_when_child_startup_is_blocked_before_initialization() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let executor = app.add_model(StartAgentExecutor::new);
         let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let action = build_start_agent_action(
             StartAgentVersion::V1,
@@ -128,7 +128,7 @@ fn execute_resolves_error_when_request_linkage_happens_after_child_already_faile
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let executor = app.add_model(StartAgentExecutor::new);
         let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let action = build_start_agent_action(
             StartAgentVersion::V1,
@@ -205,7 +205,7 @@ fn execute_resolves_success_when_request_linkage_happens_after_child_already_sta
         app.add_singleton_model(OrchestrationEventStreamer::new);
         let executor = app.add_model(StartAgentExecutor::new);
         let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let action = build_start_agent_action(
             StartAgentVersion::V1,
@@ -282,7 +282,7 @@ fn execute_returns_detailed_error_when_child_startup_fails_before_initialization
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let executor = app.add_model(StartAgentExecutor::new);
         let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let action = build_start_agent_action(
             StartAgentVersion::V1,
@@ -352,7 +352,7 @@ fn execute_returns_error_when_local_harness_child_requires_orchestration_v2() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let executor = app.add_model(StartAgentExecutor::new);
         let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let action = build_start_agent_action(
             StartAgentVersion::V2,
@@ -389,7 +389,7 @@ fn execute_rejects_invalid_local_harness_names_before_pane_creation() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let executor = app.add_model(StartAgentExecutor::new);
         let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let action = build_start_agent_action(
             StartAgentVersion::V2,
@@ -426,7 +426,7 @@ fn execute_returns_error_when_local_harness_child_missing_parent_run_id() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let executor = app.add_model(StartAgentExecutor::new);
         let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let action = build_start_agent_action(
             StartAgentVersion::V2,
@@ -464,7 +464,7 @@ fn parallel_dispatch_keeps_two_pendings_distinguishable_by_request_id() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let executor = app.add_model(StartAgentExecutor::new);
         let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         let action_a = build_start_agent_action(
@@ -514,7 +514,7 @@ fn parallel_pendings_each_resolve_independently_via_recorded_child_id() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let executor = app.add_model(StartAgentExecutor::new);
         let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         let action_a = build_start_agent_action(
@@ -631,7 +631,7 @@ fn execute_returns_error_when_remote_opencode_harness_is_requested() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let executor = app.add_model(StartAgentExecutor::new);
         let parent_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let action = build_start_agent_action(
             StartAgentVersion::V2,

--- a/app/src/ai/blocklist/action_model/execute/upload_artifact_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/upload_artifact_tests.rs
@@ -140,7 +140,7 @@ fn should_autoexecute_honors_file_read_permissions_for_resolved_path() {
         let executor =
             app.add_model(|_| UploadArtifactExecutor::new(active_session, terminal_view_id));
         let conversation_id = history.update(&mut app, |history, ctx| {
-            history.start_new_conversation(terminal_view_id, false, false, ctx)
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let action = build_upload_artifact_action("reports/report.txt");
 
@@ -190,7 +190,7 @@ fn execute_returns_error_when_conversation_has_not_synced_to_server() {
         let executor =
             app.add_model(|_| UploadArtifactExecutor::new(active_session, terminal_view_id));
         let conversation_id = history.update(&mut app, |history, ctx| {
-            history.start_new_conversation(terminal_view_id, false, false, ctx)
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let action = build_upload_artifact_action(&artifact_path.display().to_string());
 

--- a/app/src/ai/blocklist/agent_view/controller.rs
+++ b/app/src/ai/blocklist/agent_view/controller.rs
@@ -767,12 +767,18 @@ impl AgentViewController {
             (conversation.id(), conversation.exchange_count())
         } else {
             let id = history_model.update(ctx, |history_model, ctx| {
-                history_model.start_new_conversation(
+                let id = history_model.start_new_conversation(
                     self.terminal_view_id,
                     false,
                     matches!(origin, AgentViewEntryOrigin::CloudAgent),
                     ctx,
-                )
+                );
+                if matches!(origin, AgentViewEntryOrigin::ThirdPartyCloudAgent) {
+                    if let Some(conversation) = history_model.conversation_mut(&id) {
+                        conversation.mark_as_cli_agent_transcript();
+                    }
+                }
+                id
             });
             (id, 0)
         };

--- a/app/src/ai/blocklist/agent_view/controller.rs
+++ b/app/src/ai/blocklist/agent_view/controller.rs
@@ -767,18 +767,13 @@ impl AgentViewController {
             (conversation.id(), conversation.exchange_count())
         } else {
             let id = history_model.update(ctx, |history_model, ctx| {
-                let id = history_model.start_new_conversation(
+                history_model.start_new_conversation(
                     self.terminal_view_id,
                     false,
                     matches!(origin, AgentViewEntryOrigin::CloudAgent),
+                    matches!(origin, AgentViewEntryOrigin::ThirdPartyCloudAgent),
                     ctx,
-                );
-                if matches!(origin, AgentViewEntryOrigin::ThirdPartyCloudAgent) {
-                    if let Some(conversation) = history_model.conversation_mut(&id) {
-                        conversation.mark_as_cli_agent_transcript();
-                    }
-                }
-                id
+                )
             });
             (id, 0)
         };

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
@@ -9,7 +9,7 @@ fn descendant_conversation_ids_in_spawn_order_flattens_nested_children_preorder(
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
 
         let orchestrator_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let child_a = history_model.update(&mut app, |history_model, ctx| {
             history_model.start_new_child_conversation(
@@ -103,7 +103,7 @@ fn descendant_conversation_ids_in_spawn_order_returns_empty_without_children() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
 
         let orchestrator_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         history_model.read(&app, |history_model, _| {

--- a/app/src/ai/blocklist/block/view_impl/orchestration_tests.rs
+++ b/app/src/ai/blocklist/block/view_impl/orchestration_tests.rs
@@ -20,7 +20,7 @@ fn child_conversation_card_data_for_success_result_returns_conversation_id_and_t
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
             let conversation_id =
-                history_model.start_new_conversation(EntityId::new(), false, false, ctx);
+                history_model.start_new_conversation(EntityId::new(), false, false, false, ctx);
             history_model.set_server_conversation_token_for_conversation(
                 conversation_id,
                 "child-agent-id".to_string(),
@@ -100,7 +100,7 @@ fn child_conversation_card_data_for_success_result_without_available_title_uses_
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
             let conversation_id =
-                history_model.start_new_conversation(EntityId::new(), false, false, ctx);
+                history_model.start_new_conversation(EntityId::new(), false, false, false, ctx);
             history_model.set_server_conversation_token_for_conversation(
                 conversation_id,
                 "child-agent-id".to_string(),
@@ -165,7 +165,7 @@ fn agent_display_name_from_id_returns_child_agent_name() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         history_model.update(&mut app, |history_model, ctx| {
             let conversation_id =
-                history_model.start_new_conversation(EntityId::new(), false, false, ctx);
+                history_model.start_new_conversation(EntityId::new(), false, false, false, ctx);
             history_model.set_server_conversation_token_for_conversation(
                 conversation_id,
                 "child-agent-id".to_string(),
@@ -189,7 +189,7 @@ fn agent_display_name_from_id_returns_orchestrator_label() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         history_model.update(&mut app, |history_model, ctx| {
             let conversation_id =
-                history_model.start_new_conversation(EntityId::new(), false, false, ctx);
+                history_model.start_new_conversation(EntityId::new(), false, false, false, ctx);
             let conversation = history_model
                 .conversation_mut(&conversation_id)
                 .expect("conversation should exist");
@@ -220,7 +220,7 @@ fn participant_for_agent_id_uses_pill_style_child_agent_avatar() {
         history_model.update(&mut app, |history_model, ctx| {
             let terminal_view_id = EntityId::new();
             let parent_conversation_id =
-                history_model.start_new_conversation(terminal_view_id, false, false, ctx);
+                history_model.start_new_conversation(terminal_view_id, false, false, false, ctx);
             history_model.set_server_conversation_token_for_conversation(
                 parent_conversation_id,
                 "orchestrator-agent-id".to_string(),

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2107,6 +2107,7 @@ impl BlocklistAIController {
                 self.terminal_view_id,
                 is_autoexecute_override,
                 false,
+                false,
                 ctx,
             )
         });

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -160,7 +160,7 @@ impl BlocklistAIController {
             })
             .unwrap_or_else(|| {
                 history.update(ctx, |h, ctx| {
-                    h.start_new_conversation(terminal_view_id, false, true, ctx)
+                    h.start_new_conversation(terminal_view_id, false, true, false, ctx)
                 })
             });
         if self.should_skip_replayed_response_for_existing_conversation(

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -415,7 +415,7 @@ impl BlocklistAIHistoryModel {
 
         let auto_execute = true; // Child auto-executes by default.
         let conversation_id =
-            self.start_new_conversation(terminal_view_id, auto_execute, false, ctx);
+            self.start_new_conversation(terminal_view_id, auto_execute, false, false, ctx);
         {
             let conversation = self
                 .conversation_mut(&conversation_id)
@@ -830,9 +830,11 @@ impl BlocklistAIHistoryModel {
         terminal_view_id: EntityId,
         is_autoexecute_override: bool,
         is_viewing_shared_session: bool,
+        is_cli_agent_transcript: bool,
         ctx: &mut ModelContext<Self>,
     ) -> AIConversationId {
-        let mut new_conversation = AIConversation::new(is_viewing_shared_session);
+        let mut new_conversation =
+            AIConversation::new(is_viewing_shared_session, is_cli_agent_transcript);
         if is_autoexecute_override {
             new_conversation.toggle_autoexecute_override();
         }
@@ -1039,7 +1041,8 @@ impl BlocklistAIHistoryModel {
             exchange_ids_to_transfer.len()
         );
 
-        let new_conversation_id = self.start_new_conversation(terminal_view_id, false, false, ctx);
+        let new_conversation_id =
+            self.start_new_conversation(terminal_view_id, false, false, false, ctx);
         for exchange_id in exchange_ids_to_transfer {
             let old_conversation = self
                 .conversations_by_id

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -98,7 +98,7 @@ fn start_new_child_conversation_persists_harness_metadata() {
 
         let (child_a, child_b, child_ids) = history_model.update(&mut app, |history_model, ctx| {
             let parent_conversation_id =
-                history_model.start_new_conversation(terminal_view_id, false, false, ctx);
+                history_model.start_new_conversation(terminal_view_id, false, false, false, ctx);
             history_model.set_server_conversation_token_for_conversation(
                 parent_conversation_id,
                 "parent-agent-id".to_string(),
@@ -209,7 +209,7 @@ fn test_ai_queries_for_terminal_view_up_arrow_history() {
 
         // Start a new conversation and add "live query 1"
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         let stream_id = ResponseStreamId::new_for_test();
@@ -251,7 +251,7 @@ fn test_ai_queries_for_terminal_view_up_arrow_history() {
 
         // Start another new conversation and add "live query 2"
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         history_model.update(&mut app, |history_model, ctx| {
@@ -311,7 +311,7 @@ fn test_ai_queries_for_terminal_view_up_arrow_history() {
 
         // Start a new conversation after clearing and add "new query after clear"
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         history_model.update(&mut app, |history_model, ctx| {
@@ -493,7 +493,7 @@ fn test_merge_cloud_metadata_updates_already_restored_conversations() {
         let terminal_view_id = EntityId::new();
 
         // Create a conversation with a server token and restore it
-        let mut conversation = AIConversation::new(false);
+        let mut conversation = AIConversation::new(false, false);
         conversation.set_server_conversation_token("token-1".to_string());
         let conversation_id = conversation.id();
 
@@ -555,7 +555,7 @@ fn test_transcript_viewer_terminal_view_is_not_marked_historical() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         history_model.update(&mut app, |history_model, ctx| {
@@ -705,10 +705,10 @@ fn test_set_parent_for_conversation_populates_index() {
 
         // Create parent and child conversations via start_new_conversation.
         let parent_id = history_model.update(&mut app, |model, ctx| {
-            model.start_new_conversation(terminal_view_id, false, false, ctx)
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let child_id = history_model.update(&mut app, |model, ctx| {
-            model.start_new_conversation(terminal_view_id, false, false, ctx)
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         // Set the parent-child relationship.
@@ -739,10 +739,10 @@ fn test_set_parent_for_conversation_dedup() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
         let parent_id = history_model.update(&mut app, |model, ctx| {
-            model.start_new_conversation(terminal_view_id, false, false, ctx)
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let child_id = history_model.update(&mut app, |model, ctx| {
-            model.start_new_conversation(terminal_view_id, false, false, ctx)
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         // Set the same parent-child relationship twice.
@@ -765,13 +765,13 @@ fn test_set_parent_multiple_children() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
         let parent_id = history_model.update(&mut app, |model, ctx| {
-            model.start_new_conversation(terminal_view_id, false, false, ctx)
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let child_a = history_model.update(&mut app, |model, ctx| {
-            model.start_new_conversation(terminal_view_id, false, false, ctx)
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
         let child_b = history_model.update(&mut app, |model, ctx| {
-            model.start_new_conversation(terminal_view_id, false, false, ctx)
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         history_model.update(&mut app, |model, _| {
@@ -811,7 +811,7 @@ fn test_restore_conversations_maintains_children_by_parent() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
         let parent_id = AIConversationId::new();
-        let mut child_conv = AIConversation::new(false);
+        let mut child_conv = AIConversation::new(false, false);
         child_conv.set_parent_conversation_id(parent_id);
         let child_id = child_conv.id();
 
@@ -834,7 +834,7 @@ fn test_restore_conversations_dedup_children_by_parent() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
         let parent_id = AIConversationId::new();
-        let mut child_conv_a = AIConversation::new(false);
+        let mut child_conv_a = AIConversation::new(false, false);
         child_conv_a.set_parent_conversation_id(parent_id);
         let child_id = child_conv_a.id();
         let child_conv_b = child_conv_a.clone();
@@ -863,7 +863,7 @@ fn test_all_cleared_conversations_includes_terminal_view_id() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         history_model.update(&mut app, |history_model, ctx| {
@@ -926,7 +926,7 @@ fn test_toggle_autoexecute_override_persists_updated_conversation_state() {
         let terminal_view_id = EntityId::new();
 
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         history_model.update(&mut app, |history_model, ctx| {
@@ -966,7 +966,7 @@ fn test_update_event_sequence_persists_updated_conversation_state() {
         let terminal_view_id = EntityId::new();
 
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         history_model.update(&mut app, |history_model, ctx| {
@@ -1035,7 +1035,7 @@ fn test_find_by_token_after_restore_conversations() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
         let terminal_view_id = EntityId::new();
 
-        let mut conversation = AIConversation::new(false);
+        let mut conversation = AIConversation::new(false, false);
         conversation.set_server_conversation_token("restored-token".to_string());
         let conversation_id = conversation.id();
 
@@ -1135,7 +1135,7 @@ fn test_find_by_token_after_initialize_output_for_response_stream() {
         let terminal_view_id = EntityId::new();
 
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
         });
 
         // Prime a pending request so StreamInit can install the token.
@@ -1201,7 +1201,8 @@ fn test_find_by_token_after_assign_run_id_for_conversation() {
         let terminal_view_id = EntityId::new();
 
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            let id = history_model.start_new_conversation(terminal_view_id, false, false, ctx);
+            let id =
+                history_model.start_new_conversation(terminal_view_id, false, false, false, ctx);
             // Seed a token so assign_run_id has one to forward into the index.
             history_model
                 .conversation_mut(&id)
@@ -1292,7 +1293,7 @@ fn test_find_by_token_after_mark_conversations_historical_for_terminal_view() {
         let terminal_view_id = EntityId::new();
 
         // Needs a real exchange to pass `conversation_would_render_in_blocklist`.
-        let mut conversation = AIConversation::new(false);
+        let mut conversation = AIConversation::new(false, false);
         conversation.set_server_conversation_token("historical-token".to_string());
         let conversation_id = conversation.id();
 
@@ -1363,7 +1364,8 @@ fn test_set_server_conversation_token_rebinds_reverse_index() {
         let terminal_view_id = EntityId::new();
 
         let conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            let id = history_model.start_new_conversation(terminal_view_id, false, false, ctx);
+            let id =
+                history_model.start_new_conversation(terminal_view_id, false, false, false, ctx);
             history_model.set_server_conversation_token_for_conversation(id, "old".to_string());
             id
         });

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -253,8 +253,8 @@ fn dormant_local_claude_child_skips_generic_sse_but_allows_wake_listener() {
 
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
-        let parent_id = AIConversation::new(false).id();
-        let mut conversation = AIConversation::new(false);
+        let parent_id = AIConversation::new(false, false).id();
+        let mut conversation = AIConversation::new(false, false);
         let run_id = "550e8400-e29b-41d4-a716-446655440610".to_string();
         conversation.set_run_id(run_id.clone());
         conversation.set_parent_conversation_id(parent_id);
@@ -314,8 +314,8 @@ fn dormant_local_claude_child_uses_task_harness_when_server_metadata_missing() {
 
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
-        let parent_id = AIConversation::new(false).id();
-        let mut conversation = AIConversation::new(false);
+        let parent_id = AIConversation::new(false, false).id();
+        let mut conversation = AIConversation::new(false, false);
         let run_id = "550e8400-e29b-41d4-a716-446655440611".to_string();
         conversation.set_run_id(run_id.clone());
         conversation.set_parent_conversation_id(parent_id);
@@ -425,7 +425,7 @@ fn restored_conversations_skip_v2_streaming_when_orchestration_v2_disabled() {
 
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
-        let mut conversation = AIConversation::new(false);
+        let mut conversation = AIConversation::new(false, false);
         conversation.set_run_id("550e8400-e29b-41d4-a716-446655440500".to_string());
         let conversation_id = conversation.id();
         let terminal_view_id = warpui::EntityId::new();
@@ -531,7 +531,7 @@ fn finish_restore_fetch_uses_server_cursor_when_sqlite_is_absent() {
         // Restore a conversation with no SQLite cursor (`last_event_sequence:
         // None`). After the server fetch completes with `Some(42)` we expect
         // the in-memory cursor to be 42 (max(0, 42)).
-        let conversation = AIConversation::new(false);
+        let conversation = AIConversation::new(false, false);
         let conversation_id = conversation.id();
         let terminal_view_id = warpui::EntityId::new();
         history_model.update(&mut app, |model, ctx| {
@@ -599,7 +599,7 @@ fn handle_event_batch_persists_max_seq_to_history_model() {
 
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
-        let mut conversation = AIConversation::new(false);
+        let mut conversation = AIConversation::new(false, false);
         conversation.set_run_id("550e8400-e29b-41d4-a716-446655440200".to_string());
         let conversation_id: AIConversationId = conversation.id();
         let terminal_view_id = warpui::EntityId::new();
@@ -686,7 +686,7 @@ fn handle_event_batch_drops_events_for_killed_run_ids_after_persisting_cursor() 
 
         let parent_run_id = "550e8400-e29b-41d4-a716-446655440700".to_string();
         let killed_run_id = "550e8400-e29b-41d4-a716-446655440701".to_string();
-        let mut parent_conversation = AIConversation::new(false);
+        let mut parent_conversation = AIConversation::new(false, false);
         parent_conversation.set_run_id(parent_run_id.clone());
         let parent_conversation_id = parent_conversation.id();
         let terminal_view_id = warpui::EntityId::new();
@@ -821,7 +821,7 @@ fn finish_restore_fetch_no_ops_when_conversation_deleted_mid_flight() {
 
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
-        let mut conversation = AIConversation::new(false);
+        let mut conversation = AIConversation::new(false, false);
         conversation.set_run_id("550e8400-e29b-41d4-a716-446655440300".to_string());
         let conversation_id = conversation.id();
         let terminal_view_id = warpui::EntityId::new();
@@ -890,7 +890,7 @@ fn finish_restore_fetch_err_does_not_resurrect_deleted_conversation() {
 
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
-        let mut conversation = AIConversation::new(false);
+        let mut conversation = AIConversation::new(false, false);
         conversation.set_run_id("550e8400-e29b-41d4-a716-446655440500".to_string());
         let conversation_id = conversation.id();
         let terminal_view_id = warpui::EntityId::new();
@@ -955,8 +955,8 @@ fn on_conversation_removed_prunes_stale_child_run_id_from_parent() {
 
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
-        let parent_id = AIConversation::new(false).id();
-        let mut child_conversation = AIConversation::new(false);
+        let parent_id = AIConversation::new(false, false).id();
+        let mut child_conversation = AIConversation::new(false, false);
         let child_run_id = "550e8400-e29b-41d4-a716-446655440600".to_string();
         child_conversation.set_run_id(child_run_id.clone());
         let child_id = child_conversation.id();
@@ -1014,8 +1014,8 @@ fn on_conversation_removed_prunes_killed_child_run_id_from_parent_but_keeps_tomb
 
         app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
-        let parent_id = AIConversation::new(false).id();
-        let child_id = AIConversation::new(false).id();
+        let parent_id = AIConversation::new(false, false).id();
+        let child_id = AIConversation::new(false, false).id();
         let child_run_id = "550e8400-e29b-41d4-a716-446655440601".to_string();
 
         let mock = MockAIClient::new();
@@ -1066,7 +1066,7 @@ fn finish_restore_fetch_reconnects_sse_when_children_added_to_open_connection() 
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
         let own_run_id = "550e8400-e29b-41d4-a716-446655440400";
-        let mut conversation = AIConversation::new(false);
+        let mut conversation = AIConversation::new(false, false);
         conversation.set_run_id(own_run_id.to_string());
         let conversation_id = conversation.id();
         let terminal_view_id = warpui::EntityId::new();

--- a/app/src/ai/blocklist/orchestration_events_tests.rs
+++ b/app/src/ai/blocklist/orchestration_events_tests.rs
@@ -406,8 +406,13 @@ fn test_emit_child_killed_enqueues_cancelled_event_for_parent() {
 
         let (parent_conversation_id, child_conversation_id) =
             history_model.update(&mut app, |history_model, ctx| {
-                let parent_conversation_id =
-                    history_model.start_new_conversation(terminal_view_id, false, false, ctx);
+                let parent_conversation_id = history_model.start_new_conversation(
+                    terminal_view_id,
+                    false,
+                    false,
+                    false,
+                    ctx,
+                );
                 history_model.assign_run_id_for_conversation(
                     parent_conversation_id,
                     parent_run_id,
@@ -471,7 +476,8 @@ fn test_emit_child_killed_drops_when_no_parent() {
 
         // Create a standalone conversation (no parent) with a run_id.
         let orphan_conversation_id = history_model.update(&mut app, |history_model, ctx| {
-            let id = history_model.start_new_conversation(terminal_view_id, false, false, ctx);
+            let id =
+                history_model.start_new_conversation(terminal_view_id, false, false, false, ctx);
             history_model.assign_run_id_for_conversation(
                 id,
                 child_run_id,
@@ -509,8 +515,13 @@ fn test_emit_child_killed_drops_when_child_already_terminal() {
 
         let (parent_conversation_id, child_conversation_id) =
             history_model.update(&mut app, |history_model, ctx| {
-                let parent_conversation_id =
-                    history_model.start_new_conversation(terminal_view_id, false, false, ctx);
+                let parent_conversation_id = history_model.start_new_conversation(
+                    terminal_view_id,
+                    false,
+                    false,
+                    false,
+                    ctx,
+                );
                 history_model.assign_run_id_for_conversation(
                     parent_conversation_id,
                     parent_run_id,
@@ -561,8 +572,13 @@ fn test_restored_v1_child_reregisters_lifecycle_subscription() {
 
         let (_parent_conversation_id, child_conversation_id) =
             history_model.update(&mut app, |history_model, ctx| {
-                let parent_conversation_id =
-                    history_model.start_new_conversation(terminal_view_id, false, false, ctx);
+                let parent_conversation_id = history_model.start_new_conversation(
+                    terminal_view_id,
+                    false,
+                    false,
+                    false,
+                    ctx,
+                );
                 history_model.set_server_conversation_token_for_conversation(
                     parent_conversation_id,
                     "parent-token".to_string(),

--- a/app/src/ai/blocklist/permissions_tests.rs
+++ b/app/src/ai/blocklist/permissions_tests.rs
@@ -91,7 +91,7 @@ fn initialize_permissions_test_with_mode(
     let user_workspaces = app.add_singleton_model(UserWorkspaces::default_mock);
 
     let conversation_id = history.update(app, |history_model, ctx| {
-        history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+        history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
     });
 
     PermissionsTestState {

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -342,7 +342,7 @@ fn test_server_conversation_metadata(
 }
 
 fn cloud_conversation_with_ambient_task(task_id: AmbientAgentTaskId) -> CloudConversationData {
-    let mut conversation = AIConversation::new(false);
+    let mut conversation = AIConversation::new(false, false);
     conversation.set_task_id(task_id);
     conversation.set_server_metadata(test_server_conversation_metadata(Some(task_id)));
     CloudConversationData::Oz(Box::new(conversation))
@@ -365,7 +365,7 @@ fn start_parent_conversation_for_terminal_view(
     ctx: &mut ViewContext<PaneGroup>,
 ) -> AIConversationId {
     BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-        history_model.start_new_conversation(terminal_view_id, false, false, ctx)
+        history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
     })
 }
 
@@ -374,7 +374,7 @@ fn restore_child_conversation_for_terminal_view(
     parent_conversation_id: AIConversationId,
     ctx: &mut ViewContext<PaneGroup>,
 ) -> AIConversationId {
-    let mut child_conversation = AIConversation::new(false);
+    let mut child_conversation = AIConversation::new(false, false);
     child_conversation.set_parent_conversation_id(parent_conversation_id);
     let child_conversation_id = child_conversation.id();
 
@@ -709,7 +709,7 @@ fn test_restored_hidden_child_pane_reapplies_ambient_task_id_to_controller() {
             let parent_conversation_id = start_parent_conversation(panes, parent_pane_id, ctx);
             let task_id = new_ambient_agent_task_id();
 
-            let mut child_conversation = AIConversation::new(false);
+            let mut child_conversation = AIConversation::new(false, false);
             child_conversation.set_parent_conversation_id(parent_conversation_id);
             child_conversation.set_task_id(task_id);
             let child_conversation_id = child_conversation.id();
@@ -748,7 +748,7 @@ fn test_restored_remote_hidden_child_pane_enters_existing_ambient_session() {
             let parent_conversation_id = start_parent_conversation(panes, parent_pane_id, ctx);
             let task_id = new_ambient_agent_task_id();
 
-            let mut child_conversation = AIConversation::new(false);
+            let mut child_conversation = AIConversation::new(false, false);
             child_conversation.set_parent_conversation_id(parent_conversation_id);
             child_conversation.set_task_id(task_id);
             child_conversation.mark_as_remote_child();

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -12986,7 +12986,7 @@ impl TerminalView {
         } else {
             Some(
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-                    history_model.start_new_conversation(self.view_id, false, false, ctx)
+                    history_model.start_new_conversation(self.view_id, false, false, false, ctx)
                 }),
             )
         }) else {
@@ -21625,7 +21625,8 @@ impl TerminalView {
         let terminal_view_id = ctx.view_id();
         let mut new_conversation_id = None;
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, model_ctx| {
-            let id = history.start_new_conversation(terminal_view_id, false, false, model_ctx);
+            let id =
+                history.start_new_conversation(terminal_view_id, false, false, false, model_ctx);
             // Mark it active for good measure (not strictly required for rendering).
             history.set_active_conversation_id(id, terminal_view_id, model_ctx);
             new_conversation_id = Some(id);

--- a/app/src/terminal/view/agent_view.rs
+++ b/app/src/terminal/view/agent_view.rs
@@ -93,19 +93,17 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) -> Option<AIConversationId> {
         let origin = AgentViewEntryOrigin::ThirdPartyCloudAgent;
-        let conversation_id = BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
-            let conversation_id = history.start_new_conversation(self.view_id, false, false, ctx);
-            let title = fallback_title.trim();
-            if !title.is_empty() {
-                if let Some(conversation) = history.conversation_mut(&conversation_id) {
-                    conversation.set_fallback_display_title(title.to_owned());
-                }
-            }
-            conversation_id
-        });
 
-        match self.try_enter_agent_view(None, origin, Some(conversation_id), ctx) {
+        match self.try_enter_agent_view(None, origin, None, ctx) {
             Ok(conversation_id) => {
+                let title = fallback_title.trim();
+                if !title.is_empty() {
+                    BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _| {
+                        if let Some(conversation) = history.conversation_mut(&conversation_id) {
+                            conversation.set_fallback_display_title(title.to_owned());
+                        }
+                    });
+                }
                 self.redetermine_global_focus(ctx);
                 Some(conversation_id)
             }

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -840,7 +840,7 @@ fn test_shared_followup_on_existing_conversation_converts_user_query_input() {
         let conversation_id =
             BlocklistAIHistoryModel::handle(&app).update(&mut app, |model, ctx| {
                 let conversation_id =
-                    model.start_new_conversation(terminal_view_id, false, false, ctx);
+                    model.start_new_conversation(terminal_view_id, false, false, false, ctx);
                 model.set_server_conversation_token_for_conversation(
                     conversation_id,
                     conversation_token.to_string(),
@@ -1022,7 +1022,8 @@ fn test_on_ambient_agent_execution_ended_refreshes_open_details_panel_to_termina
             model.insert_task_for_test(task);
         });
         BlocklistAIHistoryModel::handle(&app).update(&mut app, |model, ctx| {
-            let conversation_id = model.start_new_conversation(terminal.id(), false, false, ctx);
+            let conversation_id =
+                model.start_new_conversation(terminal.id(), false, false, false, ctx);
             model.assign_run_id_for_conversation(
                 conversation_id,
                 task_id.to_string(),

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -129,7 +129,7 @@ fn append_exchange_with_inputs_and_handle_event(
     let (conversation_id, task_id, exchange_id, response_stream_id) =
         history_model.update(ctx, |history_model, ctx| {
             let conversation_id =
-                history_model.start_new_conversation(view.view_id, false, false, ctx);
+                history_model.start_new_conversation(view.view_id, false, false, false, ctx);
             let task_id = history_model
                 .conversation(&conversation_id)
                 .expect("conversation should exist")
@@ -4978,7 +4978,7 @@ fn cli_session_status_updates_active_child_conversation() {
         let child_conversation_id = terminal.update(&mut app, |view, ctx| {
             let parent_conversation_id =
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-                    history_model.start_new_conversation(view.view_id, false, false, ctx)
+                    history_model.start_new_conversation(view.view_id, false, false, false, ctx)
                 });
             let child_conversation_id =
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
@@ -5126,7 +5126,7 @@ fn cli_session_status_updates_single_child_conversation_without_agent_view() {
         let child_conversation_id = terminal.update(&mut app, |view, ctx| {
             let parent_conversation_id =
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-                    history_model.start_new_conversation(view.view_id, false, false, ctx)
+                    history_model.start_new_conversation(view.view_id, false, false, false, ctx)
                 });
             let child_conversation_id =
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
When restoring third-party conversation transcripts, we create a vehicle `AIConversation` that we use to enter the agent view.

We used to be rendering these `AIConversation` entries within management surfaces throughout the app, resulting in ghost entries in the management view that got created every time you tried to restore a CLI transcript.

We fix this here by tracking when an `AIConversation` is being used as a CLI vehicle (which we set based on the `AgentEntryOrigin`) and add these to the existing `should_exclude_from_navigation`.

We didn't see this for live sessions, even though they also use vehicle conversations, because we already check in `should_exclude_from_navigation` whether we are viewing a shared session.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

Tested locally: https://www.loom.com/share/20b9e025ab9c49f49c21a929ab702d25

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

