### PR TITLE
Disable find in embedded AI code blocks

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -2752,6 +2752,7 @@ impl AIBlock {
                         ctx,
                     )
                     .with_can_show_diff_ui(false)
+                    .disable_find_and_replace()
                 });
                 view.update(ctx, |view, ctx| {
                     view.set_starting_line_number({


### PR DESCRIPTION
## Summary
- Disable code editor find/replace for embedded AI code block editors.
- Keeps embedded code blocks read-only/selectable while preventing `Cmd/Ctrl+F` from opening the code editor find bar inside them.
- Lets terminal/block-list find remain responsible for AI block find highlights.

## Validation
- `cargo fmt --manifest-path /workspace/warp/app/Cargo.toml --check`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib` (passes; existing unused-variable warnings in `app/src/terminal/input/slash_commands/mod.rs`)

## Context
Slack thread: linked code blocks were opening editor find/replace via `code_editor:find`, which is unexpected for read-only embedded AI code blocks.

cc @vkodithala @kevinyang372

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/8511ed8e-5ebd-4640-81e4-949d1628a51d_
_Run: https://oz.staging.warp.dev/runs/019e233a-31ed-792f-9dd7-c476a285763c_
_This PR was generated with [Oz](https://warp.dev/oz)._
