### PR TITLE
Remove bootstrap block conditionals from input hot path.

### DIFF
--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -423,6 +423,8 @@ pub struct Block {
     ///
     /// This is used for debugging UI shown in the block header on dogfood builds.
     nld_overridden: bool,
+
+    visible_bootstrap_block_event_sent: bool,
 }
 
 #[cfg(debug_assertions)]
@@ -1020,6 +1022,7 @@ impl Block {
             },
             nld_overridden: false,
             is_oz_environment_startup_command: false,
+            visible_bootstrap_block_event_sent: false,
         }
     }
 
@@ -1186,13 +1189,6 @@ impl Block {
     pub fn start(&mut self) {
         if self.start_ts.is_none() {
             self.start_ts = Some(Local::now());
-        }
-
-        // If we are in script execution stage and the shell starts a new block,
-        // this means we have a visible bootstrap block.
-        if self.bootstrap_stage() == BootstrapStage::ScriptExecution {
-            self.event_proxy
-                .send_terminal_event(Event::VisibleBootstrapBlock);
         }
 
         self.header_grid.start_command_grid();
@@ -1723,10 +1719,18 @@ impl Block {
     pub fn is_executing(&self) -> bool {
         self.state == BlockState::Executing
     }
+    fn is_empty_pre_bootstrap_block(&self) -> bool {
+        !self.bootstrap_stage.is_done()
+            && self.command_should_show_as_empty_when_finished()
+            && self.output_grid.should_show_as_empty_when_finished()
+    }
 
     /// Whether a command is long running.
     /// We use this to determine whether to hide the input box.
     pub fn is_active_and_long_running(&self) -> bool {
+        if self.is_empty_pre_bootstrap_block() {
+            return false;
+        }
         // Use the command grid start time by default (which should be earlier)
         // than the output grid start time.  If for some reason there isn't a
         // command grid start time, then fall back to the start time of the output
@@ -1948,6 +1952,15 @@ impl Block {
 
     pub fn bootstrap_stage(&self) -> BootstrapStage {
         self.bootstrap_stage
+    }
+
+    pub(super) fn should_emit_visible_bootstrap_block_event(&self) -> bool {
+        self.bootstrap_stage == BootstrapStage::ScriptExecution
+            && !self.visible_bootstrap_block_event_sent
+    }
+
+    pub(super) fn mark_visible_bootstrap_block_event_sent(&mut self) {
+        self.visible_bootstrap_block_event_sent = true;
     }
 
     /// Returns the ENTIRE HEIGHT of the prompt and command (no padding top or middle included).

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -1719,6 +1719,7 @@ impl Block {
     pub fn is_executing(&self) -> bool {
         self.state == BlockState::Executing
     }
+
     fn is_empty_pre_bootstrap_block(&self) -> bool {
         !self.bootstrap_stage.is_done()
             && self.command_should_show_as_empty_when_finished()

--- a/app/src/terminal/model/block_tests.rs
+++ b/app/src/terminal/model/block_tests.rs
@@ -287,6 +287,38 @@ pub fn test_long_running_block_bottom_padding() {
     });
 }
 
+#[test]
+pub fn empty_pre_bootstrap_block_is_not_long_running() {
+    warpui::r#async::block_on(async {
+        let mut block = TestBlockBuilder::new()
+            .with_bootstrap_stage(BootstrapStage::ScriptExecution)
+            .build();
+
+        block.start();
+
+        let duration = LONG_RUNNING_COMMAND_DURATION_MS + 1;
+        warpui::r#async::Timer::after(Duration::from_millis(duration)).await;
+
+        assert!(!block.is_active_and_long_running());
+    });
+}
+
+#[test]
+pub fn non_empty_pre_bootstrap_block_can_be_long_running() {
+    warpui::r#async::block_on(async {
+        let mut block = TestBlockBuilder::new()
+            .with_bootstrap_stage(BootstrapStage::ScriptExecution)
+            .build();
+
+        block.start();
+        block.input('x');
+
+        let duration = LONG_RUNNING_COMMAND_DURATION_MS + 1;
+        warpui::r#async::Timer::after(Duration::from_millis(duration)).await;
+
+        assert!(block.is_active_and_long_running());
+    });
+}
 // Tests that the command grid has a non-zero height even if `preexec` is never called.
 #[test]
 pub fn test_precmd_no_preexec() {

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -609,7 +609,7 @@ impl BlockList {
     /// block.
     /// 3. Create the `BootstrapStage::WarpInput` block through
     /// `create_warp_input_block`. From here on, there is always a default
-    /// block which is hidden until it is started.
+    /// block which is hidden while it is empty.
     /// 4. We progress through the bootstrap stages with the `finalize_block_and_advance_list` function.
     /// 5. After we hit `BootstrapStage::PostBootstrapPrecmd`, it's normal
     /// execution. `finalize_block_and_advance_list` is still the main function to advance the block list.
@@ -702,10 +702,6 @@ impl BlockList {
             }
         }
         self.create_warp_input_block();
-        // Note: We no longer call start() here.
-        // When shell input arrives, the block will be started (see the `input` handler).
-        // This ensures sessions without a shell (like cloude mode) don't permanently trigger is_active_and_long_running()
-        // since the block will never be finished.
     }
 
     pub(super) fn load_shared_session_scrollback(&mut self, scrollback: &[SerializedBlock]) {
@@ -793,8 +789,7 @@ impl BlockList {
     }
 
     /// This is an important function in the block list lifecycle. After this
-    /// is called, there's an invariant where we always have an active block
-    /// that's hidden until it's `start`ed.
+    /// is called, there's an invariant where we always have an active block.
     fn create_warp_input_block(&mut self) {
         self.create_new_block(
             BlockId::new(),
@@ -802,6 +797,8 @@ impl BlockList {
             Default::default(),
             None,
         );
+        self.start_active_block();
+        self.update_active_block_height();
         self.bootstrap_stage = BootstrapStage::WarpInput;
     }
 
@@ -892,9 +889,9 @@ impl BlockList {
             cursor.slice(&BlockIndex(self.blocks.len()), SeekBias::Left)
         };
 
-        // If the active block has started (i.e. is running)--then insert the gap _after_ the block.
-        // If the active block has not started (e.g. the user pressed ctrl-l)--insert the gap
-        // _before_ the active block so the next command the user executes is after the gap.
+        // If the active block is visible, insert the gap _after_ the block.
+        // If the active block is hidden, insert the gap _before_ the active block so the next
+        // visible content is after the gap.
         let gap_height = if let Some(height) = self.next_gap_height() {
             height
         } else {
@@ -910,7 +907,7 @@ impl BlockList {
         let agent_view_state = self.agent_view_state.clone();
         let active_block_height = self.active_block_mut().height(&agent_view_state).into();
 
-        if self.active_block().started() {
+        if active_block_height > BlockHeight::zero() {
             self.block_heights
                 .push(BlockHeightItem::Block(active_block_height));
             self.block_heights.push(gap);
@@ -1039,9 +1036,8 @@ impl BlockList {
         {
             self.append_item_to_blocklist(BlockHeightItem::RichContent(item))
         } else {
-            // If there's no long-running block, then the active block is a default block that is hidden
-            // until it's started. This is an invariant of the blocklist (see create_warp_input_block). In this
-            // case, we should add the rich content above that hidden block.
+            // If there's no long-running block, then the active block is a default block with no
+            // visible content. In this case, we should add the rich content above that hidden block.
             self.insert_non_block_item_before_block(
                 self.active_block_index(),
                 BlockHeightItem::RichContent(item),
@@ -1780,6 +1776,7 @@ impl BlockList {
             }
             None => Lines::zero(),
         };
+        let mut previous_block_height = BlockHeight::zero();
         let block_height = if let Some(block) = self.block_at(block_index) {
             block.height(&self.agent_view_state).into()
         } else {
@@ -1793,6 +1790,9 @@ impl BlockList {
             let mut cursor = self.block_heights.cursor::<BlockIndex, ()>();
             let next_index = block_index + BlockIndex(1);
             let mut tree_before_last_block = cursor.slice(&next_index, SeekBias::Left);
+            if let Some(BlockHeightItem::Block(height)) = cursor.item() {
+                previous_block_height = *height;
+            }
             tree_before_last_block.push(BlockHeightItem::Block(block_height));
 
             // Advance the cursor past the current block and take the suffix to get all the items
@@ -1850,6 +1850,20 @@ impl BlockList {
 
         if let Some(removed_index) = removed_gap_index {
             self.update_block_height_indices(BlockHeightUpdate::Removal(removed_index), false);
+        }
+
+        let should_emit_visible_bootstrap_block_event = previous_block_height
+            == BlockHeight::zero()
+            && block_height > BlockHeight::zero()
+            && self
+                .block_at(block_index)
+                .is_some_and(Block::should_emit_visible_bootstrap_block_event);
+        if should_emit_visible_bootstrap_block_event {
+            if let Some(block) = self.blocks.get_mut(block_index.0) {
+                block.mark_visible_bootstrap_block_event_sent();
+            }
+            self.event_proxy
+                .send_terminal_event(TerminalEvent::VisibleBootstrapBlock);
         }
     }
 
@@ -2751,13 +2765,7 @@ impl BlockList {
         active_block.finish(0);
         self.update_active_block_height();
 
-        self.create_new_block(
-            BlockId::new(),
-            BootstrapStage::WarpInput,
-            None, /* precmd_value */
-            None, /* restored_block_is_local */
-        );
-        self.bootstrap_stage = BootstrapStage::WarpInput;
+        self.create_warp_input_block();
     }
 
     /// Starts the active block and resets block-to-block state. For local sessions, this is called
@@ -3011,6 +3019,10 @@ impl BlockList {
             None, /*precmd_value*/
             None, /* restored_block_was_local */
         );
+        if next_bootstrap_stage == BootstrapStage::ScriptExecution {
+            self.start_active_block();
+            self.update_active_block_height();
+        }
         if self.bootstrap_stage != next_bootstrap_stage {
             log::info!(
                 "Incrementing stage from {:?} to {:?}",
@@ -3362,17 +3374,6 @@ impl ansi::Handler for BlockList {
     }
 
     fn input(&mut self, c: char) {
-        let is_bootstrapped = self.is_bootstrapped();
-        let active_block = self.active_block_mut();
-
-        // We typically "start" blocks when we execute the command. Start basically
-        // means mark ready to render. For bootstrapping blocks, we start them
-        // when they receive input. Note this means that, for example, a bootstrap script that
-        // only executes `read` isn't supported.
-        if !active_block.started() && !is_bootstrapped {
-            self.start_active_block();
-            self.update_active_block_height();
-        }
         delegate!(self.input(c));
     }
 

--- a/app/src/terminal/model/blocks_tests.rs
+++ b/app/src/terminal/model/blocks_tests.rs
@@ -128,6 +128,13 @@ pub fn command_finished_and_precmd(block_list: &mut BlockList) {
     block_list.command_finished(Default::default());
     block_list.precmd(Default::default());
 }
+fn drain_terminal_events(events_rx: &async_channel::Receiver<Event>) -> Vec<Event> {
+    let mut events = Vec::new();
+    while let Ok(event) = events_rx.try_recv() {
+        events.push(event);
+    }
+    events
+}
 
 /// Advances the block list to the ScriptExecution stage.
 fn advance_to_script_execution(block_list: &mut BlockList) {
@@ -336,6 +343,7 @@ pub fn test_script_execution_block() {
 
     // We have the `WarpInput` block and the current script execution block.
     assert_eq!(block_list.blocks.len(), 2);
+    assert!(block_list.active_block().started());
     // Ensure that script execution block has a height of 0 if nothing was added to it.
     assert!(block_list
         .active_block()
@@ -352,12 +360,14 @@ pub fn test_script_execution_block() {
     advance_to_script_execution(&mut block_list);
 
     assert_eq!(block_list.blocks.len(), 2);
+    assert!(block_list.active_block().started());
     assert!(block_list
         .active_block()
         .is_empty(&AgentViewState::Inactive));
 
     // Add characters to script execution block.
     block_list.input('c');
+    block_list.update_active_block_height();
 
     assert_eq!(block_list.blocks.len(), 2);
     assert!(!block_list
@@ -392,6 +402,49 @@ pub fn test_script_execution_block() {
         block_completed_events[3].block_type,
         BlockType::BootstrapVisible(_)
     ));
+}
+#[test]
+pub fn visible_bootstrap_block_event_fires_when_script_execution_becomes_visible() {
+    let (events_tx, events_rx) = async_channel::unbounded();
+    let channel_event_proxy = ChannelEventListener::builder_for_test()
+        .with_terminal_events_tx(events_tx)
+        .build();
+
+    let mut block_list = TestBlockListBuilder::new()
+        .with_channel_event_proxy(channel_event_proxy)
+        .build();
+    advance_to_script_execution(&mut block_list);
+
+    assert!(block_list.active_block().started());
+    assert!(block_list
+        .active_block()
+        .is_empty(&AgentViewState::Inactive));
+
+    let events = drain_terminal_events(&events_rx);
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, Event::VisibleBootstrapBlock)));
+
+    block_list.input('c');
+    let events = drain_terminal_events(&events_rx);
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, Event::VisibleBootstrapBlock)));
+
+    block_list.update_active_block_height();
+    let visible_events = drain_terminal_events(&events_rx)
+        .into_iter()
+        .filter(|event| matches!(event, Event::VisibleBootstrapBlock))
+        .count();
+    assert_eq!(visible_events, 1);
+
+    block_list.input('d');
+    block_list.update_active_block_height();
+    let visible_events = drain_terminal_events(&events_rx)
+        .into_iter()
+        .filter(|event| matches!(event, Event::VisibleBootstrapBlock))
+        .count();
+    assert_eq!(visible_events, 0);
 }
 
 // Add a few restored blocks and ensure they show up appropriately.
@@ -578,7 +631,6 @@ pub fn test_basic_bootstrapping() {
         .build();
 
     // Simulate entering the bootstrap script for WarpInput mode.
-    block_list.start_active_block();
     input_string(&mut block_list, "i am the warp input");
     block_list.linefeed();
     block_list.preexec(Default::default());
@@ -649,11 +701,11 @@ pub fn test_session_restoration_separator() {
                 .as_f64()
     );
 
-    // With the active block not started during initialize,
-    // the gap is inserted before the active block in clear_visible_screen.
-    // Total items: 2 restored blocks + 1 separator + 1 gap + 1 active block = 5
+    // With the active block still hidden during initialize, the gap is inserted before the active
+    // block in clear_visible_screen.
+    // Total items: 2 restored blocks + 1 separator + 1 gap + 1 active block = 5.
     assert_eq!(block_list.block_heights.summary().total_count, 5);
-    // Gap is at index 3 (before the active block at index 4)
+    // Gap is at index 3 (before the active block at index 4).
     assert_eq!(block_list.active_gap.as_ref().unwrap().index, 3);
     assert_approx_eq!(
         Lines,


### PR DESCRIPTION
## Description
This removes pre-bootstrap block lifecycle checks from the per-character `BlockList::input()` hot path by eagerly starting bootstrap placeholder blocks when they are created or advanced into.

To preserve behavior, empty pre-bootstrap placeholders are excluded from long-running-command state, and `VisibleBootstrapBlock` is now emitted only when the `ScriptExecution` block transitions from hidden/zero-height to visible/non-zero-height. This keeps delayed or interactive bootstrap output focus behavior without treating empty shell startup placeholders as visible long-running commands.

## Linked Issue
N/A

## Testing
- [x] `cargo fmt`
- [x] `git --no-pager diff --check`
- [x] `cargo nextest run -p warp -E 'test(test_script_execution_block) | test(visible_bootstrap_block_event_fires_when_script_execution_becomes_visible) | test(test_basic_bootstrapping) | test(test_session_restoration_separator) | test(empty_pre_bootstrap_block_is_not_long_running) | test(non_empty_pre_bootstrap_block_can_be_long_running) | test(test_long_running_block_bottom_padding)'`
- [x] Manual: `WARP_BOOTSTRAP_MANUAL_TEST=1 ./script/run` with temporary zsh startup delay/output.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Agent conversation: https://staging.warp.dev/conversation/e4c54920-bb38-4e3a-8074-95d3e32f54e9

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
