### PR TITLE
Hide remote control chip in cloud mode

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -1405,6 +1405,15 @@ impl AgentInputFooter {
             return None;
         }
 
+        // Hide ShareSession for shared ambient (cloud) agent sessions —
+        // it doesn't make sense to offer remote-control when already
+        // viewing a cloud agent's shared session.
+        if matches!(item, AgentToolbarItemKind::ShareSession)
+            && self.terminal_model.lock().is_shared_ambient_agent_session()
+        {
+            return None;
+        }
+
         match item {
             AgentToolbarItemKind::ContextChip(chip_kind) => {
                 self.cli_display_chip(chip_kind.clone(), app)


### PR DESCRIPTION
## Description

WISOTT. This chip doesn't make much sense in an ambient conversation, as you're not really the sharer and can't start/stop sharing.

## Testing

<img width="1466" height="1371" alt="image" src="https://github.com/user-attachments/assets/dfe02e3a-3ad5-4a24-b42a-a40065cd787c" />

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
