### PR TITLE
Suppress cloud follow-up setup input sync

### DIFF
--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -1102,9 +1102,7 @@ impl TerminalManager {
                     {
                         return;
                     }
-                    view.input().update(ctx, |input, ctx| {
-                        input.process_remote_edits(block_id, operations.clone(), ctx);
-                    })
+                    view.apply_viewer_shared_session_input_update(block_id, operations.clone(), ctx);
                 })
             }
             NetworkEvent::RoleRequestInFlight(role_request_id) => {

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -1016,9 +1016,7 @@ impl TerminalManager {
                     {
                         return;
                     }
-                    view.input().update(ctx, |input, ctx| {
-                        input.process_remote_edits(block_id, operations.clone(), ctx);
-                    })
+                    view.apply_viewer_shared_session_input_update(block_id, operations.clone(), ctx);
                 })
             }
             NetworkEvent::RoleRequestInFlight(role_request_id) => {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7321,6 +7321,30 @@ impl TerminalView {
         self.model.lock().is_shared_session_viewer()
     }
 
+    pub(crate) fn apply_viewer_shared_session_input_update(
+        &mut self,
+        block_id: &BlockId,
+        operations: Vec<CrdtOperation>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.should_suppress_ambient_setup_input_sync(ctx) {
+            return;
+        }
+
+        self.input().update(ctx, |input, ctx| {
+            input.process_remote_edits(block_id, operations, ctx);
+        });
+    }
+
+    fn should_suppress_ambient_setup_input_sync(&self, app: &AppContext) -> bool {
+        FeatureFlag::CloudModeSetupV2.is_enabled()
+            && self.ambient_agent_view_model.as_ref().is_some_and(|model| {
+                let model = model.as_ref(app);
+                let setup_state = model.setup_command_state();
+                setup_state.should_suppress_input_sync_for_current_group()
+            })
+    }
+
     pub fn ssh_file_upload(&self) -> &ViewHandle<FileUpload> {
         &self.ssh_file_upload
     }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7133,6 +7133,29 @@ impl TerminalView {
     pub fn is_shared_session_viewer(&self) -> bool {
         self.model.lock().is_shared_session_viewer()
     }
+    pub(crate) fn should_suppress_ambient_setup_input_sync(&self, app: &AppContext) -> bool {
+        FeatureFlag::CloudModeSetupV2.is_enabled()
+            && self.ambient_agent_view_model.as_ref().is_some_and(|model| {
+                let model = model.as_ref(app);
+                let setup_state = model.setup_command_state();
+                setup_state.did_execute_a_setup_command() && setup_state.is_current_group_running()
+            })
+    }
+
+    pub(crate) fn apply_viewer_shared_session_input_update(
+        &mut self,
+        block_id: &BlockId,
+        operations: Vec<CrdtOperation>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.should_suppress_ambient_setup_input_sync(ctx) {
+            return;
+        }
+
+        self.input().update(ctx, |input, ctx| {
+            input.process_remote_edits(block_id, operations, ctx);
+        });
+    }
 
     pub fn ssh_file_upload(&self) -> &ViewHandle<FileUpload> {
         &self.ssh_file_upload

--- a/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
+++ b/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
@@ -76,6 +76,11 @@ impl SetupCommandState {
         self.running_group_id == Some(group_id)
     }
 
+    pub fn should_suppress_input_sync_for_current_group(&self) -> bool {
+        self.current_group_id != SetupCommandGroupId::initial()
+            && self.is_running(self.current_group_id)
+    }
+
     pub fn start_new_group(&mut self) -> SetupCommandGroupId {
         let group_id = SetupCommandGroupId(self.next_group_id);
         self.next_group_id += 1;

--- a/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
+++ b/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
@@ -75,6 +75,9 @@ impl SetupCommandState {
     pub fn is_running(&self, group_id: SetupCommandGroupId) -> bool {
         self.running_group_id == Some(group_id)
     }
+    pub fn is_current_group_running(&self) -> bool {
+        self.is_running(self.current_group_id)
+    }
 
     pub fn start_new_group(&mut self) -> SetupCommandGroupId {
         let group_id = SetupCommandGroupId(self.next_group_id);

--- a/app/src/terminal/view/ambient_agent/block/setup_command_text_tests.rs
+++ b/app/src/terminal/view/ambient_agent/block/setup_command_text_tests.rs
@@ -19,16 +19,20 @@ fn setup_command_groups_have_independent_visibility() {
 fn setup_command_groups_track_running_group_independently() {
     let mut state = SetupCommandState::default();
     let first_group_id = state.current_group_id();
+    assert!(!state.should_suppress_input_sync_for_current_group());
     let second_group_id = state.start_new_group();
 
     assert!(!state.is_running(first_group_id));
     assert!(state.is_running(second_group_id));
+    assert!(state.should_suppress_input_sync_for_current_group());
 
     state.finish_group(first_group_id);
 
     assert!(state.is_running(second_group_id));
+    assert!(state.should_suppress_input_sync_for_current_group());
 
     state.finish_group(second_group_id);
 
     assert!(!state.is_running(second_group_id));
+    assert!(!state.should_suppress_input_sync_for_current_group());
 }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -37,7 +37,7 @@ use crate::ai::blocklist::{
 };
 use crate::ai::llms::LLMId;
 use crate::context_chips::prompt::Prompt;
-use crate::editor::{AutosuggestionLocation, AutosuggestionType};
+use crate::editor::{AutosuggestionLocation, AutosuggestionType, CrdtOperation};
 use crate::features::FeatureFlag;
 use crate::pane_group::focus_state::PaneGroupFocusState;
 use crate::pane_group::{pane::PaneStack, BackingView, TerminalPaneId};
@@ -98,6 +98,21 @@ fn has_pending_user_query_block(view: &TerminalView) -> bool {
     };
     view.rich_content_views.iter().any(|rich_content| {
         rich_content.view_id() == view_id && rich_content.is_pending_user_query()
+    })
+}
+fn input_operations_for_buffer_content(app: &mut App, content: &str) -> Vec<CrdtOperation> {
+    let terminal = add_window_with_terminal(app, None);
+    terminal.update(app, |view, ctx| {
+        view.input().update(ctx, |input, ctx| {
+            input.replace_buffer_content(content, ctx);
+        });
+    });
+    terminal.read(app, |view, ctx| {
+        view.input()
+            .as_ref(ctx)
+            .latest_buffer_operations()
+            .cloned()
+            .collect()
     })
 }
 
@@ -1458,6 +1473,67 @@ fn cloud_mode_followup_dispatched_inserts_queued_user_query() {
             view.handle_ambient_agent_event(&AmbientAgentViewModelEvent::FollowupDispatched, ctx);
 
             assert!(has_pending_user_query_block(view));
+        });
+    });
+}
+
+#[test]
+fn cloud_mode_setup_v2_suppresses_sharer_input_updates_while_followup_setup_commands_run() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _handoff = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+        let _setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+        let setup_command_ops = input_operations_for_buffer_content(&mut app, "setup command text");
+        let normal_input_ops = input_operations_for_buffer_content(&mut app, "normal sync text");
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        let task_id = AmbientAgentTaskId::from_str("123e4567-e89b-12d3-a456-426614174000")
+            .expect("valid task id");
+
+        terminal.update(&mut app, |view, ctx| {
+            let ambient_agent_view_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .clone();
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.enter_viewing_existing_session(task_id, ctx);
+            });
+            view.handle_ambient_agent_event(&AmbientAgentViewModelEvent::FollowupDispatched, ctx);
+
+            {
+                let model = view.model.lock();
+                assert!(view.is_input_box_visible(&model, ctx));
+            }
+            assert!(view.should_suppress_ambient_setup_input_sync(ctx));
+
+            let active_block_id = view.model.lock().block_list().active_block_id().clone();
+            view.input().update(ctx, |input, ctx| {
+                input.refresh_deferred_remote_operations(ctx);
+            });
+            view.apply_viewer_shared_session_input_update(&active_block_id, setup_command_ops, ctx);
+            assert_eq!(view.input().as_ref(ctx).buffer_text(ctx), "");
+            ambient_agent_view_model.update(ctx, |model, _| {
+                model
+                    .setup_command_state_mut()
+                    .set_did_execute_a_setup_command(true);
+            });
+            assert!(view.should_suppress_ambient_setup_input_sync(ctx));
+
+            ambient_agent_view_model.update(ctx, |model, _| {
+                let group_id = model.setup_command_state().current_group_id();
+                model.setup_command_state_mut().finish_group(group_id);
+            });
+            assert!(!view.should_suppress_ambient_setup_input_sync(ctx));
+            view.apply_viewer_shared_session_input_update(&active_block_id, normal_input_ops, ctx);
+            assert_eq!(
+                view.input().as_ref(ctx).buffer_text(ctx),
+                "normal sync text"
+            );
+
+            let model = view.model.lock();
+            assert!(view.is_input_box_visible(&model, ctx));
         });
     });
 }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -27,7 +27,7 @@ use crate::ai::blocklist::{
 };
 use crate::ai::llms::LLMId;
 use crate::context_chips::prompt::Prompt;
-use crate::editor::{AutosuggestionLocation, AutosuggestionType};
+use crate::editor::{AutosuggestionLocation, AutosuggestionType, CrdtOperation};
 use crate::features::FeatureFlag;
 use crate::pane_group::focus_state::PaneGroupFocusState;
 use crate::pane_group::{pane::PaneStack, BackingView, TerminalPaneId};
@@ -80,6 +80,21 @@ fn has_pending_user_query_block(view: &TerminalView) -> bool {
     };
     view.rich_content_views.iter().any(|rich_content| {
         rich_content.view_id() == view_id && rich_content.is_pending_user_query()
+    })
+}
+fn input_operations_for_buffer_content(app: &mut App, content: &str) -> Vec<CrdtOperation> {
+    let terminal = add_window_with_terminal(app, None);
+    terminal.update(app, |view, ctx| {
+        view.input().update(ctx, |input, ctx| {
+            input.replace_buffer_content(content, ctx);
+        });
+    });
+    terminal.read(app, |view, ctx| {
+        view.input()
+            .as_ref(ctx)
+            .latest_buffer_operations()
+            .cloned()
+            .collect()
     })
 }
 
@@ -1049,6 +1064,71 @@ fn cloud_mode_followup_dispatched_inserts_queued_user_query() {
             view.handle_ambient_agent_event(&AmbientAgentViewModelEvent::FollowupDispatched, ctx);
 
             assert!(has_pending_user_query_block(view));
+        });
+    });
+}
+
+#[test]
+fn cloud_mode_setup_v2_suppresses_sharer_input_updates_while_followup_setup_commands_run() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _handoff = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+        let _setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+        let setup_command_ops = input_operations_for_buffer_content(&mut app, "setup command text");
+        let normal_input_ops = input_operations_for_buffer_content(&mut app, "normal sync text");
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        let task_id = AmbientAgentTaskId::from_str("123e4567-e89b-12d3-a456-426614174000")
+            .expect("valid task id");
+
+        terminal.update(&mut app, |view, ctx| {
+            let ambient_agent_view_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .clone();
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.enter_viewing_existing_session(task_id, ctx);
+            });
+            view.handle_ambient_agent_event(&AmbientAgentViewModelEvent::FollowupDispatched, ctx);
+
+            ambient_agent_view_model.update(ctx, |model, _| {
+                model
+                    .setup_command_state_mut()
+                    .set_did_execute_a_setup_command(true);
+            });
+
+            {
+                let model = view.model.lock();
+                assert!(view.is_input_box_visible(&model, ctx));
+            }
+            assert!(view.should_suppress_ambient_setup_input_sync(ctx));
+
+            let active_block_id = view.model.lock().block_list().active_block_id().clone();
+            view.input().update(ctx, |input, ctx| {
+                input.refresh_deferred_remote_operations(ctx);
+            });
+            view.apply_viewer_shared_session_input_update(
+                &active_block_id,
+                setup_command_ops.clone(),
+                ctx,
+            );
+            assert_eq!(view.input().as_ref(ctx).buffer_text(ctx), "");
+
+            ambient_agent_view_model.update(ctx, |model, _| {
+                let group_id = model.setup_command_state().current_group_id();
+                model.setup_command_state_mut().finish_group(group_id);
+            });
+            assert!(!view.should_suppress_ambient_setup_input_sync(ctx));
+            view.apply_viewer_shared_session_input_update(&active_block_id, normal_input_ops, ctx);
+            assert_eq!(
+                view.input().as_ref(ctx).buffer_text(ctx),
+                "normal sync text"
+            );
+
+            let model = view.model.lock();
+            assert!(view.is_input_box_visible(&model, ctx));
         });
     });
 }

--- a/specs/APP-4460/TECH.md
+++ b/specs/APP-4460/TECH.md
@@ -1,0 +1,28 @@
+# APP-4460: Suppress Cloud Mode setup input sync during follow-up setup commands
+## Context
+APP-4460 covers Cloud Mode follow-up executions that run setup commands before the next agent exchange. The desired behavior is to keep the follow-up input visible and interactive for the viewer, but prevent the ambient-agent sharer's setup-command text from syncing into the viewer's input while that setup phase is active.
+Cloud Mode panes are backed by `AmbientAgentViewModel`. Initial runs call `spawn_internal`, set `Status::WaitingForSession { kind: InitialRun }`, and emit `DispatchedAgent` in `app/src/terminal/view/ambient_agent/model.rs (1224-1248)`. Follow-ups call `submit_cloud_followup`, set `pending_followup_prompt`, transition to `Status::WaitingForSession { kind: Followup }`, and emit `FollowupDispatched` in `app/src/terminal/view/ambient_agent/model.rs (898-923)`. `TerminalView::handle_ambient_agent_event` responds to `FollowupDispatched` by starting a new setup-command group when `CloudModeSetupV2` is enabled in `app/src/terminal/view/ambient_agent/view_impl.rs (168-176)`.
+Setup-command visibility and lifetime live in `SetupCommandState` in `app/src/terminal/view/ambient_agent/block/setup_command_text.rs (23-91)`. The state has a current group, tracks whether that group has executed at least one setup command, and records the currently running group. `maybe_insert_setup_command_blocks` marks `did_execute_a_setup_command` when the first startup command block appears and inserts the setup summary and per-command rich content in `app/src/terminal/view/ambient_agent/view_impl.rs (373-453)`. The group is finished and collapsed when the first Oz exchange arrives or a third-party harness command starts.
+Viewer input updates from the ambient sharer arrive through the shared-session CRDT path. `NetworkEvent::InputUpdated` is handled in `app/src/terminal/shared_session/viewer/terminal_manager.rs`, and previously applied remote operations directly with `Input::process_remote_edits`. There is already broad startup suppression for `ambient_agent::is_cloud_agent_pre_first_exchange`, but follow-up setup groups can continue after the viewer has an ambient model and visible input, so the setup command text can still be applied to the viewer input unless the receiver suppresses it.
+## Proposed changes
+Keep the input visibility behavior unchanged for Cloud Mode setup-v2 follow-ups: the viewer input should remain visible and interactive while setup commands run.
+Add a narrow setup-v2 sync predicate on `TerminalView` that checks:
+- `FeatureFlag::CloudModeSetupV2` is enabled;
+- the pane has an `AmbientAgentViewModel`;
+- the ambient model's current setup-command group is a non-initial follow-up group;
+- that current group is still running.
+Derive input-sync suppression from the running follow-up setup group rather than from whether a setup command block has rendered, so the first setup command is suppressed even if its shared-session input update arrives before `maybe_insert_setup_command_blocks` marks the group as having executed a command.
+Route viewer shared-session input updates through `TerminalView::apply_viewer_shared_session_input_update`. That method should return without applying CRDT operations while the narrow predicate is true, and otherwise call `Input::process_remote_edits` as before. This receiver-side suppression keeps local viewer drafts intact during the follow-up setup phase and automatically resumes normal shared-session input sync once the setup group finishes.
+Do not change setup-command rendering, setup-command grouping, follow-up submission routing, tombstone behavior, or broad pre-first-exchange suppression. The fix is specific to shared-session input editor updates from the ambient-agent sharer during an active follow-up setup-command group.
+## Testing and validation
+Add unit coverage next to existing Cloud Mode terminal-view tests. The key regression test should:
+- enable `AgentView`, `CloudMode`, `CloudModeSetupV2`, and `HandoffCloudCloud`;
+- create a Cloud Mode terminal;
+- seed an existing ambient task with `enter_viewing_existing_session`;
+- start a follow-up setup-command group by handling `FollowupDispatched`;
+- assert `is_input_box_visible` remains `true`;
+- assert incoming shared-session input operations are not applied while the setup group is running, including before the first setup command block has rendered;
+- finish the setup group and assert incoming shared-session input operations apply again.
+Run the focused test by name with `cargo nextest run -p warp -E 'test(<new test name>)'`. Run `cargo fmt --manifest-path /workspace/warp/Cargo.toml -p warp --check` and a targeted `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --tests -- -D warnings` before updating the PR.
+## Parallelization
+Parallelization is not beneficial for this revision. The implementation is a small, tightly coupled change across one setup-state helper, one shared-session input receiver path, and one regression test; splitting it across agents would add coordination overhead and merge risk without reducing wall-clock time.

--- a/specs/APP-4460/TECH.md
+++ b/specs/APP-4460/TECH.md
@@ -1,0 +1,29 @@
+# APP-4460: Suppress Cloud Mode setup input sync during follow-up setup commands
+## Context
+APP-4460 covers Cloud Mode follow-up executions that run setup commands before the next agent exchange. The desired behavior is to keep the follow-up input visible and interactive for the viewer, but prevent the ambient-agent sharer's setup-command text from syncing into the viewer's input while that setup phase is active.
+Cloud Mode panes are backed by `AmbientAgentViewModel`. Initial runs call `spawn_internal`, set `Status::WaitingForSession { kind: InitialRun }`, and emit `DispatchedAgent` in `app/src/terminal/view/ambient_agent/model.rs (1224-1248)`. Follow-ups call `submit_cloud_followup`, set `pending_followup_prompt`, transition to `Status::WaitingForSession { kind: Followup }`, and emit `FollowupDispatched` in `app/src/terminal/view/ambient_agent/model.rs (898-923)`. `TerminalView::handle_ambient_agent_event` responds to `FollowupDispatched` by starting a new setup-command group when `CloudModeSetupV2` is enabled in `app/src/terminal/view/ambient_agent/view_impl.rs (168-176)`.
+Setup-command visibility and lifetime live in `SetupCommandState` in `app/src/terminal/view/ambient_agent/block/setup_command_text.rs (23-91)`. The state has a current group, tracks whether that group has executed at least one setup command, and records the currently running group. `maybe_insert_setup_command_blocks` marks `did_execute_a_setup_command` when the first startup command block appears and inserts the setup summary and per-command rich content in `app/src/terminal/view/ambient_agent/view_impl.rs (373-453)`. The group is finished and collapsed when the first Oz exchange arrives or a third-party harness command starts.
+Viewer input updates from the ambient sharer arrive through the shared-session CRDT path. `NetworkEvent::InputUpdated` is handled in `app/src/terminal/shared_session/viewer/terminal_manager.rs`, and previously applied remote operations directly with `Input::process_remote_edits`. There is already broad startup suppression for `ambient_agent::is_cloud_agent_pre_first_exchange`, but follow-up setup groups can continue after the viewer has an ambient model and visible input, so the setup command text can still be applied to the viewer input unless the receiver suppresses it.
+## Proposed changes
+Keep the input visibility behavior unchanged for Cloud Mode setup-v2 follow-ups: the viewer input should remain visible and interactive while setup commands run.
+Add a narrow setup-v2 sync predicate on `TerminalView` that checks:
+- `FeatureFlag::CloudModeSetupV2` is enabled;
+- the pane has an `AmbientAgentViewModel`;
+- the ambient model's setup-command state has executed a command in the current group;
+- that current group is still running.
+Expose the group-running check as `SetupCommandState::is_current_group_running()` so `TerminalView` does not compare group ids directly.
+Route viewer shared-session input updates through `TerminalView::apply_viewer_shared_session_input_update`. That method should return without applying CRDT operations while the narrow predicate is true, and otherwise call `Input::process_remote_edits` as before. This receiver-side suppression keeps local viewer drafts intact during the follow-up setup phase and automatically resumes normal shared-session input sync once the setup group finishes.
+Do not change setup-command rendering, setup-command grouping, follow-up submission routing, tombstone behavior, or broad pre-first-exchange suppression. The fix is specific to shared-session input editor updates from the ambient-agent sharer during an active follow-up setup-command group.
+## Testing and validation
+Add unit coverage next to existing Cloud Mode terminal-view tests. The key regression test should:
+- enable `AgentView`, `CloudMode`, `CloudModeSetupV2`, and `HandoffCloudCloud`;
+- create a Cloud Mode terminal;
+- seed an existing ambient task with `enter_viewing_existing_session`;
+- start a follow-up setup-command group by handling `FollowupDispatched`;
+- mark the current group as having executed a setup command;
+- assert `is_input_box_visible` remains `true`;
+- assert incoming shared-session input operations are not applied while the setup group is running;
+- finish the setup group and assert incoming shared-session input operations apply again.
+Run the focused test by name with `cargo nextest run -p warp -E 'test(<new test name>)'`. Run `cargo fmt --manifest-path /workspace/warp/Cargo.toml -p warp --check` and a targeted `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --tests -- -D warnings` before updating the PR.
+## Parallelization
+Parallelization is not beneficial for this revision. The implementation is a small, tightly coupled change across one setup-state helper, one shared-session input receiver path, and one regression test; splitting it across agents would add coordination overhead and merge risk without reducing wall-clock time.


### PR DESCRIPTION
## Description
Suppress incoming shared-session input editor updates from ambient agent sharers while Cloud Mode follow-up setup commands are running. This keeps the viewer's input visible and interactive without syncing transient setup-command text into it, and resumes normal input sync after the setup command group finishes.

## Linked Issue
Linear: https://linear.app/warpdotdev/issue/APP-4460/input-should-be-hidden-when-running-setup-commands-in-follow-up
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `CARGO_BUILD_JOBS=1 cargo nextest run --manifest-path /workspace/warp/Cargo.toml -p warp -E 'test(cloud_mode_setup_v2_suppresses_sharer_input_updates_while_followup_setup_commands_run)'`
- [x] `cargo fmt --manifest-path /workspace/warp/Cargo.toml -p warp --check`
- [x] `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Prevent Cloud Mode follow-up setup command text from syncing into the viewer input.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/7e2c1637-d21b-43ac-b31f-a59186713a2c_
_Run: https://oz.staging.warp.dev/runs/019e1ec1-58ce-70b3-8f05-7c9810f14ada_
_This PR was generated with [Oz](https://warp.dev/oz)._
