### PR TITLE
Hide handoff entrypoint hint when already viewing a cloud conversation

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -1983,6 +1983,7 @@ impl AgentInputFooter {
         &self,
         item: &AgentToolbarItemKind,
         shared_status: &SharedSessionStatus,
+        is_cloud_context: bool,
         app: &AppContext,
     ) -> Option<Box<dyn Element>> {
         let is_cloud_mode = FeatureFlag::CloudModeImageContext.is_enabled()
@@ -2062,11 +2063,7 @@ impl AgentInputFooter {
                 .is_enabled()
                 .then(|| ChildView::new(&self.fast_forward_button).finish()),
             AgentToolbarItemKind::HandoffToCloud => {
-                if !AISettings::as_ref(app).is_cloud_handoff_enabled(app) {
-                    return None;
-                }
-
-                if is_cloud_mode {
+                if !AISettings::as_ref(app).is_cloud_handoff_enabled(app) || is_cloud_context {
                     return None;
                 }
 
@@ -2156,9 +2153,15 @@ impl View for AgentInputFooter {
 
         let terminal_model = self.terminal_model.lock();
         let shared_status = terminal_model.shared_session_status();
+        let is_cloud_context = super::is_in_cloud_context(
+            terminal_model.block_list().agent_view_state(),
+            &terminal_model,
+        );
 
         for item in &left_items {
-            if let Some(element) = self.render_toolbar_item(item, shared_status, app) {
+            if let Some(element) =
+                self.render_toolbar_item(item, shared_status, is_cloud_context, app)
+            {
                 left_buttons.add_child(element);
             }
         }
@@ -2179,7 +2182,9 @@ impl View for AgentInputFooter {
             );
         } else {
             for item in &right_items {
-                if let Some(element) = self.render_toolbar_item(item, shared_status, app) {
+                if let Some(element) =
+                    self.render_toolbar_item(item, shared_status, is_cloud_context, app)
+                {
                     right_buttons.add_child(element);
                 }
             }

--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -18,7 +18,7 @@ use crate::ai::agent::{
 use crate::ai::blocklist::agent_view::shortcuts::AgentShortcutViewModel;
 use crate::ai::blocklist::agent_view::zero_state_block::render_ambient_credits_banner;
 use crate::ai::blocklist::agent_view::{
-    agent_view_bg_fill, AgentViewController, AgentViewControllerEvent,
+    agent_view_bg_fill, is_in_cloud_context, AgentViewController, AgentViewControllerEvent,
 };
 use crate::ai::blocklist::{
     ai_brand_color, BlocklistAIContextEvent, BlocklistAIContextModel, BlocklistAIHistoryEvent,
@@ -578,10 +578,8 @@ impl MessageProvider<AgentMessageArgs<'_>> for ZeroStateMessageProducer {
             .with_is_disabled(!is_buffer_empty),
         );
 
-        let is_cloud_agent = matches!(
-            agent_view_controller.agent_view_state(),
-            AgentViewState::Active { origin, .. } if origin.is_cloud_agent()
-        );
+        let is_cloud_agent =
+            is_in_cloud_context(agent_view_controller.agent_view_state(), terminal_model);
 
         // Handoff to cloud only available for local agents.
         if !is_cloud_agent && AISettings::as_ref(app).is_ampersand_handoff_enabled(app) {

--- a/app/src/ai/blocklist/agent_view/mod.rs
+++ b/app/src/ai/blocklist/agent_view/mod.rs
@@ -31,6 +31,7 @@ use warp_core::ui::{appearance::Appearance, color::blend::Blend};
 use warpui::keymap::Keystroke;
 use warpui::{AppContext, SingletonEntity};
 
+use crate::terminal::model::TerminalModel;
 use crate::view_components::action_button::ActionButtonTheme;
 
 pub static ENTER_AGENT_VIEW_NEW_CONVERSATION_KEYSTROKE: LazyLock<Keystroke> = LazyLock::new(|| {
@@ -72,6 +73,26 @@ pub static ENTER_CLOUD_AGENT_VIEW_NEW_CONVERSATION_KEYSTROKE: LazyLock<Keystroke
             }
         }
     });
+
+/// Returns `true` when the current pane is in a cloud or remote context where
+/// local-to-cloud handoff is not applicable. Use this to gate the `&` hint,
+/// handoff chip, `/handoff` command activation, and `&` prefix activation.
+pub fn is_in_cloud_context(
+    agent_view_state: &AgentViewState,
+    terminal_model: &TerminalModel,
+) -> bool {
+    let origin_is_cloud = matches!(
+        agent_view_state,
+        AgentViewState::Active { origin, .. }
+            if matches!(
+                origin,
+                AgentViewEntryOrigin::CloudAgent | AgentViewEntryOrigin::ThirdPartyCloudAgent
+            )
+    );
+    origin_is_cloud
+        || terminal_model.is_conversation_transcript_viewer()
+        || terminal_model.is_dummy_cloud_mode_session()
+}
 
 pub fn agent_view_bg_fill(app: &AppContext) -> Fill {
     let appearance = Appearance::as_ref(app);

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -112,7 +112,7 @@ use crate::ai::block_context::BlockContext;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::agent_view::agent_input_footer::sort_environments_by_recency;
 use crate::ai::blocklist::agent_view::{
-    AgentInputFooter, AgentInputFooterEvent, AgentViewController,
+    is_in_cloud_context, AgentInputFooter, AgentInputFooterEvent, AgentViewController,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::touched_repos::{
@@ -3852,12 +3852,19 @@ impl Input {
         let is_powershell_with_nld_enabled = self.editor.as_ref(ctx).shell_family()
             == Some(ShellFamily::PowerShell)
             && AISettings::as_ref(ctx).is_ai_autodetection_enabled(ctx);
+        let is_cloud = {
+            let terminal_model = self.model.lock();
+            is_in_cloud_context(
+                terminal_model.block_list().agent_view_state(),
+                &terminal_model,
+            )
+        };
         *edit_origin == EditOrigin::UserTyped
             && AISettings::as_ref(ctx).is_ampersand_handoff_enabled(ctx)
             && !is_powershell_with_nld_enabled
             && FeatureFlag::AgentView.is_enabled()
             && self.agent_view_controller.as_ref(ctx).is_fullscreen()
-            && self.ambient_agent_view_model().is_none()
+            && !is_cloud
             && !CLIAgentSessionsModel::as_ref(ctx).is_input_open(self.terminal_view_id)
             && self.prefix_mode(ctx) == InputPrefixMode::None
     }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

WISOTT. This hint doesn't make sense to show if we're already in a cloud mode conversation.;

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/774534f7db79460fb99f6683d2193526

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode