### PR TITLE
fix(shell-terminal): auto-dismiss slow-bootstrap banner so it can't outlive its usefulness

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -673,6 +673,14 @@ const BOOTSTRAP_FAILED_DURATION: Duration = Duration::from_secs(7);
 /// a user needing to type in one or many secret manager passwords
 /// during the bootstrap period.
 const ENV_VAR_BOOTSTRAP_FAILED_DURATION: Duration = Duration::from_secs(60);
+/// How long the slow-bootstrap banner stays visible after it first appears
+/// before it auto-dismisses. The banner used to persist until the user
+/// dismissed it manually or bootstrap finished, but in workflows where
+/// bootstrap will never complete (e.g. a shell that `exec`s into `expect`
+/// before Warp's shell integration runs), nothing ever clears it. Auto-
+/// dismissal keeps the warning informational without turning it into a
+/// permanent fixture.
+const SLOW_BOOTSTRAP_BANNER_AUTO_DISMISS_DURATION: Duration = Duration::from_secs(30);
 const KNOWN_ISSUES_URL: &str =
     "https://docs.warp.dev/support-and-community/troubleshooting-and-support/known-issues";
 
@@ -2555,6 +2563,13 @@ pub struct TerminalView {
     enter_agent_view_after_pending_commands: bool,
     slow_bootstrap_banner: ViewHandle<Banner<TerminalAction>>,
     is_slow_bootstrap_banner_open: bool,
+    /// Timer that auto-dismisses the slow-bootstrap banner after
+    /// [`SLOW_BOOTSTRAP_BANNER_AUTO_DISMISS_DURATION`]. Held so it can be
+    /// aborted when the banner is hidden for any other reason (manual
+    /// dismissal, successful bootstrap completion) — letting an in-flight
+    /// timer fire afterwards would be a no-op since `hide_slow_bootstrap_banner`
+    /// is idempotent, but aborting avoids spurious work.
+    slow_bootstrap_banner_auto_dismiss_handle: Option<SpawnedFutureHandle>,
 
     /// The handle to any currently hovered secret. Used to determine whether the
     /// secret gets a special hovered treatment.
@@ -4177,6 +4192,7 @@ impl TerminalView {
             enter_agent_view_after_pending_commands: false,
             slow_bootstrap_banner,
             is_slow_bootstrap_banner_open: false,
+            slow_bootstrap_banner_auto_dismiss_handle: None,
             incompatible_configuration_banner,
             is_incompatible_configuration_banner_open: false,
             emacs_bindings_banner,
@@ -14940,10 +14956,32 @@ impl TerminalView {
     }
 
     fn hide_slow_bootstrap_banner(&mut self, ctx: &mut ViewContext<Self>) {
+        if let Some(handle) = self.slow_bootstrap_banner_auto_dismiss_handle.take() {
+            handle.abort();
+        }
         if self.is_slow_bootstrap_banner_open {
             self.is_slow_bootstrap_banner_open = false;
             ctx.notify();
         }
+    }
+
+    /// Schedule a timer that auto-dismisses the slow-bootstrap banner after
+    /// `duration`. Exposed as a method (rather than inlined) so tests can
+    /// trigger the same scheduling path with a short duration.
+    fn start_slow_bootstrap_banner_auto_dismiss_timer(
+        &self,
+        duration: Duration,
+        ctx: &mut ViewContext<Self>,
+    ) -> SpawnedFutureHandle {
+        ctx.spawn(
+            async move {
+                Timer::after(duration).await;
+            },
+            |me, _, ctx| {
+                me.slow_bootstrap_banner_auto_dismiss_handle = None;
+                me.hide_slow_bootstrap_banner(ctx);
+            },
+        )
     }
 
     #[cfg(not(target_family = "wasm"))]
@@ -15083,6 +15121,17 @@ impl TerminalView {
         if !self.is_login_shell_bootstrapped {
             log::warn!("Showing bootstrap slow toast");
             self.is_slow_bootstrap_banner_open = true;
+            // Replace any prior auto-dismiss timer (defensive — the banner
+            // should only open once per session, but if the path is ever
+            // exercised twice we don't want to leak a SpawnedFutureHandle).
+            if let Some(handle) = self.slow_bootstrap_banner_auto_dismiss_handle.take() {
+                handle.abort();
+            }
+            self.slow_bootstrap_banner_auto_dismiss_handle =
+                Some(self.start_slow_bootstrap_banner_auto_dismiss_timer(
+                    SLOW_BOOTSTRAP_BANNER_AUTO_DISMISS_DURATION,
+                    ctx,
+                ));
             ctx.notify();
         }
 

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -3066,6 +3066,67 @@ fn test_banner_for_incompatible_plugins() {
     })
 }
 
+/// Regression test for #9011: the slow-bootstrap banner used to persist
+/// indefinitely when shell integration never sent the bootstrap signal
+/// (e.g. the user's shell `exec`s into `expect` before Warp's integration
+/// runs). The auto-dismiss timer scheduled when the banner opens must
+/// eventually close it.
+#[test]
+fn test_slow_bootstrap_banner_auto_dismisses() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal =
+            MockTerminalManager::create_new_terminal_view_window_for_test(&mut app, None);
+
+        // Open the banner directly and schedule a short-duration auto-dismiss
+        // timer. We bypass `on_bootstrap_failed_timer_complete` (which itself
+        // waits the 7-second bootstrap timeout) to keep this test fast — the
+        // important behavior under test is the auto-dismiss path.
+        terminal.update(&mut app, |view, ctx| {
+            view.is_slow_bootstrap_banner_open = true;
+            view.slow_bootstrap_banner_auto_dismiss_handle = Some(
+                view.start_slow_bootstrap_banner_auto_dismiss_timer(Duration::from_millis(50), ctx),
+            );
+        });
+
+        assert!(terminal.read(&app, |view, _ctx| view.is_slow_bootstrap_banner_open));
+
+        assert_eventually!(
+            200 => terminal.read(&app, |view, _ctx| !view.is_slow_bootstrap_banner_open
+                && view.slow_bootstrap_banner_auto_dismiss_handle.is_none()),
+            "Slow bootstrap banner did not auto-dismiss"
+        );
+    })
+}
+
+/// Regression test for #9011: when the banner is dismissed by another path
+/// (manual user dismissal or a successful bootstrap event), any pending
+/// auto-dismiss timer should be aborted so it can't fire after the fact.
+#[test]
+fn test_hide_slow_bootstrap_banner_aborts_pending_auto_dismiss() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal =
+            MockTerminalManager::create_new_terminal_view_window_for_test(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            view.is_slow_bootstrap_banner_open = true;
+            view.slow_bootstrap_banner_auto_dismiss_handle =
+                Some(view.start_slow_bootstrap_banner_auto_dismiss_timer(
+                    // Long enough that the timer can't fire before we hide.
+                    Duration::from_secs(60),
+                    ctx,
+                ));
+            view.hide_slow_bootstrap_banner(ctx);
+        });
+
+        terminal.read(&app, |view, _ctx| {
+            assert!(!view.is_slow_bootstrap_banner_open);
+            assert!(view.slow_bootstrap_banner_auto_dismiss_handle.is_none());
+        });
+    })
+}
+
 #[test]
 fn test_bash_vim_banner_already_shown() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description

The "Seems like your shell is taking a while to start" banner is only hidden when shell integration sends its bootstrap signal or the user clicks Dismiss. In workflows where the original shell `exec`s into another process before Warp's integration runs (e.g. an AppleScript that launches a tab whose rc file invokes `expect -c "spawn /bin/zsh; interact"`), that signal never arrives — leaving the banner permanently visible even though the resulting shell is fully usable.

The fix schedules a 30s auto-dismiss timer when the banner opens:

- `SLOW_BOOTSTRAP_BANNER_AUTO_DISMISS_DURATION` (`app/src/terminal/view.rs:676`) — new constant; behavior is additive.
- `TerminalView::slow_bootstrap_banner_auto_dismiss_handle: Option<SpawnedFutureHandle>` — held so the timer can be aborted if the banner is hidden by any other path.
- `start_slow_bootstrap_banner_auto_dismiss_timer` — small helper that spawns the timer and routes its completion through `hide_slow_bootstrap_banner` (which is already idempotent).
- `on_bootstrap_failed_timer_complete` now schedules the auto-dismiss right after it sets `is_slow_bootstrap_banner_open = true`, after defensively aborting any prior handle.
- `hide_slow_bootstrap_banner` aborts a pending handle before clearing the flag, so a manual dismissal or successful bootstrap doesn't leave a stale timer behind.

The 30s window is generous enough to read and act on the banner (e.g. click the existing "Show initialization block" button) but short enough that it can't persist forever. The genuine slow-bootstrap path is unchanged: if `handle_session_bootstrapped` fires within the window, the existing teardown clears both the banner and the new timer immediately. Telemetry (`BootstrappingSlow`, `BootstrappingSlowContents`) continues to fire as before.

### Why not change the trigger instead?

The root cause is that `is_active_block_bootstrapped()` returns false whenever shell integration hasn't completed, even when the shell itself is alive and responsive. Detecting "shell is alive but un-integrated" without false positives is fuzzy (PTY byte count, process-tree diffing, etc.) — happy to take that on in a follow-up if the team prefers, but auto-dismissal is the minimal change that resolves the user-visible regression without expanding the heuristic surface.

### Open question for reviewers

The 30s duration is a policy choice. Happy to adjust (or make it settings-gated) — flag it on review.

## Linked Issue

Fixes #9011.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Two regression tests added in `app/src/terminal/view_tests.rs`:

1. **`test_slow_bootstrap_banner_auto_dismisses`** — opens the banner with a short-duration timer and asserts the banner closes and the handle is cleared.
2. **`test_hide_slow_bootstrap_banner_aborts_pending_auto_dismiss`** — opens the banner with a long-duration timer, hides it via the normal path, and asserts the handle is aborted (no stale timer).

Both pass locally:

```
test terminal::view::tests::test_slow_bootstrap_banner_auto_dismisses ... ok
test terminal::view::tests::test_hide_slow_bootstrap_banner_aborts_pending_auto_dismiss ... ok
```

`cargo fmt --check` and `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` are clean on the touched crate.

- [ ] I have manually tested my changes locally with `./script/run`

  Not yet, my local build environment isn't fully set up (`./script/bootstrap` hasn't been run end-to-end). The change is additive and the tests exercise the same scheduling path that production uses, so I'm confident in correctness, but happy to add a manual repro screencast if reviewers want one.

### Screenshots / Videos

N/A — no UI changes; only the auto-dismissal behavior of an existing banner.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed the "Seems like your shell is taking a while to start" banner persisting indefinitely in workflows where shell integration never completes (e.g. an rc file that exec's into expect).
-->