### PR TITLE
Use tombstone for failure UX for cloud mode

### DIFF
--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -1754,6 +1754,7 @@ fn test_task_status_maps_blocked_state_to_blocked() {
         task.state = AmbientAgentTaskState::Blocked;
         task.status_message = Some(TaskStatusMessage {
             message: "Needs clarification".to_string(),
+            error_code: None,
         });
 
         app.update(|ctx| {

--- a/app/src/ai/ambient_agents/mod.rs
+++ b/app/src/ai/ambient_agents/mod.rs
@@ -78,19 +78,32 @@ pub fn conversation_output_status_from_conversation(
             blocked_action: blocked_action.clone(),
         });
     }
-
-    let last_exchange = conversation.root_task_exchanges().last()?;
-    if let AIAgentOutputStatus::Finished { finished_output } = &last_exchange.output_status {
-        let status = match finished_output {
-            FinishedAIAgentOutput::Cancelled { output: _, reason } => {
-                AmbientConversationStatus::Cancelled { reason: *reason }
-            }
-            FinishedAIAgentOutput::Error { output: _, error } => AmbientConversationStatus::Error {
-                error: error.clone(),
-            },
-            FinishedAIAgentOutput::Success { output: _ } => AmbientConversationStatus::Success,
-        };
-        return Some(status);
+    if let Some(last_exchange) = conversation.root_task_exchanges().last() {
+        if let AIAgentOutputStatus::Finished { finished_output } = &last_exchange.output_status {
+            let status = match finished_output {
+                FinishedAIAgentOutput::Cancelled { output: _, reason } => {
+                    AmbientConversationStatus::Cancelled { reason: *reason }
+                }
+                FinishedAIAgentOutput::Error { output: _, error } => {
+                    AmbientConversationStatus::Error {
+                        error: error.clone(),
+                    }
+                }
+                FinishedAIAgentOutput::Success { output: _ } => AmbientConversationStatus::Success,
+            };
+            return Some(status);
+        }
+    }
+    if let ConversationStatus::Error = conversation.status() {
+        if let Some(error_message) = conversation.status_error_message() {
+            return Some(AmbientConversationStatus::Error {
+                error: RenderableAIError::Other {
+                    error_message: error_message.to_string(),
+                    will_attempt_resume: false,
+                    waiting_for_network: false,
+                },
+            });
+        }
     }
 
     None

--- a/app/src/ai/ambient_agents/spawn_tests.rs
+++ b/app/src/ai/ambient_agents/spawn_tests.rs
@@ -166,6 +166,7 @@ async fn followup_terminal_failure_surfaces_status_message() {
             let mut task = task_with(AmbientAgentTaskState::Error, None, None);
             task.status_message = Some(TaskStatusMessage {
                 message: "failed to provision runtime".to_string(),
+                error_code: None,
             });
             Ok(task)
         });

--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -521,15 +521,29 @@ pub struct TaskPrincipalInfo {
 pub struct TaskStatusMessage {
     pub message: String,
     #[serde(default, alias = "errorCode")]
-    pub error_code: Option<String>,
+    pub error_code: Option<TaskStatusErrorCode>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatusErrorCode {
+    #[serde(alias = "ENVIRONMENT_SETUP_FAILED")]
+    EnvironmentSetupFailed,
+    #[serde(other)]
+    Unknown,
+}
+
+impl TaskStatusErrorCode {
+    pub fn is_environment_setup_failure(&self) -> bool {
+        matches!(self, TaskStatusErrorCode::EnvironmentSetupFailed)
+    }
 }
 
 impl TaskStatusMessage {
     pub fn is_environment_setup_failure(&self) -> bool {
-        matches!(
-            self.error_code.as_deref(),
-            Some("environment_setup_failed")
-        )
+        self.error_code
+            .as_ref()
+            .is_some_and(TaskStatusErrorCode::is_environment_setup_failure)
     }
 }
 
@@ -574,3 +588,7 @@ pub fn cancel_task_silently<V: View>(task_id: AmbientAgentTaskId, ctx: &mut View
         },
     );
 }
+
+#[cfg(test)]
+#[path = "task_tests.rs"]
+mod tests;

--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -520,6 +520,17 @@ pub struct TaskPrincipalInfo {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct TaskStatusMessage {
     pub message: String,
+    #[serde(default, alias = "errorCode")]
+    pub error_code: Option<String>,
+}
+
+impl TaskStatusMessage {
+    pub fn is_environment_setup_failure(&self) -> bool {
+        matches!(
+            self.error_code.as_deref(),
+            Some("environment_setup_failed")
+        )
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/app/src/ai/ambient_agents/task_tests.rs
+++ b/app/src/ai/ambient_agents/task_tests.rs
@@ -1,0 +1,38 @@
+use super::{TaskStatusErrorCode, TaskStatusMessage};
+
+#[test]
+fn task_status_error_code_deserializes_public_api_casing() {
+    let message: TaskStatusMessage = serde_json::from_str(
+        "{\"message\":\"setup failed\",\"error_code\":\"environment_setup_failed\"}",
+    )
+    .unwrap();
+
+    assert_eq!(
+        message.error_code,
+        Some(TaskStatusErrorCode::EnvironmentSetupFailed)
+    );
+    assert!(message.is_environment_setup_failure());
+}
+
+#[test]
+fn task_status_error_code_deserializes_graphql_casing() {
+    let message: TaskStatusMessage = serde_json::from_str(
+        "{\"message\":\"setup failed\",\"errorCode\":\"ENVIRONMENT_SETUP_FAILED\"}",
+    )
+    .unwrap();
+
+    assert_eq!(
+        message.error_code,
+        Some(TaskStatusErrorCode::EnvironmentSetupFailed)
+    );
+    assert!(message.is_environment_setup_failure());
+}
+
+#[test]
+fn task_status_error_code_deserializes_unknown_codes() {
+    let message: TaskStatusMessage =
+        serde_json::from_str("{\"message\":\"failed\",\"error_code\":\"new_error\"}").unwrap();
+
+    assert_eq!(message.error_code, Some(TaskStatusErrorCode::Unknown));
+    assert!(!message.is_environment_setup_failure());
+}

--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -944,19 +944,6 @@ impl BlocklistAIStatusBar {
             ]));
         }
 
-        if let Some(error_message) = ambient_agent_model.error_message() {
-            return Some(Message::new(vec![
-                MessageItem::Icon {
-                    icon: CoreIcon::Triangle,
-                    color: Some(error_color),
-                },
-                MessageItem::Text {
-                    content: error_message.to_owned().into(),
-                    color: Some(error_color),
-                },
-            ]));
-        }
-
         if ambient_agent_model.is_cancelled() {
             let color = theme.disabled_text_color(theme.background()).into_solid();
             return Some(Message::new(vec![

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -230,11 +230,16 @@ impl TerminalView {
                     Some(error_message.clone()),
                     ctx,
                 );
+
+                if FeatureFlag::CloudModeSetupV2.is_enabled() {
+                    self.insert_failed_conversation_ended_tombstone(error_message.clone(), ctx);
+                }
+
                 // Refresh the details panel to show failed status
                 if self.is_conversation_details_panel_open {
                     self.fetch_and_update_conversation_details_panel(ctx);
                 }
-                // Re-render to show the error state in the footer.
+                // Re-render to show the error state.
                 ctx.emit(TerminalViewEvent::TerminalViewStateChanged);
                 ctx.notify();
             }

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -232,7 +232,7 @@ impl TerminalView {
                 );
 
                 if FeatureFlag::CloudModeSetupV2.is_enabled() {
-                    self.insert_failed_conversation_ended_tombstone(error_message.clone(), ctx);
+                    self.insert_conversation_ended_tombstone(ctx);
                 }
 
                 // Refresh the details panel to show failed status

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -87,13 +87,15 @@ impl TombstoneDisplayData {
         };
 
         let conversation_status = conversation_output_status_from_conversation(conversation);
+        let is_error = matches!(
+            conversation_status,
+            Some(AmbientConversationStatus::Error { .. })
+        );
         let error_message = conversation_status
             .as_ref()
             .and_then(|status| match status {
                 AmbientConversationStatus::Error { error } => Some(error.to_string()),
-                AmbientConversationStatus::Success
-                | AmbientConversationStatus::Cancelled { .. }
-                | AmbientConversationStatus::Blocked { .. } => None,
+                _ => None,
             });
 
         // Calculate run time from exchanges
@@ -107,7 +109,7 @@ impl TombstoneDisplayData {
 
         Self {
             title: conversation.title(),
-            is_error: conversation.status().is_error() || error_message.is_some(),
+            is_error,
             error_message,
             conversation_is_transcript,
             source: None,
@@ -191,9 +193,7 @@ impl ConversationEndedTombstoneView {
     pub fn new(
         ctx: &mut ViewContext<Self>,
         terminal_view_id: EntityId,
-        #[cfg_attr(target_family = "wasm", allow(unused_variables))] task_id: Option<
-            AmbientAgentTaskId,
-        >,
+        task_id: Option<AmbientAgentTaskId>,
     ) -> Self {
         let conversation_id = BlocklistAIHistoryModel::handle(ctx)
             .as_ref(ctx)

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -69,7 +69,6 @@ impl TombstoneDisplayData {
         conversation_id: AIConversationId,
         terminal_view_id: EntityId,
         has_task_id: bool,
-        initial_error_message: Option<String>,
         ctx: &ViewContext<ConversationEndedTombstoneView>,
     ) -> Self {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
@@ -87,19 +86,14 @@ impl TombstoneDisplayData {
         };
 
         let conversation_status = conversation_output_status_from_conversation(conversation);
-        let is_error = matches!(
-            conversation_status,
-            Some(AmbientConversationStatus::Error { .. })
-        );
-        let initial_error_message = initial_error_message.filter(|message| !message.is_empty());
-        let error_message = initial_error_message.or_else(|| {
-            conversation_status
-                .as_ref()
-                .and_then(|status| match status {
-                    AmbientConversationStatus::Error { error } => Some(error.to_string()),
-                    _ => None,
-                })
-        });
+        let error_message = conversation_status
+            .as_ref()
+            .and_then(|status| match status {
+                AmbientConversationStatus::Error { error } => Some(error.to_string()),
+                AmbientConversationStatus::Success
+                | AmbientConversationStatus::Cancelled { .. }
+                | AmbientConversationStatus::Blocked { .. } => None,
+            });
 
         // Calculate run time from exchanges
         let run_time = (|| {
@@ -112,7 +106,7 @@ impl TombstoneDisplayData {
 
         Self {
             title: conversation.title(),
-            is_error: is_error || error_message.is_some(),
+            is_error: conversation.status().is_error() || error_message.is_some(),
             error_message,
             conversation_is_transcript,
             source: None,
@@ -195,36 +189,28 @@ impl ConversationEndedTombstoneView {
         #[cfg_attr(target_family = "wasm", allow(unused_variables))] task_id: Option<
             AmbientAgentTaskId,
         >,
-        initial_error_message: Option<String>,
     ) -> Self {
         let conversation_id = BlocklistAIHistoryModel::handle(ctx)
             .as_ref(ctx)
             .all_live_conversations_for_terminal_view(terminal_view_id)
             .next()
             .map(|c| c.id());
-        let initial_error_message = initial_error_message.filter(|message| !message.is_empty());
-        let is_initial_setup_failure = initial_error_message.is_some() && task_id.is_none();
-
-        let display_data = if is_initial_setup_failure {
-            TombstoneDisplayData {
-                title: Some("Cloud agent failed to start".to_string()),
-                is_error: true,
-                error_message: initial_error_message.clone(),
-                ..Default::default()
-            }
-        } else {
-            conversation_id
-                .map(|conversation_id| {
-                    TombstoneDisplayData::from_conversation(
-                        conversation_id,
-                        terminal_view_id,
-                        task_id.is_some(),
-                        initial_error_message.clone(),
-                        ctx,
-                    )
-                })
-                .unwrap_or_default()
-        };
+        let mut display_data = conversation_id
+            .map(|conversation_id| {
+                TombstoneDisplayData::from_conversation(
+                    conversation_id,
+                    terminal_view_id,
+                    task_id.is_some(),
+                    ctx,
+                )
+            })
+            .unwrap_or_default();
+        let failed_before_task_creation =
+            display_data.is_error && task_id.is_none() && !display_data.conversation_is_transcript;
+        if failed_before_task_creation {
+            display_data.title = Some("Cloud agent failed to start".to_string());
+            display_data.credits = None;
+        }
 
         let artifact_buttons_view =
             ctx.add_typed_action_view(|ctx| ArtifactButtonsRow::new(&display_data.artifacts, ctx));
@@ -244,7 +230,7 @@ impl ConversationEndedTombstoneView {
             });
 
         #[cfg(not(target_family = "wasm"))]
-        let continue_locally_button = if is_initial_setup_failure {
+        let continue_locally_button = if failed_before_task_creation {
             None
         } else {
             conversation_id.map(|conv_id| {

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -69,6 +69,7 @@ impl TombstoneDisplayData {
         conversation_id: AIConversationId,
         terminal_view_id: EntityId,
         has_task_id: bool,
+        initial_error_message: Option<String>,
         ctx: &ViewContext<ConversationEndedTombstoneView>,
     ) -> Self {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
@@ -90,12 +91,15 @@ impl TombstoneDisplayData {
             conversation_status,
             Some(AmbientConversationStatus::Error { .. })
         );
-        let error_message = conversation_status
-            .as_ref()
-            .and_then(|status| match status {
-                AmbientConversationStatus::Error { error } => Some(error.to_string()),
-                _ => None,
-            });
+        let initial_error_message = initial_error_message.filter(|message| !message.is_empty());
+        let error_message = initial_error_message.or_else(|| {
+            conversation_status
+                .as_ref()
+                .and_then(|status| match status {
+                    AmbientConversationStatus::Error { error } => Some(error.to_string()),
+                    _ => None,
+                })
+        });
 
         // Calculate run time from exchanges
         let run_time = (|| {
@@ -108,7 +112,7 @@ impl TombstoneDisplayData {
 
         Self {
             title: conversation.title(),
-            is_error,
+            is_error: is_error || error_message.is_some(),
             error_message,
             conversation_is_transcript,
             source: None,
@@ -188,24 +192,39 @@ impl ConversationEndedTombstoneView {
     pub fn new(
         ctx: &mut ViewContext<Self>,
         terminal_view_id: EntityId,
-        task_id: Option<AmbientAgentTaskId>,
+        #[cfg_attr(target_family = "wasm", allow(unused_variables))] task_id: Option<
+            AmbientAgentTaskId,
+        >,
+        initial_error_message: Option<String>,
     ) -> Self {
         let conversation_id = BlocklistAIHistoryModel::handle(ctx)
             .as_ref(ctx)
             .all_live_conversations_for_terminal_view(terminal_view_id)
             .next()
             .map(|c| c.id());
+        let initial_error_message = initial_error_message.filter(|message| !message.is_empty());
+        let is_initial_setup_failure = initial_error_message.is_some() && task_id.is_none();
 
-        let display_data = conversation_id
-            .map(|id| {
-                TombstoneDisplayData::from_conversation(
-                    id,
-                    terminal_view_id,
-                    task_id.is_some(),
-                    ctx,
-                )
-            })
-            .unwrap_or_default();
+        let display_data = if is_initial_setup_failure {
+            TombstoneDisplayData {
+                title: Some("Cloud agent failed to start".to_string()),
+                is_error: true,
+                error_message: initial_error_message.clone(),
+                ..Default::default()
+            }
+        } else {
+            conversation_id
+                .map(|conversation_id| {
+                    TombstoneDisplayData::from_conversation(
+                        conversation_id,
+                        terminal_view_id,
+                        task_id.is_some(),
+                        initial_error_message.clone(),
+                        ctx,
+                    )
+                })
+                .unwrap_or_default()
+        };
 
         let artifact_buttons_view =
             ctx.add_typed_action_view(|ctx| ArtifactButtonsRow::new(&display_data.artifacts, ctx));
@@ -225,17 +244,21 @@ impl ConversationEndedTombstoneView {
             });
 
         #[cfg(not(target_family = "wasm"))]
-        let continue_locally_button = conversation_id.map(|conv_id| {
-            ctx.add_typed_action_view(move |_| {
-                ActionButton::new("Continue locally", PrimaryTheme)
-                    .with_tooltip("Fork this conversation locally")
-                    .on_click(move |ctx| {
-                        ctx.dispatch_typed_action(
-                            ConversationEndedTombstoneAction::ContinueLocally(conv_id),
-                        );
-                    })
+        let continue_locally_button = if is_initial_setup_failure {
+            None
+        } else {
+            conversation_id.map(|conv_id| {
+                ctx.add_typed_action_view(move |_| {
+                    ActionButton::new("Continue locally", PrimaryTheme)
+                        .with_tooltip("Fork this conversation locally")
+                        .on_click(move |ctx| {
+                            ctx.dispatch_typed_action(
+                                ConversationEndedTombstoneAction::ContinueLocally(conv_id),
+                            );
+                        })
+                })
             })
-        });
+        };
 
         // In wasm, continuing locally is impossible so we instead
         // offer to open the conversation in warp (where you can continue locally).
@@ -532,6 +555,25 @@ impl ConversationEndedTombstoneView {
             return Empty::new().finish();
         }
         row.finish()
+    }
+}
+
+#[cfg(test)]
+impl ConversationEndedTombstoneView {
+    pub(in crate::terminal::view) fn title_for_test(&self) -> Option<&str> {
+        self.display_data.title.as_deref()
+    }
+
+    pub(in crate::terminal::view) fn error_message_for_test(&self) -> Option<&str> {
+        self.display_data.error_message.as_deref()
+    }
+
+    pub(in crate::terminal::view) fn credits_for_test(&self) -> Option<&str> {
+        self.display_data.credits.as_deref()
+    }
+
+    pub(in crate::terminal::view) fn has_continue_locally_button_for_test(&self) -> bool {
+        self.continue_locally_button.is_some()
     }
 }
 

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -53,6 +53,7 @@ struct TombstoneDisplayData {
     working_directory: Option<String>,
     /// Artifacts from the conversation
     artifacts: Vec<Artifact>,
+    hide_continue_actions: bool,
     /// Execution harness for the task. None until the task is loaded.
     #[cfg(not(target_family = "wasm"))]
     harness: Option<Harness>,
@@ -115,6 +116,7 @@ impl TombstoneDisplayData {
             credits: Some(format_credits(conversation.credits_spent())),
             working_directory: conversation.initial_working_directory(),
             artifacts: conversation.artifacts().to_vec(),
+            hide_continue_actions: false,
             #[cfg(not(target_family = "wasm"))]
             harness: None,
         }
@@ -147,6 +149,9 @@ impl TombstoneDisplayData {
         if task.state.is_failure_like() {
             self.is_error = true;
             if let Some(status_message) = &task.status_message {
+                if status_message.is_environment_setup_failure() {
+                    self.hide_continue_actions = true;
+                }
                 self.error_message = Some(status_message.message.clone());
             }
         }
@@ -210,6 +215,7 @@ impl ConversationEndedTombstoneView {
         if failed_before_task_creation {
             display_data.title = Some("Cloud agent failed to start".to_string());
             display_data.credits = None;
+            display_data.hide_continue_actions = true;
         }
 
         let artifact_buttons_view =
@@ -503,6 +509,9 @@ impl ConversationEndedTombstoneView {
             .with_spacing(8.);
 
         let mut has_button = false;
+        if self.display_data.hide_continue_actions {
+            return Empty::new().finish();
+        }
 
         #[cfg(not(target_family = "wasm"))]
         {
@@ -559,7 +568,11 @@ impl ConversationEndedTombstoneView {
     }
 
     pub(in crate::terminal::view) fn has_continue_locally_button_for_test(&self) -> bool {
-        self.continue_locally_button.is_some()
+        !self.display_data.hide_continue_actions && self.continue_locally_button.is_some()
+    }
+
+    pub(in crate::terminal::view) fn has_continue_in_cloud_button_for_test(&self) -> bool {
+        !self.display_data.hide_continue_actions && self.continue_in_cloud_button.is_some()
     }
 }
 

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
@@ -2,7 +2,7 @@ use chrono::{Duration, Utc};
 use warp_cli::agent::Harness;
 
 use crate::ai::ambient_agents::task::{
-    AgentConfigSnapshot, HarnessConfig, RequestUsage, TaskPrincipalInfo,
+    AgentConfigSnapshot, HarnessConfig, RequestUsage, TaskPrincipalInfo, TaskStatusMessage,
 };
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
 use crate::ai::artifacts::Artifact;
@@ -65,6 +65,25 @@ fn data_with_conversation_values() -> TombstoneDisplayData {
         credits: Some("conv credits".to_string()),
         ..Default::default()
     }
+}
+
+#[test]
+fn task_failure_status_message_overrides_initial_error() {
+    let mut task = task_with_run_time_and_credits();
+    task.state = AmbientAgentTaskState::Failed;
+    task.status_message = Some(TaskStatusMessage {
+        message: "task failed".to_string(),
+    });
+    let mut data = TombstoneDisplayData {
+        is_error: true,
+        error_message: Some("setup failed".to_string()),
+        ..Default::default()
+    };
+
+    data.enrich_from_task(task);
+
+    assert!(data.is_error);
+    assert_eq!(data.error_message.as_deref(), Some("task failed"));
 }
 
 fn pr_artifact(branch: &str) -> Artifact {

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
@@ -93,7 +93,7 @@ fn environment_setup_failure_hides_continue_actions() {
     task.state = AmbientAgentTaskState::Failed;
     task.status_message = Some(TaskStatusMessage {
         message: "Environment setup failed: Failed to run setup command: hi".to_string(),
-        error_code: Some("ENVIRONMENT_SETUP_FAILED".to_string()),
+        error_code: Some("environment_setup_failed".to_string()),
     });
     let mut data = TombstoneDisplayData::default();
 

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
@@ -73,6 +73,7 @@ fn task_failure_status_message_overrides_conversation_error() {
     task.state = AmbientAgentTaskState::Failed;
     task.status_message = Some(TaskStatusMessage {
         message: "task failed".to_string(),
+        error_code: None,
     });
     let mut data = TombstoneDisplayData {
         is_error: true,
@@ -84,6 +85,21 @@ fn task_failure_status_message_overrides_conversation_error() {
 
     assert!(data.is_error);
     assert_eq!(data.error_message.as_deref(), Some("task failed"));
+}
+
+#[test]
+fn environment_setup_failure_hides_continue_actions() {
+    let mut task = task_with_run_time_and_credits();
+    task.state = AmbientAgentTaskState::Failed;
+    task.status_message = Some(TaskStatusMessage {
+        message: "Environment setup failed: Failed to run setup command: hi".to_string(),
+        error_code: Some("ENVIRONMENT_SETUP_FAILED".to_string()),
+    });
+    let mut data = TombstoneDisplayData::default();
+
+    data.enrich_from_task(task);
+
+    assert!(data.hide_continue_actions);
 }
 
 fn pr_artifact(branch: &str) -> Artifact {

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
@@ -2,7 +2,8 @@ use chrono::{Duration, Utc};
 use warp_cli::agent::Harness;
 
 use crate::ai::ambient_agents::task::{
-    AgentConfigSnapshot, HarnessConfig, RequestUsage, TaskPrincipalInfo, TaskStatusMessage,
+    AgentConfigSnapshot, HarnessConfig, RequestUsage, TaskPrincipalInfo, TaskStatusErrorCode,
+    TaskStatusMessage,
 };
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
 use crate::ai::artifacts::Artifact;
@@ -93,7 +94,7 @@ fn environment_setup_failure_hides_continue_actions() {
     task.state = AmbientAgentTaskState::Failed;
     task.status_message = Some(TaskStatusMessage {
         message: "Environment setup failed: Failed to run setup command: hi".to_string(),
-        error_code: Some("environment_setup_failed".to_string()),
+        error_code: Some(TaskStatusErrorCode::EnvironmentSetupFailed),
     });
     let mut data = TombstoneDisplayData::default();
 

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
@@ -68,7 +68,7 @@ fn data_with_conversation_values() -> TombstoneDisplayData {
 }
 
 #[test]
-fn task_failure_status_message_overrides_initial_error() {
+fn task_failure_status_message_overrides_conversation_error() {
     let mut task = task_with_run_time_and_credits();
     task.state = AmbientAgentTaskState::Failed;
     task.status_message = Some(TaskStatusMessage {

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -1667,34 +1667,13 @@ impl TerminalView {
     }
 
     pub fn insert_conversation_ended_tombstone(&mut self, ctx: &mut ViewContext<Self>) {
-        self.insert_conversation_ended_tombstone_internal(None, ctx);
-    }
-
-    pub(in crate::terminal::view) fn insert_failed_conversation_ended_tombstone(
-        &mut self,
-        error_message: String,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        self.insert_conversation_ended_tombstone_internal(Some(error_message), ctx);
-    }
-
-    fn insert_conversation_ended_tombstone_internal(
-        &mut self,
-        initial_error_message: Option<String>,
-        ctx: &mut ViewContext<Self>,
-    ) {
         if self.conversation_ended_tombstone_view_id.is_some() {
             self.remove_conversation_ended_tombstone(ctx);
         }
         let task_id = self.ambient_agent_task_id_for_details_panel(ctx);
         let terminal_view_id = self.id();
         let tombstone_view_handle = ctx.add_typed_action_view(move |ctx| {
-            ConversationEndedTombstoneView::new(
-                ctx,
-                terminal_view_id,
-                task_id,
-                initial_error_message,
-            )
+            ConversationEndedTombstoneView::new(ctx, terminal_view_id, task_id)
         });
         #[cfg(not(target_family = "wasm"))]
         ctx.subscribe_to_view(&tombstone_view_handle, |me, _, event, ctx| match event {

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -1667,14 +1667,34 @@ impl TerminalView {
     }
 
     pub fn insert_conversation_ended_tombstone(&mut self, ctx: &mut ViewContext<Self>) {
+        self.insert_conversation_ended_tombstone_internal(None, ctx);
+    }
+
+    pub(in crate::terminal::view) fn insert_failed_conversation_ended_tombstone(
+        &mut self,
+        error_message: String,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.insert_conversation_ended_tombstone_internal(Some(error_message), ctx);
+    }
+
+    fn insert_conversation_ended_tombstone_internal(
+        &mut self,
+        initial_error_message: Option<String>,
+        ctx: &mut ViewContext<Self>,
+    ) {
         if self.conversation_ended_tombstone_view_id.is_some() {
             self.remove_conversation_ended_tombstone(ctx);
         }
         let task_id = self.ambient_agent_task_id_for_details_panel(ctx);
         let terminal_view_id = self.id();
-
-        let tombstone_view_handle = ctx.add_typed_action_view(|ctx| {
-            ConversationEndedTombstoneView::new(ctx, terminal_view_id, task_id)
+        let tombstone_view_handle = ctx.add_typed_action_view(move |ctx| {
+            ConversationEndedTombstoneView::new(
+                ctx,
+                terminal_view_id,
+                task_id,
+                initial_error_message,
+            )
         });
         #[cfg(not(target_family = "wasm"))]
         ctx.subscribe_to_view(&tombstone_view_handle, |me, _, event, ctx| match event {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -1087,6 +1087,7 @@ fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
                 Some("setup failed again")
             );
             assert_eq!(tombstone.credits_for_test(), None);
+            assert!(!tombstone.has_continue_in_cloud_button_for_test());
             assert!(!tombstone.has_continue_locally_button_for_test());
         });
     });

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -55,6 +55,7 @@ use crate::terminal::session_settings::AgentToolbarChipSelection;
 use crate::terminal::shared_session::SharedSessionStatus;
 use crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent;
 use crate::terminal::view::load_ai_conversation::RestoredAIConversation;
+use crate::terminal::view::shared_session::ConversationEndedTombstoneView;
 use crate::terminal::CLIAgent;
 
 use crate::terminal::{MockTerminalManager, TerminalManager, TerminalModel};
@@ -1027,6 +1028,65 @@ fn cloud_mode_dispatched_agent_inserts_queued_user_query() {
     });
 }
 
+#[test]
+fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+
+        terminal.update(&mut app, |view, ctx| {
+            view.insert_cloud_mode_queued_user_query_block("queued prompt".to_string(), ctx);
+            assert!(has_pending_user_query_block(view));
+
+            view.handle_ambient_agent_event(
+                &AmbientAgentViewModelEvent::Failed {
+                    error_message: "setup failed".to_string(),
+                },
+                ctx,
+            );
+
+            assert!(!has_pending_user_query_block(view));
+            assert!(view.conversation_ended_tombstone_view_id.is_some());
+            assert_eq!(view.rich_content_views.len(), 1);
+            {
+                let model = view.model.lock();
+                assert!(!view.is_input_box_visible(&model, ctx));
+            }
+
+            view.handle_ambient_agent_event(
+                &AmbientAgentViewModelEvent::Failed {
+                    error_message: "setup failed again".to_string(),
+                },
+                ctx,
+            );
+            assert_eq!(view.rich_content_views.len(), 1);
+        });
+
+        let window_id = app.read(|ctx| terminal.window_id(ctx));
+        let tombstones = app
+            .views_of_type::<ConversationEndedTombstoneView>(window_id)
+            .expect("window should have tombstone views");
+        let tombstone = tombstones
+            .last()
+            .expect("failed cloud mode should insert a tombstone");
+        tombstone.read(&app, |tombstone, _| {
+            assert_eq!(
+                tombstone.title_for_test(),
+                Some("Cloud agent failed to start")
+            );
+            assert_eq!(
+                tombstone.error_message_for_test(),
+                Some("setup failed again")
+            );
+            assert_eq!(tombstone.credits_for_test(), None);
+            assert!(!tombstone.has_continue_locally_button_for_test());
+        });
+    });
+}
 #[test]
 fn cloud_mode_followup_dispatched_inserts_queued_user_query() {
     App::test((), |mut app| async move {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -1039,6 +1039,10 @@ fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
         let terminal = add_window_with_cloud_mode_terminal(&mut app);
 
         terminal.update(&mut app, |view, ctx| {
+            view.model
+                .lock()
+                .set_shared_session_status(SharedSessionStatus::ViewPending);
+            view.enter_ambient_agent_setup(None, ctx);
             view.insert_cloud_mode_queued_user_query_block("queued prompt".to_string(), ctx);
             assert!(has_pending_user_query_block(view));
 
@@ -1087,6 +1091,7 @@ fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
         });
     });
 }
+
 #[test]
 fn cloud_mode_followup_dispatched_inserts_queued_user_query() {
     App::test((), |mut app| async move {

--- a/specs/APP-4459/TECH.md
+++ b/specs/APP-4459/TECH.md
@@ -1,0 +1,50 @@
+# Context
+APP-4459 changes Cloud Mode setup-v2 failures so they render as the conversation-ended tombstone and hide input, instead of showing the failure in the agent message bar.
+Today `AmbientAgentViewModel::handle_spawn_error` stores `Status::Failed { error_message }` and emits `AmbientAgentViewModelEvent::Failed` in `app/src/terminal/view/ambient_agent/model.rs:1318`.
+`TerminalView::handle_ambient_agent_event` handles `Failed` by removing the queued prompt block, updating the active cloud conversation status, refreshing the details panel, and notifying in `app/src/terminal/view/ambient_agent/view_impl.rs:176`.
+Setup-v2 failures currently reach `BlocklistAIStatusBar::render_cloud_mode_setup_terminal_message`, which renders `ambient_agent_model.error_message()` as a red message bar in `app/src/ai/blocklist/block/status_bar.rs:917`.
+The existing tombstone insertion path is `TerminalView::insert_conversation_ended_tombstone` in `app/src/terminal/view/shared_session/view_impl.rs:1669`. It sets `conversation_ended_tombstone_view_id`.
+Input hiding already keys off that tombstone ID in `TerminalView::is_input_box_visible` in `app/src/terminal/view.rs:7216`, so no separate input-hiding state is needed.
+`ConversationEndedTombstoneView` already enriches from `AmbientAgentTask` and uses `task.status_message.message` when `task.state.is_failure_like()` in `app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs:140`. This is the right source for task-backed failures, especially third-party harness runs where the local `AIConversation` is only a UI vehicle.
+`TaskStatusMessage` now carries optional `error_code` data in `app/src/ai/ambient_agents/task.rs:520`, with `environment_setup_failed` identifying setup-command failures that should not offer continue actions.
+Setup failures can happen before an `AmbientAgentTask` exists but still have an active local `AIConversation`. The `Failed` handler writes the error into that conversation before inserting the tombstone, so the tombstone can read conversation status.
+
+# Proposed changes
+Keep this setup-v2 only. Setup-v1 uses the old full-screen/status-footer failure UI.
+
+In `TerminalView::handle_ambient_agent_event`:
+- Keep the existing `Failed` status update and details-panel refresh.
+- When `FeatureFlag::CloudModeSetupV2.is_enabled()`, insert the tombstone after updating status.
+- Avoid duplicate insertion by respecting `conversation_ended_tombstone_view_id`.
+In `conversation_output_status_from_conversation`:
+- Keep finished root-exchange statuses as the preferred source for success, cancelled, and exchange-backed errors.
+- If there is no finished root exchange and `conversation.status()` is `ConversationStatus::Error`, convert `conversation.status_error_message()` into `AmbientConversationStatus::Error`.
+- Use `RenderableAIError::Other` with `will_attempt_resume: false` and `waiting_for_network: false` for that fallback.
+
+In `ConversationEndedTombstoneView`:
+- Read error display data from conversation status.
+- Mark display data as error when either `conversation.status().is_error()` or conversation output status has an error.
+- Add `hide_continue_actions` to suppress both Continue locally and Continue in cloud.
+- For pre-task setup failures, detect an error conversation with no task ID and no transcript, then set title to `Cloud agent failed to start`, clear credits, and hide continue actions.
+- Keep async task enrichment, and let task failure metadata override the conversation error when available.
+- When task enrichment sees failure-like state with `TaskStatusMessage.error_code == environment_setup_failed`, hide continue actions.
+- Keep existing finished-exchange/conversation-derived errors for normal Oz tombstones.
+In `BlocklistAIStatusBar::render_cloud_mode_setup_terminal_message`, remove or gate only the `ambient_agent_model.error_message()` branch. Keep the GitHub auth and cancelled branches unchanged.
+
+In `TaskStatusMessage`:
+- Add optional `error_code` with serde support for `errorCode`.
+- Add `is_environment_setup_failure()` helper for tombstone display decisions.
+
+Error source order should be:
+1. `AmbientAgentTask.status_message.message` for task-backed failures.
+2. Conversation status error, including pre-task setup failures.
+
+# Testing and validation
+Add focused Rust coverage:
+- setup-v2 `AmbientAgentViewModelEvent::Failed` inserts one tombstone and removes the queued prompt block.
+- `TerminalView::is_input_box_visible` returns false after the failure tombstone is inserted.
+- duplicate `Failed` events still keep one tombstone rich-content view.
+- pre-task failure tombstone uses `Cloud agent failed to start`, hides credits, and hides continue actions.
+- task-backed failure tombstone renders `AmbientAgentTask.status_message.message`.
+- task-backed environment setup failures hide continue actions via `TaskStatusMessage.error_code`.
+- setup-v2 status bar no longer renders the generic failure message branch.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
This PR reverts back to using the tombstone, rather than the message bar, to display setup failures in cloud mode.

In addition to showing the tombstone, we also:
- Update `conversation_output_status_from_conversation` to return statuses even when the conversation doesn't have any tasks (e.g. failure before conversation running, third-party harness)
- Deserialize an `error_code` from task status messages (already present in the GraphQL) so that for setup command failures we don't show the tombstone with Continue/Continue Locally actions (it doesn't make sense to continue for an environment that's borked). 

Loom: https://www.loom.com/share/685d737b881f4d89a1be0ade033da5ab


## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

Added unit tests and tested a variety of failure modes in the Loom above.

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

Not included in the Loom, but setup command failure:
<img width="1392" height="912" alt="image" src="https://github.com/user-attachments/assets/eefbb82c-1c0a-4ede-b92d-79d93a9faa8c" />

I don't think it's perfect but it's better than what we had before:
<img width="602" height="126" alt="image" src="https://github.com/user-attachments/assets/7a2367b7-75c9-498d-a5e8-dbb5044e73bc" />


## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode