### PR TITLE
Migrate code view to use FileLocation

### DIFF
--- a/app/src/code/active_file.rs
+++ b/app/src/code/active_file.rs
@@ -1,22 +1,21 @@
 //! Module containing the definition of [`ActiveFileModel`],
 //! which tracks the currently focused file across an entire PaneGroup.
 
-use std::path::PathBuf;
-
+use super::buffer_location::FileLocation;
 use warpui::{Entity, ModelContext};
 
 /// Events emitted by the ActiveFileModel.
 #[derive(Debug, Clone)]
 pub enum ActiveFileEvent {
     /// A new file became focused.
-    ActiveFileChanged { file_info: PathBuf },
+    ActiveFileChanged { location: FileLocation },
 }
 
 /// Model that tracks the currently focused file.
 #[derive(Default)]
 pub struct ActiveFileModel {
     /// The currently focused file, if any.
-    active_file: Option<PathBuf>,
+    active_file: Option<FileLocation>,
 }
 
 impl Entity for ActiveFileModel {
@@ -29,16 +28,16 @@ impl ActiveFileModel {
     }
 
     /// Get the currently active file, if any.
-    pub fn active_file(&self) -> Option<&PathBuf> {
+    pub fn active_file(&self) -> Option<&FileLocation> {
         self.active_file.as_ref()
     }
 
     /// Set the currently active file.
-    pub fn active_file_changed(&mut self, path: PathBuf, ctx: &mut ModelContext<Self>) {
+    pub fn active_file_changed(&mut self, location: FileLocation, ctx: &mut ModelContext<Self>) {
         // Only emit event if the active file changed.
-        if self.active_file.as_ref() != Some(&path) {
-            self.active_file = Some(path.clone());
-            ctx.emit(ActiveFileEvent::ActiveFileChanged { file_info: path });
+        if self.active_file.as_ref() != Some(&location) {
+            self.active_file = Some(location.clone());
+            ctx.emit(ActiveFileEvent::ActiveFileChanged { location });
             ctx.notify();
         }
     }

--- a/app/src/code/editor_management.rs
+++ b/app/src/code/editor_management.rs
@@ -301,6 +301,22 @@ impl CodeManager {
             .map(|(_, data)| data.locator)
     }
 
+    /// Returns the locator for a code pane that already has the given `FileLocation`
+    /// open in the given pane group. Works for both local and remote files.
+    pub fn get_locator_for_location_in_tab(
+        &self,
+        pane_group_id: EntityId,
+        location: &FileLocation,
+    ) -> Option<PaneViewLocator> {
+        self.source_to_pane_data
+            .iter()
+            .find(|(source, data)| {
+                data.locator.pane_group_id == pane_group_id
+                    && source.location().as_ref() == Some(location)
+            })
+            .map(|(_, data)| data.locator)
+    }
+
     // Allow dead_code here for wasm compilation
     #[allow(dead_code)]
     pub fn complete_pending_diffs(&mut self, source: CodeSource, ctx: &mut ModelContext<Self>) {

--- a/app/src/code/editor_management.rs
+++ b/app/src/code/editor_management.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use super::buffer_location::FileLocation;
@@ -286,21 +286,6 @@ impl CodeManager {
     pub fn deregister_pane(&mut self, source: &CodeSource) {
         self.source_to_pane_data.remove(&source.omit_line_col());
     }
-    /// Returns the locator for a code pane that already has `path` open in the given pane group.
-    pub fn get_locator_for_path_in_tab(
-        &self,
-        pane_group_id: EntityId,
-        path: &Path,
-    ) -> Option<PaneViewLocator> {
-        self.source_to_pane_data
-            .iter()
-            .find(|(source, data)| {
-                data.locator.pane_group_id == pane_group_id
-                    && source.path().is_some_and(|p| p.as_path() == path)
-            })
-            .map(|(_, data)| data.locator)
-    }
-
     /// Returns the locator for a code pane that already has the given `FileLocation`
     /// open in the given pane group. Works for both local and remote files.
     pub fn get_locator_for_location_in_tab(

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -739,9 +739,17 @@ impl FileTreeView {
     fn handle_code_event(&mut self, event: &ActiveFileEvent, ctx: &mut ViewContext<Self>) {
         // When a file is focused, scroll to show it in the file tree
         match event {
-            ActiveFileEvent::ActiveFileChanged { file_info } => {
-                let Ok(file_std) = StandardizedPath::try_from_local(file_info) else {
-                    return;
+            ActiveFileEvent::ActiveFileChanged { location } => {
+                let file_std = match location {
+                    crate::code::buffer_location::FileLocation::Local(path) => {
+                        match StandardizedPath::try_from_local(path) {
+                            Ok(std_path) => std_path,
+                            Err(_) => return,
+                        }
+                    }
+                    crate::code::buffer_location::FileLocation::Remote(remote) => {
+                        remote.path.clone()
+                    }
                 };
                 // Prefer the currently-selected item's root if the file lives under it;
                 // otherwise fall back to the deepest matching root directory.

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -187,11 +187,11 @@ pub enum CodeViewAction {
 pub enum CodeViewEvent {
     Pane(PaneEvent),
     TabChanged {
-        file_path: Option<PathBuf>,
+        location: Option<FileLocation>,
         tab_index: usize,
     },
     FileOpened {
-        file_path: PathBuf,
+        location: FileLocation,
         tab_index: usize,
     },
     RunTabConfigSkill {
@@ -213,7 +213,7 @@ struct TabDataMouseStateHandles {
 
 #[derive(Clone)]
 pub struct TabData {
-    path: Option<PathBuf>,
+    location: Option<FileLocation>,
     editor_view: ViewHandle<LocalCodeEditorView>,
     mouse_state_handles: TabDataMouseStateHandles,
     preview: bool,
@@ -227,8 +227,12 @@ pub enum PendingSaveIntent {
 }
 
 impl TabData {
-    pub fn path(&self) -> Option<PathBuf> {
-        self.path.clone()
+    /// Returns the local filesystem path, if this tab is backed by a local file.
+    /// Returns `None` for remote files and untitled tabs.
+    pub fn local_path(&self) -> Option<PathBuf> {
+        self.location
+            .as_ref()
+            .and_then(|loc| loc.to_local_path().map(|p| p.to_path_buf()))
     }
 }
 
@@ -281,7 +285,7 @@ impl CodeView {
             .local_path(ctx)
             .or_else(|| {
                 self.tab_at(self.active_tab_index)
-                    .and_then(|t| t.path.clone())
+                    .and_then(|t| t.local_path())
             })
             .or_else(|| self.source.path());
 
@@ -464,11 +468,10 @@ impl CodeView {
         preview: bool,
         ctx: &mut ViewContext<Self>,
     ) -> TabData {
-        let (code_editor, tab_path) = match location {
+        let (code_editor, tab_location) = match location {
             Some(loc) => {
-                let path = loc.to_local_path().map(|p| p.to_path_buf());
-                let editor = self.construct_editor_for_location(loc, ctx);
-                (editor, path)
+                let editor = self.construct_editor_for_location(loc.clone(), ctx);
+                (editor, Some(loc))
             }
             None => (self.construct_new_file_editor(ctx), None),
         };
@@ -487,7 +490,7 @@ impl CodeView {
         });
 
         // For new files (CodeSource::New), mark the editor as a new file and set default directory
-        if tab_path.is_none() && matches!(self.source, CodeSource::New { .. }) {
+        if tab_location.is_none() && matches!(self.source, CodeSource::New { .. }) {
             let default_directory = self.source.default_directory().cloned();
             code_editor.update(ctx, |local_editor, _ctx| {
                 local_editor.set_new_file(true);
@@ -614,7 +617,7 @@ impl CodeView {
         });
 
         TabData {
-            path: tab_path,
+            location: tab_location,
             editor_view: code_editor,
             mouse_state_handles: Default::default(),
             preview,
@@ -679,7 +682,7 @@ impl CodeView {
         if let Some(existing_index) = self
             .tab_group
             .iter()
-            .position(|tab| tab.path == Some(path.clone()))
+            .position(|tab| tab.location.as_ref() == Some(&FileLocation::Local(path.clone())))
         {
             self.set_active_tab_index(existing_index, ctx);
             self.promote_if_preview(ctx);
@@ -707,7 +710,7 @@ impl CodeView {
         self.set_active_tab_index(active_tab_index, ctx);
 
         ctx.emit(CodeViewEvent::FileOpened {
-            file_path: path,
+            location: FileLocation::Local(path),
             tab_index: self.active_tab_index,
         });
     }
@@ -730,30 +733,27 @@ impl CodeView {
         line_col: Option<LineAndColumnArg>,
         ctx: &mut ViewContext<Self>,
     ) {
-        let local_path = location
-            .as_ref()
-            .and_then(|loc| loc.to_local_path().map(|p| p.to_path_buf()));
-
         // If the tab already exists, focus it (and optionally jump) without re-opening from disk.
-        if let Some(existing_index) = self.focus_existing_tab_if_present(&local_path, ctx) {
+        if let Some(existing_index) = self.focus_existing_tab_if_present(location.as_ref(), ctx) {
             if let Some(line_col) = line_col {
                 self.jump_to_line_col_in_tab(existing_index, line_col, ctx);
             }
             return;
         }
 
-        self.open_new_tab(location, local_path, line_col, ctx);
+        self.open_new_tab(location, line_col, ctx);
     }
 
     fn focus_existing_tab_if_present(
         &mut self,
-        local_path: &Option<PathBuf>,
+        location: Option<&FileLocation>,
         ctx: &mut ViewContext<Self>,
     ) -> Option<usize> {
+        let location = location?;
         let existing_index = self
             .tab_group
             .iter()
-            .position(|tab| tab.path.as_ref() == local_path.as_ref())?;
+            .position(|tab| tab.location.as_ref() == Some(location))?;
         self.set_active_tab_index(existing_index, ctx);
         Some(existing_index)
     }
@@ -785,17 +785,16 @@ impl CodeView {
     fn open_new_tab(
         &mut self,
         location: Option<FileLocation>,
-        local_path: Option<PathBuf>,
         line_col: Option<LineAndColumnArg>,
         ctx: &mut ViewContext<Self>,
     ) {
-        let new_tab = self.build_tab_data(location, false, ctx);
+        let new_tab = self.build_tab_data(location.clone(), false, ctx);
         self.tab_group.push(new_tab);
         let active_tab_index = self.tab_group.len() - 1;
 
-        if let (Some(file_path), Some(tab)) = (local_path, self.tab_group.get(active_tab_index)) {
+        if let (Some(loc), Some(tab)) = (&location, self.tab_group.get(active_tab_index)) {
             ctx.emit(CodeViewEvent::FileOpened {
-                file_path: file_path.clone(),
+                location: loc.clone(),
                 tab_index: active_tab_index,
             });
 
@@ -988,8 +987,8 @@ impl CodeView {
                 .editor_view
                 .as_ref(ctx)
                 .file_path()
-                .map(|p| p.to_path_buf());
-            tab.path = new_path;
+                .map(|p| FileLocation::Local(p.to_path_buf()));
+            tab.location = new_path;
         }
     }
 
@@ -1132,10 +1131,10 @@ impl CodeView {
     ) {
         if let Some(tab) = self.tab_at(index) {
             let file_name = tab
-                .path
+                .location
                 .as_ref()
-                .and_then(|p| p.file_name())
-                .map(|name| name.to_string_lossy().to_string());
+                .map(|loc| loc.display_name().to_string())
+                .filter(|n| !n.is_empty());
             let summary = UnsavedStateSummary::for_editor_tab(
                 file_name,
                 vec![CodeEditorStatus::new(Self::has_unsaved_changes(tab, ctx))],
@@ -1191,7 +1190,7 @@ impl CodeView {
         index: usize,
         ctx: &mut ViewContext<Self>,
     ) -> Option<CodePane> {
-        self.tab_at(index).and_then(|t| t.path()).map(|path| {
+        self.tab_at(index).and_then(|t| t.local_path()).map(|path| {
             let source = CodeSource::Link {
                 path,
                 range_start: None,
@@ -1284,9 +1283,9 @@ impl CodeView {
         self.active_tab_index = index;
         self.update_tab_bar_state(ctx);
 
-        let file_path = self.tab_at(index).and_then(|tab| tab.path());
+        let location = self.tab_at(index).and_then(|tab| tab.location.clone());
         ctx.emit(CodeViewEvent::TabChanged {
-            file_path,
+            location,
             tab_index: index,
         });
 
@@ -1303,7 +1302,7 @@ impl CodeView {
     pub fn close_tabs_with_path(&mut self, file_path: &Path, ctx: &mut ViewContext<Self>) {
         let mut indices_to_remove = Vec::new();
         for (tab_idx, tab) in self.tab_group.iter().enumerate() {
-            if tab.path.as_ref().is_some_and(|path| path == file_path) {
+            if tab.local_path().is_some_and(|path| path == file_path) {
                 indices_to_remove.push(tab_idx);
             }
         }
@@ -1322,8 +1321,8 @@ impl CodeView {
         ctx: &mut ViewContext<Self>,
     ) {
         for tab in self.tab_group.iter_mut() {
-            if tab.path.as_ref().is_some_and(|path| path == old_path) {
-                tab.path = Some(new_path.to_path_buf());
+            if tab.local_path().is_some_and(|path| path == old_path) {
+                tab.location = Some(FileLocation::Local(new_path.to_path_buf()));
                 tab.editor_view.update(ctx, |editor, ctx| {
                     let was_unsaved = editor.has_unsaved_changes(ctx);
 
@@ -1494,9 +1493,10 @@ impl CodeView {
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween);
 
         let file_name = tab_data
-            .path
+            .location
             .as_ref()
-            .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()))
+            .map(|loc| loc.display_name().to_string())
+            .filter(|n| !n.is_empty())
             .unwrap_or_else(|| "Untitled".to_string());
         let language_icon =
             icon_from_file_path(&file_name, appearance, ItemHighlightState::Default);
@@ -1753,7 +1753,7 @@ impl CodeView {
                             .tab_draggable_state
                             .is_dragging()
                     {
-                        if let Some(path) = tab_data.path.clone() {
+                        if let Some(path) = tab_data.local_path() {
                             let tooltip = appearance
                                 .ui_builder()
                                 .tool_tip(Self::relative_path(path, self.window_id, app))
@@ -1870,20 +1870,10 @@ impl CodeView {
             .tab_group
             .first()
             .and_then(|tab| {
-                // For remote files, tab.path is None — derive the name from
-                // the editor's FileLocation metadata instead.
-                tab.path
+                tab.location
                     .as_ref()
-                    .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()))
-                    .or_else(|| {
-                        let name = tab
-                            .editor_view
-                            .as_ref(app)
-                            .file_location()
-                            .map(|loc| loc.display_name().to_string())
-                            .filter(|n| !n.is_empty());
-                        name
-                    })
+                    .map(|loc| loc.display_name().to_string())
+                    .filter(|n| !n.is_empty())
             })
             .unwrap_or_else(|| "Untitled".to_string());
 
@@ -1934,7 +1924,7 @@ impl CodeView {
                 stack.add_child(title_text);
                 if hover_state.is_hovered() {
                     let tooltip_relative_path = tab
-                        .and_then(|tab| tab.path.clone())
+                        .and_then(|tab| tab.local_path())
                         .map(|p| Self::relative_path(p, self.window_id, app));
                     if let Some(ref path) = tooltip_relative_path {
                         let tooltip = appearance
@@ -2025,19 +2015,18 @@ impl CodeView {
 
     /// Merges tabs from another `CodeView`, avoiding duplicates and updating the active tab index.
     pub fn merge_tabs(&mut self, source_code_view: &CodeView, ctx: &mut ViewContext<Self>) {
-        let existing_paths_to_idx: HashMap<String, usize> = self
+        let existing_locations_to_idx: HashMap<&FileLocation, usize> = self
             .tab_group
             .iter()
             .enumerate()
-            .filter_map(|(idx, tab)| tab.path().map(|p| (p.to_string_lossy().to_string(), idx)))
+            .filter_map(|(idx, tab)| tab.location.as_ref().map(|loc| (loc, idx)))
             .collect();
         let mut active_tab_index = self.active_tab_index();
         let mut to_extend: Vec<TabData> = Vec::new();
 
         for (i, tab_data) in source_code_view.tab_group.iter().enumerate() {
-            if let Some(path) = tab_data.path() {
-                if let Some(&index) = existing_paths_to_idx.get(&path.to_string_lossy().to_string())
-                {
+            if let Some(loc) = tab_data.location.as_ref() {
+                if let Some(&index) = existing_locations_to_idx.get(loc) {
                     // If the tab already exists in the tab group and is the active tab in the source CodeView,
                     // update the active tab index to point to it.
                     if i == source_code_view.active_tab_index() {
@@ -2051,7 +2040,7 @@ impl CodeView {
                     to_extend.push(new_data);
                     // If the newly added tab is the active tab in the source CodeView, update the active tab index to point to it.
                     if i == source_code_view.active_tab_index() {
-                        active_tab_index = existing_paths_to_idx.len() + to_extend.len() - 1;
+                        active_tab_index = existing_locations_to_idx.len() + to_extend.len() - 1;
                     }
                 }
             }
@@ -2184,7 +2173,7 @@ impl TypedActionView for CodeView {
             CodeViewAction::RenderMarkdown => {
                 let path = self.local_path(ctx).or_else(|| {
                     self.tab_at(self.active_tab_index)
-                        .and_then(|t| t.path.clone())
+                        .and_then(|t| t.local_path())
                 });
 
                 if let Some(path) = path {

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -2040,7 +2040,7 @@ impl CodeView {
                     to_extend.push(new_data);
                     // If the newly added tab is the active tab in the source CodeView, update the active tab index to point to it.
                     if i == source_code_view.active_tab_index() {
-                        active_tab_index = existing_locations_to_idx.len() + to_extend.len() - 1;
+                        active_tab_index = self.tab_group.len() + to_extend.len() - 1;
                     }
                 }
             }

--- a/app/src/code/wasm.rs
+++ b/app/src/code/wasm.rs
@@ -43,11 +43,11 @@ pub enum CodeViewAction {
 pub enum CodeViewEvent {
     Pane(PaneEvent),
     TabChanged {
-        file_path: Option<PathBuf>,
+        location: Option<FileLocation>,
         tab_index: usize,
     },
     FileOpened {
-        file_path: PathBuf,
+        location: FileLocation,
         tab_index: usize,
     },
     RunTabConfigSkill {
@@ -85,15 +85,19 @@ struct TabDataMouseStateHandles {
 #[allow(unused)]
 #[derive(Clone)]
 pub struct TabData {
-    path: Option<PathBuf>,
+    location: Option<FileLocation>,
     editor_view: ViewHandle<LocalCodeEditorView>,
     mouse_state_handles: TabDataMouseStateHandles,
     drag_position: Option<TabBarDragPosition>,
 }
 
 impl TabData {
-    pub fn path(&self) -> Option<PathBuf> {
-        self.path.clone()
+    /// Returns the local filesystem path, if this tab is backed by a local file.
+    /// Returns `None` for remote files and untitled tabs.
+    pub fn local_path(&self) -> Option<PathBuf> {
+        self.location
+            .as_ref()
+            .and_then(|loc| loc.to_local_path().map(|p| p.to_path_buf()))
     }
 }
 

--- a/app/src/pane_group/pane/code_pane.rs
+++ b/app/src/pane_group/pane/code_pane.rs
@@ -67,13 +67,13 @@ impl PaneContent for CodePane {
 
     fn pre_attach(&self, group: &PaneGroup, ctx: &mut ViewContext<PaneGroup>) -> bool {
         let source = self.file_view(ctx).as_ref(ctx).source().clone();
-        let Some(path) = source.path() else {
+        let Some(location) = source.location() else {
             return true;
         };
         let pane_group_id = ctx.view_id();
 
         let existing_locator = CodeManager::handle(ctx).read(ctx, |manager, _ctx| {
-            manager.get_locator_for_path_in_tab(pane_group_id, path.as_path())
+            manager.get_locator_for_location_in_tab(pane_group_id, &location)
         });
 
         // If the file is already open in the same tab, don't restore it, just focus it (and jump).
@@ -84,11 +84,7 @@ impl PaneContent for CodePane {
                     _ => None,
                 };
                 code_pane.file_view(ctx).update(ctx, |code_view, ctx| {
-                    code_view.open_or_focus_existing(
-                        Some(FileLocation::Local(path.clone())),
-                        line_col,
-                        ctx,
-                    );
+                    code_view.open_or_focus_existing(Some(location.clone()), line_col, ctx);
                 });
             }
 
@@ -100,13 +96,11 @@ impl PaneContent for CodePane {
 
         #[cfg(feature = "local_fs")]
         self.file_view(ctx).update(ctx, |code_view, ctx| {
-            if let Some(path) = source.path() {
-                let line_col = match &source {
-                    CodeSource::Link { range_start, .. } => *range_start,
-                    _ => None,
-                };
-                code_view.open_or_focus_existing(Some(FileLocation::Local(path)), line_col, ctx);
-            }
+            let line_col = match &source {
+                CodeSource::Link { range_start, .. } => *range_start,
+                _ => None,
+            };
+            code_view.open_or_focus_existing(Some(location.clone()), line_col, ctx);
         });
 
         true
@@ -129,21 +123,21 @@ impl PaneContent for CodePane {
                 CodeViewEvent::Pane(pane_event) => {
                     pane_group.handle_pane_event(pane_id, pane_event, ctx)
                 }
-                CodeViewEvent::TabChanged { file_path, .. } => {
-                    if let Some(path) = file_path {
+                CodeViewEvent::TabChanged { location, .. } => {
+                    if let Some(loc) = location {
                         pane_group.active_file_model().update(ctx, |model, ctx| {
-                            model.active_file_changed(path.clone(), ctx);
+                            model.active_file_changed(loc.clone(), ctx);
                         });
                     }
                 }
-                CodeViewEvent::FileOpened { file_path, .. } => {
+                CodeViewEvent::FileOpened { location, .. } => {
                     pane_group.active_file_model().update(ctx, |model, ctx| {
-                        model.active_file_changed(file_path.clone(), ctx);
+                        model.active_file_changed(location.clone(), ctx);
                     });
 
-                    // Track the opened file in the OpenedFilesModel
+                    // Track the opened file in the OpenedFilesModel (local files only)
                     #[cfg(feature = "local_fs")]
-                    {
+                    if let FileLocation::Local(file_path) = location {
                         use crate::code::opened_files::OpenedFilesModel;
                         use repo_metadata::repositories::DetectedRepositories;
 
@@ -217,7 +211,9 @@ impl PaneContent for CodePane {
 
         let tabs: Vec<CodePaneTabSnapshot> = (0..code_view_ref.tab_count())
             .filter_map(|i| code_view_ref.tab_at(i))
-            .map(|tab| CodePaneTabSnapshot { path: tab.path() })
+            .map(|tab| CodePaneTabSnapshot {
+                path: tab.local_path(),
+            })
             .collect();
 
         let active_tab_index = code_view_ref.active_tab_index();

--- a/app/src/pane_group/pane/code_pane.rs
+++ b/app/src/pane_group/pane/code_pane.rs
@@ -4,12 +4,13 @@ use warpui::{AppContext, ModelHandle, SingletonEntity, View, ViewContext, ViewHa
 use crate::{
     app_state::{CodePaneSnapShot, CodePaneTabSnapshot, LeafContents},
     code::{
-        buffer_location::FileLocation,
         editor_management::{CodeEditorStatus, CodeManager, CodeSource},
         view::{CodeView, CodeViewEvent},
     },
     pane_group::PaneGroup,
 };
+#[cfg(feature = "local_fs")]
+use crate::code::buffer_location::FileLocation;
 
 use super::{
     DetachType, PaneConfiguration, PaneContent, PaneId, PaneView, ShareableLink, ShareableLinkError,

--- a/app/src/pane_group/pane/code_pane.rs
+++ b/app/src/pane_group/pane/code_pane.rs
@@ -1,6 +1,8 @@
 use warp_util::path::LineAndColumnArg;
 use warpui::{AppContext, ModelHandle, SingletonEntity, View, ViewContext, ViewHandle};
 
+#[cfg(feature = "local_fs")]
+use crate::code::buffer_location::FileLocation;
 use crate::{
     app_state::{CodePaneSnapShot, CodePaneTabSnapshot, LeafContents},
     code::{
@@ -9,8 +11,6 @@ use crate::{
     },
     pane_group::PaneGroup,
 };
-#[cfg(feature = "local_fs")]
-use crate::code::buffer_location::FileLocation;
 
 use super::{
     DetachType, PaneConfiguration, PaneContent, PaneId, PaneView, ShareableLink, ShareableLinkError,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -7443,6 +7443,10 @@ impl Workspace {
             // If the tabbed editor view is enabled and there is an existing CodeView, we should group the newly opened file into this view.
             if let (Some(location), Some((pane_id, code_view))) = (source.location(), code_view) {
                 code_view.update(ctx, |code_view, ctx| {
+                    // Preview (single-click = light open, double-click = promote to
+                    // full tab) is only supported for local files because it relies
+                    // on `open_in_preview_or_promote` which takes a local `PathBuf`.
+                    // Remote files skip preview and open normally.
                     if preview {
                         if let Some(path) = location.to_local_path() {
                             code_view.open_in_preview_or_promote_and_jump(
@@ -7489,6 +7493,7 @@ impl Workspace {
                             pane_group.code_view_from_pane_id(locator.pane_id, ctx)
                         {
                             code_view.update(ctx, |code_view, ctx| {
+                                // Preview is local-only (see comment above).
                                 if preview {
                                     if let Some(path) = location.to_local_path() {
                                         code_view.open_in_preview_or_promote_and_jump(

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -7441,16 +7441,20 @@ impl Workspace {
                         .is_pane_hidden_for_close(*pane_id)
                 });
             // If the tabbed editor view is enabled and there is an existing CodeView, we should group the newly opened file into this view.
-            if let (Some(path), Some((pane_id, code_view))) = (source.path(), code_view) {
+            if let (Some(location), Some((pane_id, code_view))) = (source.location(), code_view) {
                 code_view.update(ctx, |code_view, ctx| {
                     if preview {
-                        code_view.open_in_preview_or_promote_and_jump(path, line_col, ctx);
+                        if let Some(path) = location.to_local_path() {
+                            code_view.open_in_preview_or_promote_and_jump(
+                                path.to_path_buf(),
+                                line_col,
+                                ctx,
+                            );
+                        } else {
+                            code_view.open_or_focus_existing(Some(location.clone()), line_col, ctx);
+                        }
                     } else {
-                        code_view.open_or_focus_existing(
-                            Some(FileLocation::Local(path)),
-                            line_col,
-                            ctx,
-                        );
+                        code_view.open_or_focus_existing(Some(location.clone()), line_col, ctx);
                     }
                     for extra in additional_paths {
                         code_view.open_or_focus_existing(
@@ -7471,10 +7475,10 @@ impl Workspace {
         } else {
             // When grouping is off, avoid opening duplicate code panes for the same file in the
             // current pane group. Instead, focus the existing pane and jump.
-            if let Some(path) = source.path() {
+            if let Some(location) = source.location() {
                 let pane_group_id = self.active_tab_pane_group().id();
                 let existing_locator = CodeManager::handle(ctx).read(ctx, |manager, _| {
-                    manager.get_locator_for_path_in_tab(pane_group_id, path.as_path())
+                    manager.get_locator_for_location_in_tab(pane_group_id, &location)
                 });
 
                 if let Some(locator) = existing_locator {
@@ -7486,14 +7490,22 @@ impl Workspace {
                         {
                             code_view.update(ctx, |code_view, ctx| {
                                 if preview {
-                                    code_view.open_in_preview_or_promote_and_jump(
-                                        path.clone(),
-                                        line_col,
-                                        ctx,
-                                    );
+                                    if let Some(path) = location.to_local_path() {
+                                        code_view.open_in_preview_or_promote_and_jump(
+                                            path.to_path_buf(),
+                                            line_col,
+                                            ctx,
+                                        );
+                                    } else {
+                                        code_view.open_or_focus_existing(
+                                            Some(location.clone()),
+                                            line_col,
+                                            ctx,
+                                        );
+                                    }
                                 } else {
                                     code_view.open_or_focus_existing(
-                                        Some(FileLocation::Local(path.clone())),
+                                        Some(location.clone()),
                                         line_col,
                                         ctx,
                                     );
@@ -14226,7 +14238,7 @@ impl Workspace {
                                                             |file_view, ctx| {
                                                                 let moved_file_path = file_view
                                                                     .tab_at(*editor_tab_index)
-                                                                    .and_then(|t| t.path());
+                                                                    .and_then(|t| t.local_path());
 
                                                                 file_view.remove_tab_for_move(
                                                                     *editor_tab_index,


### PR DESCRIPTION
## Fix: Remote file tree opens duplicate panes for the same file

### Problem
Clicking a remote file in the file tree twice opens two separate editor panes for the same file. Locally, the app correctly detects the file is already open and focuses the existing editor instead.

### Root Cause
All duplicate-detection paths relied on `CodeSource::path()`, which returns `None` for remote files (`FileLocation::Remote`). This caused every dedup check to be skipped entirely for remote files.

### Changes

**Core type migration (`TabData.path` → `TabData.location`)**
- Replaced `TabData.path: Option<PathBuf>` with `location: Option<FileLocation>`, so both local and remote files are tracked as the canonical tab identity
- Added `local_path()` convenience accessor for callers that are inherently local-only (save, rename, persistence, markdown preview)
- Migrated all callers: display (tab titles, tooltips), dedup (focus existing, merge tabs), and local-only operations

**Dedup fix (the actual bug fix)**
- `focus_existing_tab_if_present` now compares `FileLocation` instead of local path only
- Added `CodeManager::get_locator_for_location_in_tab` that matches on `CodeSource::location()` for both local and remote
- Updated `open_code` (both grouping-on and grouping-off paths) to use `source.location()` instead of `source.path()`
- Updated `CodePane::pre_attach` to use `source.location()` and the new location-based lookup

**ActiveFileModel migration**
- Changed `ActiveFileModel` to store `Option<FileLocation>` instead of `Option<PathBuf>`
- Updated `CodeViewEvent::TabChanged`/`FileOpened` to carry `FileLocation`
- File tree handler now works for both local (`try_from_local`) and remote (`remote.path` directly) — enables "reveal active file in tree" for remote files
- `OpenedFilesModel` tracking gated on `FileLocation::Local` since `DetectedRepositories` is local-only

### Bonus fixes
- Remote tab titles now show actual file name via `FileLocation::display_name()` instead of "Untitled"
- `merge_tabs` correctly deduplicates remote tabs (previously silently dropped them)
- Unsaved changes dialog shows correct file names for remote files

---
[Conversation](https://staging.warp.dev/conversation/18fcb46f-ab51-4429-833e-fb3a9d4ea203) | [Plan](https://staging.warp.dev/drive/notebook/Zr9BSvVisGLAPP8BXRyTJc)

## Demo
https://www.loom.com/share/6cc736c68bf24242b2919a3c2e746d7d