### PR TITLE
Cloud mode v2: unify no-auth-secret label

### DIFF
--- a/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
@@ -38,7 +38,7 @@ const MENU_HORIZONTAL_PADDING: f32 = 16.;
 
 const ITEM_VERTICAL_PADDING: f32 = 8.;
 
-const MENU_WIDTH: f32 = 208.;
+const MENU_WIDTH: f32 = 232.;
 
 const SIDECAR_WIDTH: f32 = 220.;
 
@@ -52,7 +52,7 @@ const MENU_HEADER_LABEL: &str = "API key";
 
 const SIDECAR_HEADER_LABEL: &str = "Choose a type";
 
-const NO_SECRET_LABEL: &str = "Inherit from environment";
+const NO_SECRET_LABEL: &str = "Inherit key from environment";
 
 const NEW_ITEM_LABEL: &str = "New";
 

--- a/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
@@ -52,7 +52,7 @@ const MENU_HEADER_LABEL: &str = "API key";
 
 const SIDECAR_HEADER_LABEL: &str = "Choose a type";
 
-const NO_SECRET_LABEL: &str = "Inherit credentials from environment";
+const NO_SECRET_LABEL: &str = "Inherit from environment";
 
 const NEW_ITEM_LABEL: &str = "New";
 

--- a/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
@@ -52,7 +52,7 @@ const MENU_HEADER_LABEL: &str = "API key";
 
 const SIDECAR_HEADER_LABEL: &str = "Choose a type";
 
-const NO_SECRET_LABEL: &str = "No API key";
+const NO_SECRET_LABEL: &str = "Inherit credentials from environment";
 
 const NEW_ITEM_LABEL: &str = "New";
 
@@ -407,7 +407,7 @@ fn build_main_menu_items(
     let mut items = vec![header];
 
     items.push(MenuItem::Item(
-        MenuItemFields::new("No secret")
+        MenuItemFields::new(NO_SECRET_LABEL)
             .with_font_size_override(ITEM_FONT_SIZE)
             .with_padding_override(ITEM_VERTICAL_PADDING, MENU_HORIZONTAL_PADDING)
             .with_override_hover_background_color(hover_background)


### PR DESCRIPTION
## Summary
- In cloud mode v2, the auth secret selector showed a discrepancy between the menu item label ("No secret") and the button label when no secret was selected ("No API key").
- Both labels now use the same text: **"Inherit from environment"** — which more clearly communicates what happens when no secret is selected.

Fixes https://linear.app/warpdotdev/issue/APP-4416/consider-renaming-no-api-key-to-something-that-makes-sense

## Testing

<img width="619" height="245" alt="Screenshot 2026-05-12 at 7 27 37 PM" src="https://github.com/user-attachments/assets/1aa03a57-9e35-42b6-8682-1139ade151fd" />


_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._