### PR TITLE
Don't run code review git operations on startup when panel is closed

### DIFF
--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -898,25 +898,29 @@ impl LocalDiffStateModel {
     ) {
         use std::time::Duration;
 
-        let new_repository_root = new_repository.as_ref(ctx).root_dir().to_local_path_lossy();
+        // Assign the repository handle before spawning the registration future.
+        // `registration_future` may resolve immediately (e.g. watcher already active), and
+        // `handle_repository_updated` relies on `self.repository` being available for cleanup.
+        self.repository = Some(new_repository.clone());
 
-        // Always include base branch metadata since only code review uses this model now.
-        let include_base_branch = true;
-        let abort_handle =
-            ctx.spawn(
+        // Only kick off the expensive metadata + diff loading when the code
+        // review pane is actually open.  When the pane opens later, `on_open`
+        // calls `set_code_review_metadata_refresh_enabled(true)` (which
+        // triggers metadata) and `load_diffs_for_current_repo` (which triggers
+        // diffs), so nothing is lost — just deferred.
+        if self.metadata_refresh_enabled {
+            let new_repository_root = new_repository.as_ref(ctx).root_dir().to_local_path_lossy();
+            // Always include base branch metadata since only code review uses this model now.
+            let include_base_branch = true;
+            let abort_handle = ctx.spawn(
                 async move {
                     Self::load_metadata_for_repo(new_repository_root, include_base_branch).await
                 },
                 move |me, res, ctx| me.handle_updated_metadata_for_repo(res, true, ctx),
             );
-
-        self.computing_metadata_abort_handle = Some(abort_handle);
-        self.state = InternalDiffState::Loading;
-
-        // Assign the repository handle before spawning the registration future.
-        // `registration_future` may resolve immediately (e.g. watcher already active), and
-        // `handle_repository_updated` relies on `self.repository` being available for cleanup.
-        self.repository = Some(new_repository.clone());
+            self.computing_metadata_abort_handle = Some(abort_handle);
+            self.state = InternalDiffState::Loading;
+        }
 
         let (repository_update_tx, repository_update_rx) = async_channel::unbounded();
         let (throttled_repository_update_tx, throttled_repository_update_rx) =
@@ -991,6 +995,14 @@ impl LocalDiffStateModel {
             index_lock_detected,
             remote_ref_updated,
         } = update;
+
+        // When the code review pane is closed (metadata_refresh_enabled ==
+        // false), skip diff reloads and per-file invalidations.  The throttled
+        // metadata path already respects this flag, and `on_open` will trigger
+        // a full reload when the pane becomes visible.
+        if !self.metadata_refresh_enabled {
+            return false;
+        }
 
         if commit_updated || remote_ref_updated {
             self.load_diffs_for_current_repo(false, ctx);


### PR DESCRIPTION
## Description

When the code review panel is closed, `LocalDiffStateModel::set_active_repository()` was eagerly spawning `load_metadata_for_repo` (with `include_base_branch=true` and `should_reload_diffs=true`) on every terminal startup. This caused ~12+ git subprocess calls (detect_main_branch, detect_current_branch, rev-parse HEAD, git status, git diff --numstat, merge-base, diff --name-status, gh pr view, plus per-file git diff/show for each changed file) — even when the user never opens the panel.

### Changes
**`set_active_repository` (local.rs):** Gated the `load_metadata_for_repo` spawn behind `self.metadata_refresh_enabled`. When the panel is closed (flag is `false`), the repository handle and file watcher are still set up, but no git commands run. When the panel opens, `on_open()` already calls both `set_code_review_metadata_refresh_enabled(true)` and `load_diffs_for_current_repo`, so everything loads correctly on demand.

**`handle_file_update` (local.rs):** Added an early return when `metadata_refresh_enabled` is `false`, preventing file watcher events from triggering diff reloads and per-file invalidations while the panel is closed.

Unaffected systems:
- **GitRepoStatusModel** (git status chip in terminal prompt) — separate model, continues to detect branch and HEAD stats independently.
- **Remote server diff_state_tracker** — creates its own `LocalDiffStateModel` with `metadata_refresh_enabled=true`.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Tested by running with `RUST_LOG="warp::util::git=debug,warp::code_review::diff_state=debug" ./script/run` and verifying:
1. With panel closed: only `GitRepoStatusModel` operations appear (detect_main_branch, detect_current_branch, diff_metadata_against_head).
2. Opening the panel: full set of git operations fire (metadata, diffs, branch list, PR info).
3. File changes while panel is closed don't trigger git commands; opening the panel afterward picks up changes.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation link](https://staging.warp.dev/conversation/6c73db4c-2091-4c7c-9d5e-b34ce72c7f5e)

Co-Authored-By: Oz <oz-agent@warp.dev>

CHANGELOG-IMPROVEMENT: Reduced unnecessary git operations on startup when the Code Review panel is closed.
