### PR TITLE
Canonicalize local conversation ID mapping to task ID for cloud agent tasks.

### DIFF
--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -101,11 +101,9 @@ pub fn convert_conversation_data_to_ai_conversation(
             orchestration_harness_type: None,
             parent_conversation_id: None,
             is_remote_child: false,
-            // TODO: Populate run_id from server metadata once it is exposed
-            // in ServerAIConversationMetadata. For cloud conversations that
-            // were spawned via the server API, the run_id is created at task
-            // dispatch time; adding it here would avoid a round-trip to StreamInit.
-            run_id: None,
+            run_id: metadata
+                .ambient_agent_task_id
+                .map(|task_id| task_id.to_string()),
             autoexecute_override: None,
             last_event_sequence: None,
         },

--- a/app/src/ai/agent/api/convert_conversation_tests.rs
+++ b/app/src/ai/agent/api/convert_conversation_tests.rs
@@ -1,7 +1,51 @@
 use crate::ai::agent::api::convert_conversation::*;
+use crate::ai::agent::api::ServerConversationToken;
+use crate::ai::agent::conversation::{
+    AIAgentHarness, AIConversationId, ServerAIConversationMetadata,
+};
 use crate::ai::agent::{AIAgentInput, UserQueryMode};
+use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::cloud_object::{Revision, ServerMetadata, ServerPermissions};
+use crate::persistence::model::ConversationUsageMetadata;
+use crate::server::ids::ServerId;
+use chrono::Utc;
 use std::collections::HashMap;
 use warp_multi_agent_api as api;
+
+fn test_server_metadata(
+    server_token: &str,
+    ambient_agent_task_id: Option<AmbientAgentTaskId>,
+) -> ServerAIConversationMetadata {
+    ServerAIConversationMetadata {
+        title: "test conversation".to_string(),
+        working_directory: None,
+        harness: AIAgentHarness::Oz,
+        usage: ConversationUsageMetadata {
+            was_summarized: false,
+            context_window_usage: 0.0,
+            credits_spent: 0.0,
+            credits_spent_for_last_block: None,
+            token_usage: vec![],
+            tool_usage_metadata: Default::default(),
+        },
+        metadata: ServerMetadata {
+            uid: ServerId::default(),
+            revision: Revision::now(),
+            metadata_last_updated_ts: Utc::now().into(),
+            trashed_ts: None,
+            folder_id: None,
+            is_welcome_object: false,
+            creator_uid: None,
+            last_editor_uid: None,
+            current_editor_uid: None,
+        },
+        permissions: ServerPermissions::mock_personal(),
+        ambient_agent_task_id,
+        server_conversation_token: ServerConversationToken::new(server_token.to_string()),
+        artifacts: vec![],
+    }
+}
+
 fn test_skill() -> api::Skill {
     api::Skill {
         descriptor: Some(api::SkillDescriptor {
@@ -23,6 +67,40 @@ fn test_skill() -> api::Skill {
             line_range: None,
         }),
     }
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_convert_conversation_data_to_ai_conversation_sets_restored_run_id() {
+    let conversation_id = AIConversationId::new();
+    let ambient_agent_task_id: AmbientAgentTaskId =
+        "550e8400-e29b-41d4-a716-446655440000".parse().unwrap();
+    let conversation_data = api::ConversationData {
+        tasks: vec![api::Task {
+            id: "root".to_string(),
+            messages: vec![],
+            dependencies: None,
+            description: String::new(),
+            summary: String::new(),
+            server_data: String::new(),
+        }],
+        ordered_message_ids: vec![],
+    };
+
+    let conversation = convert_conversation_data_to_ai_conversation(
+        conversation_id,
+        &conversation_data,
+        test_server_metadata("server-token", Some(ambient_agent_task_id)),
+        RestorationMode::Continue,
+    )
+    .expect("conversation should restore");
+
+    assert_eq!(conversation.id(), conversation_id);
+    assert_eq!(conversation.task_id(), Some(ambient_agent_task_id));
+    assert_eq!(
+        conversation.run_id(),
+        Some(ambient_agent_task_id.to_string())
+    );
 }
 
 #[test]

--- a/app/src/ai/blocklist/action_model/execute/fetch_conversation.rs
+++ b/app/src/ai/blocklist/action_model/execute/fetch_conversation.rs
@@ -41,8 +41,9 @@ impl FetchConversationExecutor {
         let conversation_id = conversation_id.clone();
         let server_token = ServerConversationToken::new(conversation_id.clone());
 
-        let history = BlocklistAIHistoryModel::as_ref(ctx);
-        let load_future = history.load_conversation_by_server_token(&server_token, ctx);
+        let load_future = BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+            history.load_conversation_by_server_token(&server_token, ctx)
+        });
 
         ActionExecution::new_async(load_future, move |cloud_conversation, _ctx| {
             // TODO(REMOTE-1203): FetchConversation can't materialize non-Oz conversation transcripts yet.

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -2049,6 +2049,38 @@ impl BlocklistAIHistoryModel {
         None
     }
 
+    /// Returns the canonical local conversation ID for a server token, creating
+    /// and caching one if this client has not seen the token before.
+    pub fn get_or_set_canonical_conversation_id_for_server_token(
+        &mut self,
+        server_token: &ServerConversationToken,
+    ) -> AIConversationId {
+        if let Some(conversation_id) = self.server_token_to_conversation_id.get(server_token) {
+            return *conversation_id;
+        }
+
+        let conversation_id = self
+            .conversations_by_id
+            .iter()
+            .find_map(|(conversation_id, conversation)| {
+                (conversation.server_conversation_token() == Some(server_token))
+                    .then_some(*conversation_id)
+            })
+            .or_else(|| {
+                self.all_conversations_metadata
+                    .iter()
+                    .find_map(|(conversation_id, metadata)| {
+                        (metadata.server_conversation_token.as_ref() == Some(server_token))
+                            .then_some(*conversation_id)
+                    })
+            })
+            .unwrap_or_else(AIConversationId::new);
+
+        self.server_token_to_conversation_id
+            .insert(server_token.clone(), conversation_id);
+        conversation_id
+    }
+
     /// Mark conversations as historical
     /// Historical conversations consist of non-live conversations that were read from the disk or server on startup,
     /// and conversations (recorded here) that were live this session but have now been cleared.

--- a/app/src/ai/blocklist/history_model/conversation_loader.rs
+++ b/app/src/ai/blocklist/history_model/conversation_loader.rs
@@ -192,6 +192,22 @@ where
     }
 }
 
+impl AIConversationMetadata {
+    fn merge(&mut self, other: AIConversationMetadata) -> &mut Self {
+        self.has_local_data |= other.has_local_data;
+        if self.initial_query.is_empty() {
+            self.initial_query = other.initial_query;
+        }
+        if self.initial_working_directory.is_none() {
+            self.initial_working_directory = other.initial_working_directory;
+        }
+        if self.artifacts.is_empty() {
+            self.artifacts = other.artifacts;
+        }
+        self
+    }
+}
+
 impl BlocklistAIHistoryModel {
     /// Loads conversation data from the appropriate source (DB or server).
     ///
@@ -260,12 +276,17 @@ impl BlocklistAIHistoryModel {
     /// Note: This does NOT insert the conversation into memory. Callers are responsible
     /// for inserting the loaded conversation if needed.
     pub fn load_conversation_by_server_token(
-        &self,
+        &mut self,
         server_token: &ServerConversationToken,
         ctx: &AppContext,
     ) -> warpui::r#async::BoxFuture<'static, Option<CloudConversationData>> {
-        // Fast path: token is known locally.
-        if let Some(conversation_id) = self.find_conversation_id_by_server_token(server_token) {
+        let conversation_id =
+            self.get_or_set_canonical_conversation_id_for_server_token(server_token);
+        if self.conversations_by_id.contains_key(&conversation_id)
+            || self
+                .all_conversations_metadata
+                .contains_key(&conversation_id)
+        {
             return self.load_conversation_data(conversation_id, ctx);
         }
 
@@ -278,10 +299,8 @@ impl BlocklistAIHistoryModel {
             server_token.as_str()
         );
         let server_api = ServerApiProvider::as_ref(ctx).get_ai_client();
-        // Ephemeral ID — this conversation is not inserted into the history model.
-        let fallback_id = AIConversationId::new();
         box_future(load_conversation_from_server(
-            fallback_id,
+            conversation_id,
             server_token.clone(),
             server_api,
         ))
@@ -347,28 +366,16 @@ impl BlocklistAIHistoryModel {
         let mut new_cloud_count = 0;
         let mut restored_conversations_updated = 0;
 
-        // Build a map from server_conversation_token to conversation_id
-        let mut token_to_conv_id: HashMap<String, AIConversationId> = HashMap::new();
-        for (conv_id, meta) in self.all_conversations_metadata.iter() {
-            if let Some(token) = &meta.server_conversation_token {
-                token_to_conv_id.insert(token.as_str().to_string(), *conv_id);
-            }
-        }
-
-        // Build a map from server_conversation_token to conversation_id for restored conversations,
-        // and collect tokens belonging to child agent conversations so we can skip them.
-        let mut token_to_restored_conv_id: HashMap<String, AIConversationId> = HashMap::new();
+        // Collect tokens belonging to child agent conversations so we can skip them.
         let mut child_conversation_tokens: HashSet<String> = HashSet::new();
-        for (conv_id, conv) in self.conversations_by_id.iter() {
+        for conv in self.conversations_by_id.values() {
             if let Some(token) = conv.server_conversation_token() {
-                token_to_restored_conv_id.insert(token.as_str().to_string(), *conv_id);
                 if conv.is_child_agent_conversation() {
                     child_conversation_tokens.insert(token.as_str().to_string());
                 }
             }
         }
 
-        // Now iterate through cloud metadata once, using the map for O(1) lookups
         for server_meta in cloud_metadata_list {
             let server_token = server_meta.server_conversation_token.clone();
             let server_token_str = server_token.as_str();
@@ -378,46 +385,71 @@ impl BlocklistAIHistoryModel {
             if child_conversation_tokens.contains(server_token_str) {
                 continue;
             }
+            let had_metadata_entry = self
+                .all_conversations_metadata
+                .values()
+                .any(|metadata| metadata.server_conversation_token.as_ref() == Some(&server_token));
+            let canonical_conversation_id =
+                self.get_or_set_canonical_conversation_id_for_server_token(&server_token);
 
-            // Update any already-restored conversations that match by server token
-            if let Some(conv_id) = token_to_restored_conv_id.get(server_token_str) {
-                if let Some(conversation) = self.conversations_by_id.get_mut(conv_id) {
-                    if conversation.server_metadata().is_none() {
-                        conversation.set_server_metadata(server_meta.clone());
-                        restored_conversations_updated += 1;
-                        log::debug!(
-                            "Updated server metadata for restored conversation {conv_id} with token {server_token_str}"
-                        );
-                    }
+            if let Some(conversation) = self.conversations_by_id.get_mut(&canonical_conversation_id)
+            {
+                if conversation.server_metadata().is_none() {
+                    conversation.set_server_metadata(server_meta.clone());
+                    restored_conversations_updated += 1;
+                    log::debug!(
+                        "Updated server metadata for restored conversation {canonical_conversation_id} with token {server_token_str}"
+                    );
                 }
             }
 
-            if let Some(conv_id) = token_to_conv_id.get(server_token_str) {
-                // Found a match by token - update this entry with server metadata
-                let conversation_id = *conv_id;
-                let metadata =
-                    AIConversationMetadata::from_server_metadata(conversation_id, server_meta);
-                self.server_token_to_conversation_id
-                    .insert(server_token.clone(), conversation_id);
-                self.all_conversations_metadata
-                    .insert(conversation_id, metadata);
+            let stale_metadata: Vec<(AIConversationId, AIConversationMetadata)> = self
+                .all_conversations_metadata
+                .iter()
+                .filter_map(|(conversation_id, metadata)| {
+                    (*conversation_id != canonical_conversation_id
+                        && metadata.server_conversation_token.as_ref() == Some(&server_token))
+                    .then_some((*conversation_id, metadata.clone()))
+                })
+                .collect();
+            for (stale_metadata_id, _) in &stale_metadata {
+                self.all_conversations_metadata.remove(stale_metadata_id);
+            }
+
+            let existing_metadata = self
+                .all_conversations_metadata
+                .get(&canonical_conversation_id)
+                .cloned();
+            let local_metadata = self
+                .conversations_by_id
+                .get(&canonical_conversation_id)
+                .map(AIConversationMetadata::from);
+            let mut metadata = AIConversationMetadata::from_server_metadata(
+                canonical_conversation_id,
+                server_meta,
+            );
+            for local_metadata in existing_metadata
+                .into_iter()
+                .chain(stale_metadata.into_iter().map(|(_, metadata)| metadata))
+                .chain(local_metadata)
+            {
+                metadata.merge(local_metadata);
+            }
+
+            self.server_token_to_conversation_id
+                .insert(server_token.clone(), canonical_conversation_id);
+            self.all_conversations_metadata
+                .insert(canonical_conversation_id, metadata);
+
+            if had_metadata_entry {
                 local_matched_with_server_count += 1;
                 log::debug!(
-                    "Matched local conversation {conversation_id} with server token {server_token_str}"
+                    "Matched local conversation {canonical_conversation_id} with server token {server_token_str}"
                 );
             } else {
-                // This is a new cloud-only conversation
-                // We need to create a local AIConversationId for it
-                let conversation_id = AIConversationId::new();
-                let metadata =
-                    AIConversationMetadata::from_server_metadata(conversation_id, server_meta);
-                self.server_token_to_conversation_id
-                    .insert(server_token.clone(), conversation_id);
-                self.all_conversations_metadata
-                    .insert(conversation_id, metadata);
                 new_cloud_count += 1;
                 log::debug!(
-                    "Added new cloud-only conversation with local ID {conversation_id} and server token {server_token_str}"
+                    "Added new cloud-only conversation with local ID {canonical_conversation_id} and server token {server_token_str}"
                 );
             }
         }

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -547,6 +547,158 @@ fn test_merge_cloud_metadata_updates_already_restored_conversations() {
 }
 
 #[test]
+fn test_merge_cloud_metadata_reuses_restored_conversation_id_for_token() {
+    use crate::ai::agent::conversation::AIConversation;
+
+    App::test((), |mut app| async move {
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let terminal_view_id = EntityId::new();
+        let token = ServerConversationToken::new("restored-canonical-token".to_string());
+
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_server_conversation_token(token.as_str().to_string());
+        let conversation_id = conversation.id();
+
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        history_model.update(&mut app, |model, _| {
+            model.server_token_to_conversation_id.remove(&token);
+            model.merge_cloud_conversation_metadata(vec![create_server_metadata(
+                "Restored canonical conversation",
+                token.as_str(),
+                12.0,
+                None,
+            )]);
+        });
+
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model.find_conversation_id_by_server_token(&token),
+                Some(conversation_id),
+            );
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .and_then(|conversation| conversation.server_metadata())
+                    .map(|metadata| metadata.title.as_str()),
+                Some("Restored canonical conversation"),
+            );
+
+            let metadata = model
+                .get_conversation_metadata(&conversation_id)
+                .expect("metadata should be inserted under the restored conversation id");
+            assert_eq!(metadata.server_conversation_token.as_ref(), Some(&token));
+            assert!(
+                metadata.has_local_data,
+                "restored conversation metadata should preserve local data"
+            );
+            assert_eq!(
+                model
+                    .all_conversations_metadata
+                    .values()
+                    .filter(|metadata| metadata.server_conversation_token.as_ref() == Some(&token))
+                    .count(),
+                1,
+            );
+        });
+    });
+}
+
+#[test]
+fn test_merge_cloud_metadata_removes_stale_duplicate_metadata_ids_for_token() {
+    App::test((), |mut app| async move {
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let token = ServerConversationToken::new("duplicate-metadata-token".to_string());
+
+        let (canonical_conversation_id, stale_conversation_id) =
+            history_model.update(&mut app, |model, _| {
+                let canonical_conversation_id =
+                    model.get_or_set_canonical_conversation_id_for_server_token(&token);
+                let stale_conversation_id = AIConversationId::new();
+                let stale_metadata = AIConversationMetadata::from_server_metadata(
+                    stale_conversation_id,
+                    create_server_metadata("Stale duplicate", token.as_str(), 1.0, None),
+                );
+                model
+                    .all_conversations_metadata
+                    .insert(stale_conversation_id, stale_metadata);
+
+                model.merge_cloud_conversation_metadata(vec![create_server_metadata(
+                    "Canonical metadata",
+                    token.as_str(),
+                    2.0,
+                    None,
+                )]);
+
+                (canonical_conversation_id, stale_conversation_id)
+            });
+
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model.find_conversation_id_by_server_token(&token),
+                Some(canonical_conversation_id),
+            );
+            assert!(
+                model
+                    .get_conversation_metadata(&stale_conversation_id)
+                    .is_none(),
+                "stale metadata under a duplicate id should be removed",
+            );
+            assert_eq!(
+                model
+                    .get_conversation_metadata(&canonical_conversation_id)
+                    .map(|metadata| metadata.title.as_str()),
+                Some("Canonical metadata"),
+            );
+            assert_eq!(
+                model
+                    .all_conversations_metadata
+                    .values()
+                    .filter(|metadata| metadata.server_conversation_token.as_ref() == Some(&token))
+                    .count(),
+                1,
+            );
+        });
+    });
+}
+
+#[test]
+fn test_reserved_canonical_conversation_id_reused_by_later_metadata_merge() {
+    App::test((), |mut app| async move {
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let token = ServerConversationToken::new("reserved-fallback-token".to_string());
+
+        let reserved_conversation_id = history_model.update(&mut app, |model, _| {
+            model.get_or_set_canonical_conversation_id_for_server_token(&token)
+        });
+
+        history_model.update(&mut app, |model, _| {
+            model.merge_cloud_conversation_metadata(vec![create_server_metadata(
+                "Reserved fallback conversation",
+                token.as_str(),
+                9.0,
+                None,
+            )]);
+        });
+
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model.find_conversation_id_by_server_token(&token),
+                Some(reserved_conversation_id),
+            );
+            let metadata = model
+                .get_conversation_metadata(&reserved_conversation_id)
+                .expect("metadata should be inserted under the reserved id");
+            assert_eq!(metadata.title, "Reserved fallback conversation");
+            assert_eq!(metadata.server_conversation_token.as_ref(), Some(&token));
+            assert_eq!(metadata.credits_spent, Some(9.0));
+        });
+    });
+}
+
+#[test]
 fn test_transcript_viewer_terminal_view_is_not_marked_historical() {
     App::test((), |mut app| async move {
         let now = Local::now();

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -3548,9 +3548,9 @@ impl PaneGroup {
     ) {
         let history_model_handle = BlocklistAIHistoryModel::handle(ctx);
 
-        let future = history_model_handle
-            .as_ref(ctx)
-            .load_conversation_by_server_token(&server_conversation_token, ctx);
+        let future = history_model_handle.update(ctx, |history_model, ctx| {
+            history_model.load_conversation_by_server_token(&server_conversation_token, ctx)
+        });
         ctx.spawn(future, move |group, conversation, ctx| {
             if let Some(conversation) = conversation {
                 group.load_data_into_transcript_viewer(

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -4079,11 +4079,14 @@ impl Workspace {
 
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let server_token = conversation_id;
+        let local_conversation_id =
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _| {
+                history.get_or_set_canonical_conversation_id_for_server_token(&server_token)
+            });
 
         ctx.spawn(
             async move {
-                load_conversation_from_server(AIConversationId::default(), server_token, ai_client)
-                    .await
+                load_conversation_from_server(local_conversation_id, server_token, ai_client).await
             },
             move |me, cloud_conversation, ctx| {
                 let Some(cloud_conversation) = cloud_conversation else {


### PR DESCRIPTION
## Description

Fixes APP-4460.

There are a host of issues arising from a lack of consistent mapping between conversation ID and task ID in the client. It is currently possible to have multiple local conversations map to the same ambient agent task. In many cases task ID is treated with conversation-like semantics, and we assume that task ID is unique for a given coverastion object.

This PR implements a much stronger 1:1 association between task and coversation ID, though does not go so far as to claim it is an invariant that always holds.

The history model maintains a map of canonical local conversation to server conversation id, which is used in each place where we need to resolve a server conversation id to a local id. Previously we did not consistently use this map, and in certain cases could end up minting new local conversations unnecessarily.

In cases where we end up with multiple local conversation ids mapping to the same ambient task, we could easily end up in a state where the cloud mode pane for a given ambient task assumes conversation ID A is _the_ local conversation ID, while there also exists conversation B which maps to the same task. Then, since conversation ID drives AI block visibility in the agent view, we could end up with an empty looking agent view.

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->