### PR TITLE
Don't wait for file-based MCPs we never attempt to start

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1175,36 +1175,20 @@ impl AgentDriver {
         ctx.subscribe_to_model(&file_based_mcp_manager, move |_me, event, ctx| {
             if let FileBasedMCPManagerEvent::CloudEnvMcpScanComplete {
                 repo_path,
-                detected_servers,
                 wait_server_uuids,
+                ..
             } = event
             {
                 if pending_repos.remove(repo_path) {
                     collected_wait_uuids.extend(wait_server_uuids.iter().copied());
-                    let detected_details = detected_servers
-                        .iter()
-                        .map(|server| {
-                            format!(
-                                "'{}' ({}) from {} config, hash={}, auto_start_eligible={}",
-                                server.name,
-                                server.uuid,
-                                server.provider.display_name(),
-                                server.hash,
-                                server.auto_start_eligible
-                            )
-                        })
-                        .join("; ");
-                    log::info!(
-                        "File-based MCP scan complete for repo {repo_path:?}: detected [{}], waiting for auto-started UUIDs {wait_server_uuids:?}",
-                        if detected_details.is_empty() { "none".to_string() } else { detected_details }
-                    );
                     // If we've received all scan results from all cloud environment repos, send
                     // back the auto-start-requested UUIDs and begin waiting for initialization.
                     if pending_repos.is_empty() {
                         let uuids = collected_wait_uuids.clone();
                         if let Some(sender) = tx.take() {
                             log::info!(
-                                "Collected auto-started file-based MCP server UUIDs from cloud environment repos: {uuids:?}"
+                                "Collected {} auto-started file-based MCP server(s) from cloud environment repos",
+                                uuids.len()
                             );
                             let _ = sender.send(uuids);
                         }
@@ -1275,10 +1259,6 @@ impl AgentDriver {
                     .collect::<HashMap<_, _>>(),
             ))
         };
-        let pending_details = pending_state_details
-            .lock()
-            .map(|details| details.values().cloned().join("; "))
-            .unwrap_or_else(|_| "<unable to read pending state>".to_string());
         let file_based_mcp_names = {
             let file_based_manager = FileBasedMCPManager::as_ref(ctx);
             pending_uuids
@@ -1293,7 +1273,7 @@ impl AgentDriver {
                 .collect::<HashMap<_, _>>()
         };
         log::info!(
-            "Waiting for {} file-based MCP server(s) to reach a terminal state: {pending_details}",
+            "Waiting for {} file-based MCP server(s) to reach a terminal state",
             pending_uuids.len()
         );
 
@@ -1309,7 +1289,6 @@ impl AgentDriver {
                 if !pending_uuids.contains(uuid) {
                     return;
                 }
-                log::info!("File-based MCP server {uuid} changed state to {state:?}");
                 let server_name = file_based_mcp_names
                     .get(uuid)
                     .map(String::as_str)

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1213,8 +1213,7 @@ impl AgentDriver {
         uuids: Vec<Uuid>,
         ctx: &mut ModelContext<Self>,
     ) -> impl Future<Output = ()> {
-        // Filter out UUIDs that have already reached a terminal state before the subscription is
-        // installed. Spawn eligibility is decided upstream by `FileBasedMCPManager`.
+        // Filter out UUIDs that have already reached a terminal state.
         let mut pending_uuids: HashSet<Uuid> = {
             let templatable_manager = TemplatableMCPServerManager::as_ref(ctx);
             uuids
@@ -1230,7 +1229,7 @@ impl AgentDriver {
 
         if pending_uuids.is_empty() {
             log::info!(
-                "No scheduled file-based MCP servers need to reach a terminal state; proceeding"
+                "All file-based MCP servers have reached a terminal state; proceeding"
             );
             return Either::Right(future::ready(()));
         }

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1146,7 +1146,7 @@ impl AgentDriver {
     }
 
     /// Subscribe to [`FileBasedMCPManagerEvent::CloudEnvMcpScanComplete`]
-    /// paths and return a receiver that fires with all discovered server UUIDs once every repo
+    /// paths and return a receiver that fires with auto-start-requested server UUIDs once every repo
     /// reports in. Must be called **before** `prepare_environment` so no events are missed.
     fn setup_file_based_mcp_discovery(
         &self,
@@ -1167,7 +1167,7 @@ impl AgentDriver {
 
         let mut tx = Some(tx);
         let mut pending_repos: HashSet<PathBuf> = HashSet::from_iter(expected_repos);
-        let mut collected_uuids = Vec::<Uuid>::new();
+        let mut collected_wait_uuids = Vec::<Uuid>::new();
 
         let file_based_mcp_manager = FileBasedMCPManager::handle(ctx);
         let manager_clone = file_based_mcp_manager.clone();
@@ -1175,21 +1175,36 @@ impl AgentDriver {
         ctx.subscribe_to_model(&file_based_mcp_manager, move |_me, event, ctx| {
             if let FileBasedMCPManagerEvent::CloudEnvMcpScanComplete {
                 repo_path,
-                server_uuids,
+                detected_servers,
+                wait_server_uuids,
             } = event
             {
                 if pending_repos.remove(repo_path) {
-                    collected_uuids.extend(server_uuids.iter().copied());
+                    collected_wait_uuids.extend(wait_server_uuids.iter().copied());
+                    let detected_details = detected_servers
+                        .iter()
+                        .map(|server| {
+                            format!(
+                                "'{}' ({}) from {} config, hash={}, auto_start_eligible={}",
+                                server.name,
+                                server.uuid,
+                                server.provider.display_name(),
+                                server.hash,
+                                server.auto_start_eligible
+                            )
+                        })
+                        .join("; ");
                     log::info!(
-                        "Found file-based MCP server UUIDs in repo {repo_path:?}: {server_uuids:?}"
+                        "File-based MCP scan complete for repo {repo_path:?}: detected [{}], waiting for auto-started UUIDs {wait_server_uuids:?}",
+                        if detected_details.is_empty() { "none".to_string() } else { detected_details }
                     );
-                    // If we've received all UUIDs from all cloud environment repos, send it back to the caller
-                    // and begin waiting for file-based MCP initialization.
+                    // If we've received all scan results from all cloud environment repos, send
+                    // back the auto-start-requested UUIDs and begin waiting for initialization.
                     if pending_repos.is_empty() {
-                        let uuids = collected_uuids.clone();
+                        let uuids = collected_wait_uuids.clone();
                         if let Some(sender) = tx.take() {
                             log::info!(
-                                "Collected file-based MCP server UUIDs from cloud environment repos: {uuids:?}"
+                                "Collected auto-started file-based MCP server UUIDs from cloud environment repos: {uuids:?}"
                             );
                             let _ = sender.send(uuids);
                         }
@@ -1202,8 +1217,7 @@ impl AgentDriver {
         rx
     }
 
-    /// Wait for discovered file-based MCP servers that were actually scheduled to start
-    /// (active or pending in the templatable manager) to reach a terminal state
+    /// Wait for auto-start-requested file-based MCP servers to reach a terminal state
     /// (`Running` or `FailedToStart`). Non-fatal: always completes without returning an error.
     ///
     /// **Sequencing note:** `AgentDriver` supports only one active subscription to
@@ -1215,32 +1229,17 @@ impl AgentDriver {
         uuids: Vec<Uuid>,
         ctx: &mut ModelContext<Self>,
     ) -> impl Future<Output = ()> {
-        // Filter out UUIDs that have already reached a terminal state or were discovered but not
-        // scheduled to start (e.g. project-scoped file-based MCP servers, which require explicit
-        // opt-in and are intentionally not auto-spawned).
+        // Filter out UUIDs that have already reached a terminal state before the subscription is
+        // installed. Spawn eligibility is decided upstream by `FileBasedMCPManager`.
         let mut pending_uuids: HashSet<Uuid> = {
             let templatable_manager = TemplatableMCPServerManager::as_ref(ctx);
-            let file_based_manager = FileBasedMCPManager::as_ref(ctx);
             uuids
                 .into_iter()
                 .filter(|uuid| {
-                    if matches!(
+                    !matches!(
                         templatable_manager.get_server_state(*uuid),
                         Some(MCPServerState::Running) | Some(MCPServerState::FailedToStart)
-                    ) {
-                        return false;
-                    }
-                    if templatable_manager.is_server_active_or_pending(*uuid) {
-                        return true;
-                    }
-                    let server_name = file_based_manager
-                        .get_installation_by_uuid(*uuid)
-                        .map(|installation| installation.templatable_mcp_server().name.as_str())
-                        .unwrap_or("<unknown>");
-                    log::info!(
-                        "Not waiting for discovered file-based MCP server '{server_name}' ({uuid}); it was not scheduled to start"
-                    );
-                    false
+                    )
                 })
                 .collect()
         };
@@ -1760,8 +1759,9 @@ impl AgentDriver {
                 .map_err(AgentDriverError::from)?;
 
             if let Some(file_based_discovery_rx) = file_based_discovery_rx {
-                // Await discovery: collect UUIDs of file-based MCP servers found in cloned repos.
-                let discovered_uuids = match file_based_discovery_rx
+                // Await discovery: collect UUIDs of file-based MCP servers that were auto-started
+                // while scanning cloned repos.
+                let wait_uuids = match file_based_discovery_rx
                     .with_timeout(MCP_SERVER_STARTUP_TIMEOUT)
                     .await
                 {
@@ -1780,16 +1780,14 @@ impl AgentDriver {
                     }
                 };
 
-                // Wait for discovered servers to reach Running (non-fatal: always unblocks).
-                if !discovered_uuids.is_empty() {
+                // Wait for auto-started servers to reach Running (non-fatal: always unblocks).
+                if !wait_uuids.is_empty() {
                     log::info!(
-                        "Checking readiness for {} discovered file-based MCP server(s)",
-                        discovered_uuids.len()
+                        "Checking readiness for {} auto-started file-based MCP server(s)",
+                        wait_uuids.len()
                     );
                     foreground
-                        .spawn(move |me, ctx| {
-                            me.wait_for_file_based_mcps_running(discovered_uuids, ctx)
-                        })
+                        .spawn(move |me, ctx| me.wait_for_file_based_mcps_running(wait_uuids, ctx))
                         .await?
                         .await;
                 }

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1188,7 +1188,9 @@ impl AgentDriver {
                     if pending_repos.is_empty() {
                         let uuids = collected_uuids.clone();
                         if let Some(sender) = tx.take() {
-                            log::info!("Waiting for file-based MCP servers to reach a terminal state: {uuids:?}");
+                            log::info!(
+                                "Collected file-based MCP server UUIDs from cloud environment repos: {uuids:?}"
+                            );
                             let _ = sender.send(uuids);
                         }
                         ctx.unsubscribe_from_model(&manager_clone);
@@ -1200,7 +1202,8 @@ impl AgentDriver {
         rx
     }
 
-    /// Wait for all file-based MCP servers with the given UUIDs to reach a terminal state
+    /// Wait for discovered file-based MCP servers that were actually scheduled to start
+    /// (active or pending in the templatable manager) to reach a terminal state
     /// (`Running` or `FailedToStart`). Non-fatal: always completes without returning an error.
     ///
     /// **Sequencing note:** `AgentDriver` supports only one active subscription to
@@ -1212,39 +1215,119 @@ impl AgentDriver {
         uuids: Vec<Uuid>,
         ctx: &mut ModelContext<Self>,
     ) -> impl Future<Output = ()> {
-        // Filter out UUIDs that have already reached a terminal state.
+        // Filter out UUIDs that have already reached a terminal state or were discovered but not
+        // scheduled to start (e.g. project-scoped file-based MCP servers, which require explicit
+        // opt-in and are intentionally not auto-spawned).
         let mut pending_uuids: HashSet<Uuid> = {
             let templatable_manager = TemplatableMCPServerManager::as_ref(ctx);
+            let file_based_manager = FileBasedMCPManager::as_ref(ctx);
             uuids
                 .into_iter()
                 .filter(|uuid| {
-                    !matches!(
+                    if matches!(
                         templatable_manager.get_server_state(*uuid),
                         Some(MCPServerState::Running) | Some(MCPServerState::FailedToStart)
-                    )
+                    ) {
+                        return false;
+                    }
+                    if templatable_manager.is_server_active_or_pending(*uuid) {
+                        return true;
+                    }
+                    let server_name = file_based_manager
+                        .get_installation_by_uuid(*uuid)
+                        .map(|installation| installation.templatable_mcp_server().name.as_str())
+                        .unwrap_or("<unknown>");
+                    log::info!(
+                        "Not waiting for discovered file-based MCP server '{server_name}' ({uuid}); it was not scheduled to start"
+                    );
+                    false
                 })
                 .collect()
         };
 
         if pending_uuids.is_empty() {
-            log::info!("All file-based MCP servers are already running; proceeding");
+            log::info!(
+                "No scheduled file-based MCP servers need to reach a terminal state; proceeding"
+            );
             return Either::Right(future::ready(()));
         }
+
+        let pending_state_details = {
+            let templatable_manager = TemplatableMCPServerManager::as_ref(ctx);
+            let file_based_manager = FileBasedMCPManager::as_ref(ctx);
+            Arc::new(Mutex::new(
+                pending_uuids
+                    .iter()
+                    .map(|uuid| {
+                        let server_name = file_based_manager
+                            .get_installation_by_uuid(*uuid)
+                            .map(|installation| installation.templatable_mcp_server().name.clone())
+                            .unwrap_or_else(|| "<unknown>".to_string());
+                        let state = templatable_manager
+                            .get_server_state(*uuid)
+                            .map(|state| format!("{state:?}"))
+                            .unwrap_or_else(|| "no state".to_string());
+                        let error = templatable_manager
+                            .get_server_error_message(*uuid)
+                            .map(|message| format!(", error={message}"))
+                            .unwrap_or_default();
+                        (*uuid, format!("{server_name} ({uuid}): {state}{error}"))
+                    })
+                    .collect::<HashMap<_, _>>(),
+            ))
+        };
+        let pending_details = pending_state_details
+            .lock()
+            .map(|details| details.values().cloned().join("; "))
+            .unwrap_or_else(|_| "<unable to read pending state>".to_string());
+        let file_based_mcp_names = {
+            let file_based_manager = FileBasedMCPManager::as_ref(ctx);
+            pending_uuids
+                .iter()
+                .map(|uuid| {
+                    let server_name = file_based_manager
+                        .get_installation_by_uuid(*uuid)
+                        .map(|installation| installation.templatable_mcp_server().name.clone())
+                        .unwrap_or_else(|| "<unknown>".to_string());
+                    (*uuid, server_name)
+                })
+                .collect::<HashMap<_, _>>()
+        };
+        log::info!(
+            "Waiting for {} file-based MCP server(s) to reach a terminal state: {pending_details}",
+            pending_uuids.len()
+        );
 
         let (tx, rx) = oneshot::channel::<()>();
         let mut tx = Some(tx);
 
         let templatable_manager_handle = TemplatableMCPServerManager::handle(ctx);
         let manager_clone = templatable_manager_handle.clone();
+        let pending_state_details_for_subscription = Arc::clone(&pending_state_details);
 
         ctx.subscribe_to_model(&templatable_manager_handle, move |_me, event, ctx| {
             if let TemplatableMCPServerManagerEvent::StateChanged { uuid, state } = event {
                 if !pending_uuids.contains(uuid) {
                     return;
                 }
+                log::info!("File-based MCP server {uuid} changed state to {state:?}");
+                let server_name = file_based_mcp_names
+                    .get(uuid)
+                    .map(String::as_str)
+                    .unwrap_or("<unknown>");
+                let error = TemplatableMCPServerManager::as_ref(ctx)
+                    .get_server_error_message(*uuid)
+                    .map(|message| format!(", error={message}"))
+                    .unwrap_or_default();
+                if let Ok(mut details) = pending_state_details_for_subscription.lock() {
+                    details.insert(*uuid, format!("{server_name} ({uuid}): {state:?}{error}"));
+                }
                 match state {
                     MCPServerState::Running | MCPServerState::FailedToStart => {
                         pending_uuids.remove(uuid);
+                        if let Ok(mut details) = pending_state_details_for_subscription.lock() {
+                            details.remove(uuid);
+                        }
                     }
                     _ => {
                         return;
@@ -1269,8 +1352,12 @@ impl AgentDriver {
                     );
                 }
                 Err(TimeoutError) => {
+                    let pending_details = pending_state_details
+                        .lock()
+                        .map(|details| details.values().cloned().join("; "))
+                        .unwrap_or_else(|_| "<unable to read pending state>".to_string());
                     log::warn!(
-                        "Timed out waiting for file-based MCP servers to reach a terminal state; proceeding without"
+                        "Timed out waiting for file-based MCP servers to reach a terminal state; proceeding without. Still pending: {pending_details}"
                     );
                 }
             }
@@ -1696,7 +1783,7 @@ impl AgentDriver {
                 // Wait for discovered servers to reach Running (non-fatal: always unblocks).
                 if !discovered_uuids.is_empty() {
                     log::info!(
-                        "Waiting for {} file-based MCP server(s) to reach a terminal state",
+                        "Checking readiness for {} discovered file-based MCP server(s)",
                         discovered_uuids.len()
                     );
                     foreground

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -114,7 +114,7 @@ use environment::PrepareEnvironmentError;
 pub(crate) use snapshot::upload_snapshot_for_handoff;
 use terminal::TerminalDriverEvent;
 
-const MCP_SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
+const MCP_SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(20);
 const HARNESS_SAVE_INTERVAL: Duration = Duration::from_secs(30);
 pub(crate) const WARP_DRIVE_SYNC_TIMEOUT: Duration = Duration::from_secs(60);
 const SETUP_FAILED_IDLE_TIMEOUT: Duration = Duration::from_secs(120);

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1228,9 +1228,7 @@ impl AgentDriver {
         };
 
         if pending_uuids.is_empty() {
-            log::info!(
-                "All file-based MCP servers have reached a terminal state; proceeding"
-            );
+            log::info!("All file-based MCP servers have reached a terminal state; proceeding");
             return Either::Right(future::ready(()));
         }
 

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -200,7 +200,7 @@ impl FileBasedMCPManager {
             scanned_servers.insert(hash);
         }
 
-        let auto_started_uuids = self.auto_start_file_based_servers(servers_to_spawn, ctx);
+        let auto_started_uuids = self.maybe_autostart_file_based_servers(servers_to_spawn, ctx);
         self.pending_scan_auto_started_servers_by_root
             .entry(root_path.clone())
             .or_default()
@@ -296,7 +296,8 @@ impl FileBasedMCPManager {
         }
     }
 
-    fn auto_start_file_based_servers(
+    /// Returns the UUIDs of servers that were actually auto-started.
+    fn maybe_autostart_file_based_servers(
         &mut self,
         servers_to_consider: Vec<TemplatableMCPServerInstallation>,
         ctx: &mut ModelContext<Self>,

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -285,14 +285,22 @@ impl FileBasedMCPManager {
         warp_managed_mcp_config_path().is_some_and(|path| root_path == path.root_path.as_path())
     }
     fn auto_start_decision(&self, hash: u64, file_based_mcp_enabled: bool) -> AutoStartDecision {
-        let is_global_warp_server = self.is_global_warp_server(hash);
-        let is_global_server = self.is_global_server(hash);
-        if is_global_warp_server || (is_global_server && file_based_mcp_enabled) {
-            AutoStartDecision::AutoStart
-        } else if is_global_server {
-            AutoStartDecision::GlobalDisabled
+        let server_type = if self.is_global_warp_server(hash) {
+            FileBasedMCPServerType::GlobalWarp
+        } else if self.is_global_server(hash) {
+            FileBasedMCPServerType::GlobalThirdParty
         } else {
-            AutoStartDecision::ProjectScoped
+            FileBasedMCPServerType::ProjectScoped
+        };
+        let should_autostart = match server_type {
+            FileBasedMCPServerType::GlobalWarp => true,
+            FileBasedMCPServerType::GlobalThirdParty => file_based_mcp_enabled,
+            FileBasedMCPServerType::ProjectScoped => false,
+        };
+
+        AutoStartDecision {
+            should_autostart,
+            server_type,
         }
     }
 
@@ -320,15 +328,15 @@ impl FileBasedMCPManager {
             };
             let installation_uuid = installation.uuid();
             let server_name = installation.templatable_mcp_server().name.clone();
-            match self.auto_start_decision(hash, mcp_enabled) {
-                AutoStartDecision::AutoStart => {
-                    log::info!(
-                        "Auto-spawning file-based MCP server '{server_name}' ({installation_uuid})"
-                    );
-                    auto_started_uuids.push(installation_uuid);
-                    to_spawn.push(installation);
-                }
-                AutoStartDecision::GlobalDisabled | AutoStartDecision::ProjectScoped => {}
+            let AutoStartDecision {
+                should_autostart, ..
+            } = self.auto_start_decision(hash, mcp_enabled);
+            if should_autostart {
+                log::info!(
+                    "Auto-spawning file-based MCP server '{server_name}' ({installation_uuid})"
+                );
+                auto_started_uuids.push(installation_uuid);
+                to_spawn.push(installation);
             }
         }
 
@@ -348,8 +356,9 @@ impl FileBasedMCPManager {
         let mcp_enabled = AISettings::as_ref(ctx).is_file_based_mcp_enabled(ctx);
         // FileMCPWatcher emits CloudEnvMcpScanComplete only after emitting ConfigParsed
         // for every provider config in this repo scan. Each ConfigParsed call records
-        // the UUIDs actually emitted through SpawnServers in auto_started_servers_by_root,
-        // so this remove() returns the wait set for this completed scan.
+        // the UUIDs actually emitted through SpawnServers in
+        // pending_scan_auto_started_servers_by_root, so this remove() returns the wait set
+        // for this completed scan.
         let wait_server_uuids: Vec<Uuid> = self
             .pending_scan_auto_started_servers_by_root
             .remove(repo_path)
@@ -369,7 +378,7 @@ impl FileBasedMCPManager {
                     let uuid = installation.uuid();
                     let auto_start_eligible = self
                         .auto_start_decision(*hash, mcp_enabled)
-                        .should_auto_start();
+                        .should_autostart;
                     detected_servers.push(CloudEnvMcpScanServer {
                         uuid,
                         name: installation.templatable_mcp_server().name.clone(),
@@ -405,7 +414,8 @@ impl FileBasedMCPManager {
             .file_based_servers
             .iter()
             .filter(|(hash, _)| {
-                self.is_global_server(**hash) && !self.is_global_warp_server(**hash)
+                self.auto_start_decision(**hash, true).server_type
+                    == FileBasedMCPServerType::GlobalThirdParty
             })
             .map(|(_, server)| server.clone())
             .collect();
@@ -504,16 +514,19 @@ impl FileBasedMCPManager {
     }
 }
 
-enum AutoStartDecision {
-    AutoStart,
-    GlobalDisabled,
-    ProjectScoped,
+struct AutoStartDecision {
+    should_autostart: bool,
+    server_type: FileBasedMCPServerType,
 }
 
-impl AutoStartDecision {
-    fn should_auto_start(&self) -> bool {
-        matches!(self, AutoStartDecision::AutoStart)
-    }
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FileBasedMCPServerType {
+    /// A file-based MCP server detected from Warp's global managed config.
+    GlobalWarp,
+    /// A file-based MCP server detected from a non-Warp provider's global user config.
+    GlobalThirdParty,
+    /// A file-based MCP server detected from a project/repository-scoped config.
+    ProjectScoped,
 }
 
 #[derive(Clone, Debug)]

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -26,7 +26,9 @@ pub struct FileBasedMCPManager {
     /// Reverse mapping: logical root path → provider → set of server hashes.
     file_based_servers_by_root: HashMap<PathBuf, HashMap<MCPProvider, HashSet<u64>>>,
     /// UUIDs that were actually auto-start requested while parsing each `(root, provider)`.
-    auto_started_servers_by_root: HashMap<PathBuf, HashMap<MCPProvider, HashSet<Uuid>>>,
+    /// They are temporarily stored here and removed to emit FileBasedMCPManagerEvent::CloudEnvMcpScanComplete
+    pending_scan_auto_started_servers_by_root:
+        HashMap<PathBuf, HashMap<MCPProvider, HashSet<Uuid>>>,
 }
 
 impl FileBasedMCPManager {
@@ -46,7 +48,7 @@ impl FileBasedMCPManager {
         Self {
             file_based_servers: Default::default(),
             file_based_servers_by_root: Default::default(),
-            auto_started_servers_by_root: Default::default(),
+            pending_scan_auto_started_servers_by_root: Default::default(),
         }
     }
 
@@ -199,7 +201,7 @@ impl FileBasedMCPManager {
         }
 
         let auto_started_uuids = self.auto_start_file_based_servers(servers_to_spawn, ctx);
-        self.auto_started_servers_by_root
+        self.pending_scan_auto_started_servers_by_root
             .entry(root_path.clone())
             .or_default()
             .insert(provider, auto_started_uuids.into_iter().collect());
@@ -343,8 +345,12 @@ impl FileBasedMCPManager {
         ctx: &mut ModelContext<Self>,
     ) {
         let mcp_enabled = AISettings::as_ref(ctx).is_file_based_mcp_enabled(ctx);
+        // FileMCPWatcher emits CloudEnvMcpScanComplete only after emitting ConfigParsed
+        // for every provider config in this repo scan. Each ConfigParsed call records
+        // the UUIDs actually emitted through SpawnServers in auto_started_servers_by_root,
+        // so this remove() returns the wait set for this completed scan.
         let wait_server_uuids: Vec<Uuid> = self
-            .auto_started_servers_by_root
+            .pending_scan_auto_started_servers_by_root
             .remove(repo_path)
             .into_iter()
             .flat_map(|provider_map| provider_map.into_values())

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -25,6 +25,8 @@ pub struct FileBasedMCPManager {
     file_based_servers: HashMap<u64, TemplatableMCPServerInstallation>,
     /// Reverse mapping: logical root path → provider → set of server hashes.
     file_based_servers_by_root: HashMap<PathBuf, HashMap<MCPProvider, HashSet<u64>>>,
+    /// UUIDs that were actually auto-start requested while parsing each `(root, provider)`.
+    auto_started_servers_by_root: HashMap<PathBuf, HashMap<MCPProvider, HashSet<Uuid>>>,
 }
 
 impl FileBasedMCPManager {
@@ -44,6 +46,7 @@ impl FileBasedMCPManager {
         Self {
             file_based_servers: Default::default(),
             file_based_servers_by_root: Default::default(),
+            auto_started_servers_by_root: Default::default(),
         }
     }
 
@@ -202,8 +205,11 @@ impl FileBasedMCPManager {
             scanned_servers.insert(hash);
         }
 
-        // If file-based MCP is enabled, spawn any new servers.
-        self.spawn_file_based_servers(servers_to_spawn, ctx);
+        let auto_started_uuids = self.auto_start_file_based_servers(servers_to_spawn, ctx);
+        self.auto_started_servers_by_root
+            .entry(root_path.clone())
+            .or_default()
+            .insert(provider, auto_started_uuids.into_iter().collect());
 
         // Determine which servers have been removed.
         let servers_to_remove = previous_scanned_servers
@@ -283,14 +289,28 @@ impl FileBasedMCPManager {
     fn is_global_warp_root(root_path: &Path) -> bool {
         warp_managed_mcp_config_path().is_some_and(|path| root_path == path.root_path.as_path())
     }
+    fn auto_start_decision(&self, hash: u64, file_based_mcp_enabled: bool) -> AutoStartDecision {
+        let is_global_warp_server = self.is_global_warp_server(hash);
+        let is_global_server = self.is_global_server(hash);
+        if is_global_warp_server || (is_global_server && file_based_mcp_enabled) {
+            AutoStartDecision::AutoStart {
+                is_global_warp_server,
+                is_global_server,
+            }
+        } else if is_global_server {
+            AutoStartDecision::GlobalDisabled
+        } else {
+            AutoStartDecision::ProjectScoped
+        }
+    }
 
-    fn spawn_file_based_servers(
+    fn auto_start_file_based_servers(
         &mut self,
-        servers_to_spawn: Vec<TemplatableMCPServerInstallation>,
+        servers_to_consider: Vec<TemplatableMCPServerInstallation>,
         ctx: &mut ModelContext<Self>,
-    ) {
-        if servers_to_spawn.is_empty() {
-            return;
+    ) -> Vec<Uuid> {
+        if servers_to_consider.is_empty() {
+            return Vec::new();
         }
         let mcp_enabled = AISettings::as_ref(ctx).is_file_based_mcp_enabled(ctx);
 
@@ -300,27 +320,34 @@ impl FileBasedMCPManager {
         // - Project-scoped (any provider): never auto-spawn; require explicit opt-in
         //   via the "Detected from {provider}" section of the MCP settings.
         let mut to_spawn = Vec::new();
-        for installation in servers_to_spawn {
+        let mut auto_started_uuids = Vec::new();
+        for installation in servers_to_consider {
             let Some(hash) = installation.hash() else {
                 continue;
             };
             let installation_uuid = installation.uuid();
             let server_name = installation.templatable_mcp_server().name.clone();
-            let is_global_warp_server = self.is_global_warp_server(hash);
-            let is_global_server = self.is_global_server(hash);
-            if is_global_warp_server || (is_global_server && mcp_enabled) {
-                log::info!(
-                    "Auto-spawning file-based MCP server '{server_name}' ({installation_uuid}); global_warp={is_global_warp_server}, global={is_global_server}, file_based_mcp_enabled={mcp_enabled}"
-                );
-                to_spawn.push(installation);
-            } else if is_global_server {
-                log::info!(
-                    "Not auto-spawning global file-based MCP server '{server_name}' ({installation_uuid}) because file-based MCP is disabled"
-                );
-            } else {
-                log::info!(
-                    "Not auto-spawning project-scoped file-based MCP server '{server_name}' ({installation_uuid}); project-scoped file-based MCP servers require explicit opt-in"
-                );
+            match self.auto_start_decision(hash, mcp_enabled) {
+                AutoStartDecision::AutoStart {
+                    is_global_warp_server,
+                    is_global_server,
+                } => {
+                    log::info!(
+                        "Auto-spawning file-based MCP server '{server_name}' ({installation_uuid}); global_warp={is_global_warp_server}, global={is_global_server}, file_based_mcp_enabled={mcp_enabled}"
+                    );
+                    auto_started_uuids.push(installation_uuid);
+                    to_spawn.push(installation);
+                }
+                AutoStartDecision::GlobalDisabled => {
+                    log::info!(
+                        "Not auto-spawning global file-based MCP server '{server_name}' ({installation_uuid}) because file-based MCP is disabled"
+                    );
+                }
+                AutoStartDecision::ProjectScoped => {
+                    log::info!(
+                        "Not auto-spawning project-scoped file-based MCP server '{server_name}' ({installation_uuid}); project-scoped file-based MCP servers require explicit opt-in"
+                    );
+                }
             }
         }
 
@@ -329,6 +356,7 @@ impl FileBasedMCPManager {
                 installations: to_spawn,
             });
         }
+        auto_started_uuids
     }
 
     fn handle_cloud_environment_scan_complete(
@@ -336,8 +364,17 @@ impl FileBasedMCPManager {
         repo_path: &PathBuf,
         ctx: &mut ModelContext<Self>,
     ) {
-        // Retrieve UUIDs of all file-based MCP servers in the repository.
-        let mut server_uuids: Vec<Uuid> = Vec::new();
+        let mcp_enabled = AISettings::as_ref(ctx).is_file_based_mcp_enabled(ctx);
+        let wait_server_uuids: Vec<Uuid> = self
+            .auto_started_servers_by_root
+            .remove(repo_path)
+            .into_iter()
+            .flat_map(|provider_map| provider_map.into_values())
+            .flatten()
+            .sorted_by_key(|uuid| uuid.to_string())
+            .collect();
+
+        let mut detected_servers: Vec<CloudEnvMcpScanServer> = Vec::new();
         let mut server_details: Vec<String> = Vec::new();
         if let Some(provider_map) = self.file_based_servers_by_root.get(repo_path) {
             for (provider, hash_set) in provider_map {
@@ -346,9 +383,18 @@ impl FileBasedMCPManager {
                         continue;
                     };
                     let uuid = installation.uuid();
-                    server_uuids.push(uuid);
+                    let auto_start_eligible = self
+                        .auto_start_decision(*hash, mcp_enabled)
+                        .should_auto_start();
+                    detected_servers.push(CloudEnvMcpScanServer {
+                        uuid,
+                        name: installation.templatable_mcp_server().name.clone(),
+                        provider: *provider,
+                        hash: *hash,
+                        auto_start_eligible,
+                    });
                     server_details.push(format!(
-                        "'{}' ({uuid}) from {} config with hash {hash}",
+                        "'{}' ({uuid}) from {} config with hash {hash}; auto_start_eligible={auto_start_eligible}",
                         installation.templatable_mcp_server().name,
                         provider.display_name()
                     ));
@@ -361,15 +407,17 @@ impl FileBasedMCPManager {
             server_details.join("; ")
         };
         log::info!(
-            "Cloud environment file-based MCP scan complete for {}: {} server(s): {server_details}",
+            "Cloud environment file-based MCP scan complete for {}: {} detected server(s), {} auto-started server(s): {server_details}",
             repo_path.display(),
-            server_uuids.len()
+            detected_servers.len(),
+            wait_server_uuids.len()
         );
 
-        // Pass the UUIDs of all detected file-based MCP servers to the AgentDriver.
+        // Pass the UUIDs of auto-start-requested file-based MCP servers to the AgentDriver.
         ctx.emit(FileBasedMCPManagerEvent::CloudEnvMcpScanComplete {
             repo_path: repo_path.clone(),
-            server_uuids,
+            detected_servers,
+            wait_server_uuids,
         });
     }
 
@@ -482,6 +530,29 @@ impl FileBasedMCPManager {
     }
 }
 
+enum AutoStartDecision {
+    AutoStart {
+        is_global_warp_server: bool,
+        is_global_server: bool,
+    },
+    GlobalDisabled,
+    ProjectScoped,
+}
+
+impl AutoStartDecision {
+    fn should_auto_start(&self) -> bool {
+        matches!(self, AutoStartDecision::AutoStart { .. })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CloudEnvMcpScanServer {
+    pub uuid: Uuid,
+    pub name: String,
+    pub provider: MCPProvider,
+    pub hash: u64,
+    pub auto_start_eligible: bool,
+}
 pub enum FileBasedMCPManagerEvent {
     SpawnServers {
         installations: Vec<TemplatableMCPServerInstallation>,
@@ -494,7 +565,8 @@ pub enum FileBasedMCPManagerEvent {
     },
     CloudEnvMcpScanComplete {
         repo_path: PathBuf,
-        server_uuids: Vec<Uuid>,
+        detected_servers: Vec<CloudEnvMcpScanServer>,
+        wait_server_uuids: Vec<Uuid>,
     },
 }
 

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -180,13 +180,6 @@ impl FileBasedMCPManager {
             let Some(hash) = installation.hash() else {
                 continue;
             };
-            log::info!(
-                "Discovered file-based MCP server '{}' ({}) from {} config under {} with hash {hash}",
-                installation.templatable_mcp_server().name,
-                installation.uuid(),
-                provider.display_name(),
-                root_path.display()
-            );
             // TODO(APP-3429): Deduplicate file-based servers across provider directories.
             if let Entry::Vacant(e) = self.file_based_servers.entry(hash) {
                 // Detected a server that hasn't previously been spawned.
@@ -293,10 +286,7 @@ impl FileBasedMCPManager {
         let is_global_warp_server = self.is_global_warp_server(hash);
         let is_global_server = self.is_global_server(hash);
         if is_global_warp_server || (is_global_server && file_based_mcp_enabled) {
-            AutoStartDecision::AutoStart {
-                is_global_warp_server,
-                is_global_server,
-            }
+            AutoStartDecision::AutoStart
         } else if is_global_server {
             AutoStartDecision::GlobalDisabled
         } else {
@@ -328,26 +318,14 @@ impl FileBasedMCPManager {
             let installation_uuid = installation.uuid();
             let server_name = installation.templatable_mcp_server().name.clone();
             match self.auto_start_decision(hash, mcp_enabled) {
-                AutoStartDecision::AutoStart {
-                    is_global_warp_server,
-                    is_global_server,
-                } => {
+                AutoStartDecision::AutoStart => {
                     log::info!(
-                        "Auto-spawning file-based MCP server '{server_name}' ({installation_uuid}); global_warp={is_global_warp_server}, global={is_global_server}, file_based_mcp_enabled={mcp_enabled}"
+                        "Auto-spawning file-based MCP server '{server_name}' ({installation_uuid})"
                     );
                     auto_started_uuids.push(installation_uuid);
                     to_spawn.push(installation);
                 }
-                AutoStartDecision::GlobalDisabled => {
-                    log::info!(
-                        "Not auto-spawning global file-based MCP server '{server_name}' ({installation_uuid}) because file-based MCP is disabled"
-                    );
-                }
-                AutoStartDecision::ProjectScoped => {
-                    log::info!(
-                        "Not auto-spawning project-scoped file-based MCP server '{server_name}' ({installation_uuid}); project-scoped file-based MCP servers require explicit opt-in"
-                    );
-                }
+                AutoStartDecision::GlobalDisabled | AutoStartDecision::ProjectScoped => {}
             }
         }
 
@@ -375,7 +353,6 @@ impl FileBasedMCPManager {
             .collect();
 
         let mut detected_servers: Vec<CloudEnvMcpScanServer> = Vec::new();
-        let mut server_details: Vec<String> = Vec::new();
         if let Some(provider_map) = self.file_based_servers_by_root.get(repo_path) {
             for (provider, hash_set) in provider_map {
                 for hash in hash_set {
@@ -393,21 +370,11 @@ impl FileBasedMCPManager {
                         hash: *hash,
                         auto_start_eligible,
                     });
-                    server_details.push(format!(
-                        "'{}' ({uuid}) from {} config with hash {hash}; auto_start_eligible={auto_start_eligible}",
-                        installation.templatable_mcp_server().name,
-                        provider.display_name()
-                    ));
                 }
             }
         }
-        let server_details = if server_details.is_empty() {
-            "none".to_string()
-        } else {
-            server_details.join("; ")
-        };
         log::info!(
-            "Cloud environment file-based MCP scan complete for {}: {} detected server(s), {} auto-started server(s): {server_details}",
+            "Cloud environment file-based MCP scan complete for {}: {} detected server(s), {} auto-started server(s)",
             repo_path.display(),
             detected_servers.len(),
             wait_server_uuids.len()
@@ -531,21 +498,19 @@ impl FileBasedMCPManager {
 }
 
 enum AutoStartDecision {
-    AutoStart {
-        is_global_warp_server: bool,
-        is_global_server: bool,
-    },
+    AutoStart,
     GlobalDisabled,
     ProjectScoped,
 }
 
 impl AutoStartDecision {
     fn should_auto_start(&self) -> bool {
-        matches!(self, AutoStartDecision::AutoStart { .. })
+        matches!(self, AutoStartDecision::AutoStart)
     }
 }
 
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub struct CloudEnvMcpScanServer {
     pub uuid: Uuid,
     pub name: String,
@@ -565,6 +530,7 @@ pub enum FileBasedMCPManagerEvent {
     },
     CloudEnvMcpScanComplete {
         repo_path: PathBuf,
+        #[allow(dead_code)]
         detected_servers: Vec<CloudEnvMcpScanServer>,
         wait_server_uuids: Vec<Uuid>,
     },

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -177,6 +177,13 @@ impl FileBasedMCPManager {
             let Some(hash) = installation.hash() else {
                 continue;
             };
+            log::info!(
+                "Discovered file-based MCP server '{}' ({}) from {} config under {} with hash {hash}",
+                installation.templatable_mcp_server().name,
+                installation.uuid(),
+                provider.display_name(),
+                root_path.display()
+            );
             // TODO(APP-3429): Deduplicate file-based servers across provider directories.
             if let Entry::Vacant(e) = self.file_based_servers.entry(hash) {
                 // Detected a server that hasn't previously been spawned.
@@ -297,11 +304,24 @@ impl FileBasedMCPManager {
             let Some(hash) = installation.hash() else {
                 continue;
             };
-            if self.is_global_warp_server(hash) || (self.is_global_server(hash) && mcp_enabled) {
+            let installation_uuid = installation.uuid();
+            let server_name = installation.templatable_mcp_server().name.clone();
+            let is_global_warp_server = self.is_global_warp_server(hash);
+            let is_global_server = self.is_global_server(hash);
+            if is_global_warp_server || (is_global_server && mcp_enabled) {
+                log::info!(
+                    "Auto-spawning file-based MCP server '{server_name}' ({installation_uuid}); global_warp={is_global_warp_server}, global={is_global_server}, file_based_mcp_enabled={mcp_enabled}"
+                );
                 to_spawn.push(installation);
+            } else if is_global_server {
+                log::info!(
+                    "Not auto-spawning global file-based MCP server '{server_name}' ({installation_uuid}) because file-based MCP is disabled"
+                );
+            } else {
+                log::info!(
+                    "Not auto-spawning project-scoped file-based MCP server '{server_name}' ({installation_uuid}); project-scoped file-based MCP servers require explicit opt-in"
+                );
             }
-
-            // Project-scoped installations are intentionally dropped from auto-spawn.
         }
 
         if !to_spawn.is_empty() {
@@ -317,18 +337,34 @@ impl FileBasedMCPManager {
         ctx: &mut ModelContext<Self>,
     ) {
         // Retrieve UUIDs of all file-based MCP servers in the repository.
-        let server_uuids: Vec<Uuid> = self
-            .file_based_servers_by_root
-            .get(repo_path)
-            .map(|provider_map| {
-                provider_map
-                    .values()
-                    .flat_map(|hash_set| hash_set.iter())
-                    .filter_map(|hash| self.file_based_servers.get(hash))
-                    .map(|installation| installation.uuid())
-                    .collect()
-            })
-            .unwrap_or_default();
+        let mut server_uuids: Vec<Uuid> = Vec::new();
+        let mut server_details: Vec<String> = Vec::new();
+        if let Some(provider_map) = self.file_based_servers_by_root.get(repo_path) {
+            for (provider, hash_set) in provider_map {
+                for hash in hash_set {
+                    let Some(installation) = self.file_based_servers.get(hash) else {
+                        continue;
+                    };
+                    let uuid = installation.uuid();
+                    server_uuids.push(uuid);
+                    server_details.push(format!(
+                        "'{}' ({uuid}) from {} config with hash {hash}",
+                        installation.templatable_mcp_server().name,
+                        provider.display_name()
+                    ));
+                }
+            }
+        }
+        let server_details = if server_details.is_empty() {
+            "none".to_string()
+        } else {
+            server_details.join("; ")
+        };
+        log::info!(
+            "Cloud environment file-based MCP scan complete for {}: {} server(s): {server_details}",
+            repo_path.display(),
+            server_uuids.len()
+        );
 
         // Pass the UUIDs of all detected file-based MCP servers to the AgentDriver.
         ctx.emit(FileBasedMCPManagerEvent::CloudEnvMcpScanComplete {

--- a/app/src/ai/mcp/file_based_manager_tests.rs
+++ b/app/src/ai/mcp/file_based_manager_tests.rs
@@ -1,4 +1,4 @@
-use super::{FileBasedMCPManager, FileBasedMCPManagerEvent, MCPProvider};
+use super::{CloudEnvMcpScanServer, FileBasedMCPManager, FileBasedMCPManagerEvent, MCPProvider};
 use crate::ai::mcp::FileMCPWatcher;
 use crate::ai::mcp::ParsedTemplatableMCPServerResult;
 use crate::auth::AuthStateProvider;
@@ -42,6 +42,14 @@ fn parse_mcp_json(json: &str) -> Vec<ParsedTemplatableMCPServerResult> {
 struct ManagerEvents {
     spawned_uuids: Vec<Uuid>,
     despawned_uuids: Vec<Uuid>,
+    scan_completions: Vec<ScanCompletion>,
+}
+
+#[derive(Clone, Debug)]
+struct ScanCompletion {
+    repo_path: PathBuf,
+    detected_servers: Vec<CloudEnvMcpScanServer>,
+    wait_server_uuids: Vec<Uuid>,
 }
 
 impl Entity for ManagerEvents {
@@ -63,8 +71,18 @@ fn subscribe_events(
                 me.despawned_uuids
                     .extend(installation_uuids.iter().copied());
             }
-            FileBasedMCPManagerEvent::PurgeCredentials { .. }
-            | FileBasedMCPManagerEvent::CloudEnvMcpScanComplete { .. } => {}
+            FileBasedMCPManagerEvent::PurgeCredentials { .. } => {}
+            FileBasedMCPManagerEvent::CloudEnvMcpScanComplete {
+                repo_path,
+                detected_servers,
+                wait_server_uuids,
+            } => {
+                me.scan_completions.push(ScanCompletion {
+                    repo_path: repo_path.clone(),
+                    detected_servers: detected_servers.clone(),
+                    wait_server_uuids: wait_server_uuids.clone(),
+                });
+            }
         });
     });
     events
@@ -408,6 +426,77 @@ fn test_project_scoped_servers_never_auto_spawn() {
                 e.despawned_uuids.is_empty(),
                 "Toggle flip must not despawn project-scoped servers, got: {:?}",
                 e.despawned_uuids
+            );
+        });
+    });
+}
+
+#[test]
+fn test_project_scoped_cloud_scan_has_detected_servers_but_empty_wait_set() {
+    let _flag_guard = FeatureFlag::FileBasedMcp.override_enabled(true);
+    let repo_path = PathBuf::from("/tmp/warp-test-cloud-repo");
+    let claude_parsed =
+        parse_mcp_json(r#"{"proj-claude": {"command": "npx", "args": ["proj-claude"]}}"#);
+    let warp_parsed = parse_mcp_json(r#"{"proj-warp": {"command": "npx", "args": ["proj-warp"]}}"#);
+
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let events = subscribe_events(&mut app, &manager);
+
+        manager.update(&mut app, |m, ctx| {
+            m.apply_parsed_servers(repo_path.clone(), MCPProvider::Claude, claude_parsed, ctx);
+            m.apply_parsed_servers(repo_path.clone(), MCPProvider::Warp, warp_parsed, ctx);
+            m.handle_cloud_environment_scan_complete(&repo_path, ctx);
+        });
+
+        events.update(&mut app, |e, _| {
+            assert_eq!(e.scan_completions.len(), 1);
+            let scan = &e.scan_completions[0];
+            assert_eq!(scan.repo_path, repo_path);
+            assert_eq!(scan.detected_servers.len(), 2);
+            assert!(
+                scan.wait_server_uuids.is_empty(),
+                "Project-scoped servers must not be included in the AgentDriver wait set, got: {:?}",
+                scan.wait_server_uuids
+            );
+            assert!(
+                scan.detected_servers
+                    .iter()
+                    .all(|server| !server.auto_start_eligible),
+                "Project-scoped servers should not be auto-start eligible: {:?}",
+                scan.detected_servers
+            );
+        });
+    });
+}
+
+#[test]
+fn test_auto_started_cloud_scan_uuids_are_in_wait_set() {
+    let _flag_guard = FeatureFlag::FileBasedMcp.override_enabled(true);
+    let Some(warp_mcp_config_path) = warp_managed_mcp_config_path() else {
+        return;
+    };
+    let root_path = warp_mcp_config_path.root_path;
+    let parsed = parse_mcp_json(r#"{"global-warp": {"command": "npx", "args": ["warp"]}}"#);
+
+    App::test((), |mut app| async move {
+        let manager = setup_app(&mut app);
+        let events = subscribe_events(&mut app, &manager);
+
+        manager.update(&mut app, |m, ctx| {
+            m.apply_parsed_servers(root_path.clone(), MCPProvider::Warp, parsed, ctx);
+            m.handle_cloud_environment_scan_complete(&root_path, ctx);
+        });
+
+        events.update(&mut app, |e, _| {
+            assert_eq!(e.spawned_uuids.len(), 1);
+            assert_eq!(e.scan_completions.len(), 1);
+            let scan = &e.scan_completions[0];
+            assert_eq!(scan.detected_servers.len(), 1);
+            assert_eq!(scan.wait_server_uuids, e.spawned_uuids);
+            assert!(
+                scan.detected_servers[0].auto_start_eligible,
+                "Global Warp server should be auto-start eligible"
             );
         });
     });

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -5,7 +5,6 @@ use crate::ai::mcp::templatable_manager::oauth::{
 };
 use crate::ai::mcp::FileBasedMCPManager;
 use core::fmt;
-use itertools::Itertools;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::{collections::HashMap, future::Future};
@@ -409,7 +408,23 @@ impl TemplatableMCPServerManager {
         {
             return;
         }
-        self.server_states.insert(installation_uuid, new_state);
+        let previous_state = self.server_states.insert(installation_uuid, new_state);
+        let server_name = self
+            .get_installed_server_name(&installation_uuid)
+            .or_else(|| {
+                FileBasedMCPManager::as_ref(ctx)
+                    .get_installation_by_uuid(installation_uuid)
+                    .map(|installation| installation.templatable_mcp_server().name.clone())
+            })
+            .or_else(|| {
+                self.active_servers
+                    .get(&installation_uuid)
+                    .map(|server| server.name().to_string())
+            })
+            .unwrap_or_else(|| "<unknown>".to_string());
+        log::info!(
+            "Templatable MCP server '{server_name}' ({installation_uuid}) changed state from {previous_state:?} to {new_state:?}"
+        );
         ctx.emit(TemplatableMCPServerManagerEvent::StateChanged {
             uuid: installation_uuid,
             state: new_state,
@@ -1678,16 +1693,31 @@ impl TemplatableMCPServerManager {
         installations: &[TemplatableMCPServerInstallation],
         ctx: &mut ModelContext<Self>,
     ) {
+        log::info!(
+            "Templatable MCP manager received {} file-based MCP server(s) to spawn",
+            installations.len()
+        );
+
         // First, check if the servers are already spawned.
-        let new_installations = installations
-            .iter()
-            .filter(|installation| {
-                let uuid = installation.uuid();
-                !self.active_servers.contains_key(&uuid)
-                    && !self.spawned_servers.contains_key(&uuid)
-            })
-            .cloned()
-            .collect_vec();
+        let mut new_installations = Vec::new();
+        for installation in installations {
+            let uuid = installation.uuid();
+            let server_name = &installation.templatable_mcp_server().name;
+            if self.active_servers.contains_key(&uuid) {
+                log::info!(
+                    "Skipping file-based MCP server '{server_name}' ({uuid}); already running"
+                );
+                continue;
+            }
+            if self.spawned_servers.contains_key(&uuid) {
+                log::info!(
+                    "Skipping file-based MCP server '{server_name}' ({uuid}); already starting"
+                );
+                continue;
+            }
+            log::info!("Spawning file-based MCP server '{server_name}' ({uuid})");
+            new_installations.push(installation.clone());
+        }
 
         // If not, spawn them.
         for installation in new_installations {

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -408,23 +408,7 @@ impl TemplatableMCPServerManager {
         {
             return;
         }
-        let previous_state = self.server_states.insert(installation_uuid, new_state);
-        let server_name = self
-            .get_installed_server_name(&installation_uuid)
-            .or_else(|| {
-                FileBasedMCPManager::as_ref(ctx)
-                    .get_installation_by_uuid(installation_uuid)
-                    .map(|installation| installation.templatable_mcp_server().name.clone())
-            })
-            .or_else(|| {
-                self.active_servers
-                    .get(&installation_uuid)
-                    .map(|server| server.name().to_string())
-            })
-            .unwrap_or_else(|| "<unknown>".to_string());
-        log::info!(
-            "Templatable MCP server '{server_name}' ({installation_uuid}) changed state from {previous_state:?} to {new_state:?}"
-        );
+        self.server_states.insert(installation_uuid, new_state);
         ctx.emit(TemplatableMCPServerManagerEvent::StateChanged {
             uuid: installation_uuid,
             state: new_state,
@@ -1693,11 +1677,6 @@ impl TemplatableMCPServerManager {
         installations: &[TemplatableMCPServerInstallation],
         ctx: &mut ModelContext<Self>,
     ) {
-        log::info!(
-            "Templatable MCP manager received {} file-based MCP server(s) to spawn",
-            installations.len()
-        );
-
         // First, check if the servers are already spawned.
         let mut new_installations = Vec::new();
         for installation in installations {


### PR DESCRIPTION
## Description

In an oz run, we were timing out after waiting 60s for discovered file-based MCP servers to reach a terminal status.

We intentionally do not start project-scoped file-based MCP servers for security reasons in [this PR](https://github.com/warpdotdev/warp-internal/pull/24640)

But the agent runner was still discovering these and waiting for them to reach a terminal status, even though we never attempt to start them

Now `CloudEnvMcpScanComplete` contains all detected file-based mcp servers, but also notes which we will actually attempt to auto-start. We only wait for those. Did some refactoring to make clear we don't auto-start every file-based mcp server we detect.

Also add some logging and reduce the timeout to 20s.
