### PR TITLE
Add more hints for local -> cloud handoff entrypoint

### DIFF
--- a/app/src/ai/agent_tips.rs
+++ b/app/src/ai/agent_tips.rs
@@ -1,3 +1,4 @@
+use crate::ai::blocklist::is_local_to_cloud_handoff_available;
 use crate::ai::persisted_workspace::PersistedWorkspace;
 use crate::palette::PaletteMode;
 use crate::server::telemetry::PaletteSource;
@@ -78,6 +79,8 @@ pub enum AgentTipKind {
     Context,
     /// Tips about code editors, file trees, and code review panes
     Code,
+    /// Tips about local-to-cloud handoff
+    Handoff,
 }
 
 static DEFAULT_TIPS: LazyLock<Vec<AgentTip>> = LazyLock::new(|| {
@@ -318,6 +321,13 @@ static DEFAULT_TIPS: LazyLock<Vec<AgentTip>> = LazyLock::new(|| {
             kind: AgentTipKind::General,
         },
         AgentTip {
+            description: "Type `&` or use the handoff chip to move a local conversation to the cloud.".to_string(),
+            link: None,
+            binding_name: None,
+            action: None,
+            kind: AgentTipKind::Handoff,
+        },
+        AgentTip {
             description: "Enable desktop notifications to get an alert when an agent needs your attention.".to_string(),
             link: Some("https://docs.warp.dev/agent-platform/cloud-agents/managing-cloud-agents#in-app-agent-notifications".to_string()),
             binding_name: None,
@@ -409,6 +419,11 @@ impl AITip for AgentTip {
             return CodebaseIndexManager::as_ref(app)
                 .get_codebase_index_status_for_path(root, app)
                 .is_none();
+        }
+        // Handoff tips only apply when the feature is available and enabled.
+        if matches!(self.kind, AgentTipKind::Handoff) {
+            return is_local_to_cloud_handoff_available()
+                && AISettings::as_ref(app).is_cloud_handoff_enabled(app);
         }
         true
     }

--- a/app/src/ai/agent_tips.rs
+++ b/app/src/ai/agent_tips.rs
@@ -1,4 +1,3 @@
-use crate::ai::blocklist::is_local_to_cloud_handoff_available;
 use crate::ai::persisted_workspace::PersistedWorkspace;
 use crate::palette::PaletteMode;
 use crate::server::telemetry::PaletteSource;
@@ -422,8 +421,7 @@ impl AITip for AgentTip {
         }
         // Handoff tips only apply when the feature is available and enabled.
         if matches!(self.kind, AgentTipKind::Handoff) {
-            return is_local_to_cloud_handoff_available()
-                && AISettings::as_ref(app).is_cloud_handoff_enabled(app);
+            return AISettings::as_ref(app).is_cloud_handoff_enabled(app);
         }
         true
     }

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -367,7 +367,7 @@ impl AgentInputFooter {
         let handoff_to_cloud_button = ctx.add_typed_action_view(|_ctx| {
             ActionButton::new("", AgentInputButtonTheme)
                 .with_icon(Icon::UploadCloud)
-                .with_tooltip("Hand off to cloud")
+                .with_tooltip("Hand off to cloud (or type &)")
                 .with_size(button_size)
                 .with_tooltip_alignment(TooltipAlignment::Left)
                 .on_click(|ctx| {

--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -54,6 +54,8 @@ use crate::terminal::view::TerminalAction;
 use crate::ui_components::blended_colors;
 use crate::util::bindings::keybinding_name_to_keystroke;
 use crate::workspace::tab_settings::{TabSettings, TabSettingsChangedEvent};
+#[cfg(not(target_family = "wasm"))]
+use crate::workspace::WorkspaceAction;
 use crate::BlocklistAIHistoryModel;
 
 const FIGMA_ICON_SIZE: f32 = 14.;
@@ -582,7 +584,7 @@ impl MessageProvider<AgentMessageArgs<'_>> for ZeroStateMessageProducer {
         );
 
         // Handoff to cloud only available for local agents.
-        if !is_cloud_agent && AISettings::as_ref(app).is_cloud_handoff_enabled(app) {
+        if !is_cloud_agent && AISettings::as_ref(app).is_ampersand_handoff_enabled(app) {
             items.push(
                 MessageItem::clickable(
                     vec![
@@ -630,6 +632,29 @@ impl MessageProvider<AgentMessageArgs<'_>> for ZeroStateMessageProducer {
                     mouse_states.toggle_conversation_menu.clone(),
                 ));
             }
+        }
+
+        // Code review only works locally.
+        #[cfg(not(target_family = "wasm"))]
+        if !is_cloud_agent
+            && !AISettings::as_ref(app).is_cloud_handoff_enabled(app)
+            && *TabSettings::as_ref(app).show_code_review_button
+        {
+            let code_review_keystroke = if OperatingSystem::get().is_mac() {
+                Keystroke::parse("cmd-shift-+").expect("keystroke should parse")
+            } else {
+                Keystroke::parse("ctrl-shift-+").expect("keystroke should parse")
+            };
+            items.push(MessageItem::clickable(
+                vec![
+                    MessageItem::keystroke(code_review_keystroke),
+                    MessageItem::text("for code review"),
+                ],
+                |ctx| {
+                    ctx.dispatch_typed_action(WorkspaceAction::ToggleRightPanel);
+                },
+                mouse_states.toggle_code_review.clone(),
+            ));
         }
 
         if has_plan {

--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -29,8 +29,11 @@ use crate::ai::mcp::{
     templatable_manager::{FigmaMcpStatus, TemplatableMCPServerManagerEvent},
     TemplatableMCPServerManager,
 };
-use crate::ai::request_usage_model::{AIRequestUsageModel, AIRequestUsageModelEvent};
+use crate::ai::request_usage_model::{
+    AIRequestUsageModel, AIRequestUsageModelEvent, AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD,
+};
 use crate::search::slash_command_menu::static_commands::commands;
+use crate::settings::AISettings;
 use crate::terminal::input::buffer_model::{InputBufferModel, InputBufferUpdateEvent};
 use crate::terminal::input::message_bar::attached_context::{
     AttachedBlocksMessageProducer, AttachedContextArgs, AttachedTextSelectionMessageProducer,
@@ -51,8 +54,6 @@ use crate::terminal::view::TerminalAction;
 use crate::ui_components::blended_colors;
 use crate::util::bindings::keybinding_name_to_keystroke;
 use crate::workspace::tab_settings::{TabSettings, TabSettingsChangedEvent};
-#[cfg(not(target_family = "wasm"))]
-use crate::workspace::WorkspaceAction;
 use crate::BlocklistAIHistoryModel;
 
 const FIGMA_ICON_SIZE: f32 = 14.;
@@ -66,6 +67,7 @@ pub struct AgentMessageBarMouseStates {
     pub toggle_plan: MouseStateHandle,
     pub toggle_conversation_menu: MouseStateHandle,
     pub toggle_code_review: MouseStateHandle,
+    pub handoff_to_cloud: MouseStateHandle,
     pub clear_attached_context: MouseStateHandle,
     /// Mouse state handle for the "Get Figma MCP" contextual button.
     pub figma_install_button: MouseStateHandle,
@@ -349,7 +351,6 @@ impl View for AgentMessageBar {
         };
 
         // Show credits banner when user has ambient credits remaining.
-        use crate::ai::request_usage_model::AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD;
         let right_element = if cfg!(target_family = "wasm") {
             None
         } else if let Some(credits) =
@@ -580,6 +581,33 @@ impl MessageProvider<AgentMessageArgs<'_>> for ZeroStateMessageProducer {
             AgentViewState::Active { origin, .. } if origin.is_cloud_agent()
         );
 
+        // Handoff to cloud only available for local agents.
+        if !is_cloud_agent && AISettings::as_ref(app).is_cloud_handoff_enabled(app) {
+            items.push(
+                MessageItem::clickable(
+                    vec![
+                        MessageItem::Keystroke {
+                            keystroke: Keystroke {
+                                key: "&".to_owned(),
+                                ..Default::default()
+                            },
+                            color: color_override_for_shortcuts_and_commands,
+                            background_color: bg_color_override_for_shortcuts_and_commands,
+                        },
+                        MessageItem::Text {
+                            content: "send task to the cloud".into(),
+                            color: color_override_for_shortcuts_and_commands,
+                        },
+                    ],
+                    |ctx| {
+                        ctx.dispatch_typed_action(InputAction::ActivateCloudHandoff);
+                    },
+                    mouse_states.handoff_to_cloud.clone(),
+                )
+                .with_is_disabled(!is_buffer_empty),
+            );
+        }
+
         let plan_count = AIDocumentModel::as_ref(app)
             .get_all_documents_for_conversation(active_conversation.id())
             .len();
@@ -602,26 +630,6 @@ impl MessageProvider<AgentMessageArgs<'_>> for ZeroStateMessageProducer {
                     mouse_states.toggle_conversation_menu.clone(),
                 ));
             }
-        }
-
-        // Code review only works locally.
-        #[cfg(not(target_family = "wasm"))]
-        if !is_cloud_agent && *TabSettings::as_ref(app).show_code_review_button {
-            let code_review_keystroke = if OperatingSystem::get().is_mac() {
-                Keystroke::parse("cmd-shift-+").expect("keystroke should parse")
-            } else {
-                Keystroke::parse("ctrl-shift-+").expect("keystroke should parse")
-            };
-            items.push(MessageItem::clickable(
-                vec![
-                    MessageItem::keystroke(code_review_keystroke),
-                    MessageItem::text("for code review"),
-                ],
-                |ctx| {
-                    ctx.dispatch_typed_action(WorkspaceAction::ToggleRightPanel);
-                },
-                mouse_states.toggle_code_review.clone(),
-            ));
         }
 
         if has_plan {

--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -51,6 +51,8 @@ use crate::terminal::input::suggestions_mode_model::{
 use crate::terminal::input::{HandoffComposeState, InputAction, SET_INPUT_MODE_AGENT_ACTION_NAME};
 use crate::terminal::model::TerminalModel;
 use crate::terminal::view::TerminalAction;
+#[cfg(not(target_family = "wasm"))]
+use crate::workspace::WorkspaceAction;
 use crate::ui_components::blended_colors;
 use crate::util::bindings::keybinding_name_to_keystroke;
 use crate::workspace::tab_settings::{TabSettings, TabSettingsChangedEvent};
@@ -630,6 +632,29 @@ impl MessageProvider<AgentMessageArgs<'_>> for ZeroStateMessageProducer {
                     mouse_states.toggle_conversation_menu.clone(),
                 ));
             }
+        }
+
+        // Code review only works locally.
+        #[cfg(not(target_family = "wasm"))]
+        if !is_cloud_agent
+            && !AISettings::as_ref(app).is_cloud_handoff_enabled(app)
+            && *TabSettings::as_ref(app).show_code_review_button
+        {
+            let code_review_keystroke = if OperatingSystem::get().is_mac() {
+                Keystroke::parse("cmd-shift-+").expect("keystroke should parse")
+            } else {
+                Keystroke::parse("ctrl-shift-+").expect("keystroke should parse")
+            };
+            items.push(MessageItem::clickable(
+                vec![
+                    MessageItem::keystroke(code_review_keystroke),
+                    MessageItem::text("for code review"),
+                ],
+                |ctx| {
+                    ctx.dispatch_typed_action(WorkspaceAction::ToggleRightPanel);
+                },
+                mouse_states.toggle_code_review.clone(),
+            ));
         }
 
         if has_plan {

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -1192,6 +1192,9 @@ pub enum InputAction {
 
     /// Fired when the "Enable Figma MCP" contextual button is clicked.
     FigmaEnableButtonClicked,
+
+    /// Activates `&` cloud handoff compose mode from the message bar hint.
+    ActivateCloudHandoff,
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -14916,6 +14919,9 @@ impl TypedActionView for Input {
             }
             InputAction::ClearAttachedContext => {
                 self.clear_attached_context(ctx);
+            }
+            InputAction::ActivateCloudHandoff => {
+                self.activate_cloud_handoff_compose(ctx);
             }
         }
     }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

This PR adds a few more hints/pieces of discoverability for local -> cloud. Specifically, it adds:
* a tip about `&` to the list of tips that we show below the warping indicator
* a note about the `&` entrypoint to the handoff chip
* a note about the `&` entrypoint to the keybinding list above the input in the agent view (replacing the code review note)

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/0b7b9aad8e7e4e209bce09c887ab1c1e

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode