### PR TITLE
Version aware daemon socket

### DIFF
--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -55,15 +55,17 @@ impl SshTransport {
 
     pub fn remote_daemon_socket_path(&self) -> String {
         format!(
-            "{}/server.sock",
-            remote_server_daemon_dir(&self.auth_context.remote_server_identity_key())
+            "{}/{}",
+            remote_server_daemon_dir(&self.auth_context.remote_server_identity_key()),
+            remote_server::setup::daemon_socket_name(),
         )
     }
 
     pub fn remote_daemon_pid_path(&self) -> String {
         format!(
-            "{}/server.pid",
-            remote_server_daemon_dir(&self.auth_context.remote_server_identity_key())
+            "{}/{}",
+            remote_server_daemon_dir(&self.auth_context.remote_server_identity_key()),
+            remote_server::setup::daemon_pid_name(),
         )
     }
 

--- a/app/src/remote_server/unix/proxy.rs
+++ b/app/src/remote_server/unix/proxy.rs
@@ -41,12 +41,16 @@ fn daemon_dir(identity_key: &str) -> PathBuf {
     PathBuf::from(expanded)
 }
 
-/// Scans the identity-key daemon directory and cleans up socket/PID files
+/// Scans the identity-key daemon directory and removes socket/PID files
 /// from previous daemon versions.
 ///
-/// For each old PID file found, sends `SIGTERM` to the old daemon (if still
-/// alive) so it shuts down gracefully, then removes both the PID and socket
-/// files. Errors are logged but do not prevent the proxy from proceeding.
+/// Old daemons are **not** killed — they may still be serving active
+/// connections from an older Warp client. Removing their socket file
+/// prevents new proxies from accidentally connecting to them, and the
+/// daemon's built-in grace timer (10 min with no connections) will shut
+/// it down naturally after the last client disconnects.
+///
+/// Errors are logged but do not prevent the proxy from proceeding.
 fn cleanup_old_versions(identity_key: &str) {
     let dir = daemon_dir(identity_key);
     let current_socket = setup::daemon_socket_name();
@@ -63,34 +67,19 @@ fn cleanup_old_versions(identity_key: &str) {
             continue;
         };
 
-        // Match old PID files: server*.pid that aren't the current version.
+        // Remove old PID files: server*.pid that aren't the current version.
         if name_str.ends_with(".pid") && name_str.starts_with("server") && name_str != current_pid {
-            let old_pid_path = entry.path();
-            // Try to SIGTERM the old daemon.
-            if let Ok(contents) = std::fs::read_to_string(&old_pid_path) {
-                if let Ok(pid) = contents.trim().parse::<libc::pid_t>() {
-                    // SAFETY: sending SIGTERM is safe — it requests graceful
-                    // shutdown. If the process doesn't exist, kill returns -1
-                    // with ESRCH which we ignore.
-                    let ret = unsafe { libc::kill(pid, libc::SIGTERM) };
-                    if ret == 0 {
-                        log::info!(
-                            "Proxy: sent SIGTERM to old daemon (pid={pid}, file={name_str})"
-                        );
-                    }
-                }
-            }
-            let _ = std::fs::remove_file(&old_pid_path);
+            log::info!("Proxy: removing old PID file {name_str}");
+            let _ = std::fs::remove_file(entry.path());
         }
 
-        // Match old socket files: server*.sock that aren't the current version.
+        // Remove old socket files: server*.sock that aren't the current version.
         if name_str.ends_with(".sock")
             && name_str.starts_with("server")
             && name_str != current_socket
         {
-            let old_sock_path = entry.path();
             log::info!("Proxy: removing old socket file {name_str}");
-            let _ = std::fs::remove_file(&old_sock_path);
+            let _ = std::fs::remove_file(entry.path());
         }
     }
 }

--- a/app/src/remote_server/unix/proxy.rs
+++ b/app/src/remote_server/unix/proxy.rs
@@ -19,18 +19,80 @@ use std::time::Duration;
 
 use super::super::setup;
 
-/// Path to the daemon's Unix domain socket.
+/// Path to the daemon's Unix domain socket, versioned on release channels.
 pub(super) fn socket_path(identity_key: &str) -> PathBuf {
     let dir = setup::remote_server_daemon_dir(identity_key);
     let expanded = shellexpand::tilde(&dir).into_owned();
-    PathBuf::from(expanded).join("server.sock")
+    PathBuf::from(expanded).join(setup::daemon_socket_name())
 }
 
-/// Path to the daemon's PID file (also used as the flock target).
+/// Path to the daemon's PID file (also used as the flock target),
+/// versioned on release channels.
 pub(super) fn pid_path(identity_key: &str) -> PathBuf {
     let dir = setup::remote_server_daemon_dir(identity_key);
     let expanded = shellexpand::tilde(&dir).into_owned();
-    PathBuf::from(expanded).join("server.pid")
+    PathBuf::from(expanded).join(setup::daemon_pid_name())
+}
+
+/// Daemon directory for the given identity key (expanded, no tilde).
+fn daemon_dir(identity_key: &str) -> PathBuf {
+    let dir = setup::remote_server_daemon_dir(identity_key);
+    let expanded = shellexpand::tilde(&dir).into_owned();
+    PathBuf::from(expanded)
+}
+
+/// Scans the identity-key daemon directory and cleans up socket/PID files
+/// from previous daemon versions.
+///
+/// For each old PID file found, sends `SIGTERM` to the old daemon (if still
+/// alive) so it shuts down gracefully, then removes both the PID and socket
+/// files. Errors are logged but do not prevent the proxy from proceeding.
+fn cleanup_old_versions(identity_key: &str) {
+    let dir = daemon_dir(identity_key);
+    let current_socket = setup::daemon_socket_name();
+    let current_pid = setup::daemon_pid_name();
+
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+
+        // Match old PID files: server*.pid that aren't the current version.
+        if name_str.ends_with(".pid") && name_str.starts_with("server") && name_str != current_pid {
+            let old_pid_path = entry.path();
+            // Try to SIGTERM the old daemon.
+            if let Ok(contents) = std::fs::read_to_string(&old_pid_path) {
+                if let Ok(pid) = contents.trim().parse::<libc::pid_t>() {
+                    // SAFETY: sending SIGTERM is safe — it requests graceful
+                    // shutdown. If the process doesn't exist, kill returns -1
+                    // with ESRCH which we ignore.
+                    let ret = unsafe { libc::kill(pid, libc::SIGTERM) };
+                    if ret == 0 {
+                        log::info!(
+                            "Proxy: sent SIGTERM to old daemon (pid={pid}, file={name_str})"
+                        );
+                    }
+                }
+            }
+            let _ = std::fs::remove_file(&old_pid_path);
+        }
+
+        // Match old socket files: server*.sock that aren't the current version.
+        if name_str.ends_with(".sock")
+            && name_str.starts_with("server")
+            && name_str != current_socket
+        {
+            let old_sock_path = entry.path();
+            log::info!("Proxy: removing old socket file {name_str}");
+            let _ = std::fs::remove_file(&old_sock_path);
+        }
+    }
 }
 
 /// Ensures the daemon directory exists with owner-only permissions.
@@ -52,6 +114,10 @@ pub fn run(identity_key: &str) -> anyhow::Result<()> {
     if let Some(parent) = socket_path.parent() {
         ensure_private_daemon_dir(parent)?;
     }
+
+    // Clean up socket/PID files from previous daemon versions so stale
+    // daemons left over after autoupdate don't linger.
+    cleanup_old_versions(identity_key);
 
     // ---- Acquire exclusive flock on the PID file --------------------------------
     //

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -343,29 +343,27 @@ pub fn remote_server_daemon_data_dir(identity_key: &str) -> String {
     format!("{}/data", remote_server_daemon_dir(identity_key))
 }
 
-/// Returns the daemon socket filename, versioned on release channels.
+/// Returns the daemon socket filename, versioned when a release tag is
+/// baked in.
 ///
-/// - Release channels: `server-{version}.sock`
-/// - Local / Oss:      `server.sock`
+/// - With `GIT_RELEASE_TAG`:    `server-{version}.sock`
+/// - Without (plain cargo run): `server.sock`
 pub fn daemon_socket_name() -> String {
-    match ChannelState::channel() {
-        Channel::Local | Channel::Oss => "server.sock".to_string(),
-        Channel::Stable | Channel::Preview | Channel::Dev | Channel::Integration => {
-            format!("server-{}.sock", pinned_version())
-        }
+    match ChannelState::app_version() {
+        Some(version) => format!("server-{version}.sock"),
+        None => "server.sock".to_string(),
     }
 }
 
-/// Returns the daemon PID filename, versioned on release channels.
+/// Returns the daemon PID filename, versioned when a release tag is
+/// baked in.
 ///
-/// - Release channels: `server-{version}.pid`
-/// - Local / Oss:      `server.pid`
+/// - With `GIT_RELEASE_TAG`:    `server-{version}.pid`
+/// - Without (plain cargo run): `server.pid`
 pub fn daemon_pid_name() -> String {
-    match ChannelState::channel() {
-        Channel::Local | Channel::Oss => "server.pid".to_string(),
-        Channel::Stable | Channel::Preview | Channel::Dev | Channel::Integration => {
-            format!("server-{}.pid", pinned_version())
-        }
+    match ChannelState::app_version() {
+        Some(version) => format!("server-{version}.pid"),
+        None => "server.pid".to_string(),
     }
 }
 

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -343,6 +343,32 @@ pub fn remote_server_daemon_data_dir(identity_key: &str) -> String {
     format!("{}/data", remote_server_daemon_dir(identity_key))
 }
 
+/// Returns the daemon socket filename, versioned on release channels.
+///
+/// - Release channels: `server-{version}.sock`
+/// - Local / Oss:      `server.sock`
+pub fn daemon_socket_name() -> String {
+    match ChannelState::channel() {
+        Channel::Local | Channel::Oss => "server.sock".to_string(),
+        Channel::Stable | Channel::Preview | Channel::Dev | Channel::Integration => {
+            format!("server-{}.sock", pinned_version())
+        }
+    }
+}
+
+/// Returns the daemon PID filename, versioned on release channels.
+///
+/// - Release channels: `server-{version}.pid`
+/// - Local / Oss:      `server.pid`
+pub fn daemon_pid_name() -> String {
+    match ChannelState::channel() {
+        Channel::Local | Channel::Oss => "server.pid".to_string(),
+        Channel::Stable | Channel::Preview | Channel::Dev | Channel::Integration => {
+            format!("server-{}.pid", pinned_version())
+        }
+    }
+}
+
 /// Returns the binary name, keyed by channel.
 ///
 /// Matches the CLI command names: `oz` (stable), `oz-preview`, `oz-dev`.


### PR DESCRIPTION
## Description
This creates a version aware daemon socket. There are two main components:
1. Now socket connections are versioned. So given proxy version X, we will connect to server-X.pid and server-X.socket. This allows proxy to enforce it's connecting to a daemon with the SAME version
2. After connection, proxy also cleans up any old socket and pid file that doesn't match with its version

## Testing
I tested the versioned socket creation and clean up separately

Versioned socket:
1. Deploy the server with dev channel and rename it to a versioned binary `v0.2026.05.12.09.10.dev_00`
2. Run a local binary with `GIT_RELEASE_TAG=v0.2026.05.12.09.10.dev_00 cargo run --bin dev`
3. Confirm the connection is successful and the right socket / pid file is created
<img width="353" height="108" alt="Screenshot 2026-05-13 at 11 02 59 AM" src="https://github.com/user-attachments/assets/97b53b18-9522-47cc-a783-720a2c8df1aa" />

Clean up:
1. Rename the existing socket/pid file from the last step to `server-old-X.pid` and `server-old-X.socket`
2. Run a local binary with `GIT_RELEASE_TAG=v0.2026.05.12.09.10.dev_00 cargo run --bin dev`
3. Confirm the connection is successful, old socket/pid is removed, new socket/pid file is created