### PR TITLE
Fix handoff for child agents

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -6883,6 +6883,19 @@ impl PaneGroup {
         self.terminal_view_from_pane_id(self.focused_pane_id(ctx), ctx)
     }
 
+    /// If the active session slot holds a swapped-in replacement (e.g. a
+    /// child agent pane), returns the displaced original's pane ID and
+    /// terminal view. Returns `None` when no swap is active.
+    pub fn original_session_if_swapped(
+        &self,
+        ctx: &AppContext,
+    ) -> Option<(PaneId, ViewHandle<TerminalView>)> {
+        let active_pane_id = PaneId::from(self.active_session_id(ctx)?);
+        let original_pane_id = self.panes.original_pane_for_replacement(active_pane_id)?;
+        let view = self.terminal_view_from_pane_id(original_pane_id, ctx)?;
+        Some((original_pane_id, view))
+    }
+
     /// Given a pane ID, retrieve its backing terminal pane contents, if the pane is a terminal pane.
     fn terminal_session_by_id(&self, pane_id: impl Into<PaneId>) -> Option<&TerminalPane> {
         self.pane_contents

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -694,29 +694,10 @@ impl TerminalView {
         self.start_cloud_mode(initial_prompt, ctx);
     }
 
-    /// Push a fresh cloud-mode pane onto this view's pane_stack for a local-to-cloud handoff.
-    /// Returns the pushed view and its `AmbientAgentViewModel` so the caller can restore the
-    /// forked conversation, bind it to the cloud-side conversation id, and seed `PendingHandoff`.
-    ///
-    /// Uses the same setup-mode initialization path as fresh cloud-mode runs (which calls
-    /// `enter_ambient_agent_setup` → `enter_agent_view_for_new_conversation` and focuses the
-    /// input) so the new pane's cloud-mode input is editable and focused immediately. The
-    /// caller then layers the forked conversation's blocks on top via
-    /// `restore_conversation_after_view_creation` and seeds `PendingHandoff`; submission uses
-    /// the cached `forked_conversation_id` from `PendingHandoff`, not the new pane's local
-    /// agent-view conversation id.
-    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-    pub(crate) fn start_local_to_cloud_handoff_pane(
-        &mut self,
-        ctx: &mut ViewContext<Self>,
-    ) -> Option<(ViewHandle<TerminalView>, ModelHandle<AmbientAgentViewModel>)> {
-        self.start_cloud_mode(None, ctx)
-    }
-
     /// Start a cloud mode session nested under this one, pushing a new pane onto this view's
     /// pane_stack and returning the pushed view + model handle. The new pane enters setup mode
     /// with `initial_prompt` (if any) pre-filled in the input.
-    fn start_cloud_mode(
+    pub(crate) fn start_cloud_mode(
         &mut self,
         initial_prompt: Option<String>,
         ctx: &mut ViewContext<Self>,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13435,6 +13435,20 @@ impl Workspace {
             return;
         };
 
+        // If the handoff target's agent view is fullscreen, exit it so the
+        // cloud pane is visible at the terminal level, not inside the agent view.
+        let target_agent_view_controller =
+            handoff_target.as_ref(ctx).agent_view_controller().clone();
+        if target_agent_view_controller
+            .as_ref(ctx)
+            .agent_view_state()
+            .is_fullscreen()
+        {
+            target_agent_view_controller.update(ctx, |controller, ctx| {
+                controller.exit_agent_view_without_confirmation(ctx);
+            });
+        }
+
         if let Some(environment_id) = environment_id {
             model_handle.update(ctx, |model, ctx| {
                 model.set_environment_id(Some(environment_id), ctx);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13388,6 +13388,30 @@ impl Workspace {
         });
     }
 
+    /// If the active session slot holds a swapped-in child agent, reverts
+    /// the swap and returns the displaced orchestrator's terminal view so
+    /// the cloud handoff PaneStack push lands on the orchestrator instead
+    /// of polluting the child's stack. Returns `source_view` unchanged
+    /// when no swap is active.
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+    fn resolve_handoff_target(
+        &mut self,
+        source_view: &ViewHandle<TerminalView>,
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<TerminalView> {
+        let pane_group = self.active_tab_pane_group().clone();
+        if let Some((original_pane_id, orchestrator_view)) =
+            pane_group.as_ref(ctx).original_session_if_swapped(ctx)
+        {
+            pane_group.update(ctx, |group, ctx| {
+                group.reveal_and_focus_pane(original_pane_id, ctx);
+            });
+            orchestrator_view
+        } else {
+            source_view.clone()
+        }
+    }
+
     /// Opens a cloud pane without forking when there is no local conversation to hand off.
     /// Still snapshots the source pane's pwd so the cloud agent receives the local repo's
     /// branch info and uncommitted diffs.
@@ -13399,8 +13423,10 @@ impl Workspace {
         environment_id: Option<SyncId>,
         ctx: &mut ViewContext<Self>,
     ) {
-        // Push a cloud-mode pane for the fresh launch.
-        let Some((new_pane_view, model_handle)) = source_view.update(ctx, |view, view_ctx| {
+        // If the active slot holds a swapped-in child, redirect the push
+        // to the orchestrator so the child's PaneStack stays clean.
+        let handoff_target = self.resolve_handoff_target(&source_view, ctx);
+        let Some((new_pane_view, model_handle)) = handoff_target.update(ctx, |view, view_ctx| {
             view.start_local_to_cloud_handoff_pane(view_ctx)
         }) else {
             log::warn!("start_local_to_cloud_handoff: failed to push fresh cloud-mode pane");
@@ -13582,8 +13608,10 @@ impl Workspace {
         };
         let local_fork_id = local_fork.id();
 
-        // Push the cloud-mode pane before attaching the forked conversation.
-        let Some((new_pane_view, model_handle)) = source_view.update(ctx, |view, view_ctx| {
+        // If the active slot holds a swapped-in child, redirect the push
+        // to the orchestrator so the child's PaneStack stays clean.
+        let handoff_target = self.resolve_handoff_target(&source_view, ctx);
+        let Some((new_pane_view, model_handle)) = handoff_target.update(ctx, |view, view_ctx| {
             view.start_local_to_cloud_handoff_pane(view_ctx)
         }) else {
             log::warn!("start_local_to_cloud_handoff: failed to push cloud-mode pane");
@@ -13618,14 +13646,16 @@ impl Workspace {
             history_model.set_viewing_shared_session_for_conversation(local_fork_id, true);
         });
 
-        let source_agent_view_controller = source_view.as_ref(ctx).agent_view_controller().clone();
-        if source_agent_view_controller
+        let target_agent_view_controller =
+            handoff_target.as_ref(ctx).agent_view_controller().clone();
+        if target_agent_view_controller
             .as_ref(ctx)
             .agent_view_state()
             .is_fullscreen()
         {
-            // Exit the source pane so focus and input move to the cloud pane.
-            source_agent_view_controller.update(ctx, |controller, ctx| {
+            // Exit the handoff target's agent view so the entry block is
+            // visible at the terminal level beneath the cloud pane.
+            target_agent_view_controller.update(ctx, |controller, ctx| {
                 controller.exit_agent_view_without_confirmation(ctx);
             });
         }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13391,9 +13391,12 @@ impl Workspace {
     /// Resolves the terminal view that should receive the handoff cloud-mode
     /// pane push and prepares it for the transition:
     ///
-    /// 1. If the active session slot holds a swapped-in child agent, reverts
+    /// 1. Finds the pane group that owns `source_view` (rather than the
+    ///    currently-active tab) so focus changes during an async fork RPC
+    ///    cannot mis-target the handoff.
+    /// 2. If the active session slot holds a swapped-in child agent, reverts
     ///    the swap so the push lands on the orchestrator's PaneStack.
-    /// 2. If the resolved view's agent view is fullscreen, exits it so the
+    /// 3. If the resolved view's agent view is fullscreen, exits it so the
     ///    cloud pane is visible at the terminal level.
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn prepare_handoff_target(
@@ -13401,7 +13404,17 @@ impl Workspace {
         source_view: &ViewHandle<TerminalView>,
         ctx: &mut ViewContext<Self>,
     ) -> ViewHandle<TerminalView> {
-        let pane_group = self.active_tab_pane_group().clone();
+        let source_view_id = source_view.id();
+        let pane_group = self
+            .tabs
+            .iter()
+            .find(|tab| {
+                tab.pane_group
+                    .as_ref(ctx)
+                    .contains_terminal_view(source_view_id, ctx)
+            })
+            .map(|tab| tab.pane_group.clone())
+            .unwrap_or_else(|| self.active_tab_pane_group().clone());
         let target = if let Some((original_pane_id, orchestrator_view)) =
             pane_group.as_ref(ctx).original_session_if_swapped(ctx)
         {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13388,19 +13388,21 @@ impl Workspace {
         });
     }
 
-    /// If the active session slot holds a swapped-in child agent, reverts
-    /// the swap and returns the displaced orchestrator's terminal view so
-    /// the cloud handoff PaneStack push lands on the orchestrator instead
-    /// of polluting the child's stack. Returns `source_view` unchanged
-    /// when no swap is active.
+    /// Resolves the terminal view that should receive the handoff cloud-mode
+    /// pane push and prepares it for the transition:
+    ///
+    /// 1. If the active session slot holds a swapped-in child agent, reverts
+    ///    the swap so the push lands on the orchestrator's PaneStack.
+    /// 2. If the resolved view's agent view is fullscreen, exits it so the
+    ///    cloud pane is visible at the terminal level.
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-    fn resolve_handoff_target(
+    fn prepare_handoff_target(
         &mut self,
         source_view: &ViewHandle<TerminalView>,
         ctx: &mut ViewContext<Self>,
     ) -> ViewHandle<TerminalView> {
         let pane_group = self.active_tab_pane_group().clone();
-        if let Some((original_pane_id, orchestrator_view)) =
+        let target = if let Some((original_pane_id, orchestrator_view)) =
             pane_group.as_ref(ctx).original_session_if_swapped(ctx)
         {
             pane_group.update(ctx, |group, ctx| {
@@ -13409,7 +13411,20 @@ impl Workspace {
             orchestrator_view
         } else {
             source_view.clone()
+        };
+
+        let agent_view_controller = target.as_ref(ctx).agent_view_controller().clone();
+        if agent_view_controller
+            .as_ref(ctx)
+            .agent_view_state()
+            .is_fullscreen()
+        {
+            agent_view_controller.update(ctx, |controller, ctx| {
+                controller.exit_agent_view_without_confirmation(ctx);
+            });
         }
+
+        target
     }
 
     /// Opens a cloud pane without forking when there is no local conversation to hand off.
@@ -13423,31 +13438,15 @@ impl Workspace {
         environment_id: Option<SyncId>,
         ctx: &mut ViewContext<Self>,
     ) {
-        // If the active slot holds a swapped-in child, redirect the push
-        // to the orchestrator so the child's PaneStack stays clean.
-        let handoff_target = self.resolve_handoff_target(&source_view, ctx);
-        let Some((new_pane_view, model_handle)) = handoff_target.update(ctx, |view, view_ctx| {
-            view.start_local_to_cloud_handoff_pane(view_ctx)
-        }) else {
+        let handoff_target = self.prepare_handoff_target(&source_view, ctx);
+        let Some((new_pane_view, model_handle)) =
+            handoff_target.update(ctx, |view, view_ctx| view.start_cloud_mode(None, view_ctx))
+        else {
             log::warn!("start_local_to_cloud_handoff: failed to push fresh cloud-mode pane");
             Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
             Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
             return;
         };
-
-        // If the handoff target's agent view is fullscreen, exit it so the
-        // cloud pane is visible at the terminal level, not inside the agent view.
-        let target_agent_view_controller =
-            handoff_target.as_ref(ctx).agent_view_controller().clone();
-        if target_agent_view_controller
-            .as_ref(ctx)
-            .agent_view_state()
-            .is_fullscreen()
-        {
-            target_agent_view_controller.update(ctx, |controller, ctx| {
-                controller.exit_agent_view_without_confirmation(ctx);
-            });
-        }
 
         if let Some(environment_id) = environment_id {
             model_handle.update(ctx, |model, ctx| {
@@ -13622,12 +13621,10 @@ impl Workspace {
         };
         let local_fork_id = local_fork.id();
 
-        // If the active slot holds a swapped-in child, redirect the push
-        // to the orchestrator so the child's PaneStack stays clean.
-        let handoff_target = self.resolve_handoff_target(&source_view, ctx);
-        let Some((new_pane_view, model_handle)) = handoff_target.update(ctx, |view, view_ctx| {
-            view.start_local_to_cloud_handoff_pane(view_ctx)
-        }) else {
+        let handoff_target = self.prepare_handoff_target(&source_view, ctx);
+        let Some((new_pane_view, model_handle)) =
+            handoff_target.update(ctx, |view, view_ctx| view.start_cloud_mode(None, view_ctx))
+        else {
             log::warn!("start_local_to_cloud_handoff: failed to push cloud-mode pane");
             Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
             return;
@@ -13659,20 +13656,6 @@ impl Workspace {
             );
             history_model.set_viewing_shared_session_for_conversation(local_fork_id, true);
         });
-
-        let target_agent_view_controller =
-            handoff_target.as_ref(ctx).agent_view_controller().clone();
-        if target_agent_view_controller
-            .as_ref(ctx)
-            .agent_view_state()
-            .is_fullscreen()
-        {
-            // Exit the handoff target's agent view so the entry block is
-            // visible at the terminal level beneath the cloud pane.
-            target_agent_view_controller.update(ctx, |controller, ctx| {
-                controller.exit_agent_view_without_confirmation(ctx);
-            });
-        }
 
         if let Some(env_id) = environment_id {
             model_handle.update(ctx, |model, ctx| {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

There was a pane re-entry bug where, if you handed-off a child of an orchestrated run, the handoff pane would take over the child pane in a weird way. What should happen is the handoff is at the same "level" as the parent pane, meaning when you exit out of the parent orchestrator pane and into the terminal view, there are two agent view blocks (for the handed off conversation and the parent orchestrator)

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/0eb0eb30b0e04cdbb0e549edc3070769

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
