### PR TITLE
feat: retry Cloud Mode initial runs after GitHub auth

### DIFF
--- a/app/src/ai/ambient_agents/github_auth_url.rs
+++ b/app/src/ai/ambient_agents/github_auth_url.rs
@@ -1,0 +1,159 @@
+use url::Url;
+
+use crate::ChannelState;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GithubAuthRedirectTarget {
+    SettingsEnvironments,
+    FocusCloudMode,
+}
+
+impl GithubAuthRedirectTarget {
+    fn next_path(self) -> &'static str {
+        match self {
+            Self::SettingsEnvironments => "settings/environments",
+            Self::FocusCloudMode => "action/focus_cloud_mode",
+        }
+    }
+}
+
+/// Indicates where the GitHub authorization flow was initiated from.
+/// This affects the redirect URL used after auth completes.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum AuthSource {
+    /// Auth initiated from the settings page (default behavior: redirect to settings)
+    #[default]
+    Settings,
+    /// Auth initiated from cloud agent setup (skip redirect, just refresh in place)
+    CloudSetup,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum OAuthNextPlatform {
+    Native,
+    Web,
+}
+
+pub fn auth_url_with_next(
+    base_auth_url: &str,
+    target: GithubAuthRedirectTarget,
+    auth_source: AuthSource,
+) -> String {
+    let scheme = oauth_next_scheme();
+    build_auth_url_with_next(base_auth_url, target, &scheme, auth_source)
+}
+pub fn settings_environments_auth_url_with_next(base_auth_url: &str) -> String {
+    auth_url_with_next(
+        base_auth_url,
+        GithubAuthRedirectTarget::SettingsEnvironments,
+        AuthSource::Settings,
+    )
+}
+
+pub fn cloud_setup_auth_url_with_next(base_auth_url: &str) -> String {
+    auth_url_with_next(
+        base_auth_url,
+        GithubAuthRedirectTarget::FocusCloudMode,
+        AuthSource::CloudSetup,
+    )
+}
+
+pub(crate) fn build_auth_url_with_next(
+    base_auth_url: &str,
+    target: GithubAuthRedirectTarget,
+    scheme: &str,
+    auth_source: AuthSource,
+) -> String {
+    let Ok(mut url) = Url::parse(base_auth_url) else {
+        return base_auth_url.to_string();
+    };
+
+    let scheme_for_next = std::env::var("WARP_OAUTH_NEXT_SCHEME")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            url.query_pairs()
+                .find(|(key, _)| key == "scheme")
+                .map(|(_, value)| value.into_owned())
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| scheme.to_string());
+
+    let platform = if cfg!(target_family = "wasm") {
+        OAuthNextPlatform::Web
+    } else {
+        OAuthNextPlatform::Native
+    };
+
+    let next_url = build_next_url(target, &scheme_for_next, auth_source, platform)
+        .unwrap_or_else(|| format!("{scheme_for_next}://{}", target.next_path()));
+
+    let existing_pairs = url
+        .query_pairs()
+        .filter(|(key, _)| key != "next")
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect::<Vec<_>>();
+
+    {
+        let mut query_pairs = url.query_pairs_mut();
+        query_pairs.clear();
+        for (key, value) in existing_pairs {
+            query_pairs.append_pair(&key, &value);
+        }
+        query_pairs.append_pair("next", &next_url);
+    }
+
+    url.to_string()
+}
+
+fn build_next_url(
+    target: GithubAuthRedirectTarget,
+    scheme_for_next: &str,
+    auth_source: AuthSource,
+    platform: OAuthNextPlatform,
+) -> Option<String> {
+    match platform {
+        OAuthNextPlatform::Native => {
+            let base = format!("{scheme_for_next}://{}", target.next_path());
+            let mut url = Url::parse(&base).ok()?;
+
+            if matches!(auth_source, AuthSource::CloudSetup) {
+                url.query_pairs_mut()
+                    .append_pair("source", crate::uri::CLOUD_SETUP_SOURCE);
+            }
+
+            Some(url.to_string())
+        }
+        OAuthNextPlatform::Web => {
+            let mut url = Url::parse(&ChannelState::server_root_url()).ok()?;
+            url.set_query(None);
+
+            match target {
+                GithubAuthRedirectTarget::SettingsEnvironments => {
+                    url.set_path("/settings/environments");
+                    {
+                        let mut pairs = url.query_pairs_mut();
+                        pairs.append_pair("oauth", "github");
+                        if matches!(auth_source, AuthSource::CloudSetup) {
+                            pairs.append_pair("source", crate::uri::CLOUD_SETUP_SOURCE);
+                        }
+                    }
+                }
+                GithubAuthRedirectTarget::FocusCloudMode => {
+                    url.set_path("/action/focus_cloud_mode");
+                }
+            }
+
+            Some(url.to_string())
+        }
+    }
+}
+
+fn oauth_next_scheme() -> String {
+    if let Ok(override_value) = std::env::var("WARP_OAUTH_NEXT_SCHEME") {
+        if !override_value.is_empty() {
+            return override_value;
+        }
+    }
+    ChannelState::url_scheme().to_string()
+}

--- a/app/src/ai/ambient_agents/mod.rs
+++ b/app/src/ai/ambient_agents/mod.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use uuid::{NonNilUuid, Uuid};
 
 pub mod github_auth_notifier;
+pub mod github_auth_url;
 pub mod scheduled;
 pub mod spawn;
 pub mod task;

--- a/app/src/pane_group/pane/environment_management_pane.rs
+++ b/app/src/pane_group/pane/environment_management_pane.rs
@@ -1,12 +1,12 @@
 use warpui::{AppContext, ModelHandle, ViewContext, ViewHandle};
 
 use crate::{
+    ai::ambient_agents::github_auth_url::GithubAuthRedirectTarget,
     app_state::{EnvironmentManagementPaneSnapshot, LeafContents},
     pane_group::focus_state::PaneFocusHandle,
     settings_view::{
         environments_page::{EnvironmentsPage, EnvironmentsPageView},
         settings_page::{PaneEventWrapper, SettingsPageEvent},
-        update_environment_form::GithubAuthRedirectTarget,
     },
 };
 

--- a/app/src/settings_view/environments_page.rs
+++ b/app/src/settings_view/environments_page.rs
@@ -11,12 +11,13 @@ use super::{
         SettingsWidget, CONTENT_FONT_SIZE,
     },
     update_environment_form::{
-        EnvironmentFormInitArgs, EnvironmentFormValues, GithubAuthRedirectTarget,
-        UpdateEnvironmentForm, UpdateEnvironmentFormEvent,
+        EnvironmentFormInitArgs, EnvironmentFormValues, UpdateEnvironmentForm,
+        UpdateEnvironmentFormEvent,
     },
     SettingsSection,
 };
 use crate::{
+    ai::ambient_agents::github_auth_url::GithubAuthRedirectTarget,
     ai::cloud_environments::{self, CloudAmbientAgentEnvironment},
     appearance::Appearance,
     cloud_object::{

--- a/app/src/settings_view/handoff_environment_creation_modal.rs
+++ b/app/src/settings_view/handoff_environment_creation_modal.rs
@@ -1,11 +1,11 @@
+use crate::ai::ambient_agents::github_auth_url::{AuthSource, GithubAuthRedirectTarget};
 use crate::ai::cloud_environments;
 use crate::appearance::Appearance;
 use crate::modal::MODAL_BACKDROP_OPACITY;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::{ClientId, SyncId};
 use crate::settings_view::update_environment_form::{
-    AuthSource, EnvironmentFormInitArgs, GithubAuthRedirectTarget, UpdateEnvironmentForm,
-    UpdateEnvironmentFormEvent,
+    EnvironmentFormInitArgs, UpdateEnvironmentForm, UpdateEnvironmentFormEvent,
 };
 use crate::ui_components::buttons::icon_button;
 use crate::ui_components::dialog::{dialog_styles, Dialog};

--- a/app/src/settings_view/update_environment_form.rs
+++ b/app/src/settings_view/update_environment_form.rs
@@ -4,7 +4,10 @@ use super::{
 };
 use crate::server::server_api::ServerApiProvider;
 use crate::{
-    ai::ambient_agents::telemetry::CloudAgentTelemetryEvent,
+    ai::ambient_agents::{
+        github_auth_url::{self, AuthSource, GithubAuthRedirectTarget},
+        telemetry::CloudAgentTelemetryEvent,
+    },
     ai::{
         ambient_agents::github_auth_notifier::{GitHubAuthEvent, GitHubAuthNotifier},
         cloud_environments::{AmbientAgentEnvironment, GithubRepo},
@@ -149,21 +152,6 @@ pub enum EnvironmentFormMode {
     Edit { env_id: SyncId },
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum GithubAuthRedirectTarget {
-    SettingsEnvironments,
-    FocusCloudMode,
-}
-
-impl GithubAuthRedirectTarget {
-    fn next_path(self) -> &'static str {
-        match self {
-            Self::SettingsEnvironments => "settings/environments",
-            Self::FocusCloudMode => "action/focus_cloud_mode",
-        }
-    }
-}
-
 /// Events emitted by UpdateEnvironmentForm.
 #[derive(Debug, Clone)]
 pub enum UpdateEnvironmentFormEvent {
@@ -255,23 +243,6 @@ enum SuggestImageState {
         key: String,
         message: String,
     },
-}
-
-/// Indicates where the GitHub authorization flow was initiated from.
-/// This affects the redirect URL used after auth completes.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum AuthSource {
-    /// Auth initiated from the settings page (default behavior: redirect to settings)
-    #[default]
-    Settings,
-    /// Auth initiated from cloud agent setup (skip redirect, just refresh in place)
-    CloudSetup,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum OAuthNextPlatform {
-    Native,
-    Web,
 }
 
 pub struct UpdateEnvironmentForm {
@@ -2715,13 +2686,17 @@ impl UpdateEnvironmentForm {
     }
 
     fn auth_url_with_next(&self, base_auth_url: &str) -> String {
-        let scheme = Self::oauth_next_scheme();
-        Self::build_auth_url_with_next_internal(
-            base_auth_url,
-            self.github_auth_redirect_target,
-            &scheme,
-            self.auth_source,
-        )
+        match (self.github_auth_redirect_target, self.auth_source) {
+            (GithubAuthRedirectTarget::SettingsEnvironments, AuthSource::Settings) => {
+                github_auth_url::settings_environments_auth_url_with_next(base_auth_url)
+            }
+            (GithubAuthRedirectTarget::FocusCloudMode, AuthSource::CloudSetup) => {
+                github_auth_url::cloud_setup_auth_url_with_next(base_auth_url)
+            }
+            (target, auth_source) => {
+                github_auth_url::auth_url_with_next(base_auth_url, target, auth_source)
+            }
+        }
     }
 
     #[cfg(test)]
@@ -2730,107 +2705,12 @@ impl UpdateEnvironmentForm {
         target: GithubAuthRedirectTarget,
         scheme: &str,
     ) -> String {
-        Self::build_auth_url_with_next_internal(base_auth_url, target, scheme, AuthSource::Settings)
-    }
-
-    fn build_auth_url_with_next_internal(
-        base_auth_url: &str,
-        target: GithubAuthRedirectTarget,
-        scheme: &str,
-        auth_source: AuthSource,
-    ) -> String {
-        let Ok(mut url) = Url::parse(base_auth_url) else {
-            return base_auth_url.to_string();
-        };
-
-        let scheme_for_next = std::env::var("WARP_OAUTH_NEXT_SCHEME")
-            .ok()
-            .filter(|value| !value.is_empty())
-            .or_else(|| {
-                url.query_pairs()
-                    .find(|(key, _)| key == "scheme")
-                    .map(|(_, value)| value.into_owned())
-            })
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| scheme.to_string());
-
-        let platform = if cfg!(target_family = "wasm") {
-            OAuthNextPlatform::Web
-        } else {
-            OAuthNextPlatform::Native
-        };
-
-        let next_url = Self::build_next_url(target, &scheme_for_next, auth_source, platform)
-            .unwrap_or_else(|| format!("{scheme_for_next}://{}", target.next_path()));
-
-        let existing_pairs = url
-            .query_pairs()
-            .filter(|(key, _)| key != "next")
-            .map(|(key, value)| (key.into_owned(), value.into_owned()))
-            .collect::<Vec<_>>();
-
-        {
-            let mut query_pairs = url.query_pairs_mut();
-            query_pairs.clear();
-            for (key, value) in existing_pairs {
-                query_pairs.append_pair(&key, &value);
-            }
-            query_pairs.append_pair("next", &next_url);
-        }
-
-        url.to_string()
-    }
-
-    fn build_next_url(
-        target: GithubAuthRedirectTarget,
-        scheme_for_next: &str,
-        auth_source: AuthSource,
-        platform: OAuthNextPlatform,
-    ) -> Option<String> {
-        match platform {
-            OAuthNextPlatform::Native => {
-                let base = format!("{scheme_for_next}://{}", target.next_path());
-                let mut url = Url::parse(&base).ok()?;
-
-                if matches!(auth_source, AuthSource::CloudSetup) {
-                    url.query_pairs_mut()
-                        .append_pair("source", crate::uri::CLOUD_SETUP_SOURCE);
-                }
-
-                Some(url.to_string())
-            }
-            OAuthNextPlatform::Web => {
-                let mut url = Url::parse(&ChannelState::server_root_url()).ok()?;
-                url.set_query(None);
-
-                match target {
-                    GithubAuthRedirectTarget::SettingsEnvironments => {
-                        url.set_path("/settings/environments");
-                        {
-                            let mut pairs = url.query_pairs_mut();
-                            pairs.append_pair("oauth", "github");
-                            if matches!(auth_source, AuthSource::CloudSetup) {
-                                pairs.append_pair("source", crate::uri::CLOUD_SETUP_SOURCE);
-                            }
-                        }
-                    }
-                    GithubAuthRedirectTarget::FocusCloudMode => {
-                        url.set_path("/action/focus_cloud_mode");
-                    }
-                }
-
-                Some(url.to_string())
-            }
-        }
-    }
-
-    fn oauth_next_scheme() -> String {
-        if let Ok(override_value) = std::env::var("WARP_OAUTH_NEXT_SCHEME") {
-            if !override_value.is_empty() {
-                return override_value;
-            }
-        }
-        ChannelState::url_scheme().to_string()
+        github_auth_url::build_auth_url_with_next(
+            base_auth_url,
+            target,
+            scheme,
+            AuthSource::Settings,
+        )
     }
 
     /// Parses a Docker image reference and returns the Docker Hub URL if it looks like a Docker Hub image.

--- a/app/src/settings_view/update_environment_form_tests.rs
+++ b/app/src/settings_view/update_environment_form_tests.rs
@@ -1,8 +1,9 @@
 use super::{
-    EnvironmentFormInitArgs, EnvironmentFormValues, GithubAuthRedirectTarget, SuggestImageState,
-    UpdateEnvironmentForm, UpdateEnvironmentFormAction,
+    EnvironmentFormInitArgs, EnvironmentFormValues, SuggestImageState, UpdateEnvironmentForm,
+    UpdateEnvironmentFormAction,
 };
 use crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier;
+use crate::ai::ambient_agents::github_auth_url::{self, AuthSource, GithubAuthRedirectTarget};
 use crate::ai::cloud_environments::GithubRepo;
 use crate::auth::AuthStateProvider;
 use crate::cloud_object::model::persistence::CloudModel;
@@ -108,6 +109,25 @@ fn test_build_auth_url_with_next_focus_cloud_mode() {
     );
 }
 
+#[test]
+fn test_build_auth_url_with_next_cloud_setup_source() {
+    let base_url = "https://example.com/oauth/connect/github";
+    let result = github_auth_url::build_auth_url_with_next(
+        base_url,
+        GithubAuthRedirectTarget::FocusCloudMode,
+        "warpdev",
+        AuthSource::CloudSetup,
+    );
+    let parsed = Url::parse(&result).expect("result should be valid url");
+    let next_value = parsed
+        .query_pairs()
+        .find(|(key, _)| key == "next")
+        .map(|(_, value)| value.into_owned());
+    assert_eq!(
+        next_value,
+        Some("warpdev://action/focus_cloud_mode?source=cloud_setup".to_string())
+    );
+}
 #[test]
 fn test_build_auth_url_with_next_uses_scheme_param() {
     let base_url = "https://example.com/oauth/connect/github?scheme=warp";

--- a/app/src/terminal/view/ambient_agent/first_time_setup.rs
+++ b/app/src/terminal/view/ambient_agent/first_time_setup.rs
@@ -5,14 +5,15 @@
 
 use crate::{
     ai::{
-        cloud_environments, request_usage_model::AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD,
+        ambient_agents::github_auth_url::{AuthSource, GithubAuthRedirectTarget},
+        cloud_environments,
+        request_usage_model::AMBIENT_AGENT_TRIAL_CREDIT_THRESHOLD,
         AIRequestUsageModel,
     },
     appearance::Appearance,
     server::{cloud_objects::update_manager::UpdateManager, ids::ClientId},
     settings_view::update_environment_form::{
-        AuthSource, EnvironmentFormInitArgs, GithubAuthRedirectTarget, UpdateEnvironmentForm,
-        UpdateEnvironmentFormEvent,
+        EnvironmentFormInitArgs, UpdateEnvironmentForm, UpdateEnvironmentFormEvent,
     },
     ui_components::blended_colors,
 };

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -186,9 +186,6 @@ pub struct AmbientAgentViewModel {
     /// The request with which the cloud agent was spawned, if it was spawned.
     request: Option<SpawnAgentRequest>,
 
-    /// Request needed to retry an initial run after GitHub auth completes.
-    initial_run_retry_request: Option<SpawnAgentRequest>,
-
     /// The terminal view this model is part of.
     terminal_view_id: EntityId,
 
@@ -284,7 +281,6 @@ impl AmbientAgentViewModel {
         Self {
             status: Status::Composing,
             request: None,
-            initial_run_retry_request: None,
             terminal_view_id,
             environment_id: None,
             progress_timer_handle: None,
@@ -915,7 +911,6 @@ impl AmbientAgentViewModel {
         );
 
         self.pending_followup_prompt = Some(prompt);
-        self.initial_run_retry_request = None;
         self.status = Status::WaitingForSession {
             progress: AgentProgress::new(),
             kind: SessionStartupKind::Followup,
@@ -960,7 +955,7 @@ impl AmbientAgentViewModel {
         self.active_execution_session_id = None;
         self.last_ended_execution_session_id = None;
         self.pending_followup_prompt = None;
-        self.initial_run_retry_request = None;
+        self.request = None;
         self.setup_commands_state = Default::default();
         self.stop_progress_timer();
         ctx.notify();
@@ -1088,7 +1083,6 @@ impl AmbientAgentViewModel {
     fn spawn_internal(&mut self, mut request: SpawnAgentRequest, ctx: &mut ModelContext<Self>) {
         request.interactive = Some(true);
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
-        self.initial_run_retry_request = Some(request.clone());
         self.request = Some(request.clone());
         let stream = spawn_task(request, ai_client, None);
 
@@ -1136,8 +1130,6 @@ impl AmbientAgentViewModel {
         match event {
             AmbientAgentEvent::TaskSpawned { task_id, run_id } => {
                 self.task_id = Some(task_id);
-                self.initial_run_retry_request = None;
-
                 if matches!(self.status, Status::Cancelled { .. }) {
                     log::info!(
                         "Received task_id after cancellation, sending server cancellation for task {}",
@@ -1256,7 +1248,6 @@ impl AmbientAgentViewModel {
                     self.active_execution_session_id = Some(session_id);
                     self.last_ended_execution_session_id = None;
                     self.pending_followup_prompt = None;
-                    self.initial_run_retry_request = None;
                     self.status = Status::AgentRunning;
                     ctx.emit(event);
                 }
@@ -1376,7 +1367,6 @@ impl AmbientAgentViewModel {
             error_message: error_message.clone(),
         };
         self.pending_followup_prompt = None;
-        self.initial_run_retry_request = None;
         ctx.emit(AmbientAgentViewModelEvent::Failed { error_message });
     }
 
@@ -1411,7 +1401,7 @@ impl AmbientAgentViewModel {
         };
 
         if !matches!(startup_kind, Some(SessionStartupKind::InitialRun)) {
-            self.initial_run_retry_request = None;
+            self.request = None;
         };
 
         self.status = Status::NeedsGithubAuth {
@@ -1429,7 +1419,7 @@ impl AmbientAgentViewModel {
             return;
         }
 
-        let Some(request) = self.initial_run_retry_request.take() else {
+        let Some(request) = self.request.clone() else {
             return;
         };
 
@@ -1460,7 +1450,6 @@ impl AmbientAgentViewModel {
 
         self.status = Status::Cancelled { progress };
         self.pending_followup_prompt = None;
-        self.initial_run_retry_request = None;
         #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
         if let Some(handoff) = self.pending_handoff.as_mut() {
             handoff.auto_submit = None;

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -11,6 +11,8 @@ use warpui::{AppContext, Entity, EntityId, ModelContext, SingletonEntity};
 
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::{conversation::AIConversationId, extract_user_query_mode};
+use crate::ai::ambient_agents::github_auth_notifier::{GitHubAuthEvent, GitHubAuthNotifier};
+use crate::ai::ambient_agents::github_auth_url;
 use crate::ai::ambient_agents::spawn::{spawn_task, submit_run_followup, AmbientAgentEvent};
 use crate::ai::ambient_agents::task::{HarnessAuthSecretsConfig, HarnessConfig};
 use crate::ai::ambient_agents::telemetry::CloudAgentTelemetryEvent;
@@ -184,6 +186,9 @@ pub struct AmbientAgentViewModel {
     /// The request with which the cloud agent was spawned, if it was spawned.
     request: Option<SpawnAgentRequest>,
 
+    /// Request needed to retry an initial run after GitHub auth completes.
+    initial_run_retry_request: Option<SpawnAgentRequest>,
+
     /// The terminal view this model is part of.
     terminal_view_id: EntityId,
 
@@ -246,6 +251,12 @@ impl AmbientAgentViewModel {
             me.validate_selected_harness(ctx);
         });
 
+        ctx.subscribe_to_model(&GitHubAuthNotifier::handle(ctx), |me, event, ctx| {
+            if matches!(event, GitHubAuthEvent::AuthCompleted) {
+                me.handle_github_auth_completed(ctx);
+            }
+        });
+
         // Validate the default environment once Warp Drive sync completes.
         // The environment ID may be restored from settings before environments are synced,
         // so we need to validate it once the initial load is complete.
@@ -273,6 +284,7 @@ impl AmbientAgentViewModel {
         Self {
             status: Status::Composing,
             request: None,
+            initial_run_retry_request: None,
             terminal_view_id,
             environment_id: None,
             progress_timer_handle: None,
@@ -903,6 +915,7 @@ impl AmbientAgentViewModel {
         );
 
         self.pending_followup_prompt = Some(prompt);
+        self.initial_run_retry_request = None;
         self.status = Status::WaitingForSession {
             progress: AgentProgress::new(),
             kind: SessionStartupKind::Followup,
@@ -947,6 +960,7 @@ impl AmbientAgentViewModel {
         self.active_execution_session_id = None;
         self.last_ended_execution_session_id = None;
         self.pending_followup_prompt = None;
+        self.initial_run_retry_request = None;
         self.setup_commands_state = Default::default();
         self.stop_progress_timer();
         ctx.notify();
@@ -1074,6 +1088,7 @@ impl AmbientAgentViewModel {
     fn spawn_internal(&mut self, mut request: SpawnAgentRequest, ctx: &mut ModelContext<Self>) {
         request.interactive = Some(true);
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        self.initial_run_retry_request = Some(request.clone());
         self.request = Some(request.clone());
         let stream = spawn_task(request, ai_client, None);
 
@@ -1121,6 +1136,7 @@ impl AmbientAgentViewModel {
         match event {
             AmbientAgentEvent::TaskSpawned { task_id, run_id } => {
                 self.task_id = Some(task_id);
+                self.initial_run_retry_request = None;
 
                 if matches!(self.status, Status::Cancelled { .. }) {
                     log::info!(
@@ -1240,6 +1256,7 @@ impl AmbientAgentViewModel {
                     self.active_execution_session_id = Some(session_id);
                     self.last_ended_execution_session_id = None;
                     self.pending_followup_prompt = None;
+                    self.initial_run_retry_request = None;
                     self.status = Status::AgentRunning;
                     ctx.emit(event);
                 }
@@ -1359,6 +1376,7 @@ impl AmbientAgentViewModel {
             error_message: error_message.clone(),
         };
         self.pending_followup_prompt = None;
+        self.initial_run_retry_request = None;
         ctx.emit(AmbientAgentViewModelEvent::Failed { error_message });
     }
 
@@ -1374,29 +1392,48 @@ impl AmbientAgentViewModel {
         let now = Instant::now();
 
         // Extract or create progress tracking.
-        let progress = if let Status::WaitingForSession { mut progress, .. } =
+        let (progress, startup_kind) = if let Status::WaitingForSession { mut progress, kind } =
             std::mem::replace(&mut self.status, Status::Composing)
         {
             progress.stopped_at = Some(now);
-            progress
+            (progress, Some(kind))
         } else {
             // If not in WaitingForSession, create a new progress with current time.
-            AgentProgress {
-                spawned_at: now,
-                claimed_at: None,
-                harness_started_at: None,
-                stopped_at: Some(now),
-            }
+            (
+                AgentProgress {
+                    spawned_at: now,
+                    claimed_at: None,
+                    harness_started_at: None,
+                    stopped_at: Some(now),
+                },
+                None,
+            )
+        };
+
+        if !matches!(startup_kind, Some(SessionStartupKind::InitialRun)) {
+            self.initial_run_retry_request = None;
         };
 
         self.status = Status::NeedsGithubAuth {
             progress,
             error_message,
-            auth_url,
+            auth_url: github_auth_url::cloud_setup_auth_url_with_next(&auth_url),
         };
         self.pending_followup_prompt = None;
 
         ctx.emit(AmbientAgentViewModelEvent::NeedsGithubAuth);
+    }
+
+    fn handle_github_auth_completed(&mut self, ctx: &mut ModelContext<Self>) {
+        if !matches!(self.status, Status::NeedsGithubAuth { .. }) {
+            return;
+        }
+
+        let Some(request) = self.initial_run_retry_request.take() else {
+            return;
+        };
+
+        self.spawn_internal(request, ctx);
     }
 
     /// Handles cancellation by transitioning to the Cancelled state.
@@ -1423,6 +1460,7 @@ impl AmbientAgentViewModel {
 
         self.status = Status::Cancelled { progress };
         self.pending_followup_prompt = None;
+        self.initial_run_retry_request = None;
         #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
         if let Some(handoff) = self.pending_handoff.as_mut() {
             handoff.auto_submit = None;

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -73,6 +73,7 @@ fn retry_request(prompt: impl Into<String>) -> SpawnAgentRequest {
         initial_snapshot_token: Some(
             serde_json::from_str("\"snapshot-token-123\"").expect("snapshot token should parse"),
         ),
+        snapshot_disabled: Some(true),
     }
 }
 
@@ -154,6 +155,7 @@ fn github_auth_completed_retries_stored_initial_run_request() {
                     .map(|token| token.as_str()),
                 Some("snapshot-token-123")
             );
+            assert_eq!(request.snapshot_disabled, Some(true));
             let config = request.config.as_ref().expect("config should be preserved");
             assert_eq!(config.environment_id.as_deref(), Some("env-123"));
             assert_eq!(config.model_id.as_deref(), Some("model-123"));

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -88,7 +88,7 @@ fn github_auth_url_for_initial_run_includes_focus_cloud_mode_next() {
                 progress: AgentProgress::new(),
                 kind: SessionStartupKind::InitialRun,
             };
-            model.initial_run_retry_request = Some(retry_request("fix tests"));
+            model.request = Some(retry_request("fix tests"));
             model.handle_needs_github_auth(
                 "https://example.com/oauth/connect/github?scheme=warpdev".to_string(),
                 "auth required".to_string(),
@@ -123,7 +123,7 @@ fn github_auth_completed_retries_stored_initial_run_request() {
                 error_message: "auth required".to_string(),
                 auth_url: "https://example.com/oauth/connect/github".to_string(),
             };
-            model.initial_run_retry_request = Some(retry_request("retry this"));
+            model.request = Some(retry_request("retry this"));
 
             model.handle_github_auth_completed(ctx);
 
@@ -166,7 +166,7 @@ fn github_auth_completed_retries_stored_initial_run_request() {
 }
 
 #[test]
-fn followup_github_auth_does_not_reuse_initial_run_retry_request() {
+fn followup_github_auth_does_not_reuse_stored_initial_request() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let model = add_model(&mut app);
@@ -176,7 +176,7 @@ fn followup_github_auth_does_not_reuse_initial_run_retry_request() {
                 progress: AgentProgress::new(),
                 kind: SessionStartupKind::Followup,
             };
-            model.initial_run_retry_request = Some(retry_request("do not retry"));
+            model.request = Some(retry_request("do not retry"));
             model.handle_needs_github_auth(
                 "https://example.com/oauth/connect/github".to_string(),
                 "auth required".to_string(),
@@ -184,7 +184,7 @@ fn followup_github_auth_does_not_reuse_initial_run_retry_request() {
             );
 
             assert!(matches!(model.status(), Status::NeedsGithubAuth { .. }));
-            assert!(model.initial_run_retry_request.is_none());
+            assert!(model.request().is_none());
 
             model.handle_github_auth_completed(ctx);
 

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -3,6 +3,7 @@ use warpui::{App, EntityId};
 use super::*;
 use crate::ai::blocklist::handoff::HandoffLaunchAttachments;
 use crate::test_util::terminal::initialize_app_for_terminal_view;
+use url::Url;
 
 fn attachment() -> AttachmentInput {
     AttachmentInput {
@@ -46,6 +47,148 @@ fn pending_handoff_fresh_launch() -> PendingHandoff {
 
 fn add_model(app: &mut App) -> warpui::ModelHandle<AmbientAgentViewModel> {
     app.add_model(|ctx| AmbientAgentViewModel::new(EntityId::new(), ctx))
+}
+
+fn retry_request(prompt: impl Into<String>) -> SpawnAgentRequest {
+    SpawnAgentRequest {
+        prompt: prompt.into(),
+        mode: crate::server::server_api::ai::UserQueryMode::Normal,
+        config: Some(AgentConfigSnapshot {
+            environment_id: Some("env-123".to_string()),
+            model_id: Some("model-123".to_string()),
+            worker_host: Some("worker-123".to_string()),
+            computer_use_enabled: Some(false),
+            ..Default::default()
+        }),
+        title: Some("Retry title".to_string()),
+        team: Some(true),
+        agent_identity_uid: Some("agent-123".to_string()),
+        skill: None,
+        attachments: vec![attachment()],
+        interactive: Some(true),
+        parent_run_id: Some("parent-run-123".to_string()),
+        runtime_skills: vec!["runtime-skill".to_string()],
+        referenced_attachments: vec!["referenced-attachment".to_string()],
+        conversation_id: Some("conversation-123".to_string()),
+        initial_snapshot_token: Some(
+            serde_json::from_str("\"snapshot-token-123\"").expect("snapshot token should parse"),
+        ),
+    }
+}
+
+#[test]
+fn github_auth_url_for_initial_run_includes_focus_cloud_mode_next() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let model = add_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.status = Status::WaitingForSession {
+                progress: AgentProgress::new(),
+                kind: SessionStartupKind::InitialRun,
+            };
+            model.initial_run_retry_request = Some(retry_request("fix tests"));
+            model.handle_needs_github_auth(
+                "https://example.com/oauth/connect/github?scheme=warpdev".to_string(),
+                "auth required".to_string(),
+                ctx,
+            );
+        });
+
+        model.read(&app, |model, _| {
+            let auth_url = model.github_auth_url().expect("auth url should be present");
+            let parsed = Url::parse(auth_url).expect("auth url should parse");
+            let next = parsed
+                .query_pairs()
+                .find(|(key, _)| key == "next")
+                .map(|(_, value)| value.into_owned());
+            assert_eq!(
+                next,
+                Some("warpdev://action/focus_cloud_mode?source=cloud_setup".to_string())
+            );
+        });
+    });
+}
+
+#[test]
+fn github_auth_completed_retries_stored_initial_run_request() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let model = add_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.status = Status::NeedsGithubAuth {
+                progress: AgentProgress::new(),
+                error_message: "auth required".to_string(),
+                auth_url: "https://example.com/oauth/connect/github".to_string(),
+            };
+            model.initial_run_retry_request = Some(retry_request("retry this"));
+
+            model.handle_github_auth_completed(ctx);
+
+            assert!(matches!(
+                model.status(),
+                Status::WaitingForSession {
+                    kind: SessionStartupKind::InitialRun,
+                    ..
+                }
+            ));
+            let request = model.request().expect("retry should spawn a request");
+            assert_eq!(request.prompt, "retry this");
+            assert_eq!(request.attachments.len(), 1);
+            assert_eq!(request.interactive, Some(true));
+            assert_eq!(request.team, Some(true));
+            assert_eq!(request.parent_run_id.as_deref(), Some("parent-run-123"));
+            assert_eq!(request.title.as_deref(), Some("Retry title"));
+            assert_eq!(request.agent_identity_uid.as_deref(), Some("agent-123"));
+            assert_eq!(request.runtime_skills, vec!["runtime-skill"]);
+            assert_eq!(
+                request.referenced_attachments,
+                vec!["referenced-attachment"]
+            );
+            assert_eq!(request.conversation_id.as_deref(), Some("conversation-123"));
+            assert_eq!(
+                request
+                    .initial_snapshot_token
+                    .as_ref()
+                    .map(|token| token.as_str()),
+                Some("snapshot-token-123")
+            );
+            let config = request.config.as_ref().expect("config should be preserved");
+            assert_eq!(config.environment_id.as_deref(), Some("env-123"));
+            assert_eq!(config.model_id.as_deref(), Some("model-123"));
+            assert_eq!(config.worker_host.as_deref(), Some("worker-123"));
+            assert_eq!(config.computer_use_enabled, Some(false));
+        });
+    });
+}
+
+#[test]
+fn followup_github_auth_does_not_reuse_initial_run_retry_request() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let model = add_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.status = Status::WaitingForSession {
+                progress: AgentProgress::new(),
+                kind: SessionStartupKind::Followup,
+            };
+            model.initial_run_retry_request = Some(retry_request("do not retry"));
+            model.handle_needs_github_auth(
+                "https://example.com/oauth/connect/github".to_string(),
+                "auth required".to_string(),
+                ctx,
+            );
+
+            assert!(matches!(model.status(), Status::NeedsGithubAuth { .. }));
+            assert!(model.initial_run_retry_request.is_none());
+
+            model.handle_github_auth_completed(ctx);
+
+            assert!(matches!(model.status(), Status::NeedsGithubAuth { .. }));
+        });
+    });
 }
 
 #[test]

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -992,11 +992,6 @@ impl Action {
                 }
             }
             Action::FocusCloudMode => {
-                // Notify that GitHub auth completed so views can refresh
-                GitHubAuthNotifier::handle(ctx).update(ctx, |notifier, ctx| {
-                    notifier.notify_auth_completed(ctx);
-                });
-
                 let active_agent_views = ActiveAgentViewsModel::as_ref(ctx);
                 let focused_conversation = primary_window_id
                     .and_then(|wid| active_agent_views.get_focused_conversation(wid));
@@ -1032,10 +1027,17 @@ impl Action {
                                 ctx,
                             );
                         });
+                        // Notify after focusing so Cloud Mode panes can retry in the selected pane.
+                        GitHubAuthNotifier::handle(ctx).update(ctx, |notifier, ctx| {
+                            notifier.notify_auth_completed(ctx);
+                        });
                         return;
                     }
                 }
 
+                GitHubAuthNotifier::handle(ctx).update(ctx, |notifier, ctx| {
+                    notifier.notify_auth_completed(ctx);
+                });
                 dispatch_action_in_new_or_existing_window(
                     primary_window_id,
                     "root_view:open_settings_page_in_existing_window",


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Implements APP-4458: when an initial Cloud Mode spawn requires GitHub auth, the auth URL now deep-links back into Warp, focuses the Cloud Mode pane, and retries the original initial-run request after auth completes.

This also centralizes GitHub auth redirect URL construction so the environment form and Cloud Mode setup flow share the same redirect-target/source handling.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
Linear: https://linear.app/warpdotdev/issue/APP-4458/deep-link-back-into-warp-after-authenticating-github-from-initial

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] `cargo fmt`
- [x] `cargo test -p warp terminal::view::ambient_agent::model::tests:: --lib`
- [x] `cargo test -p warp test_build_auth_url_with_next --lib`
- [x] `cargo fmt --check`
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

Demo video: https://www.loom.com/share/ac33da8156eb4949a14575c95209b6b9

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
-->
