### PR TITLE
Launch summary mode for vertical tabs

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -618,6 +618,7 @@ default = [
     "open_code_notifications",
     "cli_agent_rich_input",
     "vertical_tabs",
+    "vertical_tabs_summary_mode",
     "tab_configs",
     "hoa_onboarding_flow",
     "hoa_remote_control",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -930,7 +930,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::RunAgentsTool,
     FeatureFlag::GeminiNotifications,
     FeatureFlag::LocalDockerSandbox,
-    FeatureFlag::VerticalTabsSummaryMode,
     FeatureFlag::CloudModeSetupV2,
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,


### PR DESCRIPTION
## Summary
- Enable `vertical_tabs_summary_mode` in the app default Cargo feature set.

Behold:
<img width="402" height="546" alt="image" src="https://github.com/user-attachments/assets/c6e48484-0a3a-4e63-a112-eb36c8143718" />


## Validation
- `cargo metadata --manifest-path /workspace/warp/Cargo.toml --no-deps --format-version 1`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib --no-default-features --features default`

_Conversation: https://staging.warp.dev/conversation/31e27aee-b935-4127-aa28-99341b26dfb5_
_Run: https://oz.staging.warp.dev/runs/019e1f25-1f17-79b4-9241-655a832e8101_
_This PR was generated with [Oz](https://warp.dev/oz)._
