### PR TITLE
Rename `FileLocation` to `LocalOrRemotePath`

### DIFF
--- a/app/src/app_state_tests.rs
+++ b/app/src/app_state_tests.rs
@@ -59,7 +59,7 @@ fn test_code_pane_snapshot_single_tab() {
         }],
         active_tab_index: 0,
         source: Some(CodeSource::FileTree {
-            location: crate::code::buffer_location::FileLocation::Local(PathBuf::from(
+            location: crate::code::buffer_location::LocalOrRemotePath::Local(PathBuf::from(
                 "/tmp/test.rs",
             )),
         }),

--- a/app/src/code/active_file.rs
+++ b/app/src/code/active_file.rs
@@ -1,21 +1,21 @@
 //! Module containing the definition of [`ActiveFileModel`],
 //! which tracks the currently focused file across an entire PaneGroup.
 
-use super::buffer_location::FileLocation;
+use super::buffer_location::LocalOrRemotePath;
 use warpui::{Entity, ModelContext};
 
 /// Events emitted by the ActiveFileModel.
 #[derive(Debug, Clone)]
 pub enum ActiveFileEvent {
     /// A new file became focused.
-    ActiveFileChanged { location: FileLocation },
+    ActiveFileChanged { location: LocalOrRemotePath },
 }
 
 /// Model that tracks the currently focused file.
 #[derive(Default)]
 pub struct ActiveFileModel {
     /// The currently focused file, if any.
-    active_file: Option<FileLocation>,
+    active_file: Option<LocalOrRemotePath>,
 }
 
 impl Entity for ActiveFileModel {
@@ -28,12 +28,16 @@ impl ActiveFileModel {
     }
 
     /// Get the currently active file, if any.
-    pub fn active_file(&self) -> Option<&FileLocation> {
+    pub fn active_file(&self) -> Option<&LocalOrRemotePath> {
         self.active_file.as_ref()
     }
 
     /// Set the currently active file.
-    pub fn active_file_changed(&mut self, location: FileLocation, ctx: &mut ModelContext<Self>) {
+    pub fn active_file_changed(
+        &mut self,
+        location: LocalOrRemotePath,
+        ctx: &mut ModelContext<Self>,
+    ) {
         // Only emit event if the active file changed.
         if self.active_file.as_ref() != Some(&location) {
             self.active_file = Some(location.clone());

--- a/app/src/code/buffer_location.rs
+++ b/app/src/code/buffer_location.rs
@@ -8,22 +8,22 @@ use warp_util::remote_path::RemotePath;
 /// or on a remote host. Used across both the buffer model and the
 /// editor/view layers as the canonical file-identity type.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub enum FileLocation {
+pub enum LocalOrRemotePath {
     /// File on the local filesystem.
     Local(PathBuf),
     /// File on a remote host, identified by host + path.
     Remote(RemotePath),
 }
 
-impl FileLocation {
+impl LocalOrRemotePath {
     /// Returns the file name component for display (e.g. tab titles).
     pub fn display_name(&self) -> &str {
         match self {
-            FileLocation::Local(path) => path
+            LocalOrRemotePath::Local(path) => path
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or_default(),
-            FileLocation::Remote(remote) => remote.path.file_name().unwrap_or_default(),
+            LocalOrRemotePath::Remote(remote) => remote.path.file_name().unwrap_or_default(),
         }
     }
 
@@ -32,21 +32,21 @@ impl FileLocation {
     /// should use this to gate their behavior.
     pub fn to_local_path(&self) -> Option<&Path> {
         match self {
-            FileLocation::Local(path) => Some(path.as_path()),
-            FileLocation::Remote(_) => None,
+            LocalOrRemotePath::Local(path) => Some(path.as_path()),
+            LocalOrRemotePath::Remote(_) => None,
         }
     }
 }
 
-impl From<PathBuf> for FileLocation {
+impl From<PathBuf> for LocalOrRemotePath {
     fn from(path: PathBuf) -> Self {
-        FileLocation::Local(path)
+        LocalOrRemotePath::Local(path)
     }
 }
 
-impl From<RemotePath> for FileLocation {
+impl From<RemotePath> for LocalOrRemotePath {
     fn from(remote: RemotePath) -> Self {
-        FileLocation::Remote(remote)
+        LocalOrRemotePath::Remote(remote)
     }
 }
 

--- a/app/src/code/editor_management.rs
+++ b/app/src/code/editor_management.rs
@@ -3,7 +3,7 @@ use std::{
     path::PathBuf,
 };
 
-use super::buffer_location::FileLocation;
+use super::buffer_location::LocalOrRemotePath;
 use crate::ai::skills::SkillOpenOrigin;
 use ai::skills::SkillReference;
 use serde::{Deserialize, Serialize};
@@ -120,7 +120,7 @@ pub enum CodeSource {
     /// Opened from project rules (WARP.md) file.
     ProjectRules { path: PathBuf },
     /// Opened from file tree (local or remote).
-    FileTree { location: FileLocation },
+    FileTree { location: LocalOrRemotePath },
     /// Opened from macOS Finder via "Open With".
     Finder { path: PathBuf },
     /// Opened from a skill.
@@ -150,8 +150,8 @@ impl CodeSource {
         match self {
             Self::New { .. } | Self::AIAction { .. } => None,
             Self::FileTree { location, .. } => match location {
-                FileLocation::Local(path) => Some(path.clone()),
-                FileLocation::Remote(_) => None,
+                LocalOrRemotePath::Local(path) => Some(path.clone()),
+                LocalOrRemotePath::Remote(_) => None,
             },
             Self::Link { path, .. }
             | Self::ProjectRules { path }
@@ -160,27 +160,27 @@ impl CodeSource {
         }
     }
 
-    /// Returns the `FileLocation` for file tree sources.
-    pub fn file_location(&self) -> Option<&FileLocation> {
+    /// Returns the `LocalOrRemotePath` for file tree sources.
+    pub fn file_location(&self) -> Option<&LocalOrRemotePath> {
         match self {
             Self::FileTree { location } => Some(location),
             _ => None,
         }
     }
 
-    /// Returns the `FileLocation` for any source that has a backing file.
+    /// Returns the `LocalOrRemotePath` for any source that has a backing file.
     ///
     /// Unlike `path()` (which only returns local paths) and `file_location()`
     /// (which only covers `FileTree`), this covers every variant that maps to
     /// a file — local or remote.
-    pub fn location(&self) -> Option<FileLocation> {
+    pub fn location(&self) -> Option<LocalOrRemotePath> {
         match self {
             Self::New { .. } | Self::AIAction { .. } => None,
             Self::FileTree { location } => Some(location.clone()),
             Self::Link { path, .. }
             | Self::ProjectRules { path }
             | Self::Finder { path }
-            | Self::Skill { path, .. } => Some(FileLocation::Local(path.clone())),
+            | Self::Skill { path, .. } => Some(LocalOrRemotePath::Local(path.clone())),
         }
     }
 
@@ -215,7 +215,7 @@ impl CodeSource {
             Self::AIAction { .. } => "ai_action",
             Self::ProjectRules { .. } => "project_rules",
             Self::FileTree {
-                location: FileLocation::Remote(_),
+                location: LocalOrRemotePath::Remote(_),
             } => "remote_file_tree",
             Self::FileTree { .. } => "file_tree",
             Self::Finder { .. } => "finder",
@@ -232,7 +232,7 @@ impl CodeSource {
             self,
             Self::AIAction { .. }
                 | Self::FileTree {
-                    location: FileLocation::Remote(_),
+                    location: LocalOrRemotePath::Remote(_),
                 }
         )
     }
@@ -286,12 +286,13 @@ impl CodeManager {
     pub fn deregister_pane(&mut self, source: &CodeSource) {
         self.source_to_pane_data.remove(&source.omit_line_col());
     }
-    /// Returns the locator for a code pane that already has the given `FileLocation`
+
+    /// Returns the locator for a code pane that already has the given `LocalOrRemotePath`
     /// open in the given pane group. Works for both local and remote files.
     pub fn get_locator_for_location_in_tab(
         &self,
         pane_group_id: EntityId,
-        location: &FileLocation,
+        location: &LocalOrRemotePath,
     ) -> Option<PaneViewLocator> {
         self.source_to_pane_data
             .iter()

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -42,7 +42,7 @@ use warpui::{
 use warpui::{BlurContext, ModelHandle};
 
 use crate::code::active_file::{ActiveFileEvent, ActiveFileModel};
-use crate::code::buffer_location::FileLocation;
+use crate::code::buffer_location::LocalOrRemotePath;
 use crate::coding_panel_enablement_state::CodingPanelEnablementState;
 use crate::editor::{EditorOptions, EditorView, TextOptions};
 #[cfg(feature = "local_fs")]
@@ -741,13 +741,13 @@ impl FileTreeView {
         match event {
             ActiveFileEvent::ActiveFileChanged { location } => {
                 let file_std = match location {
-                    crate::code::buffer_location::FileLocation::Local(path) => {
+                    crate::code::buffer_location::LocalOrRemotePath::Local(path) => {
                         match StandardizedPath::try_from_local(path) {
                             Ok(std_path) => std_path,
                             Err(_) => return,
                         }
                     }
-                    crate::code::buffer_location::FileLocation::Remote(remote) => {
+                    crate::code::buffer_location::LocalOrRemotePath::Remote(remote) => {
                         remote.path.clone()
                     }
                 };
@@ -2233,7 +2233,7 @@ impl FileTreeView {
         );
 
         ctx.emit(FileTreeEvent::OpenFile {
-            path: FileLocation::Local(path.to_path_buf()),
+            path: LocalOrRemotePath::Local(path.to_path_buf()),
             target,
             line_col: None,
         });
@@ -2263,7 +2263,7 @@ impl FileTreeView {
                             (*metadata.path).clone(),
                         );
                         ctx.emit(FileTreeEvent::OpenFile {
-                            path: FileLocation::Remote(remote_path),
+                            path: LocalOrRemotePath::Remote(remote_path),
                             target: FileTarget::CodeEditor(EditorLayout::SplitPane),
                             line_col: None,
                         });
@@ -2892,7 +2892,7 @@ pub enum FileTreeEvent {
     AttachAsContext { path: PathBuf },
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
     OpenFile {
-        path: FileLocation,
+        path: LocalOrRemotePath,
         target: FileTarget,
         line_col: Option<LineAndColumnArg>,
     },

--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -26,7 +26,7 @@ use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity, WeakModelHandle
 
 use remote_server::manager::RemoteServerManager;
 
-use super::buffer_location::{FileLocation, SyncClock};
+use super::buffer_location::{LocalOrRemotePath, SyncClock};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
@@ -319,7 +319,7 @@ pub struct CharOffsetEdit {
 /// This allows multiple editors to share the same buffer when editing the same file,
 /// enabling consistent content synchronization and more efficient memory usage.
 pub struct GlobalBufferModel {
-    location_to_id: BiMap<FileLocation, FileId>,
+    location_to_id: BiMap<LocalOrRemotePath, FileId>,
     buffers: HashMap<FileId, InternalBufferState>,
 }
 
@@ -399,8 +399,8 @@ impl GlobalBufferModel {
         let paths_to_close: Vec<PathBuf> = ids_to_remove
             .iter()
             .filter_map(|id| match self.location_to_id.get_by_right(id) {
-                Some(FileLocation::Local(path)) => Some(path.clone()),
-                Some(FileLocation::Remote(_)) | None => None,
+                Some(LocalOrRemotePath::Local(path)) => Some(path.clone()),
+                Some(LocalOrRemotePath::Remote(_)) | None => None,
             })
             .collect();
 
@@ -435,7 +435,8 @@ impl GlobalBufferModel {
 
     fn cleanup_file_id(&mut self, file_id: FileId, _ctx: &mut ModelContext<Self>) {
         // Send didClose before removing the entry.
-        if let Some((FileLocation::Local(path), _)) = self.location_to_id.remove_by_right(&file_id)
+        if let Some((LocalOrRemotePath::Local(path), _)) =
+            self.location_to_id.remove_by_right(&file_id)
         {
             self.close_document_with_lsp(&path, _ctx);
         }
@@ -890,7 +891,7 @@ impl GlobalBufferModel {
     /// Look up the file path for a tracked buffer.
     pub fn file_path(&self, file_id: FileId) -> Option<&Path> {
         match self.location_to_id.get_by_right(&file_id) {
-            Some(FileLocation::Local(path)) => Some(path.as_path()),
+            Some(LocalOrRemotePath::Local(path)) => Some(path.as_path()),
             _ => None,
         }
     }
@@ -907,7 +908,7 @@ impl GlobalBufferModel {
     pub fn discard_unsaved_changes(&mut self, path: &Path, ctx: &mut ModelContext<Self>) {
         if let Some(id) = self
             .location_to_id
-            .get_by_left(&FileLocation::Local(path.to_path_buf()))
+            .get_by_left(&LocalOrRemotePath::Local(path.to_path_buf()))
             .cloned()
         {
             let path_clone = path.to_path_buf();
@@ -966,7 +967,7 @@ impl GlobalBufferModel {
         // Internal state cleanup is synchronous; only the LSP didClose notification
         // is dispatched asynchronously (with a no-op callback), so there is no race
         // between state removal and the close completing.
-        if let Some((FileLocation::Local(old_path), _)) =
+        if let Some((LocalOrRemotePath::Local(old_path), _)) =
             self.location_to_id.remove_by_right(&old_file_id)
         {
             self.close_document_with_lsp(&old_path, ctx);
@@ -1022,7 +1023,7 @@ impl GlobalBufferModel {
         // to avoid orphaning the previous FileId in `self.buffers`.
         if let Some(old_file_id) = self
             .location_to_id
-            .get_by_left(&FileLocation::Local(path.clone()))
+            .get_by_left(&LocalOrRemotePath::Local(path.clone()))
             .copied()
         {
             self.cleanup_file_id(old_file_id, ctx);
@@ -1036,7 +1037,7 @@ impl GlobalBufferModel {
         });
 
         self.location_to_id
-            .insert(FileLocation::Local(path.clone()), file_id);
+            .insert(LocalOrRemotePath::Local(path.clone()), file_id);
         self.buffers.insert(
             file_id,
             InternalBufferState {
@@ -1079,7 +1080,7 @@ impl GlobalBufferModel {
                 let version_matches_initial = buffer.as_ref(ctx).version_match(&initial_version);
                 let fid = me
                     .location_to_id
-                    .get_by_left(&FileLocation::Local(path_clone.clone()))
+                    .get_by_left(&LocalOrRemotePath::Local(path_clone.clone()))
                     .cloned();
                 let previous_version = fid
                     .and_then(|id| me.buffers.get(&id))
@@ -1119,15 +1120,19 @@ impl GlobalBufferModel {
     /// Dispatches to the appropriate private opener based on the location variant.
     /// If a buffer already exists for this location and is loaded, returns the
     /// existing `BufferState`.
-    pub fn open(&mut self, location: FileLocation, ctx: &mut ModelContext<Self>) -> BufferState {
+    pub fn open(
+        &mut self,
+        location: LocalOrRemotePath,
+        ctx: &mut ModelContext<Self>,
+    ) -> BufferState {
         match location {
             #[cfg(feature = "local_fs")]
-            FileLocation::Local(path) => self.open_local(path, false, ctx),
+            LocalOrRemotePath::Local(path) => self.open_local(path, false, ctx),
             #[cfg(not(feature = "local_fs"))]
-            FileLocation::Local(_) => {
+            LocalOrRemotePath::Local(_) => {
                 unimplemented!("Local buffers require the local_fs feature")
             }
-            FileLocation::Remote(remote_path) => self.open_remote_buffer(remote_path, ctx),
+            LocalOrRemotePath::Remote(remote_path) => self.open_remote_buffer(remote_path, ctx),
         }
     }
 
@@ -1148,7 +1153,7 @@ impl GlobalBufferModel {
     ) -> BufferState {
         if let Some(id) = self
             .location_to_id
-            .get_by_left(&FileLocation::Local(path.clone()))
+            .get_by_left(&LocalOrRemotePath::Local(path.clone()))
             .cloned()
         {
             debug_assert!(self.buffers.contains_key(&id));
@@ -1243,7 +1248,7 @@ impl GlobalBufferModel {
                 // This is needed to determine if we need a full sync later.
                 let file_id = me
                     .location_to_id
-                    .get_by_left(&FileLocation::Local(path_clone.clone()))
+                    .get_by_left(&LocalOrRemotePath::Local(path_clone.clone()))
                     .cloned();
                 let previous_version = file_id
                     .and_then(|id| me.buffers.get(&id))
@@ -1278,7 +1283,7 @@ impl GlobalBufferModel {
         });
 
         self.location_to_id
-            .insert(FileLocation::Local(path.to_path_buf()), file_id);
+            .insert(LocalOrRemotePath::Local(path.to_path_buf()), file_id);
         let source = if is_server_local {
             BufferSource::ServerLocal {
                 sync_clock: SyncClock::new(),
@@ -1348,7 +1353,7 @@ impl GlobalBufferModel {
 
         let file_id = self
             .location_to_id
-            .get_by_left(&FileLocation::Local(path.to_path_buf()))?;
+            .get_by_left(&LocalOrRemotePath::Local(path.to_path_buf()))?;
         let buffer = self.buffer_handle_for_id(*file_id, ctx)?;
 
         let buffer_ref = buffer.as_ref(ctx);
@@ -1498,7 +1503,7 @@ impl GlobalBufferModel {
             .location_to_id
             .iter()
             .filter_map(|(location, id)| {
-                let FileLocation::Local(path) = location else {
+                let LocalOrRemotePath::Local(path) = location else {
                     return None;
                 };
                 if !path.starts_with(workspace_path) {
@@ -1621,7 +1626,7 @@ impl GlobalBufferModel {
     /// all buffer states.
     fn find_remote_file_id(&self, host_id: &HostId, path: &str) -> Option<FileId> {
         let std_path = StandardizedPath::try_new(path).ok()?;
-        let location = FileLocation::Remote(RemotePath::new(host_id.clone(), std_path));
+        let location = LocalOrRemotePath::Remote(RemotePath::new(host_id.clone(), std_path));
         self.location_to_id.get_by_left(&location).copied()
     }
 
@@ -1638,7 +1643,7 @@ impl GlobalBufferModel {
         remote_path: RemotePath,
         ctx: &mut ModelContext<Self>,
     ) -> BufferState {
-        let location = FileLocation::Remote(remote_path.clone());
+        let location = LocalOrRemotePath::Remote(remote_path.clone());
 
         // Return existing buffer if already open.
         if let Some(id) = self.location_to_id.get_by_left(&location).cloned() {
@@ -2074,8 +2079,8 @@ impl GlobalBufferModel {
             self.location_to_id
                 .get_by_right(&file_id)
                 .and_then(|loc| match loc {
-                    FileLocation::Local(p) => Some(p.clone()),
-                    FileLocation::Remote(_) => None,
+                    LocalOrRemotePath::Local(p) => Some(p.clone()),
+                    LocalOrRemotePath::Remote(_) => None,
                 })
         else {
             return Err("force_reload: no local path for file_id={file_id:?}".to_string());
@@ -2437,7 +2442,7 @@ impl GlobalBufferModel {
         ctx: &mut ModelContext<Self>,
     ) -> BufferState {
         let remote_path = RemotePath::new(host_id, path);
-        let location = FileLocation::Remote(remote_path.clone());
+        let location = LocalOrRemotePath::Remote(remote_path.clone());
         let file_id = warp_util::file::FileId::new();
         let buffer = ctx.add_model(|_| Buffer::default());
         let version = ContentVersion::new();

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -53,7 +53,7 @@ use crate::menu::{Event, Menu, MenuItem, MenuItemFields};
 
 use crate::{
     code::{
-        buffer_location::FileLocation as BufferFileLocation,
+        buffer_location::LocalOrRemotePath as BufferFileLocation,
         editor::model::HoverableLink,
         footer::{CodeFooterView, CodeFooterViewEvent},
         global_buffer_model::{BufferState, GlobalBufferModel},

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -73,7 +73,7 @@ use crate::pane_group::{
 };
 
 use super::{
-    buffer_location::FileLocation,
+    buffer_location::LocalOrRemotePath,
     diff_viewer::DiffViewer,
     editor::view::{CodeEditorEvent, CodeEditorView},
     editor_management::{CodeManager, CodeSource},
@@ -187,11 +187,11 @@ pub enum CodeViewAction {
 pub enum CodeViewEvent {
     Pane(PaneEvent),
     TabChanged {
-        location: Option<FileLocation>,
+        location: Option<LocalOrRemotePath>,
         tab_index: usize,
     },
     FileOpened {
-        location: FileLocation,
+        location: LocalOrRemotePath,
         tab_index: usize,
     },
     RunTabConfigSkill {
@@ -213,7 +213,7 @@ struct TabDataMouseStateHandles {
 
 #[derive(Clone)]
 pub struct TabData {
-    location: Option<FileLocation>,
+    location: Option<LocalOrRemotePath>,
     editor_view: ViewHandle<LocalCodeEditorView>,
     mouse_state_handles: TabDataMouseStateHandles,
     preview: bool,
@@ -327,7 +327,7 @@ impl CodeView {
     ) -> Self {
         let mut view = Self::new_internal(source, ctx);
         for tab_snapshot in tabs {
-            let location = tab_snapshot.path.clone().map(FileLocation::Local);
+            let location = tab_snapshot.path.clone().map(LocalOrRemotePath::Local);
             let tab_data = view.build_tab_data(location, false, ctx);
             view.tab_group.push(tab_data);
         }
@@ -379,10 +379,10 @@ impl CodeView {
     /// related tooling run on the local machine.
     fn construct_editor_for_location(
         &mut self,
-        location: FileLocation,
+        location: LocalOrRemotePath,
         ctx: &mut ViewContext<Self>,
     ) -> ViewHandle<LocalCodeEditorView> {
-        let is_local = matches!(location, FileLocation::Local(_));
+        let is_local = matches!(location, LocalOrRemotePath::Local(_));
         ctx.add_typed_action_view(|ctx| {
             let mut editor = LocalCodeEditorView::new_with_global_buffer(
                 location,
@@ -464,7 +464,7 @@ impl CodeView {
 
     fn build_tab_data(
         &mut self,
-        location: Option<FileLocation>,
+        location: Option<LocalOrRemotePath>,
         preview: bool,
         ctx: &mut ViewContext<Self>,
     ) -> TabData {
@@ -589,7 +589,7 @@ impl CodeView {
                 };
 
                 me.open_or_focus_existing(
-                    Some(FileLocation::Local(path.to_path_buf())),
+                    Some(LocalOrRemotePath::Local(path.to_path_buf())),
                     Some(line_col),
                     ctx,
                 );
@@ -682,7 +682,7 @@ impl CodeView {
         if let Some(existing_index) = self
             .tab_group
             .iter()
-            .position(|tab| tab.location.as_ref() == Some(&FileLocation::Local(path.clone())))
+            .position(|tab| tab.location.as_ref() == Some(&LocalOrRemotePath::Local(path.clone())))
         {
             self.set_active_tab_index(existing_index, ctx);
             self.promote_if_preview(ctx);
@@ -691,7 +691,8 @@ impl CodeView {
 
         // Find the existing preview tab (if any) and replace it with a new GlobalBuffer-backed editor
         if let Some((preview_index, _)) = self.preview_tab() {
-            let new_tab = self.build_tab_data(Some(FileLocation::Local(path.clone())), true, ctx);
+            let new_tab =
+                self.build_tab_data(Some(LocalOrRemotePath::Local(path.clone())), true, ctx);
             self.tab_group[preview_index] = new_tab;
 
             GlobalBufferModel::handle(ctx).update(ctx, |model, ctx| {
@@ -703,14 +704,14 @@ impl CodeView {
         }
 
         // Create a new preview tab
-        let new_tab = self.build_tab_data(Some(FileLocation::Local(path.clone())), true, ctx);
+        let new_tab = self.build_tab_data(Some(LocalOrRemotePath::Local(path.clone())), true, ctx);
 
         self.tab_group.push(new_tab);
         let active_tab_index = self.tab_group.len() - 1;
         self.set_active_tab_index(active_tab_index, ctx);
 
         ctx.emit(CodeViewEvent::FileOpened {
-            location: FileLocation::Local(path),
+            location: LocalOrRemotePath::Local(path),
             tab_index: self.active_tab_index,
         });
     }
@@ -729,7 +730,7 @@ impl CodeView {
 
     pub fn open_or_focus_existing(
         &mut self,
-        location: Option<FileLocation>,
+        location: Option<LocalOrRemotePath>,
         line_col: Option<LineAndColumnArg>,
         ctx: &mut ViewContext<Self>,
     ) {
@@ -746,7 +747,7 @@ impl CodeView {
 
     fn focus_existing_tab_if_present(
         &mut self,
-        location: Option<&FileLocation>,
+        location: Option<&LocalOrRemotePath>,
         ctx: &mut ViewContext<Self>,
     ) -> Option<usize> {
         let location = location?;
@@ -784,7 +785,7 @@ impl CodeView {
 
     fn open_new_tab(
         &mut self,
-        location: Option<FileLocation>,
+        location: Option<LocalOrRemotePath>,
         line_col: Option<LineAndColumnArg>,
         ctx: &mut ViewContext<Self>,
     ) {
@@ -827,8 +828,8 @@ impl CodeView {
             .is_some_and(|t| t.editor_view.as_ref(ctx).is_new_file());
 
         let title = match &file_location {
-            Some(FileLocation::Local(path)) => path.display().to_string(),
-            Some(FileLocation::Remote(remote_path)) => remote_path.path.as_str().to_string(),
+            Some(LocalOrRemotePath::Local(path)) => path.display().to_string(),
+            Some(LocalOrRemotePath::Remote(remote_path)) => remote_path.path.as_str().to_string(),
             None => "Untitled".to_string(),
         };
 
@@ -988,7 +989,7 @@ impl CodeView {
                 .editor_view
                 .as_ref(ctx)
                 .file_path()
-                .map(|p| FileLocation::Local(p.to_path_buf()));
+                .map(|p| LocalOrRemotePath::Local(p.to_path_buf()));
             tab.location = new_path;
         }
     }
@@ -1323,7 +1324,7 @@ impl CodeView {
     ) {
         for tab in self.tab_group.iter_mut() {
             if tab.local_path().is_some_and(|path| path == old_path) {
-                tab.location = Some(FileLocation::Local(new_path.to_path_buf()));
+                tab.location = Some(LocalOrRemotePath::Local(new_path.to_path_buf()));
                 tab.editor_view.update(ctx, |editor, ctx| {
                     let was_unsaved = editor.has_unsaved_changes(ctx);
 
@@ -2055,7 +2056,7 @@ impl CodeView {
 
     /// Merges tabs from another `CodeView`, avoiding duplicates and updating the active tab index.
     pub fn merge_tabs(&mut self, source_code_view: &CodeView, ctx: &mut ViewContext<Self>) {
-        let existing_locations_to_idx: HashMap<&FileLocation, usize> = self
+        let existing_locations_to_idx: HashMap<&LocalOrRemotePath, usize> = self
             .tab_group
             .iter()
             .enumerate()

--- a/app/src/code/wasm.rs
+++ b/app/src/code/wasm.rs
@@ -7,7 +7,7 @@ use warpui::{
 };
 
 use super::{
-    buffer_location::FileLocation, editor_management::CodeSource,
+    buffer_location::LocalOrRemotePath, editor_management::CodeSource,
     local_code_editor::LocalCodeEditorView,
 };
 use crate::pane_group::{
@@ -43,11 +43,11 @@ pub enum CodeViewAction {
 pub enum CodeViewEvent {
     Pane(PaneEvent),
     TabChanged {
-        location: Option<FileLocation>,
+        location: Option<LocalOrRemotePath>,
         tab_index: usize,
     },
     FileOpened {
-        location: FileLocation,
+        location: LocalOrRemotePath,
         tab_index: usize,
     },
     RunTabConfigSkill {
@@ -85,7 +85,7 @@ struct TabDataMouseStateHandles {
 #[allow(unused)]
 #[derive(Clone)]
 pub struct TabData {
-    location: Option<FileLocation>,
+    location: Option<LocalOrRemotePath>,
     editor_view: ViewHandle<LocalCodeEditorView>,
     mouse_state_handles: TabDataMouseStateHandles,
     drag_position: Option<TabBarDragPosition>,
@@ -138,7 +138,7 @@ impl CodeView {
 
     pub fn open_or_focus_existing(
         &mut self,
-        location: Option<FileLocation>,
+        location: Option<LocalOrRemotePath>,
         line_col: Option<LineAndColumnArg>,
         ctx: &mut ViewContext<Self>,
     ) {

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -184,7 +184,7 @@ use super::{
     GlobalCodeReviewEvent, GlobalCodeReviewModel,
 };
 #[cfg(not(target_family = "wasm"))]
-use crate::code::buffer_location::FileLocation;
+use crate::code::buffer_location::LocalOrRemotePath;
 use crate::code::ShowCommentEditorProvider;
 #[cfg(not(target_family = "wasm"))]
 use crate::code::ShowFindReferencesCard;
@@ -2954,7 +2954,7 @@ impl CodeReviewView {
 
             let local_code_view = ctx.add_typed_action_view(|ctx| {
                 let editor = LocalCodeEditorView::new_with_global_buffer(
-                    FileLocation::Local(full_file_path.clone()),
+                    LocalOrRemotePath::Local(full_file_path.clone()),
                     |buffer_state, ctx| {
                         ctx.add_typed_action_view(|ctx| {
                             let mut editor_view = CodeEditorView::new(

--- a/app/src/pane_group/pane/code_pane.rs
+++ b/app/src/pane_group/pane/code_pane.rs
@@ -2,7 +2,7 @@ use warp_util::path::LineAndColumnArg;
 use warpui::{AppContext, ModelHandle, SingletonEntity, View, ViewContext, ViewHandle};
 
 #[cfg(feature = "local_fs")]
-use crate::code::buffer_location::FileLocation;
+use crate::code::buffer_location::LocalOrRemotePath;
 use crate::{
     app_state::{CodePaneSnapShot, CodePaneTabSnapshot, LeafContents},
     code::{
@@ -138,7 +138,7 @@ impl PaneContent for CodePane {
 
                     // Track the opened file in the OpenedFilesModel (local files only)
                     #[cfg(feature = "local_fs")]
-                    if let FileLocation::Local(file_path) = location {
+                    if let LocalOrRemotePath::Local(file_path) = location {
                         use crate::code::opened_files::OpenedFilesModel;
                         use repo_metadata::repositories::DetectedRepositories;
 

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -15,7 +15,7 @@ use warpui::{AppContext, SingletonEntity as _};
 use warpui::{Entity, EntityId, ModelContext};
 use warpui::{ModelHandle, ViewHandle};
 
-use crate::code::buffer_location::FileLocation;
+use crate::code::buffer_location::LocalOrRemotePath;
 #[cfg(feature = "local_fs")]
 use crate::code::file_tree::FileTreeView;
 use crate::code_review::code_review_view::CodeReviewView;
@@ -25,23 +25,23 @@ use crate::code_review::comments::{
 use crate::code_review::diff_state::{DiffMode, DiffStateModel};
 use crate::workspace::view::global_search::view::GlobalSearchView;
 
-/// Type-safe wrapper around the map of `FileLocation` → `DiffStateModel`.
+/// Type-safe wrapper around the map of `LocalOrRemotePath` → `DiffStateModel`.
 ///
 /// Enforces that local keys are always paired with local-backend models and
 /// remote keys with remote-backend models via dedicated insertion methods.
 #[cfg(feature = "local_fs")]
 #[derive(Default)]
 struct DiffStateModelMap {
-    models: HashMap<FileLocation, ModelHandle<DiffStateModel>>,
+    models: HashMap<LocalOrRemotePath, ModelHandle<DiffStateModel>>,
 }
 
 #[cfg(feature = "local_fs")]
 impl DiffStateModelMap {
-    fn get(&self, key: &FileLocation) -> Option<&ModelHandle<DiffStateModel>> {
+    fn get(&self, key: &LocalOrRemotePath) -> Option<&ModelHandle<DiffStateModel>> {
         self.models.get(key)
     }
 
-    /// Insert a model that was created from a `FileLocation::Local` key.
+    /// Insert a model that was created from a `LocalOrRemotePath::Local` key.
     fn insert_local(
         &mut self,
         path: PathBuf,
@@ -52,10 +52,10 @@ impl DiffStateModelMap {
             matches!(model.as_ref(ctx), DiffStateModel::Local(_)),
             "insert_local called with a remote-backend DiffStateModel",
         );
-        self.models.insert(FileLocation::Local(path), model);
+        self.models.insert(LocalOrRemotePath::Local(path), model);
     }
 
-    /// Insert a model that was created from a `FileLocation::Remote` key.
+    /// Insert a model that was created from a `LocalOrRemotePath::Remote` key.
     fn insert_remote(
         &mut self,
         remote_id: RemotePath,
@@ -66,10 +66,11 @@ impl DiffStateModelMap {
             matches!(model.as_ref(ctx), DiffStateModel::Remote(_)),
             "insert_remote called with a local-backend DiffStateModel",
         );
-        self.models.insert(FileLocation::Remote(remote_id), model);
+        self.models
+            .insert(LocalOrRemotePath::Remote(remote_id), model);
     }
 
-    fn remove(&mut self, key: &FileLocation) -> Option<ModelHandle<DiffStateModel>> {
+    fn remove(&mut self, key: &LocalOrRemotePath) -> Option<ModelHandle<DiffStateModel>> {
         self.models.remove(key)
     }
 }
@@ -236,7 +237,7 @@ impl WorkingDirectoriesModel {
     /// If none exists, returns `None` and callers should retry once a session is established.
     pub fn get_or_create_diff_state_model(
         &mut self,
-        key: FileLocation,
+        key: LocalOrRemotePath,
         ctx: &mut ModelContext<Self>,
     ) -> Option<ModelHandle<DiffStateModel>> {
         if let Some(model) = self.diff_state_models.get(&key) {
@@ -244,11 +245,11 @@ impl WorkingDirectoriesModel {
         }
 
         let diff_state_model = match &key {
-            FileLocation::Local(path) => {
+            LocalOrRemotePath::Local(path) => {
                 let path = path.clone();
                 ctx.add_model(|ctx| DiffStateModel::new_local(path, ctx))
             }
-            FileLocation::Remote(remote_path) => {
+            LocalOrRemotePath::Remote(remote_path) => {
                 let mgr_handle = RemoteServerManager::handle(ctx);
                 let session_id = mgr_handle
                     .as_ref(ctx)
@@ -259,11 +260,11 @@ impl WorkingDirectoriesModel {
         };
 
         match key {
-            FileLocation::Local(path) => {
+            LocalOrRemotePath::Local(path) => {
                 self.diff_state_models
                     .insert_local(path, diff_state_model.clone(), ctx);
             }
-            FileLocation::Remote(remote_id) => {
+            LocalOrRemotePath::Remote(remote_id) => {
                 self.diff_state_models
                     .insert_remote(remote_id, diff_state_model.clone(), ctx);
             }
@@ -285,7 +286,7 @@ impl WorkingDirectoriesModel {
                 .values()
                 .all(|tab| !tab.contains(&repo_path))
             {
-                let key = FileLocation::Local(repo_path);
+                let key = LocalOrRemotePath::Local(repo_path);
                 if let Some(model) = self.diff_state_models.remove(&key) {
                     model.update(ctx, |model, ctx| {
                         model.stop_active_watcher(ctx);
@@ -745,7 +746,7 @@ impl WorkingDirectoriesModel {
 
     pub fn get_or_create_diff_state_model(
         &mut self,
-        _key: FileLocation,
+        _key: LocalOrRemotePath,
         _ctx: &mut ModelContext<Self>,
     ) -> Option<ModelHandle<DiffStateModel>> {
         None

--- a/app/src/persistence/sqlite_tests.rs
+++ b/app/src/persistence/sqlite_tests.rs
@@ -322,7 +322,7 @@ fn test_sqlite_round_trips_code_pane_with_multiple_tabs() {
                         ],
                         active_tab_index: 1,
                         source: Some(CodeSource::FileTree {
-                            location: crate::code::buffer_location::FileLocation::Local(
+                            location: crate::code::buffer_location::LocalOrRemotePath::Local(
                                 PathBuf::from("/tmp/main.rs"),
                             ),
                         }),

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -84,7 +84,7 @@ use crate::app_state::{
     PaneNodeSnapshot, PaneUuid, RightPanelSnapshot, SettingsPaneSnapshot, TabSnapshot,
     TerminalPaneSnapshot, WindowSnapshot, WorkflowPaneSnapshot,
 };
-use crate::code::buffer_location::FileLocation;
+use crate::code::buffer_location::LocalOrRemotePath;
 use crate::code_review::diff_state::DiffStateModel;
 #[cfg(feature = "local_fs")]
 use crate::code_review::CodeReviewTelemetryEvent;
@@ -5934,7 +5934,7 @@ impl Workspace {
                     location: location.clone(),
                 };
                 match location {
-                    FileLocation::Local(path) => {
+                    LocalOrRemotePath::Local(path) => {
                         self.open_file_with_target(
                             path.clone(),
                             target.clone(),
@@ -5943,7 +5943,7 @@ impl Workspace {
                             ctx,
                         );
                     }
-                    FileLocation::Remote(_) => {
+                    LocalOrRemotePath::Remote(_) => {
                         #[cfg(feature = "local_fs")]
                         self.open_code(
                             code_source,
@@ -7443,7 +7443,7 @@ impl Workspace {
                     }
                     for extra in additional_paths {
                         code_view.open_or_focus_existing(
-                            Some(FileLocation::Local(extra.clone())),
+                            Some(LocalOrRemotePath::Local(extra.clone())),
                             None,
                             ctx,
                         );
@@ -7499,7 +7499,7 @@ impl Workspace {
 
                                 for extra in additional_paths {
                                     code_view.open_or_focus_existing(
-                                        Some(FileLocation::Local(extra.clone())),
+                                        Some(LocalOrRemotePath::Local(extra.clone())),
                                         None,
                                         ctx,
                                     );
@@ -7558,7 +7558,7 @@ impl Workspace {
                 code_view.update(ctx, |code_view, ctx| {
                     for path in additional_paths {
                         code_view.open_or_focus_existing(
-                            Some(FileLocation::Local(path.clone())),
+                            Some(LocalOrRemotePath::Local(path.clone())),
                             None,
                             ctx,
                         );
@@ -8137,7 +8137,7 @@ impl Workspace {
                     let diff_state_model = repo_path.as_ref().and_then(|rp: &PathBuf| {
                         self.working_directories_model.update(ctx, |model, ctx| {
                             model.get_or_create_diff_state_model(
-                                FileLocation::Local(rp.clone()),
+                                LocalOrRemotePath::Local(rp.clone()),
                                 ctx,
                             )
                         })
@@ -8184,7 +8184,7 @@ impl Workspace {
         let repo_path = panel_context.repo_path.clone();
         let diff_state_model = repo_path.as_ref().and_then(|rp| {
             self.working_directories_model.update(ctx, |model, ctx| {
-                model.get_or_create_diff_state_model(FileLocation::Local(rp.clone()), ctx)
+                model.get_or_create_diff_state_model(LocalOrRemotePath::Local(rp.clone()), ctx)
             })
         });
         let Some(diff_state_model) = diff_state_model else {
@@ -8301,7 +8301,10 @@ impl Workspace {
             |(repo_path, terminal_view): (Option<PathBuf>, WeakViewHandle<TerminalView>)| {
                 let diff_state_model = repo_path.as_ref().and_then(|rp: &PathBuf| {
                     self.working_directories_model.update(ctx, |model, ctx| {
-                        model.get_or_create_diff_state_model(FileLocation::Local(rp.clone()), ctx)
+                        model.get_or_create_diff_state_model(
+                            LocalOrRemotePath::Local(rp.clone()),
+                            ctx,
+                        )
                     })
                 })?;
                 Some(CodeReviewPaneContext {
@@ -14238,7 +14241,7 @@ impl Workspace {
                                         if let Some(path) = moved_file_path {
                                             target_code_view.update(ctx, |view, ctx| {
                                                 view.open_or_focus_existing(
-                                                    Some(FileLocation::Local(path)),
+                                                    Some(LocalOrRemotePath::Local(path)),
                                                     None,
                                                     ctx,
                                                 );
@@ -21169,7 +21172,7 @@ impl TypedActionView for Workspace {
                         let diff_state_model = repo_path.as_ref().and_then(|rp| {
                             self.working_directories_model.update(ctx, |model, ctx| {
                                 model.get_or_create_diff_state_model(
-                                    FileLocation::Local(rp.clone()),
+                                    LocalOrRemotePath::Local(rp.clone()),
                                     ctx,
                                 )
                             })

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -18,7 +18,7 @@ use warpui::{
 
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent_conversations_model::AgentConversationsModel;
-use crate::code::buffer_location::FileLocation;
+use crate::code::buffer_location::LocalOrRemotePath;
 #[cfg(feature = "local_fs")]
 use crate::code::file_tree::FileTreeEvent;
 use crate::coding_panel_enablement_state::CodingPanelEnablementState;
@@ -84,7 +84,7 @@ pub enum LeftPanelEvent {
     WarpDrive(DrivePanelEvent),
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
     OpenFileWithTarget {
-        location: FileLocation,
+        location: LocalOrRemotePath,
         target: FileTarget,
         line_col: Option<LineAndColumnArg>,
     },
@@ -729,7 +729,7 @@ impl LeftPanelView {
                 );
 
                 ctx.emit(LeftPanelEvent::OpenFileWithTarget {
-                    location: FileLocation::Local(path.clone()),
+                    location: LocalOrRemotePath::Local(path.clone()),
                     target,
                     line_col: Some(line_col),
                 });

--- a/app/src/workspace/view/right_panel.rs
+++ b/app/src/workspace/view/right_panel.rs
@@ -30,7 +30,7 @@ use crate::{
     terminal::resizable_data::{ModalType, ResizableData},
 };
 use crate::{
-    code::buffer_location::FileLocation, code_review::diff_state::DiffStateModel,
+    code::buffer_location::LocalOrRemotePath, code_review::diff_state::DiffStateModel,
     terminal::view::TerminalView,
 };
 use dunce::canonicalize;
@@ -1635,7 +1635,7 @@ impl RightPanelView {
         } else {
             let diff_state_model = self.working_directories_model.update(ctx, |model, ctx| {
                 model.get_or_create_diff_state_model(
-                    FileLocation::Local(repo_path.to_path_buf()),
+                    LocalOrRemotePath::Local(repo_path.to_path_buf()),
                     ctx,
                 )
             });


### PR DESCRIPTION
## Description
* WISOTT 
* To clarify the intent of the type and avoid the overlapping FileLocation names that are also used in agent and notebook types 

## Testing
Should be a no-op
-  [x] I have manually tested my changes locally with `./script/run`