### PR TITLE
Handle unsupported SSH extension platforms cleanly

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1361,6 +1361,12 @@ pub(crate) fn initialize_app(
     ctx.add_singleton_model(remote_server::codebase_index_model::RemoteCodebaseIndexModel::new);
     #[cfg(not(target_family = "wasm"))]
     remote_server::wire_auth_token_rotation(ctx);
+    #[cfg(not(target_family = "wasm"))]
+    if matches!(launch_mode, LaunchMode::App { .. }) {
+        remote_server::ssh_transport::installation::cleanup::schedule_remote_server_tarball_cache_cleanup(
+            ctx.background_executor().clone(),
+        );
+    }
 
     log::info!(
         "Starting warp with channel state {} and version {:?}",

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -3,13 +3,12 @@
 //! [`SshTransport`] uses an existing SSH ControlMaster socket to check/install
 //! the remote server binary and to launch the `remote-server-proxy` process
 //! whose stdin/stdout become the protocol channel.
+use anyhow::Result;
 use std::fmt;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
-
-use anyhow::Result;
 use warpui::r#async::executor;
 
 use remote_server::auth::RemoteServerAuthContext;
@@ -18,8 +17,11 @@ use remote_server::manager::RemoteServerExitStatus;
 use remote_server::setup::{
     parse_uname_output, remote_server_daemon_dir, PreinstallCheckResult, RemotePlatform,
 };
-use remote_server::ssh::{ssh_args, SshCommandError};
-use remote_server::transport::{Connection, Error, InstallOutcome, InstallSource, RemoteTransport};
+use remote_server::ssh::ssh_args;
+use remote_server::transport::{Connection, Error, InstallOutcome, RemoteTransport};
+
+#[path = "ssh_transport/installation.rs"]
+pub(crate) mod installation;
 
 /// SSH transport: connects via a ControlMaster socket.
 ///
@@ -202,72 +204,7 @@ impl RemoteTransport for SshTransport {
 
     fn install_binary(&self) -> Pin<Box<dyn Future<Output = InstallOutcome> + Send>> {
         let socket_path = self.socket_path.clone();
-        Box::pin(async move {
-            let binary_path = remote_server::setup::remote_server_binary();
-            log::info!("Installing remote server binary to {binary_path}");
-            let mut outcome = match install_on_server(&socket_path).await {
-                Ok(()) => InstallOutcome {
-                    source: Some(InstallSource::Server),
-                    result: Ok(()),
-                },
-                Err(server_err) => {
-                    let should_try_scp = !should_skip_scp_fallback(&server_err);
-
-                    if should_try_scp {
-                        log::info!("Remote server has no curl/wget, falling back to SCP upload");
-                        match scp_install_fallback(&socket_path).await {
-                            Ok(()) => InstallOutcome {
-                                source: Some(InstallSource::Client),
-                                result: Ok(()),
-                            },
-                            Err(e) => InstallOutcome {
-                                source: Some(InstallSource::Client),
-                                result: Err(Error::Other(e)),
-                            },
-                        }
-                    } else {
-                        InstallOutcome {
-                            source: Some(InstallSource::Server),
-                            result: Err(server_err),
-                        }
-                    }
-                }
-            };
-
-            // Post-install verification: confirm the binary actually
-            // landed at the expected path and is functional. This catches
-            // silent install failures (e.g. tilde-expansion bugs) that
-            // would otherwise surface as a cryptic "Response channel
-            // closed" error during the IPC handshake.
-            if outcome.result.is_ok() {
-                log::info!("Running post-install verification for {binary_path}");
-                let check_cmd = remote_server::setup::binary_check_command();
-                let verify = remote_server::ssh::run_ssh_command(
-                    &socket_path,
-                    &check_cmd,
-                    remote_server::setup::CHECK_TIMEOUT,
-                )
-                .await;
-                match verify {
-                    Ok(output) if output.status.success() => {}
-                    Ok(output) => {
-                        let code = output.status.code().unwrap_or(-1);
-                        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-                        outcome.result = Err(Error::Other(anyhow::anyhow!(
-                            "Post-install verification failed: binary not found or not \
-                             executable at {binary_path} (exit {code}): {stderr}"
-                        )));
-                    }
-                    Err(e) => {
-                        outcome.result = Err(Error::Other(anyhow::anyhow!(
-                            "Post-install verification failed: {e}"
-                        )));
-                    }
-                }
-            }
-
-            outcome
-        })
+        Box::pin(async move { installation::install_binary(&socket_path).await })
     }
 
     fn connect(
@@ -351,115 +288,6 @@ impl RemoteTransport for SshTransport {
             // No exit status available — optimistically allow reconnect.
             None => true,
         }
-    }
-}
-
-/// Exit codes where SCP fallback would not help because the failure
-/// is on the remote host itself (not a network/download issue).
-fn should_skip_scp_fallback(error: &Error) -> bool {
-    // Unsupported arch/OS — SCP won't change the architecture
-    matches!(error, Error::ScriptFailed { exit_code , .. } if *exit_code == 2)
-}
-
-/// Runs the install script on the remote host to download and install
-/// the binary directly from the CDN.
-async fn install_on_server(socket_path: &Path) -> Result<(), Error> {
-    let script = remote_server::setup::install_script(None);
-    match remote_server::ssh::run_ssh_script(
-        socket_path,
-        &script,
-        remote_server::setup::INSTALL_TIMEOUT,
-    )
-    .await
-    {
-        Ok(output) if output.status.success() => Ok(()),
-        Ok(output) => {
-            let exit_code = output.status.code().unwrap_or(-1);
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            Err(Error::ScriptFailed { exit_code, stderr })
-        }
-        Err(SshCommandError::TimedOut { .. }) => Err(Error::TimedOut),
-        Err(e) => Err(Error::Other(e.into())),
-    }
-}
-
-/// SCP install fallback: downloads the tarball locally, uploads it to
-/// the remote via SCP, then re-invokes the install script with the
-/// staging path baked in so the shared extraction tail runs.
-async fn scp_install_fallback(socket_path: &Path) -> anyhow::Result<()> {
-    use std::process::Stdio;
-
-    // Detect the remote platform so we can construct the correct download URL.
-    // This is a redundant uname call (the manager already ran detect_platform
-    // earlier), but it only happens on the rare SCP fallback path and avoids
-    // threading the platform through the trait.
-    let platform = detect_remote_platform(socket_path)
-        .await
-        .map_err(|e| anyhow::anyhow!("SCP fallback: {e:#}"))?;
-
-    let url = remote_server::setup::download_tarball_url(&platform);
-    let remote_tarball_path = format!(
-        "{}/oz-upload.tar.gz",
-        remote_server::setup::remote_server_dir()
-    );
-    let timeout = remote_server::setup::SCP_INSTALL_TIMEOUT;
-
-    // 1. Download the tarball locally into a temp directory.
-    let tmp_dir =
-        tempfile::tempdir().map_err(|e| anyhow::anyhow!("Failed to create local temp dir: {e}"))?;
-    let temp_client_tarball_path = tmp_dir.path().join("oz.tar.gz");
-
-    log::info!("Downloading tarball locally from {url}");
-    let output = command::r#async::Command::new("curl")
-        // -f: fail silently on HTTP errors (non-zero exit instead of HTML error page)
-        // -S: show errors even when -f is used
-        // -L: follow redirects (the CDN may 302 to a regional edge)
-        .arg("-fSL")
-        .arg("--connect-timeout")
-        .arg("15")
-        .arg(&url)
-        .arg("-o")
-        .arg(&temp_client_tarball_path)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .output()
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to spawn local curl: {e}"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(anyhow::anyhow!(
-            "Local curl failed (exit {:?}): {stderr}",
-            output.status.code()
-        ));
-    }
-
-    // 2. Upload to the remote via SCP.
-    log::info!("Uploading tarball to remote at {remote_tarball_path}");
-    remote_server::ssh::scp_upload(
-        socket_path,
-        &temp_client_tarball_path,
-        &remote_tarball_path,
-        timeout,
-    )
-    .await?;
-
-    // 3. Run the install script with the staging path baked in.
-    //    The script's `staging_tarball_path` variable is non-empty, so it
-    //    skips the download and extracts from the uploaded tarball.
-    log::info!("Running extraction via install script with tarball at {remote_tarball_path}");
-
-    let script = remote_server::setup::install_script(Some(&remote_tarball_path));
-
-    let output = remote_server::ssh::run_ssh_script(socket_path, &script, timeout).await?;
-    if output.status.success() {
-        Ok(())
-    } else {
-        let code = output.status.code().unwrap_or(-1);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(anyhow::anyhow!(
-            "Extraction script failed (exit {code}): {stderr}"
-        ))
     }
 }
 

--- a/app/src/remote_server/ssh_transport/installation.rs
+++ b/app/src/remote_server/ssh_transport/installation.rs
@@ -1,0 +1,441 @@
+#[path = "installation/cleanup.rs"]
+pub(crate) mod cleanup;
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context as _, Result};
+use futures::TryStreamExt as _;
+use http_client::StatusCode;
+use tokio::io::AsyncWriteExt as _;
+
+use remote_server::setup::RemotePlatform;
+use remote_server::ssh::SshCommandError;
+use remote_server::transport::{Error, InstallOutcome, InstallSource};
+
+pub(super) const REMOTE_SERVER_TARBALL_CACHE_FILE_NAME: &str = "oz.tar.gz";
+const REMOTE_SERVER_TARBALL_CACHE_VERSION_UNPINNED: &str = "unversioned";
+const REMOTE_SERVER_TARBALL_DOWNLOAD_ATTEMPTS: usize = 3;
+const REMOTE_SERVER_TARBALL_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(180);
+const REMOTE_SERVER_TARBALL_DOWNLOAD_RETRY_DELAY: Duration = Duration::from_millis(250);
+
+pub(super) fn cache_component(raw: &str) -> String {
+    if raw.is_empty() {
+        return "empty".to_string();
+    }
+
+    let mut encoded = String::with_capacity(raw.len());
+    for byte in raw.bytes() {
+        match byte {
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'.' => {
+                encoded.push(byte as char)
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+pub(super) fn remote_server_tarball_cache_root() -> PathBuf {
+    warp_core::paths::cache_dir()
+        .join("remote-server")
+        .join("tarballs")
+}
+
+pub(super) fn current_remote_server_tarball_cache_version() -> &'static str {
+    remote_server::setup::remote_server_artifact_version()
+        .unwrap_or(REMOTE_SERVER_TARBALL_CACHE_VERSION_UNPINNED)
+}
+
+fn remote_server_tarball_cache_path(platform: &RemotePlatform) -> PathBuf {
+    remote_server_tarball_cache_root()
+        .join(cache_component(
+            remote_server::setup::remote_server_download_channel(),
+        ))
+        .join(cache_component(
+            current_remote_server_tarball_cache_version(),
+        ))
+        .join(cache_component(&format!(
+            "{}-{}",
+            platform.os.as_str(),
+            platform.arch.as_str()
+        )))
+        .join(REMOTE_SERVER_TARBALL_CACHE_FILE_NAME)
+}
+
+async fn is_valid_cached_tarball(path: &Path) -> bool {
+    tokio::fs::metadata(path)
+        .await
+        .is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0)
+}
+
+async fn cached_remote_server_tarball(platform: &RemotePlatform) -> anyhow::Result<PathBuf> {
+    let cache_path = remote_server_tarball_cache_path(platform);
+    if is_valid_cached_tarball(&cache_path).await {
+        log::info!(
+            "Using cached remote-server tarball at {}",
+            cache_path.display()
+        );
+        return Ok(cache_path);
+    }
+
+    if tokio::fs::metadata(&cache_path).await.is_ok() {
+        let _ = tokio::fs::remove_file(&cache_path).await;
+    }
+
+    let url = remote_server::setup::download_tarball_url(platform);
+    log::info!(
+        "Downloading remote-server tarball from {url} into cache at {}",
+        cache_path.display()
+    );
+    download_remote_server_tarball_to_cache(&url, &cache_path).await?;
+    Ok(cache_path)
+}
+
+async fn download_remote_server_tarball_to_cache(
+    url: &str,
+    cache_path: &Path,
+) -> anyhow::Result<()> {
+    let parent = cache_path
+        .parent()
+        .context("remote-server tarball cache path has no parent directory")?;
+    tokio::fs::create_dir_all(parent).await.with_context(|| {
+        format!(
+            "Failed to create remote-server tarball cache directory '{}'",
+            parent.display()
+        )
+    })?;
+
+    let temp_path = parent.join(format!(
+        ".{REMOTE_SERVER_TARBALL_CACHE_FILE_NAME}.{}.tmp",
+        uuid::Uuid::new_v4()
+    ));
+
+    if let Err(e) = download_remote_server_tarball_with_retries(url, &temp_path).await {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Err(e);
+    }
+    if !is_valid_cached_tarball(&temp_path).await {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        anyhow::bail!("Downloaded remote-server tarball from {url} was empty");
+    }
+
+    if is_valid_cached_tarball(cache_path).await {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        return Ok(());
+    }
+
+    match tokio::fs::rename(&temp_path, cache_path).await {
+        Ok(()) => Ok(()),
+        Err(_e) if is_valid_cached_tarball(cache_path).await => {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            Ok(())
+        }
+        Err(e) => {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            Err(e).with_context(|| {
+                format!(
+                    "Failed to move remote-server tarball into cache at '{}'",
+                    cache_path.display()
+                )
+            })
+        }
+    }
+}
+
+async fn download_remote_server_tarball_with_retries(
+    url: &str,
+    temp_path: &Path,
+) -> anyhow::Result<()> {
+    let http_client = http_client::Client::new();
+    let mut last_retryable_error = None;
+
+    for attempt in 1..=REMOTE_SERVER_TARBALL_DOWNLOAD_ATTEMPTS {
+        match download_remote_server_tarball_once(&http_client, url, temp_path).await {
+            Ok(()) => return Ok(()),
+            Err(DownloadAttemptError::Permanent(e)) => return Err(e),
+            Err(DownloadAttemptError::Retryable(e)) => {
+                last_retryable_error = Some(e);
+                if attempt < REMOTE_SERVER_TARBALL_DOWNLOAD_ATTEMPTS {
+                    log::warn!("Remote-server tarball download attempt {attempt} failed; retrying");
+                    tokio::time::sleep(REMOTE_SERVER_TARBALL_DOWNLOAD_RETRY_DELAY).await;
+                }
+            }
+        }
+    }
+
+    Err(last_retryable_error.unwrap_or_else(|| {
+        anyhow::anyhow!("Remote-server tarball download failed without an error")
+    }))
+}
+
+enum DownloadAttemptError {
+    Retryable(anyhow::Error),
+    Permanent(anyhow::Error),
+}
+
+async fn download_remote_server_tarball_once(
+    http_client: &http_client::Client,
+    url: &str,
+    temp_path: &Path,
+) -> Result<(), DownloadAttemptError> {
+    let response = http_client
+        .get(url)
+        .timeout(REMOTE_SERVER_TARBALL_DOWNLOAD_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| {
+            DownloadAttemptError::Retryable(anyhow::anyhow!(
+                "Failed to download remote-server tarball from {url}: {e}"
+            ))
+        })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let error =
+            anyhow::anyhow!("Remote-server tarball download failed with status {status}: {body}");
+        return if is_retryable_download_status(status) {
+            Err(DownloadAttemptError::Retryable(error))
+        } else {
+            Err(DownloadAttemptError::Permanent(error))
+        };
+    }
+
+    let mut file = tokio::fs::File::create(temp_path).await.map_err(|e| {
+        DownloadAttemptError::Permanent(anyhow::anyhow!(
+            "Failed to create remote-server tarball cache file '{}': {e}",
+            temp_path.display()
+        ))
+    })?;
+    let mut bytes_stream = response.bytes_stream();
+    while let Some(chunk) = bytes_stream.try_next().await.map_err(|e| {
+        DownloadAttemptError::Retryable(anyhow::anyhow!(
+            "Failed to read remote-server tarball response body from {url}: {e}"
+        ))
+    })? {
+        file.write_all(&chunk).await.map_err(|e| {
+            DownloadAttemptError::Permanent(anyhow::anyhow!(
+                "Failed to write remote-server tarball cache file '{}': {e}",
+                temp_path.display()
+            ))
+        })?;
+    }
+    file.sync_data().await.map_err(|e| {
+        DownloadAttemptError::Permanent(anyhow::anyhow!(
+            "Failed to sync remote-server tarball cache file '{}': {e}",
+            temp_path.display()
+        ))
+    })?;
+
+    Ok(())
+}
+
+fn is_retryable_download_status(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+    ) || status.is_server_error()
+}
+
+/// Runs the binary install sequence for the SSH transport. It first asks the
+/// remote host to download directly, then falls back to uploading a cached
+/// client-side tarball over SCP when the remote download path fails.
+pub(super) async fn install_binary(socket_path: &Path) -> InstallOutcome {
+    let binary_path = remote_server::setup::remote_server_binary();
+    log::info!("Installing remote server binary to {binary_path}");
+    let mut outcome = match install_on_server(socket_path).await {
+        Ok(()) => InstallOutcome {
+            source: Some(InstallSource::Server),
+            result: Ok(()),
+        },
+        Err(server_err) => {
+            let should_try_scp = !should_skip_scp_fallback(&server_err);
+
+            if should_try_scp {
+                log::info!("Remote server has no curl/wget, falling back to SCP upload");
+                match scp_install_fallback(socket_path).await {
+                    Ok(()) => InstallOutcome {
+                        source: Some(InstallSource::Client),
+                        result: Ok(()),
+                    },
+                    Err(e) => InstallOutcome {
+                        source: Some(InstallSource::Client),
+                        result: Err(Error::Other(e)),
+                    },
+                }
+            } else {
+                InstallOutcome {
+                    source: Some(InstallSource::Server),
+                    result: Err(server_err),
+                }
+            }
+        }
+    };
+
+    // Post-install verification: confirm the binary actually landed at the
+    // expected path and is functional. This catches silent install failures
+    // that would otherwise surface as a cryptic IPC handshake error.
+    if outcome.result.is_ok() {
+        log::info!("Running post-install verification for {binary_path}");
+        let check_cmd = remote_server::setup::binary_check_command();
+        let verify = remote_server::ssh::run_ssh_command(
+            socket_path,
+            &check_cmd,
+            remote_server::setup::CHECK_TIMEOUT,
+        )
+        .await;
+        match verify {
+            Ok(output) if output.status.success() => {}
+            Ok(output) => {
+                let code = output.status.code().unwrap_or(-1);
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                outcome.result = Err(Error::Other(anyhow::anyhow!(
+                    "Post-install verification failed: binary not found or not \
+                     executable at {binary_path} (exit {code}): {stderr}"
+                )));
+            }
+            Err(e) => {
+                outcome.result = Err(Error::Other(anyhow::anyhow!(
+                    "Post-install verification failed: {e}"
+                )));
+            }
+        }
+    }
+
+    outcome
+}
+
+/// Exit codes where SCP fallback would not help because the failure is on the
+/// remote host itself, not a network/download issue.
+fn should_skip_scp_fallback(error: &Error) -> bool {
+    match error {
+        Error::UnsupportedOs { .. } | Error::UnsupportedArch { .. } => true,
+        Error::ScriptFailed { exit_code, .. } => *exit_code == 2,
+        _ => false,
+    }
+}
+
+fn classify_install_script_error(exit_code: i32, stderr: String) -> Error {
+    if exit_code == 2 {
+        for line in stderr.lines().map(str::trim) {
+            if let Some(arch) = line.strip_prefix("unsupported arch:") {
+                return Error::UnsupportedArch {
+                    arch: arch.trim().to_string(),
+                };
+            }
+            if let Some(os) = line.strip_prefix("unsupported OS:") {
+                return Error::UnsupportedOs {
+                    os: os.trim().to_string(),
+                };
+            }
+        }
+    }
+
+    Error::ScriptFailed { exit_code, stderr }
+}
+
+/// Runs the install script on the remote host to download and install the
+/// binary directly from the CDN.
+async fn install_on_server(socket_path: &Path) -> Result<(), Error> {
+    let script = remote_server::setup::install_script(None);
+    match remote_server::ssh::run_ssh_script(
+        socket_path,
+        &script,
+        remote_server::setup::INSTALL_TIMEOUT,
+    )
+    .await
+    {
+        Ok(output) if output.status.success() => Ok(()),
+        Ok(output) => {
+            let exit_code = output.status.code().unwrap_or(-1);
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            Err(classify_install_script_error(exit_code, stderr))
+        }
+        Err(SshCommandError::TimedOut { .. }) => Err(Error::TimedOut),
+        Err(e) => Err(Error::Other(e.into())),
+    }
+}
+
+/// SCP install fallback: downloads the tarball locally (reusing the local
+/// cache when possible), uploads it to the remote via SCP, then re-invokes the
+/// install script with the staging path baked in so the shared extraction tail
+/// runs.
+async fn scp_install_fallback(socket_path: &Path) -> anyhow::Result<()> {
+    let platform = super::detect_remote_platform(socket_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("SCP fallback: {e:#}"))?;
+
+    let client_tarball_path = cached_remote_server_tarball(&platform).await?;
+    let remote_tarball_path = format!(
+        "{}/oz-upload.tar.gz",
+        remote_server::setup::remote_server_dir()
+    );
+    let timeout = remote_server::setup::SCP_INSTALL_TIMEOUT;
+
+    log::info!("Uploading tarball to remote at {remote_tarball_path}");
+    remote_server::ssh::scp_upload(
+        socket_path,
+        &client_tarball_path,
+        &remote_tarball_path,
+        timeout,
+    )
+    .await?;
+
+    log::info!("Running extraction via install script with tarball at {remote_tarball_path}");
+    let script = remote_server::setup::install_script(Some(&remote_tarball_path));
+
+    let output = remote_server::ssh::run_ssh_script(socket_path, &script, timeout).await?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let code = output.status.code().unwrap_or(-1);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(anyhow::anyhow!(
+            "Extraction script failed (exit {code}): {stderr}"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_unsupported_arch_script_failure() {
+        let error = classify_install_script_error(2, "unsupported arch: armv7l\n".to_string());
+        assert!(matches!(
+            error,
+            Error::UnsupportedArch { arch } if arch == "armv7l"
+        ));
+    }
+
+    #[test]
+    fn classifies_unsupported_os_script_failure() {
+        let error =
+            classify_install_script_error(2, "unsupported OS: CYGWIN_NT-10.0-22621\n".to_string());
+        assert!(matches!(
+            error,
+            Error::UnsupportedOs { os } if os == "CYGWIN_NT-10.0-22621"
+        ));
+    }
+
+    #[test]
+    fn leaves_unrecognized_exit_two_as_script_failure() {
+        let error = classify_install_script_error(2, "some other failure\n".to_string());
+        assert!(matches!(
+            error,
+            Error::ScriptFailed { exit_code: 2, stderr } if stderr == "some other failure\n"
+        ));
+    }
+
+    #[test]
+    fn skips_scp_fallback_for_structured_unsupported_platform_errors() {
+        assert!(should_skip_scp_fallback(&Error::UnsupportedArch {
+            arch: "armv7l".into(),
+        }));
+        assert!(should_skip_scp_fallback(&Error::UnsupportedOs {
+            os: "CYGWIN_NT-10.0-22621".into(),
+        }));
+    }
+}

--- a/app/src/remote_server/ssh_transport/installation/cleanup.rs
+++ b/app/src/remote_server/ssh_transport/installation/cleanup.rs
@@ -1,0 +1,147 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use anyhow::Context as _;
+use warpui::r#async::executor;
+
+use super::{
+    cache_component, current_remote_server_tarball_cache_version, remote_server_tarball_cache_root,
+};
+
+const STALE_REMOTE_SERVER_TARBALL_TEMP_FILE_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+
+pub(crate) fn schedule_remote_server_tarball_cache_cleanup(executor: Arc<executor::Background>) {
+    executor
+        .spawn(async move {
+            if let Err(e) = cleanup_remote_server_tarball_cache().await {
+                log::warn!("Failed to clean up remote-server tarball cache: {e:#}");
+            }
+        })
+        .detach();
+}
+
+async fn cleanup_remote_server_tarball_cache() -> anyhow::Result<()> {
+    let current_version = cache_component(current_remote_server_tarball_cache_version());
+    cleanup_remote_server_tarball_cache_at(
+        &remote_server_tarball_cache_root(),
+        &current_version,
+        SystemTime::now(),
+        STALE_REMOTE_SERVER_TARBALL_TEMP_FILE_AGE,
+    )
+    .await
+}
+
+async fn cleanup_remote_server_tarball_cache_at(
+    root: &Path,
+    current_version: &str,
+    now: SystemTime,
+    stale_temp_file_age: Duration,
+) -> anyhow::Result<()> {
+    let Ok(metadata) = tokio::fs::metadata(root).await else {
+        return Ok(());
+    };
+    if !metadata.is_dir() {
+        return Ok(());
+    }
+
+    cleanup_stale_remote_server_tarball_temp_files(root, now, stale_temp_file_age).await?;
+
+    let mut channels = tokio::fs::read_dir(root).await.with_context(|| {
+        format!(
+            "Failed to read remote-server cache root '{}'",
+            root.display()
+        )
+    })?;
+    while let Some(channel_entry) = channels.next_entry().await? {
+        let channel_path = channel_entry.path();
+        if !channel_entry.file_type().await.is_ok_and(|ty| ty.is_dir()) {
+            continue;
+        }
+
+        let mut versions = match tokio::fs::read_dir(&channel_path).await {
+            Ok(versions) => versions,
+            Err(e) => {
+                log::warn!(
+                    "Failed to read remote-server cache channel '{}': {e}",
+                    channel_path.display()
+                );
+                continue;
+            }
+        };
+        while let Some(version_entry) = versions.next_entry().await? {
+            let version_path = version_entry.path();
+            let version_name = version_entry.file_name();
+            let version_name = version_name.to_string_lossy();
+            if version_entry.file_type().await.is_ok_and(|ty| ty.is_dir())
+                && version_name != current_version
+            {
+                if let Err(e) = tokio::fs::remove_dir_all(&version_path).await {
+                    log::warn!(
+                        "Failed to remove stale remote-server cache version '{}': {e}",
+                        version_path.display()
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn cleanup_stale_remote_server_tarball_temp_files(
+    root: &Path,
+    now: SystemTime,
+    stale_temp_file_age: Duration,
+) -> anyhow::Result<()> {
+    let mut dirs = vec![root.to_path_buf()];
+    while let Some(dir) = dirs.pop() {
+        let mut entries = match tokio::fs::read_dir(&dir).await {
+            Ok(entries) => entries,
+            Err(e) => {
+                log::warn!(
+                    "Failed to read remote-server cache directory '{}': {e}",
+                    dir.display()
+                );
+                continue;
+            }
+        };
+
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type().await else {
+                continue;
+            };
+            if file_type.is_dir() {
+                dirs.push(path);
+                continue;
+            }
+            if !file_type.is_file()
+                || !path
+                    .file_name()
+                    .is_some_and(|file_name| file_name.to_string_lossy().ends_with(".tmp"))
+            {
+                continue;
+            }
+
+            let Ok(metadata) = entry.metadata().await else {
+                continue;
+            };
+            let is_stale = metadata
+                .modified()
+                .ok()
+                .and_then(|modified| now.duration_since(modified).ok())
+                .is_some_and(|age| age >= stale_temp_file_age);
+            if is_stale {
+                if let Err(e) = tokio::fs::remove_file(&path).await {
+                    log::warn!(
+                        "Failed to remove stale remote-server temp cache file '{}': {e}",
+                        path.display()
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -2867,12 +2867,19 @@ pub enum TelemetryEvent {
     RemoteServerHostUnsupported {
         remote_os: Option<String>,
         remote_arch: Option<String>,
+        /// Machine-readable unsupported reason, e.g. `"glibc_too_old"`,
+        /// `"non_glibc"`, `"unsupported_os"`, or `"unsupported_arch"`.
+        reason: String,
         /// Detected libc on the remote host, e.g. `"glibc 2.28"`,
         /// `"musl"`, `"unknown"`.
         detected_libc: String,
         /// Required minimum glibc reported by the script. Empty when
         /// the unsupported classification was not glibc-related.
         required_glibc: String,
+        /// Raw unsupported OS value when the host's kernel is unsupported.
+        unsupported_os: Option<String>,
+        /// Raw unsupported architecture value when the CPU architecture is unsupported.
+        unsupported_arch: Option<String>,
     },
     /// Emitted when a reconnection attempt succeeds after a spontaneous disconnect.
     RemoteServerReconnection {
@@ -4259,13 +4266,19 @@ impl TelemetryEvent {
             TelemetryEvent::RemoteServerHostUnsupported {
                 remote_os,
                 remote_arch,
+                reason,
                 detected_libc,
                 required_glibc,
+                unsupported_os,
+                unsupported_arch,
             } => Some(json!({
                 "remote_os": remote_os,
                 "remote_arch": remote_arch,
+                "reason": reason,
                 "detected_libc": detected_libc,
                 "required_glibc": required_glibc,
+                "unsupported_os": unsupported_os,
+                "unsupported_arch": unsupported_arch,
             })),
             TelemetryEvent::RemoteServerReconnection {
                 attempt,

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -19,7 +19,8 @@ use crate::terminal::model::session::{IsLegacySSHSession, SessionInfo};
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
 use crate::{send_telemetry_from_ctx, TelemetryEvent};
 use remote_server::setup::{
-    PreinstallCheckResult, PreinstallStatus, RemoteLibc, RemotePlatform, UnsupportedReason,
+    unsupported_reason_from_transport_error, PreinstallCheckResult, PreinstallStatus, RemoteLibc,
+    RemotePlatform, UnsupportedReason,
 };
 use remote_server::transport::Error;
 
@@ -263,7 +264,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 "Remote server preinstall check classified as unsupported, falling back to legacy SSH: session={session_id:?} status={:?}",
                 check.status
             );
-            send_unsupported_telemetry(self.remote_platform.as_ref(), check, ctx);
+            send_unsupported_telemetry(self.remote_platform.as_ref(), &reason, Some(check), ctx);
             RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
                 mgr.mark_setup_unsupported(session_id, reason, ctx);
             });
@@ -330,6 +331,17 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 }
             }
             Err(err) => {
+                if let Some(reason) = unsupported_reason_from_transport_error(&err) {
+                    log::info!(
+                        "Remote server platform check classified host as unsupported, falling back to legacy SSH: session={session_id:?} error={err}"
+                    );
+                    send_unsupported_telemetry(self.remote_platform.as_ref(), &reason, None, ctx);
+                    RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
+                        mgr.mark_setup_unsupported(session_id, reason, ctx);
+                    });
+                    self.flush_stashed_bootstrap(session_info, ctx);
+                    return;
+                }
                 log::warn!("Remote server binary check failed: session={session_id:?} error={err}");
                 self.flush_stashed_bootstrap(session_info, ctx);
             }
@@ -509,6 +521,17 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 self.connect_session_for_current_identity(session_id, socket_path, ctx);
             }
             Err(err) => {
+                if let Some(reason) = unsupported_reason_from_transport_error(&err) {
+                    log::info!(
+                        "Remote server binary install classified host as unsupported, falling back to legacy SSH: session={session_id:?} error={err}"
+                    );
+                    send_unsupported_telemetry(self.remote_platform.as_ref(), &reason, None, ctx);
+                    RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
+                        mgr.mark_setup_unsupported(session_id, reason, ctx);
+                    });
+                    self.flush_stashed_bootstrap(session_info, ctx);
+                    return;
+                }
                 log::warn!(
                     "Remote server binary install failed: session={session_id:?} error={err}"
                 );
@@ -559,7 +582,8 @@ fn describe_libc(libc: &RemoteLibc) -> String {
 
 fn send_unsupported_telemetry<T: EventLoopSender>(
     remote_platform: Option<&RemotePlatform>,
-    check: &PreinstallCheckResult,
+    reason: &UnsupportedReason,
+    preinstall_check: Option<&PreinstallCheckResult>,
     ctx: &mut ModelContext<RemoteServerController<T>>,
 ) {
     let (remote_os, remote_arch) = remote_platform
@@ -570,18 +594,29 @@ fn send_unsupported_telemetry<T: EventLoopSender>(
             )
         })
         .unwrap_or((None, None));
-    let required_glibc = match &check.status {
-        remote_server::setup::PreinstallStatus::Unsupported {
-            reason: UnsupportedReason::GlibcTooOld { required, .. },
-        } => required.to_string(),
-        _ => String::new(),
+    let (reason_name, unsupported_os, unsupported_arch, required_glibc) = match reason {
+        UnsupportedReason::GlibcTooOld { required, .. } => {
+            ("glibc_too_old", None, None, required.to_string())
+        }
+        UnsupportedReason::NonGlibc { .. } => ("non_glibc", None, None, String::new()),
+        UnsupportedReason::UnsupportedOs { os } => {
+            ("unsupported_os", Some(os.clone()), None, String::new())
+        }
+        UnsupportedReason::UnsupportedArch { arch } => {
+            ("unsupported_arch", None, Some(arch.clone()), String::new())
+        }
     };
     send_telemetry_from_ctx!(
         TelemetryEvent::RemoteServerHostUnsupported {
             remote_os,
             remote_arch,
-            detected_libc: describe_libc(&check.libc),
+            reason: reason_name.to_string(),
+            detected_libc: preinstall_check
+                .map(|check| describe_libc(&check.libc))
+                .unwrap_or_else(|| "unknown".to_string()),
             required_glibc,
+            unsupported_os,
+            unsupported_arch,
         },
         ctx
     );

--- a/crates/remote_server/src/install_remote_server.sh
+++ b/crates/remote_server/src/install_remote_server.sh
@@ -15,7 +15,7 @@ set -e
 arch=$(uname -m)
 case "$arch" in
   x86_64|amd64)  arch_name=x86_64 ;;
-  aarch64|arm64) arch_name=aarch64 ;;
+  aarch64|arm64|armv8l) arch_name=aarch64 ;;
   *) echo "unsupported arch: $arch" >&2; exit 2 ;;
 esac
 

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -13,6 +13,7 @@ use crate::client::InitializeParams;
 use crate::client::RemoteServerClient;
 use crate::codebase_index_proto::RemoteCodebaseIndexStatus;
 use crate::proto::{DiffStateFileDelta, DiffStateMetadataUpdate, DiffStateSnapshot};
+use crate::setup::unsupported_reason_from_transport_error;
 use crate::setup::PreinstallCheckResult;
 #[cfg(not(target_family = "wasm"))]
 use crate::setup::RemoteOs;
@@ -655,15 +656,36 @@ impl RemoteServerManager {
                     // versioned binary present), so it can skip the
                     // install prompt in the update case.
                     let platform_result = transport.detect_platform().await;
-                    let check_result = transport.check_binary().await;
-                    let old_binary_result = transport.check_has_old_binary().await;
                     let platform = match platform_result {
                         Ok(p) => Some(p),
                         Err(e) => {
+                            if let Some(reason) = unsupported_reason_from_transport_error(&e) {
+                                log::info!(
+                                    "Remote server platform detection classified host as unsupported: session={session_id:?} error={e}"
+                                );
+                                let _ = spawner
+                                    .spawn(move |_me, ctx| {
+                                        ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
+                                            session_id,
+                                            state: RemoteServerSetupState::Unsupported { reason },
+                                        });
+                                        ctx.emit(RemoteServerManagerEvent::BinaryCheckComplete {
+                                            session_id,
+                                            result: Err(Arc::new(e)),
+                                            remote_platform: None,
+                                            preinstall_check: None,
+                                            has_old_binary: false,
+                                        });
+                                    })
+                                    .await;
+                                return;
+                            }
                             log::warn!("Remote server platform detection failed: session={session_id:?} error={e}");
                             None
                         }
                     };
+                    let check_result = transport.check_binary().await;
+                    let old_binary_result = transport.check_has_old_binary().await;
                     let has_old_binary = match old_binary_result {
                         Ok(has) => has,
                         Err(e) => {
@@ -698,12 +720,19 @@ impl RemoteServerManager {
                                 me.session_platforms.insert(session_id, p.clone());
                             }
                             if let Err(error) = &check_result {
-                                ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
-                                    session_id,
-                                    state: RemoteServerSetupState::Failed {
-                                        error: error.to_string(),
-                                    },
-                                });
+                                if let Some(reason) = unsupported_reason_from_transport_error(error) {
+                                    ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
+                                        session_id,
+                                        state: RemoteServerSetupState::Unsupported { reason },
+                                    });
+                                } else {
+                                    ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
+                                        session_id,
+                                        state: RemoteServerSetupState::Failed {
+                                            error: error.to_string(),
+                                        },
+                                    });
+                                }
                             }
                             ctx.emit(RemoteServerManagerEvent::BinaryCheckComplete {
                                 session_id,
@@ -792,12 +821,20 @@ impl RemoteServerManager {
                     let _ = spawner
                         .spawn(move |_me, ctx| {
                             if let Err(error) = &outcome.result {
-                                ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
-                                    session_id,
-                                    state: RemoteServerSetupState::Failed {
-                                        error: error.to_string(),
-                                    },
-                                });
+                                if let Some(reason) = unsupported_reason_from_transport_error(error)
+                                {
+                                    ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
+                                        session_id,
+                                        state: RemoteServerSetupState::Unsupported { reason },
+                                    });
+                                } else {
+                                    ctx.emit(RemoteServerManagerEvent::SetupStateChanged {
+                                        session_id,
+                                        state: RemoteServerSetupState::Failed {
+                                            error: error.to_string(),
+                                        },
+                                    });
+                                }
                             }
                             ctx.emit(RemoteServerManagerEvent::BinaryInstallComplete {
                                 session_id,

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -100,6 +100,26 @@ pub enum UnsupportedReason {
     NonGlibc {
         name: String,
     },
+    UnsupportedOs {
+        os: String,
+    },
+    UnsupportedArch {
+        arch: String,
+    },
+}
+
+pub fn unsupported_reason_from_transport_error(
+    error: &crate::transport::Error,
+) -> Option<UnsupportedReason> {
+    match error {
+        crate::transport::Error::UnsupportedOs { os } => {
+            Some(UnsupportedReason::UnsupportedOs { os: os.clone() })
+        }
+        crate::transport::Error::UnsupportedArch { arch } => {
+            Some(UnsupportedReason::UnsupportedArch { arch: arch.clone() })
+        }
+        _ => None,
+    }
 }
 
 impl PreinstallCheckResult {
@@ -426,6 +446,17 @@ fn pinned_version() -> &'static str {
     ChannelState::app_version().unwrap_or(env!("CARGO_PKG_VERSION"))
 }
 
+/// Returns the release version that identifies remote-server download
+/// artifacts, when the current channel uses version-pinned artifacts.
+pub fn remote_server_artifact_version() -> Option<&'static str> {
+    match ChannelState::channel() {
+        Channel::Local | Channel::Oss => None,
+        Channel::Stable | Channel::Preview | Channel::Dev | Channel::Integration => {
+            Some(pinned_version())
+        }
+    }
+}
+
 /// The install script template, loaded from a standalone `.sh` file for
 /// readability. Placeholders like `{download_base_url}` are substituted by
 /// [`install_script`].
@@ -490,6 +521,11 @@ fn download_channel() -> &'static str {
             "dev"
         }
     }
+}
+
+/// Returns the server-side download channel used for remote-server artifacts.
+pub fn remote_server_download_channel() -> &'static str {
+    download_channel()
 }
 
 /// Returns the version query string for the download URL (e.g.

--- a/crates/remote_server/src/setup_tests.rs
+++ b/crates/remote_server/src/setup_tests.rs
@@ -350,3 +350,146 @@ fn parse_preinstall_missing_status_falls_open() {
     assert_eq!(result.status, PreinstallStatus::Unknown);
     assert!(result.is_supported());
 }
+
+#[test]
+fn parse_uname_unsupported_cygwin_os() {
+    let result = parse_uname_output("CYGWIN_NT-10.0-22621 x86_64");
+    match result {
+        Err(crate::transport::Error::UnsupportedOs { os }) => {
+            assert_eq!(os, "CYGWIN_NT-10.0-22621");
+        }
+        other => panic!("expected UnsupportedOs, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_uname_unsupported_armv6l() {
+    let result = parse_uname_output("Linux armv6l");
+    match result {
+        Err(crate::transport::Error::UnsupportedArch { arch }) => {
+            assert_eq!(arch, "armv6l");
+        }
+        other => panic!("expected UnsupportedArch, got {other:?}"),
+    }
+}
+
+#[test]
+fn unsupported_reason_from_transport_error_maps_os_and_arch() {
+    assert_eq!(
+        unsupported_reason_from_transport_error(&crate::transport::Error::UnsupportedOs {
+            os: "CYGWIN_NT-10.0-22621".into(),
+        }),
+        Some(UnsupportedReason::UnsupportedOs {
+            os: "CYGWIN_NT-10.0-22621".into(),
+        })
+    );
+    assert_eq!(
+        unsupported_reason_from_transport_error(&crate::transport::Error::UnsupportedArch {
+            arch: "armv7l".into(),
+        }),
+        Some(UnsupportedReason::UnsupportedArch {
+            arch: "armv7l".into(),
+        })
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn install_script_platform_mapping_handles_supported_and_unsupported_targets() {
+    use command::blocking::Command;
+    use std::process::Stdio;
+
+    let bash = if std::path::Path::new("/bin/bash").exists() {
+        "/bin/bash"
+    } else {
+        "bash"
+    };
+
+    let script = install_script(None);
+    let cutoff = script.find("install_dir=").expect(
+        "install script no longer contains the install_dir checkpoint this test relies on; update the test alongside the script change",
+    );
+    let prefix = &script[..cutoff];
+
+    struct Case<'a> {
+        name: &'a str,
+        os: &'a str,
+        arch: &'a str,
+        expected_status: i32,
+        expected_stdout: &'a str,
+        expected_stderr: &'a str,
+    }
+
+    let cases = [
+        Case {
+            name: "armv8l is treated as aarch64",
+            os: "Linux",
+            arch: "armv8l",
+            expected_status: 0,
+            expected_stdout: "linux/aarch64",
+            expected_stderr: "",
+        },
+        Case {
+            name: "armv6l remains unsupported",
+            os: "Linux",
+            arch: "armv6l",
+            expected_status: 2,
+            expected_stdout: "",
+            expected_stderr: "unsupported arch: armv6l",
+        },
+        Case {
+            name: "cygwin remains unsupported",
+            os: "CYGWIN_NT-10.0-22621",
+            arch: "x86_64",
+            expected_status: 2,
+            expected_stdout: "",
+            expected_stderr: "unsupported OS: CYGWIN_NT-10.0-22621",
+        },
+    ];
+
+    for case in cases {
+        let probe = format!(
+            r#"uname() {{
+  case "$1" in
+    -m) printf '%s\n' '{arch}' ;;
+    -s) printf '%s\n' '{os}' ;;
+    *) return 1 ;;
+  esac
+}}
+{prefix}
+printf '%s/%s' "$os_name" "$arch_name"
+"#,
+            arch = case.arch,
+            os = case.os,
+            prefix = prefix,
+        );
+
+        let output = Command::new(bash)
+            .arg("-c")
+            .arg(&probe)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("failed to spawn bash");
+
+        assert_eq!(
+            output.status.code(),
+            Some(case.expected_status),
+            "{}: unexpected status; stderr={}",
+            case.name,
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            case.expected_stdout,
+            "{}: unexpected stdout",
+            case.name,
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stderr).trim(),
+            case.expected_stderr,
+            "{}: unexpected stderr",
+            case.name,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Route unsupported SSH extension OS/architecture detections through the structured unsupported-host fallback instead of generic setup failures.
- Align install-script architecture handling with Rust platform detection by treating `armv8l` as `aarch64`.
- Classify install-script `unsupported OS:` / `unsupported arch:` exit-2 failures into typed transport errors and skip SCP fallback for those non-recoverable cases.
- Extend unsupported-host telemetry with a machine-readable reason and raw unsupported OS/architecture fields.
- Preserve and include the existing SCP tarball cache/refactor handoff changes.

## Validation
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p remote_server`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp unsupported -- --nocapture`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- `cargo build --manifest-path /workspace/warp/Cargo.toml -p warp --bin dev`

## SSH container verification
- Installed `podman` and `openssh-client` in the sandbox because Docker was unavailable.
- Built a temporary SSH image with a fake `uname` shim using `podman --storage-driver=vfs --root /tmp/warp-podman-root --runroot /tmp/warp-podman-runroot build --isolation=chroot`.
- Runtime container startup was blocked by sandbox kernel restrictions (`crun: create keyring ... Operation not permitted` and netlink permission errors), so full live SSH container sessions could not be started in this environment.
- The script-level platform behavior was still verified by tests that execute the production `install_remote_server.sh` prefix under bash with stubbed `uname`: `armv8l` maps to `linux/aarch64`, `armv6l` exits 2 with `unsupported arch`, and `CYGWIN_NT-10.0-22621` exits 2 with `unsupported OS`.
- Computer-use verification independently confirmed Docker was unavailable and re-ran the targeted `remote_server unsupported` and `warp unsupported` test filters successfully.

_Conversation: https://staging.warp.dev/conversation/09fe221b-b43d-4497-8757-e26695cb3f02_
_Run: https://oz.staging.warp.dev/runs/019e23e9-2a57-75ee-afb3-5b03cef79dc2_
_This PR was generated with [Oz](https://warp.dev/oz)._
