### PR TITLE
fix(agent): sanitize overlong tool call IDs before OpenAI Responses requests (#8997)

### DIFF
--- a/app/src/ai/agent/api/convert_to.rs
+++ b/app/src/ai/agent/api/convert_to.rs
@@ -3,6 +3,7 @@
 use ai::agent::convert::ConvertToAPITypeError;
 use anyhow::anyhow;
 use chrono::{DateTime, Local, Timelike};
+use sha2::Digest as _;
 use warp_multi_agent_api as api;
 
 use crate::ai::{
@@ -14,11 +15,28 @@ use crate::ai::{
     block_context::BlockContext,
 };
 
+const OPENAI_RESPONSES_MAX_TOOL_CALL_ID_LEN: usize = 64;
+const SANITIZED_TOOL_CALL_ID_PREFIX: &str = "call_";
+
 fn local_datetime_to_timestamp(timestamp: DateTime<Local>) -> prost_types::Timestamp {
     prost_types::Timestamp {
         seconds: timestamp.timestamp(),
         nanos: timestamp.timestamp_subsec_nanos() as i32,
     }
+}
+
+/// Some OpenAI-compatible providers emit tool call IDs that OpenAI's Responses
+/// API rejects when Warp sends the corresponding tool call result downstream.
+fn tool_call_id_for_request(id: impl Into<String>) -> String {
+    let id = id.into();
+    if id.len() <= OPENAI_RESPONSES_MAX_TOOL_CALL_ID_LEN {
+        return id;
+    }
+
+    let digest = sha2::Sha256::digest(id.as_bytes());
+    let mut sanitized = format!("{SANITIZED_TOOL_CALL_ID_PREFIX}{digest:x}");
+    sanitized.truncate(OPENAI_RESPONSES_MAX_TOOL_CALL_ID_LEN);
+    sanitized
 }
 
 impl TryFrom<StaticQueryType> for api::request::input::query_with_canned_response::Type {
@@ -712,7 +730,7 @@ impl TryFrom<AIAgentActionResult> for api::request::input::user_inputs::user_inp
         Ok(
             api::request::input::user_inputs::user_input::Input::ToolCallResult(
                 api::request::input::ToolCallResult {
-                    tool_call_id: action_result.id.into(),
+                    tool_call_id: tool_call_id_for_request(action_result.id),
                     result,
                 },
             ),

--- a/app/src/ai/agent/api/convert_to_tests.rs
+++ b/app/src/ai/agent/api/convert_to_tests.rs
@@ -8,6 +8,55 @@ use chrono::Utc;
 use warp_core::command::ExitCode;
 use warp_multi_agent_api as api;
 
+fn open_code_review_tool_call_result_id(action_id: &str) -> String {
+    let input =
+        api::request::input::user_inputs::user_input::Input::try_from(AIAgentActionResult {
+            id: action_id.to_string().into(),
+            task_id: TaskId::new("task".to_string()),
+            result: AIAgentActionResultType::OpenCodeReview,
+        })
+        .unwrap();
+
+    match input {
+        api::request::input::user_inputs::user_input::Input::ToolCallResult(result) => {
+            result.tool_call_id
+        }
+        other => panic!("Expected tool-call-result input, got {other:?}"),
+    }
+}
+
+#[test]
+fn tool_call_result_preserves_openai_compatible_tool_call_id() {
+    let id = "a".repeat(super::OPENAI_RESPONSES_MAX_TOOL_CALL_ID_LEN);
+
+    assert_eq!(open_code_review_tool_call_result_id(&id), id);
+}
+
+#[test]
+fn tool_call_result_hashes_long_tool_call_id_for_openai_responses() {
+    let id = "glm_tool_call_".repeat(16);
+    assert!(id.len() > super::OPENAI_RESPONSES_MAX_TOOL_CALL_ID_LEN);
+
+    let sanitized = open_code_review_tool_call_result_id(&id);
+
+    assert_eq!(
+        sanitized.len(),
+        super::OPENAI_RESPONSES_MAX_TOOL_CALL_ID_LEN
+    );
+    assert!(sanitized.starts_with(super::SANITIZED_TOOL_CALL_ID_PREFIX));
+    assert_ne!(sanitized, id);
+    assert_eq!(open_code_review_tool_call_result_id(&id), sanitized);
+}
+
+#[test]
+fn tool_call_result_hashes_long_tool_call_ids_without_truncation_collisions() {
+    let first = open_code_review_tool_call_result_id(&format!("{}a", "kimi_tool_call_".repeat(16)));
+    let second =
+        open_code_review_tool_call_result_id(&format!("{}b", "kimi_tool_call_".repeat(16)));
+
+    assert_ne!(first, second);
+}
+
 #[test]
 fn transfer_control_snapshot_result_converts_to_tool_call_result_input() {
     let block_id = BlockId::default();


### PR DESCRIPTION
## Description

When using GLM-5 or Kimi models via OpenAI-compatible BYOK endpoints, the upstream provider emits `tool_call_id` values that exceed OpenAI's Responses API 64-character limit. The result is an unrecoverable 400 from OpenAI when Warp sends the corresponding tool-call result downstream:

```text
OpenAI API error: POST "https://api.openai.com/v1/responses": 400 Bad Request {
    "message": "Invalid 'input[24].call_id': string too long. Expected a string
                with maximum length 64, but got a string with length 210 instead.",
    "type": "invalid_request_error",
    "param": "input[24].call_id",
    "code": "string_above_max_length"
}
```

Fix: at the request-building boundary (`AIAgentInput → api::request::input::ToolCallResult`), pass `tool_call_id` through a new `tool_call_id_for_request` helper that:

- passes through IDs `<= 64` chars unchanged (preserves OpenAI-native IDs)
- for longer IDs, SHA-256-hashes the original and emits `call_<hex>` truncated to 64 chars

The mapping is deterministic, preserving the OpenAI tool-call ↔ result pairing invariant: the same upstream ID always sanitizes to the same client-side ID.

## Testing

Three new unit tests cover the three behavior cases:

- `tool_call_result_preserves_openai_compatible_tool_call_id` — IDs at exactly 64 chars aren't rewritten.
- `tool_call_result_hashes_long_tool_call_id_for_openai_responses` — overlong IDs get a `"call_"`-prefixed deterministic hash `<= 64` chars.
- `tool_call_result_hashes_long_tool_call_ids_without_truncation_collisions` — two different overlong IDs that share a prefix produce distinct sanitized IDs (no birthday-prefix-truncation collision).

Verified locally:

```text
cargo nextest run -p warp -E 'test(tool_call_id) or test(hash_long_tool_call) or test(transfer_control_)'
8 tests run: 8 passed

cargo clippy -p warp --tests -- -D warnings
Finished (no warnings)

cargo fmt -p warp -- --check
clean
```

## Server API dependencies

None — this is client-only. The sanitization happens before the request leaves the Rust client.

## Agent Mode

Unchecked (external contribution).

## Changelog

`CHANGELOG-BUG-FIX: Sanitize tool call IDs longer than 64 chars before sending to OpenAI Responses API. Fixes recoverability when using GLM-5 / Kimi via BYOK.`

Fixes #8997
