### PR TITLE
Support secrets on Oz CLI environments

### DIFF
--- a/app/src/ai/agent_sdk/environment.rs
+++ b/app/src/ai/agent_sdk/environment.rs
@@ -18,7 +18,7 @@ use crate::ai::agent_sdk::driver::WARP_DRIVE_SYNC_TIMEOUT;
 use crate::ai::agent_sdk::oauth_flow::poll_oauth_until_terminal;
 use crate::ai::cloud_environments::{
     AmbientAgentEnvironment, BaseImage, CloudAmbientAgentEnvironment,
-    CloudAmbientAgentEnvironmentModel, GithubRepo,
+    CloudAmbientAgentEnvironmentModel, EnvironmentSecretRef, GithubRepo,
 };
 use crate::auth::UserUid;
 use crate::cloud_object::model::generic_string_model::GenericStringObjectId;
@@ -57,6 +57,27 @@ fn parse_repos(repo_strings: Vec<String>) -> anyhow::Result<Vec<GithubRepo>> {
         .collect()
 }
 
+fn secret_refs_from_names(names: Vec<String>) -> Vec<EnvironmentSecretRef> {
+    let mut seen = HashSet::new();
+    names
+        .into_iter()
+        .filter(|name| seen.insert(name.clone()))
+        .map(|name| EnvironmentSecretRef { name })
+        .collect()
+}
+
+fn format_secrets(secrets: &Option<Vec<EnvironmentSecretRef>>) -> String {
+    match secrets {
+        Some(secret_refs) if secret_refs.is_empty() => "None".to_string(),
+        Some(secret_refs) => secret_refs
+            .iter()
+            .map(|secret| secret.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+        None => "Not configured".to_string(),
+    }
+}
+
 /// Handle environment-related CLI commands.
 pub fn run(
     ctx: &mut AppContext,
@@ -75,6 +96,7 @@ pub fn run(
             docker_image,
             repo,
             setup_command,
+            secret,
             scope,
         } => {
             let repos = parse_repos(repo)?;
@@ -86,6 +108,7 @@ pub fn run(
                     docker_image,
                     repos,
                     setup_command,
+                    secret,
                     scope,
                     ctx,
                 )
@@ -106,6 +129,9 @@ pub fn run(
             setup_command,
             remove_repo,
             remove_setup_command,
+            secret,
+            remove_secret,
+            clear_secrets,
             force,
         } => {
             let repos = parse_repos(repo)?;
@@ -122,6 +148,9 @@ pub fn run(
                     setup_command,
                     remove_repos,
                     remove_setup_command,
+                    secret,
+                    remove_secret,
+                    clear_secrets,
                     force,
                     ctx,
                 )
@@ -210,6 +239,7 @@ impl EnvironmentCommandRunner {
                     let base_image = environment.model().string_model.base_image.clone();
                     let github_repos = environment.model().string_model.github_repos.clone();
                     let setup_commands = environment.model().string_model.setup_commands.clone();
+                    let secrets = environment.model().string_model.secrets.clone();
 
                     let creator_email = environment
                         .metadata()
@@ -243,6 +273,7 @@ impl EnvironmentCommandRunner {
                         base_image,
                         github_repos,
                         setup_commands,
+                        secrets,
                         creator_email,
                         last_edited,
                         last_edited_utc,
@@ -323,6 +354,7 @@ impl EnvironmentCommandRunner {
                 println!("  {}. {}", i + 1, cmd);
             }
         }
+        println!("Secrets: {}", format_secrets(&env.secrets));
     }
 
     /// Handle inquire errors, returning true if the error was handled (and caller should return early).
@@ -426,9 +458,11 @@ impl EnvironmentCommandRunner {
         docker_image: Option<String>,
         github_repos: Vec<GithubRepo>,
         setup_commands: Vec<String>,
+        secret_names: Vec<String>,
         scope: warp_cli::scope::ObjectScope,
         ctx: &mut ModelContext<Self>,
     ) {
+        let secrets = secret_refs_from_names(secret_names);
         if let Some(image) = docker_image {
             Self::create_with_image(
                 name,
@@ -436,6 +470,7 @@ impl EnvironmentCommandRunner {
                 image,
                 github_repos,
                 setup_commands,
+                secrets,
                 scope,
                 ctx,
             );
@@ -448,6 +483,7 @@ impl EnvironmentCommandRunner {
                         image,
                         github_repos,
                         setup_commands,
+                        secrets,
                         scope,
                         ctx,
                     );
@@ -464,6 +500,7 @@ impl EnvironmentCommandRunner {
         docker_image: String,
         github_repos: Vec<GithubRepo>,
         setup_commands: Vec<String>,
+        secrets: Vec<EnvironmentSecretRef>,
         scope: warp_cli::scope::ObjectScope,
         ctx: &mut ModelContext<Self>,
     ) {
@@ -492,6 +529,7 @@ impl EnvironmentCommandRunner {
                         github_repos,
                         docker_image,
                         setup_commands,
+                        secrets,
                         scope,
                         ctx,
                     );
@@ -721,22 +759,25 @@ impl EnvironmentCommandRunner {
     }
 
     // Helper function to create environment after successful auth check
+    #[allow(clippy::too_many_arguments)]
     fn create_environment_after_auth_check(
         name: String,
         description: Option<String>,
         github_repos: Vec<GithubRepo>,
         docker_image: String,
         setup_commands: Vec<String>,
+        secrets: Vec<EnvironmentSecretRef>,
         scope: ObjectScope,
         ctx: &mut ModelContext<Self>,
     ) {
-        let environment = AmbientAgentEnvironment::new(
+        let mut environment = AmbientAgentEnvironment::new(
             name,
             description,
             github_repos,
             docker_image,
             setup_commands,
         );
+        environment.secrets = Some(secrets);
         let client_id = ClientId::default();
 
         let owner = match super::common::resolve_owner(scope.team, scope.personal, ctx) {
@@ -846,6 +887,9 @@ impl EnvironmentCommandRunner {
         add_setup_commands: Vec<String>,
         remove_repos: Vec<GithubRepo>,
         remove_setup_commands: Vec<String>,
+        add_secret_names: Vec<String>,
+        remove_secret_names: Vec<String>,
+        clear_secrets: bool,
         force: bool,
         ctx: &mut ModelContext<Self>,
     ) {
@@ -889,6 +933,7 @@ impl EnvironmentCommandRunner {
             // confirmed with the user and checked on auth.
             let environment_clone = environment.clone();
             let repos_clone = add_repos.clone();
+            let add_secrets = secret_refs_from_names(add_secret_names);
             let execute_update = move |ctx: &mut ModelContext<Self>| {
                 Self::update_environment_after_auth_check(
                     &environment_clone,
@@ -901,6 +946,9 @@ impl EnvironmentCommandRunner {
                     add_setup_commands,
                     remove_repos,
                     remove_setup_commands,
+                    add_secrets,
+                    remove_secret_names,
+                    clear_secrets,
                     ctx,
                 );
             };
@@ -938,6 +986,9 @@ impl EnvironmentCommandRunner {
         add_setup_commands: Vec<String>,
         remove_repos: Vec<GithubRepo>,
         remove_setup_commands: Vec<String>,
+        add_secrets: Vec<EnvironmentSecretRef>,
+        remove_secret_names: Vec<String>,
+        clear_secrets: bool,
         ctx: &mut ModelContext<Self>,
     ) {
         let mut updated_env = environment.model().string_model.clone();
@@ -986,6 +1037,29 @@ impl EnvironmentCommandRunner {
                     "Warning: setup command '{cmd}' not found in environment, skipping removal"
                 );
             }
+        }
+        if clear_secrets {
+            updated_env.secrets = Some(Vec::new());
+        } else if !add_secrets.is_empty() || !remove_secret_names.is_empty() {
+            let mut secrets = updated_env.secrets.take().unwrap_or_default();
+
+            for secret_name in &remove_secret_names {
+                if let Some(pos) = secrets.iter().position(|s| s.name == *secret_name) {
+                    secrets.remove(pos);
+                } else {
+                    eprintln!(
+                        "Warning: secret '{secret_name}' not found in environment, skipping removal"
+                    );
+                }
+            }
+
+            for secret in add_secrets {
+                if !secrets.iter().any(|s| s.name == secret.name) {
+                    secrets.push(secret);
+                }
+            }
+
+            updated_env.secrets = Some(secrets);
         }
 
         // Update the environment via UpdateManager
@@ -1126,6 +1200,8 @@ struct EnvironmentInfo {
     base_image: BaseImage,
     github_repos: Vec<GithubRepo>,
     setup_commands: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    secrets: Option<Vec<EnvironmentSecretRef>>,
     creator_email: String,
     #[serde(skip_serializing)]
     last_edited: String,
@@ -1143,6 +1219,7 @@ impl TableFormat for EnvironmentInfo {
             Cell::new("Base image"),
             Cell::new("Git repos"),
             Cell::new("Setup commands"),
+            Cell::new("Secrets"),
             Cell::new("Creator"),
             Cell::new("Last edited"),
             Cell::new("Scope"),
@@ -1158,6 +1235,7 @@ impl TableFormat for EnvironmentInfo {
             .join(", ");
         let setup_commands_display = self.setup_commands.join("\n");
         let description_display = self.description.as_deref().unwrap_or("");
+        let secrets_display = format_secrets(&self.secrets);
 
         vec![
             Cell::new(&self.id),
@@ -1166,6 +1244,7 @@ impl TableFormat for EnvironmentInfo {
             Cell::new(self.base_image.to_string()),
             Cell::new(github_repos_display),
             Cell::new(setup_commands_display),
+            Cell::new(secrets_display),
             Cell::new(&self.creator_email),
             Cell::new(&self.last_edited),
             Cell::new(&self.scope),

--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -82,6 +82,17 @@ impl ProvidersConfig {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnvironmentSecretRef {
+    pub name: String,
+}
+
+impl fmt::Display for EnvironmentSecretRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.name.fmt(f)
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 /// An AmbientAgentEnvironment represents an environment that we would run a Warp agent in.
 pub struct AmbientAgentEnvironment {
@@ -103,6 +114,12 @@ pub struct AmbientAgentEnvironment {
     /// Optional cloud provider configurations for automatic auth.
     #[serde(default, skip_serializing_if = "ProvidersConfig::is_empty")]
     pub providers: ProvidersConfig,
+    /// Optional list of default managed secrets for runs using this environment.
+    ///
+    /// `None` represents legacy environments without explicit secret scoping.
+    /// `Some(vec![])` means no secrets by default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<Vec<EnvironmentSecretRef>>,
 }
 
 pub type CloudAmbientAgentEnvironment =
@@ -142,6 +159,7 @@ impl AmbientAgentEnvironment {
             base_image: BaseImage::DockerImage(docker_image),
             setup_commands,
             providers: ProvidersConfig::default(),
+            secrets: Some(Vec::new()),
         }
     }
 }

--- a/app/src/ai/cloud_environments/mod_tests.rs
+++ b/app/src/ai/cloud_environments/mod_tests.rs
@@ -18,6 +18,7 @@ fn deserialize_legacy_environment_without_providers() {
         BaseImage::DockerImage("ubuntu:latest".into())
     );
     assert_eq!(env.setup_commands, vec!["echo hello"]);
+    assert_eq!(env.secrets, None);
 }
 
 #[test]
@@ -125,6 +126,43 @@ fn serialize_with_providers_none_omits_field() {
 
     let json = serde_json::to_value(&env).unwrap();
     assert!(!json.as_object().unwrap().contains_key("providers"));
+}
+#[test]
+fn new_environment_serializes_empty_secrets() {
+    let env = AmbientAgentEnvironment::new(
+        "test-env".into(),
+        None,
+        vec![],
+        "ubuntu:latest".into(),
+        vec![],
+    );
+
+    assert_eq!(env.secrets, Some(vec![]));
+    let json = serde_json::to_value(&env).unwrap();
+    assert_eq!(json.get("secrets"), Some(&serde_json::json!([])));
+}
+
+#[test]
+fn roundtrip_serde_with_secrets() {
+    let mut env = AmbientAgentEnvironment::new(
+        "secret-env".into(),
+        None,
+        vec![],
+        "ubuntu:latest".into(),
+        vec![],
+    );
+    env.secrets = Some(vec![
+        EnvironmentSecretRef {
+            name: "API_KEY".into(),
+        },
+        EnvironmentSecretRef {
+            name: "DATABASE_URL".into(),
+        },
+    ]);
+
+    let serialized = serde_json::to_string(&env).unwrap();
+    let deserialized: AmbientAgentEnvironment = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(env, deserialized);
 }
 
 #[test]

--- a/app/src/settings_view/environments_page.rs
+++ b/app/src/settings_view/environments_page.rs
@@ -797,6 +797,8 @@ impl EnvironmentsPageView {
                     );
                     return;
                 };
+                let mut environment = environment.clone();
+                environment.secrets = existing_env.model().string_model.secrets.clone();
 
                 // Get the revision from the existing environment
                 let revision = existing_env.metadata.revision.clone();
@@ -807,7 +809,7 @@ impl EnvironmentsPageView {
                 // Update via UpdateManager
                 UpdateManager::handle(ctx).update(ctx, |update_manager, ctx| {
                     update_manager.update_ambient_agent_environment(
-                        environment.clone(),
+                        environment,
                         *env_id,
                         revision,
                         ctx,

--- a/crates/warp_cli/src/environment.rs
+++ b/crates/warp_cli/src/environment.rs
@@ -18,6 +18,16 @@ fn validate_description(s: &str) -> Result<String, String> {
     }
 }
 
+/// Validates and normalizes a managed secret name.
+fn validate_secret_name(s: &str) -> Result<String, String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        Err("Secret name must not be empty".to_string())
+    } else {
+        Ok(trimmed.to_string())
+    }
+}
+
 /// Environment-related subcommands.
 #[derive(Debug, Clone, Subcommand)]
 #[command(group(ArgGroup::new("scope").required(false)))]
@@ -46,6 +56,9 @@ pub enum EnvironmentCommand {
         /// Accept multiple setup command args to be run after cloning
         #[arg(long = "setup-command", short = 'c', action = ArgAction::Append)]
         setup_command: Vec<String>,
+        /// Managed secret name to make available by default in this environment (can be specified multiple times)
+        #[arg(long = "secret", short = 's', action = ArgAction::Append, value_parser = validate_secret_name)]
+        secret: Vec<String>,
 
         #[command(flatten)]
         scope: ObjectScope,
@@ -95,6 +108,15 @@ pub enum EnvironmentCommand {
         /// Setup command to remove from the list (can be specified multiple times)
         #[arg(long, action = ArgAction::Append)]
         remove_setup_command: Vec<String>,
+        /// Managed secret name to make available by default in this environment (can be specified multiple times)
+        #[arg(long = "secret", short = 's', action = ArgAction::Append, value_parser = validate_secret_name)]
+        secret: Vec<String>,
+        /// Managed secret name to remove from this environment (can be specified multiple times)
+        #[arg(long, action = ArgAction::Append, value_parser = validate_secret_name, conflicts_with = "clear_secrets")]
+        remove_secret: Vec<String>,
+        /// Remove all default secrets from this environment
+        #[arg(long, default_value_t = false, conflicts_with_all = ["secret", "remove_secret"])]
+        clear_secrets: bool,
         /// Force update without checking for integration usage
         #[arg(long, default_value_t = false)]
         force: bool,

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -1202,6 +1202,36 @@ fn environment_create_accepts_description() {
     assert_eq!(description.as_deref(), Some("A test environment"));
     assert_eq!(docker_image.as_deref(), Some("ubuntu:latest"));
 }
+#[test]
+fn environment_create_accepts_secrets() {
+    let args = Args::try_parse_from([
+        "warp",
+        "environment",
+        "create",
+        "--name",
+        "test-env",
+        "--docker-image",
+        "ubuntu:latest",
+        "--secret",
+        "API_KEY",
+        "--secret",
+        "  DATABASE_URL  ",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp environment create` command");
+    };
+    let CliCommand::Environment(EnvironmentCommand::Create { secret, .. }) = boxed_cmd.as_ref()
+    else {
+        panic!("Expected `warp environment create` command");
+    };
+
+    assert_eq!(
+        secret,
+        &vec!["API_KEY".to_string(), "DATABASE_URL".to_string()]
+    );
+}
 
 #[test]
 fn environment_create_description_max_length() {
@@ -1306,6 +1336,119 @@ fn environment_update_accepts_remove_description() {
     assert_eq!(id, "env-id");
     assert!(description.is_none());
     assert!(remove_description);
+}
+#[test]
+fn environment_update_accepts_secret_changes() {
+    let args = Args::try_parse_from([
+        "warp",
+        "environment",
+        "update",
+        "env-id",
+        "--secret",
+        "API_KEY",
+        "--remove-secret",
+        "DATABASE_URL",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp environment update` command");
+    };
+    let CliCommand::Environment(EnvironmentCommand::Update {
+        secret,
+        remove_secret,
+        clear_secrets,
+        ..
+    }) = boxed_cmd.as_ref()
+    else {
+        panic!("Expected `warp environment update` command");
+    };
+
+    assert_eq!(secret, &vec!["API_KEY".to_string()]);
+    assert_eq!(remove_secret, &vec!["DATABASE_URL".to_string()]);
+    assert!(!clear_secrets);
+}
+
+#[test]
+fn environment_update_accepts_clear_secrets() {
+    let args = Args::try_parse_from(["warp", "environment", "update", "env-id", "--clear-secrets"])
+        .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp environment update` command");
+    };
+    let CliCommand::Environment(EnvironmentCommand::Update {
+        secret,
+        remove_secret,
+        clear_secrets,
+        ..
+    }) = boxed_cmd.as_ref()
+    else {
+        panic!("Expected `warp environment update` command");
+    };
+
+    assert!(secret.is_empty());
+    assert!(remove_secret.is_empty());
+    assert!(clear_secrets);
+}
+
+#[test]
+fn environment_update_clear_secrets_conflicts_with_secret_changes() {
+    assert!(
+        Args::try_parse_from([
+            "warp",
+            "environment",
+            "update",
+            "env-id",
+            "--clear-secrets",
+            "--secret",
+            "API_KEY",
+        ])
+        .is_err()
+    );
+
+    assert!(
+        Args::try_parse_from([
+            "warp",
+            "environment",
+            "update",
+            "env-id",
+            "--clear-secrets",
+            "--remove-secret",
+            "API_KEY",
+        ])
+        .is_err()
+    );
+}
+
+#[test]
+fn environment_secret_names_must_not_be_blank() {
+    assert!(
+        Args::try_parse_from([
+            "warp",
+            "environment",
+            "create",
+            "--name",
+            "test-env",
+            "--docker-image",
+            "ubuntu:latest",
+            "--secret",
+            "   ",
+        ])
+        .is_err()
+    );
+
+    assert!(
+        Args::try_parse_from([
+            "warp",
+            "environment",
+            "update",
+            "env-id",
+            "--remove-secret",
+            "",
+        ])
+        .is_err()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description
- Adds `--secret` support to `oz environment create` for default managed secrets.
- Adds `--secret`, `--remove-secret`, and `--clear-secrets` to `oz environment update`.
- Persists environment secrets in the client environment model and shows them in `environment get` / `environment list` output.
- Preserves existing environment secrets when the native settings form edits fields it does not render.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo +1.92.0 fmt`
- [x] `cargo +1.92.0 clippy -p warp_cli -p warp --all-targets --tests -- -D warnings`
- [x] `cargo +1.92.0 test -p warp_cli environment_`
- [x] `cargo +1.92.0 test -p warp cloud_environments::tests`
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Oz CLI environments now support default managed secrets.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/15bdd831-a8ec-43ba-a444-6be596607e82_
_Run: https://oz.staging.warp.dev/runs/019e2885-fdd7-7c0f-ac8f-e2903b007386_
_This PR was generated with [Oz](https://warp.dev/oz)._
