### PR TITLE
Fix shared session scrollback restore

### DIFF
--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -1501,8 +1501,8 @@ impl Block {
         self.should_hide_command_grid = should_hide;
     }
 
-    /// Returns true iff this block should be used as a scrollback block
-    /// in a shared session context. Note the active block is included in scrollback to get the active prompt.
+    /// Returns true iff this block should be used as a scrollback block in a shared session context.
+    /// The active block is included when it is eligible so viewers can restore the active prompt.
     pub fn is_scrollback_block_for_shared_session(
         &self,
         agent_view_state: &AgentViewState,

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -545,6 +545,26 @@ enum BlockHeightUpdate {
     Removal(TotalIndex),
 }
 
+struct SharedSessionScrollbackBlocks<'a> {
+    completed_blocks: &'a [SerializedBlock],
+    active_block: Option<&'a SerializedBlock>,
+}
+
+impl<'a> SharedSessionScrollbackBlocks<'a> {
+    fn new(scrollback: &'a [SerializedBlock]) -> Self {
+        match scrollback.split_last() {
+            Some((active_block, completed_blocks)) if active_block.completed_ts.is_none() => Self {
+                completed_blocks,
+                active_block: Some(active_block),
+            },
+            _ => Self {
+                completed_blocks: scrollback,
+                active_block: None,
+            },
+        }
+    }
+}
+
 impl BlockList {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -689,37 +709,34 @@ impl BlockList {
     }
 
     pub(super) fn load_shared_session_scrollback(&mut self, scrollback: &[SerializedBlock]) {
-        // When we're loading the shared session scrollback, first check
-        // if there's an unfinished block; if there is, finish it because it
-        // will otherwise remain unfinished in perpetuity.
-        if !self.active_block().finished() {
+        let scrollback_blocks = SharedSessionScrollbackBlocks::new(scrollback);
+        // If the snapshot will restore any blocks, finish the placeholder active block first.
+        // For an empty snapshot, keep the existing placeholder active block instead of replacing
+        // it with another hidden block.
+        if !scrollback.is_empty() && !self.active_block().finished() {
             self.active_block_mut().finish(0);
         }
 
-        // Simulate finishing bootstrapping once we get the scrollback, since the scrollback contains the active prompt.
+        // Simulate finishing bootstrapping once we get the scrollback.
         self.set_bootstrapped();
         let mut processor: Processor = Processor::new();
 
-        let Some((active_block, completed_blocks)) = scrollback.split_last() else {
-            return;
-        };
-
-        for block in completed_blocks {
+        for block in scrollback_blocks.completed_blocks {
             if block.start_ts.is_some() && block.completed_ts.is_some() {
                 self.restore_block(block, BootstrapStage::PostBootstrapPrecmd, &mut processor);
             } else {
                 log::warn!("A non-active scrollback block was either not started or not completed");
             }
         }
-
-        // The last block being restored is the active block
-        // (potentially long-running) and has the latest prompt.
-        debug_assert!(active_block.completed_ts.is_none());
-        self.restore_block(
-            active_block,
-            BootstrapStage::PostBootstrapPrecmd,
-            &mut processor,
-        );
+        if let Some(active_block) = scrollback_blocks.active_block {
+            self.restore_block(
+                active_block,
+                BootstrapStage::PostBootstrapPrecmd,
+                &mut processor,
+            );
+        } else {
+            self.ensure_active_block_after_shared_session_scrollback();
+        }
     }
 
     pub(super) fn append_followup_shared_session_scrollback(
@@ -728,12 +745,9 @@ impl BlockList {
     ) {
         self.set_bootstrapped();
         let mut processor = Processor::new();
+        let scrollback_blocks = SharedSessionScrollbackBlocks::new(scrollback);
 
-        let Some((active_block, completed_blocks)) = scrollback.split_last() else {
-            return;
-        };
-
-        for block in completed_blocks {
+        for block in scrollback_blocks.completed_blocks {
             if self.block_index_for_id(&block.id).is_some() {
                 continue;
             }
@@ -745,14 +759,18 @@ impl BlockList {
             }
         }
 
-        if self.block_index_for_id(&active_block.id).is_none() {
-            debug_assert!(active_block.completed_ts.is_none());
-            self.finish_active_block_before_followup_append();
-            self.restore_block(
-                active_block,
-                BootstrapStage::PostBootstrapPrecmd,
-                &mut processor,
-            );
+        match scrollback_blocks.active_block {
+            Some(active_block) if self.block_index_for_id(&active_block.id).is_none() => {
+                self.finish_active_block_before_followup_append();
+                self.restore_block(
+                    active_block,
+                    BootstrapStage::PostBootstrapPrecmd,
+                    &mut processor,
+                );
+            }
+            Some(_) | None => {
+                self.ensure_active_block_after_shared_session_scrollback();
+            }
         }
     }
 
@@ -760,6 +778,17 @@ impl BlockList {
         if !self.active_block().finished() {
             self.active_block_mut().finish(0);
             self.update_active_block_height();
+        }
+    }
+
+    fn ensure_active_block_after_shared_session_scrollback(&mut self) {
+        if self.active_block().finished() {
+            self.create_new_block(
+                BlockId::new(),
+                BootstrapStage::PostBootstrapPrecmd,
+                None,
+                None,
+            );
         }
     }
 

--- a/app/src/terminal/shared_session/mod.rs
+++ b/app/src/terminal/shared_session/mod.rs
@@ -173,11 +173,11 @@ impl SharedSessionStatus {
 /// Note: currently, these options only encode the point at which
 /// scrollback _starts_. We do not yet support more
 /// selective scrollback (e.g. a closed range).
-/// The active block is always included in scrollback for the prompt.
+/// The active block is included for the prompt when it is scrollback-eligible.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SharedSessionScrollbackType {
     /// Do not include any scrollback in this shared session.
-    /// Note the active block is still sent as part of scrollback for the prompt.
+    /// The active block can still be sent as part of scrollback for the prompt.
     /// TODO(suraj): consider renaming this to "from active block" or encapsulating
     /// this with the `FromBlock` variant with the block_index equal to the
     /// active block index.
@@ -195,7 +195,7 @@ impl SharedSessionScrollbackType {
     /// Note that some blocks might not actually be included in the scrollback
     /// even if they were specified as part of the scrollback type.
     /// For example, if the [`Self::All]` variant is used, restored blocks
-    /// _won't_ be included in scrollback.
+    /// _won't_ be included in scrollback, and neither will hidden active blocks.
     fn to_scrollback(self, model: &TerminalModel) -> Scrollback {
         let first_block_index = self.first_block_index(model);
         let blocks = model

--- a/app/src/terminal/shared_session/mod_tests.rs
+++ b/app/src/terminal/shared_session/mod_tests.rs
@@ -301,6 +301,48 @@ fn test_loading_scrollback() {
 }
 
 #[test]
+fn test_loading_scrollback_with_completed_last_block_creates_active_block() {
+    let scrollback_blocks = &[
+        SerializedBlock::new_for_test("block1".into(), "block1".into()),
+        SerializedBlock::new_for_test("block2".into(), "block2".into()),
+    ];
+    let channel_event_proxy = ChannelEventListener::new_for_test();
+    let mut model = terminal_model_for_viewer(channel_event_proxy);
+    model.load_shared_session_scrollback(scrollback_blocks);
+
+    // 4 blocks: first is the bootstrap block, the next two are completed scrollback blocks.
+    // Since no active block was serialized, restore creates a fresh active block.
+    assert_eq!(model.block_list().blocks().len(), 4);
+
+    assert_eq!(
+        model
+            .block_list()
+            .block_at(1.into())
+            .unwrap()
+            .command_to_string(),
+        "block1"
+    );
+    assert_eq!(
+        model
+            .block_list()
+            .block_at(2.into())
+            .unwrap()
+            .command_to_string(),
+        "block2"
+    );
+
+    assert_eq!(model.block_list().active_block_index(), 3.into());
+    assert_eq!(
+        model
+            .block_list()
+            .active_block()
+            .height(&AgentViewState::Inactive),
+        Lines::zero()
+    );
+    assert!(!model.block_list().active_block().started());
+}
+
+#[test]
 fn test_loading_scrollback_in_alt_screen() {
     let scrollback_blocks = &[
         SerializedBlock::new_for_test("block1".into(), "block1".into()),

--- a/app/src/terminal/shared_session/viewer/event_loop_tests.rs
+++ b/app/src/terminal/shared_session/viewer/event_loop_tests.rs
@@ -281,6 +281,96 @@ fn test_append_followup_scrollback_skips_duplicates() {
 }
 
 #[test]
+fn test_append_followup_scrollback_with_completed_last_block_creates_active_block() {
+    App::test((), |mut app| async move {
+        let channel_event_proxy = ChannelEventListener::new_for_test();
+        let model = Arc::new(FairMutex::new(terminal_model_for_viewer(
+            channel_event_proxy.clone(),
+        )));
+
+        let terminal_view = terminal_view(&mut app);
+        let initial_completed = completed_block("initial-command", "initial-output");
+        let initial_active = active_block();
+        app.add_model(|ctx| {
+            EventLoop::new(
+                model.clone(),
+                terminal_view.downgrade(),
+                channel_event_proxy.clone(),
+                WindowSize {
+                    num_rows: 0,
+                    num_cols: 0,
+                },
+                Scrollback {
+                    blocks: vec![
+                        scrollback_block(&initial_completed),
+                        scrollback_block(&initial_active),
+                    ],
+                    is_alt_screen_active: false,
+                },
+                None,
+                SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                ctx,
+            )
+        });
+
+        let followup_completed = completed_block("followup-command", "followup-output");
+        app.add_model(|ctx| {
+            EventLoop::new(
+                model.clone(),
+                terminal_view.downgrade(),
+                channel_event_proxy.clone(),
+                WindowSize {
+                    num_rows: 0,
+                    num_cols: 0,
+                },
+                Scrollback {
+                    blocks: vec![
+                        scrollback_block(&initial_completed),
+                        scrollback_block(&followup_completed),
+                    ],
+                    is_alt_screen_active: false,
+                },
+                None,
+                SharedSessionInitialLoadMode::AppendFollowupScrollback,
+                ctx,
+            )
+        });
+
+        let model = model.lock();
+        let commands = model
+            .block_list()
+            .blocks()
+            .iter()
+            .map(|block| block.command_to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(model.block_list().blocks().len(), 5);
+        assert_eq!(
+            commands
+                .iter()
+                .filter(|command| command.as_str() == "initial-command")
+                .count(),
+            1
+        );
+        assert_eq!(
+            commands
+                .iter()
+                .filter(|command| command.as_str() == "followup-command")
+                .count(),
+            1
+        );
+        assert_eq!(model.block_list().active_block_index(), 4.into());
+        assert_eq!(
+            model
+                .block_list()
+                .active_block()
+                .height(&AgentViewState::Inactive),
+            Lines::zero()
+        );
+        assert!(!model.block_list().active_block().started());
+    })
+}
+
+#[test]
 fn test_append_followup_replay_marks_existing_conversations_suppressible() {
     App::test((), |mut app| async move {
         let channel_event_proxy = ChannelEventListener::new_for_test();

--- a/specs/APP-4457/TECH.md
+++ b/specs/APP-4457/TECH.md
@@ -1,0 +1,73 @@
+# APP-4457 — Shared-session scrollback restore optional active block
+
+Linear: [APP-4457](https://linear.app/warpdotdev/issue/APP-4457/fix-shared-session-scrollback-restore-crash-when-active-block-is)
+Sentry: [7475296168](https://warpdotdev.sentry.io/issues/7475296168/?alert_rule_id=15217488&alert_type=issue&notification_uuid=93ccd349-0267-4363-90d3-925a1c8ca43f&project=5701177&referrer=slack)
+
+## Context
+
+Shared-session scrollback restoration crashed because the viewer restore path inferred that the final serialized block was always the unfinished active prompt block. That contract is too strong: the sharer serializes only blocks that pass shared-session visibility rules, so the active block can be absent when it is hidden or otherwise not scrollback-eligible.
+
+The producer side lives in `app/src/terminal/shared_session/mod.rs`. `SharedSessionScrollbackType` starts the serialized range at the selected block or active block (`mod.rs:178`), and `to_scrollback` filters each block through `Block::is_scrollback_block_for_shared_session` before serializing it (`mod.rs:199`). That filter is implemented in `app/src/terminal/model/block.rs:1506`; it excludes hidden/restored blocks and therefore does not guarantee the active block will be emitted.
+
+The consumer side lives in `app/src/terminal/model/blocks.rs`. `BlockList::load_shared_session_scrollback` handles initial viewer restore (`blocks.rs:711`), and `BlockList::append_followup_shared_session_scrollback` handles cloud/follow-up session append (`blocks.rs:742`). Both paths need the same scrollback shape so initial joins and follow-up joins do not diverge.
+
+The affected Sentry issue points at a debug assertion in the old restore shape: after `split_last()`, the final item was asserted to be unfinished. When the final serialized item was a completed block, that assertion failed instead of restoring completed history and leaving the viewer with a valid active block.
+
+## Proposed changes
+
+Treat a shared-session scrollback snapshot as completed historical blocks plus an optional active prompt block. The active block is present only when the final serialized block is unfinished (`completed_ts.is_none()`). All other serialized blocks are historical blocks and must be completed before they are restored.
+
+Add a small private parser near the restore code:
+
+- `SharedSessionScrollbackBlocks` in `app/src/terminal/model/blocks.rs:548`
+- `completed_blocks: &[SerializedBlock]`
+- `active_block: Option<&SerializedBlock>`
+
+The parser calls `split_last()` only to classify the final item. If the final item has `completed_ts.is_none()`, it becomes the optional active block and the prefix becomes completed history. Otherwise the full slice is completed history and `active_block` is `None`.
+
+Update `load_shared_session_scrollback` to:
+
+1. Finish any pre-existing unfinished local active block before restore.
+2. Restore each parsed completed block only if it has both `start_ts` and `completed_ts`.
+3. Restore the optional active block when present.
+4. Otherwise call `ensure_active_block_after_shared_session_scrollback` to create a fresh post-bootstrap active block if the current active block is finished.
+
+Update `append_followup_shared_session_scrollback` to use the same parsed shape while preserving its existing duplicate-block behavior:
+
+1. Skip completed blocks whose IDs already exist in the viewer model.
+2. Finish the current active block before restoring new completed blocks or a new active block.
+3. Skip duplicate active blocks by ID.
+4. If the follow-up snapshot has no active block, keep the current unfinished active block when one exists; otherwise create a fresh hidden active block.
+
+Update producer/consumer comments so they describe the actual contract: active prompt state is included only when the active block is scrollback-eligible, not unconditionally.
+
+## Testing and validation
+
+Add regression coverage for both restore paths:
+
+- `app/src/terminal/shared_session/mod_tests.rs:304` — initial restore with a completed final serialized block restores all completed blocks and creates a fresh hidden active block.
+- `app/src/terminal/shared_session/viewer/event_loop_tests.rs:284` — follow-up append with a completed final serialized block preserves duplicate skipping, appends new completed history, and leaves a fresh hidden active block.
+
+Keep existing active-block-present tests unchanged so normal live-sharing behavior remains covered:
+
+- `test_loading_scrollback`
+- `test_loading_scrollback_in_alt_screen`
+- `test_append_followup_scrollback_skips_duplicates`
+
+Validation commands:
+
+- `cargo nextest run -p warp --lib test_loading_scrollback`
+- `cargo nextest run -p warp --lib test_append_followup_scrollback`
+- `git --no-pager diff --check -- app/src/terminal/model/blocks.rs app/src/terminal/model/block.rs app/src/terminal/shared_session/mod.rs app/src/terminal/shared_session/mod_tests.rs app/src/terminal/shared_session/viewer/event_loop_tests.rs specs/APP-4457/TECH.md`
+
+Do not use `cargo fmt --all` or file-specific `cargo fmt`. If formatting is required before review, use the repo-standard `cargo fmt`.
+
+## Parallelization
+
+Sub-agents are not useful for this change. The implementation is small and tightly coupled across one restore parser, two restore paths, nearby contract comments, and focused tests. Parallel edits would introduce coordination overhead and risk conflicting changes in the same files. Validation is also fast enough to run sequentially.
+
+## Risks and mitigations
+
+The main risk is accidentally changing the active-block-present path used by normal live sharing. Keep that path covered by the existing `test_loading_scrollback` and follow-up duplicate tests, and make the new parser classify an active block solely by the persisted completion state.
+
+Follow-up append has a second risk: completed history from the original snapshot may be replayed during follow-up attach. Preserve ID-based duplicate skipping for completed and active blocks so the follow-up path appends only newly observed blocks.


### PR DESCRIPTION
## Description
- Formalizes shared-session scrollback snapshots as completed historical blocks plus an optional unfinished active block.
- Restores completed-only snapshots without asserting that the final serialized block is active, and ensures the viewer model still has a fresh hidden active block.
- Preserves follow-up duplicate skipping and adds focused regression coverage.
- Adds `specs/APP-4457/TECH.md` documenting the crash, Sentry issue, contract, and validation strategy.

## Linked Issue
- Linear: https://linear.app/warpdotdev/issue/APP-4457/fix-shared-session-scrollback-restore-crash-when-active-block-is
- Sentry: https://warpdotdev.sentry.io/issues/7475296168/?alert_rule_id=15217488&alert_type=issue&notification_uuid=93ccd349-0267-4363-90d3-925a1c8ca43f&project=5701177&referrer=slack
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. N/A: this is a newly-created Linear issue for the crash fix.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes). N/A: no UI change.

## Testing
- `cargo fmt`
- `cargo nextest run -p warp --lib test_loading_scrollback`
- `cargo nextest run -p warp --lib test_append_followup_scrollback`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- `git --no-pager diff --check -- app/src/terminal/model/blocks.rs app/src/terminal/model/block.rs app/src/terminal/shared_session/mod.rs app/src/terminal/shared_session/mod_tests.rs app/src/terminal/shared_session/viewer/event_loop_tests.rs specs/APP-4457/TECH.md`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — no user-visible UI change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
Co-Authored-By: Oz <oz-agent@warp.dev>