### PR TITLE
Clip inline menu header to prevent split-pane overflow

### DIFF
--- a/app/src/terminal/input/inline_menu/view.rs
+++ b/app/src/terminal/input/inline_menu/view.rs
@@ -847,7 +847,8 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
             )
             .finish();
 
-        Some(header)
+        // Clip so trailing controls don't paint past the pane in a narrow split pane.
+        Some(Clipped::new(header).finish())
     }
 
     pub fn render_results_only(


### PR DESCRIPTION
## Description

`InlineMenuView::render_header` in `app/src/terminal/input/inline_menu/view.rs` returned its header row unclipped, while the menu body below was already wrapped in `Clipped`. In a narrow split pane the header's trailing controls (drag indicator + e.g. "Manage defaults" button for the `/model` menu) painted past the pane boundary into the adjacent pane.

This PR wraps the returned header in `Clipped` to match the body's behavior. `InlineMenuView` is the shared inline menu used by `/model`, `/commands`, etc., so all of them benefit.

> Note: an earlier revision of this PR also touched `render_cloud_mode_v2_footer` in `agent_input_footer/mod.rs` for the issue's original screenshot (the footer model chip overflow). Per review feedback that path is gated behind the dogfood-only `CloudModeInputV2` flag, so I dropped that commit. The same `Flex → Wrap`/`WrapFill` treatment should be applied to the V2 footer before that flag promotes — tracked as a follow-up.

## Videos

### Before

https://github.com/user-attachments/assets/6f37bfe7-83a2-490f-b468-9720546dd006

### After 


https://github.com/user-attachments/assets/919fa4a4-866d-4879-a488-2586112642bc



## Linked Issue

Fixes #10724

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Reproduction:
1. Open a Warp pane.
2. Split the workspace so another pane is immediately adjacent.
3. Narrow the first pane.
4. Type `/model` (or any inline menu trigger) to open the inline menu.
5. Verify the header row (tabs, drag indicator, "Manage defaults") stays inside the pane.

Before: `Manage defaults` and drag indicator extended past the divider into the adjacent pane.
After: the menu header clips at the pane edge, matching the menu body which was already clipped.

`cargo fmt --check` and `cargo clippy -p warp --all-targets -- -D warnings` both clean.

No integration test added — fix is a single `Clipped` wrapper and is most cheaply verified by manual repro in a narrow split pane.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed inline /model menu header overflowing past the pane boundary into adjacent split panes.
-->