### PR TITLE
Fix pane header not updating immediately on harness selection change

### DIFF
--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -293,6 +293,7 @@ impl TerminalView {
             }
             AmbientAgentViewModelEvent::HarnessSelected => {
                 self.maybe_enter_agent_view_for_shared_third_party_viewer(ctx);
+                self.update_pane_configuration(ctx);
                 ctx.emit(TerminalViewEvent::TerminalViewStateChanged);
                 ctx.notify();
             }


### PR DESCRIPTION
## Description

There was a small bug where changing the selected harness in the cloud mode input didn't immediately update the pane header's harness icon (it took a few seconds). This PR fixes that.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

## Demo

https://www.loom.com/share/ecc2232d42c541b3a1f6bd3a48a55278

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/bf2b05c9-657b-420e-98e9-4b0ed358de51_
_Run: https://oz.staging.warp.dev/runs/019e2322-b3f1-74ae-9fa8-c756abdeacc0_
_This PR was generated with [Oz](https://warp.dev/oz)._
