### PR TITLE
Speed up inline repos menu

### DIFF
--- a/app/src/terminal/input/repos/data_source.rs
+++ b/app/src/terminal/input/repos/data_source.rs
@@ -1,87 +1,211 @@
-//! Async data source for the inline repos menu.
+//! Data source for the inline repos menu.
 
-use std::path::PathBuf;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-use warpui::{AppContext, Entity, SingletonEntity};
+use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 
 use crate::ai::persisted_workspace::PersistedWorkspace;
 use crate::search::data_source::{Query, QueryResult};
-use crate::search::mixer::{AsyncDataSource, BoxFuture, DataSourceRunErrorWrapper};
+use crate::search::mixer::{DataSourceRunErrorWrapper, SyncDataSource};
+#[cfg(feature = "local_fs")]
+use crate::terminal::input::repos::search_item::{repo_display_name, RepoSearchItem};
 use crate::terminal::input::repos::AcceptRepo;
+#[cfg(feature = "local_fs")]
+use crate::util::git::{get_repo_git_summary, RepoGitSummary};
 
-pub struct RepoMenuDataSource;
+#[cfg(feature = "local_fs")]
+const GIT_SUMMARY_TTL: Duration = Duration::from_secs(30);
+#[cfg(feature = "local_fs")]
+const MAX_CONCURRENT_GIT_SUMMARIES: usize = 4;
 
-impl RepoMenuDataSource {
+#[derive(Debug, Clone)]
+pub enum RepoGitSummaryCacheEvent {
+    Updated,
+}
+
+pub struct RepoGitSummaryCache {
+    #[cfg(feature = "local_fs")]
+    summaries: HashMap<PathBuf, RepoGitSummaryCacheEntry>,
+    #[cfg(feature = "local_fs")]
+    in_flight: HashSet<PathBuf>,
+}
+
+#[cfg(feature = "local_fs")]
+struct RepoGitSummaryCacheEntry {
+    summary: Option<RepoGitSummary>,
+    updated_at: instant::Instant,
+}
+
+impl RepoGitSummaryCache {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            #[cfg(feature = "local_fs")]
+            summaries: HashMap::new(),
+            #[cfg(feature = "local_fs")]
+            in_flight: HashSet::new(),
+        }
+    }
+
+    #[cfg(feature = "local_fs")]
+    pub fn summary(&self, path: &Path) -> Option<RepoGitSummary> {
+        self.summaries
+            .get(path)
+            .and_then(|entry| entry.summary.clone())
+    }
+
+    pub fn refresh_missing(&mut self, paths: Vec<PathBuf>, ctx: &mut ModelContext<Self>) {
+        #[cfg(feature = "local_fs")]
+        {
+            use futures_util::stream::{self, StreamExt};
+
+            let now = instant::Instant::now();
+            let paths_to_refresh = paths
+                .into_iter()
+                .filter(|path| {
+                    if self.in_flight.contains(path) {
+                        return false;
+                    }
+
+                    !self
+                        .summaries
+                        .get(path)
+                        .is_some_and(|entry| now.duration_since(entry.updated_at) < GIT_SUMMARY_TTL)
+                })
+                .collect::<Vec<_>>();
+
+            if paths_to_refresh.is_empty() {
+                return;
+            }
+
+            self.in_flight.extend(paths_to_refresh.iter().cloned());
+
+            let stream = stream::iter(paths_to_refresh)
+                .map(|path| async move {
+                    let summary = get_repo_git_summary(&path).await;
+                    (path, summary)
+                })
+                .buffer_unordered(MAX_CONCURRENT_GIT_SUMMARIES);
+
+            ctx.spawn_stream_local(
+                stream,
+                |me, (path, summary), ctx| {
+                    me.in_flight.remove(&path);
+                    me.summaries.insert(
+                        path,
+                        RepoGitSummaryCacheEntry {
+                            summary,
+                            updated_at: instant::Instant::now(),
+                        },
+                    );
+                    ctx.emit(RepoGitSummaryCacheEvent::Updated);
+                },
+                |_, _| {},
+            );
+        }
+
+        #[cfg(not(feature = "local_fs"))]
+        {
+            let _ = paths;
+            let _ = ctx;
+        }
     }
 }
 
-impl AsyncDataSource for RepoMenuDataSource {
+impl Entity for RepoGitSummaryCache {
+    type Event = RepoGitSummaryCacheEvent;
+}
+
+pub struct RepoMenuDataSource {
+    git_summary_cache: ModelHandle<RepoGitSummaryCache>,
+}
+
+impl RepoMenuDataSource {
+    pub fn new(git_summary_cache: ModelHandle<RepoGitSummaryCache>) -> Self {
+        Self { git_summary_cache }
+    }
+
+    pub fn matching_paths(query: &Query, app: &AppContext) -> Vec<PathBuf> {
+        let query_text = normalized_query_text(query);
+        PersistedWorkspace::as_ref(app)
+            .workspaces()
+            .map(|m| m.path)
+            .filter(|path| repo_matches_query(path, &query_text))
+            .collect()
+    }
+}
+
+impl SyncDataSource for RepoMenuDataSource {
     type Action = AcceptRepo;
 
     fn run_query(
         &self,
         query: &Query,
         app: &AppContext,
-    ) -> BoxFuture<'static, Result<Vec<QueryResult<Self::Action>>, DataSourceRunErrorWrapper>> {
-        let workspace_paths: Vec<PathBuf> = PersistedWorkspace::as_ref(app)
-            .workspaces()
-            .map(|m| m.path)
-            .collect();
+    ) -> Result<Vec<QueryResult<Self::Action>>, DataSourceRunErrorWrapper> {
+        #[cfg(feature = "local_fs")]
+        {
+            let query_text = normalized_query_text(query);
+            let git_summary_cache = self.git_summary_cache.as_ref(app);
+            let mut items = PersistedWorkspace::as_ref(app)
+                .workspaces()
+                .filter_map(|metadata| {
+                    let display_name = repo_display_name(&metadata.path);
+                    let match_result = match_result(&display_name, &query_text)?;
+                    let git_summary = git_summary_cache.summary(&metadata.path);
+                    Some(
+                        RepoSearchItem::new(metadata.path, display_name, git_summary)
+                            .with_name_match_result(match_result),
+                    )
+                })
+                .collect::<Vec<_>>();
 
-        let query_text = query.text.trim().to_lowercase();
+            items.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+            Ok(items.into_iter().map(QueryResult::from).collect())
+        }
 
-        Box::pin(async move {
-            #[cfg(feature = "local_fs")]
-            {
-                use crate::terminal::input::repos::search_item::RepoSearchItem;
-                use crate::util::git::get_repo_git_summary;
-
-                let futures: Vec<_> = workspace_paths
-                    .into_iter()
-                    .map(|path| async move {
-                        let summary = get_repo_git_summary(&path).await;
-                        RepoSearchItem::new(path, summary)
-                    })
-                    .collect();
-
-                let mut items: Vec<RepoSearchItem> = futures::future::join_all(futures).await;
-                items.sort_by(|a, b| a.display_name.cmp(&b.display_name));
-
-                let results: Vec<QueryResult<AcceptRepo>> = if query_text.is_empty() {
-                    items.into_iter().map(QueryResult::from).collect()
-                } else {
-                    items
-                        .into_iter()
-                        .filter_map(|item| {
-                            let match_result = fuzzy_match::match_indices_case_insensitive(
-                                &item.display_name,
-                                &query_text,
-                            )?;
-                            if match_result.score < 25 {
-                                return None;
-                            }
-                            Some(QueryResult::from(
-                                item.with_name_match_result(Some(match_result)),
-                            ))
-                        })
-                        .collect()
-                };
-
-                Ok(results)
-            }
-
-            #[cfg(not(feature = "local_fs"))]
-            {
-                let _ = workspace_paths;
-                let _ = query_text;
-                Ok(vec![])
-            }
-        })
+        #[cfg(not(feature = "local_fs"))]
+        {
+            let _ = query;
+            let _ = app;
+            Ok(vec![])
+        }
     }
 }
 
-impl Entity for RepoMenuDataSource {
-    type Event = ();
+fn normalized_query_text(query: &Query) -> String {
+    query.text.trim().to_lowercase()
+}
+
+fn repo_matches_query(path: &Path, query_text: &str) -> bool {
+    #[cfg(feature = "local_fs")]
+    {
+        let display_name = repo_display_name(path);
+        match_result(&display_name, query_text).is_some()
+    }
+
+    #[cfg(not(feature = "local_fs"))]
+    {
+        let _ = path;
+        let _ = query_text;
+        false
+    }
+}
+
+#[cfg(feature = "local_fs")]
+fn match_result(
+    display_name: &str,
+    query_text: &str,
+) -> Option<Option<fuzzy_match::FuzzyMatchResult>> {
+    if query_text.is_empty() {
+        return Some(None);
+    }
+
+    let match_result = fuzzy_match::match_indices_case_insensitive(display_name, query_text)?;
+    if match_result.score < 25 {
+        return None;
+    }
+
+    Some(Some(match_result))
 }

--- a/app/src/terminal/input/repos/search_item.rs
+++ b/app/src/terminal/input/repos/search_item.rs
@@ -28,8 +28,7 @@ pub(super) struct RepoSearchItem {
 }
 
 impl RepoSearchItem {
-    pub fn new(path: PathBuf, git_summary: Option<RepoGitSummary>) -> Self {
-        let display_name = repo_display_name(&path);
+    pub fn new(path: PathBuf, display_name: String, git_summary: Option<RepoGitSummary>) -> Self {
         Self {
             path,
             display_name,
@@ -44,7 +43,7 @@ impl RepoSearchItem {
     }
 }
 
-fn repo_display_name(repo_path: &Path) -> String {
+pub(super) fn repo_display_name(repo_path: &Path) -> String {
     dirs::home_dir()
         .and_then(|home| repo_path.strip_prefix(&home).ok().map(|p| p.to_path_buf()))
         .map(|relative_path| format!("~/{}", relative_path.display()))

--- a/app/src/terminal/input/repos/view.rs
+++ b/app/src/terminal/input/repos/view.rs
@@ -8,10 +8,12 @@ use warpui::{Element, Entity, ModelHandle, View, ViewContext, ViewHandle};
 
 use crate::ai::blocklist::agent_view::AgentViewController;
 use crate::search::data_source::{Query, QueryFilter};
-use crate::search::mixer::{AddAsyncSourceOptions, SearchMixer};
+use crate::search::mixer::SearchMixer;
 use crate::terminal::input::buffer_model::{InputBufferModel, InputBufferUpdateEvent};
 use crate::terminal::input::inline_menu::{InlineMenuEvent, InlineMenuPositioner, InlineMenuView};
-use crate::terminal::input::repos::data_source::RepoMenuDataSource;
+use crate::terminal::input::repos::data_source::{
+    RepoGitSummaryCache, RepoGitSummaryCacheEvent, RepoMenuDataSource,
+};
 use crate::terminal::input::repos::AcceptRepo;
 use crate::terminal::input::suggestions_mode_model::{
     InputSuggestionsModeEvent, InputSuggestionsModeModel,
@@ -29,6 +31,7 @@ pub enum InlineReposMenuEvent {
 pub struct InlineReposMenuView {
     menu_view: ViewHandle<InlineMenuView<AcceptRepo>>,
     mixer: ModelHandle<SearchMixer<AcceptRepo>>,
+    git_summary_cache: ModelHandle<RepoGitSummaryCache>,
     input_suggestions_model: ModelHandle<InputSuggestionsModeModel>,
     input_buffer_model: ModelHandle<InputBufferModel>,
 }
@@ -41,21 +44,12 @@ impl InlineReposMenuView {
         positioner: &ModelHandle<InlineMenuPositioner>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        let data_source = ctx.add_model(|_| RepoMenuDataSource::new());
+        let git_summary_cache = ctx.add_model(|_| RepoGitSummaryCache::new());
+        let data_source = RepoMenuDataSource::new(git_summary_cache.clone());
 
-        let mixer = ctx.add_model(|ctx| {
+        let mixer = ctx.add_model(|_| {
             let mut mixer = SearchMixer::<AcceptRepo>::new();
-            mixer.add_async_source(
-                data_source.clone(),
-                [QueryFilter::Repos],
-                AddAsyncSourceOptions {
-                    debounce_interval: None,
-                    run_in_zero_state: true,
-                    run_when_unfiltered: false,
-                },
-                ctx,
-            );
-            mixer.run_query(repos_query(""), ctx);
+            mixer.add_sync_source(data_source, [QueryFilter::Repos]);
             mixer
         });
 
@@ -91,12 +85,8 @@ impl InlineReposMenuView {
             |me, input_suggestions_model, event, ctx| {
                 let InputSuggestionsModeEvent::ModeChanged { .. } = event;
                 if input_suggestions_model.as_ref(ctx).is_repos_menu() {
-                    me.mixer.update(ctx, |mixer, ctx| {
-                        mixer.run_query(
-                            repos_query(me.input_buffer_model.as_ref(ctx).current_value()),
-                            ctx,
-                        );
-                    });
+                    let query = me.input_buffer_model.as_ref(ctx).current_value().to_owned();
+                    me.run_query(&query, ctx);
                 }
             },
         );
@@ -104,8 +94,16 @@ impl InlineReposMenuView {
         ctx.subscribe_to_model(input_buffer_model, |me, _, event, ctx| {
             if me.input_suggestions_model.as_ref(ctx).is_repos_menu() {
                 let InputBufferUpdateEvent { new_content, .. } = event;
+                me.run_query(new_content, ctx);
+            }
+        });
+
+        ctx.subscribe_to_model(&git_summary_cache, |me, _, event, ctx| {
+            let RepoGitSummaryCacheEvent::Updated = event;
+            if me.input_suggestions_model.as_ref(ctx).is_repos_menu() {
+                let query = me.input_buffer_model.as_ref(ctx).current_value().to_owned();
                 me.mixer.update(ctx, |mixer, ctx| {
-                    mixer.run_query(repos_query(new_content), ctx);
+                    mixer.run_query(repos_query(&query), ctx);
                 });
             }
         });
@@ -113,9 +111,21 @@ impl InlineReposMenuView {
         Self {
             menu_view,
             mixer,
+            git_summary_cache,
             input_suggestions_model,
             input_buffer_model: input_buffer_model.clone(),
         }
+    }
+
+    fn run_query(&self, text: &str, ctx: &mut ViewContext<Self>) {
+        let query = repos_query(text);
+        let matching_paths = RepoMenuDataSource::matching_paths(&query, ctx);
+        self.mixer.update(ctx, |mixer, ctx| {
+            mixer.run_query(query, ctx);
+        });
+        self.git_summary_cache.update(ctx, |cache, ctx| {
+            cache.refresh_missing(matching_paths, ctx);
+        });
     }
 
     pub fn select_up(&self, ctx: &mut ViewContext<Self>) {
@@ -132,7 +142,7 @@ impl InlineReposMenuView {
     }
 }
 
-/// Build a Query that includes the Repos filter so the async source runs.
+/// Build a Query that includes the Repos filter so the repo source runs.
 fn repos_query(text: &str) -> Query {
     Query {
         text: text.to_owned(),


### PR DESCRIPTION
## Description
Speeds up the inline `/Repos` menu by rendering repo paths synchronously and lazy-loading git metadata in a bounded background cache.

Changes:
- Replaces the repo menu async source with a sync source for cheap path filtering.
- Removes eager repo query work during input construction.
- Adds a per-menu git summary cache with TTL, in-flight dedupe, and bounded concurrency.
- Refreshes menu rows as cached git summaries arrive.

## Linked Issue
No linked issue; Slack request.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --manifest-path /workspace/warp/app/Cargo.toml`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; compile-only validation in sandbox.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/6fdc6ee1-55d6-4c21-b3f5-a48e6f1f8b52_
_Run: https://oz.staging.warp.dev/runs/019e22dc-3131-7eaf-8471-1cc43cc2756f_

Co-Authored-By: Oz <oz-agent@warp.dev>
_This PR was generated with [Oz](https://warp.dev/oz)._
