### PR TITLE
Fix pane header not updating immediately on harness change

### DIFF
--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -293,6 +293,9 @@ impl TerminalView {
             }
             AmbientAgentViewModelEvent::HarnessSelected => {
                 self.maybe_enter_agent_view_for_shared_third_party_viewer(ctx);
+                self.pane_configuration.update(ctx, |pane_config, ctx| {
+                    pane_config.notify_header_content_changed(ctx);
+                });
                 ctx.emit(TerminalViewEvent::TerminalViewStateChanged);
                 ctx.notify();
             }


### PR DESCRIPTION
## Description

When switching harnesses in the cloud mode dropdown, the pane header icon was not updating immediately. It would eventually update, but not in response to the selection.

The root cause: the `HarnessSelected` event handler in `view_impl.rs` called `ctx.notify()` (which re-renders the `TerminalView` body) but did not call `pane_config.notify_header_content_changed()`. The pane header is managed by the pane infrastructure and only re-renders when `PaneConfigurationEvent::HeaderContentChanged` is emitted — `ctx.notify()` alone is insufficient.

The fix adds `pane_config.notify_header_content_changed(ctx)` to the `HarnessSelected` handler, matching the pattern used by other events like `ProgressUpdated` and `DispatchedAgent`.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fix pane header icon not updating immediately when changing agent harness in cloud mode
-->

_Conversation: https://staging.warp.dev/conversation/8f2639a9-6434-425a-a78c-5a58033ba695_
_Run: https://oz.staging.warp.dev/runs/019e2313-238b-78bd-af1e-e702c9bfec02_
_This PR was generated with [Oz](https://warp.dev/oz)._
