### PR TITLE
docs: clarify bug readiness wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for helping improve Warp! This guide explains how to open issues, propose
 
 ## TL;DR
 
-- Bug fixes are welcome for any issue. All bugs are marked as `ready-to-implement`.
+- Bug fixes are welcome once the report is actionable from the provided details or maintainer triage.
 - Feature requests must be marked `ready-to-spec` or `ready-to-implement` before PRs are accepted.
 - Specs are the place where technical and design discussion on larger issues happen.
 - Oz automatically triages incoming issues and reviews open PRs.
@@ -20,7 +20,7 @@ Warp's contribution model is shaped by [Oz](https://oz.warp.dev), an agent that 
 - **Feature requests differ from bug fixes:**
   - Features are gated by readiness labels — `ready-to-spec`, then `ready-to-implement` once the design is settled — that signal when contributors can pick up the work. Discussion alone is not approval to begin work.
   - Feature work needs a written spec first: feature requests go through a spec PR (a *product spec* + *tech spec* committed under [`specs/`](specs/)) before any code is written.
-  - Bug fixes skip both steps; they are implicitly `ready-to-implement` once triaged.
+  - Bug fixes can go straight to a code PR once the report is reproducible or otherwise actionable; they do not require spec PRs unless the scope or design is unclear.
 - **Review is largely automated.** When you open a PR, Oz is auto-assigned and produces an initial review. Once Oz approves, it automatically requests a follow-up review from a Warp team subject-matter expert — you do not need to assign human reviewers yourself.
 
 ### Readiness labels
@@ -28,7 +28,7 @@ Warp's contribution model is shaped by [Oz](https://oz.warp.dev), an agent that 
 The Warp team applies one of the following labels when an issue is ready for contribution:
 
 - **`ready-to-spec`** — The problem is understood but the design is open. Open a spec PR with a *product spec* (`product.md`) and a *tech spec* (`tech.md`) under [`specs/`](specs/) — see [Opening a Spec PR](#opening-a-spec-pr) for what goes in each. This label is **reserved for feature requests**.
-- **`ready-to-implement`** — The design is settled. Open a code PR. **All triaged bug reports are implicitly `ready-to-implement`** once accepted — you don't need to wait for an explicit label on a confirmed bug.
+- **`ready-to-implement`** — The issue is ready for a code PR. For bugs, this means the report is sufficiently reproducible or actionable and the likely fix does not need a spec, mocks, or deeper investigation.
 - **`needs-mocks`** — Design mocks are required before implementation can begin. Wait for the Warp team to land them.
 
 Anyone can pick up a ready issue — readiness labels are not assignments, and the best implementation wins through normal review. If an issue has been sitting un-triaged or you'd like readiness re-evaluated, mention **@oss-maintainers** in a comment to flag it for the team.
@@ -44,7 +44,7 @@ flowchart TD
     B -- needs-mocks --> D[Design mocks produced]
     D --> E[Open code PR]
     C -- specs approved --> E
-    B -- ready-to-implement<br/>(incl. all triaged bugs) --> E
+    B -- ready-to-implement<br/>(actionable bugs or settled designs) --> E
     E --> F[Oz review → SME review → CI → merge]
 
     classDef contributor fill:#fef3c7,stroke:#b45309,color:#78350f;
@@ -69,7 +69,7 @@ A good bug report includes:
 - Warp version and OS (see `Settings → About`).
 - Logs, screenshots, or screen recordings when relevant.
 
-Once an issue is triaged as a bug (by Oz's triage agent or a maintainer), it is implicitly **`ready-to-implement`** — you can pick it up and open a code PR without waiting for a separate label.
+Once an issue is triaged as an actionable bug (by Oz's triage agent or a maintainer), it may be labeled **`ready-to-implement`** so you can pick it up and open a code PR.
 
 ### Feature requests
 
@@ -99,7 +99,7 @@ To open a spec PR:
 
 ## Opening a Code PR
 
-For issues labeled `ready-to-implement` (this includes any triaged bug):
+For issues labeled `ready-to-implement`:
 
 1. Branch from `master`.
 2. Implement the change and add tests (see [Testing](#testing)).

--- a/FAQ.md
+++ b/FAQ.md
@@ -6,7 +6,7 @@ This FAQ covers the questions we hear most often about contributing to the Warp 
 
 ### How do I contribute?
 
-Start with a GitHub issue. Bug reports are implicitly ready to fix once triaged; feature requests go through a short spec PR before any code is written. The full flow — readiness labels, spec PRs, code PRs, review — is documented in [CONTRIBUTING.md](CONTRIBUTING.md).
+Start with a GitHub issue. Bug reports can go straight to a code PR once they are triaged as actionable; feature requests go through a short spec PR before any code is written. The full flow — readiness labels, spec PRs, code PRs, review — is documented in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### How do I file a good bug report or feature request?
 
@@ -17,7 +17,7 @@ If you're already running Warp, the `/feedback` command files an issue with logs
 ### What do the readiness labels mean?
 
 - **`ready-to-spec`** — the problem is understood, the design is open. Next step is a spec PR.
-- **`ready-to-implement`** — the design is settled, or it's a triaged bug. Next step is a code PR.
+- **`ready-to-implement`** — the issue is ready for a code PR. For bugs, this means the report is sufficiently reproducible or actionable.
 - **`needs-mocks`** — design mocks are required before implementation can start.
 
 Anyone can pick up a labeled issue. Mention **@oss-maintainers** on an issue if it needs triage or readiness re-evaluation.


### PR DESCRIPTION
## Description
Updates `CONTRIBUTING.md` and `FAQ.md` to remove language saying all triaged bug reports are explicitly or implicitly `ready-to-implement`.

Clarifies that bug readiness depends on the report being reproducible or actionable and not requiring a spec, mocks, or deeper investigation.

## Linked Issue
Slack request; no linked GitHub issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. N/A — docs-only Slack request.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes). N/A — docs-only copy change.

## Testing
- `git -C /workspace/warp --no-pager diff --check`
- Phrase check for removed readiness wording in `CONTRIBUTING.md` and `FAQ.md`

- [ ] I have manually tested my changes locally with `./script/run`. N/A — docs-only copy change.

### Screenshots / Videos
N/A — docs-only copy change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/c915a2f3-3a97-499e-b50d-e348da673f84_
_Run: https://oz.staging.warp.dev/runs/019e23c0-de09-7c47-8b32-af0420e13e43_
_This PR was generated with [Oz](https://warp.dev/oz)._
