### PR TITLE
Keep failed cloud query visible

### DIFF
--- a/app/src/ai/blocklist/block/pending_user_query_block.rs
+++ b/app/src/ai/blocklist/block/pending_user_query_block.rs
@@ -22,8 +22,13 @@ use crate::{
     ui_components::{blended_colors, icons::Icon},
     view_components::action_button::{ActionButton, ButtonSize, NakedTheme},
 };
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PendingUserQueryDisplayState {
+    Queued,
+    Unsent,
+}
 
-/// Renders a pending user query block with dimmed text and a "Queued" badge.
+/// Renders a pending user query block with dimmed text and an optional status badge.
 /// Displayed when a follow-up prompt is queued via `/fork-and-compact <prompt>`,
 /// `/compact-and <prompt>`, `/queue <prompt>`, or for the initial prompt of a
 /// Cloud Mode run waiting for its real shared-session transcript query to arrive.
@@ -38,6 +43,7 @@ pub struct PendingUserQueryBlock {
     selected_text: Arc<RwLock<Option<String>>>,
     close_button: Option<ViewHandle<ActionButton>>,
     send_now_button: Option<ViewHandle<ActionButton>>,
+    display_state: PendingUserQueryDisplayState,
 }
 
 impl PendingUserQueryBlock {
@@ -78,6 +84,7 @@ impl PendingUserQueryBlock {
             selected_text: Default::default(),
             close_button,
             send_now_button,
+            display_state: PendingUserQueryDisplayState::Queued,
         }
     }
 
@@ -91,6 +98,16 @@ impl PendingUserQueryBlock {
         self.selection_handle.clear();
         *self.selected_text.write() = None;
         ctx.notify();
+    }
+
+    pub fn mark_unsent(&mut self, ctx: &mut ViewContext<Self>) {
+        self.display_state = PendingUserQueryDisplayState::Unsent;
+        ctx.notify();
+    }
+
+    #[cfg(test)]
+    pub fn display_state_for_test(&self) -> PendingUserQueryDisplayState {
+        self.display_state
     }
 }
 
@@ -163,23 +180,23 @@ impl View for PendingUserQueryBlock {
         .with_selectable(true)
         .finish();
 
-        let queued_badge = Text::new(
-            "Queued",
-            appearance.ui_font_family(),
-            appearance.monospace_font_size().max(4.) - 2.,
-        )
-        .with_style(Properties {
-            style: Style::Italic,
-            weight: Weight::Normal,
-        })
-        .with_color(dimmed_color)
-        .with_selectable(false)
-        .finish();
-
-        let selectable_child = Flex::column()
-            .with_child(prompt_text)
-            .with_child(Container::new(queued_badge).with_margin_top(4.).finish())
+        let mut selectable_child = Flex::column().with_child(prompt_text);
+        if matches!(self.display_state, PendingUserQueryDisplayState::Queued) {
+            let queued_badge = Text::new(
+                "Queued",
+                appearance.ui_font_family(),
+                appearance.monospace_font_size().max(4.) - 2.,
+            )
+            .with_style(Properties {
+                style: Style::Italic,
+                weight: Weight::Normal,
+            })
+            .with_color(dimmed_color)
+            .with_selectable(false)
             .finish();
+            selectable_child.add_child(Container::new(queued_badge).with_margin_top(4.).finish());
+        }
+        let selectable_child = selectable_child.finish();
 
         let semantic_selection = SemanticSelection::as_ref(app);
         let selected_text = self.selected_text.clone();

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -1131,6 +1131,12 @@ impl BlockList {
         }
     }
 
+    pub fn unpin_rich_content_if_pinned(&mut self, view_id: EntityId) {
+        if self.pinned_to_bottom == Some(view_id) {
+            self.pinned_to_bottom = None;
+        }
+    }
+
     pub fn update_agent_view_conversation_id_for_rich_content(
         &mut self,
         rich_content_view_id: EntityId,

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -102,14 +102,10 @@ impl TerminalView {
         };
 
         // Tear down the cloud-mode queued-prompt block on terminal / transition
-        // events that replace it. `Failed`, `NeedsGithubAuth`, and `Cancelled` hand off
-        // to the existing error / auth / cancelled UI; `HarnessCommandStarted` hands
-        // off to the live third-party harness CLI block. Idempotent and cheap when no
-        // block exists.
+        // events that replace it. Failure retains the query and marks it unsent.
         if matches!(
             event,
-            AmbientAgentViewModelEvent::Failed { .. }
-                | AmbientAgentViewModelEvent::NeedsGithubAuth
+            AmbientAgentViewModelEvent::NeedsGithubAuth
                 | AmbientAgentViewModelEvent::Cancelled
                 | AmbientAgentViewModelEvent::HarnessCommandStarted { .. }
                 | AmbientAgentViewModelEvent::HandoffSnapshotUploadFailed { .. }
@@ -232,6 +228,7 @@ impl TerminalView {
                 );
 
                 if FeatureFlag::CloudModeSetupV2.is_enabled() {
+                    self.mark_cloud_mode_query_unsent_after_failure(ctx);
                     self.insert_conversation_ended_tombstone(ctx);
                 }
 

--- a/app/src/terminal/view/pending_user_query.rs
+++ b/app/src/terminal/view/pending_user_query.rs
@@ -118,6 +118,45 @@ impl TerminalView {
         }
     }
 
+    pub(super) fn mark_cloud_mode_query_unsent_after_failure(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.pending_user_query_kind != Some(PendingUserQueryKind::CloudMode) {
+            return;
+        }
+        let Some(view_id) = self.pending_user_query_view_id else {
+            return;
+        };
+        let Some(handle) =
+            self.rich_content_views
+                .iter()
+                .find_map(|rich_content| match rich_content.metadata() {
+                    Some(RichContentMetadata::PendingUserQuery {
+                        pending_user_query_block_handle,
+                    }) if pending_user_query_block_handle.id() == view_id => {
+                        Some(pending_user_query_block_handle.clone())
+                    }
+                    _ => None,
+                })
+        else {
+            return;
+        };
+
+        handle.update(ctx, |block, ctx| {
+            block.mark_unsent(ctx);
+        });
+        self.model
+            .lock()
+            .block_list_mut()
+            .unpin_rich_content_if_pinned(view_id);
+        self.model
+            .lock()
+            .block_list_mut()
+            .mark_rich_content_dirty(view_id);
+        ctx.notify();
+    }
+
     /// Removes the pending block and immediately submits the queued prompt.
     ///
     /// The plain-text submission path cancels any in-flight stream itself (via

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -21,6 +21,7 @@ use warpui::{App, ReadModel};
 
 use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
 use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
+use crate::ai::blocklist::block::pending_user_query_block::PendingUserQueryDisplayState;
 use crate::ai::blocklist::{
     agent_view::AgentViewEntryOrigin, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
     InputConfig, InputType, ResponseStreamId,
@@ -82,6 +83,24 @@ fn has_pending_user_query_block(view: &TerminalView) -> bool {
     view.rich_content_views.iter().any(|rich_content| {
         rich_content.view_id() == view_id && rich_content.is_pending_user_query()
     })
+}
+fn pending_user_query_display_state(
+    view: &TerminalView,
+    ctx: &AppContext,
+) -> Option<PendingUserQueryDisplayState> {
+    let view_id = view.pending_user_query_view_id?;
+    view.rich_content_views
+        .iter()
+        .find_map(|rich_content| match rich_content.metadata() {
+            Some(RichContentMetadata::PendingUserQuery {
+                pending_user_query_block_handle,
+            }) if pending_user_query_block_handle.id() == view_id => Some(
+                pending_user_query_block_handle
+                    .as_ref(ctx)
+                    .display_state_for_test(),
+            ),
+            _ => None,
+        })
 }
 
 fn exchange_with_inputs(inputs: Vec<AIAgentInput>) -> AIAgentExchange {
@@ -1024,6 +1043,10 @@ fn cloud_mode_dispatched_agent_inserts_queued_user_query() {
             view.handle_ambient_agent_event(&AmbientAgentViewModelEvent::DispatchedAgent, ctx);
 
             assert!(has_pending_user_query_block(view));
+            assert_eq!(
+                pending_user_query_display_state(view, ctx),
+                Some(PendingUserQueryDisplayState::Queued)
+            );
         });
     });
 }
@@ -1045,6 +1068,10 @@ fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
             view.enter_ambient_agent_setup(None, ctx);
             view.insert_cloud_mode_queued_user_query_block("queued prompt".to_string(), ctx);
             assert!(has_pending_user_query_block(view));
+            assert_eq!(
+                pending_user_query_display_state(view, ctx),
+                Some(PendingUserQueryDisplayState::Queued)
+            );
 
             view.handle_ambient_agent_event(
                 &AmbientAgentViewModelEvent::Failed {
@@ -1053,9 +1080,18 @@ fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
                 ctx,
             );
 
-            assert!(!has_pending_user_query_block(view));
+            assert!(has_pending_user_query_block(view));
+            assert_eq!(
+                pending_user_query_display_state(view, ctx),
+                Some(PendingUserQueryDisplayState::Unsent)
+            );
             assert!(view.conversation_ended_tombstone_view_id.is_some());
-            assert_eq!(view.rich_content_views.len(), 1);
+            assert_eq!(view.rich_content_views.len(), 2);
+            assert!(view.rich_content_views[0].is_pending_user_query());
+            assert_eq!(
+                Some(view.rich_content_views[1].view_id()),
+                view.conversation_ended_tombstone_view_id
+            );
             {
                 let model = view.model.lock();
                 assert!(!view.is_input_box_visible(&model, ctx));
@@ -1067,7 +1103,12 @@ fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
                 },
                 ctx,
             );
-            assert_eq!(view.rich_content_views.len(), 1);
+            assert_eq!(view.rich_content_views.len(), 2);
+            assert!(has_pending_user_query_block(view));
+            assert_eq!(
+                pending_user_query_display_state(view, ctx),
+                Some(PendingUserQueryDisplayState::Unsent)
+            );
         });
 
         let window_id = app.read(|ctx| terminal.window_id(ctx));
@@ -1093,6 +1134,37 @@ fn cloud_mode_failed_inserts_tombstone_and_hides_input() {
     });
 }
 
+#[test]
+fn queued_prompt_not_marked_unsent_by_cloud_failure_helper() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _pending_query = FeatureFlag::PendingUserQueryIndicator.override_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            view.send_user_query_after_next_conversation_finished(
+                "queued prompt".to_string(),
+                true,
+                true,
+                ctx,
+            );
+            assert!(has_pending_user_query_block(view));
+            assert_eq!(
+                pending_user_query_display_state(view, ctx),
+                Some(PendingUserQueryDisplayState::Queued)
+            );
+
+            view.mark_cloud_mode_query_unsent_after_failure(ctx);
+
+            assert!(has_pending_user_query_block(view));
+            assert_eq!(
+                pending_user_query_display_state(view, ctx),
+                Some(PendingUserQueryDisplayState::Queued)
+            );
+        });
+    });
+}
 #[test]
 fn cloud_mode_followup_dispatched_inserts_queued_user_query() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
Summary:
- Keep failed Cloud Mode Setup V2 query visible.
- Mark retained query as unsent, hiding the Queued badge.
- Unpin query before tombstone insert so error follows query.

Tests:
- cargo fmt --manifest-path /workspace/warp/Cargo.toml --all -- --check
- cargo nextest run --manifest-path /workspace/warp/Cargo.toml -p warp --lib cloud_mode_failed_inserts_tombstone_and_hides_input queued_prompt_not_marked_unsent_by_cloud_failure_helper cloud_mode_dispatched_agent_inserts_queued_user_query pending_cloud_mode_query_waits_for_renderable_user_query_exchange pending_cloud_mode_query_clears_when_streaming_exchange_becomes_renderable

_Conversation: https://staging.warp.dev/conversation/c32f52ee-6baa-44fa-a08b-0243040ca5e8_
_Run: https://oz.staging.warp.dev/runs/019e2898-99eb-7ddb-b107-d16f150d26be_
_Plans_:
- _[Keep cloud query visible after failed cloud start](https://staging.warp.dev/drive/notebook/GnjKxqEj24NAMrPnNLGYn4)_

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
