### PR TITLE
Fix unsaved changes UI not showing up

### DIFF
--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -844,6 +844,7 @@ impl CodeView {
             pane_config.set_title(title, ctx);
             pane_config.set_title_secondary(secondary, ctx);
             ctx.emit(PaneConfigurationEvent::TitleUpdated);
+            ctx.emit(PaneConfigurationEvent::HeaderContentChanged);
         });
     }
 
@@ -1925,13 +1926,32 @@ impl CodeView {
         let tab = self.tab_group.first();
         let tab_handle = tab.map(|tab| tab.mouse_state_handles.tab_handle.clone());
 
+        // Check unsaved changes for the active tab.
+        let has_unsaved = tab.is_some_and(|tab| Self::has_unsaved_changes(tab, app));
+
         // Build the center title element, with a hover tooltip showing the full path.
         let title_element: Box<dyn Element> = match tab_handle {
             Some(handle) => Hoverable::new(handle, |hover_state| {
                 let title_text =
                     render_pane_header_title_text(title.clone(), appearance, ClipConfig::start());
+
+                let mut title_row = Flex::row()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_main_axis_size(MainAxisSize::Min);
+                if has_unsaved {
+                    let dot_color = appearance
+                        .theme()
+                        .sub_text_color(appearance.theme().background());
+                    title_row.add_child(
+                        Container::new(render_unsaved_changes_icon(dot_color.into()))
+                            .with_margin_right(4.)
+                            .finish(),
+                    );
+                }
+                title_row.add_child(title_text);
+
                 let mut stack = Stack::new();
-                stack.add_child(title_text);
+                stack.add_child(title_row.finish());
                 if hover_state.is_hovered() {
                     let tooltip_relative_path = tab
                         .and_then(|tab| tab.path.clone())
@@ -1956,7 +1976,27 @@ impl CodeView {
                 stack.finish()
             })
             .finish(),
-            None => render_pane_header_title_text(title, appearance, ClipConfig::start()),
+            None => {
+                let title_text =
+                    render_pane_header_title_text(title, appearance, ClipConfig::start());
+                if has_unsaved {
+                    let dot_color = appearance
+                        .theme()
+                        .sub_text_color(appearance.theme().background());
+                    let mut row = Flex::row()
+                        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                        .with_main_axis_size(MainAxisSize::Min);
+                    row.add_child(
+                        Container::new(render_unsaved_changes_icon(dot_color.into()))
+                            .with_margin_right(4.)
+                            .finish(),
+                    );
+                    row.add_child(title_text);
+                    row.finish()
+                } else {
+                    title_text
+                }
+            }
         };
 
         render_three_column_header(


### PR DESCRIPTION
## Description

**Fix unsaved changes dot not rendering in the single-tab editor pane header.**

This is a regression from PR #20688 ("Refactor pane header APIs to allow rendering arbitrary custom element"), which replaced the old `RenderPaneHeaderElementFn`-based mechanism with the new `BackingView::render_header_content` API. The new single-tab path (`HeaderContent::Standard`, later converted to `HeaderContent::Custom` in PR #22570) never included unsaved changes rendering.

### Changes
1. **Render the unsaved dot in `render_single_tab_header`** (`app/src/code/view.rs`): Check `has_unsaved_changes` for the active tab and render the dot (reusing `render_unsaved_changes_icon`) to the left of the title text, matching the multi-tab behavior.
2. **Ensure header re-renders on content changes** (`app/src/code/view.rs`): In `CodeView::set_title`, emit `PaneConfigurationEvent::HeaderContentChanged` unconditionally so the pane header re-renders when content changes — even when the filename itself has not changed.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the unsaved changes dot not appearing in the single-tab editor pane header.
