### PR TITLE
Fix discard files panic

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -712,13 +712,13 @@ impl CodeReviewView {
 
     fn to_standardized_path(&self, path: &PathBuf) -> Option<StandardizedPath> {
         if path.is_absolute() {
-            return Some(StandardizedPath::from_local_absolute_unchecked(&path));
+            Some(StandardizedPath::from_local_absolute_unchecked(path))
         } else {
             let repo_path = self.repo_path()?;
             let absolute_path = repo_path.join(path);
-            return Some(StandardizedPath::from_local_absolute_unchecked(
+            Some(StandardizedPath::from_local_absolute_unchecked(
                 &absolute_path,
-            ));
+            ))
         }
     }
 
@@ -7302,9 +7302,9 @@ impl TypedActionView for CodeReviewView {
                                 .get(path)
                                 .unwrap_or(&false)
                             {
-                                return None;
+                                None
                             } else {
-                                return self.to_standardized_path(&path);
+                                self.to_standardized_path(path)
                             }
                         })
                         .collect();

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -710,6 +710,18 @@ impl CodeReviewView {
         self.active_repo.as_ref().map(|repo| &repo.repo_path)
     }
 
+    fn to_standardized_path(&self, path: &PathBuf) -> Option<StandardizedPath> {
+        if path.is_absolute() {
+            return Some(StandardizedPath::from_local_absolute_unchecked(&path));
+        } else {
+            let repo_path = self.repo_path()?;
+            let absolute_path = repo_path.join(path);
+            return Some(StandardizedPath::from_local_absolute_unchecked(
+                &absolute_path,
+            ));
+        }
+    }
+
     pub fn diff_state_model(&self) -> &ModelHandle<DiffStateModel> {
         &self.diff_state_model
     }
@@ -5578,23 +5590,31 @@ impl CodeReviewView {
             .finish()
     }
 
-    fn create_file_status_info(&self, path: PathBuf) -> FileStatusInfo {
+    fn create_file_status_info(&self, path: StandardizedPath) -> FileStatusInfo {
+        let Some(local_path) = path.to_local_path() else {
+            return FileStatusInfo {
+                path,
+                status: GitFileStatus::Modified,
+            };
+        };
         let status = match self.state() {
             CodeReviewViewState::Loaded(loaded_state) => loaded_state
                 .file_states
-                .get(&path)
+                .get(&local_path)
                 .map(|fs| fs.file_diff.status.clone())
                 .unwrap_or(GitFileStatus::Modified),
             _ => GitFileStatus::Modified,
         };
-        FileStatusInfo {
-            path: StandardizedPath::from_local_absolute_unchecked(&path),
-            status,
-        }
+        FileStatusInfo { path, status }
     }
 
-    fn discard_file(&mut self, path: &Path, should_stash: bool, ctx: &mut ViewContext<Self>) {
-        let file_info = self.create_file_status_info(path.to_path_buf());
+    fn discard_file(
+        &mut self,
+        path: StandardizedPath,
+        should_stash: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let file_info = self.create_file_status_info(path);
 
         let branch_name = match &self.discard_dialog_state.operation_type {
             DiscardOperationType::FileChangesAgainstBranch(None) => {
@@ -5613,7 +5633,7 @@ impl CodeReviewView {
 
     fn discard_multiple_files(
         &mut self,
-        file_paths: Vec<PathBuf>,
+        file_paths: Vec<StandardizedPath>,
         should_stash: bool,
         ctx: &mut ViewContext<Self>,
     ) {
@@ -7271,18 +7291,22 @@ impl TypedActionView for CodeReviewView {
 
                 if is_discard_all {
                     // Get list of selected files
-                    let selected_files: Vec<PathBuf> = self
+                    let selected_files: Vec<StandardizedPath> = self
                         .discard_dialog_state
                         .discard_file_paths
                         .iter()
-                        .filter(|path| {
-                            *self
+                        .filter_map(|path| {
+                            if !*self
                                 .discard_dialog_state
                                 .selected_files
-                                .get(*path)
+                                .get(path)
                                 .unwrap_or(&false)
+                            {
+                                return None;
+                            } else {
+                                return self.to_standardized_path(&path);
+                            }
                         })
-                        .cloned()
                         .collect();
 
                     if !selected_files.is_empty() {
@@ -7294,11 +7318,13 @@ impl TypedActionView for CodeReviewView {
                     }
                 } else {
                     let file_path = self.discard_dialog_state.discard_file_paths[0].clone();
-                    self.discard_file(
-                        &file_path,
-                        self.discard_dialog_state.stash_changes_enabled,
-                        ctx,
-                    );
+                    if let Some(standardized_path) = self.to_standardized_path(&file_path) {
+                        self.discard_file(
+                            standardized_path,
+                            self.discard_dialog_state.stash_changes_enabled,
+                            ctx,
+                        );
+                    }
                 }
                 self.discard_dialog_state.show_discard_confirm_dialog = false;
                 self.discard_dialog_state.discard_file_paths.clear();


### PR DESCRIPTION
## Description
* WISOTT 
* Discard files was packing due to a change to `FileStatusInfo` where it is expecting a `StandardizedPath` 
* This ensures we're properly converting to `StandardizedPath` when calling discard files 

## Linked Issue
Reported in: 
* https://warpdev.slack.com/archives/C08KTPNQN65/p1778768774291739
* https://warpdev.slack.com/archives/C08KTPNQN65/p1778709304030439
* https://warpdotdev.sentry.io/issues/7479418842/?project=5701177&query=is%3Aunresolved%20panic&referrer=issue-stream 

## Testing
Tested manually - discarding a file, a hunk and an entire diff set work as expected - repro-ed the panic and can confirm it no longer panics.
- [x] I have manually tested my changes locally with `./script/run`