### PR TITLE
set the minimum window size in AppKit

### DIFF
--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -21,6 +21,8 @@ NSWindowStyleMask warpWindowMask = NSWindowStyleMaskClosable | NSWindowStyleMask
 
 // The default macOS titlebar height (in points).
 static const CGFloat DEFAULT_TITLEBAR_HEIGHT = 28.0;
+static const NSSize MIN_WINDOW_SIZE = {480.0, 192.0};
+static const NSSize TEST_MIN_WINDOW_SIZE = {124.0, 34.0};
 
 // A back-to-front ordered array of windows, identified by their `windowNumber`
 // property.
@@ -285,6 +287,7 @@ static NSLayoutConstraint *configure_titlebar_height(NSWindow *window, CGFloat h
 void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, bool hideTitleBar) {
     window.testMode = testMode;
     window.hideTitleBar = hideTitleBar;
+    NSSize minWindowSize = testMode ? TEST_MIN_WINDOW_SIZE : MIN_WINDOW_SIZE;
 
     // Set the background color to clear to support window background transparency. When this is set
     // to NSColor.clearColor with alpha = 0 and window drop shadows are enabled, MacOS renders a
@@ -298,6 +301,11 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     window.acceptsMouseMovedEvents = YES;
     window.titlebarAppearsTransparent = hideTitleBar;
     window.titleVisibility = hideTitleBar ? NSWindowTitleHidden : NSWindowTitleVisible;
+    window.minSize = minWindowSize;
+    window.contentMinSize = minWindowSize;
+    if ([window respondsToSelector:@selector(setMinFullScreenContentSize:)]) {
+        window.minFullScreenContentSize = minWindowSize;
+    }
 }
 
 @implementation WarpWindow {


### PR DESCRIPTION
## Description

This PR sets a minimum size on our application windows on MacOS. We don't actually enforce this, and so that permits some absurd sizes.

https://github.com/user-attachments/assets/c5901191-28c6-446d-8ee3-e9299ba39498

So why do this now? The actual motivation is that this fixes a bug. There is a bug with the "tiling menu" on MacOS. If you're not familiar, that is this thing that comes when you hover the maximize 🚥 button:

<img width="1728" height="1117" alt="Screenshot 2026-05-14 at 3 30 49 PM" src="https://github.com/user-attachments/assets/264534c5-116d-4660-8dad-f35b1132cac2" />

Sometimes clicking the left half or right half causes the window to vanish to nothing (0px wide). This persists across session restoration. See #10083

It turns out this fixes that. It's not clear to me why that is the case. I can't find any documentation stating that tiling depends on setting a minimum size. Maybe it's a bug in AppKit? In any case, we _should_ set this to bring it to parity with our winit code

https://github.com/warpdotdev/warp/blob/ae69bd4c7c4f402746e10e63edd16659c81c3bfb/crates/warpui/src/windowing/winit/window.rs#L81-L81

## Linked Issue

Fixes #10083 (1 of 2)

To fix that issue, there are 2 action items.

1. This PR.
2. Add validations to SQLite to reject sizes smaller than the minimum limit. A contributor has already opened a PR for this.

## Testing

Ran this locally and tiling is now working as expected.

<!--
## Changelog Entries for Stable


CHANGELOG-BUG-FIX: [MacOS] The tiling menu should now work as expected.
-->
