### PR TITLE
Add NLD classification telemetry in AgentModeChangedInputType

### DIFF
--- a/app/src/ai/blocklist/input_model.rs
+++ b/app/src/ai/blocklist/input_model.rs
@@ -17,7 +17,7 @@ use settings::Setting as _;
 use warp_core::features::FeatureFlag;
 use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
-pub use input_classifier::InputType;
+pub use input_classifier::{ClassificationSource, InputType};
 
 use super::agent_view::{AgentViewController, AgentViewControllerEvent, AgentViewEntryOrigin};
 use super::context_model::BlocklistAIContextModel;
@@ -645,15 +645,39 @@ impl BlocklistAIInputModel {
             .split(',')
             .collect();
 
+        let current_input_type = self.input_type();
+        let is_udi_enabled = InputSettings::as_ref(ctx).is_universal_developer_input_enabled(ctx);
+
         // Early return if the first token is included in the denylist. No need to parse history.
         if denylist.contains(&first_token_str.as_str()) {
+            let new_input_type = InputType::Shell;
             self.set_input_config_internal(
                 InputConfig {
-                    input_type: InputType::Shell,
+                    input_type: new_input_type,
                     ..self.input_config()
                 },
                 ctx,
             );
+            if current_input_type != new_input_type {
+                let buffer_length = input.buffer_text.len();
+                let input_buffer_text_for_telemetry = should_collect_ai_ugc_telemetry(
+                    ctx,
+                    PrivacySettings::as_ref(ctx).is_telemetry_enabled,
+                )
+                .then_some(input.buffer_text.clone());
+                send_telemetry_from_ctx!(
+                    TelemetryEvent::AgentModeChangedInputType {
+                        input: input_buffer_text_for_telemetry,
+                        buffer_length,
+                        is_manually_changed: false,
+                        new_input_type,
+                        active_block_id: self.model.lock().block_list().active_block_id().clone(),
+                        is_udi_enabled,
+                        source: ClassificationSource::Denylist,
+                    },
+                    ctx
+                );
+            }
             return;
         }
 
@@ -677,9 +701,6 @@ impl BlocklistAIInputModel {
 
         let buffer_cloned = input.buffer_text.clone();
         let other_buffer_cloned = buffer_cloned.clone();
-        let current_input_type = self.input_type();
-
-        let is_udi_enabled = InputSettings::as_ref(ctx).is_universal_developer_input_enabled(ctx);
 
         // Determine if the input is a follow-up to an AI block.
         let is_agent_follow_up = {
@@ -700,14 +721,14 @@ impl BlocklistAIInputModel {
                     if matches!(current_input_type, InputType::AI)
                         && is_one_off_natural_language_word(first_token_str.to_lowercase().as_str())
                     {
-                        return InputType::AI;
+                        return (InputType::AI, ClassificationSource::OneOffWhitelist);
                     }
 
                     // If this is clearly intended to be a follow-up to an AI block, classify it as AI.
                     if is_agent_follow_up
                         && is_agent_follow_up_input(&buffer_cloned.trim().to_lowercase())
                     {
-                        return InputType::AI;
+                        return (InputType::AI, ClassificationSource::AgentFollowUp);
                     }
 
                     // If we have history entries (i.e., a live session), check for
@@ -720,7 +741,7 @@ impl BlocklistAIInputModel {
                         )
                         .await
                         {
-                            return InputType::Shell;
+                            return (InputType::Shell, ClassificationSource::HistoryMatch);
                         }
                     }
 
@@ -737,14 +758,14 @@ impl BlocklistAIInputModel {
                         current_input_type,
                         is_agent_follow_up,
                     };
-                    let new_input_type =
+                    let (new_input_type, source) =
                         classifier.detect_input_type(input.clone(), &context).await;
 
                     futures_lite::future::yield_now().await;
 
-                    new_input_type
+                    (new_input_type, source)
                 },
-                move |me, new_input_type, ctx| {
+                move |me, (new_input_type, source), ctx| {
                     // In theory, we shouldn't need to check this, as we only run autodetection if the input
                     // is not locked, and we should abort the autodetect future if the input is locked, but
                     // we do it anyway out of an abundance of caution.
@@ -784,6 +805,7 @@ impl BlocklistAIInputModel {
                                     .active_block_id()
                                     .clone(),
                                 is_udi_enabled,
+                                source,
                             },
                             ctx
                         );

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -61,7 +61,7 @@ pub(crate) use history_model::{
     ConversationStatusUpdate, FORK_PREFIX, PRE_REWIND_PREFIX,
 };
 pub(crate) use input_model::{
-    BlocklistAIInputEvent, BlocklistAIInputModel, InputConfig, InputType,
+    BlocklistAIInputEvent, BlocklistAIInputModel, ClassificationSource, InputConfig, InputType,
 };
 pub(crate) use passive_suggestions::{
     LegacyPassiveSuggestionsEvent, LegacyPassiveSuggestionsModel, MaaPassiveSuggestionsEvent,

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -33,6 +33,7 @@ use crate::ai::agent_management::notifications::NotificationSourceAgent;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::ai::blocklist::AIBlockResponseRating;
+use crate::ai::blocklist::ClassificationSource;
 use crate::ai::blocklist::CommandExecutionPermissionAllowedReason;
 use crate::ai::blocklist::InputType;
 use crate::ai::execution_profiles::AskUserQuestionPermission;
@@ -1992,6 +1993,10 @@ pub enum TelemetryEvent {
         active_block_id: BlockId,
         /// Whether or not Universal Developer Input mode is enabled
         is_udi_enabled: bool,
+        /// Which branch of the NLD pipeline produced this classification. For manual
+        /// user toggles this is [`ClassificationSource::UserManual`]; for autodetection
+        /// it reflects the short-circuit branch or classifier that fired.
+        source: ClassificationSource,
     },
 
     /// Emitted when the user manually toggles the terminal input from AI mode to shell mode when
@@ -3550,8 +3555,9 @@ impl TelemetryEvent {
                 new_input_type,
                 active_block_id,
                 is_udi_enabled,
+                source,
             } => Some(
-                json!({"input": input, "buffer_length": buffer_length, "is_manually_changed": is_manually_changed, "new_input_type": new_input_type, "active_block_id": active_block_id, "is_udi_enabled": is_udi_enabled}),
+                json!({"input": input, "buffer_length": buffer_length, "is_manually_changed": is_manually_changed, "new_input_type": new_input_type, "active_block_id": active_block_id, "is_udi_enabled": is_udi_enabled, "source": source}),
             ),
             TelemetryEvent::AgentModePrediction {
                 was_suggestion_accepted,

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -144,8 +144,8 @@ use crate::{
             telemetry_banner::should_collect_ai_ugc_telemetry,
             BlocklistAIContextEvent, BlocklistAIContextModel, BlocklistAIController,
             BlocklistAIControllerEvent, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
-            BlocklistAIInputEvent, BlocklistAIInputModel, InputConfig, InputType,
-            BLOCK_CONTEXT_ATTACHMENT_REGEX, DIFF_HUNK_ATTACHMENT_REGEX,
+            BlocklistAIInputEvent, BlocklistAIInputModel, ClassificationSource, InputConfig,
+            InputType, BLOCK_CONTEXT_ATTACHMENT_REGEX, DIFF_HUNK_ATTACHMENT_REGEX,
             DRIVE_OBJECT_ATTACHMENT_REGEX,
         },
         llms::{LLMPreferences, LLMPreferencesEvent},
@@ -8571,6 +8571,7 @@ impl Input {
                 new_input_type,
                 active_block_id: self.model.lock().block_list().active_block_id().clone(),
                 is_udi_enabled,
+                source: ClassificationSource::UserManual,
             },
             ctx
         );

--- a/crates/input_classifier/src/bin/evaluate.rs
+++ b/crates/input_classifier/src/bin/evaluate.rs
@@ -222,10 +222,10 @@ async fn handle_classify(
             }
             Err(_) => {
                 // Fallback to detect_input_type if classify_input fails
-                let result = classifier
+                let (result, source) = classifier
                     .detect_input_type(parsed_input.clone(), &context)
                     .await;
-                println!("  {name}: {result} (probabilities unavailable)");
+                println!("  {name}: {result} (source: {source:?}, probabilities unavailable)");
             }
         }
     }
@@ -277,7 +277,7 @@ async fn handle_verify(
                 }
                 Err(_) => {
                     // Fallback to detect_input_type if classify_input fails
-                    let result = classifier
+                    let (result, _source) = classifier
                         .detect_input_type(parsed_input.clone(), &context)
                         .await;
                     let is_correct = result == expected;

--- a/crates/input_classifier/src/heuristic_classifier/mod.rs
+++ b/crates/input_classifier/src/heuristic_classifier/mod.rs
@@ -6,7 +6,7 @@ use natural_language_detection::natural_language_words_score;
 use warp_completer::ParsedTokensSnapshot;
 
 use crate::{
-    ClassificationResult, Context, InputClassifier, InputType,
+    ClassificationResult, ClassificationSource, Context, InputClassifier, InputType,
     parser::parse_query_into_tokens,
     util::{
         is_installed_binary, is_likely_shell_command, is_one_off_natural_language_word_or_prefix,
@@ -39,24 +39,30 @@ pub struct HeuristicClassifier;
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl InputClassifier for HeuristicClassifier {
-    async fn detect_input_type(&self, input: ParsedTokensSnapshot, context: &Context) -> InputType {
+    async fn detect_input_type(
+        &self,
+        input: ParsedTokensSnapshot,
+        context: &Context,
+    ) -> (InputType, ClassificationSource) {
         let word_tokens = parse_query_into_tokens(input.buffer_text.as_str());
         let total_word_token_count = word_tokens.len();
 
         if total_word_token_count == 1
             && is_one_off_natural_language_word_or_prefix(&word_tokens[0].to_lowercase())
         {
-            return InputType::AI;
+            return (InputType::AI, ClassificationSource::OneOffWhitelist);
         }
 
         if is_likely_shell_command(&input, total_word_token_count).await {
-            return InputType::Shell;
+            return (InputType::Shell, ClassificationSource::ShellHeuristic);
         }
 
-        self.classify_input(input, context)
+        let input_type = self
+            .classify_input(input, context)
             .await
             .map(|result| result.to_input_type())
-            .unwrap_or(context.current_input_type)
+            .unwrap_or(context.current_input_type);
+        (input_type, ClassificationSource::NldClassifier)
     }
 
     async fn classify_input(

--- a/crates/input_classifier/src/heuristic_classifier/mod_tests.rs
+++ b/crates/input_classifier/src/heuristic_classifier/mod_tests.rs
@@ -21,7 +21,7 @@ fn test_input_detection() {
 
         let token = mock_parsed_input_token("cargo --version".to_string()).await;
         assert_eq!(
-            classifier.detect_input_type(token, &context).await,
+            classifier.detect_input_type(token, &context).await.0,
             InputType::Shell
         );
 
@@ -32,14 +32,14 @@ fn test_input_detection() {
         let mut token = mock_parsed_input_token("cargo --version".to_string()).await;
         token.parsed_tokens[0].token_description = None;
         assert_eq!(
-            classifier.detect_input_type(token, &context).await,
+            classifier.detect_input_type(token, &context).await.0,
             InputType::Shell
         );
 
         let mut token = mock_parsed_input_token("rvm install 3.3".to_string()).await;
         token.parsed_tokens[0].token_description = None;
         assert_eq!(
-            classifier.detect_input_type(token, &context).await,
+            classifier.detect_input_type(token, &context).await.0,
             InputType::Shell
         );
 
@@ -47,7 +47,7 @@ fn test_input_detection() {
         let mut token = mock_parsed_input_token("Explain this".to_string()).await;
         token.parsed_tokens[0].token_description = None;
         assert_eq!(
-            classifier.detect_input_type(token.clone(), &context).await,
+            classifier.detect_input_type(token.clone(), &context).await.0,
             InputType::AI
         );
 
@@ -57,21 +57,21 @@ fn test_input_detection() {
         let mut token = mock_parsed_input_token("fix this".to_string()).await;
         token.parsed_tokens[0].token_description = None;
         assert_eq!(
-            classifier.detect_input_type(token, &context).await,
+            classifier.detect_input_type(token, &context).await.0,
             InputType::AI,
         );
 
         // Short queries with punctuation should be parsed as AI input.
         let token = mock_parsed_input_token("What went wrong?".to_string()).await;
         assert_eq!(
-            classifier.detect_input_type(token, &context).await,
+            classifier.detect_input_type(token, &context).await.0,
             InputType::AI
         );
         // Short queries with contractions should be parsed as AI input.
         let mut token = mock_parsed_input_token("What's the reason".to_string()).await;
         token.parsed_tokens[0].token_description = None;
         assert_eq!(
-            classifier.detect_input_type(token, &context).await,
+            classifier.detect_input_type(token, &context).await.0,
             InputType::AI
         );
 
@@ -80,7 +80,7 @@ fn test_input_detection() {
             mock_parsed_input_token("The message is \"utils::future ... ok\"".to_string()).await;
         token.parsed_tokens[0].token_description = None;
         assert_eq!(
-            classifier.detect_input_type(token, &context).await,
+            classifier.detect_input_type(token, &context).await.0,
             InputType::AI
         );
 
@@ -88,7 +88,7 @@ fn test_input_detection() {
         let mut token = mock_parsed_input_token("The type is \"<>\"".to_string()).await;
         token.parsed_tokens[0].token_description = None;
         assert_eq!(
-            classifier.detect_input_type(token, &context).await,
+            classifier.detect_input_type(token, &context).await.0,
             InputType::AI
         );
     });

--- a/crates/input_classifier/src/lib.rs
+++ b/crates/input_classifier/src/lib.rs
@@ -7,11 +7,29 @@ pub mod test_utils;
 pub mod util;
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 pub use heuristic_classifier::HeuristicClassifier;
 pub use input_type::InputType;
 #[cfg(feature = "onnx")]
 pub use onnx::{Model as OnnxModel, OnnxClassifier};
+
+/// The decision source that produced the `InputType` returned from
+/// [`InputClassifier::detect_input_type`] (or, for app-level short-circuits,
+/// from the wrapping `BlocklistAIInputModel::detect_and_set_input_type`).
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClassificationSource {
+    Denylist,
+    OneOffWhitelist,
+    AgentFollowUp,
+    HistoryMatch,
+    ShellHeuristic,
+    NldClassifier,
+    NldClassifierFallbackHeuristic,
+    UserManual,
+}
 
 /// An input classifier, which can take some parsed user input and determine
 /// what type of input it is.
@@ -22,7 +40,7 @@ pub trait InputClassifier: 'static + Send + Sync {
         &self,
         input: warp_completer::ParsedTokensSnapshot,
         context: &Context,
-    ) -> InputType;
+    ) -> (InputType, ClassificationSource);
 
     async fn classify_input(
         &self,

--- a/crates/input_classifier/src/onnx/mod.rs
+++ b/crates/input_classifier/src/onnx/mod.rs
@@ -11,7 +11,7 @@ use rust_embed::RustEmbed;
 use warp_completer::ParsedTokensSnapshot;
 
 use crate::{
-    ClassificationResult, Context, InputClassifier, InputType,
+    ClassificationResult, ClassificationSource, Context, InputClassifier, InputType,
     parser::parse_query_into_tokens,
     util::{
         is_likely_shell_command, is_one_off_natural_language_word, is_one_off_shell_command_keyword,
@@ -87,51 +87,18 @@ impl OnnxClassifier {
     }
 }
 
-#[cfg_attr(not(target_family = "wasm"), async_trait)]
-#[cfg_attr(target_family = "wasm", async_trait(?Send))]
-impl InputClassifier for OnnxClassifier {
-    async fn detect_input_type(&self, input: ParsedTokensSnapshot, context: &Context) -> InputType {
-        let word_tokens = parse_query_into_tokens(input.buffer_text.as_str());
-
-        let total_word_token_count = word_tokens.len();
-
-        // Start by applying some simple heuristics before running the full classifier.
-        if let Some(first_word) = word_tokens.first() {
-            let first_word = first_word.to_lowercase();
-
-            // If the input is a single word and the word is one of a specific set of words, classify it as AI
-            if word_tokens.len() == 1 && is_one_off_natural_language_word(&first_word) {
-                return InputType::AI;
-            }
-
-            // If the first token is one of a specific set of shell command keywords (e.g.: echo or sudo),
-            // we should classify it as shell.
-            if is_one_off_shell_command_keyword(&first_word) {
-                return InputType::Shell;
-            }
-        }
-
-        if is_likely_shell_command(&input, total_word_token_count).await {
-            return InputType::Shell;
-        }
-
-        // Otherwise, defer all decision-making to the model.
-        self.classify_input(input, context)
-            .await
-            .map(|result| result.to_input_type())
-            .unwrap_or(context.current_input_type)
-    }
-
-    async fn classify_input(
+impl OnnxClassifier {
+    async fn classify_input_with_source(
         &self,
         input: warp_completer::ParsedTokensSnapshot,
-        _context: &Context,
-    ) -> anyhow::Result<ClassificationResult> {
+        context: &Context,
+    ) -> anyhow::Result<(ClassificationResult, ClassificationSource)> {
         // If we ever panicked while running inference, we should fall back to the heuristic classifier.
         if self.has_panicked.has_panicked() {
-            return crate::heuristic_classifier::HeuristicClassifier
-                .classify_input(input, _context)
-                .await;
+            let result = crate::heuristic_classifier::HeuristicClassifier
+                .classify_input(input, context)
+                .await?;
+            return Ok((result, ClassificationSource::NldClassifierFallbackHeuristic));
         }
 
         // Given that we only can get here if we have never panicked, we don't have to
@@ -161,17 +128,66 @@ impl InputClassifier for OnnxClassifier {
                 }
             }
         }) {
-            Ok(result) => result,
+            // Inference ran cleanly (success or non-panic error): the model is the source.
+            Ok(result) => result.map(|r| (r, ClassificationSource::NldClassifier)),
+            // Inference panicked: mark the sticky bit and fall back to the heuristic.
             Err(_) => {
                 log::error!(
                     "Caught panic while running inference; falling back to heuristic classifier."
                 );
                 self.has_panicked.on_panic();
-                crate::heuristic_classifier::HeuristicClassifier
-                    .classify_input(input, _context)
-                    .await
+                let result = crate::heuristic_classifier::HeuristicClassifier
+                    .classify_input(input, context)
+                    .await?;
+                Ok((result, ClassificationSource::NldClassifierFallbackHeuristic))
             }
         }
+    }
+}
+
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+impl InputClassifier for OnnxClassifier {
+    async fn detect_input_type(
+        &self,
+        input: ParsedTokensSnapshot,
+        context: &Context,
+    ) -> (InputType, ClassificationSource) {
+        let word_tokens = parse_query_into_tokens(input.buffer_text.as_str());
+
+        let total_word_token_count = word_tokens.len();
+
+
+        if let Some(first_word) = word_tokens.first() {
+            let first_word = first_word.to_lowercase();
+
+            if word_tokens.len() == 1 && is_one_off_natural_language_word(&first_word) {
+                return (InputType::AI, ClassificationSource::OneOffWhitelist);
+            }
+
+            if is_one_off_shell_command_keyword(&first_word) {
+                return (InputType::Shell, ClassificationSource::OneOffWhitelist);
+            }
+        }
+
+        if is_likely_shell_command(&input, total_word_token_count).await {
+            return (InputType::Shell, ClassificationSource::ShellHeuristic);
+        }
+
+        match self.classify_input_with_source(input, context).await {
+            Ok((result, source)) => (result.to_input_type(), source),
+            Err(_) => (context.current_input_type, ClassificationSource::NldClassifier),
+        }
+    }
+
+    async fn classify_input(
+        &self,
+        input: warp_completer::ParsedTokensSnapshot,
+        context: &Context,
+    ) -> anyhow::Result<ClassificationResult> {
+        self.classify_input_with_source(input, context)
+            .await
+            .map(|(result, _source)| result)
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
