### PR TITLE
Fix onnx runtime incompatibility on new NLD classifier

### DIFF
--- a/crates/input_classifier/models/onnx/bert_tiny_v2.onnx
+++ b/crates/input_classifier/models/onnx/bert_tiny_v2.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fd8afc92b849ad1ac1d6b35ec24702ee10bfd263aa1c2cd137cb2e2fd4737e1
-size 17576491
+oid sha256:ed2cea2884206a66fd8e96bf51895aa4e5696a09d8f344e132f84246e40f7b83
+size 17582121

--- a/crates/input_classifier/src/bin/evaluate.rs
+++ b/crates/input_classifier/src/bin/evaluate.rs
@@ -74,7 +74,7 @@ use input_classifier::{OnnxClassifier, OnnxModel};
 // Pick the ONNX model whose bytes are actually embedded in the binary
 #[cfg(feature = "nld_classifier_v1")]
 const DEFAULT_ONNX_MODEL: OnnxModel = OnnxModel::BertTinyV1;
-#[cfg(feature = "nld_classifier_v2")]
+#[cfg(all(not(feature = "nld_classifier_v1"), feature = "nld_classifier_v2"))]
 const DEFAULT_ONNX_MODEL: OnnxModel = OnnxModel::BertTinyV2;
 
 #[derive(Parser)]

--- a/crates/input_classifier/src/bin/evaluate.rs
+++ b/crates/input_classifier/src/bin/evaluate.rs
@@ -74,7 +74,7 @@ use input_classifier::{OnnxClassifier, OnnxModel};
 // Pick the ONNX model whose bytes are actually embedded in the binary
 #[cfg(feature = "nld_classifier_v1")]
 const DEFAULT_ONNX_MODEL: OnnxModel = OnnxModel::BertTinyV1;
-#[cfg(all(not(feature = "nld_classifier_v1"), feature = "nld_classifier_v2"))]
+#[cfg(feature = "nld_classifier_v2")]
 const DEFAULT_ONNX_MODEL: OnnxModel = OnnxModel::BertTinyV2;
 
 #[derive(Parser)]

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -197,7 +197,7 @@ if [[ "$ARTIFACT" == "cli" ]]; then
 elif [[ "$ARTIFACT" == "app" ]]; then
   FEATURES="$FEATURES,gui"
   if [[ "$RELEASE_CHANNEL" == "local" || "$RELEASE_CHANNEL" == "dev" ]]; then
-    FEATURES="$FEATURES,nld_classifier_v1"
+    FEATURES="$FEATURES,nld_classifier_v2"
   else
     FEATURES="$FEATURES,nld_classifier_v1"
   fi

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -354,7 +354,7 @@ if [[ "$ARTIFACT" == cli ]]; then
 elif [[ "$ARTIFACT" == app ]]; then
   FEATURES="$FEATURES,gui"
   if [[ "$RELEASE_CHANNEL" == "local" || "$RELEASE_CHANNEL" == "dev" ]]; then
-    FEATURES="$FEATURES,nld_classifier_v1"
+    FEATURES="$FEATURES,nld_classifier_v2"
   else
     FEATURES="$FEATURES,nld_classifier_v1"
   fi

--- a/script/windows/bundle.ps1
+++ b/script/windows/bundle.ps1
@@ -116,7 +116,7 @@ if ("$CHANNEL" -eq 'local') {
 }
 
 if (("$CHANNEL" -eq 'local') -or ("$CHANNEL" -eq 'dev')) {
-    $FEATURES = "$FEATURES,nld_classifier_v1"
+    $FEATURES = "$FEATURES,nld_classifier_v2"
 } else {
     $FEATURES = "$FEATURES,nld_classifier_v1"
 }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
1. re-enable nld_classifier_v2 to warplocal and warpdev
2. update bert_tiny_v2.onnx with a candle compatible model graph
## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->
<img width="1280" height="132" alt="image" src="https://github.com/user-attachments/assets/5bdbc92a-311b-4c12-8628-bffe497b0a87" />
Now no more error message and we see the classifier result in debug log

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
