### PR TITLE
use agent status component component for agent view entry blocks

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_view_block.rs
+++ b/app/src/ai/blocklist/agent_view/agent_view_block.rs
@@ -17,12 +17,14 @@ use warpui::{
 
 use crate::{
     ai::{
-        active_agent_views_model::ActiveAgentViewsModel,
-        agent::conversation::{AIConversationId, ConversationStatus},
+        active_agent_views_model::ActiveAgentViewsModel, agent::conversation::AIConversationId,
         blocklist::BlocklistAIHistoryEvent,
     },
     terminal::BlockListSettings,
-    ui_components::blended_colors,
+    ui_components::{
+        blended_colors,
+        icon_with_status::{render_icon_with_status, IconWithStatusVariant},
+    },
     view_components::DismissibleToast,
     workspace::{ToastStack, WorkspaceAction},
     BlocklistAIHistoryModel,
@@ -273,25 +275,16 @@ impl View for AgentViewEntryBlock {
             return Empty::new().finish();
         }
 
-        fn with_opacity(mut color: ColorU, opacity: u8) -> ColorU {
-            color.a = opacity;
-            color
-        }
-
-        let status_icon = conversation.status().render_icon(appearance);
-        let status_icon_bg = match conversation.status() {
-            ConversationStatus::InProgress => {
-                with_opacity(appearance.theme().ansi_fg_magenta(), 25)
-            }
-            ConversationStatus::Success => with_opacity(appearance.theme().ansi_fg_green(), 25),
-            ConversationStatus::Error => with_opacity(appearance.theme().ansi_fg_red(), 25),
-            ConversationStatus::Cancelled => {
-                with_opacity(blended_colors::neutral_5(appearance.theme()), 25)
-            }
-            ConversationStatus::Blocked { .. } => {
-                with_opacity(appearance.theme().ansi_fg_yellow(), 25)
-            }
-        };
+        let agent_icon = render_icon_with_status(
+            IconWithStatusVariant::OzAgent {
+                status: Some(conversation.status().clone()),
+                is_ambient: false,
+            },
+            24.,
+            0.,
+            theme,
+            theme.background(),
+        );
 
         let is_active =
             ActiveAgentViewsModel::as_ref(app).is_conversation_open(self.conversation_id, app);
@@ -385,19 +378,7 @@ impl View for AgentViewEntryBlock {
         let row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_main_axis_size(MainAxisSize::Max)
-            .with_child(
-                Container::new(
-                    ConstrainedBox::new(status_icon.finish())
-                        .with_height(16.)
-                        .with_width(16.)
-                        .finish(),
-                )
-                .with_uniform_padding(2.)
-                .with_background_color(status_icon_bg)
-                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
-                .with_margin_right(8.)
-                .finish(),
-            )
+            .with_child(Container::new(agent_icon).with_margin_right(8.).finish())
             // Expanded fills all remaining space, pushing buttons to the right.
             .with_child(Expanded::new(1., title_section.finish()).finish())
             .with_child(Container::new(fork_button).with_margin_left(8.).finish())

--- a/app/src/terminal/view/ambient_agent/block/entry.rs
+++ b/app/src/terminal/view/ambient_agent/block/entry.rs
@@ -10,7 +10,6 @@ use warpui::{
     },
     fonts::Properties,
     platform::Cursor,
-    prelude::{CornerRadius, Radius},
     text_layout::ClipConfig,
     Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
     WeakModelHandle,
@@ -21,14 +20,15 @@ use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
 use crate::{
     pane_group::pane::{PaneConfiguration, PaneConfigurationEvent, PaneStack},
     terminal::{BlockListSettings, TerminalManager, TerminalView},
-    ui_components::blended_colors,
+    ui_components::{
+        agent_icon::terminal_view_agent_icon_variant,
+        blended_colors,
+        icon_with_status::{render_icon_with_status, IconWithStatusVariant},
+    },
 };
 
 use super::super::{AmbientAgentViewModelEvent, Status};
 use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEntryPoint};
-
-/// Icon size for the status indicator
-const STATUS_ICON_SIZE: f32 = 16.;
 
 #[derive(Default)]
 struct StateHandles {
@@ -136,47 +136,6 @@ impl AmbientAgentEntryBlock {
             Status::Cancelled { .. } => Some("Cancelled"),
         }
     }
-
-    /// Renders the status icon based on the ambient agent status.
-    fn render_status_icon(
-        &self,
-        appearance: &Appearance,
-        app: &AppContext,
-    ) -> Box<dyn warpui::Element> {
-        let theme = appearance.theme();
-
-        let Some(view_model) = self.ambient_agent_view_model(app) else {
-            return Empty::new().finish();
-        };
-        let (icon, color) = if view_model.is_failed() {
-            (Icon::AlertTriangle, theme.ui_error_color())
-        } else if view_model.is_needs_github_auth() {
-            (Icon::Info, blended_colors::accent(theme).into_solid())
-        } else if view_model.is_cancelled() {
-            (
-                Icon::Cancelled,
-                theme.disabled_text_color(theme.background()).into_solid(),
-            )
-        } else if view_model.is_waiting_for_session() {
-            (Icon::ClockLoader, theme.ansi_fg_magenta())
-        } else {
-            (
-                Icon::OzCloud,
-                theme.main_text_color(theme.background()).into_solid(),
-            )
-        };
-
-        Container::new(
-            ConstrainedBox::new(icon.to_warpui_icon(color.into()).finish())
-                .with_width(STATUS_ICON_SIZE)
-                .with_height(STATUS_ICON_SIZE)
-                .finish(),
-        )
-        .with_uniform_padding(2.)
-        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
-        .with_margin_right(8.)
-        .finish()
-    }
 }
 
 impl View for AmbientAgentEntryBlock {
@@ -231,10 +190,17 @@ impl View for AmbientAgentEntryBlock {
             );
         }
 
+        let icon_variant = terminal_view_agent_icon_variant(self.terminal_view.as_ref(app), app)
+            .unwrap_or(IconWithStatusVariant::OzAgent {
+                status: None,
+                is_ambient: true,
+            });
+        let agent_icon = render_icon_with_status(icon_variant, 24., 0., theme, theme.background());
+
         let row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_main_axis_size(MainAxisSize::Max)
-            .with_child(self.render_status_icon(appearance, app))
+            .with_child(Container::new(agent_icon).with_margin_right(8.).finish())
             .with_child(Shrinkable::new(1., title_row.finish()).finish())
             .with_child(
                 Container::new(Empty::new().finish())


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

We should use the same agent + status component that we use in the vertical tabs, pane header, etc, for the agent view entry blocks as well. This also lets us distinguish between different cloud harnesses in the agent view entry block.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/6bd103b3ba78408aaa3b2a0b2edcf91c

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode