### PR TITLE
Handle null upload target fields

### DIFF
--- a/app/src/server/server_api/harness_support.rs
+++ b/app/src/server/server_api/harness_support.rs
@@ -21,6 +21,7 @@ pub use super::presigned_upload::FileUploadBody;
 pub use super::presigned_upload::UploadBody;
 
 /// A presigned upload target returned by the server.
+#[serde_with::serde_as]
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct UploadTarget {
     pub url: String,
@@ -28,6 +29,7 @@ pub struct UploadTarget {
     pub headers: HashMap<String, String>,
     /// Ordered multipart form fields for POST uploads.
     #[serde(default)]
+    #[serde_as(deserialize_as = "serde_with::DefaultOnNull")]
     pub fields: Vec<UploadField>,
 }
 

--- a/app/src/server/server_api/harness_support_tests.rs
+++ b/app/src/server/server_api/harness_support_tests.rs
@@ -1,5 +1,20 @@
 use crate::ai::artifacts::Artifact;
 
+#[test]
+fn upload_target_deserializes_null_fields_as_empty() {
+    use super::UploadTarget;
+
+    let target: UploadTarget = serde_json::from_value(serde_json::json!({
+        "url": "https://example.com/upload",
+        "method": "PUT",
+        "headers": {},
+        "fields": null
+    }))
+    .unwrap();
+
+    assert_eq!(target.fields.len(), 0);
+}
+
 /// Assert that `Artifact`s serialize to the expected format for the /harness-support/report-artifact
 /// endpoint.
 /// If `Artifact` serialization changes, this test will catch it.


### PR DESCRIPTION
## Description
Use `serde_with::DefaultOnNull` on `UploadTarget::fields` so the Rust client treats an explicit JSON `null` the same as a missing field and deserializes it as an empty vector. This keeps local-to-cloud handoff snapshot uploads from failing when the server returns `"fields": null`.

## Linked Issue
N/A - Slack request from `#pod-oz-handoff`.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --manifest-path /workspace/warp/app/Cargo.toml --check`
- `CARGO_BUILD_JOBS=1 cargo nextest run --manifest-path /workspace/warp/Cargo.toml -p warp -E 'test(upload_target_deserializes_null_fields_as_empty)'`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A - no UI changes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Fixed local-to-cloud handoff snapshot upload allocation when the server returns no upload form fields.

_Conversation: https://staging.warp.dev/conversation/d49e5635-e39d-46d4-b6fd-12f04271a381_
_Run: https://oz.staging.warp.dev/runs/019e2875-6204-77b7-9d97-70b6a9e871d8_
_This PR was generated with [Oz](https://warp.dev/oz)._
