### PR TITLE
Improve reliability tracking for remote server

### DIFF
--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -814,6 +814,9 @@ impl GlobalBufferModel {
                 let path = remote_path.path.as_str().to_string();
                 let manager = RemoteServerManager::handle(ctx);
                 let Some(client) = manager.as_ref(ctx).client_for_host(&host_id).cloned() else {
+                    log::error!(
+                        "[remote-buffer] No remote server client for save: host={host_id:?}"
+                    );
                     return Err(FileSaveError::RemoteError(
                         "No remote server client available".to_string(),
                     ));
@@ -1761,7 +1764,7 @@ impl GlobalBufferModel {
 
         // Look up the client on the main thread, then send OpenBuffer asynchronously.
         let Some(client) = client_for_sub else {
-            log::warn!("[remote-buffer] No remote server client for host {host_id:?}");
+            log::error!("[remote-buffer] No remote server client for host {host_id:?}");
             ctx.emit(GlobalBufferModelEvent::FailedToLoad {
                 file_id,
                 error: Rc::new(FileLoadError::DoesNotExist),
@@ -1797,8 +1800,12 @@ impl GlobalBufferModel {
         ctx: &mut ModelContext<Self>,
     ) {
         let res = result.and_then(|res| {
-            res.result
-                .ok_or("No result in OpenBuffer response".to_string())
+            res.result.ok_or_else(|| {
+                log::error!(
+                    "[remote-buffer] No result in OpenBuffer response for file_id={file_id:?}"
+                );
+                "No result in OpenBuffer response".to_string()
+            })
         });
         match res {
             Ok(remote_server::proto::open_buffer_response::Result::Success(
@@ -1813,7 +1820,7 @@ impl GlobalBufferModel {
                     server_version,
                 );
                 let Some(state) = self.buffers.get_mut(&file_id) else {
-                    log::warn!("[remote-buffer] Buffer state missing for file_id={file_id:?}");
+                    log::error!("[remote-buffer] Buffer state missing for file_id={file_id:?}");
                     return;
                 };
                 if let BufferSource::Remote {
@@ -1830,7 +1837,9 @@ impl GlobalBufferModel {
                     }
                 }
                 let Some(buffer) = state.buffer.upgrade(ctx) else {
-                    log::warn!("[remote-buffer] Buffer handle deallocated for file_id={file_id:?}");
+                    log::error!(
+                        "[remote-buffer] Buffer handle deallocated for file_id={file_id:?}"
+                    );
                     return;
                 };
                 let version = ContentVersion::new();
@@ -2218,7 +2227,7 @@ impl GlobalBufferModel {
         log::debug!("[remote-buffer] BufferConflictDetected: host={host_id} path={path}");
 
         let Some(file_id) = self.find_remote_file_id(host_id, path) else {
-            log::warn!("[remote-buffer] BufferConflictDetected for unknown buffer: {path}");
+            log::error!("[remote-buffer] BufferConflictDetected for unknown buffer: {path}");
             return;
         };
 
@@ -2256,7 +2265,7 @@ impl GlobalBufferModel {
         );
 
         let Some(file_id) = self.find_remote_file_id(host_id, path) else {
-            log::warn!("[remote-buffer] BufferUpdatedPush for unknown remote buffer: {path}");
+            log::error!("[remote-buffer] BufferUpdatedPush for unknown remote buffer: {path}");
             return;
         };
 

--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -11,7 +11,7 @@ use lsp::types::TextDocumentContentChangeEvent;
 use lsp::{LspManagerModel, LspServerLogLevel, LspServerModel};
 use string_offset::{ByteOffset, CharOffset};
 use vec1::vec1;
-use warp_core::features::FeatureFlag;
+use warp_core::{features::FeatureFlag, safe_error};
 use warp_editor::content::buffer::{Buffer, ToBufferCharOffset};
 use warp_editor::content::diff::{text_diff, TextDiff};
 use warp_editor::content::edit::PreciseDelta;
@@ -814,8 +814,9 @@ impl GlobalBufferModel {
                 let path = remote_path.path.as_str().to_string();
                 let manager = RemoteServerManager::handle(ctx);
                 let Some(client) = manager.as_ref(ctx).client_for_host(&host_id).cloned() else {
-                    log::error!(
-                        "[remote-buffer] No remote server client for save: host={host_id:?}"
+                    safe_error!(
+                        safe: ("[remote-buffer] No remote server client at buffer save time"),
+                        full: ("[remote-buffer] No remote server client for save: host={host_id:?}")
                     );
                     return Err(FileSaveError::RemoteError(
                         "No remote server client available".to_string(),
@@ -1764,7 +1765,10 @@ impl GlobalBufferModel {
 
         // Look up the client on the main thread, then send OpenBuffer asynchronously.
         let Some(client) = client_for_sub else {
-            log::error!("[remote-buffer] No remote server client for host {host_id:?}");
+            safe_error!(
+                safe: ("[remote-buffer] No remote server client at buffer open time"),
+                full: ("[remote-buffer] No remote server client for host {host_id:?}")
+            );
             ctx.emit(GlobalBufferModelEvent::FailedToLoad {
                 file_id,
                 error: Rc::new(FileLoadError::DoesNotExist),
@@ -1801,8 +1805,9 @@ impl GlobalBufferModel {
     ) {
         let res = result.and_then(|res| {
             res.result.ok_or_else(|| {
-                log::error!(
-                    "[remote-buffer] No result in OpenBuffer response for file_id={file_id:?}"
+                safe_error!(
+                    safe: ("[remote-buffer] No result in OpenBuffer response"),
+                    full: ("[remote-buffer] No result in OpenBuffer response for file_id={file_id:?}")
                 );
                 "No result in OpenBuffer response".to_string()
             })
@@ -1820,7 +1825,10 @@ impl GlobalBufferModel {
                     server_version,
                 );
                 let Some(state) = self.buffers.get_mut(&file_id) else {
-                    log::error!("[remote-buffer] Buffer state missing for file_id={file_id:?}");
+                    safe_error!(
+                        safe: ("[remote-buffer] Buffer state missing after OpenBuffer response"),
+                        full: ("[remote-buffer] Buffer state missing for file_id={file_id:?}")
+                    );
                     return;
                 };
                 if let BufferSource::Remote {
@@ -1837,8 +1845,9 @@ impl GlobalBufferModel {
                     }
                 }
                 let Some(buffer) = state.buffer.upgrade(ctx) else {
-                    log::error!(
-                        "[remote-buffer] Buffer handle deallocated for file_id={file_id:?}"
+                    safe_error!(
+                        safe: ("[remote-buffer] Buffer handle deallocated before OpenBuffer response"),
+                        full: ("[remote-buffer] Buffer handle deallocated for file_id={file_id:?}")
                     );
                     return;
                 };
@@ -2227,7 +2236,10 @@ impl GlobalBufferModel {
         log::debug!("[remote-buffer] BufferConflictDetected: host={host_id} path={path}");
 
         let Some(file_id) = self.find_remote_file_id(host_id, path) else {
-            log::error!("[remote-buffer] BufferConflictDetected for unknown buffer: {path}");
+            safe_error!(
+                safe: ("[remote-buffer] BufferConflictDetected for unknown buffer"),
+                full: ("[remote-buffer] BufferConflictDetected for unknown buffer: {path}")
+            );
             return;
         };
 
@@ -2265,7 +2277,10 @@ impl GlobalBufferModel {
         );
 
         let Some(file_id) = self.find_remote_file_id(host_id, path) else {
-            log::error!("[remote-buffer] BufferUpdatedPush for unknown remote buffer: {path}");
+            safe_error!(
+                safe: ("[remote-buffer] BufferUpdatedPush for unknown remote buffer"),
+                full: ("[remote-buffer] BufferUpdatedPush for unknown remote buffer: {path}")
+            );
             return;
         };
 

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -306,11 +306,12 @@ impl RemoteTransport for SshTransport {
                 .take()
                 .ok_or_else(|| anyhow::anyhow!("Failed to capture child stderr"))?;
 
-            let (client, event_rx) =
+            let (client, event_rx, failure_rx) =
                 RemoteServerClient::from_child_streams(stdin, stdout, stderr, &executor);
             Ok(Connection {
                 client,
                 event_rx,
+                failure_rx,
                 child,
                 control_path: Some(socket_path),
             })

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -2874,6 +2874,20 @@ pub enum TelemetryEvent {
         /// the unsupported classification was not glibc-related.
         required_glibc: String,
     },
+    /// Emitted when a reconnection attempt succeeds after a spontaneous disconnect.
+    RemoteServerReconnection {
+        attempt: u32,
+        remote_os: Option<String>,
+        remote_arch: Option<String>,
+    },
+    /// Emitted when all reconnection attempts are exhausted.
+    RemoteServerReconnectExhausted {
+        attempts: u32,
+        remote_os: Option<String>,
+        remote_arch: Option<String>,
+        exit_code: Option<i32>,
+        signal_killed: Option<bool>,
+    },
 }
 
 impl TelemetryEventTrait for TelemetryEvent {
@@ -4253,6 +4267,28 @@ impl TelemetryEvent {
                 "detected_libc": detected_libc,
                 "required_glibc": required_glibc,
             })),
+            TelemetryEvent::RemoteServerReconnection {
+                attempt,
+                remote_os,
+                remote_arch,
+            } => Some(json!({
+                "attempt": attempt,
+                "remote_os": remote_os,
+                "remote_arch": remote_arch,
+            })),
+            TelemetryEvent::RemoteServerReconnectExhausted {
+                attempts,
+                remote_os,
+                remote_arch,
+                exit_code,
+                signal_killed,
+            } => Some(json!({
+                "attempts": attempts,
+                "remote_os": remote_os,
+                "remote_arch": remote_arch,
+                "exit_code": exit_code,
+                "signal_killed": signal_killed,
+            })),
             TelemetryEvent::ConversationListItemOpened { is_ambient_agent } => Some(json!({
                 "is_ambient_agent": is_ambient_agent,
             })),
@@ -5072,7 +5108,9 @@ impl TelemetryEvent {
             | TelemetryEvent::RemoteServerClientRequestError { .. }
             | TelemetryEvent::RemoteServerMessageDecodingError { .. }
             | TelemetryEvent::RemoteServerSetupDuration { .. }
-            | TelemetryEvent::RemoteServerHostUnsupported { .. } => false,
+            | TelemetryEvent::RemoteServerHostUnsupported { .. }
+            | TelemetryEvent::RemoteServerReconnection { .. }
+            | TelemetryEvent::RemoteServerReconnectExhausted { .. } => false,
             #[cfg(feature = "local_fs")]
             TelemetryEvent::CodePaneOpened { .. }
             | TelemetryEvent::CodePanelsFileOpened { .. }
@@ -5639,7 +5677,9 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             | Self::RemoteServerClientRequestError
             | Self::RemoteServerMessageDecodingError
             | Self::RemoteServerSetupDuration
-            | Self::RemoteServerHostUnsupported => {
+            | Self::RemoteServerHostUnsupported
+            | Self::RemoteServerReconnection
+            | Self::RemoteServerReconnectExhausted => {
                 EnablementState::Flag(FeatureFlag::SshRemoteServer)
             }
         }
@@ -6049,6 +6089,8 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             Self::RemoteServerMessageDecodingError => "RemoteServer.MessageDecodingError",
             Self::RemoteServerSetupDuration => "RemoteServer.SetupDuration",
             Self::RemoteServerHostUnsupported => "RemoteServer.HostUnsupported",
+            Self::RemoteServerReconnection => "RemoteServer.Reconnection",
+            Self::RemoteServerReconnectExhausted => "RemoteServer.ReconnectExhausted",
             #[cfg(windows)]
             Self::WSLRegistryError => "WSL Distribution Registry Error",
             #[cfg(windows)]
@@ -7092,6 +7134,12 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             Self::RemoteServerHostUnsupported => {
                 "Preinstall check classified the remote host as unsupported, \
                  falling back to the legacy SSH flow"
+            }
+            Self::RemoteServerReconnection => {
+                "A reconnection attempt succeeded after a spontaneous disconnect"
+            }
+            Self::RemoteServerReconnectExhausted => {
+                "All reconnection attempts were exhausted after a spontaneous disconnect"
             }
         }
     }

--- a/app/src/terminal/model/session/command_executor/remote_server_executor.rs
+++ b/app/src/terminal/model/session/command_executor/remote_server_executor.rs
@@ -9,7 +9,7 @@ use warp_completer::completer::{CommandExitStatus, CommandOutput};
 use warp_core::command::ExitCode;
 use warp_core::SessionId;
 
-use crate::remote_server::proto::run_command_response;
+use crate::remote_server::proto::{run_command_response, RunCommandErrorCode};
 use crate::terminal::model::session::command_executor::{CommandExecutor, ExecuteCommandOptions};
 use crate::terminal::shell::Shell;
 
@@ -85,16 +85,32 @@ impl CommandExecutor for RemoteServerCommandExecutor {
                     exit_code: success.exit_code.map(ExitCode::from),
                 })
             }
-            Some(run_command_response::Result::Error(err)) => Err(anyhow!(
-                "Remote command error (session={:?}, code={:?}): {}",
-                self.session_id,
-                err.code(),
-                err.message,
-            )),
-            None => Err(anyhow!(
-                "Remote command returned empty response (session={:?})",
-                self.session_id,
-            )),
+            Some(run_command_response::Result::Error(err)) => {
+                if err.code() == RunCommandErrorCode::SessionNotFound {
+                    log::error!(
+                        "Remote command SESSION_NOT_FOUND (session={:?}): {} — \
+                         the SessionBootstrapped notification was likely lost",
+                        self.session_id,
+                        err.message,
+                    );
+                }
+                Err(anyhow!(
+                    "Remote command error (session={:?}, code={:?}): {}",
+                    self.session_id,
+                    err.code(),
+                    err.message,
+                ))
+            }
+            None => {
+                log::error!(
+                    "Remote command returned empty response (session={:?}) — proto-level bug",
+                    self.session_id,
+                );
+                Err(anyhow!(
+                    "Remote command returned empty response (session={:?})",
+                    self.session_id,
+                ))
+            }
         }
     }
 

--- a/app/src/terminal/model/session/command_executor/remote_server_executor.rs
+++ b/app/src/terminal/model/session/command_executor/remote_server_executor.rs
@@ -87,11 +87,9 @@ impl CommandExecutor for RemoteServerCommandExecutor {
             }
             Some(run_command_response::Result::Error(err)) => {
                 if err.code() == RunCommandErrorCode::SessionNotFound {
-                    log::error!(
-                        "Remote command SESSION_NOT_FOUND (session={:?}): {} — \
-                         the SessionBootstrapped notification was likely lost",
-                        self.session_id,
-                        err.message,
+                    warp_core::safe_error!(
+                        safe: ("Remote command SESSION_NOT_FOUND — SessionBootstrapped notification likely lost"),
+                        full: ("Remote command SESSION_NOT_FOUND (session={:?}): {} — the SessionBootstrapped notification was likely lost", self.session_id, err.message)
                     );
                 }
                 Err(anyhow!(
@@ -102,9 +100,9 @@ impl CommandExecutor for RemoteServerCommandExecutor {
                 ))
             }
             None => {
-                log::error!(
-                    "Remote command returned empty response (session={:?}) — proto-level bug",
-                    self.session_id,
+                warp_core::safe_error!(
+                    safe: ("Remote command returned empty response — proto-level bug"),
+                    full: ("Remote command returned empty response (session={:?}) — proto-level bug", self.session_id)
                 );
                 Err(anyhow!(
                     "Remote command returned empty response (session={:?})",

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4391,7 +4391,12 @@ impl TerminalView {
                             );
                         }
                     }
-                    RemoteServerManagerEvent::SessionDisconnected { session_id, .. } => {
+                    RemoteServerManagerEvent::SessionDisconnected {
+                        session_id,
+                        exit_status,
+                        was_reconnect_attempt,
+                        ..
+                    } => {
                         let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
                             .as_ref(ctx)
                             .platform_for_session(*session_id)
@@ -4402,13 +4407,26 @@ impl TerminalView {
                                 )
                             })
                             .unwrap_or((None, None));
-                        send_telemetry_from_ctx!(
-                            TelemetryEvent::RemoteServerDisconnection {
-                                remote_os,
-                                remote_arch,
-                            },
-                            ctx
-                        );
+                        if *was_reconnect_attempt {
+                            send_telemetry_from_ctx!(
+                                TelemetryEvent::RemoteServerReconnectExhausted {
+                                    attempts: remote_server::manager::MAX_RECONNECT_ATTEMPTS,
+                                    remote_os,
+                                    remote_arch,
+                                    exit_code: exit_status.as_ref().and_then(|s| s.code),
+                                    signal_killed: exit_status.as_ref().map(|s| s.signal_killed),
+                                },
+                                ctx
+                            );
+                        } else {
+                            send_telemetry_from_ctx!(
+                                TelemetryEvent::RemoteServerDisconnection {
+                                    remote_os,
+                                    remote_arch,
+                                },
+                                ctx
+                            );
+                        }
                     }
                     RemoteServerManagerEvent::SessionDeregistered { session_id } => {
                         // Clean up any stale SSH remote-server choice block if the
@@ -4548,8 +4566,31 @@ impl TerminalView {
                             }));
                         }
                     }
+                    RemoteServerManagerEvent::SessionReconnected {
+                        session_id,
+                        attempt,
+                        ..
+                    } => {
+                        let (remote_os, remote_arch) = RemoteServerManager::handle(ctx)
+                            .as_ref(ctx)
+                            .platform_for_session(*session_id)
+                            .map(|p| {
+                                (
+                                    Some(p.os.as_str().to_owned()),
+                                    Some(p.arch.as_str().to_owned()),
+                                )
+                            })
+                            .unwrap_or((None, None));
+                        send_telemetry_from_ctx!(
+                            TelemetryEvent::RemoteServerReconnection {
+                                attempt: *attempt,
+                                remote_os,
+                                remote_arch,
+                            },
+                            ctx
+                        );
+                    }
                     RemoteServerManagerEvent::SessionConnecting { .. }
-                    | RemoteServerManagerEvent::SessionReconnected { .. }
                     | RemoteServerManagerEvent::HostConnected { .. }
                     | RemoteServerManagerEvent::HostDisconnected { .. }
                     | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -403,7 +403,13 @@ impl RemoteServerClient {
             )),
         };
 
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::GetFragmentMetadataFromHash,
+            )
+            .await?;
 
         match response.message {
             Some(server_message::Message::GetFragmentMetadataFromHashResponse(resp)) => {

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -88,15 +88,6 @@ pub enum ClientEvent {
     CodebaseIndexStatusUpdated { status: RemoteCodebaseIndexStatus },
     /// A server message could not be decoded and had no parseable request_id.
     MessageDecodingError,
-    /// A client request to the remote server failed at the transport level
-    /// (timeout, disconnect, protocol error, etc.). Emitted automatically by
-    /// `send_request` so upstream callers get telemetry for free.
-    RequestFailed {
-        /// Which RPC failed.
-        operation: crate::manager::RemoteServerOperation,
-        /// Classified error kind for telemetry aggregation.
-        error_kind: crate::manager::RemoteServerErrorKind,
-    },
     /// A buffer was updated on the server (file changed on disk).
     BufferUpdated {
         path: String,
@@ -144,6 +135,18 @@ pub struct InitializeParams {
 /// rather than by `Arc` refcount -- cloning `Arc<RemoteServerClient>`
 /// into other owners (e.g. the command executor) no longer keeps the
 /// child alive.
+
+/// A request-failure notification emitted by [`RemoteServerClient::send_request`].
+/// Delivered on a dedicated channel separate from the lifecycle
+/// [`ClientEvent`] stream so that holding this sender does not prevent
+/// the lifecycle stream from closing (which would block
+/// `mark_session_disconnected`).
+#[derive(Clone, Debug)]
+pub struct RequestFailedEvent {
+    pub operation: crate::manager::RemoteServerOperation,
+    pub error_kind: crate::manager::RemoteServerErrorKind,
+}
+
 pub struct RemoteServerClient {
     /// Channel for queuing ClientMessages to send to the remote server.
     outbound_tx: async_channel::Sender<ClientMessage>,
@@ -156,10 +159,11 @@ pub struct RemoteServerClient {
     /// on a dead connection.
     disconnected: Arc<AtomicBool>,
 
-    /// Clone of the event channel used by the reader task. Stored here so
-    /// `send_request` can fire `ClientEvent::RequestFailed` events
-    /// without requiring callers to thread the channel through.
-    event_tx: async_channel::Sender<ClientEvent>,
+    /// Dedicated channel for `RequestFailed` telemetry events. Separate from
+    /// the lifecycle `event_tx` so that holding this sender does not keep the
+    /// lifecycle stream alive (which would prevent `spawn_stream_local`'s
+    /// completion callback from firing `mark_session_disconnected`).
+    failure_tx: async_channel::Sender<RequestFailedEvent>,
 }
 
 impl fmt::Debug for RemoteServerClient {
@@ -191,7 +195,11 @@ impl RemoteServerClient {
         stdout: async_process::ChildStdout,
         stderr: async_process::ChildStderr,
         executor: &executor::Background,
-    ) -> (Self, async_channel::Receiver<ClientEvent>) {
+    ) -> (
+        Self,
+        async_channel::Receiver<ClientEvent>,
+        async_channel::Receiver<RequestFailedEvent>,
+    ) {
         spawn_stderr_forwarder(stderr, executor);
         Self::new(stdout, stdin, executor)
     }
@@ -207,15 +215,18 @@ impl RemoteServerClient {
         reader: impl AsyncRead + TransportStream,
         writer: impl AsyncWrite + TransportStream,
         executor: &executor::Background,
-    ) -> (Self, async_channel::Receiver<ClientEvent>) {
+    ) -> (
+        Self,
+        async_channel::Receiver<ClientEvent>,
+        async_channel::Receiver<RequestFailedEvent>,
+    ) {
         let pending_requests: Arc<
             DashMap<RequestId, oneshot::Sender<Result<ServerMessage, ClientError>>>,
         > = Arc::new(DashMap::new());
         let (outbound_tx, outbound_rx) = async_channel::unbounded::<ClientMessage>();
         let (event_tx, event_rx) = async_channel::unbounded::<ClientEvent>();
+        let (failure_tx, failure_rx) = async_channel::unbounded::<RequestFailedEvent>();
         let disconnected = Arc::new(AtomicBool::new(false));
-        // Clone before moving into background tasks so the struct can hold one.
-        let event_tx_for_client = event_tx.clone();
 
         executor
             .spawn(Self::writer_task(
@@ -238,9 +249,10 @@ impl RemoteServerClient {
                 outbound_tx,
                 pending_requests,
                 disconnected,
-                event_tx: event_tx_for_client,
+                failure_tx,
             },
             event_rx,
+            failure_rx,
         )
     }
 
@@ -851,9 +863,7 @@ impl RemoteServerClient {
         let result = self.send_request_internal(request_id, msg).await;
         if let Err(ref e) = result {
             let error_kind = crate::manager::RemoteServerErrorKind::from_client_error(e);
-            // Best-effort: if the channel is closed the disconnect event
-            // will fire separately via the reader task.
-            let _ = self.event_tx.try_send(ClientEvent::RequestFailed {
+            let _ = self.failure_tx.try_send(RequestFailedEvent {
                 operation,
                 error_kind,
             });

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -116,6 +116,17 @@ pub struct InitializeParams {
     pub crash_reporting_enabled: bool,
 }
 
+/// A request-failure notification emitted by [`RemoteServerClient::send_request`].
+/// Delivered on a dedicated channel separate from the lifecycle
+/// [`ClientEvent`] stream so that holding this sender does not prevent
+/// the lifecycle stream from closing (which would block
+/// `mark_session_disconnected`).
+#[derive(Clone, Debug)]
+pub struct RequestFailedEvent {
+    pub operation: crate::manager::RemoteServerOperation,
+    pub error_kind: crate::manager::RemoteServerErrorKind,
+}
+
 /// Client for communicating with a `remote_server` process over the remote server protocol.
 ///
 /// Exposes async request/response APIs over generic I/O streams (child-process pipes,
@@ -135,18 +146,6 @@ pub struct InitializeParams {
 /// rather than by `Arc` refcount -- cloning `Arc<RemoteServerClient>`
 /// into other owners (e.g. the command executor) no longer keeps the
 /// child alive.
-
-/// A request-failure notification emitted by [`RemoteServerClient::send_request`].
-/// Delivered on a dedicated channel separate from the lifecycle
-/// [`ClientEvent`] stream so that holding this sender does not prevent
-/// the lifecycle stream from closing (which would block
-/// `mark_session_disconnected`).
-#[derive(Clone, Debug)]
-pub struct RequestFailedEvent {
-    pub operation: crate::manager::RemoteServerOperation,
-    pub error_kind: crate::manager::RemoteServerErrorKind,
-}
-
 pub struct RemoteServerClient {
     /// Channel for queuing ClientMessages to send to the remote server.
     outbound_tx: async_channel::Sender<ClientMessage>,

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -88,6 +88,15 @@ pub enum ClientEvent {
     CodebaseIndexStatusUpdated { status: RemoteCodebaseIndexStatus },
     /// A server message could not be decoded and had no parseable request_id.
     MessageDecodingError,
+    /// A client request to the remote server failed at the transport level
+    /// (timeout, disconnect, protocol error, etc.). Emitted automatically by
+    /// `send_tracked_request` so upstream callers get telemetry for free.
+    RequestFailed {
+        /// Static tag identifying which RPC failed (e.g. `"open_buffer"`).
+        operation: &'static str,
+        /// Classified error kind for telemetry aggregation.
+        error_kind: crate::manager::RemoteServerErrorKind,
+    },
     /// A buffer was updated on the server (file changed on disk).
     BufferUpdated {
         path: String,
@@ -146,6 +155,11 @@ pub struct RemoteServerClient {
     /// `send_request` after inserting into `pending_requests` to avoid hanging
     /// on a dead connection.
     disconnected: Arc<AtomicBool>,
+
+    /// Clone of the event channel used by the reader task. Stored here so
+    /// `send_tracked_request` can fire `ClientEvent::RequestFailed` events
+    /// without requiring callers to thread the channel through.
+    event_tx: async_channel::Sender<ClientEvent>,
 }
 
 impl fmt::Debug for RemoteServerClient {
@@ -200,6 +214,8 @@ impl RemoteServerClient {
         let (outbound_tx, outbound_rx) = async_channel::unbounded::<ClientMessage>();
         let (event_tx, event_rx) = async_channel::unbounded::<ClientEvent>();
         let disconnected = Arc::new(AtomicBool::new(false));
+        // Clone before moving into background tasks so the struct can hold one.
+        let event_tx_for_client = event_tx.clone();
 
         executor
             .spawn(Self::writer_task(
@@ -222,6 +238,7 @@ impl RemoteServerClient {
                 outbound_tx,
                 pending_requests,
                 disconnected,
+                event_tx: event_tx_for_client,
             },
             event_rx,
         )
@@ -278,7 +295,9 @@ impl RemoteServerClient {
              repo_path={repo_path_for_log}"
         );
 
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_tracked_request(request_id, msg, "index_codebase")
+            .await?;
 
         match response.message {
             Some(server_message::Message::CodebaseIndexStatusUpdated(update)) => {
@@ -322,7 +341,9 @@ impl RemoteServerClient {
              repo_path={repo_path_for_log}"
         );
 
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_tracked_request(request_id, msg, "drop_codebase_index")
+            .await?;
 
         match response.message {
             Some(server_message::Message::CodebaseIndexStatusUpdated(update)) => {
@@ -451,7 +472,9 @@ impl RemoteServerClient {
             )),
         };
 
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_tracked_request(request_id, msg, "navigate_to_directory")
+            .await?;
 
         match response.message {
             Some(server_message::Message::NavigatedToDirectoryResponse(resp)) => Ok(resp),
@@ -482,7 +505,9 @@ impl RemoteServerClient {
             )),
         };
 
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_tracked_request(request_id, msg, "load_repo_metadata_directory")
+            .await?;
 
         match response.message {
             Some(server_message::Message::LoadRepoMetadataDirectoryResponse(resp)) => Ok(resp),
@@ -507,7 +532,9 @@ impl RemoteServerClient {
                 content,
             })),
         };
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_tracked_request(request_id, msg, "write_file")
+            .await?;
         match response.message {
             Some(server_message::Message::WriteFileResponse(resp)) => match resp.result {
                 Some(crate::proto::write_file_response::Result::Success(_)) | None => Ok(()),
@@ -540,7 +567,9 @@ impl RemoteServerClient {
             request_id: request_id.to_string(),
             message: Some(client_message::Message::ReadFileContext(request)),
         };
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_tracked_request(request_id, msg, "read_file_context")
+            .await?;
         match response.message {
             Some(server_message::Message::ReadFileContextResponse(resp)) => Ok(resp),
             other => {
@@ -570,7 +599,9 @@ impl RemoteServerClient {
                 force_reload,
             })),
         };
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_tracked_request(request_id, msg, "open_buffer")
+            .await?;
         match response.message {
             Some(server_message::Message::OpenBufferResponse(resp)) => Ok(resp),
             other => {
@@ -607,7 +638,9 @@ impl RemoteServerClient {
             request_id: request_id.to_string(),
             message: Some(client_message::Message::SaveBuffer(SaveBuffer { path })),
         };
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_tracked_request(request_id, msg, "save_buffer")
+            .await?;
         match response.message {
             Some(server_message::Message::SaveBufferResponse(resp)) => match resp.result {
                 Some(crate::proto::save_buffer_response::Result::Success(_)) | None => Ok(()),
@@ -638,7 +671,9 @@ impl RemoteServerClient {
             request_id: request_id.to_string(),
             message: Some(client_message::Message::DeleteFile(DeleteFile { path })),
         };
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_tracked_request(request_id, msg, "delete_file")
+            .await?;
         match response.message {
             Some(server_message::Message::DeleteFileResponse(resp)) => match resp.result {
                 Some(crate::proto::delete_file_response::Result::Success(_)) | None => Ok(()),
@@ -747,7 +782,9 @@ impl RemoteServerClient {
             })),
         };
 
-        let response = self.send_request(request_id, msg).await?;
+        let response = self
+            .send_tracked_request(request_id, msg, "run_command")
+            .await?;
 
         match response.message {
             Some(server_message::Message::RunCommandResponse(resp)) => Ok(resp),
@@ -759,6 +796,29 @@ impl RemoteServerClient {
                 Err(ClientError::UnexpectedResponse)
             }
         }
+    }
+
+    /// Wrapper around [`send_request`] that automatically fires a
+    /// [`ClientEvent::RequestFailed`] event on error, so transport-level
+    /// failures are tracked for telemetry without requiring each caller
+    /// to instrument its own error path.
+    async fn send_tracked_request(
+        &self,
+        request_id: RequestId,
+        msg: ClientMessage,
+        operation: &'static str,
+    ) -> Result<ServerMessage, ClientError> {
+        let result = self.send_request(request_id, msg).await;
+        if let Err(ref e) = result {
+            let error_kind = crate::manager::RemoteServerErrorKind::from_client_error(e);
+            // Best-effort: if the channel is closed the disconnect event
+            // will fire separately via the reader task.
+            let _ = self.event_tx.try_send(ClientEvent::RequestFailed {
+                operation,
+                error_kind,
+            });
+        }
+        result
     }
 
     /// Generic request/response correlation.

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -90,10 +90,10 @@ pub enum ClientEvent {
     MessageDecodingError,
     /// A client request to the remote server failed at the transport level
     /// (timeout, disconnect, protocol error, etc.). Emitted automatically by
-    /// `send_tracked_request` so upstream callers get telemetry for free.
+    /// `send_request` so upstream callers get telemetry for free.
     RequestFailed {
-        /// Static tag identifying which RPC failed (e.g. `"open_buffer"`).
-        operation: &'static str,
+        /// Which RPC failed.
+        operation: crate::manager::RemoteServerOperation,
         /// Classified error kind for telemetry aggregation.
         error_kind: crate::manager::RemoteServerErrorKind,
     },
@@ -157,7 +157,7 @@ pub struct RemoteServerClient {
     disconnected: Arc<AtomicBool>,
 
     /// Clone of the event channel used by the reader task. Stored here so
-    /// `send_tracked_request` can fire `ClientEvent::RequestFailed` events
+    /// `send_request` can fire `ClientEvent::RequestFailed` events
     /// without requiring callers to thread the channel through.
     event_tx: async_channel::Sender<ClientEvent>,
 }
@@ -261,7 +261,7 @@ impl RemoteServerClient {
             })),
         };
 
-        let response = self.send_request(request_id, msg).await?;
+        let response = self.send_request_internal(request_id, msg).await?;
 
         match response.message {
             Some(server_message::Message::InitializeResponse(resp)) => Ok(resp),
@@ -296,7 +296,11 @@ impl RemoteServerClient {
         );
 
         let response = self
-            .send_tracked_request(request_id, msg, "index_codebase")
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::IndexCodebase,
+            )
             .await?;
 
         match response.message {
@@ -342,7 +346,11 @@ impl RemoteServerClient {
         );
 
         let response = self
-            .send_tracked_request(request_id, msg, "drop_codebase_index")
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::DropCodebaseIndex,
+            )
             .await?;
 
         match response.message {
@@ -473,7 +481,11 @@ impl RemoteServerClient {
         };
 
         let response = self
-            .send_tracked_request(request_id, msg, "navigate_to_directory")
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::NavigateToDirectory,
+            )
             .await?;
 
         match response.message {
@@ -506,7 +518,11 @@ impl RemoteServerClient {
         };
 
         let response = self
-            .send_tracked_request(request_id, msg, "load_repo_metadata_directory")
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::LoadRepoMetadataDirectory,
+            )
             .await?;
 
         match response.message {
@@ -533,7 +549,11 @@ impl RemoteServerClient {
             })),
         };
         let response = self
-            .send_tracked_request(request_id, msg, "write_file")
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::WriteFile,
+            )
             .await?;
         match response.message {
             Some(server_message::Message::WriteFileResponse(resp)) => match resp.result {
@@ -568,7 +588,11 @@ impl RemoteServerClient {
             message: Some(client_message::Message::ReadFileContext(request)),
         };
         let response = self
-            .send_tracked_request(request_id, msg, "read_file_context")
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::ReadFileContext,
+            )
             .await?;
         match response.message {
             Some(server_message::Message::ReadFileContextResponse(resp)) => Ok(resp),
@@ -600,7 +624,11 @@ impl RemoteServerClient {
             })),
         };
         let response = self
-            .send_tracked_request(request_id, msg, "open_buffer")
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::OpenBuffer,
+            )
             .await?;
         match response.message {
             Some(server_message::Message::OpenBufferResponse(resp)) => Ok(resp),
@@ -639,7 +667,11 @@ impl RemoteServerClient {
             message: Some(client_message::Message::SaveBuffer(SaveBuffer { path })),
         };
         let response = self
-            .send_tracked_request(request_id, msg, "save_buffer")
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::SaveBuffer,
+            )
             .await?;
         match response.message {
             Some(server_message::Message::SaveBufferResponse(resp)) => match resp.result {
@@ -672,7 +704,11 @@ impl RemoteServerClient {
             message: Some(client_message::Message::DeleteFile(DeleteFile { path })),
         };
         let response = self
-            .send_tracked_request(request_id, msg, "delete_file")
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::DeleteFile,
+            )
             .await?;
         match response.message {
             Some(server_message::Message::DeleteFileResponse(resp)) => match resp.result {
@@ -783,7 +819,11 @@ impl RemoteServerClient {
         };
 
         let response = self
-            .send_tracked_request(request_id, msg, "run_command")
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::RunCommand,
+            )
             .await?;
 
         match response.message {
@@ -798,17 +838,17 @@ impl RemoteServerClient {
         }
     }
 
-    /// Wrapper around [`send_request`] that automatically fires a
+    /// Wrapper around [`send_request_internal`] that automatically fires a
     /// [`ClientEvent::RequestFailed`] event on error, so transport-level
     /// failures are tracked for telemetry without requiring each caller
     /// to instrument its own error path.
-    async fn send_tracked_request(
+    async fn send_request(
         &self,
         request_id: RequestId,
         msg: ClientMessage,
-        operation: &'static str,
+        operation: crate::manager::RemoteServerOperation,
     ) -> Result<ServerMessage, ClientError> {
-        let result = self.send_request(request_id, msg).await;
+        let result = self.send_request_internal(request_id, msg).await;
         if let Err(ref e) = result {
             let error_kind = crate::manager::RemoteServerErrorKind::from_client_error(e);
             // Best-effort: if the channel is closed the disconnect event
@@ -826,7 +866,7 @@ impl RemoteServerClient {
     /// Registers a oneshot channel keyed by `request_id`, sends the message
     /// through the outbound channel, and awaits the correlated response.
     /// Times out after `REQUEST_TIMEOUT` and sends an `Abort` to the server.
-    async fn send_request(
+    async fn send_request_internal(
         &self,
         request_id: RequestId,
         msg: ClientMessage,

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -61,7 +61,7 @@ async fn codebase_index_push_messages_become_client_events() {
     drop(server_read);
 
     let executor = executor::Background::default();
-    let (_client, event_rx) =
+    let (_client, event_rx, _failure_rx) =
         RemoteServerClient::new(client_read.compat(), client_write.compat_write(), &executor);
     let mut writer = server_write.compat_write();
 
@@ -132,7 +132,7 @@ where
     ));
 
     let executor = executor::Background::default();
-    let (client, event_rx) =
+    let (client, event_rx, _failure_rx) =
         RemoteServerClient::new(client_read.compat(), client_write.compat_write(), &executor);
     (client, event_rx, executor)
 }
@@ -313,7 +313,7 @@ async fn authenticate_sends_fire_and_forget_message() {
     let (server_read, _server_write) = tokio::io::split(server_stream);
     let (client_read, client_write) = tokio::io::split(client_stream);
     let executor = executor::Background::default();
-    let (client, _event_rx) =
+    let (client, _event_rx, _failure_rx) =
         RemoteServerClient::new(client_read.compat(), client_write.compat_write(), &executor);
 
     client.authenticate("rotated-secret");
@@ -337,7 +337,7 @@ async fn disconnected_on_closed_stream() {
 
     let (client_read, client_write) = tokio::io::split(client_stream);
     let executor = executor::Background::default();
-    let (client, disconnect_rx) =
+    let (client, disconnect_rx, _failure_rx) =
         RemoteServerClient::new(client_read.compat(), client_write.compat_write(), &executor);
 
     // An initialize call on a dead stream must complete with an error rather than hang.

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -112,6 +112,7 @@ pub enum RemoteServerOperation {
     ReadFileContext,
     DeleteFile,
     RunCommand,
+    GetFragmentMetadataFromHash,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -35,7 +35,6 @@ use warpui::r#async::FutureExt as _;
 use warpui::{Entity, ModelContext, ModelSpawner, SingletonEntity};
 
 /// Maximum number of reconnection attempts after a spontaneous disconnect.
-#[cfg(not(target_family = "wasm"))]
 pub const MAX_RECONNECT_ATTEMPTS: u32 = 2;
 /// Delay between reconnection attempts.
 #[cfg(not(target_family = "wasm"))]

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -61,6 +61,7 @@ struct ReconnectParams {
 struct InitializeHandshake {
     host_id: HostId,
     event_rx: async_channel::Receiver<ClientEvent>,
+    failure_rx: async_channel::Receiver<crate::client::RequestFailedEvent>,
 }
 
 /// Error from [`RemoteServerManager::run_connect_and_handshake`] that
@@ -222,7 +223,6 @@ fn client_event_kind(event: &ClientEvent) -> &'static str {
         ClientEvent::DiffStateMetadataUpdateReceived { .. } => "diff_state_metadata_update",
         ClientEvent::DiffStateFileDeltaReceived { .. } => "diff_state_file_delta",
         ClientEvent::MessageDecodingError => "message_decoding_error",
-        ClientEvent::RequestFailed { .. } => "request_failed",
     }
 }
 
@@ -1001,6 +1001,7 @@ impl RemoteServerManager {
         let Connection {
             client,
             event_rx,
+            failure_rx,
             child,
             control_path,
         } = transport
@@ -1099,6 +1100,7 @@ impl RemoteServerManager {
         Ok(InitializeHandshake {
             host_id: HostId::new(resp.host_id),
             event_rx,
+            failure_rx,
         })
     }
 
@@ -1666,16 +1668,6 @@ impl RemoteServerManager {
             ClientEvent::DiffStateFileDeltaReceived { delta } => {
                 ctx.emit(RemoteServerManagerEvent::DiffStateFileDeltaReceived { host_id, delta });
             }
-            ClientEvent::RequestFailed {
-                operation,
-                error_kind,
-            } => {
-                ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
-                    session_id,
-                    operation,
-                    error_kind,
-                });
-            }
             ClientEvent::Disconnected => {
                 // Handled by the drain loop's completion callback.
             }
@@ -1693,7 +1685,11 @@ impl RemoteServerManager {
         transport: Arc<dyn RemoteTransport>,
         ctx: &mut ModelContext<Self>,
     ) {
-        let InitializeHandshake { host_id, event_rx } = handshake;
+        let InitializeHandshake {
+            host_id,
+            event_rx,
+            failure_rx,
+        } = handshake;
         log::info!("Remote server connected: session={session_id:?} host={host_id}");
 
         // Only transition if the session is still in Initializing state.
@@ -1730,6 +1726,20 @@ impl RemoteServerManager {
             move |me, ctx| {
                 me.mark_session_disconnected(session_id, ctx);
             },
+        );
+        // Drain the separate failure channel for request-failed telemetry.
+        // This stream is independent of the lifecycle stream above, so
+        // holding its sender on the client does not block disconnect.
+        ctx.spawn_stream_local(
+            failure_rx,
+            move |_me, event, ctx| {
+                ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
+                    session_id,
+                    operation: event.operation,
+                    error_kind: event.error_kind,
+                });
+            },
+            |_, _| {}, // no-op on done
         );
         if is_first_session {
             ctx.emit(RemoteServerManagerEvent::HostConnected {

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -36,7 +36,7 @@ use warpui::{Entity, ModelContext, ModelSpawner, SingletonEntity};
 
 /// Maximum number of reconnection attempts after a spontaneous disconnect.
 #[cfg(not(target_family = "wasm"))]
-const MAX_RECONNECT_ATTEMPTS: u32 = 2;
+pub const MAX_RECONNECT_ATTEMPTS: u32 = 2;
 /// Delay between reconnection attempts.
 #[cfg(not(target_family = "wasm"))]
 const RECONNECT_DELAY: Duration = Duration::from_secs(2);
@@ -105,6 +105,33 @@ pub enum RemoteServerOperation {
     LoadRepoMetadataDirectory,
     IndexCodebase,
     DropCodebaseIndex,
+    OpenBuffer,
+    SaveBuffer,
+    WriteFile,
+    ReadFileContext,
+    DeleteFile,
+    RunCommand,
+}
+
+impl RemoteServerOperation {
+    /// Converts a static operation tag (as used by
+    /// [`ClientEvent::RequestFailed`]) into the corresponding enum variant.
+    /// Returns `None` for unrecognised tags.
+    pub fn from_tag(tag: &str) -> Option<Self> {
+        match tag {
+            "navigate_to_directory" => Some(Self::NavigateToDirectory),
+            "load_repo_metadata_directory" => Some(Self::LoadRepoMetadataDirectory),
+            "index_codebase" => Some(Self::IndexCodebase),
+            "drop_codebase_index" => Some(Self::DropCodebaseIndex),
+            "open_buffer" => Some(Self::OpenBuffer),
+            "save_buffer" => Some(Self::SaveBuffer),
+            "write_file" => Some(Self::WriteFile),
+            "read_file_context" => Some(Self::ReadFileContext),
+            "delete_file" => Some(Self::DeleteFile),
+            "run_command" => Some(Self::RunCommand),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -216,6 +243,7 @@ fn client_event_kind(event: &ClientEvent) -> &'static str {
         ClientEvent::DiffStateMetadataUpdateReceived { .. } => "diff_state_metadata_update",
         ClientEvent::DiffStateFileDeltaReceived { .. } => "diff_state_file_delta",
         ClientEvent::MessageDecodingError => "message_decoding_error",
+        ClientEvent::RequestFailed { operation, .. } => operation,
     }
 }
 
@@ -354,6 +382,11 @@ pub enum RemoteServerManagerEvent {
         /// `None` when the session was explicitly deregistered or when
         /// the exit status could not be determined.
         exit_status: Option<RemoteServerExitStatus>,
+        /// `true` when this disconnect follows exhausted reconnection
+        /// attempts. `false` for first-time disconnects and explicit
+        /// deregistrations. Used by the view layer to distinguish
+        /// reconnect-exhausted telemetry from regular disconnections.
+        was_reconnect_attempt: bool,
     },
     /// A reconnection attempt succeeded. Downstream owners (e.g.
     /// `RemoteServerCommandExecutor`) should swap their client reference
@@ -1166,6 +1199,7 @@ impl RemoteServerManager {
                 session_id,
                 host_id: host_id.clone(),
                 exit_status: None,
+                was_reconnect_attempt: false,
             });
             if !self.host_to_sessions.contains_key(&host_id) {
                 ctx.emit(RemoteServerManagerEvent::HostDisconnected { host_id });
@@ -1395,16 +1429,8 @@ impl RemoteServerManager {
                              operation={operation:?} host={host_id} session={session_id:?} \
                              repo_path={repo_path_for_log} error={e}"
                         );
-                        let error_kind = RemoteServerErrorKind::from_client_error(&e);
-                        let _ = spawner
-                            .spawn(move |_me, ctx| {
-                                ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
-                                    session_id,
-                                    operation,
-                                    error_kind,
-                                });
-                            })
-                            .await;
+                        // Transport-level telemetry is emitted automatically
+                        // by send_tracked_request via ClientEvent::RequestFailed.
                     }
                 }
             })
@@ -1470,16 +1496,8 @@ impl RemoteServerManager {
                     }
                     Err(e) => {
                         log::warn!("Remote server navigate_to_directory failed: session={session_id:?} error={e}");
-                        let error_kind = RemoteServerErrorKind::from_client_error(&e);
-                        let _ = spawner
-                            .spawn(move |_me, ctx| {
-                                ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
-                                    session_id,
-                                    operation: RemoteServerOperation::NavigateToDirectory,
-                                    error_kind,
-                                });
-                            })
-                            .await;
+                        // Transport-level telemetry is emitted automatically
+                        // by send_tracked_request via ClientEvent::RequestFailed.
                     }
                 }
             })
@@ -1565,16 +1583,8 @@ impl RemoteServerManager {
                         log::warn!(
                             "Remote server load_repo_metadata_directory failed: session={session_id:?} error={e}"
                         );
-                        let error_kind = RemoteServerErrorKind::from_client_error(&e);
-                        let _ = spawner
-                            .spawn(move |_me, ctx| {
-                                ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
-                                    session_id,
-                                    operation: RemoteServerOperation::LoadRepoMetadataDirectory,
-                                    error_kind,
-                                });
-                            })
-                            .await;
+                        // Transport-level telemetry is emitted automatically
+                        // by send_tracked_request via ClientEvent::RequestFailed.
                     }
                 }
             })
@@ -1676,6 +1686,20 @@ impl RemoteServerManager {
             }
             ClientEvent::DiffStateFileDeltaReceived { delta } => {
                 ctx.emit(RemoteServerManagerEvent::DiffStateFileDeltaReceived { host_id, delta });
+            }
+            ClientEvent::RequestFailed {
+                operation,
+                error_kind,
+            } => {
+                if let Some(operation) = RemoteServerOperation::from_tag(operation) {
+                    ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
+                        session_id,
+                        operation,
+                        error_kind,
+                    });
+                } else {
+                    log::warn!("Unknown remote server operation tag in RequestFailed: {operation}");
+                }
             }
             ClientEvent::Disconnected => {
                 // Handled by the drain loop's completion callback.
@@ -2089,6 +2113,7 @@ impl RemoteServerManager {
                 session_id,
                 host_id: params.host_id,
                 exit_status: params.exit_status,
+                was_reconnect_attempt: true,
             });
             // Note: HostDisconnected was already emitted by
             // mark_session_disconnected when entering the reconnect flow.
@@ -2118,6 +2143,7 @@ impl RemoteServerManager {
             session_id,
             host_id: host_id.clone(),
             exit_status,
+            was_reconnect_attempt: false,
         });
         if !self.host_to_sessions.contains_key(&host_id) {
             ctx.emit(RemoteServerManagerEvent::HostDisconnected { host_id });

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -113,27 +113,6 @@ pub enum RemoteServerOperation {
     RunCommand,
 }
 
-impl RemoteServerOperation {
-    /// Converts a static operation tag (as used by
-    /// [`ClientEvent::RequestFailed`]) into the corresponding enum variant.
-    /// Returns `None` for unrecognised tags.
-    pub fn from_tag(tag: &str) -> Option<Self> {
-        match tag {
-            "navigate_to_directory" => Some(Self::NavigateToDirectory),
-            "load_repo_metadata_directory" => Some(Self::LoadRepoMetadataDirectory),
-            "index_codebase" => Some(Self::IndexCodebase),
-            "drop_codebase_index" => Some(Self::DropCodebaseIndex),
-            "open_buffer" => Some(Self::OpenBuffer),
-            "save_buffer" => Some(Self::SaveBuffer),
-            "write_file" => Some(Self::WriteFile),
-            "read_file_context" => Some(Self::ReadFileContext),
-            "delete_file" => Some(Self::DeleteFile),
-            "run_command" => Some(Self::RunCommand),
-            _ => None,
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug)]
 enum RemoteCodebaseIndexMutation {
     Index,
@@ -243,7 +222,7 @@ fn client_event_kind(event: &ClientEvent) -> &'static str {
         ClientEvent::DiffStateMetadataUpdateReceived { .. } => "diff_state_metadata_update",
         ClientEvent::DiffStateFileDeltaReceived { .. } => "diff_state_file_delta",
         ClientEvent::MessageDecodingError => "message_decoding_error",
-        ClientEvent::RequestFailed { operation, .. } => operation,
+        ClientEvent::RequestFailed { .. } => "request_failed",
     }
 }
 
@@ -1691,15 +1670,11 @@ impl RemoteServerManager {
                 operation,
                 error_kind,
             } => {
-                if let Some(operation) = RemoteServerOperation::from_tag(operation) {
-                    ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
-                        session_id,
-                        operation,
-                        error_kind,
-                    });
-                } else {
-                    log::warn!("Unknown remote server operation tag in RequestFailed: {operation}");
-                }
+                ctx.emit(RemoteServerManagerEvent::ClientRequestFailed {
+                    session_id,
+                    operation,
+                    error_kind,
+                });
             }
             ClientEvent::Disconnected => {
                 // Handled by the drain loop's completion callback.

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -152,6 +152,10 @@ impl Error {
 pub struct Connection {
     pub client: RemoteServerClient,
     pub event_rx: Receiver<ClientEvent>,
+    /// Receiver for request-failure telemetry events. Separate from
+    /// `event_rx` so the failure sender on the client doesn't keep the
+    /// lifecycle event channel alive.
+    pub failure_rx: async_channel::Receiver<crate::client::RequestFailedEvent>,
     /// The subprocess whose stdio backs the client (e.g.
     /// `ssh … remote-server-proxy`). Spawned with `kill_on_drop(true)`
     /// by the transport, so dropping this `Child` sends SIGKILL to the


### PR DESCRIPTION
## Description
Right now we have solid telemetry tracking for initialization / installation process. But there are still a few gaps:
1. There is no telemetry events for post-connection server status (e.g. disconnects, reconnect attempts)
2. We have some request level error tracking metrics. But they are ad-hoc and incomplete
3. We don't have great sentry logging for unexpected error cases. We should properly bump them to error logs and strip sensitive user infos

Specifically for (2), the previous flow requires us to specifically emit the manager `RemoteServerManagerEvent::ClientRequestFailed` event at each message callsite. This is a footgun since developers could easily forget to add this. With this PR, we probably move the emission of that event to within each RemoteServerClient

## Testing
Tested locally