### PR TITLE
Avoid redundant uname in SCP fallback

### DIFF
--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use warpui::r#async::executor;
@@ -31,6 +31,7 @@ use remote_server::transport::{Connection, Error, InstallOutcome, InstallSource,
 pub struct SshTransport {
     socket_path: PathBuf,
     auth_context: Arc<RemoteServerAuthContext>,
+    detected_platform: Arc<Mutex<Option<RemotePlatform>>>,
 }
 
 impl fmt::Debug for SshTransport {
@@ -46,6 +47,7 @@ impl SshTransport {
         Self {
             socket_path,
             auth_context,
+            detected_platform: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -75,6 +77,23 @@ impl SshTransport {
         let quoted_identity_key = shell_words::quote(&identity_key);
         format!("{binary} remote-server-proxy --identity-key {quoted_identity_key}")
     }
+
+    fn cache_detected_platform(&self, platform: RemotePlatform) {
+        match self.detected_platform.lock() {
+            Ok(mut cached) => *cached = Some(platform),
+            Err(e) => log::warn!("Failed to cache detected remote platform: {e}"),
+        }
+    }
+
+    fn cached_detected_platform(&self) -> Option<RemotePlatform> {
+        match self.detected_platform.lock() {
+            Ok(cached) => cached.clone(),
+            Err(e) => {
+                log::warn!("Failed to read cached remote platform: {e}");
+                None
+            }
+        }
+    }
 }
 
 /// Runs `uname -sm` on the remote host via the ControlMaster socket and
@@ -103,7 +122,12 @@ impl RemoteTransport for SshTransport {
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<RemotePlatform, Error>> + Send>> {
         let socket_path = self.socket_path.clone();
-        Box::pin(async move { detect_remote_platform(&socket_path).await })
+        let transport = self.clone();
+        Box::pin(async move {
+            let platform = detect_remote_platform(&socket_path).await?;
+            transport.cache_detected_platform(platform.clone());
+            Ok(platform)
+        })
     }
 
     fn run_preinstall_check(
@@ -202,6 +226,7 @@ impl RemoteTransport for SshTransport {
 
     fn install_binary(&self) -> Pin<Box<dyn Future<Output = InstallOutcome> + Send>> {
         let socket_path = self.socket_path.clone();
+        let cached_platform = self.cached_detected_platform();
         Box::pin(async move {
             let binary_path = remote_server::setup::remote_server_binary();
             log::info!("Installing remote server binary to {binary_path}");
@@ -215,7 +240,7 @@ impl RemoteTransport for SshTransport {
 
                     if should_try_scp {
                         log::info!("Remote server has no curl/wget, falling back to SCP upload");
-                        match scp_install_fallback(&socket_path).await {
+                        match scp_install_fallback(&socket_path, cached_platform).await {
                             Ok(()) => InstallOutcome {
                                 source: Some(InstallSource::Client),
                                 result: Ok(()),
@@ -386,16 +411,13 @@ async fn install_on_server(socket_path: &Path) -> Result<(), Error> {
 /// SCP install fallback: downloads the tarball locally, uploads it to
 /// the remote via SCP, then re-invokes the install script with the
 /// staging path baked in so the shared extraction tail runs.
-async fn scp_install_fallback(socket_path: &Path) -> anyhow::Result<()> {
+async fn scp_install_fallback(
+    socket_path: &Path,
+    cached_platform: Option<RemotePlatform>,
+) -> anyhow::Result<()> {
     use std::process::Stdio;
 
-    // Detect the remote platform so we can construct the correct download URL.
-    // This is a redundant uname call (the manager already ran detect_platform
-    // earlier), but it only happens on the rare SCP fallback path and avoids
-    // threading the platform through the trait.
-    let platform = detect_remote_platform(socket_path)
-        .await
-        .map_err(|e| anyhow::anyhow!("SCP fallback: {e:#}"))?;
+    let platform = platform_for_scp_fallback(socket_path, cached_platform).await?;
 
     let url = remote_server::setup::download_tarball_url(&platform);
     let remote_tarball_path = format!(
@@ -461,6 +483,23 @@ async fn scp_install_fallback(socket_path: &Path) -> anyhow::Result<()> {
             "Extraction script failed (exit {code}): {stderr}"
         ))
     }
+}
+
+async fn platform_for_scp_fallback(
+    socket_path: &Path,
+    cached_platform: Option<RemotePlatform>,
+) -> anyhow::Result<RemotePlatform> {
+    if let Some(platform) = cached_platform {
+        return Ok(platform);
+    }
+
+    // Fall back to probing when install_binary is invoked without a prior
+    // detect_platform call. The normal setup flow detects the platform before
+    // install, and reusing that result avoids an extra ControlMaster session
+    // while recovering from a server-side install failure.
+    detect_remote_platform(socket_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("SCP fallback: {e:#}"))
 }
 
 #[cfg(test)]

--- a/app/src/remote_server/ssh_transport_tests.rs
+++ b/app/src/remote_server/ssh_transport_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use remote_server::setup::{RemoteArch, RemoteOs};
 use warpui::r#async::BoxFuture;
 
 fn static_auth_context() -> Arc<RemoteServerAuthContext> {
@@ -22,4 +23,38 @@ fn remote_proxy_command_quotes_identity_key() {
 
     assert!(command.contains("remote-server-proxy --identity-key"));
     assert!(command.contains("'user id/with spaces'"));
+}
+
+#[test]
+fn detected_platform_cache_is_shared_between_transport_clones() {
+    let transport = SshTransport::new(
+        PathBuf::from("/tmp/control-master.sock"),
+        static_auth_context(),
+    );
+    let clone = transport.clone();
+    let platform = RemotePlatform {
+        os: RemoteOs::Linux,
+        arch: RemoteArch::X86_64,
+    };
+
+    transport.cache_detected_platform(platform.clone());
+
+    assert_eq!(clone.cached_detected_platform(), Some(platform));
+}
+
+#[tokio::test]
+async fn scp_fallback_reuses_cached_platform_without_uname_probe() {
+    let cached = RemotePlatform {
+        os: RemoteOs::Linux,
+        arch: RemoteArch::X86_64,
+    };
+
+    let platform = platform_for_scp_fallback(
+        Path::new("/tmp/nonexistent-control-master.sock"),
+        Some(cached.clone()),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(platform, cached);
 }


### PR DESCRIPTION
## Summary
- Cache the successful `uname -sm` platform result on `SshTransport` and share it across transport clones.
- Reuse the cached platform in the SCP fallback path instead of issuing a redundant `uname -sm` over the ControlMaster.
- Add regression tests for clone-shared platform caching and cached SCP fallback platform reuse.

## Validation
- Reproduced the target production-shaped failure with a localhost `sshd` configured with `MaxSessions 1`: initial `uname -sm` succeeded, then a second Warp-shaped slave command returned exit 255 with empty stdout while another mux session occupied the ControlMaster.
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --package warp --check`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp scp_fallback_reuses_cached_platform_without_uname_probe -- --nocapture`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp detected_platform_cache_is_shared_between_transport_clones -- --nocapture`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp remote_proxy_command_quotes_identity_key -- --nocapture`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/5ddef5c9-9601-452b-baf0-39ff0e28c7b9_
_Run: https://oz.staging.warp.dev/runs/019e23f7-3429-7a9f-9504-55bfdf38ca98_

_This PR was generated with [Oz](https://warp.dev/oz)._
