### PR TITLE
Send custom endpoints to server

### DIFF
--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -105,7 +105,7 @@ pub async fn generate_multi_agent_output(
             supports_bundled_skills: FeatureFlag::BundledSkills.is_enabled(),
             supports_research_agent: params.research_agent_enabled,
             supports_orchestration_v2: FeatureFlag::OrchestrationV2.is_enabled(),
-            custom_model_providers: None,
+            custom_model_providers: params.custom_model_providers,
         }),
         metadata: Some(api::request::Metadata {
             logging: logging_metadata,


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

We were hardcoding custom model providers to `None` instead of passing up the actual list.
