### PR TITLE
Make orchestration pill bar background transparent

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -535,7 +535,6 @@ impl OrchestrationPillBar {
         if children.is_empty() {
             return None;
         }
-
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
 
@@ -770,9 +769,6 @@ impl View for OrchestrationPillBar {
             return Empty::new().finish();
         };
 
-        let appearance = Appearance::as_ref(app);
-        let theme = appearance.theme();
-
         // The row uses `MainAxisSize::Max` so the bar's intrinsic width
         // is the parent's available width (i.e. the pane width passed in
         // by the wrapping `Flex::column` in `pane_impl.rs`), not the sum
@@ -834,8 +830,8 @@ impl View for OrchestrationPillBar {
         drop(overflow_states);
 
         // Wrap in a container with a touch of horizontal padding so the bar
-        // doesn't sit flush against the pane edges, and with the same overlay
-        // background as the rest of the agent view header so it merges visually.
+        // doesn't sit flush against the pane edges while leaving the row itself
+        // transparent so the pane's theme background shows through.
         //
         // Wrap the whole thing in a `Clipped` so when the orchestrator's
         // pane is narrower than the natural width of the pill row
@@ -851,7 +847,6 @@ impl View for OrchestrationPillBar {
                 .with_padding_right(12.)
                 .with_padding_top(4.)
                 .with_padding_bottom(4.)
-                .with_background(theme.surface_overlay_1())
                 .finish(),
         )
         .finish();


### PR DESCRIPTION
Fixes first half of https://linear.app/warpdotdev/issue/QUALITY-693/pill-bar-mock-deviations

Before:
<img width="707" height="207" alt="image" src="https://github.com/user-attachments/assets/c2ed54b4-424a-412a-9420-5b6b62188b6e" />


After:
<img width="726" height="228" alt="image" src="https://github.com/user-attachments/assets/b9d55eee-677b-4146-8225-59dcfcf1e97d" />


## Description
Removes the explicit `surface_overlay_1` background from the orchestration agent pill bar container so the bar itself is transparent and shows the pane/theme background behind it. The selected, hover, and rest styling for individual pills remains unchanged.

## Testing
- `cargo fmt`
- `git --no-pager diff --check`
- `cargo clippy -p warp --lib -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` failed in unrelated `input_classifier` all-features bin compilation: duplicate `DEFAULT_ONNX_MODEL` definitions in `crates/input_classifier/src/bin/evaluate.rs`.
- `cargo test -p warp orchestration_pill_bar --lib` was cancelled after the user asked to skip remaining checks.
