### PR TITLE
Fix spurious unsaved diff state

### DIFF
--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -652,14 +652,20 @@ impl GlobalBufferModel {
         state.set_base_content_version(new_version);
 
         if let Some(char_offset_edits) = char_offset_edits {
-            if let BufferSource::ServerLocal { sync_clock, .. } = &mut state.source {
-                let new_sv = sync_clock.bump_server();
-                ctx.emit(GlobalBufferModelEvent::ServerLocalBufferUpdated {
-                    file_id,
-                    edits: char_offset_edits,
-                    new_server_version: new_sv,
-                    expected_client_version: sync_clock.client_version,
-                });
+            // Skip broadcasting empty edits — the file-watcher detected a write
+            // but the content is identical (e.g. after a save). Sending an empty
+            // BufferUpdatedPush would cause clients to advance base_content_version
+            // without updating the buffer version, creating a spurious mismatch.
+            if !char_offset_edits.is_empty() {
+                if let BufferSource::ServerLocal { sync_clock, .. } = &mut state.source {
+                    let new_sv = sync_clock.bump_server();
+                    ctx.emit(GlobalBufferModelEvent::ServerLocalBufferUpdated {
+                        file_id,
+                        edits: char_offset_edits,
+                        new_server_version: new_sv,
+                        expected_client_version: sync_clock.client_version,
+                    });
+                }
             }
         } else {
             ctx.emit(GlobalBufferModelEvent::BufferUpdatedFromFileEvent {

--- a/crates/editor/src/content/buffer.rs
+++ b/crates/editor/src/content/buffer.rs
@@ -4493,6 +4493,8 @@ impl Buffer {
         ctx: &mut ModelContext<Self>,
     ) {
         if edits.is_empty() {
+            self.reset_undo_stack();
+            self.set_version(new_version);
             return;
         }
 

--- a/crates/editor/src/content/buffer.rs
+++ b/crates/editor/src/content/buffer.rs
@@ -4493,6 +4493,7 @@ impl Buffer {
         ctx: &mut ModelContext<Self>,
     ) {
         if edits.is_empty() {
+            // TODO: This is temporary. We will add support to properly maintain the undo stack after incremental updates.
             self.reset_undo_stack();
             self.set_version(new_version);
             return;

--- a/crates/editor/src/content/buffer_tests.rs
+++ b/crates/editor/src/content/buffer_tests.rs
@@ -45,6 +45,7 @@ use warpui::text::point::Point;
 use crate::content::buffer::{Buffer, StyledBufferRun};
 
 use super::{BufferEvent, EditResult, ToBufferCharOffset};
+use warp_util::content_version::ContentVersion;
 
 #[derive(Debug)]
 pub struct TestEmbeddedItem {
@@ -14162,6 +14163,65 @@ fn test_undo_redo_versions() {
 
             assert!(!buffer.version_match(&version1));
             assert!(buffer.version_match(&version2));
+        });
+    });
+}
+
+/// Regression test: after a remote file save, the server's file-watcher sends a
+/// `BufferUpdatedPush` with the same content the client just saved.
+/// `insert_at_char_offset_ranges` is a no-op (content unchanged) and returns early
+/// without calling `set_version(new_version)`. But the caller updates
+/// `base_content_version` to `new_version` anyway, creating a mismatch that makes
+/// `has_unsaved_changes` return true — causing a spurious "Save changes?" dialog.
+#[test]
+fn test_insert_at_char_offset_ranges_noop_skips_set_version() {
+    App::test((), |mut app| async move {
+        let buffer = app.add_model(|_| Buffer::new(Box::new(|_, _| IndentBehavior::Ignore)));
+        let selection = app.add_model(|_| BufferSelectionModel::new(buffer.clone()));
+
+        buffer.update(&mut app, |buffer, ctx| {
+            // Step 1: Simulate initial file load — populate buffer and set version.
+            buffer.replace_all("hello world", ctx);
+            let load_version = ContentVersion::new();
+            buffer.set_version(load_version);
+            assert!(buffer.version_match(&load_version));
+
+            // Step 2: User edits the buffer.
+            buffer.update_content(
+                BufferEditAction::Insert {
+                    text: "!",
+                    style: TextStyles::default(),
+                    override_text_style: None,
+                },
+                EditOrigin::UserTyped,
+                selection.clone(),
+                ctx,
+            );
+            assert!(!buffer.version_match(&load_version));
+
+            // Step 3: Simulate save — capture the current buffer version as the base.
+            let save_version = buffer.version();
+            assert!(buffer.version_match(&save_version));
+
+            // Step 4: Simulate post-save server push with NO edits.
+            // The server file-watcher detected the save, computed a diff against
+            // the buffer content, and found zero changes — so the push carries
+            // an empty edit list.
+            let push_version = ContentVersion::new();
+            buffer.insert_at_char_offset_ranges(vec![], push_version, ctx);
+
+            // Step 5: The caller (GlobalBufferModel) would set base_content_version = push_version.
+            // version_match(push_version) should be true — the content hasn't changed.
+            // BUG: insert_at_char_offset_ranges returned early without calling set_version,
+            // so the buffer version is still save_version, not push_version.
+            assert!(
+                buffer.version_match(&push_version),
+                "version_match should return true after a no-op insert_at_char_offset_ranges, \
+                 but the buffer version was not updated because the no-op early return \
+                 skipped set_version. Buffer version is {:?}, expected to match {:?}",
+                buffer.version(),
+                push_version,
+            );
         });
     });
 }


### PR DESCRIPTION
## Description
The spurious unsaved diff is caused by the following flow of events:
1. T0: User triggers save. This request is forwarded to the remote server
2. T1: Remote server executes the save
3. T2: The file watcher receives the echoed back save. We parse out the diff (which is empty) and sent it back to client
4. T3: Client has received the empty diff. When applying the empty diff, we actually didn't bump the client buffer version, causing the unsaved changes state to show up

The fix is two fold:
1. On the server, avoid sending empty diffs
2. On the client, defensive fix to set the version on receiving empty diffs in buffer as well

## Testing
Unit test coverage + manually tested