### PR TITLE
Add logging around canceling conversation streams

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -17,8 +17,8 @@ mod preprocess;
 
 use crate::ai::agent::conversation::ConversationStatus;
 use crate::ai::agent::{
-    AIAgentActionResultType, AIAgentActionType, AIAgentExchange, CancellationReason,
-    CreateDocumentsResult, EditDocumentsResult, RequestCommandOutputResult,
+    AIAgentActionResultType, AIAgentActionType, AIAgentActionTypeDiscriminants, AIAgentExchange,
+    CancellationReason, CreateDocumentsResult, EditDocumentsResult, RequestCommandOutputResult,
 };
 use crate::ai::{
     agent::AIAgentInput,
@@ -1099,6 +1099,12 @@ impl BlocklistAIActionModel {
             return;
         };
         for action in actions_to_cancel.drain(..).collect_vec() {
+            log::info!(
+                "Canceling pending action of type {:?} action_id={:?}, reason={:?}",
+                AIAgentActionTypeDiscriminants::from(&action.action),
+                action.id,
+                reason
+            );
             self.cancel_pending_action(conversation_id, action, reason, ctx);
         }
     }

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1098,14 +1098,13 @@ impl BlocklistAIActionModel {
         let Some(actions_to_cancel) = self.pending_actions.get_mut(&conversation_id) else {
             return;
         };
-        log::info!("Canceling pending actions for conversation_id={conversation_id:?}, reason={reason:?}, backtrace=\n{}",
-        std::backtrace::Backtrace::force_capture());
         for action in actions_to_cancel.drain(..).collect_vec() {
             log::info!(
-                "Canceling pending action of type {:?} action_id={:?}, reason={:?}",
+                "Canceling pending action of type {:?} conversation_id={conversation_id:?} action_id={:?}, reason={:?}, backtrace=\n{}",
                 AIAgentActionTypeDiscriminants::from(&action.action),
                 action.id,
-                reason
+                reason,
+                std::backtrace::Backtrace::force_capture()
             );
             self.cancel_pending_action(conversation_id, action, reason, ctx);
         }

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1098,6 +1098,8 @@ impl BlocklistAIActionModel {
         let Some(actions_to_cancel) = self.pending_actions.get_mut(&conversation_id) else {
             return;
         };
+        log::info!("Canceling pending actions for conversation_id={conversation_id:?}, reason={reason:?}, backtrace=\n{}",
+        std::backtrace::Backtrace::force_capture());
         for action in actions_to_cancel.drain(..).collect_vec() {
             log::info!(
                 "Canceling pending action of type {:?} action_id={:?}, reason={:?}",

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -818,7 +818,8 @@ impl BlocklistAIActionExecutor {
         if let Some(running) = self.async_executing_actions.remove(action_id) {
             let action_kind = AIAgentActionTypeDiscriminants::from(&running.action.action);
             log::info!(
-                "Canceling running async action of type {action_kind:?} action_id={action_id:?}, reason={reason:?}",
+                "Canceling running async action of type {action_kind:?} action_id={action_id:?}, reason={reason:?}, backtrace=\n{}",
+                std::backtrace::Backtrace::force_capture()
             );
             if running.is_shell_command_action() {
                 self.shell_command_executor.update(ctx, |executor, ctx| {

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -90,8 +90,9 @@ use crate::{
     ai::{
         agent::{
             conversation::AIConversationId, task::TaskId, AIAgentAction, AIAgentActionId,
-            AIAgentActionResult, AIAgentActionResultType, AIAgentActionType, CancellationReason,
-            FileContext, FileLocations, ServerOutputId,
+            AIAgentActionResult, AIAgentActionResultType, AIAgentActionType,
+            AIAgentActionTypeDiscriminants, CancellationReason, FileContext, FileLocations,
+            ServerOutputId,
         },
         ambient_agents::AmbientAgentTaskId,
         get_relevant_files::controller::GetRelevantFilesController,
@@ -815,6 +816,10 @@ impl BlocklistAIActionExecutor {
             return;
         }
         if let Some(running) = self.async_executing_actions.remove(action_id) {
+            let action_kind = AIAgentActionTypeDiscriminants::from(&running.action.action);
+            log::info!(
+                "Canceling running async action of type {action_kind:?} action_id={action_id:?}, reason={reason:?}",
+            );
             if running.is_shell_command_action() {
                 self.shell_command_executor.update(ctx, |executor, ctx| {
                     executor.cancel_execution(&running.action.id, ctx);

--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -386,7 +386,7 @@ impl CLISubagentController {
         }
         log::info!(
             "handoff_active_command_control_to_agent: block_id={block_id:?}, \
-             conversation_id={conversation_id:?}, will_resume=true"
+             conversation_id={conversation_id:?}, lrc_state={lrc_state_debug}"
         );
         let action_id = active_block.requested_command_action_id().cloned();
         let agent_has_control = active_block.is_agent_in_control();

--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -317,8 +317,14 @@ impl CLISubagentController {
 
         let active_block = terminal_model.block_list_mut().active_block_mut();
         let block_id = active_block.id().clone();
-        if let Err(e) = active_block.take_over_control_for_user(reason) {
-            log::error!("Failed to take control for user: {e:?}");
+        let interaction_mode_debug = format!("{:?}", active_block.interaction_mode());
+        let lrc_state_debug = format!("{:?}", active_block.long_running_control_state());
+        if let Err(e) = active_block.take_over_control_for_user(reason.clone()) {
+            log::error!(
+                "Failed to take control for user: {e:?}, reason={reason:?}, \
+                 block_id={block_id:?}, interaction_mode={interaction_mode_debug}, \
+                 lrc_state={lrc_state_debug}"
+            );
             return;
         }
 
@@ -365,15 +371,23 @@ impl CLISubagentController {
         let active_block = terminal_model.block_list_mut().active_block_mut();
         let conversation_id = active_block.ai_conversation_id();
         let block_id = active_block.id().clone();
+        let lrc_state_debug = format!("{:?}", active_block.long_running_control_state());
         // Check if control was transferred from agent before handoff.
         let was_transfer_from_agent = active_block
             .long_running_control_state()
             .and_then(|state| state.user_take_over_reason())
             .is_some_and(|reason| reason.is_transfer_from_agent());
         if let Err(e) = active_block.handoff_control_to_agent() {
-            log::error!("Failed to handoff control to agent: {e:?}");
+            log::error!(
+                "Failed to handoff control to agent: {e:?}, \
+                 block_id={block_id:?}, lrc_state={lrc_state_debug}"
+            );
             return;
         }
+        log::info!(
+            "handoff_active_command_control_to_agent: block_id={block_id:?}, \
+             conversation_id={conversation_id:?}, will_resume=true"
+        );
         let action_id = active_block.requested_command_action_id().cloned();
         let agent_has_control = active_block.is_agent_in_control();
         drop(terminal_model);

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2410,6 +2410,16 @@ impl BlocklistAIController {
         reason: CancellationReason,
         ctx: &mut ModelContext<Self>,
     ) {
+        let has_active_stream = self
+            .in_flight_response_streams
+            .has_active_stream_for_conversation(conversation_id, ctx);
+        log::info!(
+            "cancel_conversation_progress called: conversation_id={conversation_id:?}, \
+             reason={reason}, has_active_stream={has_active_stream}, \
+             backtrace={}",
+            std::backtrace::Backtrace::force_capture()
+        );
+
         // Cancel any pending auto-resume for this conversation.
         if let Some(handle) = self.pending_auto_resume_handles.remove(&conversation_id) {
             handle.abort();

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2423,8 +2423,6 @@ impl BlocklistAIController {
             .in_flight_response_streams
             .try_cancel_streams_for_conversation(conversation_id, reason, ctx)
         {
-            log::info!("No active streams to cancel. Canceling pending actions for conversation_id={conversation_id:?}, reason={reason:?}, backtrace=\n{}",
-                std::backtrace::Backtrace::force_capture());
             // Otherwise, cancel pending actions and update the input state.
             self.action_model.update(ctx, |action_model, ctx| {
                 action_model.cancel_all_pending_actions(conversation_id, Some(reason), ctx);

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2410,16 +2410,6 @@ impl BlocklistAIController {
         reason: CancellationReason,
         ctx: &mut ModelContext<Self>,
     ) {
-        let has_active_stream = self
-            .in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, ctx);
-        log::info!(
-            "cancel_conversation_progress called: conversation_id={conversation_id:?}, \
-             reason={reason}, has_active_stream={has_active_stream}, \
-             backtrace={}",
-            std::backtrace::Backtrace::force_capture()
-        );
-
         // Cancel any pending auto-resume for this conversation.
         if let Some(handle) = self.pending_auto_resume_handles.remove(&conversation_id) {
             handle.abort();
@@ -2433,6 +2423,8 @@ impl BlocklistAIController {
             .in_flight_response_streams
             .try_cancel_streams_for_conversation(conversation_id, reason, ctx)
         {
+            log::info!("No active streams to cancel. Canceling pending actions for conversation_id={conversation_id:?}, reason={reason:?}, backtrace=\n{}",
+                std::backtrace::Backtrace::force_capture());
             // Otherwise, cancel pending actions and update the input state.
             self.action_model.update(ctx, |action_model, ctx| {
                 action_model.cancel_all_pending_actions(conversation_id, Some(reason), ctx);

--- a/app/src/ai/blocklist/controller/pending_response_streams.rs
+++ b/app/src/ai/blocklist/controller/pending_response_streams.rs
@@ -100,7 +100,7 @@ impl PendingResponseStreams {
         } else {
             for response_stream in streams_to_cancel.into_iter() {
                 log::info!(
-                    "canceling active stream for conversation_id={conversation_id:?}, \
+                    "Canceling active stream for conversation_id={conversation_id:?}, \
                      reason={reason}, backtrace=\n{}",
                     std::backtrace::Backtrace::force_capture()
                 );

--- a/app/src/ai/blocklist/controller/pending_response_streams.rs
+++ b/app/src/ai/blocklist/controller/pending_response_streams.rs
@@ -99,6 +99,11 @@ impl PendingResponseStreams {
             false
         } else {
             for response_stream in streams_to_cancel.into_iter() {
+                log::info!(
+                    "canceling active stream for conversation_id={conversation_id:?}, \
+                     reason={reason}, backtrace=\n{}",
+                    std::backtrace::Backtrace::force_capture()
+                );
                 response_stream.update(ctx, |stream, ctx| {
                     stream.cancel(reason, conversation_id, ctx)
                 });

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -2125,6 +2125,10 @@ impl TerminalManager {
                     if let Some(interaction_state) =
                         context_update.long_running_command_agent_interaction_state
                     {
+                        log::info!(
+                            "[sharer] UniversalDeveloperInputContextUpdated: \
+                             applying LRC interaction_state={interaction_state:?}"
+                        );
                         terminal_view.update(ctx, |view, ctx| {
                             view.apply_long_running_command_agent_interaction_state(
                                 interaction_state,

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -897,6 +897,10 @@ impl TerminalManager {
                     if let Some(interaction_state) =
                         context_update.long_running_command_agent_interaction_state
                     {
+                        log::info!(
+                            "[viewer] UniversalDeveloperInputContextUpdated: \
+                             applying LRC interaction_state={interaction_state:?}"
+                        );
                         if let Some(view) = weak_view_handle.upgrade(ctx) {
                             view.update(ctx, |view, ctx| {
                                 view.apply_long_running_command_agent_interaction_state(

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7385,6 +7385,10 @@ impl TerminalView {
                 LongRunningCommandAgentInteractionState::NotInteracting
             }
         };
+        log::info!(
+            "emit_long_running_command_agent_interaction_state_changed: \
+             agent_has_control={agent_has_control}, emitting state={state:?}"
+        );
         ctx.emit(Event::LongRunningCommandAgentInteractionStateChanged { state });
     }
 


### PR DESCRIPTION
## Description

We need more logging to debug cases where oz tasks seem to get canceled when a CLI subagent is spawned and reports the read shell command output result. Log when this happens with a backtrace so we know what's calling it.

Also adds logging around `UniversalDeveloperInputContextUpdated` in shared sessions since it's possible this could be a source. If we receive this shared session event with either `TaggedIn` or `NotInteracting` agent interaction state, we end up calling `switch_control_to_user(UserTakeOverReason::Manual)`. Not sure exactly how this could happen, but this is my main suspicion right now.

## Testing

Tested locally that backtrace has what we need. We only log the backtrace when a stream is actually canceled or an action is canceled, not every time `cancel_conversation_progress` is called which often no-ops.