### PR TITLE
fix(mcp): respect secret-redaction toggle when saving MCP server config (#8761)

### DIFF
--- a/app/src/settings_view/mcp_servers/edit_page.rs
+++ b/app/src/settings_view/mcp_servers/edit_page.rs
@@ -26,6 +26,8 @@ use warpui::{
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
 };
 
+use settings::Setting as _;
+
 use crate::ai::blocklist::secret_redaction::find_secrets_in_text;
 use crate::ai::mcp::parsing::{prettify_json, resolve_json, ParsedTemplatableMCPServerResult};
 use crate::ai::mcp::templatable::CloudTemplatableMCPServer;
@@ -46,6 +48,7 @@ use crate::settings_view::mcp_servers::destructive_mcp_confirmation_dialog::{
     DestructiveMCPConfirmationDialogVariant,
 };
 use crate::settings_view::mcp_servers::{style, ServerCardItemId};
+use crate::terminal::safe_mode_settings::SafeModeSettings;
 use crate::ui_components::buttons::icon_button;
 use crate::ui_components::icons::Icon;
 use crate::view_components::action_button::{
@@ -53,6 +56,7 @@ use crate::view_components::action_button::{
 };
 use crate::view_components::DismissibleToast;
 use crate::workspace::ToastStack;
+use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::GlobalResourceHandlesProvider;
 
 const DEFAULT_JSON_TEXT: &str = r#"{
@@ -525,22 +529,26 @@ impl MCPServersEditPageView {
         ctx: &mut ViewContext<Self>,
         templatable_mcp_server: &TemplatableMCPServer,
     ) -> Result<(), String> {
+        let safe_mode_enabled = *SafeModeSettings::as_ref(ctx).safe_mode_enabled.value();
+        let enterprise_enforced =
+            UserWorkspaces::as_ref(ctx).is_enterprise_secret_redaction_enabled();
         let contains_secrets =
             !find_secrets_in_text(&templatable_mcp_server.template.json).is_empty();
 
-        if contains_secrets {
-            let window_id = ctx.window_id();
-            ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                toast_stack.add_ephemeral_toast(
-                    DismissibleToast::error("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string()),
-                    window_id,
-                    ctx,
-                );
-            });
-            return Err("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string());
+        if !should_block_save_for_secrets(safe_mode_enabled, enterprise_enforced, contains_secrets)
+        {
+            return Ok(());
         }
 
-        Ok(())
+        let window_id = ctx.window_id();
+        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+            toast_stack.add_ephemeral_toast(
+                DismissibleToast::error("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string()),
+                window_id,
+                ctx,
+            );
+        });
+        Err("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string())
     }
 
     fn parse_templatable_json(
@@ -941,5 +949,72 @@ impl TypedActionView for MCPServersEditPageView {
                 }
             }
         }
+    }
+}
+
+/// Decide whether to block saving an MCP server config because secret
+/// redaction is in force AND the parsed config contains secret-shaped strings.
+///
+/// We block only when redaction is actually active — either the user-level
+/// Settings > Privacy > Secret redaction toggle is on, or the user's workspace
+/// has enterprise enforcement enabled. With both off, the user has explicitly
+/// opted to embed secrets in the config and we save it as written (#8761).
+fn should_block_save_for_secrets(
+    safe_mode_enabled: bool,
+    enterprise_enforced: bool,
+    contains_secrets: bool,
+) -> bool {
+    (safe_mode_enabled || enterprise_enforced) && contains_secrets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_block_save_for_secrets;
+
+    /// #8761: with redaction disabled and no enterprise enforcement, saving a
+    /// config that contains secrets must NOT be blocked.
+    #[test]
+    fn does_not_block_when_redaction_off_even_if_secrets_present() {
+        assert!(!should_block_save_for_secrets(false, false, true));
+    }
+
+    /// User-level toggle on AND secrets present → block. This is the case the
+    /// original check was written to catch; the redaction-aware predicate
+    /// must preserve it.
+    #[test]
+    fn blocks_when_user_redaction_on_and_secrets_present() {
+        assert!(should_block_save_for_secrets(true, false, true));
+    }
+
+    /// Enterprise enforcement alone is enough to gate the save, even if the
+    /// user toggled their personal redaction off — orgs that mandate redaction
+    /// must not be bypassed at the MCP-config layer.
+    #[test]
+    fn blocks_when_enterprise_enforced_and_secrets_present() {
+        assert!(should_block_save_for_secrets(false, true, true));
+    }
+
+    /// Configs without any detected secrets are never blocked, regardless of
+    /// the redaction-toggle state. The check is purely a guard against
+    /// accidentally persisting secrets — it has nothing to add when none exist.
+    #[test]
+    fn does_not_block_when_no_secrets_regardless_of_toggle() {
+        for safe_mode in [false, true] {
+            for enterprise in [false, true] {
+                assert!(
+                    !should_block_save_for_secrets(safe_mode, enterprise, false),
+                    "expected no block when contains_secrets=false \
+                     (safe_mode={safe_mode}, enterprise={enterprise})",
+                );
+            }
+        }
+    }
+
+    /// Both toggles on AND secrets present → block. Defensive: equivalent to
+    /// either one being on, but exhaustively pinned for the full 2x2x2 sweep
+    /// of (safe_mode, enterprise, contains_secrets).
+    #[test]
+    fn blocks_when_both_redactions_on_and_secrets_present() {
+        assert!(should_block_save_for_secrets(true, true, true));
     }
 }

--- a/app/src/settings_view/mcp_servers/edit_page.rs
+++ b/app/src/settings_view/mcp_servers/edit_page.rs
@@ -9,6 +9,7 @@ use diesel::SqliteConnection;
 #[cfg(feature = "local_fs")]
 use parking_lot::Mutex;
 use pathfinder_geometry::vector::vec2f;
+use settings::Setting as _;
 use uuid::Uuid;
 use warp_core::send_telemetry_from_ctx;
 use warp_core::ui::appearance::Appearance;
@@ -25,8 +26,6 @@ use warpui::ui_components::components::UiComponent;
 use warpui::{
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
 };
-
-use settings::Setting as _;
 
 use crate::ai::blocklist::secret_redaction::find_secrets_in_text;
 use crate::ai::mcp::parsing::{prettify_json, resolve_json, ParsedTemplatableMCPServerResult};
@@ -967,53 +966,5 @@ fn should_block_save_for_secrets(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::should_block_save_for_secrets;
-
-    /// #8761: with redaction disabled and no enterprise enforcement, saving a
-    /// config that contains secrets must NOT be blocked.
-    #[test]
-    fn does_not_block_when_redaction_off_even_if_secrets_present() {
-        assert!(!should_block_save_for_secrets(false, false, true));
-    }
-
-    /// User-level toggle on AND secrets present → block. This is the case the
-    /// original check was written to catch; the redaction-aware predicate
-    /// must preserve it.
-    #[test]
-    fn blocks_when_user_redaction_on_and_secrets_present() {
-        assert!(should_block_save_for_secrets(true, false, true));
-    }
-
-    /// Enterprise enforcement alone is enough to gate the save, even if the
-    /// user toggled their personal redaction off — orgs that mandate redaction
-    /// must not be bypassed at the MCP-config layer.
-    #[test]
-    fn blocks_when_enterprise_enforced_and_secrets_present() {
-        assert!(should_block_save_for_secrets(false, true, true));
-    }
-
-    /// Configs without any detected secrets are never blocked, regardless of
-    /// the redaction-toggle state. The check is purely a guard against
-    /// accidentally persisting secrets — it has nothing to add when none exist.
-    #[test]
-    fn does_not_block_when_no_secrets_regardless_of_toggle() {
-        for safe_mode in [false, true] {
-            for enterprise in [false, true] {
-                assert!(
-                    !should_block_save_for_secrets(safe_mode, enterprise, false),
-                    "expected no block when contains_secrets=false \
-                     (safe_mode={safe_mode}, enterprise={enterprise})",
-                );
-            }
-        }
-    }
-
-    /// Both toggles on AND secrets present → block. Defensive: equivalent to
-    /// either one being on, but exhaustively pinned for the full 2x2x2 sweep
-    /// of (safe_mode, enterprise, contains_secrets).
-    #[test]
-    fn blocks_when_both_redactions_on_and_secrets_present() {
-        assert!(should_block_save_for_secrets(true, true, true));
-    }
-}
+#[path = "edit_page_tests.rs"]
+mod tests;

--- a/app/src/settings_view/mcp_servers/edit_page.rs
+++ b/app/src/settings_view/mcp_servers/edit_page.rs
@@ -535,20 +535,19 @@ impl MCPServersEditPageView {
         let contains_secrets =
             !find_secrets_in_text(&templatable_mcp_server.template.json).is_empty();
 
-        if !should_block_save_for_secrets(safe_mode_enabled, enterprise_enforced, contains_secrets)
-        {
-            return Ok(());
+        if should_block_save_for_secrets(safe_mode_enabled, enterprise_enforced, contains_secrets) {
+            let window_id = ctx.window_id();
+            ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                toast_stack.add_ephemeral_toast(
+                    DismissibleToast::error("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string()),
+                    window_id,
+                    ctx,
+                );
+            });
+            return Err("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string());
         }
 
-        let window_id = ctx.window_id();
-        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-            toast_stack.add_ephemeral_toast(
-                DismissibleToast::error("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string()),
-                window_id,
-                ctx,
-            );
-        });
-        Err("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string())
+        Ok(())
     }
 
     fn parse_templatable_json(

--- a/app/src/settings_view/mcp_servers/edit_page_tests.rs
+++ b/app/src/settings_view/mcp_servers/edit_page_tests.rs
@@ -1,0 +1,48 @@
+use super::should_block_save_for_secrets;
+
+/// #8761: with redaction disabled and no enterprise enforcement, saving a
+/// config that contains secrets must NOT be blocked.
+#[test]
+fn does_not_block_when_redaction_off_even_if_secrets_present() {
+    assert!(!should_block_save_for_secrets(false, false, true));
+}
+
+/// User-level toggle on AND secrets present → block. This is the case the
+/// original check was written to catch; the redaction-aware predicate
+/// must preserve it.
+#[test]
+fn blocks_when_user_redaction_on_and_secrets_present() {
+    assert!(should_block_save_for_secrets(true, false, true));
+}
+
+/// Enterprise enforcement alone is enough to gate the save, even if the
+/// user toggled their personal redaction off — orgs that mandate redaction
+/// must not be bypassed at the MCP-config layer.
+#[test]
+fn blocks_when_enterprise_enforced_and_secrets_present() {
+    assert!(should_block_save_for_secrets(false, true, true));
+}
+
+/// Configs without any detected secrets are never blocked, regardless of
+/// the redaction-toggle state. The check is purely a guard against
+/// accidentally persisting secrets — it has nothing to add when none exist.
+#[test]
+fn does_not_block_when_no_secrets_regardless_of_toggle() {
+    for safe_mode in [false, true] {
+        for enterprise in [false, true] {
+            assert!(
+                !should_block_save_for_secrets(safe_mode, enterprise, false),
+                "expected no block when contains_secrets=false \
+                 (safe_mode={safe_mode}, enterprise={enterprise})",
+            );
+        }
+    }
+}
+
+/// Both toggles on AND secrets present → block. Defensive: equivalent to
+/// either one being on, but exhaustively pinned for the full 2x2x2 sweep
+/// of (safe_mode, enterprise, contains_secrets).
+#[test]
+fn blocks_when_both_redactions_on_and_secrets_present() {
+    assert!(should_block_save_for_secrets(true, true, true));
+}


### PR DESCRIPTION
## Description

When a user defines an MCP server config (Settings → MCP Servers → Add) that contains a value matching the secret-detection regexes — for example:

```json
{
  "mcpServers": {
    "test": {
      "url": "http://127.0.0.1:8766/mcp/",
      "headers": {
        "Authorization": "Bearer <real-token>"
      }
    }
  }
}
```

…the save is rejected with:

> "This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings."

…**even when the user has explicitly disabled secret redaction in Settings → Privacy**. The error message tells the user to visit the Privacy settings — but those settings have no effect on this code path.

## Root cause

`detect_secrets_in_templatable_mcp_server` in [`app/src/settings_view/mcp_servers/edit_page.rs`](app/src/settings_view/mcp_servers/edit_page.rs) called `find_secrets_in_text` unconditionally and rejected the save on any match, without consulting either:

- the **user-level** toggle (`SafeModeSettings::safe_mode_enabled`, surfaced as Settings → Privacy → Secret redaction), or
- the **enterprise-level** enforcement flag (`UserWorkspaces::is_enterprise_secret_redaction_enabled`).

## Fix

Gate the save-blocking decision on whether redaction is actually in force. Extracted a pure predicate so the policy is one expression in one place:

```rust
fn should_block_save_for_secrets(
    safe_mode_enabled: bool,
    enterprise_enforced: bool,
    contains_secrets: bool,
) -> bool {
    (safe_mode_enabled || enterprise_enforced) && contains_secrets
}
```

- When **both** toggles are off, the user has explicitly opted to embed secrets in the config; the save proceeds.
- **Enterprise enforcement still wins** over a personal toggle — orgs that mandate redaction can't be bypassed at the MCP-config layer.

## Testing

5 unit tests covering the predicate's truth table:

| Test | safe_mode | enterprise | secrets | block? |
|------|:-:|:-:|:-:|:-:|
| `does_not_block_when_redaction_off_even_if_secrets_present` (the #8761 case) | ❌ | ❌ | ✅ | ❌ |
| `blocks_when_user_redaction_on_and_secrets_present` | ✅ | ❌ | ✅ | ✅ |
| `blocks_when_enterprise_enforced_and_secrets_present` | ❌ | ✅ | ✅ | ✅ |
| `does_not_block_when_no_secrets_regardless_of_toggle` (2×2 sweep) | * | * | ❌ | ❌ |
| `blocks_when_both_redactions_on_and_secrets_present` | ✅ | ✅ | ✅ | ✅ |

```text
cargo nextest run -p warp -E 'test(should_block_save_for_secrets) or test(does_not_block_when) or test(blocks_when_)'
5 tests run: 5 passed

cargo clippy -p warp --tests -- -D warnings
Finished (no warnings)

cargo fmt -p warp -- --check
clean
```

## Demo

End-to-end Settings UI recording demonstrating the truth table:

![PR #10839 truth-table demo](https://raw.githubusercontent.com/david-engelmann/warp-taper/main/docs/evidence/10839-mcp-redaction-toggle/master.gif)

Recipe: [`scripts/recipes/8761-mcp-secret-redaction.json`](https://github.com/david-engelmann/warp-taper/blob/main/scripts/recipes/8761-mcp-secret-redaction.json) — six phases driven by [`scripts/warp-driver.swift`](https://github.com/david-engelmann/warp-taper/blob/main/scripts/warp-driver.swift) (OCR-gated, no manual driving) against a local build of this branch:

- **A** Settings → Privacy. `Secret redaction` toggle starts OFF (no "Secret visual redaction mode" dropdown).
- **B** Click toggle ON. Dropdown appears — visual proof `safe_mode_enabled = true` at runtime.
- **C** Settings → MCP Servers → `+ Add` → paste config with `Bearer sk-FAKE0000000000FAKEdemoWARP10839v2` in `headers.Authorization` → click Save → error toast: *"This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings."* — predicate correctly blocks.
- **D** Back to Privacy. Click toggle OFF.
- **E** `+ Add` → paste the **same** secret-bearing config → Save → server lands in `MY MCPS` as `demo-pr10839-v2`. This is the #8761 user case — save now succeeds.
- **F** Back to Privacy. Click toggle ON → dropdown returns.

The token (`sk-FAKE…WARP10839v2`) is a deterministic placeholder matching the Generic SK regex from the persisted `custom_secret_regex_list` — clearly not a real credential.

While building this evidence pipeline I uncovered three follow-up bugs in adjacent MCP-save secret-detection code paths: #11262 (SECRETS_REGEX silently empty at startup), #11263 (env/headers templatization wipes secrets before scan), and #11265 (`+ Add` path bypasses the predicate entirely). Each has its own isolated repro recording linked from the ticket.


## Server API dependencies

None — this is client-only.

## Agent Mode

Unchecked (external contribution).

## Changelog

`CHANGELOG-BUG-FIX: Defining an MCP server config with a literal secret no longer fails when Settings → Privacy → Secret redaction is disabled.`

Fixes #8761

