### PR TITLE
Fix API key dropdown menu styling

### DIFF
--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Local};
 use pathfinder_color::ColorU;
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::{vec2f, Vector2F};
-use warp_core::ui::color::blend::Blend;
+use warp_core::ui::color::{blend::Blend, OPAQUE};
 use warpui::elements::{
     ChildAnchor, ClippedScrollStateHandle, ClippedScrollable, DropShadow, OffsetPositioning,
     ParentAnchor, ParentOffsetBounds, PositionedElementAnchor, PositionedElementOffsetBounds,
@@ -125,6 +125,9 @@ pub struct Menu<A: Action + Clone = ()> {
     /// Optional overrides for the depth-0 menu content padding.
     content_top_padding_override: Option<f32>,
     content_bottom_padding_override: Option<f32>,
+    /// When true, force the menu background's alpha to fully opaque while
+    /// preserving the current theme-derived surface color.
+    force_opaque_background: bool,
     /// If false, selecting a menu item updates selection and emits menu events
     /// without dispatching the item's typed action directly from the menu.
     dispatch_item_actions: bool,
@@ -2144,6 +2147,7 @@ impl<A: Action + Clone> Menu<A> {
             pinned_header_builder: None,
             content_top_padding_override: None,
             content_bottom_padding_override: None,
+            force_opaque_background: false,
             dispatch_item_actions: true,
         }
     }
@@ -2183,6 +2187,14 @@ impl<A: Action + Clone> Menu<A> {
     pub fn with_drop_shadow(mut self) -> Self {
         self.with_drop_shadow = true;
         self
+    }
+    pub fn with_force_opaque_background(mut self) -> Self {
+        self.force_opaque_background = true;
+        self
+    }
+
+    pub fn set_force_opaque_background(&mut self, force_opaque_background: bool) {
+        self.force_opaque_background = force_opaque_background;
     }
 
     /// Prevent menu item clicks and Enter from dispatching their typed actions
@@ -2616,13 +2628,19 @@ impl<A: Action + Clone> SubMenu<A> {
         pinned_header_builder: Option<&PinnedHeaderBuilder>,
         content_top_padding_override: Option<f32>,
         content_bottom_padding_override: Option<f32>,
+        force_opaque_background: bool,
         app: &AppContext,
     ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         let selected_row_index = self.selected_row_index;
         let selected_item_index = self.selected_item_index;
-
-        let background_color = appearance.theme().surface_2();
+        let background_color = if force_opaque_background {
+            let mut color = appearance.theme().surface_2().into_solid();
+            color.a = OPAQUE;
+            Fill::Solid(color)
+        } else {
+            appearance.theme().surface_2()
+        };
         let submenus = self.render_submenus(
             submenu_width,
             background_color,
@@ -2794,6 +2812,7 @@ impl<A: Action + Clone> View for Menu<A> {
             self.pinned_header_builder.as_deref(),
             self.content_top_padding_override,
             self.content_bottom_padding_override,
+            self.force_opaque_background,
             app,
         )
     }

--- a/app/src/settings_view/platform/create_api_key_modal.rs
+++ b/app/src/settings_view/platform/create_api_key_modal.rs
@@ -165,8 +165,9 @@ impl CreateApiKeyModal {
         let agent_dropdown =
             ctx.add_typed_action_view(DropdownView::<CreateApiKeyModalAction>::new);
         agent_dropdown.update(ctx, |dropdown, ctx| {
-            dropdown.set_top_bar_max_width(INPUT_WIDTH);
+            dropdown.set_top_bar_width(INPUT_WIDTH, ctx);
             dropdown.set_menu_width(INPUT_WIDTH, ctx);
+            dropdown.set_force_opaque_menu_background(true, ctx);
         });
 
         let api_key_type_control = ctx.add_typed_action_view(move |ctx| {
@@ -241,8 +242,9 @@ impl CreateApiKeyModal {
             .collect();
         expiration_dropdown.update(ctx, |dropdown, ctx| {
             dropdown.set_items(items, ctx);
-            dropdown.set_top_bar_max_width(INPUT_WIDTH);
+            dropdown.set_top_bar_width(INPUT_WIDTH, ctx);
             dropdown.set_menu_width(INPUT_WIDTH, ctx);
+            dropdown.set_force_opaque_menu_background(true, ctx);
             dropdown.set_selected_by_action(
                 CreateApiKeyModalAction::SetExpiration(default_expiration),
                 ctx,

--- a/app/src/view_components/dropdown.rs
+++ b/app/src/view_components/dropdown.rs
@@ -69,6 +69,7 @@ pub struct Dropdown<A: Action + Clone> {
     disabled: bool,
     top_bar_mouse_state: MouseStateHandle,
     top_bar_max_width: f32,
+    top_bar_width: Option<f32>,
     element_anchor: PositionedElementAnchor,
     child_anchor: ChildAnchor,
     main_axis_size: MainAxisSize,
@@ -238,6 +239,7 @@ where
             dropdown,
             top_bar_mouse_state: Default::default(),
             top_bar_max_width: TOP_MENU_BAR_MAX_WIDTH,
+            top_bar_width: None,
             selected_item: None,
             menu_header_text_override: None,
             self_handle: ctx.handle(),
@@ -450,11 +452,28 @@ where
 
     pub fn set_top_bar_max_width(&mut self, max_width: f32) {
         self.top_bar_max_width = max_width;
+        self.top_bar_width = None;
+    }
+
+    pub fn set_top_bar_width(&mut self, width: f32, ctx: &mut ViewContext<Self>) {
+        self.top_bar_width = Some(width);
+        self.top_bar_max_width = width;
+        ctx.notify();
     }
 
     pub fn set_menu_width(&mut self, width: f32, ctx: &mut ViewContext<Self>) {
         self.dropdown.update(ctx, |menu, ctx| {
             menu.set_width(width);
+            ctx.notify();
+        })
+    }
+    pub fn set_force_opaque_menu_background(
+        &mut self,
+        force_opaque_background: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.dropdown.update(ctx, |menu, ctx| {
+            menu.set_force_opaque_background(force_opaque_background);
             ctx.notify();
         })
     }
@@ -565,14 +584,16 @@ where
             ctx.dispatch_typed_action(DropdownAction::<A>::ToggleExpanded);
         });
 
+        let mut top_bar_box =
+            ConstrainedBox::new(top_bar_element.finish()).with_height(self.top_bar_height);
+        top_bar_box = if let Some(width) = self.top_bar_width {
+            top_bar_box.with_width(width)
+        } else {
+            top_bar_box.with_max_width(self.top_bar_max_width)
+        };
+
         SavePosition::new(
-            Container::new(
-                ConstrainedBox::new(top_bar_element.finish())
-                    .with_max_width(self.top_bar_max_width)
-                    .with_height(self.top_bar_height)
-                    .finish(),
-            )
-            .finish(),
+            Container::new(top_bar_box.finish()).finish(),
             &self.top_bar_label(),
         )
         .finish()


### PR DESCRIPTION
## Description
Fixes the native Rust client "New API key" modal dropdown styling when creating an Agent API key.

The Agent/Expiration dropdowns now:
- render their menu surface with a forced opaque theme-derived background so later modal fields do not show through
- use an exact top-bar width in addition to the existing exact menu width so the trigger and open menu stay aligned

## Linked Issue
Slack report from `feedback-platform`.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all --check`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp menu --lib`

I did not manually test with `./script/run` in this sandboxed environment.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not captured in this sandboxed environment.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/119bbc44-a4f0-42f1-bbcc-2b68d8db973b_
_Run: https://oz.staging.warp.dev/runs/019e27b7-101c-7b50-9947-bcfcc8bffee1_
_This PR was generated with [Oz](https://warp.dev/oz)._
