### PR TITLE
Remove command palette fixed filters

### DIFF
--- a/app/src/palette.rs
+++ b/app/src/palette.rs
@@ -8,5 +8,4 @@ pub enum PaletteMode {
     WarpDrive,
     Files,
     Conversations,
-    ConversationsAndRepos,
 }

--- a/app/src/search/command_palette/conversations/data_source.rs
+++ b/app/src/search/command_palette/conversations/data_source.rs
@@ -57,8 +57,6 @@ impl ConversationSection {
 /// Data source that produces conversations for a user to navigate to.
 pub struct DataSource {
     searcher: FuzzyConversationSearcher,
-    /// Whether to include extra conversation actions (i.e. new conversation & fork conversation)
-    add_conversation_actions: bool,
 }
 
 impl Default for DataSource {
@@ -71,14 +69,6 @@ impl DataSource {
     pub fn new() -> Self {
         Self {
             searcher: FuzzyConversationSearcher::new(),
-            add_conversation_actions: true,
-        }
-    }
-
-    pub fn historical() -> Self {
-        Self {
-            searcher: FuzzyConversationSearcher::historical(),
-            add_conversation_actions: false,
         }
     }
 
@@ -208,7 +198,7 @@ impl SyncDataSource for DataSource {
         };
 
         // When the query is empty, we want to add the "new conversation" and "fork conversation" items.
-        if self.add_conversation_actions && query.text.trim().is_empty() {
+        if query.text.trim().is_empty() {
             result.map(|mut results| {
                 if !cfg!(target_family = "wasm") {
                     if let Some(conversation) = selected_conversation_in_focused_pane(app) {

--- a/app/src/search/command_palette/conversations/search.rs
+++ b/app/src/search/command_palette/conversations/search.rs
@@ -178,36 +178,15 @@ pub trait ConversationSearcher {
     ) -> anyhow::Result<Vec<QueryResult<SearcherAction>>>;
 }
 
-#[derive(PartialEq)]
-pub enum ConversationType {
-    All,
-    Historical,
-}
-
-pub struct FuzzyConversationSearcher {
-    filter: ConversationType,
-}
+pub struct FuzzyConversationSearcher;
 
 impl FuzzyConversationSearcher {
     pub fn new() -> Self {
-        Self {
-            filter: ConversationType::All,
-        }
-    }
-
-    pub fn historical() -> Self {
-        Self {
-            filter: ConversationType::Historical,
-        }
+        Self
     }
 
     pub fn searchable_conversations(&self, app: &AppContext) -> Vec<ConversationNavigationData> {
-        match self.filter {
-            ConversationType::Historical => {
-                ConversationNavigationData::historical_conversations(app)
-            }
-            ConversationType::All => ConversationNavigationData::all_conversations(app),
-        }
+        ConversationNavigationData::all_conversations(app)
     }
 }
 

--- a/app/src/search/command_palette/data_sources.rs
+++ b/app/src/search/command_palette/data_sources.rs
@@ -31,7 +31,6 @@ pub struct DataSourceStore {
     warp_drive_data_source: ModelHandle<warp_drive::DataSource>,
     launch_config_data_source: ModelHandle<launch_config::DataSource>,
     new_session_data_source: Option<ModelHandle<NewSessionDataSource>>,
-    historical_conversation_data_source: ModelHandle<conversations::DataSource>,
     all_conversation_data_source: ModelHandle<conversations::DataSource>,
     repo_data_source: ModelHandle<RepoDataSource>,
     tabs_data_source: Option<ModelHandle<tabs::DataSource>>,
@@ -57,9 +56,6 @@ impl DataSourceStore {
             && cfg!(feature = "local_tty"))
         .then_some(ctx.add_model(|ctx| NewSessionDataSource::new(binding_source, ctx)));
 
-        let historical_conversation_data_source: ModelHandle<conversations::DataSource> =
-            ctx.add_model(|_| conversations::DataSource::historical());
-
         let all_conversation_data_source: ModelHandle<conversations::DataSource> =
             ctx.add_model(|_| conversations::DataSource::new());
 
@@ -71,7 +67,6 @@ impl DataSourceStore {
             warp_drive_data_source,
             launch_config_data_source,
             new_session_data_source,
-            historical_conversation_data_source,
             all_conversation_data_source,
             repo_data_source,
             tabs_data_source: None,
@@ -155,11 +150,6 @@ impl DataSourceStore {
                 mixer.add_sync_source(
                     self.all_conversation_data_source.clone(),
                     HashSet::from([QueryFilter::Conversations]),
-                );
-
-                mixer.add_sync_source(
-                    self.historical_conversation_data_source.clone(),
-                    HashSet::from([QueryFilter::HistoricalConversations]),
                 );
             }
 

--- a/app/src/search/command_palette/filter_chip_renderer.rs
+++ b/app/src/search/command_palette/filter_chip_renderer.rs
@@ -115,11 +115,8 @@ impl FilterChipRenderer for QueryFilter {
             | QueryFilter::Skills
             | QueryFilter::BaseModels
             | QueryFilter::FullTerminalUseModels
+            | QueryFilter::Conversations
             | QueryFilter::CurrentDirectoryConversations => appearance
-                .theme()
-                .main_text_color(appearance.theme().surface_2())
-                .into_solid(),
-            QueryFilter::Conversations | QueryFilter::HistoricalConversations => appearance
                 .theme()
                 .main_text_color(appearance.theme().surface_2())
                 .into_solid(),

--- a/app/src/search/command_palette/view.rs
+++ b/app/src/search/command_palette/view.rs
@@ -337,18 +337,6 @@ impl View {
             .map(|item| &item.search_result)
     }
 
-    pub fn set_fixed_query_filters(
-        &mut self,
-        title: String,
-        filters: Vec<QueryFilter>,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        self.search_bar.update(ctx, |search_bar, ctx| {
-            search_bar.set_fixed_filters(title, filters, ctx);
-        });
-        ctx.notify();
-    }
-
     /// Set the active query filter in the search bar to be `filter`.
     pub fn set_active_query_filter(&mut self, filter: QueryFilter, ctx: &mut ViewContext<Self>) {
         self.search_bar.update(ctx, |view, ctx| {

--- a/app/src/search/data_source.rs
+++ b/app/src/search/data_source.rs
@@ -173,9 +173,6 @@ pub enum QueryFilter {
     /// Filter results for all conversations.
     Conversations,
 
-    /// Filter results for only historical conversations. Used in the "View All" palette on new tabs
-    HistoricalConversations,
-
     /// Filter results for launch configurations.
     LaunchConfigurations,
 
@@ -244,7 +241,6 @@ impl QueryFilter {
             QueryFilter::Sessions => "Search sessions",
             QueryFilter::Tabs => "Search tabs",
             QueryFilter::Conversations => "Search conversations",
-            QueryFilter::HistoricalConversations => "Search historical conversations",
             QueryFilter::LaunchConfigurations => "Search launch configurations",
             QueryFilter::Drive => "Search objects in drive",
             QueryFilter::EnvironmentVariables => "Search environment variables",
@@ -291,7 +287,6 @@ impl QueryFilter {
             QueryFilter::Repos => &REPOS_FILTER_ATOM,
             QueryFilter::DiffSets => &DIFFSETS_FILTER_ATOM,
             QueryFilter::StaticSlashCommands => &STATIC_SLASH_COMMANDS_FILTER_ATOM,
-            QueryFilter::HistoricalConversations => &NO_FILTER_ATOM,
             QueryFilter::Skills => &NO_FILTER_ATOM,
             QueryFilter::BaseModels => &NO_FILTER_ATOM,
             QueryFilter::FullTerminalUseModels => &NO_FILTER_ATOM,
@@ -324,7 +319,6 @@ impl QueryFilter {
             QueryFilter::Repos => "repos",
             QueryFilter::DiffSets => "diff sets",
             QueryFilter::StaticSlashCommands => "slash commands",
-            QueryFilter::HistoricalConversations => "historical conversations",
             QueryFilter::Skills => "skills",
             QueryFilter::BaseModels => "base models",
             QueryFilter::FullTerminalUseModels => "full terminal use models",
@@ -349,9 +343,7 @@ impl QueryFilter {
             QueryFilter::Actions => None,
             QueryFilter::Sessions => Some("bundled/svg/terminal-input.svg"),
             QueryFilter::Tabs => Some("bundled/svg/terminal-input.svg"),
-            QueryFilter::Conversations | QueryFilter::HistoricalConversations => {
-                Some("bundled/svg/conversation.svg")
-            }
+            QueryFilter::Conversations => Some("bundled/svg/conversation.svg"),
             QueryFilter::LaunchConfigurations => Some("bundled/svg/navigation.svg"),
             QueryFilter::Drive => Some("bundled/svg/warp-drive.svg"),
             QueryFilter::EnvironmentVariables => Some("bundled/svg/env-var-collection.svg"),

--- a/app/src/search/search_bar.rs
+++ b/app/src/search/search_bar.rs
@@ -84,18 +84,12 @@ pub enum FilterState {
 
     /// A single filter has been selected by and is visible to the user
     Visible(QueryFilter),
-
-    /// A fixed set of filters has been applied and is not visible to the user
-    Fixed {
-        placeholder_text: String,
-        query_filters: Vec<QueryFilter>,
-    },
 }
 
 /// View state for the search bar.
 pub struct SearchBarState<T: Action + Clone> {
     selected_index: Option<usize>,
-    /// Tracks whether filters are unfiltered, single, or multiple.
+    /// Tracks whether a filter is active.
     query_filter: FilterState,
     /// The filter atom text to be rendered in the Search input, representing the currently applied
     /// filter.
@@ -326,12 +320,10 @@ impl<T: Action + Clone> SearchBarState<T> {
         self.query_result_renderers.as_ref()
     }
 
-    /// Returns the active visible [`QueryFilter`] or `None` if either there is no filter set
-    /// or the search bar is in a "fixed filters" state.
+    /// Returns the active visible [`QueryFilter`] or `None` if there is no filter set.
     pub fn active_visible_query_filter(&self) -> Option<QueryFilter> {
         match self.query_filter {
             FilterState::Visible(filter) => Some(filter),
-            FilterState::Fixed { .. } => None,
             FilterState::Unfiltered => None,
         }
     }
@@ -496,10 +488,7 @@ impl<T: Action + Clone> SearchBar<T> {
                 cleared_buffer_len: buffer_len,
             } => self.buffer_cleared(ctx, *buffer_len),
             EditorEvent::BackspaceOnEmptyBuffer => {
-                // Only clear filter on backspace if it's a user-modifiable state
-                if self.filterable(ctx) {
-                    self.set_visible_query_filter(None, ctx);
-                }
+                self.set_visible_query_filter(None, ctx);
             }
             EditorEvent::Navigate(NavigationKey::Tab) => {
                 self.handle_editor_tab(ctx);
@@ -581,7 +570,6 @@ impl<T: Action + Clone> SearchBar<T> {
         let filter_and_atom_text = match &self.state.as_ref(ctx).query_filter {
             FilterState::Visible(filter) => Some((*filter, filter.filter_atom().primary_text)),
             FilterState::Unfiltered => None,
-            FilterState::Fixed { .. } => None,
         };
         self.set_visible_query_filter(filter_and_atom_text, ctx);
         self.handle_editor_text_update(ctx);
@@ -598,7 +586,7 @@ impl<T: Action + Clone> SearchBar<T> {
             .editor_handle
             .read(ctx, |editor, ctx| editor.buffer_text(ctx));
 
-        if self.filterable(ctx) && !buffer_text.is_empty() {
+        if !buffer_text.is_empty() {
             let registered_filters = self.mixer.as_ref(ctx).registered_filters().collect_vec();
             for filter in registered_filters {
                 if filter.filter_atom().primary_text.starts_with(&buffer_text) {
@@ -626,35 +614,6 @@ impl<T: Action + Clone> SearchBar<T> {
         })
     }
 
-    /// Returns true if this search bar is eligible for user-modifiable filters
-    pub fn filterable(&self, ctx: &ViewContext<Self>) -> bool {
-        match self.state.as_ref(ctx).query_filter {
-            FilterState::Unfiltered => true,
-            FilterState::Visible(_) => true,
-            FilterState::Fixed { .. } => false,
-        }
-    }
-
-    /// Sets this search bar to fixed query filter mode - it will not display the filters to the user
-    /// and the user cannot cancel them by hitting backspace
-    pub fn set_fixed_filters(
-        &mut self,
-        label: String,
-        filters: Vec<QueryFilter>,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        self.state.update(ctx, |state, ctx| {
-            state.query_filter = FilterState::Fixed {
-                placeholder_text: label,
-                query_filters: filters,
-            };
-            ctx.notify();
-        });
-
-        self.update_placeholder_text(ctx);
-        self.run_query_internal(ctx);
-    }
-
     /// Updates the active filter and re-runs the query if the current search state warrants it.
     ///
     /// Empty zero-state buffers skip querying unless this search bar has opted into
@@ -664,24 +623,22 @@ impl<T: Action + Clone> SearchBar<T> {
         filter_and_atom_text: Option<(QueryFilter, &'static str)>,
         ctx: &mut ViewContext<Self>,
     ) {
-        if self.filterable(ctx) {
-            let new_filter = filter_and_atom_text.map(|(filter, _)| filter);
-            let new_filter_atom_text = filter_and_atom_text.map(|(_, atom_text)| atom_text);
-            // NOTE: This event is deferred. When this method starts a query below, handlers
-            // receive it after the async search has already started. Handlers must not reset or
-            // modify the mixer, as doing so would abort the in-flight query without re-running it.
-            ctx.emit(SearchBarEvent::QueryFilterChanged { new_filter });
+        let new_filter = filter_and_atom_text.map(|(filter, _)| filter);
+        let new_filter_atom_text = filter_and_atom_text.map(|(_, atom_text)| atom_text);
+        // NOTE: This event is deferred. When this method starts a query below, handlers
+        // receive it after the async search has already started. Handlers must not reset or
+        // modify the mixer, as doing so would abort the in-flight query without re-running it.
+        ctx.emit(SearchBarEvent::QueryFilterChanged { new_filter });
 
-            self.state.update(ctx, |state, ctx| {
-                state.query_filter = if let Some(filter) = new_filter {
-                    FilterState::Visible(filter)
-                } else {
-                    FilterState::Unfiltered
-                };
-                state.filter_atom_text = new_filter_atom_text;
-                ctx.notify();
-            });
-        }
+        self.state.update(ctx, |state, ctx| {
+            state.query_filter = if let Some(filter) = new_filter {
+                FilterState::Visible(filter)
+            } else {
+                FilterState::Unfiltered
+            };
+            state.filter_atom_text = new_filter_atom_text;
+            ctx.notify();
+        });
 
         if self.should_run_query(ctx) {
             self.run_query_internal(ctx);
@@ -705,7 +662,6 @@ impl<T: Action + Clone> SearchBar<T> {
         let filters: HashSet<QueryFilter> = match &self.state.as_ref(ctx).query_filter {
             FilterState::Unfiltered => HashSet::new(),
             FilterState::Visible(filter) => HashSet::from_iter([*filter]),
-            FilterState::Fixed { query_filters, .. } => HashSet::from_iter(query_filters.clone()),
         };
 
         self.mixer.update(ctx, |mixer, ctx| {
@@ -814,25 +770,23 @@ impl<T: Action + Clone> SearchBar<T> {
                 self.run_query_internal(ctx);
             }
         } else {
-            if self.filterable(ctx) {
-                let registered_filters = self.mixer.as_ref(ctx).registered_filters().collect_vec();
-                for filter in registered_filters {
-                    if let Some(matched_filter_atom) =
-                        filter.filter_atom().query_match(&current_buffer_text)
-                    {
-                        self.set_visible_query_filter(Some((filter, matched_filter_atom)), ctx);
-                        self.editor_handle.update(ctx, |editor, ctx| {
-                            // The 'filter atom text' will be rendered separately (not as text
-                            // within the editor), so remove it from the editor contents.
-                            editor.clear_buffer(ctx);
-                            editor.user_initiated_insert(
-                                current_buffer_text[matched_filter_atom.len()..].trim(),
-                                EditorAction::SystemInsert,
-                                ctx,
-                            );
-                        });
-                        break;
-                    }
+            let registered_filters = self.mixer.as_ref(ctx).registered_filters().collect_vec();
+            for filter in registered_filters {
+                if let Some(matched_filter_atom) =
+                    filter.filter_atom().query_match(&current_buffer_text)
+                {
+                    self.set_visible_query_filter(Some((filter, matched_filter_atom)), ctx);
+                    self.editor_handle.update(ctx, |editor, ctx| {
+                        // The 'filter atom text' will be rendered separately (not as text
+                        // within the editor), so remove it from the editor contents.
+                        editor.clear_buffer(ctx);
+                        editor.user_initiated_insert(
+                            current_buffer_text[matched_filter_atom.len()..].trim(),
+                            EditorAction::SystemInsert,
+                            ctx,
+                        );
+                    });
+                    break;
                 }
             }
             self.run_query_internal(ctx);
@@ -850,11 +804,6 @@ impl<T: Action + Clone> SearchBar<T> {
                 match &self.state.as_ref(ctx).query_filter {
                     FilterState::Visible(filter) => {
                         editor.set_placeholder_text(filter.placeholder_text(), ctx);
-                    }
-                    FilterState::Fixed {
-                        placeholder_text, ..
-                    } => {
-                        editor.set_placeholder_text(placeholder_text.clone(), ctx);
                     }
                     FilterState::Unfiltered => {
                         editor.set_placeholder_text(self.placeholder_text, ctx);
@@ -898,8 +847,8 @@ impl<T: Action + Clone> SearchBar<T> {
     /// (completing the 'history:' atom text) as an autosuggestion.
     fn update_filter_autosuggestion_text(&self, ctx: &mut ViewContext<Self>) {
         match self.state.as_ref(ctx).query_filter {
-            FilterState::Visible(_) | FilterState::Fixed { .. } => {
-                // If there is an active filter or the filters are fixed, there should never be filter autosuggestion text
+            FilterState::Visible(_) => {
+                // If there is an active filter, there should never be filter autosuggestion text
                 // (the user has already applied a filter and can't apply another one).
                 if self.editor_handle.as_ref(ctx).active_autosuggestion() {
                     self.editor_handle.update(ctx, |editor, ctx| {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -12333,17 +12333,6 @@ impl Workspace {
         ctx.notify();
     }
 
-    fn open_recent_repos_and_convos_palette(&mut self, ctx: &mut ViewContext<Self>) {
-        self.palette.update(ctx, |view, ctx| {
-            view.reset(ctx);
-            view.set_fixed_query_filters(
-                "Search recent repos and conversations".to_string(),
-                vec![QueryFilter::HistoricalConversations, QueryFilter::Repos],
-                ctx,
-            );
-        });
-    }
-
     fn open_conversations_palette(&mut self, ctx: &mut ViewContext<Self>) {
         self.palette.update(ctx, |view, ctx| {
             view.reset(ctx);
@@ -12589,7 +12578,6 @@ impl Workspace {
             PaletteMode::WarpDrive => self.open_warp_drive_palette(ctx),
             PaletteMode::Files => self.open_files_palette(ctx),
             PaletteMode::Conversations => self.open_conversations_palette(ctx),
-            PaletteMode::ConversationsAndRepos => self.open_recent_repos_and_convos_palette(ctx),
         }
 
         ctx.focus(&self.palette);

--- a/crates/input_classifier/src/bin/evaluate.rs
+++ b/crates/input_classifier/src/bin/evaluate.rs
@@ -72,7 +72,7 @@ use warp_completer::{ParsedTokensSnapshot, util::parse_current_commands_and_toke
 use input_classifier::{OnnxClassifier, OnnxModel};
 
 // Pick the ONNX model whose bytes are actually embedded in the binary
-#[cfg(feature = "nld_classifier_v1")]
+#[cfg(all(feature = "nld_classifier_v1", not(feature = "nld_classifier_v2")))]
 const DEFAULT_ONNX_MODEL: OnnxModel = OnnxModel::BertTinyV1;
 #[cfg(feature = "nld_classifier_v2")]
 const DEFAULT_ONNX_MODEL: OnnxModel = OnnxModel::BertTinyV2;


### PR DESCRIPTION
## Description
Remove the dead command palette fixed-filter plumbing and the obsolete "recent conversations and repos" palette route.

This deletes:
- The `FilterState::Fixed` search bar mode and fixed-filter APIs.
- `PaletteMode::ConversationsAndRepos` and the workspace opener that used it.
- `QueryFilter::HistoricalConversations`, its historical-only conversation data source wiring, and historical-only searcher mode.

Normal command palette search, typed filter chips, conversation search, repo search, and session navigation palette paths remain intact.

Also fixes the input classifier `evaluate` binary's default ONNX model cfg so all-features clippy can compile past the pre-existing v1/v2 constant conflict.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo +1.92.0 fmt -- --check`
- `cargo +1.92.0 clippy -p warp --lib --tests --all-features -- -D warnings`
- `cargo +1.92.0 test -p warp command_palette --lib`
- `WARP_SHELL_PATH=/bin/bash cargo +1.92.0 run -p integration -- test_palette_opens_when_theme_chooser_is_open`
- `WARP_SHELL_PATH=/bin/bash cargo +1.92.0 run -p integration -- test_session_navigation_recency_change_tab`

Attempted `cargo +1.92.0 clippy --workspace --all-targets --all-features --tests -- -D warnings`; after fixing the first all-features compile error it exposed, the sandbox ran out of disk space while compiling all targets.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; validation used focused command palette and navigation palette integration tests.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/aa992a85-0769-472d-8aa2-5f599ae9ff71_
_Run: https://oz.staging.warp.dev/runs/019e235c-1f8a-7a31-adf9-646583d8e68a_
_This PR was generated with [Oz](https://warp.dev/oz)._
