### PR TITLE
Fix link display text escaping for notebooks/plans

### DIFF
--- a/crates/editor/src/content/markdown_tests.rs
+++ b/crates/editor/src/content/markdown_tests.rs
@@ -361,6 +361,46 @@ fn test_table_markdown_export_escapes_pipe_characters() {
     });
 }
 
+
+#[test]
+fn test_url_link_display_text_round_trip_is_stable() {
+    App::test((), |mut app| async move {
+        let original =
+            "[https://example.com/index.html#section](https://example.com/index.html#section)";
+        // After the first save, `.` and `#` in the display text are escaped.
+        // The URL in `(...)` is written verbatim — no escaping.
+        let expected_escaped =
+            "[https://example\\.com/index\\.html\\#section](https://example.com/index.html#section)";
+
+        let (buffer, _) = Buffer::mock_from_markdown(
+            original,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+        let after_first = app.read_model(&buffer, |buffer, _| buffer.markdown());
+        assert_eq!(after_first, expected_escaped, "first save should escape special chars in display text");
+
+        let (buffer2, _) = Buffer::mock_from_markdown(
+            &after_first,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+        let after_second = app.read_model(&buffer2, |buffer, _| buffer.markdown());
+        assert_eq!(after_second, expected_escaped, "second round-trip should be stable");
+
+        let (buffer3, _) = Buffer::mock_from_markdown(
+            &after_second,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+        let after_third = app.read_model(&buffer3, |buffer, _| buffer.markdown());
+        assert_eq!(after_third, expected_escaped, "third round-trip should be stable");
+    });
+}
+
 #[test]
 fn test_image_with_content_html_serialization() {
     App::test((), |mut app| async move {

--- a/crates/editor/src/content/markdown_tests.rs
+++ b/crates/editor/src/content/markdown_tests.rs
@@ -405,6 +405,75 @@ fn test_url_link_display_text_round_trip_is_stable() {
             after_third, expected_escaped,
             "third round-trip should be stable"
         );
+
+        // Plain text should be the clean, unescaped URL — no backslashes.
+        let plain_text = app.read_model(&buffer3, |buffer, _| buffer.text().as_str().to_string());
+        assert_eq!(plain_text, "https://example.com/index.html#section");
+    });
+}
+
+#[test]
+fn test_markdown_escapes_punctuation() {
+    App::test((), |mut app| async move {
+        // markdown() escapes special chars.
+        let markdown = "Here's a markdown comment.\n";
+        let (buffer, _) = Buffer::mock_from_markdown(
+            markdown,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+        let escaped = app.read_model(&buffer, |buffer, _| buffer.markdown());
+        assert!(
+            escaped.contains("\\."),
+            "expected escaped periods, got: {escaped}"
+        );
+    });
+}
+
+#[test]
+fn test_markdown_unescaped_does_not_escape_punctuation() {
+    App::test((), |mut app| async move {
+        // markdown_unescaped() should not add backslashes before periods.
+        let markdown = "Here's a markdown comment.\n";
+        let (buffer, _) = Buffer::mock_from_markdown(
+            markdown,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+        let unescaped = app.read_model(&buffer, |buffer, _| buffer.markdown_unescaped());
+        assert!(
+            !unescaped.contains("\\."),
+            "expected no escaped periods, got: {unescaped}"
+        );
+        assert!(
+            unescaped.contains("comment."),
+            "expected unescaped period, got: {unescaped}"
+        );
+    });
+}
+
+#[test]
+fn test_markdown_unescaped_preserves_urls() {
+    App::test((), |mut app| async move {
+        // markdown_unescaped() should not escape characters inside URLs.
+        let markdown = "Check out https://www.example.com/path\n";
+        let (buffer, _) = Buffer::mock_from_markdown(
+            markdown,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+        let unescaped = app.read_model(&buffer, |buffer, _| buffer.markdown_unescaped());
+        assert!(
+            !unescaped.contains("\\/"),
+            "expected no escaped slashes, got: {unescaped}"
+        );
+        assert!(
+            unescaped.contains("https://www.example.com/path"),
+            "expected URL preserved, got: {unescaped}"
+        );
     });
 }
 

--- a/crates/editor/src/content/markdown_tests.rs
+++ b/crates/editor/src/content/markdown_tests.rs
@@ -361,7 +361,6 @@ fn test_table_markdown_export_escapes_pipe_characters() {
     });
 }
 
-
 #[test]
 fn test_url_link_display_text_round_trip_is_stable() {
     App::test((), |mut app| async move {
@@ -369,8 +368,7 @@ fn test_url_link_display_text_round_trip_is_stable() {
             "[https://example.com/index.html#section](https://example.com/index.html#section)";
         // After the first save, `.` and `#` in the display text are escaped.
         // The URL in `(...)` is written verbatim — no escaping.
-        let expected_escaped =
-            "[https://example\\.com/index\\.html\\#section](https://example.com/index.html#section)";
+        let expected_escaped = "[https://example\\.com/index\\.html\\#section](https://example.com/index.html#section)";
 
         let (buffer, _) = Buffer::mock_from_markdown(
             original,
@@ -379,7 +377,10 @@ fn test_url_link_display_text_round_trip_is_stable() {
             &mut app,
         );
         let after_first = app.read_model(&buffer, |buffer, _| buffer.markdown());
-        assert_eq!(after_first, expected_escaped, "first save should escape special chars in display text");
+        assert_eq!(
+            after_first, expected_escaped,
+            "first save should escape special chars in display text"
+        );
 
         let (buffer2, _) = Buffer::mock_from_markdown(
             &after_first,
@@ -388,7 +389,10 @@ fn test_url_link_display_text_round_trip_is_stable() {
             &mut app,
         );
         let after_second = app.read_model(&buffer2, |buffer, _| buffer.markdown());
-        assert_eq!(after_second, expected_escaped, "second round-trip should be stable");
+        assert_eq!(
+            after_second, expected_escaped,
+            "second round-trip should be stable"
+        );
 
         let (buffer3, _) = Buffer::mock_from_markdown(
             &after_second,
@@ -397,7 +401,10 @@ fn test_url_link_display_text_round_trip_is_stable() {
             &mut app,
         );
         let after_third = app.read_model(&buffer3, |buffer, _| buffer.markdown());
-        assert_eq!(after_third, expected_escaped, "third round-trip should be stable");
+        assert_eq!(
+            after_third, expected_escaped,
+            "third round-trip should be stable"
+        );
     });
 }
 

--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1851,7 +1851,7 @@ fn parse_url_prefix<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
 // - starts with "https://" or "http://" or "www."
 // - has at least one alphanumeric char after the prefix
 // - does not include trailing formatting characters (*, _, ~)
-// - backslash escapes are processed (e.g., `\.` → `.`) 
+// - backslash escapes are processed (e.g., `\.` → `.`)
 fn parse_url<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
     i: &'a str,
 ) -> IResult<&'a str, String, E> {
@@ -1880,7 +1880,7 @@ fn parse_url<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
     let trimmed_raw_url = &i[..trimmed_len];
     let new_remaining = &i[trimmed_len..];
 
-    // Process backslash escapes within the URL using parse_escape (e.g., `\.` → `.`). 
+    // Process backslash escapes within the URL using parse_escape (e.g., `\.` → `.`).
     let mut trimmed_url = String::with_capacity(trimmed_len);
     let mut remaining = trimmed_raw_url;
     while !remaining.is_empty() {

--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1003,7 +1003,7 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
                         c.is_whitespace() || FORMATTING_DELIMITERS.contains(c) || c == '('
                     });
                 if can_autolink {
-                    state.push_closed_node(FormattedTextFragment::hyperlink(url, url));
+                    state.push_closed_node(FormattedTextFragment::hyperlink(url.clone(), url));
                 } else {
                     state.push_text(url);
                 }
@@ -1688,8 +1688,9 @@ enum InlineToken<'a> {
     /// An entire code span. Code spans have higher precedence than all other inline constructs,
     /// so we parse them into discrete tokens.
     CodeSpan(&'a str),
-    /// An autolink URL.
-    AutoLink(&'a str),
+    /// An autolink URL. Owned because backslash escapes are processed (e.g., `\.` → `.`),
+    /// so the result may differ from the input slice.
+    AutoLink(String),
     /// A closing `]` bracket, which triggers link parsing.
     LinkEnd,
     /// A closing </u>, which triggers underline parsing.
@@ -1850,11 +1851,12 @@ fn parse_url_prefix<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
 // - starts with "https://" or "http://" or "www."
 // - has at least one alphanumeric char after the prefix
 // - does not include trailing formatting characters (*, _, ~)
+// - backslash escapes are processed (e.g., `\.` → `.`) 
 fn parse_url<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
     i: &'a str,
-) -> IResult<&'a str, &'a str, E> {
+) -> IResult<&'a str, String, E> {
     // TODO: Look into other autolink rules here: https://github.github.com/gfm/#autolinks-extension-
-    let (_, url) = recognize(tuple((
+    let (_, raw_url) = recognize(tuple((
         parse_url_prefix,
         take_till1(|c: char| c.is_whitespace() || "[]<".find_token(c)),
     )))(i)?;
@@ -1862,12 +1864,12 @@ fn parse_url<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
     // Strip trailing formatting characters (*, _, ~) from the URL.
     // Per GFM spec, autolinks should not include trailing punctuation that could be
     // markdown formatting delimiters.
-    let trimmed_len = url
+    let trimmed_len = raw_url
         .trim_end_matches(|c| FORMATTING_DELIMITERS.contains(c))
         .len();
 
     // If we trimmed everything after the prefix, the URL is invalid
-    let min_valid_len = match url.find("://") {
+    let min_valid_len = match raw_url.find("://") {
         Some(pos) => pos + "://".len(),
         None => "www.".len(),
     };
@@ -1875,9 +1877,22 @@ fn parse_url<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
         return Err(nom::Err::Error(make_error(i, ErrorKind::TakeWhile1)));
     }
 
-    // Return the trimmed URL and adjust remaining
-    let trimmed_url = &i[..trimmed_len];
+    let trimmed_raw_url = &i[..trimmed_len];
     let new_remaining = &i[trimmed_len..];
+
+    // Process backslash escapes within the URL using parse_escape (e.g., `\.` → `.`). 
+    let mut trimmed_url = String::with_capacity(trimmed_len);
+    let mut remaining = trimmed_raw_url;
+    while !remaining.is_empty() {
+        if let Ok((rest, ch)) = parse_escape::<nom::error::Error<&str>>(remaining) {
+            trimmed_url.push(ch);
+            remaining = rest;
+        } else if let Some(ch) = remaining.chars().next() {
+            trimmed_url.push(ch);
+            remaining = &remaining[ch.len_utf8()..];
+        }
+    }
+
     Ok((new_remaining, trimmed_url))
 }
 

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -893,6 +893,66 @@ fn test_multi_parse_url() {
 }
 
 #[test]
+fn test_autolink_with_escaped_dot() {
+    // After a save cycle, `parse_url` may see `https://google\.com` (with `\.` from
+    // the serializer's escape of `.`). The URL should be unescaped so the buffer
+    // stores the clean string and the round-trip is stable.
+    assert_eq!(
+        test_parse_markdown("https://google\\.com"),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::hyperlink("https://google.com", "https://google.com"),
+        ])]
+    );
+}
+
+#[test]
+fn test_autolink_with_escaped_dash() {
+    assert_eq!(
+        test_parse_markdown("https://warp\\-dev.com"),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::hyperlink("https://warp-dev.com", "https://warp-dev.com"),
+        ])]
+    );
+}
+
+#[test]
+fn test_autolink_with_multiple_escapes() {
+    // Multiple escaped characters should all be unescaped.
+    assert_eq!(
+        test_parse_markdown("https://github\\.com/foo\\-bar"),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::hyperlink(
+                "https://github.com/foo-bar",
+                "https://github.com/foo-bar"
+            ),
+        ])]
+    );
+}
+
+#[test]
+fn test_autolink_in_link_label_with_escapes() {
+    // When an escaped URL appears as the display text of an explicit link
+    // (the `can_autolink = false` path), it should also be unescaped.
+    let source = "[https://google\\.com](https://google.com)";
+    assert_eq!(
+        test_parse_markdown(source),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::hyperlink("https://google.com", "https://google.com"),
+        ])]
+    );
+}
+
+#[test]
+fn test_autolink_escape_roundtrip_is_stable() {
+    // Parsing a URL with no escapes should produce the same result as
+    // parsing the same URL with `\.` in place of `.` (simulating a save cycle).
+    // Both should yield the clean, unescaped URL.
+    let clean = test_parse_markdown("https://google.com");
+    let escaped = test_parse_markdown("https://google\\.com");
+    assert_eq!(clean, escaped);
+}
+
+#[test]
 fn test_parse_url_embedded() {
     let source = "This iswww.google.comabc";
     assert_eq!(

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -917,13 +917,13 @@ fn test_autolink_with_escaped_dash() {
 
 #[test]
 fn test_autolink_with_multiple_escapes() {
-    // Multiple escaped characters should all be unescaped.
+    // Multiple escaped characters (`.`, `-`, `#`) should all be unescaped.
     assert_eq!(
-        test_parse_markdown("https://github\\.com/foo\\-bar"),
+        test_parse_markdown("https://github\\.com/foo\\-bar\\#anchor"),
         vec![FormattedTextLine::Line(vec![
             FormattedTextFragment::hyperlink(
-                "https://github.com/foo-bar",
-                "https://github.com/foo-bar"
+                "https://github.com/foo-bar#anchor",
+                "https://github.com/foo-bar#anchor"
             ),
         ])]
     );
@@ -950,6 +950,22 @@ fn test_autolink_escape_roundtrip_is_stable() {
     let clean = test_parse_markdown("https://google.com");
     let escaped = test_parse_markdown("https://google\\.com");
     assert_eq!(clean, escaped);
+}
+
+#[test]
+fn test_parse_url_preserves_non_escaped_backslash() {
+    // A backslash followed by a non-punctuation character is not a markdown escape
+    // sequence and should be left as-is.
+    let source = "https://example.com/path\\nname";
+    assert_eq!(
+        test_parse_markdown(source),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::hyperlink(
+                "https://example.com/path\\nname",
+                "https://example.com/path\\nname"
+            ),
+        ])]
+    );
 }
 
 #[test]


### PR DESCRIPTION

## Description

Resolves #10055 

Each time a notebook or plan was saved and reopened, backslash escape characters accumulated in the display text of any link. 

The root cause: `parse_url` captured URLs as raw `&str` slices without unescaping backslash sequences. When the serializer wrote those URLs back as link display text it re-escaped them (. → \\. , \\. -> \\\\\\. , etc), so each load/save cycle added another layer of backslashes.

This PR modifies `parse_url` to process backslash escapes inline (e.g. \\. → .) and return an owned String.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-2628/text-for-links-escaping-improperly-in-notebooksplans

## Testing

- [x] I have manually tested my changes locally with `./script/run` -> [Demo of fix](https://www.loom.com/share/862e429d1ea64c2b9df9a06602a02fbb)
- [x] Added several tests to `markdown_parser_tests.rs` to verify correct URL parsing behavior
- [x] Added round trip test to `markdown_tests.rs` to verify link consistency after several save/load cycles

### Screenshots / Videos

[Demo of issue](https://www.loom.com/share/7051729fc9a1433d89bd004f47cde70d)
[Demo of fix](https://www.loom.com/share/862e429d1ea64c2b9df9a06602a02fbb)


## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed escape characters accumulating in notebook and plan link display text on each save/load cycle.

