### PR TITLE
Migrate DetectedRepositories to include remote backing repos

### DIFF
--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -297,7 +297,7 @@ pub(super) async fn ensure_repo_cloned(
     // TODO(advait): When the remote code server lands for Docker sandboxes,
     // sandbox-only working directories will be reachable from the host and
     // we should register + index them here too (likely via a remote-aware
-    // path instead of `detect_possible_git_repo`/`index_directory`, which
+    // path instead of `detect_possible_local_git_repo`/`index_directory`, which
     // both assume a local filesystem). For now, skip so we don't try to
     // stat paths that only exist inside the sandbox.
     if is_sandbox {
@@ -313,7 +313,7 @@ pub(super) async fn ensure_repo_cloned(
         let detect_future = spawner
             .spawn(move |_, ctx| {
                 DetectedRepositories::handle(ctx).update(ctx, |repos, ctx| {
-                    repos.detect_possible_git_repo(
+                    repos.detect_possible_local_git_repo(
                         &repo_dir_str,
                         RepoDetectionSource::CloudEnvironmentPrep,
                         ctx,

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -5536,7 +5536,7 @@ impl AIBlock {
         let repo_path = self.current_working_directory.as_ref().and_then(|cwd| {
             DetectedRepositories::as_ref(ctx)
                 .get_root_for_path(&LocalOrRemotePath::Local(PathBuf::from(cwd.as_str())))
-                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+                .and_then(|r| PathBuf::try_from(r).ok())
         });
         #[cfg(target_family = "wasm")]
         let repo_path = self.current_working_directory.as_ref().map(PathBuf::from);

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -35,6 +35,8 @@ use crate::ai::blocklist::BlocklistAIContextModel;
 use crate::ai::blocklist::SuggestionDismissButtonTheme;
 #[cfg(not(target_family = "wasm"))]
 use repo_metadata::repositories::DetectedRepositories;
+#[cfg(not(target_family = "wasm"))]
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 #[cfg(feature = "local_fs")]
 use crate::ai::skills::SkillOpenOrigin;
@@ -5531,10 +5533,11 @@ impl AIBlock {
         ctx: &mut ViewContext<Self>,
     ) {
         #[cfg(not(target_family = "wasm"))]
-        let repo_path = self
-            .current_working_directory
-            .as_ref()
-            .and_then(|cwd| DetectedRepositories::as_ref(ctx).get_root_for_path(Path::new(cwd)));
+        let repo_path = self.current_working_directory.as_ref().and_then(|cwd| {
+            DetectedRepositories::as_ref(ctx)
+                .get_root_for_path(&LocalOrRemotePath::Local(PathBuf::from(cwd.as_str())))
+                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+        });
         #[cfg(target_family = "wasm")]
         let repo_path = self.current_working_directory.as_ref().map(PathBuf::from);
 

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -78,7 +78,7 @@ impl FileBasedMCPManager {
     ) -> Vec<&TemplatableMCPServerInstallation> {
         let repo_root = DetectedRepositories::as_ref(app)
             .get_root_for_path(&LocalOrRemotePath::Local(cwd.to_path_buf()))
-            .and_then(|r| r.to_local_path().map(Path::to_path_buf));
+            .and_then(|r| PathBuf::try_from(r).ok());
         let candidate_roots = [dirs::home_dir(), repo_root];
 
         let mut servers = Vec::new();

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -6,6 +6,7 @@ use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 use warp_core::features::FeatureFlag;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
 use crate::{
@@ -75,7 +76,9 @@ impl FileBasedMCPManager {
         cwd: &Path,
         app: &AppContext,
     ) -> Vec<&TemplatableMCPServerInstallation> {
-        let repo_root = DetectedRepositories::as_ref(app).get_root_for_path(cwd);
+        let repo_root = DetectedRepositories::as_ref(app)
+            .get_root_for_path(&LocalOrRemotePath::Local(cwd.to_path_buf()))
+            .and_then(|r| r.to_local_path().map(Path::to_path_buf));
         let candidate_roots = [dirs::home_dir(), repo_root];
 
         let mut servers = Vec::new();

--- a/app/src/ai/mcp/file_mcp_watcher.rs
+++ b/app/src/ai/mcp/file_mcp_watcher.rs
@@ -239,7 +239,7 @@ impl FileMCPWatcher {
         }
 
         let Some(repo_handle) =
-            DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(&repo_path, ctx)
+            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(&repo_path, ctx)
         else {
             return;
         };

--- a/app/src/ai/outline/native.rs
+++ b/app/src/ai/outline/native.rs
@@ -153,7 +153,7 @@ impl RepoOutlines {
             // Add all working directories to the queue and start processing.
             for dir in all_working_directories(ctx).into_iter() {
                 if let Some(repository) =
-                    DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(&dir, ctx)
+                    DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(&dir, ctx)
                 {
                     me.index_repo(repository, ctx);
                 }

--- a/app/src/ai/persisted_workspace.rs
+++ b/app/src/ai/persisted_workspace.rs
@@ -656,7 +656,12 @@ impl PersistedWorkspace {
             let auto_indexing_enabled = *CodeSettings::as_ref(ctx).auto_indexing_enabled;
 
             if auto_indexing_enabled {
-                if let Some(root) = DetectedRepositories::as_ref(ctx).get_root_for_path(&dir) {
+                if let Some(root) = DetectedRepositories::as_ref(ctx)
+                    .get_root_for_path(&warp_util::local_or_remote_path::LocalOrRemotePath::Local(
+                        dir.clone(),
+                    ))
+                    .and_then(|r| r.to_local_path().map(std::path::Path::to_path_buf))
+                {
                     manager.index_directory(root, ctx);
                 }
             }

--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -206,7 +206,7 @@ impl SkillWatcher {
 
         // Get the repository handle from DetectedRepositories.
         if let Some(repo_handle) =
-            DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(&repo_path, ctx)
+            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(&repo_path, ctx)
         {
             // Optimistically add the repository to the set of watched repositories to prevent duplicate subscriptions
             self.watched_repos.insert(repo_path.clone());

--- a/app/src/ai/skills/resolve_skill_spec.rs
+++ b/app/src/ai/skills/resolve_skill_spec.rs
@@ -19,6 +19,7 @@ use ai::skills::{
 use command::blocking::Command;
 use command::r#async::Command as AsyncCommand;
 use warp_cli::skill::SkillSpec;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::AppContext;
 use warpui::SingletonEntity as _;
 
@@ -319,7 +320,8 @@ fn resolve_unqualified(
 
     // Next, try to scope to the current repo root (if known).
     let repo_root = repo_metadata::repositories::DetectedRepositories::as_ref(ctx)
-        .get_root_for_path(working_dir);
+        .get_root_for_path(&LocalOrRemotePath::Local(working_dir.to_path_buf()))
+        .and_then(|r| r.to_local_path().map(Path::to_path_buf));
 
     if let Some(repo_root) = repo_root {
         match resolve_in_single_repo_root(spec, &repo_root, skill_manager) {

--- a/app/src/ai/skills/resolve_skill_spec.rs
+++ b/app/src/ai/skills/resolve_skill_spec.rs
@@ -321,7 +321,7 @@ fn resolve_unqualified(
     // Next, try to scope to the current repo root (if known).
     let repo_root = repo_metadata::repositories::DetectedRepositories::as_ref(ctx)
         .get_root_for_path(&LocalOrRemotePath::Local(working_dir.to_path_buf()))
-        .and_then(|r| r.to_local_path().map(Path::to_path_buf));
+        .and_then(|r| PathBuf::try_from(r).ok());
 
     if let Some(repo_root) = repo_root {
         match resolve_in_single_repo_root(spec, &repo_root, skill_manager) {

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -156,7 +156,7 @@ impl SkillManager {
         } else if let Some(working_directory) = working_directory {
             let repo_root = repo_metadata::repositories::DetectedRepositories::as_ref(ctx)
                 .get_root_for_path(&LocalOrRemotePath::Local(working_directory.to_path_buf()))
-                .and_then(|r| r.to_local_path().map(Path::to_path_buf));
+                .and_then(|r| PathBuf::try_from(r).ok());
 
             for (dir, dir_skill_paths) in &self.directory_skills {
                 if is_home_directory(dir) {

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -22,6 +22,7 @@ use ai::skills::{
 use warp_core::{
     channel::ChannelState, features::FeatureFlag, report_error, safe_warn, ui::icons::Icon,
 };
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 
 /// Activation condition for a bundled skill.
@@ -154,7 +155,8 @@ impl SkillManager {
             }
         } else if let Some(working_directory) = working_directory {
             let repo_root = repo_metadata::repositories::DetectedRepositories::as_ref(ctx)
-                .get_root_for_path(working_directory);
+                .get_root_for_path(&LocalOrRemotePath::Local(working_directory.to_path_buf()))
+                .and_then(|r| r.to_local_path().map(Path::to_path_buf));
 
             for (dir, dir_skill_paths) in &self.directory_skills {
                 if is_home_directory(dir) {

--- a/app/src/code/buffer_location.rs
+++ b/app/src/code/buffer_location.rs
@@ -1,54 +1,7 @@
-use std::path::{Path, PathBuf};
+// Re-export from warp_util so existing app-level imports continue to work.
+pub use warp_util::local_or_remote_path::LocalOrRemotePath;
 
-use serde::{Deserialize, Serialize};
 use warp_util::content_version::ContentVersion;
-use warp_util::remote_path::RemotePath;
-
-/// Uniquely identifies where a file lives — either on the local filesystem
-/// or on a remote host. Used across both the buffer model and the
-/// editor/view layers as the canonical file-identity type.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub enum LocalOrRemotePath {
-    /// File on the local filesystem.
-    Local(PathBuf),
-    /// File on a remote host, identified by host + path.
-    Remote(RemotePath),
-}
-
-impl LocalOrRemotePath {
-    /// Returns the file name component for display (e.g. tab titles).
-    pub fn display_name(&self) -> &str {
-        match self {
-            LocalOrRemotePath::Local(path) => path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or_default(),
-            LocalOrRemotePath::Remote(remote) => remote.path.file_name().unwrap_or_default(),
-        }
-    }
-
-    /// Returns the local path if this is a `Local` location, `None` for `Remote`.
-    /// Callers that only work with local files (LSP, save-to-disk, reveal-in-finder)
-    /// should use this to gate their behavior.
-    pub fn to_local_path(&self) -> Option<&Path> {
-        match self {
-            LocalOrRemotePath::Local(path) => Some(path.as_path()),
-            LocalOrRemotePath::Remote(_) => None,
-        }
-    }
-}
-
-impl From<PathBuf> for LocalOrRemotePath {
-    fn from(path: PathBuf) -> Self {
-        LocalOrRemotePath::Local(path)
-    }
-}
-
-impl From<RemotePath> for LocalOrRemotePath {
-    fn from(remote: RemotePath) -> Self {
-        LocalOrRemotePath::Remote(remote)
-    }
-}
 
 /// Tracks sync state between client and server for a single remote buffer.
 ///

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -1290,8 +1290,9 @@ impl FileTreeView {
                     remote_host_id: None,
                 });
             let root_local = root_path.to_local_path_lossy();
-            if let Some(repo_root) =
-                DetectedRepositories::as_ref(ctx).get_root_for_path(&root_local)
+            if let Some(repo_root) = DetectedRepositories::as_ref(ctx)
+                .get_root_for_path(&LocalOrRemotePath::Local(root_local))
+                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
             {
                 let repo_entry = {
                     let repo_metadata = RepoMetadataModel::as_ref(ctx);

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -1292,7 +1292,7 @@ impl FileTreeView {
             let root_local = root_path.to_local_path_lossy();
             if let Some(repo_root) = DetectedRepositories::as_ref(ctx)
                 .get_root_for_path(&LocalOrRemotePath::Local(root_local))
-                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+                .and_then(|r| PathBuf::try_from(r).ok())
             {
                 let repo_entry = {
                     let repo_metadata = RepoMetadataModel::as_ref(ctx);

--- a/app/src/code/footer.rs
+++ b/app/src/code/footer.rs
@@ -45,6 +45,8 @@ use crate::view_components::action_button::{
 };
 #[cfg(feature = "local_fs")]
 use repo_metadata::repositories::DetectedRepositories;
+#[cfg(feature = "local_fs")]
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 const FOOTER_HEIGHT: f32 = 24.;
 /// Margin around the LSP icon container
@@ -699,7 +701,8 @@ impl CodeFooterView {
 
         let repo_root = DetectedRepositories::handle(ctx)
             .as_ref(ctx)
-            .get_root_for_path(file_path)
+            .get_root_for_path(&LocalOrRemotePath::Local(file_path.to_path_buf()))
+            .and_then(|r| r.to_local_path().map(std::path::Path::to_path_buf))
             .or_else(|| file_path.parent().map(|p| p.to_path_buf()));
 
         let Some(repo_root) = repo_root else {

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -1409,7 +1409,7 @@ impl LocalCodeEditorView {
         } else {
             match DetectedRepositories::as_ref(ctx)
                 .get_root_for_path(&LocalOrRemotePath::Local(path.to_path_buf()))
-                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+                .and_then(|r| PathBuf::try_from(r).ok())
             {
                 Some(root) => Some(root),
                 None => path.parent().map(|s| s.to_path_buf()), // If we can't find root, treat the parent as the root.
@@ -1450,7 +1450,7 @@ impl LocalCodeEditorView {
         } else {
             match DetectedRepositories::as_ref(ctx)
                 .get_root_for_path(&LocalOrRemotePath::Local(path.to_path_buf()))
-                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+                .and_then(|r| PathBuf::try_from(r).ok())
             {
                 Some(root) => Some(root),
                 None => path.parent().map(|s| s.to_path_buf()),

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -73,6 +73,8 @@ use pathfinder_color::ColorU;
 use repo_metadata::repositories::DetectedRepositories;
 use vim::vim::{MotionType, VimMode};
 use warp_core::ui::icons::Icon;
+#[cfg(feature = "local_fs")]
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 use crate::ai::persisted_workspace::{PersistedWorkspace, PersistedWorkspaceEvent};
 use crate::workspace::WorkspaceAction;
@@ -1405,7 +1407,10 @@ impl LocalCodeEditorView {
         {
             Some(workspace_root.to_path_buf())
         } else {
-            match DetectedRepositories::as_ref(ctx).get_root_for_path(path) {
+            match DetectedRepositories::as_ref(ctx)
+                .get_root_for_path(&LocalOrRemotePath::Local(path.to_path_buf()))
+                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+            {
                 Some(root) => Some(root),
                 None => path.parent().map(|s| s.to_path_buf()), // If we can't find root, treat the parent as the root.
             }
@@ -1443,7 +1448,10 @@ impl LocalCodeEditorView {
         {
             Some(workspace_root.to_path_buf())
         } else {
-            match DetectedRepositories::as_ref(ctx).get_root_for_path(&path) {
+            match DetectedRepositories::as_ref(ctx)
+                .get_root_for_path(&LocalOrRemotePath::Local(path.to_path_buf()))
+                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+            {
                 Some(root) => Some(root),
                 None => path.parent().map(|s| s.to_path_buf()),
             }

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -232,7 +232,7 @@ impl TabData {
     pub fn local_path(&self) -> Option<PathBuf> {
         self.location
             .as_ref()
-            .and_then(|loc| loc.to_local_path().map(|p| p.to_path_buf()))
+            .and_then(|loc| loc.to_local_path().map(Path::to_path_buf))
     }
 }
 

--- a/app/src/code/wasm.rs
+++ b/app/src/code/wasm.rs
@@ -97,7 +97,7 @@ impl TabData {
     pub fn local_path(&self) -> Option<PathBuf> {
         self.location
             .as_ref()
-            .and_then(|loc| loc.to_local_path().map(|p| p.to_path_buf()))
+            .and_then(|loc| PathBuf::try_from(loc).ok())
     }
 }
 
@@ -142,7 +142,7 @@ impl CodeView {
         line_col: Option<LineAndColumnArg>,
         ctx: &mut ViewContext<Self>,
     ) {
-        if let Some(path) = location.and_then(|loc| loc.to_local_path().map(|p| p.to_path_buf())) {
+        if let Some(path) = location.and_then(|loc| PathBuf::try_from(loc).ok()) {
             self.open_local(None, path, line_col, ctx);
         }
     }

--- a/app/src/code/wasm.rs
+++ b/app/src/code/wasm.rs
@@ -97,7 +97,7 @@ impl TabData {
     pub fn local_path(&self) -> Option<PathBuf> {
         self.location
             .as_ref()
-            .and_then(|loc| PathBuf::try_from(loc).ok())
+            .and_then(|loc| PathBuf::try_from(loc.clone()).ok())
     }
 }
 

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -891,7 +891,10 @@ impl CodeReviewView {
             .map(|p| p.to_path_buf())
             .or_else(|| {
                 repo_metadata::repositories::DetectedRepositories::as_ref(ctx)
-                    .get_root_for_path(path)
+                    .get_root_for_path(&warp_util::local_or_remote_path::LocalOrRemotePath::Local(
+                        path.to_path_buf(),
+                    ))
+                    .and_then(|r| r.to_local_path().map(std::path::Path::to_path_buf))
             })
             .or_else(|| path.parent().map(|p| p.to_path_buf()));
 
@@ -933,7 +936,10 @@ impl CodeReviewView {
             .map(|p| p.to_path_buf())
             .or_else(|| {
                 repo_metadata::repositories::DetectedRepositories::as_ref(ctx)
-                    .get_root_for_path(path)
+                    .get_root_for_path(&warp_util::local_or_remote_path::LocalOrRemotePath::Local(
+                        path.to_path_buf(),
+                    ))
+                    .and_then(|r| r.to_local_path().map(std::path::Path::to_path_buf))
             })
             .or_else(|| path.parent().map(|p| p.to_path_buf()));
 

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -277,7 +277,7 @@ impl LocalDiffStateModel {
 
         if let Some(repo_path) = &repo_path {
             let fut = DetectedRepositories::handle(ctx).update(ctx, |model, ctx| {
-                model.detect_possible_git_repo(
+                model.detect_possible_local_git_repo(
                     repo_path,
                     RepoDetectionSource::CodeReviewInitialization,
                     ctx,
@@ -286,8 +286,8 @@ impl LocalDiffStateModel {
 
             ctx.spawn(fut, move |me, repo_path, ctx| {
                 if let Some(repo_path) = &repo_path {
-                    if let Some(repo_handle) =
-                        DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(repo_path, ctx)
+                    if let Some(repo_handle) = DetectedRepositories::as_ref(ctx)
+                        .get_local_watched_repo_for_path(repo_path, ctx)
                     {
                         me.set_active_repository(repo_handle, ctx);
                         return;

--- a/app/src/code_review/git_status_update.rs
+++ b/app/src/code_review/git_status_update.rs
@@ -89,7 +89,7 @@ impl GitStatusUpdateModel {
 
         // Create a new sub-model.
         let Some(repository_model) =
-            DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(repo_path, ctx)
+            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(repo_path, ctx)
         else {
             anyhow::bail!(
                 "No watched repository found for path: {}",

--- a/app/src/pane_group/pane/code_pane.rs
+++ b/app/src/pane_group/pane/code_pane.rs
@@ -2,8 +2,6 @@ use warp_util::path::LineAndColumnArg;
 use warpui::{AppContext, ModelHandle, SingletonEntity, View, ViewContext, ViewHandle};
 
 #[cfg(feature = "local_fs")]
-use std::path::Path;
-#[cfg(feature = "local_fs")]
 use crate::code::buffer_location::LocalOrRemotePath;
 use crate::{
     app_state::{CodePaneSnapShot, CodePaneTabSnapshot, LeafContents},
@@ -13,6 +11,8 @@ use crate::{
     },
     pane_group::PaneGroup,
 };
+#[cfg(feature = "local_fs")]
+use std::path::Path;
 
 use super::{
     DetachType, PaneConfiguration, PaneContent, PaneId, PaneView, ShareableLink, ShareableLinkError,

--- a/app/src/pane_group/pane/code_pane.rs
+++ b/app/src/pane_group/pane/code_pane.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use warp_util::path::LineAndColumnArg;
 use warpui::{AppContext, ModelHandle, SingletonEntity, View, ViewContext, ViewHandle};
 
@@ -142,8 +143,9 @@ impl PaneContent for CodePane {
                         use crate::code::opened_files::OpenedFilesModel;
                         use repo_metadata::repositories::DetectedRepositories;
 
-                        if let Some(repo_path) =
-                            DetectedRepositories::as_ref(ctx).get_root_for_path(file_path)
+                        if let Some(repo_path) = DetectedRepositories::as_ref(ctx)
+                            .get_root_for_path(&LocalOrRemotePath::Local(file_path.to_path_buf()))
+                            .and_then(|r| r.to_local_path().map(Path::to_path_buf))
                         {
                             OpenedFilesModel::handle(ctx).update(ctx, |opened_files, ctx| {
                                 opened_files.file_opened(repo_path, file_path.clone(), ctx);

--- a/app/src/pane_group/pane/code_pane.rs
+++ b/app/src/pane_group/pane/code_pane.rs
@@ -12,7 +12,7 @@ use crate::{
     pane_group::PaneGroup,
 };
 #[cfg(feature = "local_fs")]
-use std::path::Path;
+use std::path::PathBuf;
 
 use super::{
     DetachType, PaneConfiguration, PaneContent, PaneId, PaneView, ShareableLink, ShareableLinkError,
@@ -146,7 +146,7 @@ impl PaneContent for CodePane {
 
                         if let Some(repo_path) = DetectedRepositories::as_ref(ctx)
                             .get_root_for_path(&LocalOrRemotePath::Local(file_path.to_path_buf()))
-                            .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+                            .and_then(|r| PathBuf::try_from(r).ok())
                         {
                             OpenedFilesModel::handle(ctx).update(ctx, |opened_files, ctx| {
                                 opened_files.file_opened(repo_path, file_path.clone(), ctx);

--- a/app/src/pane_group/pane/code_pane.rs
+++ b/app/src/pane_group/pane/code_pane.rs
@@ -1,7 +1,8 @@
-use std::path::Path;
 use warp_util::path::LineAndColumnArg;
 use warpui::{AppContext, ModelHandle, SingletonEntity, View, ViewContext, ViewHandle};
 
+#[cfg(feature = "local_fs")]
+use std::path::Path;
 #[cfg(feature = "local_fs")]
 use crate::code::buffer_location::LocalOrRemotePath;
 use crate::{

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -483,7 +483,8 @@ impl WorkingDirectoriesModel {
         // Resolve a path to its detected repository root, or keep the path as-is if no repo is found.
         let root_for_path = |path: PathBuf| {
             DetectedRepositories::as_ref(ctx)
-                .get_root_for_path(&path)
+                .get_root_for_path(&LocalOrRemotePath::Local(path.clone()))
+                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
                 .unwrap_or(path)
         };
 
@@ -613,7 +614,9 @@ impl WorkingDirectoriesModel {
 
     /// Get the repository root for a given path.
     fn get_repo_root_for_path(&self, path: &Path, ctx: &AppContext) -> Option<PathBuf> {
-        DetectedRepositories::as_ref(ctx).get_root_for_path(path)
+        DetectedRepositories::as_ref(ctx)
+            .get_root_for_path(&LocalOrRemotePath::Local(path.to_path_buf()))
+            .and_then(|r| r.to_local_path().map(Path::to_path_buf))
     }
 
     /// Emit a DirectoriesChanged event with the current state for a specific pane group.

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -484,7 +484,7 @@ impl WorkingDirectoriesModel {
         let root_for_path = |path: PathBuf| {
             DetectedRepositories::as_ref(ctx)
                 .get_root_for_path(&LocalOrRemotePath::Local(path.clone()))
-                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+                .and_then(|r| PathBuf::try_from(r).ok())
                 .unwrap_or(path)
         };
 
@@ -616,7 +616,7 @@ impl WorkingDirectoriesModel {
     fn get_repo_root_for_path(&self, path: &Path, ctx: &AppContext) -> Option<PathBuf> {
         DetectedRepositories::as_ref(ctx)
             .get_root_for_path(&LocalOrRemotePath::Local(path.to_path_buf()))
-            .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+            .and_then(|r| PathBuf::try_from(r).ok())
     }
 
     /// Emit a DirectoriesChanged event with the current state for a specific pane group.

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -1482,7 +1482,11 @@ impl ServerModel {
         // root path (Some) or None if no git repo was found.
         let path_str = msg.path.clone();
         let git_future = DetectedRepositories::handle(ctx).update(ctx, |repos, ctx| {
-            repos.detect_possible_git_repo(&path_str, RepoDetectionSource::TerminalNavigation, ctx)
+            repos.detect_possible_local_git_repo(
+                &path_str,
+                RepoDetectionSource::TerminalNavigation,
+                ctx,
+            )
         });
 
         let request_id_for_response = request_id.clone();

--- a/app/src/search/ai_context_menu/code/data_source.rs
+++ b/app/src/search/ai_context_menu/code/data_source.rs
@@ -124,7 +124,7 @@ impl CodeSymbolCache {
                     .get_root_for_path(&LocalOrRemotePath::Local(
                         Path::new(current_dir).to_path_buf(),
                     ))
-                    .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+                    .and_then(|r| PathBuf::try_from(r).ok())
             })?;
 
         let (outline_status, _) = RepoOutlines::as_ref(app).get_outline(&git_repo_path)?;
@@ -208,7 +208,7 @@ impl CodeSymbolCache {
                     .get_root_for_path(&LocalOrRemotePath::Local(
                         Path::new(current_dir).to_path_buf(),
                     ))
-                    .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+                    .and_then(|r| PathBuf::try_from(r).ok())
             })
         else {
             return HashSet::new();

--- a/app/src/search/ai_context_menu/code/data_source.rs
+++ b/app/src/search/ai_context_menu/code/data_source.rs
@@ -36,6 +36,8 @@ use repo_metadata::repositories::DetectedRepositories;
 #[cfg(not(target_family = "wasm"))]
 use std::path::Path;
 #[cfg(not(target_family = "wasm"))]
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+#[cfg(not(target_family = "wasm"))]
 use warpui::SingletonEntity;
 
 const MAX_RESULTS: usize = 200;
@@ -118,7 +120,11 @@ impl CodeSymbolCache {
             .active_window
             .and_then(|window_id| ActiveSession::as_ref(app).path_if_local(window_id))
             .and_then(|current_dir| {
-                DetectedRepositories::as_ref(app).get_root_for_path(Path::new(current_dir))
+                DetectedRepositories::as_ref(app)
+                    .get_root_for_path(&LocalOrRemotePath::Local(
+                        Path::new(current_dir).to_path_buf(),
+                    ))
+                    .and_then(|r| r.to_local_path().map(Path::to_path_buf))
             })?;
 
         let (outline_status, _) = RepoOutlines::as_ref(app).get_outline(&git_repo_path)?;
@@ -198,7 +204,11 @@ impl CodeSymbolCache {
             .active_window
             .and_then(|window_id| ActiveSession::as_ref(app).path_if_local(window_id))
             .and_then(|current_dir| {
-                DetectedRepositories::as_ref(app).get_root_for_path(Path::new(current_dir))
+                DetectedRepositories::as_ref(app)
+                    .get_root_for_path(&LocalOrRemotePath::Local(
+                        Path::new(current_dir).to_path_buf(),
+                    ))
+                    .and_then(|r| r.to_local_path().map(Path::to_path_buf))
             })
         else {
             return HashSet::new();

--- a/app/src/search/ai_context_menu/files/data_source.rs
+++ b/app/src/search/ai_context_menu/files/data_source.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, SingletonEntity};
 
 const MAX_RESULTS: usize = 200;
@@ -111,7 +112,11 @@ fn snapshot_last_opened(app: &AppContext) -> HashMap<String, instant::Instant> {
         .active_window
         .and_then(|window_id| ActiveSession::as_ref(app).path_if_local(window_id))
         .and_then(|current_dir| {
-            DetectedRepositories::as_ref(app).get_root_for_path(Path::new(current_dir))
+            DetectedRepositories::as_ref(app)
+                .get_root_for_path(&LocalOrRemotePath::Local(
+                    Path::new(current_dir).to_path_buf(),
+                ))
+                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
         });
 
     let Some(repo_path) = git_repo_path else {

--- a/app/src/search/ai_context_menu/files/data_source.rs
+++ b/app/src/search/ai_context_menu/files/data_source.rs
@@ -116,7 +116,7 @@ fn snapshot_last_opened(app: &AppContext) -> HashMap<String, instant::Instant> {
                 .get_root_for_path(&LocalOrRemotePath::Local(
                     Path::new(current_dir).to_path_buf(),
                 ))
-                .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+                .and_then(|r| PathBuf::try_from(r).ok())
         });
 
     let Some(repo_path) = git_repo_path else {

--- a/app/src/search/ai_context_menu/view.rs
+++ b/app/src/search/ai_context_menu/view.rs
@@ -73,6 +73,8 @@ use crate::workspace::ActiveSession;
 use repo_metadata::repositories::DetectedRepositories;
 #[cfg(not(target_family = "wasm"))]
 use std::path::Path;
+#[cfg(not(target_family = "wasm"))]
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 use super::styles;
 
@@ -406,7 +408,7 @@ impl AIContextMenu {
                     .and_then(|window_id| ActiveSession::as_ref(app).path_if_local(window_id));
                 active_dir.is_some_and(|dir| {
                     DetectedRepositories::as_ref(app)
-                        .get_root_for_path(Path::new(dir))
+                        .get_root_for_path(&LocalOrRemotePath::Local(Path::new(dir).to_path_buf()))
                         .is_some()
                 })
             }

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -20,6 +20,7 @@ cfg_if::cfg_if! {
         use repo_metadata::repositories::DetectedRepositories;
         use std::cell::RefCell;
         use std::collections::HashMap;
+        use warp_util::local_or_remote_path::LocalOrRemotePath;
     }
 }
 
@@ -89,7 +90,9 @@ impl FileSearchModel {
         let current_dir = active_window_id
             .and_then(|window_id| ActiveSession::as_ref(app).path_if_local(window_id))?;
 
-        DetectedRepositories::as_ref(app).get_root_for_path(current_dir)
+        DetectedRepositories::as_ref(app)
+            .get_root_for_path(&LocalOrRemotePath::Local(current_dir.to_path_buf()))
+            .and_then(|r| r.to_local_path().map(Path::to_path_buf))
     }
 
     #[cfg(not(feature = "local_fs"))]

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -92,7 +92,7 @@ impl FileSearchModel {
 
         DetectedRepositories::as_ref(app)
             .get_root_for_path(&LocalOrRemotePath::Local(current_dir.to_path_buf()))
-            .and_then(|r| r.to_local_path().map(Path::to_path_buf))
+            .and_then(|r| PathBuf::try_from(r).ok())
     }
 
     #[cfg(not(feature = "local_fs"))]

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -10394,9 +10394,7 @@ impl Input {
                                             .get_root_for_path(&LocalOrRemotePath::Local(
                                                 Path::new(pwd).to_path_buf(),
                                             ))
-                                            .and_then(|r| {
-                                                r.to_local_path().map(Path::to_path_buf)
-                                            })?;
+                                            .and_then(|r| PathBuf::try_from(r).ok())?;
                                         let absolute_path = git_repo_path.join(file_path);
 
                                         // Try to get relative path if it's shorter

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -10389,8 +10389,14 @@ impl Input {
                                     .and_then(|pwd| {
                                         // Find git repo and construct absolute path
                                         use repo_metadata::repositories::DetectedRepositories;
+                                        use warp_util::local_or_remote_path::LocalOrRemotePath;
                                         let git_repo_path = DetectedRepositories::as_ref(ctx)
-                                            .get_root_for_path(Path::new(pwd))?;
+                                            .get_root_for_path(&LocalOrRemotePath::Local(
+                                                Path::new(pwd).to_path_buf(),
+                                            ))
+                                            .and_then(|r| {
+                                                r.to_local_path().map(Path::to_path_buf)
+                                            })?;
                                         let absolute_path = git_repo_path.join(file_path);
 
                                         // Try to get relative path if it's shorter

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -157,6 +157,7 @@ pub fn initialize_app(app: &mut App) {
     app.add_singleton_model(SessionPermissionsManager::new);
     app.add_singleton_model(DirectoryWatcher::new);
     app.add_singleton_model(|_| DetectedRepositories::default());
+    app.add_singleton_model(crate::remote_server::manager::RemoteServerManager::new);
     app.add_singleton_model(|_| crate::code_review::git_status_update::GitStatusUpdateModel::new());
     app.add_singleton_model(RepoMetadataModel::new);
     app.add_singleton_model(FileSearchModel::new);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -185,13 +185,15 @@ pub use init::{
     TOGGLE_HIDE_CLI_RESPONSES_KEYBINDING, TOGGLE_QUEUE_NEXT_PROMPT_KEYBINDING,
 };
 pub use inline_banner::{NotificationsDiscoveryBannerAction, NotificationsErrorBannerAction};
+use repo_metadata::repositories::DetectedRepositories;
 #[cfg(feature = "local_fs")]
-use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
+use repo_metadata::repositories::RepoDetectionSource;
 use session_sharing_protocol::common::LongRunningCommandAgentInteractionState;
 use session_sharing_protocol::sharer::{RoleUpdateReason, SessionEndedReason, SessionSourceType};
 use ssh_file_upload::{FileUpload, FileUploadEvent};
 use uuid::Uuid;
 use warp_core::channel::ChannelState;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::elements::{shimmering_text::ShimmeringTextStateHandle, Border, ChildView};
 use warpui::fonts::Properties;
 use warpui::{ViewHandle, WeakModelHandle};
@@ -4576,8 +4578,13 @@ impl TerminalView {
                     RemoteServerManagerEvent::NavigatedToDirectory {
                         session_id: nav_session_id,
                         remote_path,
-                        ..
+                        is_git,
                     } => {
+                        if *is_git {
+                            DetectedRepositories::handle(ctx).update(ctx, |repos, _| {
+                                repos.register_remote_repo_root(remote_path.clone());
+                            });
+                        }
                         // Check if this navigation belongs to our active session
                         // using exact session_id match (no CWD heuristics).
                         let is_relevant = me
@@ -4613,9 +4620,13 @@ impl TerminalView {
                             ctx
                         );
                     }
+                    RemoteServerManagerEvent::HostDisconnected { host_id } => {
+                        DetectedRepositories::handle(ctx).update(ctx, |repos, _| {
+                            repos.remove_roots_for_host(host_id);
+                        });
+                    }
                     RemoteServerManagerEvent::SessionConnecting { .. }
                     | RemoteServerManagerEvent::HostConnected { .. }
-                    | RemoteServerManagerEvent::HostDisconnected { .. }
                     | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                     | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
                     | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
@@ -11506,7 +11517,7 @@ impl TerminalView {
                                 let fut = DetectedRepositories::handle(ctx).update(
                                     ctx,
                                     |updater, ctx| {
-                                        updater.detect_possible_git_repo(
+                                        updater.detect_possible_local_git_repo(
                                             directory_for_detection,
                                             RepoDetectionSource::TerminalNavigation,
                                             ctx,
@@ -13353,7 +13364,7 @@ impl TerminalView {
                     .and_then(|pwd| Path::new(&pwd).canonicalize().ok())
                 {
                     DetectedRepositories::as_ref(ctx)
-                        .get_root_for_path(&pwd_path)
+                        .get_root_for_path(&LocalOrRemotePath::Local(pwd_path))
                         .is_some()
                 } else {
                     false
@@ -13462,7 +13473,7 @@ impl TerminalView {
                 .and_then(|pwd| Path::new(&pwd).canonicalize().ok())
                 .is_some_and(|pwd_path| {
                     DetectedRepositories::as_ref(ctx)
-                        .get_root_for_path(&pwd_path)
+                        .get_root_for_path(&LocalOrRemotePath::Local(pwd_path))
                         .is_some()
                 });
 
@@ -13548,7 +13559,7 @@ impl TerminalView {
             .iter()
             .any(|shown_path| shown_path == directory);
         let is_repo = DetectedRepositories::as_ref(ctx)
-            .get_root_for_path(directory)
+            .get_root_for_path(&LocalOrRemotePath::Local(directory.to_path_buf()))
             .is_some();
         let is_any_ai_enabled =
             FeatureFlag::AgentMode.is_enabled() && AISettings::as_ref(ctx).is_any_ai_enabled(ctx);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -172,6 +172,7 @@ pub use self::link_detection::GridHighlightedLink;
 pub use self::link_detection::{RichContentLink, RichContentLinkTooltipInfo};
 use crate::ai::llms::{LLMId, LLMModelHost, LLMPreferences};
 use crate::settings::CodeSettings;
+use crate::util::repo_detection::{detect_possible_git_repo, RepoDetectionSessionType};
 pub use action::{AgentOnboardingVersion, OnboardingIntention, OnboardingVersion, TerminalAction};
 use ai::api_keys::{ApiKeyManager, AwsCredentialsState};
 use ai::index::full_source_code_embedding::manager::{BuildSource, CodebaseIndexManager};
@@ -186,14 +187,12 @@ pub use init::{
 };
 pub use inline_banner::{NotificationsDiscoveryBannerAction, NotificationsErrorBannerAction};
 use repo_metadata::repositories::DetectedRepositories;
-#[cfg(feature = "local_fs")]
 use repo_metadata::repositories::RepoDetectionSource;
 use session_sharing_protocol::common::LongRunningCommandAgentInteractionState;
 use session_sharing_protocol::sharer::{RoleUpdateReason, SessionEndedReason, SessionSourceType};
 use ssh_file_upload::{FileUpload, FileUploadEvent};
 use uuid::Uuid;
 use warp_core::channel::ChannelState;
-#[cfg(feature = "local_fs")]
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::elements::{shimmering_text::ShimmeringTextStateHandle, Border, ChildView};
 use warpui::fonts::Properties;
@@ -2798,7 +2797,7 @@ pub struct TerminalView {
     conversation_completed_callbacks: Vec<ConversationFinishedCallback>,
 
     /// Path to the current repository, or None if not currently in a repo.
-    current_repo_path: Option<PathBuf>,
+    current_repo_path: Option<LocalOrRemotePath>,
 
     /// The title of the terminal view to show when there is no selected conversation.
     terminal_title: String,
@@ -2932,8 +2931,16 @@ pub struct BlockSelectionDetails {
 
 impl TerminalView {
     /// Returns the path to the current repository, if any.
-    pub fn current_repo_path(&self) -> Option<&PathBuf> {
+    pub fn current_repo_path(&self) -> Option<&LocalOrRemotePath> {
         self.current_repo_path.as_ref()
+    }
+
+    /// Returns the local repo path, if the current repo is local.
+    /// Remote repo paths return None — full remote support is a follow-up.
+    pub fn current_local_repo_path(&self) -> Option<&Path> {
+        self.current_repo_path
+            .as_ref()
+            .and_then(|p| p.to_local_path())
     }
 
     fn is_nested_cloud_mode(&self, app: &AppContext) -> bool {
@@ -3145,7 +3152,7 @@ impl TerminalView {
                                 );
                             if should_insert_zero_state_block {
                                 let mut should_show_init_callout = false;
-                                if let Some(directory) = me.current_repo_path.as_ref() {
+                                if let Some(directory) = me.current_local_repo_path() {
                                     should_show_init_callout = me
                                         .should_show_agent_mode_setup_for_directory(directory, ctx);
                                     if should_show_init_callout {
@@ -4579,13 +4586,10 @@ impl TerminalView {
                     RemoteServerManagerEvent::NavigatedToDirectory {
                         session_id: nav_session_id,
                         remote_path,
-                        is_git,
+                        is_git: _,
                     } => {
-                        if *is_git {
-                            DetectedRepositories::handle(ctx).update(ctx, |repos, _| {
-                                repos.register_remote_repo_root(remote_path.clone());
-                            });
-                        }
+                        // Repo registration is now handled by the unified
+                        // detect_possible_git_repo callback in BlockMetadataReceived.
                         // Check if this navigation belongs to our active session
                         // using exact session_id match (no CWD heuristics).
                         let is_relevant = me
@@ -4883,7 +4887,7 @@ impl TerminalView {
         if should_subscribe {
             // Subscribe if we have a repo path but no active subscription.
             if self.git_repo_status.is_none() {
-                if let Some(repo_path) = self.current_repo_path.clone() {
+                if let Some(repo_path) = self.current_local_repo_path().map(Path::to_path_buf) {
                     let result = GitStatusUpdateModel::handle(ctx)
                         .update(ctx, |model, ctx| model.subscribe(&repo_path, ctx));
                     match result {
@@ -6264,7 +6268,7 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         let arg = CodeReviewPanelArg {
-            repo_path: self.current_repo_path.clone(),
+            repo_path: self.current_local_repo_path().map(Path::to_path_buf),
             terminal_view: self.view_handle.clone(),
             entrypoint,
             focus_new_pane,
@@ -6337,7 +6341,7 @@ impl TerminalView {
 
     #[cfg(feature = "local_fs")]
     fn handle_attach_diffset_context(&mut self, diff_mode: DiffMode, ctx: &mut ViewContext<Self>) {
-        let Some(repo_path) = self.current_repo_path.clone() else {
+        let Some(repo_path) = self.current_local_repo_path().map(Path::to_path_buf) else {
             return;
         };
 
@@ -9679,8 +9683,8 @@ impl TerminalView {
             AgentModeSetupSpeedbumpBannerAction::SetupAgentMode => {
                 send_telemetry_from_ctx!(TelemetryEvent::AgentModeSetupBannerAccepted, ctx);
                 #[cfg(feature = "local_fs")]
-                if let Some(repo_path) = self.current_repo_path.clone() {
-                    self.mark_agent_init_callout_as_shown_for_directory(&repo_path, ctx);
+                if let Some(repo_path) = self.current_local_repo_path() {
+                    self.mark_agent_init_callout_as_shown_for_directory(repo_path, ctx);
                 }
                 self.remove_agent_setup_speedbump_banner(ctx);
                 self.init_project(false, ctx)
@@ -11488,114 +11492,165 @@ impl TerminalView {
                     }
 
                     // Check if the block is done bootstrapping and the directory is set.
-                    #[cfg(feature = "local_fs")]
                     if let Some(active_directory) = block_metadata_received_event
                         .block_metadata
                         .current_working_directory()
                     {
-                        // Check if we need to index the directory
                         if block_metadata_received_event.is_done_bootstrapping {
-                            #[cfg(feature = "local_fs")]
-                            {
-                                // Convert the shell-native CWD (e.g. "/c/Users/..." for
-                                // Git Bash/MSYS2) to a Windows-native path before passing
-                                // it to repo detection, which requires an OS-native path.
-                                let native_directory = block_metadata_received_event
+                            let is_local = self.active_session_is_local(ctx) == Some(true);
+                            let session_type = if is_local {
+                                Some(RepoDetectionSessionType::Local)
+                            } else {
+                                block_metadata.session_id().map(|session_id| {
+                                    RepoDetectionSessionType::Remote { session_id }
+                                })
+                            };
+                            let Some(session_type) = session_type else {
+                                // Skip detection entirely when session type can't be determined.
+                                self.active_block_metadata = Some(block_metadata.clone());
+                                self.input.update(ctx, |view, ctx| {
+                                    view.set_active_block_metadata(
+                                        block_metadata.clone(),
+                                        block_metadata_received_event.is_after_in_band_command,
+                                        ctx,
+                                    );
+                                    ctx.notify();
+                                });
+                                return;
+                            };
+
+                            // For local sessions, convert the shell-native CWD
+                            // (e.g. "/c/Users/..." for Git Bash/MSYS2) to a
+                            // Windows-native path before repo detection.
+                            let directory_for_detection = if is_local {
+                                block_metadata_received_event
                                     .block_metadata
                                     .session_id()
-                                    .and_then(|session_id| {
-                                        self.sessions.as_ref(ctx).get(session_id)
-                                    })
+                                    .and_then(|sid| self.sessions.as_ref(ctx).get(sid))
                                     .and_then(|session| {
                                         session.launch_data().and_then(|data| {
                                             data.maybe_convert_absolute_path(active_directory)
                                         })
                                     })
-                                    .map(|path| path.to_string_lossy().into_owned());
-                                let directory_for_detection =
-                                    native_directory.as_deref().unwrap_or(active_directory);
+                                    .map(|path| path.to_string_lossy().into_owned())
+                                    .unwrap_or_else(|| active_directory.to_string())
+                            } else {
+                                active_directory.to_string()
+                            };
 
-                                let fut = DetectedRepositories::handle(ctx).update(
-                                    ctx,
-                                    |updater, ctx| {
-                                        updater.detect_possible_local_git_repo(
-                                            directory_for_detection,
-                                            RepoDetectionSource::TerminalNavigation,
+                            let fut = detect_possible_git_repo(
+                                session_type,
+                                &directory_for_detection,
+                                RepoDetectionSource::TerminalNavigation,
+                                ctx,
+                            );
+
+                            ctx.spawn(fut, move |me, repo_path_opt, ctx| {
+                                let old_repo_path = me.current_repo_path.clone();
+                                me.current_repo_path = repo_path_opt.clone();
+
+                                if old_repo_path != me.current_repo_path {
+                                    ctx.emit(Event::Pane(PaneEvent::RepoChanged));
+                                }
+
+                                let callbacks = me.block_completed_callbacks.drain(..).collect_vec();
+                                for callback in callbacks {
+                                    callback(me, ctx);
+                                }
+
+                                match &repo_path_opt {
+                                    Some(LocalOrRemotePath::Remote(remote_path)) => {
+                                        DetectedRepositories::handle(ctx).update(
                                             ctx,
-                                        )
-                                    },
-                                );
-
-                                ctx.spawn(fut, move |me, repo_path_opt, ctx| {
-                                    let old_repo_path = me.current_repo_path.clone();
-                                    // Update the current repo path
-                                    me.current_repo_path = repo_path_opt.clone();
-
-                                    // Notify the pane group that the detected repo
-                                    // changed so the code review panel can
-                                    // (re-)initialize with the correct context.
-                                    if old_repo_path != me.current_repo_path {
-                                        ctx.emit(Event::Pane(PaneEvent::RepoChanged));
+                                            |repos, _| {
+                                                repos.register_remote_repo_root(
+                                                    remote_path.clone(),
+                                                );
+                                            },
+                                        );
+                                        ctx.emit(Event::Pane(PaneEvent::RemoteRepoNavigated {
+                                            remote_path: remote_path.clone(),
+                                        }));
                                     }
+                                    Some(LocalOrRemotePath::Local(repo_path)) => {
+                                        #[cfg(feature = "local_fs")]
+                                        {
+                                            let Some(active_directory) =
+                                                me.active_session_path_if_local(ctx)
+                                            else {
+                                                me.clear_git_repo_status(ctx);
+                                                return;
+                                            };
 
-                                    let callbacks = me.block_completed_callbacks.drain(..).collect_vec();
-                                    for callback in callbacks {
-                                        callback(me, ctx);
-                                    }
+                                            let Ok(active_directory) =
+                                                repo_metadata::CanonicalizedPath::try_from(
+                                                    active_directory,
+                                                )
+                                            else {
+                                                return;
+                                            };
 
-                                    let Some(active_directory) = me.active_session_path_if_local(ctx) else {
-                                        me.clear_git_repo_status(ctx);
-                                        return;
-                                    };
+                                            let is_ancestor = active_directory
+                                                .as_path_buf()
+                                                .ancestors()
+                                                .any(|ancestor| {
+                                                    ancestor == repo_path.as_path()
+                                                });
+                                            if !is_ancestor {
+                                                return;
+                                            }
 
-                                    if let Some(repo_path) = &repo_path_opt {
-                                        let Ok(active_directory) = repo_metadata::CanonicalizedPath::try_from(active_directory) else {
-                                            return;
-                                        };
+                                            PersistedWorkspace::handle(ctx).update(
+                                                ctx,
+                                                |manager, _| {
+                                                    manager.navigated_to_path(
+                                                        active_directory.as_path_buf(),
+                                                    );
+                                                },
+                                            );
 
-                                        // Make sure the repo path is still an ancestor of the active directory.
-                                        let is_ancestor = active_directory.as_path_buf().ancestors().any(|ancestor| ancestor == repo_path.as_path());
-                                        if !is_ancestor {
-                                            return;
-                                        }
+                                            if old_repo_path
+                                                .as_ref()
+                                                .and_then(|p| p.to_local_path())
+                                                != Some(repo_path.as_path())
+                                            {
+                                                me.git_repo_status = None;
+                                                me.update_git_status_subscription(ctx);
+                                            }
 
-                                        PersistedWorkspace::handle(ctx).update(ctx, |manager, _| {
-                                            manager.navigated_to_path(active_directory.as_path_buf());
-                                        });
-
-                                        // Subscribe to GitRepoStatusModel if the repo changed
-                                        // and git status updates are needed.
-                                        if old_repo_path.as_ref() != Some(repo_path) {
-                                            // Drop old handle (unsubscribes automatically).
-                                            me.git_repo_status = None;
-                                            me.update_git_status_subscription(ctx);
-                                        }
-
-                                        // Notify chips of the new repo path.
-                                        me.input.update(ctx, |input, ctx| {
-                                            input.update_repo_path(Some(repo_path.clone()), ctx);
-                                        });
-
-                                        if FeatureFlag::AIContextMenuEnabled.is_enabled() {
                                             me.input.update(ctx, |input, ctx| {
-                                                input.check_and_update_ai_context_menu_disabled_state(
+                                                input.update_repo_path(
+                                                    Some(repo_path.clone()),
                                                     ctx,
                                                 );
                                             });
+
+                                            if FeatureFlag::AIContextMenuEnabled.is_enabled() {
+                                                me.input.update(ctx, |input, ctx| {
+                                                    input
+                                                        .check_and_update_ai_context_menu_disabled_state(
+                                                            ctx,
+                                                        );
+                                                });
+                                            }
+
+                                            me.start_lsp_server_in_active_pwd(ctx);
+
+                                            me.update_repo_banner_state(
+                                                repo_path.clone(),
+                                                ctx,
+                                            );
                                         }
-
-                                        me.start_lsp_server_in_active_pwd(ctx);
-
-                                        me.update_repo_banner_state(
-                                            repo_path.clone(),
-                                            ctx,
-                                        );
-                                    } else {
+                                        #[cfg(not(feature = "local_fs"))]
+                                        let _ = repo_path;
+                                    }
+                                    None => {
+                                        #[cfg(feature = "local_fs")]
                                         me.clear_git_repo_status(ctx);
                                         ctx.notify();
                                     }
-                                });
-                            }
+                                }
+                            });
                         }
                     }
                 }
@@ -13014,9 +13069,8 @@ impl TerminalView {
     pub fn maybe_set_pending_repo_init_path(&mut self, path: PathBuf) {
         self.on_next_block_completed(move |me, ctx| {
             if me
-                .current_repo_path
-                .as_ref()
-                .is_some_and(|repo_path| repo_path == &path)
+                .current_local_repo_path()
+                .is_some_and(|repo_path| repo_path == path)
             {
                 me.init_project_and_suppress_banners(path, ctx);
             }
@@ -19387,7 +19441,7 @@ impl TerminalView {
 
     fn imported_comments_panel_arg(&self) -> CodeReviewPanelArg {
         CodeReviewPanelArg {
-            repo_path: self.current_repo_path.clone(),
+            repo_path: self.current_local_repo_path().map(Path::to_path_buf),
             terminal_view: self.view_handle.clone(),
             entrypoint: CodeReviewPaneEntrypoint::AgentModeRunning,
             focus_new_pane: true,
@@ -20520,7 +20574,7 @@ impl TerminalView {
             }
             InputEvent::OpenCodeReviewPane => {
                 ctx.emit(Event::OpenCodeReviewPane(CodeReviewPanelArg {
-                    repo_path: self.current_repo_path.clone(),
+                    repo_path: self.current_local_repo_path().map(Path::to_path_buf),
                     terminal_view: self.view_handle.clone(),
                     entrypoint: CodeReviewPaneEntrypoint::GitDiffChip,
                     focus_new_pane: true,
@@ -25765,7 +25819,7 @@ impl TypedActionView for TerminalView {
             }
             ToggleCodeReviewPane { entrypoint } => {
                 ctx.emit(Event::ToggleCodeReviewPane(CodeReviewPanelArg {
-                    repo_path: self.current_repo_path.clone(),
+                    repo_path: self.current_local_repo_path().map(Path::to_path_buf),
                     terminal_view: self.view_handle.clone(),
                     entrypoint: *entrypoint,
                     focus_new_pane: true,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -193,6 +193,7 @@ use session_sharing_protocol::sharer::{RoleUpdateReason, SessionEndedReason, Ses
 use ssh_file_upload::{FileUpload, FileUploadEvent};
 use uuid::Uuid;
 use warp_core::channel::ChannelState;
+#[cfg(feature = "local_fs")]
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::elements::{shimmering_text::ShimmeringTextStateHandle, Border, ChildView};
 use warpui::fonts::Properties;

--- a/app/src/terminal/view/init_project/model.rs
+++ b/app/src/terminal/view/init_project/model.rs
@@ -6,6 +6,8 @@ use enum_iterator::Sequence;
 use lsp::supported_servers::LSPServerType;
 #[cfg(not(target_family = "wasm"))]
 use repo_metadata::repositories::DetectedRepositories;
+#[cfg(not(target_family = "wasm"))]
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{Entity, ModelContext, SingletonEntity as _};
 
 use crate::{
@@ -408,7 +410,8 @@ impl InitProjectModel {
         let pwd_path = pwd_path.to_path_buf();
         #[cfg(not(target_family = "wasm"))]
         let repo_root = DetectedRepositories::as_ref(ctx)
-            .get_root_for_path(&pwd_path)
+            .get_root_for_path(&LocalOrRemotePath::Local(pwd_path.clone()))
+            .and_then(|r| r.to_local_path().map(std::path::Path::to_path_buf))
             .unwrap_or_else(|| pwd_path.clone());
         #[cfg(target_family = "wasm")]
         let repo_root = pwd_path.clone();

--- a/app/src/util/mod.rs
+++ b/app/src/util/mod.rs
@@ -11,6 +11,7 @@ pub mod links;
 pub mod openable_file_type;
 #[cfg(feature = "local_tty")]
 pub mod path;
+pub mod repo_detection;
 pub mod time_format;
 pub mod tooltips;
 pub(crate) mod traffic_lights;

--- a/app/src/util/repo_detection.rs
+++ b/app/src/util/repo_detection.rs
@@ -1,13 +1,12 @@
-//! Unified repo detection for both local and remote sessions.
+//! Helpers for constructing repo detection calls from view contexts.
 //!
-//! Provides a single entry point ([`detect_possible_git_repo`]) that dispatches
-//! to either local filesystem detection or remote server detection depending on
-//! the session type. Callers spawn the returned future and handle the result
-//! uniformly regardless of whether the session is local or remote.
+//! The core detection logic lives on
+//! [`DetectedRepositories::detect_possible_git_repo`]. This module provides
+//! a thin convenience layer that constructs the appropriate remote detection
+//! future from [`RemoteServerManager`] before delegating.
 
 use std::future::Future;
 
-use futures::future::Either;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
 use warp_core::SessionId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
@@ -26,18 +25,8 @@ pub enum RepoDetectionSessionType {
 
 /// Detects the git repository root for the given working directory.
 ///
-/// - **Local sessions**: delegates to
-///   [`DetectedRepositories::detect_possible_local_git_repo`], which spawns a
-///   background filesystem check. The returned future resolves with the local
-///   repo root wrapped in [`LocalOrRemotePath::Local`].
-///
-/// - **Remote sessions**: checks whether the remote server is connected via
-///   [`RemoteServerManager::is_session_potentially_active`]. If not, resolves
-///   to `None` immediately (no point in detection). Otherwise, calls
-///   [`RemoteServerManager::navigate_to_directory`] and awaits the response.
-///   When `is_git` is true, resolves with the repo root wrapped in
-///   [`LocalOrRemotePath::Remote`]. The `NavigatedToDirectory` event is still
-///   emitted for other subscribers (file tree, etc.).
+/// Constructs the appropriate remote detection future (if needed) and delegates
+/// to [`DetectedRepositories::detect_possible_git_repo`].
 ///
 /// The caller is responsible for registering remote repo roots in
 /// `DetectedRepositories` and triggering downstream side effects (git status,
@@ -48,30 +37,23 @@ pub fn detect_possible_git_repo<V: View>(
     source: RepoDetectionSource,
     ctx: &mut ViewContext<V>,
 ) -> impl Future<Output = Option<LocalOrRemotePath>> {
-    match session_type {
-        RepoDetectionSessionType::Local => {
-            let fut = DetectedRepositories::handle(ctx).update(ctx, |repos, ctx| {
-                repos.detect_possible_local_git_repo(active_directory, source, ctx)
-            });
-            Either::Left(async move { fut.await.map(LocalOrRemotePath::Local) })
-        }
+    // Build the remote detection future if this is a remote session with an
+    // active server connection. For local sessions or remote sessions without
+    // a connected server, pass None so DetectedRepositories uses the local path.
+    let remote_detect = match session_type {
+        RepoDetectionSessionType::Local => None,
         RepoDetectionSessionType::Remote { session_id } => {
-            let fut = if RemoteServerManager::as_ref(ctx).is_session_potentially_active(session_id)
-            {
-                let inner = RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
+            if RemoteServerManager::as_ref(ctx).is_session_potentially_active(session_id) {
+                Some(RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
                     mgr.navigate_to_directory(session_id, active_directory.to_string(), ctx)
-                });
-                Some(inner)
+                }))
             } else {
                 None
-            };
-            Either::Right(async move {
-                let inner = fut?;
-                match inner.await {
-                    Some((remote_path, true)) => Some(LocalOrRemotePath::Remote(remote_path)),
-                    _ => None,
-                }
-            })
+            }
         }
-    }
+    };
+
+    DetectedRepositories::handle(ctx).update(ctx, |repos, ctx| {
+        repos.detect_possible_git_repo(active_directory, source, remote_detect, ctx)
+    })
 }

--- a/app/src/util/repo_detection.rs
+++ b/app/src/util/repo_detection.rs
@@ -7,6 +7,7 @@
 
 use std::future::Future;
 
+use futures::future::{ready, Either};
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
 use warp_core::SessionId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
@@ -37,18 +38,24 @@ pub fn detect_possible_git_repo<V: View>(
     source: RepoDetectionSource,
     ctx: &mut ViewContext<V>,
 ) -> impl Future<Output = Option<LocalOrRemotePath>> {
-    // Build the remote detection future if this is a remote session with an
-    // active server connection. For local sessions or remote sessions without
-    // a connected server, pass None so DetectedRepositories uses the local path.
+    // Build the remote detection future if this is a remote session.
+    // For local sessions, pass None so DetectedRepositories uses the local path.
+    // For remote sessions without a connected server, pass a future that
+    // resolves to None immediately — this avoids falling through to local
+    // detection, which would misclassify a remote CWD as a local repo if
+    // the same absolute path happens to exist locally.
     let remote_detect = match session_type {
         RepoDetectionSessionType::Local => None,
         RepoDetectionSessionType::Remote { session_id } => {
             if RemoteServerManager::as_ref(ctx).is_session_potentially_active(session_id) {
-                Some(RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
-                    mgr.navigate_to_directory(session_id, active_directory.to_string(), ctx)
-                }))
+                Some(Either::Left(RemoteServerManager::handle(ctx).update(
+                    ctx,
+                    |mgr, ctx| {
+                        mgr.navigate_to_directory(session_id, active_directory.to_string(), ctx)
+                    },
+                )))
             } else {
-                None
+                Some(Either::Right(ready(None)))
             }
         }
     };

--- a/app/src/util/repo_detection.rs
+++ b/app/src/util/repo_detection.rs
@@ -1,0 +1,77 @@
+//! Unified repo detection for both local and remote sessions.
+//!
+//! Provides a single entry point ([`detect_possible_git_repo`]) that dispatches
+//! to either local filesystem detection or remote server detection depending on
+//! the session type. Callers spawn the returned future and handle the result
+//! uniformly regardless of whether the session is local or remote.
+
+use std::future::Future;
+
+use futures::future::Either;
+use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
+use warp_core::SessionId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::{SingletonEntity, View, ViewContext};
+
+use crate::remote_server::manager::RemoteServerManager;
+
+/// Describes whether the active session is local or remote.
+pub enum RepoDetectionSessionType {
+    /// A local terminal session — repo detection runs on the local filesystem.
+    Local,
+    /// A remote SSH session — repo detection is delegated to the remote server
+    /// via `navigate_to_directory`.
+    Remote { session_id: SessionId },
+}
+
+/// Detects the git repository root for the given working directory.
+///
+/// - **Local sessions**: delegates to
+///   [`DetectedRepositories::detect_possible_local_git_repo`], which spawns a
+///   background filesystem check. The returned future resolves with the local
+///   repo root wrapped in [`LocalOrRemotePath::Local`].
+///
+/// - **Remote sessions**: checks whether the remote server is connected via
+///   [`RemoteServerManager::is_session_potentially_active`]. If not, resolves
+///   to `None` immediately (no point in detection). Otherwise, calls
+///   [`RemoteServerManager::navigate_to_directory`] and awaits the response.
+///   When `is_git` is true, resolves with the repo root wrapped in
+///   [`LocalOrRemotePath::Remote`]. The `NavigatedToDirectory` event is still
+///   emitted for other subscribers (file tree, etc.).
+///
+/// The caller is responsible for registering remote repo roots in
+/// `DetectedRepositories` and triggering downstream side effects (git status,
+/// code review, etc.) in the spawn callback.
+pub fn detect_possible_git_repo<V: View>(
+    session_type: RepoDetectionSessionType,
+    active_directory: &str,
+    source: RepoDetectionSource,
+    ctx: &mut ViewContext<V>,
+) -> impl Future<Output = Option<LocalOrRemotePath>> {
+    match session_type {
+        RepoDetectionSessionType::Local => {
+            let fut = DetectedRepositories::handle(ctx).update(ctx, |repos, ctx| {
+                repos.detect_possible_local_git_repo(active_directory, source, ctx)
+            });
+            Either::Left(async move { fut.await.map(LocalOrRemotePath::Local) })
+        }
+        RepoDetectionSessionType::Remote { session_id } => {
+            let fut = if RemoteServerManager::as_ref(ctx).is_session_potentially_active(session_id)
+            {
+                let inner = RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
+                    mgr.navigate_to_directory(session_id, active_directory.to_string(), ctx)
+                });
+                Some(inner)
+            } else {
+                None
+            };
+            Either::Right(async move {
+                let inner = fut?;
+                match inner.await {
+                    Some((remote_path, true)) => Some(LocalOrRemotePath::Remote(remote_path)),
+                    _ => None,
+                }
+            })
+        }
+    }
+}

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -270,8 +270,6 @@ use crate::pane_group::{
     TabBarHoverIndex,
 };
 use crate::remote_server::manager::RemoteServerManager;
-#[cfg(feature = "local_fs")]
-use crate::remote_server::manager::RemoteServerManagerEvent;
 use crate::terminal::keys_settings::KeysSettings;
 use crate::terminal::shared_session::SharedSessionActionSource;
 
@@ -2860,28 +2858,6 @@ impl Workspace {
             &SessionSettings::handle(ctx),
             Self::handle_session_settings_event,
         );
-
-        // When a remote server session finishes its initialize handshake, re-run
-        // update_active_session so navigate_to_directory fires now that the
-        // client is connected (it may have been skipped on the initial pwd change
-        // because the handshake was still in progress).
-        #[cfg(feature = "local_fs")]
-        if FeatureFlag::SshRemoteServer.is_enabled() {
-            ctx.subscribe_to_model(
-                &RemoteServerManager::handle(ctx),
-                |me, _handle, event, ctx| match event {
-                    RemoteServerManagerEvent::SessionConnected { .. } => {
-                        me.update_active_session(ctx);
-                    }
-                    RemoteServerManagerEvent::SetupStateChanged { state, .. }
-                        if state.is_failed() =>
-                    {
-                        me.update_active_session(ctx);
-                    }
-                    _ => {}
-                },
-            );
-        }
 
         ctx.subscribe_to_model(&WindowSettings::handle(ctx), |me, _handle, event, ctx| {
             me.handle_window_settings_changed_event(event, ctx);
@@ -8128,7 +8104,10 @@ impl Workspace {
             // Read repo_path and terminal_view from the pane group (immutable context).
             let read_result = active_pane_group.read(ctx, |pane_group, ctx| {
                 pane_group.active_session_view(ctx).map(|terminal_view| {
-                    let repo_path = terminal_view.as_ref(ctx).current_repo_path().cloned();
+                    let repo_path = terminal_view
+                        .as_ref(ctx)
+                        .current_local_repo_path()
+                        .map(Path::to_path_buf);
                     (repo_path, terminal_view.downgrade())
                 })
             });
@@ -8293,7 +8272,10 @@ impl Workspace {
         // Read repo_path and terminal_view from pane group (immutable context).
         let read_result = pane_group_handle.read(ctx, |pane_group, ctx| {
             pane_group.active_session_view(ctx).map(|terminal_view| {
-                let repo_path = terminal_view.as_ref(ctx).current_repo_path().cloned();
+                let repo_path = terminal_view
+                    .as_ref(ctx)
+                    .current_local_repo_path()
+                    .map(Path::to_path_buf);
                 (repo_path, terminal_view.downgrade())
             })
         });
@@ -15079,33 +15061,24 @@ impl Workspace {
 
         if let Some(terminal_handle) = pane_group_handle.as_ref(ctx).active_session_view(ctx) {
             #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
-            let (
-                session,
-                path_if_local,
-                is_local,
-                is_wsl_session,
-                session_id,
-                pwd,
-                has_pending_ssh,
-            ) = terminal_handle.read(ctx, |terminal, ctx| {
-                let active_session_id = terminal.active_block_session_id();
-                let session =
-                    active_session_id.and_then(|id| terminal.sessions_model().as_ref(ctx).get(id));
-                let path_if_local = terminal.active_session_path_if_local(ctx);
-                let is_local = terminal.active_session_is_local(ctx);
-                let is_wsl_session = session.as_ref().map(|s| s.is_wsl()).unwrap_or(false);
-                let pwd = terminal.pwd();
-                let has_pending_ssh = terminal.has_pending_ssh_command();
-                (
-                    session,
-                    path_if_local,
-                    is_local,
-                    is_wsl_session,
-                    active_session_id,
-                    pwd,
-                    has_pending_ssh,
-                )
-            });
+            let (session, path_if_local, is_local, is_wsl_session, session_id, has_pending_ssh) =
+                terminal_handle.read(ctx, |terminal, ctx| {
+                    let active_session_id = terminal.active_block_session_id();
+                    let session = active_session_id
+                        .and_then(|id| terminal.sessions_model().as_ref(ctx).get(id));
+                    let path_if_local = terminal.active_session_path_if_local(ctx);
+                    let is_local = terminal.active_session_is_local(ctx);
+                    let is_wsl_session = session.as_ref().map(|s| s.is_wsl()).unwrap_or(false);
+                    let has_pending_ssh = terminal.has_pending_ssh_command();
+                    (
+                        session,
+                        path_if_local,
+                        is_local,
+                        is_wsl_session,
+                        active_session_id,
+                        has_pending_ssh,
+                    )
+                });
 
             let window_id = ctx.window_id();
             let working_directory_clone = path_if_local.clone();
@@ -15138,17 +15111,6 @@ impl Workspace {
                 && session_id.is_some_and(|sid| {
                     RemoteServerManager::as_ref(ctx).is_session_potentially_active(sid)
                 });
-
-            // When the session has a remote server, tell it about the current
-            // directory so it can start indexing and push repo metadata back.
-            #[cfg(feature = "local_fs")]
-            if has_remote_server {
-                if let (Some(sid), Some(cwd)) = (session_id, pwd) {
-                    RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
-                        mgr.navigate_to_directory(sid, cwd, ctx);
-                    });
-                }
-            }
 
             let enablement = CodingPanelEnablementState::from_session_env(
                 file_tree_and_global_search_are_enabled,
@@ -21265,8 +21227,10 @@ impl TypedActionView for Workspace {
                         pane_group
                             .terminal_view_from_pane_id(locator.pane_id, ctx)
                             .map(|terminal_view| {
-                                let repo_path =
-                                    terminal_view.as_ref(ctx).current_repo_path().cloned();
+                                let repo_path = terminal_view
+                                    .as_ref(ctx)
+                                    .current_local_repo_path()
+                                    .map(Path::to_path_buf);
                                 (repo_path, terminal_view.downgrade())
                             })
                     });

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -8692,7 +8692,7 @@ impl Workspace {
         // repo counts here, and it keeps linked-worktree filtering scoped to the
         // only UI that currently needs it.
         let Some(repository) =
-            DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(repo_path, ctx)
+            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(repo_path, ctx)
         else {
             return true;
         };

--- a/app/src/workspace/view/right_panel.rs
+++ b/app/src/workspace/view/right_panel.rs
@@ -1322,7 +1322,7 @@ impl RightPanelView {
     ) -> ReviewTerminalStatus {
         tv.read(ctx, |t, ctx| {
             let active_session_path = t.active_session_path_if_local(ctx);
-            let current_repo_path = t.current_repo_path().cloned();
+            let current_repo_path = t.current_local_repo_path().map(Path::to_path_buf);
             let active_cli_agent = t.active_cli_agent(ctx).map(|agent| format!("{agent:?}"));
             let model = t.model.lock();
             let is_executing = model.block_list().active_block().is_executing();

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2767,7 +2767,9 @@ fn build_vertical_tabs_summary_data(
                 }
 
                 if let (Some(repo_path), Some(branch_name)) = (
-                    terminal_view.current_repo_path().cloned(),
+                    terminal_view
+                        .current_local_repo_path()
+                        .map(Path::to_path_buf),
                     terminal_view
                         .current_git_branch(app)
                         .and_then(|branch| normalize_summary_text(&branch)),

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -338,7 +338,7 @@ impl ProjectContextModel {
         }
 
         let fut = DetectedRepositories::handle(ctx).update(ctx, |model, ctx| {
-            model.detect_possible_git_repo(
+            model.detect_possible_local_git_repo(
                 &path.to_string_lossy(),
                 RepoDetectionSource::ProjectRulesIndexing,
                 ctx,

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 #[cfg(not(target_family = "wasm"))]
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -1505,36 +1506,50 @@ impl RemoteServerManager {
     }
 
     /// Sends a `NavigatedToDirectory` request to the remote server for
-    /// the given session and emits the response as a manager event.
+    /// the given session and returns a future that resolves with
+    /// `Some((remote_path, is_git))` on success, or `None` on failure
+    /// or dedup skip. The `NavigatedToDirectory` event is still emitted
+    /// for other subscribers (file tree, etc.).
     ///
     /// Deduplicates: if the same `(session_id, path)` was already requested,
-    /// the call is a no-op.
+    /// resolves to `None` immediately.
+    ///
+    /// Callers that don't need the result can simply drop the future.
     pub fn navigate_to_directory(
         &mut self,
         session_id: SessionId,
         path: String,
         ctx: &mut ModelContext<Self>,
-    ) {
+    ) -> impl Future<Output = Option<(RemotePath, bool)>> {
+        use futures::future::ready;
+
+        match self.navigate_to_directory_impl(session_id, path, ctx) {
+            Some(rx) => futures::future::Either::Left(async move { rx.await.ok().flatten() }),
+            None => futures::future::Either::Right(ready(None)),
+        }
+    }
+
+    /// Returns `Some(receiver)` when a request was dispatched, `None` when
+    /// skipped (dedup or missing client).
+    fn navigate_to_directory_impl(
+        &mut self,
+        session_id: SessionId,
+        path: String,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<futures::channel::oneshot::Receiver<Option<(RemotePath, bool)>>> {
         // Dedup: skip if this session already navigated to the same path.
         if self.last_navigated_path.get(&session_id) == Some(&path) {
-            return;
+            return None;
         }
 
-        let Some(client) = self.client_for_session(session_id).cloned() else {
-            log::warn!(
-                "Remote server navigate_to_directory: no connected client session={session_id:?}"
-            );
-            return;
-        };
-        let Some(host_id) = self.host_id_for_session(session_id).cloned() else {
-            log::warn!("Remote server navigate_to_directory: no host_id session={session_id:?}");
-            return;
-        };
+        let client = self.client_for_session(session_id).cloned()?;
+        let host_id = self.host_id_for_session(session_id).cloned()?;
 
         // Record only after confirming the client is connected, so that a
         // retry after SessionConnected is not incorrectly deduplicated.
         self.last_navigated_path.insert(session_id, path.clone());
 
+        let (tx, rx) = futures::channel::oneshot::channel();
         let spawner = self.spawner.clone();
         ctx.background_executor()
             .spawn(async move {
@@ -1551,8 +1566,11 @@ impl RemoteServerManager {
                                          session={session_id:?} indexed_path={}",
                                         resp.indexed_path
                                     );
+                                    let _ = tx.send(None);
                                     return;
                                 };
+                                let result = Some((remote_path.clone(), resp.is_git));
+                                let _ = tx.send(result);
                                 ctx.emit(RemoteServerManagerEvent::NavigatedToDirectory {
                                     session_id,
                                     remote_path,
@@ -1563,12 +1581,13 @@ impl RemoteServerManager {
                     }
                     Err(e) => {
                         log::warn!("Remote server navigate_to_directory failed: session={session_id:?} error={e}");
-                        // Transport-level telemetry is emitted automatically
-                        // by send_tracked_request via ClientEvent::RequestFailed.
+                        let _ = tx.send(None);
                     }
                 }
             })
             .detach();
+
+        Some(rx)
     }
 
     /// Sends a `SessionBootstrapped` notification to the remote server.

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -37,7 +37,7 @@ use serde::Serialize;
 #[cfg(not(target_family = "wasm"))]
 use warp_core::channel::ChannelState;
 use warp_core::SessionId;
-use warp_util::remote_path::RemotePath;
+use warp_util::remote_path::{RemoteNavigationResult, RemotePath};
 use warp_util::standardized_path::StandardizedPath;
 #[cfg(not(target_family = "wasm"))]
 use warpui::r#async::FutureExt as _;
@@ -565,6 +565,17 @@ impl RemoteServerManagerEvent {
     }
 }
 
+/// Cached navigation state per session. Stores the last requested path
+/// (for dedup) and the result from the last successful response (so dedup
+/// returns a meaningful value instead of `None`).
+struct NavigationCache {
+    /// The path string last sent to `navigate_to_directory`.
+    path: String,
+    /// Populated by the spawner callback when the server responds
+    /// successfully. `None` until the first successful response.
+    result: Option<RemoteNavigationResult>,
+}
+
 /// Shell info recorded by [`RemoteServerManager::notify_session_bootstrapped`].
 ///
 /// Persists for the lifetime of the session (removed only in
@@ -592,10 +603,11 @@ pub struct RemoteServerManager {
     host_to_sessions: HashMap<HostId, HashSet<SessionId>>,
     /// Spawner for running closures back on the main thread.
     spawner: ModelSpawner<Self>,
-    /// Last path requested per session for dedup. Avoids redundant
+    /// Per-session navigation cache for dedup. Avoids redundant
     /// `navigate_to_directory` calls when `update_active_session` fires
-    /// repeatedly for the same CWD.
-    last_navigated_path: HashMap<SessionId, String>,
+    /// repeatedly for the same CWD, and returns the cached result on
+    /// dedup so callers don't misinterpret the skip as "not a git repo".
+    last_navigation: HashMap<SessionId, NavigationCache>,
     /// Per-session shell info recorded at bootstrap time and re-sent to the
     /// remote server daemon on every (re)connect. Persists until
     /// `deregister_session`.
@@ -621,7 +633,7 @@ impl RemoteServerManager {
             sessions: HashMap::new(),
             host_to_sessions: HashMap::new(),
             spawner: ctx.spawner(),
-            last_navigated_path: HashMap::new(),
+            last_navigation: HashMap::new(),
             session_bootstrap_info: HashMap::new(),
             auth_context: None,
             session_platforms: HashMap::new(),
@@ -1229,7 +1241,7 @@ impl RemoteServerManager {
     ///   outright. Unlike `SessionDisconnected`, this one never fires for
     ///   spontaneous drops -- only for explicit teardown.
     pub fn deregister_session(&mut self, session_id: SessionId, ctx: &mut ModelContext<Self>) {
-        self.last_navigated_path.remove(&session_id);
+        self.last_navigation.remove(&session_id);
         self.session_bootstrap_info.remove(&session_id);
         self.session_platforms.remove(&session_id);
 
@@ -1506,13 +1518,14 @@ impl RemoteServerManager {
     }
 
     /// Sends a `NavigatedToDirectory` request to the remote server for
-    /// the given session and returns a future that resolves with
-    /// `Some((remote_path, is_git))` on success, or `None` on failure
-    /// or dedup skip. The `NavigatedToDirectory` event is still emitted
-    /// for other subscribers (file tree, etc.).
+    /// the given session and returns a future that resolves with the
+    /// navigation result on success, or `None` on failure. The
+    /// `NavigatedToDirectory` event is still emitted for other
+    /// subscribers (file tree, etc.).
     ///
     /// Deduplicates: if the same `(session_id, path)` was already requested,
-    /// resolves to `None` immediately.
+    /// returns the cached result from the last successful navigation instead
+    /// of re-issuing the request.
     ///
     /// Callers that don't need the result can simply drop the future.
     pub fn navigate_to_directory(
@@ -1520,12 +1533,21 @@ impl RemoteServerManager {
         session_id: SessionId,
         path: String,
         ctx: &mut ModelContext<Self>,
-    ) -> impl Future<Output = Option<(RemotePath, bool)>> {
+    ) -> impl Future<Output = Option<RemoteNavigationResult>> {
         use futures::future::ready;
 
         match self.navigate_to_directory_impl(session_id, path, ctx) {
             Some(rx) => futures::future::Either::Left(async move { rx.await.ok().flatten() }),
-            None => futures::future::Either::Right(ready(None)),
+            None => {
+                // Dedup skip or missing client — return the cached result
+                // from the last successful navigation so callers don't
+                // misinterpret the skip as "not a git repo".
+                let cached = self
+                    .last_navigation
+                    .get(&session_id)
+                    .and_then(|c| c.result.clone());
+                futures::future::Either::Right(ready(cached))
+            }
         }
     }
 
@@ -1536,9 +1558,13 @@ impl RemoteServerManager {
         session_id: SessionId,
         path: String,
         ctx: &mut ModelContext<Self>,
-    ) -> Option<futures::channel::oneshot::Receiver<Option<(RemotePath, bool)>>> {
+    ) -> Option<futures::channel::oneshot::Receiver<Option<RemoteNavigationResult>>> {
         // Dedup: skip if this session already navigated to the same path.
-        if self.last_navigated_path.get(&session_id) == Some(&path) {
+        if self
+            .last_navigation
+            .get(&session_id)
+            .is_some_and(|c| c.path == path)
+        {
             return None;
         }
 
@@ -1547,7 +1573,13 @@ impl RemoteServerManager {
 
         // Record only after confirming the client is connected, so that a
         // retry after SessionConnected is not incorrectly deduplicated.
-        self.last_navigated_path.insert(session_id, path.clone());
+        self.last_navigation.insert(
+            session_id,
+            NavigationCache {
+                path: path.clone(),
+                result: None,
+            },
+        );
 
         let (tx, rx) = futures::channel::oneshot::channel();
         let spawner = self.spawner.clone();
@@ -1556,7 +1588,7 @@ impl RemoteServerManager {
                 match client.navigate_to_directory(path).await {
                     Ok(resp) => {
                         let _ = spawner
-                            .spawn(move |_me, ctx| {
+                            .spawn(move |me, ctx| {
                                 let Some(remote_path) = StandardizedPath::try_new(&resp.indexed_path)
                                     .ok()
                                     .map(|path| RemotePath::new(host_id, path))
@@ -1569,8 +1601,14 @@ impl RemoteServerManager {
                                     let _ = tx.send(None);
                                     return;
                                 };
-                                let result = Some((remote_path.clone(), resp.is_git));
-                                let _ = tx.send(result);
+                                let result = RemoteNavigationResult {
+                                    remote_path: remote_path.clone(),
+                                    is_git: resp.is_git,
+                                };
+                                if let Some(cache) = me.last_navigation.get_mut(&session_id) {
+                                    cache.result = Some(result.clone());
+                                }
+                                let _ = tx.send(Some(result));
                                 ctx.emit(RemoteServerManagerEvent::NavigatedToDirectory {
                                     session_id,
                                     remote_path,
@@ -2194,11 +2232,10 @@ impl RemoteServerManager {
                 });
             }
 
-            // Clear last navigated path so navigate_to_directory
-            // re-fires after reconnect.
-            // We need to do this on disconnect because the cached
-            // navigated path is only deduping for the current _remote server session.
-            self.last_navigated_path.remove(&session_id);
+            // Clear navigation cache so navigate_to_directory re-fires
+            // after reconnect. The cached path only dedupes for the
+            // current remote server session.
+            self.last_navigation.remove(&session_id);
 
             self.attempt_reconnect(
                 session_id,

--- a/crates/repo_metadata/src/lib.rs
+++ b/crates/repo_metadata/src/lib.rs
@@ -56,9 +56,10 @@ pub use watcher::{DirectoryWatcher, RepositoryUpdate, TargetFile};
 #[cfg(not(target_family = "wasm"))]
 pub fn is_in_repo(path: &str, app: &warpui::AppContext) -> bool {
     use crate::repositories::DetectedRepositories;
+    use warp_util::local_or_remote_path::LocalOrRemotePath;
 
     DetectedRepositories::as_ref(app)
-        .get_root_for_path(std::path::Path::new(path))
+        .get_root_for_path(&LocalOrRemotePath::Local(std::path::PathBuf::from(path)))
         .is_some()
 }
 

--- a/crates/repo_metadata/src/repositories.rs
+++ b/crates/repo_metadata/src/repositories.rs
@@ -3,6 +3,9 @@ use std::{collections::HashSet, future::Future, path::PathBuf};
 
 #[cfg(test)]
 use virtual_fs::{Stub, VirtualFS};
+use warp_util::host_id::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
 use warp_util::standardized_path::StandardizedPath;
 #[cfg(test)]
 use warpui::r#async::FutureId;
@@ -36,7 +39,7 @@ pub enum DetectedRepositoriesEvent {
 /// Tracks the detected _git_ repositories during the lifetime of the application. This should be the canonical source of truth for repository information.
 #[derive(Default)]
 pub struct DetectedRepositories {
-    repository_roots: HashSet<StandardizedPath>,
+    repository_roots: HashSet<LocalOrRemotePath>,
     #[cfg(test)]
     /// List of spawned background tasks, for testing.
     spawned_futures: Vec<FutureId>,
@@ -46,7 +49,7 @@ impl DetectedRepositories {
     /// Given the active directory pwd, kick off a background job to detect the git project root and emit an event
     /// to interested listeners.
     #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
-    pub fn detect_possible_git_repo(
+    pub fn detect_possible_local_git_repo(
         &mut self,
         active_directory: &str,
         source: RepoDetectionSource,
@@ -61,19 +64,22 @@ impl DetectedRepositories {
                 return Either::Right(ready(None));
             };
 
-            if let Some(repository) = self.repository_roots.get(&path) {
-                if let Some(local_path) = repository.to_local_path() {
-                    if let Some(repository) =
-                        DirectoryWatcher::as_ref(ctx).get_watched_directory_for_path(&local_path)
-                    {
-                        ctx.emit(DetectedRepositoriesEvent::DetectedGitRepo {
-                            repository: repository.clone(),
-                            source,
-                        });
+            let local_key = path.to_local_path().map(LocalOrRemotePath::Local);
+            if let Some(ref key) = local_key {
+                if self.repository_roots.contains(key) {
+                    if let Some(local_path) = path.to_local_path() {
+                        if let Some(repository) = DirectoryWatcher::as_ref(ctx)
+                            .get_watched_directory_for_path(&local_path)
+                        {
+                            ctx.emit(DetectedRepositoriesEvent::DetectedGitRepo {
+                                repository: repository.clone(),
+                                source,
+                            });
+                        }
                     }
+                    return Either::Right(ready(path.to_local_path()));
                 }
-                return Either::Right(ready(repository.to_local_path()));
-            };
+            }
 
             let local_path_for_search = path.to_local_path();
             let (tx, rx) = oneshot::channel::<Option<PathBuf>>();
@@ -92,7 +98,10 @@ impl DetectedRepositories {
                             .as_ref()
                             .and_then(|path| StandardizedPath::from_local_canonicalized(path).ok())
                         {
-                            me.repository_roots.insert(repo_root_path.clone());
+                            if let Some(local_path) = repo_root_path.to_local_path() {
+                                me.repository_roots
+                                    .insert(LocalOrRemotePath::Local(local_path));
+                            }
 
                             let external_git_dir = StandardizedPath::from_local_canonicalized(
                                 info.git_dir_path.as_path(),
@@ -152,34 +161,68 @@ impl DetectedRepositories {
         &self.spawned_futures
     }
 
-    /// Given a path, return its corresdponding watched repository, if any.
-    pub fn get_watched_repo_for_path(
+    /// Given a local path, return its corresponding watched repository, if any.
+    pub fn get_local_watched_repo_for_path(
         &self,
         path: &Path,
         ctx: &AppContext,
     ) -> Option<ModelHandle<Repository>> {
-        let root = self.get_root_for_path(path)?;
-        DirectoryWatcher::as_ref(ctx).get_watched_directory_for_path(&root)
+        let root = self.get_root_for_path(&LocalOrRemotePath::Local(path.to_path_buf()))?;
+        let local_path = root.to_local_path()?;
+        DirectoryWatcher::as_ref(ctx).get_watched_directory_for_path(local_path)
     }
 
-    /// Given a path, return its corresponding repo root. Note that this does not run the check
-    /// against the actual file system. Instead it checks against our cached path to root mapping.
-    pub fn get_root_for_path(&self, path: &Path) -> Option<PathBuf> {
-        let std_path = StandardizedPath::from_local_canonicalized(path).ok()?;
-        let repo = self.find_repository_root(&std_path)?;
-        repo.to_local_path()
-    }
-
-    /// Find the repository that contains the given path, if any.
-    fn find_repository_root(&self, path: &StandardizedPath) -> Option<StandardizedPath> {
-        let mut current = Some(path.clone());
-        while let Some(ancestor) = current {
-            if let Some(repo) = self.repository_roots.get(&ancestor) {
-                return Some(repo.clone());
+    /// Given a local or remote path, return its corresponding repo root.
+    /// This does not run the check against the actual file system.
+    /// Instead it checks against our cached path to root mapping.
+    pub fn get_root_for_path(&self, path: &LocalOrRemotePath) -> Option<LocalOrRemotePath> {
+        match path {
+            LocalOrRemotePath::Local(local_path) => {
+                let std_path = StandardizedPath::from_local_canonicalized(local_path).ok()?;
+                self.find_local_repository_root(&std_path)
             }
-            current = ancestor.parent();
+            LocalOrRemotePath::Remote(remote_path) => self.find_remote_repository_root(remote_path),
+        }
+    }
+
+    /// Find the local repository that contains the given path, if any.
+    fn find_local_repository_root(&self, path: &StandardizedPath) -> Option<LocalOrRemotePath> {
+        for ancestor in path.ancestors() {
+            if let Some(local_path) = ancestor.to_local_path() {
+                let key = LocalOrRemotePath::Local(local_path);
+                if self.repository_roots.contains(&key) {
+                    return Some(key);
+                }
+            }
         }
         None
+    }
+
+    /// Find the remote repository that contains the given path, if any.
+    fn find_remote_repository_root(&self, remote_path: &RemotePath) -> Option<LocalOrRemotePath> {
+        for ancestor in remote_path.path.ancestors() {
+            let candidate =
+                LocalOrRemotePath::Remote(RemotePath::new(remote_path.host_id.clone(), ancestor));
+            if self.repository_roots.contains(&candidate) {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    /// Register a remote repository root discovered via the remote server.
+    pub fn register_remote_repo_root(&mut self, remote_path: RemotePath) {
+        self.repository_roots
+            .insert(LocalOrRemotePath::Remote(remote_path));
+    }
+
+    /// Remove all cached repository roots for a given remote host.
+    /// Call on `HostDisconnected` to prevent stale entries.
+    pub fn remove_roots_for_host(&mut self, host_id: &HostId) {
+        self.repository_roots.retain(|entry| match entry {
+            LocalOrRemotePath::Local(_) => true,
+            LocalOrRemotePath::Remote(remote) => remote.host_id != *host_id,
+        });
     }
 }
 
@@ -192,9 +235,12 @@ impl SingletonEntity for DetectedRepositories {}
 /// Test helpers: direct mutation of internal state.
 #[cfg(any(test, feature = "test-util"))]
 impl DetectedRepositories {
-    /// Insert a repository root path directly, bypassing git detection.
+    /// Insert a local repository root path directly, bypassing git detection.
     pub fn insert_test_repo_root(&mut self, path: StandardizedPath) {
-        self.repository_roots.insert(path);
+        if let Some(local_path) = path.to_local_path() {
+            self.repository_roots
+                .insert(LocalOrRemotePath::Local(local_path));
+        }
     }
 }
 

--- a/crates/repo_metadata/src/repositories.rs
+++ b/crates/repo_metadata/src/repositories.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, future::Future, path::PathBuf};
 use virtual_fs::{Stub, VirtualFS};
 use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
-use warp_util::remote_path::RemotePath;
+use warp_util::remote_path::{RemoteNavigationResult, RemotePath};
 use warp_util::standardized_path::StandardizedPath;
 #[cfg(test)]
 use warpui::r#async::FutureId;
@@ -59,7 +59,9 @@ impl DetectedRepositories {
     /// This design avoids a circular dependency between `repo_metadata` and
     /// `remote_server` — the caller in `app/` constructs the remote future
     /// and injects it here.
-    pub fn detect_possible_git_repo<F: Future<Output = Option<(RemotePath, bool)>> + 'static>(
+    pub fn detect_possible_git_repo<
+        F: Future<Output = Option<RemoteNavigationResult>> + 'static,
+    >(
         &mut self,
         active_directory: &str,
         source: RepoDetectionSource,
@@ -74,7 +76,10 @@ impl DetectedRepositories {
             }
             Some(remote_fut) => Either::Right(async move {
                 match remote_fut.await {
-                    Some((remote_path, true)) => Some(LocalOrRemotePath::Remote(remote_path)),
+                    Some(RemoteNavigationResult {
+                        remote_path,
+                        is_git: true,
+                    }) => Some(LocalOrRemotePath::Remote(remote_path)),
                     _ => None,
                 }
             }),

--- a/crates/repo_metadata/src/repositories.rs
+++ b/crates/repo_metadata/src/repositories.rs
@@ -46,6 +46,41 @@ pub struct DetectedRepositories {
 }
 
 impl DetectedRepositories {
+    /// Detects the git repository root for the given working directory.
+    ///
+    /// For **local sessions**, pass `None` for `remote_detect` — this delegates
+    /// to the local filesystem detection path.
+    ///
+    /// For **remote sessions**, pass `Some(future)` where the future resolves
+    /// with `(RemotePath, is_git)` from the remote server. The future is
+    /// typically obtained from `RemoteServerManager::navigate_to_directory`.
+    /// When `is_git` is true, the result is `Some(LocalOrRemotePath::Remote(...))`.
+    ///
+    /// This design avoids a circular dependency between `repo_metadata` and
+    /// `remote_server` — the caller in `app/` constructs the remote future
+    /// and injects it here.
+    pub fn detect_possible_git_repo<F: Future<Output = Option<(RemotePath, bool)>> + 'static>(
+        &mut self,
+        active_directory: &str,
+        source: RepoDetectionSource,
+        remote_detect: Option<F>,
+        ctx: &mut ModelContext<Self>,
+    ) -> impl Future<Output = Option<LocalOrRemotePath>> {
+        match remote_detect {
+            None => {
+                // Local detection path.
+                let fut = self.detect_possible_local_git_repo(active_directory, source, ctx);
+                Either::Left(async move { fut.await.map(LocalOrRemotePath::Local) })
+            }
+            Some(remote_fut) => Either::Right(async move {
+                match remote_fut.await {
+                    Some((remote_path, true)) => Some(LocalOrRemotePath::Remote(remote_path)),
+                    _ => None,
+                }
+            }),
+        }
+    }
+
     /// Given the active directory pwd, kick off a background job to detect the git project root and emit an event
     /// to interested listeners.
     #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]

--- a/crates/repo_metadata/src/repositories_tests.rs
+++ b/crates/repo_metadata/src/repositories_tests.rs
@@ -3,11 +3,12 @@ use std::fs;
 use crate::repositories::{stub_git_repository, RepoDetectionSource};
 use crate::{repositories::DetectedRepositories, watcher::DirectoryWatcher};
 use virtual_fs::{Stub, VirtualFS};
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
 #[test]
-fn test_detect_possible_git_repo_non_existent_directory() {
+fn test_detect_possible_local_git_repo_non_existent_directory() {
     VirtualFS::test("detect_non_existent", |dirs, _vfs| {
         let non_existent_path = dirs.tests().join("non_existent_directory");
 
@@ -16,7 +17,7 @@ fn test_detect_possible_git_repo_non_existent_directory() {
             let repo_handle = app.add_model(|_| DetectedRepositories::default());
 
             repo_handle.update(&mut app, |watcher, ctx| {
-                std::mem::drop(watcher.detect_possible_git_repo(
+                std::mem::drop(watcher.detect_possible_local_git_repo(
                     &non_existent_path.to_string_lossy(),
                     RepoDetectionSource::TerminalNavigation,
                     ctx,
@@ -33,7 +34,7 @@ fn test_detect_possible_git_repo_non_existent_directory() {
 }
 
 #[test]
-fn test_detect_possible_git_repo_not_a_git_repo() {
+fn test_detect_possible_local_git_repo_not_a_git_repo() {
     VirtualFS::test("detect_not_git", |dirs, mut vfs| {
         // Create a regular directory structure without .git
         vfs.mkdir("regular_dir/subdir").with_files(vec![
@@ -48,7 +49,7 @@ fn test_detect_possible_git_repo_not_a_git_repo() {
             let repo_handle = app.add_model(|_| DetectedRepositories::default());
 
             repo_handle.update(&mut app, |watcher, ctx| {
-                std::mem::drop(watcher.detect_possible_git_repo(
+                std::mem::drop(watcher.detect_possible_local_git_repo(
                     &regular_dir.to_string_lossy(),
                     RepoDetectionSource::TerminalNavigation,
                     ctx,
@@ -66,14 +67,15 @@ fn test_detect_possible_git_repo_not_a_git_repo() {
             let regular_canonical =
                 StandardizedPath::from_local_canonicalized(&regular_dir).unwrap();
             repo_handle.read(&app, |watcher, _ctx| {
-                assert!(!watcher.repository_roots.contains(&regular_canonical));
+                let key = LocalOrRemotePath::Local(regular_canonical.to_local_path().unwrap());
+                assert!(!watcher.repository_roots.contains(&key));
             });
         });
     });
 }
 
 #[test]
-fn test_detect_possible_git_repo_nested_repo_created_after_parent_registration() {
+fn test_detect_possible_local_git_repo_nested_repo_created_after_parent_registration() {
     VirtualFS::test("detect_nested_repo", |dirs, mut vfs| {
         // Create a parent git repository structure
         stub_git_repository(&mut vfs, "parent_repo");
@@ -91,7 +93,7 @@ fn test_detect_possible_git_repo_nested_repo_created_after_parent_registration()
             // Now, try to detect the nested git repo.
             repo_handle
                 .update(&mut app, |repo, ctx| {
-                    std::mem::drop(repo.detect_possible_git_repo(
+                    std::mem::drop(repo.detect_possible_local_git_repo(
                         &parent_repo.to_string_lossy(),
                         RepoDetectionSource::TerminalNavigation,
                         ctx,
@@ -104,7 +106,9 @@ fn test_detect_possible_git_repo_nested_repo_created_after_parent_registration()
             // Verify parent is registered
             repo_handle.read(&app, |repo, _ctx| {
                 assert!(repo
-                    .get_root_for_path(parent_canonical_path.to_local_path().as_deref().unwrap())
+                    .get_root_for_path(&LocalOrRemotePath::Local(
+                        parent_canonical_path.to_local_path().unwrap(),
+                    ))
                     .is_some());
             });
 
@@ -115,7 +119,7 @@ fn test_detect_possible_git_repo_nested_repo_created_after_parent_registration()
             // Now, try to detect the nested git repo.
             repo_handle
                 .update(&mut app, |repo, ctx| {
-                    std::mem::drop(repo.detect_possible_git_repo(
+                    std::mem::drop(repo.detect_possible_local_git_repo(
                         &nested_project.to_string_lossy(),
                         RepoDetectionSource::TerminalNavigation,
                         ctx,
@@ -131,11 +135,15 @@ fn test_detect_possible_git_repo_nested_repo_created_after_parent_registration()
             repo_handle.read(&app, |repo, _ctx| {
                 // Parent should still be registered
                 assert!(repo
-                    .get_root_for_path(parent_canonical_path.to_local_path().as_deref().unwrap())
+                    .get_root_for_path(&LocalOrRemotePath::Local(
+                        parent_canonical_path.to_local_path().unwrap(),
+                    ))
                     .is_some());
                 // Nested project should now also be registered as its own repo
                 assert!(repo
-                    .get_root_for_path(nested_canonical_path.to_local_path().as_deref().unwrap())
+                    .get_root_for_path(&LocalOrRemotePath::Local(
+                        nested_canonical_path.to_local_path().unwrap(),
+                    ))
                     .is_some());
             });
 

--- a/crates/warp_files/src/lib.rs
+++ b/crates/warp_files/src/lib.rs
@@ -956,7 +956,7 @@ impl FileModel {
 
         // Try to find a repository for this path
         let repository =
-            DetectedRepositories::as_ref(ctx).get_watched_repo_for_path(file_path, ctx)?;
+            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(file_path, ctx)?;
 
         let repo_root = repository.as_ref(ctx).root_dir().to_local_path_lossy();
 

--- a/crates/warp_util/src/lib.rs
+++ b/crates/warp_util/src/lib.rs
@@ -9,6 +9,7 @@ pub mod file;
 pub mod file_type;
 pub mod git;
 pub mod host_id;
+pub mod local_or_remote_path;
 pub mod on_cancel;
 pub mod path;
 pub mod remote_path;

--- a/crates/warp_util/src/local_or_remote_path.rs
+++ b/crates/warp_util/src/local_or_remote_path.rs
@@ -49,3 +49,15 @@ impl From<RemotePath> for LocalOrRemotePath {
         LocalOrRemotePath::Remote(remote)
     }
 }
+
+impl TryFrom<LocalOrRemotePath> for PathBuf {
+    type Error = RemotePath;
+
+    /// Extracts the local path, returning `Err(RemotePath)` for remote locations.
+    fn try_from(value: LocalOrRemotePath) -> Result<Self, Self::Error> {
+        match value {
+            LocalOrRemotePath::Local(path) => Ok(path),
+            LocalOrRemotePath::Remote(remote) => Err(remote),
+        }
+    }
+}

--- a/crates/warp_util/src/local_or_remote_path.rs
+++ b/crates/warp_util/src/local_or_remote_path.rs
@@ -1,0 +1,51 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::remote_path::RemotePath;
+
+/// Uniquely identifies where a file lives — either on the local filesystem
+/// or on a remote host. Used across both the buffer model and the
+/// editor/view layers as the canonical file-identity type.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum LocalOrRemotePath {
+    /// File on the local filesystem.
+    Local(PathBuf),
+    /// File on a remote host, identified by host + path.
+    Remote(RemotePath),
+}
+
+impl LocalOrRemotePath {
+    /// Returns the file name component for display (e.g. tab titles).
+    pub fn display_name(&self) -> &str {
+        match self {
+            LocalOrRemotePath::Local(path) => path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default(),
+            LocalOrRemotePath::Remote(remote) => remote.path.file_name().unwrap_or_default(),
+        }
+    }
+
+    /// Returns the local path if this is a `Local` location, `None` for `Remote`.
+    /// Callers that only work with local files (LSP, save-to-disk, reveal-in-finder)
+    /// should use this to gate their behavior.
+    pub fn to_local_path(&self) -> Option<&Path> {
+        match self {
+            LocalOrRemotePath::Local(path) => Some(path.as_path()),
+            LocalOrRemotePath::Remote(_) => None,
+        }
+    }
+}
+
+impl From<PathBuf> for LocalOrRemotePath {
+    fn from(path: PathBuf) -> Self {
+        LocalOrRemotePath::Local(path)
+    }
+}
+
+impl From<RemotePath> for LocalOrRemotePath {
+    fn from(remote: RemotePath) -> Self {
+        LocalOrRemotePath::Remote(remote)
+    }
+}

--- a/crates/warp_util/src/remote_path.rs
+++ b/crates/warp_util/src/remote_path.rs
@@ -20,3 +20,12 @@ impl RemotePath {
         Self { host_id, path }
     }
 }
+
+/// The result of a `navigate_to_directory` request to the remote server.
+#[derive(Clone, Debug)]
+pub struct RemoteNavigationResult {
+    /// The canonicalized remote path returned by the server.
+    pub remote_path: RemotePath,
+    /// Whether the server detected a git repository at this path.
+    pub is_git: bool,
+}


### PR DESCRIPTION
## Description

Migrate `DetectedRepositories` to support remote repository roots, enabling code review and other repo-aware features to work over remote SSH sessions.

### Changes

**Move `LocalOrRemotePath` to `warp_util`**
- Moved enum from `app/src/code/buffer_location.rs` to `crates/warp_util/src/local_or_remote_path.rs` so `repo_metadata` can use it
- Re-exported from `buffer_location.rs` so existing app-level imports continue working

**Modify `DetectedRepositories` internals**
- Changed `repository_roots: HashSet<StandardizedPath>` → `HashSet<LocalOrRemotePath>`
- Added `detect_possible_git_repo` with dependency-injected remote detection future — avoids circular dep between `repo_metadata` and `remote_server` while keeping detection logic semantically on `DetectedRepositories`
- `get_root_for_path` now accepts `&LocalOrRemotePath` and returns `Option<LocalOrRemotePath>`, with separate local/remote ancestor-walk implementations
- Added `register_remote_repo_root(RemotePath)` and `remove_roots_for_host(&HostId)` for remote lifecycle management

**Rename local-only methods**
- `detect_possible_git_repo` → `detect_possible_local_git_repo`
- `get_watched_repo_for_path` → `get_local_watched_repo_for_path`

**Migrate `get_root_for_path` callsites (~20 files)**
- All callers now pass `&LocalOrRemotePath::Local(...)` and extract the inner `PathBuf` from the result

**Unified repo detection (`app/src/util/repo_detection.rs`)**
- Thin helper that constructs the `RemoteServerManager::navigate_to_directory` future and passes it to `DetectedRepositories::detect_possible_git_repo`
- `TerminalView::BlockMetadataReceived` now uses this for both local and remote sessions
- `current_repo_path` changed from `Option<PathBuf>` to `Option<LocalOrRemotePath>` with `current_local_repo_path()` helper for existing consumers

**`RemoteServerManager::navigate_to_directory` now returns a future**
- Single method that always returns `impl Future<Output = Option<(RemotePath, bool)>>`
- Callers that don't need the result can drop the future

**Remove redundant workspace/TV code**
- Removed `navigate_to_directory` call from `Workspace::update_active_session`
- Removed `SessionConnected` re-trigger subscription
- Removed `register_remote_repo_root` from `NavigatedToDirectory` handler (now handled by unified callback)
- Added `HostDisconnected` handler to clean up stale entries

[Conversation](https://staging.warp.dev/conversation/abfa3265-f909-4bad-ac23-4dd0343dd7ff) | [Plan](https://staging.warp.dev/drive/notebook/FVxjAZl9wx1n4LsFkoLWQa)

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Workspace compiles cleanly (`cargo check --workspace`)
- `cargo clippy` passes with zero warnings
- All 59 `repo_metadata` tests pass
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->