### PR TITLE
Add handlebars edge case tests

### DIFF
--- a/crates/handlebars/src/lib_tests.rs
+++ b/crates/handlebars/src/lib_tests.rs
@@ -91,3 +91,94 @@ fn does_not_replace_spaced_variants() {
     let out = render_template(template, &context);
     assert_eq!(out, "A {{ name }} B {{name }} C {{ name}} D ok");
 }
+
+#[test]
+fn handles_empty_template() {
+    let template = "";
+    let context = create_map(&[("unused", "value")]);
+
+    let args = get_arguments(template);
+    assert_eq!(args, Vec::<String>::new());
+
+    let out = render_template(template, &context);
+    assert_eq!(out, "");
+}
+
+#[test]
+fn renders_adjacent_placeholders_without_separators() {
+    let template = "{{first}}{{second}}{{third}}";
+    let context = create_map(&[("first", "A"), ("second", "B"), ("third", "C")]);
+
+    let args = get_arguments(template);
+    assert_eq!(
+        args.into_iter().collect::<HashSet<String>>(),
+        HashSet::from([
+            "first".to_string(),
+            "second".to_string(),
+            "third".to_string()
+        ])
+    );
+
+    let out = render_template(template, &context);
+    assert_eq!(out, "ABC");
+}
+
+#[test]
+fn renders_placeholders_at_start_and_end() {
+    let template = "{{start}} middle {{end}}";
+    let context = create_map(&[("start", "BEGIN"), ("end", "FINISH")]);
+
+    let args = get_arguments(template);
+    assert_eq!(
+        args.into_iter().collect::<HashSet<String>>(),
+        HashSet::from(["start".to_string(), "end".to_string()])
+    );
+
+    let out = render_template(template, &context);
+    assert_eq!(out, "BEGIN middle FINISH");
+}
+
+#[test]
+fn accepts_numeric_suffixes_and_long_names_but_not_numeric_prefixes() {
+    let template = "{{a1}} {{1a}} {{long_name-with-1234567890_suffix}}";
+    let context = create_map(&[
+        ("a1", "short"),
+        ("1a", "invalid"),
+        ("long_name-with-1234567890_suffix", "long"),
+    ]);
+
+    let args = get_arguments(template);
+    assert_eq!(
+        args.into_iter().collect::<HashSet<String>>(),
+        HashSet::from([
+            "a1".to_string(),
+            "long_name-with-1234567890_suffix".to_string()
+        ])
+    );
+
+    let out = render_template(template, &context);
+    assert_eq!(out, "short {{1a}} long");
+}
+
+#[test]
+fn renders_special_values_without_reparsing_or_escaping() {
+    let template = "prefix {{braces}} {{multiline}} {{empty}} suffix";
+    let context = create_map(&[
+        ("braces", "{{not_reparsed}} & <tag>"),
+        ("multiline", "line1\nline2"),
+        ("empty", ""),
+    ]);
+
+    let args = get_arguments(template);
+    assert_eq!(
+        args.into_iter().collect::<HashSet<String>>(),
+        HashSet::from([
+            "braces".to_string(),
+            "multiline".to_string(),
+            "empty".to_string()
+        ])
+    );
+
+    let out = render_template(template, &context);
+    assert_eq!(out, "prefix {{not_reparsed}} & <tag> line1\nline2  suffix");
+}


### PR DESCRIPTION
## Description
Add deterministic unit coverage for handlebars template edge cases:
- empty templates
- adjacent placeholders
- placeholders at the start and end of a template
- numeric suffixes, long names, and invalid numeric prefixes
- special rendered values that should not be reparsed or escaped

## Testing
- [x] `cargo fmt`
- [x] `cargo test -p handlebars --lib`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/d06f2b91-9030-495f-9158-b6ea3a928140_
_Run: https://oz.staging.warp.dev/runs/019e23ea-f1cd-78be-92d5-355078e97225_

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
