### PR TITLE
Log full SdkError detail on Bedrock OIDC AssumeRoleWithWebIdentity failure

### DIFF
--- a/app/src/ai/aws_credentials.rs
+++ b/app/src/ai/aws_credentials.rs
@@ -347,6 +347,11 @@ fn refresh_aws_credentials_oidc(
                 .send()
                 .await
                 .map_err(|err| {
+                    // Dump the full SDK error chain at error level so on-call has
+                    // actionable detail (failure kind, connector cause, AWS service
+                    // exception, etc.) beyond the terse top-level Display that gets
+                    // surfaced to the user.
+                    log::error!("Bedrock OIDC: STS AssumeRoleWithWebIdentity SDK error: {err:#?}");
                     // Surface the AWS service error message for a user-friendly error.
                     let detail = err
                         .as_service_error()

--- a/app/src/ai/aws_credentials.rs
+++ b/app/src/ai/aws_credentials.rs
@@ -347,10 +347,6 @@ fn refresh_aws_credentials_oidc(
                 .send()
                 .await
                 .map_err(|err| {
-                    // Dump the full SDK error chain at error level so on-call has
-                    // actionable detail (failure kind, connector cause, AWS service
-                    // exception, etc.) beyond the terse top-level Display that gets
-                    // surfaced to the user.
                     log::error!("Bedrock OIDC: STS AssumeRoleWithWebIdentity SDK error: {err:#?}");
                     // Surface the AWS service error message for a user-friendly error.
                     let detail = err


### PR DESCRIPTION
## Description
When AWS STS `AssumeRoleWithWebIdentity` fails inside the Bedrock OIDC credential refresh, the `.map_err` closure collapses the structured `SdkError` into a short `STS AssumeRoleWithWebIdentity failed: <Display>` string and uses that *both* as the user-facing error and as the only `log::error!` line — the original `SdkError` is dropped.

In practice that means on-call sees something like `dispatch failure` with no failure kind, no connector cause (hyper/rustls/DNS/TLS), and no AWS service exception. To learn anything more you have to ask the user to re-run with `RUST_LOG=aws_sdk_sts=trace,aws_smithy_runtime=trace` and reproduce the failure.

This PR mirrors what the local-chain path already does for `CredentialsError` (`app/src/ai/aws_credentials.rs:148` — `log::warn!("{e:#?}")`) and adds a single `log::error!("{err:#?}")` of the raw `SdkError` inside the OIDC `.map_err` before it gets mapped to the user-facing string. No behavior change; no change to the toast.

## Linked Issue
N/A — observability fix.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --check` passes.
- `cargo clippy -p warp --all-targets --tests -- -D warnings` passes.
- Pure log-emission addition with no control-flow change; the existing `aws_credentials` unit tests still pass and no new test surface is added.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — non-UI change. The new log line appears in client logs (and in the dev console under `./script/run`) only when STS `AssumeRoleWithWebIdentity` fails.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

---

[Conversation](https://staging.warp.dev/conversation/e2dfc517-7abb-4543-8436-dcaaf6b45545)
