### PR TITLE
[QUALITY-486] Display conversation searches by agent run title

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14908,7 +14908,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=63b333d02da4d95a716796331cb5c3049d369a7e#63b333d02da4d95a716796331cb5c3049d369a7e"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?branch=matthew%2Fconversation-search-by-agent-run-id#bc1af120153ba0e809b34928a45e1e86628c140f"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14908,7 +14908,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?branch=matthew%2Fconversation-search-by-agent-run-id#bc1af120153ba0e809b34928a45e1e86628c140f"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?branch=matthew%2Fconversation-search-by-agent-run-id#3370721c4a19ca5a51c69bd9c5b387127c2cb5a6"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14908,7 +14908,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?branch=matthew%2Fconversation-search-by-agent-run-id#3370721c4a19ca5a51c69bd9c5b387127c2cb5a6"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=9a2d2425c5d1eb40fb547956e659511906e03f9e#9a2d2425c5d1eb40fb547956e659511906e03f9e"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,7 +302,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", branch = "matthew/conversation-search-by-agent-run-id" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "9a2d2425c5d1eb40fb547956e659511906e03f9e" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,7 +302,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "63b333d02da4d95a716796331cb5c3049d369a7e" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", branch = "matthew/conversation-search-by-agent-run-id" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_from.rs
+++ b/app/src/ai/agent/api/convert_from.rs
@@ -758,7 +758,9 @@ impl ConvertAPIToolCallToAIAgentAction for api::message::ToolCall {
                 create_standard_action(request_computer_use.into())
             }
             api::message::tool_call::Tool::Subagent(subagent) => {
-                use api::message::tool_call::subagent::Metadata;
+                use api::message::tool_call::subagent::{
+                    conversation_search_metadata::Target, Metadata,
+                };
                 let subagent_type = match subagent.metadata {
                     Some(Metadata::Cli(_)) => SubagentType::Cli,
                     Some(Metadata::Research(_)) => SubagentType::Research,
@@ -771,15 +773,18 @@ impl ConvertAPIToolCallToAIAgentAction for api::message::ToolCall {
                         } else {
                             Some(cs_meta.query)
                         };
-                        let conversation_id = if cs_meta.conversation_id.is_empty() {
-                            None
-                        } else {
-                            Some(cs_meta.conversation_id)
-                        };
-                        let agent_run_id = if cs_meta.agent_run_id.is_empty() {
-                            None
-                        } else {
-                            Some(cs_meta.agent_run_id)
+                        let (conversation_id, agent_run_id) = match cs_meta.target {
+                            Some(Target::ConversationId(conversation_id))
+                                if !conversation_id.is_empty() =>
+                            {
+                                (Some(conversation_id), None)
+                            }
+                            Some(Target::AgentRunId(agent_run_id)) if !agent_run_id.is_empty() => {
+                                (None, Some(agent_run_id))
+                            }
+                            Some(Target::ConversationId(_))
+                            | Some(Target::AgentRunId(_))
+                            | None => (None, None),
                         };
                         SubagentType::ConversationSearch {
                             query,

--- a/app/src/ai/agent/api/convert_from.rs
+++ b/app/src/ai/agent/api/convert_from.rs
@@ -776,9 +776,15 @@ impl ConvertAPIToolCallToAIAgentAction for api::message::ToolCall {
                         } else {
                             Some(cs_meta.conversation_id)
                         };
+                        let agent_run_id = if cs_meta.agent_run_id.is_empty() {
+                            None
+                        } else {
+                            Some(cs_meta.agent_run_id)
+                        };
                         SubagentType::ConversationSearch {
                             query,
                             conversation_id,
+                            agent_run_id,
                         }
                     }
                     Some(Metadata::WarpDocumentationSearch(_)) => {

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -1520,9 +1520,10 @@ pub enum SubagentType {
     Summarization,
     ConversationSearch {
         query: Option<String>,
-        /// The ID of the conversation being searched. None when searching the
-        /// current conversation.
+        /// The ID of the conversation being searched.
         conversation_id: Option<String>,
+        /// The ID of the agent run being searched.
+        agent_run_id: Option<String>,
     },
     WarpDocumentationSearch,
     Unknown,

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -1520,6 +1520,8 @@ pub enum SubagentType {
     Summarization,
     ConversationSearch {
         query: Option<String>,
+        /// Search targets are mutually exclusive; at most one of `conversation_id` or
+        /// `agent_run_id` should be populated for a single conversation search subagent.
         /// The ID of the conversation being searched.
         conversation_id: Option<String>,
         /// The ID of the agent run being searched.

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -1088,11 +1088,7 @@ impl AIBlock {
         ctx.subscribe_to_model(
             &AgentConversationsModel::handle(ctx),
             |me, _, event, ctx| {
-                if matches!(event, AgentConversationsModelEvent::TasksUpdated)
-                    && me.output_references_agent_run_for_conversation_search(ctx)
-                {
-                    ctx.notify();
-                }
+                me.handle_agent_conversations_model_event(event, ctx);
             },
         );
 
@@ -2144,6 +2140,21 @@ impl AIBlock {
             AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
                 model.get_or_async_fetch_task_data(&task_id, ctx);
             });
+        }
+    }
+
+    fn handle_agent_conversations_model_event(
+        &mut self,
+        event: &AgentConversationsModelEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        // Conversation-search labels may render with an agent-run fallback before the
+        // async task title fetch completes. `TasksUpdated` is the signal that the real
+        // title may now be cached, so only notify blocks that render those labels.
+        if matches!(event, AgentConversationsModelEvent::TasksUpdated)
+            && self.output_references_agent_run_for_conversation_search(ctx)
+        {
+            ctx.notify();
         }
     }
 

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -78,6 +78,10 @@ use crate::ai::agent::AIIdentifiers;
 use crate::ai::agent::MessageId;
 use crate::ai::agent::RequestFileEditsResult;
 use crate::ai::agent::SearchCodebaseResult;
+use crate::ai::agent::SubagentCall;
+use crate::ai::agent::SubagentType;
+use crate::ai::agent_conversations_model::{AgentConversationsModel, AgentConversationsModelEvent};
+use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::action_model::NewConversationDecision;
 use crate::ai::blocklist::block::keyboard_navigable_buttons::KeyboardNavigableButtonBuilder;
 use crate::ai::blocklist::block::keyboard_navigable_buttons::KeyboardNavigableButtons;
@@ -1081,6 +1085,17 @@ impl AIBlock {
             },
         );
 
+        ctx.subscribe_to_model(
+            &AgentConversationsModel::handle(ctx),
+            |me, _, event, ctx| {
+                if matches!(event, AgentConversationsModelEvent::TasksUpdated)
+                    && me.output_references_agent_run_for_conversation_search(ctx)
+                {
+                    ctx.notify();
+                }
+            },
+        );
+
         let safe_mode_settings = SafeModeSettings::handle(ctx);
         ctx.subscribe_to_model(&safe_mode_settings, |me, _, event, ctx| {
             me.handle_safe_mode_settings_changed_event(event, ctx)
@@ -1840,6 +1855,8 @@ impl AIBlock {
             self.handle_web_fetch_messages(&output.messages, ctx);
         }
 
+        self.fetch_conversation_search_agent_run_titles(output, ctx);
+
         for action in output.actions() {
             let new_action_ids: HashSet<AIAgentActionId> =
                 output.actions().map(|action| action.id.clone()).collect();
@@ -2116,6 +2133,48 @@ impl AIBlock {
                     get_secret_obfuscation_mode(ctx).is_visually_obfuscated(),
                 );
         }
+    }
+
+    fn fetch_conversation_search_agent_run_titles(
+        &self,
+        output: &AIAgentOutput,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        for task_id in Self::conversation_search_agent_run_ids(output) {
+            AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
+                model.get_or_async_fetch_task_data(&task_id, ctx);
+            });
+        }
+    }
+
+    fn output_references_agent_run_for_conversation_search(&self, app: &AppContext) -> bool {
+        self.model
+            .status(app)
+            .output_to_render()
+            .is_some_and(|output| {
+                !Self::conversation_search_agent_run_ids(&output.get()).is_empty()
+            })
+    }
+
+    fn conversation_search_agent_run_ids(output: &AIAgentOutput) -> Vec<AmbientAgentTaskId> {
+        let mut task_ids = HashSet::new();
+        for message in &output.messages {
+            let AIAgentOutputMessageType::Subagent(SubagentCall {
+                subagent_type:
+                    SubagentType::ConversationSearch {
+                        agent_run_id: Some(agent_run_id),
+                        ..
+                    },
+                ..
+            }) = &message.message
+            else {
+                continue;
+            };
+            if let Ok(task_id) = agent_run_id.parse() {
+                task_ids.insert(task_id);
+            }
+        }
+        task_ids.into_iter().collect()
     }
 
     fn set_keyboard_navigable_buttons(

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -8,6 +8,8 @@ use crate::ai::agent::{
     AIAgentInput, CreateDocumentsResult, EditDocumentsResult, ReadFilesResult, SubagentCall,
     SubagentType, TodoOperation, UploadArtifactResult,
 };
+use crate::ai::agent_conversations_model::AgentConversationsModel;
+use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::util::truncation::truncate_from_end;
 use ai::agent::file_locations::group_file_contexts_for_display;
 
@@ -940,6 +942,7 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                                 SubagentType::ConversationSearch {
                                     ref query,
                                     ref conversation_id,
+                                    ref agent_run_id,
                                 },
                             task_id: subagent_task_id,
                         }) => {
@@ -968,13 +971,12 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                                 icons::yellow_running_icon(appearance)
                             };
 
-                            // Resolve which conversation is being searched. If
-                            // conversation_id is set and differs from the current
-                            // conversation, try to resolve a display name from
-                            // the history model; otherwise label it "this
-                            // conversation".
-                            let conversation_label =
-                                conversation_id.as_ref().and_then(|target_id| {
+                            // Resolve which conversation is being searched. Conversation IDs use
+                            // conversation history titles; agent run IDs use ambient task titles
+                            // once fetched. If neither target exists, label it "this conversation".
+                            let target_label = conversation_id
+                                .as_ref()
+                                .and_then(|target_id| {
                                     let history = BlocklistAIHistoryModel::as_ref(app);
                                     let token = ServerConversationToken::new(target_id.clone());
                                     let local_id =
@@ -992,7 +994,25 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                                     let title = target_conversation
                                         .and_then(|c| c.title())
                                         .map(|q| truncate_from_end(&q, 40));
-                                    Some(title.unwrap_or_else(|| target_id.clone()))
+                                    Some((
+                                        "conversation",
+                                        title.unwrap_or_else(|| target_id.clone()),
+                                    ))
+                                })
+                                .or_else(|| {
+                                    let target_id = agent_run_id.as_ref()?;
+                                    let title = target_id
+                                        .parse::<AmbientAgentTaskId>()
+                                        .ok()
+                                        .and_then(|task_id| {
+                                            AgentConversationsModel::as_ref(app)
+                                                .get_task_data(&task_id)
+                                        })
+                                        .map(|task| truncate_from_end(&task.title, 40));
+                                    Some((
+                                        "agent run",
+                                        title.unwrap_or_else(|| truncate_from_end(target_id, 40)),
+                                    ))
                                 });
 
                             let done = is_finished || is_cancelled;
@@ -1000,10 +1020,11 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
 
                             let mut fragments: Vec<FormattedTextFragment> =
                                 vec![FormattedTextFragment::plain_text(format!("{verb} "))];
-                            match &conversation_label {
-                                Some(name) => {
-                                    fragments
-                                        .push(FormattedTextFragment::plain_text("conversation "));
+                            match &target_label {
+                                Some((target_kind, name)) => {
+                                    fragments.push(FormattedTextFragment::plain_text(format!(
+                                        "{target_kind} "
+                                    )));
                                     fragments.push(FormattedTextFragment::weighted(
                                         name.as_str(),
                                         Some(markdown_parser::weight::CustomWeight::Bold),


### PR DESCRIPTION
## Description
Render conversation-search subagent calls that target `agent_run_id` with the searched child run title instead of treating the search as the current conversation.

This PR:
- Reads `agent_run_id` from conversation-search subagent metadata.
- Fetches missing run titles through `AgentConversationsModel` and re-renders when task data arrives.
- Falls back to `agent run <id>` when the run title is unavailable.
- Updates `warp_multi_agent_api` to the branch from https://github.com/warpdotdev/warp-proto-apis/pull/311.

Depends on:
- https://github.com/warpdotdev/warp-proto-apis/pull/311
- https://github.com/warpdotdev/warp-server/pull/11119

## Linked Issue
No linked issue.

## Testing
- [x] `cargo fmt --check`
- [x] `cargo check -p warp --lib`
- [x] `PATH="/tmp/warp-corepack-bin:$PATH" cargo clippy -p warp --lib --all-features --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

Full workspace clippy was attempted with `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`; it is currently blocked by an unrelated duplicate `DEFAULT_ONNX_MODEL` definition in `crates/input_classifier/src/bin/evaluate.rs` when `nld_classifier_v2` is enabled.

### Screenshots / Videos
Not captured.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Plan: https://staging.warp.dev/drive/notebook/xj15fRX70pF0DtEyxohVMj
Conversation: https://staging.warp.dev/conversation/7ce46a9f-3d21-41d9-becb-67d8ab107f23

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
