### PR TITLE
Use legacy changelog action for non-stable channels

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1619,7 +1619,7 @@ jobs:
 
   generate_changelogs:
     name: Generate Changelogs
-    if: ${{ needs.prepare_release.outputs.should_publish == 'true' && inputs.channel == 'stable' }}
+    if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}
     runs-on: ubuntu-latest
     needs:
       - prepare_release

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1646,7 +1646,12 @@ jobs:
           config_file: ${{ env.CONFIG_FILE }}
           channel: ${{ inputs.channel }}
 
-      - name: Generate changelog via Oz
+      # Stable releases use the Oz changelog-draft agent for higher-quality,
+      # human-reviewable output. Non-stable channels (dev/preview/beta) use the
+      # legacy generate-changelog action to avoid spending Oz agent tokens on
+      # daily dev cuts and preview RCs.
+      - name: Generate changelog via Oz (stable only)
+        if: inputs.channel == 'stable'
         uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # main
         with:
           prompt: |
@@ -1663,31 +1668,60 @@ jobs:
           warp_api_key: ${{ secrets.WARP_API_KEY }}
           share: team
 
-      - name: Convert draft JSON to release format
+      - name: Convert draft JSON to release format (stable only)
+        if: inputs.channel == 'stable'
         shell: bash
         run: |
           python3 .agents/skills/changelog-draft/scripts/convert_to_release_json.py \
             --input "${{ runner.temp }}/changelog-draft/changelog-draft.json" \
             --output "${{ runner.temp }}/changelog-draft/changelog-release.json"
 
-      - name: Load release changelog into step output
+      - name: Obtain a GitHub App Installation Access Token (non-stable only)
+        if: inputs.channel != 'stable'
+        id: github_app_auth
+        run: |
+          TOKEN="$(npx obtain-github-app-installation-access-token ci ${{ secrets.GH_APP_CREDENTIALS_TOKEN }})"
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog via legacy action (non-stable only)
+        if: inputs.channel != 'stable'
+        id: legacy_changelog
+        uses: warpdotdev/generate-changelog@70f534c1e030dafb45046ae57e4aa4d43a2f5c84 # main
+        with:
+          channel: ${{ inputs.channel }}
+          github_auth_token: ${{ steps.github_app_auth.outputs.token }}
+          version: ${{ needs.prepare_release.outputs.release_tag }}
+
+      - name: Load changelog into step output
         id: generate_changelog
         shell: bash
+        env:
+          LEGACY_CHANGELOG: ${{ steps.legacy_changelog.outputs.changelog }}
         run: |
-          # Read the release-pipeline-compatible JSON produced by the conversion
-          # script and expose it as a step output so downstream steps can consume
-          # it with the same interface as the old generate-changelog action.
-          CHANGELOG_FILE="${{ runner.temp }}/changelog-draft/changelog-release.json"
-          if [ ! -f "$CHANGELOG_FILE" ]; then
-            echo "::error::changelog-release.json not found at $CHANGELOG_FILE"
-            exit 1
+          # Bridge step: picks whichever generator ran for this channel and
+          # re-emits the changelog as outputs.changelog so downstream Slack/GCS
+          # steps work unchanged.
+          if [[ "${{ inputs.channel }}" == "stable" ]]; then
+            CHANGELOG_FILE="${{ runner.temp }}/changelog-draft/changelog-release.json"
+            if [ ! -f "$CHANGELOG_FILE" ]; then
+              echo "::error::changelog-release.json not found at $CHANGELOG_FILE"
+              exit 1
+            fi
+            jq empty "$CHANGELOG_FILE"
+            {
+              echo "changelog<<CHANGELOG_EOF"
+              cat "$CHANGELOG_FILE"
+              echo "CHANGELOG_EOF"
+            } >> $GITHUB_OUTPUT
+          else
+            echo "$LEGACY_CHANGELOG" | jq empty
+            {
+              echo "changelog<<CHANGELOG_EOF"
+              printf '%s\n' "$LEGACY_CHANGELOG"
+              echo "CHANGELOG_EOF"
+            } >> $GITHUB_OUTPUT
           fi
-          # Validate JSON
-          jq empty "$CHANGELOG_FILE"
-          # Set multiline output
-          echo "changelog<<CHANGELOG_EOF" >> $GITHUB_OUTPUT
-          cat "$CHANGELOG_FILE" >> $GITHUB_OUTPUT
-          echo "CHANGELOG_EOF" >> $GITHUB_OUTPUT
 
       - name: Build Slack changelog payload
         id: build_slack_payload


### PR DESCRIPTION
## Summary

Fixes the dev in-app changelog regression from #10832 without re-running the Oz agent on every non-stable cut.

- **Stable**: unchanged — keeps the new Oz changelog-draft agent flow.
- **Dev / preview / beta**: restores the legacy `warpdotdev/generate-changelog` action, so a fresh `changelog.json` is uploaded to GCS for every cut.
- A small bridge step picks whichever path ran and re-emits the result as `steps.generate_changelog.outputs.changelog`, so the downstream Slack post + GCS upload steps work unchanged.

## Background

#10832 gated `generate_changelogs` to stable-only to save agent tokens. That broke the dev in-app changelog: the dev client fetches `changelog.json` from GCS first (`app/src/autoupdate/changelog.rs:84` — `should_fetch_changelog_json` is `true` only for `Channel::Dev`) and falls back to `channel_versions.json`'s `changelogs.dev.latest` on 404. Skipping the upload for dev releases caused the client to surface a 2021-era `[TEST]` fixture from `channel_versions.json` in the in-app \"What's new in Oz\" section.

Preview/stable read straight from `channel_versions.json` (no GCS), so they were never exposed to the bug. The follow-up cleanup of the stale `changelogs.dev.latest` fixture in `warpdotdev/channel-versions` is in flight separately and is good hygiene regardless.

## Why hybrid instead of \"new flow everywhere\"

- Saves ~27-min agent invocation × daily dev cuts + preview/beta RCs
- Dogfooding signal on the Oz flow is preserved on stable cuts (where output quality matters most) plus the existing `workflow_dispatch` `changelog_draft.yml` for ad-hoc runs
- Existing battle-tested generate-changelog action keeps running for the channels users consume daily

## Test plan

- [ ] Watch the next dev release cut and confirm `warp-releases/dev/<release_tag>/changelog.json` is uploaded
- [ ] Confirm dev client renders the new release notes (not the `[TEST]` fixtures)
- [ ] Confirm next stable cut still runs through Oz and produces a sensible Slack post + GCS changelog.json
- [ ] Confirm preview RC cut runs the legacy path and posts to Slack as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)