### PR TITLE
Add http server unit tests

### DIFF
--- a/crates/http_server/src/lib.rs
+++ b/crates/http_server/src/lib.rs
@@ -39,15 +39,10 @@ impl HttpServer {
             .worker_threads(1)
             .enable_io()
             .build()?;
-
-        let mut root = axum::Router::new();
-        for router in routers {
-            root = root.merge(router);
-        }
+        let root = root_router(routers);
 
         runtime.spawn(async move {
-            let addr = SocketAddr::from(([127, 0, 0, 1], PORT));
-            let listener = tokio::net::TcpListener::bind(addr).await?;
+            let listener = tokio::net::TcpListener::bind(server_addr()).await?;
 
             axum::serve(listener, root.layer(TraceLayer::new_for_http())).await
         });
@@ -55,9 +50,94 @@ impl HttpServer {
         Ok(runtime)
     }
 }
+fn root_router(routers: impl IntoIterator<Item = axum::Router>) -> axum::Router {
+    let mut root = axum::Router::new();
+    for router in routers {
+        root = root.merge(router);
+    }
+    root
+}
+
+fn server_addr() -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], PORT))
+}
 
 impl Entity for HttpServer {
     type Event = ();
 }
 
 impl SingletonEntity for HttpServer {}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request, StatusCode},
+        routing::get,
+    };
+    use tower::Service;
+
+    use super::*;
+
+    #[test]
+    fn server_addr_uses_localhost_and_warp_port() {
+        assert_eq!(server_addr(), SocketAddr::from(([127, 0, 0, 1], 9277)));
+    }
+
+    #[test]
+    fn root_router_serves_routes_from_all_merged_routers() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("runtime should build");
+
+        runtime.block_on(async {
+            let first = axum::Router::new().route("/first", get(|| async { "first" }));
+            let second = axum::Router::new().route("/second", get(|| async { "second" }));
+            let mut router = root_router([first, second]);
+
+            assert_response_body(&mut router, "/first", "first").await;
+            assert_response_body(&mut router, "/second", "second").await;
+        });
+    }
+
+    #[test]
+    fn root_router_without_inputs_returns_not_found() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("runtime should build");
+
+        runtime.block_on(async {
+            let mut router = root_router([]);
+            let response = router
+                .call(
+                    Request::builder()
+                        .uri("/missing")
+                        .body(Body::empty())
+                        .expect("request should build"),
+                )
+                .await
+                .expect("router should respond");
+
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        });
+    }
+
+    async fn assert_response_body(router: &mut axum::Router, uri: &str, expected_body: &str) {
+        let response = router
+            .call(
+                Request::builder()
+                    .uri(uri)
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should be readable");
+        assert_eq!(&body[..], expected_body.as_bytes());
+    }
+}


### PR DESCRIPTION
## Description
Adds focused unit coverage for the small client HTTP server helpers:
- Verifies the server address remains localhost on the Warp port.
- Verifies merged routers serve routes from each input router.
- Verifies an empty root router returns 404 for missing routes.

## Linked Issue
None.

## Testing
- cargo fmt --manifest-path /workspace/warp/Cargo.toml -p http_server
- cargo test --manifest-path /workspace/warp/Cargo.toml -p http_server

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/74f311e5-83b4-4041-85c5-38ee0ba0dc71_
_Run: https://oz.staging.warp.dev/runs/019e23ea-f1ba-7aff-8e47-ef184f915b7d_

Co-Authored-By: Oz <oz-agent@warp.dev>
_This PR was generated with [Oz](https://warp.dev/oz)._
