### PR TITLE
Bug fix: remove lag from add custom model

### DIFF
--- a/app/src/settings_view/custom_inference_modal.rs
+++ b/app/src/settings_view/custom_inference_modal.rs
@@ -572,6 +572,9 @@ impl CustomEndpointModal {
             EditorEvent::Escape => {
                 self.cancel(ctx);
             }
+            EditorEvent::Edited(_) => {
+                ctx.notify();
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Description

In the custom endpoint modal, the "Add endpoint" / "Save" button remained disabled for a noticeable delay after entering a valid model name. This happened because the model name and alias editors did not trigger a re-render on `EditorEvent::Edited`, so `is_valid` was not re-evaluated until another event (e.g. Tab or click) forced a layout.

## How

Added `EditorEvent::Edited(_) => { ctx.notify(); }` to `handle_model_editor_event` in `CustomEndpointModal`, matching the behavior of the endpoint name, URL, and API key editors.

## Testing
- [x] Verified the modal now enables the save button immediately as the model name field receives input.

CHANGELOG-BUG-FIX: Fixed a delay in enabling the save button when adding or editing a custom model endpoint.

Co-Authored-By: Warp <agent@warp.dev>
