### PR TITLE
Revert "In-app notifications for child agents (#10111)"

### DIFF
--- a/app/src/ai/agent_management/agent_management_model.rs
+++ b/app/src/ai/agent_management/agent_management_model.rs
@@ -262,9 +262,7 @@ impl AgentNotificationsModel {
             return;
         };
 
-        if updated_conversation.should_exclude_from_navigation()
-            && !updated_conversation.is_child_agent_conversation()
-        {
+        if updated_conversation.should_exclude_from_navigation() {
             return;
         }
 
@@ -314,57 +312,16 @@ impl AgentNotificationsModel {
     ) {
         let origin = NotificationOrigin::Conversation(conversation_id);
 
-        let ai_history_model = BlocklistAIHistoryModel::as_ref(ctx);
-        let conversation = ai_history_model.conversation(&conversation_id);
-        let is_child = conversation.is_some_and(|c| c.is_child_agent_conversation());
-
-        let active_views = ActiveAgentViewsModel::as_ref(ctx);
-
-        // For child conversations, check if the child's own conversation is
-        // open in an agent view (navigate directly) or if the parent
-        // conversation is open (the child is visible via the parent's
-        // ChildAgentStatusCard — navigate to the parent's pane). For non-child
-        // conversations, just check whether the conversation itself is open.
-        let (is_open, effective_terminal_view_id, title) = if is_child {
-            let child_open = active_views.is_conversation_open(conversation_id, ctx);
-            let parent_open = !child_open
-                && conversation
-                    .and_then(|c| c.parent_conversation_id())
-                    .is_some_and(|parent_id| active_views.is_conversation_open(parent_id, ctx));
-            let nav_terminal_view_id = if child_open {
-                terminal_view_id
-            } else {
-                conversation
-                    .and_then(|c| c.parent_conversation_id())
-                    .and_then(|parent_id| {
-                        ai_history_model.terminal_view_id_for_conversation(&parent_id)
-                    })
-                    .unwrap_or(terminal_view_id)
-            };
-            let child_name = conversation
-                .and_then(|c| c.agent_name())
-                .map(|name| name.to_owned())
-                .or(latest_query)
-                .unwrap_or_else(|| "Child agent".to_owned());
-            (child_open || parent_open, nav_terminal_view_id, child_name)
-        } else {
-            let title = latest_query.unwrap_or_else(|| "Agent task".to_owned());
-            (
-                active_views.is_conversation_open(conversation_id, ctx),
-                terminal_view_id,
-                title,
-            )
-        };
-
         // If the conversation view is no longer open, don't create notifications for it
         // (there's nothing to navigate to when clicking them).
-        if !is_open {
+        if !ActiveAgentViewsModel::as_ref(ctx).is_conversation_open(conversation_id, ctx) {
             self.pending_artifacts.remove(&conversation_id);
             self.remove_notification_by_source(origin, ctx);
             return;
         }
 
-        let metadata = TerminalViewMetadata::lookup(effective_terminal_view_id, ctx);
+        let title = latest_query.unwrap_or_else(|| "Agent task".to_owned());
+        let metadata = TerminalViewMetadata::lookup(terminal_view_id, ctx);
         let oz_agent = NotificationSourceAgent::Oz {
             is_ambient: metadata.is_ambient,
         };
@@ -376,18 +333,13 @@ impl AgentNotificationsModel {
             }
             ConversationStatus::Success => {
                 let artifacts = self.flush_pending_artifacts(conversation_id);
-                let message = if is_child {
-                    "Child agent completed."
-                } else {
-                    "Task completed."
-                };
                 self.add_notification(
                     title,
-                    message.to_owned(),
+                    "Task completed.".to_owned(),
                     NotificationCategory::Complete,
                     oz_agent,
                     origin,
-                    effective_terminal_view_id,
+                    terminal_view_id,
                     artifacts,
                     metadata.branch,
                     ctx,
@@ -395,18 +347,13 @@ impl AgentNotificationsModel {
             }
             ConversationStatus::Cancelled => {
                 let artifacts = self.flush_pending_artifacts(conversation_id);
-                let message = if is_child {
-                    "Child agent was cancelled."
-                } else {
-                    "Task was cancelled."
-                };
                 self.add_notification(
                     title,
-                    message.to_owned(),
+                    "Task was cancelled.".to_owned(),
                     NotificationCategory::Complete,
                     oz_agent,
                     origin,
-                    effective_terminal_view_id,
+                    terminal_view_id,
                     artifacts,
                     metadata.branch,
                     ctx,
@@ -419,7 +366,7 @@ impl AgentNotificationsModel {
                     NotificationCategory::Request,
                     oz_agent,
                     origin,
-                    effective_terminal_view_id,
+                    terminal_view_id,
                     vec![],
                     metadata.branch,
                     ctx,
@@ -427,18 +374,13 @@ impl AgentNotificationsModel {
             }
             ConversationStatus::Error => {
                 let artifacts = self.flush_pending_artifacts(conversation_id);
-                let message = if is_child {
-                    "Child agent encountered an error."
-                } else {
-                    "Something went wrong."
-                };
                 self.add_notification(
                     title,
-                    message.to_owned(),
+                    "Something went wrong.".to_owned(),
                     NotificationCategory::Error,
                     oz_agent,
                     origin,
-                    effective_terminal_view_id,
+                    terminal_view_id,
                     artifacts,
                     metadata.branch,
                     ctx,


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Reverts to the old behaviour, where we only push notifications for updates from the main agent.