### PR TITLE
Implement consistent tombstone and follow-up visibility behavior for cloud agent conversations.

### DIFF
--- a/app/src/ai/blocklist/block/pending_user_query_block.rs
+++ b/app/src/ai/blocklist/block/pending_user_query_block.rs
@@ -86,6 +86,10 @@ impl PendingUserQueryBlock {
         self.selected_text.read().clone()
     }
 
+    pub fn prompt(&self) -> &str {
+        &self.prompt
+    }
+
     /// Clears the text selection state and visual selection highlight.
     pub fn clear_selection(&mut self, ctx: &mut ViewContext<Self>) {
         self.selection_handle.clear();

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -2049,6 +2049,22 @@ impl BlocklistAIHistoryModel {
         None
     }
 
+    pub fn get_server_conversation_metadata_by_server_token(
+        &self,
+        server_token: &ServerConversationToken,
+    ) -> Option<&ServerAIConversationMetadata> {
+        self.find_conversation_id_by_server_token(server_token)
+            .and_then(|conversation_id| self.get_server_conversation_metadata(&conversation_id))
+            .or_else(|| {
+                self.all_conversations_metadata
+                    .values()
+                    .find(|metadata| {
+                        metadata.server_conversation_token.as_ref() == Some(server_token)
+                    })
+                    .and_then(|metadata| metadata.server_conversation_metadata.as_ref())
+            })
+    }
+
     /// Finds an AIConversationId by its server conversation token.
     ///
     /// O(1) lookup via `server_token_to_conversation_id`, which is maintained

--- a/app/src/ai/blocklist/history_model/conversation_loader.rs
+++ b/app/src/ai/blocklist/history_model/conversation_loader.rs
@@ -394,13 +394,11 @@ impl BlocklistAIHistoryModel {
 
             if let Some(conversation) = self.conversations_by_id.get_mut(&canonical_conversation_id)
             {
-                if conversation.server_metadata().is_none() {
-                    conversation.set_server_metadata(server_meta.clone());
-                    restored_conversations_updated += 1;
-                    log::debug!(
-                        "Updated server metadata for restored conversation {canonical_conversation_id} with token {server_token_str}"
-                    );
-                }
+                conversation.set_server_metadata(server_meta.clone());
+                restored_conversations_updated += 1;
+                log::debug!(
+                    "Updated server metadata for restored conversation {canonical_conversation_id} with token {server_token_str}"
+                );
             }
 
             let stale_metadata: Vec<(AIConversationId, AIConversationMetadata)> = self

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -547,6 +547,55 @@ fn test_merge_cloud_metadata_updates_already_restored_conversations() {
 }
 
 #[test]
+fn test_merge_cloud_metadata_refreshes_stale_restored_conversation_metadata() {
+    use crate::ai::agent::conversation::AIConversation;
+
+    App::test((), |mut app| async move {
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let terminal_view_id = EntityId::new();
+        let token = "stale-metadata-token";
+
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_server_conversation_token(token.to_string());
+        conversation.set_server_metadata(create_server_metadata(
+            "Stale Conversation",
+            token,
+            1.0,
+            None,
+        ));
+        let conversation_id = conversation.id();
+
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        history_model.update(&mut app, |model, _| {
+            model.merge_cloud_conversation_metadata(vec![create_server_metadata(
+                "Refreshed Conversation",
+                token,
+                2.0,
+                None,
+            )]);
+        });
+
+        history_model.read(&app, |model, _| {
+            let token = ServerConversationToken::new(token.to_string());
+            let metadata = model
+                .get_server_conversation_metadata_by_server_token(&token)
+                .expect("metadata should be available by server token");
+            assert_eq!(metadata.title, "Refreshed Conversation");
+            assert_eq!(metadata.usage.credits_spent, 2.0);
+
+            let conversation_metadata = model
+                .conversation(&conversation_id)
+                .and_then(|conversation| conversation.server_metadata())
+                .expect("restored conversation metadata should be refreshed");
+            assert_eq!(conversation_metadata.title, "Refreshed Conversation");
+        });
+    });
+}
+
+#[test]
 fn test_merge_cloud_metadata_reuses_restored_conversation_id_for_token() {
     use crate::ai::agent::conversation::AIConversation;
 

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -4277,7 +4277,7 @@ impl PaneGroup {
         // Insert the conversation ended tombstone (includes Open in Warp button on WASM).
         if terminal_manager.is_some() {
             terminal_view.update(ctx, |view, ctx| {
-                view.insert_conversation_ended_tombstone(ctx);
+                view.insert_conversation_ended_tombstone_with_resolved_cta(ctx);
             });
         }
 
@@ -5710,7 +5710,7 @@ impl PaneGroup {
                 shared_session::SharedSessionStatus::FinishedViewer
             };
             view.model.lock().set_shared_session_status(status);
-            view.insert_conversation_ended_tombstone(ctx);
+            view.insert_conversation_ended_tombstone_with_resolved_cta(ctx);
         });
 
         ActiveAgentViewsModel::handle(ctx).update(ctx, |active_views, ctx| {
@@ -6359,7 +6359,7 @@ impl PaneGroup {
         let terminal_view = terminal_manager.as_ref(ctx).view();
         // Insert the conversation ended tombstone (includes Open in Warp button on WASM)
         terminal_view.update(ctx, |view, ctx| {
-            view.insert_conversation_ended_tombstone(ctx);
+            view.insert_conversation_ended_tombstone_with_resolved_cta(ctx);
         });
 
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, _ctx| {

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -1065,6 +1065,12 @@ impl BlockList {
         self.pinned_to_bottom = Some(view_id);
     }
 
+    pub(in crate::terminal) fn unpin_rich_content_from_bottom(&mut self, view_id: EntityId) {
+        if self.pinned_to_bottom == Some(view_id) {
+            self.pinned_to_bottom = None;
+        }
+    }
+
     /// If a rich content item is pinned to the bottom, removes it from its
     /// current position and re-appends it so it remains last in the blocklist.
     fn maintain_pinned_to_bottom(&mut self) {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5351,14 +5351,19 @@ impl TerminalView {
         if self.pending_user_query_kind != Some(PendingUserQueryKind::CloudMode) {
             return;
         }
+        let Some(pending_prompt) = self.pending_user_query_prompt(ctx) else {
+            return;
+        };
 
         let initial_conversation_query = ai_block_model
             .conversation(ctx)
             .and_then(|conversation| conversation.initial_user_query());
         let has_renderable_user_query = ai_block_model.inputs_to_render(ctx).iter().any(|input| {
-            input
-                .display_user_query(initial_conversation_query.as_ref())
-                .is_some()
+            input.user_query().as_deref() == Some(pending_prompt)
+                || input
+                    .display_user_query(initial_conversation_query.as_ref())
+                    .as_deref()
+                    == Some(pending_prompt)
         });
         if has_renderable_user_query {
             self.remove_pending_user_query_block(ctx);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7361,6 +7361,7 @@ impl TerminalView {
         // agent exchange arrives, we hide the interactive input view. A non-interactive footer is
         // rendered instead (see `TerminalView::render`).
         if !FeatureFlag::CloudModeSetupV2.is_enabled()
+            && !FeatureFlag::HandoffCloudCloud.is_enabled()
             && ambient_agent::is_cloud_agent_pre_first_exchange(
                 self.ambient_agent_view_model.as_ref(),
                 &self.agent_view_controller,
@@ -7439,6 +7440,22 @@ impl TerminalView {
         }
 
         true
+    }
+
+    fn should_render_legacy_ambient_agent_loading_footer(
+        &self,
+        model: &TerminalModel,
+        app: &AppContext,
+    ) -> bool {
+        !model.is_read_only()
+            && !FeatureFlag::CloudModeSetupV2.is_enabled()
+            && !FeatureFlag::HandoffCloudCloud.is_enabled()
+            && ambient_agent::is_cloud_agent_pre_first_exchange(
+                self.ambient_agent_view_model.as_ref(),
+                &self.agent_view_controller,
+                model,
+                app,
+            )
     }
 
     /// Give the agent control of the active long running command
@@ -20166,7 +20183,10 @@ impl TerminalView {
         if !FeatureFlag::HandoffCloudCloud.is_enabled() {
             return false;
         }
-        let Some(task_id) = self.pending_cloud_followup_task_id else {
+        let Some(task_id) = self
+            .pending_cloud_followup_task_id
+            .or_else(|| self.owned_ambient_agent_task_id(ctx))
+        else {
             return false;
         };
 
@@ -26230,14 +26250,7 @@ impl View for TerminalView {
 
                     if self.is_input_box_visible(&model, app) {
                         column.add_child(self.render_input());
-                    } else if !model.is_read_only()
-                        && ambient_agent::is_cloud_agent_pre_first_exchange(
-                            self.ambient_agent_view_model.as_ref(),
-                            &self.agent_view_controller,
-                            &model,
-                            app,
-                        )
-                    {
+                    } else if self.should_render_legacy_ambient_agent_loading_footer(&model, app) {
                         column.add_child(ambient_agent::render_loading_footer(appearance));
                     } else if self.show_remote_server_loading_footer(&model, app) {
                         column.add_child(

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -366,7 +366,10 @@ use session_sharing_protocol::common::{
     ServerConversationToken as SessionSharingServerConversationToken,
     WindowSize as SessionSharingWindowSize,
 };
-use shared_session::{SharedSessionAdapter, Viewer};
+use shared_session::{
+    cloud_conversation_continuation::CloudConversationContinuationUiState, SharedSessionAdapter,
+    Viewer,
+};
 use std::any::Any;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -5441,6 +5444,13 @@ impl TerminalView {
         {
             self.fetch_and_update_conversation_details_panel(ctx);
         }
+        if matches!(
+            event,
+            BlocklistAIHistoryEvent::UpdatedConversationMetadata { .. }
+                | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
+        ) {
+            self.maybe_insert_tombstone_for_non_running_shared_ambient_task(ctx);
+        }
         match event {
             BlocklistAIHistoryEvent::AppendedExchange {
                 exchange_id,
@@ -5798,7 +5808,7 @@ impl TerminalView {
                         if !conversation.status().is_in_progress()
                             && conversation_output_status_from_conversation(conversation).is_some()
                         {
-                            self.insert_conversation_ended_tombstone(ctx);
+                            self.insert_conversation_ended_tombstone_with_cta(None, ctx);
                         }
                     }
                 }
@@ -7177,17 +7187,27 @@ impl TerminalView {
             return;
         }
 
-        let can_continue_owned_task_in_cloud = self.owned_ambient_agent_task_id(ctx).is_some()
-            && FeatureFlag::HandoffCloudCloud.is_enabled();
-        if !can_continue_owned_task_in_cloud {
-            self.insert_conversation_ended_tombstone(ctx);
-        } else if !self
-            .model
-            .lock()
-            .shared_session_status()
-            .is_sharer_or_viewer()
-        {
-            self.enable_owned_cloud_followup_input(task_id, ctx)
+        if FeatureFlag::HandoffCloudCloud.is_enabled() {
+            let has_live_shared_session = {
+                let status = self.model.lock().shared_session_status().clone();
+                status.is_active_viewer() || status.is_active_sharer()
+            };
+            if has_live_shared_session {
+                return;
+            }
+            let Some(state) = self.cloud_conversation_continuation_ui_state(ctx) else {
+                return;
+            };
+            match state {
+                CloudConversationContinuationUiState::Tombstone { cta } => {
+                    self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
+                }
+                CloudConversationContinuationUiState::FollowupInput => {
+                    self.enable_cloud_followup_input(task_id, ctx);
+                }
+            }
+        } else {
+            self.insert_conversation_ended_tombstone_with_cta(None, ctx);
         }
     }
 
@@ -20146,10 +20166,7 @@ impl TerminalView {
         if !FeatureFlag::HandoffCloudCloud.is_enabled() {
             return false;
         }
-        let Some(task_id) = self
-            .pending_cloud_followup_task_id
-            .or_else(|| self.owned_ambient_agent_task_id(ctx))
-        else {
+        let Some(task_id) = self.pending_cloud_followup_task_id else {
             return false;
         };
 

--- a/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
+++ b/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
@@ -16,9 +16,7 @@ use crate::{
         inline_action::inline_action_icons,
         BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
     },
-    terminal::view::ambient_agent::{
-        block::SETUP_TEXT_BOTTOM_MARGIN, AmbientAgentViewModel, AmbientAgentViewModelEvent,
-    },
+    terminal::view::ambient_agent::{AmbientAgentViewModel, AmbientAgentViewModelEvent},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
+++ b/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
@@ -16,7 +16,9 @@ use crate::{
         inline_action::inline_action_icons,
         BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
     },
-    terminal::view::ambient_agent::{AmbientAgentViewModel, AmbientAgentViewModelEvent},
+    terminal::view::ambient_agent::{
+        block::SETUP_TEXT_BOTTOM_MARGIN, AmbientAgentViewModel, AmbientAgentViewModelEvent,
+    },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -218,6 +220,7 @@ impl View for CloudModeSetupTextBlock {
             &self.ambient_agent_view_model,
             app,
         )
+        .with_margin_top(8.)
         .finish()
     }
 }

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -232,7 +232,7 @@ impl TerminalView {
                 );
 
                 if FeatureFlag::CloudModeSetupV2.is_enabled() {
-                    self.insert_conversation_ended_tombstone(ctx);
+                    self.insert_conversation_ended_tombstone_with_resolved_cta(ctx);
                 }
 
                 // Refresh the details panel to show failed status

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -102,18 +102,21 @@ impl TerminalView {
         };
 
         // Tear down the cloud-mode queued-prompt block on terminal / transition
-        // events that replace it. `Failed`, `NeedsGithubAuth`, and `Cancelled` hand off
+        // events that replace it. Legacy `Failed`, `NeedsGithubAuth`, and `Cancelled` hand off
         // to the existing error / auth / cancelled UI; `HarnessCommandStarted` hands
         // off to the live third-party harness CLI block. Idempotent and cheap when no
         // block exists.
-        if matches!(
-            event,
-            AmbientAgentViewModelEvent::Failed { .. }
-                | AmbientAgentViewModelEvent::NeedsGithubAuth
-                | AmbientAgentViewModelEvent::Cancelled
-                | AmbientAgentViewModelEvent::HarnessCommandStarted { .. }
-                | AmbientAgentViewModelEvent::HandoffSnapshotUploadFailed { .. }
-        ) {
+        let should_remove_pending_user_query = match event {
+            AmbientAgentViewModelEvent::Failed { .. } => {
+                !FeatureFlag::CloudModeSetupV2.is_enabled()
+            }
+            AmbientAgentViewModelEvent::NeedsGithubAuth
+            | AmbientAgentViewModelEvent::Cancelled
+            | AmbientAgentViewModelEvent::HarnessCommandStarted { .. }
+            | AmbientAgentViewModelEvent::HandoffSnapshotUploadFailed { .. } => true,
+            _ => false,
+        };
+        if should_remove_pending_user_query {
             self.remove_pending_user_query_block(ctx);
         }
 

--- a/app/src/terminal/view/pending_user_query.rs
+++ b/app/src/terminal/view/pending_user_query.rs
@@ -1,5 +1,5 @@
 use warp_core::features::FeatureFlag;
-use warpui::{SingletonEntity, ViewContext};
+use warpui::{AppContext, SingletonEntity, ViewContext};
 
 use crate::{
     ai::{
@@ -13,6 +13,20 @@ use crate::{
 use super::rich_content::RichContentMetadata;
 
 impl TerminalView {
+    pub(super) fn pending_user_query_prompt<'a>(&'a self, ctx: &'a AppContext) -> Option<&'a str> {
+        let view_id = self.pending_user_query_view_id?;
+        self.rich_content_views
+            .iter()
+            .find_map(|rich_content| match rich_content.metadata() {
+                Some(RichContentMetadata::PendingUserQuery {
+                    pending_user_query_block_handle,
+                }) if pending_user_query_block_handle.id() == view_id => {
+                    Some(pending_user_query_block_handle.as_ref(ctx).prompt())
+                }
+                _ => None,
+            })
+    }
+
     pub(super) fn pending_user_query_conversation_id(&self) -> Option<AIConversationId> {
         let view_id = self.pending_user_query_view_id?;
         self.rich_content_views

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
@@ -1,0 +1,210 @@
+use crate::ai::agent::api::ServerConversationToken;
+use crate::ai::agent::conversation::{
+    AIAgentHarness, AIConversationId, ServerAIConversationMetadata,
+};
+use crate::ai::agent_conversations_model::AgentConversationsModel;
+use crate::ai::ambient_agents::{
+    conversation_output_status_from_conversation, AmbientAgentTaskId, AmbientConversationStatus,
+};
+use crate::ai::blocklist::BlocklistAIHistoryModel;
+use crate::auth::AuthStateProvider;
+use crate::cloud_object::{Owner, ServerGuestSubject};
+use crate::drive::sharing::SharingAccessLevel;
+use crate::workspaces::user_workspaces::UserWorkspaces;
+use warpui::{AppContext, EntityId, SingletonEntity};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TombstoneCta {
+    ContinueLocally { conversation_id: AIConversationId },
+    ContinueInCloud { task_id: AmbientAgentTaskId },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::terminal::view) enum CloudConversationContinuationUiState {
+    FollowupInput,
+    Tombstone { cta: Option<TombstoneCta> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::terminal::view) enum CloudConversationContinuationError {
+    MissingTask,
+    ActiveTaskExecution,
+    MissingConversationToken,
+    MissingServerConversationMetadata,
+    UnknownHarness,
+    UnknownConversationAccess,
+}
+
+impl CloudConversationContinuationError {
+    pub(in crate::terminal::view) fn should_fallback_to_tombstone(self) -> bool {
+        !matches!(self, Self::ActiveTaskExecution)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConversationAccess {
+    Edit,
+    ViewOnly,
+    Unknown,
+}
+
+pub(in crate::terminal::view) fn resolve_cloud_conversation_continuation_ui_state(
+    terminal_view_id: EntityId,
+    task_id: AmbientAgentTaskId,
+    app: &AppContext,
+) -> Result<CloudConversationContinuationUiState, CloudConversationContinuationError> {
+    let Some(task) = AgentConversationsModel::as_ref(app).get_task_data(&task_id) else {
+        return Err(CloudConversationContinuationError::MissingTask);
+    };
+    if task.has_active_execution() {
+        return Err(CloudConversationContinuationError::ActiveTaskExecution);
+    }
+    if task.state.is_failure_like()
+        && task
+            .status_message
+            .as_ref()
+            .is_some_and(|status_message| status_message.is_environment_setup_failure())
+    {
+        return Ok(CloudConversationContinuationUiState::Tombstone { cta: None });
+    }
+
+    let Some(conversation_token) = task
+        .conversation_id()
+        .map(|token| ServerConversationToken::new(token.to_string()))
+    else {
+        return Err(CloudConversationContinuationError::MissingConversationToken);
+    };
+    let history_model = BlocklistAIHistoryModel::as_ref(app);
+    let Some(metadata) =
+        history_model.get_server_conversation_metadata_by_server_token(&conversation_token)
+    else {
+        return Err(CloudConversationContinuationError::MissingServerConversationMetadata);
+    };
+
+    let access = conversation_access(metadata, app);
+    match (metadata.harness, access) {
+        (AIAgentHarness::Oz, ConversationAccess::Edit) => {
+            Ok(CloudConversationContinuationUiState::FollowupInput)
+        }
+        (AIAgentHarness::Oz, ConversationAccess::ViewOnly) => {
+            let local_conversation_id = local_conversation_id_for_local_continuation(
+                terminal_view_id,
+                &conversation_token,
+                history_model,
+            );
+            Ok(CloudConversationContinuationUiState::Tombstone {
+                cta: local_conversation_id
+                    .map(|conversation_id| TombstoneCta::ContinueLocally { conversation_id }),
+            })
+        }
+        (
+            AIAgentHarness::ClaudeCode | AIAgentHarness::Gemini | AIAgentHarness::Codex,
+            ConversationAccess::Edit,
+        ) => Ok(CloudConversationContinuationUiState::Tombstone {
+            cta: Some(TombstoneCta::ContinueInCloud { task_id }),
+        }),
+        (
+            AIAgentHarness::ClaudeCode | AIAgentHarness::Gemini | AIAgentHarness::Codex,
+            ConversationAccess::ViewOnly,
+        ) => Ok(CloudConversationContinuationUiState::Tombstone { cta: None }),
+        (AIAgentHarness::Unknown, _) => Err(CloudConversationContinuationError::UnknownHarness),
+        (_, ConversationAccess::Unknown) => {
+            Err(CloudConversationContinuationError::UnknownConversationAccess)
+        }
+    }
+}
+
+fn conversation_access(
+    metadata: &ServerAIConversationMetadata,
+    app: &AppContext,
+) -> ConversationAccess {
+    let Some(current_user_uid) = AuthStateProvider::as_ref(app).get().user_id() else {
+        return ConversationAccess::Unknown;
+    };
+
+    let mut access_level = SharingAccessLevel::View;
+    match metadata.permissions.space {
+        Owner::User { user_uid } => {
+            let is_current_user_owner = user_uid == current_user_uid;
+            if is_current_user_owner {
+                access_level = access_level.max(SharingAccessLevel::Full);
+            }
+        }
+        Owner::Team { team_uid } => {
+            let is_current_team_owner = UserWorkspaces::as_ref(app)
+                .team_from_uid_across_all_workspaces(team_uid)
+                .is_some();
+            if is_current_team_owner {
+                access_level = access_level.max(SharingAccessLevel::Full);
+            }
+        }
+    }
+
+    if let Some(link_sharing) = &metadata.permissions.anyone_link_sharing {
+        access_level = access_level.max(link_sharing.access_level.into());
+    }
+
+    // Direct user and team ACLs can both apply, so use the highest matching grant.
+    for guest in &metadata.permissions.guests {
+        match &guest.subject {
+            ServerGuestSubject::User { firebase_uid } => {
+                let matches_current_user = firebase_uid == current_user_uid.as_str();
+                if matches_current_user {
+                    access_level = access_level.max(guest.access_level.into());
+                }
+            }
+            ServerGuestSubject::Team { team_uid } => {
+                let matches_current_team = UserWorkspaces::as_ref(app)
+                    .team_from_uid_across_all_workspaces(*team_uid)
+                    .is_some();
+                if matches_current_team {
+                    access_level = access_level.max(guest.access_level.into());
+                }
+            }
+            ServerGuestSubject::PendingUser { .. } => {}
+        }
+    }
+    let is_creator = metadata
+        .metadata
+        .creator_uid
+        .as_ref()
+        .is_some_and(|creator_uid| creator_uid == current_user_uid.as_str());
+    if is_creator {
+        access_level = access_level.max(SharingAccessLevel::Edit);
+    }
+    if access_level >= SharingAccessLevel::Edit {
+        ConversationAccess::Edit
+    } else {
+        ConversationAccess::ViewOnly
+    }
+}
+
+pub(in crate::terminal::view) fn conversation_failed_before_task_creation(
+    terminal_view_id: EntityId,
+    history_model: &BlocklistAIHistoryModel,
+) -> bool {
+    if history_model.is_terminal_view_conversation_transcript_viewer(terminal_view_id) {
+        return false;
+    }
+    history_model
+        .all_live_conversations_for_terminal_view(terminal_view_id)
+        .next()
+        .and_then(conversation_output_status_from_conversation)
+        .is_some_and(|status| matches!(status, AmbientConversationStatus::Error { .. }))
+}
+
+fn local_conversation_id_for_local_continuation(
+    terminal_view_id: EntityId,
+    conversation_token: &ServerConversationToken,
+    history_model: &BlocklistAIHistoryModel,
+) -> Option<AIConversationId> {
+    history_model
+        .all_live_conversations_for_terminal_view(terminal_view_id)
+        .find(|conversation| conversation.server_conversation_token() == Some(conversation_token))
+        .map(|conversation| conversation.id())
+        .or_else(|| history_model.find_conversation_id_by_server_token(conversation_token))
+}
+
+#[cfg(test)]
+#[path = "cloud_conversation_continuation_tests.rs"]
+mod tests;

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
@@ -4,13 +4,15 @@ use crate::ai::agent::conversation::{
 };
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::{
-    conversation_output_status_from_conversation, AmbientAgentTaskId, AmbientConversationStatus,
+    conversation_output_status_from_conversation, AmbientAgentTask, AmbientAgentTaskId,
+    AmbientConversationStatus,
 };
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::auth::AuthStateProvider;
 use crate::cloud_object::{Owner, ServerGuestSubject};
 use crate::drive::sharing::SharingAccessLevel;
 use crate::workspaces::user_workspaces::UserWorkspaces;
+use warp_cli::agent::Harness;
 use warpui::{AppContext, EntityId, SingletonEntity};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,43 +61,76 @@ pub(in crate::terminal::view) fn resolve_cloud_conversation_continuation_ui_stat
     if task.has_active_execution() {
         return Err(CloudConversationContinuationError::ActiveTaskExecution);
     }
-    if task.state.is_failure_like()
+    let is_environment_setup_failure = task.state.is_failure_like()
         && task
             .status_message
             .as_ref()
-            .is_some_and(|status_message| status_message.is_environment_setup_failure())
-    {
+            .is_some_and(|status_message| status_message.is_environment_setup_failure());
+    if is_environment_setup_failure && task.conversation_id().is_none() {
         return Ok(CloudConversationContinuationUiState::Tombstone { cta: None });
     }
-
-    let Some(conversation_token) = task
+    let conversation_token = task
         .conversation_id()
-        .map(|token| ServerConversationToken::new(token.to_string()))
-    else {
-        return Err(CloudConversationContinuationError::MissingConversationToken);
-    };
+        .map(|token| ServerConversationToken::new(token.to_string()));
     let history_model = BlocklistAIHistoryModel::as_ref(app);
-    let Some(metadata) =
-        history_model.get_server_conversation_metadata_by_server_token(&conversation_token)
-    else {
-        return Err(CloudConversationContinuationError::MissingServerConversationMetadata);
-    };
 
-    let access = conversation_access(metadata, app);
-    match (metadata.harness, access) {
+    if let Some(conversation_token) = conversation_token.as_ref() {
+        if let Some(metadata) =
+            history_model.get_server_conversation_metadata_by_server_token(conversation_token)
+        {
+            return continuation_ui_state_for_harness_and_access(
+                metadata.harness,
+                conversation_access(metadata, app),
+                terminal_view_id,
+                Some(conversation_token),
+                task_id,
+                history_model,
+            );
+        }
+    }
+
+    let access = task_creator_access(&task, app);
+    if access == ConversationAccess::Edit {
+        return continuation_ui_state_for_harness_and_access(
+            task_harness(&task),
+            access,
+            terminal_view_id,
+            conversation_token.as_ref(),
+            task_id,
+            history_model,
+        );
+    }
+
+    if conversation_token.is_none() {
+        Err(CloudConversationContinuationError::MissingConversationToken)
+    } else {
+        Err(CloudConversationContinuationError::MissingServerConversationMetadata)
+    }
+}
+
+fn continuation_ui_state_for_harness_and_access(
+    harness: AIAgentHarness,
+    access: ConversationAccess,
+    terminal_view_id: EntityId,
+    conversation_token: Option<&ServerConversationToken>,
+    task_id: AmbientAgentTaskId,
+    history_model: &BlocklistAIHistoryModel,
+) -> Result<CloudConversationContinuationUiState, CloudConversationContinuationError> {
+    match (harness, access) {
         (AIAgentHarness::Oz, ConversationAccess::Edit) => {
             Ok(CloudConversationContinuationUiState::FollowupInput)
         }
         (AIAgentHarness::Oz, ConversationAccess::ViewOnly) => {
-            let local_conversation_id = local_conversation_id_for_local_continuation(
-                terminal_view_id,
-                &conversation_token,
-                history_model,
-            );
-            Ok(CloudConversationContinuationUiState::Tombstone {
-                cta: local_conversation_id
-                    .map(|conversation_id| TombstoneCta::ContinueLocally { conversation_id }),
-            })
+            let cta = conversation_token
+                .and_then(|conversation_token| {
+                    local_conversation_id_for_local_continuation(
+                        terminal_view_id,
+                        conversation_token,
+                        history_model,
+                    )
+                })
+                .map(|conversation_id| TombstoneCta::ContinueLocally { conversation_id });
+            Ok(CloudConversationContinuationUiState::Tombstone { cta })
         }
         (
             AIAgentHarness::ClaudeCode | AIAgentHarness::Gemini | AIAgentHarness::Codex,
@@ -176,6 +211,38 @@ fn conversation_access(
         ConversationAccess::Edit
     } else {
         ConversationAccess::ViewOnly
+    }
+}
+
+fn task_creator_access(task: &AmbientAgentTask, app: &AppContext) -> ConversationAccess {
+    let Some(current_user_uid) = AuthStateProvider::as_ref(app).get().user_id() else {
+        return ConversationAccess::Unknown;
+    };
+
+    if task
+        .creator
+        .as_ref()
+        .is_some_and(|creator| creator.uid == current_user_uid.as_str())
+    {
+        ConversationAccess::Edit
+    } else {
+        ConversationAccess::Unknown
+    }
+}
+
+fn task_harness(task: &AmbientAgentTask) -> AIAgentHarness {
+    match task
+        .agent_config_snapshot
+        .as_ref()
+        .and_then(|config| config.harness.as_ref())
+        .map(|harness| harness.harness_type)
+        .unwrap_or(Harness::Oz)
+    {
+        Harness::Oz => AIAgentHarness::Oz,
+        Harness::Claude => AIAgentHarness::ClaudeCode,
+        Harness::Gemini => AIAgentHarness::Gemini,
+        Harness::Codex => AIAgentHarness::Codex,
+        Harness::OpenCode | Harness::Unknown => AIAgentHarness::Unknown,
     }
 }
 

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -4,7 +4,9 @@ use persistence::model::ConversationUsageMetadata;
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{AIAgentHarness, ServerAIConversationMetadata};
 use crate::ai::agent_conversations_model::AgentConversationsModel;
-use crate::ai::ambient_agents::task::{TaskPrincipalInfo, TaskStatusErrorCode, TaskStatusMessage};
+use crate::ai::ambient_agents::task::{
+    AgentConfigSnapshot, HarnessConfig, TaskPrincipalInfo, TaskStatusErrorCode, TaskStatusMessage,
+};
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState};
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
 use crate::auth::user::TEST_USER_UID;
@@ -20,6 +22,7 @@ use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::workspaces::workspace::Workspace;
 use crate::FeatureFlag;
 use std::sync::Arc;
+use warp_cli::agent::Harness;
 use warp_graphql::object_permissions::AccessLevel;
 use warpui::{App, EntityId, SingletonEntity};
 
@@ -115,6 +118,14 @@ fn setup_app_with_creator(
 }
 
 fn setup_task_without_server_metadata(app: &mut App) -> TestHandles {
+    setup_task_without_server_metadata_for_creator(app, "other-user")
+}
+
+fn setup_owned_task_without_server_metadata(app: &mut App) -> TestHandles {
+    setup_task_without_server_metadata_for_creator(app, TEST_USER_UID)
+}
+
+fn setup_task_without_server_metadata_for_creator(app: &mut App, creator_uid: &str) -> TestHandles {
     let _agent_management_guard = FeatureFlag::AgentManagementView.override_enabled(false);
     app.add_singleton_model(|_| AuthStateProvider::new_for_test());
     app.add_singleton_model(UserWorkspaces::default_mock);
@@ -127,7 +138,8 @@ fn setup_task_without_server_metadata(app: &mut App) -> TestHandles {
         task_id,
         CONVERSATION_TOKEN,
         AmbientAgentTaskState::Succeeded,
-    );
+    )
+    .with_creator(creator_uid);
     AgentConversationsModel::handle(app).update(app, |model, _| {
         model.insert_task_for_test(task);
     });
@@ -188,6 +200,33 @@ fn active_ambient_agent_task(task_id: AmbientAgentTaskId) -> AmbientAgentTask {
     task.session_link = Some("https://example.com/session/active".to_string());
     task.is_sandbox_running = true;
     task
+}
+
+trait AmbientAgentTaskTestExt {
+    fn with_creator(self, creator_uid: &str) -> Self;
+    fn with_harness(self, harness: Harness) -> Self;
+}
+
+impl AmbientAgentTaskTestExt for AmbientAgentTask {
+    fn with_creator(mut self, creator_uid: &str) -> Self {
+        self.creator = Some(TaskPrincipalInfo {
+            creator_type: "USER".to_string(),
+            uid: creator_uid.to_string(),
+            display_name: None,
+        });
+        self
+    }
+
+    fn with_harness(mut self, harness: Harness) -> Self {
+        self.agent_config_snapshot = Some(AgentConfigSnapshot {
+            harness: (harness != Harness::Oz).then_some(HarnessConfig {
+                harness_type: harness,
+                model_id: None,
+            }),
+            ..Default::default()
+        });
+        self
+    }
 }
 
 fn current_team_uid() -> ServerId {
@@ -387,7 +426,42 @@ fn third_party_conversation_with_edit_access_shows_continue_in_cloud_tombstone()
 }
 
 #[test]
-fn environment_setup_failure_shows_tombstone_without_cta() {
+fn environment_setup_failure_without_conversation_shows_tombstone_without_cta() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::ClaudeCode,
+            ConversationPermissionFixture::CurrentUserOwner,
+        );
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            let mut task =
+                ambient_agent_task(task_id, CONVERSATION_TOKEN, AmbientAgentTaskState::Failed);
+            task.conversation_id = None;
+            task.status_message = Some(TaskStatusMessage {
+                message: "Environment setup failed: Failed to run setup command: hi".to_string(),
+                error_code: Some(TaskStatusErrorCode::EnvironmentSetupFailed),
+            });
+            model.insert_task_for_test(task);
+        });
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::Tombstone { cta: None })
+            );
+        });
+    });
+}
+
+#[test]
+fn environment_setup_failure_with_conversation_shows_continue_cta() {
     App::test((), |mut app| async move {
         let TestHandles {
             terminal_view_id,
@@ -414,11 +488,14 @@ fn environment_setup_failure_shows_tombstone_without_cta() {
 
             assert_eq!(
                 state,
-                Ok(CloudConversationContinuationUiState::Tombstone { cta: None })
+                Ok(CloudConversationContinuationUiState::Tombstone {
+                    cta: Some(TombstoneCta::ContinueInCloud { task_id }),
+                })
             );
         });
     });
 }
+
 #[test]
 fn third_party_conversation_created_by_current_user_shows_continue_in_cloud_tombstone() {
     App::test((), |mut app| async move {
@@ -500,6 +577,7 @@ fn third_party_conversation_shared_with_current_team_as_editor_shows_continue_in
         });
     });
 }
+
 #[test]
 fn third_party_conversation_with_view_access_shows_tombstone_without_cta() {
     App::test((), |mut app| async move {
@@ -564,6 +642,59 @@ fn missing_metadata_returns_error() {
             assert_eq!(
                 state,
                 Err(CloudConversationContinuationError::MissingServerConversationMetadata)
+            );
+        });
+    });
+}
+
+#[test]
+fn owned_oz_task_without_metadata_shows_inline_followup_input() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_owned_task_without_server_metadata(&mut app);
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::FollowupInput)
+            );
+        });
+    });
+}
+
+#[test]
+fn owned_third_party_task_without_metadata_shows_continue_in_cloud_tombstone() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_owned_task_without_server_metadata(&mut app);
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(
+                ambient_agent_task(
+                    task_id,
+                    CONVERSATION_TOKEN,
+                    AmbientAgentTaskState::Succeeded,
+                )
+                .with_creator(TEST_USER_UID)
+                .with_harness(Harness::Claude),
+            );
+        });
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::Tombstone {
+                    cta: Some(TombstoneCta::ContinueInCloud { task_id }),
+                })
             );
         });
     });

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -1,0 +1,598 @@
+use chrono::Utc;
+use persistence::model::ConversationUsageMetadata;
+
+use crate::ai::agent::api::ServerConversationToken;
+use crate::ai::agent::conversation::{AIAgentHarness, ServerAIConversationMetadata};
+use crate::ai::agent_conversations_model::AgentConversationsModel;
+use crate::ai::ambient_agents::task::{TaskPrincipalInfo, TaskStatusErrorCode, TaskStatusMessage};
+use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState};
+use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
+use crate::auth::user::TEST_USER_UID;
+use crate::auth::{AuthStateProvider, UserUid};
+use crate::cloud_object::{
+    Owner, Revision, ServerGuestSubject, ServerMetadata, ServerObjectGuest, ServerPermissions,
+};
+use crate::server::ids::ServerId;
+use crate::server::server_api::team::MockTeamClient;
+use crate::server::server_api::workspace::MockWorkspaceClient;
+use crate::workspaces::team::Team;
+use crate::workspaces::user_workspaces::UserWorkspaces;
+use crate::workspaces::workspace::Workspace;
+use crate::FeatureFlag;
+use std::sync::Arc;
+use warp_graphql::object_permissions::AccessLevel;
+use warpui::{App, EntityId, SingletonEntity};
+
+use super::*;
+
+const CONVERSATION_TOKEN: &str = "server-conversation-token";
+
+#[derive(Clone, Copy)]
+enum AuthFixture {
+    LoggedIn,
+    LoggedOut,
+}
+
+#[derive(Clone, Copy)]
+enum ConversationPermissionFixture {
+    CurrentUserOwner,
+    OtherUserOwner,
+    CurrentTeamOwner,
+    CurrentTeamEditorGuest,
+}
+
+struct TestHandles {
+    terminal_view_id: EntityId,
+    task_id: AmbientAgentTaskId,
+}
+
+fn setup_app(
+    app: &mut App,
+    auth_fixture: AuthFixture,
+    harness: AIAgentHarness,
+    permissions_fixture: ConversationPermissionFixture,
+) -> TestHandles {
+    setup_app_with_creator(app, auth_fixture, harness, permissions_fixture, None)
+}
+
+fn setup_app_with_creator(
+    app: &mut App,
+    auth_fixture: AuthFixture,
+    harness: AIAgentHarness,
+    permissions_fixture: ConversationPermissionFixture,
+    creator_uid: Option<String>,
+) -> TestHandles {
+    let _agent_management_guard = FeatureFlag::AgentManagementView.override_enabled(false);
+    match auth_fixture {
+        AuthFixture::LoggedIn => {
+            app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        }
+        AuthFixture::LoggedOut => {
+            app.add_singleton_model(|_| AuthStateProvider::new_logged_out_for_test());
+        }
+    }
+    let workspaces = workspaces_for_permission_fixture(permissions_fixture);
+    app.add_singleton_model(|ctx| {
+        UserWorkspaces::mock(
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+            workspaces,
+            ctx,
+        )
+    });
+    app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+    app.add_singleton_model(AgentConversationsModel::new);
+
+    let terminal_view_id = EntityId::new();
+    let task_id = ambient_task_id(1);
+    let task = ambient_agent_task(
+        task_id,
+        CONVERSATION_TOKEN,
+        AmbientAgentTaskState::Succeeded,
+    );
+
+    AgentConversationsModel::handle(app).update(app, |model, _| {
+        model.insert_task_for_test(task);
+    });
+    BlocklistAIHistoryModel::handle(app).update(app, |model, ctx| {
+        let conversation_id =
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx);
+        model.set_server_conversation_token_for_conversation(
+            conversation_id,
+            CONVERSATION_TOKEN.to_string(),
+        );
+        model.set_server_metadata_for_conversation(
+            conversation_id,
+            server_conversation_metadata(harness, permissions_fixture, Some(task_id), creator_uid),
+            ctx,
+        );
+    });
+
+    TestHandles {
+        terminal_view_id,
+        task_id,
+    }
+}
+
+fn setup_task_without_server_metadata(app: &mut App) -> TestHandles {
+    let _agent_management_guard = FeatureFlag::AgentManagementView.override_enabled(false);
+    app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+    app.add_singleton_model(UserWorkspaces::default_mock);
+    app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+    app.add_singleton_model(AgentConversationsModel::new);
+
+    let terminal_view_id = EntityId::new();
+    let task_id = ambient_task_id(1);
+    let task = ambient_agent_task(
+        task_id,
+        CONVERSATION_TOKEN,
+        AmbientAgentTaskState::Succeeded,
+    );
+    AgentConversationsModel::handle(app).update(app, |model, _| {
+        model.insert_task_for_test(task);
+    });
+
+    TestHandles {
+        terminal_view_id,
+        task_id,
+    }
+}
+
+fn ambient_task_id(index: usize) -> AmbientAgentTaskId {
+    format!("550e8400-e29b-41d4-a716-{index:012}")
+        .parse()
+        .unwrap()
+}
+
+fn ambient_agent_task(
+    task_id: AmbientAgentTaskId,
+    conversation_token: &str,
+    state: AmbientAgentTaskState,
+) -> AmbientAgentTask {
+    let now = Utc::now();
+    AmbientAgentTask {
+        task_id,
+        parent_run_id: None,
+        title: "Task".to_string(),
+        state,
+        prompt: "test".to_string(),
+        created_at: now,
+        started_at: Some(now),
+        updated_at: now,
+        status_message: None,
+        source: None,
+        session_id: None,
+        session_link: None,
+        creator: Some(TaskPrincipalInfo {
+            creator_type: "USER".to_string(),
+            uid: TEST_USER_UID.to_string(),
+            display_name: None,
+        }),
+        executor: None,
+        conversation_id: Some(conversation_token.to_string()),
+        request_usage: None,
+        is_sandbox_running: false,
+        agent_config_snapshot: None,
+        artifacts: vec![],
+        last_event_sequence: None,
+        children: vec![],
+    }
+}
+
+fn active_ambient_agent_task(task_id: AmbientAgentTaskId) -> AmbientAgentTask {
+    let mut task = ambient_agent_task(
+        task_id,
+        CONVERSATION_TOKEN,
+        AmbientAgentTaskState::InProgress,
+    );
+    task.session_link = Some("https://example.com/session/active".to_string());
+    task.is_sandbox_running = true;
+    task
+}
+
+fn current_team_uid() -> ServerId {
+    ServerId::from(123)
+}
+
+fn workspaces_for_permission_fixture(
+    permissions_fixture: ConversationPermissionFixture,
+) -> Vec<Workspace> {
+    match permissions_fixture {
+        ConversationPermissionFixture::CurrentTeamOwner
+        | ConversationPermissionFixture::CurrentTeamEditorGuest => {
+            vec![Workspace::from_local_cache(
+                ServerId::from(456).into(),
+                "Test Workspace".to_string(),
+                Some(vec![Team::from_local_cache(
+                    current_team_uid(),
+                    "Test Team".to_string(),
+                    None,
+                    None,
+                    None,
+                )]),
+            )]
+        }
+        ConversationPermissionFixture::CurrentUserOwner
+        | ConversationPermissionFixture::OtherUserOwner => vec![],
+    }
+}
+
+fn server_conversation_metadata(
+    harness: AIAgentHarness,
+    permissions_fixture: ConversationPermissionFixture,
+    ambient_agent_task_id: Option<AmbientAgentTaskId>,
+    creator_uid: Option<String>,
+) -> ServerAIConversationMetadata {
+    ServerAIConversationMetadata {
+        title: "Conversation".to_string(),
+        working_directory: None,
+        harness,
+        usage: ConversationUsageMetadata {
+            was_summarized: false,
+            context_window_usage: 0.0,
+            credits_spent: 0.0,
+            credits_spent_for_last_block: None,
+            token_usage: vec![],
+            tool_usage_metadata: Default::default(),
+        },
+        metadata: server_metadata(creator_uid),
+        permissions: server_permissions(permissions_fixture),
+        ambient_agent_task_id,
+        server_conversation_token: ServerConversationToken::new(CONVERSATION_TOKEN.to_string()),
+        artifacts: vec![],
+    }
+}
+fn server_metadata(creator_uid: Option<String>) -> ServerMetadata {
+    ServerMetadata {
+        uid: ServerId::default(),
+        revision: Revision::now(),
+        metadata_last_updated_ts: Utc::now().into(),
+        trashed_ts: None,
+        folder_id: None,
+        is_welcome_object: false,
+        creator_uid,
+        last_editor_uid: None,
+        current_editor_uid: None,
+    }
+}
+
+fn server_permissions(permissions_fixture: ConversationPermissionFixture) -> ServerPermissions {
+    let space = match permissions_fixture {
+        ConversationPermissionFixture::CurrentUserOwner => Owner::mock_current_user(),
+        ConversationPermissionFixture::OtherUserOwner
+        | ConversationPermissionFixture::CurrentTeamEditorGuest => Owner::User {
+            user_uid: UserUid::new("other-user"),
+        },
+        ConversationPermissionFixture::CurrentTeamOwner => Owner::Team {
+            team_uid: current_team_uid(),
+        },
+    };
+    let guests = match permissions_fixture {
+        ConversationPermissionFixture::CurrentTeamEditorGuest => vec![ServerObjectGuest {
+            subject: ServerGuestSubject::Team {
+                team_uid: current_team_uid(),
+            },
+            access_level: AccessLevel::Editor,
+            source: None,
+        }],
+        ConversationPermissionFixture::CurrentUserOwner
+        | ConversationPermissionFixture::OtherUserOwner
+        | ConversationPermissionFixture::CurrentTeamOwner => vec![],
+    };
+
+    ServerPermissions {
+        space,
+        guests,
+        anyone_link_sharing: None,
+        permissions_last_updated_ts: Utc::now().into(),
+    }
+}
+
+#[test]
+fn missing_task_returns_error() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id, ..
+        } = setup_task_without_server_metadata(&mut app);
+        let missing_task_id = ambient_task_id(2);
+
+        app.update(|ctx| {
+            let state = resolve_cloud_conversation_continuation_ui_state(
+                terminal_view_id,
+                missing_task_id,
+                ctx,
+            );
+            assert_eq!(state, Err(CloudConversationContinuationError::MissingTask));
+        });
+    });
+}
+
+#[test]
+fn oz_conversation_with_edit_access_shows_inline_followup_input() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::Oz,
+            ConversationPermissionFixture::CurrentUserOwner,
+        );
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::FollowupInput)
+            );
+        });
+    });
+}
+
+#[test]
+fn oz_conversation_with_view_access_shows_continue_locally_tombstone() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::Oz,
+            ConversationPermissionFixture::OtherUserOwner,
+        );
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx)
+                    .unwrap();
+
+            assert!(matches!(
+                state,
+                CloudConversationContinuationUiState::Tombstone {
+                    cta: Some(TombstoneCta::ContinueLocally { .. })
+                }
+            ));
+        });
+    });
+}
+
+#[test]
+fn third_party_conversation_with_edit_access_shows_continue_in_cloud_tombstone() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::ClaudeCode,
+            ConversationPermissionFixture::CurrentUserOwner,
+        );
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::Tombstone {
+                    cta: Some(TombstoneCta::ContinueInCloud { task_id }),
+                })
+            );
+        });
+    });
+}
+
+#[test]
+fn environment_setup_failure_shows_tombstone_without_cta() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::ClaudeCode,
+            ConversationPermissionFixture::CurrentUserOwner,
+        );
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            let mut task =
+                ambient_agent_task(task_id, CONVERSATION_TOKEN, AmbientAgentTaskState::Failed);
+            task.status_message = Some(TaskStatusMessage {
+                message: "Environment setup failed: Failed to run setup command: hi".to_string(),
+                error_code: Some(TaskStatusErrorCode::EnvironmentSetupFailed),
+            });
+            model.insert_task_for_test(task);
+        });
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::Tombstone { cta: None })
+            );
+        });
+    });
+}
+#[test]
+fn third_party_conversation_created_by_current_user_shows_continue_in_cloud_tombstone() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app_with_creator(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::ClaudeCode,
+            ConversationPermissionFixture::OtherUserOwner,
+            Some(TEST_USER_UID.to_string()),
+        );
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::Tombstone {
+                    cta: Some(TombstoneCta::ContinueInCloud { task_id }),
+                })
+            );
+        });
+    });
+}
+
+#[test]
+fn third_party_conversation_owned_by_current_team_shows_continue_in_cloud_tombstone() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::ClaudeCode,
+            ConversationPermissionFixture::CurrentTeamOwner,
+        );
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::Tombstone {
+                    cta: Some(TombstoneCta::ContinueInCloud { task_id }),
+                })
+            );
+        });
+    });
+}
+
+#[test]
+fn third_party_conversation_shared_with_current_team_as_editor_shows_continue_in_cloud_tombstone() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::ClaudeCode,
+            ConversationPermissionFixture::CurrentTeamEditorGuest,
+        );
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::Tombstone {
+                    cta: Some(TombstoneCta::ContinueInCloud { task_id }),
+                })
+            );
+        });
+    });
+}
+#[test]
+fn third_party_conversation_with_view_access_shows_tombstone_without_cta() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::ClaudeCode,
+            ConversationPermissionFixture::OtherUserOwner,
+        );
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::Tombstone { cta: None })
+            );
+        });
+    });
+}
+
+#[test]
+fn unknown_access_returns_error() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedOut,
+            AIAgentHarness::ClaudeCode,
+            ConversationPermissionFixture::CurrentUserOwner,
+        );
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Err(CloudConversationContinuationError::UnknownConversationAccess)
+            );
+        });
+    });
+}
+
+#[test]
+fn missing_metadata_returns_error() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_task_without_server_metadata(&mut app);
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Err(CloudConversationContinuationError::MissingServerConversationMetadata)
+            );
+        });
+    });
+}
+
+#[test]
+fn active_task_execution_returns_error() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::Oz,
+            ConversationPermissionFixture::CurrentUserOwner,
+        );
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(active_ambient_agent_task(task_id));
+        });
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+
+            assert_eq!(
+                state,
+                Err(CloudConversationContinuationError::ActiveTaskExecution)
+            );
+        });
+    });
+}

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -216,7 +216,7 @@ impl ConversationEndedTombstoneView {
             Some(TombstoneCta::ContinueLocally { conversation_id }) => {
                 Some(ctx.add_typed_action_view(move |_| {
                     ActionButton::new("Continue locally", PrimaryTheme)
-                        .with_tooltip("Fork this conversation into a local Warp session")
+                        .with_tooltip("Fork this conversation locally")
                         .on_click(move |ctx| {
                             ctx.dispatch_typed_action(
                                 ConversationEndedTombstoneAction::ContinueLocally(conversation_id),

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -166,6 +166,7 @@ pub struct ConversationEndedTombstoneView {
 }
 
 impl ConversationEndedTombstoneView {
+    #[cfg_attr(target_family = "wasm", allow(unused_variables))]
     pub fn new(
         ctx: &mut ViewContext<Self>,
         terminal_view_id: EntityId,

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -14,10 +14,6 @@ use crate::util::time_format::human_readable_precise_duration;
 use crate::view_components::action_button::{ActionButton, PrimaryTheme};
 use crate::workspace::WorkspaceAction;
 use std::path::Path;
-#[cfg(not(target_family = "wasm"))]
-use warp_cli::agent::Harness;
-#[cfg(not(target_family = "wasm"))]
-use warp_core::features::FeatureFlag;
 use warp_core::paths::home_relative_path;
 use warp_core::send_telemetry_from_ctx;
 use warp_core::ui::icons::Icon;
@@ -32,6 +28,7 @@ use warpui::{
     ViewHandle,
 };
 
+use super::cloud_conversation_continuation::TombstoneCta;
 use crate::server::server_api::ServerApiProvider;
 
 /// Metadata collected for display in the tombstone.
@@ -53,10 +50,6 @@ struct TombstoneDisplayData {
     working_directory: Option<String>,
     /// Artifacts from the conversation
     artifacts: Vec<Artifact>,
-    hide_continue_actions: bool,
-    /// Execution harness for the task. None until the task is loaded.
-    #[cfg(not(target_family = "wasm"))]
-    harness: Option<Harness>,
 }
 
 #[derive(Debug, Clone)]
@@ -118,9 +111,6 @@ impl TombstoneDisplayData {
             credits: Some(format_credits(conversation.credits_spent())),
             working_directory: conversation.initial_working_directory(),
             artifacts: conversation.artifacts().to_vec(),
-            hide_continue_actions: false,
-            #[cfg(not(target_family = "wasm"))]
-            harness: None,
         }
     }
 
@@ -135,25 +125,11 @@ impl TombstoneDisplayData {
         }
         if let Some(config) = &task.agent_config_snapshot {
             self.skill_name = config.name.clone();
-            #[cfg(not(target_family = "wasm"))]
-            {
-                // Only desktop uses harness to decide whether "Continue locally" is allowed.
-                self.harness = Some(
-                    config
-                        .harness
-                        .as_ref()
-                        .map(|h| h.harness_type)
-                        .unwrap_or(Harness::Oz),
-                );
-            }
         }
 
         if task.state.is_failure_like() {
             self.is_error = true;
             if let Some(status_message) = &task.status_message {
-                if status_message.is_environment_setup_failure() {
-                    self.hide_continue_actions = true;
-                }
                 self.error_message = Some(status_message.message.clone());
             }
         }
@@ -194,62 +170,61 @@ impl ConversationEndedTombstoneView {
         ctx: &mut ViewContext<Self>,
         terminal_view_id: EntityId,
         task_id: Option<AmbientAgentTaskId>,
+        tombstone_cta: Option<TombstoneCta>,
     ) -> Self {
         let conversation_id = BlocklistAIHistoryModel::handle(ctx)
             .as_ref(ctx)
             .all_live_conversations_for_terminal_view(terminal_view_id)
             .next()
             .map(|c| c.id());
+
         let mut display_data = conversation_id
-            .map(|conversation_id| {
+            .map(|id| {
                 TombstoneDisplayData::from_conversation(
-                    conversation_id,
+                    id,
                     terminal_view_id,
                     task_id.is_some(),
                     ctx,
                 )
             })
             .unwrap_or_default();
-        let failed_before_task_creation =
-            display_data.is_error && task_id.is_none() && !display_data.conversation_is_transcript;
-        if failed_before_task_creation {
+        if display_data.is_error && task_id.is_none() && !display_data.conversation_is_transcript {
             display_data.title = Some("Cloud agent failed to start".to_string());
             display_data.credits = None;
-            display_data.hide_continue_actions = true;
         }
 
         let artifact_buttons_view =
             ctx.add_typed_action_view(|ctx| ArtifactButtonsRow::new(&display_data.artifacts, ctx));
         #[cfg(not(target_family = "wasm"))]
-        let continue_in_cloud_button = task_id
-            .filter(|_| FeatureFlag::HandoffCloudCloud.is_enabled())
-            .map(|task_id| {
-                ctx.add_typed_action_view(move |_| {
+        let continue_in_cloud_button = match tombstone_cta {
+            Some(TombstoneCta::ContinueInCloud { task_id }) => {
+                Some(ctx.add_typed_action_view(move |_| {
                     ActionButton::new("Continue", PrimaryTheme)
-                        .with_tooltip("Continue this task in Cloud Mode")
+                        .with_tooltip("Continue this cloud conversation")
                         .on_click(move |ctx| {
                             ctx.dispatch_typed_action(
                                 ConversationEndedTombstoneAction::ContinueInCloud { task_id },
                             );
                         })
-                })
-            });
+                }))
+            }
+            Some(TombstoneCta::ContinueLocally { .. }) | None => None,
+        };
 
         #[cfg(not(target_family = "wasm"))]
-        let continue_locally_button = if failed_before_task_creation {
-            None
-        } else {
-            conversation_id.map(|conv_id| {
-                ctx.add_typed_action_view(move |_| {
+        let continue_locally_button = match tombstone_cta {
+            Some(TombstoneCta::ContinueLocally { conversation_id }) => {
+                Some(ctx.add_typed_action_view(move |_| {
                     ActionButton::new("Continue locally", PrimaryTheme)
-                        .with_tooltip("Fork this conversation locally")
+                        .with_tooltip("Fork this conversation into a local Warp session")
                         .on_click(move |ctx| {
                             ctx.dispatch_typed_action(
-                                ConversationEndedTombstoneAction::ContinueLocally(conv_id),
+                                ConversationEndedTombstoneAction::ContinueLocally(conversation_id),
                             );
                         })
-                })
-            })
+                }))
+            }
+            Some(TombstoneCta::ContinueInCloud { .. }) | None => None,
         };
 
         // In wasm, continuing locally is impossible so we instead
@@ -509,28 +484,18 @@ impl ConversationEndedTombstoneView {
             .with_spacing(8.);
 
         let mut has_button = false;
-        if self.display_data.hide_continue_actions {
-            return Empty::new().finish();
-        }
 
         #[cfg(not(target_family = "wasm"))]
         {
-            // Hide for non-Oz harnesses (e.g. Claude, Gemini): they can't be
-            // forked into a local Warp conversation. Unknown harness (None) is
-            // treated as allowed so plain conversations and pre-load tasks still
-            // show the button.
-            let harness_allows_continue =
-                !matches!(self.display_data.harness, Some(h) if h != Harness::Oz);
-            if AISettings::as_ref(app).is_any_ai_enabled(app) {
+            let is_any_ai_enabled = AISettings::as_ref(app).is_any_ai_enabled(app);
+            if is_any_ai_enabled {
                 if let Some(continue_in_cloud_button) = &self.continue_in_cloud_button {
                     row.add_child(ChildView::new(continue_in_cloud_button).finish());
                     has_button = true;
                 }
-                if harness_allows_continue {
-                    if let Some(continue_locally_button) = &self.continue_locally_button {
-                        row.add_child(ChildView::new(continue_locally_button).finish());
-                        has_button = true;
-                    }
+                if let Some(continue_locally_button) = &self.continue_locally_button {
+                    row.add_child(ChildView::new(continue_locally_button).finish());
+                    has_button = true;
                 }
             }
         }
@@ -567,15 +532,16 @@ impl ConversationEndedTombstoneView {
         self.display_data.credits.as_deref()
     }
 
+    #[cfg(not(target_family = "wasm"))]
     pub(in crate::terminal::view) fn has_continue_locally_button_for_test(&self) -> bool {
-        !self.display_data.hide_continue_actions && self.continue_locally_button.is_some()
+        self.continue_locally_button.is_some()
     }
 
+    #[cfg(not(target_family = "wasm"))]
     pub(in crate::terminal::view) fn has_continue_in_cloud_button_for_test(&self) -> bool {
-        !self.display_data.hide_continue_actions && self.continue_in_cloud_button.is_some()
+        self.continue_in_cloud_button.is_some()
     }
 }
-
 #[derive(Debug, Clone)]
 pub enum ConversationEndedTombstoneAction {
     #[cfg(not(target_family = "wasm"))]

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
@@ -1,10 +1,6 @@
 use chrono::{Duration, Utc};
-use warp_cli::agent::Harness;
 
-use crate::ai::ambient_agents::task::{
-    AgentConfigSnapshot, HarnessConfig, RequestUsage, TaskPrincipalInfo, TaskStatusErrorCode,
-    TaskStatusMessage,
-};
+use crate::ai::ambient_agents::task::{RequestUsage, TaskPrincipalInfo, TaskStatusMessage};
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::format_credits;
@@ -86,21 +82,6 @@ fn task_failure_status_message_overrides_conversation_error() {
 
     assert!(data.is_error);
     assert_eq!(data.error_message.as_deref(), Some("task failed"));
-}
-
-#[test]
-fn environment_setup_failure_hides_continue_actions() {
-    let mut task = task_with_run_time_and_credits();
-    task.state = AmbientAgentTaskState::Failed;
-    task.status_message = Some(TaskStatusMessage {
-        message: "Environment setup failed: Failed to run setup command: hi".to_string(),
-        error_code: Some(TaskStatusErrorCode::EnvironmentSetupFailed),
-    });
-    let mut data = TombstoneDisplayData::default();
-
-    data.enrich_from_task(task);
-
-    assert!(data.hide_continue_actions);
 }
 
 fn pr_artifact(branch: &str) -> Artifact {
@@ -191,47 +172,4 @@ fn empty_task_artifacts_preserve_conversation_artifacts() {
     data.enrich_from_task(task);
 
     assert_eq!(data.artifacts, conversation_artifacts);
-}
-
-#[test]
-fn task_without_snapshot_leaves_harness_unset() {
-    let task = task_with_run_time_and_credits();
-    assert!(task.agent_config_snapshot.is_none());
-    let mut data = TombstoneDisplayData::default();
-
-    data.enrich_from_task(task);
-
-    assert_eq!(data.harness, None);
-}
-
-#[test]
-fn snapshot_without_explicit_harness_defaults_to_oz() {
-    let mut task = task_with_run_time_and_credits();
-    task.agent_config_snapshot = Some(AgentConfigSnapshot::default());
-    let mut data = TombstoneDisplayData::default();
-
-    data.enrich_from_task(task);
-
-    assert_eq!(data.harness, Some(Harness::Oz));
-}
-
-#[test]
-fn snapshot_with_explicit_harness_propagates() {
-    for harness in [
-        Harness::Oz,
-        Harness::Claude,
-        Harness::Gemini,
-        Harness::Unknown,
-    ] {
-        let mut task = task_with_run_time_and_credits();
-        task.agent_config_snapshot = Some(AgentConfigSnapshot {
-            harness: Some(HarnessConfig::from_harness_type(harness)),
-            ..Default::default()
-        });
-        let mut data = TombstoneDisplayData::default();
-
-        data.enrich_from_task(task);
-
-        assert_eq!(data.harness, Some(harness), "harness {harness:?}");
-    }
 }

--- a/app/src/terminal/view/shared_session/mod.rs
+++ b/app/src/terminal/view/shared_session/mod.rs
@@ -1,6 +1,7 @@
 //! Session-sharing logic related to the terminal view.
 
 pub(in crate::terminal::view) mod adapter;
+pub(in crate::terminal::view) mod cloud_conversation_continuation;
 mod conversation_ended_tombstone_view;
 pub(in crate::terminal::view) mod sharer;
 #[cfg(test)]

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -68,6 +68,10 @@ use warpui::elements::MouseStateHandle;
 use warpui::AppContext;
 
 use super::adapter::{Adapter, Kind, Participant};
+use super::cloud_conversation_continuation::{
+    conversation_failed_before_task_creation, resolve_cloud_conversation_continuation_ui_state,
+    CloudConversationContinuationUiState, TombstoneCta,
+};
 use super::sharer::inactivity_modal::InactivityModalEvent;
 use super::sharer::Sharer;
 use super::viewer::Viewer;
@@ -122,6 +126,35 @@ impl TerminalView {
         )
     }
 
+    pub(in crate::terminal::view) fn cloud_conversation_continuation_ui_state(
+        &self,
+        ctx: &AppContext,
+    ) -> Option<CloudConversationContinuationUiState> {
+        let task_id = {
+            let model = self.model.lock();
+            if !FeatureFlag::CloudModeSetupV2.is_enabled()
+                || !FeatureFlag::HandoffCloudCloud.is_enabled()
+                || model.is_receiving_agent_conversation_replay()
+            {
+                return None;
+            }
+            self.ambient_agent_task_id_for_details_panel_from_model(&model, ctx)
+        };
+        let Some(task_id) = task_id else {
+            return conversation_failed_before_task_creation(
+                self.id(),
+                BlocklistAIHistoryModel::as_ref(ctx),
+            )
+            .then_some(CloudConversationContinuationUiState::Tombstone { cta: None });
+        };
+        match resolve_cloud_conversation_continuation_ui_state(self.id(), task_id, ctx) {
+            Ok(state) => Some(state),
+            Err(error) => error
+                .should_fallback_to_tombstone()
+                .then_some(CloudConversationContinuationUiState::Tombstone { cta: None }),
+        }
+    }
+
     pub(crate) fn owned_ambient_agent_task_id(
         &self,
         ctx: &AppContext,
@@ -146,7 +179,7 @@ impl TerminalView {
             .is_some_and(|creator_uid| creator_uid == current_user_uid)
     }
 
-    pub(in crate::terminal::view) fn enable_owned_cloud_followup_input(
+    pub(in crate::terminal::view) fn enable_cloud_followup_input(
         &mut self,
         task_id: AmbientAgentTaskId,
         ctx: &mut ViewContext<Self>,
@@ -726,19 +759,21 @@ impl TerminalView {
     /// Clear the presence manager and handle any UI necessary on shared session end.
     /// Applies to both sharer and viewer when the session sharing ends.
     pub fn on_session_share_ended(&mut self, ctx: &mut ViewContext<Self>) {
-        let viewed_ambient_task_id_owned_by_current_user = self.owned_ambient_agent_task_id(ctx);
-        let can_continue_owned_task_in_cloud = FeatureFlag::HandoffCloudCloud.is_enabled();
-        let should_insert_tombstone = {
+        let viewed_ambient_task_id = self.ambient_agent_task_id_for_details_panel(ctx);
+        let handoff_continuation_state = self.cloud_conversation_continuation_ui_state(ctx);
+        let should_insert_legacy_tombstone = {
             let model = self.model.lock();
-            FeatureFlag::CloudModeSetupV2.is_enabled()
+            !FeatureFlag::CloudModeSetupV2.is_enabled()
                 && model.is_shared_ambient_agent_session()
-                && (viewed_ambient_task_id_owned_by_current_user.is_none()
-                    || !can_continue_owned_task_in_cloud)
                 && self.conversation_ended_tombstone_view_id.is_none()
                 && !model.is_receiving_agent_conversation_replay()
         };
-        if should_insert_tombstone {
-            self.insert_conversation_ended_tombstone(ctx);
+        if let Some(state) = handoff_continuation_state {
+            if let CloudConversationContinuationUiState::Tombstone { cta } = state {
+                self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
+            }
+        } else if should_insert_legacy_tombstone {
+            self.insert_conversation_ended_tombstone_with_cta(None, ctx);
         }
         // Ensure inactivity timer is aborted for sharer
         if let Some(sharer) = self.shared_session_sharer_mut() {
@@ -776,10 +811,13 @@ impl TerminalView {
         });
 
         if self.pending_cloud_followup_task_id.is_none() {
-            if let Some(task_id) = viewed_ambient_task_id_owned_by_current_user
-                .filter(|_| can_continue_owned_task_in_cloud)
-            {
-                self.enable_owned_cloud_followup_input(task_id, ctx);
+            if matches!(
+                handoff_continuation_state,
+                Some(CloudConversationContinuationUiState::FollowupInput)
+            ) {
+                if let Some(task_id) = viewed_ambient_task_id {
+                    self.enable_cloud_followup_input(task_id, ctx);
+                }
             } else if self.model.lock().shared_session_status().is_viewer() {
                 // When the session is ended, the input should be uneditable iff this is a viewer.
                 self.input().update(ctx, |input, ctx| {
@@ -799,43 +837,48 @@ impl TerminalView {
     }
 
     pub fn on_ambient_agent_execution_ended(&mut self, ctx: &mut ViewContext<Self>) {
-        let has_live_shared_session = {
-            let status = self.model.lock().shared_session_status().clone();
-            status.is_active_viewer() || status.is_active_sharer()
-        };
-        self.handle_non_running_ambient_agent_task(has_live_shared_session, ctx);
+        self.handle_non_running_ambient_agent_task(ctx);
     }
 
-    fn handle_non_running_ambient_agent_task(
-        &mut self,
-        has_live_shared_session: bool,
-        ctx: &mut ViewContext<Self>,
-    ) {
+    fn handle_non_running_ambient_agent_task(&mut self, ctx: &mut ViewContext<Self>) {
         if let Some(task_id) = self.ambient_agent_task_id_for_details_panel(ctx) {
             AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
                 model.mark_task_execution_ended(task_id, ctx);
             });
         }
         self.refresh_conversation_details_panel_if_open(ctx);
-        if !FeatureFlag::CloudModeSetupV2.is_enabled()
-            || self.conversation_ended_tombstone_view_id.is_some()
-            || self.pending_cloud_followup_task_id.is_some()
-        {
-            return;
-        }
-        if !FeatureFlag::HandoffCloudCloud.is_enabled() {
-            self.insert_conversation_ended_tombstone(ctx);
-            return;
-        }
-        let Some(task_id) = self.owned_ambient_agent_task_id(ctx) else {
-            self.insert_conversation_ended_tombstone(ctx);
-            return;
+        let has_live_shared_session = {
+            let status = self.model.lock().shared_session_status().clone();
+            status.is_active_viewer() || status.is_active_sharer()
         };
         if has_live_shared_session {
             return;
         }
-
-        self.enable_owned_cloud_followup_input(task_id, ctx);
+        let has_existing_tombstone = self.conversation_ended_tombstone_view_id.is_some();
+        let has_pending_cloud_followup = self.pending_cloud_followup_task_id.is_some();
+        if !FeatureFlag::CloudModeSetupV2.is_enabled()
+            || has_existing_tombstone
+            || has_pending_cloud_followup
+        {
+            return;
+        }
+        if !FeatureFlag::HandoffCloudCloud.is_enabled() {
+            self.insert_conversation_ended_tombstone_with_cta(None, ctx);
+            return;
+        }
+        let Some(state) = self.cloud_conversation_continuation_ui_state(ctx) else {
+            return;
+        };
+        match state {
+            CloudConversationContinuationUiState::Tombstone { cta } => {
+                self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
+            }
+            CloudConversationContinuationUiState::FollowupInput => {
+                if let Some(task_id) = self.ambient_agent_task_id_for_details_panel(ctx) {
+                    self.enable_cloud_followup_input(task_id, ctx);
+                }
+            }
+        }
     }
 
     #[cfg(not(target_family = "wasm"))]
@@ -1666,14 +1709,19 @@ impl TerminalView {
         ctx.notify();
     }
 
-    pub fn insert_conversation_ended_tombstone(&mut self, ctx: &mut ViewContext<Self>) {
+    pub(crate) fn insert_conversation_ended_tombstone_with_cta(
+        &mut self,
+        tombstone_cta: Option<TombstoneCta>,
+        ctx: &mut ViewContext<Self>,
+    ) {
         if self.conversation_ended_tombstone_view_id.is_some() {
             self.remove_conversation_ended_tombstone(ctx);
         }
         let task_id = self.ambient_agent_task_id_for_details_panel(ctx);
         let terminal_view_id = self.id();
-        let tombstone_view_handle = ctx.add_typed_action_view(move |ctx| {
-            ConversationEndedTombstoneView::new(ctx, terminal_view_id, task_id)
+
+        let tombstone_view_handle = ctx.add_typed_action_view(|ctx| {
+            ConversationEndedTombstoneView::new(ctx, terminal_view_id, task_id, tombstone_cta)
         });
         #[cfg(not(target_family = "wasm"))]
         ctx.subscribe_to_view(&tombstone_view_handle, |me, _, event, ctx| match event {
@@ -1694,7 +1742,36 @@ impl TerminalView {
         self.conversation_ended_tombstone_view_id = Some(tombstone_view_id);
     }
 
-    fn remove_conversation_ended_tombstone(&mut self, ctx: &mut ViewContext<Self>) {
+    pub(crate) fn insert_conversation_ended_tombstone_with_resolved_cta(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !FeatureFlag::HandoffCloudCloud.is_enabled() {
+            self.insert_conversation_ended_tombstone_with_cta(None, ctx);
+            return;
+        }
+
+        match self.cloud_conversation_continuation_ui_state(ctx) {
+            Some(CloudConversationContinuationUiState::Tombstone { cta }) => {
+                self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
+            }
+            Some(CloudConversationContinuationUiState::FollowupInput) => {
+                if let Some(task_id) = self.ambient_agent_task_id_for_details_panel(ctx) {
+                    self.enable_cloud_followup_input(task_id, ctx);
+                } else {
+                    self.insert_conversation_ended_tombstone_with_cta(None, ctx);
+                }
+            }
+            None => {
+                self.insert_conversation_ended_tombstone_with_cta(None, ctx);
+            }
+        }
+    }
+
+    pub(in crate::terminal::view) fn remove_conversation_ended_tombstone(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) {
         let Some(view_id) = self.conversation_ended_tombstone_view_id.take() else {
             return;
         };

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -24,8 +24,9 @@ use crate::terminal::shared_session::{
     COPY_LINK_TEXT,
 };
 use crate::terminal::view::{
-    ContextMenuAction, Event, InlineBannerItem, InlineBannerType, RichContentInsertionPosition,
-    SharedSessionBanners, SizeUpdateBuilder, TerminalAction, TerminalView,
+    ContextMenuAction, Event, InlineBannerItem, InlineBannerType, PendingUserQueryKind,
+    RichContentInsertionPosition, SharedSessionBanners, SizeUpdateBuilder, TerminalAction,
+    TerminalView,
 };
 use crate::terminal::TerminalModel;
 use crate::view_components::{DismissibleToast, ToastFlavor};
@@ -188,6 +189,9 @@ impl TerminalView {
         self.input.update(ctx, |input, ctx| {
             input.reset_after_cloud_followup_submission(ctx);
             input.set_input_mode_agent(true, ctx);
+            input.editor().update(ctx, |editor, ctx| {
+                editor.set_interaction_state(InteractionState::Editable, ctx);
+            });
         });
         self.update_pane_configuration(ctx);
         ctx.notify();
@@ -769,8 +773,13 @@ impl TerminalView {
                 && !model.is_receiving_agent_conversation_replay()
         };
         if let Some(state) = handoff_continuation_state {
-            if let CloudConversationContinuationUiState::Tombstone { cta } = state {
-                self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
+            match state {
+                CloudConversationContinuationUiState::Tombstone { cta } => {
+                    self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
+                }
+                CloudConversationContinuationUiState::FollowupInput => {
+                    self.remove_conversation_ended_tombstone(ctx);
+                }
             }
         } else if should_insert_legacy_tombstone {
             self.insert_conversation_ended_tombstone_with_cta(None, ctx);
@@ -854,12 +863,8 @@ impl TerminalView {
         if has_live_shared_session {
             return;
         }
-        let has_existing_tombstone = self.conversation_ended_tombstone_view_id.is_some();
         let has_pending_cloud_followup = self.pending_cloud_followup_task_id.is_some();
-        if !FeatureFlag::CloudModeSetupV2.is_enabled()
-            || has_existing_tombstone
-            || has_pending_cloud_followup
-        {
+        if !FeatureFlag::CloudModeSetupV2.is_enabled() || has_pending_cloud_followup {
             return;
         }
         if !FeatureFlag::HandoffCloudCloud.is_enabled() {
@@ -874,6 +879,7 @@ impl TerminalView {
                 self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
             }
             CloudConversationContinuationUiState::FollowupInput => {
+                self.remove_conversation_ended_tombstone(ctx);
                 if let Some(task_id) = self.ambient_agent_task_id_for_details_panel(ctx) {
                     self.enable_cloud_followup_input(task_id, ctx);
                 }
@@ -901,12 +907,7 @@ impl TerminalView {
             return;
         }
         self.remove_conversation_ended_tombstone(ctx);
-
-        self.pending_cloud_followup_task_id = Some(task_id);
-        self.input.update(ctx, |input, ctx| {
-            input.reset_after_cloud_followup_submission(ctx);
-            input.set_input_mode_agent(true, ctx);
-        });
+        self.enable_cloud_followup_input(task_id, ctx);
         self.focus_input_box(ctx);
         ctx.notify();
     }
@@ -1730,6 +1731,14 @@ impl TerminalView {
             }
         });
         let tombstone_view_id = tombstone_view_handle.id();
+        if self.pending_user_query_kind == Some(PendingUserQueryKind::CloudMode) {
+            if let Some(pending_query_view_id) = self.pending_user_query_view_id {
+                self.model
+                    .lock()
+                    .block_list_mut()
+                    .unpin_rich_content_from_bottom(pending_query_view_id);
+            }
+        }
         self.insert_rich_content(
             None,
             tombstone_view_handle,
@@ -1756,6 +1765,7 @@ impl TerminalView {
                 self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
             }
             Some(CloudConversationContinuationUiState::FollowupInput) => {
+                self.remove_conversation_ended_tombstone(ctx);
                 if let Some(task_id) = self.ambient_agent_task_id_for_details_panel(ctx) {
                     self.enable_cloud_followup_input(task_id, ctx);
                 } else {

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -1,4 +1,8 @@
+use crate::ai::agent::api::ServerConversationToken;
+use crate::ai::agent::conversation::{AIAgentHarness, ServerAIConversationMetadata};
+use chrono::Utc;
 use pathfinder_geometry::vector::vec2f;
+use persistence::model::ConversationUsageMetadata;
 use session_sharing_protocol::sharer::SessionSourceType;
 use std::collections::HashMap;
 use warp_multi_agent_api::{self as api, client_action as api_client_action};
@@ -7,11 +11,15 @@ use crate::ai::agent::conversation::ConversationStatus;
 use crate::ai::agent::AIAgentInput;
 use crate::ai::agent_conversations_model::{AgentConversationsModel, AgentRunDisplayStatus};
 use crate::ai::ambient_agents::task::TaskPrincipalInfo;
-use crate::ai::ambient_agents::{AgentSource, AmbientAgentTask, AmbientAgentTaskState};
+use crate::ai::ambient_agents::{
+    AgentSource, AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState,
+};
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
 use crate::auth::user::TEST_USER_UID;
+use crate::cloud_object::{Owner, Revision, ServerMetadata, ServerPermissions};
+use crate::server::ids::ServerId;
 use warpui::platform::WindowStyle;
-use warpui::{App, ViewHandle};
+use warpui::{App, EntityId, ViewHandle};
 
 use crate::context_chips::prompt_type::PromptType;
 use crate::editor::InteractionState;
@@ -405,7 +413,8 @@ fn test_on_session_share_ended_restores_size_after_viewer_driven_resize() {
 }
 
 #[test]
-fn test_on_session_share_ended_inserts_tombstone_for_ambient_session_under_cloud_mode_setup_v2() {
+fn test_on_session_share_ended_does_not_insert_tombstone_for_ambient_session_under_cloud_mode_setup_v2(
+) {
     let _flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
 
     App::test((), |mut app| async move {
@@ -424,8 +433,10 @@ fn test_on_session_share_ended_inserts_tombstone_for_ambient_session_under_cloud
         terminal.read(&app, |view, _| {
             let final_block_height_items =
                 view.model.lock().block_list().block_heights().items().len();
-            // Shared session ended banner + conversation ended tombstone.
-            assert_eq!(final_block_height_items, initial_block_height_items + 2);
+            // Only shared session ended banner. Ended-state continuation UI is
+            // driven by the task resolver path under CloudModeSetupV2.
+            assert_eq!(final_block_height_items, initial_block_height_items + 1);
+            assert!(view.conversation_ended_tombstone_view_id.is_none());
         });
     });
 }
@@ -461,6 +472,83 @@ fn create_cloud_mode_task_for_user(creator_uid: &str) -> AmbientAgentTask {
     }
 }
 
+fn insert_cloud_mode_task_with_server_metadata(
+    app: &mut App,
+    terminal_view_id: EntityId,
+    mut task: AmbientAgentTask,
+    harness: AIAgentHarness,
+    permissions: ServerPermissions,
+) {
+    let task_id = task.task_id;
+    let conversation_token = task_id.to_string();
+    task.conversation_id = Some(conversation_token.clone());
+
+    AgentConversationsModel::handle(app).update(app, |model, _| {
+        model.insert_task_for_test(task);
+    });
+    BlocklistAIHistoryModel::handle(app).update(app, |model, ctx| {
+        let conversation_id =
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx);
+        model.set_server_conversation_token_for_conversation(
+            conversation_id,
+            conversation_token.clone(),
+        );
+        model.set_server_metadata_for_conversation(
+            conversation_id,
+            server_conversation_metadata(harness, task_id, conversation_token, permissions),
+            ctx,
+        );
+    });
+}
+
+fn server_conversation_metadata(
+    harness: AIAgentHarness,
+    ambient_agent_task_id: AmbientAgentTaskId,
+    server_conversation_token: String,
+    permissions: ServerPermissions,
+) -> ServerAIConversationMetadata {
+    ServerAIConversationMetadata {
+        title: "Conversation".to_string(),
+        working_directory: None,
+        harness,
+        usage: ConversationUsageMetadata {
+            was_summarized: false,
+            context_window_usage: 0.0,
+            credits_spent: 0.0,
+            credits_spent_for_last_block: None,
+            token_usage: vec![],
+            tool_usage_metadata: Default::default(),
+        },
+        metadata: ServerMetadata {
+            uid: ServerId::default(),
+            revision: Revision::now(),
+            metadata_last_updated_ts: Utc::now().into(),
+            trashed_ts: None,
+            folder_id: None,
+            is_welcome_object: false,
+            creator_uid: None,
+            last_editor_uid: None,
+            current_editor_uid: None,
+        },
+        permissions,
+        ambient_agent_task_id: Some(ambient_agent_task_id),
+        server_conversation_token: ServerConversationToken::new(server_conversation_token),
+        artifacts: vec![],
+    }
+}
+
+fn current_user_owner_permissions() -> ServerPermissions {
+    server_permissions(Owner::mock_current_user())
+}
+
+fn server_permissions(space: Owner) -> ServerPermissions {
+    ServerPermissions {
+        space,
+        guests: vec![],
+        anyone_link_sharing: None,
+        permissions_last_updated_ts: Utc::now().into(),
+    }
+}
 fn cloud_mode_terminal_for_test(app: &mut App) -> ViewHandle<TerminalView> {
     initialize_app_for_terminal_view(app);
     let tips_model = app.add_model(|_| Default::default());
@@ -468,6 +556,51 @@ fn cloud_mode_terminal_for_test(app: &mut App) -> ViewHandle<TerminalView> {
         TerminalView::new_for_test_with_cloud_mode(tips_model, None, true, ctx)
     });
     terminal
+}
+#[test]
+fn test_restored_ambient_view_resolves_cta_from_view_model_task_id() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = cloud_mode_terminal_for_test(&mut app);
+        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task_id = task.task_id;
+
+        insert_cloud_mode_task_with_server_metadata(
+            &mut app,
+            terminal.id(),
+            task,
+            AIAgentHarness::ClaudeCode,
+            current_user_owner_permissions(),
+        );
+
+        terminal.update(&mut app, |view, ctx| {
+            let ambient_agent_view_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .clone();
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.enter_viewing_existing_session(task_id, ctx);
+            });
+
+            {
+                let model = view.model.lock();
+                assert!(!model.is_shared_ambient_agent_session());
+                assert!(model.conversation_transcript_viewer_status().is_none());
+            }
+
+            let state = view
+                .cloud_conversation_continuation_ui_state(ctx)
+                .expect("ambient view model task ID should pass the continuation gate");
+            assert!(matches!(
+                state,
+                CloudConversationContinuationUiState::Tombstone {
+                    cta: Some(TombstoneCta::ContinueInCloud { task_id: resolved_task_id })
+                } if resolved_task_id == task_id
+            ));
+        });
+    });
 }
 
 #[test]
@@ -481,9 +614,13 @@ fn test_on_session_share_ended_enables_followup_input_without_tombstone_for_owne
         let task = create_cloud_mode_task_for_user(TEST_USER_UID);
         let task_id = task.task_id;
 
-        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
-            model.insert_task_for_test(task);
-        });
+        insert_cloud_mode_task_with_server_metadata(
+            &mut app,
+            terminal.id(),
+            task,
+            AIAgentHarness::Oz,
+            current_user_owner_permissions(),
+        );
         let initial_block_height_items = terminal.read(&app, |view, _| {
             view.model.lock().block_list().block_heights().items().len()
         });
@@ -516,7 +653,8 @@ fn test_on_session_share_ended_enables_followup_input_without_tombstone_for_owne
 }
 
 #[test]
-fn test_on_session_share_ended_inserts_tombstone_for_owned_ambient_session_without_handoff() {
+fn test_on_session_share_ended_does_not_insert_tombstone_for_owned_ambient_session_without_handoff()
+{
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(false);
     let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
 
@@ -525,9 +663,13 @@ fn test_on_session_share_ended_inserts_tombstone_for_owned_ambient_session_witho
         let task = create_cloud_mode_task_for_user(TEST_USER_UID);
         let task_id = task.task_id;
 
-        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
-            model.insert_task_for_test(task);
-        });
+        insert_cloud_mode_task_with_server_metadata(
+            &mut app,
+            terminal.id(),
+            task,
+            AIAgentHarness::Oz,
+            current_user_owner_permissions(),
+        );
         let initial_block_height_items = terminal.read(&app, |view, _| {
             view.model.lock().block_list().block_heights().items().len()
         });
@@ -544,8 +686,8 @@ fn test_on_session_share_ended_inserts_tombstone_for_owned_ambient_session_witho
         terminal.read(&app, |view, ctx| {
             let final_block_height_items =
                 view.model.lock().block_list().block_heights().items().len();
-            assert_eq!(final_block_height_items, initial_block_height_items + 2);
-            assert!(view.conversation_ended_tombstone_view_id.is_some());
+            assert_eq!(final_block_height_items, initial_block_height_items + 1);
+            assert!(view.conversation_ended_tombstone_view_id.is_none());
             assert_eq!(view.pending_cloud_followup_task_id, None);
             assert_eq!(
                 view.input()
@@ -556,7 +698,7 @@ fn test_on_session_share_ended_inserts_tombstone_for_owned_ambient_session_witho
                 InteractionState::Selectable
             );
             let model = view.model.lock();
-            assert!(!view.should_publish_shared_session_input_editor_update(&model, ctx));
+            assert!(view.should_publish_shared_session_input_editor_update(&model, ctx));
         });
     });
 }
@@ -571,9 +713,13 @@ fn test_on_session_share_ended_clears_frozen_followup_input_for_owned_ambient_se
         let task = create_cloud_mode_task_for_user(TEST_USER_UID);
         let task_id = task.task_id;
 
-        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
-            model.insert_task_for_test(task);
-        });
+        insert_cloud_mode_task_with_server_metadata(
+            &mut app,
+            terminal.id(),
+            task,
+            AIAgentHarness::Oz,
+            current_user_owner_permissions(),
+        );
 
         terminal.update(&mut app, |view, ctx| {
             view.input().update(ctx, |input, ctx| {
@@ -637,11 +783,21 @@ fn test_on_ambient_agent_execution_ended_inserts_tombstone_when_handoff_enabled(
 
     App::test((), |mut app| async move {
         let terminal = terminal_view_for_viewer(&mut app);
+        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task_id = task.task_id;
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(task);
+        });
         let initial_block_height_items = terminal.read(&app, |view, _| {
             view.model.lock().block_list().block_heights().items().len()
         });
 
         terminal.update(&mut app, |view, ctx| {
+            view.model
+                .lock()
+                .set_shared_session_source_type(SessionSourceType::AmbientAgent {
+                    task_id: Some(task_id.to_string()),
+                });
             view.on_ambient_agent_execution_ended(ctx);
             view.on_ambient_agent_execution_ended(ctx);
         });
@@ -665,9 +821,13 @@ fn test_on_ambient_agent_execution_ended_enables_followup_input_without_tombston
         let task = create_cloud_mode_task_for_user(TEST_USER_UID);
         let task_id = task.task_id;
 
-        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
-            model.insert_task_for_test(task);
-        });
+        insert_cloud_mode_task_with_server_metadata(
+            &mut app,
+            terminal.id(),
+            task,
+            AIAgentHarness::Oz,
+            current_user_owner_permissions(),
+        );
         let initial_block_height_items = terminal.read(&app, |view, _| {
             view.model.lock().block_list().block_heights().items().len()
         });
@@ -731,7 +891,7 @@ fn test_restored_owned_tombstone_hides_input_until_continue() {
                 model.enter_viewing_existing_session(task_id, ctx);
             });
 
-            view.insert_conversation_ended_tombstone(ctx);
+            view.insert_conversation_ended_tombstone_with_cta(None, ctx);
             assert!(view.conversation_ended_tombstone_view_id.is_some());
             {
                 let model = view.model.lock();
@@ -815,7 +975,7 @@ fn test_try_submit_pending_cloud_followup_allows_repeat_submission_for_owned_tas
                 model.enter_viewing_existing_session(task_id, ctx);
             });
 
-            view.enable_owned_cloud_followup_input(task_id, ctx);
+            view.enable_cloud_followup_input(task_id, ctx);
             assert!(view.try_submit_pending_cloud_followup("follow up".to_string(), ctx));
             assert_eq!(view.pending_cloud_followup_task_id, Some(task_id));
             assert!(view.try_submit_pending_cloud_followup("second follow up".to_string(), ctx));
@@ -972,7 +1132,7 @@ fn test_non_owned_tombstone_is_removed_for_followup_and_reinserted_after_complet
             let initial_block_height_items =
                 view.model.lock().block_list().block_heights().items().len();
 
-            view.insert_conversation_ended_tombstone(ctx);
+            view.insert_conversation_ended_tombstone_with_cta(None, ctx);
             assert!(view.conversation_ended_tombstone_view_id.is_some());
             assert_eq!(
                 view.model.lock().block_list().block_heights().items().len(),

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -10,7 +10,7 @@ use warp_multi_agent_api::{self as api, client_action as api_client_action};
 use crate::ai::agent::conversation::ConversationStatus;
 use crate::ai::agent::AIAgentInput;
 use crate::ai::agent_conversations_model::{AgentConversationsModel, AgentRunDisplayStatus};
-use crate::ai::ambient_agents::task::TaskPrincipalInfo;
+use crate::ai::ambient_agents::task::{TaskPrincipalInfo, TaskStatusErrorCode, TaskStatusMessage};
 use crate::ai::ambient_agents::{
     AgentSource, AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState,
 };
@@ -557,6 +557,7 @@ fn cloud_mode_terminal_for_test(app: &mut App) -> ViewHandle<TerminalView> {
     });
     terminal
 }
+
 #[test]
 fn test_restored_ambient_view_resolves_cta_from_view_model_task_id() {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
@@ -604,6 +605,63 @@ fn test_restored_ambient_view_resolves_cta_from_view_model_task_id() {
 }
 
 #[test]
+fn test_restored_oz_edit_access_view_uses_followup_input_without_tombstone() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = cloud_mode_terminal_for_test(&mut app);
+        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task_id = task.task_id;
+
+        insert_cloud_mode_task_with_server_metadata(
+            &mut app,
+            terminal.id(),
+            task,
+            AIAgentHarness::Oz,
+            current_user_owner_permissions(),
+        );
+
+        terminal.update(&mut app, |view, ctx| {
+            view.input().update(ctx, |input, ctx| {
+                input.editor().update(ctx, |editor, ctx| {
+                    editor.set_interaction_state(InteractionState::Selectable, ctx);
+                });
+            });
+            let ambient_agent_view_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .clone();
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.enter_viewing_existing_session(task_id, ctx);
+            });
+            let initial_block_height_items =
+                view.model.lock().block_list().block_heights().items().len();
+
+            view.insert_conversation_ended_tombstone_with_resolved_cta(ctx);
+
+            assert_eq!(
+                view.model.lock().block_list().block_heights().items().len(),
+                initial_block_height_items
+            );
+            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert_eq!(view.pending_cloud_followup_task_id, Some(task_id));
+            {
+                let model = view.model.lock();
+                assert!(view.is_input_box_visible(&model, ctx));
+            }
+            assert_eq!(
+                view.input()
+                    .as_ref(ctx)
+                    .editor()
+                    .as_ref(ctx)
+                    .interaction_state(ctx),
+                InteractionState::Editable
+            );
+        });
+    });
+}
+#[test]
 fn test_on_session_share_ended_enables_followup_input_without_tombstone_for_owned_ambient_session()
 {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
@@ -647,6 +705,63 @@ fn test_on_session_share_ended_enables_followup_input_without_tombstone_for_owne
                     .as_ref(ctx)
                     .interaction_state(ctx),
                 InteractionState::Editable
+            );
+        });
+    });
+}
+
+#[test]
+fn test_on_session_share_ended_hides_input_for_no_cta_tombstone() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = terminal_view_for_viewer(&mut app);
+        let mut task = create_cloud_mode_task_for_user("another-user");
+        let task_id = task.task_id;
+        task.state = AmbientAgentTaskState::Failed;
+        task.status_message = Some(TaskStatusMessage {
+            message: "Environment setup failed: Failed to run setup command".to_string(),
+            error_code: Some(TaskStatusErrorCode::EnvironmentSetupFailed),
+        });
+
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(task);
+        });
+        let initial_block_height_items = terminal.read(&app, |view, _| {
+            view.model.lock().block_list().block_heights().items().len()
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.input().update(ctx, |input, ctx| {
+                input.editor().update(ctx, |editor, ctx| {
+                    editor.set_interaction_state(InteractionState::Editable, ctx);
+                });
+            });
+            view.model
+                .lock()
+                .set_shared_session_source_type(SessionSourceType::AmbientAgent {
+                    task_id: Some(task_id.to_string()),
+                });
+
+            view.on_session_share_ended(ctx);
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let model = view.model.lock();
+            assert_eq!(
+                model.block_list().block_heights().items().len(),
+                initial_block_height_items + 2
+            );
+            assert!(view.conversation_ended_tombstone_view_id.is_some());
+            assert!(!view.is_input_box_visible(&model, ctx));
+            assert_eq!(
+                view.input()
+                    .as_ref(ctx)
+                    .editor()
+                    .as_ref(ctx)
+                    .interaction_state(ctx),
+                InteractionState::Selectable
             );
         });
     });
@@ -783,7 +898,7 @@ fn test_on_ambient_agent_execution_ended_inserts_tombstone_when_handoff_enabled(
 
     App::test((), |mut app| async move {
         let terminal = terminal_view_for_viewer(&mut app);
-        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task = create_cloud_mode_task_for_user("another-user");
         let task_id = task.task_id;
         AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
             model.insert_task_for_test(task);
@@ -807,6 +922,51 @@ fn test_on_ambient_agent_execution_ended_inserts_tombstone_when_handoff_enabled(
                 view.model.lock().block_list().block_heights().items().len();
             assert_eq!(final_block_height_items, initial_block_height_items + 1);
             assert!(view.conversation_ended_tombstone_view_id.is_some());
+        });
+    });
+}
+
+#[test]
+fn test_on_ambient_agent_execution_ended_enables_followup_for_owned_task_without_metadata() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = terminal_view_for_viewer(&mut app);
+        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task_id = task.task_id;
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(task);
+        });
+        let initial_block_height_items = terminal.read(&app, |view, _| {
+            view.model.lock().block_list().block_heights().items().len()
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            let mut model = view.model.lock();
+            model.set_shared_session_source_type(SessionSourceType::AmbientAgent {
+                task_id: Some(task_id.to_string()),
+            });
+            model.set_shared_session_status(SharedSessionStatus::NotShared);
+            drop(model);
+
+            view.on_ambient_agent_execution_ended(ctx);
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let final_block_height_items =
+                view.model.lock().block_list().block_heights().items().len();
+            assert_eq!(final_block_height_items, initial_block_height_items);
+            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert_eq!(view.pending_cloud_followup_task_id, Some(task_id));
+            assert_eq!(
+                view.input()
+                    .as_ref(ctx)
+                    .editor()
+                    .as_ref(ctx)
+                    .interaction_state(ctx),
+                InteractionState::Editable
+            );
         });
     });
 }
@@ -890,8 +1050,16 @@ fn test_restored_owned_tombstone_hides_input_until_continue() {
             ambient_agent_view_model.update(ctx, |model, ctx| {
                 model.enter_viewing_existing_session(task_id, ctx);
             });
+            view.input().update(ctx, |input, ctx| {
+                input.editor().update(ctx, |editor, ctx| {
+                    editor.set_interaction_state(InteractionState::Selectable, ctx);
+                });
+            });
 
-            view.insert_conversation_ended_tombstone_with_cta(None, ctx);
+            view.insert_conversation_ended_tombstone_with_cta(
+                Some(TombstoneCta::ContinueInCloud { task_id }),
+                ctx,
+            );
             assert!(view.conversation_ended_tombstone_view_id.is_some());
             {
                 let model = view.model.lock();
@@ -905,6 +1073,14 @@ fn test_restored_owned_tombstone_hides_input_until_continue() {
                 let model = view.model.lock();
                 assert!(view.is_input_box_visible(&model, ctx));
             }
+            assert_eq!(
+                view.input()
+                    .as_ref(ctx)
+                    .editor()
+                    .as_ref(ctx)
+                    .interaction_state(ctx),
+                InteractionState::Editable
+            );
         });
     });
 }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -992,6 +992,7 @@ fn cloud_mode_dispatched_agent_inserts_queued_user_query() {
         initialize_app_for_terminal_view(&mut app);
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
         let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _handoff = FeatureFlag::HandoffCloudCloud.override_enabled(true);
         let _setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
 
         let terminal = add_window_with_cloud_mode_terminal(&mut app);
@@ -1029,11 +1030,12 @@ fn cloud_mode_dispatched_agent_inserts_queued_user_query() {
 }
 
 #[test]
-fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
+fn cloud_mode_failed_keeps_queued_query_above_tombstone_and_hides_input() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
         let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _handoff = FeatureFlag::HandoffCloudCloud.override_enabled(true);
         let _setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
 
         let terminal = add_window_with_cloud_mode_terminal(&mut app);
@@ -1045,6 +1047,9 @@ fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
             view.enter_ambient_agent_setup(None, ctx);
             view.insert_cloud_mode_queued_user_query_block("queued prompt".to_string(), ctx);
             assert!(has_pending_user_query_block(view));
+            let pending_query_view_id = view
+                .pending_user_query_view_id
+                .expect("queued query should have a view id");
 
             view.handle_ambient_agent_event(
                 &AmbientAgentViewModelEvent::Failed {
@@ -1053,12 +1058,46 @@ fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
                 ctx,
             );
 
-            assert!(!has_pending_user_query_block(view));
+            assert!(has_pending_user_query_block(view));
             assert!(view.conversation_ended_tombstone_view_id.is_some());
-            assert_eq!(view.rich_content_views.len(), 1);
+            assert_eq!(view.rich_content_views.len(), 2);
             {
                 let model = view.model.lock();
                 assert!(!view.is_input_box_visible(&model, ctx));
+                let tombstone_view_id = view
+                    .conversation_ended_tombstone_view_id
+                    .expect("failed cloud mode should insert a tombstone");
+                let rich_content_view_ids = model
+                    .block_list()
+                    .block_heights()
+                    .items()
+                    .iter()
+                    .filter_map(|item| {
+                        match item {
+                            crate::terminal::model::blocks::BlockHeightItem::RichContent(item) => {
+                                Some(item.view_id)
+                            }
+                            crate::terminal::model::blocks::BlockHeightItem::Block(_)
+                            | crate::terminal::model::blocks::BlockHeightItem::Gap(_)
+                            | crate::terminal::model::blocks::BlockHeightItem::RestoredBlockSeparator {
+                                ..
+                            }
+                            | crate::terminal::model::blocks::BlockHeightItem::InlineBanner { .. }
+                            | crate::terminal::model::blocks::BlockHeightItem::SubshellSeparator {
+                                ..
+                            } => None,
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                let pending_query_position = rich_content_view_ids
+                    .iter()
+                    .position(|view_id| *view_id == pending_query_view_id)
+                    .expect("queued query should be in the block list");
+                let tombstone_position = rich_content_view_ids
+                    .iter()
+                    .position(|view_id| *view_id == tombstone_view_id)
+                    .expect("tombstone should be in the block list");
+                assert!(pending_query_position < tombstone_position);
             }
 
             view.handle_ambient_agent_event(
@@ -1067,7 +1106,7 @@ fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
                 },
                 ctx,
             );
-            assert_eq!(view.rich_content_views.len(), 1);
+            assert_eq!(view.rich_content_views.len(), 2);
         });
 
         let window_id = app.read(|ctx| terminal.window_id(ctx));
@@ -1154,7 +1193,7 @@ fn pending_cloud_mode_query_waits_for_renderable_user_query_exchange() {
                 },
                 ctx,
             );
-            assert!(!has_pending_user_query_block(view));
+            assert!(has_pending_user_query_block(view));
         });
     });
 }

--- a/specs/APP-4483/PRODUCT.md
+++ b/specs/APP-4483/PRODUCT.md
@@ -1,0 +1,108 @@
+# Cloud agent tombstone and followup input behavior — Product Spec
+Linear: APP-4483. Figma: none.
+## Summary
+When `FeatureFlag::HandoffCloudCloud` is enabled, make the idle-state UI for cloud agent conversations consistent and permission-aware. The decision to show the conversation-ended tombstone, the inline followup input, and any continue CTA should depend on two product concepts:
+- Which harness produced the conversation: Oz vs. a third-party harness such as Claude Code.
+- Whether the current user has edit access to the underlying AI conversation object.
+Oz conversations should feel directly resumable when the user can edit the conversation. Third-party harness conversations should always preserve the terminal transcript boundary with a tombstone when no execution is active, because their continuation flow is different and they cannot be forked into a local Oz conversation.
+## Problem
+Today the tombstone/input behavior is scattered across session-sharing end handling, ambient task end handling, tombstone CTA rendering, and followup input state. The primary gate is currently whether the current user appears to own the ambient task. That is not the correct product model for shared cloud conversations: access should follow the underlying conversation permissions, not just task creator identity.
+This leads to inconsistent outcomes when `FeatureFlag::HandoffCloudCloud` is enabled:
+- A user with edit access to a shared Oz conversation may not get the inline followup input if they are not the task creator.
+- A user who can only view an Oz conversation can see continuation affordances that imply they can mutate the original conversation.
+- Third-party harness conversations can be treated like Oz conversations even though local forking is unsupported for those harnesses.
+## Goals
+- Use edit access to the underlying AI conversation as the product source of truth for whether the current user may continue the original cloud conversation.
+- For Oz conversations:
+  - Hide the tombstone and show the followup input when the current user can edit the underlying conversation.
+  - Show the tombstone and the existing local continuation CTA when the current user can only view the underlying conversation.
+- For third-party harness conversations:
+  - Always show the tombstone when there is no active execution.
+  - Show a cloud continuation CTA only when the current user can edit the underlying conversation.
+  - Never show a fork-local CTA.
+- Keep active executions unchanged: while the cloud execution is live, the user should see the active shared/cloud session rather than an ended-state tombstone.
+## Non-goals
+- Implement fork-and-continue for third-party harness conversations.
+- Change tombstone metadata, credits, artifacts, runtime, or error presentation.
+- Change server-side authorization rules. The client should reflect permissions, but the server remains authoritative for followup submission.
+- Redesign the tombstone UI layout beyond which CTA is present.
+- Change behavior when `FeatureFlag::HandoffCloudCloud` is disabled.
+## Product concepts
+### Conversation edit access
+“Edit access” means the current user has at least edit-level access to the underlying AI conversation object. This should be derived from the conversation’s server permissions, not from ambient task ownership.
+If the client has not yet loaded permissions, it should avoid presenting mutation affordances that might be wrong. The safe default is to treat access as view-only until edit access is known.
+### Harness
+Harness should come from the conversation/task metadata already used to identify Oz vs. non-Oz runs. `Oz` is the only harness eligible for local fork continuation. Any other known harness, including Claude Code, Codex, Gemini, or future third-party harnesses, should follow the third-party behavior.
+If the harness is unknown while metadata is still loading, the safe default is to show the tombstone and hide mutation CTAs until the harness and permissions are known.
+### Active execution
+This spec applies when the cloud agent conversation has no active execution. If an execution is currently active, the live session UI remains the source of truth and the ended-state tombstone should not be inserted.
+## Behavior
+### Oz harness
+If the conversation was produced by Oz and there is no active execution:
+- User has edit access:
+  - Tombstone: hidden.
+  - Followup input: shown and editable.
+  - CTA: none, because the input is already available.
+  - Submitting the input continues the same cloud conversation.
+- User has view access only:
+  - Tombstone: shown.
+  - Followup input: hidden or non-editable.
+  - CTA: show `Continue locally`.
+  - Clicking the CTA forks the cloud conversation into a local Warp conversation and continues locally, without mutating the original shared conversation.
+### Third-party harness
+If the conversation was produced by a third-party harness and there is no active execution:
+- User has edit access:
+  - Tombstone: shown.
+  - Followup input: hidden until the user explicitly chooses to continue.
+  - CTA: show `Continue`.
+  - Clicking `Continue` starts the third-party cloud followup flow for the same conversation/run.
+- User has view access only:
+  - Tombstone: shown.
+  - Followup input: hidden or non-editable.
+  - CTA: none.
+  - The user can inspect the transcript but cannot continue or fork it from this UI.
+### Behavior invariants
+- B1: Oz + edit access + no active execution: no tombstone, show followup input.
+- B2: Oz + view-only access + no active execution: show tombstone with `Continue locally`.
+- B3: Third-party + edit access + no active execution: show tombstone with `Continue`.
+- B4: Third-party + view-only access + no active execution: show tombstone with no continue CTA.
+- B5: Any harness + active execution: no ended-state tombstone; keep live execution UI.
+- B6: Unknown harness or unknown access + no active execution: show tombstone with no mutation CTA.
+### UI state table
+| Harness | Conversation access | Execution state | Tombstone | Followup input | CTA | Result |
+| --- | --- | --- | --- | --- | --- | --- |
+| Oz | Edit | Active execution | Hidden | Hidden while execution is active | None | User watches or interacts with the live cloud execution UI. |
+| Oz | View only | Active execution | Hidden | Hidden while execution is active | None | User watches the live cloud execution UI without ended-state affordances. |
+| Third-party | Edit | Active execution | Hidden | Hidden while execution is active | None | User watches or interacts with the live third-party cloud execution UI. |
+| Third-party | View only | Active execution | Hidden | Hidden while execution is active | None | User watches the live third-party cloud execution UI without ended-state affordances. |
+| Oz | Edit | No active execution | Hidden | Shown and editable | None | User submits a followup that continues the same cloud conversation. |
+| Oz | View only | No active execution | Shown | Hidden or non-editable | `Continue locally` | User forks into a local Warp conversation before continuing. |
+| Third-party | Edit | No active execution | Shown | Hidden until continuation starts | `Continue` | User continues via the existing third-party cloud followup execution flow. |
+| Third-party | View only | No active execution | Shown | Hidden or non-editable | None | User can inspect the transcript but cannot continue from this UI. |
+| Unknown | Any or unknown | No active execution | Shown | Hidden or non-editable | None | Client waits for metadata before showing mutation affordances. |
+## Copy
+Preferred CTA copy:
+- Oz, view-only: `Continue locally`
+- Third-party, edit access: `Continue`
+Tooltips can clarify the distinction:
+- Oz local continuation CTA: “Fork this conversation into a local Warp session.”
+- Third-party continue CTA: “Continue this cloud conversation.”
+Avoid showing “Continue locally” for third-party harnesses, because local continuation is unsupported and misleading.
+## Edge cases
+- Metadata not loaded: show the tombstone and hide continue CTAs until both harness and editability are known.
+- Permissions change while viewing: recompute the tombstone/input state from the latest conversation permissions. If edit access is revoked, hide the followup input and remove any continue CTA that would mutate the original conversation.
+- Conversation has task metadata but no conversation metadata: show the tombstone and hide mutation CTAs until conversation metadata is available, unless there is an existing server-confirmed editability signal.
+- Followup submission fails due to server-side permission denial: keep the user in the ended-state UI, restore their draft if possible, and show a concise error toast.
+- Third-party harness later gains local fork support: this spec should be revisited; until then, third-party harnesses must not show fork-local affordances.
+## Success criteria
+- An Oz cloud conversation where the current user has edit access ends with an editable followup input and no tombstone.
+- An Oz cloud conversation where the current user only has view access ends with a tombstone containing `Continue locally`, and no inline followup input.
+- A Claude Code cloud conversation where the current user has edit access ends with a tombstone containing `Continue`, and no fork-local CTA.
+- A Claude Code cloud conversation where the current user only has view access ends with a tombstone and no continue CTA.
+- Ambient task creator identity is no longer the product source of truth for showing the followup input; conversation edit access is.
+- Active executions do not show the ended-state tombstone regardless of harness or permissions.
+- Existing behavior remains unchanged when `FeatureFlag::HandoffCloudCloud` is disabled.
+## Resolved decisions
+- Keep the existing `Continue locally` copy for the Oz view-only local continuation CTA.
+- Third-party `Continue` uses the existing third-party followup execution flow. This spec should not introduce a new modal, inline input mode, or alternate continuation concept.
+- For view-only third-party conversations, the absence of a CTA is sufficient; no explanatory subtitle is required.

--- a/specs/APP-4483/TECH.md
+++ b/specs/APP-4483/TECH.md
@@ -1,0 +1,127 @@
+# Cloud agent tombstone and followup input behavior — Tech Spec
+Product spec: `specs/APP-4483/PRODUCT.md`
+## Context
+`PRODUCT.md` defines behavior invariants B1–B6. This technical spec implements those invariants when `FeatureFlag::HandoffCloudCloud` is enabled, while preserving existing behavior when that flag is disabled.
+The current UI decision points are split across three places:
+- `app/src/terminal/view/shared_session/view_impl.rs:729` computes `viewed_ambient_task_id_owned_by_current_user` and uses task creator ownership to decide whether `on_session_share_ended` inserts a tombstone.
+- `app/src/terminal/view/shared_session/view_impl.rs:779` enables the followup input only when the current user owns the ambient task.
+- `app/src/terminal/view/shared_session/view_impl.rs:811` repeats the same ownership model for `handle_non_running_ambient_agent_task`.
+There is a second delayed path for already-loaded ambient tasks:
+- `app/src/terminal/view.rs:7123` checks whether a non-running shared ambient task should get a tombstone.
+- `app/src/terminal/view.rs:7149` again uses `owned_ambient_agent_task_id` plus `HandoffCloudCloud` to decide whether to show the input instead.
+The tombstone currently makes an independent CTA decision:
+- `app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs:207` creates a `Continue` cloud button whenever a task id exists and `HandoffCloudCloud` is enabled.
+- `app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs:221` creates a `Continue locally` button whenever a conversation id exists.
+- `app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs:473` hides local continuation for known non-Oz harnesses, but treats unknown harness metadata as local-continuable.
+The data needed for the new product model is already present:
+- `ServerAIConversationMetadata` contains `harness` and `permissions` in `app/src/ai/agent/conversation.rs:3849`.
+- `AIAgentHarness` distinguishes Oz, Claude Code, Gemini, Codex, and Unknown in `app/src/ai/agent/conversation.rs:3821`.
+- `BlocklistAIHistoryModel::get_server_conversation_metadata` already looks up loaded conversation metadata with a fallback to cached conversation metadata in `app/src/ai/blocklist/history_model.rs:1986`.
+- `AgentConversationsModel::fetch_ambient_agent_tasks_and_cloud_convo_metadata` fetches ambient tasks and cloud conversation metadata together, including additional metadata for task conversation IDs missing from the first metadata response, in `app/src/ai/agent_conversations_model.rs:675`.
+- `AmbientAgentTask` exposes `conversation_id`, active execution state, and whether cloud followup submission is allowed in `app/src/ai/ambient_agents/task.rs:317`.
+- `SharingAccessLevel` is ordered as View < Edit < Full in `crates/warp_server_client/src/drive/sharing.rs:8`.
+There is an object-access precedent, but it is tied to loaded Warp Drive objects:
+- `CloudViewModel::access_level` defaults missing objects to view access in `app/src/cloud_object/model/view.rs:173`.
+- `CloudViewModel::object_access_level` grants full access for personal/team-space objects, applies link and guest ACLs for shared-space objects, and upgrades creator access to edit in `app/src/cloud_object/model/view.rs:181`.
+The APP-4483 implementation should reuse the same permission semantics where possible, but must operate directly on `ServerAIConversationMetadata.permissions` because AI conversation metadata is not a `CloudObject`.
+## Proposed changes
+### 1. Add a single continuation UI state resolver
+Add a small helper module under `app/src/terminal/view/shared_session/`, for example `cloud_conversation_continuation.rs`, and use it from all tombstone/followup decision paths.
+Suggested core types:
+- `ContinuationHarness`: `Oz`, `ThirdParty`, or `Unknown`.
+- `ConversationAccess`: `Edit`, `ViewOnly`, or `Unknown`.
+- `TombstoneCta`: `ContinueLocally`, `ContinueInCloud { task_id }`, or none.
+- `CloudConversationContinuationUiState`, containing:
+  - whether the ended-state tombstone should be present;
+  - whether the inline cloud followup input should be enabled;
+  - the task id to use for cloud followup input submission, if any;
+  - the tombstone CTA to render, if any.
+The resolver should accept the terminal view id, optional ambient task id, whether a live shared session is still active, and `AppContext`. It should derive:
+- active execution from the ambient task when present;
+- harness from `ServerAIConversationMetadata.harness`, not from tombstone display metadata;
+- edit access from `ServerAIConversationMetadata.permissions`;
+- unknown state when task or conversation metadata is unavailable.
+Mapping:
+- B1: Oz + edit + no active execution returns no tombstone and followup input enabled for that task.
+- B2: Oz + view-only + no active execution returns tombstone with `ContinueLocally`.
+- B3: third-party + edit + no active execution returns tombstone with `ContinueInCloud`.
+- B4: third-party + view-only + no active execution returns tombstone with no CTA.
+- B5: any harness/access + active execution or live shared session returns no ended-state tombstone and no followup input transition.
+- B6: unknown harness or unknown access + no active execution returns tombstone with no CTA.
+When `FeatureFlag::HandoffCloudCloud` is disabled, keep the existing pre-APP-4483 behavior path: ended ambient sessions may show the tombstone, but the permission-aware cloud followup state should not be used.
+### 2. Resolve conversation metadata by server token
+Add a `BlocklistAIHistoryModel` helper that returns `ServerAIConversationMetadata` by `ServerConversationToken`, for example:
+- check `server_token_to_conversation_id`;
+- if found, reuse `get_server_conversation_metadata`;
+- otherwise scan `all_conversations_metadata` for matching `server_conversation_token`;
+- return `None` if metadata is not loaded.
+This avoids forcing callers to manufacture or resolve an `AIConversationId` before they can inspect task-linked conversation permissions. `AmbientAgentTask::conversation_id` returns the token string at `app/src/ai/ambient_agents/task.rs:317`, so the resolver can construct a `ServerConversationToken` from that value and ask the history model for metadata.
+If metadata is missing, do not fetch synchronously from the UI resolver. Treat the state as B6 and let the existing `AgentConversationsModel` fetch path populate metadata asynchronously.
+### 3. Compute edit access from `ServerPermissions`
+Add a pure helper near the resolver or in a small permission utility that computes the current user's effective `SharingAccessLevel` from `ServerAIConversationMetadata`.
+Rules:
+- If the current user is missing or logged out, start at `SharingAccessLevel::View`.
+- If `permissions.space` is `Owner::User` for the current user, return at least `Full`.
+- If `permissions.space` is `Owner::Team` and the team appears in `UserWorkspaces::team_from_uid_across_all_workspaces`, return at least `Full`.
+- Apply `permissions.anyone_link_sharing` as a baseline when present.
+- Apply user guest ACLs when `ServerGuestSubject::User { firebase_uid }` matches the current user.
+- Apply team guest ACLs when the current user belongs to the guest team according to `UserWorkspaces`.
+- Ignore pending-user ACLs for this UI decision.
+- If `metadata.creator_uid` matches the current user, upgrade to at least `Edit`, matching the creator fallback in `CloudViewModel::object_access_level`.
+- Return `ConversationAccess::Edit` for `Edit` or `Full`; return `ViewOnly` for `View`.
+If team membership data is not loaded and access is only knowable through a team owner/guest ACL, do not assume edit access. The safe UI state remains view-only/unknown until workspace metadata is available.
+### 4. Replace ownership-based UI branching
+Replace the creator-owned task gate in these call sites with the resolver:
+- `on_session_share_ended` in `app/src/terminal/view/shared_session/view_impl.rs:727`.
+- `handle_non_running_ambient_agent_task` in `app/src/terminal/view/shared_session/view_impl.rs:811`.
+- `maybe_insert_tombstone_for_non_running_shared_ambient_task` in `app/src/terminal/view.rs:7123`.
+Add a shared method on `TerminalView`, for example `refresh_non_running_cloud_agent_continuation_ui`, that:
+- exits early for disabled `CloudModeSetupV2`, active replay, existing pending cloud followup submission, or disabled `HandoffCloudCloud`;
+- asks the resolver for the current state;
+- removes an existing tombstone when the new state is B1 and enables the cloud followup input;
+- inserts or updates the tombstone when the new state is B2, B3, B4, or B6;
+- keeps input selectable/read-only for viewers when no continuation input should be shown.
+`enable_owned_cloud_followup_input` should be renamed or wrapped with a permission-neutral name, such as `enable_cloud_followup_input`, because it will now be used for users with edit access who may not be the task creator.
+Update `try_submit_pending_cloud_followup` in `app/src/terminal/view.rs:20026` so it does not fall back to `owned_ambient_agent_task_id`. Submission should use an explicit `pending_cloud_followup_task_id` or a task id that the resolver stored when it enabled the inline input. This prevents creator ownership from remaining a hidden permission bypass.
+### 5. Make tombstone CTAs data-driven
+Change `ConversationEndedTombstoneView::new` to accept a CTA decision from the resolver rather than constructing both buttons from `task_id` and `conversation_id`.
+The tombstone should render:
+- `Continue locally` only for `TombstoneCta::ContinueLocally`.
+- `Continue` only for `TombstoneCta::ContinueInCloud { task_id }`.
+- no button when the CTA is absent.
+Keep `ConversationEndedTombstoneEvent::ContinueInCloud` and `start_cloud_followup_from_tombstone` for B3. Keep `ContinueLocally` behavior for B2. Keep `TombstoneDisplayData::enrich_from_task` for display metadata only; it should no longer decide CTA visibility after an async task fetch.
+This removes the current mismatch where `Continue` is shown for any task id and `Continue locally` is shown for unknown harness metadata.
+### 6. Recompute when metadata changes
+Permissions and metadata can arrive after the tombstone is first inserted. Recompute the continuation UI state when:
+- `AgentConversationsModelEvent::TasksUpdated` updates task active-execution state or task conversation id;
+- `AgentConversationsModelEvent::ConversationsLoaded` merges cloud conversation metadata;
+- `BlocklistAIHistoryEvent::UpdatedConversationMetadata` updates server metadata for a live conversation.
+If recomputation transitions:
+- from B6 to B1, remove the tombstone and enable the input;
+- from B6 to B2/B3/B4, update or reinsert the tombstone with the correct CTA;
+- from B1 to a non-edit state, clear/disable the input and show the tombstone state for the latest access.
+Use the resolver as the only source of truth for these transitions.
+## Testing and validation
+Add focused unit tests for the resolver and update existing shared-session tests so validation maps directly to `PRODUCT.md` B1–B6:
+- B1: Oz metadata + edit access + ended execution produces no tombstone, editable followup input, and cloud submission uses the same task id even when task creator is someone else.
+- B2: Oz metadata + view-only access produces a tombstone with `Continue locally`, no inline followup input, and no cloud CTA.
+- B3: Claude Code/Codex/Gemini metadata + edit access produces a tombstone with `Continue`, and clicking it enters the existing cloud followup flow.
+- B4: third-party metadata + view-only access produces a tombstone with no continue CTA.
+- B5: active execution or live shared session does not insert an ended-state tombstone regardless of harness/access.
+- B6: missing metadata, unknown harness, or unknown access produces a tombstone with no mutation CTA.
+Permission helper tests should cover:
+- user owner;
+- team owner with current-user team membership;
+- user guest view vs edit;
+- team guest view vs edit;
+- link sharing view only;
+- creator fallback to edit;
+- missing current user defaults to non-edit.
+Update or replace creator-based assertions in `app/src/terminal/view/shared_session/view_impl_tests.rs`, especially the tests currently named around “owned” ambient sessions. Add tombstone CTA tests in `app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs` once CTA state is data-driven.
+Suggested targeted commands:
+- `cargo test -p warp --lib terminal::view::shared_session::view_impl_tests`
+- `cargo test -p warp --lib terminal::view::shared_session::conversation_ended_tombstone_view_tests`
+- `cargo test -p warp --lib terminal::view::shared_session::cloud_conversation_continuation`
+Before PR/update, run the repository-required format and clippy checks from the PR workflow. Do not use `cargo fmt --all` or file-specific `cargo fmt`.
+## Parallelization
+Do not split this implementation across sub-agents. The changes are tightly coupled across one UI state resolver, terminal view lifecycle transitions, tombstone CTA rendering, and existing shared-session tests. Parallel edits would likely touch the same files and increase merge overhead more than they reduce wall-clock time.


### PR DESCRIPTION
## Description

[Demo](https://www.loom.com/share/f591784f65444cc894cedb194a2416a7)

[Demo pt II with 3rd party harnesses](https://www.loom.com/share/df53c75e0deb4c3eba7110eb85861691)

This cleans up the ended-session-state UI for cloud agent conversations behind `FeatureFlag::HandoffCloudCloud`.

The important bit is that we now make the tombstone / followup input / CTA decision from the underlying conversation metadata.
- Oz/Warp agent + edit access: hide the tombstone and show the input directly.
- Oz/warp agent + view-only access: show the tombstone with `Continue locally`.
- Third-party harness + edit access: show the tombstone with `Continue`.
- Third-party harness + view-only access, or missing metadata: show the tombstone, no continue action.

I also pulled that branching into a shared resolver, made tombstone CTAs data-driven, and added specs/tests around the behavior so we do not keep re-implementing the same checks in terminal view code.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
