### PR TITLE
Install libclang and protoc in Windows bootstrap

### DIFF
--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -46,7 +46,7 @@ function Show-BootstrapPreview {
     Write-Output 'It will:'
     Write-Output '  - Check for Git for Windows.'
     Write-Output '  - Install Rust if cargo is unavailable.'
-    Write-Output '  - Install Visual Studio Build Tools, jq, CMake, InnoSetup, and gcloud as needed.'
+    Write-Output '  - Install Visual Studio Build Tools, jq, CMake, InnoSetup, LLVM, Protobuf, and gcloud as needed.'
     Write-Output '  - Install Cargo test dependencies.'
 
     if (-not $InstallCommonSkills) {
@@ -88,6 +88,14 @@ if (-not $gitBinDir) {
     exit 1
 }
 $env:PATH = "$gitBinDir;$env:PATH"
+
+# Also add usr\bin so unix tools shipped with Git for Windows (patch.exe, awk, etc.)
+# are on PATH; patch is needed by the rquickjs-sys build script.
+$gitUsrBinDir = (Split-Path -Parent $gitBinDir) + '\usr\bin'
+if (Test-Path -PathType Container $gitUsrBinDir) {
+    $env:PATH = "$gitUsrBinDir;$env:PATH"
+}
+
 function Resolve-CommonSkillsScript {
     param([string]$ScriptName)
 
@@ -156,6 +164,16 @@ winget install -e --id Kitware.CMake
 
 # We use InnoSetup to build our release bundle installer.
 winget install -e --id JRSoftware.InnoSetup
+
+# libclang is required by `bindgen`, invoked transitively by the `minimp4-sys` crate build.
+winget install -e --id LLVM.LLVM --accept-package-agreements --accept-source-agreements
+$llvmBin = "$env:PROGRAMFILES\LLVM\bin"
+if (Test-Path -PathType Container $llvmBin) {
+    $env:LIBCLANG_PATH = $llvmBin
+}
+
+# protoc is required by `prost-build`, invoked transitively by the `warp_multi_agent_api` crate build.
+winget install -e --id Google.Protobuf --accept-package-agreements --accept-source-agreements
 
 # If we don't see gcloud command, try adding the install location to the PATH.
 if (-not (Get-Command -Name gcloud -Type Application -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
## Description
Running `./script/windows/bootstrap.ps1` on a clean Windows machine and then
`cargo check --workspace --exclude command-signatures-v2` currently fails
three times before the build succeeds:

1. `Unable to find libclang: "couldn't find any valid shared libraries..."`
   — `bindgen` (used transitively by the `minimp4-sys` crate build) needs
   `libclang.dll`.
2. `Could not find protoc. ... Try installing protobuf-compiler` —
   `prost-build` (used transitively by the `warp_multi_agent_api` crate build)
   needs `protoc`. #9230 added a winget fallback for the CI workflow, but
   the local bootstrap was not updated.
3. `Unable to execute patch, you may need to install it` — the `rquickjs-sys`
   build script needs Unix `patch.exe`. It ships with Git for Windows at
   `C:\Program Files\Git\usr\bin\patch.exe`, but only `Git\bin` is added to
   PATH today, not `Git\usr\bin`.

This PR installs LLVM and Protobuf via winget alongside the other build-time
dependencies, sets `LIBCLANG_PATH` for the current PowerShell session, and
prepends `Git\usr\bin` to PATH so `patch.exe` resolves. Mirrors the
Linux-side fix in #9527.

## Linked Issue
N/A — small Windows build-setup fix.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
Verified on a clean Windows 11 checkout that the following sequence now
completes without the three failures listed above:

```powershell
.\script\windows\bootstrap.ps1
cargo check --workspace --exclude command-signatures-v2
```

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — build script change.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE
