### PR TITLE
Fix theme picker displaying stale colors when os sync is toggled

### DIFF
--- a/crates/onboarding/src/slides/theme_picker_slide.rs
+++ b/crates/onboarding/src/slides/theme_picker_slide.rs
@@ -134,12 +134,15 @@ impl ThemePickerSlide {
         app: &AppContext,
     ) -> Box<dyn Element> {
         // The option "chrome" (background, borders, text) should be styled using the currently
-        // selected theme.
-        let selected_theme = self
-            .theme_options
-            .get(self.selected_theme_index)
-            .map(|option| option.theme.clone())
-            .unwrap_or_else(|| self.theme_options[0].theme.clone());
+        // selected theme, if sync_with_os is not selected.
+        let selected_theme = if self.sync_with_os {
+            appearance.theme().clone()
+        } else {
+            self.theme_options
+                .get(self.selected_theme_index)
+                .map(|option| option.theme.clone())
+                .unwrap_or_else(|| self.theme_options[0].theme.clone())
+        };
 
         let bottom_nav = self.render_bottom_nav(appearance, app);
 


### PR DESCRIPTION
## Description

Resolves #10041 

When “Sync light/dark theme with OS” was enabled in the onboarding theme picker, the theme option rows would keep rendering with stale selected-theme colors.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4053/theme-sync-toggle-can-leave-theme-picker-rows-with-stale-colors

## Testing
- [x] I have manually tested my changes locally with `./script/run` -> [Demo video](https://www.loom.com/share/8354121fe9644122b8dcec6450843785)

### Screenshots / Videos

[Demo of issue](https://www.loom.com/share/5663d47841994a46a1900d3fc1f8ab0c)

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed stale theme picker row colors when toggling OS theme sync during onboarding.

