### PR TITLE
Respect CODEX_HOME and CLAUDE_CONFIG_DIR for writing config.

### DIFF
--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -27,8 +27,8 @@ use warp_managed_secrets::ManagedSecretValue;
 use super::super::terminal::{CommandHandle, TerminalDriver};
 use super::super::{AgentDriver, AgentDriverError};
 use super::claude_transcript::{
-    claude_config_dir, read_envelope, write_envelope, write_session_index_entry, ClaudeResumeInfo,
-    ClaudeTranscriptEnvelope,
+    claude_config_dir, home_dir_for_claude_config, read_envelope, write_envelope,
+    write_session_index_entry, ClaudeResumeInfo, ClaudeTranscriptEnvelope,
 };
 use super::json_utils::{read_json_file_or_default, write_json_file};
 use super::{
@@ -594,7 +594,7 @@ fn claude_global_config_path() -> Result<PathBuf> {
         }
     }
 
-    dirs::home_dir()
+    home_dir_for_claude_config()
         .map(|home| home.join(CLAUDE_JSON_FILE_NAME))
         .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))
 }

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -578,8 +578,7 @@ pub(crate) fn prepare_claude_environment_config(
     working_dir: &Path,
     resolved_env_vars: &HashMap<OsString, OsString>,
 ) -> Result<()> {
-    let home_dir = claude_home_dir()?;
-    let claude_json_path = home_dir.join(CLAUDE_JSON_FILE_NAME);
+    let claude_json_path = claude_global_config_path()?;
     let claude_settings_path = claude_config_dir()?.join(CLAUDE_SETTINGS_FILE_NAME);
     let api_key_suffix = resolve_anthropic_api_key_suffix(resolved_env_vars);
     prepare_claude_config(&claude_json_path, working_dir, api_key_suffix.as_deref())?;
@@ -587,15 +586,17 @@ pub(crate) fn prepare_claude_environment_config(
     Ok(())
 }
 
-fn claude_home_dir() -> Result<PathBuf> {
-    #[cfg(test)]
-    if let Some(home_dir) = std::env::var_os("HOME") {
-        if !home_dir.as_os_str().is_empty() {
-            return Ok(PathBuf::from(home_dir));
+// This function is used specifically for determining where to land `.claude.json`.
+fn claude_global_config_path() -> Result<PathBuf> {
+    if let Ok(dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+        if !dir.is_empty() {
+            return Ok(PathBuf::from(dir).join(CLAUDE_JSON_FILE_NAME));
         }
     }
 
-    dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not determine home directory"))
+    dirs::home_dir()
+        .map(|home| home.join(CLAUDE_JSON_FILE_NAME))
+        .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))
 }
 
 fn prepare_claude_config(

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -669,6 +669,72 @@ fn prepare_claude_config_none_suffix_preserves_existing_responses() {
 
 #[test]
 #[serial_test::serial]
+fn prepare_claude_environment_config_without_config_dir_uses_home_global_config() {
+    let home_dir = TempDir::new().unwrap();
+    let old_home = std::env::var_os("HOME");
+    let old_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
+    std::env::set_var("HOME", home_dir.path());
+    std::env::remove_var("CLAUDE_CONFIG_DIR");
+
+    let working_dir = home_dir.path().join("workspace/project");
+    prepare_claude_environment_config(&working_dir, &HashMap::new()).unwrap();
+
+    assert!(home_dir.path().join(CLAUDE_JSON_FILE_NAME).exists());
+    assert!(home_dir
+        .path()
+        .join(".claude")
+        .join(CLAUDE_SETTINGS_FILE_NAME)
+        .exists());
+    assert!(!home_dir
+        .path()
+        .join(".claude")
+        .join(CLAUDE_JSON_FILE_NAME)
+        .exists());
+
+    match old_home {
+        Some(home) => std::env::set_var("HOME", home),
+        None => std::env::remove_var("HOME"),
+    }
+    match old_config_dir {
+        Some(dir) => std::env::set_var("CLAUDE_CONFIG_DIR", dir),
+        None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn prepare_claude_environment_config_with_config_dir_uses_dir_global_config() {
+    let home_dir = TempDir::new().unwrap();
+    let claude_config_dir = TempDir::new().unwrap();
+    let old_home = std::env::var_os("HOME");
+    let old_config_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
+    std::env::set_var("HOME", home_dir.path());
+    std::env::set_var("CLAUDE_CONFIG_DIR", claude_config_dir.path());
+
+    let working_dir = home_dir.path().join("workspace/project");
+    prepare_claude_environment_config(&working_dir, &HashMap::new()).unwrap();
+
+    assert!(claude_config_dir
+        .path()
+        .join(CLAUDE_JSON_FILE_NAME)
+        .exists());
+    assert!(claude_config_dir
+        .path()
+        .join(CLAUDE_SETTINGS_FILE_NAME)
+        .exists());
+    assert!(!home_dir.path().join(CLAUDE_JSON_FILE_NAME).exists());
+
+    match old_home {
+        Some(home) => std::env::set_var("HOME", home),
+        None => std::env::remove_var("HOME"),
+    }
+    match old_config_dir {
+        Some(dir) => std::env::set_var("CLAUDE_CONFIG_DIR", dir),
+        None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+    }
+}
+#[test]
+#[serial_test::serial]
 fn resolve_suffix_from_resolved_env_vars() {
     std::env::remove_var(ANTHROPIC_API_KEY_ENV);
     let key = "sk-ant-api03-abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghij1234567890QLWn-dUnuwQ-hIhDiAAA";

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -827,7 +827,10 @@ fn prepare_local_wake_command_rehydrates_transcript_with_self_managed_listener()
         restored_envelope.entries,
         vec![serde_json::json!({"type": "assistant", "text": "done"})]
     );
-    assert!(home_dir.path().join(".claude.json").exists());
+    assert!(claude_config_dir
+        .path()
+        .join(CLAUDE_JSON_FILE_NAME)
+        .exists());
     assert!(claude_config_dir
         .path()
         .join(CLAUDE_SETTINGS_FILE_NAME)

--- a/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_transcript.rs
@@ -85,9 +85,21 @@ pub(crate) fn claude_config_dir() -> Result<PathBuf> {
     if let Ok(dir) = std::env::var("CLAUDE_CONFIG_DIR") {
         return Ok(PathBuf::from(dir));
     }
-    dirs::home_dir()
+    home_dir_for_claude_config()
         .map(|h| h.join(".claude"))
         .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))
+}
+
+/// In tests on Windows, `dirs::home_dir()` ignores `HOME`, so we check it
+/// manually so that tests can override the home directory.
+pub(super) fn home_dir_for_claude_config() -> Option<PathBuf> {
+    #[cfg(test)]
+    if let Some(home) = std::env::var_os("HOME") {
+        if !home.is_empty() {
+            return Some(PathBuf::from(home));
+        }
+    }
+    dirs::home_dir()
 }
 
 /// Assemble a [`ClaudeTranscriptEnvelope`] from the Claude config directory.

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -439,6 +439,7 @@ async fn upload_transcript(
 }
 
 const CODEX_CONFIG_DIR: &str = ".codex";
+const CODEX_HOME_ENV: &str = "CODEX_HOME";
 const CODEX_AGENTS_OVERRIDE_FILE_NAME: &str = "AGENTS.override.md";
 const CODEX_AUTH_FILE_NAME: &str = "auth.json";
 const CODEX_CONFIG_TOML_FILE_NAME: &str = "config.toml";
@@ -469,9 +470,7 @@ fn prepare_codex_environment_config(
     resolved_mcp_servers: &HashMap<String, JSONMCPServer>,
     third_party_harness_model_config: Option<&HarnessModelConfig>,
 ) -> Result<()> {
-    let home_dir =
-        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?;
-    let codex_dir = home_dir.join(CODEX_CONFIG_DIR);
+    let codex_dir = codex_config_dir()?;
 
     if let Some(prompt) = system_prompt {
         write_codex_agents_override(&codex_dir, prompt)?;
@@ -495,6 +494,17 @@ fn prepare_codex_environment_config(
         openai_base_url.as_deref(),
     )?;
     Ok(())
+}
+
+fn codex_config_dir() -> Result<PathBuf> {
+    if let Ok(dir) = std::env::var(CODEX_HOME_ENV) {
+        if !dir.is_empty() {
+            return Ok(PathBuf::from(dir));
+        }
+    }
+    dirs::home_dir()
+        .map(|home| home.join(CODEX_CONFIG_DIR))
+        .ok_or_else(|| anyhow::anyhow!("could not determine home directory"))
 }
 
 fn write_codex_agents_override(codex_dir: &Path, system_prompt: &str) -> Result<()> {

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -166,6 +166,53 @@ fn resolve_openai_api_key_uses_resolved_map_when_env_empty() {
     assert_eq!(result.as_deref(), Some("sk-from-secret"));
 }
 
+#[test]
+#[serial_test::serial]
+fn prepare_codex_environment_config_honors_codex_home() {
+    let tmp = TempDir::new().unwrap();
+    let codex_home = tmp.path().join("codex-home");
+    let working_dir = tmp.path().join("workspace");
+    fs::create_dir_all(&working_dir).unwrap();
+    let prev_codex_home = std::env::var(CODEX_HOME_ENV).ok();
+    let prev_openai_api_key = std::env::var(OPENAI_API_KEY_ENV).ok();
+    std::env::set_var(CODEX_HOME_ENV, &codex_home);
+    std::env::remove_var(OPENAI_API_KEY_ENV);
+    let resolved = HashMap::from([(
+        OsString::from(OPENAI_API_KEY_ENV),
+        OsString::from("sk-from-secret"),
+    )]);
+
+    let result = prepare_codex_environment_config(
+        &working_dir,
+        Some("system prompt"),
+        &resolved,
+        &HashMap::new(),
+        Some("gpt-5.5"),
+    );
+
+    match prev_codex_home {
+        Some(v) => std::env::set_var(CODEX_HOME_ENV, v),
+        None => std::env::remove_var(CODEX_HOME_ENV),
+    }
+    match prev_openai_api_key {
+        Some(v) => std::env::set_var(OPENAI_API_KEY_ENV, v),
+        None => std::env::remove_var(OPENAI_API_KEY_ENV),
+    }
+
+    result.unwrap();
+    assert_eq!(
+        fs::read_to_string(codex_home.join(CODEX_AGENTS_OVERRIDE_FILE_NAME)).unwrap(),
+        "system prompt"
+    );
+    let auth: Value =
+        serde_json::from_slice(&fs::read(codex_home.join(CODEX_AUTH_FILE_NAME)).unwrap()).unwrap();
+    assert_eq!(auth["OPENAI_API_KEY"], "sk-from-secret");
+    let cfg = read_codex_config(&codex_home.join(CODEX_CONFIG_TOML_FILE_NAME));
+    assert_eq!(cfg["model"].as_str(), Some("gpt-5.5"));
+    assert_eq!(cfg["openai_base_url"].as_str(), Some(CODEX_OPENAI_BASE_URL));
+    assert!(!tmp.path().join(CODEX_CONFIG_DIR).exists());
+}
+
 fn read_codex_config(path: &std::path::Path) -> toml::Table {
     let content = fs::read_to_string(path).unwrap();
     toml::from_str(&content).unwrap()

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -182,13 +182,14 @@ fn prepare_codex_environment_config_honors_codex_home() {
         OsString::from("sk-from-secret"),
     )]);
 
+    let model_config = harness_model_config("gpt-5.5", None);
     let result = prepare_codex_environment_config(
         &working_dir,
         Some("system prompt"),
         &resolved,
         &HashMap::new(),
         &HashMap::new(),
-        Some("gpt-5.5"),
+        Some(&model_config),
     );
 
     match prev_codex_home {

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -187,6 +187,7 @@ fn prepare_codex_environment_config_honors_codex_home() {
         Some("system prompt"),
         &resolved,
         &HashMap::new(),
+        &HashMap::new(),
         Some("gpt-5.5"),
     );
 
@@ -209,7 +210,7 @@ fn prepare_codex_environment_config_honors_codex_home() {
     assert_eq!(auth["OPENAI_API_KEY"], "sk-from-secret");
     let cfg = read_codex_config(&codex_home.join(CODEX_CONFIG_TOML_FILE_NAME));
     assert_eq!(cfg["model"].as_str(), Some("gpt-5.5"));
-    assert_eq!(cfg["openai_base_url"].as_str(), Some(CODEX_OPENAI_BASE_URL));
+    assert!(!cfg.contains_key("openai_base_url"));
     assert!(!tmp.path().join(CODEX_CONFIG_DIR).exists());
 }
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
Update the implementations for claude and codex harnesses to consistently respect the environment variables `CLAUDE_CONFIG_DIR` and `CODEX_HOME` respectively.

While `.claude.json` gets written to `~` (not `~/.claude`) when the `CLAUDE_CONFIG_DIR` is unset, we need to make sure that we set it to `CLAUDE_CONFIG_DIR/.claude.json` when the environment variable is set.

This is important for the self-hosted worker direct backend, to make sure that we can seed per-task config in worker-scoped repos. Associated `oz-agent-worker` PR: https://github.com/warpdotdev/oz-agent-worker/pull/72

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

Ran with `./script/oz-local` and passed in `-e CODEX_HOME` and `-e CLAUDE_CONFIG_DIR`. Nuked my local `~/.claude` and `~/.codex` directories and then confirmed agents could run to completion and seed the correct config files.

Also ran without setting the env vars and confirmed that we run to completion.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

