### PR TITLE
Don't set computer_use_enabled on config snapshot for third-party harnesses

### DIFF
--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1906,6 +1906,8 @@ fn launch_remote_child(
             }
         }
     };
+    let computer_use_enabled =
+        (orchestration_harness == Harness::Oz).then_some(computer_use_enabled);
     let spawn_request = SpawnAgentRequest {
         prompt: request.prompt,
         mode: UserQueryMode::Normal,
@@ -1913,7 +1915,7 @@ fn launch_remote_child(
             environment_id,
             model_id: (!model_id.is_empty()).then_some(model_id),
             worker_host: (!worker_host.is_empty()).then_some(worker_host),
-            computer_use_enabled: Some(computer_use_enabled),
+            computer_use_enabled,
             harness: harness_override,
             ..Default::default()
         }),

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -972,12 +972,15 @@ impl AmbientAgentViewModel {
     /// and harness. Shared by `spawn_agent` and the local-to-cloud handoff path so
     /// both flows route to the same worker host and inherit the same defaults.
     pub(crate) fn build_default_spawn_config(&self, ctx: &AppContext) -> AgentConfigSnapshot {
-        // Determine computer_use_enabled based on workspace AI autonomy settings
-        let CloudAgentComputerUseState { enabled, .. } =
-            ComputerUsePermission::resolve_cloud_agent_state(ctx);
-        let computer_use_enabled = Some(enabled);
-
         let selected_harness = self.selected_harness();
+        let computer_use_enabled = if selected_harness == Harness::Oz {
+            // If the harness is Oz, determine computer use based on workspace AI autonomy settings.
+            let CloudAgentComputerUseState { enabled, .. } =
+                ComputerUsePermission::resolve_cloud_agent_state(ctx);
+            Some(enabled)
+        } else {
+            None
+        };
 
         let oz_model = (selected_harness == Harness::Oz).then(|| {
             LLMPreferences::as_ref(ctx)


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
WISOTT. Noticed while testing cloud mode that we set this in the snapshot, which doesn't make sense:

<img width="421" height="155" alt="image" src="https://github.com/user-attachments/assets/acae3b45-797e-4520-8b16-1a35e14c34f4" />

This is a noop change, since we just ignored the flag before, even if it was set on the snapshot.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
