### PR TITLE
address missed PR comment about using branch_name

### DIFF
--- a/app/src/context_chips/git_branch_on_click.rs
+++ b/app/src/context_chips/git_branch_on_click.rs
@@ -59,7 +59,7 @@ impl GitBranchOnClickValue {
                     .map(str::to_string);
                 Self::linked_worktree(branch_name, worktree_path)
             }
-            _ => Self::new(value.to_string()),
+            _ => Self::new(branch_name),
         }
     }
 }
@@ -197,6 +197,17 @@ mod tests {
         for value in values {
             assert_eq!(GitBranchOnClickValue::decode(&value.encode()), value);
         }
+    }
+
+    #[test]
+    fn test_git_branch_on_click_value_decode_uses_branch_name_for_unknown_payload() {
+        let value =
+            format!("feature-a{ENCODED_VALUE_SEPARATOR}unknown{ENCODED_VALUE_SEPARATOR}metadata");
+
+        assert_eq!(
+            GitBranchOnClickValue::decode(&value),
+            GitBranchOnClickValue::new("feature-a".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description
This comment was accidentally missed by the PR author: https://github.com/warpdotdev/warp/pull/9905/changes#r3190780039

I'm adding the intended implementation from the comment

## Linked Issue
https://github.com/warpdotdev/warp/issues/9170
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Added unit tests + locally ran to make sure things still work as expected

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
https://github.com/user-attachments/assets/33a84967-4171-49ed-9fbe-aa414d795173

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode