### PR TITLE
Add telemetry for local-to-cloud handoff

### DIFF
--- a/app/src/ai/ambient_agents/telemetry.rs
+++ b/app/src/ai/ambient_agents/telemetry.rs
@@ -83,6 +83,7 @@ pub enum CloudAgentTelemetryEvent {
         error: String,
     },
     /// User initiated a local-to-cloud handoff.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     HandoffInitiated {
         /// How the handoff was triggered.
         entry_point: HandoffEntryPoint,

--- a/app/src/ai/ambient_agents/telemetry.rs
+++ b/app/src/ai/ambient_agents/telemetry.rs
@@ -19,6 +19,19 @@ pub enum CloudModeEntryPoint {
     EntryBlock,
 }
 
+/// The entry point through which a local-to-cloud handoff was initiated.
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HandoffEntryPoint {
+    /// User typed `&` in the input to enter handoff compose mode.
+    #[default]
+    Ampersand,
+    /// User used the `/handoff` slash command.
+    SlashCommand,
+    /// User clicked the "Hand off to cloud" chip in the footer toolbar.
+    FooterChip,
+}
+
 /// Telemetry events for client interactions with cloud agents.
 #[derive(Debug, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumIter))]
@@ -69,6 +82,13 @@ pub enum CloudAgentTelemetryEvent {
         /// Error message describing the failure.
         error: String,
     },
+    /// User initiated a local-to-cloud handoff.
+    HandoffInitiated {
+        /// How the handoff was triggered.
+        entry_point: HandoffEntryPoint,
+        /// Whether the handoff forked an existing conversation.
+        forked_existing_conversation: bool,
+    },
 }
 
 impl TelemetryEvent for CloudAgentTelemetryEvent {
@@ -107,6 +127,13 @@ impl TelemetryEvent for CloudAgentTelemetryEvent {
             CloudAgentTelemetryEvent::GitHubAuthFromEnvironmentForm => None,
             CloudAgentTelemetryEvent::DispatchFailed { error } => Some(json!({
                 "error": error,
+            })),
+            CloudAgentTelemetryEvent::HandoffInitiated {
+                entry_point,
+                forked_existing_conversation,
+            } => Some(json!({
+                "entry_point": entry_point,
+                "forked_existing_conversation": forked_existing_conversation,
             })),
         }
     }
@@ -149,6 +176,7 @@ impl TelemetryEventDesc for CloudAgentTelemetryEventDiscriminants {
                 "AmbientAgent.CloudMode.EnvironmentSettings.GitHubAuth"
             }
             Self::DispatchFailed => "AmbientAgent.DispatchFailed",
+            Self::HandoffInitiated => "AmbientAgent.Handoff.Initiated",
         }
     }
 
@@ -170,6 +198,7 @@ impl TelemetryEventDesc for CloudAgentTelemetryEventDiscriminants {
                 "User started GitHub authentication from the environment form"
             }
             Self::DispatchFailed => "Ambient agent failed to dispatch or encountered an error",
+            Self::HandoffInitiated => "User initiated a local-to-cloud handoff",
         }
     }
 

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -14937,7 +14937,7 @@ impl TypedActionView for Input {
                 self.clear_attached_context(ctx);
             }
             InputAction::ActivateCloudHandoff => {
-                self.activate_cloud_handoff_compose(ctx);
+                self.activate_cloud_handoff_compose(HandoffEntryPoint::Ampersand, ctx);
             }
         }
     }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3710,7 +3710,7 @@ impl Input {
         environment_id: Option<SyncId>,
         ctx: &mut ViewContext<Self>,
     ) {
-        self.activate_cloud_handoff_compose(HandoffEntryPoint::default(), ctx);
+        self.activate_cloud_handoff_compose(HandoffEntryPoint::Ampersand, ctx);
         self.editor.update(ctx, |editor, ctx| {
             editor.set_buffer_text(&launch.prompt, ctx);
         });
@@ -3811,6 +3811,11 @@ impl Input {
                 }
             },
         );
+    }
+
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    pub(crate) fn handoff_entry_point(&self, ctx: &AppContext) -> HandoffEntryPoint {
+        self.handoff_compose_state.as_ref(ctx).entry_point()
     }
 
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -31,6 +31,7 @@ pub use self::handoff_compose::{HandoffComposeState, HandoffComposeStateEvent};
 use crate::ai::active_agent_views_model::{ActiveAgentViewsModel, ConversationOrTaskId};
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{AIAgentExchangeId, CancellationReason};
+use crate::ai::ambient_agents::telemetry::HandoffEntryPoint;
 use crate::ai::blocklist::agent_view::shortcuts::AgentShortcutViewModel;
 use crate::ai::blocklist::agent_view::{AgentViewEntryOrigin, EphemeralMessageModel};
 use crate::ai::blocklist::block::cli_controller::CLISubagentController;
@@ -2544,7 +2545,7 @@ impl Input {
                     ctx.emit(Event::OpenPluginInstructionsPane(*agent, *kind));
                 }
                 AgentInputFooterEvent::OpenHandoffPane => {
-                    me.activate_cloud_handoff_compose(ctx);
+                    me.activate_cloud_handoff_compose(HandoffEntryPoint::FooterChip, ctx);
                 }
             }
         });
@@ -3709,7 +3710,7 @@ impl Input {
         environment_id: Option<SyncId>,
         ctx: &mut ViewContext<Self>,
     ) {
-        self.activate_cloud_handoff_compose(ctx);
+        self.activate_cloud_handoff_compose(HandoffEntryPoint::default(), ctx);
         self.editor.update(ctx, |editor, ctx| {
             editor.set_buffer_text(&launch.prompt, ctx);
         });
@@ -3742,7 +3743,11 @@ impl Input {
 
     /// Switches the input into cloud handoff compose mode, locking it to AI input
     /// and activating the handoff compose state.
-    fn activate_cloud_handoff_compose(&mut self, ctx: &mut ViewContext<Self>) {
+    fn activate_cloud_handoff_compose(
+        &mut self,
+        entry_point: HandoffEntryPoint,
+        ctx: &mut ViewContext<Self>,
+    ) {
         if self.prefix_mode(ctx) == InputPrefixMode::CloudHandoff {
             return;
         }
@@ -3760,7 +3765,7 @@ impl Input {
         });
 
         self.handoff_compose_state
-            .update(ctx, |state, ctx| state.activate(ctx));
+            .update(ctx, |state, ctx| state.activate(entry_point, ctx));
         self.is_editor_empty_on_last_edit = is_input_buffer_empty;
 
         #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -3898,8 +3903,9 @@ impl Input {
             );
         });
 
-        self.handoff_compose_state
-            .update(ctx, |state, ctx| state.activate(ctx));
+        self.handoff_compose_state.update(ctx, |state, ctx| {
+            state.activate(HandoffEntryPoint::Ampersand, ctx)
+        });
         self.is_editor_empty_on_last_edit = is_input_buffer_empty;
 
         #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -4006,6 +4012,7 @@ impl Input {
             .as_ref(ctx)
             .selected_environment_id()
             .cloned();
+        let entry_point = self.handoff_compose_state.as_ref(ctx).entry_point();
         let launch = PendingCloudLaunch {
             prompt,
             attachments,
@@ -4016,6 +4023,7 @@ impl Input {
         ctx.dispatch_typed_action_deferred(WorkspaceAction::OpenLocalToCloudHandoffPane {
             launch: Some(launch),
             environment_id,
+            entry_point,
         });
         true
     }

--- a/app/src/terminal/input/handoff_compose.rs
+++ b/app/src/terminal/input/handoff_compose.rs
@@ -1,6 +1,7 @@
 //! Tracks the `&` prefix mode drafting state in the local input while the user
 //! writes a cloud handoff prompt, before a cloud pane/model exists.
 
+use crate::ai::ambient_agents::telemetry::HandoffEntryPoint;
 use crate::server::ids::SyncId;
 use warpui::{Entity, ModelContext};
 
@@ -17,6 +18,7 @@ pub struct HandoffComposeState {
     active: bool,
     selected_environment_id: Option<SyncId>,
     has_explicit_environment_selection: bool,
+    entry_point: HandoffEntryPoint,
 }
 
 impl HandoffComposeState {
@@ -24,10 +26,19 @@ impl HandoffComposeState {
         self.active
     }
 
-    pub(crate) fn activate(&mut self, ctx: &mut ModelContext<Self>) {
+    pub(crate) fn activate(
+        &mut self,
+        entry_point: HandoffEntryPoint,
+        ctx: &mut ModelContext<Self>,
+    ) {
         self.active = true;
         self.has_explicit_environment_selection = false;
+        self.entry_point = entry_point;
         ctx.emit(HandoffComposeStateEvent::ActiveChanged);
+    }
+
+    pub(crate) fn entry_point(&self) -> HandoffEntryPoint {
+        self.entry_point
     }
 
     pub(crate) fn exit(&mut self, ctx: &mut ModelContext<Self>) {

--- a/app/src/terminal/input/handoff_compose.rs
+++ b/app/src/terminal/input/handoff_compose.rs
@@ -37,6 +37,7 @@ impl HandoffComposeState {
         ctx.emit(HandoffComposeStateEvent::ActiveChanged);
     }
 
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(crate) fn entry_point(&self) -> HandoffEntryPoint {
         self.entry_point
     }

--- a/app/src/terminal/input/handoff_compose_tests.rs
+++ b/app/src/terminal/input/handoff_compose_tests.rs
@@ -1,4 +1,5 @@
 use super::HandoffComposeState;
+use crate::ai::ambient_agents::telemetry::HandoffEntryPoint;
 use crate::server::ids::{ClientId, SyncId};
 use warpui::App;
 
@@ -10,7 +11,7 @@ fn preserves_explicit_environment_selection() {
         let explicit_environment_id = SyncId::ClientId(ClientId::new());
 
         state.update(&mut app, |state, ctx| {
-            state.activate(ctx);
+            state.activate(HandoffEntryPoint::Ampersand, ctx);
             state.ensure_default_environment_id(default_environment_id, ctx);
         });
         state.read(&app, |state, _| {

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -26,6 +26,8 @@ use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::agent_management::telemetry::AgentManagementTelemetryEvent;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::ambient_agents::telemetry::HandoffEntryPoint;
 use crate::ai::blocklist::agent_view::{
     AgentViewEntryOrigin, DismissalStrategy, EphemeralMessage, ENTER_OR_EXIT_CONFIRMATION_WINDOW,
 };
@@ -914,12 +916,13 @@ impl Input {
                         WorkspaceAction::OpenLocalToCloudHandoffPane {
                             launch: Some(launch),
                             environment_id: None,
+                            entry_point: HandoffEntryPoint::SlashCommand,
                         },
                     );
                 } else {
                     // `/handoff` with no query enters `&` compose mode,
                     // same as the footer chip.
-                    self.activate_cloud_handoff_compose(ctx);
+                    self.activate_cloud_handoff_compose(HandoffEntryPoint::SlashCommand, ctx);
                 }
             }
             fork if command.name == commands::FORK.name => {

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -495,6 +495,7 @@ pub enum WorkspaceAction {
         #[cfg(not(all(feature = "local_fs", not(target_family = "wasm"))))]
         launch: Option<()>,
         environment_id: Option<crate::server::ids::SyncId>,
+        entry_point: crate::ai::ambient_agents::telemetry::HandoffEntryPoint,
     },
     /// Show the environment creation modal during `&` handoff compose when no
     /// environments exist.

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -47,9 +47,9 @@ use crate::ai::agent_management::view::{AgentManagementView, AgentManagementView
 use crate::ai::agent_management::AgentManagementEvent;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::agent_sdk::driver::upload_snapshot_for_handoff;
-use crate::ai::ambient_agents::telemetry::{
-    CloudAgentTelemetryEvent, CloudModeEntryPoint, HandoffEntryPoint,
-};
+use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEntryPoint};
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::ambient_agents::telemetry::HandoffEntryPoint;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::agent_input_footer::editor::AgentToolbarEditorMode;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -47,9 +47,9 @@ use crate::ai::agent_management::view::{AgentManagementView, AgentManagementView
 use crate::ai::agent_management::AgentManagementEvent;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::agent_sdk::driver::upload_snapshot_for_handoff;
-use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEntryPoint};
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::ambient_agents::telemetry::HandoffEntryPoint;
+use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEntryPoint};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::agent_input_footer::editor::AgentToolbarEditorMode;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
@@ -13218,7 +13218,7 @@ impl Workspace {
                 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
                 {
                     if let Some(source_view) = source_view.as_ref() {
-                        let launch = source_view.update(ctx, |view, ctx| {
+                        let (launch, entry_point) = source_view.update(ctx, |view, ctx| {
                             let input = view.input().clone();
                             input.update(ctx, |input, ctx| {
                                 let prompt = input
@@ -13228,22 +13228,24 @@ impl Workspace {
                                     .trim()
                                     .to_owned();
                                 let attachments = input.collect_cloud_launch_attachments(ctx);
+                                let entry_point = input.handoff_entry_point(ctx);
                                 input.exit_cloud_handoff_compose_and_clear(ctx);
-                                if prompt.is_empty() {
+                                let launch = if prompt.is_empty() {
                                     None
                                 } else {
                                     Some(PendingCloudLaunch {
                                         prompt,
                                         attachments,
                                     })
-                                }
+                                };
+                                (launch, entry_point)
                             })
                         });
                         ctx.dispatch_typed_action_deferred(
                             WorkspaceAction::OpenLocalToCloudHandoffPane {
                                 launch,
                                 environment_id: Some(env_id),
-                                entry_point: HandoffEntryPoint::default(),
+                                entry_point,
                             },
                         );
                     }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -47,7 +47,9 @@ use crate::ai::agent_management::view::{AgentManagementView, AgentManagementView
 use crate::ai::agent_management::AgentManagementEvent;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::agent_sdk::driver::upload_snapshot_for_handoff;
-use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEntryPoint};
+use crate::ai::ambient_agents::telemetry::{
+    CloudAgentTelemetryEvent, CloudModeEntryPoint, HandoffEntryPoint,
+};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::agent_input_footer::editor::AgentToolbarEditorMode;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
@@ -13241,6 +13243,7 @@ impl Workspace {
                             WorkspaceAction::OpenLocalToCloudHandoffPane {
                                 launch,
                                 environment_id: Some(env_id),
+                                entry_point: HandoffEntryPoint::default(),
                             },
                         );
                     }
@@ -13443,6 +13446,7 @@ impl Workspace {
         &mut self,
         launch: Option<PendingCloudLaunch>,
         environment_id: Option<SyncId>,
+        entry_point: HandoffEntryPoint,
         ctx: &mut ViewContext<Self>,
     ) {
         if !AISettings::as_ref(ctx).is_cloud_handoff_enabled(ctx) {
@@ -13463,6 +13467,16 @@ impl Workspace {
             .as_ref(ctx)
             .active_conversation(terminal_view_id)
             .cloned();
+
+        let has_existing_conversation = source_conversation.as_ref().is_some_and(|c| !c.is_empty());
+
+        send_telemetry_from_ctx!(
+            CloudAgentTelemetryEvent::HandoffInitiated {
+                entry_point,
+                forked_existing_conversation: has_existing_conversation,
+            },
+            ctx
+        );
 
         let Some(source_conversation) =
             source_conversation.filter(|conversation| !conversation.is_empty())
@@ -20902,12 +20916,18 @@ impl TypedActionView for Workspace {
             OpenLocalToCloudHandoffPane {
                 launch,
                 environment_id,
+                entry_point,
             } => {
                 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-                self.start_local_to_cloud_handoff(launch.clone(), *environment_id, ctx);
+                self.start_local_to_cloud_handoff(
+                    launch.clone(),
+                    *environment_id,
+                    *entry_point,
+                    ctx,
+                );
                 #[cfg(not(all(feature = "local_fs", not(target_family = "wasm"))))]
                 {
-                    let _ = (launch, environment_id);
+                    let _ = (launch, environment_id, entry_point);
                 }
             }
             ShowHandoffEnvironmentCreationModal => {


### PR DESCRIPTION
## Summary

WISOTT. Telemetry records handoff origin and whether it's forking a conversation or for a new request.

Implements APP-4482


## Demo

https://www.loom.com/share/05fdd258a36542d3b22017941c656227

_Conversation: https://staging.warp.dev/conversation/4ae4f166-864a-428e-bdbe-f8e07a2a6ef6_
_Run: https://oz.staging.warp.dev/runs/019e233a-af48-7297-98b0-b66bf9af549d_
_This PR was generated with [Oz](https://warp.dev/oz)._
