### PR TITLE
Fix incorrect uses of Itertools::format in logs

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -99,6 +99,7 @@ This is a Rust-based terminal emulator with a custom UI framework called **WarpU
   functions that take a closure parameter, in which case the closure should be last.
 - Always remove unused parameters completely rather than prefixing them with `_`. Update the function signature and all call sites accordingly.
 - Prefer inline format arguments in macros like `println!`, `eprintln!`, and `format!` (for example, `eprintln!("{message}")` instead of `eprintln!("{}", message)`) to satisfy Clippy's `uninlined_format_args` lint.
+- Do not pass `Itertools::format` results directly to logging macros (`log::*`, `safe_*`, etc.). `Itertools::format` produces a single-use formatter, while logging implementations may format a message more than once. Use a reusable `String` such as `iter.join(", ")` for logging arguments instead. Direct use in `format!` or `write!` is fine.
 - Do not remove existing comments when making unrelated changes. Only remove or modify a comment if the logic it describes has changed.
 
 **Terminal Model Locking**:

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1346,7 +1346,7 @@ impl AgentDriver {
             safe: ("Loading skills from {} environment repositories", repos.len()),
             full: (
                 "Loading environment skills from repositories: {}",
-                repos.iter().format(", ")
+                repos.iter().join(", ")
             )
         );
 
@@ -1470,8 +1470,8 @@ impl AgentDriver {
             safe: ("Loading {} global skill(s) from {} repo(s)", specs.len(), repos.len()),
             full: (
                 "Loading global skills {} from repos: {}",
-                specs.iter().map(|s| &s.skill_identifier).format(", "),
-                repos.iter().format(", ")
+                specs.iter().map(|s| &s.skill_identifier).join(", "),
+                repos.iter().join(", ")
             )
         );
 


### PR DESCRIPTION
## Description

#10363 introduced a few log messages that use [`Itertools::format`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.format). Because it requires consuming an iterator, the helper cannot be formatted more than once. This is fine in almost all cases; however, our logging pipeline does format messages more than once. Specifically, we format messages for terminal output and Sentry reporting, which is why this wasn't caught in local testing.

The fix is to use `.join` - the allocation overhead is negligible for a few log lines. I also updated `WARP.md` to call out this case, to be safe.

## Testing

See above on why this can't be tested locally. I've confirmed the root cause against the Sentry crash report, and audited the codebase for other `.format` calls in log messages.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
