### PR TITLE
Make worktree menu paths readable for long entries (#10862)

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -8745,6 +8745,7 @@ impl Workspace {
         .with_padding_override(0., 0.)
         .into_item();
         let query = self.worktree_sidecar_search_query.trim().to_lowercase();
+        let home = dirs::home_dir().map(|p| p.display().to_string());
         let mut items = vec![search_item];
         items.extend(
             PersistedWorkspace::as_ref(ctx)
@@ -8763,11 +8764,14 @@ impl Workspace {
                 })
                 .map(|ws| {
                     let path_str = ws.path.to_string_lossy().into_owned();
-                    MenuItemFields::new(path_str.clone())
+                    let display = user_friendly_path(&path_str, home.as_deref()).into_owned();
+                    MenuItemFields::new(display)
                         .with_on_select_action(NewSessionSidecarSelection::OpenWorktreeRepo {
-                            repo_path: path_str,
+                            repo_path: path_str.clone(),
                         })
                         .with_icon(icons::Icon::Folder)
+                        .with_clip_config(ClipConfig::start())
+                        .with_tooltip(path_str)
                         .into_item()
                 })
                 .collect::<Vec<_>>(),


### PR DESCRIPTION
## Description

Fixes #10862. The new-tab worktree menu truncates long repo paths from the right, hiding the distinguishing trailing folder when worktrees share a long parent path. Maintainer @moirahuang scoped the work to mirror the repo-picker fix from PR #9451 (#9439), excluding the "management controls" half of the original ask.

This PR ports the same three-part pattern to `build_worktree_sidecar_items` in `app/src/workspace/view.rs`:

1. Tilde-substitute the home directory in the displayed label via `warp_util::path::user_friendly_path`.
2. Apply `ClipConfig::start()` so truncation eats from the left and the trailing repo name stays visible.
3. Add `with_tooltip(path_str)` so the full absolute path is available on hover.

The raw path is preserved unchanged in the `OpenWorktreeRepo { repo_path }` action, so the actual cd target is unaffected.

## Linked Issue

Fixes #10862.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

**Automated.** No new tests added, matching the precedent set by reference PR #9451 (`b87da5fe`), which made the same three-part change to the repo picker without new tests. The change is mechanical builder calls on `MenuItemFields`; no logic to regress. Full warp-crate test suite passes locally (`cargo nextest run -p warp`: 4144/4144 pass).

**Manual.** Built with `./script/run`, opened the new-tab menu, hovered "New worktree config", and verified worktree entries render with tilde-substituted display labels. Screenshot below.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

![Worktree menu in new-tab dropdown after the fix: every indexed repo's path is shown with the home directory abbreviated to `~/...`.](https://i.ibb.co/5hkf6G0V/Screenshot-2026-05-14-at-6-12-05-PM.png)

## Agent Mode

- [ ] Warp Agent Mode

CHANGELOG-IMPROVEMENT: The new-tab worktree menu now abbreviates the home directory to `~`, left-truncates long paths so the trailing repo name stays visible, and surfaces the full absolute path on hover (#10862).