### PR TITLE
Release local -> cloud handoff (and other necessary flags)

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -629,6 +629,9 @@ default = [
     "settings_file",
     "directory_tab_colors",
     "configurable_context_window",
+    "oz_handoff",
+    "handoff_local_cloud",
+    "pending_user_query_indicator",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -914,7 +914,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::AgentViewBlockContext,
     FeatureFlag::OzLaunchModal,
     FeatureFlag::OzChangelogUpdates,
-    FeatureFlag::PendingUserQueryIndicator,
     FeatureFlag::QueueSlashCommand,
     // These are enabled via 100% experiment on prod warp-server,
     // but we need to enable here for dogfood builds.
@@ -926,7 +925,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::EditableMarkdownMermaid,
     FeatureFlag::CodeReviewScrollPreservation,
     FeatureFlag::AgentHarness,
-    FeatureFlag::OzHandoff,
     FeatureFlag::ConversationApi,
     FeatureFlag::RememberFastForwardState,
     FeatureFlag::HOANotifications,
@@ -936,7 +934,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,
     FeatureFlag::CloudModeInputV2,
-    FeatureFlag::HandoffLocalCloud,
     FeatureFlag::DragTabsToWindows,
     FeatureFlag::OrchestrationLaunchModal,
     FeatureFlag::NamedAgents,


### PR DESCRIPTION
## Description

🚀 WISOTT. the queued block UI is necessary because that's what we use for the startup UI, and the oz handoff flag gates snapshotting.

CHANGELOG-NEW-FEATURE: You can now hand off local Warp Agent conversations to the cloud.

Co-Authored-By: Oz <oz-agent@warp.dev>