### PR TITLE
Don't run repo menu git stats on startup

### DIFF
--- a/app/src/terminal/input/repos/view.rs
+++ b/app/src/terminal/input/repos/view.rs
@@ -55,7 +55,6 @@ impl InlineReposMenuView {
                 },
                 ctx,
             );
-            mixer.run_query(repos_query(""), ctx);
             mixer
         });
 


### PR DESCRIPTION
## Description
Remove the eager `mixer.run_query()` call from `InlineReposMenuView::new()`. The existing `ModeChanged` subscription already re-runs the query when the `/open-repo` menu is actually opened, making the initial query redundant.

Previously, every terminal tab construction would trigger `get_repo_git_summary()` for every persisted workspace, running 3+ git commands per repo (`symbolic-ref`, `diff --shortstat`, `ls-files`). With N workspaces and M tabs, this produced N×M×3+ git processes on startup — all for data only needed when the user opens the repo menu.

[Oz conversation](https://staging.warp.dev/conversation/a1d499da-bebe-4537-818d-d9b98ad1da46) | [Plan](https://staging.warp.dev/drive/notebook/MbMDoUBj3GGOFZw1ueVqFc)

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Verified via `./script/run` that the repo menu still loads correctly when opened via `/open-repo`, and that no git stats commands are triggered on startup.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Reduced unnecessary git commands on startup by deferring repo menu stats loading until the menu is opened.
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
