### PR TITLE
Fix Arabic / RTL text rendering in terminal output Closes #10355

### DIFF
--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -318,6 +318,13 @@ pub fn render_grid<'a>(
     // codepath (which is known to be less performant) if the font does not
     // even support ligatures.
     let respect_displayed_output = matches!(respect_displayed_output, RespectDisplayedOutput::Yes);
+    // RTL / complex scripts (Arabic, Hebrew, etc.) cannot be rendered through the cheap
+    // per-cell `glyph_for_char` path: that path does no bidi reorder and no Arabic
+    // shaping, so the text renders left-to-right with isolated forms. Force the
+    // ligature/`layout_line` path for frames that contain such characters; rows
+    // without complex scripts still take the fast cell-by-cell path inside it.
+    let use_ligature_rendering =
+        use_ligature_rendering || frame_contains_complex_script(grid, start_row, end_row);
     match (use_ligature_rendering, grid.displayed_output_rows()) {
         (true, Some(rows)) if respect_displayed_output => {
             let visible_rows = rows.skip(start_row).take(end_row.saturating_sub(start_row));
@@ -1445,13 +1452,17 @@ fn render_grid_with_ligatures<'a>(
         );
         let line_origin =
             grid_origin + vec2f(0., cell_size.y() * offset_row as f32) + baseline_position;
-        paint_line(
-            laid_out.as_ref(),
-            line_origin,
-            cell_size.x(),
-            &string_data.character_index_to_cell_map,
-            ctx.scene,
-        );
+        if row_needs_complex_layout(&string_data.line) {
+            paint_complex_line(laid_out.as_ref(), line_origin, ctx.scene);
+        } else {
+            paint_line(
+                laid_out.as_ref(),
+                line_origin,
+                cell_size.x(),
+                &string_data.character_index_to_cell_map,
+                ctx.scene,
+            );
+        }
 
         if grid.filter_has_context_lines() {
             maybe_render_dotted_lines(
@@ -1504,6 +1515,75 @@ fn paint_line(
         for glyph in &run.glyphs {
             let glyph_x = character_index_to_cell_map[glyph.index] as f32 * cell_width;
             let glyph_origin = baseline + vec2f(glyph_x, 0.);
+
+            scene.draw_glyph(
+                glyph_origin,
+                glyph.id,
+                run.font_id,
+                line.font_size,
+                glyph_color,
+            );
+        }
+    }
+}
+
+/// Returns true if `c` belongs to a script that requires bidi reordering and/or
+/// contextual shaping at paint time. For these characters, mapping a glyph back
+/// to its logical cell column (as `paint_line` does) destroys both visual order
+/// and joining, so the row must instead be painted at shaper-produced
+/// positions via `paint_complex_line`.
+fn is_complex_script_char(c: char) -> bool {
+    matches!(
+        c as u32,
+        0x0590..=0x05FF    // Hebrew
+        | 0x0600..=0x06FF  // Arabic
+        | 0x0700..=0x074F  // Syriac
+        | 0x0750..=0x077F  // Arabic Supplement
+        | 0x0780..=0x07BF  // Thaana
+        | 0x07C0..=0x07FF  // NKo
+        | 0x0860..=0x086F  // Syriac Supplement
+        | 0x0870..=0x089F  // Arabic Extended-B
+        | 0x08A0..=0x08FF  // Arabic Extended-A
+        | 0xFB1D..=0xFDFF  // Hebrew + Arabic Presentation Forms-A
+        | 0xFE70..=0xFEFF  // Arabic Presentation Forms-B
+    )
+}
+
+fn row_needs_complex_layout(line: &str) -> bool {
+    line.chars().any(is_complex_script_char)
+}
+
+/// Pre-scan visible rows in `start_row..end_row` for any character that requires
+/// bidi reorder or contextual shaping. If found, the dispatcher routes the
+/// whole frame through `render_grid_with_ligatures` so RTL rows can reach
+/// `layout_line` (the only path that runs `BidiParagraphs` + `ShapeLine`).
+///
+/// Walks rows directly via `grid.row(idx)`; short-circuits at the first hit.
+fn frame_contains_complex_script(grid: &GridHandler, start_row: usize, end_row: usize) -> bool {
+    for row_idx in start_row..end_row {
+        let Some(row) = grid.row(row_idx) else {
+            continue;
+        };
+        for col in 0..row.occ {
+            if is_complex_script_char(row[col].c) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Paint a laid-out line using the shaper's own glyph positions.
+/// Unlike `paint_line`, which forces each glyph back to its logical cell's
+/// `column * cell_width` (which undoes bidi reorder and disconnects Arabic
+/// joining), this honors `glyph.position_along_baseline` directly, so RTL
+/// reorder and contextual shaping are preserved.
+fn paint_complex_line(line: &Line, baseline: Vector2F, scene: &mut Scene) {
+    for run in &line.runs {
+        let glyph_color = run.styles.foreground_color.unwrap_or_default();
+
+        for glyph in &run.glyphs {
+            let glyph_origin = baseline + glyph.position_along_baseline;
 
             scene.draw_glyph(
                 glyph_origin,

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -315,6 +315,13 @@ pub fn render_grid<'a>(
     // codepath (which is known to be less performant) if the font does not
     // even support ligatures.
     let respect_displayed_output = matches!(respect_displayed_output, RespectDisplayedOutput::Yes);
+    // RTL / complex scripts (Arabic, Hebrew, etc.) cannot be rendered through the cheap
+    // per-cell `glyph_for_char` path: that path does no bidi reorder and no Arabic
+    // shaping, so the text renders left-to-right with isolated forms. Force the
+    // ligature/`layout_line` path for frames that contain such characters; rows
+    // without complex scripts still take the fast cell-by-cell path inside it.
+    let use_ligature_rendering =
+        use_ligature_rendering || frame_contains_complex_script(grid, start_row, end_row);
     match (use_ligature_rendering, grid.displayed_output_rows()) {
         (true, Some(rows)) if respect_displayed_output => {
             let visible_rows = rows.skip(start_row).take(end_row.saturating_sub(start_row));
@@ -1442,13 +1449,17 @@ fn render_grid_with_ligatures<'a>(
         );
         let line_origin =
             grid_origin + vec2f(0., cell_size.y() * offset_row as f32) + baseline_position;
-        paint_line(
-            laid_out.as_ref(),
-            line_origin,
-            cell_size.x(),
-            &string_data.character_index_to_cell_map,
-            ctx.scene,
-        );
+        if row_needs_complex_layout(&string_data.line) {
+            paint_complex_line(laid_out.as_ref(), line_origin, ctx.scene);
+        } else {
+            paint_line(
+                laid_out.as_ref(),
+                line_origin,
+                cell_size.x(),
+                &string_data.character_index_to_cell_map,
+                ctx.scene,
+            );
+        }
 
         if grid.filter_has_context_lines() {
             maybe_render_dotted_lines(
@@ -1501,6 +1512,75 @@ fn paint_line(
         for glyph in &run.glyphs {
             let glyph_x = character_index_to_cell_map[glyph.index] as f32 * cell_width;
             let glyph_origin = baseline + vec2f(glyph_x, 0.);
+
+            scene.draw_glyph(
+                glyph_origin,
+                glyph.id,
+                run.font_id,
+                line.font_size,
+                glyph_color,
+            );
+        }
+    }
+}
+
+/// Returns true if `c` belongs to a script that requires bidi reordering and/or
+/// contextual shaping at paint time. For these characters, mapping a glyph back
+/// to its logical cell column (as `paint_line` does) destroys both visual order
+/// and joining, so the row must instead be painted at shaper-produced
+/// positions via `paint_complex_line`.
+fn is_complex_script_char(c: char) -> bool {
+    matches!(
+        c as u32,
+        0x0590..=0x05FF    // Hebrew
+        | 0x0600..=0x06FF  // Arabic
+        | 0x0700..=0x074F  // Syriac
+        | 0x0750..=0x077F  // Arabic Supplement
+        | 0x0780..=0x07BF  // Thaana
+        | 0x07C0..=0x07FF  // NKo
+        | 0x0860..=0x086F  // Syriac Supplement
+        | 0x0870..=0x089F  // Arabic Extended-B
+        | 0x08A0..=0x08FF  // Arabic Extended-A
+        | 0xFB1D..=0xFDFF  // Hebrew + Arabic Presentation Forms-A
+        | 0xFE70..=0xFEFF  // Arabic Presentation Forms-B
+    )
+}
+
+fn row_needs_complex_layout(line: &str) -> bool {
+    line.chars().any(is_complex_script_char)
+}
+
+/// Pre-scan visible rows in `start_row..end_row` for any character that requires
+/// bidi reorder or contextual shaping. If found, the dispatcher routes the
+/// whole frame through `render_grid_with_ligatures` so RTL rows can reach
+/// `layout_line` (the only path that runs `BidiParagraphs` + `ShapeLine`).
+///
+/// Walks rows directly via `grid.row(idx)`; short-circuits at the first hit.
+fn frame_contains_complex_script(grid: &GridHandler, start_row: usize, end_row: usize) -> bool {
+    for row_idx in start_row..end_row {
+        let Some(row) = grid.row(row_idx) else {
+            continue;
+        };
+        for col in 0..row.occ {
+            if is_complex_script_char(row[col].c) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Paint a laid-out line using the shaper's own glyph positions.
+/// Unlike `paint_line`, which forces each glyph back to its logical cell's
+/// `column * cell_width` (which undoes bidi reorder and disconnects Arabic
+/// joining), this honors `glyph.position_along_baseline` directly, so RTL
+/// reorder and contextual shaping are preserved.
+fn paint_complex_line(line: &Line, baseline: Vector2F, scene: &mut Scene) {
+    for run in &line.runs {
+        let glyph_color = run.styles.foreground_color.unwrap_or_default();
+
+        for glyph in &run.glyphs {
+            let glyph_origin = baseline + glyph.position_along_baseline;
 
             scene.draw_glyph(
                 glyph_origin,

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -1,5 +1,9 @@
-use super::{active_or_next_match, CachedBackgroundColor};
+use super::{
+    active_or_next_match, frame_contains_complex_script, is_complex_script_char,
+    row_needs_complex_layout, CachedBackgroundColor,
+};
 use crate::terminal::grid_size_util::calculate_grid_baseline_position;
+use crate::terminal::model::grid::grid_handler::GridHandler;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::selection::SelectionPoint;
 use crate::terminal::{grid_renderer, SizeInfo};
@@ -260,4 +264,82 @@ fn test_calculate_selection_bounds() {
     assert_selection_bounds(5.into_lines()); // Without scroll clipping
     assert_selection_bounds(10.into_lines()); // Without scroll clipping (but on the cusp of clipping)
     assert_selection_bounds(80.into_lines()); // With scroll clipping
+}
+
+#[test]
+fn test_is_complex_script_char_detects_rtl_scripts() {
+    // Arabic
+    assert!(is_complex_script_char('ا')); // U+0627 ALEF
+    assert!(is_complex_script_char('ع')); // U+0639 AIN
+    assert!(is_complex_script_char('ي')); // U+064A YEH
+                                          // Arabic Supplement / Extended
+    assert!(is_complex_script_char('\u{0750}')); // Arabic Supplement
+    assert!(is_complex_script_char('\u{08A0}')); // Arabic Extended-A
+                                                 // Hebrew
+    assert!(is_complex_script_char('א')); // U+05D0 ALEF
+    assert!(is_complex_script_char('ש')); // U+05E9 SHIN
+                                          // Syriac, Thaana, NKo
+    assert!(is_complex_script_char('\u{0710}')); // Syriac ALAPH
+    assert!(is_complex_script_char('\u{0780}')); // Thaana
+    assert!(is_complex_script_char('\u{07C0}')); // NKo
+                                                 // Arabic Presentation Forms-A and -B (shaped forms emitted by the shaper).
+    assert!(is_complex_script_char('\u{FB50}'));
+    assert!(is_complex_script_char('\u{FE70}'));
+}
+
+#[test]
+fn test_is_complex_script_char_excludes_simple_scripts() {
+    // Latin
+    assert!(!is_complex_script_char('a'));
+    assert!(!is_complex_script_char('Z'));
+    // Digits and punctuation
+    assert!(!is_complex_script_char('0'));
+    assert!(!is_complex_script_char(' '));
+    assert!(!is_complex_script_char('!'));
+    // CJK (Han)
+    assert!(!is_complex_script_char('中'));
+    // Cyrillic
+    assert!(!is_complex_script_char('Я'));
+    // Emoji
+    assert!(!is_complex_script_char('😀'));
+}
+
+#[test]
+fn test_row_needs_complex_layout_positive() {
+    assert!(row_needs_complex_layout("مرحبا"));
+    assert!(row_needs_complex_layout("שלום"));
+    // Mixed LTR + RTL — also needs complex layout.
+    assert!(row_needs_complex_layout("hello مرحبا"));
+}
+
+#[test]
+fn test_row_needs_complex_layout_negative() {
+    assert!(!row_needs_complex_layout(""));
+    assert!(!row_needs_complex_layout("hello world"));
+    assert!(!row_needs_complex_layout("ls -la /tmp"));
+    assert!(!row_needs_complex_layout("中文"));
+    assert!(!row_needs_complex_layout("12345"));
+}
+
+#[test]
+fn test_frame_contains_complex_script_pure_latin() {
+    let mut grid = GridHandler::new_for_test(5, 20);
+    grid.input_at_cursor("hello world");
+    assert!(!frame_contains_complex_script(&grid, 0, 5));
+}
+
+#[test]
+fn test_frame_contains_complex_script_arabic() {
+    let mut grid = GridHandler::new_for_test(5, 20);
+    grid.input_at_cursor("مرحبا");
+    assert!(frame_contains_complex_script(&grid, 0, 5));
+}
+
+#[test]
+fn test_frame_contains_complex_script_respects_range() {
+    // Arabic content written into row 0; scanning a later range must not detect it.
+    let mut grid = GridHandler::new_for_test(5, 20);
+    grid.input_at_cursor("مرحبا");
+    assert!(frame_contains_complex_script(&grid, 0, 1));
+    assert!(!frame_contains_complex_script(&grid, 2, 5));
 }

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -3,8 +3,12 @@ use pathfinder_geometry::vector::{vec2f, Vector2F};
 use warpui::fonts::Cache as FontCache;
 use warpui::units::{IntoLines, Lines, Pixels};
 
-use super::{active_or_next_match, CachedBackgroundColor};
+use super::{
+    active_or_next_match, frame_contains_complex_script, is_complex_script_char,
+    row_needs_complex_layout, CachedBackgroundColor,
+};
 use crate::terminal::grid_size_util::calculate_grid_baseline_position;
+use crate::terminal::model::grid::grid_handler::GridHandler;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::selection::SelectionPoint;
 use crate::terminal::{grid_renderer, SizeInfo};
@@ -261,4 +265,82 @@ fn test_calculate_selection_bounds() {
     assert_selection_bounds(5.into_lines()); // Without scroll clipping
     assert_selection_bounds(10.into_lines()); // Without scroll clipping (but on the cusp of clipping)
     assert_selection_bounds(80.into_lines()); // With scroll clipping
+}
+
+#[test]
+fn test_is_complex_script_char_detects_rtl_scripts() {
+    // Arabic
+    assert!(is_complex_script_char('ا')); // U+0627 ALEF
+    assert!(is_complex_script_char('ع')); // U+0639 AIN
+    assert!(is_complex_script_char('ي')); // U+064A YEH
+                                          // Arabic Supplement / Extended
+    assert!(is_complex_script_char('\u{0750}')); // Arabic Supplement
+    assert!(is_complex_script_char('\u{08A0}')); // Arabic Extended-A
+                                                 // Hebrew
+    assert!(is_complex_script_char('א')); // U+05D0 ALEF
+    assert!(is_complex_script_char('ש')); // U+05E9 SHIN
+                                          // Syriac, Thaana, NKo
+    assert!(is_complex_script_char('\u{0710}')); // Syriac ALAPH
+    assert!(is_complex_script_char('\u{0780}')); // Thaana
+    assert!(is_complex_script_char('\u{07C0}')); // NKo
+                                                 // Arabic Presentation Forms-A and -B (shaped forms emitted by the shaper).
+    assert!(is_complex_script_char('\u{FB50}'));
+    assert!(is_complex_script_char('\u{FE70}'));
+}
+
+#[test]
+fn test_is_complex_script_char_excludes_simple_scripts() {
+    // Latin
+    assert!(!is_complex_script_char('a'));
+    assert!(!is_complex_script_char('Z'));
+    // Digits and punctuation
+    assert!(!is_complex_script_char('0'));
+    assert!(!is_complex_script_char(' '));
+    assert!(!is_complex_script_char('!'));
+    // CJK (Han)
+    assert!(!is_complex_script_char('中'));
+    // Cyrillic
+    assert!(!is_complex_script_char('Я'));
+    // Emoji
+    assert!(!is_complex_script_char('😀'));
+}
+
+#[test]
+fn test_row_needs_complex_layout_positive() {
+    assert!(row_needs_complex_layout("مرحبا"));
+    assert!(row_needs_complex_layout("שלום"));
+    // Mixed LTR + RTL — also needs complex layout.
+    assert!(row_needs_complex_layout("hello مرحبا"));
+}
+
+#[test]
+fn test_row_needs_complex_layout_negative() {
+    assert!(!row_needs_complex_layout(""));
+    assert!(!row_needs_complex_layout("hello world"));
+    assert!(!row_needs_complex_layout("ls -la /tmp"));
+    assert!(!row_needs_complex_layout("中文"));
+    assert!(!row_needs_complex_layout("12345"));
+}
+
+#[test]
+fn test_frame_contains_complex_script_pure_latin() {
+    let mut grid = GridHandler::new_for_test(5, 20);
+    grid.input_at_cursor("hello world");
+    assert!(!frame_contains_complex_script(&grid, 0, 5));
+}
+
+#[test]
+fn test_frame_contains_complex_script_arabic() {
+    let mut grid = GridHandler::new_for_test(5, 20);
+    grid.input_at_cursor("مرحبا");
+    assert!(frame_contains_complex_script(&grid, 0, 5));
+}
+
+#[test]
+fn test_frame_contains_complex_script_respects_range() {
+    // Arabic content written into row 0; scanning a later range must not detect it.
+    let mut grid = GridHandler::new_for_test(5, 20);
+    grid.input_at_cursor("مرحبا");
+    assert!(frame_contains_complex_script(&grid, 0, 1));
+    assert!(!frame_contains_complex_script(&grid, 2, 5));
 }

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -2530,7 +2530,7 @@ impl GridHandler {
     /// If the written text wraps to a new line, the WRAPLINE flag will be set
     /// appropriately.
     #[cfg(test)]
-    pub(super) fn input_at_cursor(&mut self, text: &str) {
+    pub(crate) fn input_at_cursor(&mut self, text: &str) {
         use warp_terminal::model::VisiblePoint;
 
         let columns = self.columns();

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -2571,7 +2571,7 @@ impl GridHandler {
     /// If the written text wraps to a new line, the WRAPLINE flag will be set
     /// appropriately.
     #[cfg(test)]
-    pub(super) fn input_at_cursor(&mut self, text: &str) {
+    pub(crate) fn input_at_cursor(&mut self, text: &str) {
         use warp_terminal::model::VisiblePoint;
 
         let columns = self.columns();


### PR DESCRIPTION
## Description

Terminal output rendered Arabic and other RTL scripts left-to-right with isolated (unjoined) forms, while the input editor rendered the same text correctly. The two paths diverged at the painter, not at the shaper:

- The input editor renders through `TextLayoutSystem::layout_text`, which runs `BidiParagraphs` + `ShapeLine` with `Shaping::Advanced` — bidi reorder and rustybuzz Arabic shaping both apply.
- The terminal grid had two paths and both broke that:
  - **Without ligatures (default):** `render_grid_without_ligatures` walks cells one by one and calls `glyph_for_char` per codepoint — no shaping, no bidi.
  - **With ligatures:** `render_grid_with_ligatures` *does* call `layout_line`, but `paint_line` then discarded the shaper's `glyph.x` and forced every glyph back to `original_logical_column * cell_width`, undoing the bidi reorder and disconnecting joined glyphs.

This change keeps the existing fast cell-by-cell path for plain LTR rows and only diverts rows that need bidi + shaping:

- `is_complex_script_char` covers Arabic (all blocks), Hebrew, Syriac, Thaana, NKo, Arabic Presentation Forms A/B.
- `row_needs_complex_layout` (row predicate) and `frame_contains_complex_script` (frame pre-scan, short-circuits).
- When the frame contains any complex-script char, the dispatcher forces the ligature path so RTL rows reach `layout_line`.
- Complex-script rows are routed to a new `paint_complex_line` that positions glyphs at `glyph.position_along_baseline` — the shaper-produced visual x — preserving bidi reorder and contextual joining.
- Non-RTL rows continue through `paint_line` unchanged.

**Deferred (separate change):** cursor placement, selection highlight rect, mouse hit-testing, and per-cell backgrounds on RTL rows still use logical cell coordinates and will be visually offset from the shaped glyphs. Most visible in alt-screen apps (vim/less/htop). Fixing it correctly needs a visual↔logical cell map shared between the renderer and those consumers; bundling it here would balloon the diff and risks regressing non-RTL behaviour.

## Linked Issue

Fixes #10355 — *RTL (Right-to-Left) text direction support for Hebrew, Arabic, and other languages* (rendering subset; cursor / selection / hit-test on RTL rows tracked as a follow-up; see *Deferred* note above). Also addresses #3589, #279, #125, #7889 (the recurring "RTL works in command line but not in result blocks" symptom).

- [x] The linked issue is labeled \`ready-to-spec\` or \`ready-to-implement\`.
  > Note: #10355 is currently labeled \`enhancement, needs-info, triaged, accessibility\`. The narrow inconsistency this PR fixes — *input editor renders Arabic correctly, terminal output does not* — reads as a bug rather than a feature ask. Flagging **@oss-maintainers** to confirm the right readiness label here, or to point me at a separate bug issue to link instead.
- [x] Screenshots of the implementation are included below.

## Testing

- [x] I have manually tested my changes locally with \`./script/run\` (built via \`target/debug/bundle/osx/WarpOss.app\`, verified \`echo "مرحبا بالعالم"\` renders RTL and joined).
- **Unit tests added** in \`grid_renderer_tests.rs\`:
  - \`test_is_complex_script_char_detects_rtl_scripts\` / \`test_is_complex_script_char_excludes_simple_scripts\`
  - \`test_row_needs_complex_layout_positive\` / \`test_row_needs_complex_layout_negative\`
  - \`test_frame_contains_complex_script_pure_latin\` / \`_arabic\` / \`_respects_range\`
- **Presubmit (Rust portions)** clean locally: \`cargo fmt --check\`, \`cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings\` and \`cargo clippy -p warp_completer ...\`, \`cargo nextest run --workspace\`, \`cargo test --doc\`. (clang-format / wgslfmt not run locally; no C/Obj-C/WGSL files touched in this diff.)

### Screenshots / Videos

<!--
Before / after of \`echo "مرحبا بالعالم"\` to be attached when you upload them in the GitHub UI.
-->

### Before
<img width="770" height="109" alt="image" src="https://github.com/user-attachments/assets/2da8a023-b465-4445-a164-0ae3ec0ebcf8" />


### After
<img width="770" height="109" alt="image" src="https://github.com/user-attachments/assets/7053bb45-f869-487d-8bf4-a6e35fe47876" />


## Agent Mode

- [ ] Warp Agent Mode

<!--
## Changelog Entries for Stable
-->

CHANGELOG-BUG-FIX: Fix Arabic / RTL text in terminal output being rendered left-to-right with unjoined letter forms.
