### PR TITLE
Fix script/run common-skills reinstall check

### DIFF
--- a/script/run
+++ b/script/run
@@ -95,6 +95,9 @@ while (( "$#" )); do
   esac
 done
 
+common_skills_match_lock() {
+  ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" "$@" --verify-only --quiet >/dev/null 2>&1
+}
 if [[ "$INSTALL_COMMON_SKILLS" -eq 1 ]]; then
   COMMON_SKILLS_ARGS=()
   if [[ "${COMMON_SKILLS_TARGET}" = "project" || "${COMMON_SKILLS_TARGET}" = "global" ]]; then
@@ -108,6 +111,8 @@ if [[ "$INSTALL_COMMON_SKILLS" -eq 1 ]]; then
     else
       ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" --force --prompt-for-target
     fi
+  elif common_skills_match_lock "${COMMON_SKILLS_ARGS[@]}"; then
+    :
   else
     if [[ "${#COMMON_SKILLS_ARGS[@]}" -gt 0 ]]; then
       ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" "${COMMON_SKILLS_ARGS[@]}" --if-needed --quiet

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -3,77 +3,72 @@
   "skills": {
     "brandalf": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/brandalf/SKILL.md",
       "computedHash": "44eccce975aeb4df325f0112602d4e3181c80cf7febe659367c524a18dd61da9"
     },
     "create-pr": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/create-pr/SKILL.md",
       "computedHash": "d9f06f0219b3d402cf1ff3b0ee3a4d6d38f259a0dcf6103a99b1815c2b81d95b"
     },
     "diagnose-ci-failures": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/diagnose-ci-failures/SKILL.md",
       "computedHash": "7a7bbe627bbf747c05e37f9a815ddaedea30a588c452e9279b1305ec172d1006"
     },
     "fix-errors": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/fix-errors/SKILL.md",
       "computedHash": "f5099304ec8e6bc8be578ebc973de31e46ff1e8f0fe671d1641a395a9470ff7a"
     },
     "implement-specs": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/implement-specs/SKILL.md",
       "computedHash": "bd2787a63cfdc917275769ef2d9c7adc701cfaf1a74344b3a6248d4116a8923e"
     },
+    "pr-walkthrough": {
+      "source": "warpdotdev/common-skills",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/pr-walkthrough/SKILL.md",
+      "computedHash": "990e8549611cff4b82036d4c7cc50d23eb2cbb27272926142d3fd8ad17a5e18f"
+    },
     "resolve-merge-conflicts": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/resolve-merge-conflicts/SKILL.md",
       "computedHash": "5376b5692901c624e8f20a5a04aeea5f5a94f5168d29852a8a639aded6408f2e"
     },
     "review-pr": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/review-pr/SKILL.md",
       "computedHash": "5bb3ee6ea66cd018fe6bc08d003493fc2abce29441af73e86fd35a590312eaff"
     },
     "spec-driven-implementation": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/spec-driven-implementation/SKILL.md",
       "computedHash": "e334d0f6f0e8fc39055314acad911f36d92d1919372b5e2973cc99d7f8c901b4"
     },
     "update-skill": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/update-skill/SKILL.md",
       "computedHash": "1e23c5a5c37ed084eced7fa507031e3cdb8e23f09cd5d004e00efd6f66bf200f"
     },
     "write-product-spec": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/write-product-spec/SKILL.md",
       "computedHash": "f20d141e67057570b1fe7c902d5e563415c5ae4a72027d069550ff5b4c5917f2"
     },
     "write-tech-spec": {
       "source": "warpdotdev/common-skills",
-      "ref": "main",
       "sourceType": "github",
       "skillPath": ".agents/skills/write-tech-spec/SKILL.md",
       "computedHash": "3b5eb4ef021112d473984eca28412d372e87d9337ad5d9754f3ad3e01f94d39b"


### PR DESCRIPTION
## Description

Updates `script/run` so common-skills setup is quiet when the installed skills already match `skills-lock.json`, but still falls through to the installer when verification fails.

This keeps the no-op `./script/run` path from showing common-skills install prompts/messages, while preserving reinstall behavior when the local installation or lockfile is out of date.

Also updates `skills-lock.json` for the latest common-skills contents.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `bash -n script/run`
- `git --no-pager diff --check`
- `./script/resolve_common_skills install_common_skills -- --repo-root /Users/zach/Projects/warp --verify-only --quiet`
- `./script/run` updated/reinstalled common skills when the lock/install was out of date, then a subsequent `./script/run` skipped common-skills output and proceeded directly to bundling.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not applicable; this is a developer script behavior change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/4a5898ce-eb4d-415a-94a3-55897c7399a5

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
