### PR TITLE
Refactor cloud mode v2 history menu.

### DIFF
--- a/app/src/terminal/input/cloud_mode_v2_history_menu.rs
+++ b/app/src/terminal/input/cloud_mode_v2_history_menu.rs
@@ -3,9 +3,8 @@ use std::collections::HashSet;
 use pathfinder_color::ColorU;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::color::internal_colors;
-use warp_core::ui::theme::Fill;
 use warpui::elements::{
-    Align, Border, ConstrainedBox, Container, CornerRadius, DropShadow, Radius, Text,
+    Border, ChildView, ConstrainedBox, Container, CornerRadius, DropShadow, Radius,
 };
 use warpui::{
     AppContext, Element, Entity, EntityId, ModelHandle, SingletonEntity, View, ViewContext,
@@ -13,14 +12,17 @@ use warpui::{
 };
 
 use crate::ai::blocklist::agent_view::AgentViewController;
-use crate::search::data_source::QueryFilter;
-use crate::terminal::input::buffer_model::InputBufferModel;
+use crate::search::data_source::{Query, QueryFilter};
+use crate::search::mixer::SearchMixer;
+use crate::terminal::input::buffer_model::{InputBufferModel, InputBufferUpdateEvent};
 use crate::terminal::input::inline_history::{
-    AcceptHistoryItem, HistoryTab, InlineHistoryMenuEvent, InlineHistoryMenuView,
+    AcceptHistoryItem, InlineHistoryMenuDataSource, InlineHistoryMenuEvent,
 };
-use crate::terminal::input::inline_menu::styles as inline_menu_styles;
-use crate::terminal::input::inline_menu::{InlineMenuPositioner, InlineMenuTabConfig};
-use crate::terminal::input::suggestions_mode_model::InputSuggestionsModeModel;
+use crate::terminal::input::inline_menu::{InlineMenuEvent, InlineMenuPositioner, InlineMenuView};
+use crate::terminal::input::suggestions_mode_model::{
+    InputSuggestionsModeEvent, InputSuggestionsModeModel,
+};
+use crate::terminal::input::InputSuggestionsMode;
 use crate::terminal::model::session::active_session::ActiveSession;
 
 const MENU_MAX_HEIGHT: f32 = 168.;
@@ -37,7 +39,11 @@ const DROP_SHADOW_COLOR: ColorU = ColorU {
 };
 
 pub struct CloudModeV2HistoryMenuView {
-    inner: ViewHandle<InlineHistoryMenuView>,
+    menu_view: ViewHandle<InlineMenuView<AcceptHistoryItem>>,
+    mixer: ModelHandle<SearchMixer<AcceptHistoryItem>>,
+    buffer_model: ModelHandle<InputBufferModel>,
+    suggestions_mode_model: ModelHandle<InputSuggestionsModeModel>,
+    pending_initial_buffer_sync: bool,
 }
 
 impl CloudModeV2HistoryMenuView {
@@ -51,50 +57,112 @@ impl CloudModeV2HistoryMenuView {
         buffer_model: ModelHandle<InputBufferModel>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        let tab_configs = vec![InlineMenuTabConfig {
-            id: HistoryTab::Prompts,
-            label: "Prompts".to_string(),
-            filters: HashSet::from([QueryFilter::PromptHistory]),
-        }];
-        let inner = ctx.add_view(|ctx| {
-            InlineHistoryMenuView::new_with_tab_configs(
+        let data_source = ctx.add_model(|_| {
+            InlineHistoryMenuDataSource::new(
                 terminal_view_id,
                 active_session,
-                input_suggestions_model,
-                agent_view_controller,
-                positioner,
-                buffer_model,
-                tab_configs,
-                ctx,
+                agent_view_controller.clone(),
             )
         });
 
-        ctx.subscribe_to_view(&inner, |_, _, event, ctx| {
-            ctx.emit(event.clone());
-            ctx.notify();
+        let mixer = ctx.add_model(|ctx| {
+            let mut mixer = SearchMixer::<AcceptHistoryItem>::new();
+            mixer.add_sync_source(data_source, [QueryFilter::PromptHistory]);
+            mixer.run_query(prompts_query(""), ctx);
+            mixer
         });
 
-        Self { inner }
+        let menu_view = ctx.add_typed_action_view(|ctx| {
+            InlineMenuView::new(
+                mixer.clone(),
+                positioner.clone(),
+                input_suggestions_model,
+                agent_view_controller,
+                ctx,
+            )
+            .with_compact_layout()
+            .with_dismiss_on_row_click()
+        });
+
+        ctx.subscribe_to_view(&menu_view, |me, _, event, ctx| match event {
+            InlineMenuEvent::AcceptedItem {
+                item: AcceptHistoryItem::AIPrompt { query_text },
+                ..
+            } => {
+                ctx.emit(InlineHistoryMenuEvent::AcceptAIPrompt {
+                    query_text: query_text.clone(),
+                });
+            }
+            InlineMenuEvent::SelectedItem {
+                item: AcceptHistoryItem::AIPrompt { query_text },
+            } => {
+                ctx.emit(InlineHistoryMenuEvent::SelectAIPrompt {
+                    query_text: query_text.clone(),
+                });
+            }
+            InlineMenuEvent::Dismissed => {
+                me.suggestions_mode_model.update(ctx, |model, ctx| {
+                    model.set_mode(InputSuggestionsMode::Closed, ctx);
+                });
+            }
+            InlineMenuEvent::NoResults => {
+                ctx.emit(InlineHistoryMenuEvent::NoResults);
+            }
+            InlineMenuEvent::AcceptedItem { .. }
+            | InlineMenuEvent::SelectedItem { .. }
+            | InlineMenuEvent::TabChanged => {}
+        });
+
+        ctx.subscribe_to_model(input_suggestions_model, |me, model, event, ctx| {
+            let InputSuggestionsModeEvent::ModeChanged { .. } = event;
+            if model.as_ref(ctx).is_inline_history_menu() {
+                me.open_with_current_buffer(ctx);
+            }
+        });
+
+        ctx.subscribe_to_model(&buffer_model, |me, _, _: &InputBufferUpdateEvent, ctx| {
+            if !me
+                .suggestions_mode_model
+                .as_ref(ctx)
+                .is_inline_history_menu()
+            {
+                return;
+            }
+            if !me.pending_initial_buffer_sync {
+                return;
+            }
+            me.pending_initial_buffer_sync = false;
+            me.open_with_current_buffer(ctx);
+        });
+
+        Self {
+            menu_view,
+            mixer,
+            buffer_model,
+            suggestions_mode_model: input_suggestions_model.clone(),
+            pending_initial_buffer_sync: false,
+        }
     }
 
     pub fn select_up(&self, ctx: &mut ViewContext<Self>) {
-        self.inner.update(ctx, |v, ctx| v.select_up(ctx));
-    }
-
-    pub fn arm_initial_buffer_sync(&self, ctx: &mut ViewContext<Self>) {
-        self.inner.update(ctx, |v, _| v.arm_initial_buffer_sync());
+        self.menu_view.update(ctx, |v, ctx| v.select_up(ctx));
     }
 
     pub fn select_down(&self, ctx: &mut ViewContext<Self>) {
-        self.inner.update(ctx, |v, ctx| v.select_down(ctx));
+        self.menu_view.update(ctx, |v, ctx| v.select_down(ctx));
     }
 
     pub fn accept_selected(&self, ctx: &mut ViewContext<Self>) {
-        self.inner.update(ctx, |v, ctx| v.accept_selected_item(ctx));
+        self.menu_view
+            .update(ctx, |v, ctx| v.accept_selected_item(false, ctx));
+    }
+
+    pub fn arm_initial_buffer_sync(&mut self, _ctx: &mut ViewContext<Self>) {
+        self.pending_initial_buffer_sync = true;
     }
 
     pub fn has_selection(&self, app: &AppContext) -> bool {
-        self.inner
+        self.menu_view
             .as_ref(app)
             .model()
             .as_ref(app)
@@ -104,13 +172,34 @@ impl CloudModeV2HistoryMenuView {
 
     /// Returns the currently selected AI prompt's query text, if any.
     ///
-    /// The cloud-mode V2 menu is restricted to `AcceptHistoryItem::AIPrompt`
-    /// items via its tab filters, so we only ever expect prompt selections.
+    /// The cloud-mode v2 menu is restricted to `AcceptHistoryItem::AIPrompt`
+    /// items via its data source filter, so we only ever expect prompt
+    /// selections; the other arms are unreachable but matched defensively.
     pub fn selected_query_text(&self, app: &AppContext) -> Option<String> {
-        match self.inner.as_ref(app).model().as_ref(app).selected_item()? {
+        match self
+            .menu_view
+            .as_ref(app)
+            .model()
+            .as_ref(app)
+            .selected_item()?
+        {
             AcceptHistoryItem::AIPrompt { query_text } => Some(query_text.clone()),
             AcceptHistoryItem::Command { .. } | AcceptHistoryItem::Conversation { .. } => None,
         }
+    }
+
+    fn open_with_current_buffer(&mut self, ctx: &mut ViewContext<Self>) {
+        let text = self.buffer_model.as_ref(ctx).current_value().to_owned();
+        self.mixer.update(ctx, |mixer, ctx| {
+            mixer.run_query(prompts_query(&text), ctx);
+        });
+    }
+}
+
+fn prompts_query(text: &str) -> Query {
+    Query {
+        text: text.to_owned(),
+        filters: HashSet::from([QueryFilter::PromptHistory]),
     }
 }
 
@@ -124,40 +213,16 @@ impl View for CloudModeV2HistoryMenuView {
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
-        let row_count = self.inner.as_ref(app).result_count(app);
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
         let border_color = internal_colors::neutral_4(theme);
         let background = internal_colors::neutral_1(theme);
 
-        let item_height = appearance.monospace_font_size() + 8.;
-        let visible_row_count = row_count.max(1) as f32;
-        let content_height = (item_height * visible_row_count
-            + 2. * inline_menu_styles::CONTENT_VERTICAL_PADDING)
-            .min(MENU_MAX_HEIGHT);
-
-        let content: Box<dyn Element> = if row_count == 0 {
-            let no_results_text = Text::new(
-                "No results".to_string(),
-                appearance.ui_font_family(),
-                inline_menu_styles::font_size(appearance),
-            )
-            .with_color(
-                theme
-                    .disabled_text_color(Fill::Solid(background))
-                    .into_solid(),
-            )
-            .finish();
-            Align::new(no_results_text).finish()
-        } else {
-            self.inner.as_ref(app).render_results_only(app)
-        };
-
-        let constrained = ConstrainedBox::new(content)
-            .with_height(content_height)
+        let menu_with_height = ConstrainedBox::new(ChildView::new(&self.menu_view).finish())
+            .with_max_height(MENU_MAX_HEIGHT)
             .finish();
 
-        let padded = Container::new(constrained)
+        let padded = Container::new(menu_with_height)
             .with_padding_top(MENU_VERTICAL_PADDING)
             .with_padding_bottom(MENU_VERTICAL_PADDING)
             .finish();

--- a/app/src/terminal/input/cloud_mode_v2_history_menu.rs
+++ b/app/src/terminal/input/cloud_mode_v2_history_menu.rs
@@ -149,7 +149,20 @@ impl CloudModeV2HistoryMenuView {
     }
 
     pub fn select_down(&self, ctx: &mut ViewContext<Self>) {
-        self.menu_view.update(ctx, |v, ctx| v.select_down(ctx));
+        // Mirror the legacy `InlineHistoryMenuView::select_down` behavior:
+        // pressing Down past the last item (or with no results) closes the
+        // history menu rather than wrapping back to the first item.
+        let should_close = self.menu_view.read(ctx, |v, _| {
+            let result_count = v.result_count();
+            let is_last_item_selected =
+                result_count > 0 && v.selected_idx().is_some_and(|idx| idx == result_count - 1);
+            is_last_item_selected || result_count == 0
+        });
+        if should_close {
+            ctx.emit(InlineHistoryMenuEvent::Close);
+        } else {
+            self.menu_view.update(ctx, |v, ctx| v.select_down(ctx));
+        }
     }
 
     pub fn accept_selected(&self, ctx: &mut ViewContext<Self>) {

--- a/app/src/terminal/input/inline_history/mod.rs
+++ b/app/src/terminal/input/inline_history/mod.rs
@@ -6,5 +6,5 @@ mod data_source;
 mod search_item;
 mod view;
 
-pub use data_source::AcceptHistoryItem;
+pub use data_source::{AcceptHistoryItem, InlineHistoryMenuDataSource};
 pub use view::{HistoryTab, InlineHistoryMenuEvent, InlineHistoryMenuView};

--- a/app/src/terminal/input/inline_menu/view.rs
+++ b/app/src/terminal/input/inline_menu/view.rs
@@ -310,6 +310,8 @@ pub struct InlineMenuView<A: InlineMenuAction, T: 'static + Send + Sync = ()> {
     banner_fn: Option<BannerFn>,
     resize_handle: DragResizeHandle,
     drag_indicator_mouse_state: MouseStateHandle,
+    compact_layout: bool,
+    dismiss_on_row_click: bool,
 }
 
 impl<A: InlineMenuAction> InlineMenuView<A> {
@@ -423,6 +425,7 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
 
                 let results = me.mixer.as_ref(ctx).results();
 
+                let dismiss_on_row_click = me.dismiss_on_row_click;
                 me.result_renderers = results
                     .clone()
                     .into_iter()
@@ -444,6 +447,9 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
                                     }
                                 };
                                 ctx.dispatch_typed_action(action);
+                                if dismiss_on_row_click {
+                                    ctx.dispatch_typed_action(InlineMenuRowAction::<A>::Dismiss);
+                                }
                             },
                             *QUERY_RESULT_RENDERER_STYLES,
                         )
@@ -499,11 +505,23 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
             banner_fn: None,
             resize_handle: drag_resize_handle(),
             drag_indicator_mouse_state: MouseStateHandle::default(),
+            compact_layout: false,
+            dismiss_on_row_click: false,
         }
     }
 
     pub fn with_header_config(mut self, config: InlineMenuHeaderConfig) -> Self {
         self.header_config = config;
+        self
+    }
+
+    pub fn with_compact_layout(mut self) -> Self {
+        self.compact_layout = true;
+        self
+    }
+
+    pub fn with_dismiss_on_row_click(mut self) -> Self {
+        self.dismiss_on_row_click = true;
         self
     }
 
@@ -930,8 +948,11 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
             .positioner
             .as_ref(app)
             .should_render_results_in_reverse(app);
-        let horizontal_padding =
-            *terminal::view::PADDING_LEFT - QUERY_RESULT_RENDERER_STYLES.result_horizontal_padding;
+        let horizontal_padding = if self.compact_layout {
+            0.
+        } else {
+            *terminal::view::PADDING_LEFT - QUERY_RESULT_RENDERER_STYLES.result_horizontal_padding
+        };
         let results = self.render_results_only(should_reverse, horizontal_padding, app);
 
         if let Some(banner) = self.banner_fn.as_ref().and_then(|f| f(app)) {
@@ -1099,6 +1120,10 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> View for InlineMenuView<A, T
             } else {
                 content = results_list;
             }
+        }
+
+        if self.compact_layout {
+            return Clipped::new(content).finish();
         }
 
         let aligned_content = if is_rendering_below_input {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Fixes REMOTE-1669 and fixes APP-4450.

Refactors the history menu to remove a layer of indirection that makes supporting new features easier and also eliminates a crash that Aloke experienced (only once ever).

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/7499f85761234f559cedbef62f5a89d9

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

