### PR TITLE
Fix batched remote editor edits

### DIFF
--- a/app/src/code/buffer_location_tests.rs
+++ b/app/src/code/buffer_location_tests.rs
@@ -729,6 +729,93 @@ fn apply_client_edit_multiple_edits_in_batch() {
 }
 
 #[test]
+fn apply_client_edit_sequential_insertions() {
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        app.add_singleton_model(GlobalBufferModel::new);
+
+        // Simulate a file with content "def fib(n):\n    pass"
+        let _buffer_state = gbm(&app).update(&mut app, |gbm, ctx| {
+            let state = gbm.open_server_local("/tmp/test_seq_insert.txt".into(), ctx);
+            gbm.populate_buffer_with_read_content(
+                state.file_id,
+                "def fib(n):\n    pass",
+                ContentVersion::new(),
+                ContentVersion::new(),
+                true,
+                ctx,
+            );
+            state
+        });
+        let file_id = _buffer_state.file_id;
+
+        let sv = server_version(&app, file_id);
+
+        // Simulate rapid typing of "hello" at position 13 (after '\n', start of line 2).
+        // Each edit's offset is in sequential coordinates (post-previous-edit).
+        let accepted = gbm(&app).update(&mut app, |gbm, ctx| {
+            gbm.apply_client_edit(
+                file_id,
+                &[
+                    text_edit(13, 13, "h"),
+                    text_edit(14, 14, "e"),
+                    text_edit(15, 15, "l"),
+                    text_edit(16, 16, "l"),
+                    text_edit(17, 17, "o"),
+                ],
+                sv,
+                ContentVersion::new(),
+                ctx,
+            )
+        });
+
+        assert!(accepted);
+        assert_eq!(content(&app, file_id), "def fib(n):\nhello    pass");
+    })
+}
+
+#[test]
+fn apply_client_edit_insertion_then_edit_at_shifted_offset() {
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        app.add_singleton_model(GlobalBufferModel::new);
+
+        let _buffer_state = gbm(&app).update(&mut app, |gbm, ctx| {
+            let state = gbm.open_server_local("/tmp/test_mixed_batch.txt".into(), ctx);
+            gbm.populate_buffer_with_read_content(
+                state.file_id,
+                "aaa bbb",
+                ContentVersion::new(),
+                ContentVersion::new(),
+                true,
+                ctx,
+            );
+            state
+        });
+        let file_id = _buffer_state.file_id;
+
+        let sv = server_version(&app, file_id);
+
+        // Edit 0: insert "xx" at position 4 → "aaaxx bbb"  (net +2 chars)
+        // Edit 1: replace positions 6..9 in post-edit-0 state (" bb") with "ZZ"
+        //         In original coords this would be 4..7, but the client sends
+        //         sequential coords: 6..9.
+        let accepted = gbm(&app).update(&mut app, |gbm, ctx| {
+            gbm.apply_client_edit(
+                file_id,
+                &[text_edit(4, 4, "xx"), text_edit(6, 9, "ZZ")],
+                sv,
+                ContentVersion::new(),
+                ctx,
+            )
+        });
+
+        assert!(accepted);
+        assert_eq!(content(&app, file_id), "aaaxxZZb");
+    })
+}
+
+#[test]
 fn handle_buffer_updated_push_multiple_edits_in_batch() {
     App::test((), |mut app| async move {
         init_app(&mut app);

--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -1920,8 +1920,7 @@ impl GlobalBufferModel {
                 let max_offset = buffer.max_charoffset();
                 let start =
                     CharOffset::from((edit.start_offset as usize).min(max_offset.as_usize()));
-                let end =
-                    CharOffset::from((edit.end_offset as usize).min(max_offset.as_usize()));
+                let end = CharOffset::from((edit.end_offset as usize).min(max_offset.as_usize()));
                 buffer.insert_at_char_offset_ranges(
                     vec![(start..end, edit.text.clone())],
                     ContentVersion::new(),

--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -1871,6 +1871,15 @@ impl GlobalBufferModel {
     /// the edits are applied to the in-memory buffer (no disk write) and the
     /// client version is updated. Returns `true` if accepted, `false` if rejected
     /// (stale edit — silently discarded).
+    ///
+    /// **Coordinate convention:** Each `TextEdit` in `edits` uses sequential
+    /// coordinates — its offsets reference the buffer state *after* all
+    /// preceding edits in the slice have been applied. This matches how the
+    /// client constructs edits from `PreciseDelta.replaced_range`, which is
+    /// resolved via anchors in intermediate buffer states. Edits are therefore
+    /// applied one at a time rather than in a single batch call to
+    /// `insert_at_char_offset_ranges` (which expects all offsets in the
+    /// original-buffer coordinate space).
     #[cfg(feature = "local_fs")]
     pub fn apply_client_edit(
         &mut self,
@@ -1903,22 +1912,23 @@ impl GlobalBufferModel {
             return false;
         };
 
-        // Wire offsets are 1-indexed (matching CharOffset), so no conversion needed.
-        let new_version = ContentVersion::new();
+        // Apply each edit sequentially: offsets are in sequential coordinates
+        // (each relative to the buffer after all preceding edits), so we must
+        // apply one at a time and recompute max_offset for each.
+        let final_version = ContentVersion::new();
         buffer.update(ctx, |buffer, ctx| {
-            let max_offset = buffer.max_charoffset();
-            let char_edits: Vec<(std::ops::Range<CharOffset>, String)> = edits
-                .iter()
-                .map(|edit| {
-                    let start =
-                        CharOffset::from((edit.start_offset as usize).min(max_offset.as_usize()));
-                    let end =
-                        CharOffset::from((edit.end_offset as usize).min(max_offset.as_usize()));
-                    (start..end, edit.text.clone())
-                })
-                .collect();
-
-            buffer.insert_at_char_offset_ranges(char_edits, new_version, ctx);
+            for edit in edits {
+                let max_offset = buffer.max_charoffset();
+                let start =
+                    CharOffset::from((edit.start_offset as usize).min(max_offset.as_usize()));
+                let end = CharOffset::from((edit.end_offset as usize).min(max_offset.as_usize()));
+                buffer.insert_at_char_offset_ranges(
+                    vec![(start..end, edit.text.clone())],
+                    ContentVersion::new(),
+                    ctx,
+                );
+            }
+            buffer.set_version(final_version);
         });
 
         true

--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -1915,22 +1915,23 @@ impl GlobalBufferModel {
         // Apply each edit sequentially: offsets are in sequential coordinates
         // (each relative to the buffer after all preceding edits), so we must
         // apply one at a time and recompute max_offset for each.
-        let final_version = ContentVersion::new();
         buffer.update(ctx, |buffer, ctx| {
             for edit in edits {
                 let max_offset = buffer.max_charoffset();
                 let start =
                     CharOffset::from((edit.start_offset as usize).min(max_offset.as_usize()));
-                let end = CharOffset::from((edit.end_offset as usize).min(max_offset.as_usize()));
+                let end =
+                    CharOffset::from((edit.end_offset as usize).min(max_offset.as_usize()));
                 buffer.insert_at_char_offset_ranges(
                     vec![(start..end, edit.text.clone())],
                     ContentVersion::new(),
                     ctx,
                 );
             }
-            buffer.set_version(final_version);
+            // Allocate the final version after all per-edit versions so the
+            // monotonic ContentVersion counter moves forward.
+            buffer.set_version(ContentVersion::new());
         });
-
         true
     }
 


### PR DESCRIPTION
## Description

Fix corrupted file content when typing rapidly in a remote-backed SSH editor.

When the client debounce-batches multiple keystrokes into a single `BufferEdit` message, each `TextEdit` offset is in **sequential coordinates** (relative to the buffer after all preceding edits). However, the daemon's `apply_client_edit` was passing the entire batch to `insert_at_char_offset_ranges` in one call, which uses anchor-based offset shifting that expects **original-buffer coordinates**. This caused a double-shift: each subsequent character was inserted progressively further from the intended position, scattering typed text through the file.

**Fix:** Apply each `TextEdit` in the batch individually so its offsets correctly reference the buffer's current state after preceding edits.

## Linked Issue

N/A — reproduced via manual testing on SSH remote editor.

## Testing

- [x] I have manually tested my changes locally with `./script/run`
- Added 2 regression tests in `buffer_location_tests.rs`:
  - `apply_client_edit_sequential_insertions` — simulates rapid typing of "hello" as 5 batched character insertions
  - `apply_client_edit_insertion_then_edit_at_shifted_offset` — insertion followed by a replacement at a shifted offset
- All 18 `buffer_location_tests` and 4 `global_buffer_model_tests` pass
- Manually verified fix on remote SSH session: typed rapidly in the remote editor, file content on the server matches the editor

### Screenshots / Videos

Before fix — typing "hellopppp" scatters characters through the file:
Characters appear as `h`, then `e lp plp po` interleaved with the docstring.

After fix — characters are inserted consecutively as expected.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed remote SSH editor corrupting file content when typing rapidly, where batched keystrokes would scatter characters throughout the file instead of inserting them consecutively.
-->