### PR TITLE
Allow cloud agent view exiting during LRCs

### DIFF
--- a/app/src/ai/blocklist/agent_view/controller.rs
+++ b/app/src/ai/blocklist/agent_view/controller.rs
@@ -430,6 +430,7 @@ impl AgentViewController {
                 .block_list()
                 .active_block()
                 .is_active_and_long_running();
+
         // Cloud agent panes do not have the same underlying terminal ownership
         // constraint (no local shell process), so long-running third party agent
         // commands should not trap the user in agent view.

--- a/app/src/ai/blocklist/agent_view/controller.rs
+++ b/app/src/ai/blocklist/agent_view/controller.rs
@@ -430,9 +430,16 @@ impl AgentViewController {
                 .block_list()
                 .active_block()
                 .is_active_and_long_running();
+        let is_cloud_agent_view = self
+            .agent_view_state
+            .origin()
+            .is_some_and(|origin| matches!(origin, AgentViewEntryOrigin::CloudAgent));
 
-        // In a non-ambient agent case, users cannot exit the fullscreen agent view with an active long running command.
-        if is_fullscreen_with_long_running {
+        // In a non-ambient agent case, users cannot exit the fullscreen agent view
+        // with an active long-running command. Cloud agent panes do not have the
+        // same underlying terminal ownership constraint, so long-running third
+        // party agent commands should not trap the user in agent view.
+        if is_fullscreen_with_long_running && !is_cloud_agent_view {
             return Err(ExitAgentViewError::LongRunningCommand);
         }
 

--- a/app/src/ai/blocklist/agent_view/controller.rs
+++ b/app/src/ai/blocklist/agent_view/controller.rs
@@ -430,16 +430,10 @@ impl AgentViewController {
                 .block_list()
                 .active_block()
                 .is_active_and_long_running();
-        let is_cloud_agent_view = self
-            .agent_view_state
-            .origin()
-            .is_some_and(|origin| matches!(origin, AgentViewEntryOrigin::CloudAgent));
-
-        // In a non-ambient agent case, users cannot exit the fullscreen agent view
-        // with an active long-running command. Cloud agent panes do not have the
-        // same underlying terminal ownership constraint, so long-running third
-        // party agent commands should not trap the user in agent view.
-        if is_fullscreen_with_long_running && !is_cloud_agent_view {
+        // Cloud agent panes do not have the same underlying terminal ownership
+        // constraint (no local shell process), so long-running third party agent
+        // commands should not trap the user in agent view.
+        if is_fullscreen_with_long_running && !model.is_dummy_cloud_mode_session() {
             return Err(ExitAgentViewError::LongRunningCommand);
         }
 

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -1438,6 +1438,11 @@ impl TerminalModel {
         self.is_dummy_cloud_mode_session
     }
 
+    #[cfg(test)]
+    pub fn set_is_dummy_cloud_mode_session(&mut self, value: bool) {
+        self.is_dummy_cloud_mode_session = value;
+    }
+
     pub fn is_shared_ambient_agent_session(&self) -> bool {
         matches!(
             self.shared_session_source_type,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -54,7 +54,7 @@ use crate::ai::blocklist::agent_view::{
     agent_view_bg_fill, get_agent_view_entry_block_position_id, AgentViewController,
     AgentViewControllerEvent, AgentViewDisplayMode, AgentViewEntryBlockParams,
     AgentViewEntryOrigin, AgentViewHeaderDisabledTheme, AgentViewHeaderTheme,
-    AgentViewZeroStateBlock, AgentViewZeroStateEvent, EphemeralMessageModel, ExitAgentViewError,
+    AgentViewZeroStateBlock, AgentViewZeroStateEvent, EphemeralMessageModel,
     ExitConfirmationTrigger, InlineAgentViewHeader, OrchestrationPillBar,
     ENTER_OR_EXIT_CONFIRMATION_WINDOW,
 };
@@ -4713,20 +4713,6 @@ impl TerminalView {
         callback(self, ctx);
     }
 
-    fn can_exit_agent_view_for_terminal_view(
-        &self,
-        ctx: &AppContext,
-    ) -> Result<(), ExitAgentViewError> {
-        match self.agent_view_controller.as_ref(ctx).can_exit_agent_view() {
-            Err(ExitAgentViewError::LongRunningCommand)
-                if self.can_pop_nested_cloud_agent_view(ctx) =>
-            {
-                Ok(())
-            }
-            result => result,
-        }
-    }
-
     /// If the active conversation is a child agent, navigate to the parent
     /// and return `true`; otherwise return `false` so the caller can run
     /// the normal exit-agent-view flow. Cross-tab and swap-target cases
@@ -4765,10 +4751,6 @@ impl TerminalView {
             });
         }
         true
-    }
-
-    fn can_pop_nested_cloud_agent_view(&self, ctx: &AppContext) -> bool {
-        self.is_ambient_agent_session(ctx) && self.is_nested_cloud_mode(ctx)
     }
 
     /// Exits the active agent, either:
@@ -10760,7 +10742,9 @@ impl TerminalView {
         let disabled_reason = if is_child_agent {
             None
         } else {
-            self.can_exit_agent_view_for_terminal_view(ctx)
+            self.agent_view_controller
+                .as_ref(ctx)
+                .can_exit_agent_view()
                 .err()
                 .map(|e| e.to_string())
         };
@@ -20565,7 +20549,12 @@ impl TerminalView {
                     }
 
                     // Disable escape completely for ambient agents without a parent terminal.
-                    if self.can_exit_agent_view_for_terminal_view(ctx).is_err() {
+                    if self
+                        .agent_view_controller
+                        .as_ref(ctx)
+                        .can_exit_agent_view()
+                        .is_err()
+                    {
                         return;
                     }
 
@@ -20575,7 +20564,7 @@ impl TerminalView {
                         .block_list()
                         .active_block()
                         .is_active_and_long_running();
-                    if is_long_running && self.can_pop_nested_cloud_agent_view(ctx) {
+                    if is_long_running && self.is_ambient_agent_session(ctx) {
                         self.exit_agent_view(ctx);
                     } else if !is_long_running {
                         // During first-time setup, always exit directly without confirmation
@@ -26175,7 +26164,12 @@ impl TypedActionView for TerminalView {
                 // to the in-place exit flow.
                 if self.try_navigate_to_parent_conversation(ctx) {
                     ctx.notify();
-                } else if self.can_exit_agent_view_for_terminal_view(ctx).is_ok() {
+                } else if self
+                    .agent_view_controller
+                    .as_ref(ctx)
+                    .can_exit_agent_view()
+                    .is_ok()
+                {
                     self.exit_agent_view(ctx);
                     ctx.notify();
                 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4718,7 +4718,9 @@ impl TerminalView {
         ctx: &AppContext,
     ) -> Result<(), ExitAgentViewError> {
         match self.agent_view_controller.as_ref(ctx).can_exit_agent_view() {
-            Err(ExitAgentViewError::LongRunningCommand) if self.is_ambient_agent_session(ctx) => {
+            Err(ExitAgentViewError::LongRunningCommand)
+                if self.can_pop_nested_cloud_agent_view(ctx) =>
+            {
                 Ok(())
             }
             result => result,
@@ -20573,7 +20575,7 @@ impl TerminalView {
                         .block_list()
                         .active_block()
                         .is_active_and_long_running();
-                    if is_long_running && self.is_ambient_agent_session(ctx) {
+                    if is_long_running && self.can_pop_nested_cloud_agent_view(ctx) {
                         self.exit_agent_view(ctx);
                     } else if !is_long_running {
                         // During first-time setup, always exit directly without confirmation

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4755,11 +4755,12 @@ impl TerminalView {
 
     /// Exits the active agent, either:
     /// * Exiting agent view for the selected conversation
-    /// * Popping the current view off the navigation stack (for cloud mode agents)
+    /// * Popping the current view off the navigation stack (for nested cloud mode agents)
+    /// Root cloud-mode panes (stack depth ≤ 1) are a no-op — there is nowhere to return to.
     fn exit_agent_view(&mut self, ctx: &mut ViewContext<Self>) {
         // For nested ambient agent sessions (cloud mode), pop from pane stack.
-        // Root cloud-mode panes have no parent terminal to return to, so exit
-        // the fullscreen agent view in place instead.
+        // Root cloud-mode panes have no parent terminal to return to, so escape
+        // is a no-op to avoid leaving the app in a borked state.
         if self.is_ambient_agent_session(ctx) {
             if let Some(pane_stack) = self
                 .pane_stack
@@ -4769,10 +4770,6 @@ impl TerminalView {
             {
                 pane_stack.update(ctx, |stack, ctx| {
                     stack.pop(ctx);
-                });
-            } else {
-                self.agent_view_controller.update(ctx, |controller, ctx| {
-                    controller.exit_agent_view_without_confirmation(ctx);
                 });
             }
         } else {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4718,9 +4718,7 @@ impl TerminalView {
         ctx: &AppContext,
     ) -> Result<(), ExitAgentViewError> {
         match self.agent_view_controller.as_ref(ctx).can_exit_agent_view() {
-            Err(ExitAgentViewError::LongRunningCommand)
-                if self.can_pop_nested_cloud_agent_view(ctx) =>
-            {
+            Err(ExitAgentViewError::LongRunningCommand) if self.is_ambient_agent_session(ctx) => {
                 Ok(())
             }
             result => result,
@@ -4775,13 +4773,22 @@ impl TerminalView {
     /// * Exiting agent view for the selected conversation
     /// * Popping the current view off the navigation stack (for cloud mode agents)
     fn exit_agent_view(&mut self, ctx: &mut ViewContext<Self>) {
-        // For ambient agent sessions (cloud mode), always pop from pane stack.
-        // These sessions are pushed onto a nav stack and have no underlying terminal
-        // to return to via the normal agent view exit path.
+        // For nested ambient agent sessions (cloud mode), pop from pane stack.
+        // Root cloud-mode panes have no parent terminal to return to, so exit
+        // the fullscreen agent view in place instead.
         if self.is_ambient_agent_session(ctx) {
-            if let Some(pane_stack) = self.pane_stack.as_ref().and_then(|h| h.upgrade(ctx)) {
+            if let Some(pane_stack) = self
+                .pane_stack
+                .as_ref()
+                .and_then(|h| h.upgrade(ctx))
+                .filter(|stack| stack.as_ref(ctx).depth() > 1)
+            {
                 pane_stack.update(ctx, |stack, ctx| {
                     stack.pop(ctx);
+                });
+            } else {
+                self.agent_view_controller.update(ctx, |controller, ctx| {
+                    controller.exit_agent_view_without_confirmation(ctx);
                 });
             }
         } else {
@@ -20566,7 +20573,7 @@ impl TerminalView {
                         .block_list()
                         .active_block()
                         .is_active_and_long_running();
-                    if is_long_running && self.can_pop_nested_cloud_agent_view(ctx) {
+                    if is_long_running && self.is_ambient_agent_session(ctx) {
                         self.exit_agent_view(ctx);
                     } else if !is_long_running {
                         // During first-time setup, always exit directly without confirmation

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -683,7 +683,8 @@ fn escape_pops_nested_cloud_agent_view_with_long_running_command() {
                 .lock()
                 .simulate_long_running_block("sleep 10", "running");
 
-            assert!(view.can_pop_nested_cloud_agent_view(ctx));
+            assert!(view.is_ambient_agent_session(ctx));
+            assert!(view.is_nested_cloud_mode(ctx));
             assert_eq!(view.can_exit_agent_view_for_terminal_view(ctx), Ok(()));
         });
 

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -704,6 +704,30 @@ fn escape_pops_nested_cloud_agent_view_with_long_running_command() {
 }
 
 #[test]
+fn escape_exits_root_cloud_agent_view_with_long_running_command() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+
+        terminal.update(&mut app, |view, ctx| {
+            view.enter_agent_view_for_new_conversation(None, AgentViewEntryOrigin::CloudAgent, ctx);
+            view.model
+                .lock()
+                .simulate_long_running_block("claude", "running");
+
+            assert_eq!(view.can_exit_agent_view_for_terminal_view(ctx), Ok(()));
+
+            view.handle_input_event(&InputEvent::Escape, ctx);
+
+            assert!(!view.agent_view_controller().as_ref(ctx).is_active());
+        });
+    })
+}
+
+#[test]
 fn escape_does_not_exit_local_agent_view_with_long_running_command() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -714,7 +714,7 @@ fn escape_pops_nested_cloud_agent_view_with_long_running_command() {
 }
 
 #[test]
-fn escape_exits_root_cloud_agent_view_with_long_running_command() {
+fn escape_does_not_exit_root_cloud_agent_view_with_long_running_command() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
@@ -728,16 +728,11 @@ fn escape_exits_root_cloud_agent_view_with_long_running_command() {
                 .lock()
                 .simulate_long_running_block("claude", "running");
 
-            assert_eq!(
-                view.agent_view_controller()
-                    .as_ref(ctx)
-                    .can_exit_agent_view(),
-                Ok(())
-            );
-
             view.handle_input_event(&InputEvent::Escape, ctx);
 
-            assert!(!view.agent_view_controller().as_ref(ctx).is_active());
+            // Root cloud-mode pane has no parent terminal to return to,
+            // so Escape is a no-op and agent view stays active.
+            assert!(view.agent_view_controller().as_ref(ctx).is_active());
         });
     })
 }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -26,6 +26,7 @@ use warpui::{
 use warpui::{App, ReadModel};
 
 use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
+use crate::ai::blocklist::agent_view::ExitAgentViewError;
 use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
 use crate::ai::blocklist::{
     agent_view::AgentViewEntryOrigin, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
@@ -77,6 +78,9 @@ fn add_window_with_cloud_mode_terminal(app: &mut App) -> ViewHandle<TerminalView
     let tips_model = app.add_model(|_| Default::default());
     let (_, terminal) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
         TerminalView::new_for_test_with_cloud_mode(tips_model, None, true, ctx)
+    });
+    terminal.update(app, |view, _| {
+        view.model.lock().set_is_dummy_cloud_mode_session(true);
     });
     terminal
 }
@@ -685,7 +689,12 @@ fn escape_pops_nested_cloud_agent_view_with_long_running_command() {
 
             assert!(view.is_ambient_agent_session(ctx));
             assert!(view.is_nested_cloud_mode(ctx));
-            assert_eq!(view.can_exit_agent_view_for_terminal_view(ctx), Ok(()));
+            assert_eq!(
+                view.agent_view_controller()
+                    .as_ref(ctx)
+                    .can_exit_agent_view(),
+                Ok(())
+            );
         });
 
         assert_eq!(
@@ -719,7 +728,12 @@ fn escape_exits_root_cloud_agent_view_with_long_running_command() {
                 .lock()
                 .simulate_long_running_block("claude", "running");
 
-            assert_eq!(view.can_exit_agent_view_for_terminal_view(ctx), Ok(()));
+            assert_eq!(
+                view.agent_view_controller()
+                    .as_ref(ctx)
+                    .can_exit_agent_view(),
+                Ok(())
+            );
 
             view.handle_input_event(&InputEvent::Escape, ctx);
 
@@ -749,7 +763,9 @@ fn escape_does_not_exit_local_agent_view_with_long_running_command() {
                 .simulate_long_running_block("sleep 10", "running");
 
             assert!(matches!(
-                view.can_exit_agent_view_for_terminal_view(ctx),
+                view.agent_view_controller()
+                    .as_ref(ctx)
+                    .can_exit_agent_view(),
                 Err(ExitAgentViewError::LongRunningCommand)
             ));
 


### PR DESCRIPTION
## Description

There was a bug where you sometimes couldn't exit an ambient agent view when there was an LRC. The issue was that we weren't always checking whether or not the pane was an ambient agent pane before blocking exit on an LRC being in progress. This PR fixes that issue, centralizing all surfaces to call one helper fn that does the correct check.

## Testing
- [x] I have manually tested my changes locally with `./script/run`

## Demo

https://www.loom.com/share/0e81e231888a42bf958effd28e911183

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._