### PR TITLE
Remove dead command palette fixed filters

### DIFF
--- a/app/src/palette.rs
+++ b/app/src/palette.rs
@@ -8,5 +8,4 @@ pub enum PaletteMode {
     WarpDrive,
     Files,
     Conversations,
-    ConversationsAndRepos,
 }

--- a/app/src/search/command_palette/conversations/data_source.rs
+++ b/app/src/search/command_palette/conversations/data_source.rs
@@ -75,13 +75,6 @@ impl DataSource {
         }
     }
 
-    pub fn historical() -> Self {
-        Self {
-            searcher: FuzzyConversationSearcher::historical(),
-            add_conversation_actions: false,
-        }
-    }
-
     /// Returns a [`QueryResult`] for a conversation identified by `conversation_id`. `None` if no result was
     /// found with the given ID.
     pub fn query_result(

--- a/app/src/search/command_palette/conversations/search.rs
+++ b/app/src/search/command_palette/conversations/search.rs
@@ -178,36 +178,15 @@ pub trait ConversationSearcher {
     ) -> anyhow::Result<Vec<QueryResult<SearcherAction>>>;
 }
 
-#[derive(PartialEq)]
-pub enum ConversationType {
-    All,
-    Historical,
-}
-
-pub struct FuzzyConversationSearcher {
-    filter: ConversationType,
-}
+pub struct FuzzyConversationSearcher;
 
 impl FuzzyConversationSearcher {
     pub fn new() -> Self {
-        Self {
-            filter: ConversationType::All,
-        }
-    }
-
-    pub fn historical() -> Self {
-        Self {
-            filter: ConversationType::Historical,
-        }
+        Self
     }
 
     pub fn searchable_conversations(&self, app: &AppContext) -> Vec<ConversationNavigationData> {
-        match self.filter {
-            ConversationType::Historical => {
-                ConversationNavigationData::historical_conversations(app)
-            }
-            ConversationType::All => ConversationNavigationData::all_conversations(app),
-        }
+        ConversationNavigationData::all_conversations(app)
     }
 }
 

--- a/app/src/search/command_palette/data_sources.rs
+++ b/app/src/search/command_palette/data_sources.rs
@@ -31,7 +31,6 @@ pub struct DataSourceStore {
     warp_drive_data_source: ModelHandle<warp_drive::DataSource>,
     launch_config_data_source: ModelHandle<launch_config::DataSource>,
     new_session_data_source: Option<ModelHandle<NewSessionDataSource>>,
-    historical_conversation_data_source: ModelHandle<conversations::DataSource>,
     all_conversation_data_source: ModelHandle<conversations::DataSource>,
     repo_data_source: ModelHandle<RepoDataSource>,
     tabs_data_source: Option<ModelHandle<tabs::DataSource>>,
@@ -57,9 +56,6 @@ impl DataSourceStore {
             && cfg!(feature = "local_tty"))
         .then_some(ctx.add_model(|ctx| NewSessionDataSource::new(binding_source, ctx)));
 
-        let historical_conversation_data_source: ModelHandle<conversations::DataSource> =
-            ctx.add_model(|_| conversations::DataSource::historical());
-
         let all_conversation_data_source: ModelHandle<conversations::DataSource> =
             ctx.add_model(|_| conversations::DataSource::new());
 
@@ -71,7 +67,6 @@ impl DataSourceStore {
             warp_drive_data_source,
             launch_config_data_source,
             new_session_data_source,
-            historical_conversation_data_source,
             all_conversation_data_source,
             repo_data_source,
             tabs_data_source: None,
@@ -155,11 +150,6 @@ impl DataSourceStore {
                 mixer.add_sync_source(
                     self.all_conversation_data_source.clone(),
                     HashSet::from([QueryFilter::Conversations]),
-                );
-
-                mixer.add_sync_source(
-                    self.historical_conversation_data_source.clone(),
-                    HashSet::from([QueryFilter::HistoricalConversations]),
                 );
             }
 

--- a/app/src/search/command_palette/filter_chip_renderer.rs
+++ b/app/src/search/command_palette/filter_chip_renderer.rs
@@ -119,7 +119,7 @@ impl FilterChipRenderer for QueryFilter {
                 .theme()
                 .main_text_color(appearance.theme().surface_2())
                 .into_solid(),
-            QueryFilter::Conversations | QueryFilter::HistoricalConversations => appearance
+            QueryFilter::Conversations => appearance
                 .theme()
                 .main_text_color(appearance.theme().surface_2())
                 .into_solid(),

--- a/app/src/search/command_palette/view.rs
+++ b/app/src/search/command_palette/view.rs
@@ -337,22 +337,10 @@ impl View {
             .map(|item| &item.search_result)
     }
 
-    pub fn set_fixed_query_filters(
-        &mut self,
-        title: String,
-        filters: Vec<QueryFilter>,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        self.search_bar.update(ctx, |search_bar, ctx| {
-            search_bar.set_fixed_filters(title, filters, ctx);
-        });
-        ctx.notify();
-    }
-
     /// Set the active query filter in the search bar to be `filter`.
     pub fn set_active_query_filter(&mut self, filter: QueryFilter, ctx: &mut ViewContext<Self>) {
         self.search_bar.update(ctx, |view, ctx| {
-            view.set_visible_query_filter(Some((filter, filter.filter_atom().primary_text)), ctx)
+            view.set_query_filter(Some((filter, filter.filter_atom().primary_text)), ctx)
         });
         ctx.notify();
     }
@@ -385,9 +373,7 @@ impl View {
 
     /// Returns the active query filters
     pub fn active_query_filter(&self, app: &AppContext) -> Option<QueryFilter> {
-        self.search_bar_state
-            .as_ref(app)
-            .active_visible_query_filter()
+        self.search_bar_state.as_ref(app).active_query_filter()
     }
 
     pub fn is_mode_enabled(&self, mode: PaletteMode, app: &AppContext) -> bool {

--- a/app/src/search/command_search/view.rs
+++ b/app/src/search/command_search/view.rs
@@ -405,10 +405,7 @@ impl CommandSearchView {
 
     fn close(&self, ctx: &mut ViewContext<Self>) {
         let query = self.search_bar.as_ref(ctx).query(ctx);
-        let filter = self
-            .search_bar_state
-            .as_ref(ctx)
-            .active_visible_query_filter();
+        let filter = self.search_bar_state.as_ref(ctx).active_query_filter();
         ctx.emit(CommandSearchEvent::Close { query, filter });
     }
 
@@ -484,15 +481,13 @@ impl CommandSearchView {
         ctx: &mut ViewContext<Self>,
     ) {
         self.search_bar.update(ctx, |search_bar, ctx| {
-            search_bar.set_visible_query_filter(filter_and_atom_text, ctx);
+            search_bar.set_query_filter(filter_and_atom_text, ctx);
         });
     }
 
     /// Returns the active query filters
     fn active_query_filter(&self, app: &AppContext) -> Option<QueryFilter> {
-        self.search_bar_state
-            .as_ref(app)
-            .active_visible_query_filter()
+        self.search_bar_state.as_ref(app).active_query_filter()
     }
 
     /// Emits the `ItemSelected` event containing the passed `CommandSearchEventPayload` and closes
@@ -545,10 +540,7 @@ impl CommandSearchView {
                 TelemetryEvent::CommandSearchResultAccepted {
                     result_index,
                     result_type: (&result_action).into(),
-                    query_filter: self
-                        .search_bar_state
-                        .as_ref(ctx)
-                        .active_visible_query_filter(),
+                    query_filter: self.search_bar_state.as_ref(ctx).active_query_filter(),
                     buffer_length: self.search_bar.as_ref(ctx).query(ctx).len(),
                     was_immediately_executed,
                 },

--- a/app/src/search/data_source.rs
+++ b/app/src/search/data_source.rs
@@ -173,9 +173,6 @@ pub enum QueryFilter {
     /// Filter results for all conversations.
     Conversations,
 
-    /// Filter results for only historical conversations. Used in the "View All" palette on new tabs
-    HistoricalConversations,
-
     /// Filter results for launch configurations.
     LaunchConfigurations,
 
@@ -244,7 +241,6 @@ impl QueryFilter {
             QueryFilter::Sessions => "Search sessions",
             QueryFilter::Tabs => "Search tabs",
             QueryFilter::Conversations => "Search conversations",
-            QueryFilter::HistoricalConversations => "Search historical conversations",
             QueryFilter::LaunchConfigurations => "Search launch configurations",
             QueryFilter::Drive => "Search objects in drive",
             QueryFilter::EnvironmentVariables => "Search environment variables",
@@ -291,7 +287,6 @@ impl QueryFilter {
             QueryFilter::Repos => &REPOS_FILTER_ATOM,
             QueryFilter::DiffSets => &DIFFSETS_FILTER_ATOM,
             QueryFilter::StaticSlashCommands => &STATIC_SLASH_COMMANDS_FILTER_ATOM,
-            QueryFilter::HistoricalConversations => &NO_FILTER_ATOM,
             QueryFilter::Skills => &NO_FILTER_ATOM,
             QueryFilter::BaseModels => &NO_FILTER_ATOM,
             QueryFilter::FullTerminalUseModels => &NO_FILTER_ATOM,
@@ -324,7 +319,6 @@ impl QueryFilter {
             QueryFilter::Repos => "repos",
             QueryFilter::DiffSets => "diff sets",
             QueryFilter::StaticSlashCommands => "slash commands",
-            QueryFilter::HistoricalConversations => "historical conversations",
             QueryFilter::Skills => "skills",
             QueryFilter::BaseModels => "base models",
             QueryFilter::FullTerminalUseModels => "full terminal use models",
@@ -349,9 +343,7 @@ impl QueryFilter {
             QueryFilter::Actions => None,
             QueryFilter::Sessions => Some("bundled/svg/terminal-input.svg"),
             QueryFilter::Tabs => Some("bundled/svg/terminal-input.svg"),
-            QueryFilter::Conversations | QueryFilter::HistoricalConversations => {
-                Some("bundled/svg/conversation.svg")
-            }
+            QueryFilter::Conversations => Some("bundled/svg/conversation.svg"),
             QueryFilter::LaunchConfigurations => Some("bundled/svg/navigation.svg"),
             QueryFilter::Drive => Some("bundled/svg/warp-drive.svg"),
             QueryFilter::EnvironmentVariables => Some("bundled/svg/env-var-collection.svg"),

--- a/app/src/search/search_bar.rs
+++ b/app/src/search/search_bar.rs
@@ -76,27 +76,11 @@ impl MoveDirection {
     }
 }
 
-/// Represents the current filter mode/state for the search bar.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum FilterState {
-    /// No filter has been applied, but the user can apply a filter by typing an atom
-    Unfiltered,
-
-    /// A single filter has been selected by and is visible to the user
-    Visible(QueryFilter),
-
-    /// A fixed set of filters has been applied and is not visible to the user
-    Fixed {
-        placeholder_text: String,
-        query_filters: Vec<QueryFilter>,
-    },
-}
-
 /// View state for the search bar.
 pub struct SearchBarState<T: Action + Clone> {
     selected_index: Option<usize>,
-    /// Tracks whether filters are unfiltered, single, or multiple.
-    query_filter: FilterState,
+    /// The active query filter, if any.
+    query_filter: Option<QueryFilter>,
     /// The filter atom text to be rendered in the Search input, representing the currently applied
     /// filter.
     filter_atom_text: Option<&'static str>,
@@ -169,7 +153,7 @@ impl<T: Action + Clone> SearchBarState<T> {
     pub fn new(ordering: SearchResultOrdering) -> Self {
         Self {
             selected_index: None,
-            query_filter: FilterState::Unfiltered,
+            query_filter: None,
             filter_atom_text: None,
             query_result_renderers: None,
             ordering,
@@ -326,14 +310,9 @@ impl<T: Action + Clone> SearchBarState<T> {
         self.query_result_renderers.as_ref()
     }
 
-    /// Returns the active visible [`QueryFilter`] or `None` if either there is no filter set
-    /// or the search bar is in a "fixed filters" state.
-    pub fn active_visible_query_filter(&self) -> Option<QueryFilter> {
-        match self.query_filter {
-            FilterState::Visible(filter) => Some(filter),
-            FilterState::Fixed { .. } => None,
-            FilterState::Unfiltered => None,
-        }
+    /// Returns the active [`QueryFilter`], if any.
+    pub fn active_query_filter(&self) -> Option<QueryFilter> {
+        self.query_filter
     }
 
     /// Returns the index of currently selected search result.
@@ -496,10 +475,7 @@ impl<T: Action + Clone> SearchBar<T> {
                 cleared_buffer_len: buffer_len,
             } => self.buffer_cleared(ctx, *buffer_len),
             EditorEvent::BackspaceOnEmptyBuffer => {
-                // Only clear filter on backspace if it's a user-modifiable state
-                if self.filterable(ctx) {
-                    self.set_visible_query_filter(None, ctx);
-                }
+                self.set_query_filter(None, ctx);
             }
             EditorEvent::Navigate(NavigationKey::Tab) => {
                 self.handle_editor_tab(ctx);
@@ -555,11 +531,7 @@ impl<T: Action + Clone> SearchBar<T> {
         self.state.update(ctx, |state, ctx| {
             state.ordering = ordering;
 
-            state.query_filter = if let Some(filter) = query_filter {
-                FilterState::Visible(filter)
-            } else {
-                FilterState::Unfiltered
-            };
+            state.query_filter = query_filter;
 
             ctx.notify();
         });
@@ -578,12 +550,12 @@ impl<T: Action + Clone> SearchBar<T> {
 
         // Reset the query filter state before processing any initial query text,
         // as it may contain a filter atom that should be immediately applied.
-        let filter_and_atom_text = match &self.state.as_ref(ctx).query_filter {
-            FilterState::Visible(filter) => Some((*filter, filter.filter_atom().primary_text)),
-            FilterState::Unfiltered => None,
-            FilterState::Fixed { .. } => None,
-        };
-        self.set_visible_query_filter(filter_and_atom_text, ctx);
+        let filter_and_atom_text = self
+            .state
+            .as_ref(ctx)
+            .query_filter
+            .map(|filter| (filter, filter.filter_atom().primary_text));
+        self.set_query_filter(filter_and_atom_text, ctx);
         self.handle_editor_text_update(ctx);
         ctx.notify();
     }
@@ -598,16 +570,13 @@ impl<T: Action + Clone> SearchBar<T> {
             .editor_handle
             .read(ctx, |editor, ctx| editor.buffer_text(ctx));
 
-        if self.filterable(ctx) && !buffer_text.is_empty() {
+        if !buffer_text.is_empty() && self.state.as_ref(ctx).query_filter.is_none() {
             let registered_filters = self.mixer.as_ref(ctx).registered_filters().collect_vec();
             for filter in registered_filters {
                 if filter.filter_atom().primary_text.starts_with(&buffer_text) {
                     self.editor_handle
                         .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
-                    self.set_visible_query_filter(
-                        Some((filter, filter.filter_atom().primary_text)),
-                        ctx,
-                    );
+                    self.set_query_filter(Some((filter, filter.filter_atom().primary_text)), ctx);
                 }
             }
         }
@@ -626,62 +595,27 @@ impl<T: Action + Clone> SearchBar<T> {
         })
     }
 
-    /// Returns true if this search bar is eligible for user-modifiable filters
-    pub fn filterable(&self, ctx: &ViewContext<Self>) -> bool {
-        match self.state.as_ref(ctx).query_filter {
-            FilterState::Unfiltered => true,
-            FilterState::Visible(_) => true,
-            FilterState::Fixed { .. } => false,
-        }
-    }
-
-    /// Sets this search bar to fixed query filter mode - it will not display the filters to the user
-    /// and the user cannot cancel them by hitting backspace
-    pub fn set_fixed_filters(
-        &mut self,
-        label: String,
-        filters: Vec<QueryFilter>,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        self.state.update(ctx, |state, ctx| {
-            state.query_filter = FilterState::Fixed {
-                placeholder_text: label,
-                query_filters: filters,
-            };
-            ctx.notify();
-        });
-
-        self.update_placeholder_text(ctx);
-        self.run_query_internal(ctx);
-    }
-
     /// Updates the active filter and re-runs the query if the current search state warrants it.
     ///
     /// Empty zero-state buffers skip querying unless this search bar has opted into
     /// `run_query_on_buffer_empty`.
-    pub fn set_visible_query_filter(
+    pub fn set_query_filter(
         &mut self,
         filter_and_atom_text: Option<(QueryFilter, &'static str)>,
         ctx: &mut ViewContext<Self>,
     ) {
-        if self.filterable(ctx) {
-            let new_filter = filter_and_atom_text.map(|(filter, _)| filter);
-            let new_filter_atom_text = filter_and_atom_text.map(|(_, atom_text)| atom_text);
-            // NOTE: This event is deferred. When this method starts a query below, handlers
-            // receive it after the async search has already started. Handlers must not reset or
-            // modify the mixer, as doing so would abort the in-flight query without re-running it.
-            ctx.emit(SearchBarEvent::QueryFilterChanged { new_filter });
+        let new_filter = filter_and_atom_text.map(|(filter, _)| filter);
+        let new_filter_atom_text = filter_and_atom_text.map(|(_, atom_text)| atom_text);
+        // NOTE: This event is deferred. When this method starts a query below, handlers
+        // receive it after the async search has already started. Handlers must not reset or
+        // modify the mixer, as doing so would abort the in-flight query without re-running it.
+        ctx.emit(SearchBarEvent::QueryFilterChanged { new_filter });
 
-            self.state.update(ctx, |state, ctx| {
-                state.query_filter = if let Some(filter) = new_filter {
-                    FilterState::Visible(filter)
-                } else {
-                    FilterState::Unfiltered
-                };
-                state.filter_atom_text = new_filter_atom_text;
-                ctx.notify();
-            });
-        }
+        self.state.update(ctx, |state, ctx| {
+            state.query_filter = new_filter;
+            state.filter_atom_text = new_filter_atom_text;
+            ctx.notify();
+        });
 
         if self.should_run_query(ctx) {
             self.run_query_internal(ctx);
@@ -703,9 +637,8 @@ impl<T: Action + Clone> SearchBar<T> {
             .editor_handle
             .read(ctx, |editor, ctx| editor.buffer_text(ctx));
         let filters: HashSet<QueryFilter> = match &self.state.as_ref(ctx).query_filter {
-            FilterState::Unfiltered => HashSet::new(),
-            FilterState::Visible(filter) => HashSet::from_iter([*filter]),
-            FilterState::Fixed { query_filters, .. } => HashSet::from_iter(query_filters.clone()),
+            Some(filter) => HashSet::from_iter([*filter]),
+            None => HashSet::new(),
         };
 
         self.mixer.update(ctx, |mixer, ctx| {
@@ -814,13 +747,13 @@ impl<T: Action + Clone> SearchBar<T> {
                 self.run_query_internal(ctx);
             }
         } else {
-            if self.filterable(ctx) {
+            if self.state.as_ref(ctx).query_filter.is_none() {
                 let registered_filters = self.mixer.as_ref(ctx).registered_filters().collect_vec();
                 for filter in registered_filters {
                     if let Some(matched_filter_atom) =
                         filter.filter_atom().query_match(&current_buffer_text)
                     {
-                        self.set_visible_query_filter(Some((filter, matched_filter_atom)), ctx);
+                        self.set_query_filter(Some((filter, matched_filter_atom)), ctx);
                         self.editor_handle.update(ctx, |editor, ctx| {
                             // The 'filter atom text' will be rendered separately (not as text
                             // within the editor), so remove it from the editor contents.
@@ -847,16 +780,11 @@ impl<T: Action + Clone> SearchBar<T> {
         self.editor_handle.update(ctx, |editor, ctx| {
             if editor.is_empty(ctx) {
                 // Set the appropriate placeholder text if the editor buffer is empty.
-                match &self.state.as_ref(ctx).query_filter {
-                    FilterState::Visible(filter) => {
+                match self.state.as_ref(ctx).query_filter {
+                    Some(filter) => {
                         editor.set_placeholder_text(filter.placeholder_text(), ctx);
                     }
-                    FilterState::Fixed {
-                        placeholder_text, ..
-                    } => {
-                        editor.set_placeholder_text(placeholder_text.clone(), ctx);
-                    }
-                    FilterState::Unfiltered => {
+                    None => {
                         editor.set_placeholder_text(self.placeholder_text, ctx);
                     }
                 }
@@ -881,7 +809,7 @@ impl<T: Action + Clone> SearchBar<T> {
 
     pub fn should_show_zero_state(&self, app: &AppContext) -> bool {
         self.editor_handle.as_ref(app).is_empty(app)
-            && self.state.as_ref(app).query_filter == FilterState::Unfiltered
+            && self.state.as_ref(app).query_filter.is_none()
     }
 
     fn should_run_query(&self, app: &AppContext) -> bool {
@@ -898,8 +826,8 @@ impl<T: Action + Clone> SearchBar<T> {
     /// (completing the 'history:' atom text) as an autosuggestion.
     fn update_filter_autosuggestion_text(&self, ctx: &mut ViewContext<Self>) {
         match self.state.as_ref(ctx).query_filter {
-            FilterState::Visible(_) | FilterState::Fixed { .. } => {
-                // If there is an active filter or the filters are fixed, there should never be filter autosuggestion text
+            Some(_) => {
+                // If there is an active filter, there should never be filter autosuggestion text
                 // (the user has already applied a filter and can't apply another one).
                 if self.editor_handle.as_ref(ctx).active_autosuggestion() {
                     self.editor_handle.update(ctx, |editor, ctx| {
@@ -907,7 +835,7 @@ impl<T: Action + Clone> SearchBar<T> {
                     });
                 }
             }
-            FilterState::Unfiltered => {
+            None => {
                 self.editor_handle.update(ctx, |editor, ctx| {
                     if !editor.buffer_text(ctx).is_empty() {
                         let filters = self.mixer.as_ref(ctx).registered_filters().collect_vec();
@@ -1014,6 +942,6 @@ impl<T: Action + Clone> View for SearchBar<T> {
 #[cfg(feature = "integration_tests")]
 impl<T: Action + Clone> SearchBar<T> {
     pub fn active_query_filter(&self, app: &AppContext) -> Option<QueryFilter> {
-        self.state.as_ref(app).active_visible_query_filter()
+        self.state.as_ref(app).active_query_filter()
     }
 }

--- a/app/src/search/search_results_menu/view.rs
+++ b/app/src/search/search_results_menu/view.rs
@@ -267,7 +267,7 @@ impl<T: Action + Clone> SearchResultsMenuView<T> {
         ctx: &mut ViewContext<Self>,
     ) {
         self.search_bar.update(ctx, |view, ctx| {
-            view.set_visible_query_filter(
+            view.set_query_filter(
                 filter.map(|filter| (filter, filter.filter_atom().primary_text)),
                 ctx,
             )
@@ -282,7 +282,7 @@ impl<T: Action + Clone> SearchResultsMenuView<T> {
         let selected_index = state.selected_index();
         let query_result_renderers = state.query_result_renderers();
 
-        let active_filter = state.active_visible_query_filter();
+        let active_filter = state.active_query_filter();
         let appearance = Appearance::as_ref(app);
 
         let mut column = Flex::column();

--- a/app/src/search/welcome_palette/view.rs
+++ b/app/src/search/welcome_palette/view.rs
@@ -391,7 +391,7 @@ impl WelcomePalette {
     /// Set the active query filter in the search bar to be `filter`.
     pub fn set_active_query_filter(&mut self, filter: QueryFilter, ctx: &mut ViewContext<Self>) {
         self.search_bar.update(ctx, |view, ctx| {
-            view.set_visible_query_filter(Some((filter, filter.filter_atom().primary_text)), ctx)
+            view.set_query_filter(Some((filter, filter.filter_atom().primary_text)), ctx)
         });
         ctx.notify();
     }
@@ -411,9 +411,7 @@ impl WelcomePalette {
     }
 
     pub fn active_query_filter(&self, app: &AppContext) -> Option<QueryFilter> {
-        self.search_bar_state
-            .as_ref(app)
-            .active_visible_query_filter()
+        self.search_bar_state.as_ref(app).active_query_filter()
     }
 
     pub fn is_mode_enabled(&self, mode: PaletteMode, app: &AppContext) -> bool {

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -464,7 +464,6 @@ pub enum PaletteSource {
     ConversationManager,
     ContextChip,
     PaneHeader,
-    RecentsViewAll,
     AgentTip,
     TitleBarSearchBar,
 }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -12334,17 +12334,6 @@ impl Workspace {
         ctx.notify();
     }
 
-    fn open_recent_repos_and_convos_palette(&mut self, ctx: &mut ViewContext<Self>) {
-        self.palette.update(ctx, |view, ctx| {
-            view.reset(ctx);
-            view.set_fixed_query_filters(
-                "Search recent repos and conversations".to_string(),
-                vec![QueryFilter::HistoricalConversations, QueryFilter::Repos],
-                ctx,
-            );
-        });
-    }
-
     fn open_conversations_palette(&mut self, ctx: &mut ViewContext<Self>) {
         self.palette.update(ctx, |view, ctx| {
             view.reset(ctx);
@@ -12590,7 +12579,6 @@ impl Workspace {
             PaletteMode::WarpDrive => self.open_warp_drive_palette(ctx),
             PaletteMode::Files => self.open_files_palette(ctx),
             PaletteMode::Conversations => self.open_conversations_palette(ctx),
-            PaletteMode::ConversationsAndRepos => self.open_recent_repos_and_convos_palette(ctx),
         }
 
         ctx.focus(&self.palette);


### PR DESCRIPTION
## Summary

We are effectively undoing these PRs:

- https://github.com/warpdotdev/warp-internal/pull/17647
- https://github.com/warpdotdev/warp-internal/pull/17674

The changes are:

- Remove the dead command palette fixed-filter path and collapse the search bar filter state to one optional active filter.
- Delete the obsolete recent repos/conversations palette mode, palette source telemetry, and workspace entrypoint.
- Remove the historical-conversations-only command palette filter/data source while keeping regular conversations search intact.

## Testing

Manually tested in local build.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/4cd240e9-5d73-4a0c-8b4c-0fa4d439c964_
_Run: https://oz.staging.warp.dev/runs/019e23ce-5deb-7161-bbe0-be661c0d9bf4_
_This PR was generated with [Oz](https://warp.dev/oz)._
