### PR TITLE
Fix errant task status update emission from cloud agent viewer client.

### DIFF
--- a/app/src/ai/active_agent_views_model.rs
+++ b/app/src/ai/active_agent_views_model.rs
@@ -5,7 +5,9 @@ use chrono::{DateTime, Utc};
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent_conversations_model::AgentConversationEntryId;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
-use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
+use crate::ai::blocklist::agent_view::{
+    AgentViewController, AgentViewControllerEvent, AgentViewEntryOrigin,
+};
 use crate::ai::blocklist::orchestration_event_streamer::{
     register_agent_event_consumer, unregister_agent_event_consumer,
 };
@@ -487,6 +489,20 @@ impl ActiveAgentViewsModel {
         }
 
         None
+    }
+
+    /// Returns the active agent-view entry origin for a terminal view.
+    pub fn agent_view_origin_for_terminal_view(
+        &self,
+        terminal_view_id: EntityId,
+        ctx: &AppContext,
+    ) -> Option<AgentViewEntryOrigin> {
+        let controller = self
+            .agent_view_handles
+            .get(&terminal_view_id)?
+            .controller
+            .upgrade(ctx)?;
+        controller.as_ref(ctx).agent_view_state().origin()
     }
 
     /// Get all currently active conversation IDs.

--- a/app/src/ai/blocklist/agent_view/controller.rs
+++ b/app/src/ai/blocklist/agent_view/controller.rs
@@ -260,6 +260,13 @@ impl AgentViewState {
         }
     }
 
+    pub fn origin(&self) -> Option<AgentViewEntryOrigin> {
+        match self {
+            AgentViewState::Active { origin, .. } => Some(*origin),
+            AgentViewState::Inactive => None,
+        }
+    }
+
     /// Returns `true` if in an active agent view state.
     pub fn is_active(&self) -> bool {
         matches!(self, AgentViewState::Active { .. })

--- a/app/src/ai/blocklist/task_status_sync_model.rs
+++ b/app/src/ai/blocklist/task_status_sync_model.rs
@@ -1,9 +1,11 @@
 use super::history_model::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatusUpdate,
 };
+use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::agent::{AIAgentOutputStatus, FinishedAIAgentOutput, RenderableAIError};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::server::server_api::ai::{AIClient, TaskStatusUpdate};
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::cli_agent_sessions::{
@@ -87,11 +89,12 @@ impl TaskStatusSyncModel {
         match event {
             BlocklistAIHistoryEvent::UpdatedConversationStatus {
                 conversation_id,
+                terminal_view_id,
                 update,
                 ..
             } => {
                 if matches!(update, ConversationStatusUpdate::Changed { .. }) {
-                    self.on_conversation_status_updated(*conversation_id, ctx);
+                    self.on_conversation_status_updated(*conversation_id, *terminal_view_id, ctx);
                 }
             }
             // When the server token (and thus task_id) is first assigned to a
@@ -99,9 +102,10 @@ impl TaskStatusSyncModel {
             // where ConversationStatus::InProgress fires before task_id is
             // available — we catch up here once the task_id arrives.
             BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
-                conversation_id, ..
+                conversation_id,
+                terminal_view_id,
             } => {
-                self.on_conversation_status_updated(*conversation_id, ctx);
+                self.on_conversation_status_updated(*conversation_id, *terminal_view_id, ctx);
             }
             _ => {}
         }
@@ -132,9 +136,16 @@ impl TaskStatusSyncModel {
     fn on_conversation_status_updated(
         &self,
         conversation_id: AIConversationId,
+        terminal_view_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
         let (task_id, task_state, status_message) = {
+            if !should_sync_task_status_to_server(
+                ActiveAgentViewsModel::as_ref(ctx)
+                    .agent_view_origin_for_terminal_view(terminal_view_id, ctx),
+            ) {
+                return;
+            }
             let Some(conversation) =
                 BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
             else {
@@ -201,6 +212,13 @@ impl TaskStatusSyncModel {
             |_, _, _| {},
         );
     }
+}
+
+pub(crate) fn should_sync_task_status_to_server(origin: Option<AgentViewEntryOrigin>) -> bool {
+    !matches!(
+        origin,
+        Some(AgentViewEntryOrigin::CloudAgent | AgentViewEntryOrigin::ThirdPartyCloudAgent)
+    )
 }
 
 impl Entity for TaskStatusSyncModel {

--- a/app/src/ai/blocklist/task_status_sync_model_tests.rs
+++ b/app/src/ai/blocklist/task_status_sync_model_tests.rs
@@ -1,9 +1,9 @@
+use super::{classify_renderable_error, map_cli_session_status, should_sync_task_status_to_server};
 use crate::ai::agent::RenderableAIError;
+use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::server::server_api::ai::TaskStatusUpdate;
 use crate::terminal::cli_agent_sessions::CLIAgentSessionStatus;
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
-
-use super::{classify_renderable_error, map_cli_session_status};
 
 /// Helper to assert a (state, Option<TaskStatusUpdate>) tuple.
 fn assert_update(
@@ -142,4 +142,22 @@ fn cli_blocked_without_message() {
     let (state, update) = map_cli_session_status(&CLIAgentSessionStatus::Blocked { message: None });
     assert_eq!(state, AgentTaskState::Blocked);
     assert!(update.is_none());
+}
+
+#[test]
+fn cloud_agent_view_origin_does_not_sync_task_status() {
+    assert!(!should_sync_task_status_to_server(Some(
+        AgentViewEntryOrigin::CloudAgent
+    )));
+    assert!(!should_sync_task_status_to_server(Some(
+        AgentViewEntryOrigin::ThirdPartyCloudAgent
+    )));
+}
+
+#[test]
+fn driver_and_unknown_view_origins_sync_task_status() {
+    assert!(should_sync_task_status_to_server(Some(
+        AgentViewEntryOrigin::Cli
+    )));
+    assert!(should_sync_task_status_to_server(None));
 }


### PR DESCRIPTION
## Description

Don't sync task status updates back to the server for cloud mode viewer clients, should only be done by the actual agent driver client. This codepath was getting hit both for the cloud mode viewer client and the executor client, which revealed a race condition in the task status state machine in the server.
