### PR TITLE
Demote fancy harness command UI from dogfood

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -941,7 +941,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::NamedAgents,
     FeatureFlag::GitCredentialRefresh,
     FeatureFlag::HandoffCloudCloud,
-    FeatureFlag::HarnessSessionHeader,
     FeatureFlag::SoloUserByok,
 ];
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
We've been seeing some issues with the fancy harness command UI introduced in https://github.com/warpdotdev/warp/pull/10448 (namely: lots of blank space gets rendered below CLI agents running as cloud agents, and the blank space goes away when we toggle the collapsed command open)/

Given that launch is soon, I'm demoting the flag and will take another look at this UI when I have more cycles. I suspect it's something to do with not correctly updating the sumtree/block heights when we hide the harness command.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

Ran locally without the flag, not seeing a ton of blank lines get printed beneath the running CLI agent in cloud mode.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

