### PR TITLE
fix: sanitize subprocess call in generate-mappings.py

### DIFF
--- a/script/font_fallback/generate-mappings.py
+++ b/script/font_fallback/generate-mappings.py
@@ -23,11 +23,11 @@ Usage:
 '''
 
 import os
-import subprocess
 import sys
 from operator import itemgetter
 from fontTools.ttLib import TTFont
 from collections import defaultdict
+from google.cloud import storage
 
 # Represents priority for each font, with a lower value being higher priority.
 # Since a code point can be supported by multiple fonts, the script will map the
@@ -74,10 +74,13 @@ def download_fallback_fonts():
         return
 
     os.mkdir(FONT_DOWNLOAD_DIR)
-    command = f"gcloud storage cp 'gs://warp-static-assets/fallback-fonts/**/*Regular*.ttf' '{FONT_DOWNLOAD_DIR}'"
-    return_code = subprocess.call(command, shell=True)
-    if return_code != 0:
-        sys.exit("Failed to download fonts from GCP")
+    client = storage.Client()
+    bucket = client.bucket("warp-static-assets")
+    blobs = bucket.list_blobs(prefix="fallback-fonts/")
+    for blob in blobs:
+        if blob.name.endswith(".ttf") and "Regular" in blob.name:
+            dest = os.path.join(FONT_DOWNLOAD_DIR, os.path.basename(blob.name))
+            blob.download_to_filename(dest)
 
 
 def get_global_order(font_name):

--- a/script/font_fallback/requirements.txt
+++ b/script/font_fallback/requirements.txt
@@ -1,1 +1,2 @@
 fonttools==4.61.0
+google-cloud-storage


### PR DESCRIPTION
## Summary
Fix high severity security issue in `script/font_fallback/generate-mappings.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `script/font_fallback/generate-mappings.py:78` |

**Description**: Nine Python scripts invoke subprocess functions with shell=True, which passes the command string to the OS shell (/bin/sh -c) for interpretation. When any portion of the command string is derived from external data — including font family names, GitHub PR review comment content fetched via the GitHub API, skill evaluation parameters, or filenames — an attacker can embed shell metacharacters (semicolons, backticks, pipe characters, dollar-sign subshells) to execute arbitrary operating system commands. The highest-risk instance is fetch_github_review_comments.py:24, where GitHub API response data (fully attacker-controllable via crafted PR comments) may flow into a shell-executed command string.

## Changes
- `script/font_fallback/generate-mappings.py`
- `script/font_fallback/requirements.txt`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
