### PR TITLE
Show the create environment modal if submitting with a new environment.

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -1105,6 +1105,7 @@ pub enum Event {
     OpenShareSessionModal,
     StartRemoteControl,
     OpenHandoffEnvironmentCreationModal,
+    OpenCloudModeV2EnvironmentCreationModal,
 }
 
 pub enum InputState {
@@ -5758,6 +5759,10 @@ impl Input {
 
     pub fn editor(&self) -> &ViewHandle<EditorView> {
         &self.editor
+    }
+
+    pub(crate) fn ai_context_model(&self) -> &ModelHandle<BlocklistAIContextModel> {
+        &self.ai_context_model
     }
 
     pub fn buffer_text(&self, ctx: &AppContext) -> String {
@@ -12661,6 +12666,18 @@ impl Input {
                                 ctx,
                             );
                         });
+                        return;
+                    }
+                }
+
+                if let Some(ambient_agent_view_model) = self.ambient_agent_view_model() {
+                    let needs_env_modal = {
+                        let model = ambient_agent_view_model.as_ref(ctx);
+                        !model.is_local_to_cloud_handoff()
+                            && model.selected_environment_id().is_none()
+                    };
+                    if needs_env_modal {
+                        ctx.emit(Event::OpenCloudModeV2EnvironmentCreationModal);
                         return;
                     }
                 }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -12634,14 +12634,16 @@ impl Input {
                     return;
                 }
 
-                if let Some(ambient_agent_view_model) = self.ambient_agent_view_model() {
-                    let needs_env_modal = ambient_agent_view_model
-                        .as_ref(ctx)
-                        .selected_environment_id()
-                        .is_none();
-                    if needs_env_modal {
-                        ctx.emit(Event::OpenCloudModeV2EnvironmentCreationModal);
-                        return;
+                if self.is_cloud_mode_input_v2_composing(ctx) {
+                    if let Some(ambient_agent_view_model) = self.ambient_agent_view_model() {
+                        let needs_env_modal = ambient_agent_view_model
+                            .as_ref(ctx)
+                            .selected_environment_id()
+                            .is_none();
+                        if needs_env_modal {
+                            ctx.emit(Event::OpenCloudModeV2EnvironmentCreationModal);
+                            return;
+                        }
                     }
                 }
 

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -12634,6 +12634,17 @@ impl Input {
                     return;
                 }
 
+                if let Some(ambient_agent_view_model) = self.ambient_agent_view_model() {
+                    let needs_env_modal = ambient_agent_view_model
+                        .as_ref(ctx)
+                        .selected_environment_id()
+                        .is_none();
+                    if needs_env_modal {
+                        ctx.emit(Event::OpenCloudModeV2EnvironmentCreationModal);
+                        return;
+                    }
+                }
+
                 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
                 let attachments = self
                     .collect_cloud_launch_attachments(ctx)
@@ -12666,18 +12677,6 @@ impl Input {
                                 ctx,
                             );
                         });
-                        return;
-                    }
-                }
-
-                if let Some(ambient_agent_view_model) = self.ambient_agent_view_model() {
-                    let needs_env_modal = {
-                        let model = ambient_agent_view_model.as_ref(ctx);
-                        !model.is_local_to_cloud_handoff()
-                            && model.selected_environment_id().is_none()
-                    };
-                    if needs_env_modal {
-                        ctx.emit(Event::OpenCloudModeV2EnvironmentCreationModal);
                         return;
                     }
                 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -20497,6 +20497,11 @@ impl TerminalView {
             InputEvent::OpenHandoffEnvironmentCreationModal => {
                 ctx.dispatch_typed_action(&WorkspaceAction::ShowHandoffEnvironmentCreationModal);
             }
+            InputEvent::OpenCloudModeV2EnvironmentCreationModal => {
+                ctx.dispatch_typed_action(
+                    &WorkspaceAction::ShowCloudModeV2EnvironmentCreationModal,
+                );
+            }
         }
     }
 

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -4,6 +4,12 @@ use crate::ai::agent::{
     AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, UserQueryMode,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::ai::cloud_environments::{
+    AmbientAgentEnvironment, CloudAmbientAgentEnvironment, CloudAmbientAgentEnvironmentModel,
+};
+use crate::cloud_object::model::persistence::CloudModel;
+use crate::cloud_object::{CloudObjectMetadata, CloudObjectPermissions};
+use crate::server::ids::{ClientId, SyncId};
 use chrono::Local;
 use parking_lot::FairMutex;
 use std::any::Any;
@@ -871,6 +877,18 @@ fn cloud_mode_v2_agent_prefixed_query_spawns_cloud_agent() {
         let terminal = add_window_with_cloud_mode_terminal(&mut app);
         let input = terminal.read(&app, |view, _| view.input.clone());
 
+        // The cloud mode v2 submit path now opens a create-environment modal if
+        // no environment is selected. Register a stub environment and select it
+        // so the test exercises the spawn path instead of the modal-open path.
+        let env_id = register_test_cloud_environment(&mut app);
+        terminal.update(&mut app, |view, ctx| {
+            view.ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .update(ctx, |model, ctx| {
+                    model.set_environment_id(Some(env_id), ctx);
+                });
+        });
+
         input.update(&mut app, |input, ctx| {
             assert!(input.is_cloud_mode_input_v2_composing(ctx));
             input.replace_buffer_content("/agent fix the tests", ctx);
@@ -890,6 +908,31 @@ fn cloud_mode_v2_agent_prefixed_query_spawns_cloud_agent() {
             assert!(input.as_ref(ctx).buffer_text(ctx).is_empty());
         });
     });
+}
+
+/// Registers a stub `CloudAmbientAgentEnvironment` in the test `CloudModel` and
+/// returns its `SyncId` so the caller can attach it to an ambient view model.
+fn register_test_cloud_environment(app: &mut App) -> SyncId {
+    let sync_id = SyncId::ClientId(ClientId::new());
+    app.update(|ctx| {
+        let environment = AmbientAgentEnvironment::new(
+            "Test Environment".to_string(),
+            None,
+            vec![],
+            "ubuntu:latest".to_string(),
+            vec![],
+        );
+        let object = CloudAmbientAgentEnvironment::new(
+            sync_id,
+            CloudAmbientAgentEnvironmentModel::new(environment),
+            CloudObjectMetadata::mock(),
+            CloudObjectPermissions::mock_personal(),
+        );
+        CloudModel::handle(ctx).update(ctx, |model, ctx| {
+            model.create_object(sync_id, object, ctx);
+        });
+    });
+    sync_id
 }
 
 #[test]

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -500,6 +500,7 @@ pub enum WorkspaceAction {
     /// Show the environment creation modal during `&` handoff compose when no
     /// environments exist.
     ShowHandoffEnvironmentCreationModal,
+    ShowCloudModeV2EnvironmentCreationModal,
     /// Summarize the active AI conversation in the focused pane.
     SummarizeAIConversation {
         prompt: Option<String>,
@@ -959,6 +960,7 @@ impl WorkspaceAction {
             | FixSettingsWithOz { .. }
             | OpenLocalToCloudHandoffPane { .. }
             | ShowHandoffEnvironmentCreationModal
+            | ShowCloudModeV2EnvironmentCreationModal
             | OpenNetworkLogPane => false,
             #[cfg(debug_assertions)]
             ShowHoaOnboardingFlow => false,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -332,10 +332,9 @@ use crate::terminal::session_settings::{
 };
 use crate::terminal::settings::{SpacingMode, TerminalSettings};
 use crate::terminal::shell::ShellType;
-use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::terminal::view::ambient_agent::{
-    HandoffSubmissionState, PendingHandoff, SnapshotUploadStatus,
+    AmbientAgentViewModel, HandoffSubmissionState, PendingHandoff, SnapshotUploadStatus,
 };
 #[cfg(feature = "local_tty")]
 use crate::terminal::view::docker_sandbox::DEFAULT_DOCKER_SANDBOX_BASE_IMAGE;

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13198,14 +13198,16 @@ impl Workspace {
         else {
             return;
         };
-        let Some(model_handle) = source_view.as_ref(ctx).ambient_agent_view_model().cloned() else {
-            return;
-        };
         let modal = ctx.add_typed_action_view(HandoffEnvironmentCreationModal::new);
         ctx.subscribe_to_view(&modal, move |me, _, event, ctx| match event {
             HandoffEnvironmentCreationModalEvent::Created { env_id } => {
                 let env_id = *env_id;
                 me.handoff_environment_creation_modal = None;
+                let Some(model_handle) =
+                    source_view.as_ref(ctx).ambient_agent_view_model().cloned()
+                else {
+                    return;
+                };
                 let pending = source_view.update(ctx, |view, ctx| {
                     let input = view.input().clone();
                     input.update(ctx, |input, ctx| {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -332,9 +332,10 @@ use crate::terminal::session_settings::{
 };
 use crate::terminal::settings::{SpacingMode, TerminalSettings};
 use crate::terminal::shell::ShellType;
+use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::terminal::view::ambient_agent::{
-    AmbientAgentViewModel, HandoffSubmissionState, PendingHandoff, SnapshotUploadStatus,
+    HandoffSubmissionState, PendingHandoff, SnapshotUploadStatus,
 };
 #[cfg(feature = "local_tty")]
 use crate::terminal::view::docker_sandbox::DEFAULT_DOCKER_SANDBOX_BASE_IMAGE;
@@ -13189,6 +13190,79 @@ impl Workspace {
         ctx.notify();
     }
 
+    fn show_cloud_mode_v2_environment_creation_modal(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(source_view) = self
+            .active_tab_pane_group()
+            .as_ref(ctx)
+            .active_session_view(ctx)
+        else {
+            return;
+        };
+        let Some(model_handle) = source_view.as_ref(ctx).ambient_agent_view_model().cloned() else {
+            return;
+        };
+        let modal = ctx.add_typed_action_view(HandoffEnvironmentCreationModal::new);
+        ctx.subscribe_to_view(&modal, move |me, _, event, ctx| match event {
+            HandoffEnvironmentCreationModalEvent::Created { env_id } => {
+                let env_id = *env_id;
+                me.handoff_environment_creation_modal = None;
+                let pending = source_view.update(ctx, |view, ctx| {
+                    let input = view.input().clone();
+                    input.update(ctx, |input, ctx| {
+                        let prompt = input
+                            .editor()
+                            .as_ref(ctx)
+                            .buffer_text(ctx)
+                            .trim()
+                            .to_owned();
+                        if prompt.is_empty() {
+                            return None;
+                        }
+                        #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+                        let attachments = input
+                            .collect_cloud_launch_attachments(ctx)
+                            .request_attachments;
+                        #[cfg(not(all(feature = "local_fs", not(target_family = "wasm"))))]
+                        let attachments = Vec::new();
+                        input.editor().update(ctx, |editor, ctx| {
+                            editor.clear_buffer(ctx);
+                        });
+                        input.ai_context_model().update(ctx, |model, ctx| {
+                            model.clear_pending_attachments(ctx);
+                        });
+                        Some((prompt, attachments))
+                    })
+                });
+                model_handle.update(ctx, |model, ctx| {
+                    model.set_environment_id(Some(env_id), ctx);
+                    if let Some((prompt, attachments)) = pending {
+                        model.spawn_agent(prompt, attachments, ctx);
+                    }
+                });
+            }
+            HandoffEnvironmentCreationModalEvent::Cancelled => {
+                me.handoff_environment_creation_modal = None;
+                me.focus_active_tab(ctx);
+            }
+            HandoffEnvironmentCreationModalEvent::CreationFailed { error_message } => {
+                me.handoff_environment_creation_modal = None;
+                me.toast_stack.update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::error(format!(
+                            "Failed to create environment: {error_message}"
+                        )),
+                        ctx,
+                    );
+                });
+                me.focus_active_tab(ctx);
+            }
+        });
+        modal.update(ctx, |modal, ctx| modal.show(ctx));
+        ctx.focus(&modal);
+        self.handoff_environment_creation_modal = Some(modal);
+        ctx.notify();
+    }
+
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn show_handoff_prepare_failed_toast(window_id: WindowId, ctx: &mut ViewContext<Self>) {
         WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
@@ -20802,6 +20876,9 @@ impl TypedActionView for Workspace {
             }
             ShowHandoffEnvironmentCreationModal => {
                 self.show_handoff_environment_creation_modal(ctx);
+            }
+            ShowCloudModeV2EnvironmentCreationModal => {
+                self.show_cloud_mode_v2_environment_creation_modal(ctx);
             }
             OpenNetworkLogPane => {
                 self.open_network_log_pane(ctx);


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Completes APP-4415. Adds a create environment modal step when trying to submit a cloud mode query with "new environment" selected. Only new users can get into this state.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`
yessir

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/b582b904039e45a0a5b3a457d3c61194

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

