### PR TITLE
Hide tombstone CTAs for platform errors

### DIFF
--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -527,8 +527,42 @@ pub struct TaskStatusMessage {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatusErrorCode {
+    #[serde(alias = "AUTHENTICATION_REQUIRED")]
+    AuthenticationRequired,
+    #[serde(alias = "BUDGET_EXCEEDED")]
+    BudgetExceeded,
+    #[serde(alias = "CONFLICT")]
+    Conflict,
+    #[serde(alias = "CONTENT_POLICY_VIOLATION")]
+    ContentPolicyViolation,
     #[serde(alias = "ENVIRONMENT_SETUP_FAILED")]
     EnvironmentSetupFailed,
+    #[serde(alias = "EXTERNAL_AUTHENTICATION_REQUIRED")]
+    ExternalAuthenticationRequired,
+    #[serde(alias = "FEATURE_NOT_AVAILABLE")]
+    FeatureNotAvailable,
+    #[serde(alias = "INSUFFICIENT_CREDITS")]
+    InsufficientCredits,
+    #[serde(alias = "INTEGRATION_DISABLED")]
+    IntegrationDisabled,
+    #[serde(alias = "INTEGRATION_NOT_CONFIGURED")]
+    IntegrationNotConfigured,
+    #[serde(alias = "INTERNAL_ERROR")]
+    InternalError,
+    #[serde(alias = "INVALID_REQUEST")]
+    InvalidRequest,
+    #[serde(alias = "NOT_AUTHORIZED")]
+    NotAuthorized,
+    #[serde(alias = "OPERATION_NOT_SUPPORTED")]
+    OperationNotSupported,
+    #[serde(alias = "RESOURCE_NOT_FOUND")]
+    ResourceNotFound,
+    #[serde(alias = "RESOURCE_UNAVAILABLE")]
+    ResourceUnavailable,
+    #[serde(alias = "INFRASTRUCTURE_TIMEOUT")]
+    InfrastructureTimeout,
+    #[serde(alias = "AGENT_PROCESS_FAILED")]
+    AgentProcessFailed,
     #[serde(other)]
     Unknown,
 }
@@ -537,6 +571,31 @@ impl TaskStatusErrorCode {
     pub fn is_environment_setup_failure(&self) -> bool {
         matches!(self, TaskStatusErrorCode::EnvironmentSetupFailed)
     }
+
+    pub fn should_hide_continue_actions(&self) -> bool {
+        matches!(
+            self,
+            TaskStatusErrorCode::AuthenticationRequired
+                | TaskStatusErrorCode::BudgetExceeded
+                | TaskStatusErrorCode::Conflict
+                | TaskStatusErrorCode::ContentPolicyViolation
+                | TaskStatusErrorCode::EnvironmentSetupFailed
+                | TaskStatusErrorCode::ExternalAuthenticationRequired
+                | TaskStatusErrorCode::FeatureNotAvailable
+                | TaskStatusErrorCode::InsufficientCredits
+                | TaskStatusErrorCode::IntegrationDisabled
+                | TaskStatusErrorCode::IntegrationNotConfigured
+                | TaskStatusErrorCode::InternalError
+                | TaskStatusErrorCode::InvalidRequest
+                | TaskStatusErrorCode::NotAuthorized
+                | TaskStatusErrorCode::OperationNotSupported
+                | TaskStatusErrorCode::ResourceNotFound
+                | TaskStatusErrorCode::ResourceUnavailable
+                | TaskStatusErrorCode::InfrastructureTimeout
+                | TaskStatusErrorCode::AgentProcessFailed
+                | TaskStatusErrorCode::Unknown
+        )
+    }
 }
 
 impl TaskStatusMessage {
@@ -544,6 +603,12 @@ impl TaskStatusMessage {
         self.error_code
             .as_ref()
             .is_some_and(TaskStatusErrorCode::is_environment_setup_failure)
+    }
+
+    pub fn should_hide_continue_actions(&self) -> bool {
+        self.error_code
+            .as_ref()
+            .is_some_and(TaskStatusErrorCode::should_hide_continue_actions)
     }
 }
 

--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -527,88 +527,15 @@ pub struct TaskStatusMessage {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatusErrorCode {
-    #[serde(alias = "AUTHENTICATION_REQUIRED")]
-    AuthenticationRequired,
-    #[serde(alias = "BUDGET_EXCEEDED")]
-    BudgetExceeded,
-    #[serde(alias = "CONFLICT")]
-    Conflict,
-    #[serde(alias = "CONTENT_POLICY_VIOLATION")]
-    ContentPolicyViolation,
     #[serde(alias = "ENVIRONMENT_SETUP_FAILED")]
     EnvironmentSetupFailed,
-    #[serde(alias = "EXTERNAL_AUTHENTICATION_REQUIRED")]
-    ExternalAuthenticationRequired,
-    #[serde(alias = "FEATURE_NOT_AVAILABLE")]
-    FeatureNotAvailable,
-    #[serde(alias = "INSUFFICIENT_CREDITS")]
-    InsufficientCredits,
-    #[serde(alias = "INTEGRATION_DISABLED")]
-    IntegrationDisabled,
-    #[serde(alias = "INTEGRATION_NOT_CONFIGURED")]
-    IntegrationNotConfigured,
-    #[serde(alias = "INTERNAL_ERROR")]
-    InternalError,
-    #[serde(alias = "INVALID_REQUEST")]
-    InvalidRequest,
-    #[serde(alias = "NOT_AUTHORIZED")]
-    NotAuthorized,
-    #[serde(alias = "OPERATION_NOT_SUPPORTED")]
-    OperationNotSupported,
-    #[serde(alias = "RESOURCE_NOT_FOUND")]
-    ResourceNotFound,
-    #[serde(alias = "RESOURCE_UNAVAILABLE")]
-    ResourceUnavailable,
-    #[serde(alias = "INFRASTRUCTURE_TIMEOUT")]
-    InfrastructureTimeout,
-    #[serde(alias = "AGENT_PROCESS_FAILED")]
-    AgentProcessFailed,
     #[serde(other)]
     Unknown,
 }
 
-impl TaskStatusErrorCode {
-    pub fn is_environment_setup_failure(&self) -> bool {
-        matches!(self, TaskStatusErrorCode::EnvironmentSetupFailed)
-    }
-
-    pub fn should_hide_continue_actions(&self) -> bool {
-        matches!(
-            self,
-            TaskStatusErrorCode::AuthenticationRequired
-                | TaskStatusErrorCode::BudgetExceeded
-                | TaskStatusErrorCode::Conflict
-                | TaskStatusErrorCode::ContentPolicyViolation
-                | TaskStatusErrorCode::EnvironmentSetupFailed
-                | TaskStatusErrorCode::ExternalAuthenticationRequired
-                | TaskStatusErrorCode::FeatureNotAvailable
-                | TaskStatusErrorCode::InsufficientCredits
-                | TaskStatusErrorCode::IntegrationDisabled
-                | TaskStatusErrorCode::IntegrationNotConfigured
-                | TaskStatusErrorCode::InternalError
-                | TaskStatusErrorCode::InvalidRequest
-                | TaskStatusErrorCode::NotAuthorized
-                | TaskStatusErrorCode::OperationNotSupported
-                | TaskStatusErrorCode::ResourceNotFound
-                | TaskStatusErrorCode::ResourceUnavailable
-                | TaskStatusErrorCode::InfrastructureTimeout
-                | TaskStatusErrorCode::AgentProcessFailed
-                | TaskStatusErrorCode::Unknown
-        )
-    }
-}
-
 impl TaskStatusMessage {
-    pub fn is_environment_setup_failure(&self) -> bool {
-        self.error_code
-            .as_ref()
-            .is_some_and(TaskStatusErrorCode::is_environment_setup_failure)
-    }
-
-    pub fn should_hide_continue_actions(&self) -> bool {
-        self.error_code
-            .as_ref()
-            .is_some_and(TaskStatusErrorCode::should_hide_continue_actions)
+    pub fn is_platform_failure(&self) -> bool {
+        self.error_code.is_some()
     }
 }
 

--- a/app/src/ai/ambient_agents/task_tests.rs
+++ b/app/src/ai/ambient_agents/task_tests.rs
@@ -35,4 +35,50 @@ fn task_status_error_code_deserializes_unknown_codes() {
 
     assert_eq!(message.error_code, Some(TaskStatusErrorCode::Unknown));
     assert!(!message.is_environment_setup_failure());
+    assert!(message.should_hide_continue_actions());
+}
+
+#[test]
+fn platform_error_codes_hide_continue_actions() {
+    let codes = [
+        "authentication_required",
+        "budget_exceeded",
+        "conflict",
+        "content_policy_violation",
+        "environment_setup_failed",
+        "external_authentication_required",
+        "feature_not_available",
+        "insufficient_credits",
+        "integration_disabled",
+        "integration_not_configured",
+        "internal_error",
+        "invalid_request",
+        "not_authorized",
+        "operation_not_supported",
+        "resource_not_found",
+        "resource_unavailable",
+        "infrastructure_timeout",
+        "agent_process_failed",
+    ];
+
+    for code in codes {
+        let json = format!("{{\"message\":\"failed\",\"error_code\":\"{code}\"}}");
+        let message: TaskStatusMessage = serde_json::from_str(&json).unwrap();
+
+        assert!(message.should_hide_continue_actions(), "code {code}");
+    }
+}
+
+#[test]
+fn platform_error_codes_deserialize_graphql_casing() {
+    let message: TaskStatusMessage = serde_json::from_str(
+        "{\"message\":\"capacity full\",\"errorCode\":\"RESOURCE_UNAVAILABLE\"}",
+    )
+    .unwrap();
+
+    assert_eq!(
+        message.error_code,
+        Some(TaskStatusErrorCode::ResourceUnavailable)
+    );
+    assert!(message.should_hide_continue_actions());
 }

--- a/app/src/ai/ambient_agents/task_tests.rs
+++ b/app/src/ai/ambient_agents/task_tests.rs
@@ -11,7 +11,7 @@ fn task_status_error_code_deserializes_public_api_casing() {
         message.error_code,
         Some(TaskStatusErrorCode::EnvironmentSetupFailed)
     );
-    assert!(message.is_environment_setup_failure());
+    assert!(message.is_platform_failure());
 }
 
 #[test]
@@ -25,7 +25,7 @@ fn task_status_error_code_deserializes_graphql_casing() {
         message.error_code,
         Some(TaskStatusErrorCode::EnvironmentSetupFailed)
     );
-    assert!(message.is_environment_setup_failure());
+    assert!(message.is_platform_failure());
 }
 
 #[test]
@@ -34,51 +34,5 @@ fn task_status_error_code_deserializes_unknown_codes() {
         serde_json::from_str("{\"message\":\"failed\",\"error_code\":\"new_error\"}").unwrap();
 
     assert_eq!(message.error_code, Some(TaskStatusErrorCode::Unknown));
-    assert!(!message.is_environment_setup_failure());
-    assert!(message.should_hide_continue_actions());
-}
-
-#[test]
-fn platform_error_codes_hide_continue_actions() {
-    let codes = [
-        "authentication_required",
-        "budget_exceeded",
-        "conflict",
-        "content_policy_violation",
-        "environment_setup_failed",
-        "external_authentication_required",
-        "feature_not_available",
-        "insufficient_credits",
-        "integration_disabled",
-        "integration_not_configured",
-        "internal_error",
-        "invalid_request",
-        "not_authorized",
-        "operation_not_supported",
-        "resource_not_found",
-        "resource_unavailable",
-        "infrastructure_timeout",
-        "agent_process_failed",
-    ];
-
-    for code in codes {
-        let json = format!("{{\"message\":\"failed\",\"error_code\":\"{code}\"}}");
-        let message: TaskStatusMessage = serde_json::from_str(&json).unwrap();
-
-        assert!(message.should_hide_continue_actions(), "code {code}");
-    }
-}
-
-#[test]
-fn platform_error_codes_deserialize_graphql_casing() {
-    let message: TaskStatusMessage = serde_json::from_str(
-        "{\"message\":\"capacity full\",\"errorCode\":\"RESOURCE_UNAVAILABLE\"}",
-    )
-    .unwrap();
-
-    assert_eq!(
-        message.error_code,
-        Some(TaskStatusErrorCode::ResourceUnavailable)
-    );
-    assert!(message.should_hide_continue_actions());
+    assert!(message.is_platform_failure());
 }

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -151,7 +151,7 @@ impl TombstoneDisplayData {
         if task.state.is_failure_like() {
             self.is_error = true;
             if let Some(status_message) = &task.status_message {
-                if status_message.is_environment_setup_failure() {
+                if status_message.should_hide_continue_actions() {
                     self.hide_continue_actions = true;
                 }
                 self.error_message = Some(status_message.message.clone());

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -151,7 +151,7 @@ impl TombstoneDisplayData {
         if task.state.is_failure_like() {
             self.is_error = true;
             if let Some(status_message) = &task.status_message {
-                if status_message.should_hide_continue_actions() {
+                if status_message.is_platform_failure() {
                     self.hide_continue_actions = true;
                 }
                 self.error_message = Some(status_message.message.clone());

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
@@ -103,21 +103,6 @@ fn environment_setup_failure_hides_continue_actions() {
     assert!(data.hide_continue_actions);
 }
 
-#[test]
-fn platform_error_hides_continue_actions() {
-    let mut task = task_with_run_time_and_credits();
-    task.state = AmbientAgentTaskState::Error;
-    task.status_message = Some(TaskStatusMessage {
-        message: "Agent capacity is temporarily full.".to_string(),
-        error_code: Some(TaskStatusErrorCode::ResourceUnavailable),
-    });
-    let mut data = TombstoneDisplayData::default();
-
-    data.enrich_from_task(task);
-
-    assert!(data.hide_continue_actions);
-}
-
 fn pr_artifact(branch: &str) -> Artifact {
     Artifact::PullRequest {
         url: format!("https://github.com/example/repo/pull/{branch}"),

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view_tests.rs
@@ -103,6 +103,21 @@ fn environment_setup_failure_hides_continue_actions() {
     assert!(data.hide_continue_actions);
 }
 
+#[test]
+fn platform_error_hides_continue_actions() {
+    let mut task = task_with_run_time_and_credits();
+    task.state = AmbientAgentTaskState::Error;
+    task.status_message = Some(TaskStatusMessage {
+        message: "Agent capacity is temporarily full.".to_string(),
+        error_code: Some(TaskStatusErrorCode::ResourceUnavailable),
+    });
+    let mut data = TombstoneDisplayData::default();
+
+    data.enrich_from_task(task);
+
+    assert!(data.hide_continue_actions);
+}
+
 fn pr_artifact(branch: &str) -> Artifact {
     Artifact::PullRequest {
         url: format!("https://github.com/example/repo/pull/{branch}"),


### PR DESCRIPTION
## Description
Hide tombstone continue actions for task-backed platform errors. Before this was just done for environment setup command failures, now it's done for everything with an error code—I went through the error codes and I think this makes sense to do for all tasks with `Some(error_code)`. 

## Testing
Tested locally: https://www.loom.com/share/9df288ab78e74608ac1f39d224184bed

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/e900ee63-26bd-4d49-9613-4ef88c4ac91f_
_Run: https://oz.staging.warp.dev/runs/019e27db-1bdf-719c-b6ce-fcf2438d91ea_
_This PR was generated with [Oz](https://warp.dev/oz)._
