### PR TITLE
Add auth secret dropdown picker for non-Oz orchestration

### DIFF
--- a/app/src/ai/agent/api/convert_from.rs
+++ b/app/src/ai/agent/api/convert_from.rs
@@ -154,6 +154,10 @@ fn convert_run_agents(run_agents: api::RunAgents) -> AIAgentActionType {
             })
             .collect(),
         plan_id,
+        // Auth secret is a client-side dispatch concern populated by the
+        // confirmation card from `CloudAgentSettings.last_selected_auth_secret`
+        // before Accept. The proto does not carry it.
+        harness_auth_secret_name: None,
     })
 }
 
@@ -175,6 +179,9 @@ fn convert_start_agent_v2_execution_mode(
                 harness_type: convert_start_agent_v2_harness_type(remote.harness)
                     .unwrap_or_default(),
                 title: remote.title,
+                // Auth secret is plumbed client-side via `RunAgentsRequest`;
+                // StartAgentV2 from the server never carries it.
+                auth_secret_name: None,
             }
         }
         Some(api::start_agent_v2::execution_mode::Mode::Local(local)) => {

--- a/app/src/ai/agent/api/convert_from_tests.rs
+++ b/app/src/ai/agent/api/convert_from_tests.rs
@@ -520,6 +520,7 @@ fn converts_remote_start_agent_with_environment_id() {
             worker_host: String::new(),
             harness_type: String::new(),
             title: String::new(),
+            auth_secret_name: None,
         }
     );
     assert_eq!(lifecycle_subscription, None);
@@ -560,6 +561,7 @@ fn converts_remote_start_agent_v2_with_skill_references() {
             worker_host: "worker-host".to_string(),
             harness_type: "claude-code".to_string(),
             title: "Remote child".to_string(),
+            auth_secret_name: None,
         }
     );
     assert_eq!(lifecycle_subscription, None);

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -119,6 +119,7 @@ impl RunAgentsExecutor {
             skills,
             agent_run_configs,
             base_prompt,
+            harness_auth_secret_name,
             ..
         } = request;
 
@@ -130,6 +131,7 @@ impl RunAgentsExecutor {
                 &harness_type,
                 &model_id,
                 &skills,
+                harness_auth_secret_name.as_deref(),
                 cfg,
             ) {
                 Ok(mode) => mode,
@@ -368,11 +370,16 @@ pub fn compose_run_agents_child_prompt(base_prompt: &str, per_agent_prompt: &str
 /// Translates run-wide config into a per-child
 /// [`StartAgentExecutionMode`]. Returns `Err` for rejected
 /// combinations (e.g. OpenCode+Remote).
+///
+/// `run_auth_secret_name` is the managed-secret name the orchestration UI
+/// resolved for the run-wide harness; only Remote mode currently consumes
+/// it (Local children inherit auth from the user's shell environment).
 pub fn run_agents_to_start_agent_mode(
     run_execution_mode: &RunAgentsExecutionMode,
     run_harness_type: &str,
     run_model_id: &str,
     run_skills: &[SkillReference],
+    run_auth_secret_name: Option<&str>,
     cfg: &RunAgentsAgentRunConfig,
 ) -> Result<StartAgentExecutionMode, String> {
     match run_execution_mode {
@@ -412,6 +419,9 @@ pub fn run_agents_to_start_agent_mode(
                 worker_host: worker_host.clone(),
                 harness_type: run_harness_type.to_string(),
                 title: cfg.title.clone(),
+                auth_secret_name: run_auth_secret_name
+                    .map(str::to_string)
+                    .filter(|s| !s.trim().is_empty()),
             })
         }
     }

--- a/app/src/ai/blocklist/action_model/execute/start_agent.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent.rs
@@ -374,6 +374,7 @@ impl StartAgentExecutor {
                 worker_host,
                 harness_type,
                 title,
+                auth_secret_name,
             } => {
                 if !FeatureFlag::OrchestrationV2.is_enabled() {
                     return ActionExecution::Sync(AIAgentActionResultType::StartAgent(
@@ -430,6 +431,7 @@ impl StartAgentExecutor {
                         worker_host,
                         harness_type,
                         title,
+                        auth_secret_name,
                     },
                     Some(parent_run_id),
                 )

--- a/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
@@ -643,6 +643,7 @@ fn execute_returns_error_when_remote_opencode_harness_is_requested() {
                 worker_host: String::new(),
                 harness_type: "opencode".to_string(),
                 title: String::new(),
+                auth_secret_name: None,
             },
         );
 

--- a/app/src/ai/blocklist/block/view_impl/orchestration_tests.rs
+++ b/app/src/ai/blocklist/block/view_impl/orchestration_tests.rs
@@ -77,6 +77,7 @@ fn start_agent_copy_uses_remote_labels_for_remote_children() {
         worker_host: String::new(),
         harness_type: String::new(),
         title: String::new(),
+        auth_secret_name: None,
     };
 
     assert_eq!(start_agent_success_suffix(&execution_mode), " remotely.");

--- a/app/src/ai/blocklist/block_tests.rs
+++ b/app/src/ai/blocklist/block_tests.rs
@@ -156,6 +156,7 @@ fn remote_arm_propagates_skills_into_skill_references() {
         "oz",
         "auto",
         &skills,
+        None,
         &agent_cfg(),
     )
     .expect("Remote+oz must convert");
@@ -167,6 +168,7 @@ fn remote_arm_propagates_skills_into_skill_references() {
         model_id,
         computer_use_enabled,
         title,
+        auth_secret_name,
     } = mode
     else {
         panic!("expected Remote start-agent mode");
@@ -178,6 +180,7 @@ fn remote_arm_propagates_skills_into_skill_references() {
     assert_eq!(model_id, "auto");
     assert!(computer_use_enabled);
     assert_eq!(title, "Child");
+    assert_eq!(auth_secret_name, None);
 }
 
 #[test]
@@ -191,6 +194,7 @@ fn remote_arm_with_empty_skills_propagates_empty_vec() {
         "claude",
         "auto",
         &[],
+        None,
         &agent_cfg(),
     )
     .expect("Remote+claude must convert");
@@ -214,10 +218,74 @@ fn remote_arm_rejects_opencode() {
         "opencode",
         "auto",
         &[],
+        None,
         &agent_cfg(),
     )
     .expect_err("Remote+opencode must be rejected");
     assert!(err.to_lowercase().contains("opencode"));
+}
+
+#[test]
+fn remote_arm_propagates_claude_auth_secret_into_mode() {
+    let mode = run_agents_to_start_agent_mode(
+        &RunAgentsExecutionMode::Remote {
+            environment_id: "env-1".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: false,
+        },
+        "claude",
+        "auto",
+        &[],
+        Some("my-claude-key"),
+        &agent_cfg(),
+    )
+    .expect("Remote+claude must convert");
+    let StartAgentExecutionMode::Remote {
+        auth_secret_name, ..
+    } = mode
+    else {
+        panic!("expected Remote start-agent mode");
+    };
+    assert_eq!(auth_secret_name.as_deref(), Some("my-claude-key"));
+}
+
+#[test]
+fn remote_arm_filters_whitespace_auth_secret_name_to_none() {
+    let mode = run_agents_to_start_agent_mode(
+        &RunAgentsExecutionMode::Remote {
+            environment_id: "env-1".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: false,
+        },
+        "codex",
+        "auto",
+        &[],
+        Some("   "),
+        &agent_cfg(),
+    )
+    .expect("Remote+codex must convert");
+    let StartAgentExecutionMode::Remote {
+        auth_secret_name, ..
+    } = mode
+    else {
+        panic!("expected Remote start-agent mode");
+    };
+    assert_eq!(auth_secret_name, None);
+}
+
+#[test]
+fn local_arm_ignores_auth_secret_name() {
+    let mode = run_agents_to_start_agent_mode(
+        &RunAgentsExecutionMode::Local,
+        "claude",
+        "auto",
+        &[],
+        Some("my-claude-key"),
+        &agent_cfg(),
+    )
+    .expect("Local+claude must convert");
+    // Local children don't carry an auth_secret_name field.
+    assert!(matches!(mode, StartAgentExecutionMode::Local { .. }));
 }
 
 #[test]

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -31,13 +31,15 @@ use warp_cli::agent::Harness;
 use warp_core::channel::{Channel, ChannelState};
 use warp_core::ui::theme::Fill;
 
+use crate::ai::auth_secret_types::auth_secret_types_for_harness;
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::execution_profiles::model_menu_items::available_model_menu_items;
-use crate::ai::harness_availability::HarnessAvailabilityModel;
+use crate::ai::harness_availability::{AuthSecretFetchState, HarnessAvailabilityModel};
 use crate::ai::harness_display;
 use crate::appearance::Appearance;
 use crate::menu::{MenuItem, MenuItemFields};
+use crate::report_if_error;
 use crate::ui_components::blended_colors;
 use crate::view_components::dropdown::{Dropdown, DropdownAction, DropdownStyle};
 use crate::view_components::FilterableDropdown;
@@ -56,6 +58,12 @@ pub const ORCHESTRATION_PICKER_MAX_WIDTH: f32 = 205.;
 
 const DEFAULT_MODEL_LABEL: &str = "Default model";
 
+/// Label shown in the auth secret picker when no secret is selected
+/// (the child agent will inherit credentials from its environment).
+const AUTH_SECRET_INHERIT_LABEL: &str = "Inherit key from environment";
+/// Label for the auth secret column.
+pub const AUTH_SECRET_COLUMN_LABEL: &str = "API key";
+
 // ── Action trait ────────────────────────────────────────────────────
 
 /// Trait that both `RunAgentsCardViewAction` and
@@ -67,6 +75,9 @@ pub trait OrchestrationControlAction: Clone + Debug + Send + Sync + 'static {
     fn harness_changed(harness_type: String) -> Self;
     fn environment_changed(environment_id: String) -> Self;
     fn worker_host_changed(worker_host: String) -> Self;
+    /// Fires when the auth secret picker selects a managed secret.
+    /// `None` means "clear the selection / inherit from environment".
+    fn auth_secret_changed(name: Option<String>) -> Self;
 }
 
 // ── Shared edit state ───────────────────────────────────────────────
@@ -80,6 +91,12 @@ pub struct OrchestrationEditState {
     pub model_id: String,
     pub harness_type: String,
     pub execution_mode: RunAgentsExecutionMode,
+    /// Managed-secret name selected for the active harness, when the
+    /// harness is non-Oz and the execution mode is Cloud.
+    /// Persisted side-channel via `CloudAgentSettings.last_selected_auth_secret`
+    /// and propagated onto `RunAgentsRequest.harness_auth_secret_name` at
+    /// dispatch time. The proto does NOT carry this field.
+    pub auth_secret_name: Option<String>,
 }
 
 impl OrchestrationEditState {
@@ -92,6 +109,7 @@ impl OrchestrationEditState {
             model_id: model_id.to_string(),
             harness_type: harness_type.to_string(),
             execution_mode: execution_mode.clone(),
+            auth_secret_name: None,
         }
     }
 
@@ -111,6 +129,7 @@ impl OrchestrationEditState {
             model_id: config.model_id.clone(),
             harness_type: config.harness_type.clone(),
             execution_mode,
+            auth_secret_name: None,
         }
     }
 
@@ -250,6 +269,11 @@ pub struct OrchestrationPickerHandles<A: OrchestrationControlAction> {
     pub harness_picker: Option<ViewHandle<Dropdown<A>>>,
     pub environment_picker: Option<ViewHandle<FilterableDropdown<A>>>,
     pub host_picker: Option<ViewHandle<Dropdown<A>>>,
+    /// Picker for the managed auth secret used by non-Oz cloud children.
+    /// `None` when the picker hasn't been built yet (e.g. harness is Oz or
+    /// execution mode is Local), or when the harness has no supported
+    /// auth-secret types.
+    pub auth_secret_picker: Option<ViewHandle<Dropdown<A>>>,
     pub local_toggle: MouseStateHandle,
     pub cloud_toggle: MouseStateHandle,
 }
@@ -261,6 +285,7 @@ impl<A: OrchestrationControlAction> Default for OrchestrationPickerHandles<A> {
             harness_picker: None,
             environment_picker: None,
             host_picker: None,
+            auth_secret_picker: None,
             local_toggle: MouseStateHandle::default(),
             cloud_toggle: MouseStateHandle::default(),
         }
@@ -710,6 +735,170 @@ pub fn persist_environment_selection<V: View>(environment_id: &str, ctx: &mut Vi
     }
 }
 
+// ── Auth secret helpers ────────────────────────────────────────────
+
+/// Returns `true` when the orchestration UI should expose the auth
+/// secret picker for the given edit state. Currently gated on:
+/// - execution mode is `Remote` (Cloud), AND
+/// - harness is non-Oz, AND
+/// - the harness has at least one supported auth-secret type.
+///
+/// Local non-Oz children inherit auth from the user's shell environment,
+/// matching cloud-mode's `AuthSecretSelector` gating.
+pub fn should_show_auth_secret_picker(state: &OrchestrationEditState) -> bool {
+    if !state.execution_mode.is_remote() {
+        return false;
+    }
+    let Some(harness) = Harness::parse_orchestration_harness(&state.harness_type) else {
+        return false;
+    };
+    if harness == Harness::Oz {
+        return false;
+    }
+    !auth_secret_types_for_harness(harness).is_empty()
+}
+
+/// Reads the user's last-selected auth secret for the given harness
+/// from `CloudAgentSettings.last_selected_auth_secret`. Returns `None`
+/// when no secret is saved or when the harness has no canonical name.
+pub fn resolve_default_auth_secret_for_harness(
+    harness_type: &str,
+    ctx: &AppContext,
+) -> Option<String> {
+    let harness = Harness::parse_orchestration_harness(harness_type)?;
+    if harness == Harness::Oz {
+        return None;
+    }
+    CloudAgentSettings::as_ref(ctx)
+        .last_selected_auth_secret
+        .value()
+        .get(harness.config_name())
+        .cloned()
+        .filter(|name| !name.trim().is_empty())
+}
+
+/// Populates the auth secret picker for the given harness. Items:
+///   1. "Inherit key from environment" (clears the selection)
+///   2. The loaded managed secrets for the harness
+///
+/// Also kicks off a lazy fetch of the harness's auth secrets when the
+/// menu opens, so the first paint shows "Loading…" and rerenders once
+/// the secrets arrive (via `HarnessAvailabilityEvent::AuthSecretsLoaded`).
+pub fn populate_auth_secret_picker_for_harness<A: OrchestrationControlAction, V: View>(
+    dropdown: &ViewHandle<Dropdown<A>>,
+    initial_secret_name: Option<&str>,
+    harness_type: &str,
+    ctx: &mut ViewContext<V>,
+) {
+    let Some(harness) = Harness::parse_orchestration_harness(harness_type) else {
+        return;
+    };
+    if harness == Harness::Oz {
+        return;
+    }
+    // Trigger lazy fetch so the next paint shows real entries.
+    HarnessAvailabilityModel::handle(ctx).update(ctx, |model, ctx| {
+        model.ensure_auth_secrets_fetched(harness, ctx);
+    });
+
+    let initial = initial_secret_name.map(str::to_string);
+    dropdown.update(ctx, |dropdown, ctx_dropdown| {
+        let availability = HarnessAvailabilityModel::as_ref(ctx_dropdown);
+        let mut items: Vec<MenuItem<DropdownAction<A>>> = Vec::new();
+
+        // "Inherit from environment" — always available, clears the selection.
+        items.push(MenuItem::Item(
+            MenuItemFields::new(AUTH_SECRET_INHERIT_LABEL).with_on_select_action(
+                DropdownAction::SelectActionAndClose(A::auth_secret_changed(None)),
+            ),
+        ));
+
+        let mut selected_display_name: Option<String> = None;
+        match availability.auth_secrets_for(harness) {
+            AuthSecretFetchState::Loaded(secrets) => {
+                for secret in secrets {
+                    let name = secret.name.clone();
+                    if Some(&name) == initial.as_ref() {
+                        selected_display_name = Some(name.clone());
+                    }
+                    items.push(MenuItem::Item(
+                        MenuItemFields::new(&name).with_on_select_action(
+                            DropdownAction::SelectActionAndClose(A::auth_secret_changed(Some(
+                                name.clone(),
+                            ))),
+                        ),
+                    ));
+                }
+            }
+            AuthSecretFetchState::NotFetched | AuthSecretFetchState::Loading => {
+                items.push(MenuItem::Item(
+                    MenuItemFields::new("Loading…").with_disabled(true),
+                ));
+            }
+            AuthSecretFetchState::Failed(_) => {
+                items.push(MenuItem::Item(
+                    MenuItemFields::new("Unable to load secrets").with_disabled(true),
+                ));
+            }
+        }
+
+        dropdown.set_rich_items(items, ctx_dropdown);
+        if let Some(name) = &selected_display_name {
+            dropdown.set_selected_by_name(name, ctx_dropdown);
+        } else {
+            dropdown.set_selected_by_name(AUTH_SECRET_INHERIT_LABEL, ctx_dropdown);
+        }
+    });
+}
+
+/// Updates the edit state with a new auth secret selection and
+/// persists it to `CloudAgentSettings.last_selected_auth_secret` so the
+/// selection survives across sessions and stays in sync with cloud
+/// mode's single-agent picker.
+///
+/// Does NOT call `populate_auth_secret_picker_for_harness` or
+/// `sync_picker_selections` — the auth secret picker dispatched this
+/// action and must not be re-entered (would cause a `Circular view
+/// update` panic). The dropdown already shows the user's chosen value.
+pub fn apply_auth_secret_change<A: OrchestrationControlAction, V: View>(
+    state: &mut OrchestrationEditState,
+    _handles: &OrchestrationPickerHandles<A>,
+    new_name: Option<String>,
+    ctx: &mut ViewContext<V>,
+) {
+    state.auth_secret_name = new_name.filter(|s| !s.trim().is_empty());
+    persist_auth_secret_selection(&state.harness_type, state.auth_secret_name.clone(), ctx);
+}
+
+/// Writes the selected secret name into `last_selected_auth_secret`
+/// for the active harness. `None` clears the entry. No-op when the
+/// harness is unknown or Oz.
+fn persist_auth_secret_selection<V: View>(
+    harness_type: &str,
+    name: Option<String>,
+    ctx: &mut ViewContext<V>,
+) {
+    let Some(harness) = Harness::parse_orchestration_harness(harness_type) else {
+        return;
+    };
+    if harness == Harness::Oz {
+        return;
+    }
+    let key = harness.config_name().to_string();
+    CloudAgentSettings::handle(ctx).update(ctx, |settings, ctx| {
+        let mut map = settings.last_selected_auth_secret.value().clone();
+        match name {
+            Some(name) => {
+                map.insert(key, name);
+            }
+            None => {
+                map.remove(&key);
+            }
+        }
+        report_if_error!(settings.last_selected_auth_secret.set_value(map, ctx));
+    });
+}
+
 // ── Shared action helpers ───────────────────────────────────────────
 
 /// Handles a harness change for both card views: saves the current
@@ -717,6 +906,9 @@ pub fn persist_environment_selection<V: View>(environment_id: &str, ctx: &mut Vi
 /// the new harness (if still valid), falls back to a caller-provided
 /// base model id or the first available model, and repopulates the
 /// model picker.
+///
+/// Also re-resolves the auth secret selection from settings for the
+/// new harness so the picker and edit state agree.
 ///
 /// Does NOT call `sync_picker_selections` — the harness picker
 /// dispatched this action and must not be re-entered.
@@ -753,6 +945,17 @@ pub fn apply_harness_change<A: OrchestrationControlAction, V: View>(
     }
     if let Some(handle) = &handles.model_picker {
         populate_model_picker_for_harness(handle, &state.model_id, new_harness_type, is_local, ctx);
+    }
+
+    // Re-resolve auth secret from settings for the new harness.
+    state.auth_secret_name = resolve_default_auth_secret_for_harness(new_harness_type, ctx);
+    if let Some(handle) = &handles.auth_secret_picker {
+        populate_auth_secret_picker_for_harness(
+            handle,
+            state.auth_secret_name.as_deref(),
+            new_harness_type,
+            ctx,
+        );
     }
 }
 
@@ -800,9 +1003,9 @@ pub fn apply_execution_mode_change<A: OrchestrationControlAction, V: View>(
 
 // ── Picker repopulation + selection sync ──
 
-/// Repopulates both the harness and model pickers from the current
-/// server-provided data, revalidates `state.model_id` against the
-/// updated catalog (resetting to default if the model disappeared),
+/// Repopulates the harness, model, and auth-secret pickers from the
+/// current server-provided data, revalidates `state.model_id` against
+/// the updated catalog (resetting to default if the model disappeared),
 /// then re-syncs dropdown selections.
 pub fn repopulate_all_pickers<A: OrchestrationControlAction, V: View>(
     state: &mut OrchestrationEditState,
@@ -826,6 +1029,14 @@ pub fn repopulate_all_pickers<A: OrchestrationControlAction, V: View>(
             &state.model_id,
             &state.harness_type,
             is_local,
+            ctx,
+        );
+    }
+    if let Some(handle) = &handles.auth_secret_picker {
+        populate_auth_secret_picker_for_harness(
+            handle,
+            state.auth_secret_name.as_deref(),
+            &state.harness_type,
             ctx,
         );
     }
@@ -904,6 +1115,16 @@ pub fn sync_picker_selections<A: OrchestrationControlAction, V: View>(
         };
         host_picker.update(ctx, |dropdown, ctx_dropdown| {
             dropdown.set_selected_by_name(&worker_host, ctx_dropdown);
+        });
+    }
+    if let Some(auth_secret_picker) = handles.auth_secret_picker.clone() {
+        let target = state.auth_secret_name.clone();
+        auth_secret_picker.update(ctx, |dropdown, ctx_dropdown| {
+            let label = target
+                .as_deref()
+                .unwrap_or(AUTH_SECRET_INHERIT_LABEL)
+                .to_string();
+            dropdown.set_selected_by_name(&label, ctx_dropdown);
         });
     }
 }
@@ -1176,6 +1397,8 @@ pub fn render_picker_row_with_layout<A: OrchestrationControlAction>(
 ) -> Box<dyn Element> {
     let is_remote = state.execution_mode.is_remote();
 
+    let show_auth_picker = should_show_auth_secret_picker(state);
+
     if vertical {
         let mut column = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
@@ -1219,6 +1442,16 @@ pub fn render_picker_row_with_layout<A: OrchestrationControlAction>(
                 .as_ref()
                 .map(|p| ChildView::new(p).finish()),
         );
+        if show_auth_picker {
+            add(
+                &mut column,
+                AUTH_SECRET_COLUMN_LABEL,
+                handles
+                    .auth_secret_picker
+                    .as_ref()
+                    .map(|p| ChildView::new(p).finish()),
+            );
+        }
 
         Container::new(column.finish())
             .with_margin_top(12.)
@@ -1266,6 +1499,16 @@ pub fn render_picker_row_with_layout<A: OrchestrationControlAction>(
                 .as_ref()
                 .map(|p| ChildView::new(p).finish()),
         );
+        if show_auth_picker {
+            add_picker(
+                &mut row,
+                AUTH_SECRET_COLUMN_LABEL,
+                handles
+                    .auth_secret_picker
+                    .as_ref()
+                    .map(|p| ChildView::new(p).finish()),
+            );
+        }
 
         Container::new(row.finish()).with_margin_top(12.).finish()
     }

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -1408,6 +1408,10 @@ pub fn render_picker_row_with_layout<A: OrchestrationControlAction>(
             col.add_child(render_picker_column(label, picker, appearance));
         };
 
+        // Plan-card ordering groups harness-scoped pickers (harness + API
+        // key) before host/environment/model so the API key sits directly
+        // under the harness selector and does not split the model picker
+        // from the "Primary model…" subtext that follows the picker row.
         add(
             &mut column,
             "Agent harness",
@@ -1416,6 +1420,16 @@ pub fn render_picker_row_with_layout<A: OrchestrationControlAction>(
                 .as_ref()
                 .map(|p| ChildView::new(p).finish()),
         );
+        if show_auth_picker {
+            add(
+                &mut column,
+                AUTH_SECRET_COLUMN_LABEL,
+                handles
+                    .auth_secret_picker
+                    .as_ref()
+                    .map(|p| ChildView::new(p).finish()),
+            );
+        }
         if is_remote {
             add(
                 &mut column,
@@ -1442,16 +1456,6 @@ pub fn render_picker_row_with_layout<A: OrchestrationControlAction>(
                 .as_ref()
                 .map(|p| ChildView::new(p).finish()),
         );
-        if show_auth_picker {
-            add(
-                &mut column,
-                AUTH_SECRET_COLUMN_LABEL,
-                handles
-                    .auth_secret_picker
-                    .as_ref()
-                    .map(|p| ChildView::new(p).finish()),
-            );
-        }
 
         Container::new(column.finish())
             .with_margin_top(12.)

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -435,7 +435,7 @@ impl RunAgentsCardView {
                 HarnessAvailabilityEvent::Changed
                 | HarnessAvailabilityEvent::AuthSecretsLoaded
                 | HarnessAvailabilityEvent::AuthSecretCreated { .. }
-                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed => {
                     // Repopulate on fetch failure too, otherwise the picker
                     // would stay on the "Loading…" placeholder we wrote
                     // when the fetch started.

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -97,12 +97,16 @@ pub struct RunAgentsEditState {
 
 impl RunAgentsEditState {
     pub fn from_request(req: &RunAgentsRequest) -> Self {
+        let mut orch = oc::OrchestrationEditState::from_run_agents_fields(
+            &req.model_id,
+            &req.harness_type,
+            &req.execution_mode,
+        );
+        // Carry the request's auth secret onto the edit state so an
+        // explicit value from a previous dispatch survives the round trip.
+        orch.auth_secret_name = req.harness_auth_secret_name.clone();
         Self {
-            orch: oc::OrchestrationEditState::from_run_agents_fields(
-                &req.model_id,
-                &req.harness_type,
-                &req.execution_mode,
-            ),
+            orch,
             agent_run_configs: req.agent_run_configs.clone(),
             base_prompt: req.base_prompt.clone(),
             summary: req.summary.clone(),
@@ -121,6 +125,7 @@ impl RunAgentsEditState {
             execution_mode: self.orch.execution_mode.clone(),
             agent_run_configs: self.agent_run_configs.clone(),
             plan_id: self.plan_id.clone(),
+            harness_auth_secret_name: self.orch.auth_secret_name.clone(),
         }
     }
 }
@@ -140,6 +145,9 @@ impl OrchestrationControlAction for RunAgentsCardViewAction {
     }
     fn worker_host_changed(worker_host: String) -> Self {
         Self::WorkerHostChanged { worker_host }
+    }
+    fn auth_secret_changed(auth_secret_name: Option<String>) -> Self {
+        Self::AuthSecretChanged { auth_secret_name }
     }
 }
 
@@ -162,6 +170,7 @@ pub enum RunAgentsCardViewAction {
     HarnessChanged { harness_type: String },
     EnvironmentChanged { environment_id: String },
     WorkerHostChanged { worker_host: String },
+    AuthSecretChanged { auth_secret_name: Option<String> },
 }
 
 #[derive(Clone, Debug)]
@@ -416,15 +425,20 @@ impl RunAgentsCardView {
             }
         });
 
-        // Repopulate harness and model pickers when the server-provided
-        // harness list or harness model catalogs change.
+        // Repopulate pickers when the server-provided harness list,
+        // harness model catalogs, or per-harness auth secrets change.
+        // Without an `AuthSecretsLoaded` handler the picker stays on
+        // "Loading…" forever after the lazy fetch completes.
         ctx.subscribe_to_model(
             &HarnessAvailabilityModel::handle(ctx),
-            |me, _, event, ctx| {
-                if let HarnessAvailabilityEvent::Changed = event {
+            |me, _, event, ctx| match event {
+                HarnessAvailabilityEvent::Changed
+                | HarnessAvailabilityEvent::AuthSecretsLoaded
+                | HarnessAvailabilityEvent::AuthSecretCreated { .. } => {
                     oc::repopulate_all_pickers(&mut me.state.orch, &me.handles.pickers, ctx);
                     ctx.notify();
                 }
+                HarnessAvailabilityEvent::AuthSecretCreationFailed { .. } => {}
             },
         );
 
@@ -479,6 +493,14 @@ impl RunAgentsCardView {
                 }
             }
         }
+        // The proto-derived state never has an auth secret. Re-seed from
+        // the persisted per-harness setting so a plan-card selection (or
+        // a previous confirmation-card pick) is honored at dispatch time,
+        // even if the user never touches the picker on this card.
+        if new_state.orch.auth_secret_name.is_none() {
+            new_state.orch.auth_secret_name =
+                oc::resolve_default_auth_secret_for_harness(&new_state.orch.harness_type, ctx);
+        }
         if self.state != new_state {
             let harness_or_model_changed = self.state.orch.harness_type
                 != new_state.orch.harness_type
@@ -530,6 +552,18 @@ impl RunAgentsCardView {
                 && !self.state.agent_run_configs.is_empty()
             {
                 self.state.orch.override_from_approved_config(config);
+
+                // `override_from_approved_config` may have changed the
+                // harness; re-resolve the auth secret from settings so
+                // the auto-launched dispatch carries the user's
+                // plan-card pick instead of `None`.
+                if self.state.orch.auth_secret_name.is_none() {
+                    self.state.orch.auth_secret_name =
+                        oc::resolve_default_auth_secret_for_harness(
+                            &self.state.orch.harness_type,
+                            ctx,
+                        );
+                }
 
                 self.auto_launched = true;
                 ctx.notify();
@@ -638,6 +672,28 @@ impl RunAgentsCardView {
             oc::populate_host_picker(&handle, initial_host, ctx);
             Self::subscribe_picker_close(&handle, ctx);
             self.handles.pickers.host_picker = Some(handle);
+        }
+
+        if self.handles.pickers.auth_secret_picker.is_none() {
+            // Seed from the request's secret name first; otherwise fall
+            // back to the persisted per-harness selection so the picker
+            // matches what cloud-mode would show.
+            if self.state.orch.auth_secret_name.is_none() {
+                self.state.orch.auth_secret_name =
+                    oc::resolve_default_auth_secret_for_harness(&self.state.orch.harness_type, ctx);
+            }
+            let initial_secret = self.state.orch.auth_secret_name.clone();
+            let harness_type = self.state.orch.harness_type.clone();
+            let handle = oc::new_standard_picker_dropdown(&colors, ctx);
+            Self::set_upward_menu_position(&handle, ctx);
+            oc::populate_auth_secret_picker_for_harness(
+                &handle,
+                initial_secret.as_deref(),
+                &harness_type,
+                ctx,
+            );
+            Self::subscribe_picker_close(&handle, ctx);
+            self.handles.pickers.auth_secret_picker = Some(handle);
         }
 
         self.sync_picker_selections(ctx);
@@ -863,6 +919,15 @@ impl TypedActionView for RunAgentsCardView {
             }
             RunAgentsCardViewAction::WorkerHostChanged { worker_host } => {
                 self.state.orch.set_worker_host(worker_host.clone());
+                ctx.notify();
+            }
+            RunAgentsCardViewAction::AuthSecretChanged { auth_secret_name } => {
+                oc::apply_auth_secret_change(
+                    &mut self.state.orch,
+                    &self.handles.pickers,
+                    auth_secret_name.clone(),
+                    ctx,
+                );
                 ctx.notify();
             }
         }

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -434,7 +434,11 @@ impl RunAgentsCardView {
             |me, _, event, ctx| match event {
                 HarnessAvailabilityEvent::Changed
                 | HarnessAvailabilityEvent::AuthSecretsLoaded
-                | HarnessAvailabilityEvent::AuthSecretCreated { .. } => {
+                | HarnessAvailabilityEvent::AuthSecretCreated { .. }
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {
+                    // Repopulate on fetch failure too, otherwise the picker
+                    // would stay on the "Loading…" placeholder we wrote
+                    // when the fetch started.
                     oc::repopulate_all_pickers(&mut me.state.orch, &me.handles.pickers, ctx);
                     ctx.notify();
                 }
@@ -553,16 +557,18 @@ impl RunAgentsCardView {
             {
                 self.state.orch.override_from_approved_config(config);
 
-                // `override_from_approved_config` may have changed the
-                // harness; re-resolve the auth secret from settings so
-                // the auto-launched dispatch carries the user's
-                // plan-card pick instead of `None`.
-                if self.state.orch.auth_secret_name.is_none() {
-                    self.state.orch.auth_secret_name = oc::resolve_default_auth_secret_for_harness(
-                        &self.state.orch.harness_type,
-                        ctx,
-                    );
-                }
+                // Always re-resolve the auth secret from settings keyed by
+                // the (now authoritative) harness from the approved config.
+                // Unconditional — not gated on `is_none()` — because if
+                // streaming had set `auth_secret_name` based on a different
+                // (proto-suggested) harness, the value belongs to that
+                // harness and must not be carried forward; otherwise we'd
+                // route e.g. a Codex secret name into Claude's auth field
+                // in `launch_remote_child`.
+                self.state.orch.auth_secret_name = oc::resolve_default_auth_secret_for_harness(
+                    &self.state.orch.harness_type,
+                    ctx,
+                );
 
                 self.auto_launched = true;
                 ctx.notify();

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -558,11 +558,10 @@ impl RunAgentsCardView {
                 // the auto-launched dispatch carries the user's
                 // plan-card pick instead of `None`.
                 if self.state.orch.auth_secret_name.is_none() {
-                    self.state.orch.auth_secret_name =
-                        oc::resolve_default_auth_secret_for_harness(
-                            &self.state.orch.harness_type,
-                            ctx,
-                        );
+                    self.state.orch.auth_secret_name = oc::resolve_default_auth_secret_for_harness(
+                        &self.state.orch.harness_type,
+                        ctx,
+                    );
                 }
 
                 self.auto_launched = true;

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -565,10 +565,8 @@ impl RunAgentsCardView {
                 // harness and must not be carried forward; otherwise we'd
                 // route e.g. a Codex secret name into Claude's auth field
                 // in `launch_remote_child`.
-                self.state.orch.auth_secret_name = oc::resolve_default_auth_secret_for_harness(
-                    &self.state.orch.harness_type,
-                    ctx,
-                );
+                self.state.orch.auth_secret_name =
+                    oc::resolve_default_auth_secret_for_harness(&self.state.orch.harness_type, ctx);
 
                 self.auto_launched = true;
                 ctx.notify();

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
@@ -30,6 +30,7 @@ fn make_request_with_skills(
             title: "Child agent".to_string(),
         }],
         plan_id: String::new(),
+        harness_auth_secret_name: None,
     }
 }
 

--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -199,7 +199,7 @@ impl OrchestrationConfigBlockView {
                 HarnessAvailabilityEvent::Changed
                 | HarnessAvailabilityEvent::AuthSecretsLoaded
                 | HarnessAvailabilityEvent::AuthSecretCreated { .. }
-                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed => {
                     // Repopulate on fetch failure too, otherwise the picker
                     // would stay on the "Loading…" placeholder we wrote
                     // when the fetch started.

--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -83,6 +83,7 @@ pub enum OrchestrationConfigBlockAction {
     HarnessChanged { harness_type: String },
     EnvironmentChanged { environment_id: String },
     WorkerHostChanged { worker_host: String },
+    AuthSecretChanged { auth_secret_name: Option<String> },
 }
 
 impl OrchestrationControlAction for OrchestrationConfigBlockAction {
@@ -100,6 +101,9 @@ impl OrchestrationControlAction for OrchestrationConfigBlockAction {
     }
     fn worker_host_changed(worker_host: String) -> Self {
         Self::WorkerHostChanged { worker_host }
+    }
+    fn auth_secret_changed(auth_secret_name: Option<String>) -> Self {
+        Self::AuthSecretChanged { auth_secret_name }
     }
 }
 
@@ -185,17 +189,22 @@ impl OrchestrationConfigBlockView {
             }
         });
 
-        // Repopulate harness and model pickers when the server-provided
-        // harness list or harness model catalogs change.
+        // Repopulate pickers when the server-provided harness list,
+        // harness model catalogs, or per-harness auth secrets change.
+        // Without an `AuthSecretsLoaded` handler the picker stays on
+        // "Loading…" forever after the lazy fetch completes.
         ctx.subscribe_to_model(
             &HarnessAvailabilityModel::handle(ctx),
-            |me, _, event, ctx| {
-                if let HarnessAvailabilityEvent::Changed = event {
+            |me, _, event, ctx| match event {
+                HarnessAvailabilityEvent::Changed
+                | HarnessAvailabilityEvent::AuthSecretsLoaded
+                | HarnessAvailabilityEvent::AuthSecretCreated { .. } => {
                     if me.pickers_initialized {
                         oc::repopulate_all_pickers(&mut me.edit_state, &me.pickers, ctx);
                     }
                     ctx.notify();
                 }
+                HarnessAvailabilityEvent::AuthSecretCreationFailed { .. } => {}
             },
         );
 
@@ -315,6 +324,22 @@ impl OrchestrationConfigBlockView {
         host_handle.update(ctx, |d, c| d.set_use_overlay_layer(true, c));
         oc::populate_host_picker(&host_handle, initial_host, ctx);
         self.pickers.host_picker = Some(host_handle);
+
+        // Seed the auth secret from persisted per-harness settings before
+        // building the picker so the dropdown shows the last selection.
+        if self.edit_state.auth_secret_name.is_none() {
+            self.edit_state.auth_secret_name =
+                oc::resolve_default_auth_secret_for_harness(&self.edit_state.harness_type, ctx);
+        }
+        let auth_secret_handle = oc::new_standard_picker_dropdown(&colors, ctx);
+        auth_secret_handle.update(ctx, |d, c| d.set_use_overlay_layer(true, c));
+        oc::populate_auth_secret_picker_for_harness(
+            &auth_secret_handle,
+            self.edit_state.auth_secret_name.as_deref(),
+            &self.edit_state.harness_type,
+            ctx,
+        );
+        self.pickers.auth_secret_picker = Some(auth_secret_handle);
 
         self.pickers_initialized = true;
         oc::sync_picker_selections(&self.edit_state, &self.pickers, ctx);
@@ -575,6 +600,18 @@ impl TypedActionView for OrchestrationConfigBlockView {
             OrchestrationConfigBlockAction::WorkerHostChanged { worker_host } => {
                 self.edit_state.set_worker_host(worker_host.clone());
                 self.apply_field_change(ctx);
+                ctx.notify();
+            }
+            OrchestrationConfigBlockAction::AuthSecretChanged { auth_secret_name } => {
+                // No `apply_field_change` here: the secret name is persisted
+                // side-channel via `CloudAgentSettings.last_selected_auth_secret`
+                // and never round-trips through `OrchestrationConfig`.
+                oc::apply_auth_secret_change(
+                    &mut self.edit_state,
+                    &self.pickers,
+                    auth_secret_name.clone(),
+                    ctx,
+                );
                 ctx.notify();
             }
         }

--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -603,9 +603,13 @@ impl TypedActionView for OrchestrationConfigBlockView {
                 ctx.notify();
             }
             OrchestrationConfigBlockAction::AuthSecretChanged { auth_secret_name } => {
-                // No `apply_field_change` here: the secret name is persisted
-                // side-channel via `CloudAgentSettings.last_selected_auth_secret`
-                // and never round-trips through `OrchestrationConfig`.
+                // No `apply_field_change` here: managed secrets are user-scoped
+                // (not plan-scoped), so they are persisted side-channel via
+                // `CloudAgentSettings.last_selected_auth_secret` instead of
+                // being baked into `OrchestrationConfig`. Consequence: changing
+                // the picker doesn't surface a "config modified" signal, and
+                // two users on the same approved plan can have different secret
+                // selections without conflicting.
                 oc::apply_auth_secret_change(
                     &mut self.edit_state,
                     &self.pickers,

--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -198,7 +198,11 @@ impl OrchestrationConfigBlockView {
             |me, _, event, ctx| match event {
                 HarnessAvailabilityEvent::Changed
                 | HarnessAvailabilityEvent::AuthSecretsLoaded
-                | HarnessAvailabilityEvent::AuthSecretCreated { .. } => {
+                | HarnessAvailabilityEvent::AuthSecretCreated { .. }
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {
+                    // Repopulate on fetch failure too, otherwise the picker
+                    // would stay on the "Loading…" placeholder we wrote
+                    // when the fetch started.
                     if me.pickers_initialized {
                         oc::repopulate_all_pickers(&mut me.edit_state, &me.pickers, ctx);
                     }

--- a/app/src/ai/harness_availability.rs
+++ b/app/src/ai/harness_availability.rs
@@ -64,9 +64,20 @@ pub enum HarnessAvailabilityEvent {
     /// re-render so any "Loading…" placeholders can transition to an
     /// error state — without this signal the picker would otherwise be
     /// stuck on the loading placeholder until the next refetch.
-    AuthSecretsFetchFailed { harness: Harness },
-    AuthSecretCreated { harness: Harness, name: String },
-    AuthSecretCreationFailed { error: String },
+    ///
+    /// `harness` is kept on the payload for future subscribers that
+    /// need to filter by harness; current subscribers ignore it.
+    AuthSecretsFetchFailed {
+        #[allow(dead_code)]
+        harness: Harness,
+    },
+    AuthSecretCreated {
+        harness: Harness,
+        name: String,
+    },
+    AuthSecretCreationFailed {
+        error: String,
+    },
 }
 
 pub struct HarnessAvailabilityModel {

--- a/app/src/ai/harness_availability.rs
+++ b/app/src/ai/harness_availability.rs
@@ -60,6 +60,11 @@ pub struct AuthSecretEntry {
 pub enum HarnessAvailabilityEvent {
     Changed,
     AuthSecretsLoaded,
+    /// Emitted when a lazy auth-secrets fetch fails. Subscribers should
+    /// re-render so any "Loading…" placeholders can transition to an
+    /// error state — without this signal the picker would otherwise be
+    /// stuck on the loading placeholder until the next refetch.
+    AuthSecretsFetchFailed { harness: Harness },
     AuthSecretCreated { harness: Harness, name: String },
     AuthSecretCreationFailed { error: String },
 }
@@ -189,6 +194,10 @@ impl HarnessAvailabilityModel {
                         report_error!(e.context("Failed to fetch harness auth secrets"));
                         me.auth_secrets
                             .insert(harness, AuthSecretFetchState::Failed(msg));
+                        // Notify subscribers so they can drop any
+                        // "Loading…" placeholder rendered during the
+                        // in-flight fetch and surface the error state.
+                        ctx.emit(HarnessAvailabilityEvent::AuthSecretsFetchFailed { harness });
                     }
                 }
             },

--- a/app/src/ai/harness_availability.rs
+++ b/app/src/ai/harness_availability.rs
@@ -64,13 +64,7 @@ pub enum HarnessAvailabilityEvent {
     /// re-render so any "Loading…" placeholders can transition to an
     /// error state — without this signal the picker would otherwise be
     /// stuck on the loading placeholder until the next refetch.
-    ///
-    /// `harness` is kept on the payload for future subscribers that
-    /// need to filter by harness; current subscribers ignore it.
-    AuthSecretsFetchFailed {
-        #[allow(dead_code)]
-        harness: Harness,
-    },
+    AuthSecretsFetchFailed,
     AuthSecretCreated {
         harness: Harness,
         name: String,
@@ -208,7 +202,7 @@ impl HarnessAvailabilityModel {
                         // Notify subscribers so they can drop any
                         // "Loading…" placeholder rendered during the
                         // in-flight fetch and surface the error state.
-                        ctx.emit(HarnessAvailabilityEvent::AuthSecretsFetchFailed { harness });
+                        ctx.emit(HarnessAvailabilityEvent::AuthSecretsFetchFailed);
                     }
                 }
             },

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1555,6 +1555,7 @@ fn dispatch_start_agent_conversation(
             worker_host,
             harness_type,
             title,
+            auth_secret_name,
         } => {
             launch_remote_child(
                 group,
@@ -1568,6 +1569,7 @@ fn dispatch_start_agent_conversation(
                     worker_host,
                     harness_type,
                     title,
+                    auth_secret_name,
                 },
                 ctx,
             );
@@ -1783,6 +1785,10 @@ struct RemoteLaunchFields {
     worker_host: String,
     harness_type: String,
     title: String,
+    /// Managed-secret name forwarded from the orchestration UI for non-Oz
+    /// harness credentials. Resolved to `AgentConfigSnapshot.harness_auth_secrets`
+    /// when applicable.
+    auth_secret_name: Option<String>,
 }
 
 /// Sets up a hidden ambient-agent pane for a Remote child agent: creates the
@@ -1813,6 +1819,7 @@ fn launch_remote_child(
         worker_host,
         harness_type,
         title,
+        auth_secret_name,
     } = fields;
 
     let request_id = request.id;
@@ -1909,6 +1916,25 @@ fn launch_remote_child(
     };
     let computer_use_enabled =
         (orchestration_harness == Harness::Oz).then_some(computer_use_enabled);
+    // Map the run-wide auth secret name into the harness-specific
+    // config variant. For unsupported harnesses (Oz, OpenCode, Gemini,
+    // Unknown), the secret is silently ignored — those harnesses either
+    // use Warp's built-in auth (Oz) or don't currently support managed
+    // secrets via this flow.
+    let harness_auth_secrets = auth_secret_name
+        .as_ref()
+        .filter(|name| !name.trim().is_empty())
+        .and_then(|name| match orchestration_harness {
+            Harness::Claude => Some(crate::ai::ambient_agents::task::HarnessAuthSecretsConfig {
+                claude_auth_secret_name: Some(name.clone()),
+                codex_auth_secret_name: None,
+            }),
+            Harness::Codex => Some(crate::ai::ambient_agents::task::HarnessAuthSecretsConfig {
+                claude_auth_secret_name: None,
+                codex_auth_secret_name: Some(name.clone()),
+            }),
+            Harness::Oz | Harness::OpenCode | Harness::Gemini | Harness::Unknown => None,
+        });
     let spawn_request = SpawnAgentRequest {
         prompt: request.prompt,
         mode: UserQueryMode::Normal,
@@ -1918,6 +1944,7 @@ fn launch_remote_child(
             worker_host: (!worker_host.is_empty()).then_some(worker_host),
             computer_use_enabled,
             harness: harness_override,
+            harness_auth_secrets,
             ..Default::default()
         }),
         title: (!title.is_empty()).then_some(title),

--- a/app/src/terminal/view/ambient_agent/auth_secret_ftux_dropdown.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_ftux_dropdown.rs
@@ -142,7 +142,7 @@ impl AuthSecretFtuxDropdown {
             |me, _, event, ctx| match event {
                 HarnessAvailabilityEvent::AuthSecretsLoaded
                 | HarnessAvailabilityEvent::AuthSecretCreated { .. }
-                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed => {
                     me.refresh_menu(ctx);
                     ctx.notify();
                 }

--- a/app/src/terminal/view/ambient_agent/auth_secret_ftux_dropdown.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_ftux_dropdown.rs
@@ -141,7 +141,8 @@ impl AuthSecretFtuxDropdown {
             &HarnessAvailabilityModel::handle(ctx),
             |me, _, event, ctx| match event {
                 HarnessAvailabilityEvent::AuthSecretsLoaded
-                | HarnessAvailabilityEvent::AuthSecretCreated { .. } => {
+                | HarnessAvailabilityEvent::AuthSecretCreated { .. }
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {
                     me.refresh_menu(ctx);
                     ctx.notify();
                 }

--- a/app/src/terminal/view/ambient_agent/auth_secret_ftux_view.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_ftux_view.rs
@@ -161,8 +161,9 @@ impl AuthSecretFtuxView {
                         ctx.notify();
                     }
                 }
-                HarnessAvailabilityEvent::Changed | HarnessAvailabilityEvent::AuthSecretsLoaded => {
-                }
+                HarnessAvailabilityEvent::Changed
+                | HarnessAvailabilityEvent::AuthSecretsLoaded
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {}
             },
         );
 

--- a/app/src/terminal/view/ambient_agent/auth_secret_ftux_view.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_ftux_view.rs
@@ -163,7 +163,7 @@ impl AuthSecretFtuxView {
                 }
                 HarnessAvailabilityEvent::Changed
                 | HarnessAvailabilityEvent::AuthSecretsLoaded
-                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {}
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed => {}
             },
         );
 

--- a/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
@@ -152,7 +152,8 @@ impl AuthSecretSelector {
             &HarnessAvailabilityModel::handle(ctx),
             |me, _, event, ctx| match event {
                 HarnessAvailabilityEvent::AuthSecretsLoaded
-                | HarnessAvailabilityEvent::AuthSecretCreated { .. } => {
+                | HarnessAvailabilityEvent::AuthSecretCreated { .. }
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {
                     me.refresh_menu(ctx);
                     me.refresh_button(ctx);
                 }

--- a/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
@@ -153,7 +153,7 @@ impl AuthSecretSelector {
             |me, _, event, ctx| match event {
                 HarnessAvailabilityEvent::AuthSecretsLoaded
                 | HarnessAvailabilityEvent::AuthSecretCreated { .. }
-                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed => {
                     me.refresh_menu(ctx);
                     me.refresh_button(ctx);
                 }

--- a/app/src/terminal/view/ambient_agent/model_selector.rs
+++ b/app/src/terminal/view/ambient_agent/model_selector.rs
@@ -191,7 +191,8 @@ impl ModelSelector {
                 }
                 HarnessAvailabilityEvent::AuthSecretsLoaded
                 | HarnessAvailabilityEvent::AuthSecretCreated { .. }
-                | HarnessAvailabilityEvent::AuthSecretCreationFailed { .. } => {}
+                | HarnessAvailabilityEvent::AuthSecretCreationFailed { .. }
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {}
             },
         );
 

--- a/app/src/terminal/view/ambient_agent/model_selector.rs
+++ b/app/src/terminal/view/ambient_agent/model_selector.rs
@@ -192,7 +192,7 @@ impl ModelSelector {
                 HarnessAvailabilityEvent::AuthSecretsLoaded
                 | HarnessAvailabilityEvent::AuthSecretCreated { .. }
                 | HarnessAvailabilityEvent::AuthSecretCreationFailed { .. }
-                | HarnessAvailabilityEvent::AuthSecretsFetchFailed { .. } => {}
+                | HarnessAvailabilityEvent::AuthSecretsFetchFailed => {}
             },
         );
 

--- a/crates/ai/src/agent/action/mod.rs
+++ b/crates/ai/src/agent/action/mod.rs
@@ -193,12 +193,7 @@ pub struct RunAgentsRequest {
     pub execution_mode: RunAgentsExecutionMode,
     pub agent_run_configs: Vec<RunAgentsAgentRunConfig>,
     pub plan_id: String,
-    /// Name of a managed secret to forward as the authentication credential
-    /// for non-Oz cloud child agents (Claude / Codex). Resolved client-side
-    /// from `CloudAgentSettings.last_selected_auth_secret` at dispatch time;
-    /// not serialized to the wire — the field is populated by the UI on
-    /// Accept and consumed by `launch_remote_child` when building the
-    /// `AgentConfigSnapshot.harness_auth_secrets`.
+    /// Resolved client-side at dispatch time; not serialized to the wire.
     pub harness_auth_secret_name: Option<String>,
 }
 

--- a/crates/ai/src/agent/action/mod.rs
+++ b/crates/ai/src/agent/action/mod.rs
@@ -193,6 +193,13 @@ pub struct RunAgentsRequest {
     pub execution_mode: RunAgentsExecutionMode,
     pub agent_run_configs: Vec<RunAgentsAgentRunConfig>,
     pub plan_id: String,
+    /// Name of a managed secret to forward as the authentication credential
+    /// for non-Oz cloud child agents (Claude / Codex). Resolved client-side
+    /// from `CloudAgentSettings.last_selected_auth_secret` at dispatch time;
+    /// not serialized to the wire — the field is populated by the UI on
+    /// Accept and consumed by `launch_remote_child` when building the
+    /// `AgentConfigSnapshot.harness_auth_secrets`.
+    pub harness_auth_secret_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -238,6 +245,11 @@ pub enum StartAgentExecutionMode {
         worker_host: String,
         harness_type: String,
         title: String,
+        /// Name of a managed secret to forward as the authentication
+        /// credential for the remote child when running a non-Oz harness.
+        /// `None` means no client-side secret was selected — the remote
+        /// environment falls back to its own ambient credentials.
+        auth_secret_name: Option<String>,
     },
 }
 
@@ -267,6 +279,7 @@ impl StartAgentExecutionMode {
             worker_host: String::new(),
             harness_type: String::new(),
             title: String::new(),
+            auth_secret_name: None,
         }
     }
 }

--- a/crates/ai/src/agent/orchestration_config_tests.rs
+++ b/crates/ai/src/agent/orchestration_config_tests.rs
@@ -38,6 +38,7 @@ fn make_request(model: &str, harness: &str, remote: bool) -> RunAgentsRequest {
             title: String::new(),
         }],
         plan_id: String::new(),
+        harness_auth_secret_name: None,
     }
 }
 


### PR DESCRIPTION
Loom for run agents card: https://www.loom.com/share/10263029b97d4bada81f24b2081e3410
Loom for plan card: https://www.loom.com/share/f3e9b7dc44044b8187c723c8d59e4ae4
Fixes https://linear.app/warpdotdev/issue/QUALITY-700/api-key-configuration-for-orchestration-card-in-line-and-plan

## Description

Adds an "API key" picker to the orchestration plan card and the `run_agents` confirmation card. When the orchestration harness is set to a non-Oz harness (Claude Code or Codex) running on Cloud, the user can now pick a managed secret that will be injected into each cloud child agent as it spawns. This unblocks the multi-harness local → cloud orchestration flow that broke when the team-scoped Anthropic / OpenAI blanket env var was removed — Ian's screenshot of a Claude Code child failing to authenticate with no Oz-side fix was the immediate motivation.

Note that we haven't added the ability to add in a new secret via this flow yet - I'll follow up on that in another PR, but this should unblock the demo I believe. We can pop up a modal for new secret flow.

Let me know if I missed anything here - I have less context on these codepaths/product flows!

### High-level design

The selection lives in the same per-harness setting that cloud single-agent mode already uses, so picking a key from either the plan card, the confirmation card, or the existing single-agent cloud picker is unified — change it in one place and every surface reflects the choice. The picker is gated by the same condition cloud-mode applies: only shown when execution mode is Cloud and the harness has at least one supported managed-secret type. Local harness children continue to inherit credentials from the user's shell environment as they did before.

On dispatch, the selected secret flows through the existing orchestration pipeline as a Rust-only field that does not round-trip through the multi-agent proto. The orchestrate request carries it from the UI into the per-child Start-Agent dispatch, where it gets mapped into the harness-specific config shape the cloud worker already understands. No server or proto changes are needed because the cloud spawn API has supported per-harness auth secrets ever since the single-agent feature shipped — this PR just teaches the orchestration pathway to populate that field instead of leaving it empty. The persistence story is also reused: the secret name is stored client-side in the same settings entry as cloud mode, so it survives across sessions and across both UIs without introducing new state.

Two flow-control subtleties worth flagging for reviewers: the picker's action handler intentionally does not re-render its own dropdown (the user's click already updated the selection, and a self-update would trip the UI framework's circular-update guard), and the confirmation card's streaming/auto-launch paths re-seed the secret from settings after every proto-derived state rebuild so a plan-card pick survives the auto-launch handoff. Both came up during local testing and are documented inline.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Manual:
- Created an API key for myself for both CC and Codex, tested with that - see Looms

Automated:
- Added unit tests covering: Claude/Codex auth-secret propagation through the orchestrate → start-agent conversion, whitespace-only names being normalized to None, Local mode ignoring the field.
- Updated the existing orchestration / start-agent / convert-from / block-tests test suites for the new struct field; all 131 orchestration/run_agents/start_agent tests pass.

